### PR TITLE
[Trilinos] make block BS consistent

### DIFF
--- a/applications/TrilinosApplication/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
+++ b/applications/TrilinosApplication/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
@@ -405,6 +405,9 @@ public:
         KRATOS_TRY
 
         BuildRHS(pScheme, rModelPart, rb);
+
+        ApplyDirichletConditions(pScheme, rModelPart, rA, rDx, rb);
+
         SystemSolveWithPhysics(rA, rDx, rb, rModelPart);
 
         KRATOS_CATCH("")

--- a/applications/TrilinosApplication/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
+++ b/applications/TrilinosApplication/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
@@ -177,9 +177,6 @@ public:
 
         KRATOS_ERROR_IF(!pScheme) << "No scheme provided!" << std::endl;
 
-        // Resetting to zero the vector of reactions
-        TSparseSpace::SetToZero(*BaseType::mpReactionsVector);
-
         // Contributions to the system
         LocalSystemMatrixType LHS_Contribution = LocalSystemMatrixType(0, 0);
         LocalSystemVectorType RHS_Contribution = LocalSystemVectorType(0);
@@ -246,8 +243,6 @@ public:
                   TSystemMatrixType& rA) override
     {
         KRATOS_TRY
-        // Resetting to zero the vector of reactions
-        TSparseSpace::SetToZero(*BaseType::mpReactionsVector);
 
         // Contributions to the system
         LocalSystemMatrixType LHS_Contribution = LocalSystemMatrixType(0, 0);
@@ -430,8 +425,6 @@ public:
         if (BaseType::GetEchoLevel() > 0) {
             START_TIMER("BuildRHS ", 0)
         }
-        // Resetting to zero the vector of reactions
-        TSparseSpace::SetToZero(*BaseType::mpReactionsVector);
 
         // Contributions to the system
         LocalSystemMatrixType LHS_Contribution = LocalSystemMatrixType(0, 0);


### PR DESCRIPTION
**Description**
I noticed two things:
- The reactions vector is set to zero in any Build function. This is not the case in the serial version
- `ApplyDirichletConditions` is missing in `BuildRHSAndSolve`

I am not sure if my changes are correct, lets discuss it, maybe there is a reason it is done like this

maybe also comment from @KratosMultiphysics/altair ?