### PR TITLE
[CI] Update nightly_build with Boost download for win

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -95,10 +95,18 @@ jobs:
       with:
         python-version: '3.6'
 
+    - name: Download boost
+      run: |
+        $url = "https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.gz/download"
+        (New-Object System.Net.WebClient).DownloadFile($url, "$env:TEMP\boost.tar.gz")
+        7z.exe x "$env:TEMP\boost.tar.gz" -o"$env:TEMP\boostArchive" -y | Out-Null
+        7z.exe x "$env:TEMP\boostArchive" -o"$env:TEMP\boost" -y | Out-Null
+        
     - name: Installing dependencies
       shell: cmd
       run: |
         pip install numpy
+        pip install h5py
 
     - name: Build
       shell: cmd


### PR DESCRIPTION
**Description**
Nightly build was not updated with the Boost download.

@philbucher not sure if you did not do this because you have something different planned.

**Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Added Boost download
- Added install of h5py
