### PR TITLE
[Core] Remove python 2 support from core

### DIFF
--- a/kratos/mpi/python_scripts/distributed_gid_output_process.py
+++ b/kratos/mpi/python_scripts/distributed_gid_output_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 import KratosMultiphysics as KM
 from KratosMultiphysics.kratos_utilities import CheckIfApplicationsAvailable
 if CheckIfApplicationsAvailable("TrilinosApplication"):

--- a/kratos/mpi/python_scripts/distributed_gid_output_process.py
+++ b/kratos/mpi/python_scripts/distributed_gid_output_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 import KratosMultiphysics as KM
 from KratosMultiphysics.kratos_utilities import CheckIfApplicationsAvailable

--- a/kratos/mpi/python_scripts/distributed_gid_output_process.py
+++ b/kratos/mpi/python_scripts/distributed_gid_output_process.py
@@ -1,4 +1,3 @@
-
 import KratosMultiphysics as KM
 from KratosMultiphysics.kratos_utilities import CheckIfApplicationsAvailable
 if CheckIfApplicationsAvailable("TrilinosApplication"):

--- a/kratos/mpi/python_scripts/distributed_gid_output_process.py
+++ b/kratos/mpi/python_scripts/distributed_gid_output_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 import KratosMultiphysics as KM
 from KratosMultiphysics.kratos_utilities import CheckIfApplicationsAvailable

--- a/kratos/python_scripts/KratosMonitor.py
+++ b/kratos/python_scripts/KratosMonitor.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 import tkinter
 
 

--- a/kratos/python_scripts/KratosMonitor.py
+++ b/kratos/python_scripts/KratosMonitor.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 import tkinter
 
 

--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing Kratos
 import KratosMultiphysics

--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing Kratos
 import KratosMultiphysics
 from KratosMultiphysics.process_factory import KratosProcessFactory

--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -1,4 +1,3 @@
-
 # Importing Kratos
 import KratosMultiphysics
 from KratosMultiphysics.process_factory import KratosProcessFactory

--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing Kratos
 import KratosMultiphysics

--- a/kratos/python_scripts/application_generator/applicationGenerator.py
+++ b/kratos/python_scripts/application_generator/applicationGenerator.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import os
 import sys
 import shutil

--- a/kratos/python_scripts/application_generator/applicationGenerator.py
+++ b/kratos/python_scripts/application_generator/applicationGenerator.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import os
 import sys

--- a/kratos/python_scripts/application_generator/applicationGenerator.py
+++ b/kratos/python_scripts/application_generator/applicationGenerator.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import os
 import sys

--- a/kratos/python_scripts/application_generator/classes/classCreator.py
+++ b/kratos/python_scripts/application_generator/classes/classCreator.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import difflib
 import re
 import os

--- a/kratos/python_scripts/application_generator/classes/classCreator.py
+++ b/kratos/python_scripts/application_generator/classes/classCreator.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import difflib
 import re

--- a/kratos/python_scripts/application_generator/classes/classCreator.py
+++ b/kratos/python_scripts/application_generator/classes/classCreator.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import difflib
 import re

--- a/kratos/python_scripts/application_generator/classes/classMemberCreator.py
+++ b/kratos/python_scripts/application_generator/classes/classMemberCreator.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import sys
 
 from utils.io import bcolors, Formatc

--- a/kratos/python_scripts/application_generator/classes/classMemberCreator.py
+++ b/kratos/python_scripts/application_generator/classes/classMemberCreator.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import sys
 

--- a/kratos/python_scripts/application_generator/classes/classMemberCreator.py
+++ b/kratos/python_scripts/application_generator/classes/classMemberCreator.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import sys
 

--- a/kratos/python_scripts/application_generator/classes/conditionCreator.py
+++ b/kratos/python_scripts/application_generator/classes/conditionCreator.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 from classes.classCreator import ClassCreator
 from utils.constants import ctab
 

--- a/kratos/python_scripts/application_generator/classes/conditionCreator.py
+++ b/kratos/python_scripts/application_generator/classes/conditionCreator.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 from classes.classCreator import ClassCreator
 from utils.constants import ctab

--- a/kratos/python_scripts/application_generator/classes/conditionCreator.py
+++ b/kratos/python_scripts/application_generator/classes/conditionCreator.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 from classes.classCreator import ClassCreator
 from utils.constants import ctab

--- a/kratos/python_scripts/application_generator/classes/elementCreator.py
+++ b/kratos/python_scripts/application_generator/classes/elementCreator.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 from classes.classCreator import ClassCreator
 from utils.constants import ctab
 

--- a/kratos/python_scripts/application_generator/classes/elementCreator.py
+++ b/kratos/python_scripts/application_generator/classes/elementCreator.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 from classes.classCreator import ClassCreator
 from utils.constants import ctab

--- a/kratos/python_scripts/application_generator/classes/elementCreator.py
+++ b/kratos/python_scripts/application_generator/classes/elementCreator.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 from classes.classCreator import ClassCreator
 from utils.constants import ctab

--- a/kratos/python_scripts/application_generator/classes/processCreator.py
+++ b/kratos/python_scripts/application_generator/classes/processCreator.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 from classes.classCreator import ClassCreator
 
 # from utils.constants import ctab

--- a/kratos/python_scripts/application_generator/classes/processCreator.py
+++ b/kratos/python_scripts/application_generator/classes/processCreator.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 from classes.classCreator import ClassCreator
 

--- a/kratos/python_scripts/application_generator/classes/processCreator.py
+++ b/kratos/python_scripts/application_generator/classes/processCreator.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 from classes.classCreator import ClassCreator
 

--- a/kratos/python_scripts/application_generator/classes/variableCreator.py
+++ b/kratos/python_scripts/application_generator/classes/variableCreator.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 from utils.constants import ctab
 
 

--- a/kratos/python_scripts/application_generator/classes/variableCreator.py
+++ b/kratos/python_scripts/application_generator/classes/variableCreator.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 from utils.constants import ctab
 

--- a/kratos/python_scripts/application_generator/classes/variableCreator.py
+++ b/kratos/python_scripts/application_generator/classes/variableCreator.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 from utils.constants import ctab
 

--- a/kratos/python_scripts/application_generator/createApplication.py
+++ b/kratos/python_scripts/application_generator/createApplication.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import sys
 
 from classes.elementCreator import ElementCreator

--- a/kratos/python_scripts/application_generator/createApplication.py
+++ b/kratos/python_scripts/application_generator/createApplication.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import sys
 

--- a/kratos/python_scripts/application_generator/createApplication.py
+++ b/kratos/python_scripts/application_generator/createApplication.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import sys
 

--- a/kratos/python_scripts/application_generator/laplacian_application_example.py
+++ b/kratos/python_scripts/application_generator/laplacian_application_example.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import sys
 
 from classes.elementCreator import ElementCreator

--- a/kratos/python_scripts/application_generator/laplacian_application_example.py
+++ b/kratos/python_scripts/application_generator/laplacian_application_example.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import sys
 

--- a/kratos/python_scripts/application_generator/laplacian_application_example.py
+++ b/kratos/python_scripts/application_generator/laplacian_application_example.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import sys
 

--- a/kratos/python_scripts/application_generator/utils/io.py
+++ b/kratos/python_scripts/application_generator/utils/io.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import re
 import os
 

--- a/kratos/python_scripts/application_generator/utils/io.py
+++ b/kratos/python_scripts/application_generator/utils/io.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import re
 import os

--- a/kratos/python_scripts/application_generator/utils/io.py
+++ b/kratos/python_scripts/application_generator/utils/io.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import re
 import os

--- a/kratos/python_scripts/application_generator/utils/templateRule.py
+++ b/kratos/python_scripts/application_generator/utils/templateRule.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import sys
 
 from utils.io import bcolors, Formatc

--- a/kratos/python_scripts/application_generator/utils/templateRule.py
+++ b/kratos/python_scripts/application_generator/utils/templateRule.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import sys
 

--- a/kratos/python_scripts/application_generator/utils/templateRule.py
+++ b/kratos/python_scripts/application_generator/utils/templateRule.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import sys
 

--- a/kratos/python_scripts/assign_flag_process.py
+++ b/kratos/python_scripts/assign_flag_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 
@@ -18,16 +17,16 @@ class AssignFlagProcess(KratosMultiphysics.Process):
     Model -- the container of the different model parts.
     settings -- Kratos parameters containing solver settings.
     """
-    
+
     def __init__(self, Model, settings ):
         """ The default constructor of the class
-        
+
         Keyword arguments:
         self -- It signifies an instance of a class.
         Model -- the container of the different model parts.
         settings -- Kratos parameters containing solver settings.
         """
-        
+
         KratosMultiphysics.Process.__init__(self)
 
         #The value can be a double or a string (function)

--- a/kratos/python_scripts/assign_flag_process.py
+++ b/kratos/python_scripts/assign_flag_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 
@@ -17,16 +18,16 @@ class AssignFlagProcess(KratosMultiphysics.Process):
     Model -- the container of the different model parts.
     settings -- Kratos parameters containing solver settings.
     """
-
+    
     def __init__(self, Model, settings ):
         """ The default constructor of the class
-
+        
         Keyword arguments:
         self -- It signifies an instance of a class.
         Model -- the container of the different model parts.
         settings -- Kratos parameters containing solver settings.
         """
-
+        
         KratosMultiphysics.Process.__init__(self)
 
         #The value can be a double or a string (function)

--- a/kratos/python_scripts/assign_scalar_input_to_conditions_process.py
+++ b/kratos/python_scripts/assign_scalar_input_to_conditions_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_input_to_conditions_process.py
+++ b/kratos/python_scripts/assign_scalar_input_to_conditions_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_input_to_elements_process.py
+++ b/kratos/python_scripts/assign_scalar_input_to_elements_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_input_to_elements_process.py
+++ b/kratos/python_scripts/assign_scalar_input_to_elements_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_input_to_entities_process.py
+++ b/kratos/python_scripts/assign_scalar_input_to_entities_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_input_to_entities_process.py
+++ b/kratos/python_scripts/assign_scalar_input_to_entities_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_input_to_nodes_process.py
+++ b/kratos/python_scripts/assign_scalar_input_to_nodes_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_input_to_nodes_process.py
+++ b/kratos/python_scripts/assign_scalar_input_to_nodes_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_variable_process.py
+++ b/kratos/python_scripts/assign_scalar_variable_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_variable_process.py
+++ b/kratos/python_scripts/assign_scalar_variable_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_variable_to_conditions_process.py
+++ b/kratos/python_scripts/assign_scalar_variable_to_conditions_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_variable_to_conditions_process.py
+++ b/kratos/python_scripts/assign_scalar_variable_to_conditions_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_variable_to_constraints_process.py
+++ b/kratos/python_scripts/assign_scalar_variable_to_constraints_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_variable_to_constraints_process.py
+++ b/kratos/python_scripts/assign_scalar_variable_to_constraints_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_variable_to_elements_process.py
+++ b/kratos/python_scripts/assign_scalar_variable_to_elements_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_variable_to_elements_process.py
+++ b/kratos/python_scripts/assign_scalar_variable_to_elements_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_variable_to_entities_process.py
+++ b/kratos/python_scripts/assign_scalar_variable_to_entities_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_variable_to_entities_process.py
+++ b/kratos/python_scripts/assign_scalar_variable_to_entities_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_variable_to_nodes_process.py
+++ b/kratos/python_scripts/assign_scalar_variable_to_nodes_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_scalar_variable_to_nodes_process.py
+++ b/kratos/python_scripts/assign_scalar_variable_to_nodes_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_vector_by_direction_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 from KratosMultiphysics import assign_scalar_variable_process

--- a/kratos/python_scripts/assign_vector_by_direction_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 from KratosMultiphysics import assign_scalar_variable_process

--- a/kratos/python_scripts/assign_vector_by_direction_to_condition_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_condition_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_vector_by_direction_to_condition_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_condition_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_vector_by_direction_to_element_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_element_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_vector_by_direction_to_element_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_element_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_vector_by_direction_to_entity_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_entity_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 from KratosMultiphysics import assign_scalar_variable_to_entities_process

--- a/kratos/python_scripts/assign_vector_by_direction_to_entity_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_entity_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 from KratosMultiphysics import assign_scalar_variable_to_entities_process

--- a/kratos/python_scripts/assign_vector_by_direction_to_node_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_node_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_vector_by_direction_to_node_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_node_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_vector_variable_process.py
+++ b/kratos/python_scripts/assign_vector_variable_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 from KratosMultiphysics import assign_scalar_variable_process

--- a/kratos/python_scripts/assign_vector_variable_process.py
+++ b/kratos/python_scripts/assign_vector_variable_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 from KratosMultiphysics import assign_scalar_variable_process

--- a/kratos/python_scripts/assign_vector_variable_to_conditions_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_conditions_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_vector_variable_to_conditions_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_conditions_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_vector_variable_to_constraints_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_constraints_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_vector_variable_to_constraints_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_constraints_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_vector_variable_to_elements_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_elements_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_vector_variable_to_elements_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_elements_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_vector_variable_to_entities_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_entities_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 from KratosMultiphysics import assign_scalar_variable_to_entities_process

--- a/kratos/python_scripts/assign_vector_variable_to_entities_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_entities_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 from KratosMultiphysics import assign_scalar_variable_to_entities_process

--- a/kratos/python_scripts/assign_vector_variable_to_nodes_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_nodes_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/assign_vector_variable_to_nodes_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_nodes_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/auxiliary_solver_utilities.py
+++ b/kratos/python_scripts/auxiliary_solver_utilities.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 import KratosMultiphysics
 
 def AddVariables(model_part, aux_variable_list):

--- a/kratos/python_scripts/auxiliary_solver_utilities.py
+++ b/kratos/python_scripts/auxiliary_solver_utilities.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 import KratosMultiphysics
 
 def AddVariables(model_part, aux_variable_list):

--- a/kratos/python_scripts/base_convergence_criteria_factory.py
+++ b/kratos/python_scripts/base_convergence_criteria_factory.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 
@@ -7,15 +5,15 @@ import KratosMultiphysics
 class ConvergenceCriteriaFactory(object):
     def __init__(self, convergence_criterion_parameters):
         # Note that all the convergence settings are introduced via a Kratos parameters object.
-        
+
         D_RT = convergence_criterion_parameters["solution_relative_tolerance"].GetDouble()
         D_AT = convergence_criterion_parameters["solution_absolute_tolerance"].GetDouble()
         R_RT = convergence_criterion_parameters["residual_relative_tolerance"].GetDouble()
         R_AT = convergence_criterion_parameters["residual_absolute_tolerance"].GetDouble()
-        
+
         echo_level = convergence_criterion_parameters["echo_level"].GetInt()
         convergence_crit = convergence_criterion_parameters["convergence_criterion"].GetString()
-        
+
         if(echo_level >= 1):
             KratosMultiphysics.Logger.PrintInfo("::[ConvergenceCriterionFactory]:: ", "CONVERGENCE CRITERION : " +
                     convergence_criterion_parameters["convergence_criterion"].GetString())
@@ -23,18 +21,18 @@ class ConvergenceCriteriaFactory(object):
         if(convergence_crit == "solution_criterion"):
             self.convergence_criterion = KratosMultiphysics.DisplacementCriteria(D_RT, D_AT)
             self.convergence_criterion.SetEchoLevel(echo_level)
-            
+
         elif(convergence_crit == "residual_criterion"):
             self.convergence_criterion = KratosMultiphysics.ResidualCriteria(R_RT, R_AT)
             self.convergence_criterion.SetEchoLevel(echo_level)
-                
+
         elif(convergence_crit == "and_criterion"):
             Displacement = KratosMultiphysics.DisplacementCriteria(D_RT, D_AT)
             Displacement.SetEchoLevel(echo_level)
             Residual = KratosMultiphysics.ResidualCriteria(R_RT, R_AT)
             Residual.SetEchoLevel(echo_level)
             self.convergence_criterion = KratosMultiphysics.AndCriteria(Residual, Displacement)
-            
+
         elif(convergence_crit == "or_criterion"):
             Displacement = KratosMultiphysics.DisplacementCriteria(D_RT, D_AT)
             Displacement.SetEchoLevel(echo_level)
@@ -45,5 +43,5 @@ class ConvergenceCriteriaFactory(object):
             err_msg =  "The requested convergence criterion \"" + convergence_crit + "\" is not available!\n"
             err_msg += "Available options are: \"solution_criterion\", \"residual_criterion\", \"and_criterion\", \"or_criterion\""
             raise Exception(err_msg)
-        
+
 

--- a/kratos/python_scripts/base_convergence_criteria_factory.py
+++ b/kratos/python_scripts/base_convergence_criteria_factory.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics
@@ -7,15 +6,15 @@ import KratosMultiphysics
 class ConvergenceCriteriaFactory(object):
     def __init__(self, convergence_criterion_parameters):
         # Note that all the convergence settings are introduced via a Kratos parameters object.
-        
+
         D_RT = convergence_criterion_parameters["solution_relative_tolerance"].GetDouble()
         D_AT = convergence_criterion_parameters["solution_absolute_tolerance"].GetDouble()
         R_RT = convergence_criterion_parameters["residual_relative_tolerance"].GetDouble()
         R_AT = convergence_criterion_parameters["residual_absolute_tolerance"].GetDouble()
-        
+
         echo_level = convergence_criterion_parameters["echo_level"].GetInt()
         convergence_crit = convergence_criterion_parameters["convergence_criterion"].GetString()
-        
+
         if(echo_level >= 1):
             KratosMultiphysics.Logger.PrintInfo("::[ConvergenceCriterionFactory]:: ", "CONVERGENCE CRITERION : " +
                     convergence_criterion_parameters["convergence_criterion"].GetString())
@@ -23,18 +22,18 @@ class ConvergenceCriteriaFactory(object):
         if(convergence_crit == "solution_criterion"):
             self.convergence_criterion = KratosMultiphysics.DisplacementCriteria(D_RT, D_AT)
             self.convergence_criterion.SetEchoLevel(echo_level)
-            
+
         elif(convergence_crit == "residual_criterion"):
             self.convergence_criterion = KratosMultiphysics.ResidualCriteria(R_RT, R_AT)
             self.convergence_criterion.SetEchoLevel(echo_level)
-                
+
         elif(convergence_crit == "and_criterion"):
             Displacement = KratosMultiphysics.DisplacementCriteria(D_RT, D_AT)
             Displacement.SetEchoLevel(echo_level)
             Residual = KratosMultiphysics.ResidualCriteria(R_RT, R_AT)
             Residual.SetEchoLevel(echo_level)
             self.convergence_criterion = KratosMultiphysics.AndCriteria(Residual, Displacement)
-            
+
         elif(convergence_crit == "or_criterion"):
             Displacement = KratosMultiphysics.DisplacementCriteria(D_RT, D_AT)
             Displacement.SetEchoLevel(echo_level)
@@ -45,5 +44,5 @@ class ConvergenceCriteriaFactory(object):
             err_msg =  "The requested convergence criterion \"" + convergence_crit + "\" is not available!\n"
             err_msg += "Available options are: \"solution_criterion\", \"residual_criterion\", \"and_criterion\", \"or_criterion\""
             raise Exception(err_msg)
-        
+
 

--- a/kratos/python_scripts/base_convergence_criteria_factory.py
+++ b/kratos/python_scripts/base_convergence_criteria_factory.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics
@@ -6,15 +7,15 @@ import KratosMultiphysics
 class ConvergenceCriteriaFactory(object):
     def __init__(self, convergence_criterion_parameters):
         # Note that all the convergence settings are introduced via a Kratos parameters object.
-
+        
         D_RT = convergence_criterion_parameters["solution_relative_tolerance"].GetDouble()
         D_AT = convergence_criterion_parameters["solution_absolute_tolerance"].GetDouble()
         R_RT = convergence_criterion_parameters["residual_relative_tolerance"].GetDouble()
         R_AT = convergence_criterion_parameters["residual_absolute_tolerance"].GetDouble()
-
+        
         echo_level = convergence_criterion_parameters["echo_level"].GetInt()
         convergence_crit = convergence_criterion_parameters["convergence_criterion"].GetString()
-
+        
         if(echo_level >= 1):
             KratosMultiphysics.Logger.PrintInfo("::[ConvergenceCriterionFactory]:: ", "CONVERGENCE CRITERION : " +
                     convergence_criterion_parameters["convergence_criterion"].GetString())
@@ -22,18 +23,18 @@ class ConvergenceCriteriaFactory(object):
         if(convergence_crit == "solution_criterion"):
             self.convergence_criterion = KratosMultiphysics.DisplacementCriteria(D_RT, D_AT)
             self.convergence_criterion.SetEchoLevel(echo_level)
-
+            
         elif(convergence_crit == "residual_criterion"):
             self.convergence_criterion = KratosMultiphysics.ResidualCriteria(R_RT, R_AT)
             self.convergence_criterion.SetEchoLevel(echo_level)
-
+                
         elif(convergence_crit == "and_criterion"):
             Displacement = KratosMultiphysics.DisplacementCriteria(D_RT, D_AT)
             Displacement.SetEchoLevel(echo_level)
             Residual = KratosMultiphysics.ResidualCriteria(R_RT, R_AT)
             Residual.SetEchoLevel(echo_level)
             self.convergence_criterion = KratosMultiphysics.AndCriteria(Residual, Displacement)
-
+            
         elif(convergence_crit == "or_criterion"):
             Displacement = KratosMultiphysics.DisplacementCriteria(D_RT, D_AT)
             Displacement.SetEchoLevel(echo_level)
@@ -44,5 +45,5 @@ class ConvergenceCriteriaFactory(object):
             err_msg =  "The requested convergence criterion \"" + convergence_crit + "\" is not available!\n"
             err_msg += "Available options are: \"solution_criterion\", \"residual_criterion\", \"and_criterion\", \"or_criterion\""
             raise Exception(err_msg)
-
+        
 

--- a/kratos/python_scripts/compare_two_files_check_process.py
+++ b/kratos/python_scripts/compare_two_files_check_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/compare_two_files_check_process.py
+++ b/kratos/python_scripts/compare_two_files_check_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/fix_scalar_variable_process.py
+++ b/kratos/python_scripts/fix_scalar_variable_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics

--- a/kratos/python_scripts/fix_scalar_variable_process.py
+++ b/kratos/python_scripts/fix_scalar_variable_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/fix_scalar_variable_process.py
+++ b/kratos/python_scripts/fix_scalar_variable_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics

--- a/kratos/python_scripts/fix_vector_variable_process.py
+++ b/kratos/python_scripts/fix_vector_variable_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics

--- a/kratos/python_scripts/fix_vector_variable_process.py
+++ b/kratos/python_scripts/fix_vector_variable_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/fix_vector_variable_process.py
+++ b/kratos/python_scripts/fix_vector_variable_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics

--- a/kratos/python_scripts/from_json_check_result_process.py
+++ b/kratos/python_scripts/from_json_check_result_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 from KratosMultiphysics.json_utilities import read_external_json

--- a/kratos/python_scripts/from_json_check_result_process.py
+++ b/kratos/python_scripts/from_json_check_result_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 from KratosMultiphysics.json_utilities import read_external_json

--- a/kratos/python_scripts/gid_output.py
+++ b/kratos/python_scripts/gid_output.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 import os
 from KratosMultiphysics import *
 

--- a/kratos/python_scripts/gid_output.py
+++ b/kratos/python_scripts/gid_output.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 import os
 from KratosMultiphysics import *
 

--- a/kratos/python_scripts/gid_output_process.py
+++ b/kratos/python_scripts/gid_output_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 import KratosMultiphysics as KM
 from KratosMultiphysics import kratos_utilities
 from KratosMultiphysics import * # TODO remove

--- a/kratos/python_scripts/gid_output_process.py
+++ b/kratos/python_scripts/gid_output_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 import KratosMultiphysics as KM
 from KratosMultiphysics import kratos_utilities

--- a/kratos/python_scripts/gid_output_process.py
+++ b/kratos/python_scripts/gid_output_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 import KratosMultiphysics as KM
 from KratosMultiphysics import kratos_utilities

--- a/kratos/python_scripts/integration_values_extrapolation_to_nodes_process.py
+++ b/kratos/python_scripts/integration_values_extrapolation_to_nodes_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics

--- a/kratos/python_scripts/integration_values_extrapolation_to_nodes_process.py
+++ b/kratos/python_scripts/integration_values_extrapolation_to_nodes_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/integration_values_extrapolation_to_nodes_process.py
+++ b/kratos/python_scripts/integration_values_extrapolation_to_nodes_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics

--- a/kratos/python_scripts/json_output_process.py
+++ b/kratos/python_scripts/json_output_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 from KratosMultiphysics.json_utilities import read_external_json, write_external_json

--- a/kratos/python_scripts/json_output_process.py
+++ b/kratos/python_scripts/json_output_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 from KratosMultiphysics.json_utilities import read_external_json, write_external_json

--- a/kratos/python_scripts/json_utilities.py
+++ b/kratos/python_scripts/json_utilities.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 import json
 import os
 
@@ -6,8 +5,8 @@ def read_external_json(file_name):
   with open(file_name, 'r') as outfile:
       data = json.load(outfile)
   return data
-      
+
 def write_external_json(file_name, data):
   with open(file_name, 'w') as outfile:
-    json.dump(data, outfile) 
-    
+    json.dump(data, outfile)
+

--- a/kratos/python_scripts/json_utilities.py
+++ b/kratos/python_scripts/json_utilities.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 import json
 import os
 
@@ -5,8 +6,8 @@ def read_external_json(file_name):
   with open(file_name, 'r') as outfile:
       data = json.load(outfile)
   return data
-
+      
 def write_external_json(file_name, data):
   with open(file_name, 'w') as outfile:
-    json.dump(data, outfile)
-
+    json.dump(data, outfile) 
+    

--- a/kratos/python_scripts/kratos_collada.py
+++ b/kratos/python_scripts/kratos_collada.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # importing the Kratos Library
 from KratosMultiphysics import *

--- a/kratos/python_scripts/kratos_collada.py
+++ b/kratos/python_scripts/kratos_collada.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # importing the Kratos Library
 from KratosMultiphysics import *
 

--- a/kratos/python_scripts/kratos_collada.py
+++ b/kratos/python_scripts/kratos_collada.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # importing the Kratos Library
 from KratosMultiphysics import *

--- a/kratos/python_scripts/kratos_utilities.py
+++ b/kratos/python_scripts/kratos_utilities.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 import KratosMultiphysics as KM
 import os, shutil, re
 

--- a/kratos/python_scripts/kratos_utilities.py
+++ b/kratos/python_scripts/kratos_utilities.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 import KratosMultiphysics as KM
 import os, shutil, re

--- a/kratos/python_scripts/kratos_utilities.py
+++ b/kratos/python_scripts/kratos_utilities.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 import KratosMultiphysics as KM
 import os, shutil, re

--- a/kratos/python_scripts/line_output_process.py
+++ b/kratos/python_scripts/line_output_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics

--- a/kratos/python_scripts/line_output_process.py
+++ b/kratos/python_scripts/line_output_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/line_output_process.py
+++ b/kratos/python_scripts/line_output_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics

--- a/kratos/python_scripts/modeler_factory.py
+++ b/kratos/python_scripts/modeler_factory.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 

--- a/kratos/python_scripts/modeler_factory.py
+++ b/kratos/python_scripts/modeler_factory.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics as KM

--- a/kratos/python_scripts/modeler_factory.py
+++ b/kratos/python_scripts/modeler_factory.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics as KM

--- a/kratos/python_scripts/multiple_points_output_process.py
+++ b/kratos/python_scripts/multiple_points_output_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics

--- a/kratos/python_scripts/multiple_points_output_process.py
+++ b/kratos/python_scripts/multiple_points_output_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/multiple_points_output_process.py
+++ b/kratos/python_scripts/multiple_points_output_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics

--- a/kratos/python_scripts/new_linear_solver_factory.py
+++ b/kratos/python_scripts/new_linear_solver_factory.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 def ConstructSolver(configuration):
     import KratosMultiphysics
 

--- a/kratos/python_scripts/new_linear_solver_factory.py
+++ b/kratos/python_scripts/new_linear_solver_factory.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 def ConstructSolver(configuration):
     import KratosMultiphysics

--- a/kratos/python_scripts/new_linear_solver_factory.py
+++ b/kratos/python_scripts/new_linear_solver_factory.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 def ConstructSolver(configuration):
     import KratosMultiphysics

--- a/kratos/python_scripts/operation.py
+++ b/kratos/python_scripts/operation.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # this class is designed as the base class to add "custom operations"
 # it is designed so that only the constructor can be modified and all of the other
 # functions should retain the same interface

--- a/kratos/python_scripts/operation.py
+++ b/kratos/python_scripts/operation.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # this class is designed as the base class to add "custom operations"
 # it is designed so that only the constructor can be modified and all of the other
 # functions should retain the same interface

--- a/kratos/python_scripts/print_vars_to_xml.py
+++ b/kratos/python_scripts/print_vars_to_xml.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 from KratosMultiphysics import *
 from KratosMultiphysics.MeshingApplication import *
 from KratosMultiphysics.IncompressibleFluidApplication import *
@@ -13,67 +11,67 @@ def PrintVariablesString(header_name,input_string):
     #ititialize block
     outstring = "\n<xs:simpleType name=\"" + header_name + "\"> \n"
     outstring += "    <xs:restriction base=\"xs:string\"> \n"
-    
+
     words = input_string.split('\n')
-    
+
     for word in words:
         outstring += "         <xs:enumeration value=\"" + word + "\"> \n"
-        
+
     #finalize block
     outstring += "     </xs:restriction> \n"
     outstring += "</xs:simpleType> \n"
     outstring += "\n    "
-    
+
     return outstring
-    
+
 def PrintVariablesToXMLenum(filename):
-    
+
     kernel = KratosGlobals.Kernel
-    
+
     out = open(filename,'w')
-    
+
     #print XSD header
     out.write(" <?xml version=\"1.0\"?> \n")
     out.write("<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\"> \n")
-    
+
     #print double Variables
     var_list = kernel.GetDoubleVariableNames()
     var_list += kernel.GetVariableComponentVariableNames()
-    
+
     tmp = PrintVariablesString("KratosVar_double",var_list)
     out.write(tmp)
-        
+
     #print integer variables
     var_list = kernel.GetIntVariableNames()
-    var_list += kernel.GetUnsignedIntVariableNames() 
+    var_list += kernel.GetUnsignedIntVariableNames()
     tmp = PrintVariablesString("KratosVar_int",var_list)
     out.write(tmp)
-        
+
     #print Bool Variables
     var_list = kernel.GetBoolVariableNames()
     tmp = PrintVariablesString("KratosVar_bool",var_list)
-    out.write(tmp)    
-    
+    out.write(tmp)
+
     #print array_1d Variables
     var_list = kernel.GetArrayVariableNames()
     tmp = PrintVariablesString("KratosVar_Array1d",var_list)
-    out.write(tmp)      
+    out.write(tmp)
 
     #print Vector Variables
     var_list = kernel.GetVectorVariableNames()
     tmp = PrintVariablesString("KratosVar_Vector",var_list)
-    out.write(tmp) 
-    
+    out.write(tmp)
+
     #print Matrix Variables
     var_list = kernel.GetMatrixVariableNames()
     tmp = PrintVariablesString("KratosVar_Matrix",var_list)
-    out.write(tmp) 
-    
+    out.write(tmp)
+
     #print Flags
     var_list = kernel.GetFlagsVariableNames()
     tmp = PrintVariablesString("KratosVar_FlagsType",var_list)
-    out.write(tmp) 
-    
+    out.write(tmp)
+
     #finalize XSD schema and close file
     out.write("</xs:schema")
     out.close()

--- a/kratos/python_scripts/print_vars_to_xml.py
+++ b/kratos/python_scripts/print_vars_to_xml.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 from KratosMultiphysics import *
 from KratosMultiphysics.MeshingApplication import *
@@ -13,67 +12,67 @@ def PrintVariablesString(header_name,input_string):
     #ititialize block
     outstring = "\n<xs:simpleType name=\"" + header_name + "\"> \n"
     outstring += "    <xs:restriction base=\"xs:string\"> \n"
-    
+
     words = input_string.split('\n')
-    
+
     for word in words:
         outstring += "         <xs:enumeration value=\"" + word + "\"> \n"
-        
+
     #finalize block
     outstring += "     </xs:restriction> \n"
     outstring += "</xs:simpleType> \n"
     outstring += "\n    "
-    
+
     return outstring
-    
+
 def PrintVariablesToXMLenum(filename):
-    
+
     kernel = KratosGlobals.Kernel
-    
+
     out = open(filename,'w')
-    
+
     #print XSD header
     out.write(" <?xml version=\"1.0\"?> \n")
     out.write("<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\"> \n")
-    
+
     #print double Variables
     var_list = kernel.GetDoubleVariableNames()
     var_list += kernel.GetVariableComponentVariableNames()
-    
+
     tmp = PrintVariablesString("KratosVar_double",var_list)
     out.write(tmp)
-        
+
     #print integer variables
     var_list = kernel.GetIntVariableNames()
-    var_list += kernel.GetUnsignedIntVariableNames() 
+    var_list += kernel.GetUnsignedIntVariableNames()
     tmp = PrintVariablesString("KratosVar_int",var_list)
     out.write(tmp)
-        
+
     #print Bool Variables
     var_list = kernel.GetBoolVariableNames()
     tmp = PrintVariablesString("KratosVar_bool",var_list)
-    out.write(tmp)    
-    
+    out.write(tmp)
+
     #print array_1d Variables
     var_list = kernel.GetArrayVariableNames()
     tmp = PrintVariablesString("KratosVar_Array1d",var_list)
-    out.write(tmp)      
+    out.write(tmp)
 
     #print Vector Variables
     var_list = kernel.GetVectorVariableNames()
     tmp = PrintVariablesString("KratosVar_Vector",var_list)
-    out.write(tmp) 
-    
+    out.write(tmp)
+
     #print Matrix Variables
     var_list = kernel.GetMatrixVariableNames()
     tmp = PrintVariablesString("KratosVar_Matrix",var_list)
-    out.write(tmp) 
-    
+    out.write(tmp)
+
     #print Flags
     var_list = kernel.GetFlagsVariableNames()
     tmp = PrintVariablesString("KratosVar_FlagsType",var_list)
-    out.write(tmp) 
-    
+    out.write(tmp)
+
     #finalize XSD schema and close file
     out.write("</xs:schema")
     out.close()

--- a/kratos/python_scripts/print_vars_to_xml.py
+++ b/kratos/python_scripts/print_vars_to_xml.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 from KratosMultiphysics import *
 from KratosMultiphysics.MeshingApplication import *
@@ -12,67 +13,67 @@ def PrintVariablesString(header_name,input_string):
     #ititialize block
     outstring = "\n<xs:simpleType name=\"" + header_name + "\"> \n"
     outstring += "    <xs:restriction base=\"xs:string\"> \n"
-
+    
     words = input_string.split('\n')
-
+    
     for word in words:
         outstring += "         <xs:enumeration value=\"" + word + "\"> \n"
-
+        
     #finalize block
     outstring += "     </xs:restriction> \n"
     outstring += "</xs:simpleType> \n"
     outstring += "\n    "
-
+    
     return outstring
-
+    
 def PrintVariablesToXMLenum(filename):
-
+    
     kernel = KratosGlobals.Kernel
-
+    
     out = open(filename,'w')
-
+    
     #print XSD header
     out.write(" <?xml version=\"1.0\"?> \n")
     out.write("<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\"> \n")
-
+    
     #print double Variables
     var_list = kernel.GetDoubleVariableNames()
     var_list += kernel.GetVariableComponentVariableNames()
-
+    
     tmp = PrintVariablesString("KratosVar_double",var_list)
     out.write(tmp)
-
+        
     #print integer variables
     var_list = kernel.GetIntVariableNames()
-    var_list += kernel.GetUnsignedIntVariableNames()
+    var_list += kernel.GetUnsignedIntVariableNames() 
     tmp = PrintVariablesString("KratosVar_int",var_list)
     out.write(tmp)
-
+        
     #print Bool Variables
     var_list = kernel.GetBoolVariableNames()
     tmp = PrintVariablesString("KratosVar_bool",var_list)
-    out.write(tmp)
-
+    out.write(tmp)    
+    
     #print array_1d Variables
     var_list = kernel.GetArrayVariableNames()
     tmp = PrintVariablesString("KratosVar_Array1d",var_list)
-    out.write(tmp)
+    out.write(tmp)      
 
     #print Vector Variables
     var_list = kernel.GetVectorVariableNames()
     tmp = PrintVariablesString("KratosVar_Vector",var_list)
-    out.write(tmp)
-
+    out.write(tmp) 
+    
     #print Matrix Variables
     var_list = kernel.GetMatrixVariableNames()
     tmp = PrintVariablesString("KratosVar_Matrix",var_list)
-    out.write(tmp)
-
+    out.write(tmp) 
+    
     #print Flags
     var_list = kernel.GetFlagsVariableNames()
     tmp = PrintVariablesString("KratosVar_FlagsType",var_list)
-    out.write(tmp)
-
+    out.write(tmp) 
+    
     #finalize XSD schema and close file
     out.write("</xs:schema")
     out.close()

--- a/kratos/python_scripts/process_factory.py
+++ b/kratos/python_scripts/process_factory.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 

--- a/kratos/python_scripts/process_factory.py
+++ b/kratos/python_scripts/process_factory.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics as KM

--- a/kratos/python_scripts/process_factory.py
+++ b/kratos/python_scripts/process_factory.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics as KM

--- a/kratos/python_scripts/python_linear_solver_factory.py
+++ b/kratos/python_scripts/python_linear_solver_factory.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 import KratosMultiphysics as KM
 from KratosMultiphysics import kratos_utilities as kratos_utils
 from importlib import import_module

--- a/kratos/python_scripts/python_linear_solver_factory.py
+++ b/kratos/python_scripts/python_linear_solver_factory.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 import KratosMultiphysics as KM
 from KratosMultiphysics import kratos_utilities as kratos_utils

--- a/kratos/python_scripts/python_linear_solver_factory.py
+++ b/kratos/python_scripts/python_linear_solver_factory.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 import KratosMultiphysics as KM
 from KratosMultiphysics import kratos_utilities as kratos_utils

--- a/kratos/python_scripts/read_materials_process.py
+++ b/kratos/python_scripts/read_materials_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 
@@ -31,9 +29,9 @@ class ReadMaterialsProcess(KratosMultiphysics.Process):
 
         See _AssignPropertyBlock for detail on how properties are imported.
         """
-        
+
         KratosMultiphysics.Logger.PrintWarning("ReadMaterialsProcess", "\n\nDEPRECATED: This process is deprecated, please use the C++ utility: ReadMaterialsUtility")
-        
+
         KratosMultiphysics.Process.__init__(self)
         default_settings = KratosMultiphysics.Parameters("""
         {

--- a/kratos/python_scripts/read_materials_process.py
+++ b/kratos/python_scripts/read_materials_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics
@@ -31,9 +30,9 @@ class ReadMaterialsProcess(KratosMultiphysics.Process):
 
         See _AssignPropertyBlock for detail on how properties are imported.
         """
-        
+
         KratosMultiphysics.Logger.PrintWarning("ReadMaterialsProcess", "\n\nDEPRECATED: This process is deprecated, please use the C++ utility: ReadMaterialsUtility")
-        
+
         KratosMultiphysics.Process.__init__(self)
         default_settings = KratosMultiphysics.Parameters("""
         {

--- a/kratos/python_scripts/read_materials_process.py
+++ b/kratos/python_scripts/read_materials_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics
@@ -30,9 +31,9 @@ class ReadMaterialsProcess(KratosMultiphysics.Process):
 
         See _AssignPropertyBlock for detail on how properties are imported.
         """
-
+        
         KratosMultiphysics.Logger.PrintWarning("ReadMaterialsProcess", "\n\nDEPRECATED: This process is deprecated, please use the C++ utility: ReadMaterialsUtility")
-
+        
         KratosMultiphysics.Process.__init__(self)
         default_settings = KratosMultiphysics.Parameters("""
         {

--- a/kratos/python_scripts/scipy_conversion_tools.py
+++ b/kratos/python_scripts/scipy_conversion_tools.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 # Import Kratos
 import KratosMultiphysics
 

--- a/kratos/python_scripts/scipy_conversion_tools.py
+++ b/kratos/python_scripts/scipy_conversion_tools.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 # Import Kratos
 import KratosMultiphysics

--- a/kratos/python_scripts/scipy_conversion_tools.py
+++ b/kratos/python_scripts/scipy_conversion_tools.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 # Import Kratos
 import KratosMultiphysics

--- a/kratos/python_scripts/skin_detection_process.py
+++ b/kratos/python_scripts/skin_detection_process.py
@@ -1,19 +1,17 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
-import KratosMultiphysics 
- 
-def Factory(settings, Model): 
-    if(type(settings) != KratosMultiphysics.Parameters): 
-        raise Exception("expected input shall be a Parameters object, encapsulating a json string") 
+import KratosMultiphysics
+
+def Factory(settings, Model):
+    if(type(settings) != KratosMultiphysics.Parameters):
+        raise Exception("expected input shall be a Parameters object, encapsulating a json string")
     return SkinDetectionProcess(Model, settings["Parameters"])
- 
-## All the processes python should be derived from "Process" 
+
+## All the processes python should be derived from "Process"
 class SkinDetectionProcess(KratosMultiphysics.Process):
-    def __init__(self, Model, settings ): 
-        KratosMultiphysics.Process.__init__(self) 
- 
-        default_settings = KratosMultiphysics.Parameters(""" 
+    def __init__(self, Model, settings ):
+        KratosMultiphysics.Process.__init__(self)
+
+        default_settings = KratosMultiphysics.Parameters("""
         {
             "help"                                  : "This process detects the skin from a given submodelpart and it generates the correspong conditions",
             "model_part_name"                       : "Main",

--- a/kratos/python_scripts/skin_detection_process.py
+++ b/kratos/python_scripts/skin_detection_process.py
@@ -1,18 +1,19 @@
+from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
-import KratosMultiphysics
-
-def Factory(settings, Model):
-    if(type(settings) != KratosMultiphysics.Parameters):
-        raise Exception("expected input shall be a Parameters object, encapsulating a json string")
+import KratosMultiphysics 
+ 
+def Factory(settings, Model): 
+    if(type(settings) != KratosMultiphysics.Parameters): 
+        raise Exception("expected input shall be a Parameters object, encapsulating a json string") 
     return SkinDetectionProcess(Model, settings["Parameters"])
-
-## All the processes python should be derived from "Process"
+ 
+## All the processes python should be derived from "Process" 
 class SkinDetectionProcess(KratosMultiphysics.Process):
-    def __init__(self, Model, settings ):
-        KratosMultiphysics.Process.__init__(self)
-
-        default_settings = KratosMultiphysics.Parameters("""
+    def __init__(self, Model, settings ): 
+        KratosMultiphysics.Process.__init__(self) 
+ 
+        default_settings = KratosMultiphysics.Parameters(""" 
         {
             "help"                                  : "This process detects the skin from a given submodelpart and it generates the correspong conditions",
             "model_part_name"                       : "Main",

--- a/kratos/python_scripts/skin_detection_process.py
+++ b/kratos/python_scripts/skin_detection_process.py
@@ -1,19 +1,18 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
-import KratosMultiphysics 
- 
-def Factory(settings, Model): 
-    if(type(settings) != KratosMultiphysics.Parameters): 
-        raise Exception("expected input shall be a Parameters object, encapsulating a json string") 
+import KratosMultiphysics
+
+def Factory(settings, Model):
+    if(type(settings) != KratosMultiphysics.Parameters):
+        raise Exception("expected input shall be a Parameters object, encapsulating a json string")
     return SkinDetectionProcess(Model, settings["Parameters"])
- 
-## All the processes python should be derived from "Process" 
+
+## All the processes python should be derived from "Process"
 class SkinDetectionProcess(KratosMultiphysics.Process):
-    def __init__(self, Model, settings ): 
-        KratosMultiphysics.Process.__init__(self) 
- 
-        default_settings = KratosMultiphysics.Parameters(""" 
+    def __init__(self, Model, settings ):
+        KratosMultiphysics.Process.__init__(self)
+
+        default_settings = KratosMultiphysics.Parameters("""
         {
             "help"                                  : "This process detects the skin from a given submodelpart and it generates the correspong conditions",
             "model_part_name"                       : "Main",

--- a/kratos/python_scripts/sub_model_part_skin_detection_process.py
+++ b/kratos/python_scripts/sub_model_part_skin_detection_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics

--- a/kratos/python_scripts/sub_model_part_skin_detection_process.py
+++ b/kratos/python_scripts/sub_model_part_skin_detection_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/sub_model_part_skin_detection_process.py
+++ b/kratos/python_scripts/sub_model_part_skin_detection_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 # Importing the Kratos Library
 import KratosMultiphysics

--- a/kratos/python_scripts/tikz_output_process.py
+++ b/kratos/python_scripts/tikz_output_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 import KratosMultiphysics.kratos_utilities as kratos_utils

--- a/kratos/python_scripts/tikz_output_process.py
+++ b/kratos/python_scripts/tikz_output_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 import KratosMultiphysics.kratos_utilities as kratos_utils

--- a/kratos/python_scripts/timer_process.py
+++ b/kratos/python_scripts/timer_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/python_scripts/timer_process.py
+++ b/kratos/python_scripts/timer_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/tests/test_array_1d_interface.py
+++ b/kratos/tests/test_array_1d_interface.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics as KM
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_array_1d_interface.py
+++ b/kratos/tests/test_array_1d_interface.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 import KratosMultiphysics as KM
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_cad_json_input.py
+++ b/kratos/tests/test_cad_json_input.py
@@ -1,6 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
-import KratosMultiphysics
+﻿import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 
 import os

--- a/kratos/tests/test_cad_json_input.py
+++ b/kratos/tests/test_cad_json_input.py
@@ -1,5 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
+﻿
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/kratos/tests/test_cad_json_input.py
+++ b/kratos/tests/test_cad_json_input.py
@@ -1,4 +1,5 @@
-﻿
+﻿from __future__ import print_function, absolute_import, division
+
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/kratos/tests/test_calculate_distance_to_skin.py
+++ b/kratos/tests/test_calculate_distance_to_skin.py
@@ -1,6 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
-import KratosMultiphysics.KratosUnittest as KratosUnittest
+﻿import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 import os
 

--- a/kratos/tests/test_calculate_distance_to_skin.py
+++ b/kratos/tests/test_calculate_distance_to_skin.py
@@ -1,4 +1,5 @@
-﻿
+﻿from __future__ import print_function, absolute_import, division
+
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 import os

--- a/kratos/tests/test_calculate_distance_to_skin.py
+++ b/kratos/tests/test_calculate_distance_to_skin.py
@@ -1,5 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
+﻿
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 import os

--- a/kratos/tests/test_compare_elements_conditions.py
+++ b/kratos/tests/test_compare_elements_conditions.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics as KM
 

--- a/kratos/tests/test_compare_elements_conditions.py
+++ b/kratos/tests/test_compare_elements_conditions.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics as KM

--- a/kratos/tests/test_compare_elements_conditions.py
+++ b/kratos/tests/test_compare_elements_conditions.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics as KM

--- a/kratos/tests/test_compute_nodal_divergence.py
+++ b/kratos/tests/test_compute_nodal_divergence.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics

--- a/kratos/tests/test_compute_nodal_divergence.py
+++ b/kratos/tests/test_compute_nodal_divergence.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 import math

--- a/kratos/tests/test_compute_nodal_divergence.py
+++ b/kratos/tests/test_compute_nodal_divergence.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics

--- a/kratos/tests/test_condition_number.py
+++ b/kratos/tests/test_condition_number.py
@@ -1,5 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-import KratosMultiphysics
+﻿import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 from KratosMultiphysics import eigen_solver_factory
 import os

--- a/kratos/tests/test_condition_number.py
+++ b/kratos/tests/test_condition_number.py
@@ -1,4 +1,5 @@
-﻿import KratosMultiphysics
+﻿from __future__ import print_function, absolute_import, division
+import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 from KratosMultiphysics import eigen_solver_factory
 import os

--- a/kratos/tests/test_connectivity_preserve_modeler.py
+++ b/kratos/tests/test_connectivity_preserve_modeler.py
@@ -1,6 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
-import KratosMultiphysics.KratosUnittest as KratosUnittest
+﻿import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 
 class TestConnectivityPreserveModeler(KratosUnittest.TestCase):

--- a/kratos/tests/test_connectivity_preserve_modeler.py
+++ b/kratos/tests/test_connectivity_preserve_modeler.py
@@ -1,5 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
+﻿
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 

--- a/kratos/tests/test_connectivity_preserve_modeler.py
+++ b/kratos/tests/test_connectivity_preserve_modeler.py
@@ -1,4 +1,5 @@
-﻿
+﻿from __future__ import print_function, absolute_import, division
+
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 

--- a/kratos/tests/test_dofs.py
+++ b/kratos/tests/test_dofs.py
@@ -1,10 +1,8 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 
 class TestDofs(KratosUnittest.TestCase):
-    
+
     def test_model_part_sub_model_parts(self):
         current_model = KratosMultiphysics.Model()
 
@@ -31,8 +29,8 @@ class TestDofs(KratosUnittest.TestCase):
         dx.EquationId = 5
         dy.EquationId = 6
         dz.EquationId = 7
-        
-        self.assertEqual(p.GetVariable(), KratosMultiphysics.PRESSURE) 
+
+        self.assertEqual(p.GetVariable(), KratosMultiphysics.PRESSURE)
         self.assertEqual(dx.GetVariable(), KratosMultiphysics.DISPLACEMENT_X)
         self.assertEqual(dx.GetReaction(), KratosMultiphysics.REACTION_X)
         self.assertEqual(dx.EquationId, 5)

--- a/kratos/tests/test_dofs.py
+++ b/kratos/tests/test_dofs.py
@@ -1,10 +1,9 @@
-from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 
 class TestDofs(KratosUnittest.TestCase):
-    
+
     def test_model_part_sub_model_parts(self):
         current_model = KratosMultiphysics.Model()
 
@@ -31,8 +30,8 @@ class TestDofs(KratosUnittest.TestCase):
         dx.EquationId = 5
         dy.EquationId = 6
         dz.EquationId = 7
-        
-        self.assertEqual(p.GetVariable(), KratosMultiphysics.PRESSURE) 
+
+        self.assertEqual(p.GetVariable(), KratosMultiphysics.PRESSURE)
         self.assertEqual(dx.GetVariable(), KratosMultiphysics.DISPLACEMENT_X)
         self.assertEqual(dx.GetReaction(), KratosMultiphysics.REACTION_X)
         self.assertEqual(dx.EquationId, 5)

--- a/kratos/tests/test_dofs.py
+++ b/kratos/tests/test_dofs.py
@@ -1,9 +1,10 @@
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 
 class TestDofs(KratosUnittest.TestCase):
-
+    
     def test_model_part_sub_model_parts(self):
         current_model = KratosMultiphysics.Model()
 
@@ -30,8 +31,8 @@ class TestDofs(KratosUnittest.TestCase):
         dx.EquationId = 5
         dy.EquationId = 6
         dz.EquationId = 7
-
-        self.assertEqual(p.GetVariable(), KratosMultiphysics.PRESSURE)
+        
+        self.assertEqual(p.GetVariable(), KratosMultiphysics.PRESSURE) 
         self.assertEqual(dx.GetVariable(), KratosMultiphysics.DISPLACEMENT_X)
         self.assertEqual(dx.GetReaction(), KratosMultiphysics.REACTION_X)
         self.assertEqual(dx.EquationId, 5)

--- a/kratos/tests/test_embedded_skin_mapping.py
+++ b/kratos/tests/test_embedded_skin_mapping.py
@@ -1,6 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
-import KratosMultiphysics.KratosUnittest as KratosUnittest
+﻿import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 import os
 

--- a/kratos/tests/test_embedded_skin_mapping.py
+++ b/kratos/tests/test_embedded_skin_mapping.py
@@ -1,4 +1,5 @@
-﻿
+﻿from __future__ import print_function, absolute_import, division
+
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 import os

--- a/kratos/tests/test_embedded_skin_mapping.py
+++ b/kratos/tests/test_embedded_skin_mapping.py
@@ -1,5 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
+﻿
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 import os

--- a/kratos/tests/test_exact_integration.py
+++ b/kratos/tests/test_exact_integration.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/kratos/tests/test_exact_integration.py
+++ b/kratos/tests/test_exact_integration.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_exact_integration.py
+++ b/kratos/tests/test_exact_integration.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_flags.py
+++ b/kratos/tests/test_flags.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 from KratosMultiphysics import *
 

--- a/kratos/tests/test_flags.py
+++ b/kratos/tests/test_flags.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 from KratosMultiphysics import *

--- a/kratos/tests/test_flags.py
+++ b/kratos/tests/test_flags.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 from KratosMultiphysics import *

--- a/kratos/tests/test_geometries.py
+++ b/kratos/tests/test_geometries.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics as KM
 
@@ -42,7 +40,7 @@ class TestGeometry(KratosUnittest.TestCase):
         model_part= current_model.CreateModelPart("Main")
         tester = KM.GeometryTesterUtility()
         self.assertTrue( tester.TestHexahedra3D27N(model_part) )
-        
+
     def test_hexahedra_3D20N(self):
         current_model = KM.Model()
         model_part= current_model.CreateModelPart("Main")

--- a/kratos/tests/test_geometries.py
+++ b/kratos/tests/test_geometries.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics as KM
@@ -42,7 +41,7 @@ class TestGeometry(KratosUnittest.TestCase):
         model_part= current_model.CreateModelPart("Main")
         tester = KM.GeometryTesterUtility()
         self.assertTrue( tester.TestHexahedra3D27N(model_part) )
-        
+
     def test_hexahedra_3D20N(self):
         current_model = KM.Model()
         model_part= current_model.CreateModelPart("Main")

--- a/kratos/tests/test_geometries.py
+++ b/kratos/tests/test_geometries.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics as KM
@@ -41,7 +42,7 @@ class TestGeometry(KratosUnittest.TestCase):
         model_part= current_model.CreateModelPart("Main")
         tester = KM.GeometryTesterUtility()
         self.assertTrue( tester.TestHexahedra3D27N(model_part) )
-
+        
     def test_hexahedra_3D20N(self):
         current_model = KM.Model()
         model_part= current_model.CreateModelPart("Main")

--- a/kratos/tests/test_gid_io.py
+++ b/kratos/tests/test_gid_io.py
@@ -1,6 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
-import KratosMultiphysics
+﻿import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 
 import KratosMultiphysics.kratos_utilities as kratos_utils

--- a/kratos/tests/test_gid_io.py
+++ b/kratos/tests/test_gid_io.py
@@ -1,5 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
+﻿
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/kratos/tests/test_gid_io.py
+++ b/kratos/tests/test_gid_io.py
@@ -1,4 +1,5 @@
-﻿
+﻿from __future__ import print_function, absolute_import, division
+
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/kratos/tests/test_gid_io_gauss_points.py
+++ b/kratos/tests/test_gid_io_gauss_points.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 from KratosMultiphysics import *
 import KratosMultiphysics.KratosUnittest as UnitTest
 

--- a/kratos/tests/test_gid_io_gauss_points.py
+++ b/kratos/tests/test_gid_io_gauss_points.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 from KratosMultiphysics import *
 import KratosMultiphysics.KratosUnittest as UnitTest

--- a/kratos/tests/test_gid_io_gauss_points.py
+++ b/kratos/tests/test_gid_io_gauss_points.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 from KratosMultiphysics import *
 import KratosMultiphysics.KratosUnittest as UnitTest

--- a/kratos/tests/test_importing.py
+++ b/kratos/tests/test_importing.py
@@ -1,6 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
-import KratosMultiphysics as KM
+﻿import KratosMultiphysics as KM
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 
 class TestImporting(KratosUnittest.TestCase):

--- a/kratos/tests/test_importing.py
+++ b/kratos/tests/test_importing.py
@@ -1,4 +1,5 @@
-﻿
+﻿from __future__ import print_function, absolute_import, division
+
 import KratosMultiphysics as KM
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/kratos/tests/test_importing.py
+++ b/kratos/tests/test_importing.py
@@ -1,5 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
+﻿
 import KratosMultiphysics as KM
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/kratos/tests/test_kratos_parameters.py
+++ b/kratos/tests/test_kratos_parameters.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 from KratosMultiphysics import Parameters
 from KratosMultiphysics import Vector
 from KratosMultiphysics import Matrix

--- a/kratos/tests/test_kratos_parameters.py
+++ b/kratos/tests/test_kratos_parameters.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 from KratosMultiphysics import Parameters
 from KratosMultiphysics import Vector

--- a/kratos/tests/test_kratos_parameters.py
+++ b/kratos/tests/test_kratos_parameters.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 from KratosMultiphysics import Parameters
 from KratosMultiphysics import Vector

--- a/kratos/tests/test_levelset_convection.py
+++ b/kratos/tests/test_levelset_convection.py
@@ -1,6 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
-import KratosMultiphysics
+﻿import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import os
 

--- a/kratos/tests/test_levelset_convection.py
+++ b/kratos/tests/test_levelset_convection.py
@@ -1,5 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
+﻿
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import os

--- a/kratos/tests/test_levelset_convection.py
+++ b/kratos/tests/test_levelset_convection.py
@@ -1,4 +1,5 @@
-﻿
+﻿from __future__ import print_function, absolute_import, division
+
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import os

--- a/kratos/tests/test_linear_constraints.py
+++ b/kratos/tests/test_linear_constraints.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_linear_constraints.py
+++ b/kratos/tests/test_linear_constraints.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 # Importing the Kratos Library
 import KratosMultiphysics as KM

--- a/kratos/tests/test_linear_constraints.py
+++ b/kratos/tests/test_linear_constraints.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 # Importing the Kratos Library
 import KratosMultiphysics as KM

--- a/kratos/tests/test_linear_solvers.py
+++ b/kratos/tests/test_linear_solvers.py
@@ -1,5 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-import KratosMultiphysics
+﻿import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import os
 

--- a/kratos/tests/test_linear_solvers.py
+++ b/kratos/tests/test_linear_solvers.py
@@ -1,4 +1,5 @@
-﻿import KratosMultiphysics
+﻿from __future__ import print_function, absolute_import, division
+import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import os
 

--- a/kratos/tests/test_materials_input.py
+++ b/kratos/tests/test_materials_input.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import os
 import sys

--- a/kratos/tests/test_materials_input.py
+++ b/kratos/tests/test_materials_input.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import os
 import sys
 

--- a/kratos/tests/test_materials_input.py
+++ b/kratos/tests/test_materials_input.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import os
 import sys

--- a/kratos/tests/test_matrix_interface.py
+++ b/kratos/tests/test_matrix_interface.py
@@ -1,6 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
-import KratosMultiphysics.KratosUnittest as KratosUnittest
+﻿import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics as KM
 import math
 

--- a/kratos/tests/test_matrix_interface.py
+++ b/kratos/tests/test_matrix_interface.py
@@ -1,5 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
+﻿
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics as KM
 import math

--- a/kratos/tests/test_matrix_interface.py
+++ b/kratos/tests/test_matrix_interface.py
@@ -1,4 +1,5 @@
-﻿
+﻿from __future__ import print_function, absolute_import, division
+
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics as KM
 import math

--- a/kratos/tests/test_matrix_market_interface.py
+++ b/kratos/tests/test_matrix_market_interface.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utils
@@ -58,7 +56,7 @@ class TestMatrixMarketInterface(KratosUnittest.TestCase):
 
         b = KratosMultiphysics.ComplexVector()
         KratosMultiphysics.ReadMatrixMarketVector('a.mm', b)
-        
+
         self.assertVectorAlmostEqual(a, b)
         kratos_utils.DeleteFileIfExisting("a.mm")
 

--- a/kratos/tests/test_matrix_market_interface.py
+++ b/kratos/tests/test_matrix_market_interface.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
@@ -57,7 +58,7 @@ class TestMatrixMarketInterface(KratosUnittest.TestCase):
 
         b = KratosMultiphysics.ComplexVector()
         KratosMultiphysics.ReadMatrixMarketVector('a.mm', b)
-
+        
         self.assertVectorAlmostEqual(a, b)
         kratos_utils.DeleteFileIfExisting("a.mm")
 

--- a/kratos/tests/test_matrix_market_interface.py
+++ b/kratos/tests/test_matrix_market_interface.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
@@ -58,7 +57,7 @@ class TestMatrixMarketInterface(KratosUnittest.TestCase):
 
         b = KratosMultiphysics.ComplexVector()
         KratosMultiphysics.ReadMatrixMarketVector('a.mm', b)
-        
+
         self.assertVectorAlmostEqual(a, b)
         kratos_utils.DeleteFileIfExisting("a.mm")
 

--- a/kratos/tests/test_model.py
+++ b/kratos/tests/test_model.py
@@ -1,6 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
-import KratosMultiphysics
+﻿import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utils
 

--- a/kratos/tests/test_model.py
+++ b/kratos/tests/test_model.py
@@ -1,5 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
+﻿
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utils

--- a/kratos/tests/test_model.py
+++ b/kratos/tests/test_model.py
@@ -1,4 +1,5 @@
-﻿
+﻿from __future__ import print_function, absolute_import, division
+
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utils

--- a/kratos/tests/test_mortar_mapper.py
+++ b/kratos/tests/test_mortar_mapper.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/kratos/tests/test_mortar_mapper.py
+++ b/kratos/tests/test_mortar_mapper.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_mortar_mapper.py
+++ b/kratos/tests/test_mortar_mapper.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_normal_utils.py
+++ b/kratos/tests/test_normal_utils.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import os
 import math
 

--- a/kratos/tests/test_normal_utils.py
+++ b/kratos/tests/test_normal_utils.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import os
 import math

--- a/kratos/tests/test_normal_utils.py
+++ b/kratos/tests/test_normal_utils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import os
 import math

--- a/kratos/tests/test_numpy_export_dense_matrix.py
+++ b/kratos/tests/test_numpy_export_dense_matrix.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/kratos/tests/test_numpy_export_dense_matrix.py
+++ b/kratos/tests/test_numpy_export_dense_matrix.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_numpy_export_dense_matrix.py
+++ b/kratos/tests/test_numpy_export_dense_matrix.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_object_printing.py
+++ b/kratos/tests/test_object_printing.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_object_printing.py
+++ b/kratos/tests/test_object_printing.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_processes.py
+++ b/kratos/tests/test_processes.py
@@ -1,5 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
+﻿
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/tests/test_processes.py
+++ b/kratos/tests/test_processes.py
@@ -1,4 +1,5 @@
-﻿
+﻿from __future__ import print_function, absolute_import, division
+
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/kratos/tests/test_processes.py
+++ b/kratos/tests/test_processes.py
@@ -1,6 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
-# Importing the Kratos Library
+﻿# Importing the Kratos Library
 import KratosMultiphysics
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_python_generic_function_utility.py
+++ b/kratos/tests/test_python_generic_function_utility.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/kratos/tests/test_python_generic_function_utility.py
+++ b/kratos/tests/test_python_generic_function_utility.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_python_generic_function_utility.py
+++ b/kratos/tests/test_python_generic_function_utility.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_redistance.py
+++ b/kratos/tests/test_redistance.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics

--- a/kratos/tests/test_redistance.py
+++ b/kratos/tests/test_redistance.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory

--- a/kratos/tests/test_redistance.py
+++ b/kratos/tests/test_redistance.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics

--- a/kratos/tests/test_reorder.py
+++ b/kratos/tests/test_reorder.py
@@ -1,6 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
-import KratosMultiphysics.KratosUnittest as KratosUnittest
+﻿import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 
 import os

--- a/kratos/tests/test_reorder.py
+++ b/kratos/tests/test_reorder.py
@@ -1,5 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
+﻿
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 

--- a/kratos/tests/test_reorder.py
+++ b/kratos/tests/test_reorder.py
@@ -1,4 +1,5 @@
-﻿
+﻿from __future__ import print_function, absolute_import, division
+
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 

--- a/kratos/tests/test_restart.py
+++ b/kratos/tests/test_restart.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/kratos/tests/test_restart.py
+++ b/kratos/tests/test_restart.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_restart.py
+++ b/kratos/tests/test_restart.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_scipy_conversion_tools.py
+++ b/kratos/tests/test_scipy_conversion_tools.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/kratos/tests/test_scipy_conversion_tools.py
+++ b/kratos/tests/test_scipy_conversion_tools.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_scipy_conversion_tools.py
+++ b/kratos/tests/test_scipy_conversion_tools.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_serializer.py
+++ b/kratos/tests/test_serializer.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import os
 
 # Importing the Kratos Library

--- a/kratos/tests/test_serializer.py
+++ b/kratos/tests/test_serializer.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import os
 

--- a/kratos/tests/test_serializer.py
+++ b/kratos/tests/test_serializer.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import os
 

--- a/kratos/tests/test_skin_detection_process.py
+++ b/kratos/tests/test_skin_detection_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_skin_detection_process.py
+++ b/kratos/tests/test_skin_detection_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_sparse_multiplication.py
+++ b/kratos/tests/test_sparse_multiplication.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 # Import Kratos
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_sparse_multiplication.py
+++ b/kratos/tests/test_sparse_multiplication.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 # Import Kratos
 import KratosMultiphysics

--- a/kratos/tests/test_sparse_multiplication.py
+++ b/kratos/tests/test_sparse_multiplication.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 # Import Kratos
 import KratosMultiphysics

--- a/kratos/tests/test_tetrahedral_mesh_orientation_check.py
+++ b/kratos/tests/test_tetrahedral_mesh_orientation_check.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_tetrahedral_mesh_orientation_check.py
+++ b/kratos/tests/test_tetrahedral_mesh_orientation_check.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_tikz_output_process.py
+++ b/kratos/tests/test_tikz_output_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/kratos/tests/test_tikz_output_process.py
+++ b/kratos/tests/test_tikz_output_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_tikz_output_process.py
+++ b/kratos/tests/test_tikz_output_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_time_discretization.py
+++ b/kratos/tests/test_time_discretization.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics as KM
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/kratos/tests/test_time_discretization.py
+++ b/kratos/tests/test_time_discretization.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics as KM
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_time_discretization.py
+++ b/kratos/tests/test_time_discretization.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics as KM
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_variable_component.py
+++ b/kratos/tests/test_variable_component.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/kratos/tests/test_variable_component.py
+++ b/kratos/tests/test_variable_component.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_variable_component.py
+++ b/kratos/tests/test_variable_component.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_variable_utils.py
+++ b/kratos/tests/test_variable_utils.py
@@ -1,6 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
-# Importing the Kratos Library
+﻿# Importing the Kratos Library
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/kratos/tests/test_variable_utils.py
+++ b/kratos/tests/test_variable_utils.py
@@ -1,5 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
+﻿
 # Importing the Kratos Library
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_variable_utils.py
+++ b/kratos/tests/test_variable_utils.py
@@ -1,4 +1,5 @@
-﻿
+﻿from __future__ import print_function, absolute_import, division
+
 # Importing the Kratos Library
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_vector_interface.py
+++ b/kratos/tests/test_vector_interface.py
@@ -1,6 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
-import KratosMultiphysics.KratosUnittest as KratosUnittest
+﻿import KratosMultiphysics.KratosUnittest as KratosUnittest
 from KratosMultiphysics import *
 import math
 

--- a/kratos/tests/test_vector_interface.py
+++ b/kratos/tests/test_vector_interface.py
@@ -1,5 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
+﻿
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 from KratosMultiphysics import *
 import math

--- a/kratos/tests/test_vector_interface.py
+++ b/kratos/tests/test_vector_interface.py
@@ -1,4 +1,5 @@
-﻿
+﻿from __future__ import print_function, absolute_import, division
+
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 from KratosMultiphysics import *
 import math

--- a/kratos/tests/test_vtk_output_process.py
+++ b/kratos/tests/test_vtk_output_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/kratos/tests/test_vtk_output_process.py
+++ b/kratos/tests/test_vtk_output_process.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_vtk_output_process.py
+++ b/kratos/tests/test_vtk_output_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest


### PR DESCRIPTION
**Description**
As in the title this removes `from __future__ import` lines from python scripts.

**Changelog**
- Removes python 2 support from core