### PR TITLE
[Core] Modify BruteForcePointLocator behaviour

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_brute_force_point_locator.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_brute_force_point_locator.cpp
@@ -233,6 +233,11 @@ KRATOS_TEST_CASE_IN_SUITE(BruteForcePointLocatorCurrentConfigurationTriangleElem
 
     const int found_id = point_locator.FindElement(the_point, shape_function_values);
 
+    // Check whether the current configuration is restored after the search
+    for ( Node<3>& r_node : p_element->GetGeometry() )
+        for ( double component : r_node )
+            KRATOS_CHECK_NEAR( component, 0.0, 1e-16 );
+
     KRATOS_CHECK_EQUAL(found_id, elem_id_to_be_found);
     KRATOS_CHECK_EQUAL(shape_function_values.size(), 3);
 

--- a/kratos/tests/cpp_tests/utilities/test_brute_force_point_locator.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_brute_force_point_locator.cpp
@@ -208,5 +208,38 @@ KRATOS_TEST_CASE_IN_SUITE(BruteForcePointLocatorQuadrilateralCondition, KratosCo
     KRATOS_CHECK_NEAR(shape_function_values[3], 0.48245, 1e-06);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(BruteForcePointLocatorCurrentConfigurationTriangleElement, KratosCoreFastSuite)
+{
+    Model current_model;
+    ModelPart& model_part = current_model.CreateModelPart("Triangle");
+    model_part.GetProcessInfo().SetValue(DOMAIN_SIZE, 2);
+
+    model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    Properties::Pointer p_properties(new Properties(0));
+    const int elem_id_to_be_found = 43;
+    Element::Pointer p_element = model_part.CreateNewElement("Element2D3N", elem_id_to_be_found, {1, 2, 3}, p_properties);
+
+    // Set current configuration of the element (degenerate)
+    for ( Node<3>& r_node : p_element->GetGeometry() )
+        r_node.Coordinates() = array_1d<double, 3>( 3, 0.0 );
+
+    BruteForcePointLocator point_locator(model_part);
+
+    Point the_point(0.1, 0.25, 0.0);
+
+    Vector shape_function_values;
+
+    const int found_id = point_locator.FindElement(the_point, shape_function_values);
+
+    KRATOS_CHECK_EQUAL(found_id, elem_id_to_be_found);
+    KRATOS_CHECK_EQUAL(shape_function_values.size(), 3);
+
+    KRATOS_CHECK_NEAR(shape_function_values[0], 0.65, 1e-06);
+    KRATOS_CHECK_NEAR(shape_function_values[1], 0.1,  1e-06);
+    KRATOS_CHECK_NEAR(shape_function_values[2], 0.25, 1e-06);
+}
+
 } // namespace Testing
 }  // namespace Kratos.


### PR DESCRIPTION
**Description**
Modify BruteForcePointLocator to search through the initial configuration instead of the current one.

**Changelog**
- BruteForcePointLocator moves Nodes of all searched objects to the initial configuration, performs the membership test, then restores the current configuration
- Added a test that requires BruteForcePointLocator to use the initial configuration, and checks whether the current configuration gets correctly restored after the search.
