### PR TITLE
[MPM] Change default dynamic scheme from Bossak to UNSPECIFIED

### DIFF
--- a/applications/ParticleMechanicsApplication/python_scripts/mpm_implicit_dynamic_solver.py
+++ b/applications/ParticleMechanicsApplication/python_scripts/mpm_implicit_dynamic_solver.py
@@ -23,7 +23,7 @@ class MPMImplicitDynamicSolver(MPMSolver):
     @classmethod
     def GetDefaultParameters(cls):
         this_defaults = KratosMultiphysics.Parameters("""{
-            "scheme_type"   : "bossak",
+            "scheme_type"   : "UNSPECIFIED",
             "damp_factor_m" : -0.3,
             "newmark_beta"  : 0.25
         }""")


### PR DESCRIPTION
**Description**
Change the default MPM implicit dynamic solver scheme to 'UNSPECIFIED'. This at least forces the use the choose the time-stepping algorithm, instead of having one chosen for them and them possibly assuming they are using another!

**A story of my misery**
Once upon a time, a Newmark lover much desired to use average acceleration implicit MPM to model great things, however, his results did not make sense. After much investigation, he found the evil Bossak had infiltrated and corrupted his model, unbeknownst to him.