### PR TITLE
CableNetApp/Porting OMP Atomic to AtomicUtilities

### DIFF
--- a/applications/CableNetApplication/custom_elements/empirical_spring.cpp
+++ b/applications/CableNetApplication/custom_elements/empirical_spring.cpp
@@ -536,14 +536,9 @@ void EmpiricalSpringElement3D2N::AddExplicitContribution(
 
         for (int i = 0; i < msNumberOfNodes; ++i) {
             double& r_nodal_mass = GetGeometry()[i].GetValue(NODAL_MASS);
-            array_1d<double, msDimension>& r_nodal_inertia = GetGeometry()[i].GetValue(NODAL_INERTIA);
             int index = i * msDimension;
 
             AtomicAdd(r_nodal_mass, mass_vector[index]);
-
-            for (int k = 0; k < msDimension; ++k) {
-                AtomicAdd(r_nodal_inertia[k], 0.0);
-            }
         }
     }
 

--- a/applications/CableNetApplication/custom_elements/empirical_spring.cpp
+++ b/applications/CableNetApplication/custom_elements/empirical_spring.cpp
@@ -21,6 +21,7 @@
 #include "includes/checks.h"
 #include "custom_utilities/structural_mechanics_element_utilities.h"
 #include "includes/variables.h"
+#include "utilities/atomic_utilities.h"
 
 
 namespace Kratos {
@@ -494,8 +495,7 @@ void EmpiricalSpringElement3D2N::AddExplicitContribution(
             double& r_nodal_mass = r_geom[i].GetValue(NODAL_MASS);
             int index = i * msDimension;
 
-            #pragma omp atomic
-            r_nodal_mass += element_mass_vector(index);
+            AtomicAdd(r_nodal_mass, element_mass_vector(index));
         }
     }
 
@@ -525,8 +525,7 @@ void EmpiricalSpringElement3D2N::AddExplicitContribution(
             size_t index = msDimension * i;
             array_1d<double, 3>& r_force_residual = GetGeometry()[i].FastGetSolutionStepValue(FORCE_RESIDUAL);
             for (size_t j = 0; j < msDimension; ++j) {
-                #pragma omp atomic
-                r_force_residual[j] += rRHSVector[index + j] - damping_residual_contribution[index + j];
+                AtomicAdd(r_force_residual[j], rRHSVector[index + j] - damping_residual_contribution[index + j]);
             }
         }
     } else if (rDestinationVariable == NODAL_INERTIA) {
@@ -540,12 +539,10 @@ void EmpiricalSpringElement3D2N::AddExplicitContribution(
             array_1d<double, msDimension>& r_nodal_inertia = GetGeometry()[i].GetValue(NODAL_INERTIA);
             int index = i * msDimension;
 
-            #pragma omp atomic
-            r_nodal_mass += mass_vector[index];
+            AtomicAdd(r_nodal_mass, mass_vector[index]);
 
             for (int k = 0; k < msDimension; ++k) {
-                #pragma omp atomic
-                r_nodal_inertia[k] += 0.0;
+                AtomicAdd(r_nodal_inertia[k], 0.0);
             }
         }
     }

--- a/applications/CableNetApplication/custom_elements/ring_element_3D.cpp
+++ b/applications/CableNetApplication/custom_elements/ring_element_3D.cpp
@@ -21,6 +21,7 @@
 #include "includes/define.h"
 #include "structural_mechanics_application_variables.h"
 #include "includes/checks.h"
+#include "utilities/atomic_utilities.h"
 
 
 namespace Kratos {
@@ -577,8 +578,7 @@ void RingElement3D::AddExplicitContribution(
             double &r_nodal_mass = r_geom[i].GetValue(NODAL_MASS);
             int index = i * dimension;
 
-            #pragma omp atomic
-            r_nodal_mass += element_mass_vector(index);
+            AtomicAdd(r_nodal_mass, element_mass_vector(index));
         }
     }
     KRATOS_CATCH("")
@@ -610,8 +610,7 @@ void RingElement3D::AddExplicitContribution(
             size_t index = dimension * i;
             array_1d<double, 3> &r_force_residual = GetGeometry()[i].FastGetSolutionStepValue(FORCE_RESIDUAL);
             for (size_t j = 0; j < dimension; ++j) {
-                #pragma omp atomic
-                r_force_residual[j] += rRHSVector[index + j] - damping_residual_contribution[index + j];
+                AtomicAdd(r_force_residual[j], rRHSVector[index + j] - damping_residual_contribution[index + j] );
             }
         }
     } else if (rDestinationVariable == NODAL_INERTIA) {
@@ -625,12 +624,10 @@ void RingElement3D::AddExplicitContribution(
             array_1d<double, dimension> &r_nodal_inertia = GetGeometry()[i].GetValue(NODAL_INERTIA);
             int index = i * dimension;
 
-            #pragma omp atomic
-            r_nodal_mass += mass_vector[index];
+            AtomicAdd(r_nodal_mass, mass_vector[index]);
 
             for (int k = 0; k < dimension; ++k) {
-                #pragma omp atomic
-                r_nodal_inertia[k] += 0.0;
+                AtomicAdd(r_nodal_inertia[k], 0.0);
             }
         }
     }

--- a/applications/CableNetApplication/custom_elements/ring_element_3D.cpp
+++ b/applications/CableNetApplication/custom_elements/ring_element_3D.cpp
@@ -621,14 +621,9 @@ void RingElement3D::AddExplicitContribution(
 
         for (int i = 0; i < points_number; ++i) {
             double &r_nodal_mass = GetGeometry()[i].GetValue(NODAL_MASS);
-            array_1d<double, dimension> &r_nodal_inertia = GetGeometry()[i].GetValue(NODAL_INERTIA);
             int index = i * dimension;
 
             AtomicAdd(r_nodal_mass, mass_vector[index]);
-
-            for (int k = 0; k < dimension; ++k) {
-                AtomicAdd(r_nodal_inertia[k], 0.0);
-            }
         }
     }
     KRATOS_CATCH("")

--- a/applications/CableNetApplication/custom_elements/sliding_cable_element_3D.cpp
+++ b/applications/CableNetApplication/custom_elements/sliding_cable_element_3D.cpp
@@ -748,14 +748,9 @@ void SlidingCableElement3D::AddExplicitContribution(
 
         for (int i = 0; i < points_number; ++i) {
             double &r_nodal_mass = GetGeometry()[i].GetValue(NODAL_MASS);
-            array_1d<double, dimension> &r_nodal_inertia = GetGeometry()[i].GetValue(NODAL_INERTIA);
             int index = i * dimension;
 
             AtomicAdd(r_nodal_mass, mass_vector[index]);
-
-            for (int k = 0; k < dimension; ++k) {
-                AtomicAdd(r_nodal_inertia[k], 0.0);
-            }
         }
     }
     KRATOS_CATCH("")

--- a/applications/CableNetApplication/custom_elements/sliding_cable_element_3D.cpp
+++ b/applications/CableNetApplication/custom_elements/sliding_cable_element_3D.cpp
@@ -22,6 +22,7 @@
 #include "structural_mechanics_application_variables.h"
 #include "includes/checks.h"
 #include "includes/variables.h"
+#include "utilities/atomic_utilities.h"
 
 
 namespace Kratos {
@@ -704,8 +705,7 @@ void SlidingCableElement3D::AddExplicitContribution(
             double &r_nodal_mass = r_geom[i].GetValue(NODAL_MASS);
             int index = i * dimension;
 
-            #pragma omp atomic
-            r_nodal_mass += element_mass_vector(index);
+            AtomicAdd(r_nodal_mass, element_mass_vector(index));
         }
     }
     KRATOS_CATCH("")
@@ -737,8 +737,7 @@ void SlidingCableElement3D::AddExplicitContribution(
             size_t index = dimension * i;
             array_1d<double, 3> &r_force_residual = GetGeometry()[i].FastGetSolutionStepValue(FORCE_RESIDUAL);
             for (size_t j = 0; j < dimension; ++j) {
-                #pragma omp atomic
-                r_force_residual[j] += rRHSVector[index + j] - damping_residual_contribution[index + j];
+                AtomicAdd(r_force_residual[j], rRHSVector[index + j] - damping_residual_contribution[index + j] );
             }
         }
     } else if (rDestinationVariable == NODAL_INERTIA) {
@@ -752,12 +751,10 @@ void SlidingCableElement3D::AddExplicitContribution(
             array_1d<double, dimension> &r_nodal_inertia = GetGeometry()[i].GetValue(NODAL_INERTIA);
             int index = i * dimension;
 
-            #pragma omp atomic
-            r_nodal_mass += mass_vector[index];
+            AtomicAdd(r_nodal_mass, mass_vector[index]);
 
             for (int k = 0; k < dimension; ++k) {
-                #pragma omp atomic
-                r_nodal_inertia[k] += 0.0;
+                AtomicAdd(r_nodal_inertia[k], 0.0);
             }
         }
     }

--- a/applications/CableNetApplication/custom_elements/weak_coupling_slide.cpp
+++ b/applications/CableNetApplication/custom_elements/weak_coupling_slide.cpp
@@ -23,6 +23,7 @@
 #include "includes/variables.h"
 #include "custom_utilities/structural_mechanics_element_utilities.h"
 #include "includes/checks.h"
+#include "utilities/atomic_utilities.h"
 
 
 namespace Kratos {
@@ -387,8 +388,7 @@ void WeakSlidingElement3D3N::AddExplicitContribution(
             size_t index = msDimension * i;
             array_1d<double, 3>& r_force_residual = GetGeometry()[i].FastGetSolutionStepValue(FORCE_RESIDUAL);
             for (size_t j = 0; j < msDimension; ++j) {
-                #pragma omp atomic
-                r_force_residual[j] += rRHSVector[index + j];
+                AtomicAdd(r_force_residual[j], rRHSVector[index + j]);
             }
         }
     }


### PR DESCRIPTION
**Description**
Porting OMP Atomic statements to use Atomic Utilities

- Atomic Utilities
- CableNetApplication

**Changelog**
- Changed statements from empirical_spring.cpp
- Changed statements from ring_element_3D.cpp
- Changed statements from sliding_cable_element_3D.cpp
- Changed statements from weak_coupling_slides.cpp
