### PR TITLE
[Core] missing include

### DIFF
--- a/kratos/utilities/parallel_utilities.cpp
+++ b/kratos/utilities/parallel_utilities.cpp
@@ -13,6 +13,7 @@
 //
 
 // System includes
+#include <algorithm>
 #include <cstdlib> // for std::getenv
 
 // External includes
@@ -56,7 +57,7 @@ int ParallelUtilities::GetNumProcs()
 
 #elif defined(KRATOS_SMP_CXX11)
     // NOTE: std::thread::hardware_concurrency() can return 0 in some systems!
-    unsigned num_procs = std::thread::hardware_concurrency();
+    int num_procs = std::thread::hardware_concurrency();
 
     KRATOS_WARNING_IF("ParallelUtilities", num_procs == 0) << "The number of processors cannot be determined correctly on this machine. Please check your setup carefully!" << std::endl;
 


### PR DESCRIPTION
**Description**
This part is only compiled if C++ is chosen as parallelization thats why it was not detected earlier