### PR TITLE
[FastPR][Hotfix][Core] Assign by direction zero check

### DIFF
--- a/kratos/python_scripts/assign_vector_by_direction_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_process.py
@@ -90,7 +90,7 @@ class AssignVectorByDirectionProcess(KratosMultiphysics.Process):
                 # Compute the average conditions normal in the submodelpart of interest
                 avg_normal = KratosMultiphysics.VariableUtils().SumConditionVectorVariable(KratosMultiphysics.NORMAL, self.model_part)
                 avg_normal_norm = math.sqrt(pow(avg_normal[0],2) + pow(avg_normal[1],2) + pow(avg_normal[2],2))
-                if avg_normal_norm < 1.0e-6:
+                if avg_normal_norm < 1.0e-12:
                     raise Exception("Direction norm is close to 0 in AssignVectorByDirectionProcess.")
 
                 unit_direction = KratosMultiphysics.Vector(3)
@@ -115,7 +115,7 @@ class AssignVectorByDirectionProcess(KratosMultiphysics.Process):
             # Normalize direction
             if all_numeric:
                 direction_norm = math.sqrt(direction_norm)
-                if direction_norm < 1.0e-6:
+                if direction_norm < 1.0e-12:
                     raise Exception("Direction norm is close to 0 in AssignVectorByDirectionProcess.")
                 for i in range(0,3):
                     unit_direction[i] = unit_direction[i]/direction_norm


### PR DESCRIPTION
**Description**
The zero normal check in the `AssignVectorByDirection` process was too large. As reported by @soudah this can give problems in problems with small scales. This PR changes it to a more reasonable value.
