### PR TITLE
[StructuralMechanicsApplication] Adding slave solution reconstruction to eigensolver strategy

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_processes/postprocess_eigenvalues_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/postprocess_eigenvalues_process.cpp
@@ -207,12 +207,6 @@ void PostprocessEigenvaluesProcess::ExecuteFinalizeSolutionStep()
                 }
             }
 
-            // Reconstruct the animation on slave-dofs
-            if (mrModelPart.NumberOfMasterSlaveConstraints() > 0) {
-                ConstraintUtilities::ResetSlaveDofs(mrModelPart);
-                ConstraintUtilities::ApplyConstraints(mrModelPart);
-            }
-
             p_eigen_io_wrapper->PrintOutput(label, i, requested_double_results, requested_vector_results);
         }
     }

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/eigensolver_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/eigensolver_strategy.hpp
@@ -587,9 +587,9 @@ private:
     ///@name Private Operations
     ///@{
 
-    /// Recover the solution related to the slave dofs in case of master-slave constraints.
     /**
-     *  This function is an adaptation of the implementation in ConstraintUtilities,
+     * @brief Recover the solution related to the slave dofs in case of master-slave constraints.
+     * @details This function is an adaptation of the implementation in ConstraintUtilities,
      *  since there the variables are assumed to be stored in SolutionStepValue.
      *  Beware that this implementation is only valid for Block B&S, since the master-slave constraints
      *  don't work with Elimination B&S yet.

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/eigensolver_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/eigensolver_strategy.hpp
@@ -447,7 +447,7 @@ public:
                 << system_solve_time.ElapsedSeconds() << std::endl;
 
         if (master_slave_constraints_defined)
-            this->RecoverSolution(Eigenvectors);
+            this->ReconstructSolution(Eigenvectors);
 
         this->AssignVariables(Eigenvalues,Eigenvectors);
 
@@ -594,7 +594,7 @@ private:
      *  Beware that this implementation is only valid for Block B&S, since the master-slave constraints
      *  don't work with Elimination B&S yet.
      */
-    void RecoverSolution(
+    void ReconstructSolution(
         DenseMatrixType& rEigenvectors
     )
     {

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/eigensolver_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/eigensolver_strategy.hpp
@@ -22,7 +22,6 @@
 // Project includes
 #include "solving_strategies/strategies/solving_strategy.h"
 #include "utilities/builtin_timer.h"
-#include "spaces/ublas_space.h"
 
 // Application includes
 #include "structural_mechanics_application_variables.h"
@@ -446,8 +445,9 @@ public:
         KRATOS_INFO_IF("System Solve Time", BaseType::GetEchoLevel() > 0)
                 << system_solve_time.ElapsedSeconds() << std::endl;
 
-        if (master_slave_constraints_defined)
+        if (master_slave_constraints_defined){
             this->ReconstructSolution(Eigenvectors);
+        }
 
         this->AssignVariables(Eigenvalues,Eigenvectors);
 
@@ -600,51 +600,53 @@ private:
     {
         KRATOS_TRY
 
-        const auto& rModelPart = BaseType::GetModelPart();
-        const auto& r_master_slave_constraints = rModelPart.MasterSlaveConstraints();
-        const std::size_t number_of_constraints = rModelPart.NumberOfMasterSlaveConstraints();
+        auto& r_model_part = BaseType::GetModelPart();
         const std::size_t number_of_eigenvalues = rEigenvectors.size1();
+
+        struct TLS{
+            Matrix relation_matrix;
+            Vector constant_vector;
+            Vector master_dofs_values;
+        };
 
         for (std::size_t i_eigenvalue = 0; i_eigenvalue < number_of_eigenvalues; ++i_eigenvalue){
 
             // Reset slave dofs
-            for (std::size_t i_const = 0; i_const < number_of_constraints; ++i_const) {
-                auto it_const = r_master_slave_constraints.begin() + i_const;
-                const auto& r_slave_dofs_vector = it_const->GetSlaveDofsVector();
-                for (IndexType i = 0; i < r_slave_dofs_vector.size(); ++i)
-                    rEigenvectors(i_eigenvalue, r_slave_dofs_vector[i]->EquationId()) = 0.0;
-            }
-            
+            block_for_each(r_model_part.MasterSlaveConstraints(), [&i_eigenvalue, &rEigenvectors](const MasterSlaveConstraint& r_master_slave_constraint){
+                const auto& r_slave_dofs_vector = r_master_slave_constraint.GetSlaveDofsVector();
+                for (const auto& r_slave_dof: r_slave_dofs_vector){
+                    rEigenvectors(i_eigenvalue, r_slave_dof->EquationId()) = 0.0;
+                }
+            });
+
             // Apply constraints
-            for (std::size_t i_const = 0; i_const < number_of_constraints; ++i_const) {
-                
-                auto it_const = r_master_slave_constraints.begin() + i_const;
+            block_for_each(r_model_part.MasterSlaveConstraints(), TLS(), [&i_eigenvalue, &rEigenvectors, &r_model_part](const MasterSlaveConstraint& r_master_slave_constraint, TLS& rTLS){
                 // Detect if the constraint is active or not. If the user did not make any choice the constraint
                 // It is active by default
                 bool constraint_is_active = true;
-                if (it_const->IsDefined(ACTIVE))
-                    constraint_is_active = it_const->Is(ACTIVE);
+                if (r_master_slave_constraint.IsDefined(ACTIVE))
+                    constraint_is_active = r_master_slave_constraint.Is(ACTIVE);
                 if (constraint_is_active) {
-                    
                     // Saving the master dofs values
-                    const auto& r_master_dofs_vector = it_const->GetMasterDofsVector();
-                    const auto& r_slave_dofs_vector = it_const->GetSlaveDofsVector();
-                    Vector master_dofs_values(r_master_dofs_vector.size());
-                    for (IndexType i = 0; i < r_master_dofs_vector.size(); ++i)
-                        master_dofs_values[i] = rEigenvectors(i_eigenvalue, r_master_dofs_vector[i]->EquationId());
+                    const auto& r_master_dofs_vector = r_master_slave_constraint.GetMasterDofsVector();
+                    const auto& r_slave_dofs_vector = r_master_slave_constraint.GetSlaveDofsVector();
+                    rTLS.master_dofs_values.resize(r_master_dofs_vector.size());
+                    for (IndexType i = 0; i < r_master_dofs_vector.size(); ++i) {
+                        rTLS.master_dofs_values[i] = rEigenvectors(i_eigenvalue, r_master_dofs_vector[i]->EquationId());
+                    }
                     // Apply the constraint to the slave dofs
-                    Matrix relation_matrix;
-                    Vector constant_vector;
-                    it_const->GetLocalSystem(relation_matrix, constant_vector, rModelPart.GetProcessInfo());
-                    for (IndexType i = 0; i < relation_matrix.size1(); ++i) {
-                        double aux = constant_vector[i];
-                        for(IndexType j = 0; j < relation_matrix.size2(); ++j) {
-                            aux += relation_matrix(i,j) * master_dofs_values[j];
+                    r_master_slave_constraint.GetLocalSystem(rTLS.relation_matrix, rTLS.constant_vector, r_model_part.GetProcessInfo());
+                    double aux;
+                    for (IndexType i = 0; i < rTLS.relation_matrix.size1(); ++i) {
+                        aux = rTLS.constant_vector[i];
+                        for(IndexType j = 0; j < rTLS.relation_matrix.size2(); ++j) {
+                            aux += rTLS.relation_matrix(i,j) * rTLS.master_dofs_values[j];
                         }
+                        #pragma omp atomic
                         rEigenvectors(i_eigenvalue, r_slave_dofs_vector[i]->EquationId()) += aux;
                     }
                 }
-            }
+            });            
         }
 
         KRATOS_CATCH("")

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/eigensolver_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/eigensolver_strategy.hpp
@@ -22,6 +22,7 @@
 // Project includes
 #include "solving_strategies/strategies/solving_strategy.h"
 #include "utilities/builtin_timer.h"
+#include "utilities/atomic_utilities.h"
 
 // Application includes
 #include "structural_mechanics_application_variables.h"
@@ -642,8 +643,7 @@ private:
                         for(IndexType j = 0; j < rTLS.relation_matrix.size2(); ++j) {
                             aux += rTLS.relation_matrix(i,j) * rTLS.master_dofs_values[j];
                         }
-                        #pragma omp atomic
-                        rEigenvectors(i_eigenvalue, r_slave_dofs_vector[i]->EquationId()) += aux;
+                        AtomicAdd(rEigenvectors(i_eigenvalue, r_slave_dofs_vector[i]->EquationId()), aux);
                     }
                 }
             });            

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/eigensolver_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/eigensolver_strategy.hpp
@@ -601,24 +601,24 @@ private:
         KRATOS_TRY
 
         const auto& rModelPart = BaseType::GetModelPart();
-        const auto& master_slave_constraints = rModelPart.MasterSlaveConstraints();
-        std::size_t number_of_constraints = rModelPart.NumberOfMasterSlaveConstraints();
-        std::size_t number_of_eigenvalues = rEigenvectors.size1();
+        const auto& r_master_slave_constraints = rModelPart.MasterSlaveConstraints();
+        const std::size_t number_of_constraints = rModelPart.NumberOfMasterSlaveConstraints();
+        const std::size_t number_of_eigenvalues = rEigenvectors.size1();
 
         for (std::size_t i_eigenvalue = 0; i_eigenvalue < number_of_eigenvalues; ++i_eigenvalue){
 
             // Reset slave dofs
             for (std::size_t i_const = 0; i_const < number_of_constraints; ++i_const) {
-                auto it_const = master_slave_constraints.begin() + i_const;
-                const auto& slave_dofs_vector = it_const->GetSlaveDofsVector();
-                for (IndexType i = 0; i < slave_dofs_vector.size(); ++i)
-                    rEigenvectors(i_eigenvalue, slave_dofs_vector[i]->EquationId()) = 0.0;
+                auto it_const = r_master_slave_constraints.begin() + i_const;
+                const auto& r_slave_dofs_vector = it_const->GetSlaveDofsVector();
+                for (IndexType i = 0; i < r_slave_dofs_vector.size(); ++i)
+                    rEigenvectors(i_eigenvalue, r_slave_dofs_vector[i]->EquationId()) = 0.0;
             }
             
             // Apply constraints
             for (std::size_t i_const = 0; i_const < number_of_constraints; ++i_const) {
                 
-                auto it_const = master_slave_constraints.begin() + i_const;
+                auto it_const = r_master_slave_constraints.begin() + i_const;
                 // Detect if the constraint is active or not. If the user did not make any choice the constraint
                 // It is active by default
                 bool constraint_is_active = true;
@@ -627,11 +627,11 @@ private:
                 if (constraint_is_active) {
                     
                     // Saving the master dofs values
-                    const auto& master_dofs_vector = it_const->GetMasterDofsVector();
-                    const auto& slave_dofs_vector = it_const->GetSlaveDofsVector();
-                    Vector master_dofs_values(master_dofs_vector.size());
-                    for (IndexType i = 0; i < master_dofs_vector.size(); ++i)
-                        master_dofs_values[i] = rEigenvectors(i_eigenvalue, master_dofs_vector[i]->EquationId());
+                    const auto& r_master_dofs_vector = it_const->GetMasterDofsVector();
+                    const auto& r_slave_dofs_vector = it_const->GetSlaveDofsVector();
+                    Vector master_dofs_values(r_master_dofs_vector.size());
+                    for (IndexType i = 0; i < r_master_dofs_vector.size(); ++i)
+                        master_dofs_values[i] = rEigenvectors(i_eigenvalue, r_master_dofs_vector[i]->EquationId());
                     // Apply the constraint to the slave dofs
                     Matrix relation_matrix;
                     Vector constant_vector;
@@ -641,7 +641,7 @@ private:
                         for(IndexType j = 0; j < relation_matrix.size2(); ++j) {
                             aux += relation_matrix(i,j) * master_dofs_values[j];
                         }
-                        rEigenvectors(i_eigenvalue, slave_dofs_vector[i]->EquationId()) += aux;
+                        rEigenvectors(i_eigenvalue, r_slave_dofs_vector[i]->EquationId()) += aux;
                     }
                 }
             }
@@ -824,4 +824,3 @@ private:
 } /* namespace Kratos */
 
 #endif /* KRATOS_EIGENSOLVER_STRATEGY  defined */
-

--- a/applications/StructuralMechanicsApplication/tests/test_eigen_solver_with_constraints.py
+++ b/applications/StructuralMechanicsApplication/tests/test_eigen_solver_with_constraints.py
@@ -91,6 +91,8 @@ class TestEigenSolverWithConstraints(KratosUnittest.TestCase):
 
         self.__CompareEigenSolution(model_part, model_part_with_constraints)
 
+        self.__CompareEigenSolutionMasterSlave(model_part_with_constraints)
+
     def __CompareEigenSolution(self, model_part, model_part_with_constraints):
         eigen_val_vec = model_part.ProcessInfo[StructuralMechanicsApplication.EIGENVALUE_VECTOR]
         eigen_val_vec_with_constraints = model_part_with_constraints.ProcessInfo[StructuralMechanicsApplication.EIGENVALUE_VECTOR]
@@ -106,6 +108,21 @@ class TestEigenSolverWithConstraints(KratosUnittest.TestCase):
             eig_vec_mat_contr = node_const[StructuralMechanicsApplication.EIGENVECTOR_MATRIX]
 
             self.__CompareMatrix(eig_vec_mat, eig_vec_mat_contr, 10) # Note: this might me too strict depending on the eigenvalue solver (works fine with eigen_eigensystem in compination with the eigen sparse-lu)
+
+    def __CompareEigenSolutionMasterSlave(self, model_part_with_constraints):
+        
+        num_nodes = model_part_with_constraints.NumberOfNodes()
+
+        master_node_id = int(num_nodes/2)
+        slave_node_id = num_nodes # note that this is different from before bcs now there is also the constraint node in the model-part
+
+        master_node = model_part_with_constraints.Nodes[master_node_id]
+        slave_node = model_part_with_constraints.Nodes[slave_node_id]
+
+        eig_vec_mat_master = master_node[StructuralMechanicsApplication.EIGENVECTOR_MATRIX]
+        eig_vec_mat_slave = slave_node[StructuralMechanicsApplication.EIGENVECTOR_MATRIX]
+
+        self.__CompareMatrix(eig_vec_mat_master, eig_vec_mat_slave)
 
     def __CompareMatrix(self, mat_1, mat_2, tol=7):
         self.assertEqual(mat_1.Size1(), mat_2.Size1())


### PR DESCRIPTION
**Description**
This PR adds reconstructing solution for slave DOFs to the Eigensolver Strategy for master-slave constraints, specifically for Block B&S. Without this addition, the slave DOF solution is not written to nodal `EIGENVECTOR_MATRIX` variable and the responsibility is shifted to the `postprocess_eigenvalues_process`.

**Changelog**
- Added ReconstructSolution function to `eigensolver_strategy.hpp`
- Deleted solution reconstruction from `postprocess_eigenvalues_process.cpp`

**Remark**
A much cleaner solution would be to add a function to BuilderAndSolver base class that recovers the slave DOF solution, which can then be called from the strategy directly. This is not done here, since the master-slave constraints don't work with all other B&S consistently yet.