### PR TITLE
Fracstep_GLS_strategy has been fixed

### DIFF
--- a/applications/PFEM2Application/custom_strategies/fracstep_GLS_strategy.h
+++ b/applications/PFEM2Application/custom_strategies/fracstep_GLS_strategy.h
@@ -137,6 +137,7 @@ namespace Kratos
       /**@name Life Cycle
        */
       /*@{ */
+      
 
       /**
        * Constructor of the FracStepStrategy. Implements the solutions strategy for a Navier Stokes solver
@@ -197,19 +198,19 @@ namespace Kratos
 	  typedef Scheme< TSparseSpace, TDenseSpace > SchemeType;
 	  typename SchemeType::Pointer pscheme = typename SchemeType::Pointer(new ResidualBasedIncrementalUpdateStaticScheme< TSparseSpace, TDenseSpace > ());
 
-	  // BuilderSolverTypePointer vel_build = BuilderSolverTypePointer(new ResidualBasedEliminationBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver > (pNewVelocityLinearSolver));
+	  // BuilderSolverTypePointer pVelocityBuildAndSolver = BuilderSolverTypePointer(new ResidualBasedEliminationBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver > (pNewVelocityLinearSolver));
+    BuilderSolverTypePointer pVelocityBuildAndSolver = BuilderSolverTypePointer(new ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver > (pNewVelocityLinearSolver));
 
-
-	  // this->mpfracvel_strategy = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (model_part, pscheme, pNewVelocityLinearSolver, vel_build, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
-    this->mpfracvel_strategy = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (model_part, pscheme, pNewVelocityLinearSolver, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
+    this->mpfracvel_strategy = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (model_part, pscheme, pVelocityBuildAndSolver, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
 
 	  this->mpfracvel_strategy->SetEchoLevel(1);
 
 
-	  // BuilderSolverTypePointer pressure_build = BuilderSolverTypePointer(new ResidualBasedEliminationBuilderAndSolverComponentwise<TSparseSpace, TDenseSpace, TLinearSolver, Variable<double> >(pNewPressureLinearSolver, PRESSURE));
+	  // BuilderSolverTypePointer pPressureBuildAndSolver = BuilderSolverTypePointer(new ResidualBasedEliminationBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver > (pNewVelocityLinearSolver));
+    BuilderSolverTypePointer pPressureBuildAndSolver = BuilderSolverTypePointer(new ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver > (pNewPressureLinearSolver));
 
 	  // this->mppressurestep = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (model_part, pscheme,pNewPressureLinearSolver, pressure_build, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
-    this->mppressurestep = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (model_part, pscheme,pNewPressureLinearSolver, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
+    this->mppressurestep = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (model_part, pscheme,pPressureBuildAndSolver, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
 	  this->mppressurestep->SetEchoLevel(2);
 
 	  this->m_step = 1;


### PR DESCRIPTION
A couple of days back, I'd updated the PFEM2Application according to the latest changes in the Kratos core. However, there were issues with two strategy files, namely "fracstep_GLS_strategy" and "pfem_2_monolithic_slip_strategy", and for the sake of applying the vital changes in the core, I'd temporarily omitted those strategies. After that successful PR, here are the updates regarding these two strategies. First of all, "pfem_2_monolithic_slip_strategy.h" is a ghost strategy header file. It's not included in any part of the PFEM2Application, however, it's there somehow. I'm afraid PFEM2Application has several ghost elements like this, and I believe I'll deal with them in the upcoming days. That being said, I've updated "fracstep_GLS_strategy" according to the Fractional Step Strategy in the FluidDynamicsApplication. There, the builder and solver was set to be ResidualBasedBlockBuilderAndSolver, however, in the older version of "fracstep_GLS_strategy" it was ResidualBasedEliminationBuilderAndSolver. We could discuss again which one to use, therefore I add ResidualBasedEliminationBuilderAndSolver as commented in the code. 
This should work now. Feel free to comment.
Kind Regards,
Deniz
