### PR TITLE
[Core] Set unitialized quad point parent to null

### DIFF
--- a/kratos/geometries/quadrature_point_geometry.h
+++ b/kratos/geometries/quadrature_point_geometry.h
@@ -452,7 +452,7 @@ private:
 
     // quatrature point can be related to a parent geometry. To keep the connection,
     // this geometry is related to the integration point.
-    GeometryType* mpGeometryParent;
+    GeometryType* mpGeometryParent = nullptr;
 
     ///@}
     ///@name Serialization


### PR DESCRIPTION
**Description**
This sets the uninitialized quad point parent to null.
