### PR TITLE
[Core] Replace simple omp loops in spatial_containers

### DIFF
--- a/kratos/spatial_containers/bins_dynamic.h
+++ b/kratos/spatial_containers/bins_dynamic.h
@@ -20,6 +20,7 @@
 #include <algorithm>
 
 #include "tree.h"
+#include "utilities/parallel_utilities.h"
 
 namespace Kratos
 {
@@ -466,9 +467,10 @@ public:
 
     void SearchNearestPoint( PointType* const& ThisPoints, SizeType const& NumberOfPoints, IteratorType &Results, std::vector<CoordinateType> ResultsDistances)
     {
-        #pragma omp parallel for
-        for(int k=0; k< NumberOfPoints; k++)
-            Results[k] = SearchNearestPoint(ThisPoints[k],ResultsDistances[k]);
+        IndexPartition<SizeType>(NumberOfPoints).for_each(
+            [&](SizeType iPoint)
+            { Results[iPoint] = SearchNearestPoint(ThisPoints[iPoint],ResultsDistances[iPoint]); }
+        );
     }
 
     //************************************************************************
@@ -542,9 +544,10 @@ public:
     void SearchInRadius( PointerType const& ThisPoints, SizeType const& NumberOfPoints, CoordinateVectorType const& Radius, IteratorVectorType Results,
                          DistanceIteratorVectorType ResultsDistances, std::vector<SizeType>& NumberOfResults, SizeType const& MaxNumberOfResults )
     {
-        #pragma omp parallel for
-        for(int k=0; k< NumberOfPoints; k++)
-            NumberOfResults[k] = SearchInRadius(ThisPoints[k],Radius[k],Results[k],ResultsDistances[k],MaxNumberOfResults);
+        IndexPartition<SizeType>(NumberOfPoints).for_each(
+            [&](SizeType iPoint)
+            { NumberOfResults[iPoint] = SearchInRadius(ThisPoints[iPoint],Radius[iPoint],Results[iPoint],ResultsDistances[iPoint],MaxNumberOfResults); }
+        );
     }
 
     // **** THREAD SAFE

--- a/kratos/spatial_containers/bins_static.h
+++ b/kratos/spatial_containers/bins_static.h
@@ -16,6 +16,7 @@
 #define KRATOS_BINS_CONTAINER_H_INCLUDE
 
 #include "tree.h"
+#include "utilities/parallel_utilities.h"
 
 
 namespace Kratos
@@ -515,9 +516,10 @@ public:
     
     void SearchNearestPoint( PointerType const& ThisPoints, SizeType const& NumberOfPoints, IteratorType &Results, std::vector<CoordinateType> ResultsDistances)
     {
-        #pragma omp parallel for
-        for(int k=0; k< NumberOfPoints; k++)
-	        Results[k] = SearchNearestPoint((&(*ThisPoints))[k],ResultsDistances[k]);
+        IndexPartition<SizeType>(NumberOfPoints).for_each(
+            [&](SizeType iPoint)
+            { Results[iPoint] = SearchNearestPoint((&(*ThisPoints))[iPoint],ResultsDistances[iPoint]); }
+        );
     }
 
     //************************************************************************
@@ -615,9 +617,10 @@ public:
    void SearchInRadius( PointerType const& ThisPoints, SizeType const& NumberOfPoints, std::vector<CoordinateType> const& Radius, std::vector<IteratorType> Results,
                         std::vector<DistanceIteratorType> ResultsDistances, std::vector<SizeType>& NumberOfResults, SizeType const& MaxNumberOfResults )
     {
-        #pragma omp parallel for
-        for(int k=0; k< NumberOfPoints; k++)
-	  NumberOfResults[k] = SearchInRadius((&(*ThisPoints))[k],Radius[k],Results[k],ResultsDistances[k],MaxNumberOfResults);
+        IndexPartition<SizeType>(NumberOfPoints).for_each(
+            [&](SizeType iPoint)
+            { NumberOfResults[iPoint] = SearchInRadius((&(*ThisPoints))[iPoint],Radius[iPoint],Results[iPoint],ResultsDistances[iPoint],MaxNumberOfResults); }
+        );
     }
 
     //************************************************************************

--- a/kratos/spatial_containers/tree.h
+++ b/kratos/spatial_containers/tree.h
@@ -28,6 +28,7 @@
 
 // Project includes
 #include "search_structure.h"
+#include "utilities/parallel_utilities.h"
 
 namespace Kratos
 {
@@ -328,9 +329,10 @@ public:
     
     void SearchNearestPoint( PointerType const& ThisPoints, SizeType const& NumberOfPoints, IteratorType &Results, std::vector<CoordinateType> ResultsDistances)
     {
-        #pragma omp parallel for
-        for(int k=0; k< NumberOfPoints; k++)
-            Results[k] = SearchNearestPoint(ThisPoints[k],ResultsDistances[k]);
+        IndexPartition<SizeType>(NumberOfPoints).for_each(
+            [&](SizeType iPoint)
+            { Results[iPoint] = SearchNearestPoint(ThisPoints[iPoint],ResultsDistances[iPoint]); }
+        );
     }
 
     SizeType SearchInRadius(PointType const& ThisPoint, CoordinateType Radius, IteratorType Results,
@@ -360,9 +362,10 @@ public:
     void SearchInRadius( PointerType const& ThisPoints, SizeType const& NumberOfPoints, std::vector<CoordinateType> const& Radius, std::vector<IteratorType> Results,
                         std::vector<DistanceIteratorType> ResultsDistances, std::vector<SizeType>& NumberOfResults, SizeType const& MaxNumberOfResults )
     {
-        #pragma omp parallel for
-        for(int k=0; k< NumberOfPoints; k++)
-            NumberOfResults[k] = SearchInRadius(ThisPoints[k],Radius[k],Results[k],ResultsDistances[k],MaxNumberOfResults);
+        IndexPartition<SizeType>(NumberOfPoints).for_each(
+            [&](SizeType iPoint)
+            { NumberOfResults[iPoint] = SearchInRadius(ThisPoints[iPoint],Radius[iPoint],Results[iPoint],ResultsDistances[iPoint],MaxNumberOfResults); }
+        );
     }
 
     SizeType SearchInBox(PointType const& MinPointBox, PointType const& MaxPointBox, IteratorType Results, SizeType MaxNumberOfResults )


### PR DESCRIPTION
**Description**
Replace simple OpenMP ```for``` loops in spatial containers with index paritioned loops.