### PR TITLE
[ContactStructuralMechanicsApplication] Fix bug in NormalCheckProcess

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_processes/normal_check_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/normal_check_process.cpp
@@ -169,7 +169,7 @@ void NormalCheckProcess::Execute()
     MortarUtilities::InvertNormalForFlag<PointerVectorSet<Element, IndexedObject>>(r_elements_array, MARKER);
 
     // Auxiliar boolean
-    bool inverted_condition = true;
+    bool inverted_condition = false;
 
     #pragma omp parallel for firstprivate(inverted_condition)
     for(int i = 0; i < number_of_conditions; ++i) {
@@ -177,8 +177,8 @@ void NormalCheckProcess::Execute()
         const auto& r_geometry = it_cond->GetGeometry();
 
         for (auto& r_node : r_geometry) {
-            if (r_node.IsNot(MARKER)) {
-                inverted_condition = false;
+            if (r_node.Is(MARKER)) {
+                inverted_condition = true;
                 break;
             }
         }
@@ -186,7 +186,7 @@ void NormalCheckProcess::Execute()
             it_cond->Set(MARKER);
         }
 
-        inverted_condition = true;
+        inverted_condition = false;
     }
 
     // Invert conditions

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/normal_check_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/normal_check_process.cpp
@@ -26,6 +26,9 @@ void NormalCheckProcess::Execute()
 {
     KRATOS_TRY
 
+    // The propoortion of length considered in the normal check
+    const double length_proportion = mParameters["length_proportion"].GetDouble();
+
     // First we compute the normals
     NormalCalculationUtils().CalculateUnitNormals<Condition>(mrModelPart, true);
 
@@ -136,7 +139,7 @@ void NormalCheckProcess::Execute()
                 // First check if the elements are inverted
                 r_face.PointLocalCoordinates(aux_coords, r_face.Center());
                 const array_1d<double, 3> normal = r_face.UnitNormal(aux_coords);
-                aux_perturbed_coords = r_face.Center() + 1.0e-1 * r_face.Length() * normal;
+                aux_perturbed_coords = r_face.Center() + length_proportion * r_face.Length() * normal;
                 if (r_geometry.IsInside(aux_perturbed_coords, aux_coords, 5.0e-7)) {
                     it_elem->Set(MARKER);
                     KRATOS_INFO("NormalCheckProcess") << "Normal inverted in element: " << it_elem->Id() << " the corresponding element will be inverted" << std::endl;
@@ -148,7 +151,7 @@ void NormalCheckProcess::Execute()
         for (auto& r_node : r_geometry) {
             if (r_node.Is(INTERFACE)) {
                 const array_1d<double, 3>& r_normal = r_node.FastGetSolutionStepValue(NORMAL);
-                aux_perturbed_coords = r_node.Coordinates() + 1.0e-1 * r_geometry.Length() * r_normal;
+                aux_perturbed_coords = r_node.Coordinates() + length_proportion * r_geometry.Length() * r_normal;
 
                 if (r_geometry.IsInside(aux_perturbed_coords, aux_coords, 5.0e-7)) {
                     r_node.SetLock();
@@ -222,6 +225,23 @@ void NormalCheckProcess::Execute()
 
     // We re-compute the normals
     NormalCalculationUtils().CalculateUnitNormals<Condition>(mrModelPart, true);
+
+    KRATOS_CATCH("")
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+const Parameters NormalCheckProcess::GetDefaultParameters() const
+{
+    KRATOS_TRY
+
+    const Parameters default_parameters = Parameters(R"(
+    {
+        "length_proportion" : 0.1
+    })" );
+
+    return default_parameters;
 
     KRATOS_CATCH("")
 }

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/normal_check_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/normal_check_process.h
@@ -80,14 +80,17 @@ public:
     /**
      * @brief The constructor of the normal check process
      * @param rModelPart The model part to be considered
+     * @param ThisParameters The configuration parameters
      */
     NormalCheckProcess(
-        ModelPart& rModelPart
-        ) : mrModelPart(rModelPart)
+        ModelPart& rModelPart,
+        Parameters ThisParameters =  Parameters(R"({})")
+        ) : mrModelPart(rModelPart),
+            mParameters(ThisParameters)
     {
     }
 
-    virtual ~NormalCheckProcess()= default;;
+    virtual ~NormalCheckProcess()= default;
 
     ///@}
     ///@name Operators
@@ -110,6 +113,11 @@ public:
      * @brief Execute method is used to execute the Process algorithms.
      */
     void Execute() override;
+
+    /**
+     * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
+     */
+    const Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access
@@ -155,6 +163,7 @@ protected:
     ///@{
 
     ModelPart& mrModelPart;  /// The model part to be considered
+    Parameters mParameters;  /// The configuration parameters
 
     ///@}
     ///@name Protected Operators

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/normal_check_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/normal_check_process.h
@@ -88,6 +88,8 @@ public:
         ) : mrModelPart(rModelPart),
             mParameters(ThisParameters)
     {
+        const Parameters default_parameters = GetDefaultParameters();
+        mParameters.ValidateAndAssignDefaults(default_parameters);
     }
 
     virtual ~NormalCheckProcess()= default;

--- a/applications/ContactStructuralMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
@@ -335,6 +335,7 @@ void  AddCustomProcessesToPython(pybind11::module& m)
     // Normal check process
     py::class_<NormalCheckProcess, NormalCheckProcess::Pointer, Process>(m, "NormalCheckProcess")
     .def(py::init<ModelPart&>())
+    .def(py::init<ModelPart&, Parameters>())
     ;
 
     // FindIntersectedGeometricalObjectsWithOBBContactSearchProcess

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/alm_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/alm_contact_process.py
@@ -76,6 +76,7 @@ class ALMContactProcess(search_base_process.SearchBaseProcess):
             "zero_tolerance_factor"         : 1.0,
             "integration_order"             : 2,
             "consider_tessellation"         : false,
+            "normal_check_proportion"       : 0.1,
             "clear_inactive_for_post"       : true,
             "slip_step_reset_frequency"     : 1,
             "search_parameters"             : {
@@ -141,6 +142,7 @@ class ALMContactProcess(search_base_process.SearchBaseProcess):
         base_process_settings.AddValue("zero_tolerance_factor", self.contact_settings["zero_tolerance_factor"])
         base_process_settings.AddValue("integration_order", self.contact_settings["integration_order"])
         base_process_settings.AddValue("consider_tessellation", self.contact_settings["consider_tessellation"])
+        base_process_settings.AddValue("normal_check_proportion", self.contact_settings["normal_check_proportion"])
         base_process_settings.AddValue("search_parameters", self.contact_settings["search_parameters"])
 
         # Construct the base process.

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/explicit_penalty_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/explicit_penalty_contact_process.py
@@ -58,6 +58,7 @@ class ExplicitPenaltyContactProcess(penalty_contact_process.PenaltyContactProces
             "zero_tolerance_factor"         : 1.0,
             "integration_order"             : 2,
             "consider_tessellation"         : false,
+            "normal_check_proportion"       : 0.1,
             "clear_inactive_for_post"       : true,
             "slip_step_reset_frequency"     : 1,
             "search_parameters"             : {

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/mesh_tying_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/mesh_tying_process.py
@@ -46,6 +46,9 @@ class MeshTyingProcess(search_base_process.SearchBaseProcess):
             "interval"                    : [0.0,"End"],
             "variable_name"               : "DISPLACEMENT",
             "zero_tolerance_factor"       : 1.0,
+            "integration_order"           : 2,
+            "consider_tessellation"       : false,
+            "normal_check_proportion"     : 0.1,
             "search_parameters" : {
                 "type_search"                 : "in_radius_with_obb",
                 "search_factor"               : 3.5,
@@ -63,9 +66,7 @@ class MeshTyingProcess(search_base_process.SearchBaseProcess):
                     "lower_bounding_box_coefficient"  : 0.0,
                     "higher_bounding_box_coefficient" : 1.0
                 }
-            },
-            "integration_order"           : 2,
-            "consider_tessellation"       : false
+            }
         }
         """)
 
@@ -84,6 +85,7 @@ class MeshTyingProcess(search_base_process.SearchBaseProcess):
         base_process_settings.AddValue("zero_tolerance_factor", self.mesh_tying_settings["zero_tolerance_factor"])
         base_process_settings.AddValue("integration_order", self.mesh_tying_settings["integration_order"])
         base_process_settings.AddValue("consider_tessellation", self.mesh_tying_settings["consider_tessellation"])
+        base_process_settings.AddValue("normal_check_proportion", self.mesh_tying_settings["normal_check_proportion"])
         base_process_settings.AddValue("search_parameters", self.mesh_tying_settings["search_parameters"])
 
         # Construct the base process.

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/mpc_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/mpc_contact_process.py
@@ -73,6 +73,7 @@ class MPCContactProcess(search_base_process.SearchBaseProcess):
             "reaction_check_stiffness_factor" : 1.0e-10,
             "integration_order"               : 2,
             "consider_tessellation"           : false,
+            "normal_check_proportion"         : 0.1,
             "clear_inactive_for_post"         : true,
             "update_condition_relation_step"  : false,
             "search_parameters" : {
@@ -118,6 +119,7 @@ class MPCContactProcess(search_base_process.SearchBaseProcess):
         base_process_settings.AddValue("zero_tolerance_factor", self.contact_settings["zero_tolerance_factor"])
         base_process_settings.AddValue("integration_order", self.contact_settings["integration_order"])
         base_process_settings.AddValue("consider_tessellation", self.contact_settings["consider_tessellation"])
+        base_process_settings.AddValue("normal_check_proportion", self.contact_settings["normal_check_proportion"])
         base_process_settings.AddValue("search_parameters", self.contact_settings["search_parameters"])
 
         # Construct the base process.

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/penalty_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/penalty_contact_process.py
@@ -57,7 +57,8 @@ class PenaltyContactProcess(alm_contact_process.ALMContactProcess):
             "slip_threshold"                : 2.0e-2,
             "zero_tolerance_factor"         : 1.0,
             "integration_order"             : 2,
-            "consider_tessellation"          : false,
+            "consider_tessellation"         : false,
+            "normal_check_proportion"       : 0.1,
             "clear_inactive_for_post"       : true,
             "slip_step_reset_frequency"     : 1,
             "search_parameters"             : {

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/search_base_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/search_base_process.py
@@ -47,6 +47,7 @@ class SearchBaseProcess(KM.Process):
             "zero_tolerance_factor"       : 1.0,
             "integration_order"           : 2,
             "consider_tessellation"       : false,
+            "normal_check_proportion"     : 0.1,
             "search_parameters" : {
                 "type_search"                         : "in_radius_with_obb",
                 "simple_search"                       : false,
@@ -150,7 +151,9 @@ class SearchBaseProcess(KM.Process):
         self.find_nodal_h.Execute()
 
         # We check the normals
-        check_normal_process = CSMA.NormalCheckProcess(self.main_model_part)
+        normal_check_parameters = KM.Parameters("""{"length_proportion" : 0.1}""")
+        normal_check_parameters["length_proportion"].SetDouble(self.settings["normal_check_proportion"].GetDouble())
+        check_normal_process = CSMA.NormalCheckProcess(self.main_model_part, normal_check_parameters)
         check_normal_process.Execute()
 
         ## We recompute the search factor and the check in function of the relative size of the mesh

--- a/applications/ContactStructuralMechanicsApplication/tests/test_check_normals_process.py
+++ b/applications/ContactStructuralMechanicsApplication/tests/test_check_normals_process.py
@@ -34,10 +34,11 @@ class TestCheckNormals(KratosUnittest.TestCase):
             KM.VariableUtils().SetFlag(KM.INTERFACE, True, self.main_model_part.GetSubModelPart(custom_submodel_part).Nodes)
 
         ## DEBUG
-        #KM.ComputeNodesMeanNormalModelPart(self.main_model_part, True)
+        #KM.MortarUtilities.ComputeNodesMeanNormalModelPart(self.main_model_part, True)
 
         # Check normals
-        check_process = CSMA.NormalCheckProcess(self.main_model_part)
+        normal_check_parameters = KM.Parameters("""{"length_proportion" : 0.1}""")
+        check_process = CSMA.NormalCheckProcess(self.main_model_part, normal_check_parameters)
         check_process.Execute()
 
         ## DEBUG


### PR DESCRIPTION
**Description**
I inverted the check (from if only one then is marked, instead if at least one is not marked)

**Changelog**
- Fix check
- Custom length proportion check (unnecessary feature)

![imagen](https://user-images.githubusercontent.com/19991680/109712751-b2d1a680-7ba0-11eb-8fef-e5fcf7bc5df6.png)

