### PR TITLE
[Core] Kernel initializes ParallelUtils

### DIFF
--- a/kratos/sources/kernel.cpp
+++ b/kratos/sources/kernel.cpp
@@ -43,11 +43,12 @@ void Kernel::Initialize() {
                     << "_|\\_\\_|  \\__,_|\\__|\\___/ ____/\n"
                     << "           Multi-Physics " << GetVersionString() << std::endl;
 
-    PrintParallelismSupportInfo();
-
     if (!IsImported("KratosMultiphysics")) {
         this->ImportApplication(mpKratosCoreApplication);
+        ParallelUtilities::Initialize();
     }
+
+    PrintParallelismSupportInfo();
 }
 
 std::unordered_set<std::string> &Kernel::GetApplicationsList() {

--- a/kratos/utilities/parallel_utilities.h
+++ b/kratos/utilities/parallel_utilities.h
@@ -72,6 +72,15 @@ public:
 
     ///@}
 
+protected:
+
+    /** @brief Initializes members.
+     * Note that this method must only be called once at startup
+     * The Kernel takes care of it
+     */
+    friend class Kernel; // forward declaring to avoid the include ("parallel_utilities.h" is included in many places but "kernel.h" should not be!)
+    static void Initialize();
+
 private:
     ///@name Static Member Variables
     ///@{
@@ -91,12 +100,6 @@ private:
     static int InitializeNumberOfThreads();
     ///@}
 
-    ///@name Private Access
-    ///@{
-
-    static int& GetNumberOfThreads();
-
-    ///@}
 }; // Class ParallelUtilities
 
 


### PR DESCRIPTION
**Description**
This PR improves the initialization of some important members in the `ParallelUtilities`. Now the Kernel initializes ONCE some members at the very beginning.
This will be used in #8173 and for more developments in the future

@RiccardoRossi this will also be used for the `GlobalLock` we spoke about last week to emulate / port the `omp critical` (we need it anyway, not only for the reductions)

@roigcarlo can you have a look please if this is ok in terms of technical realization? Thx