### PR TITLE
[Core] Replace trivial omp loops in utilities/constraint_utilities

### DIFF
--- a/kratos/utilities/auxiliar_model_part_utilities.cpp
+++ b/kratos/utilities/auxiliar_model_part_utilities.cpp
@@ -19,7 +19,6 @@
 // Project includes
 #include "includes/key_hash.h"
 #include "utilities/auxiliar_model_part_utilities.h"
-#include "utilities/parallel_utilities.h"
 
 namespace Kratos
 {
@@ -105,21 +104,20 @@ void AuxiliarModelPartUtilities::RemoveElementAndBelongings(
     IndexType ElementId, Flags IdentifierFlag, IndexType ThisIndex)
 {
     auto& r_array_nodes = mrModelPart.Nodes(ThisIndex);
+    #pragma omp parallel for
+    for(int i=0; i<static_cast<int>(r_array_nodes.size()); ++i) {
+        auto it_node = r_array_nodes.begin() + i;
+        it_node->Set(IdentifierFlag, true);
+    }
 
-    block_for_each( 
-        r_array_nodes, [&IdentifierFlag]( Node<3>& r_node )
-        { r_node.Set(IdentifierFlag, true); }  
-    );
-
-    block_for_each(
-        mrModelPart.Elements(ThisIndex), [&IdentifierFlag,ElementId]( ModelPart::ElementType& r_element )
-        {
-            if (r_element.Id() != ElementId)
-                for (auto& r_node : r_element.GetGeometry())
-                    r_node.Set(IdentifierFlag, false);
+    // TODO: Add OMP
+    for (auto& elem : mrModelPart.Elements(ThisIndex)) {
+        if (elem.Id() != ElementId) {
+            for (auto& node : elem.GetGeometry()) {
+                node.Set(IdentifierFlag, false);
+            }
         }
-    );
-
+    }
     bool condition_to_remove;
     for (auto& cond : mrModelPart.Conditions(ThisIndex)) {
         condition_to_remove = true;
@@ -191,21 +189,20 @@ void AuxiliarModelPartUtilities::RemoveElementsAndBelongings(Flags IdentifierFla
     auto& meshes = mrModelPart.GetMeshes();
     for(auto i_mesh = meshes.begin() ; i_mesh != meshes.end() ; i_mesh++) {
         auto& r_array_nodes = i_mesh->Nodes();
-        block_for_each(
-            r_array_nodes,
-            [&IdentifierFlag](Node<3>& r_node)
-            { r_node.Set(IdentifierFlag, true); }
-        );
+        #pragma omp parallel for
+        for(int i=0; i<static_cast<int>(r_array_nodes.size()); ++i) {
+            auto it_node = r_array_nodes.begin() + i;
+            it_node->Set(IdentifierFlag, true);
+        }
 
-        block_for_each(
-            i_mesh->Elements(),
-            [&IdentifierFlag](ModelPart::ElementType& r_element)
-            {
-                if (r_element.IsNot(IdentifierFlag))
-                    for (auto& r_node : r_element.GetGeometry())
-                        r_node.Set(IdentifierFlag, false);
+        // TODO: Add OMP
+        for (auto& elem : i_mesh->Elements()) {
+            if (elem.IsNot(IdentifierFlag)) {
+                for (auto& node : elem.GetGeometry()) {
+                    node.Set(IdentifierFlag, false);
+                }
             }
-        );
+        }
 
         bool condition_to_remove;
         for (auto& cond : i_mesh->Conditions()) {
@@ -241,21 +238,20 @@ void AuxiliarModelPartUtilities::RemoveElementsAndBelongingsFromAllLevels(Flags 
 void AuxiliarModelPartUtilities::RemoveConditionAndBelongings(IndexType ConditionId, Flags IdentifierFlag, IndexType ThisIndex)
 {
     auto& r_array_nodes = mrModelPart.Nodes(ThisIndex);
-    block_for_each(
-        r_array_nodes,
-        [&IdentifierFlag](Node<3>& r_node)
-        { r_node.Set(IdentifierFlag, true); }
-    );
+    #pragma omp parallel for
+    for(int i=0; i<static_cast<int>(r_array_nodes.size()); ++i) {
+        auto it_node = r_array_nodes.begin() + i;
+        it_node->Set(IdentifierFlag, true);
+    }
 
-    block_for_each(
-        mrModelPart.Conditions(ThisIndex),
-        [&IdentifierFlag,ConditionId](ModelPart::ConditionType& r_condition)
-        {
-            if (r_condition.Id() != ConditionId)
-                for (auto& r_node : r_condition.GetGeometry())
-                    r_node.Set(IdentifierFlag, false);
+    // TODO: Add OMP
+    for (auto& cond : mrModelPart.Conditions(ThisIndex)) {
+        if (cond.Id() != ConditionId) {
+            for (auto& node : cond.GetGeometry()) {
+                node.Set(IdentifierFlag, false);
+            }
         }
-    );
+    }
     bool element_to_remove;
     for (auto& elem : mrModelPart.Elements(ThisIndex)) {
         element_to_remove = true;
@@ -327,21 +323,20 @@ void AuxiliarModelPartUtilities::RemoveConditionsAndBelongings(Flags IdentifierF
     auto& meshes = mrModelPart.GetMeshes();
     for(auto i_mesh = meshes.begin() ; i_mesh != meshes.end() ; i_mesh++) {
         auto& r_array_nodes = i_mesh->Nodes();
-        block_for_each(
-            r_array_nodes,
-            [&IdentifierFlag](Node<3>& r_node)
-            { r_node.Set(IdentifierFlag, true); }
-        );
+        #pragma omp parallel for
+        for(int i=0; i<static_cast<int>(r_array_nodes.size()); ++i) {
+            auto it_node = r_array_nodes.begin() + i;
+            it_node->Set(IdentifierFlag, true);
+        }
 
-        block_for_each(
-            i_mesh->Conditions(),
-            [&IdentifierFlag](ModelPart::ConditionType& r_condition)
-            {
-                if (r_condition.IsNot(IdentifierFlag))
-                    for (auto& r_node : r_condition.GetGeometry())
-                        r_node.Set(IdentifierFlag, false);
+        // TODO: Add OMP
+        for (auto& cond : i_mesh->Conditions()) {
+            if (cond.IsNot(IdentifierFlag)) {
+                for (auto& node : cond.GetGeometry()) {
+                    node.Set(IdentifierFlag, false);
+                }
             }
-        );
+        }
 
         bool element_to_remove;
         for (auto& elem : i_mesh->Elements()) {

--- a/kratos/utilities/auxiliar_model_part_utilities.cpp
+++ b/kratos/utilities/auxiliar_model_part_utilities.cpp
@@ -19,6 +19,7 @@
 // Project includes
 #include "includes/key_hash.h"
 #include "utilities/auxiliar_model_part_utilities.h"
+#include "utilities/parallel_utilities.h"
 
 namespace Kratos
 {
@@ -104,20 +105,21 @@ void AuxiliarModelPartUtilities::RemoveElementAndBelongings(
     IndexType ElementId, Flags IdentifierFlag, IndexType ThisIndex)
 {
     auto& r_array_nodes = mrModelPart.Nodes(ThisIndex);
-    #pragma omp parallel for
-    for(int i=0; i<static_cast<int>(r_array_nodes.size()); ++i) {
-        auto it_node = r_array_nodes.begin() + i;
-        it_node->Set(IdentifierFlag, true);
-    }
 
-    // TODO: Add OMP
-    for (auto& elem : mrModelPart.Elements(ThisIndex)) {
-        if (elem.Id() != ElementId) {
-            for (auto& node : elem.GetGeometry()) {
-                node.Set(IdentifierFlag, false);
-            }
+    block_for_each( 
+        r_array_nodes, [&IdentifierFlag]( Node<3>& r_node )
+        { r_node.Set(IdentifierFlag, true); }  
+    );
+
+    block_for_each(
+        mrModelPart.Elements(ThisIndex), [&IdentifierFlag,ElementId]( ModelPart::ElementType& r_element )
+        {
+            if (r_element.Id() != ElementId)
+                for (auto& r_node : r_element.GetGeometry())
+                    r_node.Set(IdentifierFlag, false);
         }
-    }
+    );
+
     bool condition_to_remove;
     for (auto& cond : mrModelPart.Conditions(ThisIndex)) {
         condition_to_remove = true;
@@ -189,20 +191,21 @@ void AuxiliarModelPartUtilities::RemoveElementsAndBelongings(Flags IdentifierFla
     auto& meshes = mrModelPart.GetMeshes();
     for(auto i_mesh = meshes.begin() ; i_mesh != meshes.end() ; i_mesh++) {
         auto& r_array_nodes = i_mesh->Nodes();
-        #pragma omp parallel for
-        for(int i=0; i<static_cast<int>(r_array_nodes.size()); ++i) {
-            auto it_node = r_array_nodes.begin() + i;
-            it_node->Set(IdentifierFlag, true);
-        }
+        block_for_each(
+            r_array_nodes,
+            [&IdentifierFlag](Node<3>& r_node)
+            { r_node.Set(IdentifierFlag, true); }
+        );
 
-        // TODO: Add OMP
-        for (auto& elem : i_mesh->Elements()) {
-            if (elem.IsNot(IdentifierFlag)) {
-                for (auto& node : elem.GetGeometry()) {
-                    node.Set(IdentifierFlag, false);
-                }
+        block_for_each(
+            i_mesh->Elements(),
+            [&IdentifierFlag](ModelPart::ElementType& r_element)
+            {
+                if (r_element.IsNot(IdentifierFlag))
+                    for (auto& r_node : r_element.GetGeometry())
+                        r_node.Set(IdentifierFlag, false);
             }
-        }
+        );
 
         bool condition_to_remove;
         for (auto& cond : i_mesh->Conditions()) {
@@ -238,20 +241,21 @@ void AuxiliarModelPartUtilities::RemoveElementsAndBelongingsFromAllLevels(Flags 
 void AuxiliarModelPartUtilities::RemoveConditionAndBelongings(IndexType ConditionId, Flags IdentifierFlag, IndexType ThisIndex)
 {
     auto& r_array_nodes = mrModelPart.Nodes(ThisIndex);
-    #pragma omp parallel for
-    for(int i=0; i<static_cast<int>(r_array_nodes.size()); ++i) {
-        auto it_node = r_array_nodes.begin() + i;
-        it_node->Set(IdentifierFlag, true);
-    }
+    block_for_each(
+        r_array_nodes,
+        [&IdentifierFlag](Node<3>& r_node)
+        { r_node.Set(IdentifierFlag, true); }
+    );
 
-    // TODO: Add OMP
-    for (auto& cond : mrModelPart.Conditions(ThisIndex)) {
-        if (cond.Id() != ConditionId) {
-            for (auto& node : cond.GetGeometry()) {
-                node.Set(IdentifierFlag, false);
-            }
+    block_for_each(
+        mrModelPart.Conditions(ThisIndex),
+        [&IdentifierFlag,ConditionId](ModelPart::ConditionType& r_condition)
+        {
+            if (r_condition.Id() != ConditionId)
+                for (auto& r_node : r_condition.GetGeometry())
+                    r_node.Set(IdentifierFlag, false);
         }
-    }
+    );
     bool element_to_remove;
     for (auto& elem : mrModelPart.Elements(ThisIndex)) {
         element_to_remove = true;
@@ -323,20 +327,21 @@ void AuxiliarModelPartUtilities::RemoveConditionsAndBelongings(Flags IdentifierF
     auto& meshes = mrModelPart.GetMeshes();
     for(auto i_mesh = meshes.begin() ; i_mesh != meshes.end() ; i_mesh++) {
         auto& r_array_nodes = i_mesh->Nodes();
-        #pragma omp parallel for
-        for(int i=0; i<static_cast<int>(r_array_nodes.size()); ++i) {
-            auto it_node = r_array_nodes.begin() + i;
-            it_node->Set(IdentifierFlag, true);
-        }
+        block_for_each(
+            r_array_nodes,
+            [&IdentifierFlag](Node<3>& r_node)
+            { r_node.Set(IdentifierFlag, true); }
+        );
 
-        // TODO: Add OMP
-        for (auto& cond : i_mesh->Conditions()) {
-            if (cond.IsNot(IdentifierFlag)) {
-                for (auto& node : cond.GetGeometry()) {
-                    node.Set(IdentifierFlag, false);
-                }
+        block_for_each(
+            i_mesh->Conditions(),
+            [&IdentifierFlag](ModelPart::ConditionType& r_condition)
+            {
+                if (r_condition.IsNot(IdentifierFlag))
+                    for (auto& r_node : r_condition.GetGeometry())
+                        r_node.Set(IdentifierFlag, false);
             }
-        }
+        );
 
         bool element_to_remove;
         for (auto& elem : i_mesh->Elements()) {


### PR DESCRIPTION
**Description**
Replace trivial ```omp``` loops with ```block_for_each``` when possible.

**Note**
```block_for_each``` does not support looping over ```const``` containers, so ```IndexPartition``` is used in these cases. I added a ```TODO``` comment for such loops.