### PR TITLE
[Trilinos] Bugifx - monotonicity preserving solver - missing global assemble

### DIFF
--- a/applications/TrilinosApplication/external_includes/trilinos_monotonicity_preserving_solver.h
+++ b/applications/TrilinosApplication/external_includes/trilinos_monotonicity_preserving_solver.h
@@ -247,6 +247,9 @@ public:
             }
         }
 
+        rA.GlobalAssemble();
+        rB.GlobalAssemble();
+
         if (mpLinearSolver->AdditionalPhysicalDataIsNeeded()) {
             mpLinearSolver->ProvideAdditionalData(rA,rX,rB,rdof_set,r_model_part);
         }


### PR DESCRIPTION
Missing the global assemble after the local assemblies. 