### PR TITLE
[MPI][ModelPartCommunicatorUtilities] deprecate SetMPICommunicator without DataCommunicator

### DIFF
--- a/kratos/mpi/python/add_mpi_utilities_to_python.cpp
+++ b/kratos/mpi/python/add_mpi_utilities_to_python.cpp
@@ -48,7 +48,14 @@ void AddMPIUtilitiesToPython(pybind11::module& m)
     namespace py = pybind11;
 
     py::class_<ModelPartCommunicatorUtilities>(m,"ModelPartCommunicatorUtilities")
-    .def_static("SetMPICommunicator",&ModelPartCommunicatorUtilities::SetMPICommunicator)
+    .def_static("SetMPICommunicator", [](ModelPart& rModelPart, const DataCommunicator& rDataCommunicator){
+        ModelPartCommunicatorUtilities::SetMPICommunicator(rModelPart, rDataCommunicator);
+    })
+    .def_static("SetMPICommunicator", [](ModelPart& rModelPart){
+        KRATOS_WARNING("ModelPartCommunicatorUtilities") << "This function is deprecated, please use the one that accepts a DataCommunicator" << std::endl;
+        // passing the default data comm as a temp solution until this function is removed to avoid the deprecation warning in the interface
+        ModelPartCommunicatorUtilities::SetMPICommunicator(rModelPart, DataCommunicator::GetDefault());
+    })
     ;
 
     py::class_<ParallelFillCommunicator, ParallelFillCommunicator::Pointer, FillCommunicator>(m,"ParallelFillCommunicator")

--- a/kratos/mpi/utilities/model_part_communicator_utilities.h
+++ b/kratos/mpi/utilities/model_part_communicator_utilities.h
@@ -55,15 +55,23 @@ public:
     ///@name Operations
     ///@{
 
-    /// Create and assign an MPI Communicator for a ModelPart instance.
-    /** Note that this does not initialize the communicator, since the ModelPart
+    /// Create and assign an MPICommunicator for a ModelPart instance.
+    /** Note that this does not initialize the Communicator, since the ModelPart
      *  may not yet contain nodes (or anything else) when this is called.
-     *  @param rThisModelPart The model part that will get an MPI communicator.
+     *  @param rThisModelPart The ModelPart that will get an MPICommunicator.
+     *  @param rDataCommunicator The DataCommunicator that will be used for the MPICommunicator.
      */
-    static inline void SetMPICommunicator(ModelPart& rThisModelPart)
+    static inline void SetMPICommunicator(ModelPart& rThisModelPart, const DataCommunicator& rDataCommunicator)
+    {
+        KRATOS_ERROR_IF_NOT(rDataCommunicator.IsDistributed()) << "Only distributed DataCommunicators can be used!" << std::endl;
+        VariablesList * p_variables_list = &rThisModelPart.GetNodalSolutionStepVariablesList();
+        rThisModelPart.SetCommunicator(Kratos::make_shared<MPICommunicator>(p_variables_list, rDataCommunicator));
+    }
+
+    KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please use the one that accepts a DataCommunicator") static inline void SetMPICommunicator(ModelPart& rThisModelPart)
     {
         VariablesList * p_variables_list = &rThisModelPart.GetNodalSolutionStepVariablesList();
-        rThisModelPart.SetCommunicator(Kratos::make_shared<MPICommunicator>(p_variables_list));
+        rThisModelPart.SetCommunicator(Kratos::make_shared<MPICommunicator>(p_variables_list, DataCommunicator::GetDefault()));
     }
 
     ///@}


### PR DESCRIPTION
**Description**
More cleanup to avoid misuse of the default `DataCommunicator`
see also #8521 