### PR TITLE
[CI] turning all Clang warnings into errors

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - master
-  
+
   workflow_dispatch:
 
 
@@ -57,7 +57,7 @@ jobs:
         elif [ ${{ matrix.compiler }} = clang ]; then
           export CC=clang-9
           export CXX=clang++-9
-          export KRATOS_CMAKE_CXX_FLAGS="-Werror=delete-non-abstract-non-virtual-dtor -Werror=extra-tokens -Werror=defaulted-function-deleted -Werror=potentially-evaluated-expression -Werror=instantiation-after-specialization -Werror=undefined-var-template -Werror=unused-lambda-capture -Werror=unused-const-variable -Werror=parentheses -Werror=pessimizing-move -Werror=c++17-extensions -Werror=logical-op-parentheses -Werror=range-loop-analysis"
+          export KRATOS_CMAKE_CXX_FLAGS="-Werror -Wall -Wno-deprecated-declarations"
           export KRATOS_CMAKE_OPTIONS_FLAGS="-DTRILINOS_EXCLUDE_AMESOS2_SOLVER=OFF -DMMG_ROOT=/external_libraries/mmg/mmg_5_4_1/"
         else
           echo 'Unsupported compiler: ${{ matrix.compiler }}'

--- a/applications/ChimeraApplication/custom_processes/rotate_region_process.cpp
+++ b/applications/ChimeraApplication/custom_processes/rotate_region_process.cpp
@@ -160,7 +160,7 @@ void RotateRegionProcess::PrintInfo(std::ostream &rOStream) const
   rOStream << "RotateRegionProcess";
 }
 
-void RotateRegionProcess::PrintData() {}
+void RotateRegionProcess::PrintData(std::ostream& rOStream) const {}
 
 RotateRegionProcess::RotationSystem::RotationSystem(const double MomentOfInertia,
                                                     const double DampingCoefficient)

--- a/applications/ChimeraApplication/custom_processes/rotate_region_process.h
+++ b/applications/ChimeraApplication/custom_processes/rotate_region_process.h
@@ -72,7 +72,7 @@ public:
   void PrintInfo(std::ostream &rOStream) const override;
 
   /// Print object's data.
-  void PrintData();
+  void PrintData(std::ostream& rOStream) const override;
 
 protected:
   ///@name Protected static Member Variables

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_contact_strategy.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_contact_strategy.h
@@ -928,7 +928,7 @@ protected:
      * @return Returns the default parameters
      */
 
-    Parameters GetDefaultParameters()
+    Parameters GetDefaultParameters() const override
     {
         Parameters default_parameters = Parameters(R"(
         {

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_mpc_contact_strategy.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_mpc_contact_strategy.h
@@ -605,7 +605,7 @@ protected:
      * @return Returns the default parameters
      */
 
-    Parameters GetDefaultParameters()
+    Parameters GetDefaultParameters() const override
     {
         Parameters default_parameters = Parameters(R"(
         {


### PR DESCRIPTION
**Description**
For the first time since I use clang the build is free of warnings. I would like to keep it that way ;)

same is already done for MSVC and GCC

includes #8214, #8215, #8216