### PR TITLE
[CI] Add workflow_dispatch

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -7,6 +7,8 @@ on:
 
   schedule:
     - cron:  '0 1 * * *'
+  
+  workflow_dispatch:
 
 
 jobs:


### PR DESCRIPTION
**Description**
Add [workflow_dispatch](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/) to avoid trigger-commits.

**Changelog**
Just add `workflow_dispatch` to the trigger events.
