### PR TITLE
[Fluid] Fluid element data clean up and non historical nodal data support

### DIFF
--- a/applications/FluidDynamicsApplication/custom_utilities/embedded_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/embedded_data.h
@@ -86,7 +86,7 @@ void Initialize(
  * @brief Fills the boundary condition data fields
  * This method needs to be called in cut elements. It fills the data structure fields related to the boundary
  * condition imposition (slip length for the slip formulation and penalty coefficient for both formulations).
- * @param rProcessInfo 
+ * @param rProcessInfo
  */
 void InitializeBoundaryConditionData(const ProcessInfo &rProcessInfo)
 {
@@ -98,10 +98,6 @@ void InitializeBoundaryConditionData(const ProcessInfo &rProcessInfo)
 
 static int Check(const Element& rElement, const ProcessInfo& rProcessInfo)
 {
-    KRATOS_CHECK_VARIABLE_KEY(DISTANCE);
-    KRATOS_CHECK_VARIABLE_KEY(SLIP_LENGTH);
-    KRATOS_CHECK_VARIABLE_KEY(PENALTY_COEFFICIENT);
-
     const Geometry< Node<3> >& r_geometry = rElement.GetGeometry();
     for (unsigned int i = 0; i < TFluidData::NumNodes; i++) {
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISTANCE,r_geometry[i]);

--- a/applications/FluidDynamicsApplication/custom_utilities/embedded_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/embedded_data.h
@@ -74,7 +74,7 @@ void Initialize(
 {
     TFluidData::Initialize(rElement, rProcessInfo);
     const Geometry<Node<3> >& r_geometry = rElement.GetGeometry();
-    this->FillFromNodalData(Distance, DISTANCE, r_geometry);
+    this->FillFromHistoricalNodalData(Distance, DISTANCE, r_geometry);
 
     NumPositiveNodes = 0;
     NumNegativeNodes = 0;

--- a/applications/FluidDynamicsApplication/custom_utilities/embedded_discontinuous_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/embedded_discontinuous_data.h
@@ -77,7 +77,7 @@ size_t NumNegativeNodes;
  * @brief Discontinuous embedded formulation data container initialization
  * This method initializes the discontinuous embedded formulation data container. This implies to intialize
  * the base formulation data container as well as to get the elemental distances from the elemental variable
- * ELEMENTAL_DISTANCES (note that this requires the ELEMENTAL_DISTANCES to be set before this operation). 
+ * ELEMENTAL_DISTANCES (note that this requires the ELEMENTAL_DISTANCES to be set before this operation).
  * @param rElement reference to the element that owns the data container
  * @param rProcessInfo reference to the current ProcessInfo container
  */
@@ -96,7 +96,7 @@ void Initialize(
  * @brief Fills the boundary condition data fields
  * This method needs to be called in cut elements. It fills the data structure fields related to the boundary
  * condition imposition (slip length and penalty coefficient) by retrieving their value from the ProcessInfo.
- * @param rProcessInfo 
+ * @param rProcessInfo
  */
 void InitializeBoundaryConditionData(const ProcessInfo& rProcessInfo)
 {
@@ -106,9 +106,9 @@ void InitializeBoundaryConditionData(const ProcessInfo& rProcessInfo)
 
 /**
  * @brief Discontinous embedded formulation data container check
- * Simple discontinuous embedded formulation data container check. The base formulation data container is 
+ * Simple discontinuous embedded formulation data container check. The base formulation data container is
  * checked as well. Returns 0 if the check process succeeds.
- * @param rElement reference to the element that owns the data container 
+ * @param rElement reference to the element that owns the data container
  * @param rProcessInfo reference to the current ProcessInfo container
  * @return int returns 0 if the check process succeeds
  */
@@ -116,10 +116,6 @@ static int Check(
     const Element& rElement,
     const ProcessInfo& rProcessInfo)
 {
-    KRATOS_CHECK_VARIABLE_KEY(SLIP_LENGTH);
-    KRATOS_CHECK_VARIABLE_KEY(PENALTY_COEFFICIENT);
-    KRATOS_CHECK_VARIABLE_KEY(ELEMENTAL_DISTANCES);
-
     int out = TFluidData::Check(rElement,rProcessInfo);
     return out;
 }

--- a/applications/FluidDynamicsApplication/custom_utilities/fic_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fic_data.h
@@ -65,10 +65,10 @@ void Initialize(const Element& rElement, const ProcessInfo& rProcessInfo) overri
 
     const Geometry< Node<3> >& r_geometry = rElement.GetGeometry();
     const Properties& r_properties = rElement.GetProperties();
-    this->FillFromNodalData(Velocity,VELOCITY,r_geometry);
-    this->FillFromNodalData(MeshVelocity,MESH_VELOCITY,r_geometry);
-    this->FillFromNodalData(BodyForce,BODY_FORCE,r_geometry);
-    this->FillFromNodalData(Pressure,PRESSURE,r_geometry);
+    this->FillFromHistoricalNodalData(Velocity,VELOCITY,r_geometry);
+    this->FillFromHistoricalNodalData(MeshVelocity,MESH_VELOCITY,r_geometry);
+    this->FillFromHistoricalNodalData(BodyForce,BODY_FORCE,r_geometry);
+    this->FillFromHistoricalNodalData(Pressure,PRESSURE,r_geometry);
     this->FillFromProperties(Density,DENSITY,r_properties);
     this->FillFromProcessInfo(DeltaTime,DELTA_TIME,rProcessInfo);
     this->FillFromProcessInfo(FICBeta,FIC_BETA,rProcessInfo);

--- a/applications/FluidDynamicsApplication/custom_utilities/fic_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fic_data.h
@@ -79,10 +79,6 @@ static int Check(const Element& rElement, const ProcessInfo& rProcessInfo)
 {
     const Geometry< Node<3> >& r_geometry = rElement.GetGeometry();
 
-    KRATOS_CHECK_VARIABLE_KEY(VELOCITY);
-    KRATOS_CHECK_VARIABLE_KEY(MESH_VELOCITY);
-    KRATOS_CHECK_VARIABLE_KEY(BODY_FORCE);
-    KRATOS_CHECK_VARIABLE_KEY(PRESSURE);
     for (unsigned int i = 0; i < TNumNodes; i++)
     {
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VELOCITY,r_geometry[i]);
@@ -90,10 +86,6 @@ static int Check(const Element& rElement, const ProcessInfo& rProcessInfo)
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(BODY_FORCE,r_geometry[i]);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(PRESSURE,r_geometry[i]);
     }
-
-    KRATOS_CHECK_VARIABLE_KEY(DENSITY);
-    KRATOS_CHECK_VARIABLE_KEY(DELTA_TIME);
-    KRATOS_CHECK_VARIABLE_KEY(FIC_BETA);
 
     return 0;
 }

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_element_data.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_element_data.cpp
@@ -62,9 +62,10 @@ void FluidElementData<TDim, TNumNodes, TElementIntegratesInTime>::UpdateGeometry
 }
 
 template <size_t TDim, size_t TNumNodes, bool TElementIntegratesInTime>
-void FluidElementData<TDim, TNumNodes, TElementIntegratesInTime>::FillFromNodalData(
-    NodalScalarData& rData, const Variable<double>& rVariable,
-    const Geometry<Node<3>>& rGeometry)
+void FluidElementData<TDim, TNumNodes, TElementIntegratesInTime>::FillFromHistoricalNodalData(
+    NodalScalarData &rData,
+    const Variable<double> &rVariable,
+    const Geometry<Node<3>> &rGeometry)
 {
     noalias(rData) = ZeroVector(TNumNodes);
     for (size_t i = 0; i < TNumNodes; i++) {
@@ -73,7 +74,8 @@ void FluidElementData<TDim, TNumNodes, TElementIntegratesInTime>::FillFromNodalD
 }
 
 template <size_t TDim, size_t TNumNodes, bool TElementIntegratesInTime>
-void FluidElementData<TDim, TNumNodes, TElementIntegratesInTime>::FillFromNodalData(NodalVectorData& rData,
+void FluidElementData<TDim, TNumNodes, TElementIntegratesInTime>::FillFromHistoricalNodalData(
+    NodalVectorData& rData,
     const Variable<array_1d<double, 3>>& rVariable,
     const Geometry<Node<3>>& rGeometry)
 {

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_element_data.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_element_data.cpp
@@ -112,6 +112,32 @@ void FluidElementData<TDim, TNumNodes, TElementIntegratesInTime>::FillFromHistor
 }
 
 template <size_t TDim, size_t TNumNodes, bool TElementIntegratesInTime>
+void FluidElementData<TDim, TNumNodes, TElementIntegratesInTime>::FillFromNonHistoricalNodalData(
+    NodalScalarData& rData,
+    const Variable<double>& rVariable,
+    const Geometry<Node<3>>& rGeometry)
+{
+    noalias(rData) = ZeroVector(TNumNodes);
+    for (size_t i = 0; i < TNumNodes; i++) {
+        rData[i] = rGeometry[i].GetValue(rVariable);
+    }
+}
+
+template <size_t TDim, size_t TNumNodes, bool TElementIntegratesInTime>
+void FluidElementData<TDim, TNumNodes, TElementIntegratesInTime>::FillFromNonHistoricalNodalData(
+    NodalVectorData& rData,
+    const Variable<array_1d<double, 3>>& rVariable,
+    const Geometry<Node<3>>& rGeometry)
+{
+    for (size_t i = 0; i < TNumNodes; i++) {
+        const array_1d<double, 3>& r_nodal_values = rGeometry[i].GetValue(rVariable);
+        for (size_t j = 0; j < rData.size2(); j++) {
+            rData(i, j) = r_nodal_values[j];
+        }
+    }
+}
+
+template <size_t TDim, size_t TNumNodes, bool TElementIntegratesInTime>
 void FluidElementData<TDim, TNumNodes, TElementIntegratesInTime>::FillFromProcessInfo(double& rData,
     const Variable<double>& rVariable, const ProcessInfo& rProcessInfo)
 {

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_element_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_element_data.h
@@ -135,6 +135,16 @@ protected:
 
     void FillFromHistoricalNodalData(NodalVectorData& rData, const Variable<array_1d<double,3>>& rVariable, const Geometry<Node<3>>& rGeometry, const unsigned int Step);
 
+    void FillFromNonHistoricalNodalData(
+        NodalScalarData& rData,
+        const Variable<double>& rVariable,
+        const Geometry<Node<3>>& rGeometry);
+
+    void FillFromNonHistoricalNodalData(
+        NodalVectorData& rData,
+        const Variable<array_1d<double,3>>& rVariable,
+        const Geometry<Node<3>>& rGeometry);
+
     void FillFromProcessInfo(double& rData, const Variable<double>& rVariable, const ProcessInfo& rProcessInfo);
 
     void FillFromProcessInfo(int& rData, const Variable<int>& rVariable, const ProcessInfo& rProcessInfo);

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_element_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_element_data.h
@@ -127,9 +127,35 @@ protected:
     ///@name Protected Operations
     ///@{
 
-    void FillFromNodalData(NodalScalarData& rData, const Variable<double>& rVariable, const Geometry<Node<3>>& rGeometry);
+    //TODO: This needs to be removed
+    void FillFromNodalData(
+        NodalScalarData &rData,
+        const Variable<double> &rVariable,
+        const Geometry<Node<3>> &rGeometry)
+    {
+        KRATOS_WARNING("FluidElementData") << "\'FillFromNodalData\' is deprecated. Use \'FillFromHistoricalNodalData\' instead." << std::endl;
+        FillFromHistoricalNodalData(rData, rVariable, rGeometry);
+    }
 
-    void FillFromNodalData(NodalVectorData& rData, const Variable<array_1d<double,3>>& rVariable, const Geometry<Node<3>>& rGeometry);
+    //TODO: This needs to be removed
+    void FillFromNodalData(
+        NodalVectorData &rData,
+        const Variable<array_1d<double, 3>> &rVariable,
+        const Geometry<Node<3>> &rGeometry)
+    {
+        KRATOS_WARNING("FluidElementData") << "\'FillFromNodalData\' is deprecated. Use \'FillFromHistoricalNodalData\' instead." << std::endl;
+        FillFromHistoricalNodalData(rData, rVariable, rGeometry);
+    }
+
+    void FillFromHistoricalNodalData(
+        NodalScalarData &rData,
+        const Variable<double> &rVariable,
+        const Geometry<Node<3>> &rGeometry);
+
+    void FillFromHistoricalNodalData(
+        NodalVectorData &rData,
+        const Variable<array_1d<double, 3>> &rVariable,
+        const Geometry<Node<3>> &rGeometry);
 
     void FillFromHistoricalNodalData(NodalScalarData& rData, const Variable<double>& rVariable, const Geometry<Node<3>>& rGeometry, const unsigned int Step);
 

--- a/applications/FluidDynamicsApplication/custom_utilities/qsvms_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/qsvms_data.h
@@ -71,12 +71,12 @@ void Initialize(const Element& rElement, const ProcessInfo& rProcessInfo) overri
 
     const Geometry< Node<3> >& r_geometry = rElement.GetGeometry();
     const Properties& r_properties = rElement.GetProperties();
-    this->FillFromNodalData(Velocity,VELOCITY,r_geometry);
-    this->FillFromNodalData(MeshVelocity,MESH_VELOCITY,r_geometry);
-    this->FillFromNodalData(BodyForce,BODY_FORCE,r_geometry);
-    this->FillFromNodalData(MomentumProjection,ADVPROJ,r_geometry);
-    this->FillFromNodalData(Pressure,PRESSURE,r_geometry);
-    this->FillFromNodalData(MassProjection,DIVPROJ,r_geometry);
+    this->FillFromHistoricalNodalData(Velocity,VELOCITY,r_geometry);
+    this->FillFromHistoricalNodalData(MeshVelocity,MESH_VELOCITY,r_geometry);
+    this->FillFromHistoricalNodalData(BodyForce,BODY_FORCE,r_geometry);
+    this->FillFromHistoricalNodalData(MomentumProjection,ADVPROJ,r_geometry);
+    this->FillFromHistoricalNodalData(Pressure,PRESSURE,r_geometry);
+    this->FillFromHistoricalNodalData(MassProjection,DIVPROJ,r_geometry);
     this->FillFromProperties(Density,DENSITY,r_properties);
     this->FillFromProperties(DynamicViscosity,DYNAMIC_VISCOSITY,r_properties); //TODO: remove once we have a Smagorinky constitutive law
     this->FillFromElementData(CSmagorinsky,C_SMAGORINSKY,rElement); //TODO: remove once we have a Smagorinky constitutive law

--- a/applications/FluidDynamicsApplication/custom_utilities/qsvms_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/qsvms_data.h
@@ -91,13 +91,6 @@ static int Check(const Element& rElement, const ProcessInfo& rProcessInfo)
 {
     const Geometry< Node<3> >& r_geometry = rElement.GetGeometry();
 
-    KRATOS_CHECK_VARIABLE_KEY(VELOCITY);
-    KRATOS_CHECK_VARIABLE_KEY(MESH_VELOCITY);
-    KRATOS_CHECK_VARIABLE_KEY(BODY_FORCE);
-    KRATOS_CHECK_VARIABLE_KEY(ADVPROJ);
-    KRATOS_CHECK_VARIABLE_KEY(PRESSURE);
-    KRATOS_CHECK_VARIABLE_KEY(DIVPROJ);
-
     for (unsigned int i = 0; i < TNumNodes; i++)
     {
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VELOCITY,r_geometry[i]);
@@ -107,13 +100,6 @@ static int Check(const Element& rElement, const ProcessInfo& rProcessInfo)
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(PRESSURE,r_geometry[i]);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DIVPROJ,r_geometry[i]);
     }
-
-    KRATOS_CHECK_VARIABLE_KEY(DENSITY);
-    KRATOS_CHECK_VARIABLE_KEY(DYNAMIC_VISCOSITY);
-    KRATOS_CHECK_VARIABLE_KEY(C_SMAGORINSKY);
-    KRATOS_CHECK_VARIABLE_KEY(DELTA_TIME);
-    KRATOS_CHECK_VARIABLE_KEY(DYNAMIC_TAU);
-    KRATOS_CHECK_VARIABLE_KEY(OSS_SWITCH);
 
     return 0;
 }

--- a/applications/FluidDynamicsApplication/custom_utilities/qsvms_dem_coupled_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/qsvms_dem_coupled_data.h
@@ -70,12 +70,12 @@ void Initialize(
     // Base class Initialize manages constitutive law parameters
     QSVMSData<TDim, TNumNodes, TElementIntegratesInTime>::Initialize(rElement,rProcessInfo);
     const auto& r_geometry = rElement.GetGeometry();
-    this->FillFromNodalData(FluidFraction, FLUID_FRACTION, r_geometry);
-    this->FillFromNodalData(FluidFractionRate, FLUID_FRACTION_RATE, r_geometry);
-    this->FillFromNodalData(FluidFractionGradient, FLUID_FRACTION_GRADIENT, r_geometry);
-    this->FillFromNodalData(MassSource, MASS_SOURCE, r_geometry);
-    this->FillFromNodalData(Acceleration, ACCELERATION, r_geometry);
-    this->FillFromNodalData(BodyForce,BODY_FORCE,r_geometry);
+    this->FillFromHistoricalNodalData(FluidFraction, FLUID_FRACTION, r_geometry);
+    this->FillFromHistoricalNodalData(FluidFractionRate, FLUID_FRACTION_RATE, r_geometry);
+    this->FillFromHistoricalNodalData(FluidFractionGradient, FLUID_FRACTION_GRADIENT, r_geometry);
+    this->FillFromHistoricalNodalData(MassSource, MASS_SOURCE, r_geometry);
+    this->FillFromHistoricalNodalData(Acceleration, ACCELERATION, r_geometry);
+    this->FillFromHistoricalNodalData(BodyForce,BODY_FORCE,r_geometry);
 
     ElementSize = ElementSizeCalculator<TDim,TNumNodes>::MinimumElementSize(r_geometry);
 }

--- a/applications/FluidDynamicsApplication/custom_utilities/symbolic_navier_stokes_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/symbolic_navier_stokes_data.h
@@ -82,12 +82,12 @@ void Initialize(const Element& rElement, const ProcessInfo& rProcessInfo) overri
 
     const Geometry< Node<3> >& r_geometry = rElement.GetGeometry();
     const Properties& r_properties = rElement.GetProperties();
-    this->FillFromNodalData(Velocity,VELOCITY,r_geometry);
+    this->FillFromHistoricalNodalData(Velocity,VELOCITY,r_geometry);
     this->FillFromHistoricalNodalData(Velocity_OldStep1,VELOCITY,r_geometry,1);
     this->FillFromHistoricalNodalData(Velocity_OldStep2,VELOCITY,r_geometry,2);
-    this->FillFromNodalData(MeshVelocity,MESH_VELOCITY,r_geometry);
-    this->FillFromNodalData(BodyForce,BODY_FORCE,r_geometry);
-    this->FillFromNodalData(Pressure,PRESSURE,r_geometry);
+    this->FillFromHistoricalNodalData(MeshVelocity,MESH_VELOCITY,r_geometry);
+    this->FillFromHistoricalNodalData(BodyForce,BODY_FORCE,r_geometry);
+    this->FillFromHistoricalNodalData(Pressure,PRESSURE,r_geometry);
     this->FillFromHistoricalNodalData(Pressure_OldStep1,PRESSURE,r_geometry,1);
     this->FillFromHistoricalNodalData(Pressure_OldStep2,PRESSURE,r_geometry,2);
     this->FillFromProperties(Density,DENSITY,r_properties);

--- a/applications/FluidDynamicsApplication/custom_utilities/symbolic_navier_stokes_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/symbolic_navier_stokes_data.h
@@ -120,11 +120,6 @@ static int Check(const Element& rElement, const ProcessInfo& rProcessInfo)
 {
     const Geometry< Node<3> >& r_geometry = rElement.GetGeometry();
 
-    KRATOS_CHECK_VARIABLE_KEY(VELOCITY);
-    KRATOS_CHECK_VARIABLE_KEY(MESH_VELOCITY);
-    KRATOS_CHECK_VARIABLE_KEY(BODY_FORCE);
-    KRATOS_CHECK_VARIABLE_KEY(PRESSURE);
-
     for (unsigned int i = 0; i < TNumNodes; i++)
     {
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VELOCITY,r_geometry[i]);
@@ -132,13 +127,6 @@ static int Check(const Element& rElement, const ProcessInfo& rProcessInfo)
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(BODY_FORCE,r_geometry[i]);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(PRESSURE,r_geometry[i]);
     }
-
-    KRATOS_CHECK_VARIABLE_KEY(DENSITY);
-    KRATOS_CHECK_VARIABLE_KEY(DYNAMIC_VISCOSITY);
-    KRATOS_CHECK_VARIABLE_KEY(SOUND_VELOCITY);
-    KRATOS_CHECK_VARIABLE_KEY(DELTA_TIME);
-    KRATOS_CHECK_VARIABLE_KEY(DYNAMIC_TAU);
-    KRATOS_CHECK_VARIABLE_KEY(BDF_COEFFICIENTS);
 
     return 0;
 }

--- a/applications/FluidDynamicsApplication/custom_utilities/symbolic_stokes_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/symbolic_stokes_data.h
@@ -85,11 +85,11 @@ void Initialize(
 
     const Geometry< Node<3> >& r_geometry = rElement.GetGeometry();
     const Properties& r_properties = rElement.GetProperties();
-    this->FillFromNodalData(Velocity, VELOCITY, r_geometry);
+    this->FillFromHistoricalNodalData(Velocity, VELOCITY, r_geometry);
     this->FillFromHistoricalNodalData(Velocity_OldStep1, VELOCITY, r_geometry, 1);
     this->FillFromHistoricalNodalData(Velocity_OldStep2, VELOCITY, r_geometry, 2);
-    this->FillFromNodalData(BodyForce, BODY_FORCE, r_geometry);
-    this->FillFromNodalData(Pressure, PRESSURE, r_geometry);
+    this->FillFromHistoricalNodalData(BodyForce, BODY_FORCE, r_geometry);
+    this->FillFromHistoricalNodalData(Pressure, PRESSURE, r_geometry);
     this->FillFromProperties(Density, DENSITY, r_properties);
     this->FillFromProperties(DynamicViscosity, DYNAMIC_VISCOSITY, r_properties);
     this->FillFromProcessInfo(DeltaTime, DELTA_TIME, rProcessInfo);

--- a/applications/FluidDynamicsApplication/custom_utilities/time_integrated_fic_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/time_integrated_fic_data.h
@@ -66,10 +66,9 @@ void Initialize(const Element& rElement, const ProcessInfo& rProcessInfo) overri
 
 static int Check(const Element& rElement, const ProcessInfo& rProcessInfo)
 {
-    FICData<TDim,TNumNodes,true>::Check(rElement,rProcessInfo);
-    KRATOS_CHECK_VARIABLE_KEY(BDF_COEFFICIENTS);
+    int out = FICData<TDim,TNumNodes,true>::Check(rElement,rProcessInfo);
 
-    return 0;
+    return out;
 }
 
 ///@}

--- a/applications/FluidDynamicsApplication/custom_utilities/time_integrated_qsvms_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/time_integrated_qsvms_data.h
@@ -66,10 +66,9 @@ void Initialize(const Element& rElement, const ProcessInfo& rProcessInfo) overri
 
 static int Check(const Element& rElement, const ProcessInfo& rProcessInfo)
 {
-    QSVMSData<TDim,TNumNodes,true>::Check(rElement,rProcessInfo);
-    KRATOS_CHECK_VARIABLE_KEY(BDF_COEFFICIENTS);
+    int out = QSVMSData<TDim,TNumNodes,true>::Check(rElement,rProcessInfo);
 
-    return 0;
+    return out;
 }
 
 ///@}

--- a/applications/FluidDynamicsApplication/custom_utilities/two_fluid_navier_stokes_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/two_fluid_navier_stokes_data.h
@@ -181,12 +181,6 @@ static int Check(const Element& rElement, const ProcessInfo& rProcessInfo)
 {
     const Geometry< Node<3> >& r_geometry = rElement.GetGeometry();
 
-    KRATOS_CHECK_VARIABLE_KEY(VELOCITY);
-	KRATOS_CHECK_VARIABLE_KEY(DISTANCE);
-    KRATOS_CHECK_VARIABLE_KEY(MESH_VELOCITY);
-    KRATOS_CHECK_VARIABLE_KEY(BODY_FORCE);
-    KRATOS_CHECK_VARIABLE_KEY(PRESSURE);
-
     for (unsigned int i = 0; i < TNumNodes; i++)
     {
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VELOCITY,r_geometry[i]);
@@ -195,12 +189,6 @@ static int Check(const Element& rElement, const ProcessInfo& rProcessInfo)
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(BODY_FORCE,r_geometry[i]);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(PRESSURE,r_geometry[i]);
     }
-
-    KRATOS_CHECK_VARIABLE_KEY(DENSITY);
-    KRATOS_CHECK_VARIABLE_KEY(DYNAMIC_VISCOSITY);
-    KRATOS_CHECK_VARIABLE_KEY(DELTA_TIME);
-    KRATOS_CHECK_VARIABLE_KEY(DYNAMIC_TAU);
-    KRATOS_CHECK_VARIABLE_KEY(BDF_COEFFICIENTS);
 
     return 0;
 }

--- a/applications/FluidDynamicsApplication/custom_utilities/two_fluid_navier_stokes_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/two_fluid_navier_stokes_data.h
@@ -113,15 +113,15 @@ void Initialize(const Element& rElement, const ProcessInfo& rProcessInfo) overri
 
     const Geometry< Node<3> >& r_geometry = rElement.GetGeometry();
     const Properties& r_properties = rElement.GetProperties();
-    this->FillFromNodalData(Velocity,VELOCITY,r_geometry);
+    this->FillFromHistoricalNodalData(Velocity,VELOCITY,r_geometry);
     this->FillFromHistoricalNodalData(Velocity_OldStep1,VELOCITY,r_geometry,1);
     this->FillFromHistoricalNodalData(Velocity_OldStep2,VELOCITY,r_geometry,2);
-	this->FillFromNodalData(Distance, DISTANCE, r_geometry);
-    this->FillFromNodalData(MeshVelocity,MESH_VELOCITY,r_geometry);
-    this->FillFromNodalData(BodyForce,BODY_FORCE,r_geometry);
-    this->FillFromNodalData(Pressure,PRESSURE,r_geometry);
-    this->FillFromNodalData(NodalDensity, DENSITY, r_geometry);
-    this->FillFromNodalData(NodalDynamicViscosity, DYNAMIC_VISCOSITY, r_geometry);
+	this->FillFromHistoricalNodalData(Distance, DISTANCE, r_geometry);
+    this->FillFromHistoricalNodalData(MeshVelocity,MESH_VELOCITY,r_geometry);
+    this->FillFromHistoricalNodalData(BodyForce,BODY_FORCE,r_geometry);
+    this->FillFromHistoricalNodalData(Pressure,PRESSURE,r_geometry);
+    this->FillFromHistoricalNodalData(NodalDensity, DENSITY, r_geometry);
+    this->FillFromHistoricalNodalData(NodalDynamicViscosity, DYNAMIC_VISCOSITY, r_geometry);
     this->FillFromProperties(SmagorinskyConstant, C_SMAGORINSKY, r_properties);
     this->FillFromProperties(LinearDarcyCoefficient, LIN_DARCY_COEF, r_properties);
     this->FillFromProperties(NonLinearDarcyCoefficient, NONLIN_DARCY_COEF, r_properties);

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_element_data.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_element_data.cpp
@@ -33,7 +33,7 @@ public:
 
     void Initialize(
         const Element& rElement, const ProcessInfo& rProcessInfo) override {
-        this->FillFromNodalData(Velocity, VELOCITY, rElement.GetGeometry());
+        this->FillFromHistoricalNodalData(Velocity, VELOCITY, rElement.GetGeometry());
         this->FillFromHistoricalNodalData(
             Velocity_OldStep1, VELOCITY, rElement.GetGeometry(), 1);
     }
@@ -57,7 +57,7 @@ public:
 
     void Initialize(
         const Element& rElement, const ProcessInfo& rProcessInfo) override {
-        this->FillFromNodalData(Pressure, PRESSURE, rElement.GetGeometry());
+        this->FillFromHistoricalNodalData(Pressure, PRESSURE, rElement.GetGeometry());
         this->FillFromHistoricalNodalData(
             Pressure_OldStep1, PRESSURE, rElement.GetGeometry(), 1);
     }


### PR DESCRIPTION
**Description**
This enhances the `FluidElementData` containers in order to allow using non-historical nodal variables. This implies having `GetFromNodalData`, `GetFromHistoricalData` and `GetFromNonHistoricalData` (new one) methods. As `GetFromNodalData` and `GetFromHistoricalData` do basically the same but the second one allows passing a step as argument I decided to overload the first one, which I think becomes way misleading after the addition of the new `GetFromNonHistoricalData`. To avoid breaking the API in case there is someone using this out of the master branch, I issued a deprecation warning.

I also took the chance to remove the annoying variable key checks.

@pau-mar you need this to be merged in order to access non-historical variables (i.e. the `SOUND_VELOCITY` and the artificial magnitudes) in the new element.

**Changelog**
- Add non-historical nodal data support in the `FluidElementData`
- Deprecate the `GetFromNodalData` in favor of a new `GetFromHistoricalData` that does the same but overloading the `GetFromHistoricalData` with step argument.
