### PR TITLE
[StructuralMechanicsApplication] Adding INTEGRATION_COORDINATES to beam elements

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
@@ -746,9 +746,11 @@ void CrBeamElement2D2N::CalculateOnIntegrationPoints(
 {
 
     KRATOS_TRY
-    // element with two nodes can only represent results at one node
-    const unsigned int& write_points_number =
-        GetGeometry().IntegrationPointsNumber(Kratos::GeometryData::GI_GAUSS_3);
+
+    // Element with two nodes can only represent results at one node
+    const auto& r_geometry = GetGeometry();
+    const GeometryType::IntegrationPointsArrayType& r_integration_points = r_geometry.IntegrationPoints(Kratos::GeometryData::GI_GAUSS_3);
+    const SizeType write_points_number = r_integration_points.size();
     if (rOutput.size() != write_points_number) {
         rOutput.resize(write_points_number);
     }
@@ -772,8 +774,7 @@ void CrBeamElement2D2N::CalculateOnIntegrationPoints(
         rOutput[0][2] = 1.0 * stress[2] * 0.75 - stress[5] * 0.25;
         rOutput[1][2] = 1.0 * stress[2] * 0.50 - stress[5] * 0.50;
         rOutput[2][2] = 1.0 * stress[2] * 0.25 - stress[5] * 0.75;
-    }
-    if (rVariable == FORCE) {
+    } else if (rVariable == FORCE) {
         rOutput[0][0] = -1.0 * stress[0] * 0.75 + stress[3] * 0.25;
         rOutput[1][0] = -1.0 * stress[0] * 0.50 + stress[3] * 0.50;
         rOutput[2][0] = -1.0 * stress[0] * 0.25 + stress[3] * 0.75;
@@ -785,6 +786,12 @@ void CrBeamElement2D2N::CalculateOnIntegrationPoints(
         rOutput[0][2] = 0.00;
         rOutput[1][2] = 0.00;
         rOutput[2][2] = 0.00;
+    } else if (rVariable == INTEGRATION_COORDINATES) {
+        Point global_point;
+        for (IndexType point_number = 0; point_number < write_points_number; ++point_number) {
+            r_geometry.GlobalCoordinates(global_point, r_integration_points[point_number]);
+            rOutput[point_number] = global_point.Coordinates();
+        }
     }
 
     KRATOS_CATCH("")

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
@@ -1214,15 +1214,15 @@ void CrBeamElement3D2N::CalculateOnIntegrationPoints(
     std::vector<array_1d<double, 3>>& rOutput,
     const ProcessInfo& rCurrentProcessInfo)
 {
-
     KRATOS_TRY
-    // element with two nodes can only represent results at one node
-    const unsigned int& write_points_number =
-        GetGeometry().IntegrationPointsNumber(Kratos::GeometryData::GI_GAUSS_3);
+
+    // Element with two nodes can only represent results at one node
+    const auto& r_geometry = GetGeometry();
+    const GeometryType::IntegrationPointsArrayType& r_integration_points = r_geometry.IntegrationPoints(Kratos::GeometryData::GI_GAUSS_3);
+    const SizeType write_points_number = r_integration_points.size();
     if (rOutput.size() != write_points_number) {
         rOutput.resize(write_points_number);
     }
-
 
     // rOutput[GP 1,2,3][x,y,z]
 
@@ -1252,9 +1252,7 @@ void CrBeamElement3D2N::CalculateOnIntegrationPoints(
         rOutput[0][2] = -1.0 * nodal_forces_local_qe[2] * 0.75 + nodal_forces_local_qe[8] * 0.25;
         rOutput[1][2] = -1.0 * nodal_forces_local_qe[2] * 0.50 + nodal_forces_local_qe[8] * 0.50;
         rOutput[2][2] = -1.0 * nodal_forces_local_qe[2] * 0.25 + nodal_forces_local_qe[8] * 0.75;
-    }
-
-    else if (rVariable == LOCAL_AXIS_1) {
+    } else if (rVariable == LOCAL_AXIS_1) {
         BoundedMatrix<double, msElementSize, msElementSize> rotation_matrix = GetTransformationMatrixGlobal();
         for (SizeType i =0; i<msDimension; ++i) {
             rOutput[1][i] = column(rotation_matrix, 0)[i];
@@ -1269,8 +1267,13 @@ void CrBeamElement3D2N::CalculateOnIntegrationPoints(
         for (SizeType i =0; i<msDimension; ++i) {
             rOutput[1][i] = column(rotation_matrix, 2)[i];
         }
+    } else if (rVariable == INTEGRATION_COORDINATES) {
+        Point global_point;
+        for (IndexType point_number = 0; point_number < write_points_number; ++point_number) {
+            r_geometry.GlobalCoordinates(global_point, r_integration_points[point_number]);
+            rOutput[point_number] = global_point.Coordinates();
+        }
     }
-
 
     KRATOS_CATCH("")
 }


### PR DESCRIPTION
**Description**
Adding INTEGRATION_COORDINATES to beam elements CalculateOnIntegrationPoints. This is required by a user external to GitHub

**Changelog**
- Adding INTEGRATION_COORDINATES to beam elements CalculateOnIntegrationPoints
