### PR TITLE
[ConvDiff][Fluid] Fix conv diff solvers wrapper and buoyancy test

### DIFF
--- a/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_explicit_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_explicit_solver.py
@@ -55,6 +55,7 @@ class ConvectionDiffusionExplicitSolver(convection_diffusion_solver.ConvectionDi
         default_settings = KratosMultiphysics.Parameters(
         """
         {
+            "time_integration_method" : "explicit",
             "use_orthogonal_subscales" : false,
             "dynamic_tau": 1.0
         }

--- a/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
@@ -79,7 +79,6 @@ class ConvectionDiffusionSolver(PythonSolver):
             "domain_size" : -1,
             "echo_level": 0,
             "analysis_type": "linear",
-            "time_integration_method": "implicit",
             "solver_type": "convection_diffusion_solver",
             "model_import_settings": {
                 "input_type": "mdpa",

--- a/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_transient_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_transient_solver.py
@@ -33,6 +33,7 @@ class ConvectionDiffusionTransientSolver(convection_diffusion_solver.ConvectionD
     @classmethod
     def GetDefaultParameters(cls):
         this_defaults = KratosMultiphysics.Parameters(r"""{
+            "time_integration_method" : "implicit",
             "transient_parameters" : {
                 "dynamic_tau": 1.0,
                 "theta"    : 0.5

--- a/applications/ConvectionDiffusionApplication/python_scripts/python_solvers_wrapper_convection_diffusion.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/python_solvers_wrapper_convection_diffusion.py
@@ -13,53 +13,45 @@ def CreateSolverByParameters(model, solver_settings, parallelism):
 
     solver_type = solver_settings["solver_type"].GetString()
 
-    if not solver_settings.Has("time_integration_method"):
-        KratosMultiphysics.Logger.PrintWarning("Time integration method was not provided. Setting \'implicit\' as default.")
-        solver_settings.AddEmptyValue("time_integration_method").SetString("implicit")
-    time_integration_method = solver_settings["time_integration_method"].GetString()
-
     # Solvers for OpenMP parallelism
     if (parallelism == "OpenMP"):
-        if time_integration_method == "explicit":
-            if solver_type == "transient":
-                solver_module_name = "convection_diffusion_explicit_solver"
-            else:
-                err_msg =  "The requested solver type {} is not in the python solvers wrapper\n".format(solver_type)
-                err_msg += "Available options are: \"transient\""
-                raise Exception(err_msg)
-        elif time_integration_method == "implicit":
-            if (solver_type == "transient" or solver_type == "Transient"):
+        # Transient solvers
+        if (solver_type == "transient" or solver_type == "Transient"):
+            # If not provided, set implicit time integration as default
+            if not solver_settings.Has("time_integration_method"):
+                KratosMultiphysics.Logger.PrintWarning("Time integration method was not provided. Setting \'implicit\' as default.")
+                solver_settings.AddEmptyValue("time_integration_method").SetString("implicit")
+            time_integration_method = solver_settings["time_integration_method"].GetString()
+            # Check transient integration method
+            if time_integration_method == "implicit":
                 solver_module_name = "convection_diffusion_transient_solver"
-
-            elif (solver_type == "stationary" or solver_type == "Stationary"):
-                solver_module_name = "convection_diffusion_stationary_solver"
-
-            elif (solver_type == "thermally_coupled" or solver_type == "ThermallyCoupled"):
-                solver_module_name = "coupled_fluid_thermal_solver"
-
-            elif (solver_type == "thermo_mechanically_coupled" or solver_type == "ThermoMechanicallyCoupled"):
-                solver_module_name = "coupled_structural_thermal_solver"
-
-            elif (solver_type == "conjugate_heat_transfer" or solver_type == "ConjugateHeatTransfer"):
-                solver_module_name = "conjugate_heat_transfer_solver"
-
-            elif solver_type == "adjoint_stationary":
-                solver_module_name = "adjoint_diffusion_solver"
-
-            else:
-                err_msg =  "The requested solver type {} is not in the python solvers wrapper\n".format(solver_type)
-                err_msg += "Available options are: \"transient\", \"stationary\", \"thermally_coupled\", \"conjugate_heat_transfer\""
-                raise Exception(err_msg)
-        elif time_integration_method == "semi_implicit":
-            if solver_type == "transient":
+            elif time_integration_method == "explicit":
+                solver_module_name = "convection_diffusion_explicit_solver"
+            elif time_integration_method == "semi_implicit":
                 solver_module_name = "convection_diffusion_semi_eulerian_solver"
             else:
-                err_msg =  "The requested solver type {} is not in the python solvers wrapper\n".format(solver_type)
-                err_msg += "Available options are: \"transient\""
+                err_msg =  "The requested time integration method {} is not in the Python solvers wrapper\n".format(time_integration_method)
+                err_msg += "Available options are: \"explicit\", \"implicit\" and \"semi_implicit\""
                 raise Exception(err_msg)
+        # Steady solver
+        elif (solver_type == "stationary" or solver_type == "Stationary"):
+            solver_module_name = "convection_diffusion_stationary_solver"
+        # Coupled CFD-thermal solvers (volume coupling by Boussinesq approximation)
+        elif (solver_type == "thermally_coupled" or solver_type == "ThermallyCoupled"):
+            solver_module_name = "coupled_fluid_thermal_solver"
+        # Coupled mechanical-thermal solver
+        elif (solver_type == "thermo_mechanically_coupled" or solver_type == "ThermoMechanicallyCoupled"):
+            solver_module_name = "coupled_structural_thermal_solver"
+        # Coupled CHT solver (space thermal - CFD-thermal coupling)
+        elif (solver_type == "conjugate_heat_transfer" or solver_type == "ConjugateHeatTransfer"):
+            solver_module_name = "conjugate_heat_transfer_solver"
+        # Steady adjoints solver
+        elif solver_type == "adjoint_stationary":
+            solver_module_name = "adjoint_diffusion_solver"
+        # Wrong solver check
         else:
-            err_msg =  "The requested time integration method {} is not in the Python solvers wrapper\n".format(time_integration_method)
-            err_msg += "Available options are: \"explicit\", \"implicit\" and \"semi_implicit\""
+            err_msg =  "The requested solver type {} is not in the python solvers wrapper\n".format(solver_type)
+            err_msg += "Available options are: \"transient\", \"stationary\", \"thermally_coupled\", \"thermo_mechanically_coupled\", \"conjugate_heat_transfer\" and \"adjoint_stationary\""
             raise Exception(err_msg)
 
     # Solvers for MPI parallelism

--- a/applications/ConvectionDiffusionApplication/tests/SourceTermTest/SourceTermTestProjectParameters.json
+++ b/applications/ConvectionDiffusionApplication/tests/SourceTermTest/SourceTermTestProjectParameters.json
@@ -8,6 +8,7 @@
     },
     "solver_settings"  : {
         "solver_type"                        : "transient",
+        "time_integration_method"            : "implicit",
         "analysis_type"                      : "non_linear",
         "model_part_name"                    : "ThermalModelPart",
         "domain_size"                        : 2,

--- a/applications/ConvectionDiffusionApplication/tests/basic_conv_diffusion_test/basic_conv_diffusion_test_stationary_parameters.json
+++ b/applications/ConvectionDiffusionApplication/tests/basic_conv_diffusion_test/basic_conv_diffusion_test_stationary_parameters.json
@@ -9,7 +9,7 @@
     "solver_settings"          : {
         "model_part_name"                    : "Thermic",
         "domain_size"                        : 2,
-        "solver_type"                        : "Stationary",
+        "solver_type"                        : "stationary",
         "echo_level"                         : 0,
         "analysis_type"                      : "non_linear",
         "model_import_settings"              : {

--- a/applications/ConvectionDiffusionApplication/tests/basic_conv_diffusion_test/basic_conv_diffusion_test_transient_parameters.json
+++ b/applications/ConvectionDiffusionApplication/tests/basic_conv_diffusion_test/basic_conv_diffusion_test_transient_parameters.json
@@ -10,6 +10,7 @@
         "model_part_name"                    : "Thermic",
         "domain_size"                        : 2,
         "solver_type"                        : "transient",
+        "time_integration_method"            : "implicit",
         "echo_level"                         : 0,
         "analysis_type"                      : "non_linear",
         "model_import_settings"              : {

--- a/applications/ConvectionDiffusionApplication/tests/basic_conv_diffusion_test/basic_diffusion_test_stationary_parameters.json
+++ b/applications/ConvectionDiffusionApplication/tests/basic_conv_diffusion_test/basic_diffusion_test_stationary_parameters.json
@@ -9,7 +9,7 @@
     "solver_settings"          : {
         "model_part_name"                    : "Thermic",
         "domain_size"                        : 2,
-        "solver_type"                        : "Stationary",
+        "solver_type"                        : "stationary",
         "echo_level"                         : 0,
         "analysis_type"                      : "non_linear",
         "model_import_settings"              : {

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/cylinder_test_adjoint_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/cylinder_test_adjoint_parameters.json
@@ -157,7 +157,7 @@
                 "model_part_name"  : "MainModelPart.Parts_Fluid",
                 "output_file_settings": {
                     "file_name"  : "cylinder_test_adjoint_probe1.dat",
-                    "folder_name": "AdjointVMSSensitivity2DTest"
+                    "output_path": "AdjointVMSSensitivity2DTest"
                 },
                 "output_variables" : ["ADJOINT_FLUID_VECTOR_1_X", "ADJOINT_FLUID_VECTOR_1_Y"]
             }
@@ -171,7 +171,7 @@
                 "model_part_name"  : "MainModelPart.Parts_Fluid",
                 "output_file_settings": {
                     "file_name"  : "cylinder_test_adjoint_probe2.dat",
-                    "folder_name": "AdjointVMSSensitivity2DTest"
+                    "output_path": "AdjointVMSSensitivity2DTest"
                 },
                 "output_variables" : ["ADJOINT_FLUID_SCALAR_1"]
             }
@@ -185,7 +185,7 @@
                 "model_part_name"  : "MainModelPart.Parts_Fluid",
                 "output_file_settings": {
                     "file_name"  : "cylinder_test_adjoint_probe3.dat",
-                    "folder_name": "AdjointVMSSensitivity2DTest"
+                    "output_path": "AdjointVMSSensitivity2DTest"
                 },
                 "output_variables" : ["SHAPE_SENSITIVITY_X", "SHAPE_SENSITIVITY_Y"]
             }

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/cylinder_test_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/cylinder_test_parameters.json
@@ -164,7 +164,7 @@
                 "model_part_name"  : "MainModelPart.Parts_Fluid",
                 "output_file_settings": {
                     "file_name"  : "cylinder_test_probe1.dat",
-                    "folder_name": "AdjointVMSSensitivity2DTest"
+                    "output_path": "AdjointVMSSensitivity2DTest"
                 },
                 "output_variables" : [
                     "VELOCITY_X",
@@ -181,7 +181,7 @@
                 "model_part_name"  : "MainModelPart.Parts_Fluid",
                 "output_file_settings": {
                     "file_name"  : "cylinder_test_probe2.dat",
-                    "folder_name": "AdjointVMSSensitivity2DTest"
+                    "output_path": "AdjointVMSSensitivity2DTest"
                 },
                 "output_variables" : [
                     "VELOCITY_X",

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/mpi_cylinder_test_adjoint_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/mpi_cylinder_test_adjoint_parameters.json
@@ -127,7 +127,7 @@
                 "model_part_name"  : "MainModelPart.Parts_Fluid",
                 "output_file_settings": {
                     "file_name"  : "mpi_cylinder_test_adjoint_probe1.dat",
-                    "folder_name": "AdjointVMSSensitivity2DTest",
+                    "output_path": "AdjointVMSSensitivity2DTest",
                     "write_buffer_size" : 1
                 },
                 "output_variables" : ["ADJOINT_FLUID_VECTOR_1_X", "ADJOINT_FLUID_VECTOR_1_Y"]
@@ -142,7 +142,7 @@
                 "model_part_name"  : "MainModelPart.Parts_Fluid",
                 "output_file_settings": {
                     "file_name"  : "mpi_cylinder_test_adjoint_probe2.dat",
-                    "folder_name": "AdjointVMSSensitivity2DTest",
+                    "output_path": "AdjointVMSSensitivity2DTest",
                     "write_buffer_size" : 1
                 },
                 "output_variables" : ["ADJOINT_FLUID_SCALAR_1"]
@@ -157,7 +157,7 @@
                 "model_part_name"  : "MainModelPart.Parts_Fluid",
                 "output_file_settings": {
                     "file_name"  : "mpi_cylinder_test_adjoint_probe3.dat",
-                    "folder_name": "AdjointVMSSensitivity2DTest",
+                    "output_path": "AdjointVMSSensitivity2DTest",
                     "write_buffer_size" : 1
                 },
                 "output_variables" : ["SHAPE_SENSITIVITY_X", "SHAPE_SENSITIVITY_Y"]

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/mpi_cylinder_test_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/mpi_cylinder_test_parameters.json
@@ -118,7 +118,7 @@
                 "model_part_name"  : "MainModelPart.Parts_Fluid",
                 "output_file_settings": {
                     "file_name"  : "mpi_cylinder_test_probe1.dat",
-                    "folder_name": "AdjointVMSSensitivity2DTest",
+                    "output_path": "AdjointVMSSensitivity2DTest",
                     "write_buffer_size" : 1
                 },
                 "output_variables" : [
@@ -136,7 +136,7 @@
                 "model_part_name"  : "MainModelPart.Parts_Fluid",
                 "output_file_settings": {
                     "file_name"  : "mpi_cylinder_test_probe2.dat",
-                    "folder_name": "AdjointVMSSensitivity2DTest",
+                    "output_path": "AdjointVMSSensitivity2DTest",
                     "write_buffer_size" : 1
                 },
                 "output_variables" : [

--- a/applications/FluidDynamicsApplication/tests/BuoyancyTest/ProjectParameters.json
+++ b/applications/FluidDynamicsApplication/tests/BuoyancyTest/ProjectParameters.json
@@ -1,0 +1,90 @@
+{
+    "problem_data"     : {
+        "problem_name"  : "buoyancy_test",
+        "domain_size"   : 2,
+        "parallel_type" : "OpenMP",
+        "echo_level"    : 0,
+        "start_time"    : 0.0,
+        "end_time"      : 1.5
+    },
+    "solver_settings" : {
+        "solver_type"             : "ThermallyCoupled",
+        "domain_size"             : 2,
+        "echo_level"              : 0,
+        "fluid_solver_settings"   : {
+            "solver_type"                   : "Monolithic",
+            "model_part_name"               : "FluidModelPart",
+            "domain_size"                   : 2,
+            "model_import_settings"       : {
+                "input_type"     : "mdpa",
+                "input_filename" : "cavity10"
+            },
+            "material_import_settings": {
+                "materials_filename": "buoyancy_test_materials.json"
+            },
+            "echo_level"                  : 0,
+            "compute_reactions"           : false,
+            "relative_velocity_tolerance" : 1e-5,
+            "absolute_velocity_tolerance" : 1e-7,
+            "relative_pressure_tolerance" : 1e-5,
+            "absolute_pressure_tolerance" : 1e-7,
+            "linear_solver_settings"      : {
+                "solver_type"         : "amgcl"
+            },
+            "maximum_iterations"          : 50,
+            "formulation"               : {
+                "element_type"            : "vms",
+                "use_orthogonal_subscales": false,
+                "dynamic_tau"             : 1.0
+            },
+            "volume_model_part_name"      : "Fluid",
+            "skin_parts"                  : [],
+            "no_skin_parts"               : [],
+            "time_stepping"               : {
+                "automatic_time_step" : false,
+                "time_step"           : 0.5
+            }
+        },
+        "thermal_solver_settings" : {
+            "solver_type"                        : "transient",
+            "time_integration_method"            : "TO_BE_DEFINED",
+            "analysis_type"                      : "non_linear",
+            "model_part_name"                    : "ThermalModelPart",
+            "domain_size"                        : 2,
+            "model_import_settings"              : {
+                "input_type"     : "mdpa",
+                "input_filename" : "cavity10"
+            },
+            "material_import_settings"           : {
+                "materials_filename" : "buoyancy_test_materials.json"
+            },
+            "line_search"                        : false,
+            "echo_level"                         : 0,
+            "compute_reactions"                  : false,
+            "max_iteration"                      : 10,
+            "convergence_criterion"              : "residual_criterion",
+            "solution_relative_tolerance"        : 1e-5,
+            "solution_absolute_tolerance"        : 1e-7,
+            "residual_relative_tolerance"        : 1e-5,
+            "residual_absolute_tolerance"        : 1e-7,
+            "problem_domain_sub_model_part_list" : ["Fluid"],
+            "processes_sub_model_part_list"      : [],
+            "time_stepping"                      : {
+                "time_step" : 0.5
+            }
+        }
+    },
+    "processes" : {
+        "boussinesq_process_list" : [{
+            "python_module" : "apply_boussinesq_force_process",
+            "kratos_module" : "KratosMultiphysics.FluidDynamicsApplication",
+            "process_name"  : "ApplyBoussinesqForceProcess",
+            "Parameters"    : {
+                "model_part_name"     : "ThermalModelPart.Fluid"
+            }
+        }]
+    },
+    "output_processes" : {
+        "gid_output" : []
+    }
+}

--- a/applications/FluidDynamicsApplication/tests/buoyancy_test.py
+++ b/applications/FluidDynamicsApplication/tests/buoyancy_test.py
@@ -6,140 +6,12 @@ import KratosMultiphysics.kratos_utilities as KratosUtilities
 
 have_convection_diffusion = KratosUtilities.CheckIfApplicationsAvailable("ConvectionDiffusionApplication")
 if have_convection_diffusion:
-    import KratosMultiphysics.ConvectionDiffusionApplication as ConvDiff
+    from KratosMultiphysics.ConvectionDiffusionApplication.convection_diffusion_analysis import ConvectionDiffusionAnalysis
 
-import KratosMultiphysics.FluidDynamicsApplication.navier_stokes_solver_vmsmonolithic as navier_stokes_solver
+class BuoyancyTestConvectionDiffusionAnalysis(ConvectionDiffusionAnalysis):
+    def ModifyAfterSolverInitialize(self):
+        super().ModifyAfterSolverInitialize()
 
-@UnitTest.skipIfApplicationsNotAvailable("ConvectionDiffusionApplication")
-class BuoyancyTest(UnitTest.TestCase):
-
-    def setUp(self):
-        self.domain_size = 2
-        self.reference_file = "reference10"
-        self.input_file = "cavity10"
-
-        self.convection_diffusion_solver = "eulerian"
-        self.nsteps = 3
-        self.thermal_expansion_coefficient = None # If set, it will be used instead of 1./AmbientTemperature
-
-        self.check_tolerance = 1e-6
-        self.print_output = False
-        self.print_reference_values = False
-
-    def tearDown(self):
-        with UnitTest.WorkFolderScope("BuoyancyTest", __file__):
-            KratosUtilities.DeleteFileIfExisting(self.input_file+'.time')
-
-    def testEulerian(self):
-        self.convection_diffusion_solver = "eulerian"
-        self.reference_file = "reference10_eulerian"
-        self.testBuoyancy()
-
-
-    def testThermalExpansionCoefficient(self):
-        self.convection_diffusion_solver = "eulerian"
-        self.reference_file = "reference10_eulerian"
-        self.thermal_expansion_coefficient = 1./293.15
-        self.testBuoyancy()
-
-    def testBFECC(self):
-        self.convection_diffusion_solver = "bfecc"
-        self.reference_file = "reference10_bfecc"
-        self.check_tolerance = 1e-1 # The bfecc solver shows some variation between runs, we cannot be too strict here
-        self.testBuoyancy()
-
-    def validationEulerian(self):
-        self.input_file = "cavity80"
-        self.reference_file = "reference80_eulerian"
-
-        self.convection_diffusion_solver = "eulerian"
-        self.nsteps = 200
-
-        self.testBuoyancy()
-
-    def testBuoyancy(self):
-        with UnitTest.WorkFolderScope("BuoyancyTest", __file__):
-            self.setUpModel()
-            self.setUpSolvers()
-            self.setUpProblem()
-
-            self.runTest()
-
-            self.checkResults()
-            if self.print_output:
-                self.printOutput()
-
-    def setUpModel(self):
-        self.model = Model()
-
-        with open("solver_settings.json","r") as settings_file:
-            settings = Parameters(settings_file.read())
-
-        settings["solver_settings"]["model_import_settings"]["input_filename"].SetString(self.input_file)
-        thermal_settings = ConvectionDiffusionSettings()
-        thermal_settings.SetUnknownVariable(TEMPERATURE)
-        thermal_settings.SetDensityVariable(DENSITY)
-        thermal_settings.SetSpecificHeatVariable(SPECIFIC_HEAT)
-        thermal_settings.SetDiffusionVariable(CONDUCTIVITY)
-        #thermal_settings.SetVolumeSourceVariable(HEAT_FLUX)
-        #thermal_settings.SetSurfaceSourceVariable(FACE_HEAT_FLUX)
-        thermal_settings.SetVelocityVariable(VELOCITY)
-        thermal_settings.SetMeshVelocityVariable(MESH_VELOCITY)
-        if self.convection_diffusion_solver == 'bfecc':
-            thermal_settings.SetProjectionVariable(ConvDiff.PROJECTED_SCALAR1)
-
-        self.fluid_solver = navier_stokes_solver.CreateSolver(self.model,settings["solver_settings"])
-
-        print(self.model)
-        self.fluid_model_part = self.model.GetModelPart(settings["solver_settings"]["model_part_name"].GetString())
-        self.fluid_model_part.ProcessInfo.SetValue(CONVECTION_DIFFUSION_SETTINGS,thermal_settings)
-
-    def setUpSolvers(self):
-
-        if self.convection_diffusion_solver == 'bfecc':
-            import KratosMultiphysics.ConvectionDiffusionApplication.bfecc_convection_diffusion_solver as thermal_solver
-        elif self.convection_diffusion_solver == 'eulerian':
-            import KratosMultiphysics.ConvectionDiffusionApplication.convection_diffusion_solver as thermal_solver
-        else:
-            raise Exception("Unsupported convection-diffusion solver option: {0}".format(self.convection_diffusion_solver))
-
-        self.fluid_solver.AddVariables()
-        thermal_solver.AddVariables(self.fluid_model_part)
-
-        self.fluid_solver.ImportModelPart()
-        self.fluid_solver.PrepareModelPart()
-
-        self.fluid_model_part.SetBufferSize(2)
-
-        self.fluid_solver.AddDofs()
-        thermal_solver.AddDofs(self.fluid_model_part)
-
-        self.fluid_solver.Initialize()
-
-        if self.convection_diffusion_solver == 'eulerian':
-            # Duplicate model part
-
-            thermal_model_part = self.model.CreateModelPart("Thermal")
-            conv_diff_element = "EulerianConvDiff2D"
-            conv_diff_condition = "LineCondition2D2N"
-
-            MergeVariableListsUtility().Merge(self.fluid_model_part, thermal_model_part)
-
-            modeler = ConnectivityPreserveModeler()
-            modeler.GenerateModelPart(self.fluid_model_part,thermal_model_part,conv_diff_element,conv_diff_condition)
-
-            # thermal solver
-            self.thermal_solver = thermal_solver.ConvectionDiffusionSolver(thermal_model_part,self.domain_size)
-        else:
-            class SolverSettings:
-                def __init__(self,domain_size):
-                    self.domain_size = domain_size
-            settings = SolverSettings(self.domain_size)
-            self.thermal_solver = thermal_solver.CreateSolver(self.model_part,settings)
-        self.thermal_solver.Initialize()
-
-
-    def setUpProblem(self):
         xmin = 0.0
         xmax = 1.0
         ymin = 0.0
@@ -155,20 +27,14 @@ class BuoyancyTest(UnitTest.TestCase):
         mu = 0.71*k/c # For Prandlt = 0.71
         nu = mu/rho
 
-        if self.thermal_expansion_coefficient is not None:
-            parameter_string = '{ "gravity" : [ 0.0, -' + str(g) +', 0.0 ], "thermal_expansion_coefficient" : '+ str(self.thermal_expansion_coefficient) +' }'
-        else:
-            parameter_string = '{ "gravity" : [ 0.0, -' + str(g) +', 0.0 ] }'
-        parameters = Parameters(parameter_string)
-        self.buoyancy_process = BoussinesqForceProcess(self.fluid_model_part,parameters)
-
         ## Set initial and boundary conditions
-        self.fluid_model_part.ProcessInfo.SetValue(AMBIENT_TEMPERATURE,T1)
-        for node in self.fluid_model_part.Nodes:
-            node.SetSolutionStepValue(DENSITY,rho)
-            node.SetSolutionStepValue(VISCOSITY,nu)
-            node.SetSolutionStepValue(CONDUCTIVITY,k)
-            node.SetSolutionStepValue(SPECIFIC_HEAT,c)
+        model_part = self._GetSolver().GetComputingModelPart()
+        model_part.ProcessInfo.SetValue(AMBIENT_TEMPERATURE,T1)
+        for node in model_part.Nodes:
+            node.SetSolutionStepValue(DENSITY, rho)
+            node.SetSolutionStepValue(VISCOSITY, nu)
+            node.SetSolutionStepValue(CONDUCTIVITY, k)
+            node.SetSolutionStepValue(SPECIFIC_HEAT, c)
 
             if node.X == xmin or node.X == xmax or node.Y == ymin or node.Y == ymax:
                 node.Fix(VELOCITY_X)
@@ -178,37 +44,89 @@ class BuoyancyTest(UnitTest.TestCase):
 
             if node.X == xmin:
                 node.Fix(TEMPERATURE)
-                node.SetSolutionStepValue(TEMPERATURE,T2)
+                node.SetSolutionStepValue(TEMPERATURE, T2)
             elif node.X == xmax:
                 node.Fix(TEMPERATURE)
-                node.SetSolutionStepValue(TEMPERATURE,T1)
+                node.SetSolutionStepValue(TEMPERATURE, T1)
             else:
                 T = T2 + (T1-T2)*(node.X-xmin)/(xmax-xmin)
-                node.SetSolutionStepValue(TEMPERATURE,T)
-                #node.SetSolutionStepValue(TEMPERATURE,T1)
+                node.SetSolutionStepValue(TEMPERATURE, T)
 
-        self.buoyancy_process.ExecuteInitialize()
+@UnitTest.skipIfApplicationsNotAvailable("ConvectionDiffusionApplication")
+class BuoyancyTest(UnitTest.TestCase):
+
+    def testEulerian(self):
+        self.convection_diffusion_solver = "eulerian"
+        self.reference_file = "reference10_eulerian"
+        self.thermal_expansion_coefficient = None # If set, it will be used instead of 1./AmbientTemperature
+
+    def testThermalExpansionCoefficient(self):
+        self.convection_diffusion_solver = "eulerian"
+        self.reference_file = "reference10_eulerian"
+        self.thermal_expansion_coefficient = 1.0/293.15
+
+    def testBFECC(self):
+        self.convection_diffusion_solver = "bfecc"
+        self.reference_file = "reference10_bfecc"
+        self.thermal_expansion_coefficient = None # If set, it will be used instead of 1./AmbientTemperature
+        self.check_tolerance = 1e-1 # The bfecc solver shows some variation between runs, we cannot be too strict here
+
+    def validationEulerian(self):
+        self.convection_diffusion_solver = "eulerian"
+        self.reference_file = "reference80_eulerian"
+        self.thermal_expansion_coefficient = None # If set, it will be used instead of 1./AmbientTemperature
+        
+        #TODO: MODIFY THIS IN THE JSON SETTINGS
+        self.nsteps = 200
+        self.input_file = "cavity80"
+
+    def setUp(self):
+        self.check_tolerance = 1e-6
+        self.print_output = False
+        self.print_reference_values = False
+
+        # Open parameters
+        with UnitTest.WorkFolderScope("BuoyancyTest", __file__):
+            with open("ProjectParameters.json",'r') as parameter_file:
+                self.parameters = Parameters(parameter_file.read())
 
     def runTest(self):
-        time = 0.0
+        with UnitTest.WorkFolderScope("BuoyancyTest", __file__):
+            # If required, add the output process to the test settings
+            if self.print_output:
+                self._AddOutput()
 
-        for step in range(self.nsteps):
-            time = self.fluid_solver.AdvanceInTime(time)
-            self.buoyancy_process.ExecuteInitializeSolutionStep()
+            # Set thermal solver
+            if self.convection_diffusion_solver == 'bfecc':
+                self.parameters["solver_settings"]["thermal_solver_settings"]["time_integration_method"].SetString("semi_eulerian")
+            elif self.convection_diffusion_solver == 'eulerian':
+                self.parameters["solver_settings"]["thermal_solver_settings"]["time_integration_method"].SetString("implicit")
+            else:
+                raise Exception("Unsupported convection-diffusion solver option: {0}".format(self.convection_diffusion_solver))
 
-            self.fluid_solver.InitializeSolutionStep()
-            self.fluid_solver.Predict()
-            self.fluid_solver.SolveSolutionStep()
-            self.fluid_solver.FinalizeSolutionStep()
+            # Set buoyancy process
+            gravity = Vector(3)
+            gravity[0] = 0.0
+            gravity[1] = 9.81
+            gravity[2] = 0.0
+            self.parameters["processes"]["boussinesq_process_list"][0]["Parameters"].AddVector("gravity", gravity)
+            if self.thermal_expansion_coefficient is not None:
+                self.parameters["processes"]["boussinesq_process_list"][0]["Parameters"].AddDouble("thermal_expansion_coefficient", self.thermal_expansion_coefficient)
 
-            self.thermal_solver.Solve()
+            # Set up the modified analysis stage with intial and boundary conditions and run
+            model = Model()
+            self.simulation = BuoyancyTestConvectionDiffusionAnalysis(model, self.parameters)
+            self.simulation.Run()
+
+            # Check results
+            self.checkResults()
 
     def checkResults(self):
-
+        model_part = self.simulation._GetSolver().GetComputingModelPart()
         if self.print_reference_values:
             with open(self.reference_file+'.csv','w') as ref_file:
                 ref_file.write("#ID, VELOCITY_X, VELOCITY_Y, TEMPERATURE\n")
-                for node in self.fluid_model_part.Nodes:
+                for node in model_part.Nodes:
                     vel = node.GetSolutionStepValue(VELOCITY,0)
                     temp = node.GetSolutionStepValue(TEMPERATURE,0)
                     ref_file.write("{0}, {1}, {2}, {3}\n".format(node.Id, vel[0], vel[1], temp))
@@ -216,9 +134,7 @@ class BuoyancyTest(UnitTest.TestCase):
             with open(self.reference_file+'.csv','r') as reference_file:
                 reference_file.readline() # skip header
                 line = reference_file.readline()
-                node_iter = self.fluid_model_part.Nodes
-
-                for node in self.fluid_model_part.Nodes:
+                for node in model_part.Nodes:
                     values = [ float(i) for i in line.rstrip('\n ').split(',') ]
                     node_id = values[0]
                     reference_vel_x = values[1]
@@ -235,36 +151,51 @@ class BuoyancyTest(UnitTest.TestCase):
                 if line != '': # If we did not reach the end of the reference file
                     self.fail("The number of nodes in the mdpa is smaller than the number of nodes in the output file")
 
-    def printOutput(self):
-        gid_mode = GiDPostMode.GiD_PostBinary
-        multifile = MultiFileFlag.SingleFile
-        deformed_mesh_flag = WriteDeformedMeshFlag.WriteUndeformed
-        write_conditions = WriteConditionsFlag.WriteElementsOnly
-        gid_io = GidIO(self.input_file,gid_mode,multifile,deformed_mesh_flag, write_conditions)
+    def tearDown(self):
+        with UnitTest.WorkFolderScope("BuoyancyTest", __file__):
+            filename = self.parameters["solver_settings"]["fluid_solver_settings"]["model_import_settings"]["input_filename"].GetString()
+            KratosUtilities.DeleteFileIfExisting(filename + '.time')
 
-        mesh_name = 0.0
-        gid_io.InitializeMesh( mesh_name)
-        gid_io.WriteMesh( self.fluid_model_part.GetMesh() )
-        gid_io.FinalizeMesh()
-        gid_io.InitializeResults(mesh_name,(self.fluid_model_part).GetMesh())
-
-        label = self.fluid_model_part.ProcessInfo[TIME]
-        gid_io.WriteNodalResults(VELOCITY,self.fluid_model_part.Nodes,label,0)
-        gid_io.WriteNodalResults(PRESSURE,self.fluid_model_part.Nodes,label,0)
-        gid_io.WriteNodalResults(TEMPERATURE,self.fluid_model_part.Nodes,label,0)
-        gid_io.WriteNodalResults(DENSITY,self.fluid_model_part.Nodes,label,0)
-        gid_io.WriteNodalResults(VISCOSITY,self.fluid_model_part.Nodes,label,0)
-        gid_io.WriteNodalResults(CONDUCTIVITY,self.fluid_model_part.Nodes,label,0)
-        gid_io.WriteNodalResults(SPECIFIC_HEAT,self.fluid_model_part.Nodes,label,0)
-        gid_io.WriteNodalResults(BODY_FORCE,self.fluid_model_part.Nodes,label,0)
-
-        gid_io.FinalizeResults()
+    def _AddOutput(self):
+        gid_output_settings = Parameters("""{
+            "python_module" : "gid_output_process",
+            "kratos_module" : "KratosMultiphysics",
+            "process_name"  : "GiDOutputProcess",
+            "help"          : "This process writes postprocessing files for GiD",
+            "Parameters"    : {
+                "model_part_name"        : "FluidModelPart",
+                "output_name"            : "TO_BE_DEFINED",
+                "postprocess_parameters" : {
+                    "result_file_configuration" : {
+                        "gidpost_flags"               : {
+                            "GiDPostMode"           : "GiD_PostBinary",
+                            "WriteDeformedMeshFlag" : "WriteDeformed",
+                            "WriteConditionsFlag"   : "WriteConditions",
+                            "MultiFileFlag"         : "SingleFile"
+                        },
+                        "file_label"                  : "step",
+                        "output_control_type"         : "step",
+                        "output_frequency"            : 1.0,
+                        "body_output"                 : true,
+                        "node_output"                 : false,
+                        "skin_output"                 : false,
+                        "plane_output"                : [],
+                        "nodal_results"               : ["VELOCITY","PRESSURE","TEMPERATURE","DENSITY","VISCOSITY","CONDUCTIVITY","SPECIFIC_HEAT","BODY_FORCE"]
+                    },
+                    "point_data_configuration"  : []
+                }
+            }
+        }""")
+        gid_output_settings["Parameters"]["output_name"].SetString(self.input_file)
+        self.parameters["output_processes"]["gid_output"].Append(gid_output_settings)
 
 if __name__ == '__main__':
     test = BuoyancyTest()
     test.setUp()
     #test.print_reference_values = True
     test.print_output = True
-    #test.testEulerian()
-    test.validationEulerian()
+    test.testEulerian()
+    #test.testThermalExpansionCoefficient()
+    #test.testBFECC()
+    test.runTest()
     test.tearDown()

--- a/applications/FluidDynamicsApplication/tests/test_flows_measuring_utility.py
+++ b/applications/FluidDynamicsApplication/tests/test_flows_measuring_utility.py
@@ -20,7 +20,7 @@ class FlowsMeasuringUtilityTest(UnitTest.TestCase):
             "model_part_name_list" : ["FluidMOdelPart.first", "FluidMOdelPart.second"],
             "output_file_settings": {
                     "file_name"  : "test_flow_data_output.dat",
-                    "folder_name": ""
+                    "output_path": ""
             }
         }
         """)


### PR DESCRIPTION
**Description**
Several convection-diffusion and fluid fixes.

@roigcarlo this needs to be included in the release branch.
@jginternational this fixes the issues you observed in the GiD buoyancy examples.

Please mark the PR with appropriate tags: 
- Warning
- Applications
- Testing
- Continuous Integration
- Inconsistent

**Changelog**
- Make the Python solvers wrapper of the `ConvectionDiffusionApplication` consistent. After the addition of the explicit solvers, the new `time_integration_method` field of the `solver_settings` was always required, even for steady simulations. Right now, this is only checked in transient simulation. As before, the `implicit` is set by default if it is not user-defined.
- After the clean up of the `ConvectionDiffusionApplication` #7537 the buoyancy test in the `FluidDynamicsApplication` stopped working (this is why the nightly build was failing) as it relied on a legacy solver. Hence, I've refactored the test completely to use the "official" solvers.
- Remove some warnings in the `FluidDynamicsApplication` tests from the ASCII file writer.
