### PR TITLE
[Core] adding compiler warning after 7725

### DIFF
--- a/kratos/includes/checks.h
+++ b/kratos/includes/checks.h
@@ -169,8 +169,9 @@ try {                                                                           
 }
 
 // this macro is to be removed, as it is no longer required to check the keys of Variables (are now assigned at compiletime)
-// adding dummy usage to avoid unused variable warnings
-#define KRATOS_CHECK_VARIABLE_KEY(TheVariable) TheVariable.Key();
+#define KRATOS_CHECK_VARIABLE_KEY(TheVariable) \
+    _Pragma ("message \"'KRATOS_CHECK_VARIABLE_KEY' macro is no longer needed and can be safely removed\""); \
+    TheVariable.Key(); // adding dummy usage to avoid unused variable warnings
 
 #define KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TheVariable, TheNode)                          \
     KRATOS_ERROR_IF_NOT(TheNode.SolutionStepsDataHas(TheVariable))                         \

--- a/kratos/includes/checks.h
+++ b/kratos/includes/checks.h
@@ -170,7 +170,7 @@ try {                                                                           
 
 // this macro is to be removed, as it is no longer required to check the keys of Variables (are now assigned at compiletime)
 #define KRATOS_CHECK_VARIABLE_KEY(TheVariable) \
-    _Pragma ("message \"'KRATOS_CHECK_VARIABLE_KEY' macro is no longer needed and can be safely removed\""); \
+    _Pragma ("message( \"'KRATOS_CHECK_VARIABLE_KEY' macro is no longer needed and can be safely removed\")"); \
     TheVariable.Key(); // adding dummy usage to avoid unused variable warnings
 
 #define KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TheVariable, TheNode)                          \

--- a/kratos/solving_strategies/schemes/residual_based_bdf_custom_scheme.h
+++ b/kratos/solving_strategies/schemes/residual_based_bdf_custom_scheme.h
@@ -345,15 +345,6 @@ public:
         const int err = BDFBaseType::Check(rModelPart);
         if(err!=0) return err;
 
-        // Check for variables keys
-        // Verify that the variables are correctly initialized
-        for ( auto p_var : mDoubleVariable)
-            KRATOS_CHECK_VARIABLE_KEY((*p_var))
-        for ( auto p_var : mFirstDoubleDerivatives)
-            KRATOS_CHECK_VARIABLE_KEY((*p_var))
-        for ( auto p_var : mSecondDoubleDerivatives)
-            KRATOS_CHECK_VARIABLE_KEY((*p_var))
-
         // Check that variables are correctly allocated
         for(auto& r_node : rModelPart.Nodes()) {
             for ( auto p_var : mDoubleVariable)

--- a/kratos/solving_strategies/schemes/residual_based_bdf_displacement_scheme.h
+++ b/kratos/solving_strategies/schemes/residual_based_bdf_displacement_scheme.h
@@ -332,12 +332,6 @@ public:
         const int err = BDFBaseType::Check(rModelPart);
         if(err!=0) return err;
 
-        // Check for variables keys
-        // Verify that the variables are correctly initialized
-        KRATOS_CHECK_VARIABLE_KEY(DISPLACEMENT)
-        KRATOS_CHECK_VARIABLE_KEY(VELOCITY)
-        KRATOS_CHECK_VARIABLE_KEY(ACCELERATION)
-
         // Check that variables are correctly allocated
         for(auto& rnode : rModelPart.Nodes()) {
             KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISPLACEMENT,rnode)

--- a/kratos/solving_strategies/schemes/residual_based_bossak_displacement_scheme.hpp
+++ b/kratos/solving_strategies/schemes/residual_based_bossak_displacement_scheme.hpp
@@ -422,12 +422,6 @@ public:
         const int err = ImplicitBaseType::Check(rModelPart);
         if(err != 0) return err;
 
-        // Check for variables keys
-        // Verify that the variables are correctly initialized
-        KRATOS_CHECK_VARIABLE_KEY(DISPLACEMENT)
-        KRATOS_CHECK_VARIABLE_KEY(VELOCITY)
-        KRATOS_CHECK_VARIABLE_KEY(ACCELERATION)
-
         // Check that variables are correctly allocated
         for (const auto& rnode : rModelPart.Nodes()) {
             KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISPLACEMENT,rnode)

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -1544,7 +1544,6 @@ public:
         KRATOS_TRY
 
         // First we do a chek
-        KRATOS_CHECK_VARIABLE_KEY(rVar)
         if(rModelPart.NumberOfNodes() != 0)
             KRATOS_ERROR_IF_NOT(rModelPart.NodesBegin()->SolutionStepsDataHas(rVar)) << "ERROR:: Variable : " << rVar << "not included in the Solution step data ";
 
@@ -1573,9 +1572,6 @@ public:
         )
     {
         KRATOS_TRY
-
-        KRATOS_CHECK_VARIABLE_KEY(rVar)
-        KRATOS_CHECK_VARIABLE_KEY(rReactionVar)
 
         if(rModelPart.NumberOfNodes() != 0) {
             KRATOS_ERROR_IF_NOT(rModelPart.NodesBegin()->SolutionStepsDataHas(rVar)) << "ERROR:: DoF Variable : " << rVar << "not included in the Soluttion step data ";


### PR DESCRIPTION
**Description**
Followup of #7725, now it also prints a warning at compile time so that devs know to clean up

I tested it with GCC, Clang and Intel, also MSVC should support it [according to their docs](https://devblogs.microsoft.com/cppblog/announcing-full-support-for-a-c-c-conformant-preprocessor-in-msvc/#_pragma) (we will know if CI passes)