### PR TITLE
[Core] using msvc specific version of pragma for backward compatibility

### DIFF
--- a/kratos/includes/checks.h
+++ b/kratos/includes/checks.h
@@ -171,7 +171,7 @@ try {                                                                           
 // this macro is to be removed, as it is no longer required to check the keys of Variables (are now assigned at compiletime)
 #if defined(_MSC_VER)
 #define KRATOS_CHECK_VARIABLE_KEY(TheVariable) \
-    __pragma(message("\"'KRATOS_CHECK_VARIABLE_KEY' macro is no longer needed and can be safely removed\"")); \
+    __pragma(message("\"'KRATOS_CHECK_VARIABLE_KEY' macro is no longer needed and can be safely removed\""));
 #else
 #define KRATOS_CHECK_VARIABLE_KEY(TheVariable) \
     _Pragma ("message( \"'KRATOS_CHECK_VARIABLE_KEY' macro is no longer needed and can be safely removed\")"); \

--- a/kratos/includes/checks.h
+++ b/kratos/includes/checks.h
@@ -169,13 +169,14 @@ try {                                                                           
 }
 
 // this macro is to be removed, as it is no longer required to check the keys of Variables (are now assigned at compiletime)
-#define KRATOS_CHECK_VARIABLE_KEY(TheVariable) \
 #if defined(_MSC_VER)
+#define KRATOS_CHECK_VARIABLE_KEY(TheVariable) \
     __pragma(message("\"'KRATOS_CHECK_VARIABLE_KEY' macro is no longer needed and can be safely removed\"")); \
 #else
+#define KRATOS_CHECK_VARIABLE_KEY(TheVariable) \
     _Pragma ("message( \"'KRATOS_CHECK_VARIABLE_KEY' macro is no longer needed and can be safely removed\")"); \
-#endif
     TheVariable.Key(); // adding dummy usage to avoid unused variable warnings
+#endif
 
 #define KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TheVariable, TheNode)                          \
     KRATOS_ERROR_IF_NOT(TheNode.SolutionStepsDataHas(TheVariable))                         \

--- a/kratos/includes/checks.h
+++ b/kratos/includes/checks.h
@@ -170,7 +170,11 @@ try {                                                                           
 
 // this macro is to be removed, as it is no longer required to check the keys of Variables (are now assigned at compiletime)
 #define KRATOS_CHECK_VARIABLE_KEY(TheVariable) \
+#if defined(_MSC_VER)
+    __pragma(message("\"'KRATOS_CHECK_VARIABLE_KEY' macro is no longer needed and can be safely removed\"")); \
+#else
     _Pragma ("message( \"'KRATOS_CHECK_VARIABLE_KEY' macro is no longer needed and can be safely removed\")"); \
+#endif
     TheVariable.Key(); // adding dummy usage to avoid unused variable warnings
 
 #define KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TheVariable, TheNode)                          \


### PR DESCRIPTION
**Description**
Apparently only newer versions of MSVC support `_Pragma`
Hence using the MSVC specific version: `__pragma`

@AlejandroCornejo can you please check if it compiles now?

closes #7976 

(@AlejandroCornejo another fix would have been to just remove `KRATOS_CHECK_VARIABLE_KEY` everywhere)