### PR TITLE
[DEM] Added 1 noded edge and face

### DIFF
--- a/applications/DEMApplication/DEM_application.cpp
+++ b/applications/DEMApplication/DEM_application.cpp
@@ -483,8 +483,10 @@ KratosDEMApplication::KratosDEMApplication() : KratosApplication("DEMApplication
     mRigidFace3D2N(0, Element::GeometryType::Pointer(new Line3D2<Node<3> >(Element::GeometryType::PointsArrayType(2)))),
     mRigidFace3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
     mRigidFace3D4N(0, Element::GeometryType::Pointer(new Quadrilateral3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+    mRigidFace3D1N(0, Element::GeometryType::Pointer(new Point3D<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
     mAnalyticRigidFace3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
     mRigidEdge2D2N(0, Element::GeometryType::Pointer(new Line2D2<Node<3> >(Element::GeometryType::PointsArrayType(2)))),
+    mRigidEdge2D1N(0, Element::GeometryType::Pointer(new Point2D<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
     mRigidBodyElement3D(0, Element::GeometryType::Pointer(new Point3D<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
     mShipElement3D(0, Element::GeometryType::Pointer(new Point3D<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
     mContactInfoSphericParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
@@ -916,9 +918,12 @@ void KratosDEMApplication::Register() {
     KRATOS_REGISTER_CONDITION("RigidFace3D2N", mRigidFace3D2N)
     KRATOS_REGISTER_CONDITION("RigidFace3D3N", mRigidFace3D3N)
     KRATOS_REGISTER_CONDITION("RigidFace3D4N", mRigidFace3D4N)
+    KRATOS_REGISTER_CONDITION("RigidFace3D1N", mRigidFace3D1N)
     KRATOS_REGISTER_CONDITION("AnalyticRigidFace3D", mAnalyticRigidFace3D3N)
     KRATOS_REGISTER_CONDITION("AnalyticRigidFace3D3N", mAnalyticRigidFace3D3N)
     KRATOS_REGISTER_CONDITION("RigidEdge2D2N", mRigidEdge2D2N)
+    KRATOS_REGISTER_CONDITION("RigidEdge2D1N", mRigidEdge2D1N)
+
 
     // SERIALIZER
     Serializer::Register("PropertiesProxy", PropertiesProxy());

--- a/applications/DEMApplication/DEM_application.h
+++ b/applications/DEMApplication/DEM_application.h
@@ -105,8 +105,10 @@ private:
     const RigidFace3D  mRigidFace3D2N;
     const RigidFace3D  mRigidFace3D3N;
     const RigidFace3D  mRigidFace3D4N;
+    const RigidFace3D  mRigidFace3D1N;
     const AnalyticRigidFace3D  mAnalyticRigidFace3D3N;
     const RigidEdge2D  mRigidEdge2D2N;
+    const RigidEdge2D  mRigidEdge2D1N;
     const RigidBodyElement3D mRigidBodyElement3D;
     const ShipElement3D mShipElement3D;
     const ContactInfoSphericParticle mContactInfoSphericParticle3D;

--- a/applications/DEMApplication/custom_conditions/RigidEdge.cpp
+++ b/applications/DEMApplication/custom_conditions/RigidEdge.cpp
@@ -70,11 +70,10 @@ RigidEdge2D::~RigidEdge2D()
 void RigidEdge2D::Initialize(const ProcessInfo& rCurrentProcessInfo) {
 
     if (! rCurrentProcessInfo[IS_RESTARTED]){
-        this->GetGeometry()[0].FastGetSolutionStepValue(NON_DIMENSIONAL_VOLUME_WEAR) = 0.0;
-        this->GetGeometry()[1].FastGetSolutionStepValue(NON_DIMENSIONAL_VOLUME_WEAR) = 0.0;
-
-        this->GetGeometry()[0].FastGetSolutionStepValue(IMPACT_WEAR) = 0.0;
-        this->GetGeometry()[1].FastGetSolutionStepValue(IMPACT_WEAR) = 0.0;
+        for (SizeType i=0;i<this->GetGeometry().size();++i){
+            this->GetGeometry()[i].FastGetSolutionStepValue(NON_DIMENSIONAL_VOLUME_WEAR) = 0.0;
+            this->GetGeometry()[i].FastGetSolutionStepValue(IMPACT_WEAR) = 0.0;
+        }
     }
 }
 
@@ -147,14 +146,16 @@ void RigidEdge2D::ComputeConditionRelativeData(int rigid_neighbour_index,
 
 void RigidEdge2D::CalculateNormal(array_1d<double, 3>& rnormal){
 
-    double delta_x = GetGeometry()[1].X() - GetGeometry()[0].X();
-    double delta_y = GetGeometry()[1].Y() - GetGeometry()[0].Y();
+    if (GetGeometry().size()>1){
+        double delta_x = GetGeometry()[1].X() - GetGeometry()[0].X();
+        double delta_y = GetGeometry()[1].Y() - GetGeometry()[0].Y();
 
-    rnormal[0] = - delta_y;
-    rnormal[1] = delta_x;
-    rnormal[2] = 0.0;
+        rnormal[0] = - delta_y;
+        rnormal[1] = delta_x;
+        rnormal[2] = 0.0;
 
-    rnormal /= MathUtils<double>::Norm3(rnormal);
+        rnormal /= MathUtils<double>::Norm3(rnormal);
+    }
 }
 
 

--- a/applications/DEMApplication/custom_utilities/rigid_face_geometrical_object_configure.h
+++ b/applications/DEMApplication/custom_utilities/rigid_face_geometrical_object_configure.h
@@ -415,7 +415,10 @@ public:
         const GeometryType& FE_Geom = rObj_2->GetGeometry();
         unsigned int FE_size = FE_Geom.size();
 
-        if(FE_size==2) {
+        if (FE_size==1) {
+          DoubleHierarchyMethod1D(rObj_1,rObj_2, Distance_Array, Normal_Array,Weight_Array, Id_Array,ContactType_Array);
+        }
+        else if (FE_size==2) {
           DoubleHierarchyMethod2D(rObj_1,rObj_2, Distance_Array, Normal_Array,Weight_Array, Id_Array,ContactType_Array);
         }
         else {
@@ -571,6 +574,46 @@ public:
       return;
     }//DoubleHierarchyMethod2D
 
+    static inline void DoubleHierarchyMethod1D(SphericParticle* rObj_1,
+                                               DEMWall* rObj_2,
+                                               std::vector< double > & Distance_Array,
+                                               std::vector< array_1d<double,3> >& Normal_Array,
+                                               std::vector< array_1d<double,4> >& Weight_Array,
+                                               std::vector< int > & Id_Array,
+                                               std::vector< int > & ContactType_Array
+                                              )
+      {
+      //rObj_1 is particle,  and rObj_2 is condition
+      int ContactType          = -1;
+      //-1: No contact;
+      // 3: Vertex.
+
+      bool ContactExists = false;
+
+      const GeometryType& DE_Geom = rObj_1->GetGeometry();
+
+      double Radius = rObj_1->GetInteractionRadius();
+
+      const GeometryType& FE_Geom = rObj_2->GetGeometry();
+
+      double local_coord_system[3][3]  = { {0.0},{0.0},{0.0} };
+      std::vector<double> Weight(4,0.0);
+
+      double distance_point_to_vertex = 0.0;
+      ContactExists = GeometryFunctions::VertexCheck(FE_Geom[0].Coordinates(),
+                  DE_Geom[0].Coordinates(), Radius, local_coord_system,
+                  distance_point_to_vertex);
+
+      if (ContactExists) {
+        ContactType = 3;
+        Weight[0] = 1.0; //the rest weights stay 0.0;
+        ContactExists = DistanceHierarchy(rObj_1,rObj_2, local_coord_system,
+                    distance_point_to_vertex, Weight, ContactType, Distance_Array,
+                    Normal_Array, Weight_Array, Id_Array, ContactType_Array);
+        return;
+      }
+      return;
+    }//DoubleHierarchyMethod2D
 
 
 


### PR DESCRIPTION
Hi, this PR should enable the use of single vertices as rigid boundaries.

Here's what I did:
- Registering the one noded element for 2D (RigidEdge) and 3D (RigidFace)
- RigidEdge2D::Initialize: Loop over nodes instead of taking always 2
- RigidEdge2D::CalculateNormal: Do this only if nodes are > 1
- rigid_face_geometrical_object_configure::DoubleHierarchyMethod1D: Called when element has only 1 node and check only contact to vertex

I ran the tests_DEMApplication.py and noticed no erros.