### PR TITLE
PFEM2 compilation error has been fixed

### DIFF
--- a/applications/PFEM2Application/custom_conditions/autoslip_inlet.h
+++ b/applications/PFEM2Application/custom_conditions/autoslip_inlet.h
@@ -206,7 +206,7 @@ public:
       */
     virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                       VectorType& rRightHandSideVector,
-                                      ProcessInfo& rCurrentProcessInfo) override;
+                                      const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /// Return local right hand side of the correct size, filled with zeros (for compatibility with time schemes).
@@ -214,7 +214,7 @@ public:
       @see CalculateLocalVelocityContribution
       */
     virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                        ProcessInfo& rCurrentProcessInfo) override;
+                                        const ProcessInfo& rCurrentProcessInfo) override;
 
 
 
@@ -224,7 +224,7 @@ public:
      * @param rCurrentProcessInfo the current process info object (unused)
      */
     virtual void EquationIdVector(EquationIdVectorType& rResult,
-                                  ProcessInfo& rCurrentProcessInfo) override;
+                                  const ProcessInfo& rCurrentProcessInfo) const override;
 
 
     /// Returns a list of the element's Dofs
@@ -233,7 +233,7 @@ public:
      * @param rCurrentProcessInfo the current process info instance
      */
     virtual void GetDofList(DofsVectorType& ConditionDofList,
-                            ProcessInfo& CurrentProcessInfo) override;
+                            const ProcessInfo& CurrentProcessInfo) const override;
 
 
     /// Returns VELOCITY_X, VELOCITY_Y, (VELOCITY_Z,) PRESSURE for each node

--- a/applications/PFEM2Application/custom_conditions/autoslip_inlet_3d.cpp
+++ b/applications/PFEM2Application/custom_conditions/autoslip_inlet_3d.cpp
@@ -8,7 +8,7 @@ namespace Kratos
 
 void MonolithicAutoSlipInlet3D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                       VectorType& rRightHandSideVector,
-                                      ProcessInfo& rCurrentProcessInfo)
+                                      const ProcessInfo& rCurrentProcessInfo)
     {
         const SizeType BlockSize = 1;
         unsigned int TNumNodes = GetGeometry().size();
@@ -47,7 +47,7 @@ void MonolithicAutoSlipInlet3D::CalculateLocalSystem(MatrixType& rLeftHandSideMa
     }
 
 void MonolithicAutoSlipInlet3D::CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                        ProcessInfo& rCurrentProcessInfo)
+                                        const ProcessInfo& rCurrentProcessInfo)
 {
         const SizeType BlockSize = 1;
         unsigned int TNumNodes = GetGeometry().size();
@@ -61,7 +61,7 @@ void MonolithicAutoSlipInlet3D::CalculateRightHandSide(VectorType& rRightHandSid
     
 	
 void MonolithicAutoSlipInlet3D::EquationIdVector(EquationIdVectorType& rResult,
-        ProcessInfo& rCurrentProcessInfo)
+        const ProcessInfo& rCurrentProcessInfo) const
 {
     const SizeType NumNodes = 3;
     const SizeType LocalSize = 3;
@@ -80,7 +80,7 @@ void MonolithicAutoSlipInlet3D::EquationIdVector(EquationIdVectorType& rResult,
 }
 
 void MonolithicAutoSlipInlet3D::GetDofList(DofsVectorType& rElementalDofList,
-        ProcessInfo& rCurrentProcessInfo)
+        const ProcessInfo& rCurrentProcessInfo) const
 {
     const SizeType NumNodes = 3;
     const SizeType LocalSize = 3;

--- a/applications/PFEM2Application/custom_conditions/autoslip_inlet_3d.h
+++ b/applications/PFEM2Application/custom_conditions/autoslip_inlet_3d.h
@@ -204,7 +204,7 @@ public:
       */
     virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                       VectorType& rRightHandSideVector,
-                                      ProcessInfo& rCurrentProcessInfo) override;
+                                      const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /// Return local right hand side of the correct size, filled with zeros (for compatibility with time schemes).
@@ -212,7 +212,7 @@ public:
       @see CalculateLocalVelocityContribution
       */
     virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                        ProcessInfo& rCurrentProcessInfo) override;
+                                        const ProcessInfo& rCurrentProcessInfo) override;
 
 
 
@@ -222,7 +222,7 @@ public:
      * @param rCurrentProcessInfo the current process info object (unused)
      */
     virtual void EquationIdVector(EquationIdVectorType& rResult,
-                                  ProcessInfo& rCurrentProcessInfo) override;
+                                  const ProcessInfo& rCurrentProcessInfo) const override;
 
 
     /// Returns a list of the element's Dofs
@@ -231,7 +231,7 @@ public:
      * @param rCurrentProcessInfo the current process info instance
      */
     virtual void GetDofList(DofsVectorType& ConditionDofList,
-                            ProcessInfo& CurrentProcessInfo) override;
+                            const ProcessInfo& CurrentProcessInfo) const override;
 
 
     ///@}

--- a/applications/PFEM2Application/custom_conditions/fixed_pressure_2d.cpp
+++ b/applications/PFEM2Application/custom_conditions/fixed_pressure_2d.cpp
@@ -31,7 +31,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	void FixedPressure2D::CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+	void FixedPressure2D::CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY
 		{
@@ -42,7 +42,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	void FixedPressure2D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+	void FixedPressure2D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY
 		{
@@ -69,7 +69,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	void FixedPressure2D::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo)
+	void FixedPressure2D::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const
 	{
 		{
 			int number_of_nodes = GetGeometry().PointsNumber();
@@ -83,7 +83,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	  void FixedPressure2D::GetDofList(DofsVectorType& ConditionalDofList,ProcessInfo& rCurrentProcessInfo)
+	  void FixedPressure2D::GetDofList(DofsVectorType& ConditionalDofList,const ProcessInfo& rCurrentProcessInfo) const
 	{
 		{
 			const unsigned int TDim = 2;

--- a/applications/PFEM2Application/custom_conditions/fixed_pressure_2d.h
+++ b/applications/PFEM2Application/custom_conditions/fixed_pressure_2d.h
@@ -33,15 +33,15 @@ public:
 
     Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const override;
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
     //virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void GetDofList(DofsVectorType& ConditionalDofList,ProcessInfo& CurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& ConditionalDofList,const ProcessInfo& CurrentProcessInfo) const override;
 
 protected:
 

--- a/applications/PFEM2Application/custom_conditions/fixed_pressure_3d.cpp
+++ b/applications/PFEM2Application/custom_conditions/fixed_pressure_3d.cpp
@@ -31,7 +31,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	void FixedPressure3D::CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+	void FixedPressure3D::CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY
 		{
@@ -42,7 +42,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	void FixedPressure3D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+	void FixedPressure3D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY
 		{
@@ -69,7 +69,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	void FixedPressure3D::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo)
+	void FixedPressure3D::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const
 	{
 		{
 			int number_of_nodes = GetGeometry().PointsNumber();
@@ -83,7 +83,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	  void FixedPressure3D::GetDofList(DofsVectorType& ConditionalDofList,ProcessInfo& rCurrentProcessInfo)
+	  void FixedPressure3D::GetDofList(DofsVectorType& ConditionalDofList,const ProcessInfo& rCurrentProcessInfo) const
 	{
 		{
 			const unsigned int TDim = 3;

--- a/applications/PFEM2Application/custom_conditions/fixed_pressure_3d.h
+++ b/applications/PFEM2Application/custom_conditions/fixed_pressure_3d.h
@@ -33,15 +33,15 @@ public:
 
     Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const override;
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
     //virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void GetDofList(DofsVectorType& ConditionalDofList,ProcessInfo& CurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& ConditionalDofList,const ProcessInfo& CurrentProcessInfo) const override;
 
 protected:
 

--- a/applications/PFEM2Application/custom_conditions/fixed_velocity_2d.cpp
+++ b/applications/PFEM2Application/custom_conditions/fixed_velocity_2d.cpp
@@ -31,7 +31,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	void FixedVelocity2D::CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+	void FixedVelocity2D::CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY
 		if(rCurrentProcessInfo[FRACTIONAL_STEP]==2)
@@ -43,7 +43,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	void FixedVelocity2D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+	void FixedVelocity2D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY
 
@@ -72,7 +72,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	void FixedVelocity2D::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo)
+	void FixedVelocity2D::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const
 	{
 		if(rCurrentProcessInfo[FRACTIONAL_STEP]==2)
 		{
@@ -90,7 +90,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	  void FixedVelocity2D::GetDofList(DofsVectorType& ConditionalDofList,ProcessInfo& rCurrentProcessInfo)
+	  void FixedVelocity2D::GetDofList(DofsVectorType& ConditionalDofList,const ProcessInfo& rCurrentProcessInfo) const
 	{
 		if(rCurrentProcessInfo[FRACTIONAL_STEP]==2)
 		{

--- a/applications/PFEM2Application/custom_conditions/fixed_velocity_2d.h
+++ b/applications/PFEM2Application/custom_conditions/fixed_velocity_2d.h
@@ -33,15 +33,15 @@ public:
 
     Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const override;
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
     //virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void GetDofList(DofsVectorType& ConditionalDofList,ProcessInfo& CurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& ConditionalDofList,const ProcessInfo& CurrentProcessInfo) const override;
 
 protected:
 

--- a/applications/PFEM2Application/custom_conditions/fixed_velocity_3d.cpp
+++ b/applications/PFEM2Application/custom_conditions/fixed_velocity_3d.cpp
@@ -31,7 +31,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	void FixedVelocity3D::CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+	void FixedVelocity3D::CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY
 		if(rCurrentProcessInfo[FRACTIONAL_STEP]==2)
@@ -50,7 +50,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	void FixedVelocity3D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+	void FixedVelocity3D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY
 
@@ -79,7 +79,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	void FixedVelocity3D::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo)
+	void FixedVelocity3D::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const
 	{
 		if(rCurrentProcessInfo[FRACTIONAL_STEP]==2)
 		{
@@ -97,7 +97,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	  void FixedVelocity3D::GetDofList(DofsVectorType& ConditionalDofList,ProcessInfo& rCurrentProcessInfo)
+	  void FixedVelocity3D::GetDofList(DofsVectorType& ConditionalDofList,const ProcessInfo& rCurrentProcessInfo) const
 	{
 		if(rCurrentProcessInfo[FRACTIONAL_STEP]==2)
 		{

--- a/applications/PFEM2Application/custom_conditions/fixed_velocity_3d.h
+++ b/applications/PFEM2Application/custom_conditions/fixed_velocity_3d.h
@@ -34,15 +34,15 @@ public:
 
     Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const override;
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
     //virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void GetDofList(DofsVectorType& ConditionalDofList,ProcessInfo& CurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& ConditionalDofList,const ProcessInfo& CurrentProcessInfo) const override;
 
 protected:
 

--- a/applications/PFEM2Application/custom_elements/fractional_step_pfem_2_2d.cpp
+++ b/applications/PFEM2Application/custom_elements/fractional_step_pfem_2_2d.cpp
@@ -56,7 +56,7 @@ namespace Kratos
 	//************************************************************************************
 
 
-	void FractionalStepPFEM22D::AddExplicitContribution(ProcessInfo& rCurrentProcessInfo)
+	void FractionalStepPFEM22D::AddExplicitContribution(const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY;
 
@@ -85,7 +85,7 @@ namespace Kratos
 
 	void FractionalStepPFEM22D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
 													VectorType& rRightHandSideVector,
-													ProcessInfo& rCurrentProcessInfo)
+													const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY;
 
@@ -110,7 +110,7 @@ namespace Kratos
 	//************************************************************************************
 
 	void FractionalStepPFEM22D::EquationIdVector(EquationIdVectorType& rResult,
-												ProcessInfo& rCurrentProcessInfo)
+												const ProcessInfo& rCurrentProcessInfo) const
 	{
 		KRATOS_TRY;
 
@@ -136,7 +136,7 @@ namespace Kratos
 
 
 	void FractionalStepPFEM22D::GetDofList(DofsVectorType& rElementalDofList,
-										  ProcessInfo& rCurrentProcessInfo)
+										  const ProcessInfo& rCurrentProcessInfo) const
 	{
 		KRATOS_TRY;
 
@@ -166,7 +166,7 @@ namespace Kratos
 
 
 
-	void FractionalStepPFEM22D::CalculateLocalPressureSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+	void FractionalStepPFEM22D::CalculateLocalPressureSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY
 
@@ -466,7 +466,7 @@ namespace Kratos
 	//************************************************************************************
 
 
-		void FractionalStepPFEM22D::CalculateViscousRHS(ProcessInfo& rCurrentProcessInfo)
+		void FractionalStepPFEM22D::CalculateViscousRHS(const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY
 
@@ -677,7 +677,7 @@ namespace Kratos
 	//***************************************************************************
 
 
-	void FractionalStepPFEM22D::CalculatePressureProjection(ProcessInfo& rCurrentProcessInfo)
+	void FractionalStepPFEM22D::CalculatePressureProjection(const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY
 		            const unsigned int TDim=2;
@@ -942,7 +942,7 @@ namespace Kratos
 	//************************************************************************************
 	// this subroutine calculates the nodal contributions for the explicit steps of the
 	// fractional step procedure
-	void FractionalStepPFEM22D::InitializeSolutionStep(ProcessInfo& CurrentProcessInfo)
+	void FractionalStepPFEM22D::InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo)
 	{
 		KRATOS_TRY
 		///WARNING!!!! not calculating the pressure projection since i'm supposing it's being done before!
@@ -955,7 +955,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	void FractionalStepPFEM22D::PressureEquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo)
+	void FractionalStepPFEM22D::PressureEquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const
 	{
 		unsigned int number_of_nodes = GetGeometry().PointsNumber();
 		if(rResult.size() != number_of_nodes)
@@ -968,7 +968,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	void FractionalStepPFEM22D::GetPressureDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo)
+	void FractionalStepPFEM22D::GetPressureDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const
 	{
 		unsigned int number_of_nodes = GetGeometry().PointsNumber();
 		if(ElementalDofList.size() != number_of_nodes)
@@ -1055,7 +1055,7 @@ bool FractionalStepPFEM22D::InvertMatrix(const T& input, T& inverse)
 
 
    //TO PRINT ELEMENTAL VARIABLES (ONLY ONE GAUSS POINT PER ELEMENT)
-    void FractionalStepPFEM22D::GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+    void FractionalStepPFEM22D::CalculateOnIntegrationPoints(const Variable<double>& rVariable,
             std::vector<double>& rValues,
             const ProcessInfo& rCurrentProcessInfo)
 	{
@@ -1100,7 +1100,7 @@ bool FractionalStepPFEM22D::InvertMatrix(const T& input, T& inverse)
 	}
 
 
-	  void FractionalStepPFEM22D::GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+	  void FractionalStepPFEM22D::CalculateOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
             std::vector<array_1d<double, 3 > >& rValues,
             const ProcessInfo& rCurrentProcessInfo)
 	{

--- a/applications/PFEM2Application/custom_elements/fractional_step_pfem_2_2d.h
+++ b/applications/PFEM2Application/custom_elements/fractional_step_pfem_2_2d.h
@@ -67,35 +67,35 @@ namespace Kratos
 
      Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const override;
 
-     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
-     void AddExplicitContribution(ProcessInfo& CurrentProcessInfo) override;
+     void AddExplicitContribution(const ProcessInfo& CurrentProcessInfo) override;
 
-     void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+     void EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo) const override;
 
-     void GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo) override;
+     void GetDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const override;
 
-     void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+     void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
-    virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+    virtual void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
             std::vector<double>& rValues,
             const ProcessInfo& rCurrentProcessInfo) override;
 
-    virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+    virtual void CalculateOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
             std::vector<array_1d<double, 3 > >& rValues,
             const ProcessInfo& rCurrentProcessInfo) override;
 
    protected:
 
-       	void CalculateLocalPressureSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+       	void CalculateLocalPressureSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo);
 
-       	void PressureEquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo);
+       	void PressureEquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const;
 
-        void GetPressureDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo);
+        void GetPressureDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const;
 
-        void CalculateViscousRHS(ProcessInfo& CurrentProcessInfo);
+        void CalculateViscousRHS(const ProcessInfo& CurrentProcessInfo);
 
-       	void CalculatePressureProjection(ProcessInfo& CurrentProcessInfo);
+       	void CalculatePressureProjection(const ProcessInfo& CurrentProcessInfo);
 
         void AddViscousTerm(BoundedMatrix<double, (2-1)*6, (2-1)*6 >& rDampMatrix,
                          BoundedMatrix<double, (2+1), 2 >& rShapeDeriv,

--- a/applications/PFEM2Application/custom_elements/fractional_step_pfem_2_3d.cpp
+++ b/applications/PFEM2Application/custom_elements/fractional_step_pfem_2_3d.cpp
@@ -56,7 +56,7 @@ namespace Kratos
 	//************************************************************************************
 
 
-	void FractionalStepPFEM23D::AddExplicitContribution(ProcessInfo& rCurrentProcessInfo)
+	void FractionalStepPFEM23D::AddExplicitContribution(const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY;
 
@@ -85,7 +85,7 @@ namespace Kratos
 
 	void FractionalStepPFEM23D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
 													VectorType& rRightHandSideVector,
-													ProcessInfo& rCurrentProcessInfo)
+													const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY;
 
@@ -110,7 +110,7 @@ namespace Kratos
 	//************************************************************************************
 
 	void FractionalStepPFEM23D::EquationIdVector(EquationIdVectorType& rResult,
-												ProcessInfo& rCurrentProcessInfo)
+												const ProcessInfo& rCurrentProcessInfo) const
 	{
 		KRATOS_TRY;
 
@@ -136,7 +136,7 @@ namespace Kratos
 
 
 	void FractionalStepPFEM23D::GetDofList(DofsVectorType& rElementalDofList,
-										  ProcessInfo& rCurrentProcessInfo)
+										  const ProcessInfo& rCurrentProcessInfo) const
 	{
 		KRATOS_TRY;
 
@@ -166,7 +166,7 @@ namespace Kratos
 
 
 
-	void FractionalStepPFEM23D::CalculateLocalPressureSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+	void FractionalStepPFEM23D::CalculateLocalPressureSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY
 
@@ -469,7 +469,7 @@ namespace Kratos
 	//************************************************************************************
 
 
-		void FractionalStepPFEM23D::CalculateViscousRHS(ProcessInfo& rCurrentProcessInfo)
+		void FractionalStepPFEM23D::CalculateViscousRHS(const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY
 
@@ -681,7 +681,7 @@ namespace Kratos
 	//***************************************************************************
 
 
-	void FractionalStepPFEM23D::CalculatePressureProjection(ProcessInfo& rCurrentProcessInfo)
+	void FractionalStepPFEM23D::CalculatePressureProjection(const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY
 		            const unsigned int TDim=3;
@@ -947,7 +947,7 @@ namespace Kratos
 	//************************************************************************************
 	// this subroutine calculates the nodal contributions for the explicit steps of the
 	// fractional step procedure
-	void FractionalStepPFEM23D::InitializeSolutionStep(ProcessInfo& CurrentProcessInfo)
+	void FractionalStepPFEM23D::InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo)
 	{
 		KRATOS_TRY
 		///WARNING!!!! not calculating the pressure projection since i'm supposing it's being done before!
@@ -960,7 +960,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	void FractionalStepPFEM23D::PressureEquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo)
+	void FractionalStepPFEM23D::PressureEquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const
 	{
 		unsigned int number_of_nodes = GetGeometry().PointsNumber();
 		if(rResult.size() != number_of_nodes)
@@ -973,7 +973,7 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	void FractionalStepPFEM23D::GetPressureDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo)
+	void FractionalStepPFEM23D::GetPressureDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const
 	{
 		unsigned int number_of_nodes = GetGeometry().PointsNumber();
 		if(ElementalDofList.size() != number_of_nodes)
@@ -1066,7 +1066,7 @@ bool FractionalStepPFEM23D::InvertMatrix(const T& input, T& inverse)
 
 
    //TO PRINT ELEMENTAL VARIABLES (ONLY ONE GAUSS POINT PER ELEMENT)
-    void FractionalStepPFEM23D::GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+    void FractionalStepPFEM23D::CalculateOnIntegrationPoints(const Variable<double>& rVariable,
             std::vector<double>& rValues,
             const ProcessInfo& rCurrentProcessInfo)
 	{
@@ -1111,7 +1111,7 @@ bool FractionalStepPFEM23D::InvertMatrix(const T& input, T& inverse)
 	}
 
 
-	  void FractionalStepPFEM23D::GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+	  void FractionalStepPFEM23D::CalculateOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
             std::vector<array_1d<double, 3 > >& rValues,
             const ProcessInfo& rCurrentProcessInfo)
 	{

--- a/applications/PFEM2Application/custom_elements/fractional_step_pfem_2_3d.h
+++ b/applications/PFEM2Application/custom_elements/fractional_step_pfem_2_3d.h
@@ -67,35 +67,35 @@ namespace Kratos
 
      Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const override;
 
-     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
-     void AddExplicitContribution(ProcessInfo& CurrentProcessInfo) override;
+     void AddExplicitContribution(const ProcessInfo& CurrentProcessInfo) override;
 
-     void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+     void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
-     void GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo) override;
+     void GetDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const override;
 
-     void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+     void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
-    virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+    virtual void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
             std::vector<double>& rValues,
             const ProcessInfo& rCurrentProcessInfo) override;
 
-    virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+    virtual void CalculateOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
             std::vector<array_1d<double, 3 > >& rValues,
             const ProcessInfo& rCurrentProcessInfo) override;
 
    protected:
 
-       	void CalculateLocalPressureSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+       	void CalculateLocalPressureSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo);
 
-       	void PressureEquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo);
+       	void PressureEquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const;
 
-        void GetPressureDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo);
+        void GetPressureDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const;
 
-        void CalculateViscousRHS(ProcessInfo& CurrentProcessInfo);
+        void CalculateViscousRHS(const ProcessInfo& CurrentProcessInfo);
 
-       	void CalculatePressureProjection(ProcessInfo& CurrentProcessInfo);
+       	void CalculatePressureProjection(const ProcessInfo& CurrentProcessInfo);
 
         void AddViscousTerm(BoundedMatrix<double, (3-1)*6, (3-1)*6 >& rDampMatrix,
                          BoundedMatrix<double, (3+1), 3 >& rShapeDeriv,

--- a/applications/PFEM2Application/custom_elements/monolithic_2fluid_2d.cpp
+++ b/applications/PFEM2Application/custom_elements/monolithic_2fluid_2d.cpp
@@ -49,7 +49,7 @@ namespace Kratos
 	//************************************************************************************
 
 
-	void MonolithicPFEM22D::AddExplicitContribution(ProcessInfo& rCurrentProcessInfo)
+	void MonolithicPFEM22D::AddExplicitContribution(const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY;
 
@@ -72,7 +72,7 @@ namespace Kratos
 	//************************************************************************************
 	//************************************************************************************
 
-	void MonolithicPFEM22D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+	void MonolithicPFEM22D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY
 
@@ -741,7 +741,7 @@ namespace Kratos
 	//************************************************************************************
 	// this subroutine calculates the nodal contributions for the explicit steps of the
 	// fractional step procedure
-	void MonolithicPFEM22D::InitializeSolutionStep(ProcessInfo& CurrentProcessInfo)
+	void MonolithicPFEM22D::InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo)
 	{
 		KRATOS_TRY
 
@@ -751,7 +751,7 @@ namespace Kratos
 	//************************************************************************************
 	//************************************************************************************
 
-	void MonolithicPFEM22D::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo)
+	void MonolithicPFEM22D::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const
 	{
 		if(CurrentProcessInfo[FRACTIONAL_STEP]<100 )
 		{
@@ -759,7 +759,7 @@ namespace Kratos
 
 		const SizeType NumNodes = TDim+1;
 		const SizeType LocalSize = (TDim+1)*(TDim+1);
-		GeometryType& rGeom = this->GetGeometry();
+		const GeometryType& rGeom = this->GetGeometry();
 
 		SizeType LocalIndex = 0;
 
@@ -779,7 +779,7 @@ namespace Kratos
 
 			const SizeType NumNodes = TDim+1;
 			const SizeType LocalSize = (TDim+1);
-			GeometryType& rGeom = this->GetGeometry();
+			const GeometryType& rGeom = this->GetGeometry();
 
 			SizeType LocalIndex = 0;
 
@@ -801,7 +801,7 @@ namespace Kratos
 	//************************************************************************************
 	//************************************************************************************
 
-	void MonolithicPFEM22D::GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo)
+	void MonolithicPFEM22D::GetDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const
 	{                                                                                                                                                                                                                   
 		if(CurrentProcessInfo[FRACTIONAL_STEP]<100 )
 		{
@@ -809,7 +809,7 @@ namespace Kratos
 
 		const SizeType NumNodes = TDim+1;
 		const SizeType LocalSize = (TDim+1)*(TDim+1);
-		GeometryType& rGeom = this->GetGeometry();
+		const GeometryType& rGeom = this->GetGeometry();
 
 		if (ElementalDofList.size() != LocalSize)
 			ElementalDofList.resize(LocalSize);
@@ -829,7 +829,7 @@ namespace Kratos
 
 			const SizeType NumNodes = TDim+1;
 			const SizeType LocalSize = (TDim+1);
-			GeometryType& rGeom = this->GetGeometry();
+			const GeometryType& rGeom = this->GetGeometry();
 
 			if (ElementalDofList.size() != LocalSize)
 				ElementalDofList.resize(LocalSize);
@@ -854,7 +854,7 @@ namespace Kratos
 	//************************************************************************************
 	//************************************************************************************
 
-	void MonolithicPFEM22D::CalculatePressureProjection(ProcessInfo& CurrentProcessInfo)
+	void MonolithicPFEM22D::CalculatePressureProjection(const ProcessInfo& CurrentProcessInfo)
 	{
 		KRATOS_TRY
 

--- a/applications/PFEM2Application/custom_elements/monolithic_2fluid_2d.h
+++ b/applications/PFEM2Application/custom_elements/monolithic_2fluid_2d.h
@@ -80,20 +80,20 @@ public:
 
     Element::Pointer Create(IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties) const override;
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void AddExplicitContribution(ProcessInfo& CurrentProcessInfo) override;
+    void AddExplicitContribution(const ProcessInfo& CurrentProcessInfo) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const override;
 
-    void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
 
 protected:
 
-    void CalculatePressureProjection(ProcessInfo& CurrentProcessInfo);
+    void CalculatePressureProjection(const ProcessInfo& CurrentProcessInfo);
 
     virtual void AddViscousTerm(MatrixType& rDampMatrix,
         const BoundedMatrix<double, 3, 2>& rShapeDeriv,

--- a/applications/PFEM2Application/custom_elements/monolithic_2fluid_2d_partintegration.cpp
+++ b/applications/PFEM2Application/custom_elements/monolithic_2fluid_2d_partintegration.cpp
@@ -55,7 +55,7 @@ namespace Kratos
 	//************************************************************************************
 
 
-	void MonolithicAutoSlipPFEM22D::AddExplicitContribution(ProcessInfo& rCurrentProcessInfo)
+	void MonolithicAutoSlipPFEM22D::AddExplicitContribution(const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY;
 
@@ -87,7 +87,7 @@ namespace Kratos
 	//************************************************************************************
 	//************************************************************************************
 
-	void MonolithicAutoSlipPFEM22D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+	void MonolithicAutoSlipPFEM22D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 /*	{
 		KRATOS_TRY
 
@@ -1369,7 +1369,7 @@ namespace Kratos
 	//************************************************************************************
 	// this subroutine calculates the nodal contributions for the explicit steps of the
 	// fractional step procedure
-	void MonolithicAutoSlipPFEM22D::InitializeSolutionStep(ProcessInfo& CurrentProcessInfo)
+	void MonolithicAutoSlipPFEM22D::InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo)
 	{
 		KRATOS_TRY
 
@@ -1378,11 +1378,11 @@ namespace Kratos
 
 	//************************************************************************************
 	//************************************************************************************
-	void MonolithicAutoSlipPFEM22D::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo)
+	void MonolithicAutoSlipPFEM22D::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const
 	{
 		const SizeType NumNodes = 3;
 		const SizeType LocalSize = 9;
-		GeometryType& rGeom = this->GetGeometry();
+		const GeometryType& rGeom = this->GetGeometry();
 
 		SizeType LocalIndex = 0;
 
@@ -1402,11 +1402,11 @@ namespace Kratos
 	//************************************************************************************
 	//************************************************************************************
 
-	void MonolithicAutoSlipPFEM22D::GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo)
+	void MonolithicAutoSlipPFEM22D::GetDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const
 	{
 		const SizeType NumNodes = 3;
 		const SizeType LocalSize = 9;
-		GeometryType& rGeom = this->GetGeometry();
+		const GeometryType& rGeom = this->GetGeometry();
 
 		if (ElementalDofList.size() != LocalSize)
 			ElementalDofList.resize(LocalSize);
@@ -1427,7 +1427,7 @@ namespace Kratos
 	//************************************************************************************
 	//************************************************************************************
 
-	void MonolithicAutoSlipPFEM22D::CalculatePressureProjection(ProcessInfo& CurrentProcessInfo)
+	void MonolithicAutoSlipPFEM22D::CalculatePressureProjection(const ProcessInfo& CurrentProcessInfo)
 	{
 		KRATOS_TRY
 

--- a/applications/PFEM2Application/custom_elements/monolithic_2fluid_2d_partintegration.h
+++ b/applications/PFEM2Application/custom_elements/monolithic_2fluid_2d_partintegration.h
@@ -67,17 +67,17 @@ namespace Kratos
 
      Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const override;
 
-     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
      //void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
 
-     void AddExplicitContribution(ProcessInfo& CurrentProcessInfo) override;
+     void AddExplicitContribution(const ProcessInfo& CurrentProcessInfo) override;
 
-     void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+     void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
-     void GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo) override;
+     void GetDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const override;
 
-     void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+     void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
 
 
@@ -85,49 +85,49 @@ namespace Kratos
 
         void CalculateLocalFractionalVelocitySystem(MatrixType& rLeftHandSideMatrix,
                                                     VectorType& rRightHandSideVector,
-                                                    ProcessInfo& rCurrentProcessInfo);
+                                                    const ProcessInfo& rCurrentProcessInfo);
 
         void CalculateLocalPressureSystem(MatrixType& rLeftHandSideMatrix,
                                           VectorType& rRightHandSideVector,
-                                          ProcessInfo& rCurrentProcessInfo);
+                                          const ProcessInfo& rCurrentProcessInfo);
 
         void CalculateLocalFinalVelocitySystem(MatrixType& rLeftHandSideMatrix,
                                                 VectorType& rRightHandSideVector,
-                                                ProcessInfo& rCurrentProcessInfo);
+                                                const ProcessInfo& rCurrentProcessInfo);
 
         void CalculateLocalThermalSystem(MatrixType& rLeftHandSideMatrix,
                                                 VectorType& rRightHandSideVector,
-                                                ProcessInfo& rCurrentProcessInfo);
+                                                const ProcessInfo& rCurrentProcessInfo);
 
-        void CalculateViscousRHS(ProcessInfo& CurrentProcessInfo);
+        void CalculateViscousRHS(const ProcessInfo& CurrentProcessInfo);
 
-       	void CalculatePressureProjection(ProcessInfo& CurrentProcessInfo);
+       	void CalculatePressureProjection(const ProcessInfo& CurrentProcessInfo);
 
-       	void CalculateMassMatrix(ProcessInfo& CurrentProcessInfo);
+       	void CalculateMassMatrix(const ProcessInfo& CurrentProcessInfo);
 
         void VelocityEquationIdVector(EquationIdVectorType& rResult,
-                                      ProcessInfo& rCurrentProcessInfo);
+                                      const ProcessInfo& rCurrentProcessInfo);
 
         void FractionalVelocityEquationIdVector(EquationIdVectorType& rResult,
-                                      ProcessInfo& rCurrentProcessInfo);
+                                      const ProcessInfo& rCurrentProcessInfo);
 
         void PressureEquationIdVector(EquationIdVectorType& rResult,
-                                      ProcessInfo& rCurrentProcessInfo);
+                                      const ProcessInfo& rCurrentProcessInfo);
 
         void ThermalEquationIdVector(EquationIdVectorType& rResult,
-                                      ProcessInfo& rCurrentProcessInfo);
+                                      const ProcessInfo& rCurrentProcessInfo);
 
         void GetVelocityDofList(DofsVectorType& rElementalDofList,
-                                ProcessInfo& rCurrentProcessInfo);
+                                const ProcessInfo& rCurrentProcessInfo);
 
         void GetFractionalVelocityDofList(DofsVectorType& rElementalDofList,
-                                ProcessInfo& rCurrentProcessInfo);
+                                const ProcessInfo& rCurrentProcessInfo);
 
         void GetPressureDofList(DofsVectorType& rElementalDofList,
-                                ProcessInfo& rCurrentProcessInfo);
+                                const ProcessInfo& rCurrentProcessInfo);
 
         void GetThermalDofList(DofsVectorType& rElementalDofList,
-                                ProcessInfo& rCurrentProcessInfo);
+                                const ProcessInfo& rCurrentProcessInfo);
 
         void AddViscousTerm(MatrixType& rDampMatrix,
                                        const BoundedMatrix<double, 3, 2>& rShapeDeriv,

--- a/applications/PFEM2Application/custom_elements/monolithic_2fluid_3d.cpp
+++ b/applications/PFEM2Application/custom_elements/monolithic_2fluid_3d.cpp
@@ -49,7 +49,7 @@ namespace Kratos
 	//************************************************************************************
 
 
-	void MonolithicPFEM23D::AddExplicitContribution(ProcessInfo& rCurrentProcessInfo)
+	void MonolithicPFEM23D::AddExplicitContribution(const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY;
 
@@ -72,7 +72,7 @@ namespace Kratos
 	//************************************************************************************
 	//************************************************************************************
 
-	void MonolithicPFEM23D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+	void MonolithicPFEM23D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY
 
@@ -626,7 +626,7 @@ namespace Kratos
 	//************************************************************************************
 	// this subroutine calculates the nodal contributions for the explicit steps of the
 	// fractional step procedure
-	void MonolithicPFEM23D::InitializeSolutionStep(ProcessInfo& CurrentProcessInfo)
+	void MonolithicPFEM23D::InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo)
 	{
 		KRATOS_TRY
 
@@ -636,13 +636,13 @@ namespace Kratos
 	//************************************************************************************
 	//************************************************************************************
 
-	void MonolithicPFEM23D::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo)
+	void MonolithicPFEM23D::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const
 	{
 		const int TDim = 3;
 
 		const SizeType NumNodes = TDim+1;
 		const SizeType LocalSize = (TDim+1)*(TDim+1);
-		GeometryType& rGeom = this->GetGeometry();
+		const GeometryType& rGeom = this->GetGeometry();
 
 		SizeType LocalIndex = 0;
 
@@ -661,13 +661,13 @@ namespace Kratos
 	//************************************************************************************
 	//************************************************************************************
 
-	void MonolithicPFEM23D::GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo)
+	void MonolithicPFEM23D::GetDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const
 	{
 		const int TDim = 3;
 
 		const SizeType NumNodes = TDim+1;
 		const SizeType LocalSize = (TDim+1)*(TDim+1);
-		GeometryType& rGeom = this->GetGeometry();
+		const GeometryType& rGeom = this->GetGeometry();
 
 		if (ElementalDofList.size() != LocalSize)
 			ElementalDofList.resize(LocalSize);
@@ -688,7 +688,7 @@ namespace Kratos
 	//************************************************************************************
 	//************************************************************************************
 
-	void MonolithicPFEM23D::CalculatePressureProjection(ProcessInfo& CurrentProcessInfo)
+	void MonolithicPFEM23D::CalculatePressureProjection(const ProcessInfo& CurrentProcessInfo)
 	{
 			KRATOS_TRY
 

--- a/applications/PFEM2Application/custom_elements/monolithic_2fluid_3d.h
+++ b/applications/PFEM2Application/custom_elements/monolithic_2fluid_3d.h
@@ -78,20 +78,20 @@ public:
 
     Element::Pointer Create(IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties) const override;
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void AddExplicitContribution(ProcessInfo& CurrentProcessInfo) override;
+    void AddExplicitContribution(const ProcessInfo& CurrentProcessInfo) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const override;
 
-    void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
 
 protected:
 
-    void CalculatePressureProjection(ProcessInfo& CurrentProcessInfo);
+    void CalculatePressureProjection(const ProcessInfo& CurrentProcessInfo);
 
     virtual void AddViscousTerm(MatrixType& rDampMatrix,
         const BoundedMatrix<double, 4, 3>& rShapeDeriv,

--- a/applications/PFEM2Application/custom_elements/monolithic_2fluid_3d_partintegration.cpp
+++ b/applications/PFEM2Application/custom_elements/monolithic_2fluid_3d_partintegration.cpp
@@ -55,7 +55,7 @@ namespace Kratos
 	//************************************************************************************
 
 
-	void MonolithicAutoSlipPFEM23D::AddExplicitContribution(ProcessInfo& rCurrentProcessInfo)
+	void MonolithicAutoSlipPFEM23D::AddExplicitContribution(const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY;
 
@@ -78,7 +78,7 @@ namespace Kratos
 	//************************************************************************************
 	//************************************************************************************
 
-	void MonolithicAutoSlipPFEM23D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+	void MonolithicAutoSlipPFEM23D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 	{
 		KRATOS_TRY
 
@@ -717,7 +717,7 @@ namespace Kratos
 	//************************************************************************************
 	// this subroutine calculates the nodal contributions for the explicit steps of the
 	// fractional step procedure
-	void MonolithicAutoSlipPFEM23D::InitializeSolutionStep(ProcessInfo& CurrentProcessInfo)
+	void MonolithicAutoSlipPFEM23D::InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo)
 	{
 		KRATOS_TRY
 
@@ -727,13 +727,13 @@ namespace Kratos
 	//************************************************************************************
 	//************************************************************************************
 
-	void MonolithicAutoSlipPFEM23D::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo)
+	void MonolithicAutoSlipPFEM23D::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const
 	{
 		const int TDim = 3;
 
 		const SizeType NumNodes = TDim+1;
 		const SizeType LocalSize = (TDim+1)*(TDim+1);
-		GeometryType& rGeom = this->GetGeometry();
+		const GeometryType& rGeom = this->GetGeometry();
 
 		SizeType LocalIndex = 0;
 
@@ -752,13 +752,13 @@ namespace Kratos
 	//************************************************************************************
 	//************************************************************************************
 
-	void MonolithicAutoSlipPFEM23D::GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo)
+	void MonolithicAutoSlipPFEM23D::GetDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const
 	{
 		const int TDim = 3;
 
 		const SizeType NumNodes = TDim+1;
 		const SizeType LocalSize = (TDim+1)*(TDim+1);
-		GeometryType& rGeom = this->GetGeometry();
+		const GeometryType& rGeom = this->GetGeometry();
 
 		if (ElementalDofList.size() != LocalSize)
 			ElementalDofList.resize(LocalSize);
@@ -779,7 +779,7 @@ namespace Kratos
 	//************************************************************************************
 	//************************************************************************************
 
-	void MonolithicAutoSlipPFEM23D::CalculatePressureProjection(ProcessInfo& CurrentProcessInfo)
+	void MonolithicAutoSlipPFEM23D::CalculatePressureProjection(const ProcessInfo& CurrentProcessInfo)
 	{
 			KRATOS_TRY
 

--- a/applications/PFEM2Application/custom_elements/monolithic_2fluid_3d_partintegration.h
+++ b/applications/PFEM2Application/custom_elements/monolithic_2fluid_3d_partintegration.h
@@ -75,22 +75,22 @@ namespace Kratos
 
      Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const override;
 
-     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
-     void AddExplicitContribution(ProcessInfo& CurrentProcessInfo) override;
+     void AddExplicitContribution(const ProcessInfo& CurrentProcessInfo) override;
 
-     void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+     void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
-     void GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo) override;
+     void GetDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const override;
 
-     void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+     void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
 
 
    protected:
 
 
-       void CalculatePressureProjection(ProcessInfo& CurrentProcessInfo);
+       void CalculatePressureProjection(const ProcessInfo& CurrentProcessInfo);
 
        virtual void AddViscousTerm(MatrixType& rDampMatrix,
                                        const BoundedMatrix<double, 4, 3>& rShapeDeriv,

--- a/applications/PFEM2Application/custom_elements/monolithic_3fluid_2d.h
+++ b/applications/PFEM2Application/custom_elements/monolithic_3fluid_2d.h
@@ -66,17 +66,17 @@ public:
 
      Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const override;
 
-     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
      //void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
 
-     void AddExplicitContribution(ProcessInfo& CurrentProcessInfo) override;
+     void AddExplicitContribution(const ProcessInfo& CurrentProcessInfo) override;
 
-     void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+     void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
-     void GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo) override;
+     void GetDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const override;
 
-     void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+     void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
 
 

--- a/applications/PFEM2Application/custom_elements/monolithic_3fluid_3d.h
+++ b/applications/PFEM2Application/custom_elements/monolithic_3fluid_3d.h
@@ -66,17 +66,17 @@ public:
 
      Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const override;
 
-     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
      //void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
 
-     void AddExplicitContribution(ProcessInfo& CurrentProcessInfo) override;
+     void AddExplicitContribution(const ProcessInfo& CurrentProcessInfo) override;
 
-     void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+     void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
-     void GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo) override;
+     void GetDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const override;
 
-     void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+     void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
 
 protected:

--- a/applications/PFEM2Application/custom_elements/qfluid_2d.cpp
+++ b/applications/PFEM2Application/custom_elements/qfluid_2d.cpp
@@ -54,7 +54,7 @@ QFluid2D::QFluid2D(IndexType NewId, GeometryType::Pointer pGeometry)
   }
 
 
-  void QFluid2D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+  void QFluid2D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -73,7 +73,7 @@ QFluid2D::QFluid2D(IndexType NewId, GeometryType::Pointer pGeometry)
       }
 
 
-void QFluid2D::Stage1(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector,ProcessInfo& rCurrentProcessInfo)
+void QFluid2D::Stage1(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector,const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY;
 
@@ -281,7 +281,7 @@ void QFluid2D::Stage1(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSid
 
 
 
-  void QFluid2D::CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+  void QFluid2D::CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
   {
 
     KRATOS_TRY
@@ -438,7 +438,7 @@ void QFluid2D::Stage1(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSid
 
    KRATOS_CATCH("")
      }
-  void QFluid2D::Stage2(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+  void QFluid2D::Stage2(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -479,7 +479,7 @@ void QFluid2D::Stage1(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSid
     KRATOS_CATCH("")
       }
 
-  void QFluid2D::InitializeSolutionStep(ProcessInfo& CurrentProcessInfo)
+  void QFluid2D::InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -837,7 +837,7 @@ void QFluid2D::Stage1(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSid
     KRATOS_CATCH("");
 }
 
-void QFluid2D::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo)
+void QFluid2D::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const
 {
     unsigned int number_of_nodes = GetGeometry().PointsNumber();
     unsigned int dim = 2;
@@ -865,7 +865,7 @@ void QFluid2D::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& Curr
     }
 }
 
-  void QFluid2D::GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo)
+  void QFluid2D::GetDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const
   {
     unsigned int number_of_nodes = GetGeometry().PointsNumber();
     unsigned int dim = 2;
@@ -984,7 +984,7 @@ void QFluid2D::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& Curr
 
   //************************************************************************************
 
-  int QFluid2D::Check(const ProcessInfo& rCurrentProcessInfo)
+  int QFluid2D::Check(const ProcessInfo& rCurrentProcessInfo) const
   {
     KRATOS_TRY
 

--- a/applications/PFEM2Application/custom_elements/qfluid_2d.h
+++ b/applications/PFEM2Application/custom_elements/qfluid_2d.h
@@ -106,21 +106,21 @@ namespace Kratos
 
     Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override;
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void GetDofList(DofsVectorType& ElementalDofList, ProcessInfo& CurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& ElementalDofList, const ProcessInfo& CurrentProcessInfo) const override;
 
-    void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
     //void Calculate(const Variable<double>& rVariable, double& Output, const ProcessInfo& rCurrentProcessInfo);
     //void CalculateViscousMatrix(MatrixType& K, const BoundedMatrix<double,3,2>& DN_DX, const double& nu);
     void CalculateViscousMatrix(MatrixType& K  , const BoundedMatrix<double,3,2>& DN_DX, const double& nu, const double& deltat, const double& bulk); //, const double& k);
 
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access
@@ -213,8 +213,8 @@ namespace Kratos
     ///@}
     ///@name Private Operators
     ///@{
-    void Stage1(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);//, unsigned int ComponentIndex);
-    void Stage2(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+    void Stage1(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo);//, unsigned int ComponentIndex);
+    void Stage2(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo);
     // inline double CalculateTau(BoundedMatrix<double, 3,2 > & DN_DX, array_1d<double, 2 > & vel_gauss, const double h, const double nu, const double norm_u, const ProcessInfo& CurrentProcessInfo);
     double ComputeSmagorinskyViscosity(const BoundedMatrix<double, 3, 2 > & DN_DX,
                                        const double& h,

--- a/applications/PFEM2Application/custom_elements/qfluid_3d.cpp
+++ b/applications/PFEM2Application/custom_elements/qfluid_3d.cpp
@@ -52,7 +52,7 @@ namespace Kratos
   }
 
 
-  void QFluid3D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+  void QFluid3D::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -71,7 +71,7 @@ namespace Kratos
       }
 
 
-  void QFluid3D::CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+  void QFluid3D::CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_ERROR<< "method not implemented";
   }
@@ -79,7 +79,7 @@ namespace Kratos
 
   //calculation by component of the fractional step VELOCITY corresponding to the first stage
   void QFluid3D::Stage1(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector,
-			ProcessInfo& rCurrentProcessInfo)
+			const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY;
 
@@ -227,7 +227,7 @@ namespace Kratos
   }
 
   void QFluid3D::Stage2(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector,
-			ProcessInfo& rCurrentProcessInfo)
+			const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY;
 
@@ -359,7 +359,7 @@ namespace Kratos
     KRATOS_CATCH("");
   }
 
-  void QFluid3D::InitializeSolutionStep(ProcessInfo& CurrentProcessInfo)
+  void QFluid3D::InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo)
   {
     KRATOS_TRY
       int FractionalStepNumber = CurrentProcessInfo[FRACTIONAL_STEP];
@@ -700,7 +700,7 @@ namespace Kratos
     KRATOS_CATCH("");
   }
 
-  void QFluid3D::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo)
+  void QFluid3D::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const
   {
     const unsigned int number_of_nodes = GetGeometry().PointsNumber();
     const unsigned int dim = 3;
@@ -729,7 +729,7 @@ namespace Kratos
 
   }
 
-  void QFluid3D::GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo)
+  void QFluid3D::GetDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const
   {
     unsigned int number_of_nodes = GetGeometry().PointsNumber();
     unsigned int dim = 3;

--- a/applications/PFEM2Application/custom_elements/qfluid_3d.h
+++ b/applications/PFEM2Application/custom_elements/qfluid_3d.h
@@ -94,16 +94,16 @@ namespace Kratos
 
     Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const override;
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
     //virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& ElementalDofList,const ProcessInfo& CurrentProcessInfo) const override;
 
-    void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
     ///@}
     ///@name Access
@@ -211,8 +211,8 @@ namespace Kratos
     ///@}
     ///@name Private Operators
     ///@{
-    void Stage1(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
-    void Stage2(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+    void Stage1(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo);
+    void Stage2(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo);
 
     inline double CalculateH(double Volume);
 

--- a/applications/PFEM2Application/custom_strategies/fracstep_GLS_strategy.h
+++ b/applications/PFEM2Application/custom_strategies/fracstep_GLS_strategy.h
@@ -197,17 +197,19 @@ namespace Kratos
 	  typedef Scheme< TSparseSpace, TDenseSpace > SchemeType;
 	  typename SchemeType::Pointer pscheme = typename SchemeType::Pointer(new ResidualBasedIncrementalUpdateStaticScheme< TSparseSpace, TDenseSpace > ());
 
-	  BuilderSolverTypePointer vel_build = BuilderSolverTypePointer(new ResidualBasedEliminationBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver > (pNewVelocityLinearSolver));
+	  // BuilderSolverTypePointer vel_build = BuilderSolverTypePointer(new ResidualBasedEliminationBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver > (pNewVelocityLinearSolver));
 
 
-	  this->mpfracvel_strategy = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (model_part, pscheme, pNewVelocityLinearSolver, vel_build, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
+	  // this->mpfracvel_strategy = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (model_part, pscheme, pNewVelocityLinearSolver, vel_build, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
+    this->mpfracvel_strategy = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (model_part, pscheme, pNewVelocityLinearSolver, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
 
 	  this->mpfracvel_strategy->SetEchoLevel(1);
 
 
-	  BuilderSolverTypePointer pressure_build = BuilderSolverTypePointer(new ResidualBasedEliminationBuilderAndSolverComponentwise<TSparseSpace, TDenseSpace, TLinearSolver, Variable<double> >(pNewPressureLinearSolver, PRESSURE));
+	  // BuilderSolverTypePointer pressure_build = BuilderSolverTypePointer(new ResidualBasedEliminationBuilderAndSolverComponentwise<TSparseSpace, TDenseSpace, TLinearSolver, Variable<double> >(pNewPressureLinearSolver, PRESSURE));
 
-	  this->mppressurestep = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (model_part, pscheme,pNewPressureLinearSolver, pressure_build, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
+	  // this->mppressurestep = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (model_part, pscheme,pNewPressureLinearSolver, pressure_build, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
+    this->mppressurestep = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (model_part, pscheme,pNewPressureLinearSolver, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
 	  this->mppressurestep->SetEchoLevel(2);
 
 	  this->m_step = 1;

--- a/applications/PFEM2Application/custom_strategies/pfem_2_monolithic_slip_scheme.h
+++ b/applications/PFEM2Application/custom_strategies/pfem_2_monolithic_slip_scheme.h
@@ -217,11 +217,11 @@ namespace Kratos {
         LHS and to the RHS
           of the system
          */
-        void CalculateSystemContributions(Element::Pointer rCurrentElement,
+        void CalculateSystemContributions(Element& rCurrentElement,
                                           LocalSystemMatrixType& LHS_Contribution,
                                           LocalSystemVectorType& RHS_Contribution,
                                           Element::EquationIdVectorType& EquationId,
-                                          ProcessInfo& CurrentProcessInfo) override
+                                          const ProcessInfo& CurrentProcessInfo) override
         {
             KRATOS_TRY
 
@@ -229,52 +229,52 @@ namespace Kratos {
             //(rCurrentElement) -> InitializeNonLinearIteration(CurrentProcessInfo);
             //KRATOS_WATCH(LHS_Contribution);
             //basic operations for the element considered
-            (rCurrentElement)->CalculateLocalSystem(LHS_Contribution, RHS_Contribution, CurrentProcessInfo);
+            rCurrentElement.CalculateLocalSystem(LHS_Contribution, RHS_Contribution, CurrentProcessInfo);
 
-            (rCurrentElement)->EquationIdVector(EquationId, CurrentProcessInfo);
+            rCurrentElement.EquationIdVector(EquationId, CurrentProcessInfo);
 
             // If there is a slip condition, apply it on a rotated system of coordinates
-            mRotationTool.Rotate(LHS_Contribution,RHS_Contribution,rCurrentElement->GetGeometry());
-            mRotationTool.ApplySlipCondition(LHS_Contribution,RHS_Contribution,rCurrentElement->GetGeometry());
+            mRotationTool.Rotate(LHS_Contribution,RHS_Contribution,rCurrentElement.GetGeometry());
+            mRotationTool.ApplySlipCondition(LHS_Contribution,RHS_Contribution,rCurrentElement.GetGeometry());
 
             KRATOS_CATCH("")
         }
 
-        void Calculate_RHS_Contribution(Element::Pointer rCurrentElement,
+        void CalculateRHSContribution(Element& rCurrentElement,
                                         LocalSystemVectorType& RHS_Contribution,
                                         Element::EquationIdVectorType& EquationId,
-                                        ProcessInfo& CurrentProcessInfo) override
+                                        const ProcessInfo& CurrentProcessInfo) override
         {
 
             //Initializing the non linear iteration for the current element
-            (rCurrentElement) -> InitializeNonLinearIteration(CurrentProcessInfo);
+            rCurrentElement.InitializeNonLinearIteration(CurrentProcessInfo);
 
             //basic operations for the element considered
-            (rCurrentElement)->CalculateRightHandSide(RHS_Contribution, CurrentProcessInfo);
+            rCurrentElement.CalculateRightHandSide(RHS_Contribution, CurrentProcessInfo);
 
-            (rCurrentElement)->EquationIdVector(EquationId, CurrentProcessInfo);
+            rCurrentElement.EquationIdVector(EquationId, CurrentProcessInfo);
 
 
             // If there is a slip condition, apply it on a rotated system of coordinates
-            mRotationTool.Rotate(RHS_Contribution,rCurrentElement->GetGeometry());
-            mRotationTool.ApplySlipCondition(RHS_Contribution,rCurrentElement->GetGeometry());
+            mRotationTool.Rotate(RHS_Contribution,rCurrentElement.GetGeometry());
+            mRotationTool.ApplySlipCondition(RHS_Contribution,rCurrentElement.GetGeometry());
         }
 
         /** functions totally analogous to the precedent but applied to
         the "condition" objects
          */
-        virtual void Condition_CalculateSystemContributions(Condition::Pointer rCurrentCondition,
+        virtual void CalculateSystemContributions(Condition& rCurrentCondition,
                                                             LocalSystemMatrixType& LHS_Contribution,
                                                             LocalSystemVectorType& RHS_Contribution,
                                                             Element::EquationIdVectorType& EquationId,
-                                                            ProcessInfo& CurrentProcessInfo) override
+                                                            const ProcessInfo& CurrentProcessInfo) override
         {
             KRATOS_TRY
 
             //KRATOS_WATCH("CONDITION LOCALVELOCITYCONTRIBUTION IS NOT DEFINED");
-            (rCurrentCondition) -> InitializeNonLinearIteration(CurrentProcessInfo);
-            (rCurrentCondition)->CalculateLocalSystem(LHS_Contribution, RHS_Contribution, CurrentProcessInfo);
-            (rCurrentCondition)->EquationIdVector(EquationId, CurrentProcessInfo);
+            rCurrentCondition.InitializeNonLinearIteration(CurrentProcessInfo);
+            rCurrentCondition.CalculateLocalSystem(LHS_Contribution, RHS_Contribution, CurrentProcessInfo);
+            rCurrentCondition.EquationIdVector(EquationId, CurrentProcessInfo);
 
             // Rotate contributions (to match coordinates for slip conditions)
             //mRotationTool.Rotate(LHS_Contribution,RHS_Contribution,rCurrentCondition->GetGeometry());
@@ -283,27 +283,27 @@ namespace Kratos {
             KRATOS_CATCH("")
         }
 
-        virtual void Condition_Calculate_RHS_Contribution(Condition::Pointer rCurrentCondition,
+        virtual void CalculateRHSContribution(Condition& rCurrentCondition,
                                                           LocalSystemVectorType& RHS_Contribution,
                                                           Element::EquationIdVectorType& EquationId,
-                                                          ProcessInfo& rCurrentProcessInfo) override
+                                                          const ProcessInfo& rCurrentProcessInfo) override
         {
             KRATOS_TRY;
 
 
             //KRATOS_WATCH("CONDITION LOCALVELOCITYCONTRIBUTION IS NOT DEFINED");
             //Initializing the non linear iteration for the current condition
-            (rCurrentCondition) -> InitializeNonLinearIteration(rCurrentProcessInfo);
+            rCurrentCondition.InitializeNonLinearIteration(rCurrentProcessInfo);
 
             //basic operations for the element considered
-            (rCurrentCondition)->CalculateRightHandSide(RHS_Contribution,rCurrentProcessInfo);
+            rCurrentCondition.CalculateRightHandSide(RHS_Contribution,rCurrentProcessInfo);
 
-            (rCurrentCondition)->EquationIdVector(EquationId,rCurrentProcessInfo);
+            rCurrentCondition.EquationIdVector(EquationId,rCurrentProcessInfo);
 
 
             // Rotate contributions (to match coordinates for slip conditions)
-            mRotationTool.Rotate(RHS_Contribution,rCurrentCondition->GetGeometry());
-            mRotationTool.ApplySlipCondition(RHS_Contribution,rCurrentCondition->GetGeometry());
+            mRotationTool.Rotate(RHS_Contribution,rCurrentCondition.GetGeometry());
+            mRotationTool.ApplySlipCondition(RHS_Contribution,rCurrentCondition.GetGeometry());
 
             KRATOS_CATCH("");
         }
@@ -315,7 +315,7 @@ namespace Kratos {
                                             TSystemVectorType& Dx,
                                             TSystemVectorType& b) override
         {
-            ProcessInfo& CurrentProcessInfo = r_model_part.GetProcessInfo();
+            const ProcessInfo& CurrentProcessInfo = r_model_part.GetProcessInfo();
 
             Scheme<TSparseSpace, TDenseSpace>::InitializeSolutionStep(r_model_part, A, Dx, b);
 

--- a/applications/PFEM2Application/custom_strategies/pfem_2_monolithic_slip_strategy.h
+++ b/applications/PFEM2Application/custom_strategies/pfem_2_monolithic_slip_strategy.h
@@ -165,16 +165,18 @@ MoveMeshFlag)
         }
 
         //CONSTRUCTION OF VELOCITY
-        BuilderSolverTypePointer vel_build = BuilderSolverTypePointer(new ResidualBasedEliminationBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver > (pVelocityLinearSolver));
+        // BuilderSolverTypePointer vel_build = BuilderSolverTypePointer(new ResidualBasedEliminationBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver > (pVelocityLinearSolver));
 //        BuilderSolverTypePointer vel_build = BuilderSolverTypePointer(new ResidualBasedEliminationBuilderAndSolverSlip<TSparseSpace, TDenseSpace, TLinearSolver, VarComponent > (pNewVelocityLinearSolver, this->mDomainSize, VELOCITY_X, VELOCITY_Y, VELOCITY_Z));
-        this->mpMomentumStrategy = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (rModelPart, pScheme, pVelocityLinearSolver, vel_build, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
+        // this->mpMomentumStrategy = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (rModelPart, pScheme, pVelocityLinearSolver, vel_build, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
+        this->mpMomentumStrategy = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (rModelPart, pScheme, pVelocityLinearSolver, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
         this->mpMomentumStrategy->SetEchoLevel( BaseType::GetEchoLevel() );
 
-        BuilderSolverTypePointer pressure_build = BuilderSolverTypePointer(
-                    //new ResidualBasedEliminationBuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver>(pPressureLinearSolver));
-                new ResidualBasedEliminationBuilderAndSolverComponentwise<TSparseSpace, TDenseSpace, TLinearSolver, Variable<double> >(pPressureLinearSolver, PRESSURE));
+        // BuilderSolverTypePointer pressure_build = BuilderSolverTypePointer(
+        //             //new ResidualBasedEliminationBuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver>(pPressureLinearSolver));
+        //         new ResidualBasedEliminationBuilderAndSolverComponentwise<TSparseSpace, TDenseSpace, TLinearSolver, Variable<double> >(pPressureLinearSolver, PRESSURE));
 
-        this->mpPressureStrategy = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (rModelPart, pScheme, pPressureLinearSolver, pressure_build, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
+        // this->mpPressureStrategy = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (rModelPart, pScheme, pPressureLinearSolver, pressure_build, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
+        this->mpPressureStrategy = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (rModelPart, pScheme, pPressureLinearSolver, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
         this->mpPressureStrategy->SetEchoLevel( BaseType::GetEchoLevel() );
 
         if (mUseSlipConditions)


### PR DESCRIPTION
Mostly due to the changes in [](https://github.com/KratosMultiphysics/Kratos/issues/7381), PFEM2 was not compiling. I've done all the necessary changes and it compiles right now. I'm open to any feedback.
@juliobarna right now, I've done some modifications in fracstep_GLS_strategy and pfem_2_monolithic_slip_strategy. I haven't deleted the previous lines though, rather commented. Let's discuss the minor changes during the week.
Thanks in advance and have a nice weekend!
Regards,
Deniz