### PR TITLE
[Core] Element Size Derivative Calculator BugFix for NaNs

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_element_size_calculator.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_element_size_calculator.cpp
@@ -156,8 +156,8 @@ namespace Kratos
             Geometry<NodeType>::PointsArrayType nodes;
             nodes.push_back(NodeType::Pointer(new NodeType(1, 0.0, 0.0, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(2, 1.0, 2.0, 0.0)));
-            nodes.push_back(NodeType::Pointer(new NodeType(3, 0.5, 0.5, 0.0)));
-            nodes.push_back(NodeType::Pointer(new NodeType(4, 0.2, 0.3, 1.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(3, 0.2, 0.3, 1.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(4, 0.5, 0.5, 0.0)));
             auto geometry = *GeometryType::Pointer(new Tetrahedra3D4<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
                 geometry, ElementSizeCalculator<3, 4>::AverageElementSize,

--- a/kratos/utilities/element_size_calculator.cpp
+++ b/kratos/utilities/element_size_calculator.cpp
@@ -822,7 +822,7 @@ double ElementSizeCalculator<3,4>::AverageElementSizeDerivative(
     detJ_derivative -= z10 * y20_derivative * x30;
     detJ_derivative -= z10 * y20 * x30_derivative;
 
-    return (1./3.) * (detJ_derivative/6.0) / std::pow(detJ/6.0, 2.*3.);
+    return (1./3.) * (detJ_derivative/6.0) / std::pow(detJ/6.0, 2./3.);
 
     KRATOS_CATCH("");
 }


### PR DESCRIPTION
**Description**
This PR fixes a bug in element size derivative calculator and fixes for NaN test reported in #8049.

**Changelog**
- Bug fix
