### PR TITLE
[Hotfix] Avoid using Kernel()

### DIFF
--- a/applications/FSIApplication/python_scripts/convergence_accelerator_factory.py
+++ b/applications/FSIApplication/python_scripts/convergence_accelerator_factory.py
@@ -6,12 +6,14 @@ import KratosMultiphysics
 # Import applications
 import KratosMultiphysics.FSIApplication as KratosFSI
 
-# Check if Trilinos has been imported to set the have_trilinos flag
-if (KratosMultiphysics.Kernel().IsImported("TrilinosApplication")):
-    import KratosMultiphysics.TrilinosApplication as KratosTrilinos
-    have_trilinos = True
-else:
-    have_trilinos = False
+import KratosMultiphysics.kratos_utilities as KratosUtilities
+have_trilinos = KratosUtilities.CheckIfApplicationsAvailable("TrilinosApplication")
+is_distributed = KratosMultiphysics.DataCommunicator.GetDefault().IsDistributed()
+if have_trilinos and is_distributed:
+    try:
+        import KratosMultiphysics.TrilinosApplication as KratosTrilinos
+    except Exception as e:
+        raise Exception("Trying to create a Trilinos convergence accelerator, but TrilinosApplication could not be found.")
 
 def CreateConvergenceAccelerator(configuration):
 
@@ -38,9 +40,6 @@ def CreateConvergenceAccelerator(configuration):
     return convergence_accelerator
 
 def CreateTrilinosConvergenceAccelerator(interface_model_part, epetra_communicator, configuration):
-
-    if not have_trilinos:
-        raise Exception("Trying to create a Trilinos convergence accelerator, but TrilinosApplication could not be found.")
 
     if (type(interface_model_part) != KratosMultiphysics.ModelPart):
         raise Exception("First input in Trilinos convergence accelerator factory is expceted to be provided as a Kratos ModelPart object.")

--- a/kratos/tests/test_importing.py
+++ b/kratos/tests/test_importing.py
@@ -40,14 +40,14 @@ class TestImporting(KratosUnittest.TestCase):
     def test_has_application(self):
         current_model = KM.Model()
 
-        self.assertTrue(KM.Kernel().IsImported("KratosMultiphysics"))
+        self.assertTrue(KM.KratosGlobals.Kernel.IsImported("KratosMultiphysics"))
 
         try:
             import KratosMultiphysics.ExternalSolversApplication
         except:
             self.skipTest("KratosMultiphysics.ExternalSolversApplication is not available")
 
-        self.assertTrue(KM.Kernel().IsImported("ExternalSolversApplication"))
+        self.assertTrue(KM.KratosGlobals.Kernel.IsImported("ExternalSolversApplication"))
 
     def test_variable_keys_reordering(self):
         key_vel_before_import = KM.VELOCITY.Key() # test a var from the Kernel


### PR DESCRIPTION
**Description**
Calling `Kernel()` was creating another instance of the Kratos kernel. This PR removes the few occurrences of this. Note that this was the cause of having the impression that the Kratos core was imported twice in the terminal output (not imported but created twice).

**Changelog**
- Removing all the usages of `Kernel()` constructor in applications and tests.
