### PR TITLE
Adding flush befor Cpp tests start

### DIFF
--- a/kratos/testing/tester.cpp
+++ b/kratos/testing/tester.cpp
@@ -346,6 +346,7 @@ namespace Kratos
 			if (GetInstance().mVerbosity >= Verbosity::TESTS_LIST)
 			{
 				std::cout << pTheTestCase->Name();
+				std::cout << std::flush;
 			}
 		}
 


### PR DESCRIPTION
**Description**
This causes the name of the test to be printed before executing the tests even if it fails. In some scenarios not having a `flush` or `end` could cause the name of the test to not being printed if the test crashed.

**Changelog**
- Adding flush before running cpp tests.
