### PR TITLE
[Hotfix][Core] Array initialization syntax in old compilers

### DIFF
--- a/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h
@@ -109,8 +109,8 @@ protected:
     ///@{
 
     // Arrays to get edge and node IDs of geometry from edge ID of splitting utility
-    const std::array<size_t, 6> edge_id_for_geometry = {{0, 2, 3, 1, 4, 5}};
-    const std::array<std::array<size_t,2>, 6> node_ids_for_geometry = {{{{0,1}}, {{2,0}}, {{0,3}}, {{1,2}}, {{1,3}}, {{2,3}}}};
+    const std::array<size_t, 6> edge_id_for_geometry {{0, 2, 3, 1, 4, 5}};
+    const std::array<std::array<size_t,2>, 6> node_ids_for_geometry {{{{0,1}}, {{2,0}}, {{0,3}}, {{1,2}}, {{1,3}}, {{2,3}}}};
 
     ///@}
     ///@name Protected Operators

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_incised_shape_functions.h
@@ -110,7 +110,7 @@ protected:
 
     // Arrays to get edge and node IDs of geometry from edge ID of splitting utility
     const std::array<size_t, 6> edge_id_for_geometry = {{0, 2, 3, 1, 4, 5}};
-    const std::array<std::array<size_t,2>, 6> node_ids_for_geometry = {{{0,1}, {2,0}, {0,3}, {1,2}, {1,3}, {2,3}}};
+    const std::array<std::array<size_t,2>, 6> node_ids_for_geometry = {{{{0,1}}, {{2,0}}, {{0,3}}, {{1,2}}, {{1,3}}, {{2,3}}}};
 
     ///@}
     ///@name Protected Operators

--- a/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.h
+++ b/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.h
@@ -108,7 +108,7 @@ protected:
 
     // Arrays to get edge and node IDs of geometry from edge ID of splitting utility
     const std::array<size_t, 3> edge_id_for_geometry = {{2, 0, 1}};
-    const std::array<std::array<size_t,2>, 3> node_ids_for_geometry = {{{0,1}, {1,2}, {2,0}}};
+    const std::array<std::array<size_t,2>, 3> node_ids_for_geometry = {{{{0,1}}, {{1,2}}, {{2,0}}}};
 
     ///@}
     ///@name Protected Operators

--- a/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.h
+++ b/kratos/modified_shape_functions/triangle_2d_3_ausas_incised_shape_functions.h
@@ -107,8 +107,8 @@ protected:
     ///@{
 
     // Arrays to get edge and node IDs of geometry from edge ID of splitting utility
-    const std::array<size_t, 3> edge_id_for_geometry = {{2, 0, 1}};
-    const std::array<std::array<size_t,2>, 3> node_ids_for_geometry = {{{{0,1}}, {{1,2}}, {{2,0}}}};
+    const std::array<size_t, 3> edge_id_for_geometry {{2, 0, 1}};
+    const std::array<std::array<size_t,2>, 3> node_ids_for_geometry {{{{0,1}}, {{1,2}}, {{2,0}}}};
 
     ///@}
     ///@name Protected Operators


### PR DESCRIPTION
Minor issue with the `std::array` initialization.

Fixes #8303
