### PR TITLE
[MPM] Calculate M & K for C only if alpha and beta != 0.0

### DIFF
--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -1284,8 +1284,8 @@ void UpdatedLagrangian::CalculateDampingMatrix( MatrixType& rDampingMatrix, cons
     }
 
     //2.-Calculate StiffnessMatrix:
-    MatrixType StiffnessMatrix  = Matrix();
     if (beta!=0.0){
+        MatrixType StiffnessMatrix  = Matrix();
         this->CalculateLeftHandSide( StiffnessMatrix, rCurrentProcessInfo );
         //4.1.-Compose the Damping Matrix:
         //Rayleigh Damping Matrix: alpha*M + beta*K
@@ -1293,8 +1293,8 @@ void UpdatedLagrangian::CalculateDampingMatrix( MatrixType& rDampingMatrix, cons
     }
 
     //3.-Calculate MassMatrix:
-    MatrixType MassMatrix  = Matrix();
     if (alpha!=0.0){
+        MatrixType MassMatrix  = Matrix();
         this->CalculateMassMatrix ( MassMatrix, rCurrentProcessInfo );
         //4.2.-Compose the Damping Matrix:
         //Rayleigh Damping Matrix: alpha*M + beta*K

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -1284,7 +1284,7 @@ void UpdatedLagrangian::CalculateDampingMatrix( MatrixType& rDampingMatrix, cons
     }
 
     //2.-Calculate StiffnessMatrix:
-    if (beta!=0.0){
+    if (std::abs(beta) > 1e-12){
         MatrixType StiffnessMatrix  = Matrix();
         this->CalculateLeftHandSide( StiffnessMatrix, rCurrentProcessInfo );
         //4.1.-Compose the Damping Matrix:
@@ -1293,7 +1293,7 @@ void UpdatedLagrangian::CalculateDampingMatrix( MatrixType& rDampingMatrix, cons
     }
 
     //3.-Calculate MassMatrix:
-    if (alpha!=0.0){
+    if (std::abs(alpha) > 1e-12){
         MatrixType MassMatrix  = Matrix();
         this->CalculateMassMatrix ( MassMatrix, rCurrentProcessInfo );
         //4.2.-Compose the Damping Matrix:

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -1287,18 +1287,19 @@ void UpdatedLagrangian::CalculateDampingMatrix( MatrixType& rDampingMatrix, cons
     MatrixType StiffnessMatrix  = Matrix();
     if (beta!=0.0){
         this->CalculateLeftHandSide( StiffnessMatrix, rCurrentProcessInfo );
+        //4.1.-Compose the Damping Matrix:
+        //Rayleigh Damping Matrix: alpha*M + beta*K
+        rDampingMatrix += beta  * StiffnessMatrix;
     }
 
     //3.-Calculate MassMatrix:
     MatrixType MassMatrix  = Matrix();
     if (alpha!=0.0){
         this->CalculateMassMatrix ( MassMatrix, rCurrentProcessInfo );
+        //4.2.-Compose the Damping Matrix:
+        //Rayleigh Damping Matrix: alpha*M + beta*K
+        rDampingMatrix  += alpha * MassMatrix;
     }
-
-    //4.-Compose the Damping Matrix:
-    //Rayleigh Damping Matrix: alpha*M + beta*K
-    rDampingMatrix  = alpha * MassMatrix;
-    rDampingMatrix += beta  * StiffnessMatrix;
 
     KRATOS_CATCH( "" )
 }

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -1262,15 +1262,7 @@ void UpdatedLagrangian::CalculateDampingMatrix( MatrixType& rDampingMatrix, cons
 
     noalias( rDampingMatrix ) = ZeroMatrix(matrix_size, matrix_size);
 
-    //1.-Calculate StiffnessMatrix:
-    MatrixType StiffnessMatrix  = Matrix();
-    this->CalculateLeftHandSide( StiffnessMatrix, rCurrentProcessInfo );
-
-    //2.-Calculate MassMatrix:
-    MatrixType MassMatrix  = Matrix();
-    this->CalculateMassMatrix ( MassMatrix, rCurrentProcessInfo );
-
-    //3.-Get Damping Coeffitients (RAYLEIGH_ALPHA, RAYLEIGH_BETA)
+    //1.-Get Damping Coeffitients (RAYLEIGH_ALPHA, RAYLEIGH_BETA)
     double alpha = 0;
     if( GetProperties().Has(RAYLEIGH_ALPHA) )
     {
@@ -1289,6 +1281,18 @@ void UpdatedLagrangian::CalculateDampingMatrix( MatrixType& rDampingMatrix, cons
     else if( rCurrentProcessInfo.Has(RAYLEIGH_BETA) )
     {
         beta = rCurrentProcessInfo[RAYLEIGH_BETA];
+    }
+
+    //2.-Calculate StiffnessMatrix:
+    MatrixType StiffnessMatrix  = Matrix();
+    if (beta!=0.0){
+        this->CalculateLeftHandSide( StiffnessMatrix, rCurrentProcessInfo );
+    }
+
+    //3.-Calculate MassMatrix:
+    MatrixType MassMatrix  = Matrix();
+    if (alpha!=0.0){
+        this->CalculateMassMatrix ( MassMatrix, rCurrentProcessInfo );
     }
 
     //4.-Compose the Damping Matrix:


### PR DESCRIPTION
Hi, I just realized that the updated lagrangian element in MPM always calculates M&K for the damping matrix C, even though they may not be needed in all the cases.
As I am not familiar with the MPM application let me know if this PR is useless.