### PR TITLE
[Core] Add constrained Delaunay to delaunator utilities

### DIFF
--- a/kratos/utilities/delaunator_utilities.cpp
+++ b/kratos/utilities/delaunator_utilities.cpp
@@ -273,9 +273,9 @@ std::pair<std::vector<std::size_t>, std::vector<double>> ComputeTrianglesConnect
     // "p" triangulates a Planar Straight Line Graph
     // "z" numbers all items starting from zero (rather than one)
     // "a" imposes a maximum triangle area constrain
+    char* meshing_options;
     std::string str = AreaConstraint > 0.0 ? "Qqpza" + std::to_string(AreaConstraint) : "Qqpz";
-    char *meshing_options = new char[str.length() + 1];
-    strcpy(meshing_options, str.c_str());
+    meshing_options = &str[0];
     triangulate(meshing_options, &in_mid, &out_mid, &vorout_mid);
 
     // Save the obtained connectivities in an output std::vector

--- a/kratos/utilities/delaunator_utilities.cpp
+++ b/kratos/utilities/delaunator_utilities.cpp
@@ -273,10 +273,10 @@ std::pair<std::vector<std::size_t>, std::vector<double>> ComputeTrianglesConnect
     // "p" triangulates a Planar Straight Line Graph
     // "z" numbers all items starting from zero (rather than one)
     // "a" imposes a maximum triangle area constrain
-    char* meshing_options;
-    std::string str = AreaConstraint > 0.0 ? "Qqpza" + std::to_string(AreaConstraint) : "Qqpz";
-    meshing_options = &str[0];
-    triangulate(meshing_options, &in_mid, &out_mid, &vorout_mid);
+
+    std::string meshing_options =
+        AreaConstraint > 0.0 ? "Qqpza" + std::to_string(AreaConstraint) : "Qqpz";
+    triangulate(&meshing_options[0], &in_mid, &out_mid, &vorout_mid);
 
     // Save the obtained connectivities in an output std::vector
     const auto& r_triangles_list = out_mid.trianglelist;

--- a/kratos/utilities/delaunator_utilities.cpp
+++ b/kratos/utilities/delaunator_utilities.cpp
@@ -234,6 +234,77 @@ std::vector<std::size_t> ComputeTrianglesConnectivity(const std::vector<Point>& 
     return connectivities;
 }
 
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::pair<std::vector<std::size_t>, std::vector<double>> ComputeTrianglesConnectivity(
+    const std::vector<double>& rCoordinates,
+    const std::vector<std::array<double,2>>& rSegments,
+    const double AreaConstraint)
+{
+    // Creating the containers for the input and output
+    struct triangulateio in_mid, out_mid, vorout_mid;
+
+    InitializeTriangulateIO(in_mid);
+    InitializeTriangulateIO(out_mid);
+    InitializeTriangulateIO(vorout_mid);
+
+    // Initialize the boundary points coordinates list
+    in_mid.numberofpoints = rCoordinates.size()/2;
+    in_mid.pointlist = (REAL *) malloc(in_mid.numberofpoints * 2 * sizeof(REAL));
+
+    for(std::size_t i = 0; i < rCoordinates.size(); ++i) {
+        in_mid.pointlist[i] = rCoordinates[i];
+    }
+
+    // Initilize the segment list (note that default zero markers are assumed)
+    in_mid.numberofsegments = rSegments.size();
+    in_mid.segmentlist = (int*) malloc(in_mid.numberofsegments * 2 * sizeof(int));
+    in_mid.segmentmarkerlist = (int*) malloc(in_mid.numberofsegments * sizeof(int));
+    for (std::size_t i = 0; i < in_mid.numberofsegments; ++i) {
+        const auto& r_segment = rSegments[i];
+        in_mid.segmentlist[2*i] = r_segment[0];
+        in_mid.segmentlist[2*i + 1] = r_segment[1];
+    }
+
+    // Check https://www.cs.cmu.edu/~quake/triangle.switch.html for a detailed Triangle switches description
+    // "Q" quiet (no terminal output except errors)
+    // "q" quality mesh generation with no angles smaller than 20 degrees
+    // "p" triangulates a Planar Straight Line Graph
+    // "z" numbers all items starting from zero (rather than one)
+    // "a" imposes a maximum triangle area constrain
+    std::string str = AreaConstraint > 0.0 ? "Qqpza" + std::to_string(AreaConstraint) : "Qqpz";
+    char *meshing_options = new char[str.length() + 1];
+    strcpy(meshing_options, str.c_str());
+    triangulate(meshing_options, &in_mid, &out_mid, &vorout_mid);
+
+    // Save the obtained connectivities in an output std::vector
+    const auto& r_triangles_list = out_mid.trianglelist;
+    const std::size_t number_of_triangles = out_mid.numberoftriangles;
+    std::vector<std::size_t> connectivities(3 * number_of_triangles);
+    IndexPartition<std::size_t>(number_of_triangles).for_each([&](std::size_t iTriangle){
+        connectivities[3 * iTriangle] = r_triangles_list[3 * iTriangle];
+        connectivities[3 * iTriangle + 1] = r_triangles_list[3 * iTriangle + 1];
+        connectivities[3 * iTriangle + 2] = r_triangles_list[3 * iTriangle + 2];
+    });
+
+    // Save the obtained coordinates in an output std::vector
+    const auto& r_out_points_list = out_mid.pointlist;
+    const std::size_t number_of_output_points = out_mid.numberofpoints;
+    std::vector<double> output_coordinates(2 * number_of_output_points);
+    IndexPartition<std::size_t>(number_of_output_points).for_each([&](std::size_t iPoint){
+        output_coordinates[2 * iPoint] = r_out_points_list[2 * iPoint];
+        output_coordinates[2 * iPoint + 1] = r_out_points_list[2 * iPoint + 1];
+    });
+
+    // Clean the triangle database
+    CleanTriangulateIO(in_mid);
+    CleanTriangulateIO(out_mid);
+    CleanTriangulateIO(vorout_mid);
+
+    return std::make_pair(connectivities, output_coordinates);
+}
+
 } // namespace DelaunatorUtilities
 } // namespace Kratos
 

--- a/kratos/utilities/delaunator_utilities.cpp
+++ b/kratos/utilities/delaunator_utilities.cpp
@@ -261,7 +261,7 @@ std::pair<std::vector<std::size_t>, std::vector<double>> ComputeTrianglesConnect
     in_mid.numberofsegments = rSegments.size();
     in_mid.segmentlist = (int*) malloc(in_mid.numberofsegments * 2 * sizeof(int));
     in_mid.segmentmarkerlist = (int*) malloc(in_mid.numberofsegments * sizeof(int));
-    for (std::size_t i = 0; i < in_mid.numberofsegments; ++i) {
+    for (std::size_t i = 0; i < rSegments.size(); ++i) {
         const auto& r_segment = rSegments[i];
         in_mid.segmentlist[2*i] = r_segment[0];
         in_mid.segmentlist[2*i + 1] = r_segment[1];

--- a/kratos/utilities/delaunator_utilities.cpp
+++ b/kratos/utilities/delaunator_utilities.cpp
@@ -250,6 +250,8 @@ std::pair<std::vector<std::size_t>, std::vector<double>> ComputeTrianglesConnect
     InitializeTriangulateIO(vorout_mid);
 
     // Initialize the boundary points coordinates list
+    // Note 1: that InitializeTriangulateIO allocates nothing for this by default
+    // Note 2: this will be deallocated within the ClearTriangulateIO call below
     in_mid.numberofpoints = rCoordinates.size()/2;
     in_mid.pointlist = (REAL *) malloc(in_mid.numberofpoints * 2 * sizeof(REAL));
 
@@ -273,9 +275,7 @@ std::pair<std::vector<std::size_t>, std::vector<double>> ComputeTrianglesConnect
     // "p" triangulates a Planar Straight Line Graph
     // "z" numbers all items starting from zero (rather than one)
     // "a" imposes a maximum triangle area constrain
-
-    std::string meshing_options =
-        AreaConstraint > 0.0 ? "Qqpza" + std::to_string(AreaConstraint) : "Qqpz";
+    std::string meshing_options = AreaConstraint > 0.0 ? "Qqpza" + std::to_string(AreaConstraint) : "Qqpz";
     triangulate(&meshing_options[0], &in_mid, &out_mid, &vorout_mid);
 
     // Save the obtained connectivities in an output std::vector

--- a/kratos/utilities/delaunator_utilities.h
+++ b/kratos/utilities/delaunator_utilities.h
@@ -71,6 +71,18 @@ namespace DelaunatorUtilities
      */
     std::vector<std::size_t> KRATOS_API(KRATOS_CORE) ComputeTrianglesConnectivity(const std::vector<Point>& rPoints);
 
+    /**
+     * @brief This methods does a Constrained Delaunay Triangularization from a list of coordinates and segments (using triangle library)
+     * @param rCoordinates The list of coordinates, first X, then Y, for each point of the point cloud
+     * @param rSegments The list of segments, each segment is determined in one std::array with from its i and j nodal ids
+     * @param AreaConstraint If provided, imposes that value as a constraint on the maximum area
+     * @return A pair containing in first position a list with the triangles connectivities and in second position a list with the x and y nodal coordinates 
+     */
+    std::pair<std::vector<std::size_t>, std::vector<double>> KRATOS_API(KRATOS_CORE) ComputeTrianglesConnectivity(
+        const std::vector<double>& rCoordinates,
+        const std::vector<std::array<double,2>>& rSegments,
+        const double AreaConstraint = 0);
+
 }; // namespace DelaunatorUtilities
 }  // namespace Kratos
 #endif /* KRATOS_DELAUNATOR_UTILITIES defined */


### PR DESCRIPTION
**Description**
This adds the possibility to use the constrained Delaunay algorithm in the triangle library. To do that I overloaded the already existent function with an extra segments list (that ones that are to be enforced in the constrained Delaunay). I also added an argument for the maximum area surface of the resultant triangles (if not provided it is defaulted to zero and non-used).

I didn't add this new method to the Python layer as I don't expect it to be used so much and the utilities interface is way too big.

This is to be used in an upcoming PR with the CAD tessellation modeller.

@loumalouomega as it is right now, I can't see any reference to the Delaunator library. If this is the case, I think we should rename the utilities to something like `TriangleUtilities` or `DelaunayUtilities`. There are not many usages so it should be easy.
