### PR TITLE
[Fluid] fix check in two fluid Newtonian Constitutive Law

### DIFF
--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_2d_law.cpp
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_2d_law.cpp
@@ -54,6 +54,24 @@ std::string NewtonianTwoFluid2DLaw::Info() const {
     return "NewtonianTwoFluid2DLaw";
 }
 
+int NewtonianTwoFluid2DLaw::Check(
+    const Properties& rMaterialProperties,
+    const GeometryType& rElementGeometry,
+    const ProcessInfo& rCurrentProcessInfo)
+{
+    for (unsigned int i = 0; i < rElementGeometry.size(); i++) {
+        const Node<3>& rNode = rElementGeometry[i];
+        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DYNAMIC_VISCOSITY,rNode);
+        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DENSITY,rNode);
+        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISTANCE,rNode);
+        KRATOS_ERROR_IF(rNode.GetSolutionStepValue(DYNAMIC_VISCOSITY) <= 0.0)
+            << "DYNAMIC_VISCOSITY was not correctly assigned to nodes for Constitutive Law.\n";
+        KRATOS_ERROR_IF(rNode.GetSolutionStepValue(DENSITY) <= 0.0)
+            << "DENSITY was not correctly assigned to nodes for Constitutive Law.\n";
+    }
+    return 0;
+}
+
 double NewtonianTwoFluid2DLaw::GetEffectiveViscosity(ConstitutiveLaw::Parameters& rParameters) const
 {
     double viscosity;

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_2d_law.h
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_2d_law.h
@@ -71,11 +71,24 @@ public:
     ~NewtonianTwoFluid2DLaw() override;
 
     /**
+     * Turn back information as a string.
+     * This function is designed to be called once to perform all the checks needed
+     * on the input provided. Checks can be "expensive" as the function is designed
+     * to catch user's errors.
+     * @param rMaterialProperties
+     * @param rElementGeometry
+     * @param rCurrentProcessInfo
+     * @return
+     */
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+
+    
+    /**
      * Input and output
      */
+    
 
     /**
-     * Turn back information as a string.
      */
     std::string Info() const override;
 
@@ -97,6 +110,7 @@ protected:
     ///@{
 
     double GetEffectiveViscosity(ConstitutiveLaw::Parameters& rParameters) const override;
+
 
     ///@}
 

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_3d_law.cpp
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_3d_law.cpp
@@ -54,6 +54,24 @@ std::string NewtonianTwoFluid3DLaw::Info() const {
     return "NewtonianTwoFluid3DLaw";
 }
 
+int NewtonianTwoFluid3DLaw::Check(
+    const Properties& rMaterialProperties,
+    const GeometryType& rElementGeometry,
+    const ProcessInfo& rCurrentProcessInfo)
+{
+    for (unsigned int i = 0; i < rElementGeometry.size(); i++) {
+        const Node<3>& rNode = rElementGeometry[i];
+        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DYNAMIC_VISCOSITY,rNode);
+        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DENSITY,rNode);
+        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISTANCE,rNode);
+        KRATOS_ERROR_IF(rNode.GetSolutionStepValue(DYNAMIC_VISCOSITY) <= 0.0)
+            << "DYNAMIC_VISCOSITY was not correctly assigned to the nodes for Constitutive Law.\n";
+        KRATOS_ERROR_IF(rNode.GetSolutionStepValue(DENSITY) <= 0.0)
+            << "DENSITY was not correctly assigned to the nodes for Constitutive Law.\n";
+    }
+    return 0;
+}
+
 
 double NewtonianTwoFluid3DLaw::GetEffectiveViscosity(ConstitutiveLaw::Parameters& rParameters) const
 {

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_3d_law.h
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_3d_law.h
@@ -72,6 +72,17 @@ public:
 
 
     /**
+     * This function is designed to be called once to perform all the checks needed
+     * on the input provided. Checks can be "expensive" as the function is designed
+     * to catch user's errors.
+     * @param rMaterialProperties
+     * @param rElementGeometry
+     * @param rCurrentProcessInfo
+     * @return
+     */
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+    
+    /**
      * Input and output
      */
 

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_dynamics_constitutive_laws.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_dynamics_constitutive_laws.cpp
@@ -414,7 +414,6 @@ namespace Kratos {
             Model current_model;
             ModelPart& model_part = current_model.CreateModelPart("Main", 3);
             model_part.AddNodalSolutionStepVariable(DISTANCE);
-            model_part.AddNodalSolutionStepVariable(VELOCITY);
             model_part.AddNodalSolutionStepVariable(DENSITY);
             model_part.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY);
             GenerateTetrahedron(model_part, p_cons_law, SetProperties);
@@ -428,11 +427,6 @@ namespace Kratos {
             geom[1].GetSolutionStepValue(DISTANCE) = -1.0;
             geom[2].GetSolutionStepValue(DISTANCE) = -1.0;
             geom[3].GetSolutionStepValue(DISTANCE) = 1.0;
-
-            geom[0].GetSolutionStepValue(VELOCITY) = velocity;
-            geom[1].GetSolutionStepValue(VELOCITY) = velocity;
-            geom[2].GetSolutionStepValue(VELOCITY) = velocity;
-            geom[3].GetSolutionStepValue(VELOCITY) = 2.0*velocity;
 
             geom[0].GetSolutionStepValue(DENSITY) = 2.0;
             geom[1].GetSolutionStepValue(DENSITY) = 2.0;
@@ -476,30 +470,33 @@ namespace Kratos {
             cons_law_values.SetShapeFunctionsValues(N_copy);
             cons_law_values.SetShapeFunctionsDerivatives(DN_DX_copy);
 
+            p_cons_law->Check(
+                p_element->GetProperties(),
+                p_element->GetGeometry(),
+                model_part.GetProcessInfo());
             p_cons_law->CalculateMaterialResponseCauchy(cons_law_values);
 
             // Check computed values
             const double tolerance = 1e-7;
 
-            KRATOS_CHECK_NEAR(c_matrix(0,0), 0.675, tolerance);
-            KRATOS_CHECK_NEAR(c_matrix(0,1), -0.3375, tolerance);
-            KRATOS_CHECK_NEAR(c_matrix(0,2), -0.3375, tolerance);
-            KRATOS_CHECK_NEAR(c_matrix(1,0), -0.3375, tolerance);
-            KRATOS_CHECK_NEAR(c_matrix(1,1), 0.675, tolerance);
-            KRATOS_CHECK_NEAR(c_matrix(1,2), -0.3375, tolerance);
-            KRATOS_CHECK_NEAR(c_matrix(2,0), -0.3375, tolerance);
-            KRATOS_CHECK_NEAR(c_matrix(2,1), -0.3375, tolerance);
-            KRATOS_CHECK_NEAR(c_matrix(2,2), 0.675, tolerance);
-            KRATOS_CHECK_NEAR(c_matrix(3,3), 0.50625, tolerance);
-            KRATOS_CHECK_NEAR(c_matrix(4,4), 0.50625, tolerance);
-            KRATOS_CHECK_NEAR(c_matrix(5,5), 0.50625, tolerance);
+            std::vector<double> theoretical_stress_vector = {-0.3375, 2.7,-2.3625,1.0125, 1.51875,2.025 };
+            Matrix theoretical_c_matrix = ZeroMatrix(6,6);
+            theoretical_c_matrix(0,0) = 0.675;
+            theoretical_c_matrix(0,1) = -0.3375;
+            theoretical_c_matrix(0,2) = -0.3375;
+            theoretical_c_matrix(1,0) = -0.3375;
+            theoretical_c_matrix(1,1) = 0.675;
+            theoretical_c_matrix(1,2) = -0.3375;
+            theoretical_c_matrix(2,0) = -0.3375;
+            theoretical_c_matrix(2,1) = -0.3375;
+            theoretical_c_matrix(2,2) = 0.675;
+            theoretical_c_matrix(3,3) = 0.50625;
+            theoretical_c_matrix(4,4) = 0.50625;
+            theoretical_c_matrix(5,5) = 0.50625;
 
-            KRATOS_CHECK_NEAR(stress_vector(0), -0.3375, tolerance);
-            KRATOS_CHECK_NEAR(stress_vector(1), 2.7, tolerance);
-            KRATOS_CHECK_NEAR(stress_vector(2), -2.3625, tolerance);
-            KRATOS_CHECK_NEAR(stress_vector(3), 1.0125, tolerance);
-            KRATOS_CHECK_NEAR(stress_vector(4), 1.51875, tolerance);
-            KRATOS_CHECK_NEAR(stress_vector(5), 2.025, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(stress_vector, theoretical_stress_vector, tolerance);
+
+            KRATOS_CHECK_MATRIX_NEAR(c_matrix, theoretical_c_matrix, tolerance);    
 	    }
 
 	    /**


### PR DESCRIPTION
Newtonian Two Fluids Laws used Check from base class. This base class checks that DYNAMIC_VISCOSITY in the properties is defined and bigger than 0.  However, in the derived class, the viscosity is read from the nodes so this check is not needed.

So, this PR adds a check in the CL that works according to what is used later in the computation.

Test has been updated too,