### PR TITLE
[MLMC] Adapt check on power sum utility to run in MPI

### DIFF
--- a/applications/MultilevelMonteCarloApplication/custom_statistics/power_sums_statistics.cpp
+++ b/applications/MultilevelMonteCarloApplication/custom_statistics/power_sums_statistics.cpp
@@ -88,7 +88,13 @@ namespace Kratos
         KRATOS_TRY;
 
         // Check and set number of elements and check dimension
-        KRATOS_ERROR_IF(mrModelPart.NumberOfNodes() == 0) << "The number of nodes in the domain is zero. The power sums statistic cannot be applied."<< std::endl;
+        bool hasNodes = 0;
+        if(mrModelPart.NumberOfNodes() != 0)
+            hasNodes = 1;
+        hasNodes = mrModelPart.GetCommunicator().GetDataCommunicator().MaxAll(hasNodes);
+
+        KRATOS_ERROR_IF_NOT(hasNodes) << "The number of nodes in the domain is zero. The power sums statistic cannot be applied."<< std::endl;
+
         const unsigned int number_nodes = mrModelPart.NumberOfNodes();
 
         // Extract informations

--- a/applications/MultilevelMonteCarloApplication/custom_statistics/power_sums_statistics.cpp
+++ b/applications/MultilevelMonteCarloApplication/custom_statistics/power_sums_statistics.cpp
@@ -87,9 +87,8 @@ namespace Kratos
     {
         KRATOS_TRY;
 
-        // Check and set number of elements and check dimension
+        // Check and set number of nodes
         KRATOS_ERROR_IF(mrModelPart.GetCommunicator().GlobalNumberOfNodes() == 0) << "The number of nodes in the domain is zero. The power sums statistic cannot be applied."<< std::endl;
-
         const unsigned int number_nodes = mrModelPart.NumberOfNodes();
 
         // Extract informations

--- a/applications/MultilevelMonteCarloApplication/custom_statistics/power_sums_statistics.cpp
+++ b/applications/MultilevelMonteCarloApplication/custom_statistics/power_sums_statistics.cpp
@@ -88,12 +88,7 @@ namespace Kratos
         KRATOS_TRY;
 
         // Check and set number of elements and check dimension
-        bool hasNodes = 0;
-        if(mrModelPart.NumberOfNodes() != 0)
-            hasNodes = 1;
-        hasNodes = mrModelPart.GetCommunicator().GetDataCommunicator().MaxAll(hasNodes);
-
-        KRATOS_ERROR_IF_NOT(hasNodes) << "The number of nodes in the domain is zero. The power sums statistic cannot be applied."<< std::endl;
+        KRATOS_ERROR_IF(mrModelPart.GetCommunicator().GlobalNumberOfNodes() == 0) << "The number of nodes in the domain is zero. The power sums statistic cannot be applied."<< std::endl;
 
         const unsigned int number_nodes = mrModelPart.NumberOfNodes();
 

--- a/applications/MultilevelMonteCarloApplication/custom_statistics/power_sums_statistics.cpp
+++ b/applications/MultilevelMonteCarloApplication/custom_statistics/power_sums_statistics.cpp
@@ -90,10 +90,10 @@ namespace Kratos
         // Check and set number of elements and check dimension
         bool has_nodes = 0;
         if(mrModelPart.NumberOfNodes() != 0)
-            hasNodes = 1;
-        hasNodes = mrModelPart.GetCommunicator().GetDataCommunicator().MaxAll(hasNodes);
+            has_nodes = 1;
+        has_nodes = mrModelPart.GetCommunicator().GetDataCommunicator().MaxAll(has_nodes);
 
-        KRATOS_ERROR_IF_NOT(hasNodes) << "The number of nodes in the domain is zero. The power sums statistic cannot be applied."<< std::endl;
+        KRATOS_ERROR_IF_NOT(has_nodes) << "The number of nodes in the domain is zero. The power sums statistic cannot be applied."<< std::endl;
 
         const unsigned int number_nodes = mrModelPart.NumberOfNodes();
 

--- a/applications/MultilevelMonteCarloApplication/custom_statistics/power_sums_statistics.cpp
+++ b/applications/MultilevelMonteCarloApplication/custom_statistics/power_sums_statistics.cpp
@@ -88,7 +88,7 @@ namespace Kratos
         KRATOS_TRY;
 
         // Check and set number of elements and check dimension
-        bool hasNodes = 0;
+        bool has_nodes = 0;
         if(mrModelPart.NumberOfNodes() != 0)
             hasNodes = 1;
         hasNodes = mrModelPart.GetCommunicator().GetDataCommunicator().MaxAll(hasNodes);


### PR DESCRIPTION
**Description**
The check on number of nodes of the mdpa now runs well also in MPI.

Please mark the PR with appropriate tags: 
- C++, Parallel-MPI, FastPR, Bugfix

**Changelog**
Please summarize the changes in one list to generate the changelog:
- Now error is thrown only in case all partitions do not have nodes.
