### PR TITLE
[CI-Docker] adding TPetra

### DIFF
--- a/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
@@ -38,6 +38,7 @@ RUN apt-get update -y && apt-get upgrade -y && \
         libtrilinos-ifpack-dev \
         libtrilinos-ml-dev \
         libtrilinos-teuchos-dev \
+        libtrilinos-tpetra-dev
         openmpi-bin \
         python3-dev \
         python3-h5py \


### PR DESCRIPTION
unfortunately this is necessary for Amesos2
Epetra is optional, TPetra is not :/
