### PR TITLE
[GeometricalProjectionUtilities] Line2d projection

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_geometrical_projection_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_geometrical_projection_utilities.cpp
@@ -35,7 +35,7 @@ GeometryNodeType::Pointer CreateLine3D2NForTestNode2D()
 {
     GeometryNodeType::PointsArrayType points;
     points.push_back(Kratos::make_intrusive<Node<3>>(1, 0.0, 0.0, 0.0));
-    points.push_back(Kratos::make_intrusive<Node<3>>(2, 1.0, 0.0, 0.0));
+    points.push_back(Kratos::make_intrusive<Node<3>>(2, 2.0, 0.0, 0.0));
 
     return GeometryNodeType::Pointer(new Line3D2<NodeType>(points));
 }
@@ -44,7 +44,7 @@ GeometryPointType::Pointer CreateLine3D2NForTestPoint2D()
 {
     GeometryPointType::PointsArrayType points;
     points.push_back(Kratos::make_shared<Point>(0.0, 0.0, 0.0));
-    points.push_back(Kratos::make_shared<Point>(1.0, 0.0, 0.0));
+    points.push_back(Kratos::make_shared<Point>(2.0, 0.0, 0.0));
 
     return GeometryPointType::Pointer(new Line3D2<Point>(points));
 }

--- a/kratos/utilities/geometrical_projection_utilities.h
+++ b/kratos/utilities/geometrical_projection_utilities.h
@@ -222,8 +222,8 @@ public:
         normal[2] = 0.0;
 
         const double norm_normal = norm_2(normal);
-        if (norm_normal > std::numeric_limits<double>::epsilon()) normal /= norm_normal;
-        else KRATOS_ERROR << "Zero norm normal: X: " << normal[0] << "\tY: " << normal[1] << std::endl;
+        KRATOS_ERROR_IF(norm_normal <= std::numeric_limits<double>::epsilon()) << "Zero norm normal: X: " << normal[0] << "\tY: " << normal[1] << std::endl;
+        normal /= norm_normal;
 
         const array_1d<double,3> vector_points = r_p_a - r_p_c;
         const double distance = inner_prod(vector_points, normal);

--- a/kratos/utilities/geometrical_projection_utilities.h
+++ b/kratos/utilities/geometrical_projection_utilities.h
@@ -226,7 +226,7 @@ public:
         else KRATOS_ERROR << "Zero norm normal: X: " << normal[0] << "\tY: " << normal[1] << std::endl;
 
         const array_1d<double,3> vector_points = r_p_a - r_p_c;
-        const double distance = inner_prod(vector_points, normal)/norm_normal;
+        const double distance = inner_prod(vector_points, normal);
         noalias(rPointProjected.Coordinates()) = r_p_c + normal * distance;
 
         return distance;


### PR DESCRIPTION
**Description**
The Line2D projection was normalizing the normal twice, and thus, calculating wrong distances.
The unittests didn't catch that bug because the unit was already normalized.

**Changelog**
- Fix normalization
- Modify the test in order to use a normal different than 1.0
