### PR TITLE
[Fluid] Adding FluidCalculationUtilities

### DIFF
--- a/applications/FluidDynamicsApplication/CMakeLists.txt
+++ b/applications/FluidDynamicsApplication/CMakeLists.txt
@@ -12,6 +12,7 @@ set( KRATOS_FLUID_DYNAMICS_APPLICATION_CORE_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/fluid_dynamics_application_variables.cpp
 
   # utilities (compiled first because they are used within the element cpps)
+  ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/fluid_calculation_utilities.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/fluid_element_data.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/fluid_element_utilities.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/drag_utilities.cpp

--- a/applications/FluidDynamicsApplication/custom_elements/vms_adjoint_element.h
+++ b/applications/FluidDynamicsApplication/custom_elements/vms_adjoint_element.h
@@ -34,6 +34,7 @@
 #include "utilities/adjoint_extensions.h"
 
 // Application includes
+#include "custom_utilities/fluid_calculation_utilities.h"
 #include "fluid_dynamics_application_variables.h"
 
 namespace Kratos {
@@ -601,17 +602,15 @@ protected:
         GeometryUtils::CalculateGeometryData(this->GetGeometry(), DN_DX, N, Volume);
 
         // Density
-        double Density;
-        this->EvaluateInPoint(Density, DENSITY, N);
+        double Density, Viscosity;
+        array_1d<double, 3> Velocity;
 
-        // Dynamic viscosity
-        double Viscosity;
-        this->EvaluateInPoint(Viscosity, VISCOSITY, N);
+        FluidCalculationUtilities::EvaluateInPoint(this->GetGeometry(), N,
+                std::tie(Density, DENSITY),
+                std::tie(Viscosity, VISCOSITY),
+                std::tie(Velocity, VELOCITY));
+
         Viscosity *= Density;
-
-        // u
-        array_1d<double, TDim> Velocity;
-        this->EvaluateInPoint(Velocity, VELOCITY, N);
 
         // u * Grad(N)
         array_1d<double, TNumNodes> DensityVelGradN;
@@ -692,17 +691,16 @@ protected:
         GeometryUtils::CalculateGeometryData(this->GetGeometry(), DN_DX, N, Volume);
 
         // Density
-        double Density;
-        this->EvaluateInPoint(Density, DENSITY, N);
+        double Density, Viscosity;
+        array_1d<double, TDim> Velocity, X;
 
-        // Dynamic viscosity
-        double Viscosity;
-        this->EvaluateInPoint(Viscosity, VISCOSITY, N);
+        FluidCalculationUtilities::EvaluateInPoint(this->GetGeometry(), N,
+                std::tie(Density, DENSITY),
+                std::tie(Viscosity, VISCOSITY),
+                std::tie(Velocity, VELOCITY),
+                std::tie(X, rVariable));
+
         Viscosity *= Density;
-
-        // u
-        array_1d<double, TDim> Velocity;
-        this->EvaluateInPoint(Velocity, VELOCITY, N);
 
         // u * Grad(N)
         array_1d<double, TNumNodes> DensityVelGradN;
@@ -741,10 +739,6 @@ protected:
                 }
             }
         }
-
-        // rVariable (x)
-        array_1d<double, TDim> X;
-        this->EvaluateInPoint(X, rVariable, N);
 
         // x * Grad(N)
         array_1d<double, TNumNodes> DensityXGradN;
@@ -810,17 +804,15 @@ protected:
         GeometryUtils::CalculateGeometryData(this->GetGeometry(), DN_DX, N, Volume);
 
         // Density
-        double Density;
-        this->EvaluateInPoint(Density, DENSITY, N);
-
-        // Dynamic viscosity
-        double Viscosity;
-        this->EvaluateInPoint(Viscosity, VISCOSITY, N);
-        Viscosity *= Density;
-
-        // u
+        double Density, Viscosity;
         array_1d<double, TDim> Velocity;
-        this->EvaluateInPoint(Velocity, VELOCITY, N);
+
+        FluidCalculationUtilities::EvaluateInPoint(this->GetGeometry(), N,
+                std::tie(Density, DENSITY),
+                std::tie(Viscosity, VISCOSITY),
+                std::tie(Velocity, VELOCITY));
+
+        Viscosity *= Density;
 
         // u * Grad(N)
         array_1d<double, TNumNodes> DensityVelGradN;
@@ -968,17 +960,17 @@ protected:
         GeometryUtils::CalculateGeometryData(this->GetGeometry(), DN_DX, N, Volume);
 
         // Density
-        double Density;
-        this->EvaluateInPoint(Density, DENSITY, N);
+        double Density, Viscosity;
+        array_1d<double, TDim> Velocity, BodyForce;
 
-        // Dynamic viscosity
-        double Viscosity;
-        this->EvaluateInPoint(Viscosity, VISCOSITY, N);
+        FluidCalculationUtilities::EvaluateInPoint(this->GetGeometry(), N,
+                std::tie(Density, DENSITY),
+                std::tie(Viscosity, VISCOSITY),
+                std::tie(Velocity, VELOCITY),
+                std::tie(BodyForce, BODY_FORCE));
+
         Viscosity *= Density;
-
-        // u
-        array_1d<double, TDim> Velocity;
-        this->EvaluateInPoint(Velocity, VELOCITY, N);
+        BodyForce *= Density;
 
         // u * Grad(N)
         array_1d<double, TNumNodes> DensityVelGradN;
@@ -1017,10 +1009,7 @@ protected:
         noalias(DN_DX_GradP) = prod(DN_DX, GradP);
 
         // Grad(N)^T * BodyForce
-        array_1d<double, TDim> BodyForce;
         array_1d<double, TNumNodes> DN_DX_BodyForce;
-        this->EvaluateInPoint(BodyForce, BODY_FORCE, N);
-        BodyForce *= Density;
         noalias(DN_DX_BodyForce) = prod(DN_DX, BodyForce);
 
         // Stabilization parameters TauOne, TauTwo
@@ -1193,17 +1182,17 @@ protected:
         GeometryUtils::CalculateGeometryData(this->GetGeometry(), DN_DX, N, Volume);
 
         // Density
-        double Density;
-        this->EvaluateInPoint(Density, DENSITY, N);
+        double Density, Viscosity;
+        array_1d<double, TDim> Velocity, BodyForce;
 
-        // Dynamic viscosity
-        double Viscosity;
-        this->EvaluateInPoint(Viscosity, VISCOSITY, N);
+        FluidCalculationUtilities::EvaluateInPoint(this->GetGeometry(), N,
+                std::tie(Density, DENSITY),
+                std::tie(Viscosity, VISCOSITY),
+                std::tie(Velocity, VELOCITY),
+                std::tie(BodyForce, BODY_FORCE));
+
+        BodyForce *= Density;
         Viscosity *= Density;
-
-        // u
-        array_1d<double, TDim> Velocity;
-        this->EvaluateInPoint(Velocity, VELOCITY, N);
 
         // u * Grad(N)
         array_1d<double, TNumNodes> DensityVelGradN;
@@ -1221,10 +1210,6 @@ protected:
         this->CalculateStabilizationParameters(TauOne, TauTwo, VelNorm, ElemSize, Density,
                                                Viscosity, rCurrentProcessInfo);
 
-        // External body force
-        array_1d<double, TDim> BodyForce;
-        this->EvaluateInPoint(BodyForce, BODY_FORCE, N);
-        BodyForce *= Density;
 
         array_1d<double, TFluidLocalSize> FluidValues;
 
@@ -1532,55 +1517,6 @@ protected:
         const double Density,
         const double Viscosity,
         const double DetJDeriv) const;
-
-    /**
-     * @brief Returns a scalar variable at this integration point.
-     *
-     * @param rResult the value of the scalar variable at this integration point
-     * @param rVariable the variable to be evaluated
-     * @param rShapeFunc array of shape function values at this integration point
-     */
-    void EvaluateInPoint(
-        double& rResult,
-        const Variable<double>& rVariable,
-        const array_1d<double, TNumNodes>& rShapeFunc,
-        const IndexType step = 0) const
-    {
-        const auto& r_geometry = this->GetGeometry();
-        rResult = rShapeFunc[0] * r_geometry[0].FastGetSolutionStepValue(rVariable, step);
-        for (IndexType i_node = 1; i_node < TNumNodes; ++i_node) {
-            rResult += rShapeFunc[i_node] *
-                       r_geometry[i_node].FastGetSolutionStepValue(rVariable, step);
-        }
-    }
-
-    /**
-     * @brief Returns a vector variable at this integration point.
-     *
-     * @param rResult the value of the vector variable at this integration point
-     * @param rVariable the variable to be evaluated
-     * @param rShapeFunc array of shape function values at this integration point
-     */
-    void EvaluateInPoint(
-        array_1d<double, TDim>& rResult,
-        const Variable<array_1d<double, 3>>& rVariable,
-        const array_1d<double, TNumNodes>& rN,
-        const IndexType step = 0) const
-    {
-        const auto& r_geometry = this->GetGeometry();
-        const auto& r_nodal_value =
-            r_geometry[0].FastGetSolutionStepValue(rVariable, step);
-        for (IndexType d = 0; d < TDim; ++d) {
-            rResult[d] = rN[0] * r_nodal_value[d];
-        }
-        for (IndexType i_node = 1; i_node < TNumNodes; ++i_node) {
-            const auto& r_nodal_value =
-                r_geometry[i_node].FastGetSolutionStepValue(rVariable, step);
-            for (IndexType d = 0; d < TDim; ++d) {
-                rResult[d] += rN[i_node] * r_nodal_value[d];
-            }
-        }
-    }
 
     /**
      * @brief Adds viscous contributions to adjoint system matrix.

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_calculation_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_calculation_utilities.cpp
@@ -22,8 +22,8 @@ namespace Kratos
 
 template<>
 void FluidCalculationUtilities::AssignValue(
-    array_1d<double, 2>& rOutput,
-    const array_1d<double, 3>& rInput)
+    const array_1d<double, 3>& rInput,
+    array_1d<double, 2>& rOutput)
 {
     rOutput[0] = rInput[0];
     rOutput[1] = rInput[1];
@@ -31,24 +31,24 @@ void FluidCalculationUtilities::AssignValue(
 
 template<class TOutputDataType, class TInputDataType>
 void FluidCalculationUtilities::AssignValue(
-    TOutputDataType& rOutput,
-    const TInputDataType& rInput)
+    const TInputDataType& rInput,
+    TOutputDataType& rOutput)
 {
     rOutput = rInput;
 }
 
 template<>
 void FluidCalculationUtilities::UpdateValue(
-    double& rOutput,
-    const double& rInput)
+    const double& rInput,
+    double& rOutput)
 {
     rOutput += rInput;
 }
 
 template<>
 void FluidCalculationUtilities::UpdateValue(
-    array_1d<double, 2>& rOutput,
-    const array_1d<double, 3>& rInput)
+    const array_1d<double, 3>& rInput,
+    array_1d<double, 2>& rOutput)
 {
     rOutput[0] += rInput[0];
     rOutput[1] += rInput[1];
@@ -56,20 +56,20 @@ void FluidCalculationUtilities::UpdateValue(
 
 template<class TOutputDataType, class TInputDataType>
 void FluidCalculationUtilities::UpdateValue(
-    TOutputDataType& rOutput,
-    const TInputDataType& rInput)
+    const TInputDataType& rInput,
+    TOutputDataType& rOutput)
 {
     noalias(rOutput) += rInput;
 }
 
 // template instantiations
-template void FluidCalculationUtilities::AssignValue<double>(double&, const double&);
-template void FluidCalculationUtilities::AssignValue<array_1d<double, 3>>(array_1d<double, 3>&, const array_1d<double, 3>&);
-template void FluidCalculationUtilities::AssignValue<Vector>(Vector&, const Vector&);
-template void FluidCalculationUtilities::AssignValue<Matrix>(Matrix&, const Matrix&);
+template void FluidCalculationUtilities::AssignValue<double>(const double&, double&);
+template void FluidCalculationUtilities::AssignValue<array_1d<double, 3>>(const array_1d<double, 3>&, array_1d<double, 3>&);
+template void FluidCalculationUtilities::AssignValue<Vector>(const Vector&, Vector&);
+template void FluidCalculationUtilities::AssignValue<Matrix>(const Matrix&, Matrix&);
 
-template void FluidCalculationUtilities::UpdateValue<array_1d<double, 3>>(array_1d<double, 3>&, const array_1d<double, 3>&);
-template void FluidCalculationUtilities::UpdateValue<Vector>(Vector&, const Vector&);
-template void FluidCalculationUtilities::UpdateValue<Matrix>(Matrix&, const Matrix&);
+template void FluidCalculationUtilities::UpdateValue<array_1d<double, 3>>(const array_1d<double, 3>&, array_1d<double, 3>&);
+template void FluidCalculationUtilities::UpdateValue<Vector>(const Vector&, Vector&);
+template void FluidCalculationUtilities::UpdateValue<Matrix>(const Matrix&, Matrix&);
 
 } // namespace Kratos

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_calculation_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_calculation_utilities.cpp
@@ -1,0 +1,75 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Suneth Warnakulasuriya
+//
+
+// External includes
+
+// Project includes
+
+// Include base h
+#include "custom_utilities/fluid_calculation_utilities.h"
+
+namespace Kratos
+{
+
+template<>
+void FluidCalculationUtilities::AssignValue(
+    array_1d<double, 2>& rOutput,
+    const array_1d<double, 3>& rInput)
+{
+    rOutput[0] = rInput[0];
+    rOutput[1] = rInput[1];
+}
+
+template<class TOutputDataType, class TInputDataType>
+void FluidCalculationUtilities::AssignValue(
+    TOutputDataType& rOutput,
+    const TInputDataType& rInput)
+{
+    rOutput = rInput;
+}
+
+template<>
+void FluidCalculationUtilities::UpdateValue(
+    double& rOutput,
+    const double& rInput)
+{
+    rOutput += rInput;
+}
+
+template<>
+void FluidCalculationUtilities::UpdateValue(
+    array_1d<double, 2>& rOutput,
+    const array_1d<double, 3>& rInput)
+{
+    rOutput[0] += rInput[0];
+    rOutput[1] += rInput[1];
+}
+
+template<class TOutputDataType, class TInputDataType>
+void FluidCalculationUtilities::UpdateValue(
+    TOutputDataType& rOutput,
+    const TInputDataType& rInput)
+{
+    noalias(rOutput) += rInput;
+}
+
+// template instantiations
+template void FluidCalculationUtilities::AssignValue<double>(double&, const double&);
+template void FluidCalculationUtilities::AssignValue<array_1d<double, 3>>(array_1d<double, 3>&, const array_1d<double, 3>&);
+template void FluidCalculationUtilities::AssignValue<Vector>(Vector&, const Vector&);
+template void FluidCalculationUtilities::AssignValue<Matrix>(Matrix&, const Matrix&);
+
+template void FluidCalculationUtilities::UpdateValue<array_1d<double, 3>>(array_1d<double, 3>&, const array_1d<double, 3>&);
+template void FluidCalculationUtilities::UpdateValue<Vector>(Vector&, const Vector&);
+template void FluidCalculationUtilities::UpdateValue<Matrix>(Matrix&, const Matrix&);
+
+} // namespace Kratos

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_calculation_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_calculation_utilities.h
@@ -1,0 +1,171 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Suneth Warnakulasuriya
+//
+
+#if !defined(KRATOS_FLUID_CALCULATION_UTILITIES_H)
+#define KRATOS_FLUID_CALCULATION_UTILITIES_H
+
+// system includes
+#include <tuple>
+#include <type_traits>
+
+// External includes
+
+// Project includes
+#include "geometries/geometry.h"
+#include "includes/node.h"
+#include "includes/ublas_interface.h"
+
+namespace Kratos
+{
+///@addtogroup FluidDynamicsApplication
+///@{
+
+///@name Kratos classes
+///@{
+
+class KRATOS_API(FLUID_DYNAMICS_APPLICATION) FluidCalculationUtilities
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    using IndexType = std::size_t;
+
+    using NodeType = Node<3>;
+
+    using GeometryType = Geometry<NodeType>;
+
+    ///@}
+    ///@name Static Operations
+    ///@{
+
+    /**
+     * @brief Evaluates given list of variable pairs at gauss point locations at step
+     *
+     * Example:
+     *      double density;
+     *      array_1d<double, 3> velocity
+     *      EvaluateInPoint(rGeometry, rShapeFunction, Step,
+     *                      std::tie(density, DENSITY),
+     *                      std::tie(velocity, VELOCITY));
+     *
+     *      The above evaluation will fill density, and velocity variables with gauss point
+     *      evaluated DENSITY and VELOCITY at gauss point with shape function values rShapeFunction
+     *      in the geometry named rGeometry.
+     *
+     * @tparam TRefVariableValuePairArgs
+     * @param[in] rGeometry                 Geometry to get nodes
+     * @param[in] rShapeFunction            Shape function values at gauss point
+     * @param[in] Step                      Step to be evaluated
+     * @param[in/out] rValueVariablePairs   std::tuple<TDataType, const Variable<TDataType>> list of variables.
+     */
+    template <class... TRefVariableValuePairArgs>
+    static void EvaluateInPoint(
+        const GeometryType& rGeometry,
+        const Vector& rShapeFunction,
+        const int Step,
+        const TRefVariableValuePairArgs&... rValueVariablePairs)
+    {
+        KRATOS_TRY
+
+        const auto& r_node = rGeometry[0];
+        const double shape_function_value = rShapeFunction[0];
+
+        int dummy[sizeof...(TRefVariableValuePairArgs)] = {(
+            AssignValue<
+                typename std::remove_reference<typename std::tuple_element<0, TRefVariableValuePairArgs>::type>::type,
+                typename std::remove_reference<typename std::tuple_element<1, TRefVariableValuePairArgs>::type>::type::Type
+                >
+                (
+                    std::get<0>(rValueVariablePairs),
+                    r_node.FastGetSolutionStepValue(std::get<1>(rValueVariablePairs), Step) * shape_function_value
+                ),
+            0)...};
+
+        // this can be removed with fold expressions in c++17
+        *dummy = 0;
+
+        for (IndexType c = 1; c < rGeometry.PointsNumber(); ++c) {
+            const auto& r_node = rGeometry[c];
+            const double shape_function_value = rShapeFunction[c];
+
+            int dummy[sizeof...(TRefVariableValuePairArgs)] = {(
+                UpdateValue<
+                    typename std::remove_reference<typename std::tuple_element<0, TRefVariableValuePairArgs>::type>::type,
+                    typename std::remove_reference<typename std::tuple_element<1, TRefVariableValuePairArgs>::type>::type::Type
+                    >
+                    (
+                        std::get<0>(rValueVariablePairs),
+                        r_node.FastGetSolutionStepValue(std::get<1>(rValueVariablePairs), Step) * shape_function_value
+                    ),
+                0)...};
+
+            // this can be removed with fold expressions in c++17
+            *dummy = 0;
+        }
+
+        KRATOS_CATCH("");
+    }
+
+    /**
+     * @brief Evaluates given list of variable pairs at gauss point locations at current step
+     *
+     * Example:
+     *      double density;
+     *      array_1d<double, 3> velocity
+     *      EvaluateInPoint(rGeometry, rShapeFunction,
+     *                      std::tie(density, DENSITY),
+     *                      std::tie(velocity, VELOCITY));
+     *
+     *      The above evaluation will fill density, and velocity variables with gauss point
+     *      evaluated DENSITY and VELOCITY at gauss point with shape function values rShapeFunction
+     *      in the geometry named rGeometry.
+     *
+     * @tparam TRefVariableValuePairArgs
+     * @param[in] rGeometry                 Geometry to get nodes
+     * @param[in] rShapeFunction            Shape function values at gauss point
+     * @param[in/out] rValueVariablePairs   std::tuple<TDataType, const Variable<TDataType>> list of variables.
+     */
+    template <class... TRefVariableValuePairArgs>
+    static void inline EvaluateInPoint(
+        const GeometryType& rGeometry,
+        const Vector& rShapeFunction,
+        const TRefVariableValuePairArgs&... rValueVariablePairs)
+    {
+        EvaluateInPoint<TRefVariableValuePairArgs...>(
+            rGeometry, rShapeFunction, 0, rValueVariablePairs...);
+    }
+
+    ///@}
+
+private:
+    ///@name Private Operations
+    ///@{
+
+    template<class TOutputDataType, class TInputDataType = TOutputDataType>
+    static void AssignValue(
+        TOutputDataType& rOutput,
+        const TInputDataType& rInput);
+
+    template<class TOutputDataType, class TInputDataType = TOutputDataType>
+    static void UpdateValue(
+        TOutputDataType& rOutput,
+        const TInputDataType& rInput);
+
+    ///@}
+};
+
+///@}
+
+} // namespace Kratos
+
+#endif // KRATOS_FLUID_CALCULATION_UTILITIES_H

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_calculation_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_calculation_utilities.h
@@ -86,8 +86,8 @@ public:
                 typename std::remove_reference<typename std::tuple_element<1, TRefVariableValuePairArgs>::type>::type::Type
                 >
                 (
-                    std::get<0>(rValueVariablePairs),
-                    r_node.FastGetSolutionStepValue(std::get<1>(rValueVariablePairs), Step) * shape_function_value
+                    r_node.FastGetSolutionStepValue(std::get<1>(rValueVariablePairs), Step) * shape_function_value,
+                    std::get<0>(rValueVariablePairs)
                 ),
             0)...};
 
@@ -104,8 +104,8 @@ public:
                     typename std::remove_reference<typename std::tuple_element<1, TRefVariableValuePairArgs>::type>::type::Type
                     >
                     (
-                        std::get<0>(rValueVariablePairs),
-                        r_node.FastGetSolutionStepValue(std::get<1>(rValueVariablePairs), Step) * shape_function_value
+                        r_node.FastGetSolutionStepValue(std::get<1>(rValueVariablePairs), Step) * shape_function_value,
+                        std::get<0>(rValueVariablePairs)
                     ),
                 0)...};
 

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_calculation_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_calculation_utilities.h
@@ -153,13 +153,13 @@ private:
 
     template<class TOutputDataType, class TInputDataType = TOutputDataType>
     static void AssignValue(
-        TOutputDataType& rOutput,
-        const TInputDataType& rInput);
+        const TInputDataType& rInput,
+        TOutputDataType& rOutput);
 
     template<class TOutputDataType, class TInputDataType = TOutputDataType>
     static void UpdateValue(
-        TOutputDataType& rOutput,
-        const TInputDataType& rInput);
+        const TInputDataType& rInput,
+        TOutputDataType& rOutput);
 
     ///@}
 };


### PR DESCRIPTION
**Description**
This PR adds FluidCalculationUtilities to provide `EvaluateInPoint` method with Variadic template arguments. `VMSAdjointElement` is adapted to use this `EvaluateInPoint` method as a demonstrator case.

@rubenzorrilla Are we planning to change other elements also to adapt to use this method?

**Changelog**
- Added Variadic templated `EvaluateInPoint` method
