### PR TITLE
[MPI] Fill communicator factory

### DIFF
--- a/kratos/includes/fill_communicator.h
+++ b/kratos/includes/fill_communicator.h
@@ -19,6 +19,7 @@
 
 // Project includes
 #include "includes/define.h"
+#include "includes/model_part.h"
 
 namespace Kratos
 {
@@ -45,9 +46,6 @@ namespace Kratos
 ///@}
 ///@name Kratos Classes
 ///@{
-
-// Forward declaration of ModelPart
-class ModelPart;
 
 /// Base class defining the API for the fill communicator utilities
 /** The objective of this class is to set the API for the derived ParallelFillCommunicator utilities

--- a/kratos/includes/fill_communicator.h
+++ b/kratos/includes/fill_communicator.h
@@ -1,0 +1,251 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+#if !defined(KRATOS_FILL_COMMUNICATOR_H_INCLUDED )
+#define  KRATOS_FILL_COMMUNICATOR_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define.h"
+
+namespace Kratos
+{
+
+///@name Kratos Globals
+///@{
+
+
+///@}
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name  Enum's
+///@{
+
+
+///@}
+///@name  Functions
+///@{
+
+
+///@}
+///@name Kratos Classes
+///@{
+
+// Forward declaration of ModelPart
+class ModelPart;
+
+/// Base class defining the API for the fill communicator utilities
+/** The objective of this class is to set the API for the derived ParallelFillCommunicator utilities
+ */
+class KRATOS_API(KRATOS_CORE) FillCommunicator
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of FillCommunicator
+    KRATOS_CLASS_POINTER_DEFINITION(FillCommunicator);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Constructor.
+    FillCommunicator(ModelPart& rModelPart);
+
+    /// Copy constructor.
+    FillCommunicator(FillCommunicator const& rOther) = delete;
+
+    /// Destructor.
+    virtual ~FillCommunicator() = default;
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /// Assignment operator.
+    FillCommunicator& operator=(FillCommunicator const& rOther) = delete;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Execute the communicator fill
+     * This method is intended to perform the communicator filling In the current serial case it does nothing.
+     * For the parallel implementation see ParallelFillCommunicator.
+     */
+    virtual void Execute();
+
+    /**
+     * @brief Function to print DETAILED mesh information 
+     * WARNING: to be used for debugging only as many informations are plotted
+     */
+    void PrintDebugInfo();
+
+    /**
+     * @brief Function to print mesh information of the provided model part
+     * This function is intended to check and print some mesh information
+     * In the current serial case it is almost empty and only basic checks are performed
+     * @param rModelPart Reference to the model part to be checked
+     */
+    virtual void PrintModelPartDebugInfo(const ModelPart& rModelPart);
+
+    ///@}
+    ///@name Access
+    ///@{
+
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    virtual std::string Info() const;
+
+    /// Print information about this object.
+    virtual void PrintInfo(std::ostream& rOStream) const;
+
+    /// Print object's data.
+    virtual void PrintData(std::ostream& rOStream) const;
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+protected:
+    ///@name Protected static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+
+    ///@}
+    ///@name Protected  Access
+    ///@{
+
+    ModelPart& GetBaseModelPart()
+    {
+        return mrBaseModelPart;
+    }
+
+    ///@}
+    ///@name Protected Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Protected LifeCycle
+    ///@{
+
+
+    ///@}
+private:
+    ///@name Static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+    ModelPart& mrBaseModelPart;
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+
+    ///@}
+    ///@name Private Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+
+    ///@}
+}; // Class FillCommunicator
+
+///@}
+
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+/// input stream function
+inline std::istream & operator >>(
+    std::istream& rIStream,
+    FillCommunicator& rThis)
+{
+    return rIStream;
+}
+
+/// output stream function
+inline std::ostream & operator <<(
+    std::ostream& rOStream,
+    const FillCommunicator& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+
+///@}
+} // namespace Kratos.
+
+#endif // KRATOS_FILL_COMMUNICATOR_H_INCLUDED  defined
+
+

--- a/kratos/includes/parallel_environment.h
+++ b/kratos/includes/parallel_environment.h
@@ -23,6 +23,7 @@
 // Project includes
 #include "includes/define.h"
 #include "includes/data_communicator.h"
+#include "includes/fill_communicator.h"
 
 namespace Kratos
 {
@@ -89,6 +90,21 @@ class KRATOS_API(KRATOS_CORE) ParallelEnvironment
 
     static void SetUpMPIEnvironment(EnvironmentManager::Pointer pEnvironmentManager);
 
+    /**
+     * @brief Registers the fill communicator factory
+     * This method takes the provided fill communicator pointer factory and saves it to be used later on 
+     * @param FillCommunicatorFactory Factory function returning a pointer to a (parrallel or serial) fill communicator
+     */
+    static void RegisterFillCommunicatorFactory(std::function<FillCommunicator::Pointer(ModelPart&)> FillCommunicatorFactory);
+
+    /**
+     * @brief Create a fill communicator object
+     * This method uses the previously registered fill communicator factory for the creation of a new fill communicator pointer
+     * @param rModelPart Model part to which the fill communicator will be applied
+     * @return FillCommunicator::Pointer Pointer to the new fill communicator instance
+     */
+    static FillCommunicator::Pointer CreateFillCommunicator(ModelPart& rModelPart);
+
     /// Add a new DataCommunicator instance to the ParallelEnvironment.
     /** @param rName The name to be used to identify the DataCommunicator within ParallelEnvironment.
      *  @param rPrototype The DataCommunicator instance.
@@ -154,6 +170,8 @@ class KRATOS_API(KRATOS_CORE) ParallelEnvironment
 
     void SetUpMPIEnvironmentDetail(EnvironmentManager::Pointer pEnvironmentManager);
 
+    void RegisterFillCommunicatorFactoryDetail(std::function<FillCommunicator::Pointer(ModelPart&)> FillCommunicatorFactory);
+
     void RegisterDataCommunicatorDetail(
         const std::string& Name,
         DataCommunicator::UniquePointer pPrototype,
@@ -205,6 +223,8 @@ class KRATOS_API(KRATOS_CORE) ParallelEnvironment
     std::unordered_map<std::string, DataCommunicator::UniquePointer> mDataCommunicators;
 
     std::unordered_map<std::string, DataCommunicator::UniquePointer>::iterator mDefaultCommunicator;
+
+    std::function<FillCommunicator::Pointer(ModelPart&)> mFillCommunicatorFactory;
 
     int mDefaultRank;
     int mDefaultSize;

--- a/kratos/mpi/python/kratos_mpi_python.cpp
+++ b/kratos/mpi/python/kratos_mpi_python.cpp
@@ -17,6 +17,7 @@
 
 // Module includes
 #include "mpi/includes/mpi_data_communicator.h"
+#include "mpi/utilities/parallel_fill_communicator.h"
 #include "add_mpi_communicator_to_python.h"
 #include "add_mpi_data_communicator_to_python.h"
 #include "add_mpi_utilities_to_python.h"
@@ -30,6 +31,8 @@ void InitializeMPIParallelRun()
 {
     // Define the World DataCommunicator as a wrapper for MPI_COMM_WORLD and make it the default.
     ParallelEnvironment::RegisterDataCommunicator("World", MPIDataCommunicator::Create(MPI_COMM_WORLD), ParallelEnvironment::MakeDefault);
+    // Register the ParallelFillCommunicator to be used as factory for the parallel communicators fill.
+    ParallelEnvironment::RegisterFillCommunicatorFactory([](ModelPart& rModelPart)->FillCommunicator::Pointer{return FillCommunicator::Pointer(new ParallelFillCommunicator(rModelPart));});
 }
 
 PYBIND11_MODULE(KratosMPI, m)

--- a/kratos/mpi/utilities/parallel_fill_communicator.cpp
+++ b/kratos/mpi/utilities/parallel_fill_communicator.cpp
@@ -21,21 +21,17 @@
 namespace Kratos
 {
 
-ParallelFillCommunicator::ParallelFillCommunicator(ModelPart& r_model_part)
-    : mrBaseModelPart(r_model_part)
+ParallelFillCommunicator::ParallelFillCommunicator(ModelPart& rModelPart)
+    : FillCommunicator(rModelPart)
 {}
 
 void ParallelFillCommunicator::Execute()
 {
     KRATOS_TRY
     mPartitionIndexCheckPerformed = false;
-    ComputeCommunicationPlan(mrBaseModelPart);
+    auto& r_base_model_part = GetBaseModelPart();
+    ComputeCommunicationPlan(r_base_model_part);
     KRATOS_CATCH("");
-}
-
-void ParallelFillCommunicator::PrintDebugInfo()
-{
-    PrintModelPartDebugInfo(mrBaseModelPart);
 }
 
 void ParallelFillCommunicator::PrintModelPartDebugInfo(const ModelPart& rModelPart)
@@ -479,6 +475,9 @@ void ParallelFillCommunicator::GenerateMeshes(int NeighbourPID, int MyPID, unsig
     ModelPart::NodesContainerType& r_local_nodes =
         rModelPart.GetCommunicator().LocalMesh(Color).Nodes();
     r_local_nodes.clear();
+
+    KRATOS_WATCH(rModelPart)
+
     for (int id : ids_to_send)
     {
         KRATOS_DEBUG_ERROR_IF(rModelPart.Nodes().find(id) == rModelPart.Nodes().end()) << "Trying to add Node with Id #" << id << " to the local mesh, but the node does not exist in the ModelPart!" << std::endl;

--- a/kratos/mpi/utilities/parallel_fill_communicator.cpp
+++ b/kratos/mpi/utilities/parallel_fill_communicator.cpp
@@ -475,9 +475,6 @@ void ParallelFillCommunicator::GenerateMeshes(int NeighbourPID, int MyPID, unsig
     ModelPart::NodesContainerType& r_local_nodes =
         rModelPart.GetCommunicator().LocalMesh(Color).Nodes();
     r_local_nodes.clear();
-
-    KRATOS_WATCH(rModelPart)
-
     for (int id : ids_to_send)
     {
         KRATOS_DEBUG_ERROR_IF(rModelPart.Nodes().find(id) == rModelPart.Nodes().end()) << "Trying to add Node with Id #" << id << " to the local mesh, but the node does not exist in the ModelPart!" << std::endl;

--- a/kratos/mpi/utilities/parallel_fill_communicator.h
+++ b/kratos/mpi/utilities/parallel_fill_communicator.h
@@ -19,6 +19,7 @@
 
 // Project includes
 #include "includes/define.h"
+#include "includes/fill_communicator.h"
 
 namespace Kratos
 {
@@ -49,7 +50,7 @@ class ModelPart;
  * and to fill the communication plan (coloring) so to allow the communication to be performed correctly
  * It fills the Ghost and Local lists and performs the coloring, then it updates the MPI communicator
  */
-class KRATOS_API(KRATOS_MPI_CORE) ParallelFillCommunicator
+class KRATOS_API(KRATOS_MPI_CORE) ParallelFillCommunicator : public FillCommunicator
 {
 public:
     ///@name Type Definitions
@@ -63,7 +64,7 @@ public:
     ///@{
 
     /// Constructor.
-    ParallelFillCommunicator(ModelPart& r_model_part);
+    ParallelFillCommunicator(ModelPart& rModelPart);
 
     /// Destructor.
     virtual ~ParallelFillCommunicator() = default;
@@ -77,15 +78,9 @@ public:
     ///@name Operations
     ///@{
 
-    void Execute();
+    void Execute() override;
 
-    ///Function to print DETAILED mesh information.
-    /** WARNING: to be used for debugging only as many informations
-     *  are plotted
-     */
-    void PrintDebugInfo();
-
-    void PrintModelPartDebugInfo(const ModelPart& rModelPart);
+    void PrintModelPartDebugInfo(const ModelPart& rModelPart) override;
 
     ///@}
     ///@name Access
@@ -102,13 +97,13 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const;
+    std::string Info() const override;
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const;
+    void PrintInfo(std::ostream& rOStream) const override;
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const;
+    void PrintData(std::ostream& rOStream) const override;
 
     ///@}
     ///@name Friends
@@ -116,7 +111,6 @@ public:
 
 
     ///@}
-
 protected:
     ///@name Protected static Member Variables
     ///@{
@@ -170,8 +164,6 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
-
-    ModelPart& mrBaseModelPart;
 
     bool mPartitionIndexCheckPerformed = false;
 

--- a/kratos/sources/parallel_environment.cpp
+++ b/kratos/sources/parallel_environment.cpp
@@ -58,6 +58,18 @@ void ParallelEnvironment::SetUpMPIEnvironment(EnvironmentManager::Pointer pEnvir
     env.SetUpMPIEnvironmentDetail(std::move(pEnvironmentManager));
 }
 
+void ParallelEnvironment::RegisterFillCommunicatorFactory(std::function<FillCommunicator::Pointer(ModelPart&)> FillCommunicatorFactory)
+{
+    ParallelEnvironment& env = GetInstance();
+    env.RegisterFillCommunicatorFactoryDetail(FillCommunicatorFactory);
+}
+
+FillCommunicator::Pointer ParallelEnvironment::CreateFillCommunicator(ModelPart& rModelPart)
+{
+    ParallelEnvironment& env = GetInstance();
+    return env.mFillCommunicatorFactory(rModelPart);
+}
+
 void ParallelEnvironment::RegisterDataCommunicator(
     const std::string& Name,
     DataCommunicator::UniquePointer pPrototype,
@@ -120,6 +132,7 @@ void ParallelEnvironment::PrintData(std::ostream &rOStream)
 ParallelEnvironment::ParallelEnvironment()
 {
     RegisterDataCommunicatorDetail("Serial", DataCommunicator::Create(), MakeDefault);
+    RegisterFillCommunicatorFactoryDetail([&](ModelPart& rModelPart)->FillCommunicator::Pointer{return FillCommunicator::Pointer(new FillCommunicator(rModelPart));});
 }
 
 ParallelEnvironment::~ParallelEnvironment()
@@ -178,6 +191,11 @@ void ParallelEnvironment::SetUpMPIEnvironmentDetail(EnvironmentManager::Pointer 
     << "Trying to configure run for MPI twice. This should not be happening!" << std::endl;
 
     mpEnvironmentManager = std::move(pEnvironmentManager);
+}
+
+void ParallelEnvironment::RegisterFillCommunicatorFactoryDetail(std::function<FillCommunicator::Pointer(ModelPart&)> FillCommunicatorFactory)
+{
+    mFillCommunicatorFactory = FillCommunicatorFactory;
 }
 
 void ParallelEnvironment::RegisterDataCommunicatorDetail(

--- a/kratos/utilities/fill_communicator.cpp
+++ b/kratos/utilities/fill_communicator.cpp
@@ -1,0 +1,75 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+#include "includes/model_part.h"
+#include "includes/data_communicator.h"
+#include "includes/fill_communicator.h"
+#include "processes/graph_coloring_process.h"
+
+namespace Kratos
+{
+
+FillCommunicator::FillCommunicator(ModelPart& rModelPart)
+    : mrBaseModelPart(rModelPart)
+{}
+
+void FillCommunicator::Execute()
+{
+    KRATOS_TRY
+    KRATOS_CATCH("");
+}
+
+void FillCommunicator::PrintDebugInfo()
+{
+    PrintModelPartDebugInfo(mrBaseModelPart);
+}
+
+void FillCommunicator::PrintModelPartDebugInfo(const ModelPart& rModelPart)
+{
+    KRATOS_TRY
+
+    std::cout.flush();
+    const auto& r_communicator = rModelPart.GetCommunicator();
+    const auto& r_data_communicator = r_communicator.GetDataCommunicator();
+    r_data_communicator.Barrier();
+
+    // Check rank and number of processors
+    const int rank = r_data_communicator.Rank();
+    const int num_processors = r_data_communicator.Size();
+    KRATOS_ERROR_IF_NOT(rank == 0) << "Serial FillCommunicator current rank is not 0." << std::endl;
+    KRATOS_ERROR_IF_NOT(num_processors == 1) << "Serial FillCommunicator number of processors larger than 1." << std::endl;
+
+    // Check local and ghost mesh
+    KRATOS_ERROR_IF_NOT(r_communicator.NeighbourIndices().size() == 0) << "There are not expected neighbour indices" << std::endl;
+    KRATOS_ERROR_IF_NOT(r_communicator.GhostMesh().NumberOfNodes() == 0) << "There are unexpected nodes in the ghost mesh" << std::endl;
+    KRATOS_ERROR_IF_NOT(r_communicator.InterfaceMesh().NumberOfNodes() == 0) << "There are unexpected nodes in the interface mesh." << std::endl;
+    
+    KRATOS_CATCH("");
+}
+
+std::string FillCommunicator::Info() const
+{
+    std::stringstream buffer;
+    buffer << "FillCommunicator";
+    return buffer.str();
+}
+
+void FillCommunicator::PrintInfo(std::ostream& rOStream) const
+{
+    rOStream << "FillCommunicator" << std::endl;
+}
+
+void FillCommunicator::PrintData(std::ostream& rOStream) const
+{
+}
+
+}

--- a/kratos/utilities/fill_communicator.cpp
+++ b/kratos/utilities/fill_communicator.cpp
@@ -13,7 +13,6 @@
 #include "includes/model_part.h"
 #include "includes/data_communicator.h"
 #include "includes/fill_communicator.h"
-#include "processes/graph_coloring_process.h"
 
 namespace Kratos
 {


### PR DESCRIPTION
**Description**
While solving some issues with the parallel embedded skin visualization I realized that it was impossible to do a serial/parallel implementation in a unique class only because the `ParallelFillCommunicator` has no base serial class (as the `Communicator` does).

After doing so, we (@roigcarlo and I) came up with the idea of registering a factory for such fill communicator utility so it can be retrieved according to the parallel type from the `ParallelEnvironment` helper. The mechanism is pretty similar to the default communicator one.

**Changelog**
- Creation of a `FillCommunicator` baseclass
- Addition of registering/creation methods in the `ParallelEnvironment` for the fill communicator factory
