### PR TITLE
Replace lambda with a helper function for "GetSortedListOfFileNameData"

### DIFF
--- a/kratos/python/add_other_utilities_to_python.cpp
+++ b/kratos/python/add_other_utilities_to_python.cpp
@@ -547,11 +547,6 @@ void AddOtherUtilitiesToPython(pybind11::module &m)
         .def("GetFileNameDataList", &FileNameDataCollector::GetFileNameDataList)
         .def_static("ExtractFileNamePattern", &FileNameDataCollector::ExtractFileNamePattern)
         .def_static("GetSortedListOfFileNameData", &GetSortedListOfFileNameDataHelper)
-//        .def_static("GetSortedListOfFileNameData",
-//            [](std::vector<FileNameDataCollector::FileNameData>& rFileNameDataList, const std::vector<std::string>& rSortingFlagsOrder) {
-//                FileNameDataCollector::SortListOfFileNameData(rFileNameDataList, rSortingFlagsOrder);
-//                return rFileNameDataList;
-//            })
         ;
 
     // add FileNameData holder

--- a/kratos/python/add_other_utilities_to_python.cpp
+++ b/kratos/python/add_other_utilities_to_python.cpp
@@ -54,6 +54,23 @@ namespace Kratos {
 namespace Python {
 
 /**
+ * @brief A thin wrapper for GetSortedListOfFileNameData. The reason for having the wrapper is to replace the original lambda implementation as it causes gcc 4.8 to generate bad code on Centos7 which leads to memory corruption.
+ */   
+pybind11::list GetSortedListOfFileNameDataHelper(
+    std::vector<FileNameDataCollector::FileNameData>& rFileNameDataList,
+    const std::vector<std::string> & rSortingFlagsOrder
+    )
+{
+    FileNameDataCollector::SortListOfFileNameData(rFileNameDataList, rSortingFlagsOrder);
+    pybind11::list result;
+    for (unsigned int j = 0; j < rFileNameDataList.size(); j++)
+    {
+        result.append(rFileNameDataList[j]);
+    }
+    return result;
+}
+
+/**
  * @brief Sets the current table utility on the process info
  * @param rCurrentProcessInfo The process info
  */
@@ -529,11 +546,12 @@ void AddOtherUtilitiesToPython(pybind11::module &m)
         .def("RetrieveFileNameData", &FileNameDataCollector::RetrieveFileNameData)
         .def("GetFileNameDataList", &FileNameDataCollector::GetFileNameDataList)
         .def_static("ExtractFileNamePattern", &FileNameDataCollector::ExtractFileNamePattern)
-        .def_static("GetSortedListOfFileNameData",
-            [](std::vector<FileNameDataCollector::FileNameData>& rFileNameDataList, const std::vector<std::string>& rSortingFlagsOrder) {
-                FileNameDataCollector::SortListOfFileNameData(rFileNameDataList, rSortingFlagsOrder);
-                return rFileNameDataList;
-            })
+        .def_static("GetSortedListOfFileNameData", &GetSortedListOfFileNameDataHelper)
+//        .def_static("GetSortedListOfFileNameData",
+//            [](std::vector<FileNameDataCollector::FileNameData>& rFileNameDataList, const std::vector<std::string>& rSortingFlagsOrder) {
+//                FileNameDataCollector::SortListOfFileNameData(rFileNameDataList, rSortingFlagsOrder);
+//                return rFileNameDataList;
+//            })
         ;
 
     // add FileNameData holder


### PR DESCRIPTION
The reason for having the wrapper is to replace the original lambda implementation as it causes gcc 4.8 to generate bad code on Centos7 which leads to memory corruption for one of the python unit tests.

**Description**
This PR attempts to replace the original lambda function with a helper function for "GetSortedListOfFileNameData". The reason for having the helper function is that the original lambda implementation causes gcc 4.8 to generate bad code on Centos7 which leads to memory corruption for one of the python unit tests. This issue was detected on the one of the Altair CI runners.


**Changelog**
- Replaced lambda with a helper function for "GetSortedListOfFileNameData"
