### PR TITLE
[Core][Structural] improve performance of Damping

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
@@ -313,6 +313,21 @@ void CrBeamElement3D2N::CalculateDampingMatrix(
         msElementSize);
 }
 
+void CrBeamElement3D2N::CalculateDampingMatrix(
+    const MatrixType& rLeftHandSideMatrix,
+    const MatrixType& rMassMatrix,
+    MatrixType& rDampingMatrix,
+    const ProcessInfo& rCurrentProcessInfo)
+{
+    StructuralMechanicsElementUtilities::CalculateRayleighDampingMatrix(
+        rLeftHandSideMatrix,
+        rMassMatrix,
+        rDampingMatrix,
+        GetProperties(),
+        rCurrentProcessInfo,
+        msElementSize);
+}
+
 Vector CrBeamElement3D2N::CalculateLocalNodalForces() const
 {
     // deformation modes

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.hpp
@@ -211,6 +211,12 @@ public:
         MatrixType& rDampingMatrix,
         const ProcessInfo& rCurrentProcessInfo) override;
 
+    void CalculateDampingMatrix(
+        const MatrixType& rLeftHandSideMatrix,
+        const MatrixType& rMassMatrix,
+        MatrixType& rDampingMatrix,
+        const ProcessInfo& rCurrentProcessInfo) override;
+
     void AddExplicitContribution(const VectorType& rRHSVector,
                                  const Variable<VectorType>& rRHSVariable,
                                  const Variable<array_1d<double, 3> >& rDestinationVariable,

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
@@ -192,6 +192,41 @@ double GetDensityForMassMatrixComputation(const Element& rElement)
 /***********************************************************************************/
 
 void CalculateRayleighDampingMatrix(
+    const Element::MatrixType& rLeftHandSideMatrix,
+    const Element::MatrixType& rMassMatrix,
+    Element::MatrixType& rDampingMatrix,
+    const Properties& rProperties,
+    const ProcessInfo& rCurrentProcessInfo,
+    const std::size_t MatrixSize)
+{
+    KRATOS_TRY;
+    // Rayleigh Damping Matrix: alpha*M + beta*K
+
+    // 1.-Resizing if needed
+    if (rDampingMatrix.size1() != MatrixSize || rDampingMatrix.size2() != MatrixSize) {
+        rDampingMatrix.resize(MatrixSize, MatrixSize, false);
+    }
+    noalias(rDampingMatrix) = ZeroMatrix(MatrixSize, MatrixSize);
+
+    // 2.-Add StiffnessMatrix contribution (if needed):
+    const double beta = GetRayleighBeta(rProperties, rCurrentProcessInfo);
+    if (std::abs(beta) > 0.0) {
+        noalias(rDampingMatrix) += beta  * rLeftHandSideMatrix;
+    }
+
+    // 2.-Add MassMatrix contribution (if needed):
+    const double alpha = GetRayleighAlpha(rProperties, rCurrentProcessInfo);
+    if (std::abs(alpha) > 0.0) {
+        noalias(rDampingMatrix) += alpha * rMassMatrix;
+    }
+
+    KRATOS_CATCH("CalculateRayleighDampingMatrix")
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void CalculateRayleighDampingMatrix(
     Element& rElement,
     Element::MatrixType& rDampingMatrix,
     const ProcessInfo& rCurrentProcessInfo,

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.h
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.h
@@ -201,6 +201,23 @@ double GetDensityForMassMatrixComputation(const Element& rElement);
 
 /**
  * @brief Method to calculate the rayleigh damping-matrix
+ * @param rLeftHandSideMatrix The left hand side matrix of the element
+ * @param rMassMatrix The mass-matrix of the element
+ * @param rDampingMatrix The damping-matrix of the element
+ * @param rProperties The Properties where it is specified
+ * @param rCurrentProcessInfo The ProcessInfo where it is specified
+ * @param MatrixSize The size of the damping-matrix
+ */
+void CalculateRayleighDampingMatrix(
+    const Element::MatrixType& rLeftHandSideMatrix,
+    const Element::MatrixType& rMassMatrix,
+    Element::MatrixType& rDampingMatrix,
+    const Properties& rProperties,
+    const ProcessInfo& rCurrentProcessInfo,
+    const std::size_t MatrixSize);
+
+/**
+ * @brief Method to calculate the rayleigh damping-matrix
  * @param rElement The Element for which the damping-matrix should be computed
  * @param rDampingMatrix The damping-matrix of the element
  * @param rCurrentProcessInfo The ProcessInfo where it is specified

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -589,6 +589,25 @@ public:
     }
 
     /**
+     * this is called during the assembling process in order
+     * to calculate the condition damping matrix
+     * @param rLeftHandSideMatrix the condition left hand side matrix
+     * @param rMassMatrix the condition mass matrix
+     * @param rDampingMatrix the condition damping matrix
+     * @param rCurrentProcessInfo the current process info instance
+     */
+    virtual void CalculateDampingMatrix(const MatrixType& rLeftHandSideMatrix,
+                                        const MatrixType& rMassMatrix,
+                                        MatrixType& rDampingMatrix,
+                                        const ProcessInfo& rCurrentProcessInfo)
+    {
+        // in case the condition doesn't provide a special implementation for the
+        // damping matrix based on the LHS-Matrix and the MassMatrix (e.g. Rayleigh damping)
+        // then use the generic method
+        CalculateDampingMatrix(rDampingMatrix, rCurrentProcessInfo);
+    }
+
+    /**
      * CONDITIONS inherited from this class must implement this methods
      * if they need to write something at the condition geometry nodes
      * AddExplicitContribution methods are: OPTIONAL ( avoid to use them is not needed )

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -586,6 +586,25 @@ public:
     }
 
     /**
+     * this is called during the assembling process in order
+     * to calculate the elemental damping matrix
+     * @param rLeftHandSideMatrix the elemental left hand side matrix
+     * @param rMassMatrix the elemental mass matrix
+     * @param rDampingMatrix the elemental damping matrix
+     * @param rCurrentProcessInfo the current process info instance
+     */
+    virtual void CalculateDampingMatrix(const MatrixType& rLeftHandSideMatrix,
+                                        const MatrixType& rMassMatrix,
+                                        MatrixType& rDampingMatrix,
+                                        const ProcessInfo& rCurrentProcessInfo)
+    {
+        // in case the element doesn't provide a special implementation for the
+        // damping matrix based on the LHS-Matrix and the MassMatrix (e.g. Rayleigh damping)
+        // then use the generic method
+        CalculateDampingMatrix(rDampingMatrix, rCurrentProcessInfo);
+    }
+
+    /**
      * this is called during the initialize of the builder
      * to calculate the lumped mass vector
      * @param rLumpedMassVector the elemental lumped mass vector

--- a/kratos/solving_strategies/schemes/residual_based_implicit_time_scheme.h
+++ b/kratos/solving_strategies/schemes/residual_based_implicit_time_scheme.h
@@ -545,7 +545,7 @@ private:
 
         rObject.CalculateMassMatrix(mMatrix.M[this_thread],rCurrentProcessInfo);
 
-        rObject.CalculateDampingMatrix(mMatrix.D[this_thread],rCurrentProcessInfo);
+        rObject.CalculateDampingMatrix(rLHSContribution, mMatrix.M[this_thread], mMatrix.D[this_thread],rCurrentProcessInfo);
 
         AddDynamicsToLHS(rLHSContribution, mMatrix.D[this_thread], mMatrix.M[this_thread], rCurrentProcessInfo);
 


### PR DESCRIPTION
**Description**
This PR proposes to add a new method to `Element` and `Condition`: The Calculation of the Damping Matrix with precomputed LHS and MassMatrix

Motivation:
In structural problem often (for us: always) Rayleigh damping is used to calculate the damping matrix: `D = a*M + b*K`
This requires the Stiffness- and the MassMatrix. Unfortunately the current interfaces don't allow the passing of these matrices even if they are available (see the scheme I updated). Hence they have to be computed again, which is quite expensive.

Hence I am proposing the addition of a new method with which the Striffness- and MassMatrix can be used directly without having to be recomputed.
I made the necessary minimal changes and ported one element such that one can fully understand my intentions

FYI @KlausBSautter 