### PR TITLE
[CI] Update to Parmmg v1.3.0 (5ffc6ad)

### DIFF
--- a/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
@@ -1,7 +1,7 @@
 FROM ubuntu:focal
 
 ENV HOME /root
-ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/external_libraries/mmg/mmg_5_4_1/lib:/external_libraries/mmg/mmg_5_5_1/lib:/external_libraries/ParMmg_4d272bb/lib
+ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/external_libraries/mmg/mmg_5_4_1/lib:/external_libraries/mmg/mmg_5_5_1/lib:/external_libraries/ParMmg_4d272bb/lib:/external_libraries/ParMmg_5ffc6ad/lib:
 
 RUN apt-get update -y && apt-get upgrade -y && \
     apt-get -y install \

--- a/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
@@ -77,8 +77,17 @@ RUN apt-get update -y && apt-get upgrade -y && \
     cd /tmp/ParMmg_4d272bb/build && git checkout 4d272bb3d1a51d839a5fdfaa3eef93f340cafda3 && \
     cmake .. -DCMAKE_INSTALL_PREFIX="/external_libraries/ParMmg_4d272bb" -DUSE_SCOTCH=OFF -DLIBPARMMG_SHARED=ON -DDOWNLOAD_MMG=OFF -DMMG_DIR="/tmp/mmg_5_5_1" -DMMG_BUILDDIR="/tmp/mmg_5_5_1/build" -DDOWNLOAD_METIS=OFF -DMETIS_DIR="/usr/include" && \
     make install && \
-    rm -r /tmp/mmg_5_5_1 && \
     rm -r /tmp/ParMmg_4d272bb && \
+    cd / && \
+    ####
+    git clone https://github.com/MmgTools/ParMmg /tmp/ParMmg_5ffc6ad && \
+    mkdir /tmp/ParMmg_5ffc6ad/build && \
+    mkdir -p /external_libraries/ParMmg_5ffc6ad && \
+    cd /tmp/ParMmg_5ffc6ad/build && git checkout 5ffc6ada4afb1af50a43e1fa6f4c409cff2ea25c && \
+    cmake .. -DCMAKE_INSTALL_PREFIX="/external_libraries/ParMmg_5ffc6ad" -DUSE_SCOTCH=OFF -DLIBPARMMG_SHARED=ON -DDOWNLOAD_MMG=OFF -DMMG_DIR="/tmp/mmg_5_5_1" -DMMG_BUILDDIR="/tmp/mmg_5_5_1/build" -DDOWNLOAD_METIS=OFF -DMETIS_DIR="/usr/include" && \
+    make install && \
+    rm -r /tmp/mmg_5_5_1 && \
+    rm -r /tmp/ParMmg_5ffc6ad && \
     cd / && \
     # remove some now unnecessary packages
     apt-get -y remove \


### PR DESCRIPTION
**Description**
This pr adds a new version of ParMmg that solves some bugs happening in #8075. 

The version we currently have was added before the release 8.1 , and some bugs have been fixed since then here.

I have built this docker locally to ensure the image works fine.  This will allow to update the path in the tests in a future PR. 

If you agree, the old version will be kept for some time to avoid failures of the CI on those branches that are not merged with the master.  

**Changelog**
- Added Parmmg 5ffc6ad