### PR TITLE
[Core] Geometrical Sensitivities Utility Bugfix

### DIFF
--- a/kratos/utilities/geometrical_sensitivity_utility.cpp
+++ b/kratos/utilities/geometrical_sensitivity_utility.cpp
@@ -28,7 +28,7 @@ GeometricalSensitivityUtility::GeometricalSensitivityUtility(const JacobianType&
     KRATOS_TRY;
 
     Initialize();
-    
+
     KRATOS_CATCH("");
 }
 
@@ -95,7 +95,7 @@ GeometricalSensitivityUtility::MatrixType GeometricalSensitivityUtility::Calcula
             IndexType i_coord_sub = (Deriv.Direction > i) ? Deriv.Direction - 1 : Deriv.Direction;
             for (unsigned j = 0; j < mrJ.size2(); ++j)
             {
-#ifdef KRATOS_USE_AMATRIX   // This macro definition is for the migration period and to be removed afterward please do not use it 
+#ifdef KRATOS_USE_AMATRIX   // This macro definition is for the migration period and to be removed afterward please do not use it
 				DenseVector<std::size_t> ia1(mrJ.size1() - 1), ia2(mrJ.size2() - 1);
 #else
 				IndirectArrayType ia1(mrJ.size1() - 1), ia2(mrJ.size2() - 1);
@@ -112,12 +112,12 @@ GeometricalSensitivityUtility::MatrixType GeometricalSensitivityUtility::Calcula
                     if (k != j)
                         ia2(j_sub++) = k;
 
-                const SubMatrixType sub_jacobian(mrJ, ia1, ia2);
-                const MatrixType cofactor_sub_jacobian = MathUtils<double>::CofactorMatrix(sub_jacobian);
+                const MatrixType& sub_jacobian = SubMatrixType(mrJ, ia1, ia2);
+                const MatrixType& cofactor_sub_jacobian = MathUtils<double>::CofactorMatrix(sub_jacobian);
 
                 // Construct the corresponding shape function local gradients
                 // submatrix.
-                const SubMatrixType sub_DN_De(mrDN_De, ia3, ia2);
+                const MatrixType& sub_DN_De = SubMatrixType(mrDN_De, ia3, ia2);
 
                 const double first_minor_deriv = inner_prod(
                     row(cofactor_sub_jacobian, i_coord_sub),


### PR DESCRIPTION
**Description**
Since #8341, One of my tests in PR #8142 started to fail in release mode only (gcc, all others works fine). And I found out again that this is related (or indirectly related) to #7414, that is some how gcc does not do type casting properly with `boost::numeric::ublas::matrix_indirect` so I was getting garbage values hence a test fail. So now I make sure they are always translated to matrix type.

Observation:
When I put a `KRATOS_WATCH` for the variables with type `boost::numeric::ublas::matrix_indirect` then all the tests pass in release mode gcc, but if I omit it, the tests start to fail.

This was a really nasty bug to debug also. Is there a way to make sure these does not happen in the future?

**Changelog**
- Type bug fix
