### PR TITLE
[ContactStructuralMechanicsApplication] Clang compilation error fixed

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_processes/advanced_contact_search_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/advanced_contact_search_process.cpp
@@ -41,7 +41,7 @@ void AdvancedContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::CheckPairin
 {
     // Getting the corresponding submodelparts
     ModelPart& r_contact_model_part = BaseType::mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = this->IsNot(BaseType::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + BaseType::mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = this->IsNotMultipleSearchs() ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + BaseType::mThisParameters["id_name"].GetString());
     ModelPart& r_master_model_part = r_sub_contact_model_part.GetSubModelPart("MasterSubModelPart" + BaseType::mThisParameters["id_name"].GetString());
     ModelPart& r_slave_model_part = r_sub_contact_model_part.GetSubModelPart("SlaveSubModelPart" + BaseType::mThisParameters["id_name"].GetString());
 
@@ -87,7 +87,7 @@ void AdvancedContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::ComputeActi
 
     // Iterate over the nodes
     ModelPart& r_contact_model_part = BaseType::mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = this->IsNot(BaseType::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + BaseType::mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = this->IsNotMultipleSearchs() ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + BaseType::mThisParameters["id_name"].GetString());
     NodesArrayType& r_nodes_array = r_sub_contact_model_part.Nodes();
 
     // If we do an static check
@@ -178,7 +178,7 @@ void AdvancedContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::ComputeLine
 
     // Iterate over the nodes
     ModelPart& r_contact_model_part = BaseType::mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = this->IsNot(BaseType::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + BaseType::mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = this->IsNotMultipleSearchs() ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + BaseType::mThisParameters["id_name"].GetString());
     NodesArrayType& r_nodes_array = r_sub_contact_model_part.Nodes();
 
     // We compute now the normal gap and set the nodes under certain threshold as active

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/advanced_contact_search_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/advanced_contact_search_process.cpp
@@ -100,7 +100,7 @@ void AdvancedContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::ComputeActi
     #pragma omp parallel for firstprivate(auxiliar_length, auxiliar_check, has_weighted_gap)
     for(int i = 0; i < static_cast<int>(r_nodes_array.size()); ++i) {
         auto it_node = r_nodes_array.begin() + i;
-        if (it_node->Is(SLAVE) == this->IsNot(BaseType::INVERTED_SEARCH)) {
+        if (it_node->Is(SLAVE) == this->IsNotInvertedSearch()) {
             auxiliar_check = false;
             auxiliar_length = reference_auxiliar_length;
             has_weighted_gap = it_node->SolutionStepsDataHas(WEIGHTED_GAP);
@@ -440,7 +440,7 @@ void AdvancedContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::CorrectALMF
     )
 {
     if (norm_2(ItNode->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER)) < ZeroTolerance) {
-        if (ItNode->GetValue(FRICTION_COEFFICIENT) < ZeroTolerance || this->Is(BaseType::PURE_SLIP)) {
+        if (ItNode->GetValue(FRICTION_COEFFICIENT) < ZeroTolerance || this->IsPureSlip()) {
             ItNode->Set(SLIP, true);
         } else {
             ItNode->Set(SLIP, false);
@@ -557,7 +557,7 @@ void AdvancedContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::PredictALMF
     )
 {
     if (norm_2(ItNode->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER)) < ZeroTolerance) {
-        if (ItNode->GetValue(FRICTION_COEFFICIENT) < ZeroTolerance || this->Is(BaseType::PURE_SLIP)) {
+        if (ItNode->GetValue(FRICTION_COEFFICIENT) < ZeroTolerance || this->IsPureSlip()) {
             ItNode->Set(SLIP, true);
         } else {
             ItNode->Set(SLIP, false);

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.cpp
@@ -1815,6 +1815,84 @@ typename BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::CheckGap Ba
 /***********************************************************************************/
 
 template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+bool BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::IsPureSlip()
+{
+    KRATOS_TRY
+
+    return this->Is(PURE_SLIP);
+
+    KRATOS_CATCH("")
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+bool BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::IsNotPureSlip()
+{
+    KRATOS_TRY
+
+    return this->IsNot(PURE_SLIP);
+
+    KRATOS_CATCH("")
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+bool BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::IsMultipleSearchs()
+{
+    KRATOS_TRY
+
+    return this->Is(MULTIPLE_SEARCHS);
+
+    KRATOS_CATCH("")
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+bool BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::IsNotMultipleSearchs()
+{
+    KRATOS_TRY
+
+    return this->IsNot(MULTIPLE_SEARCHS);
+
+    KRATOS_CATCH("")
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+bool BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::IsInvertedSearch()
+{
+    KRATOS_TRY
+
+    return this->Is(INVERTED_SEARCH);
+
+    KRATOS_CATCH("")
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+bool BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::IsNotInvertedSearch()
+{
+    KRATOS_TRY
+
+    return this->IsNot(INVERTED_SEARCH);
+
+    KRATOS_CATCH("")
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
 const Parameters BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::GetDefaultParameters() const
 {
     KRATOS_TRY

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.h
@@ -365,6 +365,24 @@ protected:
      */
     CheckGap ConvertCheckGap(const std::string& str);
 
+    /**
+     * @brief This returns if we consider multiple searchs
+     * @return True if we consider multiple searchs
+     */
+    bool IsMultipleSearchs()
+    {
+        return this->Is(MULTIPLE_SEARCHS);
+    }
+
+    /**
+     * @brief This returns if we do not consider multiple searchs
+     * @return True if we do not consider multiple searchs
+     */
+    bool IsNotMultipleSearchs()
+    {
+        return this->IsNot(MULTIPLE_SEARCHS);
+    }
+
     ///@}
     ///@name Protected  Access
     ///@{

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.h
@@ -365,27 +365,45 @@ protected:
      */
     CheckGap ConvertCheckGap(const std::string& str);
 
+    ///@}
+    ///@name Protected  Access
+    ///@{
+
+    /**
+     * @brief This returns if we consider pure slip
+     * @return True if we consider pure slip
+     */
+    bool IsPureSlip();
+
+    /**
+     * @brief This returns if we do not consider pure slip
+     * @return True if we do not consider pure slip
+     */
+    bool IsNotPureSlip();
+
     /**
      * @brief This returns if we consider multiple searchs
      * @return True if we consider multiple searchs
      */
-    bool IsMultipleSearchs()
-    {
-        return this->Is(MULTIPLE_SEARCHS);
-    }
+    bool IsMultipleSearchs();
 
     /**
      * @brief This returns if we do not consider multiple searchs
      * @return True if we do not consider multiple searchs
      */
-    bool IsNotMultipleSearchs()
-    {
-        return this->IsNot(MULTIPLE_SEARCHS);
-    }
+    bool IsNotMultipleSearchs();
 
-    ///@}
-    ///@name Protected  Access
-    ///@{
+    /**
+     * @brief This returns if we consider inverted search
+     * @return True if we consider inverted search
+     */
+    bool IsInvertedSearch();
+
+    /**
+     * @brief This returns if we do not consider inverted search
+     * @return True if we do not consider inverted search
+     */
+    bool IsNotInvertedSearch();
 
     ///@}
     ///@name Protected Inquiry

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/mpc_contact_search_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/mpc_contact_search_process.cpp
@@ -6,7 +6,7 @@
 //  License:		 BSD License
 //					 license: StructuralMechanicsApplication/license.txt
 //
-//  Main authors:    Vicente Mataix
+//  Main authors:    Vicente Mataix Ferrandiz
 //
 
 // System includes

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/mpc_contact_search_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/mpc_contact_search_process.cpp
@@ -35,7 +35,7 @@ MPCContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::MPCContactSearchProce
 
     // We get the contact model part
     ModelPart& r_contact_model_part = BaseType::mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = this->IsNot(BaseType::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + id_name);
+    ModelPart& r_sub_contact_model_part = this->IsNotMultipleSearchs() ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + id_name);
 
     // Iterate in the constraints
     auto& r_constraints_array = r_sub_contact_model_part.MasterSlaveConstraints();
@@ -58,7 +58,7 @@ void MPCContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::CheckContactMode
 
     // Iterate in the constraints
     ModelPart& r_contact_model_part = BaseType::mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = this->IsNot(BaseType::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+BaseType::mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = this->IsNotMultipleSearchs() ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+BaseType::mThisParameters["id_name"].GetString());
     auto& r_constraints_array = r_sub_contact_model_part.MasterSlaveConstraints();
 
     const SizeType total_number_constraints = BaseType::mrMainModelPart.GetRootModelPart().NumberOfMasterSlaveConstraints();
@@ -194,7 +194,7 @@ void MPCContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::ResetContactOper
 
     // We iterate over the master nodes
     ModelPart& r_contact_model_part = BaseType::mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = this->IsNot(BaseType::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+BaseType::mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = this->IsNotMultipleSearchs() ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+BaseType::mThisParameters["id_name"].GetString());
     NodesArrayType& r_nodes_array = r_sub_contact_model_part.Nodes();
 
     if (BaseType::mrMainModelPart.Is(MODIFIED)) { // It has been remeshed. We remove everything
@@ -214,7 +214,7 @@ void MPCContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::ResetContactOper
         // We remove all the computing constraints
         const std::string sub_computing_model_part_name = "ComputingContactSub" + BaseType::mThisParameters["id_name"].GetString();
         ModelPart& r_computing_contact_model_part = BaseType::mrMainModelPart.GetSubModelPart("ComputingContact");
-        ModelPart& r_sub_computing_contact_model_part = this->IsNot(BaseType::MULTIPLE_SEARCHS) ? r_computing_contact_model_part : r_computing_contact_model_part.GetSubModelPart(sub_computing_model_part_name);
+        ModelPart& r_sub_computing_contact_model_part = this->IsNotMultipleSearchs() ? r_computing_contact_model_part : r_computing_contact_model_part.GetSubModelPart(sub_computing_model_part_name);
         auto& r_computing_constraints_array = r_sub_computing_contact_model_part.MasterSlaveConstraints();
         const int num_computing_constraints = static_cast<int>(r_computing_constraints_array.size());
 


### PR DESCRIPTION
**Description**
This fixes a clang compilation error (warning turned into error) due to template instantiation of local flags

**Changelog**
- Creating auxiliary methods to access these local flags
