### PR TITLE
[MPM] Update check function for negative element volume

### DIFF
--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -1699,7 +1699,8 @@ int  UpdatedLagrangian::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
-    Element::Check(rCurrentProcessInfo);
+    KRATOS_ERROR_IF(this->Id() < 1) << "Element found with Id " << this->Id() << std::endl;
+    KRATOS_ERROR_IF(mMP.volume <= 0.0) << "Element " << this->Id() << " has non-positive size " << mMP.volume << std::endl;
 
     const GeometryType& r_geometry = GetGeometry();
     const unsigned int number_of_nodes = r_geometry.size();


### PR DESCRIPTION
**Description**
In `UpdatedLagrangian::Check`, the MPM element calls `Element::Check` which computes volume with `DomainSize()`. This can return a negative result if the material point is initially generated near the edge of a partially distorted background grid cell.

This PR disables `Element::Check` and checks for a positive ID and element volume directly using the actual material point `mMP.volume`