### PR TITLE
Core/ausas shape functions for incised

### DIFF
--- a/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.cpp
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.cpp
@@ -1,0 +1,152 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h"
+
+namespace Kratos
+{
+
+/// Tetrahedra3D4AusasIncisedShapeFunctions implementation
+/// Default constructor
+Tetrahedra3D4AusasIncisedShapeFunctions::Tetrahedra3D4AusasIncisedShapeFunctions(const GeometryPointerType pInputGeometry,
+        const Vector& rNodalDistancesWithExrapolated, const Vector& rExtrapolatedEdgeRatios) :
+    Tetrahedra3D4AusasModifiedShapeFunctions(pInputGeometry, rNodalDistancesWithExrapolated), mExtraEdgeRatios(rExtrapolatedEdgeRatios) {};
+
+/// Destructor
+Tetrahedra3D4AusasIncisedShapeFunctions::~Tetrahedra3D4AusasIncisedShapeFunctions() {};
+
+/// Turn back information as a string.
+std::string Tetrahedra3D4AusasIncisedShapeFunctions::Info() const {
+    return "Tetrahedra3D4N Ausas incised shape functions computation class.";
+}
+
+/// Print information about this object.
+void Tetrahedra3D4AusasIncisedShapeFunctions::PrintInfo(std::ostream& rOStream) const {
+    rOStream << "Tetrahedra3D4N Ausas incised shape functions computation class.";
+}
+
+/// Print object's data.
+void Tetrahedra3D4AusasIncisedShapeFunctions::PrintData(std::ostream& rOStream) const {
+    const GeometryPointerType p_geometry = this->GetInputGeometry();
+    const Vector nodal_distances = this->GetNodalDistances();
+    rOStream << "Tetrahedra3D4N Ausas incised shape functions computation class:\n";
+    rOStream << "\tGeometry type: " << (*p_geometry).Info() << "\n";
+    std::stringstream distances_buffer;
+    std::stringstream stm;
+    for (unsigned int i = 0; i < nodal_distances.size(); ++i) {
+        stm << nodal_distances(i);
+        distances_buffer << stm.str() << " ";
+    }
+    rOStream << "\tExtrapolated distance values: " << distances_buffer.str();
+}
+
+// Returns the nodal distances vector.
+const Vector& Tetrahedra3D4AusasIncisedShapeFunctions::GetExtrapolatedEdgeRatios() const {
+    return mExtraEdgeRatios;
+}
+
+// Sets the condensation matrix to transform the subdivsion positive side values to entire element ones.
+void Tetrahedra3D4AusasIncisedShapeFunctions::SetPositiveSideCondensationMatrix(
+    Matrix& rPosSideCondMatrix,
+    const std::vector<int>& rEdgeNodeI,
+    const std::vector<int>& rEdgeNodeJ,
+    const std::vector<int>& rSplitEdges)
+{
+    const std::size_t n_nodes = 4;
+    const std::size_t n_edges = 6;
+
+    // Initialize intersection points condensation matrix
+    rPosSideCondMatrix = ZeroMatrix(n_nodes + n_edges, n_nodes);
+
+    // Get the nodal distances vector
+    const Vector& nodal_distances = this->GetNodalDistances();
+
+    // Fill the original geometry points main diagonal
+    for (std::size_t i = 0; i < n_nodes; ++i) {
+        rPosSideCondMatrix(i,i) = (nodal_distances(i) > 0.0) ? 1.0 : 0.0;
+    }
+
+    // Compute the intersection points contributions
+    for (std::size_t id_edge = 0; id_edge < n_edges; ++id_edge) {
+        // Check if the edge has an intersection point
+        if (rSplitEdges[n_nodes+id_edge] != -1) {
+            // Get the nodes that compose the edge
+            const std::size_t edge_node_i = rEdgeNodeI[id_edge];
+            const std::size_t edge_node_j = rEdgeNodeJ[id_edge];
+
+            // Transform definition of edge ID from divide_tetrahedra_3d_4.h to definition of tetrahedra_3d_4.h (geometry)
+            unsigned int ratio_edge_id = edge_id_for_geometry[id_edge];
+            // Check if edge is intersected by extrapolated skin geometry (or actual skin geometry)
+            if (mExtraEdgeRatios[ratio_edge_id] > 0.0) {
+                // Set shape function value according to the edge ratio of the extrapolated intersection.
+                rPosSideCondMatrix(n_nodes+id_edge, node_ids_for_geometry[id_edge][0]) = 1.0 - mExtraEdgeRatios[ratio_edge_id];
+                rPosSideCondMatrix(n_nodes+id_edge, node_ids_for_geometry[id_edge][1]) = mExtraEdgeRatios[ratio_edge_id];
+            } else {
+                // Set to one the shape function value along the positive side of the edge.
+                rPosSideCondMatrix(n_nodes+id_edge, edge_node_i) = (nodal_distances(edge_node_i) > 0.0) ? 1.0 : 0.0;
+                rPosSideCondMatrix(n_nodes+id_edge, edge_node_j) = (nodal_distances(edge_node_j) > 0.0) ? 1.0 : 0.0;
+            }
+        }
+    }
+}
+
+// Sets the condensation matrix to transform the subdivsion negative side values to entire element ones.
+void Tetrahedra3D4AusasIncisedShapeFunctions::SetNegativeSideCondensationMatrix(
+    Matrix& rNegSideCondMatrix,
+    const std::vector<int>& rEdgeNodeI,
+    const std::vector<int>& rEdgeNodeJ,
+    const std::vector<int>& rSplitEdges)
+{
+    const std::size_t n_nodes = 4;
+    const std::size_t n_edges = 6;
+
+    // Initialize intersection points condensation matrix
+    rNegSideCondMatrix = ZeroMatrix(n_nodes + n_edges, n_nodes);
+
+    // Get the nodal distances vector
+    const Vector& nodal_distances = this->GetNodalDistances();
+
+    // Fill the original geometry points main diagonal
+    for (std::size_t i = 0; i < n_nodes; ++i) {
+        rNegSideCondMatrix(i,i) = (nodal_distances(i) < 0.0) ? 1.0 : 0.0;
+    }
+
+    // Compute the intersection points contributions
+    for (std::size_t id_edge = 0; id_edge < n_edges; ++id_edge) {
+        // Check if the edge has an intersection point
+        if (rSplitEdges[n_nodes+id_edge] != -1) {
+            // Get the nodes that compose the edge
+            const std::size_t edge_node_i = rEdgeNodeI[id_edge];
+            const std::size_t edge_node_j = rEdgeNodeJ[id_edge];
+
+            // Transform definition of edge ID from divide_tetrahedra_3d_4.h to definition of tetrahedra_3d_4.h (geometry)
+            unsigned int ratio_edge_id = edge_id_for_geometry[id_edge];
+            // Check if edge is intersected by extrapolated skin geometry (or actual skin geometry)
+            if (mExtraEdgeRatios[ratio_edge_id] > 0.0) {
+                // Set shape function value according to the edge ratio of the extrapolated intersection.
+                rNegSideCondMatrix(n_nodes+id_edge, node_ids_for_geometry[id_edge][0]) = 1.0 - mExtraEdgeRatios[ratio_edge_id];
+                rNegSideCondMatrix(n_nodes+id_edge, node_ids_for_geometry[id_edge][1]) = mExtraEdgeRatios[ratio_edge_id];
+            } else {
+                // Set to one the shape function value along the negative side of the edge.
+                rNegSideCondMatrix(n_nodes+id_edge, edge_node_i) = (nodal_distances(edge_node_i) < 0.0) ? 1.0 : 0.0;
+                rNegSideCondMatrix(n_nodes+id_edge, edge_node_j) = (nodal_distances(edge_node_j) < 0.0) ? 1.0 : 0.0;
+            }
+        }
+    }
+}
+
+}; //namespace Kratos

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.cpp
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.cpp
@@ -50,15 +50,24 @@ void Tetrahedra3D4AusasIncisedShapeFunctions::PrintData(std::ostream& rOStream) 
 {
     const GeometryPointerType p_geometry = this->GetInputGeometry();
     const Vector nodal_distances = this->GetNodalDistances();
+    const Vector extra_edge_ratios = this->GetExtrapolatedEdgeRatios();
+
     rOStream << "Tetrahedra3D4N Ausas incised shape functions computation class:\n";
     rOStream << "\tGeometry type: " << (*p_geometry).Info() << "\n";
     std::stringstream distances_buffer;
-    std::stringstream stm;
+    std::ostringstream stm;
     for (unsigned int i = 0; i < nodal_distances.size(); ++i) {
         stm << nodal_distances(i);
         distances_buffer << stm.str() << " ";
     }
-    rOStream << "\tExtrapolated distance values: " << distances_buffer.str();
+    rOStream << "\tNodal distance values including extrapolated intersections: " << distances_buffer.str() << "\n";
+    std::stringstream ratios_buffer;
+    std::ostringstream stm2;
+    for (unsigned int i = 0; i < extra_edge_ratios.size(); ++i) {
+        stm2 << extra_edge_ratios(i);
+        ratios_buffer << stm2.str() << " ";
+    }
+    rOStream << "\tEdge ratios of extrapolated intersections: " << ratios_buffer.str();
 }
 
 // Returns the nodal distances vector.

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.cpp
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:             BSD License
-//                       Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Franziska Wahl
 //

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.cpp
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.cpp
@@ -22,15 +22,20 @@ namespace Kratos
 
 /// Tetrahedra3D4AusasIncisedShapeFunctions implementation
 /// Default constructor
-Tetrahedra3D4AusasIncisedShapeFunctions::Tetrahedra3D4AusasIncisedShapeFunctions(const GeometryPointerType pInputGeometry,
-        const Vector& rNodalDistancesWithExrapolated, const Vector& rExtrapolatedEdgeRatios) :
-    Tetrahedra3D4AusasModifiedShapeFunctions(pInputGeometry, rNodalDistancesWithExrapolated), mExtraEdgeRatios(rExtrapolatedEdgeRatios) {};
+Tetrahedra3D4AusasIncisedShapeFunctions::Tetrahedra3D4AusasIncisedShapeFunctions(
+    const GeometryPointerType pInputGeometry,
+    const Vector& rNodalDistancesWithExrapolated,
+    const Vector& rExtrapolatedEdgeRatios)
+    : Tetrahedra3D4AusasModifiedShapeFunctions(pInputGeometry, rNodalDistancesWithExrapolated)
+    , mExtraEdgeRatios(rExtrapolatedEdgeRatios)
+{};
 
 /// Destructor
 Tetrahedra3D4AusasIncisedShapeFunctions::~Tetrahedra3D4AusasIncisedShapeFunctions() {};
 
 /// Turn back information as a string.
-std::string Tetrahedra3D4AusasIncisedShapeFunctions::Info() const {
+std::string Tetrahedra3D4AusasIncisedShapeFunctions::Info() const
+{
     return "Tetrahedra3D4N Ausas incised shape functions computation class.";
 }
 

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.cpp
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.cpp
@@ -4,10 +4,10 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:             BSD License
+//                       Kratos default license: kratos/license.txt
 //
-//  Main authors:    Ruben Zorrilla
+//  Main authors:    Franziska Wahl
 //
 
 // System includes
@@ -40,12 +40,14 @@ std::string Tetrahedra3D4AusasIncisedShapeFunctions::Info() const
 }
 
 /// Print information about this object.
-void Tetrahedra3D4AusasIncisedShapeFunctions::PrintInfo(std::ostream& rOStream) const {
+void Tetrahedra3D4AusasIncisedShapeFunctions::PrintInfo(std::ostream& rOStream) const
+{
     rOStream << "Tetrahedra3D4N Ausas incised shape functions computation class.";
 }
 
 /// Print object's data.
-void Tetrahedra3D4AusasIncisedShapeFunctions::PrintData(std::ostream& rOStream) const {
+void Tetrahedra3D4AusasIncisedShapeFunctions::PrintData(std::ostream& rOStream) const
+{
     const GeometryPointerType p_geometry = this->GetInputGeometry();
     const Vector nodal_distances = this->GetNodalDistances();
     rOStream << "Tetrahedra3D4N Ausas incised shape functions computation class:\n";
@@ -60,7 +62,8 @@ void Tetrahedra3D4AusasIncisedShapeFunctions::PrintData(std::ostream& rOStream) 
 }
 
 // Returns the nodal distances vector.
-const Vector& Tetrahedra3D4AusasIncisedShapeFunctions::GetExtrapolatedEdgeRatios() const {
+const Vector& Tetrahedra3D4AusasIncisedShapeFunctions::GetExtrapolatedEdgeRatios() const
+{
     return mExtraEdgeRatios;
 }
 

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h
@@ -10,15 +10,15 @@
 //  Main authors:    Ruben Zorrilla
 //
 
-#if !defined(KRATOS_AUSAS_MODIFIED_SHAPE_FUNCTIONS)
-#define KRATOS_AUSAS_MODIFIED_SHAPE_FUNCTIONS
+#if !defined(KRATOS_TETRAHEDRA_3D_4_AUSAS_INCISED_SHAPE_FUNCTIONS)
+#define KRATOS_TETRAHEDRA_3D_4_AUSAS_INCISED_SHAPE_FUNCTIONS
 
 // System includes
 
 // External includes
 
 // Project includes
-#include "modified_shape_functions/modified_shape_functions.h"
+#include "modified_shape_functions/tetrahedra_3d_4_ausas_modified_shape_functions.h"
 
 namespace Kratos
 {
@@ -37,18 +37,18 @@ namespace Kratos
 ///@name  Functions
 ///@{
 
-class KRATOS_API(KRATOS_CORE) AusasModifiedShapeFunctions : public ModifiedShapeFunctions
+class KRATOS_API(KRATOS_CORE) Tetrahedra3D4AusasIncisedShapeFunctions : public Tetrahedra3D4AusasModifiedShapeFunctions
 {
 public:
 
     ///@name Type Definitions
     ///@{
 
-    /// Pointer definition of AusasModifiedShapeFunctions
-    KRATOS_CLASS_POINTER_DEFINITION(AusasModifiedShapeFunctions);
+    /// Pointer definition of Tetrahedra3D4AusasModifiedShapeFunctions
+    KRATOS_CLASS_POINTER_DEFINITION(Tetrahedra3D4AusasIncisedShapeFunctions);
 
     // General type definitions
-    typedef ModifiedShapeFunctions                             BaseType;
+    typedef AusasModifiedShapeFunctions                        BaseType;
     typedef BaseType::GeometryType                             GeometryType;
     typedef BaseType::GeometryPointerType                      GeometryPointerType;
     typedef BaseType::IntegrationMethodType                    IntegrationMethodType;
@@ -66,10 +66,11 @@ public:
     ///@{
 
     /// Default constructor
-    AusasModifiedShapeFunctions(const GeometryPointerType rpInputGeometry, const Vector& rNodalDistances);
+    Tetrahedra3D4AusasIncisedShapeFunctions(const GeometryPointerType rpInputGeometry,
+        const Vector& rNodalDistancesWithExtrapolated, const Vector& rExtrapolatedEdgeRatios);
 
     /// Destructor
-    ~AusasModifiedShapeFunctions();
+    ~Tetrahedra3D4AusasIncisedShapeFunctions();
 
     ///@}
     ///@name Access
@@ -100,6 +101,11 @@ public:
     ///@name Operations
     ///@{
 
+    /**
+    * Returns a reference to the extrapolated edge ratios vector member variable.
+    */
+    const Vector& GetExtrapolatedEdgeRatios() const ;
+
     ///@}
 
 protected:
@@ -110,6 +116,10 @@ protected:
     ///@name Protected member Variables
     ///@{
 
+    // Arrays to get edge and node IDs of geometry from edge ID of splitting utility
+    const size_t edge_id_for_geometry [6] = {0, 2, 3, 1, 4, 5};
+    const size_t node_ids_for_geometry [6][2] = {{0,1}, {2,0}, {0,3}, {1,2}, {1,3}, {2,3}};
+
     ///@}
     ///@name Protected Operators
     ///@{
@@ -119,34 +129,36 @@ protected:
     ///@{
 
     /**
-    * Returns the intersection points condensation matrix for positive side Ausas sh functions.
-    * This matrix is used to extrapolate the subdivisions shape funtion values to the
-    * original geometry ones. It has size (nnodes+nedges)x(nnodes).
-    * @return rPosSideCondMatrix: Reference to the intersection points condensation matrix.
+    * Returns the intersection points and extrapolated intersection points condensation matrix for
+    * positive side Ausas shape functions for incised elements.
+    * This matrix is used to transform the subdivisions shape funtion values to the
+    * original geometry ones. It has size (n_nodes+n_edges)x(n_nodes).
+    * @param rPosSideCondMatrix: Reference to the extrapolated) intersection points condensation matrix to be changed.
     * @param rEdgeNodeI Integers array containing the nodes "I" that conform the edges.
     * @param rEdgeNodeJ Integers array containing the nodes "J" that conform the edges.
     * @param rSplitEdges Integers array containing the original nodes ids and the intersected edges nodes ones.
     */
-    virtual void SetPositiveSideCondensationMatrix(
+    void SetPositiveSideCondensationMatrix(
         Matrix& rPosSideCondMatrix,
         const std::vector<int>& rEdgeNodeI,
         const std::vector<int>& rEdgeNodeJ,
-        const std::vector<int>& rSplitEdges);
+        const std::vector<int>& rSplitEdges) override;
 
     /**
-    * Returns the intersection points condensation matrix for negative side Ausas sh functions.
-    * This matrix is used to extrapolate the subdivisions shape funtion values to the
-    * original geometry ones. It has size (nnodes+nedges)x(nnodes).
-    * @return rNegSideCondMatrix: Reference to the intersection points condensation matrix.
+    * Returns the intersection points and extrapolated intersection points condensation matrix for
+    * negative side Ausas shape functions for incised elements.
+    * This matrix is used to transform the subdivisions shape funtion values to the
+    * original geometry ones. It has size (n_nodes+n_edges)x(n_nodes).
+    * @param rNegSideCondMatrix: Reference to the (extrapolated) intersection points condensation matrix to be changed.
     * @param rEdgeNodeI Integers array containing the nodes "I" that conform the edges.
     * @param rEdgeNodeJ Integers array containing the nodes "J" that conform the edges.
     * @param rSplitEdges Integers array containing the original nodes ids and the intersected edges nodes ones.
     */
-    virtual void SetNegativeSideCondensationMatrix(
+    void SetNegativeSideCondensationMatrix(
         Matrix& rNegSideCondMatrix,
         const std::vector<int>& rEdgeNodeI,
         const std::vector<int>& rEdgeNodeJ,
-        const std::vector<int>& rSplitEdges);
+        const std::vector<int>& rSplitEdges) override;
 
     ///@}
     ///@name Protected  Access
@@ -169,6 +181,8 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
+
+   const Vector mExtraEdgeRatios;
 
     ///@}
     ///@name Serialization
@@ -195,16 +209,17 @@ private:
     ///@{
 
     /// Assignment operator.
-    AusasModifiedShapeFunctions& operator=(AusasModifiedShapeFunctions const& rOther);
+    Tetrahedra3D4AusasIncisedShapeFunctions& operator=(Tetrahedra3D4AusasIncisedShapeFunctions const& rOther);
 
     /// Copy constructor.
-    AusasModifiedShapeFunctions(AusasModifiedShapeFunctions const& rOther) :
-        ModifiedShapeFunctions(rOther.GetInputGeometry(), rOther.GetNodalDistances()) {
+    Tetrahedra3D4AusasIncisedShapeFunctions(Tetrahedra3D4AusasIncisedShapeFunctions const& rOther) :
+        Tetrahedra3D4AusasModifiedShapeFunctions(rOther.GetInputGeometry(), rOther.GetNodalDistances()),
+        mExtraEdgeRatios(rOther.mExtraEdgeRatios) {
     };
 
     ///@}
 
-};// class AusasModifiedShapeFunctions
+};// class Tetrahedra3D4AusasIncisedShapeFunctions
 
 }
-#endif /* KRATOS_AUSAS_MODIFIED_SHAPE_FUNCTIONS defined */
+#endif /* KRATOS_TETRAHEDRA_3D_4_AUSAS_INCISED_SHAPE_FUNCTIONS defined */

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:             BSD License
-//                       Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Franziska Wahl
 //

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h
@@ -4,10 +4,10 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:             BSD License
+//                       Kratos default license: kratos/license.txt
 //
-//  Main authors:    Ruben Zorrilla
+//  Main authors:    Franziska Wahl
 //
 
 #if !defined(KRATOS_TETRAHEDRA_3D_4_AUSAS_INCISED_SHAPE_FUNCTIONS)

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h
@@ -56,8 +56,10 @@ public:
     ///@{
 
     /// Default constructor
-    Tetrahedra3D4AusasIncisedShapeFunctions(const GeometryPointerType rpInputGeometry,
-        const Vector& rNodalDistancesWithExtrapolated, const Vector& rExtrapolatedEdgeRatios);
+    Tetrahedra3D4AusasIncisedShapeFunctions(
+        const GeometryPointerType rpInputGeometry,
+        const Vector& rNodalDistancesWithExtrapolated,
+        const Vector& rExtrapolatedEdgeRatios);
 
     /// Destructor
     ~Tetrahedra3D4AusasIncisedShapeFunctions();

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h
@@ -109,8 +109,8 @@ protected:
     ///@{
 
     // Arrays to get edge and node IDs of geometry from edge ID of splitting utility
-    const size_t edge_id_for_geometry [6] = {0, 2, 3, 1, 4, 5};
-    const size_t node_ids_for_geometry [6][2] = {{0,1}, {2,0}, {0,3}, {1,2}, {1,3}, {2,3}};
+    const std::array<size_t, 6> edge_id_for_geometry = {{0, 2, 3, 1, 4, 5}};
+    const std::array<std::array<size_t,2>, 6> node_ids_for_geometry = {{{0,1}, {2,0}, {0,3}, {1,2}, {1,3}, {2,3}}};
 
     ///@}
     ///@name Protected Operators

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h
@@ -49,17 +49,7 @@ public:
 
     // General type definitions
     typedef AusasModifiedShapeFunctions                        BaseType;
-    typedef BaseType::GeometryType                             GeometryType;
     typedef BaseType::GeometryPointerType                      GeometryPointerType;
-    typedef BaseType::IntegrationMethodType                    IntegrationMethodType;
-    typedef BaseType::ShapeFunctionsGradientsType              ShapeFunctionsGradientsType;
-
-    typedef BaseType::IndexedPointGeometryType                 IndexedPointGeometryType;
-    typedef BaseType::IndexedPointGeometryPointerType          IndexedPointGeometryPointerType;
-
-    typedef BaseType::IntegrationPointType                     IntegrationPointType;
-    typedef BaseType::IntegrationPointsArrayType               IntegrationPointsArrayType;
-    typedef BaseType::IntegrationPointsContainerType           IntegrationPointsContainerType;
 
     ///@}
     ///@name Life Cycle

--- a/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.cpp
+++ b/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.cpp
@@ -4,10 +4,10 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:             BSD License
+//                       Kratos default license: kratos/license.txt
 //
-//  Main authors:    Ruben Zorrilla
+//  Main authors:    Franziska Wahl
 //
 
 // System includes
@@ -40,12 +40,14 @@ std::string Triangle2D3AusasIncisedShapeFunctions::Info() const
 }
 
 /// Print information about this object.
-void Triangle2D3AusasIncisedShapeFunctions::PrintInfo(std::ostream& rOStream) const {
+void Triangle2D3AusasIncisedShapeFunctions::PrintInfo(std::ostream& rOStream) const
+{
     rOStream << "Triangle2D3N Ausas incised shape functions computation class.";
 }
 
 /// Print object's data.
-void Triangle2D3AusasIncisedShapeFunctions::PrintData(std::ostream& rOStream) const {
+void Triangle2D3AusasIncisedShapeFunctions::PrintData(std::ostream& rOStream) const
+{
     const GeometryPointerType p_geometry = this->GetInputGeometry();
     const Vector nodal_distances = this->GetNodalDistances();
     rOStream << "Triangle2D3N Ausas incised shape functions computation class:\n";

--- a/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.cpp
+++ b/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.cpp
@@ -1,0 +1,152 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.h"
+
+namespace Kratos
+{
+
+/// Triangle2D3AusasIncisedShapeFunctions implementation
+/// Default constructor
+Triangle2D3AusasIncisedShapeFunctions::Triangle2D3AusasIncisedShapeFunctions(const GeometryPointerType pInputGeometry,
+        const Vector& rNodalDistancesWithExtrapolated, const Vector& rExtrapolatedEdgeRatios) :
+    Triangle2D3AusasModifiedShapeFunctions(pInputGeometry, rNodalDistancesWithExtrapolated), mExtraEdgeRatios(rExtrapolatedEdgeRatios) {};
+
+/// Destructor
+Triangle2D3AusasIncisedShapeFunctions::~Triangle2D3AusasIncisedShapeFunctions() {};
+
+/// Turn back information as a string.
+std::string Triangle2D3AusasIncisedShapeFunctions::Info() const {
+    return "Triangle2D3N Ausas incised shape functions computation class.";
+}
+
+/// Print information about this object.
+void Triangle2D3AusasIncisedShapeFunctions::PrintInfo(std::ostream& rOStream) const {
+    rOStream << "Triangle2D3N Ausas incised shape functions computation class.";
+}
+
+/// Print object's data.
+void Triangle2D3AusasIncisedShapeFunctions::PrintData(std::ostream& rOStream) const {
+    const GeometryPointerType p_geometry = this->GetInputGeometry();
+    const Vector nodal_distances = this->GetNodalDistances();
+    rOStream << "Triangle2D3N Ausas incised shape functions computation class:\n";
+    rOStream << "\tGeometry type: " << (*p_geometry).Info() << "\n";
+    std::stringstream distances_buffer;
+    std::ostringstream stm;
+    for (unsigned int i = 0; i < nodal_distances.size(); ++i) {
+        stm << nodal_distances(i);
+        distances_buffer << stm.str() << " ";
+    }
+    rOStream << "\tExtrapolated distance values: " << distances_buffer.str();
+}
+
+// Returns the nodal distances vector.
+const Vector& Triangle2D3AusasIncisedShapeFunctions::GetExtrapolatedEdgeRatios() const {
+    return mExtraEdgeRatios;
+}
+
+// Sets the condensation matrix to transform the subdivsion positive side values to entire element ones.
+void Triangle2D3AusasIncisedShapeFunctions::SetPositiveSideCondensationMatrix(
+    Matrix& rPosSideCondMatrix,
+    const std::vector<int>& rEdgeNodeI,
+    const std::vector<int>& rEdgeNodeJ,
+    const std::vector<int>& rSplitEdges)
+{
+    const std::size_t n_nodes = 3;
+    const std::size_t n_edges = 3;
+
+    // Initialize intersection points condensation matrix
+    rPosSideCondMatrix = ZeroMatrix(n_nodes + n_edges, n_nodes);
+
+    // Get the nodal distances vector
+    const Vector& nodal_distances = this->GetNodalDistances();
+
+    // Fill the original geometry points main diagonal
+    for (std::size_t i = 0; i < n_nodes; ++i) {
+        rPosSideCondMatrix(i,i) = (nodal_distances(i) > 0.0) ? 1.0 : 0.0;
+    }
+
+    // Compute the intersection points contributions
+    for (std::size_t id_edge = 0; id_edge < n_edges; ++id_edge) {
+        // Check if the edge has an intersection point
+        if (rSplitEdges[n_nodes+id_edge] != -1) {
+            // Get the nodes that compose the edge
+            const std::size_t edge_node_i = rEdgeNodeI[id_edge];
+            const std::size_t edge_node_j = rEdgeNodeJ[id_edge];
+
+            // Transform definition of edge ID from divide_triangle_2d_3.h to definition of triangle_2d_3.h (geometry)
+            unsigned int ratio_edge_id = (id_edge+2)%3;
+            // Check if edge is intersected by extrapolated skin geometry (or actual skin geometry)
+            if (mExtraEdgeRatios[ratio_edge_id] > 0.0) {
+                // Set shape function value according to the edge ratio of the extrapolated intersection.
+                rPosSideCondMatrix(n_nodes+id_edge, edge_node_i) = 1.0 - mExtraEdgeRatios[ratio_edge_id];
+                rPosSideCondMatrix(n_nodes+id_edge, edge_node_j) = mExtraEdgeRatios[ratio_edge_id];
+            } else {
+                // Set to one the shape function value along the positive side of the edge.
+                rPosSideCondMatrix(n_nodes+id_edge, edge_node_i) = (nodal_distances(edge_node_i) > 0.0) ? 1.0 : 0.0;
+                rPosSideCondMatrix(n_nodes+id_edge, edge_node_j) = (nodal_distances(edge_node_j) > 0.0) ? 1.0 : 0.0;
+            }
+        }
+    }
+}
+
+// Sets the condensation matrix to transform the subdivsion negative side values to entire element ones.
+void Triangle2D3AusasIncisedShapeFunctions::SetNegativeSideCondensationMatrix(
+    Matrix& rNegSideCondMatrix,
+    const std::vector<int>& rEdgeNodeI,
+    const std::vector<int>& rEdgeNodeJ,
+    const std::vector<int>& rSplitEdges)
+{
+    const std::size_t n_nodes = 3;
+    const std::size_t n_edges = 3;
+
+    // Initialize intersection points condensation matrix
+    rNegSideCondMatrix = ZeroMatrix(n_nodes + n_edges, n_nodes);
+
+    // Get the nodal distances vector
+    const Vector& nodal_distances = this->GetNodalDistances();
+
+    // Fill the original geometry points main diagonal
+    for (std::size_t i = 0; i < n_nodes; ++i) {
+        rNegSideCondMatrix(i,i) = (nodal_distances(i) < 0.0) ? 1.0 : 0.0;
+    }
+
+    // Compute the intersection points contributions
+    for (std::size_t id_edge = 0; id_edge < n_edges; ++id_edge) {
+        // Check if the edge has an intersection point
+        if (rSplitEdges[n_nodes+id_edge] != -1) {
+            // Get the nodes that compose the edge
+            const std::size_t edge_node_i = rEdgeNodeI[id_edge];
+            const std::size_t edge_node_j = rEdgeNodeJ[id_edge];
+
+            // Transform definition of edge ID from divide_triangle_2d_3.h to definition of triangle_2d_3.h (geometry)
+            unsigned int ratio_edge_id = (id_edge+2)%3;
+            // Check if edge is intersected by extrapolated skin geometry (or actual skin geometry)
+            if (mExtraEdgeRatios[ratio_edge_id] > 0.0) {
+                // Set shape function value according to the edge ratio of the extrapolated intersection.
+                rNegSideCondMatrix(n_nodes+id_edge, edge_node_i) = 1.0 - mExtraEdgeRatios[ratio_edge_id];
+                rNegSideCondMatrix(n_nodes+id_edge, edge_node_j) = mExtraEdgeRatios[ratio_edge_id];
+            } else {
+                // Set to one the shape function value along the negative side of the edge.
+                rNegSideCondMatrix(n_nodes+id_edge, edge_node_i) = (nodal_distances(edge_node_i) < 0.0) ? 1.0 : 0.0;
+                rNegSideCondMatrix(n_nodes+id_edge, edge_node_j) = (nodal_distances(edge_node_j) < 0.0) ? 1.0 : 0.0;
+            }
+        }
+    }
+}
+
+}; //namespace Kratos

--- a/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.cpp
+++ b/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:             BSD License
-//                       Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Franziska Wahl
 //

--- a/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.cpp
+++ b/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.cpp
@@ -22,15 +22,20 @@ namespace Kratos
 
 /// Triangle2D3AusasIncisedShapeFunctions implementation
 /// Default constructor
-Triangle2D3AusasIncisedShapeFunctions::Triangle2D3AusasIncisedShapeFunctions(const GeometryPointerType pInputGeometry,
-        const Vector& rNodalDistancesWithExtrapolated, const Vector& rExtrapolatedEdgeRatios) :
-    Triangle2D3AusasModifiedShapeFunctions(pInputGeometry, rNodalDistancesWithExtrapolated), mExtraEdgeRatios(rExtrapolatedEdgeRatios) {};
+Triangle2D3AusasIncisedShapeFunctions::Triangle2D3AusasIncisedShapeFunctions(
+    const GeometryPointerType pInputGeometry,
+    const Vector& rNodalDistancesWithExtrapolated,
+    const Vector& rExtrapolatedEdgeRatios)
+    : Triangle2D3AusasModifiedShapeFunctions(pInputGeometry, rNodalDistancesWithExtrapolated)
+    , mExtraEdgeRatios(rExtrapolatedEdgeRatios)
+{};
 
 /// Destructor
 Triangle2D3AusasIncisedShapeFunctions::~Triangle2D3AusasIncisedShapeFunctions() {};
 
 /// Turn back information as a string.
-std::string Triangle2D3AusasIncisedShapeFunctions::Info() const {
+std::string Triangle2D3AusasIncisedShapeFunctions::Info() const
+{
     return "Triangle2D3N Ausas incised shape functions computation class.";
 }
 
@@ -55,7 +60,8 @@ void Triangle2D3AusasIncisedShapeFunctions::PrintData(std::ostream& rOStream) co
 }
 
 // Returns the nodal distances vector.
-const Vector& Triangle2D3AusasIncisedShapeFunctions::GetExtrapolatedEdgeRatios() const {
+const Vector& Triangle2D3AusasIncisedShapeFunctions::GetExtrapolatedEdgeRatios() const
+{
     return mExtraEdgeRatios;
 }
 

--- a/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.cpp
+++ b/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.cpp
@@ -50,6 +50,8 @@ void Triangle2D3AusasIncisedShapeFunctions::PrintData(std::ostream& rOStream) co
 {
     const GeometryPointerType p_geometry = this->GetInputGeometry();
     const Vector nodal_distances = this->GetNodalDistances();
+    const Vector extra_edge_ratios = this->GetExtrapolatedEdgeRatios();
+
     rOStream << "Triangle2D3N Ausas incised shape functions computation class:\n";
     rOStream << "\tGeometry type: " << (*p_geometry).Info() << "\n";
     std::stringstream distances_buffer;
@@ -58,7 +60,14 @@ void Triangle2D3AusasIncisedShapeFunctions::PrintData(std::ostream& rOStream) co
         stm << nodal_distances(i);
         distances_buffer << stm.str() << " ";
     }
-    rOStream << "\tExtrapolated distance values: " << distances_buffer.str();
+    rOStream << "\tNodal distance values including extrapolated intersections: " << distances_buffer.str() << "\n";
+    std::stringstream ratios_buffer;
+    std::ostringstream stm2;
+    for (unsigned int i = 0; i < extra_edge_ratios.size(); ++i) {
+        stm2 << extra_edge_ratios(i);
+        ratios_buffer << stm2.str() << " ";
+    }
+    rOStream << "\tEdge ratios of extrapolated intersections: " << ratios_buffer.str();
 }
 
 // Returns the nodal distances vector.

--- a/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.cpp
+++ b/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.cpp
@@ -97,12 +97,12 @@ void Triangle2D3AusasIncisedShapeFunctions::SetPositiveSideCondensationMatrix(
             const std::size_t edge_node_j = rEdgeNodeJ[id_edge];
 
             // Transform definition of edge ID from divide_triangle_2d_3.h to definition of triangle_2d_3.h (geometry)
-            unsigned int ratio_edge_id = (id_edge+2)%3;
+            unsigned int ratio_edge_id = edge_id_for_geometry[id_edge];
             // Check if edge is intersected by extrapolated skin geometry (or actual skin geometry)
             if (mExtraEdgeRatios[ratio_edge_id] > 0.0) {
                 // Set shape function value according to the edge ratio of the extrapolated intersection.
-                rPosSideCondMatrix(n_nodes+id_edge, edge_node_i) = 1.0 - mExtraEdgeRatios[ratio_edge_id];
-                rPosSideCondMatrix(n_nodes+id_edge, edge_node_j) = mExtraEdgeRatios[ratio_edge_id];
+                rPosSideCondMatrix(n_nodes+id_edge, node_ids_for_geometry[id_edge][0]) = 1.0 - mExtraEdgeRatios[ratio_edge_id];
+                rPosSideCondMatrix(n_nodes+id_edge, node_ids_for_geometry[id_edge][1]) = mExtraEdgeRatios[ratio_edge_id];
             } else {
                 // Set to one the shape function value along the positive side of the edge.
                 rPosSideCondMatrix(n_nodes+id_edge, edge_node_i) = (nodal_distances(edge_node_i) > 0.0) ? 1.0 : 0.0;
@@ -142,12 +142,12 @@ void Triangle2D3AusasIncisedShapeFunctions::SetNegativeSideCondensationMatrix(
             const std::size_t edge_node_j = rEdgeNodeJ[id_edge];
 
             // Transform definition of edge ID from divide_triangle_2d_3.h to definition of triangle_2d_3.h (geometry)
-            unsigned int ratio_edge_id = (id_edge+2)%3;
+            unsigned int ratio_edge_id = edge_id_for_geometry[id_edge];
             // Check if edge is intersected by extrapolated skin geometry (or actual skin geometry)
             if (mExtraEdgeRatios[ratio_edge_id] > 0.0) {
                 // Set shape function value according to the edge ratio of the extrapolated intersection.
-                rNegSideCondMatrix(n_nodes+id_edge, edge_node_i) = 1.0 - mExtraEdgeRatios[ratio_edge_id];
-                rNegSideCondMatrix(n_nodes+id_edge, edge_node_j) = mExtraEdgeRatios[ratio_edge_id];
+                rNegSideCondMatrix(n_nodes+id_edge, node_ids_for_geometry[id_edge][0]) = 1.0 - mExtraEdgeRatios[ratio_edge_id];
+                rNegSideCondMatrix(n_nodes+id_edge, node_ids_for_geometry[id_edge][1]) = mExtraEdgeRatios[ratio_edge_id];
             } else {
                 // Set to one the shape function value along the negative side of the edge.
                 rNegSideCondMatrix(n_nodes+id_edge, edge_node_i) = (nodal_distances(edge_node_i) < 0.0) ? 1.0 : 0.0;

--- a/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.h
+++ b/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.h
@@ -4,10 +4,10 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:             BSD License
+//                       Kratos default license: kratos/license.txt
 //
-//  Main authors:    Ruben Zorrilla
+//  Main authors:    Franziska Wahl
 //
 
 #if !defined(KRATOS_TRIANGLE_2D_3_AUSAS_INCISED_SHAPE_FUNCTIONS)

--- a/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.h
+++ b/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:             BSD License
-//                       Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Franziska Wahl
 //

--- a/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.h
+++ b/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.h
@@ -106,6 +106,10 @@ protected:
     ///@name Protected member Variables
     ///@{
 
+    // Arrays to get edge and node IDs of geometry from edge ID of splitting utility
+    const std::array<size_t, 3> edge_id_for_geometry = {{2, 0, 1}};
+    const std::array<std::array<size_t,2>, 3> node_ids_for_geometry = {{{0,1}, {1,2}, {2,0}}};
+
     ///@}
     ///@name Protected Operators
     ///@{

--- a/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.h
+++ b/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.h
@@ -10,15 +10,15 @@
 //  Main authors:    Ruben Zorrilla
 //
 
-#if !defined(KRATOS_AUSAS_MODIFIED_SHAPE_FUNCTIONS)
-#define KRATOS_AUSAS_MODIFIED_SHAPE_FUNCTIONS
+#if !defined(KRATOS_TRIANGLE_2D_3_AUSAS_INCISED_SHAPE_FUNCTIONS)
+#define KRATOS_TRIANGLE_2D_3_AUSAS_INCISED_SHAPE_FUNCTIONS
 
 // System includes
 
 // External includes
 
 // Project includes
-#include "modified_shape_functions/modified_shape_functions.h"
+#include "modified_shape_functions/triangle_2d_3_ausas_modified_shape_functions.h"
 
 namespace Kratos
 {
@@ -37,18 +37,18 @@ namespace Kratos
 ///@name  Functions
 ///@{
 
-class KRATOS_API(KRATOS_CORE) AusasModifiedShapeFunctions : public ModifiedShapeFunctions
+class KRATOS_API(KRATOS_CORE) Triangle2D3AusasIncisedShapeFunctions : public Triangle2D3AusasModifiedShapeFunctions
 {
 public:
 
     ///@name Type Definitions
     ///@{
 
-    /// Pointer definition of AusasModifiedShapeFunctions
-    KRATOS_CLASS_POINTER_DEFINITION(AusasModifiedShapeFunctions);
+    /// Pointer definition of Triangle2D3AusasIncisedShapeFunctions
+    KRATOS_CLASS_POINTER_DEFINITION(Triangle2D3AusasIncisedShapeFunctions);
 
     // General type definitions
-    typedef ModifiedShapeFunctions                             BaseType;
+    typedef AusasModifiedShapeFunctions                        BaseType;
     typedef BaseType::GeometryType                             GeometryType;
     typedef BaseType::GeometryPointerType                      GeometryPointerType;
     typedef BaseType::IntegrationMethodType                    IntegrationMethodType;
@@ -66,10 +66,11 @@ public:
     ///@{
 
     /// Default constructor
-    AusasModifiedShapeFunctions(const GeometryPointerType rpInputGeometry, const Vector& rNodalDistances);
+    Triangle2D3AusasIncisedShapeFunctions(const GeometryPointerType rpInputGeometry,
+        const Vector& rNodalDistancesWithExtrapolated, const Vector& rExtrapolatedEdgeRatios);
 
     /// Destructor
-    ~AusasModifiedShapeFunctions();
+    ~Triangle2D3AusasIncisedShapeFunctions();
 
     ///@}
     ///@name Access
@@ -100,6 +101,11 @@ public:
     ///@name Operations
     ///@{
 
+    /**
+    * Returns a reference to the extrapolated edge ratios vector member variable.
+    */
+    const Vector& GetExtrapolatedEdgeRatios() const ;
+
     ///@}
 
 protected:
@@ -119,34 +125,36 @@ protected:
     ///@{
 
     /**
-    * Returns the intersection points condensation matrix for positive side Ausas sh functions.
-    * This matrix is used to extrapolate the subdivisions shape funtion values to the
-    * original geometry ones. It has size (nnodes+nedges)x(nnodes).
-    * @return rPosSideCondMatrix: Reference to the intersection points condensation matrix.
+    * Returns the intersection points and extrapolated intersection points condensation matrix for
+    * positive side Ausas shape functions for incised elements.
+    * This matrix is used to transform the subdivisions shape funtion values to the
+    * original geometry ones. It has size (n_nodes+n_edges)x(n_nodes).
+    * @param rPosSideCondMatrix: Reference to the extrapolated) intersection points condensation matrix to be changed.
     * @param rEdgeNodeI Integers array containing the nodes "I" that conform the edges.
     * @param rEdgeNodeJ Integers array containing the nodes "J" that conform the edges.
     * @param rSplitEdges Integers array containing the original nodes ids and the intersected edges nodes ones.
     */
-    virtual void SetPositiveSideCondensationMatrix(
+    void SetPositiveSideCondensationMatrix(
         Matrix& rPosSideCondMatrix,
         const std::vector<int>& rEdgeNodeI,
         const std::vector<int>& rEdgeNodeJ,
-        const std::vector<int>& rSplitEdges);
+        const std::vector<int>& rSplitEdges) override;
 
     /**
-    * Returns the intersection points condensation matrix for negative side Ausas sh functions.
-    * This matrix is used to extrapolate the subdivisions shape funtion values to the
-    * original geometry ones. It has size (nnodes+nedges)x(nnodes).
-    * @return rNegSideCondMatrix: Reference to the intersection points condensation matrix.
+    * Returns the intersection points and extrapolated intersection points condensation matrix for
+    * negative side Ausas shape functions for incised elements.
+    * This matrix is used to transform the subdivisions shape funtion values to the
+    * original geometry ones. It has size (n_nodes+n_edges)x(n_nodes).
+    * @param rNegSideCondMatrix: Reference to the (extrapolated) intersection points condensation matrix to be changed.
     * @param rEdgeNodeI Integers array containing the nodes "I" that conform the edges.
     * @param rEdgeNodeJ Integers array containing the nodes "J" that conform the edges.
     * @param rSplitEdges Integers array containing the original nodes ids and the intersected edges nodes ones.
     */
-    virtual void SetNegativeSideCondensationMatrix(
+    void SetNegativeSideCondensationMatrix(
         Matrix& rNegSideCondMatrix,
         const std::vector<int>& rEdgeNodeI,
         const std::vector<int>& rEdgeNodeJ,
-        const std::vector<int>& rSplitEdges);
+        const std::vector<int>& rSplitEdges) override;
 
     ///@}
     ///@name Protected  Access
@@ -169,6 +177,8 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
+
+    const Vector mExtraEdgeRatios;
 
     ///@}
     ///@name Serialization
@@ -195,16 +205,17 @@ private:
     ///@{
 
     /// Assignment operator.
-    AusasModifiedShapeFunctions& operator=(AusasModifiedShapeFunctions const& rOther);
+    Triangle2D3AusasIncisedShapeFunctions& operator=(Triangle2D3AusasModifiedShapeFunctions const& rOther);
 
     /// Copy constructor.
-    AusasModifiedShapeFunctions(AusasModifiedShapeFunctions const& rOther) :
-        ModifiedShapeFunctions(rOther.GetInputGeometry(), rOther.GetNodalDistances()) {
+    Triangle2D3AusasIncisedShapeFunctions(Triangle2D3AusasIncisedShapeFunctions const& rOther) :
+        Triangle2D3AusasModifiedShapeFunctions(rOther.GetInputGeometry(), rOther.GetNodalDistances()),
+        mExtraEdgeRatios(rOther.mExtraEdgeRatios) {
     };
 
     ///@}
 
-};// class AusasModifiedShapeFunctions
+};// class Triangle2D3AusasIncisedShapeFunctions
 
 }
-#endif /* KRATOS_AUSAS_MODIFIED_SHAPE_FUNCTIONS defined */
+#endif /* KRATOS_TRIANGLE_2D_3_AUSAS_INCISED_SHAPE_FUNCTIONS defined */

--- a/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.h
+++ b/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.h
@@ -49,17 +49,7 @@ public:
 
     // General type definitions
     typedef AusasModifiedShapeFunctions                        BaseType;
-    typedef BaseType::GeometryType                             GeometryType;
     typedef BaseType::GeometryPointerType                      GeometryPointerType;
-    typedef BaseType::IntegrationMethodType                    IntegrationMethodType;
-    typedef BaseType::ShapeFunctionsGradientsType              ShapeFunctionsGradientsType;
-
-    typedef BaseType::IndexedPointGeometryType                 IndexedPointGeometryType;
-    typedef BaseType::IndexedPointGeometryPointerType          IndexedPointGeometryPointerType;
-
-    typedef BaseType::IntegrationPointType                     IntegrationPointType;
-    typedef BaseType::IntegrationPointsArrayType               IntegrationPointsArrayType;
-    typedef BaseType::IntegrationPointsContainerType           IntegrationPointsContainerType;
 
     ///@}
     ///@name Life Cycle

--- a/kratos/modified_shape_functions/triangle_2d_3_ausas_modified_shape_functions.cpp
+++ b/kratos/modified_shape_functions/triangle_2d_3_ausas_modified_shape_functions.cpp
@@ -107,8 +107,8 @@ void Triangle2D3AusasModifiedShapeFunctions::ComputeNegativeSideShapeFunctionsAn
         // Get the intersection points condensation matrix
         Matrix p_matrix_neg_side;
         this->SetNegativeSideCondensationMatrix(p_matrix_neg_side,
-                                                mpTriangleSplitter->mEdgeNodeJ,
                                                 mpTriangleSplitter->mEdgeNodeI,
+                                                mpTriangleSplitter->mEdgeNodeJ,
                                                 mpTriangleSplitter->mSplitEdges);
 
         // Compute the negative side values
@@ -197,7 +197,7 @@ void Triangle2D3AusasModifiedShapeFunctions::ComputePositiveExteriorFaceShapeFun
             mpTriangleSplitter->mEdgeNodeI,
             mpTriangleSplitter->mEdgeNodeJ,
             mpTriangleSplitter->mSplitEdges);
-        
+
         // Get the external faces
         std::vector < unsigned int > exterior_faces_parent_ids_vector;
         std::vector < IndexedPointGeometryPointerType > exterior_faces_vector;
@@ -206,7 +206,7 @@ void Triangle2D3AusasModifiedShapeFunctions::ComputePositiveExteriorFaceShapeFun
             exterior_faces_parent_ids_vector,
             mpTriangleSplitter->mPositiveSubdivisions,
             FaceId);
-        
+
         // Compute the positive side external face values
         this->ComputeFaceValuesOnOneSide(
             rPositiveExteriorFaceShapeFunctionsValues,
@@ -248,7 +248,7 @@ void Triangle2D3AusasModifiedShapeFunctions::ComputeNegativeExteriorFaceShapeFun
             exterior_faces_parent_ids_vector,
             mpTriangleSplitter->mNegativeSubdivisions,
             FaceId);
-        
+
         // Compute the positive side external face values
         this->ComputeFaceValuesOnOneSide(
             rNegativeExteriorFaceShapeFunctionsValues,

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_ausas_incised_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_ausas_incised_shape_functions.cpp
@@ -103,135 +103,76 @@ namespace Kratos
             const double tolerance = 1e-10;
 
             // Check shape functions values
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 0.000, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,3), 0.750, tolerance);
+            const std::vector<double> ref_pos_sh_func = {1.0/8.0, 0.0, 1.0/8.0, 3.0/4.0};
+            KRATOS_CHECK_VECTOR_NEAR(row(positive_side_sh_func, 0), ref_pos_sh_func, tolerance);
 
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 0.500, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,3), 0.125, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,0), 0.375, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,1), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,2), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,3), 0.125, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func(2,0), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(2,1), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(2,2), 0.375, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(2,3), 0.250, tolerance);
+            Matrix ref_neg_sh_func(3, 4);
+            const std::array<double, 12> ref_neg_sh_func_array = {1.0/8.0, 1.0/2.0, 1.0/4.0, 1.0/8.0,
+                                                                  3.0/8.0, 1.0/4.0, 1.0/4.0, 1.0/8.0,
+                                                                  1.0/8.0, 1.0/4.0, 3.0/8.0, 1.0/4.0};
+            for (unsigned int i = 0; i < ref_neg_sh_func.size1(); i++) {
+                for (unsigned int j = 0; j < ref_neg_sh_func.size2(); j++) {
+                    ref_neg_sh_func(i, j) = ref_neg_sh_func_array[i * ref_neg_sh_func.size2() + j];
+                }
+            }
+            KRATOS_CHECK_MATRIX_NEAR(negative_side_sh_func, ref_neg_sh_func, tolerance);
 
             // Check Gauss pts. weights
             KRATOS_CHECK_NEAR(positive_side_weights(0), 0.02083333333, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_weights(0), 0.04166666666, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_weights(1), 0.08333333333, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_weights(2), 0.02083333333, tolerance);
+            const std::vector<double> ref_neg_weights = {0.04166666666, 0.08333333333, 0.02083333333};
+            KRATOS_CHECK_VECTOR_NEAR(negative_side_weights, ref_neg_weights, tolerance);
 
             // Check Gauss pts. shape functions gradients values
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,2),  2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,2), -1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](1,0),  2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](3,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](3,2),  1.0, tolerance);
+            Matrix ref_pos_sh_func_grad_0(4, 3);
+            Matrix ref_neg_sh_func_grad_0(4, 3);
+            Matrix ref_neg_sh_func_grad_1(4, 3);
+            Matrix ref_neg_sh_func_grad_2(4, 3);
+            const std::array<double, 12> ref_pos_sh_func_grad_0_array = {-1.0, -1.0, -1.0,  0.0,  0.0,  0.0,  0.0,  1.0,  0.0,  1.0,  0.0,  1.0};
+            const std::array<double, 12> ref_neg_sh_func_grad_0_array = {-1.0, -1.0, -1.0,  2.0,  1.0,  2.0,  0.0,  1.0,  0.0, -1.0, -1.0, -1.0};
+            const std::array<double, 12> ref_neg_sh_func_grad_1_array = {-1.0, -1.0, -1.0,  1.0,  0.0,  0.0,  0.0,  1.0,  0.0,  0.0,  0.0,  1.0};
+            const std::array<double, 12> ref_neg_sh_func_grad_2_array = {-1.0, -1.0, -1.0,  2.0,  0.0,  0.0,  0.0,  1.0,  0.0, -1.0,  0.0,  1.0};
+            for (unsigned int i = 0; i < ref_pos_sh_func_grad_0.size1(); i++) {
+                for (unsigned int j = 0; j < ref_pos_sh_func_grad_0.size2(); j++) {
+                    ref_pos_sh_func_grad_0(i, j) = ref_pos_sh_func_grad_0_array[i * ref_pos_sh_func_grad_0.size2() + j];
+                    ref_neg_sh_func_grad_0(i, j) = ref_neg_sh_func_grad_0_array[i * ref_pos_sh_func_grad_0.size2() + j];
+                    ref_neg_sh_func_grad_1(i, j) = ref_neg_sh_func_grad_1_array[i * ref_pos_sh_func_grad_0.size2() + j];
+                    ref_neg_sh_func_grad_2(i, j) = ref_neg_sh_func_grad_2_array[i * ref_pos_sh_func_grad_0.size2() + j];
+                }
+            }
+            KRATOS_CHECK_MATRIX_NEAR(positive_side_sh_func_gradients[0], ref_pos_sh_func_grad_0, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(negative_side_sh_func_gradients[0], ref_neg_sh_func_grad_0, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(negative_side_sh_func_gradients[1], ref_neg_sh_func_grad_1, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(negative_side_sh_func_gradients[2], ref_neg_sh_func_grad_2, tolerance);
 
             // Check interface shape function values
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 0.0,     tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,3), 2.0/3.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,3), 1.0/3.0, tolerance);
+            const std::vector<double> ref_pos_interface_sh_func = {1.0/6.0,     0.0, 1.0/6.0, 2.0/3.0};
+            const std::vector<double> ref_neg_interface_sh_func = {1.0/6.0, 1.0/3.0, 1.0/6.0, 1.0/3.0};
+            KRATOS_CHECK_VECTOR_NEAR(row(positive_interface_side_sh_func, 0), ref_pos_interface_sh_func, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(row(negative_interface_side_sh_func, 0), ref_neg_interface_sh_func, tolerance);
 
             // Check interface Gauss pts. weights
             KRATOS_CHECK_NEAR(positive_interface_side_weights(0), 0.125, tolerance);
             KRATOS_CHECK_NEAR(negative_interface_side_weights(0), 0.125, tolerance);
 
             // Check Gauss pts. interface shape function gradients values
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+            Matrix ref_pos_interface_sh_func_grad_0(4, 3);
+            Matrix ref_neg_interface_sh_func_grad_0(4, 3);
+            const std::array<double, 12> ref_pos_interface_sh_func_grad_0_array = {-1.0, -1.0, -1.0,  0.0,  0.0,  0.0,  0.0,  1.0,  0.0,  1.0,  0.0,  1.0};
+            const std::array<double, 12> ref_neg_interface_sh_func_grad_0_array = {-1.0, -1.0, -1.0,  2.0,  0.0,  0.0,  0.0,  1.0,  0.0, -1.0,  0.0,  1.0};
+            for (unsigned int i = 0; i < ref_pos_interface_sh_func_grad_0.size1(); i++) {
+                for (unsigned int j = 0; j < ref_pos_interface_sh_func_grad_0.size2(); j++) {
+                    ref_pos_interface_sh_func_grad_0(i, j) = ref_pos_interface_sh_func_grad_0_array[i * ref_pos_interface_sh_func_grad_0.size2() + j];
+                    ref_neg_interface_sh_func_grad_0(i, j) = ref_neg_interface_sh_func_grad_0_array[i * ref_pos_interface_sh_func_grad_0.size2() + j];
+                }
+            }
+            KRATOS_CHECK_MATRIX_NEAR(positive_interface_side_sh_func_gradients[0], ref_pos_interface_sh_func_grad_0, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(negative_interface_side_sh_func_gradients[0], ref_neg_interface_sh_func_grad_0, tolerance);
 
             // Check Gauss pts. outwards unit normal values
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), -0.125, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](2),  0.125, tolerance);
+            const std::vector<double> ref_pos_area_normals = {0.0, 0.0, -0.125};
+            const std::vector<double> ref_neg_area_normals = {0.0, 0.0,  0.125};
+            KRATOS_CHECK_VECTOR_NEAR(positive_side_area_normals[0], ref_pos_area_normals, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(negative_side_area_normals[0], ref_neg_area_normals, tolerance);
         }
 
 
@@ -316,217 +257,105 @@ namespace Kratos
             const double tolerance = 1e-10;
 
             // Check shape functions values
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,3), 0.500, tolerance);
-
-            KRATOS_CHECK_NEAR(positive_side_sh_func(1,0), 0.00, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(1,1), 0.75, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(1,2), 0.00, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(1,3), 0.25, tolerance);
-
-            KRATOS_CHECK_NEAR(positive_side_sh_func(2,0), 0.000, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(2,1), 0.500, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(2,2), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(2,3), 0.375, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 0.000, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 0.625, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,3), 0.125, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,0), 0.375, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,1), 0.000, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,2), 0.375, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,3), 0.250, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func(2,0), 0.625, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(2,1), 0.000, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(2,2), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(2,3), 0.125, tolerance);
+            Matrix ref_pos_sh_func(3, 4);
+            Matrix ref_neg_sh_func(3, 4);
+            const std::array<double, 12> ref_pos_sh_func_array = {1.0/8.0, 1.0/4.0, 1.0/8.0, 1.0/2.0,
+                                                                      0.0, 3.0/4.0,     0.0, 1.0/4.0,
+                                                                      0.0, 1.0/2.0, 1.0/8.0, 3.0/8.0};
+            const std::array<double, 12> ref_neg_sh_func_array = {1.0/4.0,     0.0, 5.0/8.0, 1.0/8.0,
+                                                                  3.0/8.0,     0.0, 3.0/8.0, 1.0/4.0,
+                                                                  5.0/8.0,     0.0, 1.0/4.0, 1.0/8.0};
+            for (unsigned int i = 0; i < ref_neg_sh_func.size1(); i++) {
+                for (unsigned int j = 0; j < ref_neg_sh_func.size2(); j++) {
+                    ref_pos_sh_func(i, j) = ref_pos_sh_func_array[i * ref_neg_sh_func.size2() + j];
+                    ref_neg_sh_func(i, j) = ref_neg_sh_func_array[i * ref_neg_sh_func.size2() + j];
+                }
+            }
+            KRATOS_CHECK_MATRIX_NEAR(positive_side_sh_func, ref_pos_sh_func, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(negative_side_sh_func, ref_neg_sh_func, tolerance);
 
             // Check Gauss pts. weights
-            KRATOS_CHECK_NEAR(positive_side_weights(0), 0.02083333333, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_weights(1), 0.04166666666, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_weights(2), 0.02083333333, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_weights(0), 0.02083333333, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_weights(1), 0.02083333333, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_weights(2), 0.04166666666, tolerance);
+            const std::vector<double> ref_pos_weights = {0.02083333333, 0.04166666666, 0.02083333333};
+            const std::vector<double> ref_neg_weights = {0.02083333333, 0.02083333333, 0.04166666666};
+            KRATOS_CHECK_VECTOR_NEAR(positive_side_weights, ref_pos_weights, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(negative_side_weights, ref_neg_weights, tolerance);
 
             // Check Gauss pts. shape functions gradients values
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  2.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](0,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](0,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](0,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](1,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](1,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](2,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](0,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](0,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](0,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](1,0),  2.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](2,0), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](2,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](2,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,2), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,2),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](0,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](1,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](3,2),  1.0, tolerance);
+            Matrix ref_pos_sh_func_grad_0(4, 3);
+            Matrix ref_pos_sh_func_grad_1(4, 3);
+            Matrix ref_pos_sh_func_grad_2(4, 3);
+            Matrix ref_neg_sh_func_grad_0(4, 3);
+            Matrix ref_neg_sh_func_grad_1(4, 3);
+            Matrix ref_neg_sh_func_grad_2(4, 3);
+            const std::array<double, 12> ref_pos_sh_func_grad_0_array = {-2.0, -1.0, -1.0,  2.0,  0.0,  0.0,  0.0,  1.0,  0.0,  0.0,  0.0,  1.0};
+            const std::array<double, 12> ref_pos_sh_func_grad_1_array = { 0.0,  0.0,  0.0,  0.0,  0.0, -1.0,  0.0,  0.0,  0.0,  0.0,  0.0,  1.0};
+            const std::array<double, 12> ref_pos_sh_func_grad_2_array = { 0.0,  0.0,  0.0,  2.0,  0.0,  0.0, -2.0,  0.0, -1.0,  0.0,  0.0,  1.0};
+            const std::array<double, 12> ref_neg_sh_func_grad_0_array = {-2.0, -2.0, -2.0,  0.0,  0.0,  0.0,  2.0,  2.0,  1.0,  0.0,  0.0,  1.0};
+            const std::array<double, 12> ref_neg_sh_func_grad_1_array = { 0.0, -1.0, -1.0,  0.0,  0.0,  0.0,  0.0,  1.0,  0.0,  0.0,  0.0,  1.0};
+            const std::array<double, 12> ref_neg_sh_func_grad_2_array = { 0.0, -1.0, -1.0,  0.0,  0.0,  0.0,  0.0,  1.0,  0.0,  0.0,  0.0,  1.0};
+            for (unsigned int i = 0; i < ref_pos_sh_func_grad_0.size1(); i++) {
+                for (unsigned int j = 0; j < ref_pos_sh_func_grad_0.size2(); j++) {
+                    ref_pos_sh_func_grad_0(i, j) = ref_pos_sh_func_grad_0_array[i * ref_pos_sh_func_grad_0.size2() + j];
+                    ref_pos_sh_func_grad_1(i, j) = ref_pos_sh_func_grad_1_array[i * ref_pos_sh_func_grad_0.size2() + j];
+                    ref_pos_sh_func_grad_2(i, j) = ref_pos_sh_func_grad_2_array[i * ref_pos_sh_func_grad_0.size2() + j];
+                    ref_neg_sh_func_grad_0(i, j) = ref_neg_sh_func_grad_0_array[i * ref_pos_sh_func_grad_0.size2() + j];
+                    ref_neg_sh_func_grad_1(i, j) = ref_neg_sh_func_grad_1_array[i * ref_pos_sh_func_grad_0.size2() + j];
+                    ref_neg_sh_func_grad_2(i, j) = ref_neg_sh_func_grad_2_array[i * ref_pos_sh_func_grad_0.size2() + j];
+                }
+            }
+            KRATOS_CHECK_MATRIX_NEAR(positive_side_sh_func_gradients[0], ref_pos_sh_func_grad_0, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(positive_side_sh_func_gradients[1], ref_pos_sh_func_grad_1, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(positive_side_sh_func_gradients[2], ref_pos_sh_func_grad_2, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(negative_side_sh_func_gradients[0], ref_neg_sh_func_grad_0, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(negative_side_sh_func_gradients[1], ref_neg_sh_func_grad_1, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(negative_side_sh_func_gradients[2], ref_neg_sh_func_grad_2, tolerance);
 
             // Check interface shape function values
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,3), 1.0/3.0, tolerance);
-
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(1,0), 0.0,     tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(1,1), 2.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(1,2), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(1,3), 1.0/6.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 0.0,     tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,3), 1.0/6.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(1,0), 1.0/2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(1,1), 0.0,     tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(1,2), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(1,3), 1.0/3.0, tolerance);
+            const std::vector<double> ref_pos_interface_sh_func_0 = {1.0/6.0, 1.0/3.0, 1.0/6.0, 1.0/3.0};
+            const std::vector<double> ref_pos_interface_sh_func_1 = {    0.0, 2.0/3.0, 1.0/6.0, 1.0/6.0};
+            const std::vector<double> ref_neg_interface_sh_func_0 = {1.0/3.0,     0.0, 1.0/2.0, 1.0/6.0};
+            const std::vector<double> ref_neg_interface_sh_func_1 = {1.0/2.0,     0.0, 1.0/6.0, 1.0/3.0};
+            KRATOS_CHECK_VECTOR_NEAR(row(positive_interface_side_sh_func, 0), ref_pos_interface_sh_func_0, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(row(positive_interface_side_sh_func, 1), ref_pos_interface_sh_func_1, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(row(negative_interface_side_sh_func, 0), ref_neg_interface_sh_func_0, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(row(negative_interface_side_sh_func, 1), ref_neg_interface_sh_func_1, tolerance);
 
             // Check interface Gauss pts. weights
-            KRATOS_CHECK_NEAR(positive_interface_side_weights(0), 0.176777, 1e-6);
-            KRATOS_CHECK_NEAR(positive_interface_side_weights(1), 0.176777, 1e-6);
-            KRATOS_CHECK_NEAR(negative_interface_side_weights(0), 0.176777, 1e-6);
-            KRATOS_CHECK_NEAR(negative_interface_side_weights(1), 0.176777, 1e-6);
+            const std::vector<double> ref_interface_weights = {0.176777, 0.176777};
+            KRATOS_CHECK_VECTOR_NEAR(positive_interface_side_weights, ref_interface_weights, 1e-6);
+            KRATOS_CHECK_VECTOR_NEAR(negative_interface_side_weights, ref_interface_weights, 1e-6);
 
             // Check Gauss pts. interface shape function gradients values
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  2.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](0,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](0,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](0,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](1,0),  2.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](2,0), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](2,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](2,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,2), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,2),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](0,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](1,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](3,2),  1.0, tolerance);
+            Matrix ref_pos_interface_sh_func_grad_0(4, 3);
+            Matrix ref_pos_interface_sh_func_grad_1(4, 3);
+            Matrix ref_neg_interface_sh_func_grad_0(4, 3);
+            Matrix ref_neg_interface_sh_func_grad_1(4, 3);
+            const std::array<double, 12> ref_pos_interface_sh_func_grad_0_array = {-2.0, -1.0, -1.0,  2.0,  0.0,  0.0,  0.0,  1.0,  0.0,  0.0,  0.0,  1.0};
+            const std::array<double, 12> ref_pos_interface_sh_func_grad_1_array = { 0.0,  0.0,  0.0,  2.0,  0.0,  0.0, -2.0,  0.0, -1.0,  0.0,  0.0,  1.0};
+            const std::array<double, 12> ref_neg_interface_sh_func_grad_0_array = {-2.0, -2.0, -2.0,  0.0,  0.0,  0.0,  2.0,  2.0,  1.0,  0.0,  0.0,  1.0};
+            const std::array<double, 12> ref_neg_interface_sh_func_grad_1_array = { 0.0, -1.0, -1.0,  0.0,  0.0,  0.0,  0.0,  1.0,  0.0,  0.0,  0.0,  1.0};
+            for (unsigned int i = 0; i < ref_pos_interface_sh_func_grad_0.size1(); i++) {
+                for (unsigned int j = 0; j < ref_pos_interface_sh_func_grad_0.size2(); j++) {
+                    ref_pos_interface_sh_func_grad_0(i, j) = ref_pos_interface_sh_func_grad_0_array[i * ref_pos_interface_sh_func_grad_0.size2() + j];
+                    ref_pos_interface_sh_func_grad_1(i, j) = ref_pos_interface_sh_func_grad_1_array[i * ref_pos_interface_sh_func_grad_0.size2() + j];
+                    ref_neg_interface_sh_func_grad_0(i, j) = ref_neg_interface_sh_func_grad_0_array[i * ref_pos_interface_sh_func_grad_0.size2() + j];
+                    ref_neg_interface_sh_func_grad_1(i, j) = ref_neg_interface_sh_func_grad_1_array[i * ref_pos_interface_sh_func_grad_0.size2() + j];
+                }
+            }
+            KRATOS_CHECK_MATRIX_NEAR(positive_interface_side_sh_func_gradients[0], ref_pos_interface_sh_func_grad_0, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(positive_interface_side_sh_func_gradients[1], ref_pos_interface_sh_func_grad_1, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(negative_interface_side_sh_func_gradients[0], ref_neg_interface_sh_func_grad_0, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(negative_interface_side_sh_func_gradients[1], ref_neg_interface_sh_func_grad_1, tolerance);
 
             // Check Gauss pts. outwards unit normal values
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), -0.125, 1e-6);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](1),  0.0, 1e-6);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), -0.125, 1e-6);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[1](0), -0.125, 1e-6);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[1](1),  0.0, 1e-6);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[1](2), -0.125, 1e-6);
-
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), 0.125, 1e-6);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.0, 1e-6);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.125, 1e-6);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[1](0), 0.125, 1e-6);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[1](1), 0.0, 1e-6);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[1](2), 0.125, 1e-6);
+            const std::vector<double> ref_pos_area_normals_0 = {-0.125, 0.0, -0.125};
+            const std::vector<double> ref_pos_area_normals_1 = {-0.125, 0.0, -0.125};
+            const std::vector<double> ref_neg_area_normals_0 = { 0.125, 0.0,  0.125};
+            const std::vector<double> ref_neg_area_normals_1 = { 0.125, 0.0,  0.125};
+            KRATOS_CHECK_VECTOR_NEAR(positive_side_area_normals[0], ref_pos_area_normals_0, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(positive_side_area_normals[1], ref_pos_area_normals_1, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(negative_side_area_normals[0], ref_neg_area_normals_0, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(negative_side_area_normals[1], ref_neg_area_normals_1, tolerance);
         }
 
 

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_ausas_incised_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_ausas_incised_shape_functions.cpp
@@ -4,11 +4,10 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:     BSD License
-//               Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
-//  Main authors:    Ruben Zorrilla
-//
+//  Main authors:    Franziska Wahl
 //
 
 // Project includes

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_ausas_incised_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_ausas_incised_shape_functions.cpp
@@ -1,0 +1,603 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:     BSD License
+//               Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+//
+
+// Project includes
+#include "testing/testing.h"
+#include "containers/model.h"
+#include "includes/checks.h"
+#include "utilities/divide_tetrahedra_3d_4.h"
+#include "modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h"
+
+namespace Kratos
+{
+    namespace Testing
+    {
+
+        KRATOS_TEST_CASE_IN_SUITE(AusasIncisedShapeFunctionsTetrahedra3D4Horizontal, KratosCoreFastSuite)
+        {
+            Model current_model;
+
+            // Generate a model part with the previous
+            ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
+            base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+            // Fill the model part geometry data
+            base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+            base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+            base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+            base_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
+            Properties::Pointer p_properties(new Properties(0));
+            base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
+
+            // Set the elemental distances vector
+            Geometry<Node<3>>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
+
+            array_1d<double, 4> distances_vector;
+            distances_vector[0] = -1.0;
+            distances_vector[1] = -1.0;
+            distances_vector[2] = -1.0;
+            distances_vector[3] =  1.0;
+            array_1d<double, 6> edge_dist_extra_vector;
+            edge_dist_extra_vector[0] = -1.0;
+            edge_dist_extra_vector[1] = -1.0;
+            edge_dist_extra_vector[2] = -1.0;
+            edge_dist_extra_vector[3] =  0.5;
+            edge_dist_extra_vector[4] = -1.0;
+            edge_dist_extra_vector[5] =  0.5;
+
+            // Call the modified shape functions calculator
+            Tetrahedra3D4AusasIncisedShapeFunctions tetrahedra_ausas_shape_functions(p_geometry, distances_vector, edge_dist_extra_vector);
+            Matrix positive_side_sh_func, negative_side_sh_func;
+            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
+            Vector positive_side_weights, negative_side_weights;
+
+            tetrahedra_ausas_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
+                positive_side_sh_func,
+                positive_side_sh_func_gradients,
+                positive_side_weights,
+                GeometryData::GI_GAUSS_1);
+
+            tetrahedra_ausas_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
+                negative_side_sh_func,
+                negative_side_sh_func_gradients,
+                negative_side_weights,
+                GeometryData::GI_GAUSS_1);
+
+            // Call the interface modified shape functions calculator
+            Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
+            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
+            Vector positive_interface_side_weights, negative_interface_side_weights;
+
+            tetrahedra_ausas_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
+                positive_interface_side_sh_func,
+                positive_interface_side_sh_func_gradients,
+                positive_interface_side_weights,
+                GeometryData::GI_GAUSS_1);
+
+            tetrahedra_ausas_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
+                negative_interface_side_sh_func,
+                negative_interface_side_sh_func_gradients,
+                negative_interface_side_weights,
+                GeometryData::GI_GAUSS_1);
+
+            // Call the interface outwards normal unit vector calculator
+            std::vector<Vector> positive_side_area_normals, negative_side_area_normals;
+
+            tetrahedra_ausas_shape_functions.ComputePositiveSideInterfaceAreaNormals(
+                positive_side_area_normals,
+                GeometryData::GI_GAUSS_1);
+
+            tetrahedra_ausas_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
+                negative_side_area_normals,
+                GeometryData::GI_GAUSS_1);
+
+            const double tolerance = 1e-10;
+
+            // Check shape functions values
+            KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 0.125, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 0.000, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 0.125, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(0,3), 0.750, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 0.125, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 0.500, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 0.250, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,3), 0.125, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func(1,0), 0.375, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(1,1), 0.250, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(1,2), 0.250, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(1,3), 0.125, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func(2,0), 0.125, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(2,1), 0.250, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(2,2), 0.375, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(2,3), 0.250, tolerance);
+
+            // Check Gauss pts. weights
+            KRATOS_CHECK_NEAR(positive_side_weights(0), 0.02083333333, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_weights(0), 0.04166666666, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_weights(1), 0.08333333333, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_weights(2), 0.02083333333, tolerance);
+
+            // Check Gauss pts. shape functions gradients values
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,0),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,2),  2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,2), -1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,0),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](3,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](3,2),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](0,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](0,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](1,0),  2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](2,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](3,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](3,2),  1.0, tolerance);
+
+            // Check interface shape function values
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 1.0/6.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 0.0,     tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,3), 2.0/3.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/6.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 1.0/3.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,3), 1.0/3.0, tolerance);
+
+            // Check interface Gauss pts. weights
+            KRATOS_CHECK_NEAR(positive_interface_side_weights(0), 0.125, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_weights(0), 0.125, tolerance);
+
+            // Check Gauss pts. interface shape function gradients values
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,0),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+            // Check Gauss pts. outwards unit normal values
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), -0.125, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_area_normals[0](0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_area_normals[0](1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_area_normals[0](2),  0.125, tolerance);
+        }
+
+
+        KRATOS_TEST_CASE_IN_SUITE(AusasIncisedShapeFunctionsTetrahedra3D4Oblique, KratosCoreFastSuite)
+        {
+            Model current_model;
+
+            // Generate a model part with the previous
+            ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
+            base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+            // Fill the model part geometry data
+            base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+            base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+            base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+            base_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
+            Properties::Pointer p_properties(new Properties(0));
+            base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
+
+            // Set the elemental distances vector
+            Geometry<Node<3>>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
+
+            array_1d<double, 4> distances_vector;
+            distances_vector[0] = -1.0;
+            distances_vector[1] =  1.0;
+            distances_vector[2] = -1.0;
+            distances_vector[3] =  1.0;
+            array_1d<double, 6> edge_dist_extra_vector;
+            edge_dist_extra_vector[0] = -1.0;
+            edge_dist_extra_vector[1] = -1.0;
+            edge_dist_extra_vector[2] = -1.0;
+            edge_dist_extra_vector[3] =  0.5;
+            edge_dist_extra_vector[4] = -1.0;
+            edge_dist_extra_vector[5] =  0.5;
+
+            // Call the modified shape functions calculator
+            Tetrahedra3D4AusasIncisedShapeFunctions tetrahedra_ausas_shape_functions(p_geometry, distances_vector, edge_dist_extra_vector);
+            Matrix positive_side_sh_func, negative_side_sh_func;
+            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
+            Vector positive_side_weights, negative_side_weights;
+
+            tetrahedra_ausas_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
+                positive_side_sh_func,
+                positive_side_sh_func_gradients,
+                positive_side_weights,
+                GeometryData::GI_GAUSS_1);
+
+            tetrahedra_ausas_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
+                negative_side_sh_func,
+                negative_side_sh_func_gradients,
+                negative_side_weights,
+                GeometryData::GI_GAUSS_1);
+
+            // Call the interface modified shape functions calculator
+            Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
+            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
+            Vector positive_interface_side_weights, negative_interface_side_weights;
+
+            tetrahedra_ausas_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
+                positive_interface_side_sh_func,
+                positive_interface_side_sh_func_gradients,
+                positive_interface_side_weights,
+                GeometryData::GI_GAUSS_1);
+
+            tetrahedra_ausas_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
+                negative_interface_side_sh_func,
+                negative_interface_side_sh_func_gradients,
+                negative_interface_side_weights,
+                GeometryData::GI_GAUSS_1);
+
+            // Call the interface outwards normal unit vector calculator
+            std::vector<Vector> positive_side_area_normals, negative_side_area_normals;
+
+            tetrahedra_ausas_shape_functions.ComputePositiveSideInterfaceAreaNormals(
+                positive_side_area_normals,
+                GeometryData::GI_GAUSS_1);
+
+            tetrahedra_ausas_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
+                negative_side_area_normals,
+                GeometryData::GI_GAUSS_1);
+
+            const double tolerance = 1e-10;
+
+            // Check shape functions values
+            KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 0.125, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 0.250, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 0.125, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(0,3), 0.500, tolerance);
+
+            KRATOS_CHECK_NEAR(positive_side_sh_func(1,0), 0.00, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(1,1), 0.75, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(1,2), 0.00, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(1,3), 0.25, tolerance);
+
+            KRATOS_CHECK_NEAR(positive_side_sh_func(2,0), 0.000, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(2,1), 0.500, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(2,2), 0.125, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(2,3), 0.375, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 0.250, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 0.000, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 0.625, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,3), 0.125, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func(1,0), 0.375, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(1,1), 0.000, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(1,2), 0.375, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(1,3), 0.250, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func(2,0), 0.625, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(2,1), 0.000, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(2,2), 0.250, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(2,3), 0.125, tolerance);
+
+            // Check Gauss pts. weights
+            KRATOS_CHECK_NEAR(positive_side_weights(0), 0.02083333333, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_weights(1), 0.04166666666, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_weights(2), 0.02083333333, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_weights(0), 0.02083333333, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_weights(1), 0.02083333333, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_weights(2), 0.04166666666, tolerance);
+
+            // Check Gauss pts. shape functions gradients values
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  2.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](0,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](0,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](0,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](1,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](1,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](2,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](3,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[1](3,2),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](0,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](0,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](0,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](1,0),  2.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](2,0), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](2,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](2,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](3,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[2](3,2),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,2), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,2),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](3,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](3,2),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](0,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](0,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](1,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](2,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](3,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[2](3,2),  1.0, tolerance);
+
+            // Check interface shape function values
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 1.0/6.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 1.0/3.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,3), 1.0/3.0, tolerance);
+
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(1,0), 0.0,     tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(1,1), 2.0/3.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(1,2), 1.0/6.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(1,3), 1.0/6.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/3.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 0.0,     tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,3), 1.0/6.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(1,0), 1.0/2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(1,1), 0.0,     tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(1,2), 1.0/6.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(1,3), 1.0/3.0, tolerance);
+
+            // Check interface Gauss pts. weights
+            KRATOS_CHECK_NEAR(positive_interface_side_weights(0), 0.176777, 1e-6);
+            KRATOS_CHECK_NEAR(positive_interface_side_weights(1), 0.176777, 1e-6);
+            KRATOS_CHECK_NEAR(negative_interface_side_weights(0), 0.176777, 1e-6);
+            KRATOS_CHECK_NEAR(negative_interface_side_weights(1), 0.176777, 1e-6);
+
+            // Check Gauss pts. interface shape function gradients values
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  2.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](0,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](0,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](0,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](1,0),  2.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](2,0), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](2,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](2,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](3,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[1](3,2),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,2), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,2),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](0,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](0,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](1,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](2,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](3,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](3,2),  1.0, tolerance);
+
+            // Check Gauss pts. outwards unit normal values
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), -0.125, 1e-6);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](1),  0.0, 1e-6);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), -0.125, 1e-6);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[1](0), -0.125, 1e-6);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[1](1),  0.0, 1e-6);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[1](2), -0.125, 1e-6);
+
+            KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), 0.125, 1e-6);
+            KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.0, 1e-6);
+            KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.125, 1e-6);
+            KRATOS_CHECK_NEAR(negative_side_area_normals[1](0), 0.125, 1e-6);
+            KRATOS_CHECK_NEAR(negative_side_area_normals[1](1), 0.0, 1e-6);
+            KRATOS_CHECK_NEAR(negative_side_area_normals[1](2), 0.125, 1e-6);
+        }
+
+
+        KRATOS_TEST_CASE_IN_SUITE(AusasIncisedShapeFunctionsTetrahedra3D4Volumes, KratosCoreFastSuite)
+        {
+            Model current_model;
+            // Generate a model part with the previous
+            ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
+            base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+            // Fill the model part geometry data
+            base_model_part.CreateNewNode(1, 0.0, 2.0, 0.0);
+            base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+            base_model_part.CreateNewNode(3, 1.0, 2.0, 0.0);
+            base_model_part.CreateNewNode(4, 1.0, 2.0, 2.0);
+            Properties::Pointer p_properties(new Properties(0));
+            base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
+
+            // Set the elemental distances vector
+            Geometry<Node<3>>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
+
+            array_1d<double, 4> distances_vector;
+            distances_vector[0] = -0.5;
+            distances_vector[1] =  1.0;
+            distances_vector[2] = -0.5;
+            distances_vector[3] =  1.0;
+            array_1d<double, 6> edge_dist_extra_vector;
+            edge_dist_extra_vector[0] = -1.0;
+            edge_dist_extra_vector[1] = -1.0;
+            edge_dist_extra_vector[2] = -1.0;
+            edge_dist_extra_vector[3] =  1.0/3.0;
+            edge_dist_extra_vector[4] = -1.0;
+            edge_dist_extra_vector[5] =  1.0/3.0;
+
+            // Call the modified shape functions calculator
+            Tetrahedra3D4AusasIncisedShapeFunctions tetrahedra_ausas_shape_functions(p_geometry, distances_vector, edge_dist_extra_vector);
+            Matrix positive_side_sh_func, negative_side_sh_func;
+            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
+            Vector positive_side_weights, negative_side_weights;
+
+            tetrahedra_ausas_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
+                positive_side_sh_func,
+                positive_side_sh_func_gradients,
+                positive_side_weights,
+                GeometryData::GI_GAUSS_2);
+
+            tetrahedra_ausas_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
+                negative_side_sh_func,
+                negative_side_sh_func_gradients,
+                negative_side_weights,
+                GeometryData::GI_GAUSS_2);
+
+            const double tolerance = 1e-10;
+
+            // Check Gauss pts. weights
+            const unsigned int n_gauss_pos = positive_side_weights.size();
+            const unsigned int n_gauss_neg = negative_side_weights.size();
+
+            double pos_vol = 0.0;
+            for (unsigned int i=0; i<n_gauss_pos; ++i) {
+                pos_vol += positive_side_weights(i);
+            }
+
+            double neg_vol = 0.0;
+            for (unsigned int i=0; i<n_gauss_neg; ++i) {
+                neg_vol += negative_side_weights(i);
+            }
+
+            const double tot_vol = 2.0*1.0*2.0/6.0;
+            KRATOS_CHECK_NEAR(pos_vol+neg_vol, tot_vol, tolerance);
+        }
+    }   // namespace Testing.
+}  // namespace Kratos.

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_ausas_incised_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_ausas_incised_shape_functions.cpp
@@ -1,0 +1,333 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:     BSD License
+//  			 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+//
+
+// Project includes
+#include "testing/testing.h"
+#include "containers/model.h"
+#include "includes/checks.h"
+#include "utilities/divide_triangle_2d_3.h"
+#include "modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.h"
+
+namespace Kratos
+{
+    namespace Testing
+    {
+
+        KRATOS_TEST_CASE_IN_SUITE(AusasIncisedShapeFunctionsTriangle2D3Horizontal, KratosCoreFastSuite)
+        {
+            Model current_model;
+
+            // Generate a model part with the previous
+            ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
+            base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+            // Fill the model part geometry data
+            base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+            base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+            base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+            Properties::Pointer p_properties(new Properties(0));
+            base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
+
+            // Set the elemental distances vector
+            Geometry<Node<3>>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
+
+            array_1d<double, 3> distances_vector;
+            distances_vector[0] = -1.0;
+            distances_vector[1] = -1.0;
+            distances_vector[2] =  1.0;
+            array_1d<double, 3> edge_dist_extra_vector;
+            edge_dist_extra_vector[0] =  0.5;
+            edge_dist_extra_vector[1] = -1.0;
+            edge_dist_extra_vector[2] = -1.0;
+
+            // Call the modified shape functions calculator
+            Triangle2D3AusasIncisedShapeFunctions triangle_ausas_shape_functions(p_geometry, distances_vector, edge_dist_extra_vector);
+            Matrix positive_side_sh_func, negative_side_sh_func;
+            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
+            Vector positive_side_weights, negative_side_weights;
+
+            triangle_ausas_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
+                positive_side_sh_func,
+                positive_side_sh_func_gradients,
+                positive_side_weights,
+                GeometryData::GI_GAUSS_1);
+
+            triangle_ausas_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
+                negative_side_sh_func,
+                negative_side_sh_func_gradients,
+                negative_side_weights,
+                GeometryData::GI_GAUSS_1);
+
+            // Call the interface modified shape functions calculator
+            Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
+            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
+            Vector positive_interface_side_weights, negative_interface_side_weights;
+
+            triangle_ausas_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
+                positive_interface_side_sh_func,
+                positive_interface_side_sh_func_gradients,
+                positive_interface_side_weights,
+                GeometryData::GI_GAUSS_1);
+
+            triangle_ausas_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
+                negative_interface_side_sh_func,
+                negative_interface_side_sh_func_gradients,
+                negative_interface_side_weights,
+                GeometryData::GI_GAUSS_1);
+
+            // Call the interface outwards normal unit vector calculator
+            std::vector<Vector> positive_side_area_normals, negative_side_area_normals;
+
+            triangle_ausas_shape_functions.ComputePositiveSideInterfaceAreaNormals(
+                positive_side_area_normals,
+                GeometryData::GI_GAUSS_1);
+
+            triangle_ausas_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
+                negative_side_area_normals,
+                GeometryData::GI_GAUSS_1);
+
+            const double tolerance = 1e-10;
+
+            // Check shape functions values
+            KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 1.0/6.0, tolerance);
+              KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 5.0/6.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 1.0/3.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 1.0/2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 1.0/6.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func(1,0), 2.0/3.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(1,1), 1.0/3.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(1,2), 0.0, tolerance);
+
+            // Check Gauss pts. weights
+            KRATOS_CHECK_NEAR(positive_side_weights(0), 1.0/8.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_weights(0), 1.0/8.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_weights(1), 1.0/4.0, tolerance);
+
+            // Check Gauss pts. shape functions gradients values
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  0.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  2.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,0),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,1),  0.0, tolerance);
+
+            // Check interface shape function values
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 1.0/4.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 3.0/4.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 1.0/4.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/4.0, tolerance);
+
+            // Check interface Gauss pts. weights
+            KRATOS_CHECK_NEAR(positive_interface_side_weights(0), 0.50, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_weights(0), 0.50, tolerance);
+
+            // Check Gauss pts. interface shape function gradients values
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  0.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  2.0, tolerance);
+
+            // Check Gauss pts. outwards unit normal values
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), 0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), -0.5, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_area_normals[0](0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_area_normals[0](1),  0.5, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_area_normals[0](2),  0.0, tolerance);
+        }
+
+
+        KRATOS_TEST_CASE_IN_SUITE(AusasIncisedShapeFunctionsTriangle2D3Vertical, KratosCoreFastSuite)
+        {
+            Model current_model;
+
+            // Generate a model part with the previous
+            ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
+            base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+            // Fill the model part geometry data
+            base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+            base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+            base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+            Properties::Pointer p_properties(new Properties(0));
+            base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
+
+            // Set the elemental distances vector
+            Geometry<Node<3>>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
+
+            array_1d<double, 3> distances_vector;
+            distances_vector[0] = -1.0;
+            distances_vector[1] =  1.0;
+            distances_vector[2] = -1.0;
+            array_1d<double, 3> edge_dist_extra_vector;
+            edge_dist_extra_vector[0] =  0.5;
+            edge_dist_extra_vector[1] = -1.0;
+            edge_dist_extra_vector[2] = -1.0;
+
+            // Call the modified shape functions calculator
+            Triangle2D3AusasIncisedShapeFunctions triangle_ausas_shape_functions(p_geometry, distances_vector, edge_dist_extra_vector);
+            Matrix positive_side_sh_func, negative_side_sh_func;
+            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
+            Vector positive_side_weights, negative_side_weights;
+
+            triangle_ausas_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
+                positive_side_sh_func,
+                positive_side_sh_func_gradients,
+                positive_side_weights,
+                GeometryData::GI_GAUSS_1);
+
+            triangle_ausas_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
+                negative_side_sh_func,
+                negative_side_sh_func_gradients,
+                negative_side_weights,
+                GeometryData::GI_GAUSS_1);
+
+            // Call the interface modified shape functions calculator
+            Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
+            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
+            Vector positive_interface_side_weights, negative_interface_side_weights;
+
+            triangle_ausas_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
+                positive_interface_side_sh_func,
+                positive_interface_side_sh_func_gradients,
+                positive_interface_side_weights,
+                GeometryData::GI_GAUSS_1);
+
+            triangle_ausas_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
+                negative_interface_side_sh_func,
+                negative_interface_side_sh_func_gradients,
+                negative_interface_side_weights,
+                GeometryData::GI_GAUSS_1);
+
+            // Call the interface outwards normal unit vector calculator
+            std::vector<Vector> positive_side_area_normals, negative_side_area_normals;
+
+            triangle_ausas_shape_functions.ComputePositiveSideInterfaceAreaNormals(
+                positive_side_area_normals,
+                GeometryData::GI_GAUSS_1);
+
+            triangle_ausas_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
+                negative_side_area_normals,
+                GeometryData::GI_GAUSS_1);
+
+            const double tolerance = 1e-10;
+
+            // Check shape functions values
+            KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 5.0/6.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 1.0/6.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 1.0/3.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 1.0/6.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 1.0/2.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func(1,0), 2.0/3.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(1,1), 0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(1,2), 1.0/3.0, tolerance);
+
+            // Check Gauss pts. weights
+            KRATOS_CHECK_NEAR(positive_side_weights(0), 1.0/8.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_weights(0), 1.0/8.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_weights(1), 1.0/4.0, tolerance);
+
+            // Check Gauss pts. shape functions gradients values
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,1),  1.0, tolerance);
+
+            // Check interface shape function values
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 3.0/4.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 1.0/4.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 1.0/4.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/4.0, tolerance);
+
+            // Check interface Gauss pts. weights
+            KRATOS_CHECK_NEAR(positive_interface_side_weights(0), 0.50, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_weights(0), 0.50, tolerance);
+
+            // Check Gauss pts. interface shape function gradients values
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  2.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+
+            // Check Gauss pts. outwards unit normal values
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), -0.5, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), 0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_area_normals[0](0),  0.5, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_area_normals[0](1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_area_normals[0](2),  0.0, tolerance);
+        }
+    }   // namespace Testing.
+}  // namespace Kratos.

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_ausas_incised_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_ausas_incised_shape_functions.cpp
@@ -4,11 +4,10 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:     BSD License
-//  			 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
-//  Main authors:    Ruben Zorrilla
-//
+//  Main authors:    Franziska Wahl
 //
 
 // Project includes

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_ausas_incised_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_ausas_incised_shape_functions.cpp
@@ -98,81 +98,71 @@ namespace Kratos
             const double tolerance = 1e-10;
 
             // Check shape functions values
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 1.0/6.0, tolerance);
-              KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 5.0/6.0, tolerance);
+            const std::vector<double> ref_pos_sh_func = {0.0, 1.0/6.0, 5.0/6.0};
+            KRATOS_CHECK_VECTOR_NEAR(row(positive_side_sh_func, 0), ref_pos_sh_func, tolerance);
 
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 1.0/2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 1.0/6.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,0), 2.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,1), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,2), 0.0, tolerance);
+            Matrix ref_neg_sh_func(2, 3);
+            const std::array<double, 6> ref_neg_sh_func_array = {1.0/3.0, 1.0/2.0, 1.0/6.0,
+                                                                 2.0/3.0, 1.0/3.0,     0.0};
+            for (unsigned int i = 0; i < ref_neg_sh_func.size1(); i++) {
+                for (unsigned int j = 0; j < ref_neg_sh_func.size2(); j++) {
+                    ref_neg_sh_func(i, j) = ref_neg_sh_func_array[i * ref_neg_sh_func.size2() + j];
+                }
+            }
+            KRATOS_CHECK_MATRIX_NEAR(negative_side_sh_func, ref_neg_sh_func, tolerance);
 
             // Check Gauss pts. weights
             KRATOS_CHECK_NEAR(positive_side_weights(0), 1.0/8.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_weights(0), 1.0/8.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_weights(1), 1.0/4.0, tolerance);
+            const std::vector<double> ref_neg_weights = {1.0/8.0, 1.0/4.0};
+            KRATOS_CHECK_VECTOR_NEAR(negative_side_weights, ref_neg_weights, tolerance);
 
             // Check Gauss pts. shape functions gradients values
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  0.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  2.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,1),  0.0, tolerance);
+            Matrix ref_pos_sh_func_grad_0(3, 2);
+            Matrix ref_neg_sh_func_grad_0(3, 2);
+            Matrix ref_neg_sh_func_grad_1(3, 2);
+            const std::array<double, 6> ref_pos_sh_func_grad_0_array = { 0.0,  0.0,  1.0,  0.0, -1.0,  0.0};
+            const std::array<double, 6> ref_neg_sh_func_grad_0_array = {-2.0, -2.0,  1.0,  0.0,  1.0,  2.0};
+            const std::array<double, 6> ref_neg_sh_func_grad_1_array = {-1.0,  0.0,  1.0,  0.0,  0.0,  0.0};
+            for (unsigned int i = 0; i < ref_pos_sh_func_grad_0.size1(); i++) {
+                for (unsigned int j = 0; j < ref_pos_sh_func_grad_0.size2(); j++) {
+                    ref_pos_sh_func_grad_0(i, j) = ref_pos_sh_func_grad_0_array[i * ref_pos_sh_func_grad_0.size2() + j];
+                    ref_neg_sh_func_grad_0(i, j) = ref_neg_sh_func_grad_0_array[i * ref_pos_sh_func_grad_0.size2() + j];
+                    ref_neg_sh_func_grad_1(i, j) = ref_neg_sh_func_grad_1_array[i * ref_pos_sh_func_grad_0.size2() + j];
+                }
+            }
+            KRATOS_CHECK_MATRIX_NEAR(positive_side_sh_func_gradients[0], ref_pos_sh_func_grad_0, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(negative_side_sh_func_gradients[0], ref_neg_sh_func_grad_0, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(negative_side_sh_func_gradients[1], ref_neg_sh_func_grad_1, tolerance);
 
             // Check interface shape function values
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 1.0/4.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 3.0/4.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 1.0/4.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/4.0, tolerance);
+            const std::vector<double> ref_pos_interface_sh_func = {    0.0, 1.0/4.0, 3.0/4.0};
+            const std::vector<double> ref_neg_interface_sh_func = {1.0/2.0, 1.0/4.0, 1.0/4.0};
+            KRATOS_CHECK_VECTOR_NEAR(row(positive_interface_side_sh_func, 0), ref_pos_interface_sh_func, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(row(negative_interface_side_sh_func, 0), ref_neg_interface_sh_func, tolerance);
 
             // Check interface Gauss pts. weights
             KRATOS_CHECK_NEAR(positive_interface_side_weights(0), 0.50, tolerance);
             KRATOS_CHECK_NEAR(negative_interface_side_weights(0), 0.50, tolerance);
 
             // Check Gauss pts. interface shape function gradients values
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  0.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  2.0, tolerance);
+            Matrix ref_pos_interface_sh_func_grad_0(3, 2);
+            Matrix ref_neg_interface_sh_func_grad_0(3, 2);
+            const std::array<double, 6> ref_pos_interface_sh_func_grad_0_array = { 0.0,  0.0,  1.0,  0.0, -1.0,  0.0};
+            const std::array<double, 6> ref_neg_interface_sh_func_grad_0_array = {-2.0, -2.0,  1.0,  0.0,  1.0,  2.0};
+            for (unsigned int i = 0; i < ref_pos_interface_sh_func_grad_0.size1(); i++) {
+                for (unsigned int j = 0; j < ref_pos_interface_sh_func_grad_0.size2(); j++) {
+                    ref_pos_interface_sh_func_grad_0(i, j) = ref_pos_interface_sh_func_grad_0_array[i * ref_pos_interface_sh_func_grad_0.size2() + j];
+                    ref_neg_interface_sh_func_grad_0(i, j) = ref_neg_interface_sh_func_grad_0_array[i * ref_pos_interface_sh_func_grad_0.size2() + j];
+                }
+            }
+            KRATOS_CHECK_MATRIX_NEAR(positive_interface_side_sh_func_gradients[0], ref_pos_interface_sh_func_grad_0, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(negative_interface_side_sh_func_gradients[0], ref_neg_interface_sh_func_grad_0, tolerance);
 
             // Check Gauss pts. outwards unit normal values
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), 0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), -0.5, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](1),  0.5, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](2),  0.0, tolerance);
+            const std::vector<double> ref_pos_area_normals = {0.0, -0.5, 0.0};
+            const std::vector<double> ref_neg_area_normals = {0.0,  0.5, 0.0};
+            KRATOS_CHECK_VECTOR_NEAR(positive_side_area_normals[0], ref_pos_area_normals, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(negative_side_area_normals[0], ref_neg_area_normals, tolerance);
         }
 
 
@@ -252,81 +242,71 @@ namespace Kratos
             const double tolerance = 1e-10;
 
             // Check shape functions values
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 5.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 1.0/6.0, tolerance);
+            const std::vector<double> ref_pos_sh_func = {0.0, 5.0/6.0, 1.0/6.0};
+            KRATOS_CHECK_VECTOR_NEAR(row(positive_side_sh_func, 0), ref_pos_sh_func, tolerance);
 
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 1.0/2.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,0), 2.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,1), 0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,2), 1.0/3.0, tolerance);
+            Matrix ref_neg_sh_func(2, 3);
+            const std::array<double, 6> ref_neg_sh_func_array = {1.0/3.0, 1.0/6.0, 1.0/2.0,
+                                                                 2.0/3.0,     0.0, 1.0/3.0};
+            for (unsigned int i = 0; i < ref_neg_sh_func.size1(); i++) {
+                for (unsigned int j = 0; j < ref_neg_sh_func.size2(); j++) {
+                    ref_neg_sh_func(i, j) = ref_neg_sh_func_array[i * ref_neg_sh_func.size2() + j];
+                }
+            }
+            KRATOS_CHECK_MATRIX_NEAR(negative_side_sh_func, ref_neg_sh_func, tolerance);
 
             // Check Gauss pts. weights
             KRATOS_CHECK_NEAR(positive_side_weights(0), 1.0/8.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_weights(0), 1.0/8.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_weights(1), 1.0/4.0, tolerance);
+            const std::vector<double> ref_neg_weights = {1.0/8.0, 1.0/4.0};
+            KRATOS_CHECK_VECTOR_NEAR(negative_side_weights, ref_neg_weights, tolerance);
 
             // Check Gauss pts. shape functions gradients values
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,1),  1.0, tolerance);
+            Matrix ref_pos_sh_func_grad_0(3, 2);
+            Matrix ref_neg_sh_func_grad_0(3, 2);
+            Matrix ref_neg_sh_func_grad_1(3, 2);
+            const std::array<double, 6> ref_pos_sh_func_grad_0_array = { 0.0,  0.0,  0.0, -1.0,  0.0,  1.0};
+            const std::array<double, 6> ref_neg_sh_func_grad_0_array = {-2.0, -2.0,  2.0,  1.0,  0.0,  1.0};
+            const std::array<double, 6> ref_neg_sh_func_grad_1_array = { 0.0, -1.0,  0.0,  0.0,  0.0,  1.0};
+            for (unsigned int i = 0; i < ref_pos_sh_func_grad_0.size1(); i++) {
+                for (unsigned int j = 0; j < ref_pos_sh_func_grad_0.size2(); j++) {
+                    ref_pos_sh_func_grad_0(i, j) = ref_pos_sh_func_grad_0_array[i * ref_pos_sh_func_grad_0.size2() + j];
+                    ref_neg_sh_func_grad_0(i, j) = ref_neg_sh_func_grad_0_array[i * ref_pos_sh_func_grad_0.size2() + j];
+                    ref_neg_sh_func_grad_1(i, j) = ref_neg_sh_func_grad_1_array[i * ref_pos_sh_func_grad_0.size2() + j];
+                }
+            }
+            KRATOS_CHECK_MATRIX_NEAR(positive_side_sh_func_gradients[0], ref_pos_sh_func_grad_0, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(negative_side_sh_func_gradients[0], ref_neg_sh_func_grad_0, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(negative_side_sh_func_gradients[1], ref_neg_sh_func_grad_1, tolerance);
 
             // Check interface shape function values
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 3.0/4.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 1.0/4.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 1.0/4.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/4.0, tolerance);
+            const std::vector<double> ref_pos_interface_sh_func = {    0.0, 3.0/4.0, 1.0/4.0};
+            const std::vector<double> ref_neg_interface_sh_func = {1.0/2.0, 1.0/4.0, 1.0/4.0};
+            KRATOS_CHECK_VECTOR_NEAR(row(positive_interface_side_sh_func, 0), ref_pos_interface_sh_func, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(row(negative_interface_side_sh_func, 0), ref_neg_interface_sh_func, tolerance);
 
             // Check interface Gauss pts. weights
             KRATOS_CHECK_NEAR(positive_interface_side_weights(0), 0.50, tolerance);
             KRATOS_CHECK_NEAR(negative_interface_side_weights(0), 0.50, tolerance);
 
             // Check Gauss pts. interface shape function gradients values
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  2.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+            Matrix ref_pos_interface_sh_func_grad_0(3, 2);
+            Matrix ref_neg_interface_sh_func_grad_0(3, 2);
+            const std::array<double, 6> ref_pos_interface_sh_func_grad_0_array = { 0.0,  0.0,  0.0, -1.0,  0.0,  1.0};
+            const std::array<double, 6> ref_neg_interface_sh_func_grad_0_array = {-2.0, -2.0,  2.0,  1.0,  0.0,  1.0};
+            for (unsigned int i = 0; i < ref_pos_interface_sh_func_grad_0.size1(); i++) {
+                for (unsigned int j = 0; j < ref_pos_interface_sh_func_grad_0.size2(); j++) {
+                    ref_pos_interface_sh_func_grad_0(i, j) = ref_pos_interface_sh_func_grad_0_array[i * ref_pos_interface_sh_func_grad_0.size2() + j];
+                    ref_neg_interface_sh_func_grad_0(i, j) = ref_neg_interface_sh_func_grad_0_array[i * ref_pos_interface_sh_func_grad_0.size2() + j];
+                }
+            }
+            KRATOS_CHECK_MATRIX_NEAR(positive_interface_side_sh_func_gradients[0], ref_pos_interface_sh_func_grad_0, tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(negative_interface_side_sh_func_gradients[0], ref_neg_interface_sh_func_grad_0, tolerance);
 
             // Check Gauss pts. outwards unit normal values
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), -0.5, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), 0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](0),  0.5, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](2),  0.0, tolerance);
+            const std::vector<double> ref_pos_area_normals = {-0.5, 0.0, 0.0};
+            const std::vector<double> ref_neg_area_normals = { 0.5, 0.0, 0.0};
+            KRATOS_CHECK_VECTOR_NEAR(positive_side_area_normals[0], ref_pos_area_normals, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(negative_side_area_normals[0], ref_neg_area_normals, tolerance);
         }
     }   // namespace Testing.
 }  // namespace Kratos.


### PR DESCRIPTION
**Description**
In order to consider incised, and not only completely cut, elements in `EmbeddedFluidElementDiscontinuous`, this pull request adds classes for Ausas incised shape functions. One triangle class for 2D and one tetrahedra class for 3D elements.

Those classes expect an equivalent of `ELEMENTAL_DISTANCES_WITH_EXTRAPOLATED` instead of `ELEMENTAL_DISTANCES` and additionally an equivalent of `ELEMENTAL_EXTRAPOLATED_EDGE_DISTANCES` from the respective element in their constructor.

`ELEMENTAL_DISTANCES_WITH_EXTRAPOLATED` are used for everything instead of only `ELEMENTAL_DISTANCES`, so the edges cut by the extrapolated skin geometry are treated the same way as edges, which are actually cut by the original geometry. This way the base classes and splitting utility "see" a completely cut element instead of an incised one.

To get Ausas incised shape functions instead of shape functions for completely cut elements, the methods for setting the positive and negative side condensation matrices are overriden in the new classes. The `ELEMENTAL_EXTRAPOLATED_EDGE_DISTANCES` are used to detect the edges, which are only cut by the extrapolated geometry. Then, the respective extrapolated edge ratio is used to set the value at the intersection as a linear interpolation of the values at the two nodes of the edge.

NOTE:
The definition of edge ID's from the respective splitting utility had to be translated to edge IDs of the geometry used for `ELEMENTAL_EXTRAPOLATED_EDGE_DISTANCES` to be able to access the entries of that variable correctly.

**Changelog**
- Added classes `Triangle2D3AusasIncisedShapeFunctions` and `Tetrahedra3D4AusasIncisedShapeFunctions`, which override the methods `SetPositiveSideCondensationMatrix`(..) and `SetNegativeSideCondensationMatrix`(..) of `AusasModifiedShapeFunctions`
- Fixed a mix up of node IDs in a call for the condensation matrix in `Triangle2D3AusasModifedShapeFunctions` 
