### PR TITLE
[Core][AMGCL] ProvideCoordinates: avoid flush on every line

### DIFF
--- a/kratos/linear_solvers/amgcl_solver.h
+++ b/kratos/linear_solvers/amgcl_solver.h
@@ -394,7 +394,7 @@ public:
                 std::ofstream coordsfile;
                 coordsfile.open ("coordinates.txt");
                 for(unsigned int i=0; i<mCoordinates.size(); i++) {
-                    coordsfile << mCoordinates[i][0] << " " << mCoordinates[i][1] << " " << mCoordinates[i][2] << std::endl;
+                    coordsfile << mCoordinates[i][0] << " " << mCoordinates[i][1] << " " << mCoordinates[i][2] << "\n";
                 }
                 coordsfile.close();
             }


### PR DESCRIPTION
**Description**
Flushing after every line can be slower esp on clusters
For me it is now 3 times faster