### PR TITLE
[MPICommunicator] deprecating CTor that uses the default DataCommunicator

### DIFF
--- a/kratos/mpi/includes/mpi_communicator.h
+++ b/kratos/mpi/includes/mpi_communicator.h
@@ -669,7 +669,7 @@ public:
     ///@{
 
     /// Constructor using the VariablesList of the ModelPart that will use this communicator.
-    MPICommunicator(VariablesList* Variables_list) : BaseType(DataCommunicator::GetDefault()), mpVariables_list(Variables_list)
+    KRATOS_DEPRECATED_MESSAGE("This constructor is deprecated, please use the one that accepts a DataCommunicator") MPICommunicator(VariablesList* Variables_list) : BaseType(DataCommunicator::GetDefault()), mpVariables_list(Variables_list)
     {}
 
     /// Constructor using the VariablesList and a custom DataCommunicator.


### PR DESCRIPTION
**Description**
This PR deprecates a constructor of the `MPICommunicator` that uses the default `DataCommunicator`
This is done in order to avoid the wrong usage of the default DataCommunicator which can lead to deadlocks in situations where the `MPI_Comm` is not `MPI_COMM_WORLD`
