### PR TITLE
[ConstitutiveModels] CalcOnIntPoints instead of GetValue #7381 #8416

### DIFF
--- a/applications/ConstitutiveModelsApplication/custom_processes/non_local_plasticity_process.cpp
+++ b/applications/ConstitutiveModelsApplication/custom_processes/non_local_plasticity_process.cpp
@@ -192,7 +192,7 @@ namespace Kratos
 
 
          std::vector<ConstitutiveLaw::Pointer> ConstitutiveLawVector(numberOfGP);
-         ie->GetValueOnIntegrationPoints(CONSTITUTIVE_LAW, ConstitutiveLawVector, rCurrentProcessInfo);
+         ie->CalculateOnIntegrationPoints(CONSTITUTIVE_LAW, ConstitutiveLawVector, rCurrentProcessInfo);
 
 
 


### PR DESCRIPTION
**Description**
Closes #8416 according to #7381

**Changelog**
Changed GetValueOnIntegrationPoints to CalculateOnIntegrationPoints
