### PR TITLE
[Core] Adding logger removal feature

### DIFF
--- a/kratos/input_output/logger.cpp
+++ b/kratos/input_output/logger.cpp
@@ -57,8 +57,9 @@ namespace Kratos
     #pragma omp critical
     {
       auto i = std::find(GetOutputsInstance().begin(), GetOutputsInstance().end(), pTheOutput);
-      KRATOS_ERROR_IF(i == GetOutputsInstance().end()) << pTheOutput->Info() << " was not found in the list of loggers.\n";
-      GetOutputsInstance().erase(i);
+      if (i != GetOutputsInstance().end()) {
+         GetOutputsInstance().erase(i);
+      }  
     }
 
     KRATOS_CATCH("");

--- a/kratos/input_output/logger.cpp
+++ b/kratos/input_output/logger.cpp
@@ -13,6 +13,7 @@
 
 
 // System includes
+#include <algorithm>
 
 
 // External includes
@@ -47,6 +48,20 @@ namespace Kratos
     {
       GetOutputsInstance().push_back(pTheOutput);
     }
+  }
+
+  void Logger::RemoveOutput(LoggerOutput::Pointer pTheOutput)
+  {
+    KRATOS_TRY
+
+    #pragma omp critical
+    {
+      auto i = std::find(GetOutputsInstance().begin(), GetOutputsInstance().end(), pTheOutput);
+      KRATOS_ERROR_IF(i == GetOutputsInstance().end()) << pTheOutput->Info() << " was not found in the list of loggers.\n";
+      GetOutputsInstance().erase(i);
+    }
+
+    KRATOS_CATCH("");
   }
 
   void Logger::Flush() {

--- a/kratos/input_output/logger.h
+++ b/kratos/input_output/logger.h
@@ -116,6 +116,8 @@ namespace Kratos
 
     static void AddOutput(LoggerOutput::Pointer pTheOutput);
 
+    static void RemoveOutput(LoggerOutput::Pointer pTheOutput);
+
     static void Flush();
 
 

--- a/kratos/python/add_logger_to_python.cpp
+++ b/kratos/python/add_logger_to_python.cpp
@@ -183,6 +183,7 @@ void  AddLoggerToPython(pybind11::module& m) {
     logger_scope.def_static("Flush", Logger::Flush);
     logger_scope.def_static("GetDefaultOutput", &Logger::GetDefaultOutputInstance, py::return_value_policy::reference); //_internal )
     logger_scope.def_static("AddOutput", &Logger::AddOutput);
+    logger_scope.def_static("RemoveOutput", &Logger::RemoveOutput);
     ;
 
     // Enums for Severity


### PR DESCRIPTION
**Description**
Adds the capability to remove loggers from the loggers list. This is usefull in the case where we have to run long sequential simulations and does not want to clutter the main logged output (such as optimization, where each iteration is logged to different iteration log file, and optimization log is shown seperately.

**Changelog**
- Adds `RemoveOutput` method to logger
- Exposes it to python