### PR TITLE
[MeshingApplication][MMG] Add optimization remeshing mode

### DIFF
--- a/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
+++ b/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
@@ -162,7 +162,6 @@ void MmgProcess<TMMGLibrary>::ExecuteInitialize()
     mMmgUtilities.SetEchoLevel(mEchoLevel);
     mMmgUtilities.SetDiscretization(mDiscretization);
     mMmgUtilities.SetRemoveRegions(mRemoveRegions);
-    // mMmgUtilities.SetMeshOptimizationMode(mThisParameters["advanced_parameters"]["mesh_optimization_only"].GetBool());
     mMmgUtilities.InitMesh();
 
     KRATOS_CATCH("");
@@ -200,7 +199,6 @@ void MmgProcess<TMMGLibrary>::ExecuteInitializeSolutionStep()
     // We initialize the mesh and solution data
     InitializeMeshData();
 
-    //
     mMmgUtilities.SetMeshOptimizationModeParameter(optimization_mode);
 
     // We retrieve the data form the Kratos model part to fill sol

--- a/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
+++ b/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
@@ -162,6 +162,7 @@ void MmgProcess<TMMGLibrary>::ExecuteInitialize()
     mMmgUtilities.SetEchoLevel(mEchoLevel);
     mMmgUtilities.SetDiscretization(mDiscretization);
     mMmgUtilities.SetRemoveRegions(mRemoveRegions);
+    // mMmgUtilities.SetMeshOptimizationMode(mThisParameters["advanced_parameters"]["mesh_optimization_only"].GetBool());
     mMmgUtilities.InitMesh();
 
     KRATOS_CATCH("");
@@ -187,6 +188,7 @@ void MmgProcess<TMMGLibrary>::ExecuteInitializeSolutionStep()
     KRATOS_TRY;
 
     const bool safe_to_file = mThisParameters["save_external_files"].GetBool();
+    const bool optimization_mode = mThisParameters["advanced_parameters"]["mesh_optimization_only"].GetBool();
 
     /* We print the original model part */
     KRATOS_INFO_IF("", mEchoLevel > 0) <<
@@ -198,11 +200,16 @@ void MmgProcess<TMMGLibrary>::ExecuteInitializeSolutionStep()
     // We initialize the mesh and solution data
     InitializeMeshData();
 
+    //
+    mMmgUtilities.SetMeshOptimizationModeParameter(optimization_mode);
+
     // We retrieve the data form the Kratos model part to fill sol
     if (mDiscretization == DiscretizationOption::ISOSURFACE) {
         InitializeSolDataDistance();
     } else {
-        InitializeSolDataMetric();
+        if (!optimization_mode) {
+            InitializeSolDataMetric();
+        }
     }
 
     // We set the displacement vector
@@ -1241,6 +1248,7 @@ const Parameters MmgProcess<TMMGLibrary>::GetDefaultParameters() const
             "normal_regularization_mesh"          : false,
             "deactivate_detect_angle"             : false,
             "force_gradation_value"               : false,
+            "mesh_optimization_only"              : false,
             "gradation_value"                     : 1.3
         },
         "collapse_prisms_elements"             : false,

--- a/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.cpp
+++ b/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.cpp
@@ -1731,9 +1731,9 @@ template<>
 void MmgUtilities<MMGLibrary::MMGS>::SetMeshOptimizationModeParameter(const bool EnableMeshOptimization)
 {
     KRATOS_TRY;
-
+#if MMG_VERSION_GE(5,5)
     KRATOS_ERROR_IF( !MMGS_Set_iparameter(mMmgMesh,mMmgMet,MMGS_IPARAM_optim, EnableMeshOptimization) ) << "Unable to set optim mode" << std::endl;
-
+#endif
     KRATOS_CATCH("");
 }
 

--- a/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.cpp
+++ b/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.cpp
@@ -1702,6 +1702,45 @@ void MmgUtilities<MMGLibrary::MMGS>::InitVerbosityParameter(const IndexType Verb
 /***********************************************************************************/
 
 template<>
+void MmgUtilities<MMGLibrary::MMG2D>::SetMeshOptimizationModeParameter(const bool EnableMeshOptimization)
+{
+    KRATOS_TRY;
+
+    KRATOS_ERROR_IF( !MMG2D_Set_iparameter(mMmgMesh,mMmgMet,MMG2D_IPARAM_optim, EnableMeshOptimization) ) << "Unable to set optim mode" << std::endl;
+
+    KRATOS_CATCH("");
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<>
+void MmgUtilities<MMGLibrary::MMG3D>::SetMeshOptimizationModeParameter(const bool EnableMeshOptimization)
+{
+    KRATOS_TRY;
+
+    KRATOS_ERROR_IF( !MMG3D_Set_iparameter(mMmgMesh,mMmgMet,MMG3D_IPARAM_optim, EnableMeshOptimization) ) << "Unable to set optim mode" << std::endl;
+
+    KRATOS_CATCH("");
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<>
+void MmgUtilities<MMGLibrary::MMGS>::SetMeshOptimizationModeParameter(const bool EnableMeshOptimization)
+{
+    KRATOS_TRY;
+
+    KRATOS_ERROR_IF( !MMGS_Set_iparameter(mMmgMesh,mMmgMet,MMGS_IPARAM_optim, EnableMeshOptimization) ) << "Unable to set optim mode" << std::endl;
+
+    KRATOS_CATCH("");
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<>
 void MmgUtilities<MMGLibrary::MMG2D>::SetMeshSize(MMGMeshInfo<MMGLibrary::MMG2D>& rMMGMeshInfo)
 {
     KRATOS_TRY;

--- a/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.h
+++ b/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.h
@@ -419,6 +419,13 @@ public:
     virtual void InitVerbosityParameter(const IndexType VerbosityMMG);
 
     /**
+     * @brief This sets the optimization mode using the API
+     * where edge lengths are preserved, ignoring the metric values.
+     * @param[in] EnableMeshOptimization Sets the mesh optimzation member variable
+     */
+    virtual void SetMeshOptimizationModeParameter(const bool EnableMeshOptimization);
+
+    /**
      * @brief This sets the size of the mesh
      * @param[in,out] rMMGMeshInfo The number of nodes, conditions and elements
      */

--- a/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.h
+++ b/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.h
@@ -421,7 +421,7 @@ public:
     /**
      * @brief This sets the optimization mode using the API
      * where edge lengths are preserved, ignoring the metric values.
-     * @param[in] EnableMeshOptimization Sets the mesh optimzation member variable
+     * @param[in] EnableMeshOptimization Boolean to set the mesh optimization mode
      */
     virtual void SetMeshOptimizationModeParameter(const bool EnableMeshOptimization);
 

--- a/applications/MeshingApplication/python_scripts/mmg_process.py
+++ b/applications/MeshingApplication/python_scripts/mmg_process.py
@@ -138,6 +138,7 @@ class MmgProcess(KratosMultiphysics.Process):
                 "no_surf_mesh"                        : false,
                 "no_insert_mesh"                      : false,
                 "no_swap_mesh"                        : false,
+                "mesh_optimization_only"              : false,
                 "deactivate_detect_angle"             : false,
                 "force_gradation_value"               : false,
                 "gradation_value"                     : 1.3
@@ -375,6 +376,9 @@ class MmgProcess(KratosMultiphysics.Process):
         mmg_parameters.AddValue("debug_result_mesh",self.settings["debug_result_mesh"])
         mmg_parameters.AddValue("initialize_entities",self.settings["initialize_entities"])
         mmg_parameters.AddValue("echo_level",self.settings["echo_level"])
+        if self.strategy == "Optimization":
+            mmg_parameters["advanced_parameters"]["mesh_optimization_only"].SetBool(True)
+
         if self.domain_size == 2:
             self.mmg_process = MeshingApplication.MmgProcess2D(self.main_model_part, mmg_parameters)
         else:
@@ -415,7 +419,7 @@ class MmgProcess(KratosMultiphysics.Process):
                     if self.interval.IsInInterval(current_time):
                         # We remesh if needed
                         if self.__execute_remesh():
-                            if self.strategy == "Hessian" or self.strategy == "LevelSet":
+                            if self.strategy in ["Hessian", "LevelSet", "Optimization"]:
                                 if self.settings["blocking_threshold_size"].GetBool():
                                     MeshingApplication.BlockThresholdSizeElements(self.main_model_part, self.settings["threshold_sizes"])
                                 self._ExecuteRefinement()

--- a/applications/MeshingApplication/python_scripts/mmg_process.py
+++ b/applications/MeshingApplication/python_scripts/mmg_process.py
@@ -376,7 +376,7 @@ class MmgProcess(KratosMultiphysics.Process):
         mmg_parameters.AddValue("debug_result_mesh",self.settings["debug_result_mesh"])
         mmg_parameters.AddValue("initialize_entities",self.settings["initialize_entities"])
         mmg_parameters.AddValue("echo_level",self.settings["echo_level"])
-        if self.strategy == "Optimization":
+        if self.strategy == "optimization":
             mmg_parameters["advanced_parameters"]["mesh_optimization_only"].SetBool(True)
 
         if self.domain_size == 2:
@@ -419,7 +419,7 @@ class MmgProcess(KratosMultiphysics.Process):
                     if self.interval.IsInInterval(current_time):
                         # We remesh if needed
                         if self.__execute_remesh():
-                            if self.strategy in ["Hessian", "LevelSet", "Optimization"]:
+                            if self.strategy in ["Hessian", "LevelSet", "optimization"]:
                                 if self.settings["blocking_threshold_size"].GetBool():
                                     MeshingApplication.BlockThresholdSizeElements(self.main_model_part, self.settings["threshold_sizes"])
                                 self._ExecuteRefinement()


### PR DESCRIPTION
**Description**
This PR enables the option to use MMG preserving edge lengthes, to be used to improve mesh quality, using the built-in option:

https://www.mmgtools.org/mmg-remesher-try-mmg/mmg-remesher-options/optim

This could be useful for optimization @sunethwarna @armingeiser.

If the option is active, no metric values have to be initialized or loaded into MMG, so a check is performed to skip the InitalizeMetricData().

Users can enable this by setting the strategy "Optimization" in the mmg_process.py.

**Changelog**
- Added -optim option through libcalls 
- Added "Optimization" strategy in the python process
