### PR TITLE
[FastPR][Fluid] VMS element override warning. 

### DIFF
--- a/applications/FluidDynamicsApplication/custom_elements/vms_adjoint_element.h
+++ b/applications/FluidDynamicsApplication/custom_elements/vms_adjoint_element.h
@@ -495,28 +495,12 @@ public:
         const ProcessInfo& rCurrentProcessInfo) override
     {
         BoundedMatrix<double, TCoordLocalSize, TFluidLocalSize> local_matrix;
-        this->CalculateSensitivityMatrix(rSensitivityVariable, local_matrix, rCurrentProcessInfo);
+        this->AuxiliaryCalculateSensitivityMatrix(rSensitivityVariable, local_matrix, rCurrentProcessInfo);
         rOutput.resize(local_matrix.size1(), local_matrix.size2(), false);
         noalias(rOutput) = local_matrix;
     }
 
-    void CalculateSensitivityMatrix(
-        const Variable<array_1d<double, 3>>& rSensitivityVariable,
-        BoundedMatrix<double, TCoordLocalSize, TFluidLocalSize>& rOutput,
-        const ProcessInfo& rCurrentProcessInfo)
-    {
-        KRATOS_TRY
 
-        if (rSensitivityVariable == SHAPE_SENSITIVITY) {
-            this->CalculateShapeGradientOfVMSSteadyTerm(rOutput, rCurrentProcessInfo);
-            this->AddShapeGradientOfVMSMassTerm(rOutput, ACCELERATION, -1.0, rCurrentProcessInfo);
-        } else {
-            KRATOS_ERROR << "Sensitivity variable " << rSensitivityVariable
-                         << " not supported." << std::endl;
-        }
-
-        KRATOS_CATCH("")
-    }
 
     void GetDofList(
         DofsVectorType& rElementalDofList,
@@ -584,6 +568,24 @@ protected:
 
     ///@name Protected Operations
     ///@{
+
+    void AuxiliaryCalculateSensitivityMatrix(
+        const Variable<array_1d<double, 3>>& rSensitivityVariable,
+        BoundedMatrix<double, TCoordLocalSize, TFluidLocalSize>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
+    {
+        KRATOS_TRY
+
+        if (rSensitivityVariable == SHAPE_SENSITIVITY) {
+            this->CalculateShapeGradientOfVMSSteadyTerm(rOutput, rCurrentProcessInfo);
+            this->AddShapeGradientOfVMSMassTerm(rOutput, ACCELERATION, -1.0, rCurrentProcessInfo);
+        } else {
+            KRATOS_ERROR << "Sensitivity variable " << rSensitivityVariable
+                         << " not supported." << std::endl;
+        }
+
+        KRATOS_CATCH("")
+    }
 
     /// Calculate VMS-stabilized (lumped) mass matrix.
     void CalculateVMSMassMatrix(


### PR DESCRIPTION
**Description**
This was giving a warning as the function in the base class has a different signature but same name.

**Changelog**
- Rename auxiliary method and make it protected.