### PR TITLE
[Fluid][FastPR] Expected penalty constant definition

### DIFF
--- a/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.cpp
@@ -837,7 +837,7 @@ double EmbeddedFluidElementDiscontinuous<TBaseElement>::ComputeNormalPenaltyCoef
     // Compute the Nitsche coefficient (including the Winter stabilization term)
     const double h = rData.ElementSize;
     const double eff_mu = rData.EffectiveViscosity;
-    const double penalty = rData.PenaltyCoefficient;
+    const double penalty = 1.0 / rData.PenaltyCoefficient;
     const double cons_coef = (eff_mu + eff_mu + gauss_pt_rho*gauss_pt_v_norm*h + gauss_pt_rho*h*h/rData.DeltaTime)/(h*penalty);
 
     return cons_coef;
@@ -847,7 +847,7 @@ template <class TBaseElement>
 std::pair<const double, const double> EmbeddedFluidElementDiscontinuous<TBaseElement>::ComputeTangentialPenaltyCoefficients(const EmbeddedDiscontinuousElementData& rData) const
 {
     const double slip_length = rData.SlipLength;;
-    const double penalty = rData.PenaltyCoefficient;
+    const double penalty = 1.0 / rData.PenaltyCoefficient;
 
     const double h = rData.ElementSize;
     const double eff_mu = rData.EffectiveViscosity;
@@ -863,7 +863,7 @@ template <class TBaseElement>
 std::pair<const double, const double> EmbeddedFluidElementDiscontinuous<TBaseElement>::ComputeTangentialNitscheCoefficients(const EmbeddedDiscontinuousElementData& rData) const
 {
     const double slip_length = rData.SlipLength;;
-    const double penalty = rData.PenaltyCoefficient;
+    const double penalty = 1.0 / rData.PenaltyCoefficient;
 
     const double h = rData.ElementSize;
     const double eff_mu = rData.EffectiveViscosity;

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_fluid_element_discontinuous.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_fluid_element_discontinuous.cpp
@@ -160,7 +160,7 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElementDiscontinuous2D3N, FluidDynamicsApplica
     }
 
     model_part.GetProcessInfo().SetValue(SLIP_LENGTH, 0.0);
-    model_part.GetProcessInfo().SetValue(PENALTY_COEFFICIENT, 10.0);
+    model_part.GetProcessInfo().SetValue(PENALTY_COEFFICIENT, 0.1);
     for (ModelPart::ElementIterator i = model_part.ElementsBegin(); i != model_part.ElementsEnd(); i++) {
         i->Set(SLIP, false);
         i->CalculateLocalSystem(LHS, RHS, r_process_info);
@@ -182,7 +182,7 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElementDiscontinuous2D3N, FluidDynamicsApplica
 
     // Test slip cut element
     model_part.GetProcessInfo().SetValue(SLIP_LENGTH, 1.0e+08);
-    model_part.GetProcessInfo().SetValue(PENALTY_COEFFICIENT, 10.0);
+    model_part.GetProcessInfo().SetValue(PENALTY_COEFFICIENT, 0.1);
     for (ModelPart::ElementIterator i = model_part.ElementsBegin(); i != model_part.ElementsEnd(); ++i) {
         i->Set(SLIP, true);
         i->CalculateLocalSystem(LHS, RHS, r_process_info);


### PR DESCRIPTION
**Description**
Expected penalty constant definition in the embedded discontinuous element. This is consistent with the other elements in the application and is what the user would expect (the larger the penalty the stronger the imposition).

@RiccardoRossi this is what you asked me to do many times. 
@frawahl note that this might affect your current simulation settings. You must obtain exactly the same results by setting 1.0 / your_current_penalty value as penalty constant.