### PR TITLE
Chimera remove strategy solve

### DIFF
--- a/applications/ChimeraApplication/custom_strategies/strategies/fs_strategy_for_chimera.h
+++ b/applications/ChimeraApplication/custom_strategies/strategies/fs_strategy_for_chimera.h
@@ -73,7 +73,7 @@ public:
 
     typedef FractionalStepSettingsForChimera<TSparseSpace,TDenseSpace,TLinearSolver> SolverSettingsType;
     
-    typedef BaseType::StrategyPointerType StrategyPointerType;
+    typedef typename BaseType::StrategyPointerType StrategyPointerType;
 
     ///@}
     ///@name Life Cycle
@@ -712,9 +712,9 @@ private:
         pStrategy->InitializeSolutionStep();
         pStrategy->Predict();
         pStrategy->SolveSolutionStep();
-        const double norm_dp = TSparseSpace::TwoNorm(pStrategy->GetSolutionVector());
+        const double norm_dx = TSparseSpace::TwoNorm(pStrategy->GetSolutionVector());
         pStrategy->FinalizeSolutionStep();        
-        return norm_dp;
+        return norm_dx;
     }
 
 


### PR DESCRIPTION
**Description**
Following the issue #6748 and the recommendation of the technical committee, the following PR removes the explicit Solve() function calls from the fs strategy of the chimera application. 

**Changelog**
Adds a local SolveStrategy function to the fs_strategy of the chimera app. And uses it to solve the momentum and pressure strategies. This function calls the Initialize, InitializeSolutionStep, SolveSolutionStep and FinializeSolutionStep in that sequence and returns the norm of the solution vector back. 

