### PR TITLE
[Potential Flow] Fixing Compressible Perturbation Element

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
@@ -816,21 +816,24 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::ComputePotenti
     array_1d<double, NumNodes> distances;
     GetWakeDistances(distances);
 
+    auto r_geometry = GetGeometry();
     for (unsigned int i = 0; i < NumNodes; i++)
     {
-        double aux_potential =
-            GetGeometry()[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL);
-        double potential = GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL);
+        double aux_potential = r_geometry[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL);
+        double potential = r_geometry[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL);
         double potential_jump = aux_potential - potential;
 
         if (distances[i] > 0)
         {
-            GetGeometry()[i].SetValue(POTENTIAL_JUMP,
-                                      -2.0 / vinfinity_norm * (potential_jump));
+            r_geometry[i].SetLock();
+            r_geometry[i].SetValue(POTENTIAL_JUMP, -2.0 / vinfinity_norm * (potential_jump));
+            r_geometry[i].UnSetLock();
         }
         else
         {
+            r_geometry[i].SetLock();
             GetGeometry()[i].SetValue(POTENTIAL_JUMP, 2.0 / vinfinity_norm * (potential_jump));
+            r_geometry[i].UnSetLock();
         }
     }
 }

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
@@ -832,7 +832,7 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::ComputePotenti
         else
         {
             r_geometry[i].SetLock();
-            GetGeometry()[i].SetValue(POTENTIAL_JUMP, 2.0 / vinfinity_norm * (potential_jump));
+            r_geometry[i].SetValue(POTENTIAL_JUMP, 2.0 / vinfinity_norm * (potential_jump));
             r_geometry[i].UnSetLock();
         }
     }

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
@@ -462,14 +462,8 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLeftH
     GetWakeDistances(data.distances);
 
     // Compute upper and lower velocities
-    const array_1d<double, 3> free_stream_velocity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
-    array_1d<double, Dim> upper_velocity = PotentialFlowUtilities::ComputeVelocityUpperWakeElement<Dim,NumNodes>(*this);
-    array_1d<double, Dim> lower_velocity = PotentialFlowUtilities::ComputeVelocityLowerWakeElement<Dim,NumNodes>(*this);
-
-    for (unsigned int i = 0; i < Dim; i++){
-        upper_velocity[i] += free_stream_velocity[i];
-        lower_velocity[i] += free_stream_velocity[i];
-    }
+    const array_1d<double, Dim> upper_velocity = PotentialFlowUtilities::ComputePerturbedVelocity<Dim,NumNodes>(*this, rCurrentProcessInfo);
+    const array_1d<double, Dim> lower_velocity = PotentialFlowUtilities::ComputePerturbedVelocityLowerElement<Dim,NumNodes>(*this, rCurrentProcessInfo);
 
     BoundedMatrix<double, NumNodes, NumNodes> upper_lhs_total = ZeroMatrix(NumNodes,NumNodes);
     BoundedMatrix<double, NumNodes, NumNodes> lower_lhs_total = ZeroMatrix(NumNodes,NumNodes);
@@ -511,14 +505,8 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateRight
     GetWakeDistances(data.distances);
 
     // Compute upper and lower velocities
-    const array_1d<double, 3> free_stream_velocity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
-    array_1d<double, Dim> upper_velocity = PotentialFlowUtilities::ComputeVelocityUpperWakeElement<Dim,NumNodes>(*this);
-    array_1d<double, Dim> lower_velocity = PotentialFlowUtilities::ComputeVelocityLowerWakeElement<Dim,NumNodes>(*this);
-
-    for (unsigned int i = 0; i < Dim; i++){
-        upper_velocity[i] += free_stream_velocity[i];
-        lower_velocity[i] += free_stream_velocity[i];
-    }
+    const array_1d<double, Dim> upper_velocity = PotentialFlowUtilities::ComputePerturbedVelocity<Dim,NumNodes>(*this, rCurrentProcessInfo);
+    const array_1d<double, Dim> lower_velocity = PotentialFlowUtilities::ComputePerturbedVelocityLowerElement<Dim,NumNodes>(*this, rCurrentProcessInfo);
 
     // Compute upper and lower rhs
     BoundedVector<double, NumNodes> upper_rhs = ZeroVector(NumNodes);
@@ -632,14 +620,8 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLeftH
         PartitionsSign, GradientsValue, NEnriched);
 
     // Compute upper and lower velocities
-    const array_1d<double, 3> free_stream_velocity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
-    array_1d<double, Dim> upper_velocity = PotentialFlowUtilities::ComputeVelocityUpperWakeElement<Dim,NumNodes>(*this);
-    array_1d<double, Dim> lower_velocity = PotentialFlowUtilities::ComputeVelocityLowerWakeElement<Dim,NumNodes>(*this);
-
-    for (unsigned int i = 0; i < Dim; i++){
-        upper_velocity[i] += free_stream_velocity[i];
-        lower_velocity[i] += free_stream_velocity[i];
-    }
+    const array_1d<double, Dim> upper_velocity = PotentialFlowUtilities::ComputePerturbedVelocity<Dim,NumNodes>(*this, rCurrentProcessInfo);
+    const array_1d<double, Dim> lower_velocity = PotentialFlowUtilities::ComputePerturbedVelocityLowerElement<Dim,NumNodes>(*this, rCurrentProcessInfo);
 
     // Compute upper and lower densities
     const double upper_local_mach_number_squared = PotentialFlowUtilities::ComputeLocalMachNumberSquared<Dim, NumNodes>(upper_velocity, rCurrentProcessInfo);

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
@@ -816,7 +816,7 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::ComputePotenti
     array_1d<double, NumNodes> distances;
     GetWakeDistances(distances);
 
-    auto r_geometry = GetGeometry();
+    auto& r_geometry = GetGeometry();
     for (unsigned int i = 0; i < NumNodes; i++)
     {
         double aux_potential = r_geometry[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL);

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
@@ -200,7 +200,7 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateOnInt
     }
     else if (rVariable == DENSITY)
     {
-        const array_1d<double, Dim> velocity = PotentialFlowUtilities::ComputePerturbedVelocity<Dim,NumNodes>(*this, rCurrentProcessInfo);
+        const array_1d<double, Dim>& velocity = PotentialFlowUtilities::ComputePerturbedVelocity<Dim,NumNodes>(*this, rCurrentProcessInfo);
 
         const double local_mach_number_squared = PotentialFlowUtilities::ComputeLocalMachNumberSquared<Dim, NumNodes>(velocity, rCurrentProcessInfo);
 
@@ -413,7 +413,7 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLeftH
     // Calculate shape functions
     GeometryUtils::CalculateGeometryData(GetGeometry(), data.DN_DX, data.N, data.vol);
 
-    const array_1d<double, Dim> velocity = PotentialFlowUtilities::ComputePerturbedVelocity<Dim,NumNodes>(*this, rCurrentProcessInfo);
+    const array_1d<double, Dim>& velocity = PotentialFlowUtilities::ComputePerturbedVelocity<Dim,NumNodes>(*this, rCurrentProcessInfo);
 
     BoundedMatrix<double, NumNodes, NumNodes> lhs = ZeroMatrix(NumNodes,NumNodes);
 
@@ -462,8 +462,8 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLeftH
     GetWakeDistances(data.distances);
 
     // Compute upper and lower velocities
-    const array_1d<double, Dim> upper_velocity = PotentialFlowUtilities::ComputePerturbedVelocity<Dim,NumNodes>(*this, rCurrentProcessInfo);
-    const array_1d<double, Dim> lower_velocity = PotentialFlowUtilities::ComputePerturbedVelocityLowerElement<Dim,NumNodes>(*this, rCurrentProcessInfo);
+    const array_1d<double, Dim>& upper_velocity = PotentialFlowUtilities::ComputePerturbedVelocity<Dim,NumNodes>(*this, rCurrentProcessInfo);
+    const array_1d<double, Dim>& lower_velocity = PotentialFlowUtilities::ComputePerturbedVelocityLowerElement<Dim,NumNodes>(*this, rCurrentProcessInfo);
 
     BoundedMatrix<double, NumNodes, NumNodes> upper_lhs_total = ZeroMatrix(NumNodes,NumNodes);
     BoundedMatrix<double, NumNodes, NumNodes> lower_lhs_total = ZeroMatrix(NumNodes,NumNodes);
@@ -505,8 +505,8 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateRight
     GetWakeDistances(data.distances);
 
     // Compute upper and lower velocities
-    const array_1d<double, Dim> upper_velocity = PotentialFlowUtilities::ComputePerturbedVelocity<Dim,NumNodes>(*this, rCurrentProcessInfo);
-    const array_1d<double, Dim> lower_velocity = PotentialFlowUtilities::ComputePerturbedVelocityLowerElement<Dim,NumNodes>(*this, rCurrentProcessInfo);
+    const array_1d<double, Dim>& upper_velocity = PotentialFlowUtilities::ComputePerturbedVelocity<Dim,NumNodes>(*this, rCurrentProcessInfo);
+    const array_1d<double, Dim>& lower_velocity = PotentialFlowUtilities::ComputePerturbedVelocityLowerElement<Dim,NumNodes>(*this, rCurrentProcessInfo);
 
     // Compute upper and lower rhs
     BoundedVector<double, NumNodes> upper_rhs = ZeroVector(NumNodes);
@@ -514,7 +514,7 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateRight
     CalculateRightHandSideContribution(upper_rhs, rCurrentProcessInfo, upper_velocity, data);
     CalculateRightHandSideContribution(lower_rhs, rCurrentProcessInfo, lower_velocity, data);
 
-    const array_1d<double, Dim> diff_velocity = upper_velocity - lower_velocity;
+    const array_1d<double, Dim>& diff_velocity = upper_velocity - lower_velocity;
 
     // Compute wake condition rhs
     const double free_stream_density = rCurrentProcessInfo[FREE_STREAM_DENSITY];
@@ -620,8 +620,8 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLeftH
         PartitionsSign, GradientsValue, NEnriched);
 
     // Compute upper and lower velocities
-    const array_1d<double, Dim> upper_velocity = PotentialFlowUtilities::ComputePerturbedVelocity<Dim,NumNodes>(*this, rCurrentProcessInfo);
-    const array_1d<double, Dim> lower_velocity = PotentialFlowUtilities::ComputePerturbedVelocityLowerElement<Dim,NumNodes>(*this, rCurrentProcessInfo);
+    const array_1d<double, Dim>& upper_velocity = PotentialFlowUtilities::ComputePerturbedVelocity<Dim,NumNodes>(*this, rCurrentProcessInfo);
+    const array_1d<double, Dim>& lower_velocity = PotentialFlowUtilities::ComputePerturbedVelocityLowerElement<Dim,NumNodes>(*this, rCurrentProcessInfo);
 
     // Compute upper and lower densities
     const double upper_local_mach_number_squared = PotentialFlowUtilities::ComputeLocalMachNumberSquared<Dim, NumNodes>(upper_velocity, rCurrentProcessInfo);

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
@@ -419,7 +419,7 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLeftH
 
     CalculateLeftHandSideContribution(lhs, rCurrentProcessInfo, velocity, data);
 
-    noalias(rLeftHandSideMatrix) += lhs;
+    noalias(rLeftHandSideMatrix) = lhs;
 }
 
 template <int Dim, int NumNodes>

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
@@ -471,38 +471,23 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLeftH
     GeometryUtils::CalculateGeometryData(GetGeometry(), data.DN_DX, data.N, data.vol);
     GetWakeDistances(data.distances);
 
-    const double density = ComputeDensity(rCurrentProcessInfo);
-    const double DrhoDu2 = ComputeDensityDerivative(density, rCurrentProcessInfo);
-
-    // Computing local velocity
+    // Compute upper and lower velocities
     const array_1d<double, 3> free_stream_velocity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
-    array_1d<double, Dim> velocity = PotentialFlowUtilities::ComputeVelocity<Dim,NumNodes>(*this);
-    for (unsigned int i = 0; i < Dim; i++){
-        velocity[i] += free_stream_velocity[i];
-    }
-
-    const BoundedVector<double, NumNodes> DNV = prod(data.DN_DX, velocity);
-
-    const BoundedMatrix<double, NumNodes, NumNodes> lhs_total =
-        data.vol * density * prod(data.DN_DX, trans(data.DN_DX)) +
-        data.vol * 2 * DrhoDu2 * outer_prod(DNV, trans(DNV));
-
+    array_1d<double, Dim> upper_velocity = PotentialFlowUtilities::ComputeVelocityUpperWakeElement<Dim,NumNodes>(*this);
     array_1d<double, Dim> lower_velocity = PotentialFlowUtilities::ComputeVelocityLowerWakeElement<Dim,NumNodes>(*this);
 
     for (unsigned int i = 0; i < Dim; i++){
+        upper_velocity[i] += free_stream_velocity[i];
         lower_velocity[i] += free_stream_velocity[i];
     }
-    const double local_mach_number_squared_lower = PotentialFlowUtilities::ComputeLocalMachNumberSquared<Dim, NumNodes>(lower_velocity, rCurrentProcessInfo);
 
-    const double density_lower = PotentialFlowUtilities::ComputeDensity<Dim, NumNodes>(local_mach_number_squared_lower, rCurrentProcessInfo);
-    const double DrhoDu2_lower = ComputeDensityDerivative(density_lower, rCurrentProcessInfo);
+    BoundedMatrix<double, NumNodes, NumNodes> upper_lhs_total = ZeroMatrix(NumNodes,NumNodes);
+    BoundedMatrix<double, NumNodes, NumNodes> lower_lhs_total = ZeroMatrix(NumNodes,NumNodes);
 
-    const BoundedVector<double, NumNodes> DNV_lower = prod(data.DN_DX, lower_velocity);
+    CalculateTotalLeftHandSideWakeElement(upper_lhs_total, rCurrentProcessInfo, upper_velocity, data);
+    CalculateTotalLeftHandSideWakeElement(lower_lhs_total, rCurrentProcessInfo, lower_velocity, data);
 
-    const BoundedMatrix<double, NumNodes, NumNodes> lhs_total_lower =
-        data.vol * density_lower * prod(data.DN_DX, trans(data.DN_DX)) +
-        data.vol * 2 * DrhoDu2_lower * outer_prod(DNV_lower, trans(DNV_lower));
-
+    // Compute lhs wake condition
     const double free_stream_density = rCurrentProcessInfo[FREE_STREAM_DENSITY];
     const BoundedMatrix<double, NumNodes, NumNodes> lhs_wake_condition = data.vol * free_stream_density * prod(data.DN_DX, trans(data.DN_DX));
 
@@ -512,30 +497,37 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLeftH
 
         CalculateLeftHandSideSubdividedElement(lhs_positive, lhs_negative, rCurrentProcessInfo);
         AssignLeftHandSideSubdividedElement(rLeftHandSideMatrix, lhs_positive,
-                                            lhs_negative, lhs_total, data);
+                                            lhs_negative, upper_lhs_total, lower_lhs_total, lhs_wake_condition, data);
     }
     else{
-        for (unsigned int row = 0; row < NumNodes; ++row){
-            // Applying wake condition on the AUXILIARY_VELOCITY_POTENTIAL dofs
-            if (data.distances[row] < 0.0){
-                for (unsigned int column = 0; column < NumNodes; ++column){
-                    // Conservation of mass
-                    rLeftHandSideMatrix(row + NumNodes, column + NumNodes) = lhs_total_lower(row, column);
-                    // Wake condition
-                    rLeftHandSideMatrix(row, column) = lhs_wake_condition(row, column); // Diagonal
-                    rLeftHandSideMatrix(row, column + NumNodes) = -lhs_wake_condition(row, column); // Off diagonal
-                }
-            }
-            else{ // else if (data.distances[row] > 0.0)
-                for (unsigned int column = 0; column < NumNodes; ++column){
-                    // Conservation of mass
-                    rLeftHandSideMatrix(row, column) = lhs_total(row, column);
-                    // Wake condition
-                    rLeftHandSideMatrix(row + NumNodes, column + NumNodes) = lhs_wake_condition(row, column); // Diagonal
-                    rLeftHandSideMatrix(row + NumNodes, column) = -lhs_wake_condition(row, column); // Off diagonal
-                }
-            }
-        }
+        AssignLeftHandSideWakeElement(rLeftHandSideMatrix, upper_lhs_total, lower_lhs_total, lhs_wake_condition, data);
+    }
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateTotalLeftHandSideWakeElement(
+    BoundedMatrix<double, NumNodes, NumNodes>& rLhs_total,
+    const ProcessInfo& rCurrentProcessInfo,
+    const array_1d<double, Dim>& rVelocity,
+    const ElementalData<NumNodes, Dim>& rData)
+{
+    // Compute density
+    const double local_mach_number_squared = PotentialFlowUtilities::ComputeLocalMachNumberSquared<Dim, NumNodes>(rVelocity, rCurrentProcessInfo);
+    const double density = PotentialFlowUtilities::ComputeDensity<Dim, NumNodes>(local_mach_number_squared, rCurrentProcessInfo);
+
+    // Compute density derivative
+    const double DrhoDu2 = PotentialFlowUtilities::ComputeDensityDerivativeWRTVelocitySquared<Dim, NumNodes>(local_mach_number_squared, rCurrentProcessInfo);
+
+    // Compute upper lhs
+    const BoundedVector<double, NumNodes> DNV = prod(rData.DN_DX, rVelocity);
+
+    rLhs_total = rData.vol * density * prod(rData.DN_DX, trans(rData.DN_DX));
+
+    const double local_velocity_squared = inner_prod(rVelocity, rVelocity);
+
+    const double max_velocity_squared = PotentialFlowUtilities::ComputeMaximumVelocitySquared<Dim, NumNodes>(rCurrentProcessInfo);
+    if (local_velocity_squared < max_velocity_squared){
+        rLhs_total += rData.vol * 2 * DrhoDu2 * outer_prod(DNV, trans(DNV));
     }
 }
 
@@ -555,8 +547,7 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateRight
     GeometryUtils::CalculateGeometryData(r_geometry, data.DN_DX, data.N, data.vol);
     GetWakeDistances(data.distances);
 
-    const double density = ComputeDensity(rCurrentProcessInfo);
-
+    // Compute upper and lower velocities
     const array_1d<double, 3> free_stream_velocity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
     array_1d<double, Dim> upper_velocity = PotentialFlowUtilities::ComputeVelocityUpperWakeElement<Dim,NumNodes>(*this);
     array_1d<double, Dim> lower_velocity = PotentialFlowUtilities::ComputeVelocityLowerWakeElement<Dim,NumNodes>(*this);
@@ -565,16 +556,22 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateRight
         upper_velocity[i] += free_stream_velocity[i];
         lower_velocity[i] += free_stream_velocity[i];
     }
-    const double local_mach_number_squared_lower = PotentialFlowUtilities::ComputeLocalMachNumberSquared<Dim, NumNodes>(lower_velocity, rCurrentProcessInfo);
 
-    const double density_lower = PotentialFlowUtilities::ComputeDensity<Dim, NumNodes>(local_mach_number_squared_lower, rCurrentProcessInfo);
+    // Compute upper and lower densities
+    const double upper_local_mach_number_squared = PotentialFlowUtilities::ComputeLocalMachNumberSquared<Dim, NumNodes>(upper_velocity, rCurrentProcessInfo);
+    const double upper_density = PotentialFlowUtilities::ComputeDensity<Dim, NumNodes>(upper_local_mach_number_squared, rCurrentProcessInfo);
+
+    const double lower_local_mach_number_squared = PotentialFlowUtilities::ComputeLocalMachNumberSquared<Dim, NumNodes>(lower_velocity, rCurrentProcessInfo);
+    const double lower_density = PotentialFlowUtilities::ComputeDensity<Dim, NumNodes>(lower_local_mach_number_squared, rCurrentProcessInfo);
+
+    // Compute upper and lower rhs
     const array_1d<double, Dim> diff_velocity = upper_velocity - lower_velocity;
+    const BoundedVector<double, NumNodes> upper_rhs = - data.vol * upper_density * prod(data.DN_DX, upper_velocity);
+    const BoundedVector<double, NumNodes> lower_rhs = - data.vol * lower_density * prod(data.DN_DX, lower_velocity);
 
-    const BoundedVector<double, NumNodes> upper_rhs = - data.vol * density * prod(data.DN_DX, upper_velocity);
-    const BoundedVector<double, NumNodes> lower_rhs = - data.vol * density_lower * prod(data.DN_DX, lower_velocity);
+    // Compute wake condition rhs
     const double free_stream_density = rCurrentProcessInfo[FREE_STREAM_DENSITY];
     const BoundedVector<double, NumNodes> wake_rhs = - data.vol * free_stream_density * prod(data.DN_DX, diff_velocity);
-    // const BoundedVector<double, NumNodes> wake_rhs_lower = data.vol * density_lower * prod(data.DN_DX, diff_velocity);
 
     if (this->Is(STRUCTURE)){
         double upper_vol = 0.0;
@@ -592,15 +589,8 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateRight
         }
     }
     else{
-        for (unsigned int rRow = 0; rRow < NumNodes; ++rRow){
-            if (data.distances[rRow] > 0.0){
-                rRightHandSideVector[rRow] = upper_rhs(rRow);
-                rRightHandSideVector[rRow + NumNodes] = -wake_rhs(rRow);
-            }
-            else{
-                rRightHandSideVector[rRow] = wake_rhs(rRow);
-                rRightHandSideVector[rRow + NumNodes] = lower_rhs(rRow);
-            }
+        for (unsigned int i = 0; i < NumNodes; ++i){
+            AssignRightHandSideWakeNode(rRightHandSideVector, upper_rhs, lower_rhs, wake_rhs, data, i);
         }
     }
 }
@@ -641,34 +631,52 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLeftH
         Points, data.DN_DX, data.distances, Volumes, GPShapeFunctionValues,
         PartitionsSign, GradientsValue, NEnriched);
 
-    const double density = ComputeDensity(rCurrentProcessInfo);
-    const double DrhoDu2 = ComputeDensityDerivative(density, rCurrentProcessInfo);
-
-    // Computing local velocity
+    // Compute upper and lower velocities
     const array_1d<double, 3> free_stream_velocity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
-    array_1d<double, Dim> velocity = PotentialFlowUtilities::ComputeVelocity<Dim,NumNodes>(*this);
+    array_1d<double, Dim> upper_velocity = PotentialFlowUtilities::ComputeVelocityUpperWakeElement<Dim,NumNodes>(*this);
+    array_1d<double, Dim> lower_velocity = PotentialFlowUtilities::ComputeVelocityLowerWakeElement<Dim,NumNodes>(*this);
+
     for (unsigned int i = 0; i < Dim; i++){
-        velocity[i] += free_stream_velocity[i];
+        upper_velocity[i] += free_stream_velocity[i];
+        lower_velocity[i] += free_stream_velocity[i];
     }
 
-    const BoundedVector<double, NumNodes> DNV = prod(data.DN_DX, velocity);
+    // Compute upper and lower densities
+    const double upper_local_mach_number_squared = PotentialFlowUtilities::ComputeLocalMachNumberSquared<Dim, NumNodes>(upper_velocity, rCurrentProcessInfo);
+    const double upper_density = PotentialFlowUtilities::ComputeDensity<Dim, NumNodes>(upper_local_mach_number_squared, rCurrentProcessInfo);
+
+    const double lower_local_mach_number_squared = PotentialFlowUtilities::ComputeLocalMachNumberSquared<Dim, NumNodes>(lower_velocity, rCurrentProcessInfo);
+    const double lower_density = PotentialFlowUtilities::ComputeDensity<Dim, NumNodes>(lower_local_mach_number_squared, rCurrentProcessInfo);
+
+    // Compute upper and lower density derivatives
+    const double upper_DrhoDu2 = PotentialFlowUtilities::ComputeDensityDerivativeWRTVelocitySquared<Dim, NumNodes>(upper_local_mach_number_squared, rCurrentProcessInfo);
+    const double lower_DrhoDu2 = PotentialFlowUtilities::ComputeDensityDerivativeWRTVelocitySquared<Dim, NumNodes>(lower_local_mach_number_squared, rCurrentProcessInfo);
+
+    // Compute upper and lower lhs
+    const BoundedVector<double, NumNodes> upper_DNV = prod(data.DN_DX, upper_velocity);
+    const BoundedVector<double, NumNodes> lower_DNV = prod(data.DN_DX, lower_velocity);
+
+    const double upper_local_velocity_squared = inner_prod(upper_velocity, upper_velocity);
+    const double lower_local_velocity_squared = inner_prod(lower_velocity, lower_velocity);
+    const double max_velocity_squared = PotentialFlowUtilities::ComputeMaximumVelocitySquared<Dim, NumNodes>(rCurrentProcessInfo);
 
     // Compute the lhs and rhs that would correspond to it being divided
     for (unsigned int i = 0; i < nsubdivisions; ++i)
     {
         if (PartitionsSign[i] > 0)
         {
-            noalias(lhs_positive) +=
-                Volumes[i] * density * prod(data.DN_DX, trans(data.DN_DX));
-            noalias(lhs_positive) +=
-                Volumes[i] * 2 * DrhoDu2 * outer_prod(DNV, trans(DNV));
+            noalias(lhs_positive) += Volumes[i] * upper_density * prod(data.DN_DX, trans(data.DN_DX));
+            if( upper_local_velocity_squared < max_velocity_squared){
+                noalias(lhs_positive) += Volumes[i] * 2 * upper_DrhoDu2 * outer_prod(upper_DNV, trans(upper_DNV));
+            }
+
         }
         else
         {
-            noalias(lhs_negative) +=
-                Volumes[i] * density * prod(data.DN_DX, trans(data.DN_DX));
-            noalias(lhs_negative) +=
-                Volumes[i] * 2 * DrhoDu2 * outer_prod(DNV, trans(DNV));
+            noalias(lhs_negative) += Volumes[i] * lower_density * prod(data.DN_DX, trans(data.DN_DX));
+            if( lower_local_velocity_squared < max_velocity_squared){
+                noalias(lhs_negative) += Volumes[i] * 2 * lower_DrhoDu2 * outer_prod(lower_DNV, trans(lower_DNV));
+            }
         }
     }
 }
@@ -733,7 +741,9 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::AssignLeftHand
     Matrix& rLeftHandSideMatrix,
     Matrix& lhs_positive,
     Matrix& lhs_negative,
-    const BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+    const BoundedMatrix<double, NumNodes, NumNodes>& rUpper_lhs_total,
+    const BoundedMatrix<double, NumNodes, NumNodes>& rLower_lhs_total,
+    const BoundedMatrix<double, NumNodes, NumNodes>& rLhs_wake_condition,
     const ElementalData<NumNodes, Dim>& data) const
 {
     const auto& r_geometry = this->GetGeometry();
@@ -748,7 +758,7 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::AssignLeftHand
             }
         }
         else{
-            AssignLeftHandSideWakeNode(rLeftHandSideMatrix, lhs_total, data, i);
+            AssignLeftHandSideWakeNode(rLeftHandSideMatrix, rUpper_lhs_total, rLower_lhs_total, rLhs_wake_condition, data, i);
         }
     }
 }
@@ -756,34 +766,44 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::AssignLeftHand
 template <int Dim, int NumNodes>
 void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::AssignLeftHandSideWakeElement(
     MatrixType& rLeftHandSideMatrix,
-    const BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
-    const ElementalData<NumNodes, Dim>& data) const
+    const BoundedMatrix<double, NumNodes, NumNodes>& rUpper_lhs_total,
+    const BoundedMatrix<double, NumNodes, NumNodes>& rLower_lhs_total,
+    const BoundedMatrix<double, NumNodes, NumNodes>& rLhs_wake_condition,
+    const ElementalData<NumNodes, Dim>& rData) const
 {
-    for (unsigned int row = 0; row < NumNodes; ++row)
-        AssignLeftHandSideWakeNode(rLeftHandSideMatrix, lhs_total, data, row);
+    for (unsigned int row = 0; row < NumNodes; ++row){
+        AssignLeftHandSideWakeNode(rLeftHandSideMatrix, rUpper_lhs_total, rLower_lhs_total, rLhs_wake_condition, rData, row);
+    }
 }
 
 template <int Dim, int NumNodes>
 void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::AssignLeftHandSideWakeNode(
     MatrixType& rLeftHandSideMatrix,
-    const BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
-    const ElementalData<NumNodes, Dim>& data,
-    unsigned int& row) const
+    const BoundedMatrix<double, NumNodes, NumNodes>& rUpper_lhs_total,
+    const BoundedMatrix<double, NumNodes, NumNodes>& rLower_lhs_total,
+    const BoundedMatrix<double, NumNodes, NumNodes>& rLhs_wake_condition,
+    const ElementalData<NumNodes, Dim>& rData,
+    unsigned int row) const
 {
-    // Filling the diagonal blocks (i.e. decoupling upper and lower dofs)
-    for (unsigned int column = 0; column < NumNodes; ++column)
-    {
-        rLeftHandSideMatrix(row, column) = lhs_total(row, column);
-        rLeftHandSideMatrix(row + NumNodes, column + NumNodes) = lhs_total(row, column);
-    }
-
     // Applying wake condition on the AUXILIARY_VELOCITY_POTENTIAL dofs
-    if (data.distances[row] < 0.0)
-        for (unsigned int column = 0; column < NumNodes; ++column)
-            rLeftHandSideMatrix(row, column + NumNodes) = -lhs_total(row, column); // Side 1
-    else if (data.distances[row] > 0.0)
-        for (unsigned int column = 0; column < NumNodes; ++column)
-            rLeftHandSideMatrix(row + NumNodes, column) = -lhs_total(row, column); // Side 2
+    if (rData.distances[row] < 0.0){
+        for (unsigned int column = 0; column < NumNodes; ++column){
+            // Conservation of mass
+            rLeftHandSideMatrix(row + NumNodes, column + NumNodes) = rLower_lhs_total(row, column);
+            // Wake condition
+            rLeftHandSideMatrix(row, column) = rLhs_wake_condition(row, column); // Diagonal
+            rLeftHandSideMatrix(row, column + NumNodes) = -rLhs_wake_condition(row, column); // Off diagonal
+        }
+    }
+    else{ // else if (data.distances[row] > 0.0)
+        for (unsigned int column = 0; column < NumNodes; ++column){
+            // Conservation of mass
+            rLeftHandSideMatrix(row, column) = rUpper_lhs_total(row, column);
+            // Wake condition
+            rLeftHandSideMatrix(row + NumNodes, column + NumNodes) = rLhs_wake_condition(row, column); // Diagonal
+            rLeftHandSideMatrix(row + NumNodes, column) = -rLhs_wake_condition(row, column); // Off diagonal
+        }
+    }
 }
 
 template <int Dim, int NumNodes>

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.h
@@ -236,6 +236,11 @@ private:
     void CalculateLeftHandSideWakeElement(MatrixType& rLeftHandSideMatrix,
                                          const ProcessInfo& rCurrentProcessInfo);
 
+    void CalculateTotalLeftHandSideWakeElement(BoundedMatrix<double, NumNodes, NumNodes>& rLhs_total,
+                                         const ProcessInfo& rCurrentProcessInfo,
+                                         const array_1d<double, Dim>& rVelocity,
+                                         const ElementalData<NumNodes, Dim>& rData);
+
     void CalculateRightHandSideWakeElement(VectorType& rRightHandSideVector,
                                          const ProcessInfo& rCurrentProcessInfo);
 
@@ -253,17 +258,23 @@ private:
     void AssignLeftHandSideSubdividedElement(Matrix& rLeftHandSideMatrix,
                                              Matrix& lhs_positive,
                                              Matrix& lhs_negative,
-                                             const BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+                                             const BoundedMatrix<double, NumNodes, NumNodes>& rUpper_lhs_total,
+                                             const BoundedMatrix<double, NumNodes, NumNodes>& rLower_lhs_total,
+                                             const BoundedMatrix<double, NumNodes, NumNodes>& rLhs_wake_condition,
                                              const ElementalData<NumNodes, Dim>& data) const;
 
     void AssignLeftHandSideWakeElement(MatrixType& rLeftHandSideMatrix,
-                                      const BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
-                                      const ElementalData<NumNodes, Dim>& data) const;
+                                    const BoundedMatrix<double, NumNodes, NumNodes>& rUpper_lhs_total,
+                                    const BoundedMatrix<double, NumNodes, NumNodes>& rLower_lhs_total,
+                                    const BoundedMatrix<double, NumNodes, NumNodes>& rLhs_wake_condition,
+                                    const ElementalData<NumNodes, Dim>& rData) const;
 
     void AssignLeftHandSideWakeNode(MatrixType& rLeftHandSideMatrix,
-                                   const BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
-                                   const ElementalData<NumNodes, Dim>& data,
-                                   unsigned int& row) const;
+                                    const BoundedMatrix<double, NumNodes, NumNodes>& rUpper_lhs_total,
+                                    const BoundedMatrix<double, NumNodes, NumNodes>& rLower_lhs_total,
+                                    const BoundedMatrix<double, NumNodes, NumNodes>& rLhs_wake_condition,
+                                    const ElementalData<NumNodes, Dim>& rData,
+                                    unsigned int row) const;
 
     void AssignRightHandSideWakeNode(VectorType& rRightHandSideVector,
                                    const BoundedVector<double, NumNodes>& rUpper_rhs,

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.h
@@ -204,11 +204,6 @@ public:
     ///@}
 protected:
 
-    double ComputeDensity(const ProcessInfo& rCurrentProcessInfo) const;
-
-    double ComputeDensityDerivative(const double density,
-                                    const ProcessInfo& rCurrentProcessInfo) const;
-
 private:
     ///@name Private Operators
     ///@{

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.h
@@ -231,13 +231,18 @@ private:
     void CalculateLeftHandSideWakeElement(MatrixType& rLeftHandSideMatrix,
                                          const ProcessInfo& rCurrentProcessInfo);
 
-    void CalculateTotalLeftHandSideWakeElement(BoundedMatrix<double, NumNodes, NumNodes>& rLhs_total,
+    void CalculateRightHandSideWakeElement(VectorType& rRightHandSideVector,
+                                         const ProcessInfo& rCurrentProcessInfo);
+
+    void CalculateLeftHandSideContribution(BoundedMatrix<double, NumNodes, NumNodes>& rLhs_total,
                                          const ProcessInfo& rCurrentProcessInfo,
                                          const array_1d<double, Dim>& rVelocity,
                                          const ElementalData<NumNodes, Dim>& rData);
 
-    void CalculateRightHandSideWakeElement(VectorType& rRightHandSideVector,
-                                         const ProcessInfo& rCurrentProcessInfo);
+    void CalculateRightHandSideContribution(BoundedVector<double, NumNodes>& rRhs_total,
+                                         const ProcessInfo& rCurrentProcessInfo,
+                                         const array_1d<double, Dim>& rVelocity,
+                                         const ElementalData<NumNodes, Dim>& rData);
 
     void CalculateLeftHandSideSubdividedElement(Matrix& lhs_positive,
                                                Matrix& lhs_negative,

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
@@ -119,11 +119,26 @@ array_1d<double, Dim> ComputeVelocity(const Element& rElement)
 
 template <int Dim, int NumNodes>
 array_1d<double, Dim> ComputePerturbedVelocity(
-    const Element& rElement, 
+    const Element& rElement,
     const ProcessInfo& rCurrentProcessInfo)
 {
     const array_1d<double, 3> free_stream_velocity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
     array_1d<double, Dim> velocity = ComputeVelocity<Dim,NumNodes>(rElement);
+    for (unsigned int i = 0; i < Dim; i++)
+    {
+        velocity[i] += free_stream_velocity[i];
+    }
+
+    return velocity;
+}
+
+template <int Dim, int NumNodes>
+array_1d<double, Dim> ComputePerturbedVelocityLowerElement(
+    const Element& rElement,
+    const ProcessInfo& rCurrentProcessInfo)
+{
+    const array_1d<double, 3> free_stream_velocity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
+    array_1d<double, Dim> velocity = ComputeVelocityLowerWakeElement<Dim,NumNodes>(rElement);
     for (unsigned int i = 0; i < Dim; i++)
     {
         velocity[i] += free_stream_velocity[i];
@@ -547,7 +562,7 @@ double ComputePerturbationLocalMachNumber(const Element& rElement, const Process
 
 template <int Dim, int NumNodes>
 double ComputeUpwindFactor(
-        double localMachNumberSquared, 
+        double localMachNumberSquared,
         const ProcessInfo& rCurrentProcessInfo)
 {
     // Following Fully Simulataneous Coupling of the Full Potential Equation
@@ -569,8 +584,8 @@ double ComputeUpwindFactor(
 
 template <int Dim, int NumNodes>
 double SelectMaxUpwindFactor(
-        const array_1d<double, Dim>& rCurrentVelocity, 
-        const array_1d<double, Dim>& rUpwindVelocity, 
+        const array_1d<double, Dim>& rCurrentVelocity,
+        const array_1d<double, Dim>& rUpwindVelocity,
         const ProcessInfo& rCurrentProcessInfo)
 {
     // Following Fully Simulataneous Coupling of the Full Potential Equation
@@ -602,7 +617,7 @@ size_t ComputeUpwindFactorCase(array_1d<double, 3>& rUpwindFactorOptions)
         rUpwindFactorOptions[2] = 0.0;
     }
     const auto max_upwind_factor_opt = std::max_element(rUpwindFactorOptions.begin(), rUpwindFactorOptions.end());
-    
+
     // Case 0: Subsonic flow
     // Case 1: Supersonic and accelerating flow (M^2 > M^2_up)
     // Case 2: Supersonic and decelerating flow (M^2 < M^2_up)
@@ -647,7 +662,7 @@ double ComputeUpwindFactorDerivativeWRTVelocitySquared(
 
 template <int Dim, int NumNodes>
 double ComputeDensity(
-    const double localMachNumberSquared, 
+    const double localMachNumberSquared,
     const ProcessInfo& rCurrentProcessInfo)
 {
     // Implemented according to Equation 8.9 of Drela, M. (2014) Flight Vehicle
@@ -673,8 +688,8 @@ double ComputeDensity(
 
 template <int Dim, int NumNodes>
 double ComputeUpwindedDensity(
-    const array_1d<double, Dim>& rCurrentVelocity, 
-    const array_1d<double, Dim>& rUpwindVelocity, 
+    const array_1d<double, Dim>& rCurrentVelocity,
+    const array_1d<double, Dim>& rUpwindVelocity,
     const ProcessInfo& rCurrentProcessInfo)
 {
     // Following Fully Simulataneous Coupling of the Full Potential Equation
@@ -694,7 +709,7 @@ double ComputeUpwindedDensity(
 
 template <int Dim, int NumNodes>
 double ComputeDensityDerivativeWRTVelocitySquared(
-    const double localMachNumberSquared, 
+    const double localMachNumberSquared,
     const ProcessInfo& rCurrentProcessInfo)
 {
     // Following Fully Simulataneous Coupling of the Full Potential Equation
@@ -726,9 +741,9 @@ double ComputeDensityDerivativeWRTVelocitySquared(
 
 template <int Dim, int NumNodes>
 double ComputeUpwindedDensityDerivativeWRTVelocitySquaredSupersonicAccelerating(
-    const array_1d<double, Dim>& rCurrentVelocity, 
+    const array_1d<double, Dim>& rCurrentVelocity,
     const double currentMachNumberSquared,
-    const double upwindMachNumberSquared, 
+    const double upwindMachNumberSquared,
     const ProcessInfo& rCurrentProcessInfo)
 {
     // Following Fully Simulataneous Coupling of the Full Potential Equation
@@ -754,7 +769,7 @@ double ComputeUpwindedDensityDerivativeWRTVelocitySquaredSupersonicDeacceleratin
 {
     // Following Fully Simulataneous Coupling of the Full Potential Equation
     //           and the Integral Boundary Layer Equations in Three Dimensions
-    //           by Brian Nishida (1996), Section A.2.6    
+    //           by Brian Nishida (1996), Section A.2.6
     // const double current_mach_sq = ComputeLocalMachNumberSquared<Dim, NumNodes>(rCurrentVelocity, rCurrentProcessInfo);
     const double Drho_Dq2 = ComputeDensityDerivativeWRTVelocitySquared<Dim, NumNodes>(currentMachNumberSquared, rCurrentProcessInfo);
 
@@ -767,7 +782,7 @@ double ComputeUpwindedDensityDerivativeWRTVelocitySquaredSupersonicDeacceleratin
 template <int Dim, int NumNodes>
 double ComputeUpwindedDensityDerivativeWRTUpwindVelocitySquaredSupersonicAccelerating(
     const double currentMachNumberSquared,
-    const double upwindMachNumberSquared, 
+    const double upwindMachNumberSquared,
     const ProcessInfo& rCurrentProcessInfo)
 {
     // Following Fully Simulataneous Coupling of the Full Potential Equation
@@ -784,7 +799,7 @@ template <int Dim, int NumNodes>
 double ComputeUpwindedDensityDerivativeWRTUpwindVelocitySquaredSupersonicDeaccelerating(
     const array_1d<double, Dim>& rUpwindVelocity,
     const double currentMachNumberSquared,
-    const double upwindMachNumberSquared, 
+    const double upwindMachNumberSquared,
     const ProcessInfo& rCurrentProcessInfo)
 {
     // Following Fully Simulataneous Coupling of the Full Potential Equation
@@ -922,6 +937,7 @@ template array_1d<double, 2> ComputeVelocityUpperWakeElement<2, 3>(const Element
 template array_1d<double, 2> ComputeVelocityLowerWakeElement<2, 3>(const Element& rElement);
 template array_1d<double, 2> ComputeVelocity<2, 3>(const Element& rElement);
 template array_1d<double, 2> ComputePerturbedVelocity<2,3>(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
+template array_1d<double, 2> ComputePerturbedVelocityLowerElement<2,3>(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
 template double ComputeMaximumVelocitySquared<2, 3>(const ProcessInfo& rCurrentProcessInfo);
 template double ComputeClampedVelocitySquared<2, 3>(const array_1d<double, 2>& rVelocity, const ProcessInfo& rCurrentProcessInfo);
 template double ComputeVelocityMagnitude<2, 3>(const double localMachNumberSquared, const ProcessInfo& rCurrentProcessInfo);
@@ -968,6 +984,7 @@ template array_1d<double, 3> ComputeVelocityUpperWakeElement<3, 4>(const Element
 template array_1d<double, 3> ComputeVelocityLowerWakeElement<3, 4>(const Element& rElement);
 template array_1d<double, 3> ComputeVelocity<3, 4>(const Element& rElement);
 template array_1d<double, 3> ComputePerturbedVelocity<3,4>(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
+template array_1d<double, 3> ComputePerturbedVelocityLowerElement<3,4>(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
 template double ComputeMaximumVelocitySquared<3, 4>(const ProcessInfo& rCurrentProcessInfo);
 template double ComputeClampedVelocitySquared<3, 4>(const array_1d<double, 3>& rVelocity, const ProcessInfo& rCurrentProcessInfo);
 template double ComputeVelocityMagnitude<3, 4>(const double localMachNumberSquared, const ProcessInfo& rCurrentProcessInfo);

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
@@ -80,6 +80,9 @@ template <int Dim, int NumNodes>
 array_1d<double, Dim> ComputePerturbedVelocity(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
 
 template <int Dim, int NumNodes>
+array_1d<double, Dim> ComputePerturbedVelocityLowerElement(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
+
+template <int Dim, int NumNodes>
 double ComputeMaximumVelocitySquared(const ProcessInfo& rCurrentProcessInfo);
 
 template <int Dim, int NumNodes>

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
@@ -85,6 +85,8 @@ array_1d<double, Dim> ComputePerturbedVelocityLowerElement(const Element& rEleme
 template <int Dim, int NumNodes>
 double ComputeMaximumVelocitySquared(const ProcessInfo& rCurrentProcessInfo);
 
+double ComputeVacuumVelocitySquared(const ProcessInfo& rCurrentProcessInfo);
+
 template <int Dim, int NumNodes>
 double ComputeClampedVelocitySquared(const array_1d<double, Dim>& rVelocity, const ProcessInfo& rCurrentProcessInfo);
 

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_compressible_perturbation_potential_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_compressible_perturbation_potential_element.cpp
@@ -51,114 +51,10 @@ void GenerateCompressiblePerturbationElement(ModelPart& rModelPart) {
     rModelPart.CreateNewElement("CompressiblePerturbationPotentialFlowElement2D3N", 1, elemNodes, pElemProp);
 }
 
-void AssignPotentialsToNormalCompressiblePerturbationElement(Element::Pointer pElement)
+void AssignPotentialsToNormalCompressiblePerturbationElement(Element::Pointer pElement, const std::array<double, 3> rPotential)
 {
-    std::array<double, 3> potential{1.0, 100.0, 150.0};
-
     for (unsigned int i = 0; i < 3; i++)
-        pElement->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL) = potential[i];
-}
-
-/** Checks the CompressiblePerturbationPotentialFlowElement.
- * Checks the RHS computation.
- */
-KRATOS_TEST_CASE_IN_SUITE(CompressiblePerturbationPotentialFlowElementRHS, CompressiblePotentialApplicationFastSuite) {
-    Model this_model;
-    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
-
-    GenerateCompressiblePerturbationElement(model_part);
-    Element::Pointer pElement = model_part.pGetElement(1);
-
-    AssignPotentialsToNormalCompressiblePerturbationElement(pElement);
-
-    // Compute RHS
-    Vector RHS = ZeroVector(3);
-
-    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
-    pElement->CalculateRightHandSide(RHS, r_current_process_info);
-
-    std::vector<double> reference{146.2643261263345,-122.1426284341492,-24.12169769218525};
-
-    KRATOS_CHECK_VECTOR_NEAR(RHS, reference, 1e-13);
-}
-
-/** Checks the CompressiblePerturbationPotentialFlowElement.
- * Checks the LHS computation.
- */
-KRATOS_TEST_CASE_IN_SUITE(CompressiblePerturbationPotentialFlowElementLHS, CompressiblePotentialApplicationFastSuite) {
-    Model this_model;
-    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
-
-    GenerateCompressiblePerturbationElement(model_part);
-    Element::Pointer pElement = model_part.pGetElement(1);
-
-    AssignPotentialsToNormalCompressiblePerturbationElement(pElement);
-
-    // Compute LHS
-    Matrix LHS = ZeroMatrix(3, 3);
-
-    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
-    pElement->CalculateLeftHandSide(LHS, r_current_process_info);
-
-    std::array<double, 9> reference{ 0.06114278464441542,-0.1306215050744058, 0.06947872042999037,
-                                     -0.1306215050744058, 0.6710758508914103,-0.5404543458170046,
-                                      0.06947872042999037,-0.5404543458170046,0.4709756253870142};
-
-    for (unsigned int i = 0; i < LHS.size1(); i++) {
-        for (unsigned int j = 0; j < LHS.size2(); j++) {
-            KRATOS_CHECK_NEAR(LHS(i, j), reference[i * 3 + j], 1e-16);
-        }
-    }
-}
-
-/** Checks the CompressiblePerturbationPotentialFlowElement.
- * Tests the LHS computation.
- */
-KRATOS_TEST_CASE_IN_SUITE(PingCompressiblePerturbationPotentialFlowElementLHS, CompressiblePotentialApplicationFastSuite) {
-    Model this_model;
-    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
-
-    GenerateCompressiblePerturbationElement(model_part);
-    Element::Pointer pElement = model_part.pGetElement(1);
-    const unsigned int number_of_nodes = pElement->GetGeometry().size();
-
-    AssignPotentialsToNormalCompressiblePerturbationElement(pElement);
-
-    Vector RHS_original = ZeroVector(number_of_nodes);
-    Matrix LHS_original = ZeroMatrix(number_of_nodes, number_of_nodes);
-    Matrix LHS_finite_diference = ZeroMatrix(number_of_nodes, number_of_nodes);
-    Matrix LHS_analytical = ZeroMatrix(number_of_nodes, number_of_nodes);
-
-    // Compute original RHS and LHS
-    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
-    pElement->CalculateLocalSystem(LHS_original, RHS_original, r_current_process_info);
-
-    double delta = 1e-3;
-    for(unsigned int i = 0; i < number_of_nodes; i++){
-        // Pinging
-        pElement->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL) += delta;
-
-        Vector RHS_pinged = ZeroVector(number_of_nodes);
-        Matrix LHS_pinged = ZeroMatrix(number_of_nodes, number_of_nodes);
-        // Compute pinged LHS and RHS
-        pElement->CalculateLocalSystem(LHS_pinged, RHS_pinged, r_current_process_info);
-
-        for(unsigned int k = 0; k < number_of_nodes; k++){
-            // Compute the finite difference estimate of the sensitivity
-            LHS_finite_diference( k, i) = -(RHS_pinged(k)-RHS_original(k)) / delta;
-            // Compute the average of the original and pinged analytic sensitivities
-            LHS_analytical( k, i) = 0.5 * (LHS_original(k,i) + LHS_pinged(k,i));
-        }
-
-        // Unpinging
-        pElement->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL) -= delta;
-    }
-
-    for (unsigned int i = 0; i < LHS_finite_diference.size1(); i++) {
-        for (unsigned int j = 0; j < LHS_finite_diference.size2(); j++) {
-            KRATOS_CHECK_NEAR(LHS_finite_diference(i,j), LHS_analytical(i,j), 1e-10);
-        }
-    }
+        pElement->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL) = rPotential[i];
 }
 
 BoundedVector<double,3> AssignDistancesToPerturbationCompressibleElement()
@@ -186,6 +82,303 @@ void AssignPotentialsToWakeCompressiblePerturbationElement(Element::Pointer pEle
     }
 }
 
+void PrintTestWakeMatrixPretty(Matrix& rMatrix){
+    std::cout.precision(5);
+    std::cout << std::scientific;
+    std::cout << std::showpos;
+    std::cout << std::endl;
+    for(unsigned int row = 0; row < rMatrix.size1(); ++row){
+        for(unsigned int column = 0; column < rMatrix.size2(); column++){
+            if(column == 2 || column == 5){
+                std::cout << " " << rMatrix(row, column) << " |";
+            }
+            else{
+                std::cout << " " << rMatrix(row, column) << " ";
+            }
+        }
+
+        std::cout << std::endl;
+
+        if(row ==2|| row == 5){
+            for(unsigned int j = 0; j < 14*rMatrix.size1(); j++){
+            std::cout << "_" ;
+            }
+            std::cout << " " << std::endl;
+        }
+        else{
+            for(unsigned int i = 0; i < 3; i++){
+                for(unsigned int j = 0; j < 14*3; j++){
+                    std::cout << " " ;
+                }
+                if(i != 2){
+                    std::cout << "|" ;
+                }
+            }
+        }
+        std::cout << std::endl;
+    }
+    std::cout << std::endl;
+}
+
+void PrintTestElementInfo(ModelPart& rModelPart){
+    const ProcessInfo& r_current_process_info = rModelPart.GetProcessInfo();
+    Element::Pointer pElement = rModelPart.pGetElement(1);
+    array_1d<double, 2> perturbed_velocity = PotentialFlowUtilities::ComputePerturbedVelocity<2,3>(*pElement, r_current_process_info);
+    const double local_velocity_squared = inner_prod(perturbed_velocity, perturbed_velocity);
+    const double local_mach_squared = PotentialFlowUtilities::ComputeLocalMachNumberSquared<2, 3>(perturbed_velocity, r_current_process_info);
+    const double max_velocity_squared = PotentialFlowUtilities::ComputeMaximumVelocitySquared<2, 3>(r_current_process_info);
+
+    std::cout.precision(16);
+    KRATOS_WATCH(perturbed_velocity)
+    KRATOS_WATCH(std::sqrt(max_velocity_squared))
+    KRATOS_WATCH(std::sqrt(local_velocity_squared))
+    KRATOS_WATCH(local_mach_squared)
+}
+
+
+/** Checks the CompressiblePerturbationPotentialFlowElement.
+ * Checks the RHS computation.
+ */
+KRATOS_TEST_CASE_IN_SUITE(CompressiblePerturbationPotentialFlowElementRHS, CompressiblePotentialApplicationFastSuite) {
+    Model this_model;
+    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+    GenerateCompressiblePerturbationElement(model_part);
+    Element::Pointer pElement = model_part.pGetElement(1);
+
+    std::array<double, 3> potential{1.0, 20.0, 50.0};
+    AssignPotentialsToNormalCompressiblePerturbationElement(pElement, potential);
+
+    // Compute RHS
+    Vector RHS = ZeroVector(3);
+
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateRightHandSide(RHS, r_current_process_info);
+
+    std::vector<double> reference{131.4361747323354,-113.768439084114,-17.66773564822145};
+
+    KRATOS_CHECK_VECTOR_NEAR(RHS, reference, 1e-13);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(CompressiblePerturbationPotentialFlowElementRHSClamping, CompressiblePotentialApplicationFastSuite) {
+    Model this_model;
+    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+    GenerateCompressiblePerturbationElement(model_part);
+    Element::Pointer pElement = model_part.pGetElement(1);
+
+    std::array<double, 3> potential{1.0, 220.0, 250.0};
+    AssignPotentialsToNormalCompressiblePerturbationElement(pElement, potential);
+
+    // Compute RHS
+    Vector RHS = ZeroVector(3);
+
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateRightHandSide(RHS, r_current_process_info);
+
+    std::vector<double> reference{205.3219372530133,-190.7662916232804,-14.55564562973297};
+
+    KRATOS_CHECK_VECTOR_NEAR(RHS, reference, 1e-13);
+}
+
+// /** Checks the CompressiblePerturbationPotentialFlowElement.
+//  * Checks the LHS computation.
+//  */
+KRATOS_TEST_CASE_IN_SUITE(CompressiblePerturbationPotentialFlowElementLHS, CompressiblePotentialApplicationFastSuite) {
+    Model this_model;
+    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+    GenerateCompressiblePerturbationElement(model_part);
+    Element::Pointer pElement = model_part.pGetElement(1);
+
+    std::array<double, 3> potential{1.0, 20.0, 50.0};
+    AssignPotentialsToNormalCompressiblePerturbationElement(pElement, potential);
+
+    // Compute LHS
+    Matrix LHS = ZeroMatrix(3, 3);
+
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateLeftHandSide(LHS, r_current_process_info);
+
+    std::array<double, 9> reference{ 0.3316096612183497,-0.3661980912374865,0.03458843001913683,
+                                    -0.3661980912374865,0.9850616437217248,-0.6188635524842382,
+                                    0.03458843001913683,-0.6188635524842382,0.5842751224651014};
+
+    for (unsigned int i = 0; i < LHS.size1(); i++) {
+        for (unsigned int j = 0; j < LHS.size2(); j++) {
+            KRATOS_CHECK_NEAR(LHS(i, j), reference[i * 3 + j], 1e-16);
+        }
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(CompressiblePerturbationPotentialFlowElementLHSClamping, CompressiblePotentialApplicationFastSuite) {
+    Model this_model;
+    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+    GenerateCompressiblePerturbationElement(model_part);
+    Element::Pointer pElement = model_part.pGetElement(1);
+
+    std::array<double, 3> potential{1.0, 220.0, 250.0};
+    AssignPotentialsToNormalCompressiblePerturbationElement(pElement, potential);
+
+    // Compute LHS
+    Matrix LHS = ZeroMatrix(3, 3);
+
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateLeftHandSide(LHS, r_current_process_info);
+
+    std::array<double, 9> reference{ 0.4851881876577658,-0.4851881876577658,0,
+                                    -0.4851881876577658,0.9703763753155316,-0.4851881876577658,
+                                    0,-0.4851881876577658,0.4851881876577658};
+
+    for (unsigned int i = 0; i < LHS.size1(); i++) {
+        for (unsigned int j = 0; j < LHS.size2(); j++) {
+            KRATOS_CHECK_NEAR(LHS(i, j), reference[i * 3 + j], 1e-16);
+        }
+    }
+}
+
+void ComputeElementalSensitivitiesMatrixRow(ModelPart& rModelPart, double delta, unsigned int row, Matrix& rLHS_original, Vector& rRHS_original, Matrix& rLHS_finite_diference, Matrix& rLHS_analytical){
+    Element::Pointer pElement = rModelPart.pGetElement(1);
+    const unsigned int number_of_nodes = pElement->GetGeometry().size();
+
+    // Compute pinged LHS and RHS
+    Vector RHS_pinged = ZeroVector(number_of_nodes);
+    Matrix LHS_pinged = ZeroMatrix(number_of_nodes, number_of_nodes);
+    const ProcessInfo& r_current_process_info = rModelPart.GetProcessInfo();
+    pElement->CalculateLocalSystem(LHS_pinged, RHS_pinged, r_current_process_info);
+
+    for(unsigned int k = 0; k < rLHS_original.size2(); k++){
+        // Compute the finite difference estimate of the sensitivity
+        rLHS_finite_diference( k, row) = -(RHS_pinged(k)-rRHS_original(k)) / delta;
+        // Compute the average of the original and pinged analytic sensitivities
+        rLHS_analytical( k, row) = 0.5 * (rLHS_original(k,row) + LHS_pinged(k,row));
+    }
+
+}
+
+void ComputeElementalSensitivities(ModelPart& rModelPart, Matrix& rLHS_finite_diference, Matrix& rLHS_analytical, const std::array<double, 3> rPotential){
+    Element::Pointer pElement = rModelPart.pGetElement(1);
+    const unsigned int number_of_nodes = pElement->GetGeometry().size();
+
+    AssignPotentialsToNormalCompressiblePerturbationElement(pElement, rPotential);
+
+    // Compute original RHS and LHS
+    Vector RHS_original = ZeroVector(number_of_nodes);
+    Matrix LHS_original = ZeroMatrix(number_of_nodes, number_of_nodes);
+    const ProcessInfo& r_current_process_info = rModelPart.GetProcessInfo();
+    pElement->CalculateLocalSystem(LHS_original, RHS_original, r_current_process_info);
+
+    double delta = 1e-3;
+    for(unsigned int i = 0; i < number_of_nodes; i++){
+        // Pinging
+        pElement->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL) += delta;
+
+        ComputeElementalSensitivitiesMatrixRow(rModelPart, delta, i, LHS_original, RHS_original, rLHS_finite_diference, rLHS_analytical);
+
+        // Unpinging
+        pElement->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL) -= delta;
+    }
+}
+
+void ComputeWakeElementalSensitivities(ModelPart& rModelPart, Matrix& rLHS_finite_diference, Matrix& rLHS_analytical, const std::array<double, 6> rPotential){
+    Element::Pointer pElement = rModelPart.pGetElement(1);
+    const unsigned int number_of_nodes = pElement->GetGeometry().size();
+
+    BoundedVector<double,3> distances = AssignDistancesToPerturbationCompressibleElement();
+    pElement->GetValue(WAKE_ELEMENTAL_DISTANCES) = distances;
+    pElement->GetValue(WAKE) = true;
+
+    AssignPotentialsToWakeCompressiblePerturbationElement(pElement, distances, rPotential);
+
+    // Compute original RHS and LHS
+    Vector RHS_original = ZeroVector(2*number_of_nodes);
+    Matrix LHS_original = ZeroMatrix(2*number_of_nodes, 2*number_of_nodes);
+    const ProcessInfo& r_current_process_info = rModelPart.GetProcessInfo();
+    pElement->CalculateLocalSystem(LHS_original, RHS_original, r_current_process_info);
+
+    double delta = 1e-3;
+    for(unsigned int i = 0; i < 2*number_of_nodes; i++){
+        if(i < number_of_nodes){
+            // Pinging
+            if (distances(i) > 0.0)
+                pElement->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL) += delta;
+            else
+                pElement->GetGeometry()[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL) += delta;
+
+            ComputeElementalSensitivitiesMatrixRow(rModelPart, delta, i, LHS_original, RHS_original, rLHS_finite_diference, rLHS_analytical);
+
+            // Unpinging
+            if (distances(i) > 0.0)
+                pElement->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL) -= delta;
+            else
+                pElement->GetGeometry()[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL) -= delta;
+        }
+        else{
+            // Pinging
+            if (distances(i-number_of_nodes) > 0.0)
+                pElement->GetGeometry()[i-number_of_nodes].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL) += delta;
+            else
+                pElement->GetGeometry()[i-number_of_nodes].FastGetSolutionStepValue(VELOCITY_POTENTIAL) += delta;
+
+            ComputeElementalSensitivitiesMatrixRow(rModelPart, delta, i, LHS_original, RHS_original, rLHS_finite_diference, rLHS_analytical);
+
+            // Unpinging
+            if (distances(i-number_of_nodes) > 0.0)
+                pElement->GetGeometry()[i-number_of_nodes].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL) -= delta;
+            else
+                pElement->GetGeometry()[i-number_of_nodes].FastGetSolutionStepValue(VELOCITY_POTENTIAL) -= delta;
+        }
+    }
+}
+
+/** Checks the CompressiblePerturbationPotentialFlowElement.
+ * Tests the LHS computation.
+ */
+KRATOS_TEST_CASE_IN_SUITE(PingCompressiblePerturbationPotentialFlowElementLHS, CompressiblePotentialApplicationFastSuite) {
+    Model this_model;
+    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+    GenerateCompressiblePerturbationElement(model_part);
+    Element::Pointer pElement = model_part.pGetElement(1);
+    const unsigned int number_of_nodes = pElement->GetGeometry().size();
+
+    std::array<double, 3> potential{1.0, 20.0, 50.0};
+
+    Matrix LHS_finite_diference = ZeroMatrix(number_of_nodes, number_of_nodes);
+    Matrix LHS_analytical = ZeroMatrix(number_of_nodes, number_of_nodes);
+
+    ComputeElementalSensitivities(model_part, LHS_finite_diference, LHS_analytical, potential);
+
+    for (unsigned int i = 0; i < LHS_finite_diference.size1(); i++) {
+        for (unsigned int j = 0; j < LHS_finite_diference.size2(); j++) {
+            KRATOS_CHECK_NEAR(LHS_finite_diference(i,j), LHS_analytical(i,j), 1e-10);
+        }
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(PingCompressiblePerturbationPotentialFlowElementLHSClamping, CompressiblePotentialApplicationFastSuite) {
+    Model this_model;
+    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+    GenerateCompressiblePerturbationElement(model_part);
+    Element::Pointer pElement = model_part.pGetElement(1);
+    const unsigned int number_of_nodes = pElement->GetGeometry().size();
+
+    std::array<double, 3> potential{1.2495, 94.1948, 182.149583};
+
+    Matrix LHS_finite_diference = ZeroMatrix(number_of_nodes, number_of_nodes);
+    Matrix LHS_analytical = ZeroMatrix(number_of_nodes, number_of_nodes);
+
+    ComputeElementalSensitivities(model_part, LHS_finite_diference, LHS_analytical, potential);
+
+    for (unsigned int i = 0; i < LHS_finite_diference.size1(); i++) {
+        for (unsigned int j = 0; j < LHS_finite_diference.size2(); j++) {
+            KRATOS_CHECK_NEAR(LHS_finite_diference(i,j), LHS_analytical(i,j), 1e-10);
+        }
+    }
+}
+
 KRATOS_TEST_CASE_IN_SUITE(WakeCompressiblePerturbationPotentialFlowElementRHS, CompressiblePotentialApplicationFastSuite) {
     Model this_model;
     ModelPart& model_part = this_model.CreateModelPart("Main", 3);
@@ -198,7 +391,7 @@ KRATOS_TEST_CASE_IN_SUITE(WakeCompressiblePerturbationPotentialFlowElementRHS, C
     pElement->GetValue(WAKE_ELEMENTAL_DISTANCES) = distances;
     pElement->GetValue(WAKE) = true;
 
-    const std::array<double, 6> potential{1.0, 101.0, 150.0, 6.0, 105.0, 155.0};
+    const std::array<double, 6> potential{1.0, 31.0, 150.0, 6.0, 75.0, 55.0};
     AssignPotentialsToWakeCompressiblePerturbationElement(pElement, distances, potential);
 
     // Compute RHS and LHS
@@ -207,7 +400,95 @@ KRATOS_TEST_CASE_IN_SUITE(WakeCompressiblePerturbationPotentialFlowElementRHS, C
     const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
     pElement->CalculateRightHandSide(RHS, r_current_process_info);
 
-    std::vector<double> reference{146.392649744264,-0.9625396130203431,0.4812698065101715,-0.4812698065101715,-121.8478896122452,-24.06349032550858};
+    PrintTestElementInfo(model_part);
+    std::cout.precision(16);
+    KRATOS_WATCH(RHS)
+
+    std::vector<double> reference{127.1146544469925,109.025,-85.1375,23.8875,-154.8303022595422,10.56213263248122};
+
+    KRATOS_CHECK_VECTOR_NEAR(RHS, reference, 1e-13);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(WakeCompressiblePerturbationPotentialFlowElementRHSClamping, CompressiblePotentialApplicationFastSuite) {
+    Model this_model;
+    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+    GenerateCompressiblePerturbationElement(model_part);
+    Element::Pointer pElement = model_part.pGetElement(1);
+
+    BoundedVector<double,3> distances = AssignDistancesToPerturbationCompressibleElement();
+
+    pElement->GetValue(WAKE_ELEMENTAL_DISTANCES) = distances;
+    pElement->GetValue(WAKE) = true;
+
+    const std::array<double, 6> potential{1.0, 151.0, 190.0, 6.0, 165.0, 195.0};
+    AssignPotentialsToWakeCompressiblePerturbationElement(pElement, distances, potential);
+
+    // Compute RHS and LHS
+    Vector RHS = ZeroVector(6);
+
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateRightHandSide(RHS, r_current_process_info);
+
+    std::vector<double> reference{171.8439523046275,11.025,-5.5125,5.5125,-161.6550003638144,-14.55564562973297};
+
+    KRATOS_CHECK_VECTOR_NEAR(RHS, reference, 1e-13);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(WakeStructureCompressiblePerturbationPotentialFlowElementRHS, CompressiblePotentialApplicationFastSuite) {
+    Model this_model;
+    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+    GenerateCompressiblePerturbationElement(model_part);
+    Element::Pointer pElement = model_part.pGetElement(1);
+    const unsigned int number_of_nodes = pElement->GetGeometry().size();
+
+    BoundedVector<double,3> distances = AssignDistancesToPerturbationCompressibleElement();
+
+    pElement->GetValue(WAKE_ELEMENTAL_DISTANCES) = distances;
+    pElement->GetValue(WAKE) = true;
+    pElement->Set(STRUCTURE);
+    pElement->GetGeometry()[number_of_nodes-1].SetValue(TRAILING_EDGE, true);
+
+    const std::array<double, 6> potential{1.0, 31.0, 150.0, 6.0, 75.0, 55.0};
+    AssignPotentialsToWakeCompressiblePerturbationElement(pElement, distances, potential);
+
+    // Compute RHS and LHS
+    Vector RHS = ZeroVector(6);
+
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateRightHandSide(RHS, r_current_process_info);
+
+    std::vector<double> reference{127.1146544469925,109.025,-16.14852237508765,23.8875,-154.8303022595422,7.921599474360912};
+
+    KRATOS_CHECK_VECTOR_NEAR(RHS, reference, 1e-13);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(WakeStructureCompressiblePerturbationPotentialFlowElementRHSClamping, CompressiblePotentialApplicationFastSuite) {
+    Model this_model;
+    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+    GenerateCompressiblePerturbationElement(model_part);
+    Element::Pointer pElement = model_part.pGetElement(1);
+    const unsigned int number_of_nodes = pElement->GetGeometry().size();
+
+    BoundedVector<double,3> distances = AssignDistancesToPerturbationCompressibleElement();
+
+    pElement->GetValue(WAKE_ELEMENTAL_DISTANCES) = distances;
+    pElement->GetValue(WAKE) = true;
+    pElement->Set(STRUCTURE);
+    pElement->GetGeometry()[number_of_nodes-1].SetValue(TRAILING_EDGE, true);
+
+    const std::array<double, 6> potential{1.0, 151.0, 190.0, 6.0, 165.0, 195.0};
+    AssignPotentialsToWakeCompressiblePerturbationElement(pElement, distances, potential);
+
+    // Compute RHS and LHS
+    Vector RHS = ZeroVector(6);
+
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateRightHandSide(RHS, r_current_process_info);
+
+    std::vector<double> reference{171.8439523046275,11.025,-4.730584829663217,5.5125,-161.6550003638144,-10.91673422229973};
 
     KRATOS_CHECK_VECTOR_NEAR(RHS, reference, 1e-13);
 }
@@ -224,7 +505,7 @@ KRATOS_TEST_CASE_IN_SUITE(WakeCompressiblePerturbationPotentialFlowElementLHS, C
     pElement->GetValue(WAKE_ELEMENTAL_DISTANCES) = distances;
     pElement->GetValue(WAKE) = true;
 
-    const std::array<double, 6> potential{1.0, 100.0, 150.0, 6.0, 105.0, 155.0};
+    const std::array<double, 6> potential{1.0, 31.0, 150.0, 6.0, 75.0, 55.0};
     AssignPotentialsToWakeCompressiblePerturbationElement(pElement, distances, potential);
 
     // Compute LHS
@@ -234,12 +515,115 @@ KRATOS_TEST_CASE_IN_SUITE(WakeCompressiblePerturbationPotentialFlowElementLHS, C
     pElement->CalculateLeftHandSide(LHS, r_current_process_info);
 
     // Check the LHS values
-    std::array<double,36> reference{0.06114278464441542,-0.1306215050744058,0.06947872042999037,0,0,0,
-    -0.1306215050744058,0.6710758508914103,-0.5404543458170046,0.1306215050744058,-0.6710758508914103,0.5404543458170046,
-    0.06947872042999037,-0.5404543458170046,0.4709756253870142,-0.06947872042999037,0.5404543458170046,-0.4709756253870142,
-    -0.06114278464441542,0.1306215050744058,-0.06947872042999037,0.06114278464441542,-0.1306215050744058,0.06947872042999037,
-    0,0,0,-0.1306215050744058,0.6710758508914103,-0.5404543458170046,
-    0,0,0,0.06947872042999037,-0.5404543458170046,0.4709756253870142};
+    std::array<double,36> reference{0.2730300317674839,-0.4101190902695764,0.1370890585020925,0,0,0,-0.6125,1.225,-0.6125,0.6125,-1.225,0.6125,0,-0.6125,0.6125,-0,0.6125,-0.6125,-0.6125,0.6125,-0,0.6125,-0.6125,0,0,0,0,-0.1405503745970895,0.6402833143676492,-0.4997329397705597,0,0,0,-0.02643811017306578,-0.4997329397705597,0.5261710499436255};
+
+    for (unsigned int i = 0; i < LHS.size1(); i++) {
+        for (unsigned int j = 0; j < LHS.size2(); j++) {
+            KRATOS_CHECK_NEAR(LHS(i, j), reference[6 * i + j], 1e-16);
+        }
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(WakeCompressiblePerturbationPotentialFlowElementLHSClamping, CompressiblePotentialApplicationFastSuite) {
+    Model this_model;
+    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+    GenerateCompressiblePerturbationElement(model_part);
+    Element::Pointer pElement = model_part.pGetElement(1);
+
+    BoundedVector<double,3> distances = AssignDistancesToPerturbationCompressibleElement();
+
+    pElement->GetValue(WAKE_ELEMENTAL_DISTANCES) = distances;
+    pElement->GetValue(WAKE) = true;
+
+    const std::array<double, 6> potential{1.0, 151.0, 190.0, 6.0, 165.0, 195.0};
+    AssignPotentialsToWakeCompressiblePerturbationElement(pElement, distances, potential);
+
+    // Compute LHS
+    Matrix LHS = ZeroMatrix(6, 6);
+
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateLeftHandSide(LHS, r_current_process_info);
+
+    PrintTestElementInfo(model_part);
+    std::cout.precision(16);
+    KRATOS_WATCH(LHS)
+
+    // Check the LHS values
+    std::array<double,36> reference{0.4851881876577658,-0.4851881876577658,0,0,0,0,-0.6125,1.225,-0.6125,0.6125,
+    -1.225,0.6125,0,-0.6125,0.6125,-0,0.6125,-0.6125,-0.6125,0.6125,-0,0.6125,-0.6125,0,0,0,0,-0.4851881876577658,0.9703763753155316,-0.4851881876577658,0,0,0,0,-0.4851881876577658,0.4851881876577658};
+
+    for (unsigned int i = 0; i < LHS.size1(); i++) {
+        for (unsigned int j = 0; j < LHS.size2(); j++) {
+            KRATOS_CHECK_NEAR(LHS(i, j), reference[6 * i + j], 1e-16);
+        }
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(WakeStructureCompressiblePerturbationPotentialFlowElementLHS, CompressiblePotentialApplicationFastSuite) {
+    Model this_model;
+    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+    GenerateCompressiblePerturbationElement(model_part);
+    Element::Pointer pElement = model_part.pGetElement(1);
+    const unsigned int number_of_nodes = pElement->GetGeometry().size();
+
+    BoundedVector<double,3> distances = AssignDistancesToPerturbationCompressibleElement();
+
+    pElement->GetValue(WAKE_ELEMENTAL_DISTANCES) = distances;
+    pElement->GetValue(WAKE) = true;
+    pElement->Set(STRUCTURE);
+    pElement->GetGeometry()[number_of_nodes-1].SetValue(TRAILING_EDGE, true);
+
+    const std::array<double, 6> potential{1.0, 31.0, 150.0, 6.0, 75.0, 55.0};
+    AssignPotentialsToWakeCompressiblePerturbationElement(pElement, distances, potential);
+
+    // Compute LHS
+    Matrix LHS = ZeroMatrix(6, 6);
+
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateLeftHandSide(LHS, r_current_process_info);
+
+    // Check the LHS values
+    std::array<double,36> reference{0.2730300317674839,-0.4101190902695764,0.1370890585020925,0,0,0,-0.6125,1.225,
+    -0.6125,0.6125,-1.225,0.6125,0.03427226462552314,-0.1525584723345968,0.1182862077090737,0,0,0,-0.6125,0.6125,
+    -0,0.6125,-0.6125,0,0,0,0,-0.1405503745970895,0.6402833143676492,-0.4997329397705597,0,0,0,-0.01982858262979934,-0.3747997048279197,0.3946282874577191};
+
+    for (unsigned int i = 0; i < LHS.size1(); i++) {
+        for (unsigned int j = 0; j < LHS.size2(); j++) {
+            KRATOS_CHECK_NEAR(LHS(i, j), reference[6 * i + j], 1e-16);
+        }
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(WakeStructureCompressiblePerturbationPotentialFlowElementLHSClamping, CompressiblePotentialApplicationFastSuite) {
+    Model this_model;
+    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+    GenerateCompressiblePerturbationElement(model_part);
+    Element::Pointer pElement = model_part.pGetElement(1);
+    const unsigned int number_of_nodes = pElement->GetGeometry().size();
+
+    BoundedVector<double,3> distances = AssignDistancesToPerturbationCompressibleElement();
+
+    pElement->GetValue(WAKE_ELEMENTAL_DISTANCES) = distances;
+    pElement->GetValue(WAKE) = true;
+    pElement->Set(STRUCTURE);
+    pElement->GetGeometry()[number_of_nodes-1].SetValue(TRAILING_EDGE, true);
+
+    const std::array<double, 6> potential{1.0, 151.0, 190.0, 6.0, 165.0, 195.0};
+    AssignPotentialsToWakeCompressiblePerturbationElement(pElement, distances, potential);
+
+    // Compute LHS
+    Matrix LHS = ZeroMatrix(6, 6);
+
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateLeftHandSide(LHS, r_current_process_info);
+
+    // Check the LHS values
+    std::array<double,36> reference{0.4851881876577658,-0.4851881876577658,0,0,0,0,-0.6125,1.225,-0.6125,0.6125,
+    -1.225,0.6125,0,-0.1212970469144414,0.1212970469144414,0,0,0,-0.6125,0.6125,-0,0.6125,-0.6125,0,0,0,0,
+    -0.4851881876577658,0.9703763753155316,-0.4851881876577658,0,0,0,0,-0.3638911407433243,0.3638911407433243};
 
     for (unsigned int i = 0; i < LHS.size1(); i++) {
         for (unsigned int j = 0; j < LHS.size2(); j++) {
@@ -256,175 +640,93 @@ KRATOS_TEST_CASE_IN_SUITE(PingWakeCompressiblePerturbationPotentialFlowElementLH
     Element::Pointer pElement = model_part.pGetElement(1);
     const unsigned int number_of_nodes = pElement->GetGeometry().size();
 
-    BoundedVector<double,3> distances = AssignDistancesToPerturbationCompressibleElement();
-
-    pElement->GetValue(WAKE_ELEMENTAL_DISTANCES) = distances;
-    pElement->GetValue(WAKE) = true;
-
     const std::array<double, 6> potential{1.0, 40.0, 35.0, 6.0, 26.0, 14.0};
-    AssignPotentialsToWakeCompressiblePerturbationElement(pElement, distances, potential);
 
-    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
-    array_1d<double, 2> perturbed_velocity = PotentialFlowUtilities::ComputePerturbedVelocity<2,3>(*pElement, r_current_process_info);
-    const double local_velocity_squared = inner_prod(perturbed_velocity, perturbed_velocity);
-    const double local_mach_squared = PotentialFlowUtilities::ComputeLocalMachNumberSquared<2, 3>(perturbed_velocity, r_current_process_info);
-    const double max_velocity_squared = PotentialFlowUtilities::ComputeMaximumVelocitySquared<2, 3>(r_current_process_info);
-
-    Vector RHS_original = ZeroVector(2*number_of_nodes);
-    Matrix LHS_original = ZeroMatrix(2*number_of_nodes, 2*number_of_nodes);
     Matrix LHS_finite_diference = ZeroMatrix(2*number_of_nodes, 2*number_of_nodes);
     Matrix LHS_analytical = ZeroMatrix(2*number_of_nodes, 2*number_of_nodes);
 
-    // Compute original RHS and LHS
-    //const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
-    pElement->CalculateLocalSystem(LHS_original, RHS_original, r_current_process_info);
-    KRATOS_WATCH(RHS_original)
+    ComputeWakeElementalSensitivities(model_part, LHS_finite_diference, LHS_analytical, potential);
 
-    double delta = 1e-3;
-    for(unsigned int i = 0; i < 2*number_of_nodes; i++){
-        if(i < number_of_nodes){
-            // Pinging
-            if (distances(i) > 0.0)
-                pElement->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL) += delta;
-            else
-                pElement->GetGeometry()[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL) += delta;
-
-            Vector RHS_pinged = ZeroVector(number_of_nodes);
-            Matrix LHS_pinged = ZeroMatrix(number_of_nodes, number_of_nodes);
-            // Compute pinged LHS and RHS
-            pElement->CalculateLocalSystem(LHS_pinged, RHS_pinged, r_current_process_info);
-
-            for(unsigned int k = 0; k < 2*number_of_nodes; k++){
-                // Compute the finite difference estimate of the sensitivity
-                LHS_finite_diference( k, i) = -(RHS_pinged(k)-RHS_original(k)) / delta;
-                // if(i==3){
-                //     KRATOS_WATCH(k)
-                //     KRATOS_WATCH(RHS_pinged(k))
-                //     KRATOS_WATCH(RHS_original(k))
-                // }
-                // Compute the average of the original and pinged analytic sensitivities
-                LHS_analytical( k, i) = 0.5 * (LHS_original(k,i) + LHS_pinged(k,i));
-            }
-
-            // Unpinging
-            if (distances(i) > 0.0)
-                pElement->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL) -= delta;
-            else
-                pElement->GetGeometry()[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL) -= delta;
-        }
-        else{
-            KRATOS_WATCH(distances(i-number_of_nodes))
-            // Pinging
-            if (distances(i-number_of_nodes) > 0.0)
-                pElement->GetGeometry()[i-number_of_nodes].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL) += delta;
-            else
-                pElement->GetGeometry()[i-number_of_nodes].FastGetSolutionStepValue(VELOCITY_POTENTIAL) += delta;
-
-            Vector RHS_pinged = ZeroVector(number_of_nodes);
-            Matrix LHS_pinged = ZeroMatrix(number_of_nodes, number_of_nodes);
-            // Compute pinged LHS and RHS
-            pElement->CalculateLocalSystem(LHS_pinged, RHS_pinged, r_current_process_info);
-            if(i==4){
-                KRATOS_WATCH(RHS_pinged)
-            }
-
-            for(unsigned int k = 0; k < 2*number_of_nodes; k++){
-                // Compute the finite difference estimate of the sensitivity
-                LHS_finite_diference( k, i) = -(RHS_pinged(k)-RHS_original(k)) / delta;
-                if(i==4){
-                    KRATOS_WATCH(k)
-                    KRATOS_WATCH(RHS_pinged(k))
-                    KRATOS_WATCH(RHS_original(k))
-                }
-                // Compute the average of the original and pinged analytic sensitivities
-                LHS_analytical( k, i) = 0.5 * (LHS_original(k,i) + LHS_pinged(k,i));
-            }
-
-            // Unpinging
-            if (distances(i-number_of_nodes) > 0.0)
-                pElement->GetGeometry()[i-number_of_nodes].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL) -= delta;
-            else
-                pElement->GetGeometry()[i-number_of_nodes].FastGetSolutionStepValue(VELOCITY_POTENTIAL) -= delta;
+    for (unsigned int i = 0; i < LHS_finite_diference.size1(); i++) {
+        for (unsigned int j = 0; j < LHS_finite_diference.size2(); j++) {
+            KRATOS_CHECK_NEAR(LHS_finite_diference(i,j), LHS_analytical(i,j), 1e-10);
         }
     }
+}
 
-    std::cout.precision(16);
+KRATOS_TEST_CASE_IN_SUITE(PingWakeCompressiblePerturbationPotentialFlowElementLHSClamping, CompressiblePotentialApplicationFastSuite) {
+    Model this_model;
+    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
 
-    KRATOS_WATCH(perturbed_velocity)
-    KRATOS_WATCH(std::sqrt(max_velocity_squared))
-    KRATOS_WATCH(std::sqrt(local_velocity_squared))
-    KRATOS_WATCH(local_mach_squared)
-    // KRATOS_WATCH(LHS_analytical)
-    // KRATOS_WATCH(LHS_finite_diference)
+    GenerateCompressiblePerturbationElement(model_part);
+    Element::Pointer pElement = model_part.pGetElement(1);
+    const unsigned int number_of_nodes = pElement->GetGeometry().size();
 
-    std::cout.precision(5);
-    std::cout << std::scientific;
-    std::cout << std::showpos;
-    std::cout << std::endl;
-    for(unsigned int row = 0; row < LHS_analytical.size1(); ++row){
-        for(unsigned int column = 0; column < LHS_analytical.size2(); column++){
-            if(column == 2 || column == 5){
-                std::cout << " " << LHS_analytical(row, column) << " |";
-            }
-            else{
-                std::cout << " " << LHS_analytical(row, column) << " ";
-            }
+    const std::array<double, 6> potential{1.285837, 170.29384, 135.1583, 6.0, 196.345, 114.0};
+
+    Matrix LHS_finite_diference = ZeroMatrix(2*number_of_nodes, 2*number_of_nodes);
+    Matrix LHS_analytical = ZeroMatrix(2*number_of_nodes, 2*number_of_nodes);
+
+    ComputeWakeElementalSensitivities(model_part, LHS_finite_diference, LHS_analytical, potential);
+
+    for (unsigned int i = 0; i < LHS_finite_diference.size1(); i++) {
+        for (unsigned int j = 0; j < LHS_finite_diference.size2(); j++) {
+            KRATOS_CHECK_NEAR(LHS_finite_diference(i,j), LHS_analytical(i,j), 1e-10);
         }
-
-        std::cout << std::endl;
-
-        if(row ==2|| row == 5){
-            for(unsigned int j = 0; j < 14*LHS_analytical.size1(); j++){
-            std::cout << "_" ;
-            }
-            std::cout << " " << std::endl;
-        }
-        else{
-            for(unsigned int i = 0; i < 3; i++){
-                for(unsigned int j = 0; j < 14*3; j++){
-                    std::cout << " " ;
-                }
-                if(i != 2){
-                    std::cout << "|" ;
-                }
-            }
-        }
-        std::cout << std::endl;
     }
-    std::cout << std::endl;
+}
 
-    for(unsigned int row = 0; row < LHS_finite_diference.size1(); ++row){
-        for(unsigned int column = 0; column < LHS_finite_diference.size2(); column++){
-            if(column == 2 || column == 5){
-                std::cout << " " << LHS_finite_diference(row, column) << " |";
-            }
-            else{
-                std::cout << " " << LHS_finite_diference(row, column) << " ";
-            }
-        }
+KRATOS_TEST_CASE_IN_SUITE(PingWakeStructureCompressiblePerturbationPotentialFlowElementLHS, CompressiblePotentialApplicationFastSuite) {
+    Model this_model;
+    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
 
-        std::cout << std::endl;
+    GenerateCompressiblePerturbationElement(model_part);
+    Element::Pointer pElement = model_part.pGetElement(1);
+    const unsigned int number_of_nodes = pElement->GetGeometry().size();
 
-        if(row ==2|| row == 5){
-            for(unsigned int j = 0; j < 14*LHS_finite_diference.size1(); j++){
-            std::cout << "_" ;
+    pElement->Set(STRUCTURE);
+    pElement->GetGeometry()[number_of_nodes-1].SetValue(TRAILING_EDGE, true);
+
+    const std::array<double, 6> potential{1.285837, 30.29384, 35.1583, 6.0, 46.345, 64.0};
+
+    Matrix LHS_finite_diference = ZeroMatrix(2*number_of_nodes, 2*number_of_nodes);
+    Matrix LHS_analytical = ZeroMatrix(2*number_of_nodes, 2*number_of_nodes);
+
+    ComputeWakeElementalSensitivities(model_part, LHS_finite_diference, LHS_analytical, potential);
+
+    PrintTestElementInfo(model_part);
+
+    for (unsigned int i = 0; i < LHS_finite_diference.size1(); i++) {
+        for (unsigned int j = 0; j < LHS_finite_diference.size2(); j++) {
+            if(std::abs(LHS_finite_diference(i,j)-LHS_analytical(i,j)) > 1e-10){
+                KRATOS_WATCH(i)
+                KRATOS_WATCH(j)
+                KRATOS_WATCH(std::abs(LHS_finite_diference(i,j)-LHS_analytical(i,j)))
             }
-            std::cout << " " << std::endl;
+            KRATOS_CHECK_NEAR(LHS_finite_diference(i,j), LHS_analytical(i,j), 1e-10);
         }
-        else{
-            for(unsigned int i = 0; i < 3; i++){
-                for(unsigned int j = 0; j < 14*3; j++){
-                    std::cout << " " ;
-                }
-                if(i != 2){
-                    std::cout << "|" ;
-                }
-            }
-        }
-        std::cout << std::endl;
     }
-    std::cout << std::endl;
+}
 
+KRATOS_TEST_CASE_IN_SUITE(PingWakeStructureCompressiblePerturbationPotentialFlowElementLHSClamping, CompressiblePotentialApplicationFastSuite) {
+    Model this_model;
+    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+    GenerateCompressiblePerturbationElement(model_part);
+    Element::Pointer pElement = model_part.pGetElement(1);
+    const unsigned int number_of_nodes = pElement->GetGeometry().size();
+
+    pElement->Set(STRUCTURE);
+    pElement->GetGeometry()[number_of_nodes-1].SetValue(TRAILING_EDGE, true);
+
+    const std::array<double, 6> potential{1.285837, 170.29384, 135.1583, 6.0, 196.345, 114.0};
+
+    Matrix LHS_finite_diference = ZeroMatrix(2*number_of_nodes, 2*number_of_nodes);
+    Matrix LHS_analytical = ZeroMatrix(2*number_of_nodes, 2*number_of_nodes);
+
+    ComputeWakeElementalSensitivities(model_part, LHS_finite_diference, LHS_analytical, potential);
+
+    PrintTestElementInfo(model_part);
 
     for (unsigned int i = 0; i < LHS_finite_diference.size1(); i++) {
         for (unsigned int j = 0; j < LHS_finite_diference.size2(); j++) {

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_compressible_perturbation_potential_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_compressible_perturbation_potential_element.cpp
@@ -400,10 +400,6 @@ KRATOS_TEST_CASE_IN_SUITE(WakeCompressiblePerturbationPotentialFlowElementRHS, C
     const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
     pElement->CalculateRightHandSide(RHS, r_current_process_info);
 
-    PrintTestElementInfo(model_part);
-    std::cout.precision(16);
-    KRATOS_WATCH(RHS)
-
     std::vector<double> reference{127.1146544469925,109.025,-85.1375,23.8875,-154.8303022595422,10.56213263248122};
 
     KRATOS_CHECK_VECTOR_NEAR(RHS, reference, 1e-13);
@@ -544,10 +540,6 @@ KRATOS_TEST_CASE_IN_SUITE(WakeCompressiblePerturbationPotentialFlowElementLHSCla
 
     const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
     pElement->CalculateLeftHandSide(LHS, r_current_process_info);
-
-    PrintTestElementInfo(model_part);
-    std::cout.precision(16);
-    KRATOS_WATCH(LHS)
 
     // Check the LHS values
     std::array<double,36> reference{0.4851881876577658,-0.4851881876577658,0,0,0,0,-0.6125,1.225,-0.6125,0.6125,
@@ -698,11 +690,6 @@ KRATOS_TEST_CASE_IN_SUITE(PingWakeStructureCompressiblePerturbationPotentialFlow
 
     for (unsigned int i = 0; i < LHS_finite_diference.size1(); i++) {
         for (unsigned int j = 0; j < LHS_finite_diference.size2(); j++) {
-            if(std::abs(LHS_finite_diference(i,j)-LHS_analytical(i,j)) > 1e-10){
-                KRATOS_WATCH(i)
-                KRATOS_WATCH(j)
-                KRATOS_WATCH(std::abs(LHS_finite_diference(i,j)-LHS_analytical(i,j)))
-            }
             KRATOS_CHECK_NEAR(LHS_finite_diference(i,j), LHS_analytical(i,j), 1e-10);
         }
     }
@@ -730,11 +717,6 @@ KRATOS_TEST_CASE_IN_SUITE(PingWakeStructureCompressiblePerturbationPotentialFlow
 
     for (unsigned int i = 0; i < LHS_finite_diference.size1(); i++) {
         for (unsigned int j = 0; j < LHS_finite_diference.size2(); j++) {
-            if(std::abs(LHS_finite_diference(i,j)-LHS_analytical(i,j)) > 1e-10){
-                KRATOS_WATCH(i)
-                KRATOS_WATCH(j)
-                KRATOS_WATCH(std::abs(LHS_finite_diference(i,j)-LHS_analytical(i,j)))
-            }
             KRATOS_CHECK_NEAR(LHS_finite_diference(i,j), LHS_analytical(i,j), 1e-10);
         }
     }


### PR DESCRIPTION
**Description**
Adding the correct lhs and rhs for clamped and lower wake elements.

**Changelog**
- Added cpp tests for all rhs and lhs cases: clamped/unclamped and normal/wake
- Added elemental sensitivities cpp tests for all cases: clamped/unclamped and normal/wake
- Fixed lhs for clamped normal and wake elements
- Fixed lhs and rhs for lower wake elements
- Added function ComputePerturbedVelocityLowerElement
- Added function ComputeVacuumVelocitySquared and corresponding tests
- Removed unused deprecated ComputeDensity and ComputeDensityDerivative functions
