### PR TITLE
[RANS] QSVMS Expansion Step 2 - Update elements to use Constitutive Laws

### DIFF
--- a/applications/RANSApplication/custom_elements/convection_diffusion_reaction_cross_wind_stabilized_element.cpp
+++ b/applications/RANSApplication/custom_elements/convection_diffusion_reaction_cross_wind_stabilized_element.cpp
@@ -31,6 +31,7 @@
 #include "custom_elements/data_containers/k_omega/omega_element_data.h"
 #include "custom_elements/data_containers/k_omega_sst/k_element_data.h"
 #include "custom_elements/data_containers/k_omega_sst/omega_element_data.h"
+#include "custom_utilities/fluid_calculation_utilities.h"
 #include "custom_utilities/rans_calculation_utilities.h"
 
 // Include base h
@@ -72,7 +73,7 @@ void ConvectionDiffusionReactionCrossWindStabilizedElement<TDim, TNumNodes, TCon
     BoundedMatrix<double, TDim, TDim> contravariant_metric_tensor;
 
     const auto& r_geometry = this->GetGeometry();
-    TConvectionDiffusionReactionData element_data(r_geometry);
+    TConvectionDiffusionReactionData element_data(r_geometry, this->GetProperties(), rCurrentProcessInfo);
 
     element_data.CalculateConstants(rCurrentProcessInfo);
 
@@ -167,7 +168,7 @@ void ConvectionDiffusionReactionCrossWindStabilizedElement<TDim, TNumNodes, TCon
     BoundedMatrix<double, TDim, TDim> contravariant_metric_tensor;
 
     const auto& r_geometry = this->GetGeometry();
-    TConvectionDiffusionReactionData element_data(r_geometry);
+    TConvectionDiffusionReactionData element_data(r_geometry, this->GetProperties(), rCurrentProcessInfo);
 
     element_data.CalculateConstants(rCurrentProcessInfo);
 
@@ -246,7 +247,7 @@ void ConvectionDiffusionReactionCrossWindStabilizedElement<TDim, TNumNodes, TCon
         primal_variable.GetTimeDerivative().GetTimeDerivative();
 
     const auto& r_geometry = this->GetGeometry();
-    TConvectionDiffusionReactionData element_data(r_geometry);
+    TConvectionDiffusionReactionData element_data(r_geometry, this->GetProperties(), rCurrentProcessInfo);
 
     element_data.CalculateConstants(rCurrentProcessInfo);
 
@@ -291,7 +292,7 @@ void ConvectionDiffusionReactionCrossWindStabilizedElement<TDim, TNumNodes, TCon
         const double velocity_dot_variable_gradient =
             inner_prod(velocity, variable_gradient);
 
-        RansCalculationUtilities::EvaluateInPoint(
+        FluidCalculationUtilities::EvaluateInPoint(
             r_geometry, gauss_shape_functions,
             std::tie(variable_value, primal_variable),
             std::tie(relaxed_variable_acceleration, relaxed_primal_rate_variable));
@@ -342,8 +343,6 @@ void ConvectionDiffusionReactionCrossWindStabilizedElement<TDim, TNumNodes, TCon
             }
         }
     }
-
-    element_data.UpdateElementDataValueContainer(*this);
 
     KRATOS_CATCH("");
 }

--- a/applications/RANSApplication/custom_elements/convection_diffusion_reaction_element.cpp
+++ b/applications/RANSApplication/custom_elements/convection_diffusion_reaction_element.cpp
@@ -27,6 +27,7 @@
 #include "custom_elements/data_containers/k_omega/omega_element_data.h"
 #include "custom_elements/data_containers/k_omega_sst/k_element_data.h"
 #include "custom_elements/data_containers/k_omega_sst/omega_element_data.h"
+#include "custom_utilities/fluid_calculation_utilities.h"
 #include "custom_utilities/rans_calculation_utilities.h"
 
 // Include base h
@@ -167,7 +168,7 @@ void ConvectionDiffusionReactionElement<TDim, TNumNodes, TConvectionDiffusionRea
     const IndexType num_gauss_points = gauss_weights.size();
 
     const auto& r_geometry = this->GetGeometry();
-    TConvectionDiffusionReactionData r_current_data(r_geometry);
+    TConvectionDiffusionReactionData r_current_data(r_geometry, this->GetProperties(), rCurrentProcessInfo);
 
     r_current_data.CalculateConstants(rCurrentProcessInfo);
 
@@ -244,7 +245,7 @@ void ConvectionDiffusionReactionElement<TDim, TNumNodes, TConvectionDiffusionRea
     const IndexType num_gauss_points = gauss_weights.size();
 
     const auto& r_geometry = this->GetGeometry();
-    TConvectionDiffusionReactionData r_current_data(r_geometry);
+    TConvectionDiffusionReactionData r_current_data(r_geometry, this->GetProperties(), rCurrentProcessInfo);
 
     r_current_data.CalculateConstants(rCurrentProcessInfo);
 
@@ -272,8 +273,6 @@ void ConvectionDiffusionReactionElement<TDim, TNumNodes, TConvectionDiffusionRea
             rDampingMatrix, reaction, effective_kinematic_viscosity,
             velocity_convective_terms, gauss_weights[g], r_shape_functions, dNa_dNb);
     }
-
-    r_current_data.UpdateElementDataValueContainer(*this);
 
     KRATOS_CATCH("");
 }

--- a/applications/RANSApplication/custom_elements/convection_diffusion_reaction_element.h
+++ b/applications/RANSApplication/custom_elements/convection_diffusion_reaction_element.h
@@ -323,6 +323,9 @@ public:
     ///@}
 
 protected:
+    ///@name Protected operations
+    ///@{
+
     /**
      * @brief Get the Values Array
      *
@@ -370,8 +373,6 @@ protected:
         const array_1d<double, 3>& rVector,
         const Matrix& rShapeDerivatives) const;
 
-    ///@name Protected Operations
-    ///@{
     /**
      * @brief Calculates shape function data for this element
      *

--- a/applications/RANSApplication/custom_elements/convection_diffusion_reaction_element_data.h
+++ b/applications/RANSApplication/custom_elements/convection_diffusion_reaction_element_data.h
@@ -19,8 +19,10 @@
 
 // Project includes
 #include "geometries/geometry.h"
+#include "includes/constitutive_law.h"
 #include "includes/node.h"
 #include "includes/process_info.h"
+#include "includes/properties.h"
 
 // Application includes
 
@@ -34,37 +36,33 @@ class ConvectionDiffusionReactionElementData
 public:
     using GeometryType = Geometry<Node<3>>;
 
-    ConvectionDiffusionReactionElementData(const GeometryType& rGeometry)
-    : mrGeometry(rGeometry)
+    ConvectionDiffusionReactionElementData(
+        const GeometryType& rGeometry,
+        const Properties& rProperties,
+        const ProcessInfo& rProcessInfo)
+        : mrGeometry(rGeometry),
+          mrProperties(rProperties),
+          mrConstitutiveLaw(*(rGeometry.GetValue(CONSTITUTIVE_LAW)))
+    {
+        mConstitutiveLawParameters =
+            ConstitutiveLaw::Parameters(rGeometry, rProperties, rProcessInfo);
+    }
+
+    virtual void Calculate(
+        const Variable<double>& rVariable,
+        double& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void CalculateConstants(
-        const ProcessInfo& rCurrentProcessInfo) = 0;
-
-    virtual void CalculateGaussPointData(
-        const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives,
-        const int Step) = 0;
-
-    virtual array_1d<double, 3> CalculateEffectiveVelocity(
-        const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const = 0;
-
-    virtual double CalculateEffectiveKinematicViscosity(
-        const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const = 0;
-
-    virtual double CalculateReactionTerm(
-        const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const = 0;
-
-    virtual double CalculateSourceTerm(
-        const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const = 0;
-
-    virtual void UpdateElementDataValueContainer(Element& rElement) const
+    ConstitutiveLaw::Parameters& GetConstitutiveLawParameters()
     {
+        return mConstitutiveLawParameters;
+    }
+
+    ConstitutiveLaw& GetConstitutiveLaw()
+    {
+        return mrConstitutiveLaw;
     }
 
     const GeometryType& GetGeometry() const
@@ -72,8 +70,16 @@ public:
         return mrGeometry;
     }
 
+    const Properties& GetProperties() const
+    {
+        return mrProperties;
+    }
+
 private:
     const GeometryType& mrGeometry;
+    const Properties& mrProperties;
+    ConstitutiveLaw& mrConstitutiveLaw;
+    ConstitutiveLaw::Parameters mConstitutiveLawParameters;
 };
 
 ///@}

--- a/applications/RANSApplication/custom_elements/convection_diffusion_reaction_residual_based_flux_corrected_element.cpp
+++ b/applications/RANSApplication/custom_elements/convection_diffusion_reaction_residual_based_flux_corrected_element.cpp
@@ -31,6 +31,7 @@
 #include "custom_elements/data_containers/k_omega/omega_element_data.h"
 #include "custom_elements/data_containers/k_omega_sst/k_element_data.h"
 #include "custom_elements/data_containers/k_omega_sst/omega_element_data.h"
+#include "custom_utilities/fluid_calculation_utilities.h"
 #include "custom_utilities/rans_calculation_utilities.h"
 #include "rans_application_variables.h"
 
@@ -84,7 +85,7 @@ void ConvectionDiffusionReactionResidualBasedFluxCorrectedElement<TDim, TNumNode
     const double element_length = this->GetGeometry().Length();
 
     const auto& r_geometry = this->GetGeometry();
-    TConvectionDiffusionReactionData r_current_data(r_geometry);
+    TConvectionDiffusionReactionData r_current_data(r_geometry, this->GetProperties(), rCurrentProcessInfo);
 
     r_current_data.CalculateConstants(rCurrentProcessInfo);
 
@@ -161,7 +162,7 @@ void ConvectionDiffusionReactionResidualBasedFluxCorrectedElement<TDim, TNumNode
     const double element_length = this->GetGeometry().Length();
 
     const auto& r_geometry = this->GetGeometry();
-    TConvectionDiffusionReactionData r_current_data(r_geometry);
+    TConvectionDiffusionReactionData r_current_data(r_geometry, this->GetProperties(), rCurrentProcessInfo);
 
     r_current_data.CalculateConstants(rCurrentProcessInfo);
 
@@ -270,7 +271,7 @@ double ConvectionDiffusionReactionResidualBasedFluxCorrectedElement<TDim, TNumNo
         primal_variable.GetTimeDerivative().GetTimeDerivative();
 
     const auto& r_geometry = this->GetGeometry();
-    TConvectionDiffusionReactionData r_current_data(r_geometry);
+    TConvectionDiffusionReactionData r_current_data(r_geometry, this->GetProperties(), rCurrentProcessInfo);
     double variable_value, relaxed_variable_acceleration;
 
     r_current_data.CalculateConstants(rCurrentProcessInfo);
@@ -304,7 +305,7 @@ double ConvectionDiffusionReactionResidualBasedFluxCorrectedElement<TDim, TNumNo
         const double velocity_dot_variable_gradient =
             inner_prod(velocity, variable_gradient);
 
-        RansCalculationUtilities::EvaluateInPoint(
+        FluidCalculationUtilities::EvaluateInPoint(
             r_geometry, gauss_shape_functions,
             std::tie(variable_value, primal_variable),
             std::tie(relaxed_variable_acceleration, relaxed_primal_rate_variable));
@@ -328,8 +329,6 @@ double ConvectionDiffusionReactionResidualBasedFluxCorrectedElement<TDim, TNumNo
             rDampingMatrix, reaction, tau, velocity_convective_terms,
             gauss_weights[g], gauss_shape_functions);
     }
-
-    r_current_data.UpdateElementDataValueContainer(*this);
 
     return scalar_multiplier / static_cast<double>(num_gauss_points);
 

--- a/applications/RANSApplication/custom_elements/data_containers/k_epsilon/epsilon_element_data.h
+++ b/applications/RANSApplication/custom_elements/data_containers/k_epsilon/epsilon_element_data.h
@@ -51,34 +51,37 @@ public:
         return "KEpsilonEpsilonElementData";
     }
 
-    EpsilonElementData(const GeomtryType& rGeometry)
-    : BaseType(rGeometry)
+    EpsilonElementData(
+        const GeometryType& rGeometry,
+        const Properties& rProperties,
+        const ProcessInfo& rProcessInfo)
+        : BaseType(rGeometry, rProperties, rProcessInfo)
     {
     }
 
     void CalculateConstants(
-        const ProcessInfo& rCurrentProcessInfo) override;
+        const ProcessInfo& rCurrentProcessInfo);
 
     void CalculateGaussPointData(
         const Vector& rShapeFunctions,
         const Matrix& rShapeFunctionDerivatives,
-        const int Step = 0) override;
+        const int Step = 0);
 
     array_1d<double, 3> CalculateEffectiveVelocity(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateEffectiveKinematicViscosity(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateReactionTerm(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateSourceTerm(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
 protected:
     BoundedMatrix<double, TDim, TDim> mVelocityGradient;
@@ -93,6 +96,7 @@ protected:
     double mKinematicViscosity;
     double mVelocityDivergence;
     double mInvEpsilonSigma;
+    double mDensity;
 };
 
 ///@}

--- a/applications/RANSApplication/custom_elements/data_containers/k_epsilon/k_element_data.h
+++ b/applications/RANSApplication/custom_elements/data_containers/k_epsilon/k_element_data.h
@@ -51,34 +51,37 @@ public:
         return "KEpsilonKElementData";
     }
 
-    KElementData(const GeomtryType& rGeometry)
-    : BaseType(rGeometry)
+    KElementData(
+        const GeometryType& rGeometry,
+        const Properties& rProperties,
+        const ProcessInfo& rProcessInfo)
+        : BaseType(rGeometry, rProperties, rProcessInfo)
     {
     }
 
     void CalculateConstants(
-        const ProcessInfo& rCurrentProcessInfo) override;
+        const ProcessInfo& rCurrentProcessInfo);
 
     void CalculateGaussPointData(
         const Vector& rShapeFunctions,
         const Matrix& rShapeFunctionDerivatives,
-        const int Step = 0) override;
+        const int Step = 0);
 
     array_1d<double, 3> CalculateEffectiveVelocity(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateEffectiveKinematicViscosity(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateReactionTerm(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateSourceTerm(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
 protected:
     BoundedMatrix<double, TDim, TDim> mVelocityGradient;
@@ -90,6 +93,7 @@ protected:
     double mVelocityDivergence;
     double mInvTkeSigma;
     double mCmu;
+    double mDensity;
 };
 
 ///@}

--- a/applications/RANSApplication/custom_elements/data_containers/k_omega/k_element_data.h
+++ b/applications/RANSApplication/custom_elements/data_containers/k_omega/k_element_data.h
@@ -55,34 +55,37 @@ public:
         return "KOmegaKElementData";
     }
 
-    KElementData(const GeomtryType& rGeometry)
-    : BaseType(rGeometry)
+    KElementData(
+        const GeometryType& rGeometry,
+        const Properties& rProperties,
+        const ProcessInfo& rProcessInfo)
+        : BaseType(rGeometry, rProperties, rProcessInfo)
     {
     }
 
     void CalculateConstants(
-        const ProcessInfo& rCurrentProcessInfo) override;
+        const ProcessInfo& rCurrentProcessInfo);
 
     void CalculateGaussPointData(
         const Vector& rShapeFunctions,
         const Matrix& rShapeFunctionDerivatives,
-        const int Step = 0) override;
+        const int Step = 0);
 
     array_1d<double, 3> CalculateEffectiveVelocity(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateEffectiveKinematicViscosity(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateReactionTerm(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateSourceTerm(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
 protected:
     BoundedMatrix<double, TDim, TDim> mVelocityGradient;
@@ -94,6 +97,7 @@ protected:
     double mVelocityDivergence;
     double mSigmaK;
     double mBetaStar;
+    double mDensity;
 };
 
 ///@}

--- a/applications/RANSApplication/custom_elements/data_containers/k_omega/omega_element_data.cpp
+++ b/applications/RANSApplication/custom_elements/data_containers/k_omega/omega_element_data.cpp
@@ -23,6 +23,7 @@
 
 // Application includes
 #include "custom_elements/data_containers/k_epsilon/element_data_utilities.h"
+#include "custom_utilities/fluid_calculation_utilities.h"
 #include "custom_utilities/rans_calculation_utilities.h"
 #include "rans_application_variables.h"
 
@@ -50,7 +51,6 @@ void OmegaElementData<TDim>::Check(
     for (int i_node = 0; i_node < number_of_nodes; ++i_node) {
         const auto& r_node = rGeometry[i_node];
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VELOCITY, r_node);
-        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(KINEMATIC_VISCOSITY, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TURBULENT_VISCOSITY, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TURBULENT_KINETIC_ENERGY, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE, r_node);
@@ -70,6 +70,7 @@ void OmegaElementData<TDim>::CalculateConstants(
     mBeta = rCurrentProcessInfo[TURBULENCE_RANS_BETA];
     mGamma = rCurrentProcessInfo[TURBULENCE_RANS_GAMMA];
     mSigmaOmega = rCurrentProcessInfo[TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE_SIGMA];
+    mDensity = this->GetProperties().GetValue(DENSITY);
 }
 
 template <unsigned int TDim>
@@ -82,11 +83,17 @@ void OmegaElementData<TDim>::CalculateGaussPointData(
 
     using namespace RansCalculationUtilities;
 
-    EvaluateInPoint(this->GetGeometry(), rShapeFunctions, Step,
-                    std::tie(mTurbulentKineticEnergy, TURBULENT_KINETIC_ENERGY),
-                    std::tie(mKinematicViscosity, KINEMATIC_VISCOSITY),
-                    std::tie(mTurbulentKinematicViscosity, TURBULENT_VISCOSITY),
-                    std::tie(mEffectiveVelocity, VELOCITY));
+    auto& cl_parameters = this->GetConstitutiveLawParameters();
+    cl_parameters.SetShapeFunctionsValues(rShapeFunctions);
+
+    this->GetConstitutiveLaw().CalculateValue(cl_parameters, EFFECTIVE_VISCOSITY, mKinematicViscosity);
+    mKinematicViscosity /= mDensity;
+
+    FluidCalculationUtilities::EvaluateInPoint(
+        this->GetGeometry(), rShapeFunctions, Step,
+        std::tie(mTurbulentKineticEnergy, TURBULENT_KINETIC_ENERGY),
+        std::tie(mTurbulentKinematicViscosity, TURBULENT_VISCOSITY),
+        std::tie(mEffectiveVelocity, VELOCITY));
 
     mVelocityDivergence =
         GetDivergence(this->GetGeometry(), VELOCITY, rShapeFunctionDerivatives);

--- a/applications/RANSApplication/custom_elements/data_containers/k_omega/omega_element_data.h
+++ b/applications/RANSApplication/custom_elements/data_containers/k_omega/omega_element_data.h
@@ -55,34 +55,37 @@ public:
         return "KOmegaOmegaElementData";
     }
 
-    OmegaElementData(const GeomtryType& rGeometry)
-    : BaseType(rGeometry)
+    OmegaElementData(
+        const GeometryType& rGeometry,
+        const Properties& rProperties,
+        const ProcessInfo& rProcessInfo)
+        : BaseType(rGeometry, rProperties, rProcessInfo)
     {
     }
 
     void CalculateConstants(
-        const ProcessInfo& rCurrentProcessInfo) override;
+        const ProcessInfo& rCurrentProcessInfo);
 
     void CalculateGaussPointData(
         const Vector& rShapeFunctions,
         const Matrix& rShapeFunctionDerivatives,
-        const int Step = 0) override;
+        const int Step = 0);
 
     array_1d<double, 3> CalculateEffectiveVelocity(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateEffectiveKinematicViscosity(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateReactionTerm(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateSourceTerm(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
 protected:
     BoundedMatrix<double, TDim, TDim> mVelocityGradient;
@@ -97,6 +100,7 @@ protected:
     double mSigmaOmega;
     double mBeta;
     double mGamma;
+    double mDensity;
 };
 
 ///@}

--- a/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/k_element_data.cpp
+++ b/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/k_element_data.cpp
@@ -19,6 +19,7 @@
 
 // Application includes
 #include "custom_elements/data_containers/k_epsilon/element_data_utilities.h"
+#include "custom_utilities/fluid_calculation_utilities.h"
 #include "custom_utilities/rans_calculation_utilities.h"
 #include "element_data_utilities.h"
 #include "rans_application_variables.h"
@@ -49,7 +50,6 @@ void KElementData<TDim>::Check(
         const auto& r_node = rGeometry[i_node];
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VELOCITY, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISTANCE, r_node);
-        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(KINEMATIC_VISCOSITY, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TURBULENT_VISCOSITY, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TURBULENT_KINETIC_ENERGY, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TURBULENT_KINETIC_ENERGY_RATE, r_node);
@@ -63,6 +63,71 @@ void KElementData<TDim>::Check(
 }
 
 template <unsigned int TDim>
+void KElementData<TDim>::Calculate(
+    const Variable<double>& rVariable,
+    double& rOutput,
+    const ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_TRY
+
+    using namespace RansCalculationUtilities;
+
+    // only needs TURBULENT_VISCOSITY, so no checks were done since this will be
+    // only an internal call
+
+    // Get Shape function data
+    Vector gauss_weights;
+    Matrix shape_functions;
+    GeometryType::ShapeFunctionsGradientsType shape_derivatives;
+    CalculateGeometryData(this->GetGeometry(), GeometryData::IntegrationMethod::GI_GAUSS_1,
+                          gauss_weights, shape_functions, shape_derivatives);
+    const int num_gauss_points = gauss_weights.size();
+
+    BoundedMatrix<double, TDim, TDim> velocity_gradient;
+
+    double tke, omega, nu, y;
+    const double rho = this->GetProperties().GetValue(DENSITY);
+    const double a1 =  rCurrentProcessInfo[TURBULENCE_RANS_A1];
+    const double beta_star = rCurrentProcessInfo[TURBULENCE_RANS_C_MU];
+
+    rOutput = 0.0;
+
+    for (int g = 0; g < num_gauss_points; ++g) {
+        const Matrix& r_shape_derivatives = shape_derivatives[g];
+        const Vector& r_gauss_shape_functions = row(shape_functions, g);
+
+        auto& cl_parameters = this->GetConstitutiveLawParameters();
+        cl_parameters.SetShapeFunctionsValues(r_gauss_shape_functions);
+
+        this->GetConstitutiveLaw().CalculateValue(cl_parameters, EFFECTIVE_VISCOSITY, nu);
+        nu /= rho;
+
+        FluidCalculationUtilities::EvaluateInPoint(
+            this->GetGeometry(), r_gauss_shape_functions,
+            std::tie(tke, TURBULENT_KINETIC_ENERGY),
+            std::tie(omega, TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE),
+            std::tie(y, DISTANCE)
+        );
+
+        CalculateGradient<TDim>(velocity_gradient, this->GetGeometry(), VELOCITY, r_shape_derivatives);
+
+        const double f_2 = KOmegaSSTElementData::CalculateF2(tke, omega, nu, y, beta_star);
+
+        const BoundedMatrix<double, TDim, TDim> symmetric_velocity_gradient =
+            (velocity_gradient + trans(velocity_gradient)) * 0.5;
+
+        const double t = norm_frobenius(symmetric_velocity_gradient) * 1.414;
+
+        rOutput += KOmegaSSTElementData::CalculateTurbulentKinematicViscosity(
+            tke, omega, t, f_2, a1);
+    }
+
+    rOutput /= num_gauss_points;
+
+    KRATOS_CATCH("");
+}
+
+template <unsigned int TDim>
 void KElementData<TDim>::CalculateConstants(
     const ProcessInfo& rCurrentProcessInfo)
 {
@@ -70,6 +135,7 @@ void KElementData<TDim>::CalculateConstants(
     mSigmaK2 = rCurrentProcessInfo[TURBULENT_KINETIC_ENERGY_SIGMA_2];
     mSigmaOmega2 = rCurrentProcessInfo[TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE_SIGMA_2];
     mBetaStar = rCurrentProcessInfo[TURBULENCE_RANS_C_MU];
+    mDensity = this->GetProperties().GetValue(DENSITY);
 }
 
 template <unsigned int TDim>
@@ -82,15 +148,21 @@ void KElementData<TDim>::CalculateGaussPointData(
 
     using namespace RansCalculationUtilities;
 
+    auto& cl_parameters = this->GetConstitutiveLawParameters();
+    cl_parameters.SetShapeFunctionsValues(rShapeFunctions);
+
+    this->GetConstitutiveLaw().CalculateValue(cl_parameters, EFFECTIVE_VISCOSITY, mKinematicViscosity);
+    mKinematicViscosity /= mDensity;
+
     const auto& r_geometry = this->GetGeometry();
 
-    EvaluateInPoint(r_geometry, rShapeFunctions, Step,
-                    std::tie(mTurbulentKineticEnergy, TURBULENT_KINETIC_ENERGY),
-                    std::tie(mTurbulentSpecificEnergyDissipationRate, TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE),
-                    std::tie(mTurbulentKinematicViscosity, TURBULENT_VISCOSITY),
-                    std::tie(mKinematicViscosity, KINEMATIC_VISCOSITY),
-                    std::tie(mWallDistance, DISTANCE),
-                    std::tie(mEffectiveVelocity, VELOCITY));
+    FluidCalculationUtilities::EvaluateInPoint(
+        r_geometry, rShapeFunctions, Step,
+        std::tie(mTurbulentKineticEnergy, TURBULENT_KINETIC_ENERGY),
+        std::tie(mTurbulentSpecificEnergyDissipationRate, TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE),
+        std::tie(mTurbulentKinematicViscosity, TURBULENT_VISCOSITY),
+        std::tie(mWallDistance, DISTANCE),
+        std::tie(mEffectiveVelocity, VELOCITY));
 
     KRATOS_ERROR_IF(mWallDistance < 0.0) << "Wall distance is negative at " << r_geometry;
 

--- a/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/k_element_data.cpp
+++ b/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/k_element_data.cpp
@@ -68,6 +68,13 @@ void KElementData<TDim>::Calculate(
     double& rOutput,
     const ProcessInfo& rCurrentProcessInfo)
 {
+    rOutput = CalculateEffectiveViscosity(rCurrentProcessInfo);
+}
+
+template <unsigned int TDim>
+double KElementData<TDim>::CalculateEffectiveViscosity(
+    const ProcessInfo& rCurrentProcessInfo)
+{
     KRATOS_TRY
 
     using namespace RansCalculationUtilities;
@@ -90,7 +97,7 @@ void KElementData<TDim>::Calculate(
     const double a1 =  rCurrentProcessInfo[TURBULENCE_RANS_A1];
     const double beta_star = rCurrentProcessInfo[TURBULENCE_RANS_C_MU];
 
-    rOutput = 0.0;
+    double nu_t = 0.0;
 
     for (int g = 0; g < num_gauss_points; ++g) {
         const Matrix& r_shape_derivatives = shape_derivatives[g];
@@ -118,11 +125,11 @@ void KElementData<TDim>::Calculate(
 
         const double t = norm_frobenius(symmetric_velocity_gradient) * 1.414;
 
-        rOutput += KOmegaSSTElementData::CalculateTurbulentKinematicViscosity(
+        nu_t += KOmegaSSTElementData::CalculateTurbulentKinematicViscosity(
             tke, omega, t, f_2, a1);
     }
 
-    rOutput /= num_gauss_points;
+    return nu_t / num_gauss_points;
 
     KRATOS_CATCH("");
 }

--- a/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/k_element_data.h
+++ b/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/k_element_data.h
@@ -89,6 +89,9 @@ public:
         const Vector& rShapeFunctions,
         const Matrix& rShapeFunctionDerivatives) const;
 
+    double CalculateEffectiveViscosity(
+        const ProcessInfo& rCurrentProcessInfo);
+
 protected:
     BoundedMatrix<double, TDim, TDim> mVelocityGradient;
     array_1d<double, 3> mEffectiveVelocity;

--- a/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/k_element_data.h
+++ b/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/k_element_data.h
@@ -52,34 +52,42 @@ public:
         return "KOmegaSSTKElementData";
     }
 
-    KElementData(const GeomtryType& rGeometry)
-    : BaseType(rGeometry)
+    KElementData(
+        const GeometryType& rGeometry,
+        const Properties& rProperties,
+        const ProcessInfo& rProcessInfo)
+        : BaseType(rGeometry, rProperties, rProcessInfo)
     {
     }
 
-    void CalculateConstants(
+    void Calculate(
+        const Variable<double>& rVariable,
+        double& rOutput,
         const ProcessInfo& rCurrentProcessInfo) override;
+
+    void CalculateConstants(
+        const ProcessInfo& rCurrentProcessInfo);
 
     void CalculateGaussPointData(
         const Vector& rShapeFunctions,
         const Matrix& rShapeFunctionDerivatives,
-        const int Step = 0) override;
+        const int Step = 0);
 
     array_1d<double, 3> CalculateEffectiveVelocity(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateEffectiveKinematicViscosity(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateReactionTerm(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateSourceTerm(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
 protected:
     BoundedMatrix<double, TDim, TDim> mVelocityGradient;
@@ -99,6 +107,7 @@ protected:
     double mCrossDiffusion;
     double mBlendedSimgaK;
     double mVelocityDivergence;
+    double mDensity;
 };
 
 ///@}

--- a/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/omega_element_data.cpp
+++ b/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/omega_element_data.cpp
@@ -19,6 +19,7 @@
 
 // Application includes
 #include "custom_elements/data_containers/k_epsilon/element_data_utilities.h"
+#include "custom_utilities/fluid_calculation_utilities.h"
 #include "custom_utilities/rans_calculation_utilities.h"
 #include "element_data_utilities.h"
 #include "rans_application_variables.h"
@@ -48,7 +49,6 @@ void OmegaElementData<TDim>::Check(
     for (int i_node = 0; i_node < number_of_nodes; ++i_node) {
         const auto& r_node = rGeometry[i_node];
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VELOCITY, r_node);
-        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(KINEMATIC_VISCOSITY, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TURBULENT_VISCOSITY, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TURBULENT_KINETIC_ENERGY, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE, r_node);
@@ -71,7 +71,8 @@ void OmegaElementData<TDim>::CalculateConstants(
     mSigmaOmega1 = rCurrentProcessInfo[TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE_SIGMA_1];
     mSigmaOmega2 = rCurrentProcessInfo[TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE_SIGMA_2];
     mBetaStar = rCurrentProcessInfo[TURBULENCE_RANS_C_MU];
-    mKappa = rCurrentProcessInfo[WALL_VON_KARMAN];
+    mKappa = this->GetProperties().GetValue(WALL_VON_KARMAN);
+    mDensity = this->GetProperties().GetValue(DENSITY);
 }
 
 template <unsigned int TDim>
@@ -84,15 +85,21 @@ void OmegaElementData<TDim>::CalculateGaussPointData(
 
     using namespace RansCalculationUtilities;
 
+    auto& cl_parameters = this->GetConstitutiveLawParameters();
+    cl_parameters.SetShapeFunctionsValues(rShapeFunctions);
+
+    this->GetConstitutiveLaw().CalculateValue(cl_parameters, EFFECTIVE_VISCOSITY, mKinematicViscosity);
+    mKinematicViscosity /= mDensity;
+
     const auto& r_geometry = this->GetGeometry();
 
-    EvaluateInPoint(this->GetGeometry(), rShapeFunctions, Step,
-                    std::tie(mTurbulentKineticEnergy, TURBULENT_KINETIC_ENERGY),
-                    std::tie(mTurbulentSpecificEnergyDissipationRate, TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE),
-                    std::tie(mKinematicViscosity, KINEMATIC_VISCOSITY),
-                    std::tie(mTurbulentKinematicViscosity, TURBULENT_VISCOSITY),
-                    std::tie(mWallDistance, DISTANCE),
-                    std::tie(mEffectiveVelocity, VELOCITY));
+    FluidCalculationUtilities::EvaluateInPoint(
+        this->GetGeometry(), rShapeFunctions, Step,
+        std::tie(mTurbulentKineticEnergy, TURBULENT_KINETIC_ENERGY),
+        std::tie(mTurbulentSpecificEnergyDissipationRate, TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE),
+        std::tie(mTurbulentKinematicViscosity, TURBULENT_VISCOSITY),
+        std::tie(mWallDistance, DISTANCE),
+        std::tie(mEffectiveVelocity, VELOCITY));
 
     KRATOS_ERROR_IF(mWallDistance < 0.0) << "Wall distance is negative at " << r_geometry;
 
@@ -135,7 +142,7 @@ array_1d<double, 3> OmegaElementData<TDim>::CalculateEffectiveVelocity(
     const Vector& rShapeFunctions,
     const Matrix& rShapeFunctionDerivatives) const
 {
-    return mEffectiveVelocity;;
+    return mEffectiveVelocity;
 }
 
 template <unsigned int TDim>

--- a/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/omega_element_data.h
+++ b/applications/RANSApplication/custom_elements/data_containers/k_omega_sst/omega_element_data.h
@@ -52,34 +52,37 @@ public:
         return "KOmegaSSTOmegaElementData";
     }
 
-    OmegaElementData(const GeomtryType& rGeometry)
-    : BaseType(rGeometry)
+    OmegaElementData(
+        const GeometryType& rGeometry,
+        const Properties& rProperties,
+        const ProcessInfo& rProcessInfo)
+        : BaseType(rGeometry, rProperties, rProcessInfo)
     {
     }
 
     void CalculateConstants(
-        const ProcessInfo& rCurrentProcessInfo) override;
+        const ProcessInfo& rCurrentProcessInfo);
 
     void CalculateGaussPointData(
         const Vector& rShapeFunctions,
         const Matrix& rShapeFunctionDerivatives,
-        const int Step = 0) override;
+        const int Step = 0);
 
     array_1d<double, 3> CalculateEffectiveVelocity(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateEffectiveKinematicViscosity(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateReactionTerm(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
     double CalculateSourceTerm(
         const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives) const override;
+        const Matrix& rShapeFunctionDerivatives) const;
 
 protected:
     BoundedMatrix<double, TDim, TDim> mVelocityGradient;
@@ -104,6 +107,7 @@ protected:
     double mVelocityDivergence;
     double mTurbulentKinematicViscosity;
     double mKappa;
+    double mDensity;
 };
 
 ///@}

--- a/applications/RANSApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/RANSApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -50,6 +50,8 @@ void AddCustomUtilitiesToPython(pybind11::module& m)
         .def("CopyNodalSolutionStepVariablesList", &RansVariableUtilities::CopyNodalSolutionStepVariablesList)
         .def("CalculateTransientVariableConvergence", &RansVariableUtilities::CalculateTransientVariableConvergence<double>)
         .def("CalculateTransientVariableConvergence", &RansVariableUtilities::CalculateTransientVariableConvergence<array_1d<double, 3>>)
+        .def("SetContainerConstitutiveLaws", &RansVariableUtilities::SetContainerConstitutiveLaws<ModelPart::ConditionsContainerType>)
+        .def("SetContainerConstitutiveLaws", &RansVariableUtilities::SetContainerConstitutiveLaws<ModelPart::ElementsContainerType>)
         ;
 
     m.def_submodule("RansCalculationUtilities")

--- a/applications/RANSApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/RANSApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -50,8 +50,7 @@ void AddCustomUtilitiesToPython(pybind11::module& m)
         .def("CopyNodalSolutionStepVariablesList", &RansVariableUtilities::CopyNodalSolutionStepVariablesList)
         .def("CalculateTransientVariableConvergence", &RansVariableUtilities::CalculateTransientVariableConvergence<double>)
         .def("CalculateTransientVariableConvergence", &RansVariableUtilities::CalculateTransientVariableConvergence<array_1d<double, 3>>)
-        .def("SetContainerConstitutiveLaws", &RansVariableUtilities::SetContainerConstitutiveLaws<ModelPart::ConditionsContainerType>)
-        .def("SetContainerConstitutiveLaws", &RansVariableUtilities::SetContainerConstitutiveLaws<ModelPart::ElementsContainerType>)
+        .def("SetElementConstitutiveLaws", &RansVariableUtilities::SetElementConstitutiveLaws)
         ;
 
     m.def_submodule("RansCalculationUtilities")

--- a/applications/RANSApplication/custom_utilities/rans_variable_utilities.cpp
+++ b/applications/RANSApplication/custom_utilities/rans_variable_utilities.cpp
@@ -304,16 +304,15 @@ std::tuple<double, double> CalculateTransientVariableConvergence(
     KRATOS_CATCH("");
 }
 
-template <class TContainerType>
-void SetContainerConstitutiveLaws(TContainerType& rContainer)
+void SetElementConstitutiveLaws(ModelPart::ElementsContainerType& rElements)
 {
     KRATOS_TRY
 
-    block_for_each(rContainer, [](typename TContainerType::value_type& rEntity){
-        if (!rEntity.Has(CONSTITUTIVE_LAW)) {
-            const auto& r_properties = rEntity.GetProperties();
+    block_for_each(rElements, [](ModelPart::ElementType& rElement){
+        if (!rElement.Has(CONSTITUTIVE_LAW)) {
+            const auto& r_properties = rElement.GetProperties();
             KRATOS_ERROR_IF_NOT(r_properties.Has(CONSTITUTIVE_LAW))
-                << "In initialization of entity " << rEntity.Info()
+                << "In initialization of entity " << rElement.Info()
                 << ": No CONSTITUTIVE_LAW defined for property "
                 << r_properties.Id() << "." << std::endl;
 
@@ -329,13 +328,13 @@ void SetContainerConstitutiveLaws(TContainerType& rContainer)
             auto p_constitutive_law =
                 KratosComponents<ConstitutiveLaw>::Get(rans_cl_name.substr(4)).Clone();
 
-            const auto& r_geometry = rEntity.GetGeometry();
+            const auto& r_geometry = rElement.GetGeometry();
             const auto& r_shape_functions =
                 r_geometry.ShapeFunctionsValues(GeometryData::GI_GAUSS_1);
             p_constitutive_law->InitializeMaterial(r_properties, r_geometry,
                                                 row(r_shape_functions, 0));
 
-            rEntity.SetValue(CONSTITUTIVE_LAW, p_constitutive_law);
+            rElement.SetValue(CONSTITUTIVE_LAW, p_constitutive_law);
         }
     });
 
@@ -355,12 +354,6 @@ template KRATOS_API(RANS_APPLICATION) std::tuple<double, double> CalculateTransi
 template KRATOS_API(RANS_APPLICATION)
     std::tuple<double, double> CalculateTransientVariableConvergence<array_1d<double, 3>>(
         const ModelPart&, const Variable<array_1d<double, 3>>&);
-
-template KRATOS_API(RANS_APPLICATION)
-    void SetContainerConstitutiveLaws<ModelPart::ConditionsContainerType>(ModelPart::ConditionsContainerType&);
-
-template KRATOS_API(RANS_APPLICATION)
-    void SetContainerConstitutiveLaws<ModelPart::ElementsContainerType>(ModelPart::ElementsContainerType&);
 
 } // namespace RansVariableUtilities
 

--- a/applications/RANSApplication/custom_utilities/rans_variable_utilities.h
+++ b/applications/RANSApplication/custom_utilities/rans_variable_utilities.h
@@ -102,9 +102,8 @@ void KRATOS_API(RANS_APPLICATION) CopyNodalSolutionStepVariablesList(
     ModelPart& rOriginModelPart,
     ModelPart& rDestinationModelPart);
 
-template <class TContainerType>
 void KRATOS_API(RANS_APPLICATION)
-    SetContainerConstitutiveLaws(TContainerType& rContainer);
+    SetElementConstitutiveLaws(ModelPart::ElementsContainerType& rElements);
 
 ///@}
 } // namespace RansVariableUtilities

--- a/applications/RANSApplication/custom_utilities/rans_variable_utilities.h
+++ b/applications/RANSApplication/custom_utilities/rans_variable_utilities.h
@@ -102,6 +102,10 @@ void KRATOS_API(RANS_APPLICATION) CopyNodalSolutionStepVariablesList(
     ModelPart& rOriginModelPart,
     ModelPart& rDestinationModelPart);
 
+template <class TContainerType>
+void KRATOS_API(RANS_APPLICATION)
+    SetContainerConstitutiveLaws(TContainerType& rContainer);
+
 ///@}
 } // namespace RansVariableUtilities
 

--- a/applications/RANSApplication/custom_utilities/test_utilities.cpp
+++ b/applications/RANSApplication/custom_utilities/test_utilities.cpp
@@ -18,6 +18,7 @@
 
 // Project includes
 #include "containers/model.h"
+#include "containers/global_pointers_vector.h"
 #include "includes/checks.h"
 #include "includes/model_part.h"
 #include "includes/ublas_interface.h"
@@ -117,15 +118,15 @@ ModelPart& CreateTestModelPart(
     using nid_list = std::vector<ModelPart::IndexType>;
 
     r_model_part.CreateNewElement(rElementName, 1, nid_list{3, 2, 1}, p_elem_prop);
+    auto& r_element = r_model_part.Elements().front();
 
-    r_model_part.CreateNewCondition(rConditionName, 1, nid_list{1, 2}, p_elem_prop);
-    r_model_part.CreateNewCondition(rConditionName, 2, nid_list{2, 3}, p_elem_prop);
-    r_model_part.CreateNewCondition(rConditionName, 3, nid_list{3, 1}, p_elem_prop);
+    r_model_part.CreateNewCondition(rConditionName, 1, nid_list{1, 2}, p_elem_prop)->SetValue(NEIGHBOUR_ELEMENTS, GlobalPointersVector<Element>{&r_element});
+    r_model_part.CreateNewCondition(rConditionName, 2, nid_list{2, 3}, p_elem_prop)->SetValue(NEIGHBOUR_ELEMENTS, GlobalPointersVector<Element>{&r_element});
+    r_model_part.CreateNewCondition(rConditionName, 3, nid_list{3, 1}, p_elem_prop)->SetValue(NEIGHBOUR_ELEMENTS, GlobalPointersVector<Element>{&r_element});
 
-    RansVariableUtilities::SetContainerConstitutiveLaws(r_model_part.Elements());
-    RansVariableUtilities::SetContainerConstitutiveLaws(r_model_part.Conditions());
+    RansVariableUtilities::SetElementConstitutiveLaws(r_model_part.Elements());
 
-    r_model_part.Elements().front().Check(r_model_part.GetProcessInfo());
+    r_element.Check(r_model_part.GetProcessInfo());
     r_model_part.Conditions().front().Check(r_model_part.GetProcessInfo());
 
     return r_model_part;

--- a/applications/RANSApplication/custom_utilities/test_utilities.h
+++ b/applications/RANSApplication/custom_utilities/test_utilities.h
@@ -40,6 +40,7 @@ KRATOS_API(RANS_APPLICATION) ModelPart& CreateTestModelPart(
     const std::string& rConditionName,
     const std::function<void(ModelPart& rModelPart)>& rAddNodalSolutionStepVariablesFuncion,
     const std::function<void(ModelPart::NodeType&)>& rAddDofsFunction,
+    const std::function<void(Properties&)>& rSetProperties,
     const int BufferSize = 2);
 
 KRATOS_API(RANS_APPLICATION) ModelPart& CreateScalarVariableTestModelPart(
@@ -47,6 +48,7 @@ KRATOS_API(RANS_APPLICATION) ModelPart& CreateScalarVariableTestModelPart(
     const std::string& rElementName,
     const std::string& rConditionName,
     const std::function<void(ModelPart& rModelPart)>& rAddNodalSolutionStepVariablesFuncion,
+    const std::function<void(Properties&)>& rSetProperties,
     const Variable<double>& rDofVariable,
     const int BufferSize = 2,
     const bool DoInitializeElements = true,

--- a/applications/RANSApplication/python_scripts/coupled_rans_solver.py
+++ b/applications/RANSApplication/python_scripts/coupled_rans_solver.py
@@ -9,6 +9,7 @@ import KratosMultiphysics.FluidDynamicsApplication as KratosCFD
 
 # Import application specific modules
 from KratosMultiphysics.RANSApplication.formulations import Factory as FormulationFactory
+from KratosMultiphysics.RANSApplication.formulations.utilities import InitializeWallLawProperties
 from KratosMultiphysics.RANSApplication import RansVariableUtilities
 from KratosMultiphysics.FluidDynamicsApplication.check_and_prepare_model_process_fluid import CheckAndPrepareModelProcess
 
@@ -297,6 +298,13 @@ class CoupledRANSSolver(PythonSolver):
                 materials_filename)
             Kratos.ReadMaterialsUtility(material_settings,
                                                     self.model)
+            # add wall law properties
+            InitializeWallLawProperties(self.model)
+
+            # initialize constitutive laws
+            RansVariableUtilities.SetContainerConstitutiveLaws(self.main_model_part.Elements)
+            RansVariableUtilities.SetContainerConstitutiveLaws(self.main_model_part.Conditions)
+
             materials_imported = True
         else:
             materials_imported = False

--- a/applications/RANSApplication/python_scripts/coupled_rans_solver.py
+++ b/applications/RANSApplication/python_scripts/coupled_rans_solver.py
@@ -302,8 +302,7 @@ class CoupledRANSSolver(PythonSolver):
             InitializeWallLawProperties(self.model)
 
             # initialize constitutive laws
-            RansVariableUtilities.SetContainerConstitutiveLaws(self.main_model_part.Elements)
-            RansVariableUtilities.SetContainerConstitutiveLaws(self.main_model_part.Conditions)
+            RansVariableUtilities.SetElementConstitutiveLaws(self.main_model_part.Elements)
 
             materials_imported = True
         else:

--- a/applications/RANSApplication/python_scripts/formulations/utilities.py
+++ b/applications/RANSApplication/python_scripts/formulations/utilities.py
@@ -9,6 +9,7 @@ from KratosMultiphysics import VariableUtils
 from KratosMultiphysics.kratos_utilities import CheckIfApplicationsAvailable
 
 from KratosMultiphysics.RANSApplication import RansVariableUtilities
+from KratosMultiphysics.RANSApplication import RansCalculationUtilities
 
 if (IsDistributedRun() and CheckIfApplicationsAvailable("TrilinosApplication")):
     from KratosMultiphysics.TrilinosApplication import TrilinosBlockBuilderAndSolverPeriodic
@@ -209,6 +210,16 @@ def InitializePeriodicConditions(
             periodic_condition = model_part.CreateNewCondition(
                 periodic_condition_name, index, node_id_list, properties)
             periodic_condition.Set(Kratos.PERIODIC)
+
+def InitializeWallLawProperties(model):
+    for model_part_name in model.GetModelPartNames():
+        for properties in model[model_part_name].Properties:
+            # logarithmic wall law
+            if (properties.Has(KratosRANS.WALL_VON_KARMAN) and properties.Has(KratosRANS.WALL_SMOOTHNESS_BETA)):
+                von_karman = properties.GetValue(KratosRANS.WALL_VON_KARMAN)
+                beta = properties.GetValue(KratosRANS.WALL_SMOOTHNESS_BETA)
+                y_plus_limit = RansCalculationUtilities.CalculateLogarithmicYPlusLimit(von_karman, beta)
+                properties.SetValue(KratosRANS.RANS_LINEAR_LOG_LAW_Y_PLUS_LIMIT, y_plus_limit)
 
 
 def GetBoundaryFlags(boundary_flags_parameters):

--- a/applications/RANSApplication/tests/BackwardFacingStepTest/backward_facing_step_material_properties.json
+++ b/applications/RANSApplication/tests/BackwardFacingStepTest/backward_facing_step_material_properties.json
@@ -1,12 +1,17 @@
 {
     "properties": [
         {
-            "model_part_name": "FluidModelPart.Parts_fluid",
+            "model_part_name": "FluidModelPart",
             "properties_id": 2,
             "Material": {
+                "constitutive_law" : {
+                    "name" : "RansNewtonian2DLaw"
+                },
                 "Variables": {
                     "DENSITY": 1.0,
-                    "DYNAMIC_VISCOSITY": 100.0
+                    "DYNAMIC_VISCOSITY": 100.0,
+                    "WALL_VON_KARMAN": 0.41,
+                    "WALL_SMOOTHNESS_BETA": 5.2
                 },
                 "Tables": {}
             }

--- a/applications/RANSApplication/tests/ChannelFlowTest/channel_flow_material_properties.json
+++ b/applications/RANSApplication/tests/ChannelFlowTest/channel_flow_material_properties.json
@@ -1,12 +1,17 @@
 {
     "properties": [
         {
-            "model_part_name": "FluidModelPart.Parts_fluid",
+            "model_part_name": "FluidModelPart",
             "properties_id": 2,
             "Material": {
+                "constitutive_law" : {
+                    "name" : "RansNewtonian2DLaw"
+                },
                 "Variables": {
                     "DENSITY": 1.0,
-                    "DYNAMIC_VISCOSITY": 1e-2
+                    "DYNAMIC_VISCOSITY": 1e-2,
+                    "WALL_VON_KARMAN": 0.41,
+                    "WALL_SMOOTHNESS_BETA": 5.2
                 },
                 "Tables": {}
             }

--- a/applications/RANSApplication/tests/cpp/k_epsilon/test_utilities.cpp
+++ b/applications/RANSApplication/tests/cpp/k_epsilon/test_utilities.cpp
@@ -46,10 +46,15 @@ ModelPart& RansKEpsilonK2D3NSetUp(
         rModelPart.AddNodalSolutionStepVariable(RANS_AUXILIARY_VARIABLE_1);
     };
 
+    const auto set_properties = [](Properties& rProperties) {
+        rProperties.SetValue(DENSITY, 1.0);
+        rProperties.SetValue(DYNAMIC_VISCOSITY, 1e-2);
+    };
+
     using namespace RansApplicationTestUtilities;
 
     auto& r_model_part = CreateScalarVariableTestModelPart(
-        rModel, rElementName, "LineCondition2D2N", add_variables_function,
+        rModel, rElementName, "LineCondition2D2N", add_variables_function, set_properties,
         TURBULENT_KINETIC_ENERGY, 1);
 
     // set nodal historical variables
@@ -58,8 +63,6 @@ ModelPart& RansKEpsilonK2D3NSetUp(
     RandomFillNodalHistoricalVariable(r_model_part, TURBULENT_KINETIC_ENERGY, 1.0, 100.0);
     RandomFillNodalHistoricalVariable(r_model_part, TURBULENT_KINETIC_ENERGY_RATE, 1.0, 50.0);
     RandomFillNodalHistoricalVariable(r_model_part, RANS_AUXILIARY_VARIABLE_1, 1.0, 10.0);
-
-    VariableUtils().SetVariable(KINEMATIC_VISCOSITY, 1e-2, r_model_part.Nodes());
 
     // set process info variables
     auto& r_process_info = r_model_part.GetProcessInfo();
@@ -83,10 +86,15 @@ ModelPart& RansKEpsilonEpsilon2D3NSetUp(
         rModelPart.AddNodalSolutionStepVariable(RANS_AUXILIARY_VARIABLE_2);
     };
 
+    const auto set_properties = [](Properties& rProperties) {
+        rProperties.SetValue(DENSITY, 1.0);
+        rProperties.SetValue(DYNAMIC_VISCOSITY, 1e-2);
+    };
+
     using namespace RansApplicationTestUtilities;
 
     auto& r_model_part = CreateScalarVariableTestModelPart(
-        rModel, rElementName, "LineCondition2D2N", add_variables_function,
+        rModel, rElementName, "LineCondition2D2N", add_variables_function, set_properties,
         TURBULENT_ENERGY_DISSIPATION_RATE, 1);
 
     // set nodal historical variables
@@ -96,8 +104,6 @@ ModelPart& RansKEpsilonEpsilon2D3NSetUp(
     RandomFillNodalHistoricalVariable(r_model_part, TURBULENT_ENERGY_DISSIPATION_RATE, 1.0, 1000.0);
     RandomFillNodalHistoricalVariable(r_model_part, TURBULENT_ENERGY_DISSIPATION_RATE_2, 1.0, 1000.0);
     RandomFillNodalHistoricalVariable(r_model_part, RANS_AUXILIARY_VARIABLE_2, 1.0, 10.0);
-
-    VariableUtils().SetVariable(KINEMATIC_VISCOSITY, 1e-2, r_model_part.Nodes());
 
     // set process info variables
     auto& r_process_info = r_model_part.GetProcessInfo();
@@ -122,10 +128,18 @@ ModelPart& RansKEpsilonEpsilon2D2NSetUp(
         rModelPart.AddNodalSolutionStepVariable(TURBULENT_ENERGY_DISSIPATION_RATE_2);
     };
 
+    const auto set_properties = [](Properties& rProperties) {
+        rProperties.SetValue(DENSITY, 1.0);
+        rProperties.SetValue(DYNAMIC_VISCOSITY, 1e-2);
+        rProperties.SetValue(WALL_VON_KARMAN, 3.1);
+        rProperties.SetValue(WALL_SMOOTHNESS_BETA, 4.2);
+        rProperties.SetValue(RANS_LINEAR_LOG_LAW_Y_PLUS_LIMIT, 12.0);
+    };
+
     using namespace RansApplicationTestUtilities;
 
     auto& r_model_part = CreateScalarVariableTestModelPart(
-        rModel, "Element2D3N", rConditionName, add_variables_function,
+        rModel, "Element2D3N", rConditionName, add_variables_function, set_properties,
         TURBULENT_ENERGY_DISSIPATION_RATE, 1);
 
     // set nodal historical variables

--- a/applications/RANSApplication/tests/cpp/k_omega/test_utilities.cpp
+++ b/applications/RANSApplication/tests/cpp/k_omega/test_utilities.cpp
@@ -47,10 +47,15 @@ ModelPart& RansKOmegaK2D3NSetUp(
         rModelPart.AddNodalSolutionStepVariable(RANS_AUXILIARY_VARIABLE_1);
     };
 
+    const auto set_properties = [](Properties& rProperties) {
+        rProperties.SetValue(DENSITY, 1.0);
+        rProperties.SetValue(DYNAMIC_VISCOSITY, 1e-2);
+    };
+
     using namespace RansApplicationTestUtilities;
 
     auto& r_model_part = CreateScalarVariableTestModelPart(
-        rModel, rElementName, "LineCondition2D2N", add_variables_function,
+        rModel, rElementName, "LineCondition2D2N", add_variables_function, set_properties,
         TURBULENT_KINETIC_ENERGY, 1);
 
     // set nodal historical variables
@@ -60,8 +65,6 @@ ModelPart& RansKOmegaK2D3NSetUp(
     RandomFillNodalHistoricalVariable(r_model_part, TURBULENT_KINETIC_ENERGY_RATE, 1.0, 50.0);
     RandomFillNodalHistoricalVariable(r_model_part, TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE, 1.0, 1000.0);
     RandomFillNodalHistoricalVariable(r_model_part, RANS_AUXILIARY_VARIABLE_1, 1.0, 10.0);
-
-    VariableUtils().SetVariable(KINEMATIC_VISCOSITY, 1e-2, r_model_part.Nodes());
 
     // set process info variables
     auto& r_process_info = r_model_part.GetProcessInfo();
@@ -85,10 +88,15 @@ ModelPart& RansKOmegaOmega2D3NSetUp(
         rModelPart.AddNodalSolutionStepVariable(RANS_AUXILIARY_VARIABLE_2);
     };
 
+    const auto set_properties = [](Properties& rProperties) {
+        rProperties.SetValue(DENSITY, 1.0);
+        rProperties.SetValue(DYNAMIC_VISCOSITY, 1e-2);
+    };
+
     using namespace RansApplicationTestUtilities;
 
     auto& r_model_part = CreateScalarVariableTestModelPart(
-        rModel, rElementName, "LineCondition2D2N", add_variables_function,
+        rModel, rElementName, "LineCondition2D2N", add_variables_function, set_properties,
         TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE, 1);
 
     // set nodal historical variables
@@ -98,8 +106,6 @@ ModelPart& RansKOmegaOmega2D3NSetUp(
     RandomFillNodalHistoricalVariable(r_model_part, TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE, 1.0, 1000.0);
     RandomFillNodalHistoricalVariable(r_model_part, TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE_2, 1.0, 1000.0);
     RandomFillNodalHistoricalVariable(r_model_part, RANS_AUXILIARY_VARIABLE_2, 1.0, 10.0);
-
-    VariableUtils().SetVariable(KINEMATIC_VISCOSITY, 1e-2, r_model_part.Nodes());
 
     // set process info variables
     auto& r_process_info = r_model_part.GetProcessInfo();
@@ -123,10 +129,18 @@ ModelPart& RansKOmegaOmega2D2NSetUp(
         rModelPart.AddNodalSolutionStepVariable(TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE_2);
     };
 
+    const auto set_properties = [](Properties& rProperties) {
+        rProperties.SetValue(DENSITY, 1.0);
+        rProperties.SetValue(DYNAMIC_VISCOSITY, 1e-2);
+        rProperties.SetValue(WALL_VON_KARMAN, 3.1);
+        rProperties.SetValue(WALL_SMOOTHNESS_BETA, 4.2);
+        rProperties.SetValue(RANS_LINEAR_LOG_LAW_Y_PLUS_LIMIT, 12.0);
+    };
+
     using namespace RansApplicationTestUtilities;
 
     auto& r_model_part = CreateScalarVariableTestModelPart(
-        rModel, "Element2D3N", rConditionName, add_variables_function,
+        rModel, "Element2D3N", rConditionName, add_variables_function, set_properties,
         TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE, 1);
 
     // set nodal historical variables

--- a/applications/RANSApplication/tests/cpp/k_omega_sst/test_utilities.cpp
+++ b/applications/RANSApplication/tests/cpp/k_omega_sst/test_utilities.cpp
@@ -48,10 +48,15 @@ ModelPart& RansKOmegaSSTK2D3NSetUp(
         rModelPart.AddNodalSolutionStepVariable(DISTANCE);
     };
 
+    const auto set_properties = [](Properties& rProperties) {
+        rProperties.SetValue(DENSITY, 1.0);
+        rProperties.SetValue(DYNAMIC_VISCOSITY, 1e-2);
+    };
+
     using namespace RansApplicationTestUtilities;
 
     auto& r_model_part = CreateScalarVariableTestModelPart(
-        rModel, rElementName, "LineCondition2D2N", add_variables_function,
+        rModel, rElementName, "LineCondition2D2N", add_variables_function, set_properties,
         TURBULENT_KINETIC_ENERGY, 1);
 
     // set nodal historical variables
@@ -63,8 +68,6 @@ ModelPart& RansKOmegaSSTK2D3NSetUp(
         r_model_part, TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE, 1.0, 1000.0);
     RandomFillNodalHistoricalVariable(r_model_part, RANS_AUXILIARY_VARIABLE_1, 1.0, 10.0);
     RandomFillNodalHistoricalVariable(r_model_part, DISTANCE, 1.0, 6.0);
-
-    VariableUtils().SetVariable(KINEMATIC_VISCOSITY, 1e-2, r_model_part.Nodes());
 
     // set process info variables
     auto& r_process_info = r_model_part.GetProcessInfo();
@@ -91,10 +94,16 @@ ModelPart& RansKOmegaSSTOmega2D3NSetUp(
         rModelPart.AddNodalSolutionStepVariable(DISTANCE);
     };
 
+    const auto set_properties = [](Properties& rProperties) {
+        rProperties.SetValue(DENSITY, 1.0);
+        rProperties.SetValue(DYNAMIC_VISCOSITY, 1e-2);
+        rProperties.SetValue(WALL_VON_KARMAN, 5.2);
+    };
+
     using namespace RansApplicationTestUtilities;
 
     auto& r_model_part = CreateScalarVariableTestModelPart(
-        rModel, rElementName, "LineCondition2D2N", add_variables_function,
+        rModel, rElementName, "LineCondition2D2N", add_variables_function, set_properties,
         TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE, 1);
 
     // set nodal historical variables
@@ -108,8 +117,6 @@ ModelPart& RansKOmegaSSTOmega2D3NSetUp(
     RandomFillNodalHistoricalVariable(r_model_part, RANS_AUXILIARY_VARIABLE_2, 1.0, 10.0);
     RandomFillNodalHistoricalVariable(r_model_part, DISTANCE, 1.0, 6.0);
 
-    VariableUtils().SetVariable(KINEMATIC_VISCOSITY, 1e-2, r_model_part.Nodes());
-
     // set process info variables
     auto& r_process_info = r_model_part.GetProcessInfo();
     r_process_info.SetValue(TURBULENCE_RANS_BETA_1, 3.1);
@@ -117,7 +124,6 @@ ModelPart& RansKOmegaSSTOmega2D3NSetUp(
     r_process_info.SetValue(TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE_SIGMA_1, 1.1);
     r_process_info.SetValue(TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE_SIGMA_2, 2.1);
     r_process_info.SetValue(TURBULENCE_RANS_C_MU, 0.4);
-    r_process_info.SetValue(WALL_VON_KARMAN, 5.2);
 
     return r_model_part;
 }

--- a/applications/RANSApplication/tests/cpp/test_incompressible_potential_flow_conditions.cpp
+++ b/applications/RANSApplication/tests/cpp/test_incompressible_potential_flow_conditions.cpp
@@ -37,12 +37,15 @@ ModelPart& RansIncompressiblePotentialFlowVelocityInlet2D2NSetUp(
         rModelPart.AddNodalSolutionStepVariable(VELOCITY);
     };
 
+    const auto set_properties = [](Properties& rProperties) {
+    };
+
     using namespace RansApplicationTestUtilities;
 
     auto& r_model_part = CreateScalarVariableTestModelPart(
         rModel, "Element2D3N",
         "RansIncompressiblePotentialFlowVelocityInlet2D2N",
-        add_variables_function, VELOCITY_POTENTIAL, 1);
+        add_variables_function, set_properties, VELOCITY_POTENTIAL, 1);
 
     // set nodal historical variables
     RandomFillNodalHistoricalVariable(r_model_part, VELOCITY_POTENTIAL, -10.0, 10.0);

--- a/applications/RANSApplication/tests/cpp/test_incompressible_potential_flow_elements.cpp
+++ b/applications/RANSApplication/tests/cpp/test_incompressible_potential_flow_elements.cpp
@@ -36,11 +36,14 @@ ModelPart& RansIncompressiblePotentialFlowVelocity2D3NSetUp(
         rModelPart.AddNodalSolutionStepVariable(VELOCITY_POTENTIAL);
     };
 
+    const auto set_properties = [](Properties& rProperties) {
+    };
+
     using namespace RansApplicationTestUtilities;
 
     auto& r_model_part = CreateScalarVariableTestModelPart(
         rModel, "RansIncompressiblePotentialFlowVelocity2D3N",
-        "LineCondition2D2N", add_variables_function, VELOCITY_POTENTIAL, 1);
+        "LineCondition2D2N", add_variables_function, set_properties, VELOCITY_POTENTIAL, 1);
 
     // set nodal historical variables
     RandomFillNodalHistoricalVariable(r_model_part, VELOCITY_POTENTIAL, -10.0, 10.0);

--- a/applications/RANSApplication/tests/cpp/test_vms_monolithic_k_based_condition.cpp
+++ b/applications/RANSApplication/tests/cpp/test_vms_monolithic_k_based_condition.cpp
@@ -44,6 +44,14 @@ ModelPart& RansVMSMonolithicKBasedWall2D2NSetUp(Model& rModel)
         rModelPart.AddNodalSolutionStepVariable(TURBULENT_KINETIC_ENERGY);
     };
 
+    const auto set_properties = [](Properties& rProperties) {
+        rProperties.SetValue(DENSITY, 2.0);
+        rProperties.SetValue(DYNAMIC_VISCOSITY, 2e-2);
+        rProperties.SetValue(WALL_VON_KARMAN, 3.1);
+        rProperties.SetValue(WALL_SMOOTHNESS_BETA, 4.2);
+        rProperties.SetValue(RANS_LINEAR_LOG_LAW_Y_PLUS_LIMIT, 12.0);
+    };
+
     using namespace RansApplicationTestUtilities;
 
     auto& r_model_part = CreateTestModelPart(
@@ -54,6 +62,7 @@ ModelPart& RansVMSMonolithicKBasedWall2D2NSetUp(Model& rModel)
             rNode.AddDof(VELOCITY_Z).SetEquationId(rNode.Id() * 4 + 2);
             rNode.AddDof(PRESSURE).SetEquationId(rNode.Id() * 4 + 3);
         },
+        set_properties,
         1);
 
     // set nodal historical variables

--- a/applications/RANSApplication/tests/custom_process_tests.py
+++ b/applications/RANSApplication/tests/custom_process_tests.py
@@ -13,7 +13,7 @@ class CustomProcessTest(UnitTest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.model = Kratos.Model()
-        cls.model_part = cls.model.CreateModelPart("test")
+        cls.model_part = cls.model.CreateModelPart("FluidModelPart")
 
         # add required variables to solution step list
         cls.model_part.AddNodalSolutionStepVariable(Kratos.VELOCITY)
@@ -37,6 +37,23 @@ class CustomProcessTest(UnitTest.TestCase):
         cls.model_part.ProcessInfo.SetValue(Kratos.STEP, 1)
 
         ReadModelPart("BackwardFacingStepTest/backward_facing_step", cls.model_part)
+        CheckAndPrepareModelProcess(cls.model_part,
+                                    Kratos.Parameters("""{
+            "volume_model_part_name": "Parts_fluid",
+            "skin_parts" : ["AutomaticInlet2D_inlet", "Outlet2D_outlet", "Slip2D"],
+            "assign_neighbour_elements_to_conditions": true
+        }""")).Execute()
+
+        # Add constitutive laws and material properties from json file to model parts.
+        material_settings = Kratos.Parameters(
+            """{
+                "Parameters": {
+                        "materials_filename": "BackwardFacingStepTest/backward_facing_step_material_properties.json"
+                    }
+                }""")
+
+        Kratos.ReadMaterialsUtility(material_settings, cls.model)
+        KratosRANS.RansVariableUtilities.SetElementConstitutiveLaws(cls.model_part.Elements)
 
     def setUp(self):
         # reinitialize variables for each test
@@ -57,7 +74,7 @@ class CustomProcessTest(UnitTest.TestCase):
                 "python_module" : "cpp_process_factory",
                 "process_name"  : "CheckScalarBoundsProcess",
                 "Parameters" : {
-                    "model_part_name"                : "test",
+                    "model_part_name"                : "FluidModelPart",
                     "variable_name"                  : "DENSITY"
                 }
             }
@@ -75,7 +92,7 @@ class CustomProcessTest(UnitTest.TestCase):
                 "python_module" : "cpp_process_factory",
                 "process_name"  : "ClipScalarVariableProcess",
                 "Parameters" : {
-                    "model_part_name"                : "test",
+                    "model_part_name"                : "FluidModelPart",
                     "variable_name"                  : "DENSITY",
                     "min_value"                      : 20.0,
                     "max_value"                      : 60.0
@@ -100,7 +117,7 @@ class CustomProcessTest(UnitTest.TestCase):
                 "python_module" : "cpp_process_factory",
                 "process_name"  : "ApplyFlagProcess",
                 "Parameters" : {
-                    "model_part_name"                : "test.Slip2D.Slip2D_walls",
+                    "model_part_name"                : "FluidModelPart.Slip2D.Slip2D_walls",
                     "echo_level"                     : 0,
                     "flag_variable_name"             : "STRUCTURE",
                     "flag_variable_value"            : true,
@@ -112,7 +129,7 @@ class CustomProcessTest(UnitTest.TestCase):
                 "python_module" : "cpp_process_factory",
                 "process_name"  : "ApplyFlagProcess",
                 "Parameters" : {
-                    "model_part_name"                : "test.AutomaticInlet2D_inlet",
+                    "model_part_name"                : "FluidModelPart.AutomaticInlet2D_inlet",
                     "echo_level"                     : 0,
                     "flag_variable_name"             : "INLET",
                     "flag_variable_value"            : true,
@@ -125,17 +142,17 @@ class CustomProcessTest(UnitTest.TestCase):
         self.process_list = factory.ConstructListOfProcesses(settings)
         self.__ExecuteProcesses()
 
-        for node in self.model.GetModelPart("test.AutomaticInlet2D_inlet").Nodes:
+        for node in self.model.GetModelPart("FluidModelPart.AutomaticInlet2D_inlet").Nodes:
             self.assertEqual(node.Is(Kratos.INLET), True)
 
-        for condition in self.model.GetModelPart("test.AutomaticInlet2D_inlet").Conditions:
+        for condition in self.model.GetModelPart("FluidModelPart.AutomaticInlet2D_inlet").Conditions:
             self.assertEqual(condition.Is(Kratos.INLET), True)
             self.assertEqual(condition.Is(Kratos.STRUCTURE), False)
 
-        for node in self.model.GetModelPart("test.Slip2D.Slip2D_walls").Nodes:
+        for node in self.model.GetModelPart("FluidModelPart.Slip2D.Slip2D_walls").Nodes:
             self.assertEqual(node.Is(Kratos.STRUCTURE), True)
 
-        for condition in self.model.GetModelPart("test.Slip2D.Slip2D_walls").Conditions:
+        for condition in self.model.GetModelPart("FluidModelPart.Slip2D.Slip2D_walls").Conditions:
             self.assertEqual(condition.Is(Kratos.STRUCTURE), True)
             self.assertEqual(condition.Is(Kratos.INLET), False)
 
@@ -147,7 +164,7 @@ class CustomProcessTest(UnitTest.TestCase):
                 "python_module" : "cpp_process_factory",
                 "process_name"  : "LineOutputProcess",
                 "Parameters" : {
-                    "model_part_name"                   : "test",
+                    "model_part_name"                   : "FluidModelPart",
                     "variable_names_list"               : ["DENSITY", "VELOCITY"],
                     "historical_value"                  : true,
                     "start_point"                       : [-0.09, 0.01, 0.0],
@@ -164,7 +181,7 @@ class CustomProcessTest(UnitTest.TestCase):
                 "python_module" : "cpp_process_factory",
                 "process_name"  : "LineOutputProcess",
                 "Parameters" : {
-                    "model_part_name"                   : "test",
+                    "model_part_name"                   : "FluidModelPart",
                     "variable_names_list"               : [
                         "DENSITY",
                         "VELOCITY",
@@ -238,7 +255,7 @@ class CustomProcessTest(UnitTest.TestCase):
                 "python_module" : "cpp_process_factory",
                 "process_name"  : "KTurbulentIntensityInletProcess",
                 "Parameters" : {
-                    "model_part_name"     : "test.AutomaticInlet2D_inlet",
+                    "model_part_name"     : "FluidModelPart.AutomaticInlet2D_inlet",
                     "turbulent_intensity" : 0.01
                 }
             }
@@ -247,7 +264,7 @@ class CustomProcessTest(UnitTest.TestCase):
         Kratos.VariableUtils().AddDof(KratosRANS.TURBULENT_KINETIC_ENERGY, self.model_part)
 
         test_variables = ["TURBULENT_KINETIC_ENERGY"]
-        test_model_part_name = "test.AutomaticInlet2D_inlet"
+        test_model_part_name = "FluidModelPart.AutomaticInlet2D_inlet"
         test_file_name = "k_turbulent_intensity_inlet_test_output"
         CustomProcessTest.__AddJsonCheckProcess(settings, test_variables, test_model_part_name, test_file_name)
         # CustomProcessTest.__AddJsonOutputProcess(settings, test_variables, test_model_part_name, test_file_name)
@@ -267,14 +284,14 @@ class CustomProcessTest(UnitTest.TestCase):
                 "python_module" : "cpp_process_factory",
                 "process_name"  : "EpsilonTurbulentMixingLengthInletProcess",
                 "Parameters" : {
-                    "model_part_name"         : "test.AutomaticInlet2D_inlet",
+                    "model_part_name"         : "FluidModelPart.AutomaticInlet2D_inlet",
                     "turbulent_mixing_length" : 0.005
                 }
             }
         ]''')
 
         test_variables = ["TURBULENT_ENERGY_DISSIPATION_RATE"]
-        test_model_part_name = "test.AutomaticInlet2D_inlet"
+        test_model_part_name = "FluidModelPart.AutomaticInlet2D_inlet"
         test_file_name = "epsilon_turbulent_mixing_length_inlet_test_output"
         CustomProcessTest.__AddJsonCheckProcess(settings, test_variables, test_model_part_name, test_file_name)
         # CustomProcessTest.__AddJsonOutputProcess(settings, test_variables, test_model_part_name, test_file_name)
@@ -296,7 +313,7 @@ class CustomProcessTest(UnitTest.TestCase):
                 "python_module" : "cpp_process_factory",
                 "process_name"  : "OmegaTurbulentMixingLengthInletProcess",
                 "Parameters" : {
-                    "model_part_name"     : "test"
+                    "model_part_name"     : "FluidModelPart"
                 }
             }
         ]''')
@@ -304,7 +321,7 @@ class CustomProcessTest(UnitTest.TestCase):
         Kratos.VariableUtils().AddDof(KratosRANS.TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE, self.model_part)
 
         test_variables = ["TURBULENT_SPECIFIC_ENERGY_DISSIPATION_RATE"]
-        test_model_part_name = "test.AutomaticInlet2D_inlet"
+        test_model_part_name = "FluidModelPart.AutomaticInlet2D_inlet"
         test_file_name = "omega_turbulent_mixing_length_inlet_test_output"
         CustomProcessTest.__AddJsonCheckProcess(settings, test_variables, test_model_part_name, test_file_name)
         # CustomProcessTest.__AddJsonOutputProcess(settings, test_variables, test_model_part_name, test_file_name)
@@ -324,13 +341,13 @@ class CustomProcessTest(UnitTest.TestCase):
                 "python_module" : "cpp_process_factory",
                 "process_name"  : "NutKEpsilonUpdateProcess",
                 "Parameters" : {
-                    "model_part_name"     : "test"
+                    "model_part_name"     : "FluidModelPart"
                 }
             }
         ]''')
 
         test_variables = ["TURBULENT_VISCOSITY", "VISCOSITY"]
-        test_model_part_name = "test.AutomaticInlet2D_inlet"
+        test_model_part_name = "FluidModelPart.AutomaticInlet2D_inlet"
         test_file_name = "nut_k_epsilon_test_output"
         CustomProcessTest.__AddJsonCheckProcess(settings, test_variables, test_model_part_name, test_file_name)
         # CustomProcessTest.__AddJsonOutputProcess(settings, test_variables, test_model_part_name, test_file_name)
@@ -347,13 +364,13 @@ class CustomProcessTest(UnitTest.TestCase):
                 "python_module" : "cpp_process_factory",
                 "process_name"  : "NutKOmegaUpdateProcess",
                 "Parameters" : {
-                    "model_part_name"     : "test"
+                    "model_part_name"     : "FluidModelPart"
                 }
             }
         ]''')
 
         test_variables = ["TURBULENT_VISCOSITY", "VISCOSITY"]
-        test_model_part_name = "test.AutomaticInlet2D_inlet"
+        test_model_part_name = "FluidModelPart.AutomaticInlet2D_inlet"
         test_file_name = "nut_k_omega_test_output"
         CustomProcessTest.__AddJsonCheckProcess(settings, test_variables, test_model_part_name, test_file_name)
         # CustomProcessTest.__AddJsonOutputProcess(settings, test_variables, test_model_part_name, test_file_name)
@@ -370,13 +387,13 @@ class CustomProcessTest(UnitTest.TestCase):
                 "python_module" : "cpp_process_factory",
                 "process_name"  : "NutKOmegaSSTUpdateProcess",
                 "Parameters" : {
-                    "model_part_name"     : "test"
+                    "model_part_name"     : "FluidModelPart"
                 }
             }
         ]''')
 
         test_variables = ["TURBULENT_VISCOSITY", "VISCOSITY"]
-        test_model_part_name = "test.AutomaticInlet2D_inlet"
+        test_model_part_name = "FluidModelPart.AutomaticInlet2D_inlet"
         test_file_name = "nut_k_omega_sst_test_output"
         CustomProcessTest.__AddJsonCheckProcess(settings, test_variables, test_model_part_name, test_file_name)
         # CustomProcessTest.__AddJsonOutputProcess(settings, test_variables, test_model_part_name, test_file_name)
@@ -393,15 +410,15 @@ class CustomProcessTest(UnitTest.TestCase):
                 "python_module" : "cpp_process_factory",
                 "process_name"  : "NutYPlusWallFunctionUpdateProcess",
                 "Parameters" : {
-                    "model_part_name"     : "test"
+                    "model_part_name"     : "FluidModelPart"
                 }
             }
         ]''')
 
-        KratosRANS.RansTestUtilities.RandomFillConditionVariable(self.model.GetModelPart("test"), KratosRANS.RANS_Y_PLUS, 10.0, 100.0)
+        KratosRANS.RansTestUtilities.RandomFillConditionVariable(self.model.GetModelPart("FluidModelPart"), KratosRANS.RANS_Y_PLUS, 10.0, 100.0)
 
         test_variables = ["TURBULENT_VISCOSITY", "VISCOSITY"]
-        test_model_part_name = "test.AutomaticInlet2D_inlet"
+        test_model_part_name = "FluidModelPart.AutomaticInlet2D_inlet"
         test_file_name = "nut_y_plus_wall_function_test_output"
         CustomProcessTest.__AddJsonCheckProcess(settings, test_variables, test_model_part_name, test_file_name)
         # CustomProcessTest.__AddJsonOutputProcess(settings, test_variables, test_model_part_name, test_file_name)
@@ -418,15 +435,15 @@ class CustomProcessTest(UnitTest.TestCase):
                 "python_module" : "cpp_process_factory",
                 "process_name"  : "ComputeReactionsProcess",
                 "Parameters" : {
-                    "model_part_name"     : "test"
+                    "model_part_name"     : "FluidModelPart"
                 }
             }
         ]''')
 
-        KratosRANS.RansTestUtilities.RandomFillConditionVariable(self.model.GetModelPart("test"), KratosRANS.FRICTION_VELOCITY, 10.0, 100.0)
+        KratosRANS.RansTestUtilities.RandomFillConditionVariable(self.model.GetModelPart("FluidModelPart"), KratosRANS.FRICTION_VELOCITY, 10.0, 100.0)
 
         test_variables = ["REACTION"]
-        test_model_part_name = "test.Slip2D.Slip2D_walls"
+        test_model_part_name = "FluidModelPart.Slip2D.Slip2D_walls"
         test_file_name = "compute_reactions_test_output"
         CustomProcessTest.__AddJsonCheckProcess(settings, test_variables, test_model_part_name, test_file_name)
         # CustomProcessTest.__AddJsonOutputProcess(settings, test_variables, test_model_part_name, test_file_name)
@@ -443,8 +460,8 @@ class CustomProcessTest(UnitTest.TestCase):
                 "python_module" : "cpp_process_factory",
                 "process_name"  : "WallDistanceCalculationProcess",
                 "Parameters" : {
-                    "main_model_part_name"             : "test",
-                    "wall_model_part_name"             : "test.Slip2D.Slip2D_walls",
+                    "main_model_part_name"             : "FluidModelPart",
+                    "wall_model_part_name"             : "FluidModelPart.Slip2D.Slip2D_walls",
                     "echo_level"                       : 0,
                     "max_distance"                     : 1e+30,
                     "max_levels"                       : 14,
@@ -454,17 +471,11 @@ class CustomProcessTest(UnitTest.TestCase):
         ]''')
 
         test_variables = ["DISTANCE"]
-        test_model_part_name = "test"
+        test_model_part_name = "FluidModelPart"
         test_file_name = "wall_distance_calculation_test_output"
         CustomProcessTest.__AddJsonCheckProcess(settings, test_variables, test_model_part_name, test_file_name)
         # CustomProcessTest.__AddJsonOutputProcess(settings, test_variables, test_model_part_name, test_file_name)
 
-        CheckAndPrepareModelProcess(self.model_part,
-                                    Kratos.Parameters("""{
-            "volume_model_part_name": "Parts_fluid",
-            "skin_parts" : ["AutomaticInlet2D_inlet", "Outlet2D_outlet", "Slip2D"],
-            "assign_neighbour_elements_to_conditions": true
-        }""")).Execute()
         CalculateNormalsOnConditions(self.model_part)
 
         factory = KratosProcessFactory(self.model)


### PR DESCRIPTION
**Description**
This PR updates RANS elements and their corresponding unit tests to use Constitutive laws. 

**Changelog**
- Updated RANS elements to use Constitutive laws.
- Updated unit tests
- Remove virtual method overrides for templates to avoid searching through vtable.
