### PR TITLE
deprecating officially the ExternalSolversApplication

### DIFF
--- a/applications/ExternalSolversApplication/CMakeLists.txt
+++ b/applications/ExternalSolversApplication/CMakeLists.txt
@@ -2,6 +2,10 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 message("**** Configuring KratosExternalSolversApplication ****")
 
+message("    !!! DEPRECATION WARNING !!!")
+message("    The ExternalSolversApplication is deprecated in favor of the LinearSolversApplication")
+message("    It is no longer updated/maintained and will be removed in the future")
+
 include_directories( ${KRATOS_SOURCE_DIR}/kratos )
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/custom_external_libraries/SuperLU_4.3 )
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/custom_external_libraries )

--- a/applications/ExternalSolversApplication/CMakeLists.txt
+++ b/applications/ExternalSolversApplication/CMakeLists.txt
@@ -4,7 +4,7 @@ message("**** Configuring KratosExternalSolversApplication ****")
 
 message("    !!! DEPRECATION WARNING !!!")
 message("    The ExternalSolversApplication is deprecated in favor of the LinearSolversApplication")
-message("    It is no longer updated/maintained and will be removed in the future")
+message("    It is no longer updated/maintained and will be removed in the future, tentatively in July 2021")
 
 include_directories( ${KRATOS_SOURCE_DIR}/kratos )
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/custom_external_libraries/SuperLU_4.3 )
@@ -129,4 +129,3 @@ install(TARGETS KratosExternalSolversApplication DESTINATION libs )
 # Install blas and lapack
 install(FILES ${BLAS_LIBRARIES} DESTINATION libs)
 install(FILES ${LAPACK_LIBRARIES} DESTINATION libs)
-

--- a/applications/ExternalSolversApplication/ExternalSolversApplication.py
+++ b/applications/ExternalSolversApplication/ExternalSolversApplication.py
@@ -8,3 +8,7 @@ application = KratosExternalSolversApplication()
 application_name = "ExternalSolversApplication"
 
 _ImportApplication(application, application_name)
+
+print("    !!! DEPRECATION WARNING !!!")
+print("    The ExternalSolversApplication is deprecated in favor of the LinearSolversApplication")
+print("    It is no longer updated/maintained and will be removed in the future")

--- a/applications/ExternalSolversApplication/ExternalSolversApplication.py
+++ b/applications/ExternalSolversApplication/ExternalSolversApplication.py
@@ -11,4 +11,4 @@ _ImportApplication(application, application_name)
 
 print("    !!! DEPRECATION WARNING !!!")
 print("    The ExternalSolversApplication is deprecated in favor of the LinearSolversApplication")
-print("    It is no longer updated/maintained and will be removed in the future")
+print("    It is no longer updated/maintained and will be removed in the future, tentatively in July 2021")


### PR DESCRIPTION
The `ExternalSolversApplication` has been implicitly deprecated for a while already, but not everyone knows this.
This PR adds warnings and tells to use the `LinearSolversApp` instead

FYI @maceligueta 