### PR TITLE
[PotentialFlow] Preparing solver for shape optimization

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -31,6 +31,8 @@ void  AddCustomUtilitiesToPython(pybind11::module& m)
 
     mod_potential_flow_utilities.def("CheckIfWakeConditionsAreFulfilled2D",&PotentialFlowUtilities::CheckIfWakeConditionsAreFulfilled<2>);
     mod_potential_flow_utilities.def("CheckIfWakeConditionsAreFulfilled3D",&PotentialFlowUtilities::CheckIfWakeConditionsAreFulfilled<3>);
+    mod_potential_flow_utilities.def("CalculateArea",&PotentialFlowUtilities::CalculateArea<ModelPart::ElementsContainerType>);
+    mod_potential_flow_utilities.def("CalculateArea",&PotentialFlowUtilities::CalculateArea<ModelPart::ConditionsContainerType>);
 }
 
 }  // namespace Python.

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
@@ -948,6 +948,16 @@ void GetNodeNeighborElementCandidates(GlobalPointersVector<Element>& ElementCand
         }
     }
 }
+
+template <class TContainerType>
+double CalculateArea(TContainerType& rContainer)
+{
+    double area = block_for_each<SumReduction<double>>(rContainer, [&](typename TContainerType::value_type& rEntity){
+        return rEntity.GetGeometry().Area();
+    });
+
+    return area;
+}
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Template instantiation
 
@@ -1045,5 +1055,7 @@ template void  KRATOS_API(COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION) CheckIfWakeCo
 template bool CheckWakeCondition<3, 4>(const Element& rElement, const double& rTolerance, const int& rEchoLevel);
 template void GetSortedIds<3, 4>(std::vector<size_t>& Ids, const GeometryType& rGeom);
 template void GetNodeNeighborElementCandidates<3, 4>(GlobalPointersVector<Element>& ElementCandidates, const GeometryType& rGeom);
+template double CalculateArea<ModelPart::ElementsContainerType>(ModelPart::ElementsContainerType& rContainer);
+template double CalculateArea<ModelPart::ConditionsContainerType>(ModelPart::ConditionsContainerType& rContainer);
 } // namespace PotentialFlow
 } // namespace Kratos

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
@@ -1055,7 +1055,7 @@ template void  KRATOS_API(COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION) CheckIfWakeCo
 template bool CheckWakeCondition<3, 4>(const Element& rElement, const double& rTolerance, const int& rEchoLevel);
 template void GetSortedIds<3, 4>(std::vector<size_t>& Ids, const GeometryType& rGeom);
 template void GetNodeNeighborElementCandidates<3, 4>(GlobalPointersVector<Element>& ElementCandidates, const GeometryType& rGeom);
-template double CalculateArea<ModelPart::ElementsContainerType>(ModelPart::ElementsContainerType& rContainer);
-template double CalculateArea<ModelPart::ConditionsContainerType>(ModelPart::ConditionsContainerType& rContainer);
+template double KRATOS_API(COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION) CalculateArea<ModelPart::ElementsContainerType>(ModelPart::ElementsContainerType& rContainer);
+template double KRATOS_API(COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION) CalculateArea<ModelPart::ConditionsContainerType>(ModelPart::ConditionsContainerType& rContainer);
 } // namespace PotentialFlow
 } // namespace Kratos

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
@@ -181,6 +181,9 @@ void GetSortedIds(std::vector<size_t>& Ids, const GeometryType& rGeom);
 
 template <int Dim, int NumNodes>
 void GetNodeNeighborElementCandidates(GlobalPointersVector<Element>& ElementCandidates, const GeometryType& rGeom);
+
+template <class TContainerType>
+double CalculateArea(TContainerType& rContainer);
 } // namespace PotentialFlow
 } // namespace Kratos
 

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_2d.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_2d.py
@@ -39,7 +39,7 @@ class DefineWakeProcess2D(KratosMultiphysics.Process):
             for node in cond.GetNodes():
                 node.Set(KratosMultiphysics.SOLID)
 
-    def ExecuteInitialize(self):
+    def ExecuteInitializeSolutionStep(self):
 
         CPFApp.Define2DWakeProcess(self.body_model_part, self.epsilon).ExecuteInitialize()
 

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_2d.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_2d.py
@@ -53,7 +53,6 @@ class DefineWakeProcess2D(KratosMultiphysics.Process):
         if self.compute_wake_at_each_step and self.fluid_model_part.ProcessInfo[KratosMultiphysics.STEP] > 1:
             CPFApp.Define2DWakeProcess(self.body_model_part, self.epsilon).ExecuteInitialize()
 
-
     def ExecuteFinalizeSolutionStep(self):
         if not self.fluid_model_part.HasSubModelPart("wake_sub_model_part"):
             raise Exception("Fluid model part does not have a wake_sub_model_part")

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_2d.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_2d.py
@@ -19,6 +19,7 @@ class DefineWakeProcess2D(KratosMultiphysics.Process):
         default_settings = KratosMultiphysics.Parameters(r'''{
             "model_part_name": "",
             "epsilon": 1e-9,
+            "compute_wake_at_each_step": false,
             "echo_level": 1
         }''')
         settings.ValidateAndAssignDefaults(default_settings)
@@ -35,15 +36,23 @@ class DefineWakeProcess2D(KratosMultiphysics.Process):
 
         self.fluid_model_part = self.body_model_part.GetRootModelPart()
 
+        self.compute_wake_at_each_step = settings["compute_wake_at_each_step"].GetBool()
+
         for cond in self.body_model_part.Conditions:
             for node in cond.GetNodes():
                 node.Set(KratosMultiphysics.SOLID)
 
-    def ExecuteInitializeSolutionStep(self):
+    def ExecuteInitialize(self):
 
         CPFApp.Define2DWakeProcess(self.body_model_part, self.epsilon).ExecuteInitialize()
 
         #self.__FindWakeElements()
+
+    def ExecuteInitializeSolutionStep(self):
+
+        if self.compute_wake_at_each_step and self.fluid_model_part.ProcessInfo[KratosMultiphysics.STEP] > 1:
+            CPFApp.Define2DWakeProcess(self.body_model_part, self.epsilon).ExecuteInitialize()
+
 
     def ExecuteFinalizeSolutionStep(self):
         if not self.fluid_model_part.HasSubModelPart("wake_sub_model_part"):

--- a/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
@@ -70,6 +70,7 @@ class PotentialFlowTests(UnitTest.TestCase):
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.MOMENT_COEFFICIENT], -0.1631792300021498, 0.0, 1e-9)
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_JUMP], 0.4876931961465126, 0.0, 1e-9)
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_FAR_FIELD], 0.4953997676243705, 0.0, 1e-9)
+            self._check_perimeter_computation()
 
             for file_name in os.listdir():
                 if file_name.endswith(".time"):
@@ -300,6 +301,12 @@ class PotentialFlowTests(UnitTest.TestCase):
         full_msg += str(rel_tol) + ", abs_tol = " + str(abs_tol)
 
         self.assertTrue(isclosethis, msg=full_msg)
+
+    def _check_perimeter_computation(self):
+        body_model_part = self.main_model_part.GetSubModelPart("Body2D_Body")
+        perimeter1 = sum([cond.GetGeometry().Area() for cond in body_model_part.Conditions])
+        perimeter2 = CPFApp.PotentialFlowUtilities.CalculateArea(body_model_part.Conditions)
+        self._check_results(perimeter1, perimeter2, 1e-9, 1e-9)
 
 if __name__ == '__main__':
     UnitTest.main()


### PR DESCRIPTION
**Description**
This prepares the solver to add a potential_flow_response script to perform optimization. The main change is to switch the ExecuteInitialize() of the wake to ExecuteInitializeSolutionStep().

Also a utility is added to compute the area given the container, to be used to compute the perimeter. 


**Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Change wake execution command.
- Add CalculateArea() utility
