### PR TITLE
[DEM-SDEM] Fix error in phantoms

### DIFF
--- a/applications/DEMApplication/custom_conditions/RigidFace.cpp
+++ b/applications/DEMApplication/custom_conditions/RigidFace.cpp
@@ -405,17 +405,17 @@ bool RigidFace3D::CheckProjectionFallsInside(SphericParticle *p_particle)
     const array_1d<double, 3>& P2 = geom[1].Coordinates();
     const array_1d<double, 3>& P3 = geom[2].Coordinates();
     const array_1d<double, 3> w  = P - P1;
-    array_1d<double, 3> u = P2 - P1;
-    array_1d<double, 3> v = P3 - P1;
-    array_1d<double, 3> n;
-    array_1d<double, 3> u_cross_w;
-    array_1d<double, 3> w_cross_v;
-    GeometryFunctions::CrossProduct(u, v, n);
-    GeometryFunctions::CrossProduct(u, w, u_cross_w);
-    GeometryFunctions::CrossProduct(w, v, w_cross_v);
-    const double n2 = DEM_INNER_PRODUCT_3(n, n);
-    const double beta = DEM_INNER_PRODUCT_3(w_cross_v, n) / n2;
-    const double gamma = DEM_INNER_PRODUCT_3(u_cross_w, n) / n2;
+    array_1d<double, 3> side_1 = P2 - P1;
+    array_1d<double, 3> side_2 = P3 - P1;
+    array_1d<double, 3> normal;
+    array_1d<double, 3> side_1_cross_w;
+    array_1d<double, 3> w_cross_side_2;
+    GeometryFunctions::CrossProduct(side_1, side_2, normal);
+    GeometryFunctions::CrossProduct(side_1, w, side_1_cross_w);
+    GeometryFunctions::CrossProduct(w, side_2, w_cross_side_2);
+    const double normal2 = DEM_INNER_PRODUCT_3(normal, normal);
+    const double beta = DEM_INNER_PRODUCT_3(w_cross_side_2, normal) / normal2;
+    const double gamma = DEM_INNER_PRODUCT_3(side_1_cross_w, normal) / normal2;
     const double alpha = 1 - beta - gamma;
     const bool falls_inside = (alpha >= 0 && beta >= 0 && gamma >= 0
                             && alpha <= 1 && beta <= 1 && gamma <= 1);

--- a/applications/DEMApplication/custom_conditions/RigidFace.cpp
+++ b/applications/DEMApplication/custom_conditions/RigidFace.cpp
@@ -419,6 +419,8 @@ bool RigidFace3D::CheckProjectionFallsInside(SphericParticle *p_particle)
     const double alpha = 1 - beta - gamma;
     const bool falls_inside = (alpha >= 0 && beta >= 0 && gamma >= 0
                             && alpha <= 1 && beta <= 1 && gamma <= 1);
+    
+    return falls_inside;
 }
 
 void RigidFace3D::FinalizeSolutionStep(const ProcessInfo& r_process_info)

--- a/applications/DEMApplication/custom_conditions/RigidFace.cpp
+++ b/applications/DEMApplication/custom_conditions/RigidFace.cpp
@@ -401,23 +401,24 @@ bool RigidFace3D::CheckProjectionFallsInside(SphericParticle *p_particle)
 {
     const array_1d<double, 3>& P = p_particle->GetGeometry()[0].Coordinates();
     const Geometry<Node<3> >& geom = GetGeometry();
-    const array_1d<double, 3> w  = P - geom[0].Coordinates();
-    array_1d<double, 3> u1 = geom[1].Coordinates() - geom[0].Coordinates();
-    array_1d<double, 3> u2 = geom[2].Coordinates() - geom[0].Coordinates();
-    array_1d<double, 3> u2_copy;
-    noalias(u2_copy) = u2;
+    const array_1d<double, 3>& P1 = geom[0].Coordinates();
+    const array_1d<double, 3>& P2 = geom[1].Coordinates();
+    const array_1d<double, 3>& P3 = geom[2].Coordinates();
+    const array_1d<double, 3> w  = P - P1;
+    array_1d<double, 3> u = P2 - P1;
+    array_1d<double, 3> v = P3 - P1;
     array_1d<double, 3> n;
-    GeometryFunctions::CrossProduct(u1, u2, n);
-    GeometryFunctions::CrossProduct(w, u2_copy, u2);
-    const double beta = DEM_INNER_PRODUCT_3(u2, n);
-    GeometryFunctions::CrossProduct(u1, w, u1);
-    const double gamma = DEM_INNER_PRODUCT_3(u1, n);
+    array_1d<double, 3> u_cross_w;
+    array_1d<double, 3> w_cross_v;
+    GeometryFunctions::CrossProduct(u, v, n);
+    GeometryFunctions::CrossProduct(u, w, u_cross_w);
+    GeometryFunctions::CrossProduct(w, v, w_cross_v);
     const double n2 = DEM_INNER_PRODUCT_3(n, n);
-    const double alpha = n2 - beta - gamma;
-
-    const bool falls_inside = alpha >=  0 && beta >=  0 && gamma >= 0 && alpha <= n2 && beta <= n2 && gamma <= n2;
-
-    return falls_inside;
+    const double beta = DEM_INNER_PRODUCT_3(w_cross_v, n) / n2;
+    const double gamma = DEM_INNER_PRODUCT_3(u_cross_w, n) / n2;
+    const double alpha = 1 - beta - gamma;
+    const bool falls_inside = (alpha >= 0 && beta >= 0 && gamma >= 0
+                            && alpha <= 1 && beta <= 1 && gamma <= 1);
 }
 
 void RigidFace3D::FinalizeSolutionStep(const ProcessInfo& r_process_info)

--- a/applications/DEMApplication/custom_conditions/analytic_RigidFace.cpp
+++ b/applications/DEMApplication/custom_conditions/analytic_RigidFace.cpp
@@ -48,7 +48,7 @@ int AnalyticRigidFace3D::CheckSide(SphericParticle* p_particle)
         mContactingNeighbourSignedIds.push_back(signed_id);
         if (just_changed_side){
             const bool is_a_crosser = CheckProjectionFallsInside(p_particle);
-            // This need to be true so in practice the function CheckProjectionFallsInside is not used. This should be checked in the future.
+            
             if (is_a_crosser){
                 mNumberThroughput += side_sign;
                 mCrossers.push_back(signed_id);

--- a/applications/DEMApplication/custom_conditions/analytic_RigidFace.cpp
+++ b/applications/DEMApplication/custom_conditions/analytic_RigidFace.cpp
@@ -49,7 +49,7 @@ int AnalyticRigidFace3D::CheckSide(SphericParticle* p_particle)
         if (just_changed_side){
             const bool is_a_crosser = CheckProjectionFallsInside(p_particle);
             // This need to be true so in practice the function CheckProjectionFallsInside is not used. This should be checked in the future.
-            if (is_a_crosser || true){
+            if (is_a_crosser){
                 mNumberThroughput += side_sign;
                 mCrossers.push_back(signed_id);
                 mMasses.push_back(p_particle->GetMass());


### PR DESCRIPTION
**Description**
This PR is aimed to fix an error in the function where the projection of a particle falls inside a plane. So far, this function was disabled. The function  `CheckProjectionFallsInside` is now implemented exactly as in [this page](https://math.stackexchange.com/questions/544946/determine-if-projection-of-3d-point-onto-plane-is-within-a-triangle) 

Please mark the PR with appropriate tags: 
- Bugfix

**Changelog**
- Update function `CheckProjectionFallsInside` from `RigidFace.cpp`
- Remove from `analytic_RigidFace.cpp` spurious true
