### PR TITLE
[CoSim] enabling UpdateInterface

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
@@ -153,6 +153,9 @@ class CoSimulationCoupledSolver(CoSimulationSolverWrapper):
         for predictor in self.predictors_list:
             predictor.InitializeSolutionStep()
 
+        for data_transfer_operator in self.data_transfer_operators_dict.values():
+            data_transfer_operator.InitializeSolutionStep()
+
         for coupling_operation in self.coupling_operations_dict.values():
             coupling_operation.InitializeSolutionStep()
 
@@ -162,6 +165,9 @@ class CoSimulationCoupledSolver(CoSimulationSolverWrapper):
 
         for predictor in self.predictors_list:
             predictor.FinalizeSolutionStep()
+
+        for data_transfer_operator in self.data_transfer_operators_dict.values():
+            data_transfer_operator.FinalizeSolutionStep()
 
         for coupling_operation in self.coupling_operations_dict.values():
             coupling_operation.FinalizeSolutionStep()

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_data_transfer_operator.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_data_transfer_operator.py
@@ -7,9 +7,42 @@ class CoSimulationDataTransferOperator:
     """
     def __init__(self, settings):
         self.settings = settings
-        self.settings.ValidateAndAssignDefaults(self._GetDefaultParameters())
+        default_parameters = self._GetDefaultParameters()
+        self.settings.ValidateAndAssignDefaults(default_parameters)
+        self.settings["update_interface"].ValidateAndAssignDefaults(default_parameters["update_interface"])
+
         self.echo_level = self.settings["echo_level"].GetInt()
         self.__checked_combinations = []
+        self.update_interface_execution_points = self.settings["update_interface"]["execution_points"].GetStringArray()
+
+        available_execution_points = [
+            "initialize_solution_step",
+            "finalize_solution_step",
+            "initialize_non_linear_iteration",
+            "finalize_non_linear_iteration"
+        ]
+
+        for execution_point in self.update_interface_execution_points:
+            if execution_point not in available_execution_points:
+                err_msg  = 'Execution point "{}" is not available, only the following options are available:\n    '.format(execution_point)
+                err_msg += "\n    ".join(available_execution_points)
+                raise Exception(err_msg)
+
+    def InitializeSolutionStep(self):
+        if "initialize_solution_step" in self.update_interface_execution_points:
+            self._UpdateInterface(self.settings["update_interface"]["settings"])
+
+    def FinalizeSolutionStep(self):
+        if "finalize_solution_step" in self.update_interface_execution_points:
+            self._UpdateInterface(self.settings["update_interface"]["settings"])
+
+    def InitializeNonLinearIteration(self):
+        if "initialize_non_linear_iteration" in self.update_interface_execution_points:
+            self._UpdateInterface(self.settings["update_interface"]["settings"])
+
+    def FinalizeNonLinearIteration(self):
+        if "finalize_non_linear_iteration" in self.update_interface_execution_points:
+            self._UpdateInterface(self.settings["update_interface"]["settings"])
 
     def TransferData(self, from_solver_data, to_solver_data, transfer_options):
         # 1. Check if specified transfer options are available
@@ -29,6 +62,9 @@ class CoSimulationDataTransferOperator:
 
     def _ExecuteTransferData(self, from_solver_data, to_solver_data, transfer_options):
         raise NotImplementedError("This function has to be implemented in the derived class!")
+
+    def _UpdateInterface(self, settings):
+        raise NotImplementedError("This function is not implemented for {}".format(self._ClassName()))
 
     def _Check(self, from_solver_data, to_solver_data):
         # this can be implemented in derived classes if necessary
@@ -58,5 +94,9 @@ class CoSimulationDataTransferOperator:
     def _GetDefaultParameters(cls):
         return KM.Parameters("""{
             "type"       : "UNSPECIFIED",
-            "echo_level" : 0
+            "echo_level" : 0,
+            "update_interface" : {
+                "execution_points" : [],
+                "settings" : {}
+            }
         }""")

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_strong.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_strong.py
@@ -73,6 +73,9 @@ class GaussSeidelStrongCoupledSolver(CoSimulationCoupledSolver):
             for coupling_op in self.coupling_operations_dict.values():
                 coupling_op.InitializeCouplingIteration()
 
+            for data_transfer_operator in self.data_transfer_operators_dict.values():
+                data_transfer_operator.InitializeNonLinearIteration()
+
             for conv_acc in self.convergence_accelerators_list:
                 conv_acc.InitializeNonLinearIteration()
 
@@ -86,6 +89,9 @@ class GaussSeidelStrongCoupledSolver(CoSimulationCoupledSolver):
 
             for coupling_op in self.coupling_operations_dict.values():
                 coupling_op.FinalizeCouplingIteration()
+
+            for data_transfer_operator in self.data_transfer_operators_dict.values():
+                data_transfer_operator.FinalizeNonLinearIteration()
 
             for conv_acc in self.convergence_accelerators_list:
                 conv_acc.FinalizeNonLinearIteration()

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_weak.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_weak.py
@@ -9,6 +9,9 @@ class GaussSeidelWeakCoupledSolver(CoSimulationCoupledSolver):
         for coupling_op in self.coupling_operations_dict.values():
             coupling_op.InitializeCouplingIteration()
 
+        for data_transfer_operator in self.data_transfer_operators_dict.values():
+            data_transfer_operator.InitializeNonLinearIteration()
+
         for solver_name, solver in self.solver_wrappers.items():
             self._SynchronizeInputData(solver_name)
             solver.SolveSolutionStep()
@@ -16,5 +19,8 @@ class GaussSeidelWeakCoupledSolver(CoSimulationCoupledSolver):
 
         for coupling_op in self.coupling_operations_dict.values():
             coupling_op.FinalizeCouplingIteration()
+
+        for data_transfer_operator in self.data_transfer_operators_dict.values():
+            data_transfer_operator.FinalizeNonLinearIteration()
 
         return True

--- a/applications/CoSimulationApplication/python_scripts/data_transfer_operators/kratos_mapping.py
+++ b/applications/CoSimulationApplication/python_scripts/data_transfer_operators/kratos_mapping.py
@@ -74,6 +74,11 @@ class KratosMappingDataTransferOperator(CoSimulationDataTransferOperator):
                 cs_tools.cs_print_info(colors.bold(self._ClassName()), "Creating Mapper took: {0:.{1}f} [s]".format(time()-mapper_creation_start_time,2))
             self.__mappers[identifier_tuple].Map(variable_origin, variable_destination, mapper_flags)
 
+    def _UpdateInterface(self, settings):
+        # TODO some updates are pending in the MappingApp, after that the "settings" will be used
+        for mapper in self.__mappers.values():
+            mapper.UpdateInterface()
+
     def _Check(self, from_solver_data, to_solver_data):
         def CheckData(data_to_check):
             if data_to_check.location != "node_historical":


### PR DESCRIPTION
**Description**
This PR enables the usage of `UpdateInterface` for the `DataTransferOperators` in the CoSimApp. This is necessary when the mesh changes (e.g. bcs it is moving or due to remeshing)

In the CoSim parameters this can be enabled in the settings of the corresponding `data_transfer_operator`. Here is an example:
~~~json
"data_transfer_operators" : {
    "mapper" : {
        "type" : "kratos_mapping",
        "mapper_settings" : {
            "mapper_type" : "nearest_neighbor"
        },
        "update_interface" : {
            "execution_points" : ["initialize_solution_step"]
        }
    }
},
~~~

@VeronikaSinger can you please test if this works for you? If so then we can think of a suitable test and merge this :)

FYI @peterjwilson 