### PR TITLE
[Core] parsing integers instead of bools in pybind lists because ... reasons

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -376,7 +376,7 @@ public:
     /**
      * @brief Calculate a boolean Variable on the Element Constitutive Law
      * @param rVariable The variable we want to get
-     * @param rOutput The values obtained int the integration points
+     * @param rOutput The values obtained in the integration points
      * @param rCurrentProcessInfo the current process info instance
      */
     void CalculateOnIntegrationPoints(
@@ -388,7 +388,7 @@ public:
     /**
      * @brief Calculate a integer Variable on the Element Constitutive Law
      * @param rVariable The variable we want to get
-     * @param rOutput The values obtained int the integration points
+     * @param rOutput The values obtained in the integration points
      * @param rCurrentProcessInfo the current process info instance
      */
     void CalculateOnIntegrationPoints(
@@ -400,7 +400,7 @@ public:
     /**
      * @brief Calculate a double Variable on the Element Constitutive Law
      * @param rVariable The variable we want to get
-     * @param rOutput The values obtained int the integration points
+     * @param rOutput The values obtained in the integration points
      * @param rCurrentProcessInfo the current process info instance
      */
     void CalculateOnIntegrationPoints(
@@ -412,7 +412,7 @@ public:
     /**
      * @brief Calculate a 3 components array_1d on the Element Constitutive Law
      * @param rVariable The variable we want to get
-     * @param rOutput The values obtained int the integration points
+     * @param rOutput The values obtained in the integration points
      * @param rCurrentProcessInfo the current process info instance
      */
     void CalculateOnIntegrationPoints(
@@ -424,7 +424,7 @@ public:
     /**
      * @brief Calculate a 6 components array_1d on the Element Constitutive Law
      * @param rVariable The variable we want to get
-     * @param rOutput The values obtained int the integration points
+     * @param rOutput The values obtained in the integration points
      * @param rCurrentProcessInfo the current process info instance
      */
     void CalculateOnIntegrationPoints(
@@ -436,7 +436,7 @@ public:
     /**
      * @brief Calculate a Vector Variable on the Element Constitutive Law
      * @param rVariable The variable we want to get
-     * @param rOutput The values obtained int the integration points
+     * @param rOutput The values obtained in the integration points
      * @param rCurrentProcessInfo the current process info instance
      */
     void CalculateOnIntegrationPoints(
@@ -448,7 +448,7 @@ public:
     /**
      * @brief Calculate a Matrix Variable on the Element Constitutive Law
      * @param rVariable The variable we want to get
-     * @param rOutput The values obtained int the integration points
+     * @param rOutput The values obtained in the integration points
      * @param rCurrentProcessInfo the current process info instance
      */
     void CalculateOnIntegrationPoints(
@@ -913,7 +913,7 @@ private:
      * @brief This method gets a value directly in the CL
      * @details Avoids code repetition
      * @param rVariable The variable we want to get
-     * @param rOutput The values obtained int the integration points
+     * @param rOutput The values obtained in the integration points
      * @tparam TType The type considered
      */
     template<class TType>
@@ -933,7 +933,7 @@ private:
      * @brief This method computes directly in the CL
      * @details Avoids code repetition
      * @param rVariable The variable we want to get
-     * @param rOutput The values obtained int the integration points
+     * @param rOutput The values obtained in the integration points
      * @param rCurrentProcessInfo the current process info instance
      * @tparam TType The type considered
      */

--- a/kratos/elements/mesh_element.cpp
+++ b/kratos/elements/mesh_element.cpp
@@ -167,6 +167,142 @@ void MeshElement::AddExplicitContribution(
 /***********************************************************************************/
 /***********************************************************************************/
 
+void MeshElement::CalculateOnIntegrationPoints(
+    const Variable<bool>& rVariable,
+    std::vector<bool>& rOutput,
+    const ProcessInfo& rCurrentProcessInfo
+    )
+{
+    const auto& r_geometry = GetGeometry();
+    const GeometryType::IntegrationPointsArrayType& r_integration_points = r_geometry.IntegrationPoints(r_geometry.GetDefaultIntegrationMethod());
+    const SizeType integration_points_number = r_integration_points.size();
+    if (rOutput.size() != integration_points_number) {
+        rOutput.resize(integration_points_number, rVariable.Zero());
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void MeshElement::CalculateOnIntegrationPoints(
+    const Variable<int>& rVariable,
+    std::vector<int>& rOutput,
+    const ProcessInfo& rCurrentProcessInfo
+    )
+{
+    const auto& r_geometry = GetGeometry();
+    const GeometryType::IntegrationPointsArrayType& r_integration_points = r_geometry.IntegrationPoints(r_geometry.GetDefaultIntegrationMethod());
+    const SizeType integration_points_number = r_integration_points.size();
+    if (rOutput.size() != integration_points_number) {
+        rOutput.resize(integration_points_number, rVariable.Zero());
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void MeshElement::CalculateOnIntegrationPoints(
+    const Variable<double>& rVariable,
+    std::vector<double>& rOutput,
+    const ProcessInfo& rCurrentProcessInfo
+    )
+{
+    const auto& r_geometry = GetGeometry();
+    const GeometryType::IntegrationPointsArrayType& r_integration_points = r_geometry.IntegrationPoints(r_geometry.GetDefaultIntegrationMethod());
+    const SizeType integration_points_number = r_integration_points.size();
+    if (rOutput.size() != integration_points_number) {
+        rOutput.resize(integration_points_number, rVariable.Zero());
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void MeshElement::CalculateOnIntegrationPoints(
+    const Variable<array_1d<double, 3 > >& rVariable,
+    std::vector< array_1d<double, 3 > >& rOutput,
+    const ProcessInfo& rCurrentProcessInfo
+    )
+{
+    const auto& r_geometry = GetGeometry();
+    const GeometryType::IntegrationPointsArrayType& r_integration_points = r_geometry.IntegrationPoints(r_geometry.GetDefaultIntegrationMethod());
+    const SizeType integration_points_number = r_integration_points.size();
+    if (rOutput.size() != integration_points_number) {
+        rOutput.resize(integration_points_number, rVariable.Zero());
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void MeshElement::CalculateOnIntegrationPoints(
+    const Variable<array_1d<double, 6 > >& rVariable,
+    std::vector< array_1d<double, 6 > >& rOutput,
+    const ProcessInfo& rCurrentProcessInfo
+    )
+{
+    const auto& r_geometry = GetGeometry();
+    const GeometryType::IntegrationPointsArrayType& r_integration_points = r_geometry.IntegrationPoints(r_geometry.GetDefaultIntegrationMethod());
+    const SizeType integration_points_number = r_integration_points.size();
+    if (rOutput.size() != integration_points_number) {
+        rOutput.resize(integration_points_number, rVariable.Zero());
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void MeshElement::CalculateOnIntegrationPoints(
+    const Variable<Vector >& rVariable,
+    std::vector< Vector >& rOutput,
+    const ProcessInfo& rCurrentProcessInfo
+    )
+{
+    const auto& r_geometry = GetGeometry();
+    const GeometryType::IntegrationPointsArrayType& r_integration_points = r_geometry.IntegrationPoints(r_geometry.GetDefaultIntegrationMethod());
+    const SizeType integration_points_number = r_integration_points.size();
+    if (rOutput.size() != integration_points_number) {
+        rOutput.resize(integration_points_number, rVariable.Zero());
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void MeshElement::CalculateOnIntegrationPoints(
+    const Variable<Matrix >& rVariable,
+    std::vector< Matrix >& rOutput,
+    const ProcessInfo& rCurrentProcessInfo
+    )
+{
+    const auto& r_geometry = GetGeometry();
+    const GeometryType::IntegrationPointsArrayType& r_integration_points = r_geometry.IntegrationPoints(r_geometry.GetDefaultIntegrationMethod());
+    const SizeType integration_points_number = r_integration_points.size();
+    if (rOutput.size() != integration_points_number) {
+        rOutput.resize(integration_points_number, rVariable.Zero());
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void MeshElement::CalculateOnIntegrationPoints(
+    const Variable<ConstitutiveLaw::Pointer>& rVariable,
+    std::vector<ConstitutiveLaw::Pointer>& rOutput,
+    const ProcessInfo& rCurrentProcessInfo
+    )
+{
+    const auto& r_geometry = GetGeometry();
+    const GeometryType::IntegrationPointsArrayType& r_integration_points = r_geometry.IntegrationPoints(r_geometry.GetDefaultIntegrationMethod());
+    const SizeType integration_points_number = r_integration_points.size();
+    if (rOutput.size() != integration_points_number) {
+        rOutput.resize(integration_points_number, nullptr);
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
 void MeshElement::save( Serializer& rSerializer ) const
 {
     KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, Element )

--- a/kratos/elements/mesh_element.h
+++ b/kratos/elements/mesh_element.h
@@ -220,6 +220,102 @@ public:
         const ProcessInfo& rCurrentProcessInfo
         ) override;
 
+    /**
+     * @brief Calculate a boolean Variable on the Element integration points
+     * @param rVariable The variable we want to get
+     * @param rOutput The values obtained in the integration points
+     * @param rCurrentProcessInfo the current process info instance
+     */
+     void CalculateOnIntegrationPoints(
+        const Variable<bool>& rVariable,
+        std::vector<bool>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo
+        ) override;
+
+    /**
+     * @brief Calculate a boolean Variable on the Element integration points
+     * @param rVariable The variable we want to get
+     * @param rOutput The values obtained in the integration points
+     * @param rCurrentProcessInfo the current process info instance
+     */
+    void CalculateOnIntegrationPoints(
+        const Variable<int>& rVariable,
+        std::vector<int>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo
+        ) override;
+
+    /**
+     * @brief Calculate a boolean Variable on the Element integration points
+     * @param rVariable The variable we want to get
+     * @param rOutput The values obtained in the integration points
+     * @param rCurrentProcessInfo the current process info instance
+     */
+    void CalculateOnIntegrationPoints(
+        const Variable<double>& rVariable,
+        std::vector<double>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo
+        ) override;
+
+    /**
+     * @brief Calculate a boolean Variable on the Element integration points
+     * @param rVariable The variable we want to get
+     * @param rOutput The values obtained in the integration points
+     * @param rCurrentProcessInfo the current process info instance
+     */
+    void CalculateOnIntegrationPoints(
+        const Variable<array_1d<double, 3 > >& rVariable,
+        std::vector< array_1d<double, 3 > >& rOutput,
+        const ProcessInfo& rCurrentProcessInfo
+        ) override;
+
+    /**
+     * @brief Calculate a boolean Variable on the Element integration points
+     * @param rVariable The variable we want to get
+     * @param rOutput The values obtained in the integration points
+     * @param rCurrentProcessInfo the current process info instance
+     */
+    void CalculateOnIntegrationPoints(
+        const Variable<array_1d<double, 6 > >& rVariable,
+        std::vector< array_1d<double, 6 > >& rOutput,
+        const ProcessInfo& rCurrentProcessInfo
+        ) override;
+
+    /**
+     * @brief Calculate a boolean Variable on the Element integration points
+     * @param rVariable The variable we want to get
+     * @param rOutput The values obtained in the integration points
+     * @param rCurrentProcessInfo the current process info instance
+     */
+    void CalculateOnIntegrationPoints(
+        const Variable<Vector >& rVariable,
+        std::vector< Vector >& rOutput,
+        const ProcessInfo& rCurrentProcessInfo
+        ) override;
+
+    /**
+     * @brief Calculate a boolean Variable on the Element integration points
+     * @param rVariable The variable we want to get
+     * @param rOutput The values obtained in the integration points
+     * @param rCurrentProcessInfo the current process info instance
+     */
+    void CalculateOnIntegrationPoints(
+        const Variable<Matrix >& rVariable,
+        std::vector< Matrix >& rOutput,
+        const ProcessInfo& rCurrentProcessInfo
+        ) override;
+
+    /**
+     * @brief Calculate a boolean Variable on the Element integration points
+     * @param rVariable The variable we want to get
+     * @param rOutput The values obtained in the integration points
+     * @param rCurrentProcessInfo the current process info instance
+     */
+    void CalculateOnIntegrationPoints(
+        const Variable<ConstitutiveLaw::Pointer>& rVariable,
+        std::vector<ConstitutiveLaw::Pointer>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo
+        ) override;
+
     ///@}
     ///@name Input and output
     ///@{

--- a/kratos/python/add_mesh_to_python.cpp
+++ b/kratos/python/add_mesh_to_python.cpp
@@ -147,9 +147,21 @@ pybind11::list CalculateOnIntegrationPoints(
     std::vector<TDataType> Output;
     dummy.CalculateOnIntegrationPoints(rVariable, Output, rProcessInfo);
     pybind11::list result;
-    for (unsigned int j = 0; j < Output.size(); j++)
-    {
+    for (std::size_t j = 0; j < Output.size(); j++) {
         result.append(Output[j]);
+    }
+    return result;
+}
+
+template< class TObject>
+pybind11::list CalculateOnIntegrationPointsBool(
+    TObject& dummy, const Variable<bool>& rVariable, const ProcessInfo& rProcessInfo)
+{
+    std::vector<bool> Output;
+    dummy.CalculateOnIntegrationPoints(rVariable, Output, rProcessInfo);
+    pybind11::list result;
+    for (std::size_t j = 0; j < Output.size(); j++) {
+        result.append(static_cast<int>(Output[j]));
     }
     return result;
 }
@@ -463,7 +475,7 @@ void  AddMeshToPython(pybind11::module& m)
     .def("GetNodes", GetNodesFromElement )
     .def("GetIntegrationPoints", GetIntegrationPointsFromElement )
     // CalculateOnIntegrationPoints
-    .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Element, bool>)
+    .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPointsBool<Element>)
     .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Element, int>)
     .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Element, double>)
     .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Element, array_1d<double, 3>>)
@@ -590,7 +602,7 @@ void  AddMeshToPython(pybind11::module& m)
     .def("GetNodes", GetNodesFromCondition )
 
     // CalculateOnIntegrationPoints
-    .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Condition, bool>)
+    .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPointsBool<Condition>)
     .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Condition, int>)
     .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Condition, double>)
     .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Condition, array_1d<double, 3>>)

--- a/kratos/tests/test_KratosCore.py
+++ b/kratos/tests/test_KratosCore.py
@@ -57,6 +57,7 @@ import test_coordinate_transformation_utils
 import test_sensitivity_utilities
 import test_file_name_data_collector
 import test_python_function_callback_utility
+import test_integration_points
 
 def AssembleTestSuites():
     ''' Populates the test suites to run.
@@ -137,6 +138,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_sensitivity_utilities.TestSensitivityUtilitiesTwoDimSymmetricalSquare]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_file_name_data_collector.TestFileNameDataCollector]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_python_function_callback_utility.TestPythonGenericFunctionUtility]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_integration_points.TestIntegrationPoints]))
 
     # Create a test suite with the selected tests plus all small tests
     nightSuite = suites['nightly']

--- a/kratos/tests/test_integration_points.py
+++ b/kratos/tests/test_integration_points.py
@@ -1,0 +1,49 @@
+import KratosMultiphysics
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+
+class TestIntegrationPoints(KratosUnittest.TestCase):
+
+    def test_calculate_on_integration_points(self):
+        current_model = KratosMultiphysics.Model()
+
+        mp = current_model.CreateModelPart("Main")
+
+        # Create nodes
+        mp.CreateNewNode(1,0.00,3.00,0.00)
+        mp.CreateNewNode(2,1.00,2.25,0.00)
+        mp.CreateNewNode(3,0.75,1.00,0.00)
+        mp.CreateNewNode(4,2.25,2.00,0.00)
+        mp.CreateNewNode(5,0.00,0.00,0.00)
+        mp.CreateNewNode(6,3.00,3.00,0.00)
+        mp.CreateNewNode(7,2.00,0.75,0.00)
+        mp.CreateNewNode(8,3.00,0.00,0.00)
+
+        # Create elements
+        mp.CreateNewElement("Element2D4N", 1, [8,7,3,5], mp.GetProperties()[1])
+        mp.CreateNewElement("Element2D4N", 2, [6,4,7,8], mp.GetProperties()[1])
+        mp.CreateNewElement("Element2D4N", 3, [1,2,4,6], mp.GetProperties()[1])
+        mp.CreateNewElement("Element2D4N", 4, [4,2,3,7], mp.GetProperties()[1])
+        mp.CreateNewElement("Element2D4N", 5, [2,1,5,3], mp.GetProperties()[1])
+
+        for elem in mp.Elements:
+            # Boolean
+            #out = elem.CalculateOnIntegrationPoints(KratosMultiphysics.IS_RESTARTED, mp.ProcessInfo)
+            #for value in out:
+                #self.assertEqual(value,False)
+            # Int
+            out = elem.CalculateOnIntegrationPoints(KratosMultiphysics.LOAD_RESTART, mp.ProcessInfo)
+            for value in out:
+                self.assertEqual(value,0)
+            # Double
+            out = elem.CalculateOnIntegrationPoints(KratosMultiphysics.PRESSURE, mp.ProcessInfo)
+            for value in out:
+                self.assertEqual(value,0.0)
+            # Array
+            out = elem.CalculateOnIntegrationPoints(KratosMultiphysics.DISPLACEMENT, mp.ProcessInfo)
+            for value in out:
+                self.assertEqual(value[0],0.0)
+                self.assertEqual(value[1],0.0)
+                self.assertEqual(value[2],0.0)
+
+if __name__ == '__main__':
+    KratosUnittest.main()

--- a/kratos/tests/test_integration_points.py
+++ b/kratos/tests/test_integration_points.py
@@ -43,9 +43,10 @@ class TestIntegrationPoints(KratosUnittest.TestCase):
             # Array
             out = elem.CalculateOnIntegrationPoints(KratosMultiphysics.DISPLACEMENT, mp.ProcessInfo)
             for value in out:
-                self.assertEqual(value[0],0.0)
-                self.assertEqual(value[1],0.0)
-                self.assertEqual(value[2],0.0)
+                self.assertAlmostEqual(value[0],0.0)
+                self.assertAlmostEqual(value[1],0.0)
+                self.assertAlmostEqual(value[2],0.0)
+
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/kratos/tests/test_integration_points.py
+++ b/kratos/tests/test_integration_points.py
@@ -38,7 +38,8 @@ class TestIntegrationPoints(KratosUnittest.TestCase):
             # Double
             out = elem.CalculateOnIntegrationPoints(KratosMultiphysics.PRESSURE, mp.ProcessInfo)
             for value in out:
-                self.assertEqual(value,0.0)
+                self.assertAlmostEqual(value,0.0)
+
             # Array
             out = elem.CalculateOnIntegrationPoints(KratosMultiphysics.DISPLACEMENT, mp.ProcessInfo)
             for value in out:

--- a/kratos/tests/test_integration_points.py
+++ b/kratos/tests/test_integration_points.py
@@ -29,7 +29,8 @@ class TestIntegrationPoints(KratosUnittest.TestCase):
             # Boolean
             out = elem.CalculateOnIntegrationPoints(KratosMultiphysics.IS_RESTARTED, mp.ProcessInfo)
             for value in out:
-                self.assertEqual(value,False)
+                self.assertFalse(value)
+
             # Int
             out = elem.CalculateOnIntegrationPoints(KratosMultiphysics.LOAD_RESTART, mp.ProcessInfo)
             for value in out:

--- a/kratos/tests/test_integration_points.py
+++ b/kratos/tests/test_integration_points.py
@@ -27,9 +27,9 @@ class TestIntegrationPoints(KratosUnittest.TestCase):
 
         for elem in mp.Elements:
             # Boolean
-            #out = elem.CalculateOnIntegrationPoints(KratosMultiphysics.IS_RESTARTED, mp.ProcessInfo)
-            #for value in out:
-                #self.assertEqual(value,False)
+            out = elem.CalculateOnIntegrationPoints(KratosMultiphysics.IS_RESTARTED, mp.ProcessInfo)
+            for value in out:
+                self.assertEqual(value,False)
             # Int
             out = elem.CalculateOnIntegrationPoints(KratosMultiphysics.LOAD_RESTART, mp.ProcessInfo)
             for value in out:


### PR DESCRIPTION
**Description**
Fixes #8163 (again)

**Changelog**
- Correcting typo in solid element
- Filling of Zero in the mesh elements (default core ones), in order to create a test
- Parsing booleans as integers
- Added test
