### PR TITLE
[Fluid] Fix nightly build with new amgcl_ns settings

### DIFF
--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/cylinder_test_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/cylinder_test_parameters.json
@@ -66,8 +66,7 @@
         "absolute_pressure_tolerance"  : 1e-5,
         "linear_solver_settings"       : {
             "solver_type"         : "amgcl_ns",
-            "verbosity"           : 0,
-            "coarse_enough"       : 500
+            "verbosity"           : 0
         },
         "volume_model_part_name"       : "Parts_Fluid",
         "skin_parts"                   : ["Inlet2D_Inlet","Outlet2D_Outlet","NoSlip2D_Wall","NoSlip2D_Cylinder"],


### PR DESCRIPTION
**Description**
A test in the fluid was not updated after the changes in the amgcl_ns in #7999 and the nightly build was failing. 

```
Running FluidDynamicsApplication tests
.............................................E.............
======================================================================
ERROR: testCylinder (adjoint_vms_sensitivity_2d.AdjointVMSSensitivity2D)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/__w/Kratos/Kratos/bin/Release/applications/FluidDynamicsApplication/tests/adjoint_vms_sensitivity_2d.py", line 134, in testCylinder
    self.solve('AdjointVMSSensitivity2DTest/cylinder_test')
  File "/__w/Kratos/Kratos/bin/Release/applications/FluidDynamicsApplication/tests/adjoint_vms_sensitivity_2d.py", line 107, in solve
    test.Run()
  File "/__w/Kratos/Kratos/bin/Release/KratosMultiphysics/analysis_stage.py", line 49, in Run
    self.Initialize()
  File "/__w/Kratos/Kratos/bin/Release/KratosMultiphysics/analysis_stage.py", line 95, in Initialize
    self._GetSolver().Initialize()
  File "/__w/Kratos/Kratos/bin/Release/KratosMultiphysics/FluidDynamicsApplication/navier_stokes_solver_vmsmonolithic.py", line 307, in Initialize
    solution_strategy = self._GetSolutionStrategy()
  File "/__w/Kratos/Kratos/bin/Release/KratosMultiphysics/FluidDynamicsApplication/fluid_solver.py", line 284, in _GetSolutionStrategy
    self._solution_strategy = self._CreateSolutionStrategy()
  File "/__w/Kratos/Kratos/bin/Release/KratosMultiphysics/FluidDynamicsApplication/fluid_solver.py", line 372, in _CreateSolutionStrategy
    solution_strategy = self._CreateNewtonRaphsonStrategy()
  File "/__w/Kratos/Kratos/bin/Release/KratosMultiphysics/FluidDynamicsApplication/fluid_solver.py", line 397, in _CreateNewtonRaphsonStrategy
    builder_and_solver = self._GetBuilderAndSolver()
  File "/__w/Kratos/Kratos/bin/Release/KratosMultiphysics/FluidDynamicsApplication/fluid_solver.py", line 279, in _GetBuilderAndSolver
    self._builder_and_solver = self._CreateBuilderAndSolver()
  File "/__w/Kratos/Kratos/bin/Release/KratosMultiphysics/FluidDynamicsApplication/fluid_solver.py", line 358, in _CreateBuilderAndSolver
    linear_solver = self._GetLinearSolver()
  File "/__w/Kratos/Kratos/bin/Release/KratosMultiphysics/FluidDynamicsApplication/fluid_solver.py", line 274, in _GetLinearSolver
    self._linear_solver = self._CreateLinearSolver()
  File "/__w/Kratos/Kratos/bin/Release/KratosMultiphysics/FluidDynamicsApplication/fluid_solver.py", line 343, in _CreateLinearSolver
    return linear_solver_factory.ConstructSolver(linear_solver_configuration)
  File "/__w/Kratos/Kratos/bin/Release/KratosMultiphysics/python_linear_solver_factory.py", line 33, in ConstructSolver
    return KM.LinearSolverFactory().Create(configuration)
RuntimeError: Error: The item with name "coarse_enough" is present in this Parameters but NOT in the default values
Hence Validation fails
Parameters being validated are : 
{
    "coarse_enough": 500,
    "solver_type": "amgcl_ns",
    "verbosity": 0
}
Defaults against which the current parameters are validated are :
{
    "inner_settings": {
        "precond": {
            "adjust_p": 0,
            "pmask_size": -1,
            "psolver": {
                "solver": {
                    "type": "preonly"
                }
            },
            "type": 2,
            "usolver": {
                "precond": {
                    "coarsening": {
                        "aggr": {
                            "eps_strong": 0
                        },
                        "type": "aggregation"
                    },
                    "relax": {
                        "type": "ilup"
                    }
                },
                "solver": {
                    "type": "preonly"
                }
            }
        },
        "solver": {
            "M": 50,
            "maxiter": 1000,
            "tol": 1e-08,
            "type": "lgmres",
            "verbose": true
        }
    },
    "scaling": false,
    "schur_variable": "PRESSURE",
    "solver_type": "amgcl_ns",
    "verbosity": 1
}




in kratos/sources/kratos_parameters.cpp:1154:void Parameters::ValidateDefaults(const Parameters&) const
   kratos/sources/kratos_parameters.cpp:1182:void Parameters::ValidateDefaults(const Parameters&) const
   kratos/sources/kratos_parameters.cpp:1132:void Parameters::ValidateAndAssignDefaults(const Parameters&)

```

Please mark the PR with appropriate tags: 
- Api Breaker, Mpi, etc...

**Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Updated settings for new amgcl_ns
