### PR TITLE
[Core] Missing include. Crashing compilation without Unity

### DIFF
--- a/kratos/includes/lock_object.h
+++ b/kratos/includes/lock_object.h
@@ -22,6 +22,7 @@
 #endif
 
 // Project includes
+#include "includes/define.h"
 
 namespace Kratos
 {


### PR DESCRIPTION
**Description**
Again...

~~~sh
In file included from /home/vmataixf/src/Kratos/kratos/includes/chunk.h:18:0,
                 from /home/vmataixf/src/Kratos/kratos/tests/cpp_tests/sources/test_chunk.cpp:22:
/home/vmataixf/src/Kratos/kratos/includes/lock_object.h:97:3: error: ‘KRATOS_DEPRECATED’ does not name a type
   KRATOS_DEPRECATED inline void SetLock() const
   ^~~~~~~~~~~~~~~~~
/home/vmataixf/src/Kratos/kratos/includes/lock_object.h:110:3: error: ‘KRATOS_DEPRECATED’ does not name a type
   KRATOS_DEPRECATED inline void UnSetLock() const
   ^~~~~~~~~~~~~~~~~
~~~

**Changelog**
- Missing define.h
