### PR TITLE
Version check

### DIFF
--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 from . import kratos_globals
 
@@ -24,6 +25,8 @@ def __ModuleInitDetail():
     and the parallel DataCommunicator are initialized when the Kernel is built.
     It is defined as a function to avoid polluting the Kratos namespace with local variables.
     """
+
+    # Detect if MPI is used
     mpi_detected = (                         # Probing the environment to see if this is an MPI run
         "OMPI_COMM_WORLD_SIZE" in os.environ # OpenMPI implementation detected
         or "PMI_SIZE" in os.environ          # Intel MPI detected
@@ -32,6 +35,7 @@ def __ModuleInitDetail():
     mpi_requested = "--using-mpi" in sys.argv[1:] # Forcing MPI initialization through command-line flag
 
     using_mpi = False
+
     if mpi_detected or mpi_requested:
         from KratosMultiphysics.kratos_utilities import IsMPIAvailable
         if IsMPIAvailable():
@@ -54,6 +58,16 @@ def __ModuleInitDetail():
                     "\nMPI was not initialized. Running in serial mode."
                 ]
                 Logger.PrintWarning("KRATOS INITIALIZATION WARNING:", "".join(msg))
+
+    # Detect the files in library folder
+    kre = re.compile('Kratos\.([^\d]+)(\d+).+')
+    kratos_version_info = [(kre.match(f))[2] for f in os.listdir(KratosPaths.kratos_libs) if kre.match(f)][0]
+
+    if sys.version_info.major != int(kratos_version_info[0]) and sys.version_info.minor != int(kratos_version_info[1]):
+        raise Exception("Kratos is running with python {}.{} but was compiled with python {}.{}. Please ensure the versions match.".format(
+            sys.version_info.major, sys.version_info.minor, 
+            kratos_version_info[0], kratos_version_info[1]
+        ))
 
     return kratos_globals.KratosGlobalsImpl(Kernel(using_mpi), KratosPaths.kratos_applications)
 

--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -59,15 +59,18 @@ def __ModuleInitDetail():
                 ]
                 Logger.PrintWarning("KRATOS INITIALIZATION WARNING:", "".join(msg))
 
-    # Detect the files in library folder
-    kre = re.compile('Kratos\.([^\d]+)(\d+).+')
-    kratos_version_info = [(kre.match(f))[2] for f in os.listdir(KratosPaths.kratos_libs) if kre.match(f)][0]
+    # Try to detect kratos library version
+    try:
+        kre = re.compile('Kratos\.([^\d]+)(\d+).+')
+        kratos_version_info = [(kre.match(f))[2] for f in os.listdir(KratosPaths.kratos_libs) if kre.match(f)][0]
 
-    if sys.version_info.major != int(kratos_version_info[0]) and sys.version_info.minor != int(kratos_version_info[1]):
-        raise Exception("Kratos is running with python {}.{} but was compiled with python {}.{}. Please ensure the versions match.".format(
-            sys.version_info.major, sys.version_info.minor, 
-            kratos_version_info[0], kratos_version_info[1]
-        ))
+        if sys.version_info.major != int(kratos_version_info[0]) and sys.version_info.minor != int(kratos_version_info[1]):
+            print("Warning: Kratos is running with python {}.{} but was compiled with python {}.{}. Please ensure the versions match.".format(
+                sys.version_info.major, sys.version_info.minor, 
+                kratos_version_info[0], kratos_version_info[1]
+            ))
+    except:
+        print("Warning: Could not determine python version used to build kratos.")
 
     return kratos_globals.KratosGlobalsImpl(Kernel(using_mpi), KratosPaths.kratos_applications)
 


### PR DESCRIPTION
**Description**
Adds a check for the Kratos version based on the module name.

@maceligueta  This is what I was speaking about in #8061. I would prefer this as like @loumalouomega says, I feel more comfortable making runtime checks without cmake participating in the process at all.

In any case I understand that this has its own problems, like being reliant on the pybind11 output module names... I will look on how to generate manifesto files for python modules, that should be the proper clean way to implement that check.