### PR TITLE
[Hotfix][FastPR][Fluid] Compressible NS solver ProcessInfo values initialization

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
@@ -103,11 +103,8 @@ class NavierStokesCompressibleExplicitSolver(FluidSolver):
         KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.TOTAL_ENERGY, KratosFluid.REACTION_ENERGY, self.main_model_part)
 
     def Initialize(self):
-        #TODO: PROPERLY IMPLEMENT THIS
-        if self.settings["use_oss"].GetBool():
-            self.GetComputingModelPart().ProcessInfo[KratosMultiphysics.OSS_SWITCH] = 1
-        if self.settings["shock_capturing"].GetBool():
-            self.GetComputingModelPart().ProcessInfo[KratosFluid.SHOCK_CAPTURING_SWITCH] = 1
+        self.GetComputingModelPart().ProcessInfo[KratosMultiphysics.OSS_SWITCH] = int(self.settings["use_oss"].GetBool())
+        self.GetComputingModelPart().ProcessInfo[KratosFluid.SHOCK_CAPTURING_SWITCH] = int(self.settings["shock_capturing"].GetBool())
 
         self.solver = self._get_solution_strategy()
         self.solver.SetEchoLevel(self.settings["echo_level"].GetInt())


### PR DESCRIPTION
**Description**
After the strategy minor changes in #7936, this throws an error when the OSS is deactivated since the corresponding variable is not set in the `ProcessInfo`. This PR ensures that the `ProcessInfo` variables are always set.
