### PR TITLE
[FastPR][Hotfix][FSI] Remove MESH_VELOCITY fixity

### DIFF
--- a/applications/FSIApplication/python_scripts/trilinos_partitioned_fsi_dirichlet_neumann_solver.py
+++ b/applications/FSIApplication/python_scripts/trilinos_partitioned_fsi_dirichlet_neumann_solver.py
@@ -83,13 +83,10 @@ class TrilinosPartitionedFSIDirichletNeumannSolver(trilinos_partitioned_fsi_base
             # Fix the VELOCITY, MESH_DISPLACEMENT and MESH_VELOCITY variables in all the fluid interface submodelparts
             KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.VELOCITY_X, True, fl_interface_submodelpart.Nodes)
             KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.VELOCITY_Y, True, fl_interface_submodelpart.Nodes)
-            KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.MESH_VELOCITY_X, True, fl_interface_submodelpart.Nodes)
-            KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.MESH_VELOCITY_Y, True, fl_interface_submodelpart.Nodes)
             KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.MESH_DISPLACEMENT_X, True, fl_interface_submodelpart.Nodes)
             KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.MESH_DISPLACEMENT_Y, True, fl_interface_submodelpart.Nodes)
             if (self.domain_size == 3):
                 KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.VELOCITY_Z, True, fl_interface_submodelpart.Nodes)
-                KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.MESH_VELOCITY_Z, True, fl_interface_submodelpart.Nodes)
                 KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.MESH_DISPLACEMENT_Z, True, fl_interface_submodelpart.Nodes)
 
             # Set the interface flag


### PR DESCRIPTION
**Description**
Remove `MESH_VELOCITY` fixity in the interface. This was working for a while as we created new DOFs if these were not present when asking for fixing them. OFC these were not required in this case. After we removed such silent creation of DOFs this crashes (thanks for reporting @SamiBidier).

Please mark the PR with appropriate tags: 
- Applications
- FastPR
- Hotfix

**Changelog**
- Removing fixity of `MESH_VELOCITY` in the fluid FSI interface

closes #7834
