### PR TITLE
[Core] Adding return_type to reducers

### DIFF
--- a/kratos/processes/find_global_nodal_neighbours_for_entities_process.cpp
+++ b/kratos/processes/find_global_nodal_neighbours_for_entities_process.cpp
@@ -254,15 +254,16 @@ std::unordered_map<int, std::vector<int>> FindNodalNeighboursForEntitiesProcess<
     {
     public:
         typedef GlobalPointersVector<NodeType> value_type;
-        value_type gp_vector;
+        typedef GlobalPointersVector<NodeType> return_type;
 
-        value_type GetValue()
+        return_type gp_vector;
+        return_type GetValue()
         {
             gp_vector.Unique();
             return gp_vector;
         }
 
-        void LocalReduce(const value_type& rGPVector)
+        void LocalReduce(const return_type& rGPVector)
         {
             for (auto& r_gp : rGPVector.GetContainer()) {
                 this->gp_vector.push_back(r_gp);

--- a/kratos/processes/find_global_nodal_neighbours_for_entities_process.cpp
+++ b/kratos/processes/find_global_nodal_neighbours_for_entities_process.cpp
@@ -263,7 +263,7 @@ std::unordered_map<int, std::vector<int>> FindNodalNeighboursForEntitiesProcess<
             return gp_vector;
         }
 
-        void LocalReduce(const return_type& rGPVector)
+        void LocalReduce(const value_type& rGPVector)
         {
             for (auto& r_gp : rGPVector.GetContainer()) {
                 this->gp_vector.push_back(r_gp);

--- a/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
@@ -309,11 +309,11 @@ KRATOS_TEST_CASE_IN_SUITE(CustomReduction, KratosCoreFastSuite)
     }
     class CustomReducer{
         public:
-            typedef std::tuple<double,double> value_type;
+            typedef double value_type;
             typedef std::tuple<double,double> return_type;
 
-            double max_value = -std::numeric_limits<double>::max();
-            double max_abs = 0.0;
+            value_type max_value = -std::numeric_limits<double>::max();
+            value_type max_abs = 0.0;
 
             return_type GetValue()
             {
@@ -323,7 +323,7 @@ KRATOS_TEST_CASE_IN_SUITE(CustomReduction, KratosCoreFastSuite)
                 return values;
             }
 
-            void LocalReduce(double function_return_value){
+            void LocalReduce(value_type function_return_value){
                 this->max_value = std::max(this->max_value,function_return_value);
                 this->max_abs   = std::max(this->max_abs,std::abs(function_return_value));
             }

--- a/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
@@ -271,6 +271,24 @@ KRATOS_TEST_CASE_IN_SUITE(IndexPartitionerThreadLocalStorage, KratosCoreFastSuit
     KRATOS_CHECK_NEAR(final_sum, exp_sum, tol);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(AccumReductionVector, KratosCoreFastSuite)
+{
+    int nsize = 1e3;
+    std::vector<int> input_data_vector(nsize);
+    std::vector<int> expct_data_vector(nsize);
+
+    std::iota(input_data_vector.begin(), input_data_vector.end(), 0);
+    std::iota(expct_data_vector.begin(), expct_data_vector.end(), 1);
+
+    auto assembled_vector = block_for_each<AccumReduction<int>>(input_data_vector, [](int& rValue) {
+        return rValue+1;
+    });
+
+    std::sort(assembled_vector.begin(), assembled_vector.end());
+
+    KRATOS_CHECK_VECTOR_EQUAL(assembled_vector, expct_data_vector);
+}
+
 KRATOS_TEST_CASE_IN_SUITE(CustomReduction, KratosCoreFastSuite)
 {
     int nsize = 1e3;
@@ -292,12 +310,14 @@ KRATOS_TEST_CASE_IN_SUITE(CustomReduction, KratosCoreFastSuite)
     class CustomReducer{
         public:
             typedef std::tuple<double,double> value_type;
+            typedef std::tuple<double,double> return_type;
+
             double max_value = -std::numeric_limits<double>::max();
             double max_abs = 0.0;
 
-            value_type GetValue()
+            return_type GetValue()
             {
-                value_type values;
+                return_type values;
                 std::get<0>(values) = max_value;
                 std::get<1>(values) = max_abs;
                 return values;

--- a/kratos/utilities/parallel_utilities.h
+++ b/kratos/utilities/parallel_utilities.h
@@ -172,7 +172,7 @@ public:
      * @param f - must be a unary function accepting as input TContainerType::value_type&
      */
     template <class TReducer, class TUnaryFunction>
-    inline typename TReducer::value_type for_each(TUnaryFunction &&f)
+    inline typename TReducer::return_type for_each(TUnaryFunction &&f)
     {
         TReducer global_reducer;
         #pragma omp parallel for
@@ -216,7 +216,7 @@ public:
      * @param f - must be a function accepting as input TContainerType::value_type& and the thread local storage
      */
     template <class TReducer, class TThreadLocalStorage, class TFunction>
-    inline typename TReducer::value_type for_each(const TThreadLocalStorage& rThreadLocalStoragePrototype, TFunction &&f)
+    inline typename TReducer::return_type for_each(const TThreadLocalStorage& rThreadLocalStoragePrototype, TFunction &&f)
     {
         static_assert(std::is_copy_constructible<TThreadLocalStorage>::value, "TThreadLocalStorage must be copy constructible!");
 
@@ -259,7 +259,7 @@ void block_for_each(TContainerType &&v, TFunctionType &&func)
  * @param func - must be a unary function accepting as input TContainerType::value_type&
  */
 template <class TReducer, class TContainerType, class TFunctionType>
-typename TReducer::value_type block_for_each(TContainerType &&v, TFunctionType &&func)
+typename TReducer::return_type block_for_each(TContainerType &&v, TFunctionType &&func)
 {
     return  BlockPartition<TContainerType>(v.begin(), v.end()).template for_each<TReducer>(std::forward<TFunctionType>(func));
 }
@@ -281,7 +281,7 @@ void block_for_each(TContainerType &&v, const TThreadLocalStorage& tls, TFunctio
  * @param func - must be a function accepting as input TContainerType::value_type& and the thread local storage
  */
 template <class TReducer, class TContainerType, class TThreadLocalStorage, class TFunctionType>
-typename TReducer::value_type block_for_each(TContainerType &&v, const TThreadLocalStorage& tls, TFunctionType &&func)
+typename TReducer::return_type block_for_each(TContainerType &&v, const TThreadLocalStorage& tls, TFunctionType &&func)
 {
     return BlockPartition<TContainerType>(v.begin(), v.end()).template for_each<TReducer>(tls, std::forward<TFunctionType>(func));
 }
@@ -377,7 +377,7 @@ public:
      * @param f - must be a unary function accepting as input IndexType
      */
     template <class TReducer, class TUnaryFunction>
-    inline typename TReducer::value_type for_each(TUnaryFunction &&f)
+    inline typename TReducer::return_type for_each(TUnaryFunction &&f)
     {
         TReducer global_reducer;
         #pragma omp parallel for
@@ -422,7 +422,7 @@ public:
      * @param f - must be a function accepting as input IndexType and the thread local storage
      */
     template <class TReducer, class TThreadLocalStorage, class TFunction>
-    inline typename TReducer::value_type for_each(const TThreadLocalStorage& rThreadLocalStoragePrototype, TFunction &&f)
+    inline typename TReducer::return_type for_each(const TThreadLocalStorage& rThreadLocalStoragePrototype, TFunction &&f)
     {
         static_assert(std::is_copy_constructible<TThreadLocalStorage>::value, "TThreadLocalStorage must be copy constructible!");
 

--- a/kratos/utilities/reduction_utilities.h
+++ b/kratos/utilities/reduction_utilities.h
@@ -32,15 +32,17 @@ namespace Kratos
 
 /** @brief utility function to do a sum reduction
  */
-template<class TDataType>
+template<class TDataType, class TReturnType = TDataType>
 class SumReduction
 {
 public:
-    typedef TDataType value_type;
-    TDataType mValue = TDataType(); // deliberately making the member value public, to allow one to change it as needed
+    typedef TDataType   value_type;
+    typedef TReturnType return_type;
+
+    TReturnType mValue = TReturnType(); // deliberately making the member value public, to allow one to change it as needed
 
     /// access to reduced value
-    TDataType GetValue() const
+    TReturnType GetValue() const
     {
         return mValue;
     }
@@ -51,7 +53,7 @@ public:
     }
 
     /// THREADSAFE (needs some sort of lock guard) reduction, to be used to sync threads
-    void ThreadSafeReduce(const SumReduction<TDataType>& rOther)
+    void ThreadSafeReduce(const SumReduction<TDataType, TReturnType>& rOther)
     {
         AtomicAdd(mValue, rOther.mValue);
     }
@@ -60,15 +62,17 @@ public:
 //***********************************************************************************
 //***********************************************************************************
 //***********************************************************************************
-template<class TDataType>
+template<class TDataType, class TReturnType = TDataType>
 class SubReduction
 {
 public:
-    typedef TDataType value_type;
-    TDataType mValue = TDataType(); // deliberately making the member value public, to allow one to change it as needed
+    typedef TDataType   value_type;
+    typedef TReturnType return_type;
+
+    TReturnType mValue = TReturnType(); // deliberately making the member value public, to allow one to change it as needed
 
     /// access to reduced value
-    TDataType GetValue() const
+    TReturnType GetValue() const
     {
         return mValue;
     }
@@ -79,7 +83,7 @@ public:
     }
 
     /// THREADSAFE (needs some sort of lock guard) reduction, to be used to sync threads
-    void ThreadSafeReduce(const SubReduction<TDataType>& rOther)
+    void ThreadSafeReduce(const SubReduction<TDataType, TReturnType>& rOther)
     {
         AtomicAdd(mValue, rOther.mValue);
     }
@@ -88,15 +92,17 @@ public:
 //***********************************************************************************
 //***********************************************************************************
 //***********************************************************************************
-template<class TDataType>
+template<class TDataType, class TReturnType = TDataType>
 class MaxReduction
 {
 public:
-    typedef TDataType value_type;
-    TDataType mValue = std::numeric_limits<TDataType>::lowest(); // deliberately making the member value public, to allow one to change it as needed
+    typedef TDataType   value_type;
+    typedef TReturnType return_type;
+
+    TReturnType mValue = std::numeric_limits<TReturnType>::lowest(); // deliberately making the member value public, to allow one to change it as needed
 
     /// access to reduced value
-    TDataType GetValue() const
+    TReturnType GetValue() const
     {
         return mValue;
     }
@@ -107,7 +113,7 @@ public:
     }
 
     /// THREADSAFE (needs some sort of lock guard) reduction, to be used to sync threads
-    void ThreadSafeReduce(const MaxReduction<TDataType>& rOther)
+    void ThreadSafeReduce(const MaxReduction<TDataType, TReturnType>& rOther)
     {
         #pragma omp critical
         mValue = std::max(mValue,rOther.mValue);
@@ -117,15 +123,17 @@ public:
 //***********************************************************************************
 //***********************************************************************************
 //***********************************************************************************
-template<class TDataType>
+template<class TDataType, class TReturnType = TDataType>
 class MinReduction
 {
 public:
-    typedef TDataType value_type;
-    TDataType mValue = std::numeric_limits<TDataType>::max(); // deliberately making the member value public, to allow one to change it as needed
+    typedef TDataType   value_type;
+    typedef TReturnType return_type;
+
+    TReturnType mValue = std::numeric_limits<TReturnType>::max(); // deliberately making the member value public, to allow one to change it as needed
 
     /// access to reduced value
-    TDataType GetValue() const
+    TReturnType GetValue() const
     {
         return mValue;
     }
@@ -136,24 +144,57 @@ public:
     }
 
     /// THREADSAFE (needs some sort of lock guard) reduction, to be used to sync threads
-    void ThreadSafeReduce(const MinReduction<TDataType>& rOther)
+    void ThreadSafeReduce(const MinReduction<TDataType, TReturnType>& rOther)
     {
         #pragma omp critical
         mValue = std::min(mValue,rOther.mValue);
     }
 };
 
+//***********************************************************************************
+//***********************************************************************************
+//***********************************************************************************
+
+template<class TDataType, class TReturnType = std::vector<TDataType>>
+class AccumReduction
+{
+public:
+    typedef TDataType   value_type;
+    typedef TReturnType return_type;
+
+    TReturnType mValue = TReturnType(); // deliberately making the member value public, to allow one to change it as needed
+
+    /// access to reduced value
+    TReturnType GetValue() const
+    {
+        return mValue;
+    }
+
+    /// NON-THREADSAFE (fast) value of reduction, to be used within a single thread
+    void LocalReduce(const TDataType value){
+        mValue.push_back(value);
+    }
+
+    /// THREADSAFE (needs some sort of lock guard) reduction, to be used to sync threads
+    void ThreadSafeReduce(const AccumReduction<TDataType, TReturnType>& rOther)
+    {
+        #pragma omp critical
+        mValue.insert(mValue.end(), rOther.mValue.begin(), rOther.mValue.end());
+    }
+};
+
 template <class... Reducer>
 struct CombinedReduction {
     typedef std::tuple<typename Reducer::value_type...> value_type;
+    typedef std::tuple<typename Reducer::return_type...> return_type;
 
     std::tuple<Reducer...> mChild;
 
     CombinedReduction() {}
 
     /// access to reduced value
-    value_type GetValue(){
-        value_type return_value;
+    return_type GetValue(){
+        return_type return_value;
         fill_value<0>(return_value);
         return return_value;
     }

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -1403,7 +1403,7 @@ private:
             return mValue;
         }
 
-        void LocalReduce(const return_type& value)
+        void LocalReduce(const value_type& value)
         {
             mValue += value;
         }

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -1393,15 +1393,17 @@ private:
     {
     public:
         typedef array_1d<double,3> value_type;
-        array_1d<double,3> mValue = ZeroVector(3);
+        typedef array_1d<double,3> return_type;
+
+        return_type mValue = ZeroVector(3);
 
         /// access to reduced value
-        array_1d<double,3> GetValue() const
+        return_type GetValue() const
         {
             return mValue;
         }
 
-        void LocalReduce(const array_1d<double,3>&value)
+        void LocalReduce(const return_type& value)
         {
             mValue += value;
         }


### PR DESCRIPTION
**Description**
Adds a `return_type` for the reducers.

This should add a little bit more flexibility to parallel utilizes for accumulation operation or for creating sets, unions, etc...
Interfaces remain the same but new CustomReducers need to define a `return_type` (which can be `value_type`, and it would work like before)

A simple example of use case (added in the tests) could be:
```c++
KRATOS_TEST_CASE_IN_SUITE(AccumReductionVector, KratosCoreFastSuite)
{
    int nsize = 1e3;
    std::vector<int> input_data_vector(nsize);
    std::vector<int> expct_data_vector(nsize);

    std::iota(input_data_vector.begin(), input_data_vector.end(), 0);
    std::iota(expct_data_vector.begin(), expct_data_vector.end(), 1);

    auto assembled_vector = block_for_each<AccumReduction<int>>(input_data_vector, [](int& rValue) {
        return rValue+1;
    });

    // Ordering is not preserved
    std::sort(assembled_vector.begin(), assembled_vector.end());

    KRATOS_CHECK_VECTOR_EQUAL(assembled_vector, expct_data_vector);
}
```

Which is a sort of "implementation" of a concurrent_vector.

**Changelog**
- Added return_type as a template parameter for reducers.
