### PR TITLE
[Core] fixing InitialState

### DIFF
--- a/kratos/includes/initial_state.h
+++ b/kratos/includes/initial_state.h
@@ -46,7 +46,14 @@ class KRATOS_API(KRATOS_CORE) InitialState
         ///@{
         typedef std::size_t SizeType;
 
-        enum class InitialImposingType {STRAIN_ONLY = 0, STRESS_ONLY = 1, DEFORMATION_GRADIENT_ONLY = 2, STRAIN_AND_STRESS = 3, DEFORMATION_GRADIENT_AND_STRESS = 4};
+        enum class InitialImposingType
+        {
+            STRAIN_ONLY = 0,
+            STRESS_ONLY = 1,
+            DEFORMATION_GRADIENT_ONLY = 2,
+            STRAIN_AND_STRESS = 3,
+            DEFORMATION_GRADIENT_AND_STRESS = 4
+        };
 
         /// Pointer definition of NodeSearchUtility
         KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(InitialState);
@@ -69,7 +76,7 @@ class KRATOS_API(KRATOS_CORE) InitialState
 
         // Selective constructor for vectors
         InitialState(const Vector& rImposingEntity,
-                     const int InitialImposingType);
+                     const InitialImposingType InitialImposition = InitialImposingType::STRAIN_ONLY);
 
         // Selective constructor for vectors (E, S)
         InitialState(const Vector& rInitialStrainVector,

--- a/kratos/sources/initial_state.cpp
+++ b/kratos/sources/initial_state.cpp
@@ -62,7 +62,7 @@ namespace Kratos
 
     // Selective constructor for vectors
     InitialState::InitialState(const Vector& rImposingEntity,
-                    const int InitialImposingType = static_cast<int>(InitialImposingType::STRAIN_ONLY))
+                    const InitialImposingType InitialImposition)
     {
         const SizeType voigt_size = rImposingEntity.size();
         const SizeType dimension = (voigt_size == 6) ? 3 : 2;
@@ -75,9 +75,9 @@ namespace Kratos
         noalias(mInitialStrainVector) = ZeroVector(voigt_size);
         noalias(mInitialStressVector) = ZeroVector(voigt_size);
 
-        if (InitialImposingType == static_cast<int>(InitialImposingType::STRAIN_ONLY)) {
+        if (InitialImposition == InitialImposingType::STRAIN_ONLY) {
             noalias(mInitialStrainVector) = rImposingEntity;
-        } else if (InitialImposingType == static_cast<int>(InitialImposingType::STRESS_ONLY)) {
+        } else if (InitialImposition == InitialImposingType::STRESS_ONLY) {
             noalias(mInitialStressVector) = rImposingEntity;
         }
     }


### PR DESCRIPTION
**Description**
Fixing the passing of the `enum` parameters in the `InitialState`
This should fix the CentOS build (hopefully)

@AlejandroCornejo we can taka a look next week at the py-exposure, this is straight forward (see e.g. [here](https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/python/add_io_to_python.cpp#L288-L293))
