### PR TITLE
[HDF5][Feature] Add ALL_VARIABLES inputs/outputs

### DIFF
--- a/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
@@ -539,13 +539,28 @@ void ContainerComponentIO<TContainerType, TContainerItemType, TComponents...>::R
     if (mComponentNames.size() == 0)
         return;
 
+    std::vector<std::string> current_components_list(mComponentNames.size());
+    std::copy(mComponentNames.begin(), mComponentNames.end(), current_components_list.begin());
+
+    if (mComponentNames.size() == 1 && mComponentNames[0] == "ALL_VARIABLES") {
+        if (mpFile->HasPath(mComponentPath)) {
+            current_components_list = std::move(mpFile->GetDataSetNames(mComponentPath));
+        } else {
+            KRATOS_WARNING("ContainerComponentIO")
+                << "ALL_VARIABLES are specified to be read, but no variable "
+                   "data is found at "
+                << mComponentPath << " in " << mpFile->GetFileName() << ".\n";
+            return;
+        }
+    }
+
     std::vector<TContainerItemType*> local_items;
     GetContainerItemReferences(local_items, rContainer);
     std::size_t start_index, block_size;
     std::tie(start_index, block_size) = StartIndexAndBlockSize(*mpFile, mComponentPath);
 
     // Read local data for each variable.
-    for (const std::string& r_component_name : mComponentNames)
+    for (const std::string& r_component_name : current_components_list)
         ReadRegisteredComponent(r_component_name, local_items, rCommunicator, *mpFile,
                                 mComponentPath, start_index, block_size, r_component_name);
 
@@ -644,7 +659,10 @@ void SetItemDataValues(Variable<TDataType> const& rVariable,
     KRATOS_TRY;
 
     KRATOS_ERROR_IF(rContainerItems.size() != rData.size())
-        << "Number of items does not equal data set dimension\n";
+        << "Number of items does not equal data set dimension\n"
+        << "[ rVariable = " << rVariable.Name() << ", rContainer.size() = "
+        << rContainerItems.size() << ", ReadData.size() = "
+        << rData.size() << " ].\n";
     for (std::size_t i = 0; i < rContainerItems.size(); ++i)
         rContainerItems[i]->GetValue(rVariable) = rData[i];
 
@@ -659,9 +677,13 @@ void SetItemDataValues(Flags const& rVariable,
     KRATOS_TRY;
 
     KRATOS_ERROR_IF(rContainerItems.size() != rData.size())
-        << "Number of items does not equal data set dimension\n";
-    for (std::size_t i = 0; i < rContainerItems.size(); ++i)
+        << "Number of items does not equal data set dimension\n"
+        << "[ rVariable = " << rVariable << ", rContainer.size() = "
+        << rContainerItems.size() << ", ReadData.size() = "
+        << rData.size() << " ].\n";
+    for (std::size_t i = 0; i < rContainerItems.size(); ++i) {
         rContainerItems[i]->Set(rVariable, static_cast<bool>(rData[i]));
+    }
 
     KRATOS_CATCH("");
 }
@@ -674,7 +696,10 @@ void SetItemDataValues(Variable<Vector<double>> const& rVariable,
     KRATOS_TRY;
 
     KRATOS_ERROR_IF(rContainerItems.size() != rData.size1())
-        << "Number of items does not equal data set dimension\n";
+        << "Number of items does not equal data set dimension\n"
+        << "[ rVariable = " << rVariable.Name() << ", rContainer.size() = "
+        << rContainerItems.size() << ", ReadData.size() = "
+        << rData.size1() << " ].\n";
     for (std::size_t i = 0; i < rContainerItems.size(); ++i)
     {
         Vector<double>& r_vec = rContainerItems[i]->GetValue(rVariable);
@@ -696,7 +721,10 @@ void SetItemDataValues(Variable<Matrix<double>> const& rVariable,
     KRATOS_TRY;
 
     KRATOS_ERROR_IF(rContainerItems.size() != rData.size1())
-        << "Number of items does not equal data set dimension\n";
+        << "Number of items does not equal data set dimension\n"
+        << "[ rVariable = " << rVariable.Name() << ", rContainer.size() = "
+        << rContainerItems.size() << ", ReadData.size() = "
+        << rData.size1() << " ].\n";
     for (std::size_t k = 0; k < rContainerItems.size(); ++k)
     {
         Matrix<double>& r_mat = rContainerItems[k]->GetValue(rVariable);

--- a/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
@@ -542,12 +542,12 @@ void ContainerComponentIO<TContainerType, TContainerItemType, TComponents...>::R
     std::vector<std::string> current_components_list(mComponentNames.size());
     std::copy(mComponentNames.begin(), mComponentNames.end(), current_components_list.begin());
 
-    if (mComponentNames.size() == 1 && mComponentNames[0] == "ALL_VARIABLES") {
+    if (mComponentNames.size() == 1 && mComponentNames[0] == "ALL_VARIABLES_FROM_FILE") {
         if (mpFile->HasPath(mComponentPath)) {
             current_components_list = std::move(mpFile->GetDataSetNames(mComponentPath));
         } else {
             KRATOS_WARNING("ContainerComponentIO")
-                << "ALL_VARIABLES are specified to be read, but no variable "
+                << "ALL_VARIABLES_FROM_FILE are specified to be read, but no variable "
                    "data is found at "
                 << mComponentPath << " in " << mpFile->GetFileName() << ".\n";
             return;

--- a/applications/HDF5Application/custom_io/hdf5_file.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file.cpp
@@ -342,6 +342,19 @@ std::vector<std::string> File::GetGroupNames(const std::string& rGroupPath) cons
     KRATOS_CATCH("");
 }
 
+std::vector<std::string> File::GetDataSetNames(const std::string& rGroupPath) const
+{
+    KRATOS_TRY;
+    std::vector<std::string> names;
+    std::vector<std::string> link_names = GetLinkNames(rGroupPath);
+    names.reserve(link_names.size());
+    for (const auto& r_name : link_names)
+        if (IsDataSet(rGroupPath + '/' + r_name))
+            names.push_back(r_name);
+    return names;
+    KRATOS_CATCH("");
+}
+
 void File::AddPath(const std::string& rPath)
 {
     KRATOS_ERROR_IF_NOT(Internals::IsPath(rPath)) << "Invalid path: " << rPath << std::endl;
@@ -654,7 +667,7 @@ void File::ReadAttribute(const std::string& rObjectPath, const std::string& rNam
     attr_type_id = H5Aget_type(attr_id);
     KRATOS_ERROR_IF(attr_type_id < 0) << "H5Aget_type failed." << std::endl;
     htri_t is_valid_type = H5Tequal(mem_type_id, attr_type_id);
-    KRATOS_ERROR_IF(H5Tclose(attr_type_id) < 0) << "H5Tclose failed." << std::endl; 
+    KRATOS_ERROR_IF(H5Tclose(attr_type_id) < 0) << "H5Tclose failed." << std::endl;
     KRATOS_ERROR_IF(is_valid_type < 0) << "H5Tequal failed." << std::endl;
     KRATOS_ERROR_IF(is_valid_type == 0) << "Memory and file data types are different." << std::endl;
 
@@ -665,9 +678,9 @@ void File::ReadAttribute(const std::string& rObjectPath, const std::string& rNam
         << "H5Sget_simple_extent_ndims failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(space_id) < 0) << "H5Sclose failed." << std::endl;
     KRATOS_ERROR_IF(ndims != 0) << "Attribute \"" << rName << "\" is not scalar." << std::endl;
-    
+
     // Read attribute.
-    KRATOS_ERROR_IF(H5Aread(attr_id, mem_type_id, &rValue) < 0) << "H5Aread failed." << std::endl; 
+    KRATOS_ERROR_IF(H5Aread(attr_id, mem_type_id, &rValue) < 0) << "H5Aread failed." << std::endl;
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
     KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
         << "Read time \"" << rObjectPath << '/' << rName
@@ -693,7 +706,7 @@ void File::ReadAttribute(const std::string& rObjectPath, const std::string& rNam
     attr_type_id = H5Aget_type(attr_id);
     KRATOS_ERROR_IF(attr_type_id < 0) << "H5Aget_type failed." << std::endl;
     htri_t is_valid_type = H5Tequal(mem_type_id, attr_type_id);
-    KRATOS_ERROR_IF(H5Tclose(attr_type_id) < 0) << "H5Tclose failed." << std::endl; 
+    KRATOS_ERROR_IF(H5Tclose(attr_type_id) < 0) << "H5Tclose failed." << std::endl;
     KRATOS_ERROR_IF(is_valid_type < 0) << "H5Tequal failed." << std::endl;
     KRATOS_ERROR_IF(is_valid_type == 0) << "Memory and file data types are different." << std::endl;
 
@@ -708,7 +721,7 @@ void File::ReadAttribute(const std::string& rObjectPath, const std::string& rNam
     KRATOS_ERROR_IF(H5Sclose(space_id) < 0) << "H5Sclose failed." << std::endl;
     rValue.resize(dims[0], false);
     // Read attribute.
-    KRATOS_ERROR_IF(H5Aread(attr_id, mem_type_id, &rValue[0]) < 0) << "H5Aread failed." << std::endl; 
+    KRATOS_ERROR_IF(H5Aread(attr_id, mem_type_id, &rValue[0]) < 0) << "H5Aread failed." << std::endl;
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
     KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
         << "Read time \"" << rObjectPath << '/' << rName
@@ -734,7 +747,7 @@ void File::ReadAttribute(const std::string& rObjectPath, const std::string& rNam
     attr_type_id = H5Aget_type(attr_id);
     KRATOS_ERROR_IF(attr_type_id < 0) << "H5Aget_type failed." << std::endl;
     htri_t is_valid_type = H5Tequal(mem_type_id, attr_type_id);
-    KRATOS_ERROR_IF(H5Tclose(attr_type_id) < 0) << "H5Tclose failed." << std::endl; 
+    KRATOS_ERROR_IF(H5Tclose(attr_type_id) < 0) << "H5Tclose failed." << std::endl;
     KRATOS_ERROR_IF(is_valid_type < 0) << "H5Tequal failed." << std::endl;
     KRATOS_ERROR_IF(is_valid_type == 0) << "Memory and file data types are different." << std::endl;
 
@@ -749,7 +762,7 @@ void File::ReadAttribute(const std::string& rObjectPath, const std::string& rNam
     KRATOS_ERROR_IF(H5Sclose(space_id) < 0) << "H5Sclose failed." << std::endl;
     rValue.resize(dims[0], dims[1], false);
     // Read attribute.
-    KRATOS_ERROR_IF(H5Aread(attr_id, mem_type_id, &rValue(0,0)) < 0) << "H5Aread failed." << std::endl; 
+    KRATOS_ERROR_IF(H5Aread(attr_id, mem_type_id, &rValue(0,0)) < 0) << "H5Aread failed." << std::endl;
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
     KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
         << "Read time \"" << rObjectPath << '/' << rName

--- a/applications/HDF5Application/custom_io/hdf5_file.h
+++ b/applications/HDF5Application/custom_io/hdf5_file.h
@@ -107,6 +107,8 @@ public:
 
     std::vector<std::string> GetGroupNames(const std::string& rGroupPath) const;
 
+    std::vector<std::string> GetDataSetNames(const std::string& rGroupPath) const;
+
     void AddPath(const std::string& rPath);
 
     template<class TScalar>
@@ -126,7 +128,7 @@ public:
     /**
      *  Performs collective write in MPI. The data is written blockwise according to
      *  processor rank.
-     * 
+     *
      * @param[out] rInfo Information about the written data set.
      */
     virtual void WriteDataSet(const std::string& rPath, const Vector<int>& rData, WriteInfo& rInfo);
@@ -136,14 +138,14 @@ public:
     virtual void WriteDataSet(const std::string& rPath, const Vector<array_1d<double, 3>>& rData, WriteInfo& rInfo);
 
     virtual void WriteDataSet(const std::string& rPath, const Matrix<int>& rData, WriteInfo& rInfo);
-    
+
     virtual void WriteDataSet(const std::string& rPath, const Matrix<double>& rData, WriteInfo& rInfo);
 
     /// Independently write data set to the HDF5 file.
     /**
-     * Performs independent write in MPI. Must be called collectively. Throws 
+     * Performs independent write in MPI. Must be called collectively. Throws
      * if more than one process has non-empty data.
-     * 
+     *
      * @param[out] rInfo Information about the written data set.
      */
     virtual void WriteDataSetIndependent(const std::string& rPath, const Vector<int>& rData, WriteInfo& rInfo);
@@ -215,7 +217,7 @@ public:
                              Matrix<int>& rData,
                              unsigned StartIndex,
                              unsigned BlockSize);
-   
+
     virtual void ReadDataSet(const std::string& rPath,
                              Matrix<double>& rData,
                              unsigned StartIndex,
@@ -244,7 +246,7 @@ public:
                                        Matrix<int>& rData,
                                        unsigned StartIndex,
                                        unsigned BlockSize);
- 
+
     virtual void ReadDataSetIndependent(const std::string& rPath,
                                        Matrix<double>& rData,
                                        unsigned StartIndex,

--- a/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_bossak_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_bossak_io.cpp
@@ -22,7 +22,7 @@ template <typename TVariable>
 class WriteNodalBossakVariableFunctor;
 }
 
-void NodalSolutionStepBossakIO::WriteNodalResults(NodesContainerType const& rNodes)
+void NodalSolutionStepBossakIO::WriteNodalResults(ModelPart& rModelPart)
 {
     KRATOS_TRY;
 
@@ -30,7 +30,7 @@ void NodalSolutionStepBossakIO::WriteNodalResults(NodesContainerType const& rNod
         return;
 
     std::vector<NodeType*> local_nodes;
-    GetLocalNodes(rNodes, local_nodes);
+    GetLocalNodes(rModelPart.Nodes(), local_nodes);
 
     // Write each variable.
     const std::string& prefix = GetPrefix();
@@ -96,10 +96,10 @@ void SetDataBuffer(TVariableType const& rVariable,
 }
 }
 
-void NodalSolutionStepBossakIO::ReadNodalResults(NodesContainerType& rNodes, Communicator& rComm)
+void NodalSolutionStepBossakIO::ReadNodalResults(ModelPart& rModelPart)
 {
     KRATOS_TRY;
-    NodalSolutionStepDataIO::ReadNodalResults(rNodes, rComm);
+    NodalSolutionStepDataIO::ReadNodalResults(rModelPart);
     KRATOS_CATCH("");
 }
 

--- a/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_bossak_io.h
+++ b/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_bossak_io.h
@@ -44,7 +44,7 @@ namespace HDF5
  * This class performs regular IO of nodal solution step data except for the
  * ACCELERATION, which is stored as a weighted combination of the current and
  * previous time step according to the Bossak scheme.
- * 
+ *
  */
 class NodalSolutionStepBossakIO : private NodalSolutionStepDataIO
 {
@@ -66,9 +66,9 @@ public:
     ///@name Operations
     ///@{
 
-    void WriteNodalResults(NodesContainerType const& rNodes);
+    void WriteNodalResults(ModelPart& rModelPart);
 
-    void ReadNodalResults(NodesContainerType& rNodes, Communicator& rComm);
+    void ReadNodalResults(ModelPart& rModelPart);
 
     void SetAlphaBossak(double alpha) noexcept;
 

--- a/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_data_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_data_io.cpp
@@ -60,6 +60,18 @@ public:
         SetNodalSolutionStepData(rVariable, data, rNodes, Step);
     }
 };
+
+template<typename TVariable>
+class CheckVariableFunctor
+{
+public:
+    void operator()(TVariable const& rVariable,
+                    const ModelPart& rModelPart,
+                    bool& IsVariableFound)
+    {
+        IsVariableFound = rModelPart.HasNodalSolutionStepVariable(rVariable);
+    }
+};
 } // unnamed namespace
 
 NodalSolutionStepDataIO::NodalSolutionStepDataIO(Parameters Settings, File::Pointer pFile)
@@ -84,16 +96,35 @@ NodalSolutionStepDataIO::NodalSolutionStepDataIO(Parameters Settings, File::Poin
     KRATOS_CATCH("");
 }
 
-void NodalSolutionStepDataIO::WriteNodalResults(NodesContainerType const& rNodes, unsigned Step)
+void NodalSolutionStepDataIO::WriteNodalResults(ModelPart& rModelPart, unsigned Step)
 {
     KRATOS_TRY;
 
     if (mVariableNames.size() == 0)
         return;
 
+    if (mVariableNames.size() == 1 && mVariableNames[0] == "ALL_VARIABLES") {
+        // Here we can change the original list because, solution step variables
+        // list is same for all the time steps. So we have to check this only
+        // once, and it will be the same for all steps.
+        mVariableNames.clear();
+
+        const auto& variable_data_list = rModelPart.GetNodalSolutionStepVariablesList();
+        for (const auto& variable_data : variable_data_list) {
+            if (variable_data.IsComponent()) {
+                const auto& source_variable = variable_data.GetSourceVariable();
+                if (std::find(mVariableNames.begin(), mVariableNames.end(), source_variable.Name()) == mVariableNames.end()) {
+                    mVariableNames.push_back(source_variable.Name());
+                }
+            } else {
+                mVariableNames.push_back(variable_data.Name());
+            }
+        }
+    }
+
     WriteInfo info;
     std::vector<NodeType*> local_nodes;
-    GetLocalNodes(rNodes, local_nodes);
+    GetLocalNodes(rModelPart.Nodes(), local_nodes);
 
     // Write each variable.
     for (const std::string& r_variable_name : mVariableNames)
@@ -107,17 +138,53 @@ void NodalSolutionStepDataIO::WriteNodalResults(NodesContainerType const& rNodes
     KRATOS_CATCH("");
 }
 
-void NodalSolutionStepDataIO::ReadNodalResults(NodesContainerType& rNodes, Communicator& rComm, unsigned Step)
+void NodalSolutionStepDataIO::ReadNodalResults(ModelPart& rModelPart, unsigned Step)
 {
     KRATOS_TRY;
 
     if (mVariableNames.size() == 0)
         return;
 
+    const std::string& current_path = mPrefix + "/NodalSolutionStepData";
+
+    if (mVariableNames.size() == 1 && mVariableNames[0] == "ALL_VARIABLES") {
+        if (mpFile->HasPath(current_path)) {
+            // Here we can change the original list because, solution step variables
+            // list is same for all the time steps. So we have to check this only
+            // once, and it will be the same for all steps.
+            mVariableNames.clear();
+            const auto& r_variables_list = mpFile->GetDataSetNames(current_path);
+            for (const auto& r_variable_name : r_variables_list) {
+                bool is_variable_found = false;
+                RegisteredComponentLookup<
+                    Variable<array_1d<double, 3>>,
+                    Variable<double>,
+                    Variable<int>
+                    >(r_variable_name)
+                    .Execute<CheckVariableFunctor>(rModelPart, is_variable_found);
+
+                if (is_variable_found) {
+                    mVariableNames.push_back(r_variable_name);
+                } else {
+                    KRATOS_WARNING("NodalSolutionStepDataIO")
+                        << "Skipping reading of " << r_variable_name
+                        << " from " << mpFile->GetFileName() << ". It is not found in solution step variables list of "
+                        << rModelPart.Name() << ".\n";
+                }
+            }
+        } else {
+            KRATOS_WARNING("NodalSolutionStepDataIO")
+                << "ALL_VARIABLES are specified to be read, but no variable "
+                   "data is found at "
+                << current_path << " in " << mpFile->GetFileName() <<".\n";
+            return;
+        }
+    }
+
     std::vector<NodeType*> local_nodes;
-    GetLocalNodes(rNodes, local_nodes);
+    GetLocalNodes(rModelPart.Nodes(), local_nodes);
     unsigned start_index, block_size;
-    std::tie(start_index, block_size) = StartIndexAndBlockSize(*mpFile, mPrefix + "/NodalSolutionStepData");
+    std::tie(start_index, block_size) = StartIndexAndBlockSize(*mpFile, current_path);
 
     // Read local data for each variable.
     for (const std::string& r_variable_name : mVariableNames)
@@ -127,7 +194,7 @@ void NodalSolutionStepDataIO::ReadNodalResults(NodesContainerType& rNodes, Commu
                                           start_index, block_size);
 
     // Synchronize ghost nodes.
-    rComm.SynchronizeNodalSolutionStepsData();
+    rModelPart.GetCommunicator().SynchronizeNodalSolutionStepsData();
 
     KRATOS_CATCH("");
 }

--- a/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_data_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_data_io.cpp
@@ -103,7 +103,7 @@ void NodalSolutionStepDataIO::WriteNodalResults(ModelPart& rModelPart, unsigned 
     if (mVariableNames.size() == 0)
         return;
 
-    if (mVariableNames.size() == 1 && mVariableNames[0] == "ALL_VARIABLES") {
+    if (mVariableNames.size() == 1 && mVariableNames[0] == "ALL_VARIABLES_FROM_VARIABLES_LIST") {
         // Here we can change the original list because, solution step variables
         // list is same for all the time steps. So we have to check this only
         // once, and it will be the same for all steps.
@@ -147,7 +147,7 @@ void NodalSolutionStepDataIO::ReadNodalResults(ModelPart& rModelPart, unsigned S
 
     const std::string& current_path = mPrefix + "/NodalSolutionStepData";
 
-    if (mVariableNames.size() == 1 && mVariableNames[0] == "ALL_VARIABLES") {
+    if (mVariableNames.size() == 1 && mVariableNames[0] == "ALL_VARIABLES_FROM_FILE") {
         if (mpFile->HasPath(current_path)) {
             // Here we can change the original list because, solution step variables
             // list is same for all the time steps. So we have to check this only
@@ -174,7 +174,7 @@ void NodalSolutionStepDataIO::ReadNodalResults(ModelPart& rModelPart, unsigned S
             }
         } else {
             KRATOS_WARNING("NodalSolutionStepDataIO")
-                << "ALL_VARIABLES are specified to be read, but no variable "
+                << "ALL_VARIABLES_FROM_FILE are specified to be read, but no variable "
                    "data is found at "
                 << current_path << " in " << mpFile->GetFileName() <<".\n";
             return;

--- a/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_data_io.h
+++ b/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_data_io.h
@@ -61,10 +61,10 @@ public:
     ///@name Operations
     ///@{
 
-    void WriteNodalResults(NodesContainerType const& rNodes, unsigned Step=0);
+    void WriteNodalResults(ModelPart& rModelPart, unsigned Step=0);
 
-    void ReadNodalResults(NodesContainerType& rNodes, Communicator& rComm, unsigned Step=0);
-    
+    void ReadNodalResults(ModelPart& rModelPart, unsigned Step=0);
+
     ///@}
 
 protected:

--- a/applications/HDF5Application/python_scripts/core/operations/model_part.py
+++ b/applications/HDF5Application/python_scripts/core/operations/model_part.py
@@ -181,7 +181,7 @@ class NodalSolutionStepDataOutput(VariableIO):
 
     def __call__(self, model_part, hdf5_file):
         KratosHDF5.HDF5NodalSolutionStepDataIO(
-            self.GetSettings(model_part).Get(), hdf5_file).WriteNodalResults(model_part.Nodes, 0)
+            self.GetSettings(model_part).Get(), hdf5_file).WriteNodalResults(model_part, 0)
 
 
 class NodalSolutionStepDataInput(VariableIO):
@@ -194,7 +194,7 @@ class NodalSolutionStepDataInput(VariableIO):
         nodal_io = KratosHDF5.HDF5NodalSolutionStepDataIO(
             self.GetSettings(model_part).Get(), hdf5_file)
         nodal_io.ReadNodalResults(
-            model_part.Nodes, model_part.GetCommunicator(), 0)
+            model_part, 0)
 
 
 class NodalDataValueOutput(VariableIO):
@@ -264,7 +264,7 @@ class PrimalBossakOutput(VariableIO):
         primal_io = KratosHDF5.HDF5NodalSolutionStepBossakIO(
             self.GetSettings(model_part).Get(), hdf5_file)
         primal_io.SetAlphaBossak(self.alpha_bossak)
-        primal_io.WriteNodalResults(model_part.Nodes)
+        primal_io.WriteNodalResults(model_part)
 
 
 class PrimalBossakInput(VariableIO):
@@ -280,7 +280,7 @@ class PrimalBossakInput(VariableIO):
         primal_io = KratosHDF5.HDF5NodalSolutionStepBossakIO(
             self.GetSettings(model_part).Get(), hdf5_file)
         primal_io.ReadNodalResults(
-            model_part.Nodes, model_part.GetCommunicator())
+            model_part)
 
 
 class MoveMesh:

--- a/applications/HDF5Application/tests/test_hdf5_model_part_io.py
+++ b/applications/HDF5Application/tests/test_hdf5_model_part_io.py
@@ -362,10 +362,10 @@ class TestCase(KratosUnittest.TestCase):
             hdf5_model_part_io = self._get_model_part_io(hdf5_file)
             hdf5_nodal_solution_step_data_io = self._get_nodal_solution_step_data_io(hdf5_file)
             hdf5_model_part_io.WriteModelPart(write_model_part)
-            hdf5_nodal_solution_step_data_io.WriteNodalResults(write_model_part.Nodes, 0)
+            hdf5_nodal_solution_step_data_io.WriteNodalResults(write_model_part, 0)
             read_model_part = model.CreateModelPart("read", 2)
             hdf5_model_part_io.ReadModelPart(read_model_part)
-            hdf5_nodal_solution_step_data_io.ReadNodalResults(read_model_part.Nodes, read_model_part.GetCommunicator(), 0)
+            hdf5_nodal_solution_step_data_io.ReadNodalResults(read_model_part, 0)
 
             assert_variables_list = [DISPLACEMENT_X, DISPLACEMENT_Y, DISPLACEMENT_Z,
                                      VELOCITY_X, VELOCITY_Y, VELOCITY_Z,

--- a/applications/HDF5Application/tests/test_hdf5_model_part_io_mpi.py
+++ b/applications/HDF5Application/tests/test_hdf5_model_part_io_mpi.py
@@ -252,8 +252,8 @@ class TestCase(KratosUnittest.TestCase):
             hdf5_model_part_io.ReadModelPart(read_model_part)
             KratosMPI.ParallelFillCommunicator(read_model_part.GetRootModelPart()).Execute()
             hdf5_nodal_solution_step_data_io = self._get_nodal_solution_step_data_io(hdf5_file)
-            hdf5_nodal_solution_step_data_io.WriteNodalResults(write_model_part.Nodes, 0)
-            hdf5_nodal_solution_step_data_io.ReadNodalResults(read_model_part.Nodes, read_model_part.GetCommunicator(), 0)
+            hdf5_nodal_solution_step_data_io.WriteNodalResults(write_model_part, 0)
+            hdf5_nodal_solution_step_data_io.ReadNodalResults(read_model_part, 0)
 
             # Check data.
             for read_node, write_node in zip(read_model_part.Nodes, write_model_part.Nodes):

--- a/applications/HDF5Application/tests/test_hdf5_nodal_solution_step_data_io.cpp
+++ b/applications/HDF5Application/tests/test_hdf5_nodal_solution_step_data_io.cpp
@@ -70,8 +70,8 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5PointsData_ReadNodalResults2, KratosHDF5TestSuite)
             "list_of_variables": ["DISPLACEMENT", "PRESSURE", "REFINEMENT_LEVEL"]
         })");
     HDF5::NodalSolutionStepDataIO data_io(io_params, p_test_file);
-    data_io.WriteNodalResults(r_write_model_part.Nodes());
-    data_io.ReadNodalResults(r_read_model_part.Nodes(), r_read_model_part.GetCommunicator());
+    data_io.WriteNodalResults(r_write_model_part);
+    data_io.ReadNodalResults(r_read_model_part);
     for (unsigned i = 0; i < 15; ++i)
     {
         HDF5::NodeType& r_read_node = r_read_model_part.Nodes()[i + 1];
@@ -129,8 +129,8 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5PointsData_ReadNodalResults, KratosHDF5TestSuite)
             "list_of_variables": ["DISPLACEMENT", "PRESSURE", "REFINEMENT_LEVEL"]
         })");
     HDF5::NodalSolutionStepDataIO data_io(io_params, p_test_file);
-    data_io.WriteNodalResults(r_write_model_part.Nodes());
-    data_io.ReadNodalResults(r_read_model_part.Nodes(), r_read_model_part.GetCommunicator());
+    data_io.WriteNodalResults(r_write_model_part);
+    data_io.ReadNodalResults(r_read_model_part);
     for (unsigned i = 0; i < 15; ++i)
     {
         HDF5::NodeType& r_read_node = r_read_model_part.Nodes()[i + 1];

--- a/applications/HDF5Application/tests/test_hdf5_processes.py
+++ b/applications/HDF5Application/tests/test_hdf5_processes.py
@@ -126,7 +126,7 @@ class TestHDF5Processes(KratosUnittest.TestCase):
         self.assertEqual(
             self.HDF5NodalSolutionStepDataIO.return_value.WriteNodalResults.call_count, 2)
         self.HDF5NodalSolutionStepDataIO.return_value.WriteNodalResults.assert_called_with(
-            self.model_part.Nodes, 0)
+            self.model_part, 0)
         self.assertEqual(self.HDF5NodalDataValueIO.call_count, 2)
         self.assertEqual(
             self.HDF5NodalDataValueIO.call_args[0][0]['prefix'].GetString(), '/ResultsData')
@@ -261,7 +261,7 @@ class TestHDF5Processes(KratosUnittest.TestCase):
         self.assertEqual(
             self.HDF5NodalSolutionStepBossakIO.return_value.WriteNodalResults.call_count, 3)
         self.HDF5NodalSolutionStepBossakIO.return_value.WriteNodalResults.assert_called_with(
-            self.model_part.Nodes)
+            self.model_part)
 
     def test_InitializationFromHDF5Process(self):
         settings = KratosMultiphysics.Parameters('''
@@ -286,7 +286,7 @@ class TestHDF5Processes(KratosUnittest.TestCase):
         self.assertEqual(
             self.HDF5NodalSolutionStepDataIO.return_value.ReadNodalResults.call_count, 1)
         self.HDF5NodalSolutionStepDataIO.return_value.ReadNodalResults.assert_called_with(
-            self.model_part.Nodes, self.model_part.GetCommunicator(), 0)
+            self.model_part, 0)
         self.assertEqual(
             self.HDF5NodalDataValueIO.return_value.ReadNodalResults.call_count, 1)
         self.HDF5NodalDataValueIO.return_value.ReadNodalResults.assert_called_with(
@@ -334,7 +334,7 @@ class TestHDF5Processes(KratosUnittest.TestCase):
         self.assertEqual(
             self.HDF5NodalSolutionStepDataIO.return_value.ReadNodalResults.call_count, 2)
         self.HDF5NodalSolutionStepDataIO.return_value.ReadNodalResults.assert_called_with(
-            self.model_part.Nodes, self.model_part.GetCommunicator(), 0)
+            self.model_part, 0)
         self.assertEqual(
             self.HDF5NodalDataValueIO.return_value.ReadNodalResults.call_count, 2)
         self.HDF5NodalDataValueIO.return_value.ReadNodalResults.assert_called_with(


### PR DESCRIPTION
**Description**
This PR adds the ability to input and output all variables from following containers

`Nodal` historical container:
- `ALL_VARIABLES` input allowed
- `ALL_VARIABLES` output allowed

`Nodal` non-historical container:
- `ALL_VARIABLES` input allowed

`Condition` datal container:
- `ALL_VARIABLES` input allowed

`Element` datal container:
- `ALL_VARIABLES` input allowed

This **does not break** the existing use cases as well as the interface.

**Changelog**
- Adds support to input/output `ALL_VARIABLES` from a data container.