### PR TITLE
Refactoring kernel creation

### DIFF
--- a/kratos/includes/kernel.h
+++ b/kratos/includes/kernel.h
@@ -70,7 +70,9 @@ class KRATOS_API(KRATOS_CORE) Kernel {
         @see KratosApplication
 
     */
-    Kernel(bool IsDistributedRun = false);
+    Kernel();
+
+    Kernel(bool IsDistributedRun);
 
     /// Copy constructor.
     /** This constructor is empty
@@ -99,8 +101,8 @@ class KRATOS_API(KRATOS_CORE) Kernel {
     /// To be deprecated becuase variables have their own hash key.
     /** The keys of Variables are not sequencial anymore, so this method will be deprecated
     */
-    void Initialize() { }
-
+    void Initialize();
+    
     /// Initializes and synchronizes the list of variables, elements and conditions in each application.
     /** This method gives the application the list of all variables, elements and condition which is registered
         by kratos and all other added applications.

--- a/kratos/sources/kernel.cpp
+++ b/kratos/sources/kernel.cpp
@@ -24,9 +24,19 @@
 #include "utilities/openmp_utils.h"
 
 namespace Kratos {
+
+Kernel::Kernel() : mpKratosCoreApplication(Kratos::make_shared<KratosApplication>(
+                std::string("KratosMultiphysics"))) {
+    Initialize();
+}
+
 Kernel::Kernel(bool IsDistributedRun) : mpKratosCoreApplication(Kratos::make_shared<KratosApplication>(
                 std::string("KratosMultiphysics"))) {
     mIsDistributedRun = IsDistributedRun;
+    Initialize();
+}
+
+void Kernel::Initialize() {
     KRATOS_INFO("") << " |  /           |\n"
                     << " ' /   __| _` | __|  _ \\   __|\n"
                     << " . \\  |   (   | |   (   |\\__ \\\n"


### PR DESCRIPTION
**Description**
Changes Kernel so it can be initialized with or without `using_mpi` flag without setting it to false in the default constructor.

**Changelog**
- Changed Kernel Initialization