### PR TITLE
[CI][Docker] adding Trilinos-Kokkos

### DIFF
--- a/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
@@ -39,6 +39,8 @@ RUN apt-get update -y && apt-get upgrade -y && \
         libtrilinos-ml-dev \
         libtrilinos-teuchos-dev \
         libtrilinos-tpetra-dev \
+        libtrilinos-kokkos-dev \
+        libtrilinos-kokkos-kernels-dev \
         openmpi-bin \
         python3-dev \
         python3-h5py \


### PR DESCRIPTION
**Description**
for #7901 

I am surprised this wasn't added automatically

When I compile Amesos2 locally it enables automatically all those packages (aka TPetra & Kokkos)