### PR TITLE
[Structural][Shells] adding consistent mass matrix

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.cpp
@@ -354,7 +354,7 @@ void BaseShellElement<TCoordinateTransformation>::CalculateRightHandSide(VectorT
 template <class TCoordinateTransformation>
 void BaseShellElement<TCoordinateTransformation>::CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
-    const bool compute_lumped_mass_matrix = true;//StructuralMechanicsElementUtilities::ComputeLumpedMassMatrix(GetProperties(), rCurrentProcessInfo);
+    const bool compute_lumped_mass_matrix = StructuralMechanicsElementUtilities::ComputeLumpedMassMatrix(GetProperties(), rCurrentProcessInfo);
 
     const SizeType num_gps = GetNumberOfGPs();
     const SizeType num_dofs = GetNumberOfDofs();

--- a/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.h
@@ -7,7 +7,7 @@
 //  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
-//  Main authors:    Philipp Bucher
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
 //                   Based on the work of Massimo Petracca and Peter Wilson
 //
 

--- a/applications/StructuralMechanicsApplication/custom_utilities/shell_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/shell_utilities.cpp
@@ -7,7 +7,7 @@
 //  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
-//  Main authors:    Philipp Bucher
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
 //
 
 // System includes

--- a/applications/StructuralMechanicsApplication/custom_utilities/shell_utilities.h
+++ b/applications/StructuralMechanicsApplication/custom_utilities/shell_utilities.h
@@ -8,7 +8,7 @@
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi (porting from utility made by Fabio Petracca and Peter Wilson)
-//					 Philipp Bucher
+//					 Philipp Bucher  (https://github.com/philbucher)
 //
 
 #if !defined(KRATOS_SHELL_UTILITIES_H_INCLUDED )
@@ -44,6 +44,12 @@ class JacobianOperator
 public:
 
     JacobianOperator();
+
+    template<class TLocalCoordinateSystem>
+    void Calculate(const TLocalCoordinateSystem& CS, const Matrix& dN)
+    {
+        KRATOS_ERROR << "This function should not be called, this type of coordinate transformation is unknown!" << std::endl;
+    }
 
     void Calculate(const ShellQ4_LocalCoordinateSystem& CS, const Matrix& dN);
 

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_shells_matrices.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_shells_matrices.cpp
@@ -130,17 +130,17 @@ void ConductShellMassMatrixTest(std::string const& rElementName, const Matrix& r
     p_elem->CalculateMassMatrix(lhs, r_process_info);
 
     // for writing the reference values
-    int counter = 0;
-    std::cout << std::endl<< std::endl << "    ";
-    for (int i=0;i<rRefMatrix.size1();++i) {
-        for (int j=0;j<rRefMatrix.size2();++j) {
-            const double val = lhs(i,j);
-            if (std::abs(val) > 1e-10) {
-                std::cout << std::setprecision(13) << "ref_mass_matrix("<<i<<","<<j<< ")=" << val << "; ";
-                if (++counter%3 == 0) { std::cout << std::endl << "    "; }
-            }
-        }
-    }
+    // int counter = 0;
+    // std::cout << std::endl<< std::endl << "    ";
+    // for (int i=0;i<rRefMatrix.size1();++i) {
+    //     for (int j=0;j<rRefMatrix.size2();++j) {
+    //         const double val = lhs(i,j);
+    //         if (std::abs(val) > 1e-10) {
+    //             std::cout << std::setprecision(13) << "ref_mass_matrix("<<i<<","<<j<< ")=" << val << "; ";
+    //             if (++counter%3 == 0) { std::cout << std::endl << "    "; }
+    //         }
+    //     }
+    // }
 
     KRATOS_CHECK_MATRIX_NEAR(lhs, rRefMatrix, 1e-8);
 

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_shells_matrices.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_shells_matrices.cpp
@@ -167,6 +167,38 @@ KRATOS_TEST_CASE_IN_SUITE(ShellElementCorotational_4N_LumpedMassMatrix, KratosSt
     ConductShellMassMatrixTest("ShellThinElementCorotational3D4N", ref_lumped_mass_matrix, true);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(ShellElementCorotational_3N_ConsistentMassMatrix, KratosStructuralMechanicsFastSuite)
+{
+    Matrix ref_lumped_mass_matrix(18, 18);
+    ref_lumped_mass_matrix = ZeroMatrix(18,18);
+    const double ref_val = 16.6666666666666666666666;
+    for (std::size_t i=0; i<3; ++i) {
+        std::size_t idx = i*6;
+        ref_lumped_mass_matrix(idx, idx) = ref_val;
+        ref_lumped_mass_matrix(idx+1, idx+1) = ref_val;
+        ref_lumped_mass_matrix(idx+2, idx+2) = ref_val;
+    }
+
+    ConductShellMassMatrixTest("ShellThickElementCorotational3D3N", ref_lumped_mass_matrix, false);
+    ConductShellMassMatrixTest("ShellThinElementCorotational3D3N", ref_lumped_mass_matrix, false);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ShellElementCorotational_4N_ConsistentMassMatrix, KratosStructuralMechanicsFastSuite)
+{
+    Matrix ref_lumped_mass_matrix(24, 24);
+    ref_lumped_mass_matrix = ZeroMatrix(24,24);
+    const double ref_val = 100;
+    for (std::size_t i=0; i<4; ++i) {
+        std::size_t idx = i*6;
+        ref_lumped_mass_matrix(idx, idx) = ref_val;
+        ref_lumped_mass_matrix(idx+1, idx+1) = ref_val;
+        ref_lumped_mass_matrix(idx+2, idx+2) = ref_val;
+    }
+
+    ConductShellMassMatrixTest("ShellThickElementCorotational3D4N", ref_lumped_mass_matrix, false);
+    ConductShellMassMatrixTest("ShellThinElementCorotational3D4N", ref_lumped_mass_matrix, false);
+}
+
 KRATOS_TEST_CASE_IN_SUITE(ShellThickElementCorotational3D3N_DampingMatrix, KratosStructuralMechanicsFastSuite)
 {
     Matrix ref_damping_matrix(18, 18);

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_shells_matrices.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_shells_matrices.cpp
@@ -128,7 +128,21 @@ void ConductShellMassMatrixTest(std::string const& rElementName, const Matrix& r
 
     Matrix lhs;
     p_elem->CalculateMassMatrix(lhs, r_process_info);
-    KRATOS_CHECK_MATRIX_NEAR(lhs, rRefMatrix, 1e-12);
+
+    // for writing the reference values
+    int counter = 0;
+    std::cout << std::endl<< std::endl << "    ";
+    for (int i=0;i<rRefMatrix.size1();++i) {
+        for (int j=0;j<rRefMatrix.size2();++j) {
+            const double val = lhs(i,j);
+            if (std::abs(val) > 1e-10) {
+                std::cout << std::setprecision(13) << "ref_mass_matrix("<<i<<","<<j<< ")=" << val << "; ";
+                if (++counter%3 == 0) { std::cout << std::endl << "    "; }
+            }
+        }
+    }
+
+    KRATOS_CHECK_MATRIX_NEAR(lhs, rRefMatrix, 1e-8);
 
     KRATOS_CATCH("ConductShellMassMatrixTest");
 }
@@ -137,66 +151,104 @@ void ConductShellMassMatrixTest(std::string const& rElementName, const Matrix& r
 
 KRATOS_TEST_CASE_IN_SUITE(ShellElementCorotational_3N_LumpedMassMatrix, KratosStructuralMechanicsFastSuite)
 {
-    Matrix ref_lumped_mass_matrix(18, 18);
-    ref_lumped_mass_matrix = ZeroMatrix(18,18);
+    Matrix ref_mass_matrix(18, 18);
+    ref_mass_matrix = ZeroMatrix(18,18);
     const double ref_val = 16.6666666666666666666666;
     for (std::size_t i=0; i<3; ++i) {
         std::size_t idx = i*6;
-        ref_lumped_mass_matrix(idx, idx) = ref_val;
-        ref_lumped_mass_matrix(idx+1, idx+1) = ref_val;
-        ref_lumped_mass_matrix(idx+2, idx+2) = ref_val;
+        ref_mass_matrix(idx, idx) = ref_val;
+        ref_mass_matrix(idx+1, idx+1) = ref_val;
+        ref_mass_matrix(idx+2, idx+2) = ref_val;
     }
 
-    ConductShellMassMatrixTest("ShellThickElementCorotational3D3N", ref_lumped_mass_matrix, true);
-    ConductShellMassMatrixTest("ShellThinElementCorotational3D3N", ref_lumped_mass_matrix, true);
+    ConductShellMassMatrixTest("ShellThickElementCorotational3D3N", ref_mass_matrix, true);
+    ConductShellMassMatrixTest("ShellThinElementCorotational3D3N", ref_mass_matrix, true);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ShellElementCorotational_4N_LumpedMassMatrix, KratosStructuralMechanicsFastSuite)
 {
-    Matrix ref_lumped_mass_matrix(24, 24);
-    ref_lumped_mass_matrix = ZeroMatrix(24,24);
+    Matrix ref_mass_matrix(24, 24);
+    ref_mass_matrix = ZeroMatrix(24,24);
     const double ref_val = 100;
     for (std::size_t i=0; i<4; ++i) {
         std::size_t idx = i*6;
-        ref_lumped_mass_matrix(idx, idx) = ref_val;
-        ref_lumped_mass_matrix(idx+1, idx+1) = ref_val;
-        ref_lumped_mass_matrix(idx+2, idx+2) = ref_val;
+        ref_mass_matrix(idx, idx) = ref_val;
+        ref_mass_matrix(idx+1, idx+1) = ref_val;
+        ref_mass_matrix(idx+2, idx+2) = ref_val;
     }
 
-    ConductShellMassMatrixTest("ShellThickElementCorotational3D4N", ref_lumped_mass_matrix, true);
-    ConductShellMassMatrixTest("ShellThinElementCorotational3D4N", ref_lumped_mass_matrix, true);
+    ConductShellMassMatrixTest("ShellThickElementCorotational3D4N", ref_mass_matrix, true);
+    ConductShellMassMatrixTest("ShellThinElementCorotational3D4N", ref_mass_matrix, true);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ShellElementCorotational_3N_ConsistentMassMatrix, KratosStructuralMechanicsFastSuite)
 {
-    Matrix ref_lumped_mass_matrix(18, 18);
-    ref_lumped_mass_matrix = ZeroMatrix(18,18);
-    const double ref_val = 16.6666666666666666666666;
-    for (std::size_t i=0; i<3; ++i) {
-        std::size_t idx = i*6;
-        ref_lumped_mass_matrix(idx, idx) = ref_val;
-        ref_lumped_mass_matrix(idx+1, idx+1) = ref_val;
-        ref_lumped_mass_matrix(idx+2, idx+2) = ref_val;
-    }
+    Matrix ref_mass_matrix(18, 18);
+    ref_mass_matrix = ZeroMatrix(18,18);
 
-    ConductShellMassMatrixTest("ShellThickElementCorotational3D3N", ref_lumped_mass_matrix, false);
-    ConductShellMassMatrixTest("ShellThinElementCorotational3D3N", ref_lumped_mass_matrix, false);
+    ref_mass_matrix(0,0)=8.333333333333; ref_mass_matrix(0,6)=4.166666666667; ref_mass_matrix(0,12)=4.166666666667;
+    ref_mass_matrix(1,1)=8.333333333333; ref_mass_matrix(1,7)=4.166666666667; ref_mass_matrix(1,13)=4.166666666667;
+    ref_mass_matrix(2,2)=8.333333333333; ref_mass_matrix(2,8)=4.166666666667; ref_mass_matrix(2,14)=4.166666666667;
+    ref_mass_matrix(3,3)=0.006944444444444; ref_mass_matrix(3,9)=0.003472222222222; ref_mass_matrix(3,15)=0.003472222222222;
+    ref_mass_matrix(4,4)=0.006944444444444; ref_mass_matrix(4,10)=0.003472222222222; ref_mass_matrix(4,16)=0.003472222222222;
+    ref_mass_matrix(5,5)=0.006944444444444; ref_mass_matrix(5,11)=0.003472222222222; ref_mass_matrix(5,17)=0.003472222222222;
+    ref_mass_matrix(6,0)=4.166666666667; ref_mass_matrix(6,6)=8.333333333333; ref_mass_matrix(6,12)=4.166666666667;
+    ref_mass_matrix(7,1)=4.166666666667; ref_mass_matrix(7,7)=8.333333333333; ref_mass_matrix(7,13)=4.166666666667;
+    ref_mass_matrix(8,2)=4.166666666667; ref_mass_matrix(8,8)=8.333333333333; ref_mass_matrix(8,14)=4.166666666667;
+    ref_mass_matrix(9,3)=0.003472222222222; ref_mass_matrix(9,9)=0.006944444444444; ref_mass_matrix(9,15)=0.003472222222222;
+    ref_mass_matrix(10,4)=0.003472222222222; ref_mass_matrix(10,10)=0.006944444444444; ref_mass_matrix(10,16)=0.003472222222222;
+    ref_mass_matrix(11,5)=0.003472222222222; ref_mass_matrix(11,11)=0.006944444444444; ref_mass_matrix(11,17)=0.003472222222222;
+    ref_mass_matrix(12,0)=4.166666666667; ref_mass_matrix(12,6)=4.166666666667; ref_mass_matrix(12,12)=8.333333333333;
+    ref_mass_matrix(13,1)=4.166666666667; ref_mass_matrix(13,7)=4.166666666667; ref_mass_matrix(13,13)=8.333333333333;
+    ref_mass_matrix(14,2)=4.166666666667; ref_mass_matrix(14,8)=4.166666666667; ref_mass_matrix(14,14)=8.333333333333;
+    ref_mass_matrix(15,3)=0.003472222222222; ref_mass_matrix(15,9)=0.003472222222222; ref_mass_matrix(15,15)=0.006944444444444;
+    ref_mass_matrix(16,4)=0.003472222222222; ref_mass_matrix(16,10)=0.003472222222222; ref_mass_matrix(16,16)=0.006944444444444;
+    ref_mass_matrix(17,5)=0.003472222222222; ref_mass_matrix(17,11)=0.003472222222222; ref_mass_matrix(17,17)=0.006944444444444;
+
+    ConductShellMassMatrixTest("ShellThickElementCorotational3D3N", ref_mass_matrix, false);
+    ConductShellMassMatrixTest("ShellThinElementCorotational3D3N", ref_mass_matrix, false);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ShellElementCorotational_4N_ConsistentMassMatrix, KratosStructuralMechanicsFastSuite)
 {
-    Matrix ref_lumped_mass_matrix(24, 24);
-    ref_lumped_mass_matrix = ZeroMatrix(24,24);
-    const double ref_val = 100;
-    for (std::size_t i=0; i<4; ++i) {
-        std::size_t idx = i*6;
-        ref_lumped_mass_matrix(idx, idx) = ref_val;
-        ref_lumped_mass_matrix(idx+1, idx+1) = ref_val;
-        ref_lumped_mass_matrix(idx+2, idx+2) = ref_val;
-    }
+    Matrix ref_mass_matrix(24, 24);
+    ref_mass_matrix = ZeroMatrix(24,24);
 
-    ConductShellMassMatrixTest("ShellThickElementCorotational3D4N", ref_lumped_mass_matrix, false);
-    ConductShellMassMatrixTest("ShellThinElementCorotational3D4N", ref_lumped_mass_matrix, false);
+    ref_mass_matrix(0,0)=44.44444444444; ref_mass_matrix(0,6)=22.22222222222; ref_mass_matrix(0,12)=11.11111111111;
+    ref_mass_matrix(0,18)=22.22222222222; ref_mass_matrix(1,1)=44.44444444444; ref_mass_matrix(1,7)=22.22222222222;
+    ref_mass_matrix(1,13)=11.11111111111; ref_mass_matrix(1,19)=22.22222222222; ref_mass_matrix(2,2)=44.44444444444;
+    ref_mass_matrix(2,8)=22.22222222222; ref_mass_matrix(2,14)=11.11111111111; ref_mass_matrix(2,20)=22.22222222222;
+    ref_mass_matrix(3,3)=0.03703703703704; ref_mass_matrix(3,9)=0.01851851851852; ref_mass_matrix(3,15)=0.009259259259259;
+    ref_mass_matrix(3,21)=0.01851851851852; ref_mass_matrix(4,4)=0.03703703703704; ref_mass_matrix(4,10)=0.01851851851852;
+    ref_mass_matrix(4,16)=0.009259259259259; ref_mass_matrix(4,22)=0.01851851851852; ref_mass_matrix(5,5)=0.03703703703704;
+    ref_mass_matrix(5,11)=0.01851851851852; ref_mass_matrix(5,17)=0.009259259259259; ref_mass_matrix(5,23)=0.01851851851852;
+    ref_mass_matrix(6,0)=22.22222222222; ref_mass_matrix(6,6)=44.44444444444; ref_mass_matrix(6,12)=22.22222222222;
+    ref_mass_matrix(6,18)=11.11111111111; ref_mass_matrix(7,1)=22.22222222222; ref_mass_matrix(7,7)=44.44444444444;
+    ref_mass_matrix(7,13)=22.22222222222; ref_mass_matrix(7,19)=11.11111111111; ref_mass_matrix(8,2)=22.22222222222;
+    ref_mass_matrix(8,8)=44.44444444444; ref_mass_matrix(8,14)=22.22222222222; ref_mass_matrix(8,20)=11.11111111111;
+    ref_mass_matrix(9,3)=0.01851851851852; ref_mass_matrix(9,9)=0.03703703703704; ref_mass_matrix(9,15)=0.01851851851852;
+    ref_mass_matrix(9,21)=0.009259259259259; ref_mass_matrix(10,4)=0.01851851851852; ref_mass_matrix(10,10)=0.03703703703704;
+    ref_mass_matrix(10,16)=0.01851851851852; ref_mass_matrix(10,22)=0.009259259259259; ref_mass_matrix(11,5)=0.01851851851852;
+    ref_mass_matrix(11,11)=0.03703703703704; ref_mass_matrix(11,17)=0.01851851851852; ref_mass_matrix(11,23)=0.009259259259259;
+    ref_mass_matrix(12,0)=11.11111111111; ref_mass_matrix(12,6)=22.22222222222; ref_mass_matrix(12,12)=44.44444444444;
+    ref_mass_matrix(12,18)=22.22222222222; ref_mass_matrix(13,1)=11.11111111111; ref_mass_matrix(13,7)=22.22222222222;
+    ref_mass_matrix(13,13)=44.44444444444; ref_mass_matrix(13,19)=22.22222222222; ref_mass_matrix(14,2)=11.11111111111;
+    ref_mass_matrix(14,8)=22.22222222222; ref_mass_matrix(14,14)=44.44444444444; ref_mass_matrix(14,20)=22.22222222222;
+    ref_mass_matrix(15,3)=0.009259259259259; ref_mass_matrix(15,9)=0.01851851851852; ref_mass_matrix(15,15)=0.03703703703704;
+    ref_mass_matrix(15,21)=0.01851851851852; ref_mass_matrix(16,4)=0.009259259259259; ref_mass_matrix(16,10)=0.01851851851852;
+    ref_mass_matrix(16,16)=0.03703703703704; ref_mass_matrix(16,22)=0.01851851851852; ref_mass_matrix(17,5)=0.009259259259259;
+    ref_mass_matrix(17,11)=0.01851851851852; ref_mass_matrix(17,17)=0.03703703703704; ref_mass_matrix(17,23)=0.01851851851852;
+    ref_mass_matrix(18,0)=22.22222222222; ref_mass_matrix(18,6)=11.11111111111; ref_mass_matrix(18,12)=22.22222222222;
+    ref_mass_matrix(18,18)=44.44444444444; ref_mass_matrix(19,1)=22.22222222222; ref_mass_matrix(19,7)=11.11111111111;
+    ref_mass_matrix(19,13)=22.22222222222; ref_mass_matrix(19,19)=44.44444444444; ref_mass_matrix(20,2)=22.22222222222;
+    ref_mass_matrix(20,8)=11.11111111111; ref_mass_matrix(20,14)=22.22222222222; ref_mass_matrix(20,20)=44.44444444444;
+    ref_mass_matrix(21,3)=0.01851851851852; ref_mass_matrix(21,9)=0.009259259259259; ref_mass_matrix(21,15)=0.01851851851852;
+    ref_mass_matrix(21,21)=0.03703703703704; ref_mass_matrix(22,4)=0.01851851851852; ref_mass_matrix(22,10)=0.009259259259259;
+    ref_mass_matrix(22,16)=0.01851851851852; ref_mass_matrix(22,22)=0.03703703703704; ref_mass_matrix(23,5)=0.01851851851852;
+    ref_mass_matrix(23,11)=0.009259259259259; ref_mass_matrix(23,17)=0.01851851851852; ref_mass_matrix(23,23)=0.03703703703704;
+
+    ConductShellMassMatrixTest("ShellThickElementCorotational3D4N", ref_mass_matrix, false);
+    ConductShellMassMatrixTest("ShellThinElementCorotational3D4N", ref_mass_matrix, false);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ShellThickElementCorotational3D3N_DampingMatrix, KratosStructuralMechanicsFastSuite)

--- a/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_3D3N_Thin_Circle_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_3D3N_Thin_Circle_test_materials.json
@@ -11,7 +11,8 @@
                             "DENSITY": 7.85000E+03,
                             "YOUNG_MODULUS": 2.06900E+11,
                             "POISSON_RATIO": 3.00000E-001,
-                            "THICKNESS": 1.00000E-02
+                            "THICKNESS": 1.00000E-02,
+                            "COMPUTE_LUMPED_MASS_MATRIX": true
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_Q4_Thick_2x2_Plate_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_Q4_Thick_2x2_Plate_test_materials.json
@@ -11,7 +11,8 @@
                             "DENSITY": 7.85000E+03,
                             "YOUNG_MODULUS": 1.00000E+07,
                             "POISSON_RATIO": 2.90000E-01,
-                            "THICKNESS": 1.00000E-01
+                            "THICKNESS": 1.00000E-01,
+                            "COMPUTE_LUMPED_MASS_MATRIX": true
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/response_function_tests/StructuralMaterials.json
+++ b/applications/StructuralMechanicsApplication/tests/response_function_tests/StructuralMaterials.json
@@ -10,7 +10,8 @@
                 "THICKNESS"     : 0.25,
                 "DENSITY"       : 7850.0,
                 "YOUNG_MODULUS" : 1000.0,
-                "POISSON_RATIO" : 0.2
+                "POISSON_RATIO" : 0.2,
+                "COMPUTE_LUMPED_MASS_MATRIX": true
             },
             "Tables"           : {}
         }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thin_nonlinear_dynamic_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thin_nonlinear_dynamic_test_materials.json
@@ -11,7 +11,8 @@
                             "YOUNG_MODULUS": 1e9,
                             "POISSON_RATIO": 0.3,
                             "THICKNESS": 0.1,
-                            "DENSITY": 7.85e3
+                            "DENSITY": 7.85e3,
+                            "COMPUTE_LUMPED_MASS_MATRIX": true
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thick_nonlinear_dynamic_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thick_nonlinear_dynamic_test_materials.json
@@ -11,7 +11,8 @@
                             "YOUNG_MODULUS": 1e9,
                             "POISSON_RATIO": 0.3,
                             "THICKNESS": 0.1,
-                            "DENSITY": 7.85e3
+                            "DENSITY": 7.85e3,
+                            "COMPUTE_LUMPED_MASS_MATRIX": true
                     },
                     "Tables": {}
             }


### PR DESCRIPTION
**Description**
This PR adds the consistent mass matrices for shells.
It was initially added by @peterjwilson but not used so far as was hardcoded to use the lumded mass matrix
