### PR TITLE
[Mapping] Add integration weight to coupling geoms integration

### DIFF
--- a/applications/MappingApplication/custom_mappers/coupling_geometry_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/coupling_geometry_mapper.cpp
@@ -58,13 +58,14 @@ void CouplingGeometryLocalSystem::CalculateAll(MatrixType& rLocalMappingMatrix,
     r_geometry_slave.DeterminantOfJacobian(det_jacobian);
     KRATOS_ERROR_IF(det_jacobian.size() != 1)
         << "Coupling Geometry Mapper should only have 1 integration point coupling per local system" << std::endl;
+    const double weight = r_geometry_slave.IntegrationPoints()[0].Weight();
 
     if (is_dual_mortar) {
         rLocalMappingMatrix.clear();
         for (IndexType integration_point_itr = 0; integration_point_itr < sf_values_slave.size1(); ++integration_point_itr) {
             for (IndexType i = 0; i < sf_values_slave.size2(); ++i) {
                 rLocalMappingMatrix(i, i) = sf_values_slave(integration_point_itr, i)
-                    * det_jacobian[integration_point_itr];
+                    * det_jacobian[integration_point_itr] * weight;
                 KRATOS_DEBUG_ERROR_IF(sf_values_slave(integration_point_itr, i) < 0.0)
                     << "DESTINATION SHAPE FUNCTIONS LESS THAN ZERO" << std::endl;
             }
@@ -84,7 +85,7 @@ void CouplingGeometryLocalSystem::CalculateAll(MatrixType& rLocalMappingMatrix,
                 for (IndexType j = 0; j < sf_values_master.size2(); ++j) {
                     rLocalMappingMatrix(i, j) = sf_values_slave(integration_point_itr, i)
                         * sf_values_master(integration_point_itr, j)
-                        * det_jacobian[integration_point_itr];
+                        * det_jacobian[integration_point_itr] * weight;
 
                     KRATOS_DEBUG_ERROR_IF(sf_values_master(integration_point_itr, j) < 0.0)
                         << "ORIGIN SHAPE FUNCTIONS LESS THAN ZERO\n" << sf_values_master << std::endl;


### PR DESCRIPTION
**Description**
Adds integration weight to numerical integration. This probably worked in the past because we use 2 gauss points (integration weight = 1.0) for structure-structure mapping.