### PR TITLE
[Structura][MPI] using amgcl as default solver

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_solver.py
@@ -31,10 +31,22 @@ class TrilinosMechanicalSolver(MechanicalSolver):
     def GetDefaultParameters(cls):
         this_defaults = KratosMultiphysics.Parameters("""{
             "multi_point_constraints_used": false,
-            "linear_solver_settings" : {
-                "solver_type" : "amesos",
-                "amesos_solver_type" : "Amesos_Klu"
-            }
+            "linear_solver_settings":{
+                "solver_type"                    :"amgcl",
+                "preconditioner_type"            : "amg",
+                "max_iteration"                  : 500,
+                "tolerance"                      : 1e-6,
+                "provide_coordinates"            : false,
+                "smoother_type"                  : "ilut",
+                "krylov_type"                    : "bicgstab_with_gmres_fallback",
+                "gmres_krylov_space_dimension"   : 100,
+                "use_block_matrices_if_possible" : false,
+                "coarsening_type"                : "smoothed_aggregation",
+                "scaling"                        : false,
+                "verbosity"                      : 1,
+                "coarse_enough"                  : 100,
+                "max_levels"                     : -1
+            },
         }""")
         this_defaults.AddMissingParameters(super().GetDefaultParameters())
         return this_defaults

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_solver.py
@@ -46,7 +46,7 @@ class TrilinosMechanicalSolver(MechanicalSolver):
                 "verbosity"                      : 1,
                 "coarse_enough"                  : 100,
                 "max_levels"                     : -1
-            },
+            }
         }""")
         this_defaults.AddMissingParameters(super().GetDefaultParameters())
         return this_defaults


### PR DESCRIPTION
**Description**
This PR replaces the default solver in distributed runs in StructuralMechanics from Trilinos-klu to amgcl
Reasons:
- Main reason: Is much (much) faster
- Those settings were extensively tested by @AndreasWinterstein with a very complex model and they work well. I also tested it with a very complex model and also for me it works very well. Kudos @ddemidov !
- Will simplify the transition to our own sparse matrices (and away from Trilinos) in the long run

the default settings of amgcl don't work for complex structural models hence they are added here.

@ddemidov @RiccardoRossi can you take a look at the settings, maybe you have an idea for further improvement

@ddemidov amgcl gives the following warning, do you know what I should change?
`[WARNING] AMGCL: Unknown parameter M`