### PR TITLE
[Core] Fix test compilation may fail if compilers detects as non initialized

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_math_utils.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_math_utils.cpp
@@ -461,7 +461,8 @@ namespace Kratos
 
             KRATOS_CHECK_NEAR(det, 4.0, tolerance);
 
-            BoundedMatrix<double,5,5> b_I = prod(b_inv, b_mat);
+            BoundedMatrix<double,5,5> b_I = ZeroMatrix(5);
+            noalias(b_I) = prod(b_inv, b_mat);
 
             for (unsigned int i = 0; i < i_dim; i++) {
                 for (unsigned int j = 0; j < i_dim; j++) {


### PR DESCRIPTION
**Description**
This fix a potential fail in compilation due to a potential detection of uninitiated in GCC 9.3 (for some reason)

**Changelog**
- Manual initialization
