### PR TITLE
[Core] Add shape derivatives to ElementSizeCalculator

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_element_size_calculator.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_element_size_calculator.cpp
@@ -17,7 +17,11 @@
 
 // Project includes
 #include "testing/testing.h"
+#include "geometries/triangle_2d_3.h"
+#include "geometries/quadrilateral_2d_4.h"
+#include "geometries/tetrahedra_3d_4.h"
 #include "geometries/prism_3d_6.h"
+#include "geometries/hexahedra_3d_8.h"
 #include "tests/cpp_tests/geometries/test_geometry.h"
 #include "utilities/element_size_calculator.h"
 
@@ -25,6 +29,33 @@ namespace Kratos
 {
     namespace Testing
     {
+        namespace
+        {
+            template<class TPrimalFunction, class TDerivativeFunction>
+            void RunElementSizeCalculatorDerivativesTest(
+                Geometry<NodeType>& rGeometry,
+                const TPrimalFunction& rPrimalMethod,
+                const TDerivativeFunction& rDerivativeMethod,
+                const double Delta,
+                const double Tolerance)
+            {
+                const double fd_ref_value = rPrimalMethod(rGeometry);
+
+                for (unsigned int c = 0; c < rGeometry.PointsNumber(); ++c) {
+                    for (unsigned int k = 0; k < rGeometry.WorkingSpaceDimension(); ++k) {
+                        const double analytical_derivative = rDerivativeMethod(c, k, rGeometry);
+
+                        rGeometry[c].Coordinates()[k] += Delta;
+                        const double fd_value = rPrimalMethod(rGeometry);
+                        rGeometry[c].Coordinates()[k] -= Delta;
+                        const double fd_derivative = (fd_value - fd_ref_value) / Delta;
+
+                        KRATOS_CHECK_NEAR(analytical_derivative, fd_derivative, Tolerance);
+                    }
+                }
+            }
+        }
+
         KRATOS_TEST_CASE_IN_SUITE(Prism3D6ElementSizeCase1, KratosCoreFastSuite)
         {
             Geometry<NodeType>::PointsArrayType nodes;
@@ -55,6 +86,146 @@ namespace Kratos
             const double average_size = ElementSizeCalculator<3, 6>::AverageElementSize(prism2);
             KRATOS_CHECK_NEAR(minimum_size, 0.5, TOLERANCE);
             KRATOS_CHECK_NEAR(average_size, std::pow(0.25, 1.0 / 3.0), TOLERANCE); //
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(Triangle2D3MinimumElementSizeDerivatives, KratosCoreFastSuite)
+        {
+            Geometry<NodeType>::PointsArrayType nodes;
+            nodes.push_back(NodeType::Pointer(new NodeType(1, 0.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(2, 1.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(3, 0.0, 1.0, 0.0)));
+            auto geometry = *GeometryType::Pointer(new Triangle2D3<NodeType>(nodes));
+            RunElementSizeCalculatorDerivativesTest(
+                geometry, ElementSizeCalculator<2, 3>::MinimumElementSize,
+                ElementSizeCalculator<2, 3>::MinimumElementSizeDerivative, 1e-8, 1e-7);
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(Triangle2D3AverageElementSizeDerivatives, KratosCoreFastSuite)
+        {
+            Geometry<NodeType>::PointsArrayType nodes;
+            nodes.push_back(NodeType::Pointer(new NodeType(1, 0.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(2, 1.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(3, 0.0, 1.0, 0.0)));
+            auto geometry = *GeometryType::Pointer(new Triangle2D3<NodeType>(nodes));
+            RunElementSizeCalculatorDerivativesTest(
+                geometry, ElementSizeCalculator<2, 3>::AverageElementSize,
+                ElementSizeCalculator<2, 3>::AverageElementSizeDerivative, 1e-8, 1e-7);
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(Quadrilateral2D4MinimumElementSizeDerivatives, KratosCoreFastSuite)
+        {
+            Geometry<NodeType>::PointsArrayType nodes;
+            nodes.push_back(NodeType::Pointer(new NodeType(1, 0.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(2, 1.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(3, 1.0, 1.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(4, 0.0, 1.0, 0.0)));
+            auto geometry = *GeometryType::Pointer(new Quadrilateral2D4<NodeType>(nodes));
+            RunElementSizeCalculatorDerivativesTest(
+                geometry, ElementSizeCalculator<2, 4>::MinimumElementSize,
+                ElementSizeCalculator<2, 4>::MinimumElementSizeDerivative, 1e-8, 1e-7);
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(Quadrilateral2D4AverageElementSizeDerivatives, KratosCoreFastSuite)
+        {
+            Geometry<NodeType>::PointsArrayType nodes;
+            nodes.push_back(NodeType::Pointer(new NodeType(1, 0.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(2, 1.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(3, 1.0, 1.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(4, 0.0, 1.0, 0.0)));
+            auto geometry = *GeometryType::Pointer(new Quadrilateral2D4<NodeType>(nodes));
+            RunElementSizeCalculatorDerivativesTest(
+                geometry, ElementSizeCalculator<2, 4>::AverageElementSize,
+                ElementSizeCalculator<2, 4>::AverageElementSizeDerivative, 1e-8, 1e-7);
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4MinimumElementSizeDerivatives, KratosCoreFastSuite)
+        {
+            Geometry<NodeType>::PointsArrayType nodes;
+            nodes.push_back(NodeType::Pointer(new NodeType(1, 0.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(2, 1.0, 2.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(3, 0.5, 0.5, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(4, 0.2, 0.3, 1.0)));
+            auto geometry = *GeometryType::Pointer(new Tetrahedra3D4<NodeType>(nodes));
+            RunElementSizeCalculatorDerivativesTest(
+                geometry, ElementSizeCalculator<3, 4>::MinimumElementSize,
+                ElementSizeCalculator<3, 4>::MinimumElementSizeDerivative, 1e-8, 1e-7);
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4AverageElementSizeDerivatives, KratosCoreFastSuite)
+        {
+            Geometry<NodeType>::PointsArrayType nodes;
+            nodes.push_back(NodeType::Pointer(new NodeType(1, 0.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(2, 1.0, 2.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(3, 0.5, 0.5, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(4, 0.2, 0.3, 1.0)));
+            auto geometry = *GeometryType::Pointer(new Tetrahedra3D4<NodeType>(nodes));
+            RunElementSizeCalculatorDerivativesTest(
+                geometry, ElementSizeCalculator<3, 4>::AverageElementSize,
+                ElementSizeCalculator<3, 4>::AverageElementSizeDerivative, 1e-8, 1e-7);
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(Prism3D6MinimumElementSizeDerivatives, KratosCoreFastSuite)
+        {
+            Geometry<NodeType>::PointsArrayType nodes;
+            nodes.push_back(NodeType::Pointer(new NodeType(1, 0.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(2, 1.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(3, 0.0, 1.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(4, 0.0, 0.0, 1.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(5, 1.0, 0.0, 1.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(6, 0.0, 1.0, 1.0)));
+            auto geometry = *GeometryType::Pointer(new Prism3D6<NodeType>(nodes));
+            RunElementSizeCalculatorDerivativesTest(
+                geometry, ElementSizeCalculator<3, 6>::MinimumElementSize,
+                ElementSizeCalculator<3, 6>::MinimumElementSizeDerivative, 1e-8, 1e-7);
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(Prism3D6AverageElementSizeDerivatives, KratosCoreFastSuite)
+        {
+            Geometry<NodeType>::PointsArrayType nodes;
+            nodes.push_back(NodeType::Pointer(new NodeType(1, 0.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(2, 1.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(3, 0.0, 1.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(4, 0.0, 0.0, 1.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(5, 1.0, 0.0, 1.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(6, 0.0, 1.0, 1.0)));
+            auto geometry = *GeometryType::Pointer(new Prism3D6<NodeType>(nodes));
+            RunElementSizeCalculatorDerivativesTest(
+                geometry, ElementSizeCalculator<3, 6>::AverageElementSize,
+                ElementSizeCalculator<3, 6>::AverageElementSizeDerivative, 1e-8, 1e-7);
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8MinimumElementSizeDerivatives, KratosCoreFastSuite)
+        {
+            Geometry<NodeType>::PointsArrayType nodes;
+            nodes.push_back(NodeType::Pointer(new NodeType(1, 0.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(2, 1.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(3, 1.0, 1.1, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(4, 0.0, 1.1, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(5, 0.1, 0.1, 0.5)));
+            nodes.push_back(NodeType::Pointer(new NodeType(6, 0.7, 0.1, 0.4)));
+            nodes.push_back(NodeType::Pointer(new NodeType(7, 0.7, 0.8, 0.3)));
+            nodes.push_back(NodeType::Pointer(new NodeType(8, 0.1, 0.8, 0.6)));
+            auto geometry = *GeometryType::Pointer(new Hexahedra3D8<NodeType>(nodes));
+            RunElementSizeCalculatorDerivativesTest(
+                geometry, ElementSizeCalculator<3, 8>::MinimumElementSize,
+                ElementSizeCalculator<3, 8>::MinimumElementSizeDerivative, 1e-8, 1e-7);
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8AverageElementSizeDerivatives, KratosCoreFastSuite)
+        {
+            Geometry<NodeType>::PointsArrayType nodes;
+            nodes.push_back(NodeType::Pointer(new NodeType(1, 0.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(2, 1.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(3, 1.0, 1.1, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(4, 0.0, 1.1, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(5, 0.1, 0.1, 0.5)));
+            nodes.push_back(NodeType::Pointer(new NodeType(6, 0.7, 0.1, 0.4)));
+            nodes.push_back(NodeType::Pointer(new NodeType(7, 0.7, 0.8, 0.3)));
+            nodes.push_back(NodeType::Pointer(new NodeType(8, 0.1, 0.8, 0.6)));
+            auto geometry = *GeometryType::Pointer(new Hexahedra3D8<NodeType>(nodes));
+            RunElementSizeCalculatorDerivativesTest(
+                geometry, ElementSizeCalculator<3, 8>::AverageElementSize,
+                ElementSizeCalculator<3, 8>::AverageElementSizeDerivative, 1e-8, 1e-7);
         }
 
     } // namespace Testing

--- a/kratos/utilities/element_size_calculator.cpp
+++ b/kratos/utilities/element_size_calculator.cpp
@@ -50,6 +50,71 @@ double ElementSizeCalculator<2,3>::MinimumElementSize(const Geometry<Node<3> >& 
 
     return std::sqrt(Hsq);
 }
+// Triangle2D3 version.
+template<>
+double ElementSizeCalculator<2,3>::MinimumElementSizeDerivative(
+    const unsigned int DerivativeNodeIndex,
+    const unsigned int DerivativeDirectionIndex,
+    const Geometry<Node<3> >& rGeometry)
+{
+    KRATOS_TRY
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeNodeIndex > 2)
+        << "Invalid DerivativeNodeIndex [ DerivativeNodeIndex = " << DerivativeNodeIndex
+        << ", expected DerivativeNodeIndex < 3 ].\n";
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeDirectionIndex > 1)
+        << "Invalid DerivativeDirectionIndex [ DerivativeDirectionIndex = " << DerivativeDirectionIndex
+        << ", expected DerivativeDirectionIndex < 2 ].\n";
+
+    /* Calculate node-edge distances */
+    const double x10 = rGeometry[1].X() - rGeometry[0].X();
+    const double x10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 0);
+
+    const double y10 = rGeometry[1].Y() - rGeometry[0].Y();
+    const double y10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 1);
+
+    const double x20 = rGeometry[2].X() - rGeometry[0].X();
+    const double x20_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 2, 0, 0);
+
+    const double y20 = rGeometry[2].Y() - rGeometry[0].Y();
+    const double y20_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 2, 0, 1);
+
+    // node 0, edge 12
+    double nx = -(y20-y10);
+    double nx_derivative = -(y20_derivative - y10_derivative);
+    double ny = x20-x10;
+    double ny_derivative = x20_derivative - x10_derivative;
+    double Hsq = x10*nx + y10*ny;
+    Hsq *= Hsq / (nx*nx + ny*ny);
+    double Hsq_derivative = HsqDerivative2D(x10, x10_derivative, nx, nx_derivative, y10, y10_derivative, ny, ny_derivative);
+
+    // node 1, edge 20
+    nx = -y20;
+    nx_derivative = -y20_derivative;
+    ny = x20;
+    ny_derivative = x20_derivative;
+    double hsq = x10*nx + y10*ny;
+    hsq *= hsq / (nx*nx + ny*ny);
+    double hsq_derivative = HsqDerivative2D(x10, x10_derivative, nx, nx_derivative, y10, y10_derivative, ny, ny_derivative);
+    Hsq_derivative = (hsq < Hsq) ? hsq_derivative : Hsq_derivative;
+    Hsq = ( hsq < Hsq ) ? hsq : Hsq;
+
+    // node 2, edge 10
+    nx = -y10;
+    nx_derivative = -y10_derivative;
+    ny = x10;
+    ny_derivative = x10_derivative;
+    hsq = x20*nx + y20*ny;
+    hsq *= hsq / (nx*nx + ny*ny);
+    hsq_derivative = HsqDerivative2D(x20, x20_derivative, nx, nx_derivative, y20, y20_derivative, ny, ny_derivative);
+    Hsq_derivative = (hsq < Hsq) ? hsq_derivative : Hsq_derivative;
+    Hsq = ( hsq < Hsq ) ? hsq : Hsq;
+
+    return 0.5 * Hsq_derivative / std::sqrt(Hsq);
+
+    KRATOS_CATCH("");
+}
 
 // Quadrilateral2D4 version.
 template<>
@@ -89,6 +154,80 @@ double ElementSizeCalculator<2,4>::MinimumElementSize(const Geometry<Node<3> >& 
     const double h2 = h2_xi < h2_eta ? h2_xi : h2_eta;
 
     return std::sqrt(h2);
+}
+
+template<>
+double ElementSizeCalculator<2,4>::MinimumElementSizeDerivative(
+    const unsigned int DerivativeNodeIndex,
+    const unsigned int DerivativeDirectionIndex,
+    const Geometry<Node<3> >& rGeometry)
+{
+    KRATOS_TRY
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeNodeIndex > 3)
+        << "Invalid DerivativeNodeIndex [ DerivativeNodeIndex = " << DerivativeNodeIndex
+        << ", expected DerivativeNodeIndex < 4 ].\n";
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeDirectionIndex > 1)
+        << "Invalid DerivativeDirectionIndex [ DerivativeDirectionIndex = " << DerivativeDirectionIndex
+        << ", expected DerivativeDirectionIndex < 2 ].\n";
+
+    const Node<3>& r_node_0 = rGeometry[0];
+    const Node<3>& r_node_1 = rGeometry[1];
+    const Node<3>& r_node_2 = rGeometry[2];
+    const Node<3>& r_node_3 = rGeometry[3];
+
+    // Calculate face centers
+    const double x10 = (r_node_1.X() + r_node_3.X())/2.;
+    const double x10_derivative = ((DerivativeNodeIndex == 1) + (DerivativeNodeIndex == 3)) * (DerivativeDirectionIndex == 0) / 2.;
+
+    const double y10 = (r_node_1.Y() + r_node_3.Y())/2.;
+    const double y10_derivative = ((DerivativeNodeIndex == 1) + (DerivativeNodeIndex == 3)) * (DerivativeDirectionIndex == 1) / 2.;
+
+    const double x21 = (r_node_2.X() + r_node_1.X())/2.;
+    const double x21_derivative = ((DerivativeNodeIndex == 2) + (DerivativeNodeIndex == 1)) * (DerivativeDirectionIndex == 0) / 2.;
+
+    const double y21 = (r_node_2.Y() + r_node_1.Y())/2.;
+    const double y21_derivative = ((DerivativeNodeIndex == 2) + (DerivativeNodeIndex == 1)) * (DerivativeDirectionIndex == 1) / 2.;
+
+    const double x32 = (r_node_3.X() + r_node_2.X())/2.;
+    const double x32_derivative = ((DerivativeNodeIndex == 3) + (DerivativeNodeIndex == 2)) * (DerivativeDirectionIndex == 0) / 2.;
+
+    const double y32 = (r_node_3.Y() + r_node_2.Y())/2.;
+    const double y32_derivative = ((DerivativeNodeIndex == 3) + (DerivativeNodeIndex == 2)) * (DerivativeDirectionIndex == 1) / 2.;
+
+    const double x03 = (r_node_0.X() + r_node_3.X())/2.;
+    const double x03_derivative = ((DerivativeNodeIndex == 0) + (DerivativeNodeIndex == 3)) * (DerivativeDirectionIndex == 0) / 2.;
+
+    const double y03 = (r_node_0.Y() + r_node_3.Y())/2.;
+    const double y03_derivative = ((DerivativeNodeIndex == 0) + (DerivativeNodeIndex == 3)) * (DerivativeDirectionIndex == 1) / 2.;
+
+    // Distance between face centers (xi direction)
+    const double dxi_x = x21 - x03;
+    const double dxi_x_derivative = x21_derivative - x03_derivative;
+
+    const double dxi_y = y21 - y03;
+    const double dxi_y_derivative = y21_derivative - y03_derivative;
+
+    const double h2_xi = dxi_x*dxi_x + dxi_y*dxi_y;
+    const double h2_xi_derivative = 2 * dxi_x * dxi_x_derivative + 2 * dxi_y * dxi_y_derivative;
+
+    // Distance between face centers (eta direction)
+    const double deta_x = x32 - x10;
+    const double deta_x_derivative = x32_derivative - x10_derivative;
+
+    const double deta_y = y32 - y10;
+    const double deta_y_derivative = y32_derivative - y10_derivative;
+
+    const double h2_eta = deta_x*deta_x + deta_y*deta_y;
+    const double h2_eta_derivative = 2 * deta_x * deta_x_derivative + 2 * deta_y * deta_y_derivative;
+
+    const double h2 = h2_xi < h2_eta ? h2_xi : h2_eta;
+    const double h2_derivative = h2_xi < h2_eta ? h2_xi_derivative : h2_eta_derivative;
+
+    return 0.5 * h2_derivative / std::sqrt(h2);
+
+    KRATOS_CATCH("");
 }
 
 // Tetrahedra3D4 version.
@@ -140,6 +279,108 @@ double ElementSizeCalculator<3,4>::MinimumElementSize(const Geometry<Node<3> >& 
     hsq *= hsq / (nx*nx + ny*ny + nz*nz);
     Hsq = (hsq < Hsq) ? hsq : Hsq;
     return std::sqrt(Hsq);
+}
+
+template<>
+double ElementSizeCalculator<3,4>::MinimumElementSizeDerivative(
+    const unsigned int DerivativeNodeIndex,
+    const unsigned int DerivativeDirectionIndex,
+    const Geometry<Node<3> >& rGeometry)
+{
+    KRATOS_TRY
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeNodeIndex > 3)
+        << "Invalid DerivativeNodeIndex [ DerivativeNodeIndex = " << DerivativeNodeIndex
+        << ", expected DerivativeNodeIndex < 4 ].\n";
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeDirectionIndex > 2)
+        << "Invalid DerivativeDirectionIndex [ DerivativeDirectionIndex = " << DerivativeDirectionIndex
+        << ", expected DerivativeDirectionIndex < 3 ].\n";
+
+    /* Calculate distances between each node and the opposite face */
+    const double x10 = rGeometry[1].X() - rGeometry[0].X();
+    const double x10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 0);
+
+    const double y10 = rGeometry[1].Y() - rGeometry[0].Y();
+    const double y10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 1);
+
+    const double z10 = rGeometry[1].Z() - rGeometry[0].Z();
+    const double z10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 2);
+
+    const double x20 = rGeometry[2].X() - rGeometry[0].X();
+    const double x20_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 2, 0, 0);
+
+    const double y20 = rGeometry[2].Y() - rGeometry[0].Y();
+    const double y20_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 2, 0, 1);
+
+    const double z20 = rGeometry[2].Z() - rGeometry[0].Z();
+    const double z20_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 2, 0, 2);
+
+    const double x30 = rGeometry[3].X() - rGeometry[0].X();
+    const double x30_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 3, 0, 0);
+
+    const double y30 = rGeometry[3].Y() - rGeometry[0].Y();
+    const double y30_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 3, 0, 1);
+
+    const double z30 = rGeometry[3].Z() - rGeometry[0].Z();
+    const double z30_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 3, 0, 2);
+
+    // face 123
+    double nx = (y30-y10)*(z20-z10) - (z30-z10)*(y20-y10);
+    double nx_derivative = (y30_derivative-y10_derivative)*(z20-z10)+(y30-y10)*(z20_derivative-z10_derivative);
+    nx_derivative -= ((z30_derivative-z10_derivative)*(y20-y10)+(z30-z10)*(y20_derivative-y10_derivative));
+    double ny = (z30-z10)*(x20-x10) - (x30-x10)*(z20-z10);
+    double ny_derivative = (z30_derivative-z10_derivative)*(x20-x10) + (z30-z10)*(x20_derivative-x10_derivative);
+    ny_derivative -= ((x30_derivative-x10_derivative)*(z20-z10) + (x30-x10)*(z20_derivative-z10_derivative));
+    double nz = (x30-x10)*(y20-y10) - (y30-y10)*(x20-x10);
+    double nz_derivative = (x30_derivative-x10_derivative)*(y20-y10) + (x30-x10)*(y20_derivative-y10_derivative);
+    nz_derivative -= ((y30_derivative-y10_derivative)*(x20-x10) + (y30-y10)*(x20_derivative-x10_derivative));
+    double Hsq = x10*nx + y10*ny + z10*nz; // scalar product x10*n
+    Hsq *= Hsq / (nx*nx + ny*ny + nz*nz); // H^2 = (x10*n)^2 / ||n||^2
+    double Hsq_derivative = HsqDerivative3D(x10, x10_derivative, nx, nx_derivative, y10, y10_derivative, ny, ny_derivative, z10, z10_derivative, nz, nz_derivative);
+
+    // face 230
+    nx = y30*z20 - z30*y20;
+    nx_derivative = y30_derivative*z20+y30*z20_derivative-z30_derivative*y20-z30*y20_derivative;
+    ny = z30*x20 - x30*z20;
+    ny_derivative = z30_derivative*x20+z30*x20_derivative-x30_derivative*z20-x30*z20_derivative;
+    nz = x30*y20 - y30*x20;
+    nz_derivative = x30_derivative*y20+x30*y20_derivative-y30_derivative*x20-y30*x20_derivative;
+    double hsq = x10*nx + y10*ny + z10*nz;
+    hsq *= hsq / (nx*nx + ny*ny + nz*nz);
+    double hsq_derivative = HsqDerivative3D(x10, x10_derivative, nx, nx_derivative, y10, y10_derivative, ny, ny_derivative, z10, z10_derivative, nz, nz_derivative);
+    Hsq_derivative = (hsq < Hsq) ? hsq_derivative : Hsq_derivative;
+    Hsq = (hsq < Hsq) ? hsq : Hsq;
+
+    // face 301
+    nx = y10*z30 - z10*y30;
+    nx_derivative = y10_derivative*z30+y10*z30_derivative-z10_derivative*y30-z10*y30_derivative;
+    ny = z10*x30 - x10*z30;
+    ny_derivative = z10_derivative*x30+z10*x30_derivative-x10_derivative*z30-x10*z30_derivative;
+    nz = x10*y30 - y10*x30;
+    nz_derivative = x10_derivative*y30+x10*y30_derivative-y10_derivative*x30-y10*x30_derivative;
+    hsq = x20*nx + y20*ny + z20*nz;
+    hsq *= hsq / (nx*nx + ny*ny + nz*nz);
+    hsq_derivative = HsqDerivative3D(x20, x20_derivative, nx, nx_derivative, y20, y20_derivative, ny, ny_derivative, z20, z20_derivative, nz, nz_derivative);
+    Hsq_derivative = (hsq < Hsq) ? hsq_derivative : Hsq_derivative;
+    Hsq = (hsq < Hsq) ? hsq : Hsq;
+
+    // face 012
+    nx = y10*z20 - z10*y20;
+    nx_derivative = y10_derivative*z20+y10*z20_derivative-z10_derivative*y20-z10*y20_derivative;
+    ny = z10*x20 - x10*z20;
+    ny_derivative = z10_derivative*x20+z10*x20_derivative-x10_derivative*z20-x10*z20_derivative;
+    nz = x10*y20 - y10*x20;
+    nz_derivative = x10_derivative*y20+x10*y20_derivative-y10_derivative*x20-y10*x20_derivative;
+    hsq = x30*nx + y30*ny + z30*nz;
+    hsq *= hsq / (nx*nx + ny*ny + nz*nz);
+    hsq_derivative = HsqDerivative3D(x30, x30_derivative, nx, nx_derivative, y30, y30_derivative, ny, ny_derivative, z30, z30_derivative, nz, nz_derivative);
+    Hsq_derivative = (hsq < Hsq) ? hsq_derivative : Hsq_derivative;
+    Hsq = (hsq < Hsq) ? hsq : Hsq;
+
+    return 0.5 * Hsq_derivative / std::sqrt(Hsq);
+
+    KRATOS_CATCH("");
 }
 
 // Prism3D6 version.
@@ -194,6 +435,94 @@ double ElementSizeCalculator<3,6>::MinimumElementSize(const Geometry<Node<3>> &r
     return std::sqrt(h2);
 }
 
+template<>
+double ElementSizeCalculator<3,6>::MinimumElementSizeDerivative(
+    const unsigned int DerivativeNodeIndex,
+    const unsigned int DerivativeDirectionIndex,
+    const Geometry<Node<3> >& rGeometry)
+{
+    KRATOS_TRY
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeNodeIndex > 5)
+        << "Invalid DerivativeNodeIndex [ DerivativeNodeIndex = " << DerivativeNodeIndex
+        << ", expected DerivativeNodeIndex < 6 ].\n";
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeDirectionIndex > 2)
+        << "Invalid DerivativeDirectionIndex [ DerivativeDirectionIndex = " << DerivativeDirectionIndex
+        << ", expected DerivativeDirectionIndex < 3 ].\n";
+
+    // Get nodes
+    const Node<3>& r_node_0 = rGeometry[0];
+    const Node<3>& r_node_1 = rGeometry[1];
+    const Node<3>& r_node_2 = rGeometry[2];
+    const Node<3>& r_node_3 = rGeometry[3];
+    const Node<3>& r_node_4 = rGeometry[4];
+    const Node<3>& r_node_5 = rGeometry[5];
+
+    // Calculate face centers (top and bottom face)
+    const double one_third = 1.0/3.0;
+    const array_1d<double,3> low_dseta = one_third * (r_node_0.Coordinates() + r_node_1.Coordinates() + r_node_2.Coordinates() );
+    array_1d<double,3> low_dseta_derivative = ZeroVector(3);
+    low_dseta_derivative[DerivativeDirectionIndex] = one_third * (DerivativeNodeIndex < 3);
+    const array_1d<double,3> high_dseta = one_third * (r_node_3.Coordinates() + r_node_4.Coordinates() + r_node_5.Coordinates() );
+    array_1d<double,3> high_dseta_derivative = ZeroVector(3);
+    high_dseta_derivative[DerivativeDirectionIndex] = one_third * (DerivativeNodeIndex > 2);
+
+    // Calculate node-edge distances (top face)
+    const double x10 = r_node_1.X() - r_node_0.X();
+    const double x10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 0);
+    const double y10 = r_node_1.Y() - r_node_0.Y();
+    const double y10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 1);
+    const double x20 = r_node_2.X() - r_node_0.X();
+    const double x20_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 2, 0, 0);
+    const double y20 = r_node_2.Y() - r_node_0.Y();
+    const double y20_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 2, 0, 1);
+
+    // node 0, edge 12
+    double nx = -(y20-y10);
+    double nx_derivative = -(y20_derivative-y10_derivative);
+    double ny = x20-x10;
+    double ny_derivative = x20_derivative-x10_derivative;
+    double Hsq = x10*nx + y10*ny;
+    Hsq *= Hsq / (nx*nx + ny*ny);
+    double Hsq_derivative = HsqDerivative2D(x10, x10_derivative, nx, nx_derivative, y10, y10_derivative, ny, ny_derivative);
+
+    // node 1, edge 20
+    nx = -y20;
+    nx_derivative = -y20_derivative;
+    ny = x20;
+    ny_derivative = x20_derivative;
+    double hsq = x10*nx + y10*ny;
+    hsq *= hsq / (nx*nx + ny*ny);
+    double hsq_derivative = HsqDerivative2D(x10, x10_derivative, nx, nx_derivative, y10, y10_derivative, ny, ny_derivative);
+    Hsq_derivative = (hsq < Hsq) ? hsq_derivative : Hsq_derivative;
+    Hsq = ( hsq < Hsq ) ? hsq : Hsq;
+
+    // node 2, edge 10
+    nx = -y10;
+    nx_derivative = -y10_derivative;
+    ny = x10;
+    ny_derivative = x10_derivative;
+    hsq = x20*nx + y20*ny;
+    hsq *= hsq / (nx*nx + ny*ny);
+    hsq_derivative = HsqDerivative2D(x20, x20_derivative, nx, nx_derivative, y20, y20_derivative, ny, ny_derivative);
+    Hsq_derivative = ( hsq < Hsq ) ? hsq_derivative : Hsq_derivative;
+    Hsq = ( hsq < Hsq ) ? hsq : Hsq;
+
+    // Calculate distance between the face centers (dseta direction)
+    const array_1d<double,3> d_dseta = high_dseta - low_dseta;
+    const array_1d<double,3> d_dseta_derivative = high_dseta_derivative - low_dseta_derivative;
+    const double h2_dseta = d_dseta[0]*d_dseta[0] + d_dseta[1]*d_dseta[1] + d_dseta[2]*d_dseta[2];
+    const double h2_dseta_derivative = NormSquareDerivative(d_dseta, d_dseta_derivative);
+
+    const double h2 = h2_dseta < Hsq?h2_dseta:Hsq;
+    const double h2_derivative = (h2_dseta < Hsq) ? h2_dseta_derivative : Hsq_derivative;
+
+    return 0.5 * h2_derivative / std::sqrt(h2);
+
+    KRATOS_CATCH("");
+}
+
 // Hexahedra3D8 version. We use the distance between face centers to compute lengths.
 template<>
 double ElementSizeCalculator<3,8>::MinimumElementSize(const Geometry<Node<3> >& rGeometry)
@@ -234,6 +563,84 @@ double ElementSizeCalculator<3,8>::MinimumElementSize(const Geometry<Node<3> >& 
     return std::sqrt(h2);
 }
 
+template<>
+double ElementSizeCalculator<3,8>::MinimumElementSizeDerivative(
+    const unsigned int DerivativeNodeIndex,
+    const unsigned int DerivativeDirectionIndex,
+    const Geometry<Node<3> >& rGeometry)
+{
+    KRATOS_TRY
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeNodeIndex > 7)
+        << "Invalid DerivativeNodeIndex [ DerivativeNodeIndex = " << DerivativeNodeIndex
+        << ", expected DerivativeNodeIndex < 8 ].\n";
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeDirectionIndex > 2)
+        << "Invalid DerivativeDirectionIndex [ DerivativeDirectionIndex = " << DerivativeDirectionIndex
+        << ", expected DerivativeDirectionIndex < 3 ].\n";
+
+    const Node<3>& r_node_0 = rGeometry[0];
+    const Node<3>& r_node_1 = rGeometry[1];
+    const Node<3>& r_node_2 = rGeometry[2];
+    const Node<3>& r_node_3 = rGeometry[3];
+    const Node<3>& r_node_4 = rGeometry[4];
+    const Node<3>& r_node_5 = rGeometry[5];
+    const Node<3>& r_node_6 = rGeometry[6];
+    const Node<3>& r_node_7 = rGeometry[7];
+
+    const auto derivative_output = [&](const unsigned int A, const unsigned int B, const unsigned int C, const unsigned int D) -> array_1d<double, 3> {
+        array_1d<double, 3> result = ZeroVector(3);
+        result[DerivativeDirectionIndex] = 0.25 * ((DerivativeNodeIndex == A) || (DerivativeNodeIndex == B) || (DerivativeNodeIndex == C) || (DerivativeNodeIndex == D));
+        return result;
+    };
+
+    // Calculate face centers
+    const array_1d<double,3> low_xi  = 0.25 * (r_node_0.Coordinates() + r_node_4.Coordinates() + r_node_3.Coordinates() + r_node_7.Coordinates());
+    const array_1d<double,3> low_xi_derivative = derivative_output(0, 4, 3, 7);
+
+    const array_1d<double,3> high_xi = 0.25 * (r_node_1.Coordinates() + r_node_2.Coordinates() + r_node_6.Coordinates() + r_node_5.Coordinates());
+    const array_1d<double,3> high_xi_derivative = derivative_output(1, 2, 6, 5);
+
+    const array_1d<double,3> low_eta  = 0.25 * (r_node_0.Coordinates() + r_node_1.Coordinates() + r_node_5.Coordinates() + r_node_4.Coordinates());
+    const array_1d<double,3> low_eta_derivative = derivative_output(0, 1, 5, 4);
+
+    const array_1d<double,3> high_eta = 0.25 * (r_node_3.Coordinates() + r_node_7.Coordinates() + r_node_6.Coordinates() + r_node_2.Coordinates());
+    const array_1d<double,3> high_eta_derivative = derivative_output(3, 7, 6, 2);
+
+    const array_1d<double,3> low_dseta  = 0.25 * (r_node_0.Coordinates() + r_node_3.Coordinates() + r_node_2.Coordinates() + r_node_1.Coordinates());
+    const array_1d<double,3> low_dseta_derivative = derivative_output(0, 3, 2, 1);
+
+    const array_1d<double,3> high_dseta = 0.25 * (r_node_4.Coordinates() + r_node_5.Coordinates() + r_node_6.Coordinates() + r_node_7.Coordinates());
+    const array_1d<double,3> high_dseta_derivative = derivative_output(4, 5, 6, 7);
+
+    // Distance between face centers (xi direction)
+    const array_1d<double,3> d_xi = high_xi - low_xi;
+    const array_1d<double,3> d_xi_derivative = high_xi_derivative - low_xi_derivative;
+    const double h2_xi = d_xi[0]*d_xi[0] + d_xi[1]*d_xi[1] + d_xi[2]*d_xi[2];
+    const double h2_xi_derivative = NormSquareDerivative(d_xi, d_xi_derivative);
+
+    // Distance between face centers (eta direction)
+    const array_1d<double,3> d_eta = high_eta - low_eta;
+    const array_1d<double,3> d_eta_derivative = high_eta_derivative - low_eta_derivative;
+    const double h2_eta = d_eta[0]*d_eta[0] + d_eta[1]*d_eta[1] + d_eta[2]*d_eta[2];
+    const double h2_eta_derivative = NormSquareDerivative(d_eta, d_eta_derivative);
+
+    // Distance between face centers (dseta direction)
+    const array_1d<double,3> d_dseta = high_dseta - low_dseta;
+    const array_1d<double,3> d_dseta_derivative = high_dseta_derivative - low_dseta_derivative;
+    const double h2_dseta = d_dseta[0]*d_dseta[0] + d_dseta[1]*d_dseta[1] + d_dseta[2]*d_dseta[2];
+    const double h2_dseta_derivative = NormSquareDerivative(d_dseta, d_dseta_derivative);
+
+    double h2 = h2_xi < h2_eta ? h2_xi : h2_eta;
+    double h2_derivative = h2_xi < h2_eta ? h2_xi_derivative : h2_eta_derivative;
+    h2_derivative = h2 < h2_dseta ? h2_derivative : h2_dseta_derivative;
+    h2 = h2 < h2_dseta ? h2 : h2_dseta;
+
+    return 0.5 * h2_derivative / std::sqrt(h2);
+
+    KRATOS_CATCH("");
+}
+
 // Triangle2D3 version.
 template<>
 double ElementSizeCalculator<2,3>::AverageElementSize(const Geometry<Node<3> >& rGeometry)
@@ -248,6 +655,39 @@ double ElementSizeCalculator<2,3>::AverageElementSize(const Geometry<Node<3> >& 
     return std::sqrt(0.5 * (x10*y20-x20*y10) );
 }
 
+template<>
+double ElementSizeCalculator<2,3>::AverageElementSizeDerivative(
+    const unsigned int DerivativeNodeIndex,
+    const unsigned int DerivativeDirectionIndex,
+    const Geometry<Node<3> >& rGeometry)
+{
+    KRATOS_TRY
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeNodeIndex > 2)
+        << "Invalid DerivativeNodeIndex [ DerivativeNodeIndex = " << DerivativeNodeIndex
+        << ", expected DerivativeNodeIndex < 3 ].\n";
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeDirectionIndex > 1)
+        << "Invalid DerivativeDirectionIndex [ DerivativeDirectionIndex = " << DerivativeDirectionIndex
+        << ", expected DerivativeDirectionIndex < 2 ].\n";
+
+    const double x10 = rGeometry[1].X() - rGeometry[0].X();
+    const double x10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 0);
+
+    const double y10 = rGeometry[1].Y() - rGeometry[0].Y();
+    const double y10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 1);
+
+    const double x20 = rGeometry[2].X() - rGeometry[0].X();
+    const double x20_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 2, 0, 0);
+
+    const double y20 = rGeometry[2].Y() - rGeometry[0].Y();
+    const double y20_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 2, 0, 1);
+
+    return 0.5 * 0.5 * (x10_derivative*y20+x10*y20_derivative-x20_derivative*y10-x20*y10_derivative) / std::sqrt(0.5 * (x10*y20-x20*y10) );
+
+    KRATOS_CATCH("");
+}
+
 // Quadrilateral2D4 version.
 template<>
 double ElementSizeCalculator<2,4>::AverageElementSize(const Geometry<Node<3> >& rGeometry)
@@ -260,6 +700,39 @@ double ElementSizeCalculator<2,4>::AverageElementSize(const Geometry<Node<3> >& 
     const double y30 = rGeometry[3].Y() - rGeometry[0].Y();
 
     return std::sqrt(x10*y30-x30*y10);
+}
+
+template<>
+double ElementSizeCalculator<2,4>::AverageElementSizeDerivative(
+    const unsigned int DerivativeNodeIndex,
+    const unsigned int DerivativeDirectionIndex,
+    const Geometry<Node<3> >& rGeometry)
+{
+    KRATOS_TRY
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeNodeIndex > 3)
+        << "Invalid DerivativeNodeIndex [ DerivativeNodeIndex = " << DerivativeNodeIndex
+        << ", expected DerivativeNodeIndex < 4 ].\n";
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeDirectionIndex > 1)
+        << "Invalid DerivativeDirectionIndex [ DerivativeDirectionIndex = " << DerivativeDirectionIndex
+        << ", expected DerivativeDirectionIndex < 2 ].\n";
+
+    const double x10 = rGeometry[1].X() - rGeometry[0].X();
+    const double x10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 0);
+
+    const double y10 = rGeometry[1].Y() - rGeometry[0].Y();
+    const double y10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 1);
+
+    const double x30 = rGeometry[3].X() - rGeometry[0].X();
+    const double x30_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 3, 0, 0);
+
+    const double y30 = rGeometry[3].Y() - rGeometry[0].Y();
+    const double y30_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 3, 0, 1);
+
+    return 0.5 * (x10_derivative*y30+x10*y30_derivative-x30_derivative*y10-x30*y10_derivative) / (x10*y30-x30*y10);
+
+    KRATOS_CATCH("");
 }
 
 // Tetrahedra3D4 version.
@@ -284,6 +757,76 @@ double ElementSizeCalculator<3,4>::AverageElementSize(const Geometry<Node<3> >& 
     return std::pow(detJ/6.0,1./3.);
 }
 
+template<>
+double ElementSizeCalculator<3,4>::AverageElementSizeDerivative(
+    const unsigned int DerivativeNodeIndex,
+    const unsigned int DerivativeDirectionIndex,
+    const Geometry<Node<3> >& rGeometry)
+{
+    KRATOS_TRY
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeNodeIndex > 3)
+        << "Invalid DerivativeNodeIndex [ DerivativeNodeIndex = " << DerivativeNodeIndex
+        << ", expected DerivativeNodeIndex < 4 ].\n";
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeDirectionIndex > 2)
+        << "Invalid DerivativeDirectionIndex [ DerivativeDirectionIndex = " << DerivativeDirectionIndex
+        << ", expected DerivativeDirectionIndex < 3 ].\n";
+
+    const double x10 = rGeometry[1].X() - rGeometry[0].X();
+    const double x10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 0);
+
+    const double y10 = rGeometry[1].Y() - rGeometry[0].Y();
+    const double y10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 1);
+
+    const double z10 = rGeometry[1].Z() - rGeometry[0].Z();
+    const double z10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 2);
+
+    const double x20 = rGeometry[2].X() - rGeometry[0].X();
+    const double x20_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 2, 0, 0);
+
+    const double y20 = rGeometry[2].Y() - rGeometry[0].Y();
+    const double y20_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 2, 0, 1);
+
+    const double z20 = rGeometry[2].Z() - rGeometry[0].Z();
+    const double z20_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 2, 0, 2);
+
+    const double x30 = rGeometry[3].X() - rGeometry[0].X();
+    const double x30_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 3, 0, 0);
+
+    const double y30 = rGeometry[3].Y() - rGeometry[0].Y();
+    const double y30_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 3, 0, 1);
+
+    const double z30 = rGeometry[3].Z() - rGeometry[0].Z();
+    const double z30_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 3, 0, 2);
+
+
+    const double detJ = x10 * y20 * z30 - x10 * y30 * z20 + y10 * z20 * x30 - y10 * x20 * z30 + z10 * x20 * y30 - z10 * y20 * x30;
+    double detJ_derivative = 0.0;
+    detJ_derivative += x10_derivative * y20 * z30;
+    detJ_derivative += x10 * y20_derivative * z30;
+    detJ_derivative += x10 * y20 * z30_derivative;
+    detJ_derivative -= x10_derivative * y30 * z20;
+    detJ_derivative -= x10 * y30_derivative * z20;
+    detJ_derivative -= x10 * y30 * z20_derivative;
+    detJ_derivative += y10_derivative * z20 * x30;
+    detJ_derivative += y10 * z20_derivative * x30;
+    detJ_derivative += y10 * z20 * x30_derivative;
+    detJ_derivative -= y10_derivative * x20 * z30;
+    detJ_derivative -= y10 * x20_derivative * z30;
+    detJ_derivative -= y10 * x20 * z30_derivative;
+    detJ_derivative += z10_derivative * x20 * y30;
+    detJ_derivative += z10 * x20_derivative * y30;
+    detJ_derivative += z10 * x20 * y30_derivative;
+    detJ_derivative -= z10_derivative * y20 * x30;
+    detJ_derivative -= z10 * y20_derivative * x30;
+    detJ_derivative -= z10 * y20 * x30_derivative;
+
+    return (1./3.) * (detJ_derivative/6.0) / std::pow(detJ/6.0, 2.*3.);
+
+    KRATOS_CATCH("");
+}
+
 // Prism3D6 version
 template <>
 double ElementSizeCalculator<3,6>::AverageElementSize(const Geometry<Node<3>> &rGeometry)
@@ -302,6 +845,82 @@ double ElementSizeCalculator<3,6>::AverageElementSize(const Geometry<Node<3>> &r
 
     const double detJ = 0.5 * (x10 * y20 * z30 - x10 * y30 * z20 + y10 * z20 * x30 - y10 * x20 * z30 + z10 * x20 * y30 - z10 * y20 * x30);
     return std::pow(detJ, 1. / 3.);
+}
+
+template<>
+double ElementSizeCalculator<3,6>::AverageElementSizeDerivative(
+    const unsigned int DerivativeNodeIndex,
+    const unsigned int DerivativeDirectionIndex,
+    const Geometry<Node<3> >& rGeometry)
+{
+    KRATOS_TRY
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeNodeIndex > 5)
+        << "Invalid DerivativeNodeIndex [ DerivativeNodeIndex = " << DerivativeNodeIndex
+        << ", expected DerivativeNodeIndex < 6 ].\n";
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeDirectionIndex > 2)
+        << "Invalid DerivativeDirectionIndex [ DerivativeDirectionIndex = " << DerivativeDirectionIndex
+        << ", expected DerivativeDirectionIndex < 3 ].\n";
+
+    const double x10 = rGeometry[1].X() - rGeometry[0].X();
+    const double x10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 0);
+
+    const double y10 = rGeometry[1].Y() - rGeometry[0].Y();
+    const double y10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 1);
+
+    const double z10 = rGeometry[1].Z() - rGeometry[0].Z();
+    const double z10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 2);
+
+    const double x20 = rGeometry[2].X() - rGeometry[0].X();
+    const double x20_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 2, 0, 0);
+
+    const double y20 = rGeometry[2].Y() - rGeometry[0].Y();
+    const double y20_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 2, 0, 1);
+
+    const double z20 = rGeometry[2].Z() - rGeometry[0].Z();
+    const double z20_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 2, 0, 2);
+
+    const double x30 = rGeometry[3].X() - rGeometry[0].X();
+    const double x30_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 3, 0, 0);
+
+    const double y30 = rGeometry[3].Y() - rGeometry[0].Y();
+    const double y30_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 3, 0, 1);
+
+    const double z30 = rGeometry[3].Z() - rGeometry[0].Z();
+    const double z30_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 3, 0, 2);
+
+    const double detJ = 0.5 * (x10 * y20 * z30 - x10 * y30 * z20 + y10 * z20 * x30 - y10 * x20 * z30 + z10 * x20 * y30 - z10 * y20 * x30);
+    double detJ_derivative = 0.0;
+    detJ_derivative += x10_derivative * y20 * z30;
+    detJ_derivative += x10 * y20_derivative * z30;
+    detJ_derivative += x10 * y20 * z30_derivative;
+
+    detJ_derivative -= x10_derivative * y30 * z20;
+    detJ_derivative -= x10 * y30_derivative * z20;
+    detJ_derivative -= x10 * y30 * z20_derivative;
+
+    detJ_derivative += y10_derivative * z20 * x30;
+    detJ_derivative += y10 * z20_derivative * x30;
+    detJ_derivative += y10 * z20 * x30_derivative;
+
+    detJ_derivative -= y10_derivative * x20 * z30;
+    detJ_derivative -= y10 * x20_derivative * z30;
+    detJ_derivative -= y10 * x20 * z30_derivative;
+
+    detJ_derivative += z10_derivative * x20 * y30;
+    detJ_derivative += z10 * x20_derivative * y30;
+    detJ_derivative += z10 * x20 * y30_derivative;
+
+    detJ_derivative -= z10_derivative * y20 * x30;
+    detJ_derivative -= z10 * y20_derivative * x30;
+    detJ_derivative -= z10 * y20 * x30_derivative;
+
+    detJ_derivative *= 0.5;
+
+    return (1./3.) * detJ_derivative / std::pow(detJ, 2./3.);
+
+    KRATOS_CATCH("");
 }
 
 // Hexahedra3D8 version.
@@ -323,6 +942,75 @@ double ElementSizeCalculator<3,8>::AverageElementSize(const Geometry<Node<3> >& 
 
     const double detJ = x10 * y30 * z40 - x10 * y40 * z30 + y10 * z30 * x40 - y10 * x30 * z40 + z10 * x30 * y40 - z10 * y30 * x40;
     return std::pow(detJ,1./3.);
+}
+
+template<>
+double ElementSizeCalculator<3,8>::AverageElementSizeDerivative(
+    const unsigned int DerivativeNodeIndex,
+    const unsigned int DerivativeDirectionIndex,
+    const Geometry<Node<3> >& rGeometry)
+{
+    KRATOS_TRY
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeNodeIndex > 7)
+        << "Invalid DerivativeNodeIndex [ DerivativeNodeIndex = " << DerivativeNodeIndex
+        << ", expected DerivativeNodeIndex < 8 ].\n";
+
+    KRATOS_DEBUG_ERROR_IF(DerivativeDirectionIndex > 2)
+        << "Invalid DerivativeDirectionIndex [ DerivativeDirectionIndex = " << DerivativeDirectionIndex
+        << ", expected DerivativeDirectionIndex < 3 ].\n";
+
+    const double x10 = rGeometry[1].X() - rGeometry[0].X();
+    const double x10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 0);
+    const double y10 = rGeometry[1].Y() - rGeometry[0].Y();
+    const double y10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 1);
+    const double z10 = rGeometry[1].Z() - rGeometry[0].Z();
+    const double z10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 2);
+
+    const double x30 = rGeometry[3].X() - rGeometry[0].X();
+    const double x30_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 3, 0, 0);
+    const double y30 = rGeometry[3].Y() - rGeometry[0].Y();
+    const double y30_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 3, 0, 1);
+    const double z30 = rGeometry[3].Z() - rGeometry[0].Z();
+    const double z30_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 3, 0, 2);
+
+    const double x40 = rGeometry[4].X() - rGeometry[0].X();
+    const double x40_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 4, 0, 0);
+    const double y40 = rGeometry[4].Y() - rGeometry[0].Y();
+    const double y40_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 4, 0, 1);
+    const double z40 = rGeometry[4].Z() - rGeometry[0].Z();
+    const double z40_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 4, 0, 2);
+
+    const double detJ = x10 * y30 * z40 - x10 * y40 * z30 + y10 * z30 * x40 - y10 * x30 * z40 + z10 * x30 * y40 - z10 * y30 * x40;
+    double detJ_derivative = 0.0;
+
+    detJ_derivative += x10_derivative * y30 * z40;
+    detJ_derivative += x10 * y30_derivative * z40;
+    detJ_derivative += x10 * y30 * z40_derivative;
+
+    detJ_derivative -= x10_derivative * y40 * z30;
+    detJ_derivative -= x10 * y40_derivative * z30;
+    detJ_derivative -= x10 * y40 * z30_derivative;
+
+    detJ_derivative += y10_derivative * z30 * x40;
+    detJ_derivative += y10 * z30_derivative * x40;
+    detJ_derivative += y10 * z30 * x40_derivative;
+
+    detJ_derivative -= y10_derivative * x30 * z40;
+    detJ_derivative -= y10 * x30_derivative * z40;
+    detJ_derivative -= y10 * x30 * z40_derivative;
+
+    detJ_derivative += z10_derivative * x30 * y40;
+    detJ_derivative += z10 * x30_derivative * y40;
+    detJ_derivative += z10 * x30 * y40_derivative;
+
+    detJ_derivative -= z10_derivative * y30 * x40;
+    detJ_derivative -= z10 * y30_derivative * x40;
+    detJ_derivative -= z10 * y30 * x40_derivative;
+
+    return (1./3.) * detJ_derivative / std::pow(detJ, 2./3);
+
+    KRATOS_CATCH("");
 }
 
 // Triangle2D3 version.

--- a/kratos/utilities/element_size_calculator.h
+++ b/kratos/utilities/element_size_calculator.h
@@ -88,11 +88,33 @@ public:
      */
     static double MinimumElementSize(const Geometry<Node<3> >& rGeometry);
 
+    /// Minimum element size derivative based on the geometry
+    /** @param DerivativeNodeIndex NodeIndex for which the derivative is obtained
+     *  @param DerivativeDirectionIndex DirectionIndex for which the derivative is obtained
+     *  @param rGeometry The geometry of calling element
+     *  @return The derivative w.r.t. DerivativeNodeIndex and DerivativeDirectionIndex
+     */
+    static double MinimumElementSizeDerivative(
+        const unsigned int DerivativeNodeIndex,
+        const unsigned int DerivativeDirectionIndex,
+        const Geometry<Node<3> >& rGeometry);
+
     /// Average element size based on the geometry.
     /** @param rGeometry The geometry of calling element.
      *  @return The computed size.
      */
     static double AverageElementSize(const Geometry<Node<3> >& rGeometry);
+
+    /// Average element size derivative based on the geometry
+    /** @param DerivativeNodeIndex NodeIndex for which the derivative is obtained
+     *  @param DerivativeDirectionIndex DirectionIndex for which the derivative is obtained
+     *  @param rGeometry The geometry of calling element
+     *  @return The derivative w.r.t. DerivativeNodeIndex and DerivativeDirectionIndex
+     */
+    static double AverageElementSizeDerivative(
+        const unsigned int DerivativeNodeIndex,
+        const unsigned int DerivativeDirectionIndex,
+        const Geometry<Node<3> >& rGeometry);
 
     /// Projected element size in the direction of the velocity vector.
     /** @param rGeometry The geometry of calling element.
@@ -113,6 +135,67 @@ public:
      *  @return The computed size.
      */
     static double GradientsElementSize(const BoundedMatrix<double, 4, 3>& rDN_DX);
+
+    ///@}
+
+private:
+    ///@name Private Operations
+    ///@{
+
+    static inline double HsqDerivative2D(
+        const double Vx,
+        const double VxDerivative,
+        const double Nx,
+        const double NxDerivative,
+        const double Vy,
+        const double VyDerivative,
+        const double Ny,
+        const double NyDerivative)
+    {
+        return 2 * (Vx * Nx + Vy * Ny) *
+                   (VxDerivative * Nx + Vx * NxDerivative + VyDerivative * Ny +
+                    Vy * NyDerivative) / (Nx * Nx + Ny * Ny) -
+               std::pow((Vx * Nx + Vy * Ny) / (Nx * Nx + Ny * Ny), 2) *
+                   (2 * Nx * NxDerivative + 2 * Ny * NyDerivative);
+    }
+
+    static inline double HsqDerivative3D(
+        const double Vx,
+        const double VxDerivative,
+        const double Nx,
+        const double NxDerivative,
+        const double Vy,
+        const double VyDerivative,
+        const double Ny,
+        const double NyDerivative,
+        const double Vz,
+        const double VzDerivative,
+        const double Nz,
+        const double NzDerivative)
+    {
+        return 2 * (Vx * Nx + Vy * Ny + Vz * Nz) *
+                   (VxDerivative * Nx + Vx * NxDerivative + VyDerivative * Ny +
+                    Vy * NyDerivative + VzDerivative * Nz + Vz * NzDerivative) / (Nx * Nx + Ny * Ny + Nz * Nz) -
+               std::pow((Vx * Nx + Vy * Ny + Vz * Nz) / (Nx * Nx + Ny * Ny + Nz * Nz), 2) *
+                   (2 * Nx * NxDerivative + 2 * Ny * NyDerivative + 2 * Nz * NzDerivative);
+    }
+
+    static inline double NormSquareDerivative(
+        const array_1d<double, 3>& rValue,
+        const array_1d<double, 3>& rValueDerivative)
+    {
+        return 2 * inner_prod(rValue, rValueDerivative);
+    }
+
+    static inline double EdgeLengthDerivative(
+        const unsigned int DerivativeNodeIndex,
+        const unsigned int DerivativeDirectionIndex,
+        const unsigned int NodeIndexA,
+        const unsigned int NodeIndexB,
+        const unsigned int EdgeDirection)
+    {
+        return ((DerivativeNodeIndex == NodeIndexA) - (DerivativeNodeIndex == NodeIndexB)) * (DerivativeDirectionIndex == EdgeDirection);
+    }
 
     ///@}
 


### PR DESCRIPTION
**Description**
This PR adds shape derivative computations for minimum and average element size methods.

**Changelog**
- Added Minimum and Average element size derivative computation methods
- Added finite difference tests