### PR TITLE
[Poro] Deprecated warning removal

### DIFF
--- a/applications/PoromechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.cpp
+++ b/applications/PoromechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.cpp
@@ -26,7 +26,7 @@ Condition::Pointer UPwFaceLoadInterfaceCondition<TDim,TNumNodes>::Create(IndexTy
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwFaceLoadInterfaceCondition<TDim,TNumNodes>::Initialize()
+void UPwFaceLoadInterfaceCondition<TDim,TNumNodes>::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
     

--- a/applications/PoromechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.hpp
+++ b/applications/PoromechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.hpp
@@ -64,7 +64,7 @@ public:
 
     Condition::Pointer Create(IndexType NewId,NodesArrayType const& ThisNodes,PropertiesType::Pointer pProperties ) const override;
  
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
  
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/PoromechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
+++ b/applications/PoromechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
@@ -50,7 +50,7 @@ Condition::Pointer GeneralUPwDiffOrderCondition::Create(IndexType NewId,NodesArr
 
 //----------------------------------------------------------------------------------------
 
-void GeneralUPwDiffOrderCondition::Initialize()
+void GeneralUPwDiffOrderCondition::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 

--- a/applications/PoromechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.hpp
+++ b/applications/PoromechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.hpp
@@ -52,7 +52,7 @@ public:
 
     Condition::Pointer Create(IndexType NewId,NodesArrayType const& ThisNodes,PropertiesType::Pointer pProperties ) const override;
 
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     void GetDofList(DofsVectorType& rConditionDofList,const ProcessInfo& rCurrentProcessInfo ) const override;
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_element.cpp
@@ -38,7 +38,7 @@ Element::Pointer UPwElement<TDim,TNumNodes>::Create(IndexType NewId, GeometryTyp
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-int UPwElement<TDim,TNumNodes>::Check( const ProcessInfo& rCurrentProcessInfo )
+int UPwElement<TDim,TNumNodes>::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_element.cpp
@@ -132,7 +132,7 @@ int UPwElement<TDim,TNumNodes>::Check( const ProcessInfo& rCurrentProcessInfo )
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwElement<TDim,TNumNodes>::Initialize()
+void UPwElement<TDim,TNumNodes>::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -520,90 +520,57 @@ void UPwElement<TDim,TNumNodes>::SetValuesOnIntegrationPoints( const Variable<do
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwElement<TDim,TNumNodes>::GetValueOnIntegrationPoints( const Variable<double>& rVariable,std::vector<double>& rValues,
+void UPwElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const Variable<double>& rVariable,std::vector<double>& rValues,
                                                                 const ProcessInfo& rCurrentProcessInfo )
 {
-    if ( rVariable == VON_MISES_STRESS )
-    {
-        if ( rValues.size() != mConstitutiveLawVector.size() )
-            rValues.resize(mConstitutiveLawVector.size());
+    //if(rVariable == DAMAGE_VARIABLE || rVariable == STATE_VARIABLE)
+    if ( rValues.size() != mConstitutiveLawVector.size() )
+        rValues.resize(mConstitutiveLawVector.size());
 
-        this->CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-    }
-    else //if(rVariable == DAMAGE_VARIABLE || rVariable == STATE_VARIABLE)
+    for ( unsigned int i = 0;  i < mConstitutiveLawVector.size(); i++ )
     {
-        if ( rValues.size() != mConstitutiveLawVector.size() )
-            rValues.resize(mConstitutiveLawVector.size());
-
-        for ( unsigned int i = 0;  i < mConstitutiveLawVector.size(); i++ )
-        {
-            rValues[i] = 0.0;
-            rValues[i] = mConstitutiveLawVector[i]->GetValue( rVariable, rValues[i] );
-        }
+        rValues[i] = 0.0;
+        rValues[i] = mConstitutiveLawVector[i]->GetValue( rVariable, rValues[i] );
     }
 }
 
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwElement<TDim,TNumNodes>::GetValueOnIntegrationPoints(const Variable<array_1d<double,3>>& rVariable,std::vector<array_1d<double,3>>& rValues,
+void UPwElement<TDim,TNumNodes>::CalculateOnIntegrationPoints(const Variable<array_1d<double,3>>& rVariable,std::vector<array_1d<double,3>>& rValues,
                                                                     const ProcessInfo& rCurrentProcessInfo)
 {
-    if(rVariable == FLUID_FLUX_VECTOR)
-    {
-        if ( rValues.size() != mConstitutiveLawVector.size() )
-            rValues.resize(mConstitutiveLawVector.size());
+    if ( rValues.size() != mConstitutiveLawVector.size() )
+        rValues.resize(mConstitutiveLawVector.size());
 
-        this->CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-    }
-    else
+    for ( unsigned int i = 0;  i < mConstitutiveLawVector.size(); i++ )
     {
-        if ( rValues.size() != mConstitutiveLawVector.size() )
-            rValues.resize(mConstitutiveLawVector.size());
-
-        for ( unsigned int i = 0;  i < mConstitutiveLawVector.size(); i++ )
-        {
-            noalias(rValues[i]) = ZeroVector(3);
-            rValues[i] = mConstitutiveLawVector[i]->GetValue( rVariable, rValues[i] );
-        }
+        noalias(rValues[i]) = ZeroVector(3);
+        rValues[i] = mConstitutiveLawVector[i]->GetValue( rVariable, rValues[i] );
     }
 }
 
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwElement<TDim,TNumNodes>::GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,std::vector<Matrix>& rValues,
+void UPwElement<TDim,TNumNodes>::CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,std::vector<Matrix>& rValues,
                                                                     const ProcessInfo& rCurrentProcessInfo)
 {
-    if( rVariable == CAUCHY_STRESS_TENSOR ||
-        rVariable == TOTAL_STRESS_TENSOR ||
-        rVariable == GREEN_LAGRANGE_STRAIN_TENSOR ||
-        rVariable == PERMEABILITY_MATRIX ) {
+    if ( rValues.size() != mConstitutiveLawVector.size() )
+        rValues.resize(mConstitutiveLawVector.size());
 
-        if ( rValues.size() != mConstitutiveLawVector.size() )
-            rValues.resize(mConstitutiveLawVector.size());
-
-        this->CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-
-    } else {
-
-        if ( rValues.size() != mConstitutiveLawVector.size() )
-            rValues.resize(mConstitutiveLawVector.size());
-
-        for ( unsigned int i = 0;  i < mConstitutiveLawVector.size(); i++ )
-        {
-            rValues[i].resize(TDim,TDim,false);
-            noalias(rValues[i]) = ZeroMatrix(TDim,TDim);
-            rValues[i] = mConstitutiveLawVector[i]->GetValue( rVariable, rValues[i] );
-        }
-
+    for ( unsigned int i = 0;  i < mConstitutiveLawVector.size(); i++ )
+    {
+        rValues[i].resize(TDim,TDim,false);
+        noalias(rValues[i]) = ZeroMatrix(TDim,TDim);
+        rValues[i] = mConstitutiveLawVector[i]->GetValue( rVariable, rValues[i] );
     }
 }
 
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwElement<TDim,TNumNodes>::GetValueOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable,std::vector<ConstitutiveLaw::Pointer>& rValues,
+void UPwElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable,std::vector<ConstitutiveLaw::Pointer>& rValues,
                                                                 const ProcessInfo& rCurrentProcessInfo )
 {
     if(rVariable == CONSTITUTIVE_LAW)

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_element.hpp
@@ -66,7 +66,7 @@ public:
 
     int Check(const ProcessInfo& rCurrentProcessInfo) override;
 
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     void GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo ) const override;
 
@@ -96,13 +96,13 @@ public:
 
     void SetValuesOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void GetValueOnIntegrationPoints(const Variable<array_1d<double,3>>& rVariable, std::vector<array_1d<double,3>>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateOnIntegrationPoints(const Variable<array_1d<double,3>>& rVariable, std::vector<array_1d<double,3>>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void GetValueOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable, std::vector<ConstitutiveLaw::Pointer>& rValues,const ProcessInfo& rCurrentProcessInfo ) override;
+    void CalculateOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable, std::vector<ConstitutiveLaw::Pointer>& rValues,const ProcessInfo& rCurrentProcessInfo ) override;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_element.hpp
@@ -64,7 +64,7 @@ public:
 
     Element::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
 
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
@@ -34,11 +34,11 @@ Element::Pointer UPwSmallStrainFICElement<TDim,TNumNodes>::Create(IndexType NewI
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainFICElement<TDim,TNumNodes>::Initialize()
+void UPwSmallStrainFICElement<TDim,TNumNodes>::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
-    UPwElement<TDim,TNumNodes>::Initialize();
+    UPwElement<TDim,TNumNodes>::Initialize(rCurrentProcessInfo);
 
     unsigned int VoigtSize = 6;
     if(TDim == 2) VoigtSize = 3;

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.hpp
@@ -70,7 +70,7 @@ public:
 
     Element::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
 
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -34,7 +34,7 @@ Element::Pointer UPwSmallStrainElement<TDim,TNumNodes>::Create(IndexType NewId, 
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-int UPwSmallStrainElement<TDim,TNumNodes>::Check( const ProcessInfo& rCurrentProcessInfo )
+int UPwSmallStrainElement<TDim,TNumNodes>::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -66,7 +66,7 @@ public:
 
     Element::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
 
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -84,11 +84,11 @@ int UPwSmallStrainInterfaceElement<TDim,TNumNodes>::Check( const ProcessInfo& rC
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::Initialize()
+void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
-    UPwElement<TDim,TNumNodes>::Initialize();
+    UPwElement<TDim,TNumNodes>::Initialize(rCurrentProcessInfo);
 
     //Compute initial gap of the joint
     this->CalculateInitialGap(this->GetGeometry());
@@ -357,7 +357,7 @@ void UPwSmallStrainInterfaceElement<3,8>::ExtrapolateGPValues (const std::vector
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::GetValueOnIntegrationPoints( const Variable<double>& rVariable,
+void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const Variable<double>& rVariable,
                                                                                     std::vector<double>& rValues,const ProcessInfo& rCurrentProcessInfo )
 {
     if(rVariable == DAMAGE_VARIABLE)
@@ -425,7 +425,7 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::GetValueOnIntegrationPoints
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::GetValueOnIntegrationPoints(const Variable<array_1d<double,3>>& rVariable,
+void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPoints(const Variable<array_1d<double,3>>& rVariable,
                                                                                     std::vector<array_1d<double,3>>& rValues,const ProcessInfo& rCurrentProcessInfo)
 {
     if(rVariable == FLUID_FLUX_VECTOR || rVariable == LOCAL_STRESS_VECTOR || rVariable == LOCAL_RELATIVE_DISPLACEMENT_VECTOR || rVariable == LOCAL_FLUID_FLUX_VECTOR)
@@ -434,7 +434,216 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::GetValueOnIntegrationPoints
         const GeometryType& Geom = this->GetGeometry();
         std::vector<array_1d<double,3>> GPValues(Geom.IntegrationPointsNumber( mThisIntegrationMethod ));
 
-        this->CalculateOnIntegrationPoints(rVariable, GPValues, rCurrentProcessInfo);
+        if(rVariable == FLUID_FLUX_VECTOR)
+        {
+            const PropertiesType& Prop = this->GetProperties();
+            const GeometryType& Geom = this->GetGeometry();
+            const unsigned int NumGPoints = Geom.IntegrationPointsNumber( mThisIntegrationMethod );
+
+            //Defining the shape functions, the jacobian and the shape functions local gradients Containers
+            const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
+            const GeometryType::ShapeFunctionsGradientsType& DN_DeContainer = Geom.ShapeFunctionsLocalGradients( mThisIntegrationMethod );
+            GeometryType::JacobiansType JContainer(NumGPoints);
+            Geom.Jacobian( JContainer, mThisIntegrationMethod );
+
+            //Defining necessary variables
+            array_1d<double,TNumNodes> PressureVector;
+            for(unsigned int i=0; i<TNumNodes; i++)
+                PressureVector[i] = Geom[i].FastGetSolutionStepValue(WATER_PRESSURE);
+            array_1d<double,TNumNodes*TDim> VolumeAcceleration;
+            PoroElementUtilities::GetNodalVariableVector(VolumeAcceleration,Geom,VOLUME_ACCELERATION);
+            array_1d<double,TDim> BodyAcceleration;
+            array_1d<double,TNumNodes*TDim> DisplacementVector;
+            PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
+            BoundedMatrix<double,TDim, TDim> RotationMatrix;
+            this->CalculateRotationMatrix(RotationMatrix,Geom);
+            BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+            array_1d<double,TDim> LocalRelDispVector;
+            array_1d<double,TDim> RelDispVector;
+            const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
+            double JointWidth;
+            BoundedMatrix<double,TNumNodes, TDim> GradNpT;
+            const double& Transversal_Permeability = Prop[TRANSVERSAL_PERMEABILITY];
+            BoundedMatrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
+            const double& DynamicViscosityInverse = 1.0/Prop[DYNAMIC_VISCOSITY];
+            const double& FluidDensity = Prop[DENSITY_WATER];
+            array_1d<double,TDim> LocalFluidFlux;
+            array_1d<double,TDim> GradPressureTerm;
+            array_1d<double,TDim> FluidFlux;
+            SFGradAuxVariables SFGradAuxVars;
+
+            //Loop over integration points
+            for ( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++ )
+            {
+                InterfaceElementUtilities::CalculateNuMatrix(Nu,NContainer,GPoint);
+
+                noalias(RelDispVector) = prod(Nu,DisplacementVector);
+
+                noalias(LocalRelDispVector) = prod(RotationMatrix,RelDispVector);
+
+                this->CalculateJointWidth(JointWidth, LocalRelDispVector[TDim-1], MinimumJointWidth,GPoint);
+
+                this->CalculateShapeFunctionsGradients< BoundedMatrix<double,TNumNodes,TDim> >(GradNpT,SFGradAuxVars,JContainer[GPoint],RotationMatrix,
+                                                                                                                    DN_DeContainer[GPoint],NContainer,JointWidth,GPoint);
+
+                PoroElementUtilities::InterpolateVariableWithComponents(BodyAcceleration,NContainer,VolumeAcceleration,GPoint);
+
+                InterfaceElementUtilities::CalculatePermeabilityMatrix(LocalPermeabilityMatrix,JointWidth,Transversal_Permeability);
+
+                noalias(GradPressureTerm) = prod(trans(GradNpT),PressureVector);
+                noalias(GradPressureTerm) += -FluidDensity*BodyAcceleration;
+
+                noalias(LocalFluidFlux) = -DynamicViscosityInverse*prod(LocalPermeabilityMatrix,GradPressureTerm);
+
+                noalias(FluidFlux) = prod(trans(RotationMatrix),LocalFluidFlux);
+
+                PoroElementUtilities::FillArray1dOutput(GPValues[GPoint],FluidFlux);
+            }
+        }
+        else if(rVariable == LOCAL_STRESS_VECTOR)
+        {
+            //Defining necessary variables
+            const PropertiesType& Prop = this->GetProperties();
+            const GeometryType& Geom = this->GetGeometry();
+            const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
+            array_1d<double,TNumNodes*TDim> DisplacementVector;
+            PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
+            BoundedMatrix<double,TDim, TDim> RotationMatrix;
+            this->CalculateRotationMatrix(RotationMatrix,Geom);
+            BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+            array_1d<double,TDim> RelDispVector;
+            const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
+            double JointWidth;
+            array_1d<double,TDim> LocalStressVector;
+
+            //Create constitutive law parameters:
+            Vector StrainVector(TDim);
+            Vector StressVectorDynamic(TDim);
+            Matrix ConstitutiveMatrix(TDim,TDim);
+            Vector Np(TNumNodes);
+            Matrix GradNpT(TNumNodes,TDim);
+            Matrix F = identity_matrix<double>(TDim);
+            double detF = 1.0;
+            ConstitutiveLaw::Parameters ConstitutiveParameters(Geom,Prop,rCurrentProcessInfo);
+            ConstitutiveParameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
+            ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
+            ConstitutiveParameters.SetConstitutiveMatrix(ConstitutiveMatrix);
+            ConstitutiveParameters.SetStressVector(StressVectorDynamic);
+            ConstitutiveParameters.SetStrainVector(StrainVector);
+            ConstitutiveParameters.SetShapeFunctionsValues(Np);
+            ConstitutiveParameters.SetShapeFunctionsDerivatives(GradNpT);
+            ConstitutiveParameters.SetDeterminantF(detF);
+            ConstitutiveParameters.SetDeformationGradientF(F);
+
+            //Loop over integration points
+            for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); GPoint++ )
+            {
+                InterfaceElementUtilities::CalculateNuMatrix(Nu,NContainer,GPoint);
+
+                noalias(RelDispVector) = prod(Nu,DisplacementVector);
+
+                noalias(StrainVector) = prod(RotationMatrix,RelDispVector);
+
+                this->CheckAndCalculateJointWidth(JointWidth, ConstitutiveParameters, StrainVector[TDim-1], MinimumJointWidth, GPoint);
+
+                noalias(Np) = row(NContainer,GPoint);
+
+                //compute constitutive tensor and/or stresses
+                mConstitutiveLawVector[GPoint]->CalculateMaterialResponseCauchy(ConstitutiveParameters);
+
+                noalias(LocalStressVector) = StressVectorDynamic;
+
+                PoroElementUtilities::FillArray1dOutput(GPValues[GPoint],LocalStressVector);
+            }
+        }
+        else if(rVariable == LOCAL_RELATIVE_DISPLACEMENT_VECTOR)
+        {
+            //Defining necessary variables
+            const GeometryType& Geom = this->GetGeometry();
+            const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
+            array_1d<double,TNumNodes*TDim> DisplacementVector;
+            PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
+            BoundedMatrix<double,TDim, TDim> RotationMatrix;
+            this->CalculateRotationMatrix(RotationMatrix,Geom);
+            BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+            array_1d<double,TDim> LocalRelDispVector;
+            array_1d<double,TDim> RelDispVector;
+
+            //Loop over integration points
+            for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); GPoint++ )
+            {
+                InterfaceElementUtilities::CalculateNuMatrix(Nu,NContainer,GPoint);
+
+                noalias(RelDispVector) = prod(Nu,DisplacementVector);
+
+                noalias(LocalRelDispVector) = prod(RotationMatrix,RelDispVector);
+
+                PoroElementUtilities::FillArray1dOutput(GPValues[GPoint],LocalRelDispVector);
+            }
+        }
+        else if(rVariable == LOCAL_FLUID_FLUX_VECTOR)
+        {
+            const PropertiesType& Prop = this->GetProperties();
+            const GeometryType& Geom = this->GetGeometry();
+            const unsigned int NumGPoints = Geom.IntegrationPointsNumber( mThisIntegrationMethod );
+
+            //Defining the shape functions, the jacobian and the shape functions local gradients Containers
+            const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
+            const GeometryType::ShapeFunctionsGradientsType& DN_DeContainer = Geom.ShapeFunctionsLocalGradients( mThisIntegrationMethod );
+            GeometryType::JacobiansType JContainer(NumGPoints);
+            Geom.Jacobian( JContainer, mThisIntegrationMethod );
+
+            //Defining necessary variables
+            array_1d<double,TNumNodes> PressureVector;
+            for(unsigned int i=0; i<TNumNodes; i++)
+                PressureVector[i] = Geom[i].FastGetSolutionStepValue(WATER_PRESSURE);
+            array_1d<double,TNumNodes*TDim> VolumeAcceleration;
+            PoroElementUtilities::GetNodalVariableVector(VolumeAcceleration,Geom,VOLUME_ACCELERATION);
+            array_1d<double,TDim> BodyAcceleration;
+            array_1d<double,TNumNodes*TDim> DisplacementVector;
+            PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
+            BoundedMatrix<double,TDim, TDim> RotationMatrix;
+            this->CalculateRotationMatrix(RotationMatrix,Geom);
+            BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+            array_1d<double,TDim> LocalRelDispVector;
+            array_1d<double,TDim> RelDispVector;
+            const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
+            double JointWidth;
+            BoundedMatrix<double,TNumNodes, TDim> GradNpT;
+            const double& Transversal_Permeability = Prop[TRANSVERSAL_PERMEABILITY];
+            BoundedMatrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
+            const double& DynamicViscosityInverse = 1.0/Prop[DYNAMIC_VISCOSITY];
+            const double& FluidDensity = Prop[DENSITY_WATER];
+            array_1d<double,TDim> LocalFluidFlux;
+            array_1d<double,TDim> GradPressureTerm;
+            SFGradAuxVariables SFGradAuxVars;
+
+            //Loop over integration points
+            for ( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++ )
+            {
+                InterfaceElementUtilities::CalculateNuMatrix(Nu,NContainer,GPoint);
+
+                noalias(RelDispVector) = prod(Nu,DisplacementVector);
+
+                noalias(LocalRelDispVector) = prod(RotationMatrix,RelDispVector);
+
+                this->CalculateJointWidth(JointWidth, LocalRelDispVector[TDim-1], MinimumJointWidth,GPoint);
+
+                this->CalculateShapeFunctionsGradients< BoundedMatrix<double,TNumNodes,TDim> >(GradNpT,SFGradAuxVars,JContainer[GPoint],RotationMatrix,
+                                                                                                                    DN_DeContainer[GPoint],NContainer,JointWidth,GPoint);
+
+                PoroElementUtilities::InterpolateVariableWithComponents(BodyAcceleration,NContainer,VolumeAcceleration,GPoint);
+
+                InterfaceElementUtilities::CalculatePermeabilityMatrix(LocalPermeabilityMatrix,JointWidth,Transversal_Permeability);
+
+                noalias(GradPressureTerm) = prod(trans(GradNpT),PressureVector);
+                noalias(GradPressureTerm) += -FluidDensity*BodyAcceleration;
+
+                noalias(LocalFluidFlux) = -DynamicViscosityInverse*prod(LocalPermeabilityMatrix,GradPressureTerm);
+
+                PoroElementUtilities::FillArray1dOutput(GPValues[GPoint],LocalFluidFlux);
+            }
+        }
 
         //Printed on standard GiD Gauss points
         const unsigned int OutputGPoints = Geom.IntegrationPointsNumber( this->GetIntegrationMethod() );
@@ -460,7 +669,7 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::GetValueOnIntegrationPoints
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,std::vector<Matrix>& rValues,
+void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,std::vector<Matrix>& rValues,
                                                                                     const ProcessInfo& rCurrentProcessInfo)
 {
     if(rVariable == PERMEABILITY_MATRIX || rVariable == LOCAL_PERMEABILITY_MATRIX)
@@ -469,8 +678,85 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::GetValueOnIntegrationPoints
         const GeometryType& Geom = this->GetGeometry();
         std::vector<Matrix> GPValues(Geom.IntegrationPointsNumber( mThisIntegrationMethod ));
 
-        this->CalculateOnIntegrationPoints(rVariable, GPValues, rCurrentProcessInfo);
+        if(rVariable == PERMEABILITY_MATRIX)
+        {
+            const GeometryType& Geom = this->GetGeometry();
+            const PropertiesType& Prop = this->GetProperties();
 
+            //Defining the shape functions container
+            const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
+
+            //Defining necessary variables
+            array_1d<double,TNumNodes*TDim> DisplacementVector;
+            PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
+            BoundedMatrix<double,TDim, TDim> RotationMatrix;
+            this->CalculateRotationMatrix(RotationMatrix,Geom);
+            BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+            array_1d<double,TDim> LocalRelDispVector;
+            array_1d<double,TDim> RelDispVector;
+            const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
+            double JointWidth;
+            const double& Transversal_Permeability = Prop[TRANSVERSAL_PERMEABILITY];
+            BoundedMatrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
+            BoundedMatrix<double,TDim, TDim> PermeabilityMatrix;
+
+            //Loop over integration points
+            for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); GPoint++ )
+            {
+                InterfaceElementUtilities::CalculateNuMatrix(Nu,NContainer,GPoint);
+
+                noalias(RelDispVector) = prod(Nu,DisplacementVector);
+
+                noalias(LocalRelDispVector) = prod(RotationMatrix,RelDispVector);
+
+                this->CalculateJointWidth(JointWidth, LocalRelDispVector[TDim-1], MinimumJointWidth,GPoint);
+
+                InterfaceElementUtilities::CalculatePermeabilityMatrix(LocalPermeabilityMatrix,JointWidth,Transversal_Permeability);
+
+                noalias(PermeabilityMatrix) = prod(trans(RotationMatrix),BoundedMatrix<double,TDim, TDim>(prod(LocalPermeabilityMatrix,RotationMatrix)));
+
+                GPValues[GPoint].resize(TDim,TDim,false);
+                noalias(GPValues[GPoint]) = PermeabilityMatrix;
+            }
+        }
+        else if(rVariable == LOCAL_PERMEABILITY_MATRIX)
+        {
+            const GeometryType& Geom = this->GetGeometry();
+            const PropertiesType& Prop = this->GetProperties();
+
+            //Defining the shape functions container
+            const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
+
+            //Defining necessary variables
+            array_1d<double,TNumNodes*TDim> DisplacementVector;
+            PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
+            BoundedMatrix<double,TDim, TDim> RotationMatrix;
+            this->CalculateRotationMatrix(RotationMatrix,Geom);
+            BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+            array_1d<double,TDim> LocalRelDispVector;
+            array_1d<double,TDim> RelDispVector;
+            const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
+            double JointWidth;
+            const double& Transversal_Permeability = Prop[TRANSVERSAL_PERMEABILITY];
+            BoundedMatrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
+
+            //Loop over integration points
+            for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); GPoint++ )
+            {
+                InterfaceElementUtilities::CalculateNuMatrix(Nu,NContainer,GPoint);
+
+                noalias(RelDispVector) = prod(Nu,DisplacementVector);
+
+                noalias(LocalRelDispVector) = prod(RotationMatrix,RelDispVector);
+
+                this->CalculateJointWidth(JointWidth, LocalRelDispVector[TDim-1], MinimumJointWidth,GPoint);
+
+                InterfaceElementUtilities::CalculatePermeabilityMatrix(LocalPermeabilityMatrix,JointWidth,Transversal_Permeability);
+
+                GPValues[GPoint].resize(TDim,TDim,false);
+                noalias(GPValues[GPoint]) = LocalPermeabilityMatrix;
+            }
+        }
         //Printed on standard GiD Gauss points
         const unsigned int OutputGPoints = Geom.IntegrationPointsNumber( this->GetIntegrationMethod() );
         if ( rValues.size() != OutputGPoints )
@@ -494,319 +780,6 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::GetValueOnIntegrationPoints
             noalias(rValues[i]) = ZeroMatrix(TDim,TDim);
         }
     }
-}
-
-//----------------------------------------------------------------------------------------
-
-template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const Variable<array_1d<double,3>>& rVariable,
-                                                                                std::vector<array_1d<double,3>>& rOutput, const ProcessInfo& rCurrentProcessInfo )
-{
-    KRATOS_TRY
-
-    if(rVariable == FLUID_FLUX_VECTOR)
-    {
-        const PropertiesType& Prop = this->GetProperties();
-        const GeometryType& Geom = this->GetGeometry();
-        const unsigned int NumGPoints = Geom.IntegrationPointsNumber( mThisIntegrationMethod );
-
-        //Defining the shape functions, the jacobian and the shape functions local gradients Containers
-        const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
-        const GeometryType::ShapeFunctionsGradientsType& DN_DeContainer = Geom.ShapeFunctionsLocalGradients( mThisIntegrationMethod );
-        GeometryType::JacobiansType JContainer(NumGPoints);
-        Geom.Jacobian( JContainer, mThisIntegrationMethod );
-
-        //Defining necessary variables
-        array_1d<double,TNumNodes> PressureVector;
-        for(unsigned int i=0; i<TNumNodes; i++)
-            PressureVector[i] = Geom[i].FastGetSolutionStepValue(WATER_PRESSURE);
-        array_1d<double,TNumNodes*TDim> VolumeAcceleration;
-        PoroElementUtilities::GetNodalVariableVector(VolumeAcceleration,Geom,VOLUME_ACCELERATION);
-        array_1d<double,TDim> BodyAcceleration;
-        array_1d<double,TNumNodes*TDim> DisplacementVector;
-        PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
-        BoundedMatrix<double,TDim, TDim> RotationMatrix;
-        this->CalculateRotationMatrix(RotationMatrix,Geom);
-        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
-        array_1d<double,TDim> LocalRelDispVector;
-        array_1d<double,TDim> RelDispVector;
-        const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
-        double JointWidth;
-        BoundedMatrix<double,TNumNodes, TDim> GradNpT;
-        const double& Transversal_Permeability = Prop[TRANSVERSAL_PERMEABILITY];
-        BoundedMatrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
-        const double& DynamicViscosityInverse = 1.0/Prop[DYNAMIC_VISCOSITY];
-        const double& FluidDensity = Prop[DENSITY_WATER];
-        array_1d<double,TDim> LocalFluidFlux;
-        array_1d<double,TDim> GradPressureTerm;
-        array_1d<double,TDim> FluidFlux;
-        SFGradAuxVariables SFGradAuxVars;
-
-        //Loop over integration points
-        for ( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++ )
-        {
-            InterfaceElementUtilities::CalculateNuMatrix(Nu,NContainer,GPoint);
-
-            noalias(RelDispVector) = prod(Nu,DisplacementVector);
-
-            noalias(LocalRelDispVector) = prod(RotationMatrix,RelDispVector);
-
-            this->CalculateJointWidth(JointWidth, LocalRelDispVector[TDim-1], MinimumJointWidth,GPoint);
-
-            this->CalculateShapeFunctionsGradients< BoundedMatrix<double,TNumNodes,TDim> >(GradNpT,SFGradAuxVars,JContainer[GPoint],RotationMatrix,
-                                                                                                                DN_DeContainer[GPoint],NContainer,JointWidth,GPoint);
-
-            PoroElementUtilities::InterpolateVariableWithComponents(BodyAcceleration,NContainer,VolumeAcceleration,GPoint);
-
-            InterfaceElementUtilities::CalculatePermeabilityMatrix(LocalPermeabilityMatrix,JointWidth,Transversal_Permeability);
-
-            noalias(GradPressureTerm) = prod(trans(GradNpT),PressureVector);
-            noalias(GradPressureTerm) += -FluidDensity*BodyAcceleration;
-
-            noalias(LocalFluidFlux) = -DynamicViscosityInverse*prod(LocalPermeabilityMatrix,GradPressureTerm);
-
-            noalias(FluidFlux) = prod(trans(RotationMatrix),LocalFluidFlux);
-
-            PoroElementUtilities::FillArray1dOutput(rOutput[GPoint],FluidFlux);
-        }
-    }
-    else if(rVariable == LOCAL_STRESS_VECTOR)
-    {
-        //Defining necessary variables
-        const PropertiesType& Prop = this->GetProperties();
-        const GeometryType& Geom = this->GetGeometry();
-        const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
-        array_1d<double,TNumNodes*TDim> DisplacementVector;
-        PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
-        BoundedMatrix<double,TDim, TDim> RotationMatrix;
-        this->CalculateRotationMatrix(RotationMatrix,Geom);
-        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
-        array_1d<double,TDim> RelDispVector;
-        const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
-        double JointWidth;
-        array_1d<double,TDim> LocalStressVector;
-
-        //Create constitutive law parameters:
-        Vector StrainVector(TDim);
-        Vector StressVectorDynamic(TDim);
-        Matrix ConstitutiveMatrix(TDim,TDim);
-        Vector Np(TNumNodes);
-        Matrix GradNpT(TNumNodes,TDim);
-        Matrix F = identity_matrix<double>(TDim);
-        double detF = 1.0;
-        ConstitutiveLaw::Parameters ConstitutiveParameters(Geom,Prop,rCurrentProcessInfo);
-        ConstitutiveParameters.Set(ConstitutiveLaw::COMPUTE_STRESS);
-        ConstitutiveParameters.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN);
-        ConstitutiveParameters.SetConstitutiveMatrix(ConstitutiveMatrix);
-        ConstitutiveParameters.SetStressVector(StressVectorDynamic);
-        ConstitutiveParameters.SetStrainVector(StrainVector);
-        ConstitutiveParameters.SetShapeFunctionsValues(Np);
-        ConstitutiveParameters.SetShapeFunctionsDerivatives(GradNpT);
-        ConstitutiveParameters.SetDeterminantF(detF);
-        ConstitutiveParameters.SetDeformationGradientF(F);
-
-        //Loop over integration points
-        for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); GPoint++ )
-        {
-            InterfaceElementUtilities::CalculateNuMatrix(Nu,NContainer,GPoint);
-
-            noalias(RelDispVector) = prod(Nu,DisplacementVector);
-
-            noalias(StrainVector) = prod(RotationMatrix,RelDispVector);
-
-            this->CheckAndCalculateJointWidth(JointWidth, ConstitutiveParameters, StrainVector[TDim-1], MinimumJointWidth, GPoint);
-
-            noalias(Np) = row(NContainer,GPoint);
-
-            //compute constitutive tensor and/or stresses
-            mConstitutiveLawVector[GPoint]->CalculateMaterialResponseCauchy(ConstitutiveParameters);
-
-            noalias(LocalStressVector) = StressVectorDynamic;
-
-            PoroElementUtilities::FillArray1dOutput(rOutput[GPoint],LocalStressVector);
-        }
-    }
-    else if(rVariable == LOCAL_RELATIVE_DISPLACEMENT_VECTOR)
-    {
-        //Defining necessary variables
-        const GeometryType& Geom = this->GetGeometry();
-        const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
-        array_1d<double,TNumNodes*TDim> DisplacementVector;
-        PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
-        BoundedMatrix<double,TDim, TDim> RotationMatrix;
-        this->CalculateRotationMatrix(RotationMatrix,Geom);
-        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
-        array_1d<double,TDim> LocalRelDispVector;
-        array_1d<double,TDim> RelDispVector;
-
-        //Loop over integration points
-        for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); GPoint++ )
-        {
-            InterfaceElementUtilities::CalculateNuMatrix(Nu,NContainer,GPoint);
-
-            noalias(RelDispVector) = prod(Nu,DisplacementVector);
-
-            noalias(LocalRelDispVector) = prod(RotationMatrix,RelDispVector);
-
-            PoroElementUtilities::FillArray1dOutput(rOutput[GPoint],LocalRelDispVector);
-        }
-    }
-    else if(rVariable == LOCAL_FLUID_FLUX_VECTOR)
-    {
-        const PropertiesType& Prop = this->GetProperties();
-        const GeometryType& Geom = this->GetGeometry();
-        const unsigned int NumGPoints = Geom.IntegrationPointsNumber( mThisIntegrationMethod );
-
-        //Defining the shape functions, the jacobian and the shape functions local gradients Containers
-        const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
-        const GeometryType::ShapeFunctionsGradientsType& DN_DeContainer = Geom.ShapeFunctionsLocalGradients( mThisIntegrationMethod );
-        GeometryType::JacobiansType JContainer(NumGPoints);
-        Geom.Jacobian( JContainer, mThisIntegrationMethod );
-
-        //Defining necessary variables
-        array_1d<double,TNumNodes> PressureVector;
-        for(unsigned int i=0; i<TNumNodes; i++)
-            PressureVector[i] = Geom[i].FastGetSolutionStepValue(WATER_PRESSURE);
-        array_1d<double,TNumNodes*TDim> VolumeAcceleration;
-        PoroElementUtilities::GetNodalVariableVector(VolumeAcceleration,Geom,VOLUME_ACCELERATION);
-        array_1d<double,TDim> BodyAcceleration;
-        array_1d<double,TNumNodes*TDim> DisplacementVector;
-        PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
-        BoundedMatrix<double,TDim, TDim> RotationMatrix;
-        this->CalculateRotationMatrix(RotationMatrix,Geom);
-        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
-        array_1d<double,TDim> LocalRelDispVector;
-        array_1d<double,TDim> RelDispVector;
-        const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
-        double JointWidth;
-        BoundedMatrix<double,TNumNodes, TDim> GradNpT;
-        const double& Transversal_Permeability = Prop[TRANSVERSAL_PERMEABILITY];
-        BoundedMatrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
-        const double& DynamicViscosityInverse = 1.0/Prop[DYNAMIC_VISCOSITY];
-        const double& FluidDensity = Prop[DENSITY_WATER];
-        array_1d<double,TDim> LocalFluidFlux;
-        array_1d<double,TDim> GradPressureTerm;
-        SFGradAuxVariables SFGradAuxVars;
-
-        //Loop over integration points
-        for ( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++ )
-        {
-            InterfaceElementUtilities::CalculateNuMatrix(Nu,NContainer,GPoint);
-
-            noalias(RelDispVector) = prod(Nu,DisplacementVector);
-
-            noalias(LocalRelDispVector) = prod(RotationMatrix,RelDispVector);
-
-            this->CalculateJointWidth(JointWidth, LocalRelDispVector[TDim-1], MinimumJointWidth,GPoint);
-
-            this->CalculateShapeFunctionsGradients< BoundedMatrix<double,TNumNodes,TDim> >(GradNpT,SFGradAuxVars,JContainer[GPoint],RotationMatrix,
-                                                                                                                DN_DeContainer[GPoint],NContainer,JointWidth,GPoint);
-
-            PoroElementUtilities::InterpolateVariableWithComponents(BodyAcceleration,NContainer,VolumeAcceleration,GPoint);
-
-            InterfaceElementUtilities::CalculatePermeabilityMatrix(LocalPermeabilityMatrix,JointWidth,Transversal_Permeability);
-
-            noalias(GradPressureTerm) = prod(trans(GradNpT),PressureVector);
-            noalias(GradPressureTerm) += -FluidDensity*BodyAcceleration;
-
-            noalias(LocalFluidFlux) = -DynamicViscosityInverse*prod(LocalPermeabilityMatrix,GradPressureTerm);
-
-            PoroElementUtilities::FillArray1dOutput(rOutput[GPoint],LocalFluidFlux);
-        }
-    }
-
-    KRATOS_CATCH( "" )
-}
-
-//----------------------------------------------------------------------------------------
-
-template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const Variable<Matrix>& rVariable, std::vector<Matrix>& rOutput,
-                                                                                    const ProcessInfo& rCurrentProcessInfo )
-{
-    KRATOS_TRY
-
-    if(rVariable == PERMEABILITY_MATRIX)
-    {
-        const GeometryType& Geom = this->GetGeometry();
-        const PropertiesType& Prop = this->GetProperties();
-
-        //Defining the shape functions container
-        const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
-
-        //Defining necessary variables
-        array_1d<double,TNumNodes*TDim> DisplacementVector;
-        PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
-        BoundedMatrix<double,TDim, TDim> RotationMatrix;
-        this->CalculateRotationMatrix(RotationMatrix,Geom);
-        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
-        array_1d<double,TDim> LocalRelDispVector;
-        array_1d<double,TDim> RelDispVector;
-        const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
-        double JointWidth;
-        const double& Transversal_Permeability = Prop[TRANSVERSAL_PERMEABILITY];
-        BoundedMatrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
-        BoundedMatrix<double,TDim, TDim> PermeabilityMatrix;
-
-        //Loop over integration points
-        for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); GPoint++ )
-        {
-            InterfaceElementUtilities::CalculateNuMatrix(Nu,NContainer,GPoint);
-
-            noalias(RelDispVector) = prod(Nu,DisplacementVector);
-
-            noalias(LocalRelDispVector) = prod(RotationMatrix,RelDispVector);
-
-            this->CalculateJointWidth(JointWidth, LocalRelDispVector[TDim-1], MinimumJointWidth,GPoint);
-
-            InterfaceElementUtilities::CalculatePermeabilityMatrix(LocalPermeabilityMatrix,JointWidth,Transversal_Permeability);
-
-            noalias(PermeabilityMatrix) = prod(trans(RotationMatrix),BoundedMatrix<double,TDim, TDim>(prod(LocalPermeabilityMatrix,RotationMatrix)));
-
-            rOutput[GPoint].resize(TDim,TDim,false);
-            noalias(rOutput[GPoint]) = PermeabilityMatrix;
-        }
-    }
-    else if(rVariable == LOCAL_PERMEABILITY_MATRIX)
-    {
-        const GeometryType& Geom = this->GetGeometry();
-        const PropertiesType& Prop = this->GetProperties();
-
-        //Defining the shape functions container
-        const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
-
-        //Defining necessary variables
-        array_1d<double,TNumNodes*TDim> DisplacementVector;
-        PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
-        BoundedMatrix<double,TDim, TDim> RotationMatrix;
-        this->CalculateRotationMatrix(RotationMatrix,Geom);
-        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
-        array_1d<double,TDim> LocalRelDispVector;
-        array_1d<double,TDim> RelDispVector;
-        const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
-        double JointWidth;
-        const double& Transversal_Permeability = Prop[TRANSVERSAL_PERMEABILITY];
-        BoundedMatrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
-
-        //Loop over integration points
-        for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); GPoint++ )
-        {
-            InterfaceElementUtilities::CalculateNuMatrix(Nu,NContainer,GPoint);
-
-            noalias(RelDispVector) = prod(Nu,DisplacementVector);
-
-            noalias(LocalRelDispVector) = prod(RotationMatrix,RelDispVector);
-
-            this->CalculateJointWidth(JointWidth, LocalRelDispVector[TDim-1], MinimumJointWidth,GPoint);
-
-            InterfaceElementUtilities::CalculatePermeabilityMatrix(LocalPermeabilityMatrix,JointWidth,Transversal_Permeability);
-
-            rOutput[GPoint].resize(TDim,TDim,false);
-            noalias(rOutput[GPoint]) = LocalPermeabilityMatrix;
-        }
-    }
-
-    KRATOS_CATCH( "" )
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -34,7 +34,7 @@ Element::Pointer UPwSmallStrainInterfaceElement<TDim,TNumNodes>::Create(IndexTyp
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-int UPwSmallStrainInterfaceElement<TDim,TNumNodes>::Check( const ProcessInfo& rCurrentProcessInfo )
+int UPwSmallStrainInterfaceElement<TDim,TNumNodes>::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
@@ -72,7 +72,7 @@ public:
 
     int Check(const ProcessInfo& rCurrentProcessInfo) override;
 
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -82,15 +82,11 @@ public:
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void GetValueOnIntegrationPoints(const Variable<array_1d<double,3>>& rVariable, std::vector<array_1d<double,3>>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateOnIntegrationPoints(const Variable<array_1d<double,3>>& rVariable, std::vector<array_1d<double,3>>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    void CalculateOnIntegrationPoints(const Variable<array_1d<double,3>>& rVariable, std::vector<array_1d<double,3>>& rOutput, const ProcessInfo& rCurrentProcessInfo) override;
-
-    void CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rOutput, const ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
@@ -70,7 +70,7 @@ public:
 
     Element::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
 
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 

--- a/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -139,7 +139,7 @@ int  SmallStrainUPwDiffOrderElement::Check( const ProcessInfo& rCurrentProcessIn
 
 //----------------------------------------------------------------------------------------
 
-void SmallStrainUPwDiffOrderElement::Initialize()
+void SmallStrainUPwDiffOrderElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -621,80 +621,6 @@ void SmallStrainUPwDiffOrderElement::SetValuesOnIntegrationPoints( const Variabl
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-void SmallStrainUPwDiffOrderElement::GetValueOnIntegrationPoints( const Variable<double>& rVariable,std::vector<double>& rValues,const ProcessInfo& rCurrentProcessInfo )
-{
-    if ( rVariable == VON_MISES_STRESS )
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-
-    else
-    {
-        const unsigned int& integration_points_number = GetGeometry().IntegrationPointsNumber( mThisIntegrationMethod );
-
-        if ( rValues.size() != integration_points_number )
-            rValues.resize( integration_points_number );
-
-        for ( unsigned int i = 0; i < integration_points_number; i++ )
-            rValues[i] = mConstitutiveLawVector[i]->GetValue( rVariable, rValues[i] );
-    }
-}
-
-//----------------------------------------------------------------------------------------
-
-void SmallStrainUPwDiffOrderElement::GetValueOnIntegrationPoints( const Variable<Vector>& rVariable,std::vector<Vector>& rValues,const ProcessInfo& rCurrentProcessInfo )
-{
-    if ( rVariable == CAUCHY_STRESS_VECTOR || rVariable == GREEN_LAGRANGE_STRAIN_VECTOR )
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-
-    else if ( rVariable == FLUID_FLUX_VECTOR )
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-
-    else
-    {
-        const unsigned int& integration_points_number = mConstitutiveLawVector.size();
-
-        if ( rValues.size() != integration_points_number )
-            rValues.resize( integration_points_number );
-
-        for ( unsigned int i = 0;  i < integration_points_number; i++ )
-            rValues[i] = mConstitutiveLawVector[i]->GetValue( rVariable, rValues[i] );
-    }
-}
-
-//----------------------------------------------------------------------------------------
-
-void SmallStrainUPwDiffOrderElement::GetValueOnIntegrationPoints( const Variable<Matrix>& rVariable,std::vector<Matrix>& rValues,const ProcessInfo& rCurrentProcessInfo )
-{
-    if ( rVariable == CAUCHY_STRESS_TENSOR || rVariable == GREEN_LAGRANGE_STRAIN_TENSOR )
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-
-    else
-    {
-        const unsigned int& integration_points_number = mConstitutiveLawVector.size();
-
-        if ( rValues.size() != integration_points_number )
-            rValues.resize( integration_points_number );
-
-        for ( unsigned int i = 0;  i < integration_points_number; i++ )
-            rValues[i] = mConstitutiveLawVector[i]->GetValue( rVariable, rValues[i] );
-    }
-}
-
-//----------------------------------------------------------------------------------------
-
-void SmallStrainUPwDiffOrderElement::GetValueOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable,std::vector<ConstitutiveLaw::Pointer>& rValues,const ProcessInfo& rCurrentProcessInfo )
-{
-    if(rVariable == CONSTITUTIVE_LAW)
-    {
-        if ( rValues.size() != mConstitutiveLawVector.size() )
-            rValues.resize(mConstitutiveLawVector.size());
-
-        for(unsigned int i=0; i<rValues.size(); i++)
-            rValues[i] = mConstitutiveLawVector[i];
-    }
-}
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
 void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints( const Variable<double>& rVariable, std::vector<double>& rOutput, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
@@ -902,6 +828,20 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints( const Variabl
     }
 
     KRATOS_CATCH( "" )
+}
+
+//----------------------------------------------------------------------------------------
+
+void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable,std::vector<ConstitutiveLaw::Pointer>& rValues,const ProcessInfo& rCurrentProcessInfo )
+{
+    if(rVariable == CONSTITUTIVE_LAW)
+    {
+        if ( rValues.size() != mConstitutiveLawVector.size() )
+            rValues.resize(mConstitutiveLawVector.size());
+
+        for(unsigned int i=0; i<rValues.size(); i++)
+            rValues[i] = mConstitutiveLawVector[i];
+    }
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -53,7 +53,7 @@ Element::Pointer SmallStrainUPwDiffOrderElement::Create( IndexType NewId, NodesA
 
 //----------------------------------------------------------------------------------------
 
-int  SmallStrainUPwDiffOrderElement::Check( const ProcessInfo& rCurrentProcessInfo )
+int  SmallStrainUPwDiffOrderElement::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 

--- a/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -55,7 +55,7 @@ public:
 
     Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override;
 
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 

--- a/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -57,7 +57,7 @@ public:
 
     int Check(const ProcessInfo& rCurrentProcessInfo) override;
 
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
@@ -87,21 +87,13 @@ public:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    void GetValueOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable, std::vector<ConstitutiveLaw::Pointer>& rValues,const ProcessInfo& rCurrentProcessInfo ) override;
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
     void CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rOutput, const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rOutput, const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateOnIntegrationPoints(const Variable<Matrix >& rVariable, std::vector< Matrix >& rOutput, const ProcessInfo& rCurrentProcessInfo) override;
+
+    void CalculateOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable, std::vector<ConstitutiveLaw::Pointer>& rValues,const ProcessInfo& rCurrentProcessInfo ) override;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_2D_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_2D_utilities.hpp
@@ -769,7 +769,7 @@ protected:
                 Vector detJContainer(NumGPoints);
                 rGeom.DeterminantOfJacobian(detJContainer,MyIntegrationMethod);
                 std::vector<double> StateVariableVector(NumGPoints);
-                itElem->GetValueOnIntegrationPoints(STATE_VARIABLE,StateVariableVector,CurrentProcessInfoOld);
+                itElem->CalculateOnIntegrationPoints(STATE_VARIABLE,StateVariableVector,CurrentProcessInfoOld);
                 int Row;
                 int Column;
 
@@ -821,7 +821,7 @@ protected:
                 Vector detJContainer(NumGPoints);
                 rGeom.DeterminantOfJacobian(detJContainer,MyIntegrationMethod);
                 std::vector<double> StateVariableVector(NumGPoints);
-                itElem->GetValueOnIntegrationPoints(STATE_VARIABLE,StateVariableVector,CurrentProcessInfoOld);
+                itElem->CalculateOnIntegrationPoints(STATE_VARIABLE,StateVariableVector,CurrentProcessInfoOld);
                 int Row;
                 int Column;
 
@@ -1204,7 +1204,7 @@ private:
                 Vector detJContainer(NumGPoints);
                 rGeom.DeterminantOfJacobian(detJContainer,MyIntegrationMethod);
                 std::vector<double> DamageVector(NumGPoints);
-                itElem->GetValueOnIntegrationPoints(DAMAGE_VARIABLE,DamageVector,CurrentProcessInfo);
+                itElem->CalculateOnIntegrationPoints(DAMAGE_VARIABLE,DamageVector,CurrentProcessInfo);
                 int Row;
                 int Column;
 
@@ -1341,7 +1341,7 @@ private:
         if (IsInside == true)
         {
             std::vector<double> DamageVector;
-            pElement->GetValueOnIntegrationPoints(DAMAGE_VARIABLE,DamageVector,CurrentProcessInfo);
+            pElement->CalculateOnIntegrationPoints(DAMAGE_VARIABLE,DamageVector,CurrentProcessInfo);
             unsigned int NumGPoints = DamageVector.size();
             double InvNumGPoints = 1.0/static_cast<double>(NumGPoints);
             double ElementDamage = 0.0;
@@ -1393,7 +1393,7 @@ private:
                 if (IsInside == true)
                 {
                     std::vector<double> DamageVector;
-                    pElement->GetValueOnIntegrationPoints(DAMAGE_VARIABLE,DamageVector,CurrentProcessInfo);
+                    pElement->CalculateOnIntegrationPoints(DAMAGE_VARIABLE,DamageVector,CurrentProcessInfo);
                     unsigned int NumGPoints = DamageVector.size();
                     double InvNumGPoints = 1.0/static_cast<double>(NumGPoints);
                     double ElementDamage = 0.0;
@@ -1428,7 +1428,7 @@ private:
                 if (IsInside == true)
                 {
                     std::vector<double> DamageVector;
-                    pElement->GetValueOnIntegrationPoints(DAMAGE_VARIABLE,DamageVector,CurrentProcessInfo);
+                    pElement->CalculateOnIntegrationPoints(DAMAGE_VARIABLE,DamageVector,CurrentProcessInfo);
                     unsigned int NumGPoints = DamageVector.size();
                     double InvNumGPoints = 1.0/static_cast<double>(NumGPoints);
                     double ElementDamage = 0.0;

--- a/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_3D_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_3D_utilities.hpp
@@ -1004,7 +1004,7 @@ protected:
                 Vector detJContainer(NumGPoints);
                 rGeom.DeterminantOfJacobian(detJContainer,MyIntegrationMethod);
                 std::vector<double> StateVariableVector(NumGPoints);
-                itElem->GetValueOnIntegrationPoints(STATE_VARIABLE,StateVariableVector,CurrentProcessInfoOld);
+                itElem->CalculateOnIntegrationPoints(STATE_VARIABLE,StateVariableVector,CurrentProcessInfoOld);
                 int Row;
                 int Column;
                 int Section;
@@ -1058,7 +1058,7 @@ protected:
                 Vector detJContainer(NumGPoints);
                 rGeom.DeterminantOfJacobian(detJContainer,MyIntegrationMethod);
                 std::vector<double> StateVariableVector(NumGPoints);
-                itElem->GetValueOnIntegrationPoints(STATE_VARIABLE,StateVariableVector,CurrentProcessInfoOld);
+                itElem->CalculateOnIntegrationPoints(STATE_VARIABLE,StateVariableVector,CurrentProcessInfoOld);
                 int Row;
                 int Column;
                 int Section;
@@ -1486,7 +1486,7 @@ private:
                 Vector detJContainer(NumGPoints);
                 rGeom.DeterminantOfJacobian(detJContainer,MyIntegrationMethod);
                 std::vector<double> DamageVector(NumGPoints);
-                itElem->GetValueOnIntegrationPoints(DAMAGE_VARIABLE,DamageVector,CurrentProcessInfo);
+                itElem->CalculateOnIntegrationPoints(DAMAGE_VARIABLE,DamageVector,CurrentProcessInfo);
                 int Row;
                 int Column;
                 int Section;
@@ -1628,7 +1628,7 @@ private:
         if (IsInside == true)
         {
             std::vector<double> DamageVector;
-            pElement->GetValueOnIntegrationPoints(DAMAGE_VARIABLE,DamageVector,CurrentProcessInfo);
+            pElement->CalculateOnIntegrationPoints(DAMAGE_VARIABLE,DamageVector,CurrentProcessInfo);
             unsigned int NumGPoints = DamageVector.size();
             double InvNumGPoints = 1.0/static_cast<double>(NumGPoints);
             double ElementDamage = 0.0;
@@ -1702,7 +1702,7 @@ private:
                 if (IsInside == true)
                 {
                     std::vector<double> DamageVector;
-                    pElement->GetValueOnIntegrationPoints(DAMAGE_VARIABLE,DamageVector,CurrentProcessInfo);
+                    pElement->CalculateOnIntegrationPoints(DAMAGE_VARIABLE,DamageVector,CurrentProcessInfo);
                     unsigned int NumGPoints = DamageVector.size();
                     double InvNumGPoints = 1.0/static_cast<double>(NumGPoints);
                     double ElementDamage = 0.0;
@@ -1737,7 +1737,7 @@ private:
                 if (IsInside == true)
                 {
                     std::vector<double> DamageVector;
-                    pElement->GetValueOnIntegrationPoints(DAMAGE_VARIABLE,DamageVector,CurrentProcessInfo);
+                    pElement->CalculateOnIntegrationPoints(DAMAGE_VARIABLE,DamageVector,CurrentProcessInfo);
                     unsigned int NumGPoints = DamageVector.size();
                     double InvNumGPoints = 1.0/static_cast<double>(NumGPoints);
                     double ElementDamage = 0.0;

--- a/applications/PoromechanicsApplication/custom_utilities/nonlocal_damage_2D_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/nonlocal_damage_2D_utilities.hpp
@@ -124,7 +124,7 @@ protected:
                 Vector detJContainer(NumGPoints);
                 rGeom.DeterminantOfJacobian(detJContainer,MyIntegrationMethod);
                 std::vector<ConstitutiveLaw::Pointer> ConstitutiveLawVector(NumGPoints);
-                itElem->GetValueOnIntegrationPoints(CONSTITUTIVE_LAW,ConstitutiveLawVector,CurrentProcessInfo);
+                itElem->CalculateOnIntegrationPoints(CONSTITUTIVE_LAW,ConstitutiveLawVector,CurrentProcessInfo);
                 int Row;
                 int Column;
 

--- a/applications/PoromechanicsApplication/custom_utilities/nonlocal_damage_3D_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/nonlocal_damage_3D_utilities.hpp
@@ -130,7 +130,7 @@ protected:
                 Vector detJContainer(NumGPoints);
                 rGeom.DeterminantOfJacobian(detJContainer,MyIntegrationMethod);
                 std::vector<ConstitutiveLaw::Pointer> ConstitutiveLawVector(NumGPoints);
-                itElem->GetValueOnIntegrationPoints(CONSTITUTIVE_LAW,ConstitutiveLawVector,CurrentProcessInfo);
+                itElem->CalculateOnIntegrationPoints(CONSTITUTIVE_LAW,ConstitutiveLawVector,CurrentProcessInfo);
                 int Row;
                 int Column;
                 int Section;


### PR DESCRIPTION
**Description**
Elements and conditions (and other calls to the affected methods) are updated to account for changes in [7381](https://github.com/KratosMultiphysics/Kratos/issues/7381).

**Changelog**
- Added const to Check in Elements and Conditions
- Added const ProcessInfo& to Initialize in Elements and Conditions
- Using CalculateOnIntegrationPoints instead of GetValueOnIntegrationPoints
