### PR TITLE
[MeshMovingApp] Extends Meshmoving strategies to support automatic mesh refinement.

### DIFF
--- a/applications/MeshMovingApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/MeshMovingApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -43,12 +43,14 @@ void AddCustomStrategiesToPython(pybind11::module& m) {
         LaplacianMeshMovingStrategy<SparseSpaceType, LocalSpaceType,LinearSolverType>::Pointer,
         BaseSolvingStrategyType>(m,"LaplacianMeshMovingStrategy")
         .def(py::init<ModelPart &, LinearSolverType::Pointer, int, bool, bool, bool, int>())
+        .def(py::init<ModelPart &, LinearSolverType::Pointer, int, bool, bool, bool, int, bool>())
         ;
 
     py::class_<StructuralMeshMovingStrategy<SparseSpaceType, LocalSpaceType,LinearSolverType>,
         StructuralMeshMovingStrategy<SparseSpaceType, LocalSpaceType,LinearSolverType>::Pointer,
         BaseSolvingStrategyType>(m,"StructuralMeshMovingStrategy")
         .def(py::init<ModelPart &, LinearSolverType::Pointer, int, bool, bool, bool, int, double>())
+        .def(py::init<ModelPart &, LinearSolverType::Pointer, int, bool, bool, bool, int, double, bool>())
         ;
 }
 

--- a/applications/MeshMovingApplication/custom_strategies/strategies/laplacian_meshmoving_strategy.h
+++ b/applications/MeshMovingApplication/custom_strategies/strategies/laplacian_meshmoving_strategy.h
@@ -80,17 +80,19 @@ public:
                               bool ReformDofSetAtEachStep = false,
                               bool ComputeReactions = false,
                               bool CalculateMeshVelocities = true,
-                              int EchoLevel = 0)
+                              int EchoLevel = 0,
+                              const bool ReInitializeModelPartEachStep = false)
       : SolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(ModelPart) {
 
     KRATOS_TRY;
 
-    mreform_dof_set_at_each_step = ReformDofSetAtEachStep;
+    mreform_dof_set_at_each_step = ReformDofSetAtEachStep || ReInitializeModelPartEachStep;
     mecho_level = EchoLevel;
     mcompute_reactions = ComputeReactions;
     mcalculate_mesh_velocities = CalculateMeshVelocities;
     mtime_order = TimeOrder;
     bool calculate_norm_dx_flag = false;
+    mreinitialize_model_part_at_each_step = ReInitializeModelPartEachStep;
 
     typename SchemeType::Pointer pscheme = typename SchemeType::Pointer(
         new ResidualBasedIncrementalUpdateStaticScheme<TSparseSpace,
@@ -161,6 +163,12 @@ public:
 
   double Solve() override {
     KRATOS_TRY;
+
+    if (mreinitialize_model_part_at_each_step) {
+        MoveMeshUtilities::InitializeMeshPartWithElements(
+            *mpmesh_model_part, BaseType::GetModelPart(),
+            mpmesh_model_part->pGetProperties(0), "LaplacianMeshMovingElement");
+    }
 
     ProcessInfo &rCurrentProcessInfo = (mpmesh_model_part)->GetProcessInfo();
 
@@ -275,6 +283,7 @@ private:
   int mtime_order;
   int mecho_level;
   bool mcalculate_mesh_velocities;
+  bool mreinitialize_model_part_at_each_step;
 
   /*@} */
   /**@name Private Operators*/

--- a/applications/MeshMovingApplication/custom_utilities/move_mesh_utilities.cpp
+++ b/applications/MeshMovingApplication/custom_utilities/move_mesh_utilities.cpp
@@ -90,6 +90,37 @@ ModelPart* GenerateMeshPart(ModelPart &rModelPart,
   KRATOS_CATCH("");
 }
 
+void InitializeMeshPartWithElements(
+    ModelPart& rDestinationModelPart,
+    ModelPart& rOriginModelPart,
+    Properties::Pointer pProperties,
+    const std::string& rElementName)
+{
+    KRATOS_TRY
+
+    // initializing mesh nodes and variables
+    rDestinationModelPart.Nodes() = rOriginModelPart.Nodes();
+
+    auto& r_elements = rDestinationModelPart.Elements();
+
+    // clear all existing elements
+    r_elements.clear();
+
+    const Element& r_reference_element = KratosComponents<Element>::Get(rElementName);
+
+    KRATOS_ERROR_IF(rOriginModelPart.GetCommunicator().GlobalNumberOfElements() == 0)
+        << "No elements are found in " << rOriginModelPart.Name()
+        << " to initialize " << rDestinationModelPart.Name() << ".\n";
+
+    for (auto& r_origin_element : rOriginModelPart.Elements()) {
+        auto p_destination_element = r_reference_element.Create(
+            r_origin_element.Id(), r_origin_element.pGetGeometry(), pProperties);
+        r_elements.push_back(p_destination_element);
+    }
+
+    KRATOS_CATCH("");
+}
+
 void SuperImposeVariables(ModelPart &rModelPart, const Variable< array_1d<double, 3> >& rVariable,
                                                  const Variable< array_1d<double, 3> >& rVariableToSuperImpose)
 {

--- a/applications/MeshMovingApplication/custom_utilities/move_mesh_utilities.h
+++ b/applications/MeshMovingApplication/custom_utilities/move_mesh_utilities.h
@@ -36,6 +36,12 @@ void KRATOS_API(MESH_MOVING_APPLICATION) MoveMesh(ModelPart::NodesContainerType 
 KRATOS_API(MESH_MOVING_APPLICATION) ModelPart* GenerateMeshPart(ModelPart &rModelPart,
                                     const std::string &rElementName);
 
+KRATOS_API(MESH_MOVING_APPLICATION) void InitializeMeshPartWithElements(
+    ModelPart& rDestinationModelPart,
+    ModelPart& rOriginModelPart,
+    Properties::Pointer pProperties,
+    const std::string& rElementName);
+
 void KRATOS_API(MESH_MOVING_APPLICATION) SuperImposeVariables(ModelPart &rModelPart, const Variable< array_1d<double, 3> >& rVariable,
                                                  const Variable< array_1d<double, 3> >& rVariableToSuperImpose);
 

--- a/applications/MeshMovingApplication/python_scripts/mesh_solver_base.py
+++ b/applications/MeshMovingApplication/python_scripts/mesh_solver_base.py
@@ -53,6 +53,8 @@ class MeshSolverBase(PythonSolver):
             self.settings["mesh_velocity_calculation"].ValidateAndAssignDefaults(default_settings)
             self.__CreateTimeIntegratorHelper()
 
+        self.reinitialize_model_part_each_step = self.settings["reinitialize_model_part_each_step"].GetBool()
+
         KratosMultiphysics.Logger.PrintInfo("::[MeshSolverBase]:: Construction finished")
 
     @classmethod
@@ -88,7 +90,8 @@ class MeshSolverBase(PythonSolver):
             "calculate_mesh_velocity"   : true,
             "mesh_velocity_calculation" : { },
             "superimpose_mesh_disp_with": [],
-            "superimpose_mesh_velocity_with": []
+            "superimpose_mesh_velocity_with": [],
+            "reinitialize_model_part_each_step": false
         }""")
         this_defaults.AddMissingParameters(super().GetDefaultParameters())
         return this_defaults

--- a/applications/MeshMovingApplication/python_scripts/mesh_solver_laplacian.py
+++ b/applications/MeshMovingApplication/python_scripts/mesh_solver_laplacian.py
@@ -37,7 +37,8 @@ class MeshSolverLaplacian(MeshSolverBase):
                                                             reform_dofs_each_step,
                                                             compute_reactions,
                                                             False,
-                                                            self.echo_level)
+                                                            self.echo_level,
+                                                            self.reinitialize_model_part_each_step)
         return solving_strategy
 
 

--- a/applications/MeshMovingApplication/python_scripts/mesh_solver_structural_similarity.py
+++ b/applications/MeshMovingApplication/python_scripts/mesh_solver_structural_similarity.py
@@ -29,5 +29,6 @@ class MeshSolverStructuralSimilarity(MeshSolverBase):
                                                              compute_reactions,
                                                              False,
                                                              self.echo_level,
-                                                             poisson_ratio)
+                                                             poisson_ratio,
+                                                             self.reinitialize_model_part_each_step)
         return solving_strategy


### PR DESCRIPTION
**Description**
This PR makes it possible to use automatic mesh refinement on the surfaces after mesh movement using mmg process. It does not change the existing behaviour nor add additional overhead on existing performance.

I did not follow the Kratos style guide in here since, the whole class needs a rework there to change it to style guide. So I will leave these changes to a fresh PR not to confuse what is added and what are cosmetic changes.

**Changelog**
- Add `InitializeMeshPartWithElements` to reinitialize the mesh moving model part aftr automatic mesh refinement
- Updated `StructuralMeshMovingStrategy` to support  automatic mesh refinement
- Updated `LaplacianMeshMovingStrategy` to support  automatic mesh refinement
