### PR TITLE
[CI] Remove prerelease ParMMG version from dockerfile

### DIFF
--- a/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
@@ -1,7 +1,7 @@
 FROM ubuntu:focal
 
 ENV HOME /root
-ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/external_libraries/mmg/mmg_5_4_1/lib:/external_libraries/mmg/mmg_5_5_1/lib:/external_libraries/ParMmg_4d272bb/lib:/external_libraries/ParMmg_5ffc6ad/lib:
+ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/external_libraries/mmg/mmg_5_4_1/lib:/external_libraries/mmg/mmg_5_5_1/lib:/external_libraries/ParMmg_5ffc6ad/lib
 
 RUN apt-get update -y && apt-get upgrade -y && \
     apt-get -y install \
@@ -71,15 +71,6 @@ RUN apt-get update -y && apt-get upgrade -y && \
     make install && \
     cd / && \
     # install PARMMG
-    git clone https://github.com/MmgTools/ParMmg /tmp/ParMmg_4d272bb && \
-    mkdir /tmp/ParMmg_4d272bb/build && \
-    mkdir -p /external_libraries/ParMmg_4d272bb && \
-    cd /tmp/ParMmg_4d272bb/build && git checkout 4d272bb3d1a51d839a5fdfaa3eef93f340cafda3 && \
-    cmake .. -DCMAKE_INSTALL_PREFIX="/external_libraries/ParMmg_4d272bb" -DUSE_SCOTCH=OFF -DLIBPARMMG_SHARED=ON -DDOWNLOAD_MMG=OFF -DMMG_DIR="/tmp/mmg_5_5_1" -DMMG_BUILDDIR="/tmp/mmg_5_5_1/build" -DDOWNLOAD_METIS=OFF -DMETIS_DIR="/usr/include" && \
-    make install && \
-    rm -r /tmp/ParMmg_4d272bb && \
-    cd / && \
-    ####
     git clone https://github.com/MmgTools/ParMmg /tmp/ParMmg_5ffc6ad && \
     mkdir /tmp/ParMmg_5ffc6ad/build && \
     mkdir -p /external_libraries/ParMmg_5ffc6ad && \


### PR DESCRIPTION
**Description**
Removing the old ParMMG version following #8145. To be merged tomorrow. 

If someone tries to merge a PR with a branch that still points to this version, the CI will fail but it should be easily fixed just by merging master

**Changelog**
- Removed ParMMG "4d272bb" from dockerfile
