### PR TITLE
[ParticleMechanicsApplication]/fix search condition geometry update 

### DIFF
--- a/applications/ParticleMechanicsApplication/custom_utilities/mpm_particle_generator_utility.cpp
+++ b/applications/ParticleMechanicsApplication/custom_utilities/mpm_particle_generator_utility.cpp
@@ -388,6 +388,8 @@ namespace MPMParticleGeneratorUtility
                             p_condition->SetValuesOnIntegrationPoints(MPC_COORD, mpc_xg , process_info);
                             p_condition->SetValuesOnIntegrationPoints(MPC_AREA, mpc_area, process_info);
                             p_condition->SetValuesOnIntegrationPoints(POINT_LOAD, { point_load }, process_info);
+                            // Mark as boundary condition
+                            p_condition->Set(BOUNDARY, true);
                             
 
                             // Add the MP Condition to the model part
@@ -439,6 +441,8 @@ namespace MPMParticleGeneratorUtility
                                 p_condition->SetValuesOnIntegrationPoints(MPC_IMPOSED_VELOCITY, { mpc_imposed_velocity }, process_info);
                                 p_condition->SetValuesOnIntegrationPoints(MPC_ACCELERATION, { mpc_acceleration }, process_info);
                                 p_condition->SetValuesOnIntegrationPoints(MPC_IMPOSED_ACCELERATION, { mpc_imposed_acceleration }, process_info);
+                                // Mark as boundary condition
+                                p_condition->Set(BOUNDARY, true);
 
                                 if (boundary_condition_type == 1)
                                 {

--- a/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h
+++ b/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h
@@ -229,13 +229,16 @@ namespace MPMSearchElementUtility
                 array_1d<double, 3> local_coordinates;
                 bool is_found = false;
 
-                GeometryType& r_found_geom = FindGridGeom(condition_itr->GetGeometry(),
+                GeometryType& r_found_geom = FindGridGeom(condition_itr->GetGeometry().GetGeometryParent(0),
                     rBackgroundGridModelPart, Tolerance, xg[0], local_coordinates,
                     rMPMModelPart.GetProcessInfo(), is_found);
 
                 if (is_found)
                 {
-                    condition_itr->GetGeometry() = r_found_geom;
+                    CreateQuadraturePointsUtility<Node<3>>::UpdateFromLocalCoordinates(
+                        condition_itr->pGetGeometry(), local_coordinates,
+                        condition_itr->GetGeometry().IntegrationPoints()[0].Weight(), r_found_geom);
+                        
                     for (IndexType j = 0; j < r_found_geom.PointsNumber(); ++j)
                         r_found_geom[j].Set(ACTIVE);
                 }
@@ -368,7 +371,13 @@ namespace MPMSearchElementUtility
                     bool is_found = SearchStructure.FindPointOnMesh(xg[0], N, pelem, result_begin, MaxNumberOfResults, Tolerance);
 
                     if (is_found == true) {
-                        condition_itr->GetGeometry() = pelem->GetGeometry();
+                        auto p_quadrature_point_geometry = condition_itr->pGetGeometry();
+                        array_1d<double, 3> local_coordinates;
+                        p_quadrature_point_geometry->PointLocalCoordinates(local_coordinates, xg[0]);
+                        CreateQuadraturePointsUtility<Node<3>>::UpdateFromLocalCoordinates(
+                            p_quadrature_point_geometry, local_coordinates,
+                            p_quadrature_point_geometry->IntegrationPoints()[0].Weight(), pelem->GetGeometry());
+                        
                         auto& r_geometry = condition_itr->GetGeometry();
 
                         for (IndexType j = 0; j < r_geometry.PointsNumber(); ++j)

--- a/applications/ParticleMechanicsApplication/tests/test_ParticleMechanicsApplication.py
+++ b/applications/ParticleMechanicsApplication/tests/test_ParticleMechanicsApplication.py
@@ -52,6 +52,7 @@ from test_generate_mpm_particle             import TestGenerateMPMParticle      
 from test_generate_mpm_particle_condition   import TestGenerateMPMParticleCondition   as TTestGenerateMPMParticleCondition
 from test_particle_erase_process            import TestParticleEraseProcess           as TTestParticleEraseProcess
 from test_search_mpm_particle               import TestSearchMPMParticle              as TTestSearchMPMParticle
+from test_search_mpm_particle_condition     import TestSearchMPMParticleCondition     as TTestSearchMPMParticleCondition
 from test_static_loading_conditions_point   import TestStaticLoadingConditionsPoint   as TTestStaticLoadingConditionsPoint
 from test_static_loading_conditions_line    import TestStaticLoadingConditionsLine    as TTestStaticLoadingConditionsLine
 from test_static_loading_conditions_surface import TestStaticLoadingConditionsSurface as TTestStaticLoadingConditionsSurface
@@ -83,6 +84,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestGenerateMPMParticleCondition]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestParticleEraseProcess]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestSearchMPMParticle]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestSearchMPMParticleCondition]))
 
     # TODO: Look further into these three tests as they are still failing for AMatrix
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestStaticLoadingConditionsPoint]))    # FIXME:

--- a/applications/ParticleMechanicsApplication/tests/test_search_mpm_particle_condition.py
+++ b/applications/ParticleMechanicsApplication/tests/test_search_mpm_particle_condition.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.ParticleMechanicsApplication as KratosParticle

--- a/applications/ParticleMechanicsApplication/tests/test_search_mpm_particle_condition.py
+++ b/applications/ParticleMechanicsApplication/tests/test_search_mpm_particle_condition.py
@@ -1,0 +1,223 @@
+from __future__ import print_function, absolute_import, division
+import KratosMultiphysics
+
+import KratosMultiphysics.ParticleMechanicsApplication as KratosParticle
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+
+
+class TestSearchMPMParticleCondition(KratosUnittest.TestCase):
+
+    def _generate_particle_condition(self, current_model, dimension, geometry_element):
+        KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.WARNING)
+
+        # Initialize model part
+        ## Material model part definition
+        material_point_model_part = current_model.CreateModelPart("dummy_name")
+        material_point_model_part.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, dimension)
+        self.process_info = material_point_model_part.ProcessInfo
+
+        ## Initial material model part definition
+        initial_mesh_model_part = current_model.CreateModelPart("Initial_dummy_name")
+        initial_mesh_model_part.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, dimension)
+
+        ## Grid model part definition
+        grid_model_part = current_model.CreateModelPart("Background_Grid")
+        grid_model_part.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, dimension)
+
+        # Create Background Grid
+        sub_background = grid_model_part.CreateSubModelPart("test")
+        self._create_background_nodes(sub_background, dimension, geometry_element)
+
+        self._create_background_elements(sub_background,dimension, geometry_element)
+
+        # Create element and nodes
+        sub_mp = initial_mesh_model_part.CreateSubModelPart("test")
+        sub_mp.GetProperties()[1].SetValue(KratosParticle.PARTICLES_PER_CONDITION, 1)
+
+        self._create_nodes(sub_mp, dimension)
+
+        self._create_conditions(sub_mp,dimension)
+
+        # Set active
+        KratosMultiphysics.VariableUtils().SetFlag(KratosMultiphysics.ACTIVE, True, initial_mesh_model_part.Elements)
+
+        # Generate MP Conditions
+        KratosParticle.GenerateMaterialPointCondition(grid_model_part, initial_mesh_model_part, material_point_model_part)
+
+
+    def _create_nodes(self, model_part, dimension):
+        if (dimension == 2):
+            model_part.CreateNewNode(13, 0.75, 0.75, 0.0)
+        if (dimension == 3):
+            model_part.CreateNewNode(13, 0.75, 0.75, 0.1)
+
+               
+
+
+    def _create_background_nodes(self, model_part, dimension, geometry_element):
+        
+        if geometry_element == "Triangle":
+            model_part.CreateNewNode(1, 0.0, 0.0, 0.0)
+            model_part.CreateNewNode(2, 1.0, 0.0, 0.0)
+            model_part.CreateNewNode(3, 0.0, 1.0, 0.0)
+            model_part.CreateNewNode(5, 1.0, 1.0, 0.0)
+            if (dimension == 3):
+                model_part.CreateNewNode(4, 0.0, 0.0, 1.0)
+                model_part.CreateNewNode(6, 1.0, 0.0, 1.0)
+                model_part.CreateNewNode(7, 0.0, 1.0, 1.0)
+                model_part.CreateNewNode(8, 1.0, 1.0, 1.0)
+        elif geometry_element == "Quadrilateral":
+            model_part.CreateNewNode(1, -0.5, -0.5, 0.0)
+            model_part.CreateNewNode(2,  0.5, -0.5, 0.0)
+            model_part.CreateNewNode(3,  0.5,  0.5, 0.0)
+            model_part.CreateNewNode(4, -0.5,  0.5, 0.0)
+            model_part.CreateNewNode(9 , 1.5, -0.5, 0.0)
+            model_part.CreateNewNode(10, 1.5,  0.5, 0.0)
+            
+            if (dimension == 3):
+                model_part.CreateNewNode(5, -0.5, -0.5, 1.0)
+                model_part.CreateNewNode(6,  0.5, -0.5, 1.0)
+                model_part.CreateNewNode(7,  0.5,  0.5, 1.0)
+                model_part.CreateNewNode(8, -0.5,  0.5, 1.0)
+                model_part.CreateNewNode(11, 1.5, -0.5, 1.0)
+                model_part.CreateNewNode(12, 1.5,  0.5, 1.0)
+
+
+    def _create_conditions(self, model_part, dimension):
+        if (dimension == 2):
+            model_part.CreateNewCondition("PointCondition2D1N", 1, [13], model_part.GetProperties()[1])
+        else:
+            model_part.CreateNewCondition("PointCondition3D1N", 1, [13], model_part.GetProperties()[1])
+
+        KratosMultiphysics.VariableUtils().SetFlag(KratosMultiphysics.BOUNDARY, True, model_part.Conditions)
+
+
+    def _create_background_elements(self, model_part, dimension, geometry_element):
+        
+        if geometry_element == "Triangle":
+            if (dimension == 2):
+                model_part.CreateNewElement("Element2D3N", 1, [1,2,3], model_part.GetProperties()[1])
+                model_part.CreateNewElement("Element2D3N", 2, [2,3,5], model_part.GetProperties()[1])
+            if (dimension == 3):
+                model_part.CreateNewElement("Element3D4N", 1, [1,2,3,4], model_part.GetProperties()[1])
+                model_part.CreateNewElement("Element3D4N", 2, [2,8,4,6], model_part.GetProperties()[1])
+                model_part.CreateNewElement("Element3D4N", 3, [4,8,3,7], model_part.GetProperties()[1])
+                model_part.CreateNewElement("Element3D4N", 4, [2,5,3,8], model_part.GetProperties()[1])
+                model_part.CreateNewElement("Element3D4N", 5, [8,3,2,4], model_part.GetProperties()[1])
+        elif geometry_element == "Quadrilateral":
+            if (dimension == 2):
+                model_part.CreateNewElement("Element2D4N", 1, [1,2,3,4], model_part.GetProperties()[1])
+                model_part.CreateNewElement("Element2D4N", 2, [2,9,10,3], model_part.GetProperties()[1])
+            if (dimension == 3):
+                model_part.CreateNewElement("Element3D8N", 1, [1,2,3,4,5,6,7,8], model_part.GetProperties()[1])
+                model_part.CreateNewElement("Element3D8N", 2, [2,9,10,3,6,11,12,7], model_part.GetProperties()[1])
+
+
+    def _move_and_search_condition(self, current_model, new_coordinate, max_num_results = 1000, specific_tolerance = 1.e-5):
+        # Get model part
+        material_point_model_part = current_model.GetModelPart("dummy_name")
+        grid_model_part           = current_model.GetModelPart("Background_Grid")
+
+        # Apply before search
+        for mpc in material_point_model_part.Conditions:
+            mpc.SetValuesOnIntegrationPoints(KratosParticle.MPC_COORD, [new_coordinate], self.process_info)
+
+        # Search element
+        KratosParticle.SearchElement(grid_model_part, material_point_model_part, max_num_results, specific_tolerance)
+
+    def _check_connectivity(self, current_model, expected_connectivity_node=[]):
+        # Get model part
+        material_point_model_part = current_model.GetModelPart("dummy_name")
+        grid_model_part           = current_model.GetModelPart("Background_Grid")
+
+        # Check the searched node as expected connectivity
+        if not expected_connectivity_node:
+            for mpc in material_point_model_part.Conditions:
+                self.assertEqual(mpc.GetNodes(), [])
+        else:
+            for mpc in material_point_model_part.Conditions:
+                for i in range (len(expected_connectivity_node)):
+                    self.assertEqual(mpc.GetNode(i).Id, grid_model_part.GetNode(expected_connectivity_node[i]).Id)
+                    self.assertEqual(mpc.GetNode(i).X, grid_model_part.GetNode(expected_connectivity_node[i]).X)
+                    self.assertEqual(mpc.GetNode(i).Y, grid_model_part.GetNode(expected_connectivity_node[i]).Y)
+                    self.assertEqual(mpc.GetNode(i).Z, grid_model_part.GetNode(expected_connectivity_node[i]).Z)
+
+    def test_SearchMPMParticleConditionTriangle2D(self):
+        current_model = KratosMultiphysics.Model()
+        self._generate_particle_condition(current_model, dimension=2, geometry_element="Triangle")
+
+        new_coordinate = [0.25, 0.25, 0.0]
+        self._move_and_search_condition(current_model, new_coordinate)
+        self._check_connectivity(current_model, [1,2,3])
+
+        new_coordinate = [0.50001, 0.50001, 0.0]
+        self._move_and_search_condition(current_model, new_coordinate)
+        self._check_connectivity(current_model, [2,3,5])
+
+        new_coordinate = [1.00001, 1.00001, 0.0]
+        self._move_and_search_condition(current_model, new_coordinate)
+        self._check_connectivity(current_model)
+
+    def test_SearchMPMParticleConditionTriangle3D(self):
+        current_model = KratosMultiphysics.Model()
+        self._generate_particle_condition(current_model, dimension=3, geometry_element="Triangle")
+
+        new_coordinate = [0.5, 0.25, 0.20]
+        self._move_and_search_condition(current_model, new_coordinate)
+        self._check_connectivity(current_model, [1,2,3,4])
+
+        new_coordinate = [0.90, 0.55, 0.90]
+        self._move_and_search_condition(current_model, new_coordinate)
+        self._check_connectivity(current_model, [2,8,4,6])
+
+        new_coordinate = [0.10, 0.90, 0.55]
+        self._move_and_search_condition(current_model, new_coordinate)
+        self._check_connectivity(current_model, [4,8,3,7])
+
+        new_coordinate = [0.90, 0.90, 0.55]
+        self._move_and_search_condition(current_model, new_coordinate)
+        self._check_connectivity(current_model, [2,5,3,8])
+
+        new_coordinate = [0.50, 0.50, 0.50]
+        self._move_and_search_condition(current_model, new_coordinate)
+        self._check_connectivity(current_model, [8,3,2,4])
+
+        new_coordinate = [1.0001, 1.0001, 1.0001]
+        self._move_and_search_condition(current_model, new_coordinate)
+        self._check_connectivity(current_model)
+
+    def test_SearchMPMParticleConditionQuadrilateral2D(self):
+        current_model = KratosMultiphysics.Model()
+        self._generate_particle_condition(current_model, dimension=2, geometry_element="Quadrilateral")
+
+        new_coordinate = [-0.11111, 0.12345, 1.0]
+        self._move_and_search_condition(current_model, new_coordinate)
+        self._check_connectivity(current_model, [1,2,3,4])
+
+        new_coordinate = [0.6, 0.12345, 1.0]
+        self._move_and_search_condition(current_model, new_coordinate)
+        self._check_connectivity(current_model, [2,9,10,3])
+
+        new_coordinate = [1.00001, 1.00001, 0.0]
+        self._move_and_search_condition(current_model, new_coordinate)
+        self._check_connectivity(current_model)
+
+    def test_SearchMPMParticleConditionQuadrilateral3D(self):
+        current_model = KratosMultiphysics.Model()
+        self._generate_particle_condition(current_model, dimension=3, geometry_element="Quadrilateral")
+
+        new_coordinate = [0.5, 0.25, 0.20]
+        self._move_and_search_condition(current_model, new_coordinate)
+        self._check_connectivity(current_model, [1,2,3,4,5,6,7,8])
+
+        new_coordinate = [0.7, 0.35, 0.3]
+        self._move_and_search_condition(current_model, new_coordinate)
+        self._check_connectivity(current_model, [2,9,10,3,6,11,12,7])
+
+        new_coordinate = [0.50001, 0.50001, 0.50001]
+        self._move_and_search_condition(current_model, new_coordinate)
+        self._check_connectivity(current_model)
+
+    
+if __name__ == '__main__':
+    KratosUnittest.main()

--- a/applications/ParticleMechanicsApplication/tests/test_search_mpm_particle_condition.py
+++ b/applications/ParticleMechanicsApplication/tests/test_search_mpm_particle_condition.py
@@ -52,8 +52,7 @@ class TestSearchMPMParticleCondition(KratosUnittest.TestCase):
             model_part.CreateNewNode(13, 0.1, 0.1, 0.1)
 
 
-    def _create_background_nodes(self, model_part, dimension, geometry_element):
-        
+    def _create_background_nodes(self, model_part, dimension, geometry_element):  
         if geometry_element == "Triangle":
             model_part.CreateNewNode(1, 0.0, 0.0, 0.0)
             model_part.CreateNewNode(2, 1.0, 0.0, 0.0)
@@ -91,7 +90,6 @@ class TestSearchMPMParticleCondition(KratosUnittest.TestCase):
 
 
     def _create_background_elements(self, model_part, dimension, geometry_element):
-        
         if geometry_element == "Triangle":
             if (dimension == 2):
                 model_part.CreateNewElement("Element2D3N", 1, [1,2,3], model_part.GetProperties()[1])


### PR DESCRIPTION
Hi,

the geometry of the background element of the condition was not updated in the search. Therefore moving particle BC did not work. This PR fixes this issue and also added a test case to detect that error in the future.
