### PR TITLE
[Core] Clean up deprecated import

### DIFF
--- a/kratos/python_scripts/run_tests.py
+++ b/kratos/python_scripts/run_tests.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import os
 import re
 import sys


### PR DESCRIPTION
**Description**
We do not support python 2.7 anymore

**Changelog**
- Remove legacy import
