### PR TITLE
[Core][ParallelUtils] fix for problem for const containers in BlockPartition

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
@@ -104,8 +104,17 @@ KRATOS_TEST_CASE_IN_SUITE(BlockPartitionerConstContainer, KratosCoreFastSuite)
         }
     );
 
+    //here we check for a reduction (computing the sum of all the entries)
+    auto final_sum_short = block_for_each<SumReduction<double>>(data_vector,
+        [](const double item)
+        {
+            return item;
+        }
+    );
+
     const double expected_value = 5.0*nsize;
     KRATOS_CHECK_DOUBLE_EQUAL(final_sum, expected_value);
+    KRATOS_CHECK_DOUBLE_EQUAL(final_sum_short, expected_value);
 }
 
 // Basic Type

--- a/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
@@ -52,9 +52,7 @@ class RHSElement
 KRATOS_TEST_CASE_IN_SUITE(BlockPartitioner, KratosCoreFastSuite)
 {
     int nsize = 1e3;
-    std::vector<double> data_vector(nsize);
-    for(auto& it : data_vector)
-        it = 5.0;
+    std::vector<double> data_vector(nsize, 5.0);
 
     //here we raise every entry of a vector to the power 0.1
     BlockPartition<std::vector<double>>(data_vector).for_each(
@@ -93,12 +91,28 @@ KRATOS_TEST_CASE_IN_SUITE(BlockPartitioner, KratosCoreFastSuite)
 }
 
 // Basic Type
+KRATOS_TEST_CASE_IN_SUITE(BlockPartitionerConstContainer, KratosCoreFastSuite)
+{
+    int nsize = 1e3;
+    const std::vector<double> data_vector(nsize, 5.0);
+
+    //here we check for a reduction (computing the sum of all the entries)
+    auto final_sum = BlockPartition<decltype(data_vector)>(data_vector).for_each<SumReduction<double>>(
+        [](const double item)
+        {
+            return item;
+        }
+    );
+
+    const double expected_value = 5.0*nsize;
+    KRATOS_CHECK_DOUBLE_EQUAL(final_sum, expected_value);
+}
+
+// Basic Type
 KRATOS_TEST_CASE_IN_SUITE(IndexPartitioner, KratosCoreFastSuite)
 {
     int nsize = 1e3;
-    std::vector<double> data_vector(nsize), output(nsize);
-    for(auto& it : data_vector)
-        it = -1.0;
+    std::vector<double> data_vector(nsize, -1.0), output(nsize);
 
     //output = 2*data_vector (in parallel, and accessing by index)
     IndexPartition<unsigned int>(data_vector.size()).for_each(

--- a/kratos/utilities/parallel_utilities.h
+++ b/kratos/utilities/parallel_utilities.h
@@ -146,7 +146,7 @@ public:
      *  @param Nchunks - number of threads to be used in the loop (must be lower than TMaxThreads)
      */
     template <class TData>
-    BlockPartition(TData &&rData, int Nchunks = omp_get_max_threads())
+    BlockPartition(TData &&rData, int Nchunks = ParallelUtilities::GetNumThreads())
         : BlockPartition(rData.begin(), rData.end(), Nchunks)
     {}
 

--- a/kratos/utilities/parallel_utilities.h
+++ b/kratos/utilities/parallel_utilities.h
@@ -110,7 +110,7 @@ private:
  */
 template<
         class TContainerType,
-        class TIteratorType=typename TContainerType::iterator,
+        class TIteratorType=decltype(std::declval<TContainerType>().begin()),
         int TMaxThreads=Globals::MaxAllowedThreads
         >
 class BlockPartition
@@ -145,8 +145,8 @@ public:
     /** @param rData - the continer to be iterated upon
      *  @param Nchunks - number of threads to be used in the loop (must be lower than TMaxThreads)
      */
-    BlockPartition(TContainerType& rData,
-                   int Nchunks = ParallelUtilities::GetNumThreads())
+    template <class TData>
+    BlockPartition(TData &&rData, int Nchunks = omp_get_max_threads())
         : BlockPartition(rData.begin(), rData.end(), Nchunks)
     {}
 
@@ -251,7 +251,7 @@ private:
 template <class TContainerType, class TFunctionType>
 void block_for_each(TContainerType &&v, TFunctionType &&func)
 {
-    BlockPartition<typename std::decay<TContainerType>::type>(std::forward<TContainerType>(v)).for_each(std::forward<TFunctionType>(func));
+    BlockPartition<TContainerType>(v.begin(), v.end()).for_each(std::forward<TFunctionType>(func));
 }
 
 /** @brief simplified version of the basic loop with reduction to enable template type deduction
@@ -261,8 +261,7 @@ void block_for_each(TContainerType &&v, TFunctionType &&func)
 template <class TReducer, class TContainerType, class TFunctionType>
 typename TReducer::value_type block_for_each(TContainerType &&v, TFunctionType &&func)
 {
-    return BlockPartition<typename std::decay<TContainerType>::type>
-        (std::forward<TContainerType>(v)).template for_each<TReducer>(std::forward<TFunctionType>(func));
+    return  BlockPartition<TContainerType>(v.begin(), v.end()).template for_each<TReducer>(std::forward<TFunctionType>(func));
 }
 
 /** @brief simplified version of the basic loop with thread local storage (TLS) to enable template type deduction
@@ -273,7 +272,7 @@ typename TReducer::value_type block_for_each(TContainerType &&v, TFunctionType &
 template <class TContainerType, class TThreadLocalStorage, class TFunctionType>
 void block_for_each(TContainerType &&v, const TThreadLocalStorage& tls, TFunctionType &&func)
 {
-    BlockPartition<typename std::decay<TContainerType>::type>(std::forward<TContainerType>(v)).for_each(tls, std::forward<TFunctionType>(func));
+     BlockPartition<TContainerType>(v.begin(), v.end()).for_each(tls, std::forward<TFunctionType>(func));
 }
 
 /** @brief simplified version of the basic loop with reduction and thread local storage (TLS) to enable template type deduction
@@ -284,8 +283,7 @@ void block_for_each(TContainerType &&v, const TThreadLocalStorage& tls, TFunctio
 template <class TReducer, class TContainerType, class TThreadLocalStorage, class TFunctionType>
 typename TReducer::value_type block_for_each(TContainerType &&v, const TThreadLocalStorage& tls, TFunctionType &&func)
 {
-    return BlockPartition<typename std::decay<TContainerType>::type>
-        (std::forward<TContainerType>(v)).template for_each<TReducer>(tls, std::forward<TFunctionType>(func));
+    return BlockPartition<TContainerType>(v.begin(), v.end()).template for_each<TReducer>(tls, std::forward<TFunctionType>(func));
 }
 
 //***********************************************************************************


### PR DESCRIPTION
This now allows to use const containers in parallel loops

**Description**
before this PR it was not possible to use block_for_each on const containers. This fixes the issue

Please mark the PR with appropriate tags: 

**Changelog**
internal changes to allow the use of const_containers. Usage remains unchanged

closes #7806