### PR TITLE
[dem] Fix memory access for 1N conditions

### DIFF
--- a/applications/DEMApplication/custom_utilities/GeometryFunctions.h
+++ b/applications/DEMApplication/custom_utilities/GeometryFunctions.h
@@ -1315,6 +1315,20 @@ namespace Kratos {
         return false;
     }//VertexCheck
 
+
+    static inline bool FastVertexCheck(const array_1d<double,3>& Coord, const array_1d<double,3>& Particle_Coord, double Radius)
+    {
+        double dist_sq = 0.0;
+        array_1d<double, 3> normal_v;
+        for (unsigned int j = 0; j < 3; j++)
+        {
+            normal_v[j] = Particle_Coord[j] - Coord[j];
+            dist_sq += normal_v[j] * normal_v[j];
+        }
+        if (dist_sq <= Radius * Radius) return true;
+        return false;
+    }//FastVertexCheck
+
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     ///////////////******The four Functions BELOW are used to calculate the weight coefficient for quadrilateral*******///////////
     ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/applications/DEMApplication/custom_utilities/rigid_face_geometrical_object_configure.h
+++ b/applications/DEMApplication/custom_utilities/rigid_face_geometrical_object_configure.h
@@ -208,6 +208,16 @@ public:
         return  intersect;
     }
 
+    static inline bool FastIntersection1D(const GeometryType& DE_Geom, const GeometryType& FE_Geom,  const double& Radius)
+    {
+      double dummy_local_coordSystem[3][3] ={{0.0}, {0.0}, {0.0}};
+      double dummy_dist_particle_to_vertex = 0;
+
+      return GeometryFunctions::VertexCheck( FE_Geom[0].Coordinates(),
+          DE_Geom[0].Coordinates(), Radius, dummy_local_coordSystem,
+          dummy_dist_particle_to_vertex);
+    }//FastIntersection1D
+
     static inline bool FastIntersection2D(const GeometryType& DE_Geom, const GeometryType& FE_Geom,  const double& Radius)
     {
       //rObj_1 is particle,  and rObj_2 is condition
@@ -267,8 +277,10 @@ public:
         const double Radius = p_particle->GetSearchRadius();
 
         int facet_size = FE_Geom.WorkingSpaceDimension();
+        const int fe_size = FE_Geom.size();
 
-        if (facet_size==2) {
+        if (fe_size==1) return FastIntersection1D(DE_Geom, FE_Geom, Radius);
+        else if (facet_size==2) {
            return FastIntersection2D(DE_Geom, FE_Geom, Radius);//, NewContactType);
         }
         else {
@@ -282,8 +294,10 @@ public:
       const GeometryType& FE_Geom = rObj_2->GetGeometry();
 
       int facet_size = FE_Geom.WorkingSpaceDimension();
+      const int fe_size = FE_Geom.size();
 
-      if (facet_size==2) {
+        if (fe_size==1) return FastIntersection1D(DE_Geom, FE_Geom, Radius);
+        else if (facet_size==2) {
          return FastIntersection2D(DE_Geom, FE_Geom, Radius);//, NewContactType);
       }
       else {

--- a/applications/DEMApplication/custom_utilities/rigid_face_geometrical_object_configure.h
+++ b/applications/DEMApplication/custom_utilities/rigid_face_geometrical_object_configure.h
@@ -208,16 +208,6 @@ public:
         return  intersect;
     }
 
-    static inline bool FastIntersection1D(const GeometryType& DE_Geom, const GeometryType& FE_Geom,  const double& Radius)
-    {
-      double dummy_local_coordSystem[3][3] ={{0.0}, {0.0}, {0.0}};
-      double dummy_dist_particle_to_vertex = 0;
-
-      return GeometryFunctions::VertexCheck( FE_Geom[0].Coordinates(),
-          DE_Geom[0].Coordinates(), Radius, dummy_local_coordSystem,
-          dummy_dist_particle_to_vertex);
-    }//FastIntersection1D
-
     static inline bool FastIntersection2D(const GeometryType& DE_Geom, const GeometryType& FE_Geom,  const double& Radius)
     {
       //rObj_1 is particle,  and rObj_2 is condition
@@ -276,10 +266,9 @@ public:
         SphericParticle* p_particle = static_cast<SphericParticle*>(&*rObj_2);
         const double Radius = p_particle->GetSearchRadius();
 
-        int facet_size = FE_Geom.WorkingSpaceDimension();
-        const int fe_size = FE_Geom.size();
+        const int facet_size = FE_Geom.size();
 
-        if (fe_size==1) return FastIntersection1D(DE_Geom, FE_Geom, Radius);
+        if (facet_size==1) return GeometryFunctions::FastVertexCheck(FE_Geom[0].Coordinates(),DE_Geom[0].Coordinates(), Radius);
         else if (facet_size==2) {
            return FastIntersection2D(DE_Geom, FE_Geom, Radius);//, NewContactType);
         }
@@ -293,11 +282,10 @@ public:
       const GeometryType& DE_Geom = rObj_1->GetGeometry();
       const GeometryType& FE_Geom = rObj_2->GetGeometry();
 
-      int facet_size = FE_Geom.WorkingSpaceDimension();
-      const int fe_size = FE_Geom.size();
+      const int facet_size = FE_Geom.size();
 
-        if (fe_size==1) return FastIntersection1D(DE_Geom, FE_Geom, Radius);
-        else if (facet_size==2) {
+      if (facet_size==1) return GeometryFunctions::FastVertexCheck(FE_Geom[0].Coordinates(),DE_Geom[0].Coordinates(), Radius);
+      else if (facet_size==2) {
          return FastIntersection2D(DE_Geom, FE_Geom, Radius);//, NewContactType);
       }
       else {
@@ -308,9 +296,10 @@ public:
     //Copy of the Intersection function accessible with geometry
     static inline bool FastIntersection(const GeometryType& DE_Geom, const GeometryType& FE_Geom,  const double& Radius) { //rObj_1 is sphere, rObj_2 is FE
 
-      int facet_size = FE_Geom.WorkingSpaceDimension();
+      int facet_size = FE_Geom.size();
 
-      if (facet_size==2) {
+      if (facet_size==1) return GeometryFunctions::FastVertexCheck(FE_Geom[0].Coordinates(),DE_Geom[0].Coordinates(), Radius);
+      else if (facet_size==2) {
          return FastIntersection2D(DE_Geom, FE_Geom, Radius);//, NewContactType);
       }
       else {


### PR DESCRIPTION
Hi, I recently made a PR #8406 to enable the direct use of 1 noded conditions. All worked fine on Linux until we ran the new test cases on a windows machine and had our simulation crashed. So we found a function that I missed and which accessed memory that is not allocated. 

This problem is fixed with this PR.