### PR TITLE
[FastPR][Hotfix][Fluid] Add dynamic_tau to dvms formulation settings

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
@@ -103,6 +103,7 @@ class StabilizedFormulation(object):
     def _SetUpDVMS(self,settings):
         default_settings = KratosMultiphysics.Parameters(r"""{
             "element_type": "dvms",
+            "dynamic_tau": 0.0,
             "use_orthogonal_subscales": false
         }""")
         settings.ValidateAndAssignDefaults(default_settings)
@@ -110,6 +111,7 @@ class StabilizedFormulation(object):
         self.element_name = "DVMS"
         self.condition_name = "NavierStokesWallCondition"
 
+        self.process_data[KratosMultiphysics.DYNAMIC_TAU] = settings["dynamic_tau"].GetDouble()
         use_oss = settings["use_orthogonal_subscales"].GetBool()
         self.process_data[KratosMultiphysics.OSS_SWITCH] = int(use_oss)
 


### PR DESCRIPTION
**Description**
This exposes the `dynamic_tau` usage in the `DVMS` formulation field. 
