### PR TITLE
[FastPR][Core] Add CreateFillCommunicator to Python

### DIFF
--- a/kratos/mpi/python/add_mpi_utilities_to_python.cpp
+++ b/kratos/mpi/python/add_mpi_utilities_to_python.cpp
@@ -51,10 +51,8 @@ void AddMPIUtilitiesToPython(pybind11::module& m)
     .def_static("SetMPICommunicator",&ModelPartCommunicatorUtilities::SetMPICommunicator)
     ;
 
-    py::class_<ParallelFillCommunicator >(m,"ParallelFillCommunicator")
+    py::class_<ParallelFillCommunicator, ParallelFillCommunicator::Pointer, FillCommunicator>(m,"ParallelFillCommunicator")
     .def(py::init<ModelPart& >() )
-    .def("Execute", &ParallelFillCommunicator::Execute )
-    .def("PrintDebugInfo", &ParallelFillCommunicator::PrintDebugInfo )
     ;
 
     m.def_submodule("DataCommunicatorFactory")

--- a/kratos/python/add_other_utilities_to_python.cpp
+++ b/kratos/python/add_other_utilities_to_python.cpp
@@ -23,6 +23,7 @@
 #include "linear_solvers/linear_solver.h"
 #include "includes/define_python.h"
 #include "processes/process.h"
+#include "includes/fill_communicator.h"
 #include "includes/global_pointer_variables.h"
 
 //Other utilities
@@ -592,6 +593,12 @@ void AddOtherUtilitiesToPython(pybind11::module &m)
         .def("Clear", &FileNameDataCollector::FileNameData::Clear)
         .def("__eq__", &FileNameDataCollector::FileNameData::operator==)
         ;
+
+    py::class_<FillCommunicator, FillCommunicator::Pointer>(m,"FillCommunicator")
+        .def(py::init<ModelPart& >() )
+        .def("Execute", &FillCommunicator::Execute)
+        .def("PrintDebugInfo", &FillCommunicator::PrintDebugInfo)
+    ;
 }
 
 } // namespace Python.

--- a/kratos/python/add_parallel_environment_to_python.cpp
+++ b/kratos/python/add_parallel_environment_to_python.cpp
@@ -37,6 +37,7 @@ void AddParallelEnvironmentToPython(pybind11::module &m)
     .def_static("GetDefaultSize",&ParallelEnvironment::GetDefaultSize)
     .def_static("HasDataCommunicator",&ParallelEnvironment::HasDataCommunicator)
     .def_static("GetDefaultDataCommunicatorName",&ParallelEnvironment::GetDefaultDataCommunicatorName)
+    .def_static("CreateFillCommunicator", &ParallelEnvironment::CreateFillCommunicator)
     .def_static("Info", []() {
         std::stringstream ss;
         ParallelEnvironment::PrintInfo(ss);


### PR DESCRIPTION
**Description**
What the tittle says, export the `CreateFillCommunicator` to Python and requirements.
