### PR TITLE
[Shallow] [TLD] Mesh acceleration

### DIFF
--- a/applications/ShallowWaterApplication/custom_elements/shallow_water_2d_3.h
+++ b/applications/ShallowWaterApplication/custom_elements/shallow_water_2d_3.h
@@ -240,7 +240,6 @@ public:
      * Specializations of element must specify the actual interface to the integration points!
      * Note, that these functions expect a std::vector of values for the specified variable type that
      * contains a value for each integration point!
-     * GetValueOnIntegrationPoints: get the values for given Variable.
      * @param rVariable: the specified variable
      * @param rValues: where to store the values for the specified variable type at each integration point
      * @param rCurrentProcessInfo: the current process info instance

--- a/applications/ShallowWaterApplication/custom_elements/shallow_water_2d_3.h
+++ b/applications/ShallowWaterApplication/custom_elements/shallow_water_2d_3.h
@@ -308,6 +308,7 @@ protected:
         array_1d<double,3> topography;
         array_1d<double,3> rain;
         array_1d<double,9> unknown;
+        array_1d<double,9> mesh_acc;
 
         void InitializeData(const ProcessInfo& rCurrentProcessInfo);
         void GetNodalData(const GeometryType& rGeometry, const BoundedMatrix<double,3,2>& rDN_DX);

--- a/applications/ShallowWaterApplication/python_scripts/stabilized_shallow_water_solver.py
+++ b/applications/ShallowWaterApplication/python_scripts/stabilized_shallow_water_solver.py
@@ -22,6 +22,7 @@ class StabilizedShallowWaterSolver(ShallowWaterBaseSolver):
         self.main_model_part.AddNodalSolutionStepVariable(KM.ACCELERATION)
         self.main_model_part.AddNodalSolutionStepVariable(SW.VERTICAL_VELOCITY)
         self.main_model_part.AddNodalSolutionStepVariable(SW.ATMOSPHERIC_PRESSURE)
+        self.main_model_part.AddNodalSolutionStepVariable(KM.MESH_ACCELERATION)
 
     def AddDofs(self):
         KM.VariableUtils().AddDof(KM.MOMENTUM_X, self.main_model_part)


### PR DESCRIPTION
**Description**
See #7867 . The mesh acceleration is included in the body force following the next expression:
![image](https://user-images.githubusercontent.com/25640870/105175805-b515ff00-5b24-11eb-8ef5-5fd9a6ecfa79.png)

The gradient stabilization and the residual stabilization are updated. Tests are passing.

**A small example**: a square with uniform horizontal acceleration along x-axis:
![mesh_acc_0](https://user-images.githubusercontent.com/25640870/105176733-e7742c00-5b25-11eb-823c-8137a08c97fd.jpg)

Initial configuration:
![height_0](https://user-images.githubusercontent.com/25640870/105176741-ed6a0d00-5b25-11eb-8260-181d6c30bb99.jpg)

Water oscillation:
![height_1](https://user-images.githubusercontent.com/25640870/105176747-f064fd80-5b25-11eb-93bf-df44ac311086.jpg)


**Changelog**
- Added new source term to the shallow water element
- Added new variable to the historical nodal database
