### PR TITLE
[Core] Add pGetGeometryPart BrepCurveOnSurface

### DIFF
--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -222,9 +222,10 @@ public:
 
     /**
     * @brief This function returns the pointer of the geometry
-    *        which is corresponding to the trim index.
-    *        Surface of the geometry is accessable with SURFACE_INDEX.
-    * @param Index: trim_index or SURFACE_INDEX.
+    *        which is corresponding to the index.
+    *        Possible indices are:
+    *        SURFACE_INDEX, EMBEDDED_CURVE_INDEX or CURVE_ON_SURFACE_INDEX.
+    * @param Index: SURFACE_INDEX, EMBEDDED_CURVE_INDEX or CURVE_ON_SURFACE_INDEX.
     * @return pointer of geometry, corresponding to the index.
     */
     const GeometryPointer pGetGeometryPart(const IndexType Index) const override

--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -74,7 +74,6 @@ public:
     typedef typename BaseType::IntegrationPointsArrayType IntegrationPointsArrayType;
 
     static constexpr IndexType SURFACE_INDEX = -1;
-    static constexpr IndexType EMBEDDED_CURVE_INDEX = -2;
     static constexpr IndexType CURVE_ON_SURFACE_INDEX = -3;
 
     ///@}
@@ -248,9 +247,6 @@ public:
     {
         if (Index == SURFACE_INDEX)
             return mpCurveOnSurface->pGetGeometryPart(SURFACE_INDEX);
-
-        if (Index == EMBEDDED_CURVE_INDEX)
-            return mpCurveOnSurface->pGetGeometryPart(EMBEDDED_CURVE_INDEX);
 
         if (Index == CURVE_ON_SURFACE_INDEX)
             return mpCurveOnSurface;

--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -228,6 +228,21 @@ public:
     * @param Index: SURFACE_INDEX, EMBEDDED_CURVE_INDEX or CURVE_ON_SURFACE_INDEX.
     * @return pointer of geometry, corresponding to the index.
     */
+    GeometryPointer pGetGeometryPart(const IndexType Index) override
+    {
+        const auto& const_this = *this;
+        return std::const_pointer_cast<GeometryType>(
+            const_this.pGetGeometryPart(Index));
+    }
+
+    /**
+    * @brief This function returns the pointer of the geometry
+    *        which is corresponding to the index.
+    *        Possible indices are:
+    *        SURFACE_INDEX, EMBEDDED_CURVE_INDEX or CURVE_ON_SURFACE_INDEX.
+    * @param Index: SURFACE_INDEX, EMBEDDED_CURVE_INDEX or CURVE_ON_SURFACE_INDEX.
+    * @return pointer of geometry, corresponding to the index.
+    */
     const GeometryPointer pGetGeometryPart(const IndexType Index) const override
     {
         if (Index == SURFACE_INDEX)

--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -258,6 +258,20 @@ public:
             << this->Id() << std::endl;
     }
 
+    /**
+    * @brief This function is used to check if the index is either
+    *        SURFACE_INDEX, EMBEDDED_CURVE_INDEX or CURVE_ON_SURFACE_INDEX.
+    * @param Index of the geometry part.
+    * @return true if SURFACE_INDEX, EMBEDDED_CURVE_INDEX or CURVE_ON_SURFACE_INDEX.
+    */
+    bool HasGeometryPart(const IndexType Index) const override
+    {
+        if (Index == SURFACE_INDEX || Index == EMBEDDED_CURVE_INDEX)
+            return true;
+
+        return false;
+    }
+
     ///@}
     ///@name Mathematical Informations
     ///@{

--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -263,10 +263,7 @@ public:
     */
     bool HasGeometryPart(const IndexType Index) const override
     {
-        if (Index == SURFACE_INDEX || Index == CURVE_ON_SURFACE_INDEX)
-            return true;
-
-        return false;
+        return (Index == SURFACE_INDEX || Index == CURVE_ON_SURFACE_INDEX);
     }
 
     ///@}

--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -53,6 +53,7 @@ public:
 
     typedef Geometry<typename TContainerPointType::value_type> BaseType;
     typedef Geometry<typename TContainerPointType::value_type> GeometryType;
+    typedef typename GeometryType::Pointer GeometryPointer;
 
     typedef GeometryData::IntegrationMethod IntegrationMethod;
 

--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -72,6 +72,10 @@ public:
     typedef typename BaseType::CoordinatesArrayType CoordinatesArrayType;
     typedef typename BaseType::IntegrationPointsArrayType IntegrationPointsArrayType;
 
+    static constexpr IndexType SURFACE_INDEX = -1;
+    static constexpr IndexType EMBEDDED_CURVE_INDEX = -2;
+    static constexpr IndexType CURVE_ON_SURFACE_INDEX = -3;
+
     ///@}
     ///@name Life Cycle
     ///@{
@@ -210,6 +214,32 @@ public:
     typename BaseType::Pointer Create( PointsArrayType const& ThisPoints ) const override
     {
         return typename BaseType::Pointer( new BrepCurveOnSurface( ThisPoints ) );
+    }
+
+    ///@}
+    ///@name Access to Geometry Parts
+    ///@{
+
+    /**
+    * @brief This function returns the pointer of the geometry
+    *        which is corresponding to the trim index.
+    *        Surface of the geometry is accessable with SURFACE_INDEX.
+    * @param Index: trim_index or SURFACE_INDEX.
+    * @return pointer of geometry, corresponding to the index.
+    */
+    const GeometryPointer pGetGeometryPart(const IndexType Index) const override
+    {
+        if (Index == SURFACE_INDEX)
+            return mpCurveOnSurface->pGetGeometryPart(SURFACE_INDEX);
+
+        if (Index == EMBEDDED_CURVE_INDEX)
+            return mpCurveOnSurface->pGetGeometryPart(EMBEDDED_CURVE_INDEX);
+
+        if (Index == CURVE_ON_SURFACE_INDEX)
+            return mpCurveOnSurface;
+
+        KRATOS_ERROR << "Index " << Index << " not existing in BrepCurveOnSurface: "
+            << this->Id() << std::endl;
     }
 
     ///@}

--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -257,13 +257,13 @@ public:
 
     /**
     * @brief This function is used to check if the index is either
-    *        SURFACE_INDEX, EMBEDDED_CURVE_INDEX or CURVE_ON_SURFACE_INDEX.
+    *        SURFACE_INDEX or CURVE_ON_SURFACE_INDEX.
     * @param Index of the geometry part.
-    * @return true if SURFACE_INDEX, EMBEDDED_CURVE_INDEX or CURVE_ON_SURFACE_INDEX.
+    * @return true if SURFACE_INDEX or CURVE_ON_SURFACE_INDEX.
     */
     bool HasGeometryPart(const IndexType Index) const override
     {
-        if (Index == SURFACE_INDEX || Index == EMBEDDED_CURVE_INDEX)
+        if (Index == SURFACE_INDEX || Index == CURVE_ON_SURFACE_INDEX)
             return true;
 
         return false;

--- a/kratos/geometries/nurbs_curve_on_surface_geometry.h
+++ b/kratos/geometries/nurbs_curve_on_surface_geometry.h
@@ -57,6 +57,9 @@ public:
     using BaseType::pGetPoint;
     using BaseType::GetPoint;
 
+    static constexpr IndexType SURFACE_INDEX = -1;
+    static constexpr IndexType EMBEDDED_CURVE_INDEX = -2;
+
     /// Counted pointer of NurbsCurveOnSurfaceGeometry
     KRATOS_CLASS_POINTER_DEFINITION(NurbsCurveOnSurfaceGeometry);
 
@@ -153,6 +156,29 @@ public:
         KRATOS_ERROR << "NurbsCurveOnSurfaceGeometry cannot be created with 'PointsArrayType const& ThisPoints'. "
             << "'Create' is not allowed as it would not contain the required pointers to the surface and the curve."
             << std::endl;
+    }
+
+    ///@}
+    ///@name Access to Geometry Parts
+    ///@{
+
+    /**
+    * @brief This function returns the pointer of the geometry
+    *        which is corresponding to the trim index.
+    *        Surface of the geometry is accessable with SURFACE_INDEX.
+    * @param Index: trim_index or SURFACE_INDEX.
+    * @return pointer of geometry, corresponding to the index.
+    */
+    const GeometryPointer pGetGeometryPart(const IndexType Index) const override
+    {
+        if (Index == SURFACE_INDEX)
+            return mpNurbsSurface;
+
+        if (Index == EMBEDDED_CURVE_INDEX)
+            return mpNurbsCurve;
+
+        KRATOS_ERROR << "Index " << Index << " not existing in NurbsCurveOnSurface: "
+            << this->Id() << std::endl;
     }
 
     ///@}

--- a/kratos/geometries/nurbs_curve_on_surface_geometry.h
+++ b/kratos/geometries/nurbs_curve_on_surface_geometry.h
@@ -165,8 +165,9 @@ public:
     /**
     * @brief This function returns the pointer of the geometry
     *        which is corresponding to the trim index.
-    *        Surface of the geometry is accessable with SURFACE_INDEX.
-    * @param Index: trim_index or SURFACE_INDEX.
+    *        Possible indices are:
+    *        SURFACE_INDEX or EMBEDDED_CURVE_INDEX.
+    * @param Index: SURFACE_INDEX or EMBEDDED_CURVE_INDEX.
     * @return pointer of geometry, corresponding to the index.
     */
     const GeometryPointer pGetGeometryPart(const IndexType Index) const override

--- a/kratos/geometries/nurbs_curve_on_surface_geometry.h
+++ b/kratos/geometries/nurbs_curve_on_surface_geometry.h
@@ -38,6 +38,8 @@ public:
 
     typedef typename TSurfaceContainerPointType::value_type NodeType;
     typedef typename TCurveContainerPointType::value_type CurveNodeType;
+
+    typedef Geometry<NodeType> GeometryType;
     typedef typename GeometryType::Pointer GeometryPointer;
 
     typedef Geometry<NodeType> BaseType;

--- a/kratos/geometries/nurbs_curve_on_surface_geometry.h
+++ b/kratos/geometries/nurbs_curve_on_surface_geometry.h
@@ -204,10 +204,7 @@ public:
     */
     bool HasGeometryPart(const IndexType Index) const override
     {
-        if (Index == SURFACE_INDEX)
-            return true;
-
-        return false;
+        return Index == SURFACE_INDEX;
     }
 
     ///@}

--- a/kratos/geometries/nurbs_curve_on_surface_geometry.h
+++ b/kratos/geometries/nurbs_curve_on_surface_geometry.h
@@ -197,6 +197,20 @@ public:
             << this->Id() << std::endl;
     }
 
+    /**
+    * @brief This function is used to check if the index is either
+    *        SURFACE_INDEX or EMBEDDED_CURVE_INDEX.
+    * @param Index of the geometry part.
+    * @return true if SURFACE_INDEX or EMBEDDED_CURVE_INDEX.
+    */
+    bool HasGeometryPart(const IndexType Index) const override
+    {
+        if (Index == SURFACE_INDEX || Index == EMBEDDED_CURVE_INDEX)
+            return true;
+
+        return false;
+    }
+
     ///@}
     ///@name Mathematical Informations
     ///@{

--- a/kratos/geometries/nurbs_curve_on_surface_geometry.h
+++ b/kratos/geometries/nurbs_curve_on_surface_geometry.h
@@ -170,6 +170,21 @@ public:
     * @param Index: SURFACE_INDEX or EMBEDDED_CURVE_INDEX.
     * @return pointer of geometry, corresponding to the index.
     */
+    GeometryPointer pGetGeometryPart(const IndexType Index) override
+    {
+        const auto& const_this = *this;
+        return std::const_pointer_cast<GeometryType>(
+            const_this.pGetGeometryPart(Index));
+    }
+
+    /**
+    * @brief This function returns the pointer of the geometry
+    *        which is corresponding to the trim index.
+    *        Possible indices are:
+    *        SURFACE_INDEX or EMBEDDED_CURVE_INDEX.
+    * @param Index: SURFACE_INDEX or EMBEDDED_CURVE_INDEX.
+    * @return pointer of geometry, corresponding to the index.
+    */
     const GeometryPointer pGetGeometryPart(const IndexType Index) const override
     {
         if (Index == SURFACE_INDEX)

--- a/kratos/geometries/nurbs_curve_on_surface_geometry.h
+++ b/kratos/geometries/nurbs_curve_on_surface_geometry.h
@@ -61,7 +61,6 @@ public:
     using BaseType::GetPoint;
 
     static constexpr IndexType SURFACE_INDEX = -1;
-    static constexpr IndexType EMBEDDED_CURVE_INDEX = -2;
 
     /// Counted pointer of NurbsCurveOnSurfaceGeometry
     KRATOS_CLASS_POINTER_DEFINITION(NurbsCurveOnSurfaceGeometry);
@@ -192,9 +191,6 @@ public:
     {
         if (Index == SURFACE_INDEX)
             return mpNurbsSurface;
-
-        if (Index == EMBEDDED_CURVE_INDEX)
-            return mpNurbsCurve;
 
         KRATOS_ERROR << "Index " << Index << " not existing in NurbsCurveOnSurface: "
             << this->Id() << std::endl;

--- a/kratos/geometries/nurbs_curve_on_surface_geometry.h
+++ b/kratos/geometries/nurbs_curve_on_surface_geometry.h
@@ -38,6 +38,7 @@ public:
 
     typedef typename TSurfaceContainerPointType::value_type NodeType;
     typedef typename TCurveContainerPointType::value_type CurveNodeType;
+    typedef typename GeometryType::Pointer GeometryPointer;
 
     typedef Geometry<NodeType> BaseType;
 

--- a/kratos/geometries/nurbs_curve_on_surface_geometry.h
+++ b/kratos/geometries/nurbs_curve_on_surface_geometry.h
@@ -197,14 +197,14 @@ public:
     }
 
     /**
-    * @brief This function is used to check if the index is either
-    *        SURFACE_INDEX or EMBEDDED_CURVE_INDEX.
+    * @brief This function is used to check if the index is
+    *        SURFACE_INDEX.
     * @param Index of the geometry part.
-    * @return true if SURFACE_INDEX or EMBEDDED_CURVE_INDEX.
+    * @return true if SURFACE_INDEX.
     */
     bool HasGeometryPart(const IndexType Index) const override
     {
-        if (Index == SURFACE_INDEX || Index == EMBEDDED_CURVE_INDEX)
+        if (Index == SURFACE_INDEX)
             return true;
 
         return false;


### PR DESCRIPTION
**Description**
Adds pGetGeometryPart to the BrepCurveOnSurface and corresponding NurbsCurveOnSurface

Helps to obtain the access to the underlying embedded parameter curve.