### PR TITLE
[Core] Replace trivial omp loops in utilities/mortar_utilities

### DIFF
--- a/kratos/utilities/mortar_utilities.cpp
+++ b/kratos/utilities/mortar_utilities.cpp
@@ -167,10 +167,8 @@ void ComputeNodesTangentModelPart(
 
     block_for_each(
         r_nodes_array,
-        [&pSlipVariable,SlipCoefficient,domain_size,has_lm,SlipAlways](Node<3>& rNode)
-        {
-            if (rNode.Is(SLAVE))
-            {
+        [&pSlipVariable,SlipCoefficient,domain_size,has_lm,SlipAlways](Node<3>& rNode) {
+            if (rNode.Is(SLAVE)) {
                 if (has_lm && !SlipAlways)
                     ComputeTangentNodeWithLMAndSlip(rNode, 0, pSlipVariable, SlipCoefficient, domain_size);
                 else
@@ -196,8 +194,7 @@ void ComputeNodesTangentFromNormalModelPart(ModelPart& rModelPart)
 
     block_for_each(
         r_nodes_array,
-        [domain_size](Node<3>& rNode)
-        {
+        [domain_size](Node<3>& rNode) {
             if (rNode.Is(SLAVE)) {
                 const array_1d<double, 3>& r_normal = rNode.FastGetSolutionStepValue(NORMAL);
                 ComputeTangentsFromNormal(rNode, r_normal, domain_size);
@@ -718,8 +715,7 @@ void UpdateDatabase<Variable<double>, MortarUtilitiesSettings::SaveAsHistoricalV
     )
 {
     IndexPartition<std::size_t>(rDx.size()).for_each(
-        [&](std::size_t i_increment)
-        {
+        [&](std::size_t i_increment) {
             auto p_node = rThisModelPart.pGetNode(rConectivityDatabase[i_increment]);
             p_node->FastGetSolutionStepValue(rThisVariable) += rDx[i_increment];
         }
@@ -739,8 +735,7 @@ void UpdateDatabase<Variable<array_1d<double, 3>>, MortarUtilitiesSettings::Save
     )
 {
     IndexPartition<std::size_t>(rDx.size()).for_each(
-        [&](std::size_t i_increment)
-        {
+        [&](std::size_t i_increment) {
             auto p_node = rThisModelPart.pGetNode(rConectivityDatabase[i_increment]);
             auto& r_value = p_node->FastGetSolutionStepValue(rThisVariable);
             r_value[Index] += rDx[i_increment];
@@ -761,8 +756,7 @@ void UpdateDatabase<Variable<double>, MortarUtilitiesSettings::SaveAsNonHistoric
     )
 {
     IndexPartition<std::size_t>(rDx.size()).for_each(
-        [&](std::size_t i_increment)
-        {
+        [&](std::size_t i_increment) {
             auto p_node = rThisModelPart.pGetNode(rConectivityDatabase[i_increment]);
             p_node->GetValue(rThisVariable) += rDx[i_increment];
         }
@@ -782,8 +776,7 @@ void UpdateDatabase<Variable<array_1d<double, 3>>, MortarUtilitiesSettings::Save
     )
 {
     IndexPartition<std::size_t>(rDx.size()).for_each(
-        [&](std::size_t i_increment)
-        {
+        [&](std::size_t i_increment) {
             auto p_node = rThisModelPart.pGetNode(rConectivityDatabase[i_increment]);
             auto& value = p_node->GetValue(rThisVariable);
             value[Index] += rDx[i_increment];

--- a/kratos/utilities/mortar_utilities.cpp
+++ b/kratos/utilities/mortar_utilities.cpp
@@ -167,14 +167,14 @@ void ComputeNodesTangentModelPart(
 
     block_for_each(
         r_nodes_array,
-        [&pSlipVariable,SlipCoefficient,domain_size,has_lm,SlipAlways](Node<3>& r_node)
+        [&pSlipVariable,SlipCoefficient,domain_size,has_lm,SlipAlways](Node<3>& rNode)
         {
-            if (r_node.Is(SLAVE))
+            if (rNode.Is(SLAVE))
             {
                 if (has_lm && !SlipAlways)
-                    ComputeTangentNodeWithLMAndSlip(r_node, 0, pSlipVariable, SlipCoefficient, domain_size);
+                    ComputeTangentNodeWithLMAndSlip(rNode, 0, pSlipVariable, SlipCoefficient, domain_size);
                 else
-                    ComputeTangentNodeWithSlip(r_node, 0, pSlipVariable, SlipCoefficient, domain_size);
+                    ComputeTangentNodeWithSlip(rNode, 0, pSlipVariable, SlipCoefficient, domain_size);
             }
         }
     );
@@ -196,12 +196,11 @@ void ComputeNodesTangentFromNormalModelPart(ModelPart& rModelPart)
 
     block_for_each(
         r_nodes_array,
-        [domain_size](Node<3>& r_node)
+        [domain_size](Node<3>& rNode)
         {
-            if (r_node.Is(SLAVE))
-            {
-                const array_1d<double, 3>& r_normal = r_node.FastGetSolutionStepValue(NORMAL);
-                ComputeTangentsFromNormal(r_node, r_normal, domain_size);
+            if (rNode.Is(SLAVE)) {
+                const array_1d<double, 3>& r_normal = rNode.FastGetSolutionStepValue(NORMAL);
+                ComputeTangentsFromNormal(rNode, r_normal, domain_size);
             }
         }
     );

--- a/kratos/utilities/mortar_utilities.cpp
+++ b/kratos/utilities/mortar_utilities.cpp
@@ -20,6 +20,7 @@
 #include "utilities/normal_calculation_utils.h"
 #include "utilities/math_utils.h"
 #include "utilities/variable_utils.h"
+#include "utilities/parallel_utilities.h"
 
 namespace Kratos
 {
@@ -163,22 +164,20 @@ void ComputeNodesTangentModelPart(
 
     // We iterate over nodes
     auto& r_nodes_array = rModelPart.Nodes();
-    const auto it_node_begin = r_nodes_array.begin();
-    const int num_nodes = static_cast<int>(r_nodes_array.size());
 
-    #pragma omp parallel for
-    for(int i = 0; i < num_nodes; ++i) {
-        auto it_node = it_node_begin + i;
-
-        // Computing only slave nodes
-        if (it_node->Is(SLAVE)) {
-            if (has_lm && !SlipAlways) {
-                ComputeTangentNodeWithLMAndSlip(*it_node, 0, pSlipVariable, SlipCoefficient, domain_size);
-            } else {
-                ComputeTangentNodeWithSlip(*it_node, 0, pSlipVariable, SlipCoefficient, domain_size);
+    block_for_each(
+        r_nodes_array,
+        [&pSlipVariable,SlipCoefficient,domain_size,has_lm,SlipAlways](Node<3>& r_node)
+        {
+            if (r_node.Is(SLAVE))
+            {
+                if (has_lm && !SlipAlways)
+                    ComputeTangentNodeWithLMAndSlip(r_node, 0, pSlipVariable, SlipCoefficient, domain_size);
+                else
+                    ComputeTangentNodeWithSlip(r_node, 0, pSlipVariable, SlipCoefficient, domain_size);
             }
         }
-    }
+    );
 }
 
 /***********************************************************************************/
@@ -194,19 +193,18 @@ void ComputeNodesTangentFromNormalModelPart(ModelPart& rModelPart)
 
     // We iterate over nodes
     auto& r_nodes_array = rModelPart.Nodes();
-    const auto it_node_begin = r_nodes_array.begin();
-    const int num_nodes = static_cast<int>(r_nodes_array.size());
 
-    #pragma omp parallel for
-    for(int i = 0; i < num_nodes; ++i) {
-        auto it_node = it_node_begin + i;
-
-        // Computing only slave nodes
-        if (it_node->Is(SLAVE)) {
-            const array_1d<double, 3>& r_normal = it_node->FastGetSolutionStepValue(NORMAL);
-            ComputeTangentsFromNormal(*it_node, r_normal, domain_size);
+    block_for_each(
+        r_nodes_array,
+        [domain_size](Node<3>& r_node)
+        {
+            if (r_node.Is(SLAVE))
+            {
+                const array_1d<double, 3>& r_normal = r_node.FastGetSolutionStepValue(NORMAL);
+                ComputeTangentsFromNormal(r_node, r_normal, domain_size);
+            }
         }
-    }
+    );
 }
 
 /***********************************************************************************/
@@ -720,11 +718,13 @@ void UpdateDatabase<Variable<double>, MortarUtilitiesSettings::SaveAsHistoricalV
     IntMap& rConectivityDatabase
     )
 {
-    #pragma omp parallel for
-    for (int i = 0; i < static_cast<int>(rDx.size()); ++i) {
-        auto p_node = rThisModelPart.pGetNode(rConectivityDatabase[i]);
-        p_node->FastGetSolutionStepValue(rThisVariable) += rDx[i];
-    }
+    IndexPartition<std::size_t>(rDx.size()).for_each(
+        [&](std::size_t i_increment)
+        {
+            auto p_node = rThisModelPart.pGetNode(rConectivityDatabase[i_increment]);
+            p_node->FastGetSolutionStepValue(rThisVariable) += rDx[i_increment];
+        }
+    );
 }
 
 /***********************************************************************************/
@@ -739,12 +739,14 @@ void UpdateDatabase<Variable<array_1d<double, 3>>, MortarUtilitiesSettings::Save
     IntMap& rConectivityDatabase
     )
 {
-    #pragma omp parallel for
-    for (int i = 0; i < static_cast<int>(rDx.size()); ++i) {
-        auto p_node = rThisModelPart.pGetNode(rConectivityDatabase[i]);
-        auto& r_value = p_node->FastGetSolutionStepValue(rThisVariable);
-        r_value[Index] += rDx[i];
-    }
+    IndexPartition<std::size_t>(rDx.size()).for_each(
+        [&](std::size_t i_increment)
+        {
+            auto p_node = rThisModelPart.pGetNode(rConectivityDatabase[i_increment]);
+            auto& r_value = p_node->FastGetSolutionStepValue(rThisVariable);
+            r_value[Index] += rDx[i_increment];
+        }
+    );
 }
 
 /***********************************************************************************/
@@ -759,11 +761,13 @@ void UpdateDatabase<Variable<double>, MortarUtilitiesSettings::SaveAsNonHistoric
     IntMap& rConectivityDatabase
     )
 {
-    #pragma omp parallel for
-    for (int i = 0; i < static_cast<int>(rDx.size()); ++i) {
-        auto p_node = rThisModelPart.pGetNode(rConectivityDatabase[i]);
-        p_node->GetValue(rThisVariable) += rDx[i];
-    }
+    IndexPartition<std::size_t>(rDx.size()).for_each(
+        [&](std::size_t i_increment)
+        {
+            auto p_node = rThisModelPart.pGetNode(rConectivityDatabase[i_increment]);
+            p_node->GetValue(rThisVariable) += rDx[i_increment];
+        }
+    );
 }
 
 /***********************************************************************************/
@@ -778,12 +782,14 @@ void UpdateDatabase<Variable<array_1d<double, 3>>, MortarUtilitiesSettings::Save
     IntMap& rConectivityDatabase
     )
 {
-    #pragma omp parallel for
-    for (int i = 0; i < static_cast<int>(rDx.size()); ++i) {
-        auto p_node = rThisModelPart.pGetNode(rConectivityDatabase[i]);
-        auto& value = p_node->GetValue(rThisVariable);
-        value[Index] += rDx[i];
-    }
+    IndexPartition<std::size_t>(rDx.size()).for_each(
+        [&](std::size_t i_increment)
+        {
+            auto p_node = rThisModelPart.pGetNode(rConectivityDatabase[i_increment]);
+            auto& value = p_node->GetValue(rThisVariable);
+            value[Index] += rDx[i_increment];
+        }
+    );
 }
 } // namespace MortarUtilities
 } // namespace Kratos


### PR DESCRIPTION
**Description**
Replace trivial ```omp``` loops with ```block_for_each``` and ```IndexPartition```.

**Note**
The ```UpdateDatabase``` functions have loops over keys of a map. If we definitely know that **all** keys will be looped over, we can replace the ```IndexPartition```s with ```block_for_each```.