### PR TITLE
[CI] fix error running mpi tests in python3.5.4

### DIFF
--- a/kratos/python_scripts/testing/utilities.py
+++ b/kratos/python_scripts/testing/utilities.py
@@ -109,7 +109,6 @@ class Commander:
         self.exitCode = 0
 
         test_script = path / Path("tests") / Path("test_{}.py".format(application))
-        directory = str( path / Path("tests"))
 
         if Path.is_file(test_script):
             full_command = "{} {} {} {} {} {} --using-mpi -v{} -l{}".format(mpi_command, mpi_flags, num_processes_flag, num_processes, command, test_script, verbose, level)

--- a/kratos/python_scripts/testing/utilities.py
+++ b/kratos/python_scripts/testing/utilities.py
@@ -109,6 +109,7 @@ class Commander:
         self.exitCode = 0
 
         test_script = path / Path("tests") / Path("test_{}.py".format(application))
+        directory = str( path / Path("tests"))
 
         if Path.is_file(test_script):
             full_command = "{} {} {} {} {} {} --using-mpi -v{} -l{}".format(mpi_command, mpi_flags, num_processes_flag, num_processes, command, test_script, verbose, level)
@@ -117,7 +118,7 @@ class Commander:
                     full_command
                 ], shell=True,
                    stdout=subprocess.PIPE,
-                   cwd=os.path.dirname(os.path.abspath(test_script)))
+                   cwd=directory)
             except:
                 print('[Error]: Unable to execute "{}"'.format(full_command), file=sys.stderr)
                 self.exitCode = 1

--- a/kratos/python_scripts/testing/utilities.py
+++ b/kratos/python_scripts/testing/utilities.py
@@ -118,7 +118,7 @@ class Commander:
                     full_command
                 ], shell=True,
                    stdout=subprocess.PIPE,
-                   cwd=directory)
+                   cwd=os.path.dirname(os.path.abspath(str(test_script))))
             except:
                 print('[Error]: Unable to execute "{}"'.format(full_command), file=sys.stderr)
                 self.exitCode = 1


### PR DESCRIPTION
I am getting an error running mpi tests. It seems "Path" is not completely supported in python 3.5.4. Is this ok for you? @philbucher 

https://stackoverflow.com/questions/48195727/running-collectstatic-on-server-attributeerror-posixpath-object-has-no-attr

FYI @KratosMultiphysics/altair 
