### PR TITLE
[Core] Adding derivatives inteface for Constitutive laws

### DIFF
--- a/kratos/includes/constitutive_law.h
+++ b/kratos/includes/constitutive_law.h
@@ -781,6 +781,98 @@ public:
     virtual array_1d<double, 6 > & CalculateValue(Parameters& rParameterValues, const Variable<array_1d<double, 6 > >& rVariable,
                           array_1d<double, 6 > & rValue);
 
+    /**
+     * @brief Calculates derivatives of a given function
+     *
+     * This method calculates derivative of a scalar function (denoted by rFunctionVariable) w.r.t.
+     * rDerivativeVariable and stores the output in rOutput. The rDerivativeVariable represents
+     * a gauss point scalar variable only.
+     *
+     * Eg: Assume following function (gauss point evaluated):
+     *      \[
+     *          \nu = \nu_{fluid} + \nu_t = \nu_{fluid} + \left(\frac{y}{\omega}\right)^2 \frac{\partial k}{\partial x_i}\frac{\partial \omega}{\partial x_i}
+     *      \]
+     *
+     *      Then in here we use rFunctionVariable = EFFECTIVE_VISCOSITY
+     *
+     *      Then if we want to take derivatives w.r.t. $\omega$ (i.e. rDerivativeVariable = OMEGA).
+     *      So following steps needs to be used.
+     *
+     *           1. First calculate derivatives w.r.t. omega (rDerivativeVariable = OMEGA)
+     *              using the call:
+     *                   CalculateDerivative(Values, EFFECTIVE_VISCOSITY, OMEGA, output);
+     *              The output will hold the following:
+     *                   \[
+     *                       \frac{\partial \nu}{\partial \omega} = \frac{\partial \nu_t}{\partial \omega} = -2\frac{y^2}{\omega^3}\frac{\partial k}{\partial x_i}\frac{\partial \omega}{\partial x_i}
+     *                   \]
+     *           2. Then calculate derivatives w.r.t. omega gradients (rDerivativeVariable = OMEGA_GRADIENT_X)
+     *              using the call: (where OMEGA_GRADIENT is a 3D vector with components)
+     *                   CalculateDerivative(Values, EFFECTIVE_VISCOSITY, OMEGA_GRADIENT_X, output);
+     *              The output will hold the following:
+     *                   \[
+     *                       \frac{\partial \nu}{\partial \nabla\omega_x} = \frac{\partial \nu_t}{\partial \nabla\omega_x} =  \left(\frac{y}{\omega}\right)^2 \frac{\partial k}{\partial x_x}
+     *                   \]
+     *              Once you have these outputs, you can transform it to a nodal derivative (eg: discrete adjoint computation)
+     *              within your element by using the chain rule. [Where $c$ is the node index of the geometry.]
+     *                   \[
+     *                       \frac{\partial \nu}{\partial \omega^c} = \frac{\partial \nu}{\partial \omega}\frac{\partial \omega}{\partial \omega^c} + \frac{\partial \nu}{\partial \nabla\omega_i}\frac{\partial \nabla\omega_i}{\partial \omega^c}
+     *                   \]
+     *
+     * @param rParameterValues      Input for the derivative calculation
+     * @param rFunctionVariable     Variable to identify the function for which derivatives are computed
+     * @param rDerivativeVariable   Scalar derivative variable
+     * @param rOutput               Output having the same type as the rFunctionVariable
+     */
+    virtual void CalculateDerivative(Parameters& rParameterValues, const Variable<double>& rFunctionVariable, const Variable<double>& rDerivativeVariable, double& rOutput);
+
+    /**
+     * @brief Calculates derivatives of a given function
+     *
+     * This method calculates derivative of a Vector function (denoted by rFunctionVariable) w.r.t.
+     * rDerivativeVariable and stores the output in rOutput. The rDerivativeVariable represents
+     * a gauss point scalar variable only.
+     *
+     * @see double overload of this method for more explanations
+     *
+     * @param rParameterValues      Input for the derivative calculation
+     * @param rFunctionVariable     Variable to identify the function for which derivatives are computed
+     * @param rDerivativeVariable   Scalar derivative variable
+     * @param rOutput               Output having the same type as the rFunctionVariable
+     */
+    virtual void CalculateDerivative(Parameters& rParameterValues, const Variable<Vector>& rFunctionVariable, const Variable<double>& rDerivativeVariable, Vector& rOutput);
+
+    /**
+     * @brief Calculates derivatives of a given function
+     *
+     * This method calculates derivative of a Matrix function (denoted by rFunctionVariable) w.r.t.
+     * rDerivativeVariable and stores the output in rOutput. The rDerivativeVariable represents
+     * a gauss point scalar variable only.
+     *
+     * @see double overload of this method for more explanations
+     *
+     * @param rParameterValues      Input for the derivative calculation
+     * @param rFunctionVariable     Variable to identify the function for which derivatives are computed
+     * @param rDerivativeVariable   Scalar derivative variable
+     * @param rOutput               Output having the same type as the rFunctionVariable
+     */
+    virtual void CalculateDerivative(Parameters& rParameterValues, const Variable<Matrix>& rFunctionVariable, const Variable<double>& rDerivativeVariable, Matrix& rOutput);
+
+    /**
+     * @brief Calculates derivatives of a given function
+     *
+     * This method calculates derivative of a array_1d<double, 3> function (denoted by rFunctionVariable) w.r.t.
+     * rDerivativeVariable and stores the output in rOutput. The rDerivativeVariable represents
+     * a gauss point scalar variable only.
+     *
+     * @see double overload of this method for more explanations
+     *
+     * @param rParameterValues      Input for the derivative calculation
+     * @param rFunctionVariable     Variable to identify the function for which derivatives are computed
+     * @param rDerivativeVariable   Scalar derivative variable
+     * @param rOutput               Output having the same type as the rFunctionVariable
+     */
+    virtual void CalculateDerivative(Parameters& rParameterValues, const Variable<array_1d<double, 3>>& rFunctionVariable, const Variable<double>& rDerivativeVariable, array_1d<double, 3>& rOutput);
+
 
      /**
       * Is called to check whether the provided material parameters in the Properties

--- a/kratos/includes/constitutive_law.h
+++ b/kratos/includes/constitutive_law.h
@@ -823,7 +823,11 @@ public:
      * @param rDerivativeVariable   Scalar derivative variable
      * @param rOutput               Output having the same type as the rFunctionVariable
      */
-    virtual void CalculateDerivative(Parameters& rParameterValues, const Variable<double>& rFunctionVariable, const Variable<double>& rDerivativeVariable, double& rOutput);
+    virtual void CalculateDerivative(
+        Parameters& rParameterValues,
+        const Variable<double>& rFunctionVariable,
+        const Variable<double>& rDerivativeVariable,
+        double& rOutput);
 
     /**
      * @brief Calculates derivatives of a given function
@@ -839,7 +843,11 @@ public:
      * @param rDerivativeVariable   Scalar derivative variable
      * @param rOutput               Output having the same type as the rFunctionVariable
      */
-    virtual void CalculateDerivative(Parameters& rParameterValues, const Variable<Vector>& rFunctionVariable, const Variable<double>& rDerivativeVariable, Vector& rOutput);
+    virtual void CalculateDerivative(
+        Parameters& rParameterValues,
+        const Variable<Vector>& rFunctionVariable,
+        const Variable<double>& rDerivativeVariable,
+        Vector& rOutput);
 
     /**
      * @brief Calculates derivatives of a given function
@@ -855,7 +863,11 @@ public:
      * @param rDerivativeVariable   Scalar derivative variable
      * @param rOutput               Output having the same type as the rFunctionVariable
      */
-    virtual void CalculateDerivative(Parameters& rParameterValues, const Variable<Matrix>& rFunctionVariable, const Variable<double>& rDerivativeVariable, Matrix& rOutput);
+    virtual void CalculateDerivative(
+        Parameters& rParameterValues,
+        const Variable<Matrix>& rFunctionVariable,
+        const Variable<double>& rDerivativeVariable,
+        Matrix& rOutput);
 
     /**
      * @brief Calculates derivatives of a given function
@@ -871,7 +883,11 @@ public:
      * @param rDerivativeVariable   Scalar derivative variable
      * @param rOutput               Output having the same type as the rFunctionVariable
      */
-    virtual void CalculateDerivative(Parameters& rParameterValues, const Variable<array_1d<double, 3>>& rFunctionVariable, const Variable<double>& rDerivativeVariable, array_1d<double, 3>& rOutput);
+    virtual void CalculateDerivative(
+        Parameters& rParameterValues,
+        const Variable<array_1d<double, 3>>& rFunctionVariable,
+        const Variable<double>& rDerivativeVariable,
+        array_1d<double, 3>& rOutput);
 
 
      /**

--- a/kratos/sources/constitutive_law.cpp
+++ b/kratos/sources/constitutive_law.cpp
@@ -447,6 +447,22 @@ array_1d<double, 6 > & ConstitutiveLaw::CalculateValue(Parameters& rParameterVal
     return rValue;
 }
 
+void ConstitutiveLaw::CalculateDerivative(Parameters& rParameterValues, const Variable<double>& rFunctionVariable, const Variable<double>& rDerivativeVariable, double& rOutput)
+{
+}
+
+void ConstitutiveLaw::CalculateDerivative(Parameters& rParameterValues, const Variable<Vector>& rFunctionVariable, const Variable<double>& rDerivativeVariable, Vector& rOutput)
+{
+}
+
+void ConstitutiveLaw::CalculateDerivative(Parameters& rParameterValues, const Variable<Matrix>& rFunctionVariable, const Variable<double>& rDerivativeVariable, Matrix& rOutput)
+{
+}
+
+void ConstitutiveLaw::CalculateDerivative(Parameters& rParameterValues, const Variable<array_1d<double, 3>>& rFunctionVariable, const Variable<double>& rDerivativeVariable, array_1d<double, 3>& rOutput)
+{
+}
+
 /**
  * Is called to check whether the provided material parameters in the Properties
  * match the requirements of current constitutive model.

--- a/kratos/sources/constitutive_law.cpp
+++ b/kratos/sources/constitutive_law.cpp
@@ -447,20 +447,56 @@ array_1d<double, 6 > & ConstitutiveLaw::CalculateValue(Parameters& rParameterVal
     return rValue;
 }
 
-void ConstitutiveLaw::CalculateDerivative(Parameters& rParameterValues, const Variable<double>& rFunctionVariable, const Variable<double>& rDerivativeVariable, double& rOutput)
+void ConstitutiveLaw::CalculateDerivative(
+    Parameters& rParameterValues,
+    const Variable<double>& rFunctionVariable,
+    const Variable<double>& rDerivativeVariable,
+    double& rOutput)
 {
+    KRATOS_TRY
+
+    KRATOS_ERROR << "Derivative of " << rFunctionVariable.Name() << " w.r.t. " << rDerivativeVariable.Name() << " is not implemented.\n";
+
+    KRATOS_CATCH("");
 }
 
-void ConstitutiveLaw::CalculateDerivative(Parameters& rParameterValues, const Variable<Vector>& rFunctionVariable, const Variable<double>& rDerivativeVariable, Vector& rOutput)
+void ConstitutiveLaw::CalculateDerivative(
+    Parameters& rParameterValues,
+    const Variable<Vector>& rFunctionVariable,
+    const Variable<double>& rDerivativeVariable,
+    Vector& rOutput)
 {
+    KRATOS_TRY
+
+    KRATOS_ERROR << "Derivative of " << rFunctionVariable.Name() << " w.r.t. " << rDerivativeVariable.Name() << " is not implemented.\n";
+
+    KRATOS_CATCH("");
 }
 
-void ConstitutiveLaw::CalculateDerivative(Parameters& rParameterValues, const Variable<Matrix>& rFunctionVariable, const Variable<double>& rDerivativeVariable, Matrix& rOutput)
+void ConstitutiveLaw::CalculateDerivative(
+    Parameters& rParameterValues,
+    const Variable<Matrix>& rFunctionVariable,
+    const Variable<double>& rDerivativeVariable,
+    Matrix& rOutput)
 {
+    KRATOS_TRY
+
+    KRATOS_ERROR << "Derivative of " << rFunctionVariable.Name() << " w.r.t. " << rDerivativeVariable.Name() << " is not implemented.\n";
+
+    KRATOS_CATCH("");
 }
 
-void ConstitutiveLaw::CalculateDerivative(Parameters& rParameterValues, const Variable<array_1d<double, 3>>& rFunctionVariable, const Variable<double>& rDerivativeVariable, array_1d<double, 3>& rOutput)
+void ConstitutiveLaw::CalculateDerivative(
+    Parameters& rParameterValues,
+    const Variable<array_1d<double, 3>>& rFunctionVariable,
+    const Variable<double>& rDerivativeVariable,
+    array_1d<double, 3>& rOutput)
 {
+    KRATOS_TRY
+
+    KRATOS_ERROR << "Derivative of " << rFunctionVariable.Name() << " w.r.t. " << rDerivativeVariable.Name() << " is not implemented.\n";
+
+    KRATOS_CATCH("");
 }
 
 /**


### PR DESCRIPTION
**Description**
This PR adds derivatives interface for constitutive laws which can be used in developing discrete adjoint formulations.

**Usage:**
Assume the following case: (Where `rFunction` variable is `EFFECTIVE_VISCOSITY` which is denoted by `\nu`)
![image](https://user-images.githubusercontent.com/7856520/107346711-4c87c580-6ac5-11eb-8193-3219c0155195.png)

In the above example, `k`, `omega` are gauss point quantities. `y` and `\nu_{fluid}` are pre defined constants. So if we want to calculate derivatives w.r.t. nodal `omega` with node index `c` (of the geometry). then following steps can be used.

1. First calculate derivatives w.r.t. `omega` (gauss point quantity)
```c++
double output_scalar_derivative;
CalculateDerivative(Values, EFFECTIVE_VISCOSITY, OMEGA, output_scalar_derivative);
```
The above code snippet will give the following for `output_scalar_derivative`
![image](https://user-images.githubusercontent.com/7856520/107347819-84dbd380-6ac6-11eb-9eab-5ab5d8d64328.png)

2. Second calculate derivatives w.r.t. `omega`'s gradient (`OMEGA_GRADIENT_X`, `OMEGA_GRADIENT_Y`, `OMEGA_GRADIENT_Z`)
```c++
array_1d<double, 3> output_gradient;
CalculateDerivative(Values, EFFECTIVE_VISCOSITY, OMEGA_GRADIENT_X, output_gradient[0]);
CalculateDerivative(Values, EFFECTIVE_VISCOSITY, OMEGA_GRADIENT_Y, output_gradient[1]);
CalculateDerivative(Values, EFFECTIVE_VISCOSITY, OMEGA_GRADIENT_Z, output_gradient[2]);
```
The above code snippet will give the following for `output_gradient[i]`
![image](https://user-images.githubusercontent.com/7856520/107348194-02074880-6ac7-11eb-96f4-cb2e4f6f568b.png)

3. Finally we can compute the nodal derivatives by using the chain rule
![image](https://user-images.githubusercontent.com/7856520/107348683-a4273080-6ac7-11eb-9f0f-8ffea51c6f99.png)
```c++
Vector nu_t_derivative = N * output_scalar_derivative + prod(dNdX, output_gradient);
```
In here quantities in `blue` are computed within the `ConstitutiveLaw`, and quantities indicated in red are computed within the adjoint `Element` .

Since this is only an interface, there are no tests.

Followings are few different use cases:
In Fluid:
https://github.com/KratosMultiphysics/Kratos/blob/4ab24c46fb793edb4226f2d07353f8d00883060c/applications/FluidDynamicsApplication/custom_elements/data_containers/qs_vms/qs_vms_residual_derivatives.h#L179-L185

https://github.com/KratosMultiphysics/Kratos/blob/4ab24c46fb793edb4226f2d07353f8d00883060c/applications/FluidDynamicsApplication/custom_constitutive/newtonian_2d_law.cpp#L87-L131

In RANS:
https://github.com/KratosMultiphysics/Kratos/blob/d87a7c5f13836f7b5492ca95ab29c6b10516be2d/applications/RANSApplication/custom_constitutive/rans_k_epsilon_newtonian_law.cpp#L118-L153

**Changelog**
- Added derivatives interface to `ConstitutiveLaw`
