### PR TITLE
[Core] Remove warning in the ReadMaterialsUtility

### DIFF
--- a/kratos/utilities/read_materials_utility.cpp
+++ b/kratos/utilities/read_materials_utility.cpp
@@ -131,8 +131,6 @@ void ReadMaterialsUtility::GetPropertyBlock(Parameters Materials)
         ModelPart& r_model_part = mrModel.GetModelPart(material["model_part_name"].GetString());
         const IndexType property_id = material["properties_id"].GetInt();
         const bool has_properties = r_model_part.RecursivelyHasProperties(property_id, mesh_id);
-        KRATOS_WARNING_IF("ReadMaterialsUtility", has_properties) << "WARNING:: The properties ID: " << property_id
-            << " in mesh ID: 0 is already defined. This will overwrite the existing values" << std::endl;
         Properties::Pointer p_prop = has_properties ? r_model_part.pGetProperties(property_id, mesh_id) : r_model_part.CreateNewProperties(property_id, mesh_id);
     }
 


### PR DESCRIPTION
**Description**
In #8304, @rubenzorrilla proposed the following

> What I agree it that defining empty properties in the mdpa and then giving values in the materials.json is quite annoying. As this is always required in order to assign properties to elements in the preprocess, I'd only throw a warning if the properties in the mdpa are not empty.

This PR addresses this comment, removing the warning. I would like to remark that we are still warning users if we are overriding some values in [here](https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/utilities/read_materials_utility.cpp#L44).

Let me know if I misunderstood something.

This PR closes #8304.

Please mark the PR with appropriate tags: 
- Kratos Core

**Changelog**
Please summarize the changes in one list to generate the changelog:
- Removed a warning, as proposed in #8304.
