### PR TITLE
[core] Fixing symbolic links for __init__.py and kratos_globals.py. Printing process id at the beginning of the computation. 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,8 +500,8 @@ install(CODE "message(STATUS \"Deleting: ${CMAKE_INSTALL_PREFIX}/libs\")")
 install(CODE "file(REMOVE_RECURSE \"${CMAKE_INSTALL_PREFIX}/libs\")")
 
 # Install core files for the KratosMultiphysics python module
-install(FILES "${KRATOS_SOURCE_DIR}/kratos/python_interface/__init__.py" DESTINATION KratosMultiphysics )
-install(FILES "${KRATOS_SOURCE_DIR}/kratos/python_interface/kratos_globals.py" DESTINATION KratosMultiphysics )
+kratos_python_install(${INSTALL_PYTHON_USING_LINKS} "${KRATOS_SOURCE_DIR}/kratos/python_interface/__init__.py" "KratosMultiphysics/__init__.py" )
+kratos_python_install(${INSTALL_PYTHON_USING_LINKS} "${KRATOS_SOURCE_DIR}/kratos/python_interface/kratos_globals.py" "KratosMultiphysics/kratos_globals.py" )
 
 # Install the libraries in the libs folder
 install(FILES ${Boost_LIBRARIES} DESTINATION libs)

--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -60,7 +60,7 @@ def __ModuleInitDetail():
 KratosGlobals = __ModuleInitDetail()
 
 # print the process id e.g. for attatching a debugger
-if KratosGlobals.Kernel.BuildType() == "FullDebug" or KratosGlobals.Kernel.BuildType() == "Debug" or KratosGlobals.Kernel.BuildType() == "RelWithDebInfo":
+if KratosGlobals.Kernel.BuildType() != "Release":
     Logger.PrintInfo("Process Id", os.getpid())
 
 def _ImportApplicationAsModule(application, application_name, application_folder, mod_path):

--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -16,6 +16,7 @@ class KratosPaths(object):
 # import core library (Kratos.so)
 sys.path.append(KratosPaths.kratos_libs)
 from Kratos import *
+Logger.PrintInfo("Process Id", os.getpid())
 
 def __ModuleInitDetail():
     """

--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -16,7 +16,6 @@ class KratosPaths(object):
 # import core library (Kratos.so)
 sys.path.append(KratosPaths.kratos_libs)
 from Kratos import *
-Logger.PrintInfo("Process Id", os.getpid())
 
 def __ModuleInitDetail():
     """
@@ -59,6 +58,10 @@ def __ModuleInitDetail():
     return kratos_globals.KratosGlobalsImpl(Kernel(using_mpi), KratosPaths.kratos_applications)
 
 KratosGlobals = __ModuleInitDetail()
+
+# print the process id e.g. for attatching a debugger
+if KratosGlobals.Kernel.BuildType() == "FullDebug" or KratosGlobals.Kernel.BuildType() == "Debug" or KratosGlobals.Kernel.BuildType() == "RelWithDebInfo":
+    Logger.PrintInfo("Process Id", os.getpid())
 
 def _ImportApplicationAsModule(application, application_name, application_folder, mod_path):
     Kernel = KratosGlobals.Kernel


### PR DESCRIPTION
**Description**
With the change, a PID is printed when the computation starts, for debugging purposes (gdb attach debugger style).
When attaching a debugger, sometimes it is difficult to know which PID is the process we are debugging. If it is printed on screen, it becomes very easy.

Also, I noticed that files __init__.py and kratos_globals.py were not links when I asked so in the configure file. This has been fixed.