### PR TITLE
[Core] Fix dof get variable performance

### DIFF
--- a/kratos/containers/variables_list_data_value_container.h
+++ b/kratos/containers/variables_list_data_value_container.h
@@ -461,6 +461,16 @@ public:
         return mpVariablesList;
     }
 
+    VariablesList& GetVariablesList()
+    {
+        return *mpVariablesList;
+    }
+
+    const VariablesList& GetVariablesList() const
+    {
+        return *mpVariablesList;
+    }
+
 
 
     void SetVariablesList(VariablesList::Pointer pVariablesList)

--- a/kratos/includes/dof.h
+++ b/kratos/includes/dof.h
@@ -319,13 +319,13 @@ public:
     /** Returns variable assigned to this degree of freedom. */
     const VariableData& GetVariable() const
     {
-        return mpNodalData->GetSolutionStepData().pGetVariablesList()->GetDofVariable(mIndex);
+        return mpNodalData->GetSolutionStepData().GetVariablesList().GetDofVariable(mIndex);
     }
 
     /** Returns reaction variable of this degree of freedom. */
     const VariableData& GetReaction() const
     {
-        auto p_reaction = mpNodalData->GetSolutionStepData().pGetVariablesList()->pGetDofReaction(mIndex);
+        auto p_reaction = mpNodalData->GetSolutionStepData().GetVariablesList().pGetDofReaction(mIndex);
         return (p_reaction == nullptr) ? msNone : *p_reaction;
     }
 


### PR DESCRIPTION
**Description**
The `GetVariable` of the Dof was using the `pGetVariablesList`. This results in creating and destroying the intrusive pointer which has considerable overhead, especially in the check if the Dof for a variable already exists. 

In my test, these changes reduce the check() call for 6M elements from 25s to 2s.

**Changelog**
Adding `GetVariablesList` method to the `VariablesListDataValueContainer`
Using `GetVariablesList` in the `Dof::GetVariable` method
