### PR TITLE
[FastPR][Fluid] Characteristic numbers fourier and rename

### DIFF
--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.cpp
@@ -77,7 +77,7 @@ namespace Kratos
     {
         // Get diffusivevalues
         const double cp = rElement.GetProperties().GetValue(SPECIFIC_HEAT);
-        const auto diff_values = GetDiffusivityValues<ConsiderArtificialMagnitudes>(rElement); 
+        const auto diff_values = GetDiffusivityValues<ConsiderArtificialMagnitudes>(rElement);
 
         // Calculate Prandtl number
         const double elem_prandtl = cp * std::get<0>(diff_values) / std::get<1>(diff_values);
@@ -191,7 +191,7 @@ namespace Kratos
         const double h = rElementSizeCalculator(rElement.GetGeometry());
 
         // Calculate Fourier numbers
-        const double aux = Dt / rho / std::pow(h,2);
+        const double aux = Dt / (rho * std::pow(h,2));
         const double cp = rElement.GetProperties().GetValue(SPECIFIC_HEAT);
         const double visc_Fo = aux * std::get<0>(diff_values);
         const double thermal_Fo =  aux * std::get<1>(diff_values) / cp;
@@ -214,7 +214,7 @@ namespace Kratos
         const double h = rElementSizeCalculator(rElement.GetGeometry());
 
         // Calculate viscous Fourier number
-        const double visc_Fo = Dt * mu / rho / std::pow(h,2);
+        const double visc_Fo = Dt * mu / (rho * std::pow(h,2));
         return visc_Fo;
     }
 
@@ -236,7 +236,7 @@ namespace Kratos
 
         // Calculate thermal Fourier number
         const double cp = rElement.GetProperties().GetValue(SPECIFIC_HEAT);
-        const double thermal_Fo =  Dt * k / rho / cp / std::pow(h,2);
+        const double thermal_Fo =  Dt * k / (rho * cp * std::pow(h,2));
         return thermal_Fo;
     }
 

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.cpp
@@ -175,6 +175,71 @@ namespace Kratos
         return k_Pe;
     }
 
+    template<bool ConsiderArtificialMagnitudes, bool DensityIsNodal>
+    std::tuple<double,double> FluidCharacteristicNumbersUtilities::CalculateElementFourierNumbers(
+        const Element& rElement,
+        const ElementSizeFunctionType& rElementSizeCalculator,
+        const double Dt)
+    {
+        // Calculate midpoint density
+        const double rho = AuxiliaryGetDensity<DensityIsNodal>(rElement);
+
+        // Calculate diffusive magnitudes
+        const auto diff_values = GetDiffusivityValues<ConsiderArtificialMagnitudes>(rElement);
+
+        // Calculate element average size
+        const double h = rElementSizeCalculator(rElement.GetGeometry());
+
+        // Calculate Fourier numbers
+        const double aux = Dt / rho / std::pow(h,2);
+        const double cp = rElement.GetProperties().GetValue(SPECIFIC_HEAT);
+        const double visc_Fo = aux * std::get<0>(diff_values);
+        const double thermal_Fo =  aux * std::get<1>(diff_values) / cp;
+        return std::make_tuple(visc_Fo, thermal_Fo);
+    }
+
+    template<bool ConsiderArtificialMagnitudes, bool DensityIsNodal>
+    double FluidCharacteristicNumbersUtilities::CalculateElementViscousFourierNumber(
+        const Element& rElement,
+        const ElementSizeFunctionType& rElementSizeCalculator,
+        const double Dt)
+    {
+        // Calculate midpoint density
+        const double rho = AuxiliaryGetDensity<DensityIsNodal>(rElement);
+
+        // Calculate dynamic viscosity
+        const double mu = GetDynamicViscosityValue<ConsiderArtificialMagnitudes>(rElement);
+
+        // Calculate element average size
+        const double h = rElementSizeCalculator(rElement.GetGeometry());
+
+        // Calculate viscous Fourier number
+        const double visc_Fo = Dt * mu / rho / std::pow(h,2);
+        return visc_Fo;
+    }
+
+
+    template<bool ConsiderArtificialMagnitudes, bool DensityIsNodal>
+    double FluidCharacteristicNumbersUtilities::CalculateElementThermalFourierNumber(
+        const Element& rElement,
+        const ElementSizeFunctionType& rElementSizeCalculator,
+        const double Dt)
+    {
+        // Calculate midpoint density
+        const double rho = AuxiliaryGetDensity<DensityIsNodal>(rElement);
+
+        // Calculate diffusive magnitudes
+        const double k = GetConductivityValue<ConsiderArtificialMagnitudes>(rElement);
+
+        // Calculate element average size
+        const double h = rElementSizeCalculator(rElement.GetGeometry());
+
+        // Calculate thermal Fourier number
+        const double cp = rElement.GetProperties().GetValue(SPECIFIC_HEAT);
+        const double thermal_Fo =  Dt * k / rho / cp / std::pow(h,2);
+        return thermal_Fo;
+    }
+
     double FluidCharacteristicNumbersUtilities::CalculateElementMachNumber(const Element &rElement)
     {
         // Get midpoint values
@@ -372,5 +437,20 @@ template std::tuple<double,double> FluidCharacteristicNumbersUtilities::Calculat
 template std::tuple<double,double> FluidCharacteristicNumbersUtilities::CalculateElementPecletNumbers<true, false>(const Element&, const ElementSizeFunctionType&);
 template std::tuple<double,double> FluidCharacteristicNumbersUtilities::CalculateElementPecletNumbers<false, true>(const Element&, const ElementSizeFunctionType&);
 template std::tuple<double,double> FluidCharacteristicNumbersUtilities::CalculateElementPecletNumbers<false, false>(const Element&, const ElementSizeFunctionType&);
+
+template double FluidCharacteristicNumbersUtilities::CalculateElementViscousFourierNumber<true, true>(const Element&, const ElementSizeFunctionType&, const double);
+template double FluidCharacteristicNumbersUtilities::CalculateElementViscousFourierNumber<true, false>(const Element&, const ElementSizeFunctionType&, const double);
+template double FluidCharacteristicNumbersUtilities::CalculateElementViscousFourierNumber<false, true>(const Element&, const ElementSizeFunctionType&, const double);
+template double FluidCharacteristicNumbersUtilities::CalculateElementViscousFourierNumber<false, false>(const Element&, const ElementSizeFunctionType&, const double);
+
+template double FluidCharacteristicNumbersUtilities::CalculateElementThermalFourierNumber<true, true>(const Element&, const ElementSizeFunctionType&, const double);
+template double FluidCharacteristicNumbersUtilities::CalculateElementThermalFourierNumber<true, false>(const Element&, const ElementSizeFunctionType&, const double);
+template double FluidCharacteristicNumbersUtilities::CalculateElementThermalFourierNumber<false, true>(const Element&, const ElementSizeFunctionType&, const double);
+template double FluidCharacteristicNumbersUtilities::CalculateElementThermalFourierNumber<false, false>(const Element&, const ElementSizeFunctionType&, const double);
+
+template std::tuple<double,double> FluidCharacteristicNumbersUtilities::CalculateElementFourierNumbers<true, true>(const Element&, const ElementSizeFunctionType&, const double);
+template std::tuple<double,double> FluidCharacteristicNumbersUtilities::CalculateElementFourierNumbers<true, false>(const Element&, const ElementSizeFunctionType&, const double);
+template std::tuple<double,double> FluidCharacteristicNumbersUtilities::CalculateElementFourierNumbers<false, true>(const Element&, const ElementSizeFunctionType&, const double);
+template std::tuple<double,double> FluidCharacteristicNumbersUtilities::CalculateElementFourierNumbers<false, false>(const Element&, const ElementSizeFunctionType&, const double);
 
 } // namespace Kratos.

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.cpp
@@ -117,7 +117,7 @@ namespace Kratos
     }
 
     template<bool ConsiderArtificialMagnitudes, bool DensityIsNodal>
-    double FluidCharacteristicNumbersUtilities::CalculateElementViscosityPecletNumber(
+    double FluidCharacteristicNumbersUtilities::CalculateElementViscousPecletNumber(
         const Element& rElement,
         const ElementSizeFunctionType& rElementSizeCalculator)
     {
@@ -146,7 +146,7 @@ namespace Kratos
 
 
     template<bool ConsiderArtificialMagnitudes, bool DensityIsNodal>
-    double FluidCharacteristicNumbersUtilities::CalculateElementConductivityPecletNumber(
+    double FluidCharacteristicNumbersUtilities::CalculateElementThermalPecletNumber(
         const Element& rElement,
         const ElementSizeFunctionType& rElementSizeCalculator)
     {
@@ -358,15 +358,15 @@ namespace Kratos
 template double FluidCharacteristicNumbersUtilities::CalculateElementPrandtlNumber<true>(const Element&);
 template double FluidCharacteristicNumbersUtilities::CalculateElementPrandtlNumber<false>(const Element&);
 
-template double FluidCharacteristicNumbersUtilities::CalculateElementViscosityPecletNumber<true, true>(const Element&, const ElementSizeFunctionType&);
-template double FluidCharacteristicNumbersUtilities::CalculateElementViscosityPecletNumber<true, false>(const Element&, const ElementSizeFunctionType&);
-template double FluidCharacteristicNumbersUtilities::CalculateElementViscosityPecletNumber<false, true>(const Element&, const ElementSizeFunctionType&);
-template double FluidCharacteristicNumbersUtilities::CalculateElementViscosityPecletNumber<false, false>(const Element&, const ElementSizeFunctionType&);
+template double FluidCharacteristicNumbersUtilities::CalculateElementViscousPecletNumber<true, true>(const Element&, const ElementSizeFunctionType&);
+template double FluidCharacteristicNumbersUtilities::CalculateElementViscousPecletNumber<true, false>(const Element&, const ElementSizeFunctionType&);
+template double FluidCharacteristicNumbersUtilities::CalculateElementViscousPecletNumber<false, true>(const Element&, const ElementSizeFunctionType&);
+template double FluidCharacteristicNumbersUtilities::CalculateElementViscousPecletNumber<false, false>(const Element&, const ElementSizeFunctionType&);
 
-template double FluidCharacteristicNumbersUtilities::CalculateElementConductivityPecletNumber<true, true>(const Element&, const ElementSizeFunctionType&);
-template double FluidCharacteristicNumbersUtilities::CalculateElementConductivityPecletNumber<true, false>(const Element&, const ElementSizeFunctionType&);
-template double FluidCharacteristicNumbersUtilities::CalculateElementConductivityPecletNumber<false, true>(const Element&, const ElementSizeFunctionType&);
-template double FluidCharacteristicNumbersUtilities::CalculateElementConductivityPecletNumber<false, false>(const Element&, const ElementSizeFunctionType&);
+template double FluidCharacteristicNumbersUtilities::CalculateElementThermalPecletNumber<true, true>(const Element&, const ElementSizeFunctionType&);
+template double FluidCharacteristicNumbersUtilities::CalculateElementThermalPecletNumber<true, false>(const Element&, const ElementSizeFunctionType&);
+template double FluidCharacteristicNumbersUtilities::CalculateElementThermalPecletNumber<false, true>(const Element&, const ElementSizeFunctionType&);
+template double FluidCharacteristicNumbersUtilities::CalculateElementThermalPecletNumber<false, false>(const Element&, const ElementSizeFunctionType&);
 
 template std::tuple<double,double> FluidCharacteristicNumbersUtilities::CalculateElementPecletNumbers<true, true>(const Element&, const ElementSizeFunctionType&);
 template std::tuple<double,double> FluidCharacteristicNumbersUtilities::CalculateElementPecletNumbers<true, false>(const Element&, const ElementSizeFunctionType&);

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.h
@@ -119,7 +119,7 @@ public:
      * @return double The element Peclet number
      */
     template<bool ConsiderArtificialMagnitudes, bool DensityIsNodal>
-    static double CalculateElementViscosityPecletNumber(
+    static double CalculateElementViscousPecletNumber(
         const Element& rElement,
         const ElementSizeFunctionType& rElementSizeCalculator);
 
@@ -132,7 +132,7 @@ public:
      * @return double The element Peclet number
      */
     template<bool ConsiderArtificialMagnitudes, bool DensityIsNodal>
-    static double CalculateElementConductivityPecletNumber(
+    static double CalculateElementThermalPecletNumber(
         const Element& rElement,
         const ElementSizeFunctionType& rElementSizeCalculator);
 

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.h
@@ -137,6 +137,49 @@ public:
         const ElementSizeFunctionType& rElementSizeCalculator);
 
     /**
+     * @brief Calculate the elemental Fourier numbers
+     * For the given element, this method calculates the Fourier number considering both the
+     * dynamic viscosity and the shear conductivity 
+     * @tparam ConsiderArtificialMagnitudes Template parameter specifying if the artificial values are considered
+     * @tparam DensityIsNodal Template parameter specifying if the density is nodally stored
+     * @param rElement Element to calculate the Fourier number
+     * @return std::tuple<double,double> Tuple containing the viscosity (first position) and thermal (second position) Fourier numbers
+     */
+    template<bool ConsiderArtificialMagnitudes, bool DensityIsNodal>
+    static std::tuple<double,double> CalculateElementFourierNumbers(
+        const Element& rElement,
+        const ElementSizeFunctionType& rElementSizeCalculator,
+        const double Dt);
+
+    /**
+     * @brief Calculate the elemental Fourier number
+     * For the given element, this method calculates the viscous Fourier number
+     * @tparam ConsiderArtificialMagnitudes Template parameter specifying if the artificial values are considered
+     * @tparam DensityIsNodal Template parameter specifying if the density is nodally stored
+     * @param rElement Element to calculate the Fourier number
+     * @return double The element Fourier number
+     */
+    template<bool ConsiderArtificialMagnitudes, bool DensityIsNodal>
+    static double CalculateElementViscousFourierNumber(
+        const Element& rElement,
+        const ElementSizeFunctionType& rElementSizeCalculator,
+        const double Dt);
+
+    /**
+     * @brief Calculate the elemental Fourier number
+     * For the given element, this method calculates the thermal Fourier number
+     * @tparam ConsiderArtificialMagnitudes Template parameter specifying if the artificial values are considered
+     * @tparam DensityIsNodal Template parameter specifying if the density is nodally stored
+     * @param rElement Element to calculate the Fourier number
+     * @return double The element Fourier number
+     */
+    template<bool ConsiderArtificialMagnitudes, bool DensityIsNodal>
+    static double CalculateElementThermalFourierNumber(
+        const Element& rElement,
+        const ElementSizeFunctionType& rElementSizeCalculator,
+        const double Dt);
+
+    /**
      * @brief Calculate the element Mach number
      * For the given element, this method calculates the midpoint Mach number
      * Note that it requires the velocity to be stored in the nodal historical

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_characteristic_numbers_utilities.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_characteristic_numbers_utilities.cpp
@@ -139,7 +139,7 @@ KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateElementPecletNumber
     KRATOS_CHECK_NEAR(std::get<1>(peclet_numbers), 0.027777777777, tolerance);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateConductivityElementPecletNumber, FluidDynamicsApplicationFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateElementThermalPecletNumber, FluidDynamicsApplicationFastSuite)
 {
     // Create the test element
     Model model;
@@ -173,6 +173,73 @@ KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateElementViscousPecle
     // Check results
     const double tolerance = 1.0e-8;
     KRATOS_CHECK_NEAR(mu_peclet_number, 0.055555555555, tolerance);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateElementFourierNumbers, FluidDynamicsApplicationFastSuite)
+{
+    // Set the current delta time to calculate the Fourier number
+    const double current_dt = 1.0e-1;
+
+    // Create the test element
+    Model model;
+    ModelPart& r_model_part = model.CreateModelPart("TestModelPart");
+    TestFluidCharacteristicNumberElementSet(r_model_part);
+
+    // Calculate the element Peclet numbers
+    std::function<double(const Geometry<Node<3>>&)> min_elem_function = ElementSizeCalculator<2,3>::MinimumElementSize;
+    const auto fourier_numbers = FluidCharacteristicNumbersUtilities::CalculateElementFourierNumbers<true, false>(
+        r_model_part.GetElement(1),
+        min_elem_function,
+        current_dt);
+
+    // Check results
+    const double tolerance = 1.0e-8;
+    KRATOS_CHECK_NEAR(std::get<0>(fourier_numbers), 3.75, tolerance);
+    KRATOS_CHECK_NEAR(std::get<1>(fourier_numbers), 7.5, tolerance);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateElementThermalFourierNumber, FluidDynamicsApplicationFastSuite)
+{
+    // Set the current delta time to calculate the Fourier number
+    const double current_dt = 1.0e-1;
+    
+    // Create the test element
+    Model model;
+    ModelPart& r_model_part = model.CreateModelPart("TestModelPart");
+    TestFluidCharacteristicNumberElementSet(r_model_part);
+
+    // Calculate the element Peclet numbers
+    std::function<double(const Geometry<Node<3>>&)> min_elem_function = ElementSizeCalculator<2,3>::MinimumElementSize;
+    const double thermal_fourier_number = FluidCharacteristicNumbersUtilities::CalculateElementThermalFourierNumber<true, false>(
+        r_model_part.GetElement(1),
+        min_elem_function,
+        current_dt);
+
+    // Check results
+    const double tolerance = 1.0e-8;
+    KRATOS_CHECK_NEAR(thermal_fourier_number, 7.5, tolerance);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateElementViscousFourierNumber, FluidDynamicsApplicationFastSuite)
+{
+    // Set the current delta time to calculate the Fourier number
+    const double current_dt = 1.0e-1;
+
+    // Create the test element
+    Model model;
+    ModelPart& r_model_part = model.CreateModelPart("TestModelPart");
+    TestFluidCharacteristicNumberElementSet(r_model_part);
+
+    // Calculate the element Peclet numbers
+    std::function<double(const Geometry<Node<3>>&)> min_elem_function = ElementSizeCalculator<2,3>::MinimumElementSize;
+    const double viscous_fourier_number = FluidCharacteristicNumbersUtilities::CalculateElementViscousFourierNumber<true, false>(
+        r_model_part.GetElement(1),
+        min_elem_function,
+        current_dt);
+
+    // Check results
+    const double tolerance = 1.0e-8;
+    KRATOS_CHECK_NEAR(viscous_fourier_number, 3.75, tolerance);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateElementMachNumber, FluidDynamicsApplicationFastSuite)

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_characteristic_numbers_utilities.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_characteristic_numbers_utilities.cpp
@@ -148,7 +148,7 @@ KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateConductivityElement
 
     // Calculate the element Peclet numbers
     std::function<double(const Geometry<Node<3>>&)> avg_elem_function = ElementSizeCalculator<2,3>::AverageElementSize;
-    const double k_peclet_number = FluidCharacteristicNumbersUtilities::CalculateElementConductivityPecletNumber<true, false>(
+    const double k_peclet_number = FluidCharacteristicNumbersUtilities::CalculateElementThermalPecletNumber<true, false>(
         r_model_part.GetElement(1),
         avg_elem_function);
 
@@ -157,7 +157,7 @@ KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateConductivityElement
     KRATOS_CHECK_NEAR(k_peclet_number, 0.027777777777, tolerance);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateElementViscosityPecletNumber, FluidDynamicsApplicationFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateElementViscousPecletNumber, FluidDynamicsApplicationFastSuite)
 {
     // Create the test element
     Model model;
@@ -166,7 +166,7 @@ KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateElementViscosityPec
 
     // Calculate the element Peclet numbers
     std::function<double(const Geometry<Node<3>>&)> avg_elem_function = ElementSizeCalculator<2,3>::AverageElementSize;
-    const double mu_peclet_number = FluidCharacteristicNumbersUtilities::CalculateElementViscosityPecletNumber<true, false>(
+    const double mu_peclet_number = FluidCharacteristicNumbersUtilities::CalculateElementViscousPecletNumber<true, false>(
         r_model_part.GetElement(1),
         avg_elem_function);
 


### PR DESCRIPTION
**Description**
Enhance the `FluidCharacteristicNumbersUtility` with the viscous and thermal Fourier number calculation. This is required for the automatic delta time estimation in thermally coupled flows (i.e. compressible NS). Tests have been added accordingly.

I also took the chance to rename the Peclet number methods to something more user-friendly before this becomes used in other places.