### PR TITLE
removing ExternalSolversApp from CI

### DIFF
--- a/.github/workflows/configure.sh
+++ b/.github/workflows/configure.sh
@@ -21,7 +21,6 @@ export KRATOS_INSTALL_PYTHON_USING_LINKS=ON
 
 # Set applications to compile
 add_app ${KRATOS_APP_DIR}/ConvectionDiffusionApplication;
-add_app ${KRATOS_APP_DIR}/ExternalSolversApplication;
 add_app ${KRATOS_APP_DIR}/LinearSolversApplication;
 add_app ${KRATOS_APP_DIR}/StructuralMechanicsApplication;
 add_app ${KRATOS_APP_DIR}/FluidDynamicsApplication;


### PR DESCRIPTION
**Description**
Now that the ExternalSolversApplication is officially deprecated, I want to remove it from the CI to see if it is still used

TODO after this is merged: remove blas & lapack from docker