### PR TITLE
adding custom exception hook to also add the source rank in MPI

### DIFF
--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -38,6 +38,22 @@ def __ModuleInitDetail():
             import KratosMultiphysics.mpi
             mpi.InitializeMPIParallelRun()
             using_mpi = True
+
+            def CustomExceptionHook(exc_type, exc_value, exc_traceback):
+                """custom exception hook that also prints the source rank where the exception was thrown"""
+                if issubclass(exc_type, KeyboardInterrupt):
+                    # call the default excepthook saved at __excepthook__
+                    sys.__excepthook__(exc_type, exc_value, exc_traceback)
+                    return
+
+                from KratosMultiphysics import DataCommunicator
+                default_data_comm = DataCommunicator.GetDefault()
+
+                exc_value = exc_type("(on rank {}): {}".format(DataCommunicator.GetDefault().Rank(), exc_value))
+                sys.__excepthook__(exc_type, exc_value, exc_traceback)
+
+            sys.excepthook = CustomExceptionHook
+
         else:
             if mpi_requested:
                 msg = [

--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -40,15 +40,13 @@ def __ModuleInitDetail():
             using_mpi = True
 
             def CustomExceptionHook(exc_type, exc_value, exc_traceback):
-                """custom exception hook that also prints the source rank where the exception was thrown"""
+                """custom exception hook that also prints the source rank where the exception was thrown."""
                 if issubclass(exc_type, KeyboardInterrupt):
                     # call the default excepthook saved at __excepthook__
                     sys.__excepthook__(exc_type, exc_value, exc_traceback)
                     return
 
                 from KratosMultiphysics import DataCommunicator
-                default_data_comm = DataCommunicator.GetDefault()
-
                 exc_value = exc_type("(on rank {}): {}".format(DataCommunicator.GetDefault().Rank(), exc_value))
                 sys.__excepthook__(exc_type, exc_value, exc_traceback)
 

--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -40,7 +40,7 @@ def __ModuleInitDetail():
             using_mpi = True
 
             def CustomExceptionHook(exc_type, exc_value, exc_traceback):
-                """custom exception hook that also prints the source rank where the exception was thrown."""
+                """Custom exception hook that also prints the source rank where the exception was thrown."""
                 if issubclass(exc_type, KeyboardInterrupt):
                     # call the default excepthook saved at __excepthook__
                     sys.__excepthook__(exc_type, exc_value, exc_traceback)


### PR DESCRIPTION
**Description**
Adding a custom exception hook (when running in MPI) which also prints the source rank where the exception is thrown
this is very helpful for debugging

e.g. 
~~~
Traceback (most recent call last):
  File "MainKratosCoSim.py", line 15, in <module>
    simulation.Run()
  File "/home/philipp/software/Kratos_prod/install/KratosMultiphysics/analysis_stage.py", line 50, in Run
    self.RunSolutionLoop()
  File "/home/philipp/software/Kratos_prod/install/KratosMultiphysics/analysis_stage.py", line 67, in RunSolutionLoop
    is_converged = self._GetSolver().SolveSolutionStep()
  File "/home/philipp/software/Kratos_prod/install/KratosMultiphysics/CoSimulationApplication/coupled_solvers/gauss_seidel_strong.py", line 83, in SolveSolutionStep
    self._SynchronizeInputData(solver_name)
  File "/home/philipp/software/Kratos_prod/install/KratosMultiphysics/CoSimulationApplication/base_classes/co_simulation_coupled_solver.py", line 213, in _SynchronizeInputData
    self.__SynchronizeData(i_data, from_solver_data, to_solver_data)
  File "/home/philipp/software/Kratos_prod/install/KratosMultiphysics/CoSimulationApplication/base_classes/co_simulation_coupled_solver.py", line 257, in __SynchronizeData
    self.__GetDataTransferOperator(data_transfer_operator_name).TransferData(from_solver_data, to_solver_data, i_data["data_transfer_operator_options"])
  File "/home/philipp/software/Kratos_prod/install/KratosMultiphysics/CoSimulationApplication/base_classes/co_simulation_data_transfer_operator.py", line 32, in TransferData
    self._ExecuteTransferData(from_solver_data, to_solver_data, transfer_options)
  File "/home/philipp/software/Kratos_prod/install/KratosMultiphysics/CoSimulationApplication/data_transfer_operators/kratos_mapping.py", line 41, in _ExecuteTransferData
    model_part_destination_name = to_solver_data.model_part_name
AttributeError: 'NoneType' object has no attribute 'model_part_name'
~~~

becomes:
~~~
Traceback (most recent call last):
  File "MainKratosCoSim.py", line 15, in <module>
    simulation.Run()
  File "/home/philipp/software/Kratos_prod/install/KratosMultiphysics/analysis_stage.py", line 50, in Run
    self.RunSolutionLoop()
  File "/home/philipp/software/Kratos_prod/install/KratosMultiphysics/analysis_stage.py", line 67, in RunSolutionLoop
    is_converged = self._GetSolver().SolveSolutionStep()
  File "/home/philipp/software/Kratos_prod/install/KratosMultiphysics/CoSimulationApplication/coupled_solvers/gauss_seidel_strong.py", line 83, in SolveSolutionStep
    self._SynchronizeInputData(solver_name)
  File "/home/philipp/software/Kratos_prod/install/KratosMultiphysics/CoSimulationApplication/base_classes/co_simulation_coupled_solver.py", line 213, in _SynchronizeInputData
    self.__SynchronizeData(i_data, from_solver_data, to_solver_data)
  File "/home/philipp/software/Kratos_prod/install/KratosMultiphysics/CoSimulationApplication/base_classes/co_simulation_coupled_solver.py", line 257, in __SynchronizeData
    self.__GetDataTransferOperator(data_transfer_operator_name).TransferData(from_solver_data, to_solver_data, i_data["data_transfer_operator_options"])
  File "/home/philipp/software/Kratos_prod/install/KratosMultiphysics/CoSimulationApplication/base_classes/co_simulation_data_transfer_operator.py", line 32, in TransferData
    self._ExecuteTransferData(from_solver_data, to_solver_data, transfer_options)
  File "/home/philipp/software/Kratos_prod/install/KratosMultiphysics/CoSimulationApplication/data_transfer_operators/kratos_mapping.py", line 41, in _ExecuteTransferData
    model_part_destination_name = to_solver_data.model_part_name
AttributeError: (on rank 1): 'NoneType' object has no attribute 'model_part_name'
~~~