### PR TITLE
[Core] Adding C++ tests for Kratos Parameters

### DIFF
--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -180,25 +180,25 @@ std::string GetJSONStringIncompleteWithExtraParameter()
 std::string GetJSONStringExpectedValidationOutput()
 {
     const std::string expected_validation_output = R"({
-        "bool_value": true,
-        "double_value": 2.0,
-        "int_value": 10,
-        "level1": {
-            "list_value": [
-                3,
-                "hi",
-                false
-            ],
-            "tmp": 5.0
-        },
-        "new_default_obj": {
-            "aaa": "string",
-            "bbb": false,
-            "ccc": 22
-        },
-        "new_default_value": -123.0,
-        "string_value": "hello"
-    })";
+    "bool_value": true,
+    "double_value": 2.0,
+    "int_value": 10,
+    "level1": {
+        "list_value": [
+            3,
+            "hi",
+            false
+        ],
+        "tmp": 5.0
+    },
+    "new_default_obj": {
+        "aaa": "string",
+        "bbb": false,
+        "ccc": 22
+    },
+    "new_default_value": -123.0,
+    "string_value": "hello"
+})";
     return expected_validation_output;
 }
 
@@ -394,27 +394,27 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersRecursiveValidation4Levels, KratosCore
     KRATOS_CHECK_IS_FALSE( kp_wrong_wariation.HasSameKeysAndTypeOfValuesAs(defaults_params) );
 }
 
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationSuccedsErroronFirstLevel, KratosCoreFastSuite)
-// {
-//     Parameters kp = Parameters(GetJSONStringWrongLevel2());
-//     Parameters defaults_params = Parameters(GetJSONStringDefaults());
-//
-//     // here no error shall be thrown since validation is only done on level0
-//     kp.ValidateAndAssignDefaults(defaults_params)
-// }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationSucceeds, KratosCoreFastSuite)
-// {
-//     Parameters kp = Parameters(GetJSONString());
-//     Parameters defaults_params = Parameters(GetJSONStringDefaults());
-//     defaults_params["level1"]["tmp"].SetDouble(2.0)  // this does not coincide with the value in kp, but is of the same type
-//
-//     kp.ValidateAndAssignDefaults(defaults_params)
-//     KRATOS_CHECK_EQUAL(kp.PrettyPrintJsonString(), expected_validation_output)
-//
-//     KRATOS_CHECK_EQUAL(kp["level1"]["tmp"].GetDouble(), 5.0)  // not 2, since kp overwrites the defaults
-// }
-//
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationSuccedsErroronFirstLevel, KratosCoreFastSuite)
+{
+    Parameters kp = Parameters(GetJSONStringWrongLevel2());
+    Parameters defaults_params = Parameters(GetJSONStringDefaults());
+
+    // Here no error shall be thrown since validation is only done on level0
+    kp.ValidateAndAssignDefaults(defaults_params);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationSucceeds, KratosCoreFastSuite)
+{
+    Parameters kp = Parameters(GetJSONString());
+    Parameters defaults_params = Parameters(GetJSONStringDefaults());
+    defaults_params["level1"]["tmp"].SetDouble(2.0);  // this does not coincide with the value in kp, but is of the same type
+
+    kp.ValidateAndAssignDefaults(defaults_params);
+    KRATOS_CHECK_STRING_EQUAL(kp.PrettyPrintJsonString(), GetJSONStringExpectedValidationOutput());
+
+    KRATOS_CHECK_DOUBLE_EQUAL(kp["level1"]["tmp"].GetDouble(), 5.0);  // not 2, since kp overwrites the defaults
+}
+
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddMissingParameters, KratosCoreFastSuite)
 // {
 //     // only missing parameters are added, no complaints if there already exist more than in the defaults

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -25,7 +25,7 @@ namespace Testing {
 // input string with ugly formatting
 std::string GetJSONString()
 {
-    const std::string json_string = R"(
+    return R"(
     {
       "bool_value" : true, "double_value": 2.0, "int_value" : 10,
       "level1":
@@ -35,12 +35,11 @@ std::string GetJSONString()
       },
       "string_value" : "hello"
     })";
-    return json_string;
 }
 
 std::string GetJSONStringPrettyOut()
-{
-    const std::string pretty_out =  R"({
+{ 
+    return R"({
     "bool_value": true,
     "double_value": 2.0,
     "int_value": 10,
@@ -54,12 +53,11 @@ std::string GetJSONStringPrettyOut()
     },
     "string_value": "hello"
 })";
-    return pretty_out;
 }
 
 std::string GetJSONStringPrettyOutAfterChange()
 {
-    const std::string pretty_out_after_change = R"({
+    return R"({
     "bool_value": true,
     "double_value": 2.0,
     "int_value": 10,
@@ -73,55 +71,48 @@ std::string GetJSONStringPrettyOutAfterChange()
     },
     "string_value": "hello"
 })";
-
-    return pretty_out_after_change;
 }
 
 // here the level1 var is set to a double so that a validation error should be thrown
 std::string GetJSONStringWrongType()
 {
-    const std::string wrong_type = R"({
+    return R"({
         "bool_value": true,
         "double_value": 2.0,
         "int_value": 10,
         "level1": 0.0,
         "string_value": "hello"
     })";
-
-    return wrong_type;
 }
 
 // int value is badly spelt
 std::string GetJSONStringWrongSpelling()
 {
-    const std::string wrong_spelling = R"({
+    return R"({
         "bool_value": true,
         "double_value": 2.0,
         "int_values": 10,
         "level1": 0.0,
         "string_value": "hello"
     })";
-
-    return wrong_spelling;
 }
 
 // wrong on the first level
 // error shall be only detective by recursive validation
 std::string GetJSONStringWrongLevel2()
 {
-    const std::string wrong_lev2 = R"({
+    return R"({
         "bool_value": true,
         "double_value": 2.0,
         "int_value": 10,
         "level1": { "a":0.0 },
         "string_value": "hello"
     })";
-    return wrong_lev2;
 }
 
 std::string GetJSONStringDefaults()
 {
-    const std::string defaults = R"({
+    return R"({
         "bool_value": false,
         "double_value": 2.0,
         "int_value": 10,
@@ -141,12 +132,11 @@ std::string GetJSONStringDefaults()
         "new_default_value": -123.0,
         "string_value": "hello"
     })";
-    return defaults;
 }
 
 std::string GetJSONStringIncomplete()
 {
-    const std::string incomplete = R"({
+    return R"({
         "level1": {
         },
         "new_default_obj": {
@@ -157,12 +147,11 @@ std::string GetJSONStringIncomplete()
         "new_default_value": -123.0,
         "string_value": "hello"
     })";
-    return incomplete;
 }
 
 std::string GetJSONStringIncompleteWithExtraParameter()
 {
-    const std::string incomplete_with_extra_parameter = R"({
+    return R"({
         "level1": {
             "new_sublevel": "this should only be assigned in recursive"
         },
@@ -174,12 +163,11 @@ std::string GetJSONStringIncompleteWithExtraParameter()
         "new_default_value": -123.0,
         "string_value": "hello"
     })";
-    return incomplete_with_extra_parameter;
 }
 
 std::string GetJSONStringExpectedValidationOutput()
 {
-    const std::string expected_validation_output = R"({
+    return R"({
     "bool_value": true,
     "double_value": 2.0,
     "int_value": 10,
@@ -199,12 +187,11 @@ std::string GetJSONStringExpectedValidationOutput()
     "new_default_value": -123.0,
     "string_value": "hello"
 })";
-    return expected_validation_output;
 }
 
 std::string GetJSONStringFourLevels()
 {
-    const std::string four_levels = R"({
+    return R"({
         "bool_value": true,
         "double_value": 2.0,
         "int_value": 10,
@@ -218,12 +205,11 @@ std::string GetJSONStringFourLevels()
         },
         "string_value": "hello"
     })";
-    return four_levels;
 }
 
 std::string GetJSONStringForLevelsVariation()
 {
-    const std::string four_levels_variation = R"({
+    return R"({
         "bool_value": true,
         "double_value": 2.0,
         "int_value": 10,
@@ -238,12 +224,11 @@ std::string GetJSONStringForLevelsVariation()
         },
         "string_value": "hello"
     })";
-    return four_levels_variation;
 }
 
 std::string GetJSONStringForLevelsWrongVariation()
 {
-    const std::string four_levels_wrong_variation = R"({
+    return R"({
         "int_value": 10,
         "double_value": "hi",
         "bool_value": true,
@@ -258,12 +243,11 @@ std::string GetJSONStringForLevelsWrongVariation()
             }
         }
     })";
-    return four_levels_wrong_variation;
 }
 
 std::string GetJSONStringForLevelsDefaults()
 {
-    const std::string four_levels_defaults = R"({
+    return R"({
         "bool_value": true,
         "double_value": 2.0,
         "int_value": 10,
@@ -281,7 +265,6 @@ std::string GetJSONStringForLevelsDefaults()
         },
         "string_value": "hello"
     })";
-    return four_levels_defaults;
 }
 
 KRATOS_TEST_CASE_IN_SUITE(KratosParameters, KratosCoreFastSuite)

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -737,49 +737,49 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersIsMethods, KratosCoreFastSuite)
 //     // This method checks all the "GetXXX" Methods if they throw an error
 //     Parameters tmp = Parameters(R"({})");
 //
-//     key = "int"
-//     tmp.AddInt(key, 10)
-//     KRATOS_CHECK_EQUAL(tmp[key].GetInt(),10)
+//     std::string key = "int";
+//     tmp.AddInt(key, 10);
+//     KRATOS_CHECK_EQUAL(tmp[key].GetInt(),10);
 //
-//     key = "double"
-//     tmp.AddDouble(key, 2.0)
-//     KRATOS_CHECK_EQUAL(tmp[key].GetDouble(),2.0)
+//     key = "double";
+//     tmp.AddDouble(key, 2.0);
+//     KRATOS_CHECK_EQUAL(tmp[key].GetDouble(),2.0);
 //
-//     key = "bool"
-//     tmp.AddBool(key, True)
-//     KRATOS_CHECK_EQUAL(tmp[key].GetBool(),True)
+//     key = "bool";
+//     tmp.AddBool(key, true);
+//     KRATOS_CHECK_EQUAL(tmp[key].GetBool(),true);
 //
 //     key = "string"
-//     tmp.AddString(key, "hello")
-//     KRATOS_CHECK_EQUAL(tmp[key].GetString(),"hello")
+//     tmp.AddString(key, "hello");
+//     KRATOS_CHECK_EQUAL(tmp[key].GetString(),"hello");
 //
-//     key = "vector"
-//     vector = Vector(3)
-//     vector[0] = 5.2
-//     vector[1] = -3.1
-//     vector[2] = 4.33
+//     key = "vector";
+//     Vector vector = ZeroVector(3);
+//     vector[0] = 5.2;
+//     vector[1] = -3.1;
+//     vector[2] = 4.33;
 //     tmp.AddVector(key, vector)
 //     V = tmp[key].GetVector()
-//     KRATOS_CHECK_EQUAL(V[0],5.2)
-//     KRATOS_CHECK_EQUAL(V[1],-3.1)
-//     KRATOS_CHECK_EQUAL(V[2],4.33)
+//     KRATOS_CHECK_DOUBLE_EQUAL(V[0],5.2);
+//     KRATOS_CHECK_DOUBLE_EQUAL(V[1],-3.1);
+//     KRATOS_CHECK_DOUBLE_EQUAL(V[2],4.33);
 //
-//     key = "matrix"
-//     matrix = Matrix(3,2)
-//     matrix[0,0] = 1.0
-//     matrix[0,1] = 2.0
-//     matrix[1,0] = 3.0
-//     matrix[1,1] = 4.0
-//     matrix[2,0] = 5.0
-//     matrix[2,1] = 6.0
-//     tmp.AddMatrix(key, matrix)
-//     A = tmp[key].GetMatrix()
-//     KRATOS_CHECK_EQUAL(A[0,0],1.0)
-//     KRATOS_CHECK_EQUAL(A[0,1],2.0)
-//     KRATOS_CHECK_EQUAL(A[1,0],3.0)
-//     KRATOS_CHECK_EQUAL(A[1,1],4.0)
-//     KRATOS_CHECK_EQUAL(A[2,0],5.0)
-//     KRATOS_CHECK_EQUAL(A[2,1],6.0)
+//     key = "matrix";
+//     Matrix matrix = ZeroMatrix(3,2);
+//     matrix[0,0] = 1.0:
+//     matrix[0,1] = 2.0;
+//     matrix[1,0] = 3.0:
+//     matrix[1,1] = 4.0;
+//     matrix[2,0] = 5.0;
+//     matrix[2,1] = 6.0;
+//     tmp.AddMatrix(key, matrix);
+//     auto& A = tmp[key].GetMatrix();
+//     KRATOS_CHECK_DOUBLE_EQUAL(A[0,0],1.0);
+//     KRATOS_CHECK_DOUBLE_EQUAL(A[0,1],2.0);
+//     KRATOS_CHECK_DOUBLE_EQUAL(A[1,0],3.0);
+//     KRATOS_CHECK_DOUBLE_EQUAL(A[1,1],4.0);
+//     KRATOS_CHECK_DOUBLE_EQUAL(A[2,0],5.0);
+//     KRATOS_CHECK_DOUBLE_EQUAL(A[2,1],6.0);
 // }
 //
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersVectorInterface, KratosCoreFastSuite)
@@ -821,20 +821,20 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersIsMethods, KratosCoreFastSuite)
 //             false_vector.GetVector()
 //
 //     // Manually assign and check a Vector
-//     vec = Vector(3)
-//     vec[0] = 1.32
-//     vec[1] = -2.22
-//     vec[2] = 5.5
+//     Vector vec = ZeroVector(3);
+//     vec[0] = 1.32;
+//     vec[1] = -2.22;
+//     vec[2] = 5.5;
 //
-//     tmp.AddEmptyValue("vector_value")
-//     tmp["vector_value"].SetVector(vec)
+//     tmp.AddEmptyValue("vector_value");
+//     tmp["vector_value"].SetVector(vec);
 //
-//     KRATOS_CHECK(tmp["vector_value"].IsVector())
+//     KRATOS_CHECK(tmp["vector_value"].IsVector());
 //
-//     V2 = tmp["vector_value"].GetVector()
-//     KRATOS_CHECK_EQUAL(V2[0],1.32)
-//     KRATOS_CHECK_EQUAL(V2[1],-2.22)
-//     KRATOS_CHECK_EQUAL(V2[2],5.5)
+//     auto V2 = tmp["vector_value"].GetVector();
+//     KRATOS_CHECK_DOUBLE_EQUAL(V2[0],1.32);
+//     KRATOS_CHECK_DOUBLE_EQUAL(V2[1],-2.22);
+//     KRATOS_CHECK_DOUBLE_EQUAL(V2[2],5.5);
 // }
 //
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersMatrixInterface, KratosCoreFastSuite)
@@ -876,18 +876,18 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersIsMethods, KratosCoreFastSuite)
 //             false_matrix.GetMatrix()
 //
 //     // Manually assign and check a Matrix
-//     mat = Matrix(3,2)
-//     mat[0,0] = 1.0
-//     mat[0,1] = 2.0
-//     mat[1,0] = 3.0
-//     mat[1,1] = 4.0
-//     mat[2,0] = 5.0
-//     mat[2,1] = 6.0
+//     Matrix mat = ZeroMatrix(3,2);
+//     mat[0,0] = 1.0;
+//     mat[0,1] = 2.0;
+//     mat[1,0] = 3.0;
+//     mat[1,1] = 4.0;
+//     mat[2,0] = 5.0;
+//     mat[2,1] = 6.0;
 //
 //     tmp.AddEmptyValue("matrix_value")
-//     tmp["matrix_value"].SetMatrix(mat)
+//     tmp["matrix_value"].SetMatrix(mat);
 //
-//     KRATOS_CHECK(tmp["matrix_value"].IsMatrix())
+//     KRATOS_CHECK(tmp["matrix_value"].IsMatrix());
 //
 //     A2 = tmp["matrix_value"].GetMatrix()
 //     KRATOS_CHECK_EQUAL(A2[0,0],1.0);
@@ -897,65 +897,68 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersIsMethods, KratosCoreFastSuite)
 //     KRATOS_CHECK_EQUAL(A2[2,0],5.0);
 //     KRATOS_CHECK_EQUAL(A2[2,1],6.0);
 // }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersNullvsNullValidation, KratosCoreFastSuite)
-// {
-//     // Supplied settings
-//     Parameters null_custom = Parameters(R"({
-//         "parameter": null
-//     })");
-//
-//     // Default settings
-//     Parameters null_default = Parameters(R"({
-//         "parameter": null
-//     })");
-//
-//     // This should NOT raise, hence making the test to pass
-//     null_custom.ValidateAndAssignDefaults(null_default)
-// }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersDoublevsNullValidation, KratosCoreFastSuite)
-// {
-//     // Supplied settings
-//     Parameters double_custom = Parameters(R"({
-//         "parameter": 0.0
-//     })");
-//
-//     // Default settings
-//     Parameters null_default = Parameters(R"({
-//         "parameter": null
-//     })");
-//
-//     with self.assertRaises(RuntimeError):
-//         double_custom.ValidateAndAssignDefaults(null_default)
-// }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersGeStringArrayValid, KratosCoreFastSuite)
-// {
-//     Parameters tmp = Parameters(R"({
-//         "parameter": ["foo", "bar"]
-//     })");
-//     v = tmp["parameter"].GetStringArray()
-//     KRATOS_CHECK_EQUAL(len(v), 2);
-//     KRATOS_CHECK_EQUAL(v[0], "foo");
-//     KRATOS_CHECK_EQUAL(v[1], "bar");
-// }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersSetStringArrayValid, KratosCoreFastSuite)
-// {
-//     Parameters initial = Parameters(R"({
-//         "parameter": ["foo", "bar"]
-//     })");
-//     string_array = initial["parameter"].GetStringArray();
-//
-//     Parameters new_param = Parameters();
-//     new_param.AddEmptyValue("new_parameter");
-//     new_param["new_parameter"].SetStringArray(string_array);
-//
-//     new_string_array = initial["parameter"].GetStringArray();
-//
-//     self.assertListEqual(new_string_array, string_array);
-// }
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersNullvsNullValidation, KratosCoreFastSuite)
+{
+    // Supplied settings
+    Parameters null_custom = Parameters(R"({
+        "parameter": null
+    })");
+
+    // Default settings
+    Parameters null_default = Parameters(R"({
+        "parameter": null
+    })");
+
+    // This should NOT raise, hence making the test to pass
+    null_custom.ValidateAndAssignDefaults(null_default);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersDoublevsNullValidation, KratosCoreFastSuite)
+{
+    // Supplied settings
+    Parameters double_custom = Parameters(R"({
+        "parameter": 0.0
+    })");
+
+    // Default settings
+    Parameters null_default = Parameters(R"({
+        "parameter": null
+    })");
+
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(double_custom.ValidateAndAssignDefaults(null_default), "");
+}
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersGeStringArrayValid, KratosCoreFastSuite)
+{
+    Parameters tmp = Parameters(R"({
+        "parameter": ["foo", "bar"]
+    })");
+    auto v = tmp["parameter"].GetStringArray();
+    KRATOS_CHECK_EQUAL(v.size(), 2);
+    KRATOS_CHECK_EQUAL(v[0], "foo");
+    KRATOS_CHECK_EQUAL(v[1], "bar");
+}
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersSetStringArrayValid, KratosCoreFastSuite)
+{
+    Parameters initial = Parameters(R"({
+        "parameter": ["foo", "bar"]
+    })");
+    auto string_array = initial["parameter"].GetStringArray();
+
+    Parameters new_param = Parameters();
+    new_param.AddEmptyValue("new_parameter");
+    new_param["new_parameter"].SetStringArray(string_array);
+
+    auto new_string_array = initial["parameter"].GetStringArray();
+
+    int counter = 0;
+    for (auto& r_string : string_array) {
+        KRATOS_CHECK_STRING_EQUAL(new_string_array[counter], r_string);
+        ++counter;
+    }
+}
 
 }  // namespace Testing.
 }  // namespace Kratos.

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -466,20 +466,18 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersRecursivelyValidateDefaults, KratosCor
     KRATOS_CHECK(kp.Has("level1"));
 }
 
-// def test_recursively_validate_defaults_fails(self):
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersSetStringArrayValid, KratosCoreFastSuite)
-// {
-//     // only parameters from defaults are validated, no new values are added
-//     Parameters kp = Parameters(GetJSONStringIncompleteWithExtraParameter());
-//     Parameters tmp = Parameters(GetJSONStringDefaults());
-//
-//     with self.assertRaises(RuntimeError):
-//         kp.RecursivelyValidateDefaults(tmp)
-//
-//     // sub_level
-//     KRATOS_CHECK_IS_FALSE(kp["level1"].Has("tmp"))
-// }
-//
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersRecursivelyValidateDefaultsFail, KratosCoreFastSuite)
+{
+    // only parameters from defaults are validated, no new values are added
+    Parameters kp = Parameters(GetJSONStringIncompleteWithExtraParameter());
+    Parameters tmp = Parameters(GetJSONStringDefaults());
+
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(kp.RecursivelyValidateDefaults(tmp), "");
+
+    // Sub_level
+    KRATOS_CHECK_IS_FALSE(kp["level1"].Has("tmp"));
+}
+
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddValue, KratosCoreFastSuite)
 // {
 //     Parameters kp = Parameters("{}")

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -587,70 +587,73 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersIsMethods, KratosCoreFastSuite)
     }
 }
 
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersGetMethods, KratosCoreFastSuite)
-// {
-//     // This method checks all the "GetXXX" Methods if they throw an error
-//     Parameters tmp = Parameters(R"({
-//         "int_value" : 10,
-//         "double_value": 2.0,
-//         "bool_value" : true,
-//         "string_value" : "hello",
-//         "vector_value" : [5.2,-3.1,4.33],
-//         "matrix_value" : [[1,2],[3,4],[5,6]]
-//     })"); // if you add more values to this, make sure to add the corresponding in the loop
-//
-//     for key in tmp.keys():
-//         val_type = key[:-6] // removing "_value"
-//
-//         // Int and Double are checked tgth bcs both internally call "IsNumber"
-//         if val_type == "int" or val_type == "double":
-//             if val_type == "int":
-//                 KRATOS_CHECK_EQUAL(tmp[key].GetInt(),10)
-//         else:
-//             with self.assertRaises(RuntimeError):
-//                 tmp[key].GetInt()
-//
-//         if val_type == "double" or val_type == "int":
-//             if val_type == "double":
-//                 KRATOS_CHECK_EQUAL(tmp[key].GetDouble(),2.0)
-//         else:
-//             with self.assertRaises(RuntimeError):
-//                 tmp[key].GetDouble()
-//
-//         if val_type == "bool":
-//             KRATOS_CHECK_EQUAL(tmp[key].GetBool(),True)
-//         else:
-//             with self.assertRaises(RuntimeError):
-//                 tmp[key].GetBool()
-//
-//         if val_type == "string":
-//             KRATOS_CHECK_EQUAL(tmp[key].GetString(),"hello")
-//         else:
-//             with self.assertRaises(RuntimeError):
-//                 tmp[key].GetString()
-//
-//         if val_type == "vector":
-//             V = tmp[key].GetVector()
-//             KRATOS_CHECK_EQUAL(V[0],5.2)
-//             KRATOS_CHECK_EQUAL(V[1],-3.1)
-//             KRATOS_CHECK_EQUAL(V[2],4.33)
-//         else:
-//             with self.assertRaises(RuntimeError):
-//                 tmp[key].GetVector()
-//
-//         if val_type == "matrix":
-//             A = tmp[key].GetMatrix()
-//             KRATOS_CHECK_EQUAL(A[0,0],1.0)
-//             KRATOS_CHECK_EQUAL(A[0,1],2.0)
-//             KRATOS_CHECK_EQUAL(A[1,0],3.0)
-//             KRATOS_CHECK_EQUAL(A[1,1],4.0)
-//             KRATOS_CHECK_EQUAL(A[2,0],5.0)
-//             KRATOS_CHECK_EQUAL(A[2,1],6.0)
-//         else:
-//             with self.assertRaises(RuntimeError):
-//                 tmp[key].GetMatrix()
-// }
-//
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersGetMethods, KratosCoreFastSuite)
+{
+    // This method checks all the "GetXXX" Methods if they throw an error
+    Parameters tmp = Parameters(R"({
+        "int_value" : 10,
+        "double_value": 2.0,
+        "bool_value" : true,
+        "string_value" : "hello",
+        "vector_value" : [5.2,-3.1,4.33],
+        "matrix_value" : [[1,2],[3,4],[5,6]]
+    })"); // if you add more values to this, make sure to add the corresponding in the loop
+
+    for(auto it=tmp.begin(); it!=tmp.end(); ++it) {
+        const std::string key = it.name();
+
+        // Int and Double are checked tgth bcs both internally call "IsNumber"
+        if (key.find("double") != std::string::npos || key.find("int") != std::string::npos) {
+            if (key.find("int") != std::string::npos) {
+                KRATOS_CHECK_EQUAL(tmp[key].GetInt(),10);
+            }
+        } else {
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(tmp[key].GetInt(), "");
+        }
+
+        if (key.find("double") != std::string::npos || key.find("int") != std::string::npos) {
+            if (key.find("double") != std::string::npos) {
+                KRATOS_CHECK_DOUBLE_EQUAL(tmp[key].GetDouble(),2.0);
+            }
+        } else {
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(tmp[key].GetDouble(), "");
+        }
+
+        if (key.find("bool") != std::string::npos) {
+            KRATOS_CHECK_EQUAL(tmp[key].GetBool(), true);
+        } else {
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(tmp[key].GetBool(), "");
+        }
+
+        if (key.find("string") != std::string::npos) {
+            KRATOS_CHECK_STRING_EQUAL(tmp[key].GetString(),"hello");
+        } else {
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(tmp[key].GetString(), "");
+        }
+
+        if (key.find("vector") != std::string::npos) {
+            const auto& V = tmp[key].GetVector();
+            KRATOS_CHECK_DOUBLE_EQUAL(V[0],5.2);
+            KRATOS_CHECK_DOUBLE_EQUAL(V[1],-3.1);
+            KRATOS_CHECK_DOUBLE_EQUAL(V[2],4.33);
+        } else {
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(tmp[key].GetVector(), "");
+        }
+
+        if (key.find("matrix") != std::string::npos) {
+            const auto& A = tmp[key].GetMatrix();
+            KRATOS_CHECK_DOUBLE_EQUAL(A(0,0), 1.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(A(0,1), 2.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(A(1,0), 3.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(A(1,1), 4.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(A(2,0), 5.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(A(2,1), 6.0);
+        } else {
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(tmp[key].GetMatrix(), "");
+        }
+    }
+}
+
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersSetMethods KratosCoreFastSuite)
 // {
 //     // This method checks all the "GetXXX" Methods if they throw an error
@@ -671,7 +674,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersIsMethods, KratosCoreFastSuite)
 //             if val_type == "int":
 //                 tmp[key].SetInt(10)
 //                 KRATOS_CHECK_EQUAL(tmp[key].GetInt(),10)
-//         else:
+//         } else {
 //             with self.assertRaises(RuntimeError):
 //                 tmp[key].GetInt()
 //
@@ -679,21 +682,21 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersIsMethods, KratosCoreFastSuite)
 //             if val_type == "double":
 //                 tmp[key].SetDouble(2.0)
 //                 KRATOS_CHECK_EQUAL(tmp[key].GetDouble(),2.0)
-//         else:
+//         } else {
 //             with self.assertRaises(RuntimeError):
 //                 tmp[key].GetDouble()
 //
 //         if val_type == "bool":
 //             tmp[key].SetBool(True)
 //             KRATOS_CHECK_EQUAL(tmp[key].GetBool(),True)
-//         else:
+//         } else {
 //             with self.assertRaises(RuntimeError):
 //                 tmp[key].GetBool()
 //
 //         if val_type == "string":
 //             tmp[key].SetString("hello")
 //             KRATOS_CHECK_EQUAL(tmp[key].GetString(),"hello")
-//         else:
+//         } else {
 //             with self.assertRaises(RuntimeError):
 //                 tmp[key].GetString()
 //
@@ -707,7 +710,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersIsMethods, KratosCoreFastSuite)
 //             KRATOS_CHECK_EQUAL(V[0],5.2)
 //             KRATOS_CHECK_EQUAL(V[1],-3.1)
 //             KRATOS_CHECK_EQUAL(V[2],4.33)
-//         else:
+//         } else {
 //             with self.assertRaises(RuntimeError):
 //                 tmp[key].GetVector()
 //
@@ -727,7 +730,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersIsMethods, KratosCoreFastSuite)
 //             KRATOS_CHECK_EQUAL(A[1,1],4.0)
 //             KRATOS_CHECK_EQUAL(A[2,0],5.0)
 //             KRATOS_CHECK_EQUAL(A[2,1],6.0)
-//         else:
+//         } else {
 //             with self.assertRaises(RuntimeError):
 //                 tmp[key].GetMatrix()
 // }

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -734,111 +734,114 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersGetMethods, KratosCoreFastSuite)
 //             with self.assertRaises(RuntimeError):
 //                 tmp[key].GetMatrix()
 // }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddMethods, KratosCoreFastSuite)
-// {
-//     // This method checks all the "GetXXX" Methods if they throw an error
-//     Parameters tmp = Parameters(R"({})");
-//
-//     std::string key = "int";
-//     tmp.AddInt(key, 10);
-//     KRATOS_CHECK_EQUAL(tmp[key].GetInt(),10);
-//
-//     key = "double";
-//     tmp.AddDouble(key, 2.0);
-//     KRATOS_CHECK_EQUAL(tmp[key].GetDouble(),2.0);
-//
-//     key = "bool";
-//     tmp.AddBool(key, true);
-//     KRATOS_CHECK_EQUAL(tmp[key].GetBool(),true);
-//
-//     key = "string"
-//     tmp.AddString(key, "hello");
-//     KRATOS_CHECK_EQUAL(tmp[key].GetString(),"hello");
-//
-//     key = "vector";
-//     Vector vector = ZeroVector(3);
-//     vector[0] = 5.2;
-//     vector[1] = -3.1;
-//     vector[2] = 4.33;
-//     tmp.AddVector(key, vector)
-//     V = tmp[key].GetVector()
-//     KRATOS_CHECK_DOUBLE_EQUAL(V[0],5.2);
-//     KRATOS_CHECK_DOUBLE_EQUAL(V[1],-3.1);
-//     KRATOS_CHECK_DOUBLE_EQUAL(V[2],4.33);
-//
-//     key = "matrix";
-//     Matrix matrix = ZeroMatrix(3,2);
-//     matrix[0,0] = 1.0:
-//     matrix[0,1] = 2.0;
-//     matrix[1,0] = 3.0:
-//     matrix[1,1] = 4.0;
-//     matrix[2,0] = 5.0;
-//     matrix[2,1] = 6.0;
-//     tmp.AddMatrix(key, matrix);
-//     auto& A = tmp[key].GetMatrix();
-//     KRATOS_CHECK_DOUBLE_EQUAL(A[0,0],1.0);
-//     KRATOS_CHECK_DOUBLE_EQUAL(A[0,1],2.0);
-//     KRATOS_CHECK_DOUBLE_EQUAL(A[1,0],3.0);
-//     KRATOS_CHECK_DOUBLE_EQUAL(A[1,1],4.0);
-//     KRATOS_CHECK_DOUBLE_EQUAL(A[2,0],5.0);
-//     KRATOS_CHECK_DOUBLE_EQUAL(A[2,1],6.0);
-// }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersVectorInterface, KratosCoreFastSuite)
-// {
-//     // Read and check Vectors from a Parameters-Object
-//     Parameters tmp = Parameters(R"({
-//         "valid_vectors" : [ []
-//         ],
-//         "false_vectors" : [ [[]],
-//                             [[2,3],2],
-//                             [2,3,[2]],
-//                             [2,3,[]],
-//                             [{"key":3},2],
-//                             [2,3,{"key":3}],
-//                             [true,2],
-//                             [2,3,true],
-//                             [5,"string",2]
-//         ]
-//     })");
-//
-//     // Check the IsVector Method
-//     for i in range(tmp["valid_vectors"].size()):
-//         valid_vector = tmp["valid_vectors"][i]
-//         KRATOS_CHECK(valid_vector.IsVector())
-//
-//     for i in range(tmp["false_vectors"].size()):
-//         false_vector = tmp["false_vectors"][i]
-//         KRATOS_CHECK_IS_FALSE(false_vector.IsVector())
-//
-//     // Check the GetVector Method also on the valid Matrices
-//     for i in range(tmp["valid_vectors"].size()):
-//         valid_vector = tmp["valid_vectors"][i]
-//         valid_vector.GetVector()
-//
-//     // Check that the errors of the GetVector method are thrown correctly
-//     for i in range(tmp["false_vectors"].size()):
-//         false_vector = tmp["false_vectors"][i]
-//         with self.assertRaises(RuntimeError):
-//             false_vector.GetVector()
-//
-//     // Manually assign and check a Vector
-//     Vector vec = ZeroVector(3);
-//     vec[0] = 1.32;
-//     vec[1] = -2.22;
-//     vec[2] = 5.5;
-//
-//     tmp.AddEmptyValue("vector_value");
-//     tmp["vector_value"].SetVector(vec);
-//
-//     KRATOS_CHECK(tmp["vector_value"].IsVector());
-//
-//     auto V2 = tmp["vector_value"].GetVector();
-//     KRATOS_CHECK_DOUBLE_EQUAL(V2[0],1.32);
-//     KRATOS_CHECK_DOUBLE_EQUAL(V2[1],-2.22);
-//     KRATOS_CHECK_DOUBLE_EQUAL(V2[2],5.5);
-// }
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddMethods, KratosCoreFastSuite)
+{
+    // This method checks all the "GetXXX" Methods if they throw an error
+    Parameters tmp = Parameters(R"({})");
+
+    std::string key = "int";
+    tmp.AddInt(key, 10);
+    KRATOS_CHECK_EQUAL(tmp[key].GetInt(),10);
+
+    key = "double";
+    tmp.AddDouble(key, 2.0);
+    KRATOS_CHECK_EQUAL(tmp[key].GetDouble(),2.0);
+
+    key = "bool";
+    tmp.AddBool(key, true);
+    KRATOS_CHECK_EQUAL(tmp[key].GetBool(),true);
+
+    key = "string";
+    tmp.AddString(key, "hello");
+    KRATOS_CHECK_EQUAL(tmp[key].GetString(),"hello");
+
+    key = "vector";
+    Vector vector = ZeroVector(3);
+    vector[0] = 5.2;
+    vector[1] = -3.1;
+    vector[2] = 4.33;
+    tmp.AddVector(key, vector);
+    const auto& V = tmp[key].GetVector();
+    KRATOS_CHECK_DOUBLE_EQUAL(V[0],5.2);
+    KRATOS_CHECK_DOUBLE_EQUAL(V[1],-3.1);
+    KRATOS_CHECK_DOUBLE_EQUAL(V[2],4.33);
+
+    key = "matrix";
+    Matrix matrix = ZeroMatrix(3,2);
+    matrix(0,0) = 1.0;
+    matrix(0,1) = 2.0;
+    matrix(1,0) = 3.0;
+    matrix(1,1) = 4.0;
+    matrix(2,0) = 5.0;
+    matrix(2,1) = 6.0;
+    tmp.AddMatrix(key, matrix);
+    const auto& A = tmp[key].GetMatrix();
+    KRATOS_CHECK_DOUBLE_EQUAL(A(0,0),1.0);
+    KRATOS_CHECK_DOUBLE_EQUAL(A(0,1),2.0);
+    KRATOS_CHECK_DOUBLE_EQUAL(A(1,0),3.0);
+    KRATOS_CHECK_DOUBLE_EQUAL(A(1,1),4.0);
+    KRATOS_CHECK_DOUBLE_EQUAL(A(2,0),5.0);
+    KRATOS_CHECK_DOUBLE_EQUAL(A(2,1),6.0);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersVectorInterface, KratosCoreFastSuite)
+{
+    // Read and check Vectors from a Parameters-Object
+    Parameters tmp = Parameters(R"({
+        "valid_vectors" : [ []
+        ],
+        "false_vectors" : [ [[]],
+                            [[2,3],2],
+                            [2,3,[2]],
+                            [2,3,[]],
+                            [{"key":3},2],
+                            [2,3,{"key":3}],
+                            [true,2],
+                            [2,3,true],
+                            [5,"string",2]
+        ]
+    })");
+
+    // Check the IsVector Method
+    for (std::size_t i = 0;  i < tmp["valid_vectors"].size(); ++i) {
+        const auto& valid_vector = tmp["valid_vectors"][i];
+        KRATOS_CHECK(valid_vector.IsVector());
+    }
+
+    for (std::size_t i = 0;  i < tmp["false_vectors"].size(); ++i) {
+        const auto& false_vector = tmp["false_vectors"][i];
+        KRATOS_CHECK_IS_FALSE(false_vector.IsVector());
+    }
+
+    // Check the GetVector Method also on the valid Matrices
+    for (std::size_t i = 0;  i < tmp["valid_vectors"].size(); ++i) {
+        const auto& valid_vector = tmp["valid_vectors"][i];
+        valid_vector.GetVector();
+    }
+
+    // Check that the errors of the GetVector method are thrown correctly
+    for (std::size_t i = 0;  i < tmp["false_vectors"].size(); ++i) {
+        const auto& false_vector = tmp["false_vectors"][i];
+        KRATOS_CHECK_EXCEPTION_IS_THROWN(false_vector.GetVector(), "");
+    }
+
+    // Manually assign and check a Vector
+    Vector vec = ZeroVector(3);
+    vec[0] = 1.32;
+    vec[1] = -2.22;
+    vec[2] = 5.5;
+
+    tmp.AddEmptyValue("vector_value");
+    tmp["vector_value"].SetVector(vec);
+
+    KRATOS_CHECK(tmp["vector_value"].IsVector());
+
+    const auto V2 = tmp["vector_value"].GetVector();
+    KRATOS_CHECK_DOUBLE_EQUAL(V2[0],1.32);
+    KRATOS_CHECK_DOUBLE_EQUAL(V2[1],-2.22);
+    KRATOS_CHECK_DOUBLE_EQUAL(V2[2],5.5);
+}
 
 KRATOS_TEST_CASE_IN_SUITE(KratosParametersMatrixInterface, KratosCoreFastSuite)
 {

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -415,24 +415,24 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationSucceeds, KratosCoreFastSuit
     KRATOS_CHECK_DOUBLE_EQUAL(kp["level1"]["tmp"].GetDouble(), 5.0);  // not 2, since kp overwrites the defaults
 }
 
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddMissingParameters, KratosCoreFastSuite)
-// {
-//     // only missing parameters are added, no complaints if there already exist more than in the defaults
-//     Parameters kp = Parameters(GetJSONString());
-//     tmp = Parameters(incomplete_with_extra_parameter)
-//
-//     kp.AddMissingParameters(tmp)
-//
-//     KRATOS_CHECK_EQUAL(kp["new_default_obj"]["aaa"].GetString(), "string")
-//     KRATOS_CHECK_EQUAL(kp["string_value"].GetString(), "hello")
-//     KRATOS_CHECK_IS_FALSE(kp["level1"].Has("new_sublevel"))
-// }
-//
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddMissingParameters, KratosCoreFastSuite)
+{
+    // Only missing parameters are added, no complaints if there already exist more than in the defaults
+    Parameters kp = Parameters(GetJSONString());
+    Parameters tmp = Parameters(GetJSONStringIncompleteWithExtraParameter());
+
+    kp.AddMissingParameters(tmp);
+
+    KRATOS_CHECK_STRING_EQUAL(kp["new_default_obj"]["aaa"].GetString(), "string");
+    KRATOS_CHECK_STRING_EQUAL(kp["string_value"].GetString(), "hello");
+    KRATOS_CHECK_IS_FALSE(kp["level1"].Has("new_sublevel"));
+}
+
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersRecursivelyAddMissingParameters, KratosCoreFastSuite)
 // {
 //     // only missing parameters are added, no complaints if there already exist more than in the defaults
 //     Parameters kp = Parameters(GetJSONString());
-//     tmp = Parameters(incomplete_with_extra_parameter)
+//     Parameters tmp = Parameters(GetJSONStringIncompleteWithExtraParameter());
 //
 //     kp.RecursivelyAddMissingParameters(tmp)
 //

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -839,67 +839,70 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersGetMethods, KratosCoreFastSuite)
 //     KRATOS_CHECK_DOUBLE_EQUAL(V2[1],-2.22);
 //     KRATOS_CHECK_DOUBLE_EQUAL(V2[2],5.5);
 // }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersMatrixInterface, KratosCoreFastSuite)
-// {
-//     // Read and check Matrices from a Parameters-Object
-//     Parameters tmp = Parameters(R"({
-//         "valid_matrices" : [ [[]],
-//                               [[],[]],
-//                               [[-9.81,8, 5.47]]
-//         ],
-//         "false_matrices" : [ [],
-//                               [[[]]],
-//                               [[3.3] , [1,2]],
-//                               [[2,1.5,3.3] , [3,{"key":3},2]],
-//                               [[2,1.5,3.3] , [5,false,2]],
-//                               [[2,1.5,3.3] , [[2,3],1,2]],
-//                               [[2,1.5,3.3] , ["string",2,9]]
-//         ]
-//     })");
-//
-//     // Check the IsMatrix Method
-//     for i in range(tmp["valid_matrices"].size()):
-//         valid_matrix = tmp["valid_matrices"][i]
-//         KRATOS_CHECK(valid_matrix.IsMatrix())
-//
-//     for i in range(tmp["false_matrices"].size()):
-//         false_matrix = tmp["false_matrices"][i]
-//         KRATOS_CHECK_IS_FALSE(false_matrix.IsMatrix())
-//
-//     // Check the GetMatrix Method also on the valid Matrices
-//     for i in range(tmp["valid_matrices"].size()):
-//         valid_matrix = tmp["valid_matrices"][i]
-//         valid_matrix.GetMatrix()
-//
-//     // Check that the errors of the GetMatrix method are thrown correctly
-//     for i in range(tmp["false_matrices"].size()):
-//         false_matrix = tmp["false_matrices"][i]
-//         with self.assertRaises(RuntimeError):
-//             false_matrix.GetMatrix()
-//
-//     // Manually assign and check a Matrix
-//     Matrix mat = ZeroMatrix(3,2);
-//     mat[0,0] = 1.0;
-//     mat[0,1] = 2.0;
-//     mat[1,0] = 3.0;
-//     mat[1,1] = 4.0;
-//     mat[2,0] = 5.0;
-//     mat[2,1] = 6.0;
-//
-//     tmp.AddEmptyValue("matrix_value")
-//     tmp["matrix_value"].SetMatrix(mat);
-//
-//     KRATOS_CHECK(tmp["matrix_value"].IsMatrix());
-//
-//     A2 = tmp["matrix_value"].GetMatrix()
-//     KRATOS_CHECK_EQUAL(A2[0,0],1.0);
-//     KRATOS_CHECK_EQUAL(A2[0,1],2.0);
-//     KRATOS_CHECK_EQUAL(A2[1,0],3.0);
-//     KRATOS_CHECK_EQUAL(A2[1,1],4.0);
-//     KRATOS_CHECK_EQUAL(A2[2,0],5.0);
-//     KRATOS_CHECK_EQUAL(A2[2,1],6.0);
-// }
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersMatrixInterface, KratosCoreFastSuite)
+{
+    // Read and check Matrices from a Parameters-Object
+    Parameters tmp = Parameters(R"({
+        "valid_matrices" : [ [[]],
+                              [[],[]],
+                              [[-9.81,8, 5.47]]
+        ],
+        "false_matrices" : [ [],
+                              [[[]]],
+                              [[3.3] , [1,2]],
+                              [[2,1.5,3.3] , [3,{"key":3},2]],
+                              [[2,1.5,3.3] , [5,false,2]],
+                              [[2,1.5,3.3] , [[2,3],1,2]],
+                              [[2,1.5,3.3] , ["string",2,9]]
+        ]
+    })");
+
+    // Check the IsMatrix Method
+    for (std::size_t i = 0;  i < tmp["valid_matrices"].size(); ++i) {
+        const auto& valid_matrix = tmp["valid_matrices"][i];
+        KRATOS_CHECK(valid_matrix.IsMatrix());
+    }
+
+    for (std::size_t i = 0;  i < tmp["false_matrices"].size(); ++i) {
+        const auto& false_matrix = tmp["false_matrices"][i];
+        KRATOS_CHECK_IS_FALSE(false_matrix.IsMatrix());
+    }
+
+    // Check the GetMatrix Method also on the valid Matrices
+    for (std::size_t i = 0;  i < tmp["valid_matrices"].size(); ++i) {
+        const auto& valid_matrix = tmp["valid_matrices"][i];
+        valid_matrix.GetMatrix();
+    }
+
+    // Check that the errors of the GetMatrix method are thrown correctly
+    for (std::size_t i = 0;  i < tmp["false_matrices"].size(); ++i) {
+        const auto& false_matrix = tmp["false_matrices"][i];
+        KRATOS_CHECK_EXCEPTION_IS_THROWN(false_matrix.GetMatrix(), "");
+    }
+
+    // Manually assign and check a Matrix
+    Matrix mat = ZeroMatrix(3,2);
+    mat(0,0) = 1.0;
+    mat(0,1) = 2.0;
+    mat(1,0) = 3.0;
+    mat(1,1) = 4.0;
+    mat(2,0) = 5.0;
+    mat(2,1) = 6.0;
+
+    tmp.AddEmptyValue("matrix_value");
+    tmp["matrix_value"].SetMatrix(mat);
+
+    KRATOS_CHECK(tmp["matrix_value"].IsMatrix());
+
+    const auto& A2 = tmp["matrix_value"].GetMatrix();
+    KRATOS_CHECK_DOUBLE_EQUAL(A2(0,0),1.0);
+    KRATOS_CHECK_DOUBLE_EQUAL(A2(0,1),2.0);
+    KRATOS_CHECK_DOUBLE_EQUAL(A2(1,0),3.0);
+    KRATOS_CHECK_DOUBLE_EQUAL(A2(1,1),4.0);
+    KRATOS_CHECK_DOUBLE_EQUAL(A2(2,0),5.0);
+    KRATOS_CHECK_DOUBLE_EQUAL(A2(2,1),6.0);
+}
 
 KRATOS_TEST_CASE_IN_SUITE(KratosParametersNullvsNullValidation, KratosCoreFastSuite)
 {

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -654,86 +654,89 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersGetMethods, KratosCoreFastSuite)
     }
 }
 
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersSetMethods KratosCoreFastSuite)
-// {
-//     // This method checks all the "GetXXX" Methods if they throw an error
-//     Parameters tmp = Parameters(R"({
-//         "int_value" : 0,
-//         "double_value": 0.0,
-//         "bool_value" : false,
-//         "string_value" : "",
-//         "vector_value" : [],
-//         "matrix_value" : [[0]]
-//     })"); // if you add more values to this, make sure to add the corresponding in the loop
-//
-//     for key in tmp.keys():
-//         val_type = key[:-6] // removing "_value"
-//
-//         // Int and Double are checked tgth bcs both internally call "IsNumber"
-//         if val_type == "int" or val_type == "double":
-//             if val_type == "int":
-//                 tmp[key].SetInt(10)
-//                 KRATOS_CHECK_EQUAL(tmp[key].GetInt(),10)
-//         } else {
-//             with self.assertRaises(RuntimeError):
-//                 tmp[key].GetInt()
-//
-//         if val_type == "double" or val_type == "int":
-//             if val_type == "double":
-//                 tmp[key].SetDouble(2.0)
-//                 KRATOS_CHECK_EQUAL(tmp[key].GetDouble(),2.0)
-//         } else {
-//             with self.assertRaises(RuntimeError):
-//                 tmp[key].GetDouble()
-//
-//         if val_type == "bool":
-//             tmp[key].SetBool(True)
-//             KRATOS_CHECK_EQUAL(tmp[key].GetBool(),True)
-//         } else {
-//             with self.assertRaises(RuntimeError):
-//                 tmp[key].GetBool()
-//
-//         if val_type == "string":
-//             tmp[key].SetString("hello")
-//             KRATOS_CHECK_EQUAL(tmp[key].GetString(),"hello")
-//         } else {
-//             with self.assertRaises(RuntimeError):
-//                 tmp[key].GetString()
-//
-//         if val_type == "vector":
-//             vector = Vector(3)
-//             vector[0] = 5.2
-//             vector[1] = -3.1
-//             vector[2] = 4.33
-//             tmp[key].SetVector(vector)
-//             V = tmp[key].GetVector()
-//             KRATOS_CHECK_EQUAL(V[0],5.2)
-//             KRATOS_CHECK_EQUAL(V[1],-3.1)
-//             KRATOS_CHECK_EQUAL(V[2],4.33)
-//         } else {
-//             with self.assertRaises(RuntimeError):
-//                 tmp[key].GetVector()
-//
-//         if val_type == "matrix":
-//             matrix = Matrix(3,2)
-//             matrix[0,0] = 1.0
-//             matrix[0,1] = 2.0
-//             matrix[1,0] = 3.0
-//             matrix[1,1] = 4.0
-//             matrix[2,0] = 5.0
-//             matrix[2,1] = 6.0
-//             tmp[key].SetMatrix(matrix)
-//             A = tmp[key].GetMatrix()
-//             KRATOS_CHECK_EQUAL(A[0,0],1.0)
-//             KRATOS_CHECK_EQUAL(A[0,1],2.0)
-//             KRATOS_CHECK_EQUAL(A[1,0],3.0)
-//             KRATOS_CHECK_EQUAL(A[1,1],4.0)
-//             KRATOS_CHECK_EQUAL(A[2,0],5.0)
-//             KRATOS_CHECK_EQUAL(A[2,1],6.0)
-//         } else {
-//             with self.assertRaises(RuntimeError):
-//                 tmp[key].GetMatrix()
-// }
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersSetMethods, KratosCoreFastSuite)
+{
+    // This method checks all the "GetXXX" Methods if they throw an error
+    Parameters tmp = Parameters(R"({
+        "int_value" : 0,
+        "double_value": 0.0,
+        "bool_value" : false,
+        "string_value" : "",
+        "vector_value" : [],
+        "matrix_value" : [[0]]
+    })"); // if you add more values to this, make sure to add the corresponding in the loop
+
+    for(auto it=tmp.begin(); it!=tmp.end(); ++it) {
+        const std::string key = it.name();
+
+        // Int and Double are checked tgth bcs both internally call "IsNumber"
+        if (key.find("double") != std::string::npos || key.find("int") != std::string::npos) {
+            if (key.find("int") != std::string::npos) {
+                tmp[key].SetInt(10);
+                KRATOS_CHECK_EQUAL(tmp[key].GetInt(),10);
+            }
+        } else {
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(tmp[key].GetInt(), "");
+        }
+
+        if (key.find("double") != std::string::npos || key.find("int") != std::string::npos) {
+            if (key.find("double") != std::string::npos) {
+                tmp[key].SetDouble(2.0);
+                KRATOS_CHECK_EQUAL(tmp[key].GetDouble(),2.0);
+            }
+        } else {
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(tmp[key].GetDouble(), "");
+        }
+
+        if (key.find("bool") != std::string::npos) {
+            tmp[key].SetBool(true);
+            KRATOS_CHECK_EQUAL(tmp[key].GetBool(),true);
+        } else {
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(tmp[key].GetBool(), "");
+        }
+
+        if (key.find("string") != std::string::npos) {
+            tmp[key].SetString("hello");
+            KRATOS_CHECK_STRING_EQUAL(tmp[key].GetString(),"hello");
+        } else {
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(tmp[key].GetString(), "");
+        }
+
+        if (key.find("vector") != std::string::npos) {
+            Vector vector = ZeroVector(3);
+            vector[0] = 5.2;
+            vector[1] = -3.1;
+            vector[2] = 4.33;
+            tmp[key].SetVector(vector);
+            const auto& V = tmp[key].GetVector();
+            KRATOS_CHECK_DOUBLE_EQUAL(V[0],5.2);
+            KRATOS_CHECK_DOUBLE_EQUAL(V[1],-3.1);
+            KRATOS_CHECK_DOUBLE_EQUAL(V[2],4.33);
+        } else {
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(tmp[key].GetVector(), "");
+        }
+
+        if (key.find("matrix") != std::string::npos) {
+            Matrix matrix = ZeroMatrix(3,2);
+            matrix(0,0) = 1.0;
+            matrix(0,1) = 2.0;
+            matrix(1,0) = 3.0;
+            matrix(1,1) = 4.0;
+            matrix(2,0) = 5.0;
+            matrix(2,1) = 6.0;
+            tmp[key].SetMatrix(matrix);
+            const auto& A = tmp[key].GetMatrix();
+            KRATOS_CHECK_DOUBLE_EQUAL(A(0,0),1.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(A(0,1),2.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(A(1,0),3.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(A(1,1),4.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(A(2,0),5.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(A(2,1),6.0);
+        } else {
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(tmp[key].GetMatrix(), "");
+        }
+    }
+}
 
 KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddMethods, KratosCoreFastSuite)
 {
@@ -746,7 +749,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddMethods, KratosCoreFastSuite)
 
     key = "double";
     tmp.AddDouble(key, 2.0);
-    KRATOS_CHECK_EQUAL(tmp[key].GetDouble(),2.0);
+    KRATOS_CHECK_DOUBLE_EQUAL(tmp[key].GetDouble(),2.0);
 
     key = "bool";
     tmp.AddBool(key, true);
@@ -754,7 +757,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddMethods, KratosCoreFastSuite)
 
     key = "string";
     tmp.AddString(key, "hello");
-    KRATOS_CHECK_EQUAL(tmp[key].GetString(),"hello");
+    KRATOS_CHECK_STRING_EQUAL(tmp[key].GetString(),"hello");
 
     key = "vector";
     Vector vector = ZeroVector(3);

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -692,9 +692,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersSetMethods, KratosCoreFastSuite)
             vector[2] = 4.33;
             tmp[key].SetVector(vector);
             const auto& V = tmp[key].GetVector();
-            KRATOS_CHECK_DOUBLE_EQUAL(V[0],5.2);
-            KRATOS_CHECK_DOUBLE_EQUAL(V[1],-3.1);
-            KRATOS_CHECK_DOUBLE_EQUAL(V[2],4.33);
+            KRATOS_CHECK_VECTOR_EQUAL(V,vector);
         } else {
             KRATOS_CHECK_EXCEPTION_IS_THROWN(tmp[key].GetVector(), "");
         }
@@ -709,12 +707,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersSetMethods, KratosCoreFastSuite)
             matrix(2,1) = 6.0;
             tmp[key].SetMatrix(matrix);
             const auto& A = tmp[key].GetMatrix();
-            KRATOS_CHECK_DOUBLE_EQUAL(A(0,0),1.0);
-            KRATOS_CHECK_DOUBLE_EQUAL(A(0,1),2.0);
-            KRATOS_CHECK_DOUBLE_EQUAL(A(1,0),3.0);
-            KRATOS_CHECK_DOUBLE_EQUAL(A(1,1),4.0);
-            KRATOS_CHECK_DOUBLE_EQUAL(A(2,0),5.0);
-            KRATOS_CHECK_DOUBLE_EQUAL(A(2,1),6.0);
+            KRATOS_CHECK_MATRIX_EQUAL(A,matrix);
         } else {
             KRATOS_CHECK_EXCEPTION_IS_THROWN(tmp[key].GetMatrix(), "");
         }
@@ -749,9 +742,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddMethods, KratosCoreFastSuite)
     vector[2] = 4.33;
     tmp.AddVector(key, vector);
     const auto& V = tmp[key].GetVector();
-    KRATOS_CHECK_DOUBLE_EQUAL(V[0],5.2);
-    KRATOS_CHECK_DOUBLE_EQUAL(V[1],-3.1);
-    KRATOS_CHECK_DOUBLE_EQUAL(V[2],4.33);
+    KRATOS_CHECK_VECTOR_EQUAL(V,vector);
 
     key = "matrix";
     Matrix matrix = ZeroMatrix(3,2);
@@ -763,12 +754,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddMethods, KratosCoreFastSuite)
     matrix(2,1) = 6.0;
     tmp.AddMatrix(key, matrix);
     const auto& A = tmp[key].GetMatrix();
-    KRATOS_CHECK_DOUBLE_EQUAL(A(0,0),1.0);
-    KRATOS_CHECK_DOUBLE_EQUAL(A(0,1),2.0);
-    KRATOS_CHECK_DOUBLE_EQUAL(A(1,0),3.0);
-    KRATOS_CHECK_DOUBLE_EQUAL(A(1,1),4.0);
-    KRATOS_CHECK_DOUBLE_EQUAL(A(2,0),5.0);
-    KRATOS_CHECK_DOUBLE_EQUAL(A(2,1),6.0);
+    KRATOS_CHECK_MATRIX_EQUAL(A,matrix);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(KratosParametersVectorInterface, KratosCoreFastSuite)
@@ -824,9 +810,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersVectorInterface, KratosCoreFastSuite)
     KRATOS_CHECK(tmp["vector_value"].IsVector());
 
     const auto V2 = tmp["vector_value"].GetVector();
-    KRATOS_CHECK_DOUBLE_EQUAL(V2[0],1.32);
-    KRATOS_CHECK_DOUBLE_EQUAL(V2[1],-2.22);
-    KRATOS_CHECK_DOUBLE_EQUAL(V2[2],5.5);
+    KRATOS_CHECK_VECTOR_EQUAL(V2,vec);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(KratosParametersMatrixInterface, KratosCoreFastSuite)
@@ -885,12 +869,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersMatrixInterface, KratosCoreFastSuite)
     KRATOS_CHECK(tmp["matrix_value"].IsMatrix());
 
     const auto& A2 = tmp["matrix_value"].GetMatrix();
-    KRATOS_CHECK_DOUBLE_EQUAL(A2(0,0),1.0);
-    KRATOS_CHECK_DOUBLE_EQUAL(A2(0,1),2.0);
-    KRATOS_CHECK_DOUBLE_EQUAL(A2(1,0),3.0);
-    KRATOS_CHECK_DOUBLE_EQUAL(A2(1,1),4.0);
-    KRATOS_CHECK_DOUBLE_EQUAL(A2(2,0),5.0);
-    KRATOS_CHECK_DOUBLE_EQUAL(A2(2,1),6.0);
+    KRATOS_CHECK_MATRIX_EQUAL(A2, mat);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(KratosParametersNullvsNullValidation, KratosCoreFastSuite)

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -1,0 +1,978 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "testing/testing.h"
+#include "includes/kratos_parameters.h"
+
+namespace Kratos {
+namespace Testing {
+
+// input string with ugly formatting
+std::string GetJSONString()
+{
+    const std::string json_string = R"(
+    {
+      "bool_value" : true, "double_value": 2.0, "int_value" : 10,
+      "level1":
+      {
+        "list_value":[ 3, "hi", false],
+        "tmp" : 5.0
+      },
+      "string_value" : "hello"
+    })";
+    return json_string;
+}
+
+std::string GetJSONStringPrettyOut()
+{
+    const std::string pretty_out =  R"(
+        "bool_value": true,
+        "double_value": 2.0,
+        "int_value": 10,
+        "level1": {
+            "list_value": [
+                3,
+                "hi",
+                false
+            ],
+            "tmp": 5.0
+        },
+        "string_value": "hello"
+    })";
+    return pretty_out;
+}
+
+// std::string GetJSONStringPrettyOutAfterChange()
+// {
+//     const std::string pretty_out_after_change = """{
+//         "bool_value": true,
+//         "double_value": 2.0,
+//         "int_value": 10,
+//         "level1": {
+//             "list_value": [
+//                 "changed",
+//                 "hi",
+//                 false
+//             ],
+//             "tmp": 5.0
+//         },
+//         "string_value": "hello"
+//     }""";
+//
+//     return pretty_out_after_change;
+// }
+//
+//     // here the level1 var is set to a double so that a validation error should be thrown
+// std::string GetJSONStringWrongType()
+// {
+//     const std::string wrong_type = """{
+//         "bool_value": true,
+//         "double_value": 2.0,
+//         "int_value": 10,
+//         "level1": 0.0,
+//         "string_value": "hello"
+//     }""";
+//
+//     return wrong_type;
+// }
+//
+// // int value is badly spelt
+// std::string GetJSONStringWrongSpelling()
+// {
+//     const std::string wrong_spelling = """{
+//         "bool_value": true,
+//         "double_value": 2.0,
+//         "int_values": 10,
+//         "level1": 0.0,
+//         "string_value": "hello"
+//     }""";
+//
+//     return wrong_spelling;
+// }
+//
+// // wrong on the first level
+// // error shall be only detective by recursive validation
+// std::string GetJSONStringWrongLevel2()
+// {
+//     const std::string wrong_lev2 = """{
+//         "bool_value": true,
+//         "double_value": 2.0,
+//         "int_value": 10,
+//         "level1": { "a":0.0 },
+//         "string_value": "hello"
+//     }""";
+//     return wrong_lev2;
+// }
+//
+// std::string GetJSONStringDefaults()
+// {
+//     const std::string defaults = """
+//     {
+//         "bool_value": false,
+//         "double_value": 2.0,
+//         "int_value": 10,
+//         "level1": {
+//             "list_value": [
+//                 3,
+//                 "hi",
+//                 false
+//             ],
+//             "tmp": "here we expect a string"
+//         },
+//         "new_default_obj": {
+//             "aaa": "string",
+//             "bbb": false,
+//             "ccc": 22
+//         },
+//         "new_default_value": -123.0,
+//         "string_value": "hello"
+//     }
+//     """;
+//     return defaults;
+// }
+//
+// std::string GetJSONStringIncomplete()
+// {
+//     const std::string incomplete = """
+//     {
+//         "level1": {
+//         },
+//         "new_default_obj": {
+//             "aaa": "string",
+//             "bbb": false,
+//             "ccc": 22
+//         },
+//         "new_default_value": -123.0,
+//         "string_value": "hello"
+//     }""";
+//     return incomplete;
+// }
+//
+// std::string GetJSONStringIncompleteWithExtraParameter()
+// {
+//     const std::string incomplete_with_extra_parameter = """
+//     {
+//         "level1": {
+//             "new_sublevel": "this should only be assigned in recursive"
+//         },
+//         "new_default_obj": {
+//             "aaa": "string",
+//             "bbb": false,
+//             "ccc": 22
+//         },
+//         "new_default_value": -123.0,
+//         "string_value": "hello"
+//     }""";
+//     return incomplete_with_extra_parameter;
+// }
+//
+// std::string GetJSONStringExpectedValidationOutput()
+// {
+//     const std::string expected_validation_output = """{
+//         "bool_value": true,
+//         "double_value": 2.0,
+//         "int_value": 10,
+//         "level1": {
+//             "list_value": [
+//                 3,
+//                 "hi",
+//                 false
+//             ],
+//             "tmp": 5.0
+//         },
+//         "new_default_obj": {
+//             "aaa": "string",
+//             "bbb": false,
+//             "ccc": 22
+//         },
+//         "new_default_value": -123.0,
+//         "string_value": "hello"
+//     }""";
+//     return expected_validation_output;
+// }
+//
+// std::string GetJSONStringFourLevels()
+// {
+//     const std::string four_levels = """{
+//         "bool_value": true,
+//         "double_value": 2.0,
+//         "int_value": 10,
+//         "level1": {
+//             "level2": {
+//                 "level3": {
+//                     "level4": {
+//                     }
+//                 }
+//             }
+//         },
+//         "string_value": "hello"
+//     }""";
+//     return four_levels;
+// }
+//
+// std::string GetJSONStringForLevelsVariation()
+// {
+//     const std::string four_levels_variation = """{
+//         "bool_value": true,
+//         "double_value": 2.0,
+//         "int_value": 10,
+//         "level1": {
+//             "a":11.0,
+//             "level2": {
+//                 "level3": {
+//                     "level4": {
+//                     }
+//                 }
+//             }
+//         },
+//         "string_value": "hello"
+//     }""";
+//     return four_levels_variation;
+// }
+//
+// std::string GetJSONStringForLevelsWrongVariation()
+// {
+//     const std::string four_levels_wrong_variation = """{
+//         "int_value": 10,
+//         "double_value": "hi",
+//         "bool_value": true,
+//         "string_value": "hello",
+//         "level1": {
+//             "a":11.0,
+//             "level2": {
+//                 "level3": {
+//                     "level4": {
+//                     }
+//                 }
+//             }
+//         }
+//     }""";
+//     return four_levels_wrong_variation;
+// }
+//
+// std::string GetJSONStringForLevelsDefaults()
+// {
+//     const std::string four_levels_defaults = """{
+//         "bool_value": true,
+//         "double_value": 2.0,
+//         "int_value": 10,
+//         "level1": {
+//             "a":1.0,
+//             "level2": {
+//                 "b":2.0,
+//                 "level3": {
+//                     "c":3.0,
+//                     "level4": {
+//                         "d":4.0
+//                     }
+//                 }
+//             }
+//         },
+//         "string_value": "hello"
+//     }""";
+//     return four_levels_defaults;
+// }
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParameters, KratosCoreFastSuite)
+{
+    Parameters kp = Parameters(GetJSONString());
+    KRATOS_CHECK_STRING_EQUAL(
+        kp.WriteJsonString(),
+        R"({"bool_value":true,"double_value":2.0,"int_value":10,"level1":{"list_value":[3,"hi",false],"tmp":5.0},"string_value":"hello"})"
+    );
+
+    KRATOS_CHECK(kp.Has("int_value"));
+    KRATOS_CHECK_IS_FALSE(kp.Has("unextisting_value"));
+
+    KRATOS_CHECK_EQUAL(kp["int_value"].GetInt(), 10);
+    KRATOS_CHECK_EQUAL(kp["double_value"].GetDouble(), 2.0);
+    KRATOS_CHECK_EQUAL(kp["bool_value"].GetBool(), true);
+    KRATOS_CHECK_EQUAL(kp["string_value"].GetString(), "hello");
+
+    KRATOS_CHECK_STRING_EQUAL(kp.PrettyPrintJsonString(), GetJSONStringPrettyOut());
+}
+
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersChangeParameters, KratosCoreFastSuite)
+// {
+//     // now change one item in the sublist
+//     subparams = self.kp["level1"]
+//
+//     my_list = subparams["list_value"]
+//
+//     for i in range(my_list.size()):
+//         if my_list[i].IsBool():
+//             KRATOS_CHECK_EQUAL(my_list[i].GetBool(), False)
+//
+//     // my_list = subparams["list_value"]
+//     subparams["list_value"][0].SetString("changed")
+//
+//     KRATOS_CHECK_EQUAL(
+//         self.kp.PrettyPrintJsonString(),
+//         pretty_out_after_change
+//     )
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersCopy, KratosCoreFastSuite)
+// {
+//     // try to make a copy
+//     original_out = self.kp.PrettyPrintJsonString()
+//     other_copy = self.kp.Clone()
+//
+//     KRATOS_CHECK_EQUAL(
+//         other_copy.PrettyPrintJsonString(),
+//         original_out
+//     )
+//
+//     other_copy["int_value"].SetInt(-1)
+//     KRATOS_CHECK_EQUAL(self.kp["int_value"].GetInt(), 10);
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersSetValue, KratosCoreFastSuite)
+// {
+//     Parameters kp = Parameters(json_string)
+//     Parameters kp1 = Parameters(pretty_out_after_change)
+//
+//     kp["bool_value"] = kp1["level1"]
+//     kp["bool_value"].PrettyPrintJsonString()
+//     KRATOS_CHECK_EQUAL(kp["bool_value"].PrettyPrintJsonString(), kp1["level1"].PrettyPrintJsonString())
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersWrongParameters, KratosCoreFastSuite)
+// {
+//     // should check which errors are thrown!!
+//     with self.assertRaisesRegex(RuntimeError, "no_value"):
+//         self.kp["no_value"].GetInt()
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationFailsDueToWrongTypes, KratosCoreFastSuite)
+// {
+//     Parameters kp = Parameters(wrong_type)
+//     Parameters defaults_params = Parameters(defaults)
+//
+//     // should check which errors are thrown!!
+//     with self.assertRaises(RuntimeError):
+//         kp.ValidateAndAssignDefaults(defaults_params)
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationFailsDueToWrongSpelling, KratosCoreFastSuite)
+// {
+//     Parameters kp = Parameters(wrong_spelling)
+//     Parameters defaults_params = Parameters(defaults)
+//
+//     // should check which errors are thrown!!
+//     with self.assertRaises(RuntimeError):
+//         kp.ValidateAndAssignDefaults(defaults_params)
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationFailsErrorsOnFirstLevel, KratosCoreFastSuite)
+// {
+//     Parameters kp = Parameters(wrong_lev2)
+//     defaults_params = Parameters(defaults)
+//
+//     // should check which errors are thrown!!
+//     with self.assertRaises(RuntimeError):
+//         kp.RecursivelyValidateAndAssignDefaults(defaults_params)
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersRecursiveValidation4Levels, KratosCoreFastSuite)
+// {
+//     Parameters kp = Parameters(four_levels)
+//     kp_variation = Parameters(four_levels_variation)
+//     kp_wrong_wariation = Parameters(four_levels_wrong_variation)
+//     defaults_params = Parameters(four_levels_defaults)
+//
+//     kp.RecursivelyValidateAndAssignDefaults(defaults_params)
+//     kp_variation.RecursivelyValidateAndAssignDefaults(defaults_params)
+//
+//     KRATOS_CHECK( kp.IsEquivalentTo(defaults_params) )
+//     KRATOS_CHECK_IS_FALSE( kp_variation.IsEquivalentTo(defaults_params) )
+//
+//     KRATOS_CHECK( kp.HasSameKeysAndTypeOfValuesAs(defaults_params) )
+//     KRATOS_CHECK( kp_variation.HasSameKeysAndTypeOfValuesAs(defaults_params) )
+//     KRATOS_CHECK_IS_FALSE( kp_wrong_wariation.HasSameKeysAndTypeOfValuesAs(defaults_params) )
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationSuccedsErroronFirstLevel, KratosCoreFastSuite)
+// {
+//     Parameters kp = Parameters(wrong_lev2)
+//     defaults_params = Parameters(defaults)
+//
+//     // here no error shall be thrown since validation is only done on level0
+//     kp.ValidateAndAssignDefaults(defaults_params)
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationSucceeds, KratosCoreFastSuite)
+// {
+//     Parameters kp = Parameters(json_string)
+//     defaults_params = Parameters(defaults)
+//     defaults_params["level1"]["tmp"].SetDouble(2.0)  // this does not coincide with the value in kp, but is of the same type
+//
+//     kp.ValidateAndAssignDefaults(defaults_params)
+//     KRATOS_CHECK_EQUAL(kp.PrettyPrintJsonString(), expected_validation_output)
+//
+//     KRATOS_CHECK_EQUAL(kp["level1"]["tmp"].GetDouble(), 5.0)  // not 2, since kp overwrites the defaults
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddMissingParameters, KratosCoreFastSuite)
+// {
+//     // only missing parameters are added, no complaints if there already exist more than in the defaults
+//     Parameters kp = Parameters(json_string)
+//     tmp = Parameters(incomplete_with_extra_parameter)
+//
+//     kp.AddMissingParameters(tmp)
+//
+//     KRATOS_CHECK_EQUAL(kp["new_default_obj"]["aaa"].GetString(), "string")
+//     KRATOS_CHECK_EQUAL(kp["string_value"].GetString(), "hello")
+//     KRATOS_CHECK_IS_FALSE(kp["level1"].Has("new_sublevel"))
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersRecursivelyAddMissingParameters, KratosCoreFastSuite)
+// {
+//     // only missing parameters are added, no complaints if there already exist more than in the defaults
+//     Parameters kp = Parameters(json_string)
+//     tmp = Parameters(incomplete_with_extra_parameter)
+//
+//     kp.RecursivelyAddMissingParameters(tmp)
+//
+//     KRATOS_CHECK(kp["level1"].Has("new_sublevel"))
+//     KRATOS_CHECK_EQUAL(kp["level1"]["new_sublevel"].GetString(), "this should only be assigned in recursive")
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidateDefaults, KratosCoreFastSuite)
+// {
+//     // only parameters from defaults are validated, no new values are added
+//     Parameters kp = Parameters(incomplete_with_extra_parameter)
+//     tmp = Parameters(defaults)
+//
+//     kp.ValidateDefaults(tmp)
+//
+//     KRATOS_CHECK_IS_FALSE(kp.Has("bool_value"))
+//     KRATOS_CHECK_IS_FALSE(kp.Has("double_value"))
+//     KRATOS_CHECK(kp.Has("level1"))
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersRecursivelyValidateDefaults, KratosCoreFastSuite)
+// {
+//     // only parameters from defaults are validated, no new values are added
+//     Parameters kp = Parameters(incomplete)
+//     tmp = Parameters(defaults)
+//
+//     kp.RecursivelyValidateDefaults(tmp)
+//
+//     KRATOS_CHECK_IS_FALSE(kp.Has("bool_value"))
+//     KRATOS_CHECK_IS_FALSE(kp.Has("double_value"))
+//     KRATOS_CHECK(kp.Has("level1"))
+// }
+//
+// def test_recursively_validate_defaults_fails(self):
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersSetStringArrayValid, KratosCoreFastSuite)
+// {
+//     // only parameters from defaults are validated, no new values are added
+//     Parameters kp = Parameters(incomplete_with_extra_parameter)
+//     tmp = Parameters(defaults)
+//
+//     with self.assertRaises(RuntimeError):
+//         kp.RecursivelyValidateDefaults(tmp)
+//
+//     // sub_level
+//     KRATOS_CHECK_IS_FALSE(kp["level1"].Has("tmp"))
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddValue, KratosCoreFastSuite)
+// {
+//     Parameters kp = Parameters("{}")
+//     kp.AddEmptyValue("new_double").SetDouble(1.0)
+//
+//     KRATOS_CHECK(kp.Has("new_double"))
+//     KRATOS_CHECK_EQUAL(kp["new_double"].GetDouble(), 1.0)
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddEmptyArray, KratosCoreFastSuite)
+// {
+//     Parameters kp = Parameters("{}")
+//     kp.AddEmptyArray("new_array")
+//
+//     KRATOS_CHECK(kp.Has("new_array"))
+//     KRATOS_CHECK_EQUAL(kp["new_array"].size(), 0)
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersIterators, KratosCoreFastSuite)
+// {
+//     Parameters kp = Parameters(json_string)
+//
+//     //iteration by range
+//     nitems = 0
+//     for iterator in kp:
+//         nitems = nitems + 1
+//     KRATOS_CHECK_EQUAL(nitems, 5)
+//
+//     //iteration by items
+//     for key,value in kp.items():
+//         //print(value.PrettyPrintJsonString())
+//         KRATOS_CHECK_EQUAL(kp[key].PrettyPrintJsonString(), value.PrettyPrintJsonString())
+//         //print(key,value)
+//
+//     //testing values
+//     expected_values = ['true', '2.0', '10', '{"list_value":[3,"hi",false],"tmp":5.0}','"hello"']
+//     counter = 0
+//
+//     for value in kp.values():
+//         KRATOS_CHECK_EQUAL(value.WriteJsonString(), expected_values[counter])
+//         counter += 1
+//
+//     //testing values
+//     expected_keys = ['bool_value', 'double_value', 'int_value', 'level1', 'string_value']
+//     counter = 0
+//     for key in kp.keys():
+//         KRATOS_CHECK_EQUAL(key, expected_keys[counter])
+//         counter += 1
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersRemoveValue, KratosCoreFastSuite)
+// {
+//     Parameters kp = Parameters(json_string)
+//     KRATOS_CHECK(kp.Has("int_value"))
+//     KRATOS_CHECK(kp.Has("level1"))
+//
+//     kp.RemoveValue("int_value")
+//     kp.RemoveValue("level1")
+//
+//     KRATOS_CHECK_IS_FALSE(kp.Has("int_value"))
+//     KRATOS_CHECK_IS_FALSE(kp.Has("level1"))
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersIsMethods, KratosCoreFastSuite)
+// {
+//     // This method checks all the "IsXXX" Methods
+//     Parameters tmp = Parameters(R"({
+//         "int_value" : 10, /* This is comment to check that comments work */
+//         "double_value": 2.0, // This is comment too, but using another comment
+//         "bool_value" : true, // This is another comment being meta as realizing that all the possibilities are already check
+//         "string_value" : "hello",/* This is a nihilist comment about the futile existence of the previous comment as a metacomment */
+//         "vector_value" : [5,3,4],
+//         "matrix_value" : [[1,2],[3,6]]
+//     })"); // if you add more values to this, make sure to add the corresponding in the loop
+//
+//     for key in tmp.keys():
+//         val_type = key[:-6] // removing "_value"
+//
+//         if val_type == "int":
+//             KRATOS_CHECK(tmp[key].IsInt())
+//         else:
+//             KRATOS_CHECK_IS_FALSE(tmp[key].IsInt())
+//
+//         if val_type == "double":
+//             KRATOS_CHECK(tmp[key].IsDouble())
+//         else:
+//             KRATOS_CHECK_IS_FALSE(tmp[key].IsDouble())
+//
+//         if val_type == "bool":
+//             KRATOS_CHECK(tmp[key].IsBool())
+//         else:
+//             KRATOS_CHECK_IS_FALSE(tmp[key].IsBool())
+//
+//         if val_type == "string":
+//             KRATOS_CHECK(tmp[key].IsString())
+//         else:
+//             KRATOS_CHECK_IS_FALSE(tmp[key].IsString())
+//
+//         if val_type == "vector":
+//             KRATOS_CHECK(tmp[key].IsVector())
+//         else:
+//             KRATOS_CHECK_IS_FALSE(tmp[key].IsVector())
+//
+//         if val_type == "matrix":
+//             KRATOS_CHECK(tmp[key].IsMatrix())
+//         else:
+//             KRATOS_CHECK_IS_FALSE(tmp[key].IsMatrix())
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersGetMethods, KratosCoreFastSuite)
+// {
+//     // This method checks all the "GetXXX" Methods if they throw an error
+//     Parameters tmp = Parameters(R"({
+//         "int_value" : 10,
+//         "double_value": 2.0,
+//         "bool_value" : true,
+//         "string_value" : "hello",
+//         "vector_value" : [5.2,-3.1,4.33],
+//         "matrix_value" : [[1,2],[3,4],[5,6]]
+//     })"); // if you add more values to this, make sure to add the corresponding in the loop
+//
+//     for key in tmp.keys():
+//         val_type = key[:-6] // removing "_value"
+//
+//         // Int and Double are checked tgth bcs both internally call "IsNumber"
+//         if val_type == "int" or val_type == "double":
+//             if val_type == "int":
+//                 KRATOS_CHECK_EQUAL(tmp[key].GetInt(),10)
+//         else:
+//             with self.assertRaises(RuntimeError):
+//                 tmp[key].GetInt()
+//
+//         if val_type == "double" or val_type == "int":
+//             if val_type == "double":
+//                 KRATOS_CHECK_EQUAL(tmp[key].GetDouble(),2.0)
+//         else:
+//             with self.assertRaises(RuntimeError):
+//                 tmp[key].GetDouble()
+//
+//         if val_type == "bool":
+//             KRATOS_CHECK_EQUAL(tmp[key].GetBool(),True)
+//         else:
+//             with self.assertRaises(RuntimeError):
+//                 tmp[key].GetBool()
+//
+//         if val_type == "string":
+//             KRATOS_CHECK_EQUAL(tmp[key].GetString(),"hello")
+//         else:
+//             with self.assertRaises(RuntimeError):
+//                 tmp[key].GetString()
+//
+//         if val_type == "vector":
+//             V = tmp[key].GetVector()
+//             KRATOS_CHECK_EQUAL(V[0],5.2)
+//             KRATOS_CHECK_EQUAL(V[1],-3.1)
+//             KRATOS_CHECK_EQUAL(V[2],4.33)
+//         else:
+//             with self.assertRaises(RuntimeError):
+//                 tmp[key].GetVector()
+//
+//         if val_type == "matrix":
+//             A = tmp[key].GetMatrix()
+//             KRATOS_CHECK_EQUAL(A[0,0],1.0)
+//             KRATOS_CHECK_EQUAL(A[0,1],2.0)
+//             KRATOS_CHECK_EQUAL(A[1,0],3.0)
+//             KRATOS_CHECK_EQUAL(A[1,1],4.0)
+//             KRATOS_CHECK_EQUAL(A[2,0],5.0)
+//             KRATOS_CHECK_EQUAL(A[2,1],6.0)
+//         else:
+//             with self.assertRaises(RuntimeError):
+//                 tmp[key].GetMatrix()
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersSetMethods KratosCoreFastSuite)
+// {
+//     // This method checks all the "GetXXX" Methods if they throw an error
+//     Parameters tmp = Parameters(R"({
+//         "int_value" : 0,
+//         "double_value": 0.0,
+//         "bool_value" : false,
+//         "string_value" : "",
+//         "vector_value" : [],
+//         "matrix_value" : [[0]]
+//     })"); // if you add more values to this, make sure to add the corresponding in the loop
+//
+//     for key in tmp.keys():
+//         val_type = key[:-6] // removing "_value"
+//
+//         // Int and Double are checked tgth bcs both internally call "IsNumber"
+//         if val_type == "int" or val_type == "double":
+//             if val_type == "int":
+//                 tmp[key].SetInt(10)
+//                 KRATOS_CHECK_EQUAL(tmp[key].GetInt(),10)
+//         else:
+//             with self.assertRaises(RuntimeError):
+//                 tmp[key].GetInt()
+//
+//         if val_type == "double" or val_type == "int":
+//             if val_type == "double":
+//                 tmp[key].SetDouble(2.0)
+//                 KRATOS_CHECK_EQUAL(tmp[key].GetDouble(),2.0)
+//         else:
+//             with self.assertRaises(RuntimeError):
+//                 tmp[key].GetDouble()
+//
+//         if val_type == "bool":
+//             tmp[key].SetBool(True)
+//             KRATOS_CHECK_EQUAL(tmp[key].GetBool(),True)
+//         else:
+//             with self.assertRaises(RuntimeError):
+//                 tmp[key].GetBool()
+//
+//         if val_type == "string":
+//             tmp[key].SetString("hello")
+//             KRATOS_CHECK_EQUAL(tmp[key].GetString(),"hello")
+//         else:
+//             with self.assertRaises(RuntimeError):
+//                 tmp[key].GetString()
+//
+//         if val_type == "vector":
+//             vector = Vector(3)
+//             vector[0] = 5.2
+//             vector[1] = -3.1
+//             vector[2] = 4.33
+//             tmp[key].SetVector(vector)
+//             V = tmp[key].GetVector()
+//             KRATOS_CHECK_EQUAL(V[0],5.2)
+//             KRATOS_CHECK_EQUAL(V[1],-3.1)
+//             KRATOS_CHECK_EQUAL(V[2],4.33)
+//         else:
+//             with self.assertRaises(RuntimeError):
+//                 tmp[key].GetVector()
+//
+//         if val_type == "matrix":
+//             matrix = Matrix(3,2)
+//             matrix[0,0] = 1.0
+//             matrix[0,1] = 2.0
+//             matrix[1,0] = 3.0
+//             matrix[1,1] = 4.0
+//             matrix[2,0] = 5.0
+//             matrix[2,1] = 6.0
+//             tmp[key].SetMatrix(matrix)
+//             A = tmp[key].GetMatrix()
+//             KRATOS_CHECK_EQUAL(A[0,0],1.0)
+//             KRATOS_CHECK_EQUAL(A[0,1],2.0)
+//             KRATOS_CHECK_EQUAL(A[1,0],3.0)
+//             KRATOS_CHECK_EQUAL(A[1,1],4.0)
+//             KRATOS_CHECK_EQUAL(A[2,0],5.0)
+//             KRATOS_CHECK_EQUAL(A[2,1],6.0)
+//         else:
+//             with self.assertRaises(RuntimeError):
+//                 tmp[key].GetMatrix()
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddMethods, KratosCoreFastSuite)
+// {
+//     // This method checks all the "GetXXX" Methods if they throw an error
+//     Parameters tmp = Parameters(R"({})");
+//
+//     key = "int"
+//     tmp.AddInt(key, 10)
+//     KRATOS_CHECK_EQUAL(tmp[key].GetInt(),10)
+//
+//     key = "double"
+//     tmp.AddDouble(key, 2.0)
+//     KRATOS_CHECK_EQUAL(tmp[key].GetDouble(),2.0)
+//
+//     key = "bool"
+//     tmp.AddBool(key, True)
+//     KRATOS_CHECK_EQUAL(tmp[key].GetBool(),True)
+//
+//     key = "string"
+//     tmp.AddString(key, "hello")
+//     KRATOS_CHECK_EQUAL(tmp[key].GetString(),"hello")
+//
+//     key = "vector"
+//     vector = Vector(3)
+//     vector[0] = 5.2
+//     vector[1] = -3.1
+//     vector[2] = 4.33
+//     tmp.AddVector(key, vector)
+//     V = tmp[key].GetVector()
+//     KRATOS_CHECK_EQUAL(V[0],5.2)
+//     KRATOS_CHECK_EQUAL(V[1],-3.1)
+//     KRATOS_CHECK_EQUAL(V[2],4.33)
+//
+//     key = "matrix"
+//     matrix = Matrix(3,2)
+//     matrix[0,0] = 1.0
+//     matrix[0,1] = 2.0
+//     matrix[1,0] = 3.0
+//     matrix[1,1] = 4.0
+//     matrix[2,0] = 5.0
+//     matrix[2,1] = 6.0
+//     tmp.AddMatrix(key, matrix)
+//     A = tmp[key].GetMatrix()
+//     KRATOS_CHECK_EQUAL(A[0,0],1.0)
+//     KRATOS_CHECK_EQUAL(A[0,1],2.0)
+//     KRATOS_CHECK_EQUAL(A[1,0],3.0)
+//     KRATOS_CHECK_EQUAL(A[1,1],4.0)
+//     KRATOS_CHECK_EQUAL(A[2,0],5.0)
+//     KRATOS_CHECK_EQUAL(A[2,1],6.0)
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersVectorInterface, KratosCoreFastSuite)
+// {
+//     // Read and check Vectors from a Parameters-Object
+//     Parameters tmp = Parameters(R"({
+//         "valid_vectors" : [ []
+//         ],
+//         "false_vectors" : [ [[]],
+//                             [[2,3],2],
+//                             [2,3,[2]],
+//                             [2,3,[]],
+//                             [{"key":3},2],
+//                             [2,3,{"key":3}],
+//                             [true,2],
+//                             [2,3,true],
+//                             [5,"string",2]
+//         ]
+//     })");
+//
+//     // Check the IsVector Method
+//     for i in range(tmp["valid_vectors"].size()):
+//         valid_vector = tmp["valid_vectors"][i]
+//         KRATOS_CHECK(valid_vector.IsVector())
+//
+//     for i in range(tmp["false_vectors"].size()):
+//         false_vector = tmp["false_vectors"][i]
+//         KRATOS_CHECK_IS_FALSE(false_vector.IsVector())
+//
+//     // Check the GetVector Method also on the valid Matrices
+//     for i in range(tmp["valid_vectors"].size()):
+//         valid_vector = tmp["valid_vectors"][i]
+//         valid_vector.GetVector()
+//
+//     // Check that the errors of the GetVector method are thrown correctly
+//     for i in range(tmp["false_vectors"].size()):
+//         false_vector = tmp["false_vectors"][i]
+//         with self.assertRaises(RuntimeError):
+//             false_vector.GetVector()
+//
+//     // Manually assign and check a Vector
+//     vec = Vector(3)
+//     vec[0] = 1.32
+//     vec[1] = -2.22
+//     vec[2] = 5.5
+//
+//     tmp.AddEmptyValue("vector_value")
+//     tmp["vector_value"].SetVector(vec)
+//
+//     KRATOS_CHECK(tmp["vector_value"].IsVector())
+//
+//     V2 = tmp["vector_value"].GetVector()
+//     KRATOS_CHECK_EQUAL(V2[0],1.32)
+//     KRATOS_CHECK_EQUAL(V2[1],-2.22)
+//     KRATOS_CHECK_EQUAL(V2[2],5.5)
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersMatrixInterface, KratosCoreFastSuite)
+// {
+//     // Read and check Matrices from a Parameters-Object
+//     Parameters tmp = Parameters(R"({
+//         "valid_matrices" : [ [[]],
+//                               [[],[]],
+//                               [[-9.81,8, 5.47]]
+//         ],
+//         "false_matrices" : [ [],
+//                               [[[]]],
+//                               [[3.3] , [1,2]],
+//                               [[2,1.5,3.3] , [3,{"key":3},2]],
+//                               [[2,1.5,3.3] , [5,false,2]],
+//                               [[2,1.5,3.3] , [[2,3],1,2]],
+//                               [[2,1.5,3.3] , ["string",2,9]]
+//         ]
+//     })");
+//
+//     // Check the IsMatrix Method
+//     for i in range(tmp["valid_matrices"].size()):
+//         valid_matrix = tmp["valid_matrices"][i]
+//         KRATOS_CHECK(valid_matrix.IsMatrix())
+//
+//     for i in range(tmp["false_matrices"].size()):
+//         false_matrix = tmp["false_matrices"][i]
+//         KRATOS_CHECK_IS_FALSE(false_matrix.IsMatrix())
+//
+//     // Check the GetMatrix Method also on the valid Matrices
+//     for i in range(tmp["valid_matrices"].size()):
+//         valid_matrix = tmp["valid_matrices"][i]
+//         valid_matrix.GetMatrix()
+//
+//     // Check that the errors of the GetMatrix method are thrown correctly
+//     for i in range(tmp["false_matrices"].size()):
+//         false_matrix = tmp["false_matrices"][i]
+//         with self.assertRaises(RuntimeError):
+//             false_matrix.GetMatrix()
+//
+//     // Manually assign and check a Matrix
+//     mat = Matrix(3,2)
+//     mat[0,0] = 1.0
+//     mat[0,1] = 2.0
+//     mat[1,0] = 3.0
+//     mat[1,1] = 4.0
+//     mat[2,0] = 5.0
+//     mat[2,1] = 6.0
+//
+//     tmp.AddEmptyValue("matrix_value")
+//     tmp["matrix_value"].SetMatrix(mat)
+//
+//     KRATOS_CHECK(tmp["matrix_value"].IsMatrix())
+//
+//     A2 = tmp["matrix_value"].GetMatrix()
+//     KRATOS_CHECK_EQUAL(A2[0,0],1.0);
+//     KRATOS_CHECK_EQUAL(A2[0,1],2.0);
+//     KRATOS_CHECK_EQUAL(A2[1,0],3.0);
+//     KRATOS_CHECK_EQUAL(A2[1,1],4.0);
+//     KRATOS_CHECK_EQUAL(A2[2,0],5.0);
+//     KRATOS_CHECK_EQUAL(A2[2,1],6.0);
+// }
+//
+// def test_null_vs_null_validation(self):
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersNullvsNullValidation, KratosCoreFastSuite)
+// {
+//     // Supplied settings
+//     Parameters null_custom = Parameters(R"({
+//         "parameter": null
+//     })");
+//
+//     // Default settings
+//     Parameters null_default = Parameters(R"({
+//         "parameter": null
+//     })");
+//
+//     // This should NOT raise, hence making the test to pass
+//     null_custom.ValidateAndAssignDefaults(null_default)
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersDoublevsNullValidation, KratosCoreFastSuite)
+// {
+//     // Supplied settings
+//     Parameters double_custom = Parameters(R"({
+//         "parameter": 0.0
+//     })");
+//
+//     // Default settings
+//     Parameters null_default = Parameters(R"({
+//         "parameter": null
+//     })");
+//
+//     with self.assertRaises(RuntimeError):
+//         double_custom.ValidateAndAssignDefaults(null_default)
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersGeStringArrayValid, KratosCoreFastSuite)
+// {
+//     Parameters tmp = Parameters(R"({
+//         "parameter": ["foo", "bar"]
+//     })");
+//     v = tmp["parameter"].GetStringArray()
+//     KRATOS_CHECK_EQUAL(len(v), 2);
+//     KRATOS_CHECK_EQUAL(v[0], "foo");
+//     KRATOS_CHECK_EQUAL(v[1], "bar");
+// }
+//
+// KRATOS_TEST_CASE_IN_SUITE(KratosParametersSetStringArrayValid, KratosCoreFastSuite)
+// {
+//     Parameters initial = Parameters(R"({
+//         "parameter": ["foo", "bar"]
+//     })");
+//     string_array = initial["parameter"].GetStringArray();
+//
+//     Parameters new_param = Parameters();
+//     new_param.AddEmptyValue("new_parameter");
+//     new_param["new_parameter"].SetStringArray(string_array);
+//
+//     new_string_array = initial["parameter"].GetStringArray();
+//
+//     self.assertListEqual(new_string_array, string_array);
+// }
+
+
+}  // namespace Testing.
+}  // namespace Kratos.

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -41,19 +41,19 @@ std::string GetJSONString()
 std::string GetJSONStringPrettyOut()
 {
     const std::string pretty_out =  R"({
-        "bool_value": true,
-        "double_value": 2.0,
-        "int_value": 10,
-        "level1": {
-            "list_value": [
-                3,
-                "hi",
-                false
-            ],
-            "tmp": 5.0
-        },
-        "string_value": "hello"
-    })";
+    "bool_value": true,
+    "double_value": 2.0,
+    "int_value": 10,
+    "level1": {
+        "list_value": [
+            3,
+            "hi",
+            false
+        ],
+        "tmp": 5.0
+    },
+    "string_value": "hello"
+})";
     return pretty_out;
 }
 

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -330,25 +330,26 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersChangeParameters, KratosCoreFastSuite)
     );
 }
 
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersCopy, KratosCoreFastSuite)
-// {
-//     // try to make a copy
-//     original_out = kp.PrettyPrintJsonString()
-//     other_copy = kp.Clone()
-//
-//     KRATOS_CHECK_EQUAL(
-//         other_copy.PrettyPrintJsonString(),
-//         original_out
-//     )
-//
-//     other_copy["int_value"].SetInt(-1)
-//     KRATOS_CHECK_EQUAL(kp["int_value"].GetInt(), 10);
-// }
-//
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersCopy, KratosCoreFastSuite)
+{
+    // Try to make a copy
+    Parameters kp = Parameters(GetJSONString());
+    auto original_out = kp.PrettyPrintJsonString();
+    auto other_copy = kp.Clone();
+
+    KRATOS_CHECK_STRING_EQUAL(
+        other_copy.PrettyPrintJsonString(),
+        original_out
+    );
+
+    other_copy["int_value"].SetInt(-1);
+    KRATOS_CHECK_EQUAL(kp["int_value"].GetInt(), 10);
+}
+
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersSetValue, KratosCoreFastSuite)
 // {
-//     Parameters kp = Parameters(json_string)
-//     Parameters kp1 = Parameters(GetJSONStringPrettyOutAfterChange())
+//     Parameters kp = Parameters(GetJSONString());
+//     Parameters kp1 = Parameters(GetJSONStringPrettyOutAfterChange());
 //
 //     kp["bool_value"] = kp1["level1"]
 //     kp["bool_value"].PrettyPrintJsonString()
@@ -357,7 +358,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersChangeParameters, KratosCoreFastSuite)
 //
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersWrongParameters, KratosCoreFastSuite)
 // {
-//     // should check which errors are thrown!!
+//     // Should check which errors are thrown!!
 //     with self.assertRaisesRegex(RuntimeError, "no_value"):
 //         kp["no_value"].GetInt()
 // }
@@ -421,7 +422,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersChangeParameters, KratosCoreFastSuite)
 //
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationSucceeds, KratosCoreFastSuite)
 // {
-//     Parameters kp = Parameters(json_string)
+//     Parameters kp = Parameters(GetJSONString());
 //     defaults_params = Parameters(defaults)
 //     defaults_params["level1"]["tmp"].SetDouble(2.0)  // this does not coincide with the value in kp, but is of the same type
 //
@@ -434,7 +435,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersChangeParameters, KratosCoreFastSuite)
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddMissingParameters, KratosCoreFastSuite)
 // {
 //     // only missing parameters are added, no complaints if there already exist more than in the defaults
-//     Parameters kp = Parameters(json_string)
+//     Parameters kp = Parameters(GetJSONString());
 //     tmp = Parameters(incomplete_with_extra_parameter)
 //
 //     kp.AddMissingParameters(tmp)
@@ -447,7 +448,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersChangeParameters, KratosCoreFastSuite)
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersRecursivelyAddMissingParameters, KratosCoreFastSuite)
 // {
 //     // only missing parameters are added, no complaints if there already exist more than in the defaults
-//     Parameters kp = Parameters(json_string)
+//     Parameters kp = Parameters(GetJSONString());
 //     tmp = Parameters(incomplete_with_extra_parameter)
 //
 //     kp.RecursivelyAddMissingParameters(tmp)
@@ -516,7 +517,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersChangeParameters, KratosCoreFastSuite)
 //
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersIterators, KratosCoreFastSuite)
 // {
-//     Parameters kp = Parameters(json_string)
+//     Parameters kp = Parameters(GetJSONString());
 //
 //     //iteration by range
 //     nitems = 0
@@ -548,7 +549,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersChangeParameters, KratosCoreFastSuite)
 //
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersRemoveValue, KratosCoreFastSuite)
 // {
-//     Parameters kp = Parameters(json_string)
+//     Parameters kp = Parameters(GetJSONString());
 //     KRATOS_CHECK(kp.Has("int_value"))
 //     KRATOS_CHECK(kp.Has("level1"))
 //

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -57,27 +57,27 @@ std::string GetJSONStringPrettyOut()
     return pretty_out;
 }
 
-// std::string GetJSONStringPrettyOutAfterChange()
-// {
-//     const std::string pretty_out_after_change = """{
-//         "bool_value": true,
-//         "double_value": 2.0,
-//         "int_value": 10,
-//         "level1": {
-//             "list_value": [
-//                 "changed",
-//                 "hi",
-//                 false
-//             ],
-//             "tmp": 5.0
-//         },
-//         "string_value": "hello"
-//     }""";
-//
-//     return pretty_out_after_change;
-// }
-//
-//     // here the level1 var is set to a double so that a validation error should be thrown
+std::string GetJSONStringPrettyOutAfterChange()
+{
+    const std::string pretty_out_after_change = R"({
+    "bool_value": true,
+    "double_value": 2.0,
+    "int_value": 10,
+    "level1": {
+        "list_value": [
+            "changed",
+            "hi",
+            false
+        ],
+        "tmp": 5.0
+    },
+    "string_value": "hello"
+})";
+
+    return pretty_out_after_change;
+}
+
+// // here the level1 var is set to a double so that a validation error should be thrown
 // std::string GetJSONStringWrongType()
 // {
 //     const std::string wrong_type = """{
@@ -307,31 +307,34 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParameters, KratosCoreFastSuite)
     KRATOS_CHECK_STRING_EQUAL(kp.PrettyPrintJsonString(), GetJSONStringPrettyOut());
 }
 
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersChangeParameters, KratosCoreFastSuite)
-// {
-//     // now change one item in the sublist
-//     subparams = self.kp["level1"]
-//
-//     my_list = subparams["list_value"]
-//
-//     for i in range(my_list.size()):
-//         if my_list[i].IsBool():
-//             KRATOS_CHECK_EQUAL(my_list[i].GetBool(), False)
-//
-//     // my_list = subparams["list_value"]
-//     subparams["list_value"][0].SetString("changed")
-//
-//     KRATOS_CHECK_EQUAL(
-//         self.kp.PrettyPrintJsonString(),
-//         pretty_out_after_change
-//     )
-// }
-//
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersChangeParameters, KratosCoreFastSuite)
+{
+    // Now change one item in the sublist
+    Parameters kp = Parameters(GetJSONString());
+    Parameters subparams = kp["level1"];
+
+    Parameters my_list = subparams["list_value"];
+
+    for (auto& r_param : my_list) {
+        if (r_param.IsBool()) {
+            KRATOS_CHECK_IS_FALSE(r_param.GetBool())
+        }
+    }
+
+    // my_list = subparams["list_value"]
+    subparams["list_value"][0].SetString("changed");
+
+    KRATOS_CHECK_STRING_EQUAL(
+        kp.PrettyPrintJsonString(),
+        GetJSONStringPrettyOutAfterChange()
+    );
+}
+
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersCopy, KratosCoreFastSuite)
 // {
 //     // try to make a copy
-//     original_out = self.kp.PrettyPrintJsonString()
-//     other_copy = self.kp.Clone()
+//     original_out = kp.PrettyPrintJsonString()
+//     other_copy = kp.Clone()
 //
 //     KRATOS_CHECK_EQUAL(
 //         other_copy.PrettyPrintJsonString(),
@@ -339,13 +342,13 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParameters, KratosCoreFastSuite)
 //     )
 //
 //     other_copy["int_value"].SetInt(-1)
-//     KRATOS_CHECK_EQUAL(self.kp["int_value"].GetInt(), 10);
+//     KRATOS_CHECK_EQUAL(kp["int_value"].GetInt(), 10);
 // }
 //
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersSetValue, KratosCoreFastSuite)
 // {
 //     Parameters kp = Parameters(json_string)
-//     Parameters kp1 = Parameters(pretty_out_after_change)
+//     Parameters kp1 = Parameters(GetJSONStringPrettyOutAfterChange())
 //
 //     kp["bool_value"] = kp1["level1"]
 //     kp["bool_value"].PrettyPrintJsonString()
@@ -356,7 +359,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParameters, KratosCoreFastSuite)
 // {
 //     // should check which errors are thrown!!
 //     with self.assertRaisesRegex(RuntimeError, "no_value"):
-//         self.kp["no_value"].GetInt()
+//         kp["no_value"].GetInt()
 // }
 //
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationFailsDueToWrongTypes, KratosCoreFastSuite)

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -478,115 +478,115 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersRecursivelyValidateDefaultsFail, Krato
     KRATOS_CHECK_IS_FALSE(kp["level1"].Has("tmp"));
 }
 
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddValue, KratosCoreFastSuite)
-// {
-//     Parameters kp = Parameters("{}")
-//     kp.AddEmptyValue("new_double").SetDouble(1.0)
-//
-//     KRATOS_CHECK(kp.Has("new_double"))
-//     KRATOS_CHECK_EQUAL(kp["new_double"].GetDouble(), 1.0)
-// }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddEmptyArray, KratosCoreFastSuite)
-// {
-//     Parameters kp = Parameters("{}")
-//     kp.AddEmptyArray("new_array")
-//
-//     KRATOS_CHECK(kp.Has("new_array"))
-//     KRATOS_CHECK_EQUAL(kp["new_array"].size(), 0)
-// }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersIterators, KratosCoreFastSuite)
-// {
-//     Parameters kp = Parameters(GetJSONString());
-//
-//     //iteration by range
-//     nitems = 0
-//     for iterator in kp:
-//         nitems = nitems + 1
-//     KRATOS_CHECK_EQUAL(nitems, 5)
-//
-//     //iteration by items
-//     for key,value in kp.items():
-//         //print(value.PrettyPrintJsonString())
-//         KRATOS_CHECK_EQUAL(kp[key].PrettyPrintJsonString(), value.PrettyPrintJsonString())
-//         //print(key,value)
-//
-//     //testing values
-//     expected_values = ['true', '2.0', '10', '{"list_value":[3,"hi",false],"tmp":5.0}','"hello"']
-//     counter = 0
-//
-//     for value in kp.values():
-//         KRATOS_CHECK_EQUAL(value.WriteJsonString(), expected_values[counter])
-//         counter += 1
-//
-//     //testing values
-//     expected_keys = ['bool_value', 'double_value', 'int_value', 'level1', 'string_value']
-//     counter = 0
-//     for key in kp.keys():
-//         KRATOS_CHECK_EQUAL(key, expected_keys[counter])
-//         counter += 1
-// }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersRemoveValue, KratosCoreFastSuite)
-// {
-//     Parameters kp = Parameters(GetJSONString());
-//     KRATOS_CHECK(kp.Has("int_value"))
-//     KRATOS_CHECK(kp.Has("level1"))
-//
-//     kp.RemoveValue("int_value")
-//     kp.RemoveValue("level1")
-//
-//     KRATOS_CHECK_IS_FALSE(kp.Has("int_value"))
-//     KRATOS_CHECK_IS_FALSE(kp.Has("level1"))
-// }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersIsMethods, KratosCoreFastSuite)
-// {
-//     // This method checks all the "IsXXX" Methods
-//     Parameters tmp = Parameters(R"({
-//         "int_value" : 10, /* This is comment to check that comments work */
-//         "double_value": 2.0, // This is comment too, but using another comment
-//         "bool_value" : true, // This is another comment being meta as realizing that all the possibilities are already check
-//         "string_value" : "hello",/* This is a nihilist comment about the futile existence of the previous comment as a metacomment */
-//         "vector_value" : [5,3,4],
-//         "matrix_value" : [[1,2],[3,6]]
-//     })"); // if you add more values to this, make sure to add the corresponding in the loop
-//
-//     for key in tmp.keys():
-//         val_type = key[:-6] // removing "_value"
-//
-//         if val_type == "int":
-//             KRATOS_CHECK(tmp[key].IsInt())
-//         else:
-//             KRATOS_CHECK_IS_FALSE(tmp[key].IsInt())
-//
-//         if val_type == "double":
-//             KRATOS_CHECK(tmp[key].IsDouble())
-//         else:
-//             KRATOS_CHECK_IS_FALSE(tmp[key].IsDouble())
-//
-//         if val_type == "bool":
-//             KRATOS_CHECK(tmp[key].IsBool())
-//         else:
-//             KRATOS_CHECK_IS_FALSE(tmp[key].IsBool())
-//
-//         if val_type == "string":
-//             KRATOS_CHECK(tmp[key].IsString())
-//         else:
-//             KRATOS_CHECK_IS_FALSE(tmp[key].IsString())
-//
-//         if val_type == "vector":
-//             KRATOS_CHECK(tmp[key].IsVector())
-//         else:
-//             KRATOS_CHECK_IS_FALSE(tmp[key].IsVector())
-//
-//         if val_type == "matrix":
-//             KRATOS_CHECK(tmp[key].IsMatrix())
-//         else:
-//             KRATOS_CHECK_IS_FALSE(tmp[key].IsMatrix())
-// }
-//
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddValue, KratosCoreFastSuite)
+{
+    Parameters kp = Parameters(R"({})");
+    kp.AddEmptyValue("new_double").SetDouble(1.0);
+
+    KRATOS_CHECK(kp.Has("new_double"));
+    KRATOS_CHECK_EQUAL(kp["new_double"].GetDouble(), 1.0);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddEmptyArray, KratosCoreFastSuite)
+{
+    Parameters kp = Parameters(R"({})");
+    kp.AddEmptyArray("new_array");
+
+    KRATOS_CHECK(kp.Has("new_array"));
+    KRATOS_CHECK_EQUAL(kp["new_array"].size(), 0);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersRemoveValue, KratosCoreFastSuite)
+{
+    Parameters kp = Parameters(GetJSONString());
+    KRATOS_CHECK(kp.Has("int_value"));
+    KRATOS_CHECK(kp.Has("level1"));
+
+    kp.RemoveValue("int_value");
+    kp.RemoveValue("level1");
+
+    KRATOS_CHECK_IS_FALSE(kp.Has("int_value"));
+    KRATOS_CHECK_IS_FALSE(kp.Has("level1"));
+}
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersIterators, KratosCoreFastSuite)
+{
+    Parameters kp = Parameters(GetJSONString());
+
+    // Iteration by range
+    int nitems = 0;
+    for(auto it=kp.begin(); it!=kp.end(); ++it) {
+        ++nitems;
+    }
+    KRATOS_CHECK_EQUAL(nitems, 5);
+
+    // Iteration by items
+    for(auto it=kp.begin(); it!=kp.end(); ++it) {
+        KRATOS_CHECK_STRING_EQUAL(kp[it.name()].PrettyPrintJsonString(), it->PrettyPrintJsonString());
+    }
+
+    // Testing values
+    std::vector<std::string> expected_keys ({"bool_value", "double_value", "int_value", "level1", "string_value"});
+    int counter = 0;
+    for(auto it=kp.begin(); it!=kp.end(); ++it) {
+        KRATOS_CHECK_STRING_EQUAL(it.name(), expected_keys[counter]);
+        ++counter;
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersIsMethods, KratosCoreFastSuite)
+{
+    // This method checks all the "IsXXX" Methods
+    Parameters tmp = Parameters(R"({
+        "int_value" : 10, /* This is comment to check that comments work */
+        "double_value": 2.0, // This is comment too, but using another comment
+        "bool_value" : true, // This is another comment being meta as realizing that all the possibilities are already check
+        "string_value" : "hello",/* This is a nihilist comment about the futile existence of the previous comment as a metacomment */
+        "vector_value" : [5,3,4],
+        "matrix_value" : [[1,2],[3,6]]
+    })"); // if you add more values to this, make sure to add the corresponding in the loop
+
+    for(auto it=tmp.begin(); it!=tmp.end(); ++it) {
+        const std::string key = it.name();
+
+        if (key.find("int") != std::string::npos) {
+            KRATOS_CHECK(tmp[key].IsInt());
+        } else {
+            KRATOS_CHECK_IS_FALSE(tmp[key].IsInt());
+        }
+
+        if (key.find("double") != std::string::npos) {
+            KRATOS_CHECK(tmp[key].IsDouble());
+        } else {
+            KRATOS_CHECK_IS_FALSE(tmp[key].IsDouble());
+        }
+
+        if (key.find("bool") != std::string::npos) {
+            KRATOS_CHECK(tmp[key].IsBool());
+        } else {
+            KRATOS_CHECK_IS_FALSE(tmp[key].IsBool());
+        }
+
+        if (key.find("string") != std::string::npos) {
+            KRATOS_CHECK(tmp[key].IsString());
+        } else {
+            KRATOS_CHECK_IS_FALSE(tmp[key].IsString());
+        }
+
+        if (key.find("vector") != std::string::npos) {
+            KRATOS_CHECK(tmp[key].IsVector());
+        } else {
+            KRATOS_CHECK_IS_FALSE(tmp[key].IsVector());
+        }
+
+        if (key.find("matrix") != std::string::npos) {
+            KRATOS_CHECK(tmp[key].IsMatrix());
+        } else {
+            KRATOS_CHECK_IS_FALSE(tmp[key].IsMatrix());
+        }
+    }
+}
+
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersGetMethods, KratosCoreFastSuite)
 // {
 //     // This method checks all the "GetXXX" Methods if they throw an error
@@ -898,7 +898,6 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersRecursivelyValidateDefaultsFail, Krato
 //     KRATOS_CHECK_EQUAL(A2[2,1],6.0);
 // }
 //
-// def test_null_vs_null_validation(self):
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersNullvsNullValidation, KratosCoreFastSuite)
 // {
 //     // Supplied settings
@@ -957,7 +956,6 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersRecursivelyValidateDefaultsFail, Krato
 //
 //     self.assertListEqual(new_string_array, string_array);
 // }
-
 
 }  // namespace Testing.
 }  // namespace Kratos.

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -144,147 +144,145 @@ std::string GetJSONStringDefaults()
     return defaults;
 }
 
-// std::string GetJSONStringIncomplete()
-// {
-//     const std::string incomplete = """
-//     {
-//         "level1": {
-//         },
-//         "new_default_obj": {
-//             "aaa": "string",
-//             "bbb": false,
-//             "ccc": 22
-//         },
-//         "new_default_value": -123.0,
-//         "string_value": "hello"
-//     }""";
-//     return incomplete;
-// }
-//
-// std::string GetJSONStringIncompleteWithExtraParameter()
-// {
-//     const std::string incomplete_with_extra_parameter = """
-//     {
-//         "level1": {
-//             "new_sublevel": "this should only be assigned in recursive"
-//         },
-//         "new_default_obj": {
-//             "aaa": "string",
-//             "bbb": false,
-//             "ccc": 22
-//         },
-//         "new_default_value": -123.0,
-//         "string_value": "hello"
-//     }""";
-//     return incomplete_with_extra_parameter;
-// }
-//
-// std::string GetJSONStringExpectedValidationOutput()
-// {
-//     const std::string expected_validation_output = """{
-//         "bool_value": true,
-//         "double_value": 2.0,
-//         "int_value": 10,
-//         "level1": {
-//             "list_value": [
-//                 3,
-//                 "hi",
-//                 false
-//             ],
-//             "tmp": 5.0
-//         },
-//         "new_default_obj": {
-//             "aaa": "string",
-//             "bbb": false,
-//             "ccc": 22
-//         },
-//         "new_default_value": -123.0,
-//         "string_value": "hello"
-//     }""";
-//     return expected_validation_output;
-// }
-//
-// std::string GetJSONStringFourLevels()
-// {
-//     const std::string four_levels = """{
-//         "bool_value": true,
-//         "double_value": 2.0,
-//         "int_value": 10,
-//         "level1": {
-//             "level2": {
-//                 "level3": {
-//                     "level4": {
-//                     }
-//                 }
-//             }
-//         },
-//         "string_value": "hello"
-//     }""";
-//     return four_levels;
-// }
-//
-// std::string GetJSONStringForLevelsVariation()
-// {
-//     const std::string four_levels_variation = """{
-//         "bool_value": true,
-//         "double_value": 2.0,
-//         "int_value": 10,
-//         "level1": {
-//             "a":11.0,
-//             "level2": {
-//                 "level3": {
-//                     "level4": {
-//                     }
-//                 }
-//             }
-//         },
-//         "string_value": "hello"
-//     }""";
-//     return four_levels_variation;
-// }
-//
-// std::string GetJSONStringForLevelsWrongVariation()
-// {
-//     const std::string four_levels_wrong_variation = """{
-//         "int_value": 10,
-//         "double_value": "hi",
-//         "bool_value": true,
-//         "string_value": "hello",
-//         "level1": {
-//             "a":11.0,
-//             "level2": {
-//                 "level3": {
-//                     "level4": {
-//                     }
-//                 }
-//             }
-//         }
-//     }""";
-//     return four_levels_wrong_variation;
-// }
-//
-// std::string GetJSONStringForLevelsDefaults()
-// {
-//     const std::string four_levels_defaults = """{
-//         "bool_value": true,
-//         "double_value": 2.0,
-//         "int_value": 10,
-//         "level1": {
-//             "a":1.0,
-//             "level2": {
-//                 "b":2.0,
-//                 "level3": {
-//                     "c":3.0,
-//                     "level4": {
-//                         "d":4.0
-//                     }
-//                 }
-//             }
-//         },
-//         "string_value": "hello"
-//     }""";
-//     return four_levels_defaults;
-// }
+std::string GetJSONStringIncomplete()
+{
+    const std::string incomplete = R"({
+        "level1": {
+        },
+        "new_default_obj": {
+            "aaa": "string",
+            "bbb": false,
+            "ccc": 22
+        },
+        "new_default_value": -123.0,
+        "string_value": "hello"
+    })";
+    return incomplete;
+}
+
+std::string GetJSONStringIncompleteWithExtraParameter()
+{
+    const std::string incomplete_with_extra_parameter = R"({
+        "level1": {
+            "new_sublevel": "this should only be assigned in recursive"
+        },
+        "new_default_obj": {
+            "aaa": "string",
+            "bbb": false,
+            "ccc": 22
+        },
+        "new_default_value": -123.0,
+        "string_value": "hello"
+    })";
+    return incomplete_with_extra_parameter;
+}
+
+std::string GetJSONStringExpectedValidationOutput()
+{
+    const std::string expected_validation_output = R"({
+        "bool_value": true,
+        "double_value": 2.0,
+        "int_value": 10,
+        "level1": {
+            "list_value": [
+                3,
+                "hi",
+                false
+            ],
+            "tmp": 5.0
+        },
+        "new_default_obj": {
+            "aaa": "string",
+            "bbb": false,
+            "ccc": 22
+        },
+        "new_default_value": -123.0,
+        "string_value": "hello"
+    })";
+    return expected_validation_output;
+}
+
+std::string GetJSONStringFourLevels()
+{
+    const std::string four_levels = R"({
+        "bool_value": true,
+        "double_value": 2.0,
+        "int_value": 10,
+        "level1": {
+            "level2": {
+                "level3": {
+                    "level4": {
+                    }
+                }
+            }
+        },
+        "string_value": "hello"
+    })";
+    return four_levels;
+}
+
+std::string GetJSONStringForLevelsVariation()
+{
+    const std::string four_levels_variation = R"({
+        "bool_value": true,
+        "double_value": 2.0,
+        "int_value": 10,
+        "level1": {
+            "a":11.0,
+            "level2": {
+                "level3": {
+                    "level4": {
+                    }
+                }
+            }
+        },
+        "string_value": "hello"
+    })";
+    return four_levels_variation;
+}
+
+std::string GetJSONStringForLevelsWrongVariation()
+{
+    const std::string four_levels_wrong_variation = R"({
+        "int_value": 10,
+        "double_value": "hi",
+        "bool_value": true,
+        "string_value": "hello",
+        "level1": {
+            "a":11.0,
+            "level2": {
+                "level3": {
+                    "level4": {
+                    }
+                }
+            }
+        }
+    })";
+    return four_levels_wrong_variation;
+}
+
+std::string GetJSONStringForLevelsDefaults()
+{
+    const std::string four_levels_defaults = R"({
+        "bool_value": true,
+        "double_value": 2.0,
+        "int_value": 10,
+        "level1": {
+            "a":1.0,
+            "level2": {
+                "b":2.0,
+                "level3": {
+                    "c":3.0,
+                    "level4": {
+                        "d":4.0
+                    }
+                }
+            }
+        },
+        "string_value": "hello"
+    })";
+    return four_levels_defaults;
+}
 
 KRATOS_TEST_CASE_IN_SUITE(KratosParameters, KratosCoreFastSuite)
 {
@@ -360,7 +358,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationFailsDueToWrongTypes, Kratos
     KRATOS_CHECK_EXCEPTION_IS_THROWN(kp.ValidateAndAssignDefaults(defaults_params), "");
 }
 
-KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationFailsDueToWrongSpelling, KratosCoreFastSuite2)
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationFailsDueToWrongSpelling, KratosCoreFastSuite)
 {
     Parameters kp = Parameters(GetJSONStringWrongSpelling());
     Parameters  defaults_params = Parameters(GetJSONStringDefaults());
@@ -369,37 +367,36 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationFailsDueToWrongSpelling, Kra
     KRATOS_CHECK_EXCEPTION_IS_THROWN(kp.ValidateAndAssignDefaults(defaults_params), "");
 }
 
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationFailsErrorsOnFirstLevel, KratosCoreFastSuite)
-// {
-//     Parameters kp = Parameters(wrong_lev2)
-//     Parameters defaults_params = Parameters(GetJSONStringDefaults());
-//
-//     // should check which errors are thrown!!
-//     with self.assertRaises(RuntimeError):
-//         kp.RecursivelyValidateAndAssignDefaults(defaults_params)
-// }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersRecursiveValidation4Levels, KratosCoreFastSuite)
-// {
-//     Parameters kp = Parameters(four_levels)
-//     kp_variation = Parameters(four_levels_variation)
-//     kp_wrong_wariation = Parameters(four_levels_wrong_variation)
-//     defaults_params = Parameters(four_levels_defaults)
-//
-//     kp.RecursivelyValidateAndAssignDefaults(defaults_params)
-//     kp_variation.RecursivelyValidateAndAssignDefaults(defaults_params)
-//
-//     KRATOS_CHECK( kp.IsEquivalentTo(defaults_params) )
-//     KRATOS_CHECK_IS_FALSE( kp_variation.IsEquivalentTo(defaults_params) )
-//
-//     KRATOS_CHECK( kp.HasSameKeysAndTypeOfValuesAs(defaults_params) )
-//     KRATOS_CHECK( kp_variation.HasSameKeysAndTypeOfValuesAs(defaults_params) )
-//     KRATOS_CHECK_IS_FALSE( kp_wrong_wariation.HasSameKeysAndTypeOfValuesAs(defaults_params) )
-// }
-//
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationFailsErrorsOnFirstLevel, KratosCoreFastSuite)
+{
+    Parameters kp = Parameters(GetJSONStringWrongLevel2());
+    Parameters defaults_params = Parameters(GetJSONStringDefaults());
+
+    // Should check which errors are thrown!!
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(kp.RecursivelyValidateAndAssignDefaults(defaults_params), "");
+}
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersRecursiveValidation4Levels, KratosCoreFastSuite)
+{
+    Parameters kp = Parameters(GetJSONStringFourLevels());
+    Parameters kp_variation = Parameters(GetJSONStringForLevelsVariation());
+    Parameters kp_wrong_wariation = Parameters(GetJSONStringForLevelsWrongVariation());
+    Parameters defaults_params = Parameters(GetJSONStringForLevelsDefaults());
+
+    kp.RecursivelyValidateAndAssignDefaults(defaults_params);
+    kp_variation.RecursivelyValidateAndAssignDefaults(defaults_params);
+
+    KRATOS_CHECK( kp.IsEquivalentTo(defaults_params) );
+    KRATOS_CHECK_IS_FALSE( kp_variation.IsEquivalentTo(defaults_params) );
+
+    KRATOS_CHECK( kp.HasSameKeysAndTypeOfValuesAs(defaults_params) );
+    KRATOS_CHECK( kp_variation.HasSameKeysAndTypeOfValuesAs(defaults_params) );
+    KRATOS_CHECK_IS_FALSE( kp_wrong_wariation.HasSameKeysAndTypeOfValuesAs(defaults_params) );
+}
+
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationSuccedsErroronFirstLevel, KratosCoreFastSuite)
 // {
-//     Parameters kp = Parameters(wrong_lev2)
+//     Parameters kp = Parameters(GetJSONStringWrongLevel2());
 //     Parameters defaults_params = Parameters(GetJSONStringDefaults());
 //
 //     // here no error shall be thrown since validation is only done on level0

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -8,7 +8,7 @@
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Vicente Mataix Ferrandiz
-//
+//                   Riccardo Rossi
 //
 
 // System includes

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -40,7 +40,7 @@ std::string GetJSONString()
 
 std::string GetJSONStringPrettyOut()
 {
-    const std::string pretty_out =  R"(
+    const std::string pretty_out =  R"({
         "bool_value": true,
         "double_value": 2.0,
         "int_value": 10,

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -428,50 +428,50 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddMissingParameters, KratosCoreFastSu
     KRATOS_CHECK_IS_FALSE(kp["level1"].Has("new_sublevel"));
 }
 
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersRecursivelyAddMissingParameters, KratosCoreFastSuite)
-// {
-//     // only missing parameters are added, no complaints if there already exist more than in the defaults
-//     Parameters kp = Parameters(GetJSONString());
-//     Parameters tmp = Parameters(GetJSONStringIncompleteWithExtraParameter());
-//
-//     kp.RecursivelyAddMissingParameters(tmp)
-//
-//     KRATOS_CHECK(kp["level1"].Has("new_sublevel"))
-//     KRATOS_CHECK_EQUAL(kp["level1"]["new_sublevel"].GetString(), "this should only be assigned in recursive")
-// }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidateDefaults, KratosCoreFastSuite)
-// {
-//     // only parameters from defaults are validated, no new values are added
-//     Parameters kp = Parameters(incomplete_with_extra_parameter)
-//     tmp = Parameters(defaults)
-//
-//     kp.ValidateDefaults(tmp)
-//
-//     KRATOS_CHECK_IS_FALSE(kp.Has("bool_value"))
-//     KRATOS_CHECK_IS_FALSE(kp.Has("double_value"))
-//     KRATOS_CHECK(kp.Has("level1"))
-// }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersRecursivelyValidateDefaults, KratosCoreFastSuite)
-// {
-//     // only parameters from defaults are validated, no new values are added
-//     Parameters kp = Parameters(incomplete)
-//     tmp = Parameters(defaults)
-//
-//     kp.RecursivelyValidateDefaults(tmp)
-//
-//     KRATOS_CHECK_IS_FALSE(kp.Has("bool_value"))
-//     KRATOS_CHECK_IS_FALSE(kp.Has("double_value"))
-//     KRATOS_CHECK(kp.Has("level1"))
-// }
-//
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersRecursivelyAddMissingParameters, KratosCoreFastSuite)
+{
+    // Only missing parameters are added, no complaints if there already exist more than in the defaults
+    Parameters kp = Parameters(GetJSONString());
+    Parameters tmp = Parameters(GetJSONStringIncompleteWithExtraParameter());
+
+    kp.RecursivelyAddMissingParameters(tmp);
+
+    KRATOS_CHECK(kp["level1"].Has("new_sublevel"));
+    KRATOS_CHECK_STRING_EQUAL(kp["level1"]["new_sublevel"].GetString(), "this should only be assigned in recursive");
+}
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidateDefaults, KratosCoreFastSuite)
+{
+    // Only parameters from defaults are validated, no new values are added
+    Parameters kp = Parameters(GetJSONStringIncompleteWithExtraParameter());
+    Parameters tmp = Parameters(GetJSONStringDefaults());
+
+    kp.ValidateDefaults(tmp);
+
+    KRATOS_CHECK_IS_FALSE(kp.Has("bool_value"));
+    KRATOS_CHECK_IS_FALSE(kp.Has("double_value"));
+    KRATOS_CHECK(kp.Has("level1"));
+}
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersRecursivelyValidateDefaults, KratosCoreFastSuite)
+{
+    // Only parameters from defaults are validated, no new values are added
+    Parameters kp = Parameters(GetJSONStringIncomplete());
+    Parameters tmp = Parameters(GetJSONStringDefaults());
+
+    kp.RecursivelyValidateDefaults(tmp);
+
+    KRATOS_CHECK_IS_FALSE(kp.Has("bool_value"));
+    KRATOS_CHECK_IS_FALSE(kp.Has("double_value"));
+    KRATOS_CHECK(kp.Has("level1"));
+}
+
 // def test_recursively_validate_defaults_fails(self):
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersSetStringArrayValid, KratosCoreFastSuite)
 // {
 //     // only parameters from defaults are validated, no new values are added
-//     Parameters kp = Parameters(incomplete_with_extra_parameter)
-//     tmp = Parameters(defaults)
+//     Parameters kp = Parameters(GetJSONStringIncompleteWithExtraParameter());
+//     Parameters tmp = Parameters(GetJSONStringDefaults());
 //
 //     with self.assertRaises(RuntimeError):
 //         kp.RecursivelyValidateDefaults(tmp)

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -77,75 +77,73 @@ std::string GetJSONStringPrettyOutAfterChange()
     return pretty_out_after_change;
 }
 
-// // here the level1 var is set to a double so that a validation error should be thrown
-// std::string GetJSONStringWrongType()
-// {
-//     const std::string wrong_type = """{
-//         "bool_value": true,
-//         "double_value": 2.0,
-//         "int_value": 10,
-//         "level1": 0.0,
-//         "string_value": "hello"
-//     }""";
-//
-//     return wrong_type;
-// }
-//
-// // int value is badly spelt
-// std::string GetJSONStringWrongSpelling()
-// {
-//     const std::string wrong_spelling = """{
-//         "bool_value": true,
-//         "double_value": 2.0,
-//         "int_values": 10,
-//         "level1": 0.0,
-//         "string_value": "hello"
-//     }""";
-//
-//     return wrong_spelling;
-// }
-//
-// // wrong on the first level
-// // error shall be only detective by recursive validation
-// std::string GetJSONStringWrongLevel2()
-// {
-//     const std::string wrong_lev2 = """{
-//         "bool_value": true,
-//         "double_value": 2.0,
-//         "int_value": 10,
-//         "level1": { "a":0.0 },
-//         "string_value": "hello"
-//     }""";
-//     return wrong_lev2;
-// }
-//
-// std::string GetJSONStringDefaults()
-// {
-//     const std::string defaults = """
-//     {
-//         "bool_value": false,
-//         "double_value": 2.0,
-//         "int_value": 10,
-//         "level1": {
-//             "list_value": [
-//                 3,
-//                 "hi",
-//                 false
-//             ],
-//             "tmp": "here we expect a string"
-//         },
-//         "new_default_obj": {
-//             "aaa": "string",
-//             "bbb": false,
-//             "ccc": 22
-//         },
-//         "new_default_value": -123.0,
-//         "string_value": "hello"
-//     }
-//     """;
-//     return defaults;
-// }
-//
+// here the level1 var is set to a double so that a validation error should be thrown
+std::string GetJSONStringWrongType()
+{
+    const std::string wrong_type = R"({
+        "bool_value": true,
+        "double_value": 2.0,
+        "int_value": 10,
+        "level1": 0.0,
+        "string_value": "hello"
+    })";
+
+    return wrong_type;
+}
+
+// int value is badly spelt
+std::string GetJSONStringWrongSpelling()
+{
+    const std::string wrong_spelling = R"({
+        "bool_value": true,
+        "double_value": 2.0,
+        "int_values": 10,
+        "level1": 0.0,
+        "string_value": "hello"
+    })";
+
+    return wrong_spelling;
+}
+
+// wrong on the first level
+// error shall be only detective by recursive validation
+std::string GetJSONStringWrongLevel2()
+{
+    const std::string wrong_lev2 = R"({
+        "bool_value": true,
+        "double_value": 2.0,
+        "int_value": 10,
+        "level1": { "a":0.0 },
+        "string_value": "hello"
+    })";
+    return wrong_lev2;
+}
+
+std::string GetJSONStringDefaults()
+{
+    const std::string defaults = R"({
+        "bool_value": false,
+        "double_value": 2.0,
+        "int_value": 10,
+        "level1": {
+            "list_value": [
+                3,
+                "hi",
+                false
+            ],
+            "tmp": "here we expect a string"
+        },
+        "new_default_obj": {
+            "aaa": "string",
+            "bbb": false,
+            "ccc": 22
+        },
+        "new_default_value": -123.0,
+        "string_value": "hello"
+    })";
+    return defaults;
+}
+
 // std::string GetJSONStringIncomplete()
 // {
 //     const std::string incomplete = """
@@ -346,47 +344,35 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersCopy, KratosCoreFastSuite)
     KRATOS_CHECK_EQUAL(kp["int_value"].GetInt(), 10);
 }
 
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersSetValue, KratosCoreFastSuite)
-// {
-//     Parameters kp = Parameters(GetJSONString());
-//     Parameters kp1 = Parameters(GetJSONStringPrettyOutAfterChange());
-//
-//     kp["bool_value"] = kp1["level1"]
-//     kp["bool_value"].PrettyPrintJsonString()
-//     KRATOS_CHECK_EQUAL(kp["bool_value"].PrettyPrintJsonString(), kp1["level1"].PrettyPrintJsonString())
-// }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersWrongParameters, KratosCoreFastSuite)
-// {
-//     // Should check which errors are thrown!!
-//     with self.assertRaisesRegex(RuntimeError, "no_value"):
-//         kp["no_value"].GetInt()
-// }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationFailsDueToWrongTypes, KratosCoreFastSuite)
-// {
-//     Parameters kp = Parameters(wrong_type)
-//     Parameters defaults_params = Parameters(defaults)
-//
-//     // should check which errors are thrown!!
-//     with self.assertRaises(RuntimeError):
-//         kp.ValidateAndAssignDefaults(defaults_params)
-// }
-//
-// KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationFailsDueToWrongSpelling, KratosCoreFastSuite)
-// {
-//     Parameters kp = Parameters(wrong_spelling)
-//     Parameters defaults_params = Parameters(defaults)
-//
-//     // should check which errors are thrown!!
-//     with self.assertRaises(RuntimeError):
-//         kp.ValidateAndAssignDefaults(defaults_params)
-// }
-//
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersWrongParameters, KratosCoreFastSuite)
+{
+    // Should check which errors are thrown!!
+    Parameters kp = Parameters(GetJSONString());
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(kp["no_value"].GetInt(), "");
+}
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationFailsDueToWrongTypes, KratosCoreFastSuite)
+{
+    Parameters kp = Parameters(GetJSONStringWrongType());
+    Parameters defaults_params = Parameters(GetJSONStringDefaults());
+
+    // Should check which errors are thrown!!
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(kp.ValidateAndAssignDefaults(defaults_params), "");
+}
+
+KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationFailsDueToWrongSpelling, KratosCoreFastSuite2)
+{
+    Parameters kp = Parameters(GetJSONStringWrongSpelling());
+    Parameters  defaults_params = Parameters(GetJSONStringDefaults());
+
+    // Should check which errors are thrown!!
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(kp.ValidateAndAssignDefaults(defaults_params), "");
+}
+
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationFailsErrorsOnFirstLevel, KratosCoreFastSuite)
 // {
 //     Parameters kp = Parameters(wrong_lev2)
-//     defaults_params = Parameters(defaults)
+//     Parameters defaults_params = Parameters(GetJSONStringDefaults());
 //
 //     // should check which errors are thrown!!
 //     with self.assertRaises(RuntimeError):
@@ -414,7 +400,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersCopy, KratosCoreFastSuite)
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationSuccedsErroronFirstLevel, KratosCoreFastSuite)
 // {
 //     Parameters kp = Parameters(wrong_lev2)
-//     defaults_params = Parameters(defaults)
+//     Parameters defaults_params = Parameters(GetJSONStringDefaults());
 //
 //     // here no error shall be thrown since validation is only done on level0
 //     kp.ValidateAndAssignDefaults(defaults_params)
@@ -423,7 +409,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersCopy, KratosCoreFastSuite)
 // KRATOS_TEST_CASE_IN_SUITE(KratosParametersValidationSucceeds, KratosCoreFastSuite)
 // {
 //     Parameters kp = Parameters(GetJSONString());
-//     defaults_params = Parameters(defaults)
+//     Parameters defaults_params = Parameters(GetJSONStringDefaults());
 //     defaults_params["level1"]["tmp"].SetDouble(2.0)  // this does not coincide with the value in kp, but is of the same type
 //
 //     kp.ValidateAndAssignDefaults(defaults_params)


### PR DESCRIPTION
**Description**
This adds a translation of the python tests to C++ (I consider important to test both in python and C++), this also helps to understand the API in C++ aside of python

**Changelog**
- Adding C++ tests for Kratos Parameters
