### PR TITLE
[core] Actually removing new Python Path in Kratos Unit Test class

### DIFF
--- a/kratos/python_scripts/KratosUnittest.py
+++ b/kratos/python_scripts/KratosUnittest.py
@@ -280,4 +280,4 @@ class WorkFolderScope:
     def __exit__(self, exc_type, exc_value, traceback):
         os.chdir(self.currentPath)
         if self.add_to_path:
-            sys.path = self.currentPythonpath
+            sys.path.remove(self.scope)


### PR DESCRIPTION
**Description**
Correction of a bug. Previously, new Python paths were not correctly removed.

Let's have a look at this:
~~~sh
>>> import sys
>>> import os
# save old path
>>> old = sys.path
>>> old
[]
# add twice the same path
>>> sys.path.append("ciao")
>>> sys.path.append("ciao")
>>> sys.path
['ciao', 'ciao']
# restore original path, attempt 1 (current implementation)
>>> sys.path = old
>>> sys.path
['ciao', 'ciao']
# restore original path, attempt 2 (new implementation)
>>> sys.path.remove("ciao")
>>> sys.path
['ciao']
>>> sys.path.remove("ciao")
>>> sys.path
[]
~~~

Therefore, we can conclude that `sys.path = old` does not work. On the other hand, sys.path.remove("ciao") does work.

Please mark the PR with appropriate tags: 
- Python, Testing, Bugfix

**Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Correct Python Path bug of `WorkFolderScope` class.