### PR TITLE
[Fluid] Two fluid distance correction into solver

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -73,7 +73,15 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
             "bfecc_number_substeps" : 10,
             "distance_reinitialization" : "variational",
             "distance_smoothing" : false,
-            "distance_smoothing_coefficient" : 1.0
+            "distance_smoothing_coefficient" : 1.0,
+            "distance_modification_settings": {
+                "model_part_name": "",
+                "distance_threshold": 1e-5,
+                "continuous_distance": true,
+                "check_at_each_time_step": true,
+                "avoid_almost_empty_elements": false,
+                "deactivate_full_negative_elements": false
+            }
         }""")
 
         default_settings.AddMissingParameters(super(NavierStokesTwoFluidsSolver, cls).GetDefaultParameters())
@@ -179,6 +187,9 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
         solution_strategy.SetEchoLevel(self.settings["echo_level"].GetInt())
         solution_strategy.Initialize()
 
+        # Initialize the distance correction process
+        self._GetDistanceModificationProcess().ExecuteInitialize()
+
         KratosMultiphysics.Logger.PrintInfo(self.__class__.__name__, "Solver initialization finished.")
 
     def InitializeSolutionStep(self):
@@ -215,7 +226,8 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
 
             # TODO: Performing mass conservation check and correction process
 
-            # TODO: Doing the distance modification to prevent zero-cuts
+            # Perform distance correction to prevent ill-conditioned cuts
+            self._GetDistanceModificationProcess().ExecuteInitializeSolutionStep()
 
             # Update the DENSITY and DYNAMIC_VISCOSITY values according to the new level-set
             self._SetNodalProperties()
@@ -246,6 +258,7 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
             KratosMultiphysics.Logger.PrintInfo(self.__class__.__name__, "Redistancing process is finished.")
 
         if self._TimeBufferIsInitialized():
+            self._GetDistanceModificationProcess().ExecuteFinalizeSolutionStep()
             self._GetSolutionStrategy().FinalizeSolutionStep()
             self._GetAccelerationLimitationUtility().Execute()
 
@@ -360,6 +373,11 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
             self._consistent_nodal_pressure_gradient_process = self._CreateConsistentNodalPressureGradientProcess()
         return self._consistent_nodal_pressure_gradient_process
 
+    def _GetDistanceModificationProcess(self):
+        if not hasattr(self, '_distance_modification_process'):
+            self._distance_modification_process = self.__CreateDistanceModificationProcess()
+        return self._distance_modification_process
+
     def __CreateAccelerationLimitationUtility(self):
         maximum_multiple_of_g_acceleration_allowed = 5.0
         acceleration_limitation_utility = KratosCFD.AccelerationLimitationUtilities(
@@ -471,3 +489,30 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
                 self.main_model_part)
 
         return consistent_nodal_pressure_gradient_process
+
+    def __CreateDistanceModificationProcess(self):
+        # Set suitable distance correction settings for free-surface problems
+        # Note that the distance modification process is applied to the volume model part
+        distance_modification_settings = self.settings["distance_modification_settings"]
+        distance_modification_settings.ValidateAndAssignDefaults(self.GetDefaultParameters()["distance_modification_settings"])
+        aux_full_volume_part_name = self.settings["model_part_name"].GetString() + "." + self.settings["volume_model_part_name"].GetString()
+        distance_modification_settings["model_part_name"].SetString(aux_full_volume_part_name)
+
+        # Check user provided settings
+        if not distance_modification_settings["continuous_distance"].GetBool():
+            distance_modification_settings["continuous_distance"].SetBool(True)
+            KratosMultiphysics.Logger.PrintWarning("Provided distance correction \'continuous_distance\' is \'False\'. Setting to \'True\'.")
+        if not distance_modification_settings["check_at_each_time_step"].GetBool():
+            distance_modification_settings["check_at_each_time_step"].SetBool(True)
+            KratosMultiphysics.Logger.PrintWarning("Provided distance correction \'check_at_each_time_step\' is \'False\'. Setting to \'True\'.")
+        if distance_modification_settings["avoid_almost_empty_elements"].GetBool():
+            distance_modification_settings["avoid_almost_empty_elements"].SetBool(False)
+            KratosMultiphysics.Logger.PrintWarning("Provided distance correction \'avoid_almost_empty_elements\' is \'True\'. Setting to \'False\' to avoid modifying the distance sign.")
+        if distance_modification_settings["deactivate_full_negative_elements"].GetBool():
+            distance_modification_settings["deactivate_full_negative_elements"].SetBool(False)
+            KratosMultiphysics.Logger.PrintWarning("Provided distance correction \'deactivate_full_negative_elements\' is \'True\'. Setting to \'False\' to avoid deactivating the negative volume (e.g. water).")
+
+        # Create and return the distance correction process
+        return KratosCFD.DistanceModificationProcess(
+            self.model,
+            distance_modification_settings)

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -488,11 +488,10 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
 
     def __CreateDistanceModificationProcess(self):
         # Set suitable distance correction settings for free-surface problems
-        # Note that the distance modification process is applied to the volume model part
+        # Note that the distance modification process is applied to the computing model part
         distance_modification_settings = self.settings["distance_modification_settings"]
         distance_modification_settings.ValidateAndAssignDefaults(self.GetDefaultParameters()["distance_modification_settings"])
-        aux_full_volume_part_name = self.settings["model_part_name"].GetString() + "." + self.settings["volume_model_part_name"].GetString()
-        distance_modification_settings["model_part_name"].SetString(aux_full_volume_part_name)
+        distance_modification_settings["model_part_name"].SetString(self.GetComputingModelPart().FullName())
 
         # Check user provided settings
         if not distance_modification_settings["continuous_distance"].GetBool():

--- a/applications/FluidDynamicsApplication/tests/TwoFluidInletTest/parameters_mpi.json
+++ b/applications/FluidDynamicsApplication/tests/TwoFluidInletTest/parameters_mpi.json
@@ -51,7 +51,10 @@
             "block_size" : 3,
             "use_block_matrices_if_possible" : true,
             "coarse_enough" : 500
-    	}
+    	},
+        "distance_modification_settings": {
+            "distance_threshold": 0.0000001
+        }
     },
 	"processes"	:	{
     	"initial_conditions_process_list"  : [],
@@ -109,19 +112,7 @@
             	"direction"       : [0.0,0.0,-1.0]
         	}
     	}],
-    	"auxiliar_process_list"            : [{
-        	"python_module" : "apply_distance_modification_process",
-        	"kratos_module" : "KratosMultiphysics.FluidDynamicsApplication",
-        	"process_name"  : "ApplyDistanceModificationProcess",
-        	"Parameters"    : {
-            	"model_part_name"                        : "FluidModelPart.Parts_Fluid",
-            	"distance_threshold"                     : 0.0000001,
-            	"check_at_each_time_step"                : false,
-            	"avoid_almost_empty_elements"            : true,
-            	"deactivate_full_negative_elements"      : false,
-            	"recover_original_distance_at_each_step" : false
-        	}
-    	}]
+    	"auxiliar_process_list"            : []
 	},
 	"output_processes" 	:	{}
 }

--- a/applications/FluidDynamicsApplication/tests/TwoFluidInletTest/parameters_serial.json
+++ b/applications/FluidDynamicsApplication/tests/TwoFluidInletTest/parameters_serial.json
@@ -16,7 +16,7 @@
         },
         "material_import_settings": {
             "materials_filename": "TwoFluidInletTest/materials.json"
-        },    
+        },
 		"maximum_iterations"			: 3,
     	"formulation": {
         	"dynamic_tau" : 1.0
@@ -51,7 +51,10 @@
             "block_size" : 3,
             "use_block_matrices_if_possible" : true,
             "coarse_enough" : 500
-    	}
+    	},
+        "distance_modification_settings": {
+            "distance_threshold": 0.0000001
+        }
     },
 	"processes"	:	{
     	"initial_conditions_process_list"  : [],
@@ -109,19 +112,7 @@
             	"direction"       : [0.0,0.0,-1.0]
         	}
     	}],
-    	"auxiliar_process_list"            : [{
-        	"python_module" : "apply_distance_modification_process",
-        	"kratos_module" : "KratosMultiphysics.FluidDynamicsApplication",
-        	"process_name"  : "ApplyDistanceModificationProcess",
-        	"Parameters"    : {
-            	"model_part_name"                        : "FluidModelPart.Parts_Fluid",
-            	"distance_threshold"                     : 0.0000001,
-            	"check_at_each_time_step"                : false,
-            	"avoid_almost_empty_elements"            : true,
-            	"deactivate_full_negative_elements"      : false,
-            	"recover_original_distance_at_each_step" : false
-        	}
-    	}]
+    	"auxiliar_process_list"            : []
 	},
 	"output_processes" 	:	{}
 }

--- a/applications/FluidDynamicsApplication/tests/TwoFluidStaticPoolTest/TwoFluidStaticPoolTest2D.json
+++ b/applications/FluidDynamicsApplication/tests/TwoFluidStaticPoolTest/TwoFluidStaticPoolTest2D.json
@@ -45,6 +45,9 @@
             "block_size" : 1,
             "use_block_matrices_if_possible" : true,
             "coarse_enough" : 500
+        },
+        "distance_modification_settings": {
+            "distance_threshold": 0.001
         }
     },
 	"processes"	:	{
@@ -62,18 +65,6 @@
             	"direction"       : [0.0,-1.0,0.0]
         	}
     	}],
-    	"auxiliar_process_list"            : [{
-        	"python_module" : "apply_distance_modification_process",
-        	"kratos_module" : "KratosMultiphysics.FluidDynamicsApplication",
-        	"process_name"  : "ApplyDistanceModificationProcess",
-        	"Parameters"    : {
-            	"model_part_name"                        : "FluidModelPart.Parts_Fluid",
-            	"distance_threshold"                     : 0.001,
-            	"check_at_each_time_step"                : false,
-            	"avoid_almost_empty_elements"            : true,
-            	"deactivate_full_negative_elements"      : false,
-            	"recover_original_distance_at_each_step" : false
-        	}
-    	}]
+    	"auxiliar_process_list"            : []
 	}
 }

--- a/applications/FluidDynamicsApplication/tests/TwoFluidStaticPoolTest/TwoFluidStaticPoolTest3D.json
+++ b/applications/FluidDynamicsApplication/tests/TwoFluidStaticPoolTest/TwoFluidStaticPoolTest3D.json
@@ -45,6 +45,9 @@
             "block_size" : 1,
             "use_block_matrices_if_possible" : true,
             "coarse_enough" : 500
+        },
+        "distance_modification_settings": {
+            "distance_threshold": 0.001
         }
     },
 	"processes"	:	{
@@ -62,18 +65,6 @@
             	"direction"       : [0.0,0.0,-1.0]
         	}
     	}],
-    	"auxiliar_process_list"            : [{
-        	"python_module" : "apply_distance_modification_process",
-        	"kratos_module" : "KratosMultiphysics.FluidDynamicsApplication",
-        	"process_name"  : "ApplyDistanceModificationProcess",
-        	"Parameters"    : {
-            	"model_part_name"                        : "FluidModelPart.Parts_Fluid",
-            	"distance_threshold"                     : 0.001,
-            	"check_at_each_time_step"                : false,
-            	"avoid_almost_empty_elements"            : true,
-            	"deactivate_full_negative_elements"      : false,
-            	"recover_original_distance_at_each_step" : false
-        	}
-    	}]
+    	"auxiliar_process_list"            : []
 	}
 }


### PR DESCRIPTION
**Description**
This introduces the distance modification into the two-fluids solver as was done long time ago in the embedded one. This enhances robustness as suitable settings can be provided for non-experienced users, aside of ensuring that the distance is modified prior to the NS problem resolution (see #8346)

FYI: @ddiezrod @uxuech 
