### PR TITLE
[MeshingApplication] Remove duplicated GetMetric call and fix for v5.5

### DIFF
--- a/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.cpp
+++ b/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.cpp
@@ -3541,8 +3541,15 @@ void MmgUtilities<MMGLibrary::MMG3D>::GetMetricTensor(array_1d<double, 6>& rMetr
     KRATOS_TRY;
 
     // The order is XX, XY, XZ, YY, YZ, ZZ
-    KRATOS_ERROR_IF( MMG3D_Get_tensorSol(mMmgMet, &rMetric[0], &rMetric[3], &rMetric[5], &rMetric[1], &rMetric[4], &rMetric[2]) != 1 ) << "Unable to get tensor metric" << std::endl;
-
+    #if MMG_VERSION_GE(5,5)
+        if (mDiscretization == DiscretizationOption::ISOSURFACE) {
+            rMetric = ZeroVector(6);
+        } else {
+            KRATOS_ERROR_IF( MMG3D_Get_tensorSol(mMmgMet, &rMetric[0], &rMetric[3], &rMetric[5], &rMetric[1], &rMetric[4], &rMetric[2]) != 1 ) << "Unable to get tensor metric" << std::endl;
+        }
+    #else
+        KRATOS_ERROR_IF( MMG3D_Get_tensorSol(mMmgMet, &rMetric[0], &rMetric[3], &rMetric[5], &rMetric[1], &rMetric[4], &rMetric[2]) != 1 ) << "Unable to get tensor metric" << std::endl;
+    #endif
     KRATOS_CATCH("");
 }
 

--- a/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.cpp
+++ b/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.cpp
@@ -4204,14 +4204,15 @@ void MmgUtilities<TMMGLibrary>::GenerateSolDataFromModelPart(ModelPart& rModelPa
     // Set size of the solution
     /* In case of considering metric tensor */
     const Variable<TensorArrayType>& r_tensor_variable = KratosComponents<Variable<TensorArrayType>>::Get("METRIC_TENSOR_" + std::to_string(Dimension)+"D");
-    if (it_node_begin->Has(r_tensor_variable)) {
+    mUsingMetricTensor = it_node_begin->Has(r_tensor_variable);
+    if (mUsingMetricTensor) {
         SetSolSizeTensor(r_nodes_array.size());
     } else {
         SetSolSizeScalar(r_nodes_array.size());
     }
 
     // In case of considering metric tensor
-    if (it_node_begin->Has(r_tensor_variable)) {
+    if (mUsingMetricTensor) {
         #pragma omp parallel for
         for(int i = 0; i < static_cast<int>(r_nodes_array.size()); ++i) {
             auto it_node = it_node_begin + i;
@@ -4501,7 +4502,7 @@ void MmgUtilities<TMMGLibrary>::WriteSolDataToModelPart(ModelPart& rModelPart)
     const Variable<TensorArrayType>& r_tensor_variable = KratosComponents<Variable<TensorArrayType>>::Get("METRIC_TENSOR_" + std::to_string(Dimension)+"D");
 
     // In case of considering metric tensor
-    if (it_node_begin->Has(r_tensor_variable)) {
+    if (mUsingMetricTensor) {
         // Auxilia metric
         TensorArrayType metric = ZeroVector(3 * (Dimension - 1));
 

--- a/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.h
+++ b/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.h
@@ -789,7 +789,7 @@ private:
     SizeType mEchoLevel = 0;                                               /// The echo level of the utilities
     bool mRemoveRegions = false;                                           /// Cuttig-out specified regions during surface remeshing
     DiscretizationOption mDiscretization = DiscretizationOption::STANDARD; /// Discretization The discretization type
-    bool mUsingMetricTensor = true;                                          /// Controls if the metric used is a tensor (true) or a scalar (false)
+    bool mUsingMetricTensor = true;                                        /// Controls if the metric used is a tensor (true) or a scalar (false)
 
     ///@}
     ///@name Private Operators

--- a/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.h
+++ b/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.h
@@ -789,6 +789,7 @@ private:
     SizeType mEchoLevel = 0;                                               /// The echo level of the utilities
     bool mRemoveRegions = false;                                           /// Cuttig-out specified regions during surface remeshing
     DiscretizationOption mDiscretization = DiscretizationOption::STANDARD; /// Discretization The discretization type
+    bool mUsingMetricTensor = true;                                          /// Controls if the metric used is a tensor (true) or a scalar (false)
 
     ///@}
     ///@name Private Operators


### PR DESCRIPTION
**Description**
For some cases, the line:
https://github.com/KratosMultiphysics/Kratos/blob/02a2fa770cb352886bd54bd65e8919cd9511de78/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp#L293
was giving an error as the variable was not properly intialized. When debugging this, I realized this operation is done twice, also in mmg_utilities. 

In this PR, the duplicated call is removed. The operation is perfomed after all the renumbering of ids and submodelpart retrievals is finished. Also, I noticed that the check to use SCALAR/TENSOR variables was not working properly, so that has been replaced. Finally, the GetMetricTensor3D call was not adapted to v5.5 causing it to fail after the last two changes.

**Changelog**
- Proper check to use metric tensor or scalar
- Remove duplicated GetMetricTensor calls
- Fix v5.5 GetMetricTensor3D
