### PR TITLE
[ParMMG] Fix preserve_flags option

### DIFF
--- a/applications/MeshingApplication/custom_utilities/parmmg/pmmg_utilities.cpp
+++ b/applications/MeshingApplication/custom_utilities/parmmg/pmmg_utilities.cpp
@@ -1375,7 +1375,33 @@ void ParMmgUtilities<TPMMGLibrary>::WriteReferenceEntitities(
 template<PMMGLibrary TPMMGLibrary>
 void ParMmgUtilities<TPMMGLibrary>::CreateAuxiliarSubModelPartForFlags(ModelPart& rModelPart)
 {
-    BaseType::CreateAuxiliarSubModelPartForFlags(rModelPart);
+    KRATOS_TRY;
+
+    auto& data_comm = rModelPart.GetCommunicator().GetDataCommunicator();
+
+    ModelPart& r_auxiliar_model_part = rModelPart.CreateSubModelPart("AUXILIAR_MODEL_PART_TO_LATER_REMOVE");
+
+    const auto& r_flags = KratosComponents<Flags>::GetComponents();
+
+    for (auto& r_flag : r_flags) {
+        const std::string name_sub_model = "FLAG_" + r_flag.first;
+        if (name_sub_model.find("NOT") == std::string::npos && name_sub_model.find("ALL") == std::string::npos) { // Avoiding inactive flags
+            r_auxiliar_model_part.CreateSubModelPart(name_sub_model);
+            ModelPart& r_auxiliar_sub_model_part = r_auxiliar_model_part.GetSubModelPart(name_sub_model);
+            FastTransferBetweenModelPartsProcess(r_auxiliar_sub_model_part, rModelPart, FastTransferBetweenModelPartsProcess::EntityTransfered::ALL, *(r_flag.second)).Execute();
+
+            const bool is_aux_sub_model_empty = r_auxiliar_sub_model_part.NumberOfNodes() == 0
+                && r_auxiliar_sub_model_part.NumberOfElements() == 0
+                && r_auxiliar_sub_model_part.NumberOfConditions() == 0;
+
+            // Remove sub model part if it is empty in all ranks
+            if (data_comm.MinAll(is_aux_sub_model_empty)) {
+                r_auxiliar_model_part.RemoveSubModelPart(name_sub_model);
+            }
+        }
+    }
+
+    KRATOS_CATCH("");
 }
 
 /***********************************************************************************/

--- a/applications/MeshingApplication/tests/parmmg_eulerian_test/cond_ref_map.json
+++ b/applications/MeshingApplication/tests/parmmg_eulerian_test/cond_ref_map.json
@@ -1,9 +1,12 @@
 {
     "0": "SurfaceCondition3D3N",
     "1": "SurfaceCondition3D3N",
+    "10": "SurfaceCondition3D3N",
+    "11": "SurfaceCondition3D3N",
     "2": "SurfaceCondition3D3N",
+    "4": "SurfaceCondition3D3N",
     "5": "SurfaceCondition3D3N",
-    "6": "SurfaceCondition3D3N",
     "7": "SurfaceCondition3D3N",
-    "8": "SurfaceCondition3D3N"
+    "8": "SurfaceCondition3D3N",
+    "9": "SurfaceCondition3D3N"
 }

--- a/applications/MeshingApplication/tests/parmmg_eulerian_test/elem_ref_map.json
+++ b/applications/MeshingApplication/tests/parmmg_eulerian_test/elem_ref_map.json
@@ -1,5 +1,8 @@
 {
     "0": "Element3D4N",
+    "13": "Element3D4N",
     "3": "Element3D4N",
-    "4": "Element3D4N"
+    "4": "Element3D4N",
+    "5": "Element3D4N",
+    "7": "Element3D4N"
 }

--- a/applications/MeshingApplication/tests/test_mpi_parmmg.py
+++ b/applications/MeshingApplication/tests/test_mpi_parmmg.py
@@ -37,6 +37,12 @@ class TestMPIParMmg(KratosUnittest.TestCase):
             distance = math.sqrt(node.X**2+node.Y**2+node.Z**2) - 1.0/2.0
             node.SetSolutionStepValue(KratosMultiphysics.DISTANCE,distance)
 
+        # Setting some flags on submodelparts entities arbitrarily
+        for cond in main_model_part.GetSubModelPart("SurfaceLoad3D_Load_on_surfaces_Auto3").Conditions:
+            cond.Set(KratosMultiphysics.STRUCTURE)
+        for elem in main_model_part.GetSubModelPart("Parts_Solid_Solid_Auto1").Elements:
+            elem.Set(KratosMultiphysics.VISITED)
+
         ##COMPUTE DISTANCE GRADIENT AND NODAL_H
         local_gradient = KratosMultiphysics.ComputeNodalGradientProcess3D(main_model_part,
         KratosMultiphysics.DISTANCE,
@@ -73,7 +79,7 @@ class TestMPIParMmg(KratosUnittest.TestCase):
             "save_external_files"              : true,
             "save_colors_files"                : true,
             "initialize_entities"              : false,
-            "preserve_flags"                   : false,
+            "preserve_flags"                   : true,
             "echo_level"                       : 0,
             "advanced_parameters" : {
                 "number_of_iterations"         : 4
@@ -96,6 +102,19 @@ class TestMPIParMmg(KratosUnittest.TestCase):
         with open(result_dict_file_name, 'r') as f:
             reference_hierarchy = json.load(f)
         self.CheckModelPartHierarchie(main_model_part, reference_hierarchy[str(communicator.Size())])
+
+        # Check flags are correctly set on the corresponding submodelparts only
+        for cond in main_model_part.Conditions:
+            if cond in main_model_part.GetSubModelPart("SurfaceLoad3D_Load_on_surfaces_Auto3").Conditions:
+                self.assertTrue(cond.Is(KratosMultiphysics.STRUCTURE))
+            else:
+                self.assertTrue(cond.IsNot(KratosMultiphysics.STRUCTURE))
+
+        for elem in main_model_part.Elements:
+            if elem in main_model_part.GetSubModelPart("Parts_Solid_Solid_Auto1").Elements:
+                self.assertTrue(elem.Is(KratosMultiphysics.VISITED))
+            else:
+                self.assertTrue(elem.IsNot(KratosMultiphysics.VISITED))
 
         for file_name in os.listdir(GetFilePath("")):
             if file_name.endswith(".json") or file_name.endswith(".mdpa") or file_name.endswith(".mesh") or  file_name.endswith(".sol"):


### PR DESCRIPTION
**Description**
There is an option in our interface with MMG that is "preserve_flags", where auxiliar model parts are created to recover the flags in the original model after remeshing. In MPI this was not working correctly as there was a missing synchronization to check if submodelparts are empty.

**Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Fix preserve_flags feature on Parmmg
- Updated parmmg test
