### PR TITLE
[StatApp] Activating MPI tests

### DIFF
--- a/applications/StatisticsApplication/README.md
+++ b/applications/StatisticsApplication/README.md
@@ -103,7 +103,7 @@ Following example illustrates different methods used in different containers wit
                         "write_time_stamp"       : false,
                         "output_file_settings"   : {
                             "file_name"  : "<model_part_name>_<container>_<norm_type>_<method_name>.dat",
-                            "folder_name": "spatial_statistics_process",
+                            "output_path": "spatial_statistics_process",
                             "write_buffer_size" : -1
                         }
                     }
@@ -644,7 +644,7 @@ This is a seperate process, which can be included in the json file as an auxilia
         "write_time_stamp"       : true,
         "output_file_settings"   : {
             "file_name"  : "<model_part_name>_<container>_<norm_type>_<method_name>.dat",
-            "folder_name": "spatial_statistics_output",
+            "output_path": "spatial_statistics_output",
             "write_buffer_size" : -1
         }
     }

--- a/applications/StatisticsApplication/python_scripts/spatial_statistics_process.py
+++ b/applications/StatisticsApplication/python_scripts/spatial_statistics_process.py
@@ -56,7 +56,7 @@ class SpatialStatisticsProcess(Kratos.Process):
                 "write_time_stamp"       : true,
                 "output_file_settings"   : {
                     "file_name"  : "<model_part_name>_<container>_<norm_type>_<method_name>.dat",
-                    "folder_name": "spatial_statistics_output",
+                    "output_path": "spatial_statistics_output",
                     "write_buffer_size" : -1
                 }
             }
@@ -159,8 +159,8 @@ class SpatialStatisticsProcess(Kratos.Process):
             current_output_file_settings = Kratos.Parameters("""{}""")
             current_output_file_settings.AddEmptyValue("file_name")
             current_output_file_settings["file_name"].SetString(output_file_name)
-            current_output_file_settings.AddEmptyValue("folder_name")
-            current_output_file_settings["folder_name"].SetString(output_file_settings["folder_name"].GetString())
+            current_output_file_settings.AddEmptyValue("output_path")
+            current_output_file_settings["output_path"].SetString(output_file_settings["output_path"].GetString())
             # restarting is not supported if STEP is used as the control variable
             if (self.__is_writing_process()):
                 self.output_files.append(TimeBasedAsciiFileWriterUtility(self.__get_model_part(), current_output_file_settings, msg_header))

--- a/applications/StatisticsApplication/tests/spatial_statistics_test_case.py
+++ b/applications/StatisticsApplication/tests/spatial_statistics_test_case.py
@@ -1,6 +1,5 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 import KratosMultiphysics as Kratos
+import KratosMultiphysics.KratosUnittest as KratosUnittest
 from KratosMultiphysics.process_factory import KratosProcessFactory
 import KratosMultiphysics.StatisticsApplication as KratosStats
 
@@ -45,18 +44,19 @@ class SpatialStatisticsTestCase(statistics_test_case.StatisticsTestCase):
         self.__TestMethod(settings)
 
     def __TestMethod(self, settings):
-        factory = KratosProcessFactory(self.current_model)
-        self.process_list = factory.ConstructListOfProcesses(settings)
-        InitializeProcesses(self)
+        with KratosUnittest.WorkFolderScope(".", __file__):
+            factory = KratosProcessFactory(self.current_model)
+            self.process_list = factory.ConstructListOfProcesses(settings)
+            InitializeProcesses(self)
 
-        for step in range(0, 12, 2):
-            self.model_part.CloneTimeStep(step)
-            self.model_part.ProcessInfo[Kratos.STEP] = step
-            InitializeModelPartVariables(self.model_part, False)
-            ExecuteProcessFinalizeSolutionStep(self)
+            for step in range(0, 12, 2):
+                self.model_part.CloneTimeStep(step)
+                self.model_part.ProcessInfo[Kratos.STEP] = step
+                InitializeModelPartVariables(self.model_part, False)
+                ExecuteProcessFinalizeSolutionStep(self)
 
-        for process in self.process_list:
-            process.ExecuteFinalize()
+            for process in self.process_list:
+                process.ExecuteFinalize()
 
     @staticmethod
     def __GetDefaultParameters(container_name):
@@ -159,7 +159,7 @@ class SpatialStatisticsTestCase(statistics_test_case.StatisticsTestCase):
                         "write_time_stamp"       : false,
                         "output_file_settings"   : {
                             "file_name"  : "<model_part_name>_<container>_<norm_type>_<method_name>.dat",
-                            "folder_name": "spatial_statistics_process",
+                            "output_path": "spatial_statistics_process",
                             "write_buffer_size" : -1
                         }
                     }

--- a/applications/StatisticsApplication/tests/statistics_test_case.py
+++ b/applications/StatisticsApplication/tests/statistics_test_case.py
@@ -1,8 +1,6 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 import KratosMultiphysics as Kratos
 from KratosMultiphysics import KratosUnittest
-
+from KratosMultiphysics.testing.utilities import ReadModelPart
 from KratosMultiphysics.StatisticsApplication.test_utilities import InitializeModelPartVariables
 
 class StatisticsTestCase(KratosUnittest.TestCase):
@@ -18,12 +16,8 @@ class StatisticsTestCase(KratosUnittest.TestCase):
         cls.model_part.ProcessInfo.SetValue(Kratos.DOMAIN_SIZE, 2)
 
         cls.AddVariables()
-
-        communicator = Kratos.DataCommunicator.GetDefault()
-        if communicator.IsDistributed():
-            ReadDistributedModelPart(cls.model_part, mdpa_file_name)
-        else:
-            ReadModelPart(cls.model_part, mdpa_file_name)
+        with KratosUnittest.WorkFolderScope(".", __file__):
+            ReadModelPart(mdpa_file_name, cls.model_part)
 
     @classmethod
     def AddVariables(cls):
@@ -37,24 +31,3 @@ class StatisticsTestCase(KratosUnittest.TestCase):
 
     def GetModel(self):
         return self.current_model
-
-def ReadModelPart(model_part, mdpa_file_name):
-    import_flags = Kratos.ModelPartIO.READ | Kratos.ModelPartIO.SKIP_TIMER
-    Kratos.ModelPartIO(mdpa_file_name, import_flags).ReadModelPart(model_part)
-
-def ReadDistributedModelPart(model_part, mdpa_file_name):
-    from KratosMultiphysics.mpi import distributed_import_model_part_utility
-    model_part.AddNodalSolutionStepVariable(Kratos.PARTITION_INDEX)
-
-    importer_settings = Kratos.Parameters("""{
-        "model_import_settings": {
-            "input_type": "mdpa",
-            "input_filename": \"""" + mdpa_file_name + """\",
-            "partition_in_memory" : true
-        },
-        "echo_level" : 0
-    }""")
-
-    model_part_import_util = distributed_import_model_part_utility.DistributedImportModelPartUtility(model_part, importer_settings)
-    model_part_import_util.ImportModelPart()
-    model_part_import_util.CreateCommunicators()

--- a/applications/StatisticsApplication/tests/test_StatisticsApplication_mpi.py
+++ b/applications/StatisticsApplication/tests/test_StatisticsApplication_mpi.py
@@ -32,17 +32,17 @@ def AssembleTestSuites():
 
     ### Small MPI tests ########################################################
     smallMPISuite = suites['mpi_small']
+    smallMPISuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([SpatialStatisticsProcessTest]))
+    smallMPISuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TemporalSumMethodTests]))
+    smallMPISuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TemporalMeanMethodTests]))
+    smallMPISuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TemporalVarianceMethodTests]))
+    smallMPISuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TemporalMinMethodTests]))
+    smallMPISuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TemporalMaxMethodTests]))
+    smallMPISuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TemporalRootMeanSquareMethodTests]))
 
     ### Nightly MPI tests ######################################################
     nightlyMPISuite = suites['mpi_nightly']
     nightlyMPISuite.addTests(smallMPISuite)
-    # nightlyMPISuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([SpatialStatisticsProcessTest]))
-    # nightlyMPISuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TemporalSumMethodTests]))
-    # nightlyMPISuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TemporalMeanMethodTests]))
-    # nightlyMPISuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TemporalVarianceMethodTests]))
-    # nightlyMPISuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TemporalMinMethodTests]))
-    # nightlyMPISuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TemporalMaxMethodTests]))
-    # nightlyMPISuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TemporalRootMeanSquareMethodTests]))
 
     ### Full MPI set ###########################################################
     allMPISuite = suites['mpi_all']

--- a/applications/StatisticsApplication/tests/test_spatial_statistics_process.py
+++ b/applications/StatisticsApplication/tests/test_spatial_statistics_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 import KratosMultiphysics as Kratos
 import spatial_statistics_test_case
 


### PR DESCRIPTION
**Description**
This PR activates MPI tests in StatisticsApplication after #8130.

**Changelog**
- Reactivating mpi tests
- Removes python 2 support
- Changes `folder_name` to `output_path` in TimeBasedASCIIwriter
- Using `ReadModelPart` from core testing utilities
