### PR TITLE
[FastPR][Hotfix][Fluid] More robust condition selection

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
@@ -15,6 +15,9 @@ class StabilizedFormulation(object):
         self.element_has_nodal_properties = False
         self.process_data = {}
 
+        #TODO: Keep this until the MonolithicWallCondition is removed to ensure backwards compatibility in solvers with no defined condition_name
+        self.condition_name = "MonolithicWallCondition"
+
         if settings.Has("element_type"):
             formulation = settings["element_type"].GetString()
             if formulation == "vms":

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
@@ -11,7 +11,6 @@ class StabilizedFormulation(object):
     """Helper class to define stabilization-dependent parameters."""
     def __init__(self,settings):
         self.element_name = None
-        self.condition_name = "MonolithicWallCondition"
         self.element_integrates_in_time = False
         self.element_has_nodal_properties = False
         self.process_data = {}
@@ -58,6 +57,7 @@ class StabilizedFormulation(object):
         else:
             self.non_newtonian_option = False
             self.element_name = 'VMS'
+        self.condition_name = "MonolithicWallCondition"
 
         settings.ValidateAndAssignDefaults(default_settings)
 
@@ -91,6 +91,7 @@ class StabilizedFormulation(object):
         else:
             self.element_name = "TimeIntegratedQSVMS"
             self.element_integrates_in_time = True
+        self.condition_name = "NavierStokesWallCondition"
 
         self.process_data[KratosMultiphysics.DYNAMIC_TAU] = settings["dynamic_tau"].GetDouble()
         use_oss = settings["use_orthogonal_subscales"].GetBool()
@@ -104,6 +105,7 @@ class StabilizedFormulation(object):
         settings.ValidateAndAssignDefaults(default_settings)
 
         self.element_name = "DVMS"
+        self.condition_name = "NavierStokesWallCondition"
 
         use_oss = settings["use_orthogonal_subscales"].GetBool()
         self.process_data[KratosMultiphysics.OSS_SWITCH] = int(use_oss)
@@ -123,6 +125,7 @@ class StabilizedFormulation(object):
             KratosMultiphysics.Logger.PrintWarning("NavierStokesSolverVMSMonolithic","FIC with dynamic beta not yet implemented, using provided beta as a constant value")
         else:
             self.element_name = "FIC"
+        self.condition_name = "NavierStokesWallCondition"
 
         self.process_data[KratosCFD.FIC_BETA] = settings["beta"].GetDouble()
         self.process_data[KratosMultiphysics.OSS_SWITCH] = 0


### PR DESCRIPTION
**Description**
This makes the selection of the `condition_name` field in the monolithic formulations much more robust. Thanks to the inclusion of the new elements in the GUI I realized that the ones with property-based physical magnitudes were trying to use the old  `MonolithicWallCondition`, which requires physical magnitudes to be stored nodally. With this change it is make clear the associated condition (`NavierStokesWallCondition` for all the elements except the old VMS) to each one of the elements.

I'd like to note that at some point we need to recover the `ApplyWallLaw` function in the `MonolithicWallCondition` to introduce it in the `NavierStokesWallCondition`. This must be accompanied by an upgrade in the wall condition imposition. IMO we should upgrade the `apply_slip_process.py` to be `apply_wall_condition_process.py`.

@jginternational this could help fixing some of the errors you reported.

Please mark the PR with appropriate tags: 
- Applications
- Hotfix
- FastPR

**Changelog**
- Declare `condition_name` for each element.
