### PR TITLE
[Core] bugfix in parallel redistance calculator

### DIFF
--- a/kratos/utilities/parallel_levelset_distance_calculator.h
+++ b/kratos/utilities/parallel_levelset_distance_calculator.h
@@ -603,9 +603,12 @@ protected:
                 if (b > 0) q = -0.5 * (b + sqrt_det);
                 else q = -0.5 * (b - sqrt_det);
                 root1 = q / a;
-                root2 = c / q;
-                if (root1 > root2) distance = root1;
-                else distance = root2;
+                distance = root1;
+                if( q != 0.0)
+                {
+                    root2 = c / q;
+                    if (root2 > root1) distance = root2;
+                }
             }
             else   //in this case we have a linear equation
             {

--- a/kratos/utilities/parallel_levelset_distance_calculator.h
+++ b/kratos/utilities/parallel_levelset_distance_calculator.h
@@ -604,8 +604,7 @@ protected:
                 else q = -0.5 * (b - sqrt_det);
                 root1 = q / a;
                 distance = root1;
-                if( q != 0.0)
-                {
+                if(std::abs(q) > 0.0) {
                     root2 = c / q;
                     if (root2 > root1) distance = root2;
                 }


### PR DESCRIPTION
When computing distance to nodes, i have a geometry with following results on a tetra3D4N with 3 coplanar nodes :
`a=1.0E+06`
`b=0.0`
`c=0.0`
It leads to :
`q=0.0`, so `root1 = 0.0` and `root2 = nan`. As `0.0 > nan`, result is `nan` on some nodes.
I just added a check `if q==0.0`
@ddiezrod @pooyan-dadvand @pablobecker 