### PR TITLE
[DEM-SDEM]Implement dem inlet seed update

### DIFF
--- a/applications/DEMApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/DEMApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -177,7 +177,7 @@ void AddCustomUtilitiesToPython(pybind11::module& m) {
         ;
 
     py::class_<DEM_Inlet, DEM_Inlet::Pointer>(m, "DEM_Inlet")
-        .def(py::init<ModelPart&>())
+        .def(py::init<ModelPart&, int&, bool&>())
         .def("CreateElementsFromInletMesh", &DEM_Inlet::CreateElementsFromInletMesh)
         .def("InitializeDEM_Inlet", &DEM_Inlet::InitializeDEM_Inlet
             ,py::arg("model_part")
@@ -188,7 +188,7 @@ void AddCustomUtilitiesToPython(pybind11::module& m) {
         ;
 
     py::class_<DEM_Force_Based_Inlet, DEM_Force_Based_Inlet::Pointer, DEM_Inlet>(m, "DEM_Force_Based_Inlet")
-        .def(py::init<ModelPart&, array_1d<double, 3>>())
+        .def(py::init<ModelPart&, array_1d<double, 3>, int&, bool&>())
         ;
 
     py::class_<SphericElementGlobalPhysicsCalculator, SphericElementGlobalPhysicsCalculator::Pointer >(m, "SphericElementGlobalPhysicsCalculator")

--- a/applications/DEMApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/DEMApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -177,7 +177,8 @@ void AddCustomUtilitiesToPython(pybind11::module& m) {
         ;
 
     py::class_<DEM_Inlet, DEM_Inlet::Pointer>(m, "DEM_Inlet")
-        .def(py::init<ModelPart&, int&>())
+        .def(py::init<ModelPart&>())
+        .def(py::init<ModelPart&, const int>())
         .def("CreateElementsFromInletMesh", &DEM_Inlet::CreateElementsFromInletMesh)
         .def("InitializeDEM_Inlet", &DEM_Inlet::InitializeDEM_Inlet
             ,py::arg("model_part")
@@ -188,7 +189,8 @@ void AddCustomUtilitiesToPython(pybind11::module& m) {
         ;
 
     py::class_<DEM_Force_Based_Inlet, DEM_Force_Based_Inlet::Pointer, DEM_Inlet>(m, "DEM_Force_Based_Inlet")
-        .def(py::init<ModelPart&, array_1d<double, 3>, int&>())
+        .def(py::init<ModelPart&, array_1d<double, 3>, const int>())
+        .def(py::init<ModelPart&, array_1d<double, 3>>())
         ;
 
     py::class_<SphericElementGlobalPhysicsCalculator, SphericElementGlobalPhysicsCalculator::Pointer >(m, "SphericElementGlobalPhysicsCalculator")

--- a/applications/DEMApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/DEMApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -177,7 +177,7 @@ void AddCustomUtilitiesToPython(pybind11::module& m) {
         ;
 
     py::class_<DEM_Inlet, DEM_Inlet::Pointer>(m, "DEM_Inlet")
-        .def(py::init<ModelPart&, int&, bool&>())
+        .def(py::init<ModelPart&, int&>())
         .def("CreateElementsFromInletMesh", &DEM_Inlet::CreateElementsFromInletMesh)
         .def("InitializeDEM_Inlet", &DEM_Inlet::InitializeDEM_Inlet
             ,py::arg("model_part")
@@ -188,7 +188,7 @@ void AddCustomUtilitiesToPython(pybind11::module& m) {
         ;
 
     py::class_<DEM_Force_Based_Inlet, DEM_Force_Based_Inlet::Pointer, DEM_Inlet>(m, "DEM_Force_Based_Inlet")
-        .def(py::init<ModelPart&, array_1d<double, 3>, int&, bool&>())
+        .def(py::init<ModelPart&, array_1d<double, 3>, int&>())
         ;
 
     py::class_<SphericElementGlobalPhysicsCalculator, SphericElementGlobalPhysicsCalculator::Pointer >(m, "SphericElementGlobalPhysicsCalculator")

--- a/applications/DEMApplication/custom_utilities/force_based_inlet.cpp
+++ b/applications/DEMApplication/custom_utilities/force_based_inlet.cpp
@@ -6,8 +6,8 @@
 
 namespace Kratos {
 
-DEM_Force_Based_Inlet::DEM_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, int& seed, bool& use_external_seed):
-               DEM_Inlet(inlet_modelpart, seed, use_external_seed), mInjectionForce(injection_force)
+DEM_Force_Based_Inlet::DEM_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, int& seed):
+               DEM_Inlet(inlet_modelpart, seed), mInjectionForce(injection_force)
 {}
 
 void DEM_Force_Based_Inlet::RemoveInjectionConditions(Element &element, int dimension)

--- a/applications/DEMApplication/custom_utilities/force_based_inlet.cpp
+++ b/applications/DEMApplication/custom_utilities/force_based_inlet.cpp
@@ -1,6 +1,5 @@
 // Author: Guillermo Casas (gcasas@cimne.upc.edu)
 
-#include "<random>"
 #include "force_based_inlet.h"
 #include "custom_elements/spheric_particle.h"
 

--- a/applications/DEMApplication/custom_utilities/force_based_inlet.cpp
+++ b/applications/DEMApplication/custom_utilities/force_based_inlet.cpp
@@ -1,5 +1,6 @@
 // Author: Guillermo Casas (gcasas@cimne.upc.edu)
 
+#include "<random>"
 #include "force_based_inlet.h"
 #include "custom_elements/spheric_particle.h"
 

--- a/applications/DEMApplication/custom_utilities/force_based_inlet.cpp
+++ b/applications/DEMApplication/custom_utilities/force_based_inlet.cpp
@@ -6,8 +6,8 @@
 
 namespace Kratos {
 
-DEM_Force_Based_Inlet::DEM_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force):
-               DEM_Inlet(inlet_modelpart), mInjectionForce(injection_force)
+DEM_Force_Based_Inlet::DEM_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, int& seed, bool& use_external_seed):
+               DEM_Inlet(inlet_modelpart, seed, use_external_seed), mInjectionForce(injection_force)
 {}
 
 void DEM_Force_Based_Inlet::RemoveInjectionConditions(Element &element, int dimension)

--- a/applications/DEMApplication/custom_utilities/force_based_inlet.cpp
+++ b/applications/DEMApplication/custom_utilities/force_based_inlet.cpp
@@ -6,7 +6,7 @@
 
 namespace Kratos {
 
-DEM_Force_Based_Inlet::DEM_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, int& seed):
+DEM_Force_Based_Inlet::DEM_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, const int seed):
                DEM_Inlet(inlet_modelpart, seed), mInjectionForce(injection_force)
 {}
 

--- a/applications/DEMApplication/custom_utilities/force_based_inlet.h
+++ b/applications/DEMApplication/custom_utilities/force_based_inlet.h
@@ -18,7 +18,7 @@ namespace Kratos {
         KRATOS_CLASS_POINTER_DEFINITION(DEM_Force_Based_Inlet);
 
         /// Constructor:
-        DEM_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, int& seed);
+        DEM_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, const int seed=42);
 
         /// Destructor.
         virtual ~DEM_Force_Based_Inlet(){}

--- a/applications/DEMApplication/custom_utilities/force_based_inlet.h
+++ b/applications/DEMApplication/custom_utilities/force_based_inlet.h
@@ -18,7 +18,7 @@ namespace Kratos {
         KRATOS_CLASS_POINTER_DEFINITION(DEM_Force_Based_Inlet);
 
         /// Constructor:
-        DEM_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force);
+        DEM_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, int& seed, bool& use_external_seed);
 
         /// Destructor.
         virtual ~DEM_Force_Based_Inlet(){}

--- a/applications/DEMApplication/custom_utilities/force_based_inlet.h
+++ b/applications/DEMApplication/custom_utilities/force_based_inlet.h
@@ -18,7 +18,7 @@ namespace Kratos {
         KRATOS_CLASS_POINTER_DEFINITION(DEM_Force_Based_Inlet);
 
         /// Constructor:
-        DEM_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, int& seed, bool& use_external_seed);
+        DEM_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, int& seed);
 
         /// Destructor.
         virtual ~DEM_Force_Based_Inlet(){}

--- a/applications/DEMApplication/custom_utilities/inlet.cpp
+++ b/applications/DEMApplication/custom_utilities/inlet.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <iostream>
 #include <random>
+#include <functional>
 
 #include "inlet.h"
 #include "create_and_destroy.h"

--- a/applications/DEMApplication/custom_utilities/inlet.cpp
+++ b/applications/DEMApplication/custom_utilities/inlet.cpp
@@ -41,7 +41,7 @@ namespace Kratos {
 
     /// Constructor
 
-    DEM_Inlet::DEM_Inlet(ModelPart& inlet_modelpart): mInletModelPart(inlet_modelpart)
+    DEM_Inlet::DEM_Inlet(ModelPart& inlet_modelpart, int& seed, bool& use_external_seed): mInletModelPart(inlet_modelpart)
     {
         const int number_of_submodelparts = inlet_modelpart.NumberOfSubModelParts();
         mPartialParticleToInsert.resize(number_of_submodelparts);
@@ -51,6 +51,18 @@ namespace Kratos {
         mNumberOfParticlesInjected.resize(number_of_submodelparts);
         mMassInjected.resize(number_of_submodelparts);
 
+        if(use_external_seed) {
+            std::random_device rd;
+            mSeed = seed;
+        }
+        else {
+            std::random_device rd;
+            mSeed = rd();
+        }
+
+        std::mt19937 gen(mSeed);
+        mGenerator = gen;
+        
         int smp_iterator_number = 0;
         for (ModelPart::SubModelPartsContainerType::iterator sub_model_part = inlet_modelpart.SubModelPartsBegin(); sub_model_part != inlet_modelpart.SubModelPartsEnd(); ++sub_model_part) {
             mPartialParticleToInsert[smp_iterator_number] = 0.0;
@@ -601,6 +613,8 @@ namespace Kratos {
 
                 const double mass_that_should_have_been_inserted_so_far = mass_flow * (current_time - inlet_start_time);
 
+                std::uniform_int_distribution<> distrib(0, valid_elements_length - 1);
+                
                 int i=0;
                 for (i = 0; i < number_of_particles_to_insert; i++) {
 
@@ -610,7 +624,8 @@ namespace Kratos {
                         }
                     }
 
-                    int random_pos = random_generator() % valid_elements_length;
+                    int random_pos = distrib(mGenerator);
+                    
                     Element* p_injector_element = valid_elements[random_pos].get();
 
                     if (mp[CONTAINS_CLUSTERS] == false) {

--- a/applications/DEMApplication/custom_utilities/inlet.cpp
+++ b/applications/DEMApplication/custom_utilities/inlet.cpp
@@ -603,8 +603,6 @@ namespace Kratos {
 
                 const double mass_that_should_have_been_inserted_so_far = mass_flow * (current_time - inlet_start_time);
 
-                //std::uniform_int_distribution<> distrib(0, valid_elements_length - 1);
-
                 int i=0;
                 for (i = 0; i < number_of_particles_to_insert; i++) {
 
@@ -613,8 +611,6 @@ namespace Kratos {
                             break;
                         }
                     }
-
-                    //int random_pos = distrib(mGenerator);
 
                     int random_pos = mGenerator() % valid_elements_length;
 

--- a/applications/DEMApplication/custom_utilities/inlet.cpp
+++ b/applications/DEMApplication/custom_utilities/inlet.cpp
@@ -549,8 +549,6 @@ namespace Kratos {
             }
 
             if (number_of_particles_to_insert) {
-                //randomizing mesh
-                std::mt19937 random_generator(r_modelpart.GetProcessInfo()[TIME_STEPS]);
 
                 ModelPart::ElementsContainerType::ContainerType valid_elements(mesh_size_elements); //This is a new vector we are going to work on
                 int valid_elements_length = 0;

--- a/applications/DEMApplication/custom_utilities/inlet.cpp
+++ b/applications/DEMApplication/custom_utilities/inlet.cpp
@@ -42,7 +42,7 @@ namespace Kratos {
 
     /// Constructor
 
-    DEM_Inlet::DEM_Inlet(ModelPart& inlet_modelpart, int& seed, bool& use_external_seed): mInletModelPart(inlet_modelpart)
+    DEM_Inlet::DEM_Inlet(ModelPart& inlet_modelpart, int& seed): mInletModelPart(inlet_modelpart)
     {
         const int number_of_submodelparts = inlet_modelpart.NumberOfSubModelParts();
         mPartialParticleToInsert.resize(number_of_submodelparts);
@@ -51,19 +51,11 @@ namespace Kratos {
         mLayerRemoved.resize(number_of_submodelparts);
         mNumberOfParticlesInjected.resize(number_of_submodelparts);
         mMassInjected.resize(number_of_submodelparts);
-
-        if(use_external_seed) {
-            std::random_device rd;
-            mSeed = seed;
-        }
-        else {
-            std::random_device rd;
-            mSeed = rd();
-        }
+        mSeed = seed;
 
         std::mt19937 gen(mSeed);
         mGenerator = gen;
-        
+
         int smp_iterator_number = 0;
         for (ModelPart::SubModelPartsContainerType::iterator sub_model_part = inlet_modelpart.SubModelPartsBegin(); sub_model_part != inlet_modelpart.SubModelPartsEnd(); ++sub_model_part) {
             mPartialParticleToInsert[smp_iterator_number] = 0.0;
@@ -615,7 +607,7 @@ namespace Kratos {
                 const double mass_that_should_have_been_inserted_so_far = mass_flow * (current_time - inlet_start_time);
 
                 std::uniform_int_distribution<> distrib(0, valid_elements_length - 1);
-                
+
                 int i=0;
                 for (i = 0; i < number_of_particles_to_insert; i++) {
 
@@ -626,7 +618,7 @@ namespace Kratos {
                     }
 
                     int random_pos = distrib(mGenerator);
-                    
+
                     Element* p_injector_element = valid_elements[random_pos].get();
 
                     if (mp[CONTAINS_CLUSTERS] == false) {

--- a/applications/DEMApplication/custom_utilities/inlet.cpp
+++ b/applications/DEMApplication/custom_utilities/inlet.cpp
@@ -42,7 +42,7 @@ namespace Kratos {
 
     /// Constructor
 
-    DEM_Inlet::DEM_Inlet(ModelPart& inlet_modelpart, int& seed): mInletModelPart(inlet_modelpart)
+    DEM_Inlet::DEM_Inlet(ModelPart& inlet_modelpart, const int seed): mInletModelPart(inlet_modelpart)
     {
         const int number_of_submodelparts = inlet_modelpart.NumberOfSubModelParts();
         mPartialParticleToInsert.resize(number_of_submodelparts);
@@ -51,9 +51,8 @@ namespace Kratos {
         mLayerRemoved.resize(number_of_submodelparts);
         mNumberOfParticlesInjected.resize(number_of_submodelparts);
         mMassInjected.resize(number_of_submodelparts);
-        mSeed = seed;
 
-        std::mt19937 gen(mSeed);
+        std::mt19937 gen(seed);
         mGenerator = gen;
 
         int smp_iterator_number = 0;
@@ -604,7 +603,7 @@ namespace Kratos {
 
                 const double mass_that_should_have_been_inserted_so_far = mass_flow * (current_time - inlet_start_time);
 
-                std::uniform_int_distribution<> distrib(0, valid_elements_length - 1);
+                //std::uniform_int_distribution<> distrib(0, valid_elements_length - 1);
 
                 int i=0;
                 for (i = 0; i < number_of_particles_to_insert; i++) {
@@ -615,7 +614,9 @@ namespace Kratos {
                         }
                     }
 
-                    int random_pos = distrib(mGenerator);
+                    //int random_pos = distrib(mGenerator);
+
+                    int random_pos = mGenerator() % valid_elements_length;
 
                     Element* p_injector_element = valid_elements[random_pos].get();
 

--- a/applications/DEMApplication/custom_utilities/inlet.h
+++ b/applications/DEMApplication/custom_utilities/inlet.h
@@ -47,7 +47,7 @@ namespace Kratos {
         KRATOS_CLASS_POINTER_DEFINITION(DEM_Inlet);
 
         /// Constructor:
-        DEM_Inlet(ModelPart& inlet_modelpart, int& seed);
+        DEM_Inlet(ModelPart& inlet_modelpart, const int seed=42);
 
         /// Destructor.
         virtual ~DEM_Inlet(){}
@@ -97,7 +97,7 @@ namespace Kratos {
         std::vector<int> mNumberOfParticlesInjected;
         std::map<int, std::string> mOriginInletSubmodelPartIndexes;
         double mTotalMassInjected;
-        int mSeed;
+        //int mSeed;
         std::vector<double> mMassInjected;
         std::mt19937 mGenerator;
         // The following two ratios mark the limit indentation (normalized by the radius) for releasing a particle

--- a/applications/DEMApplication/custom_utilities/inlet.h
+++ b/applications/DEMApplication/custom_utilities/inlet.h
@@ -47,7 +47,7 @@ namespace Kratos {
         KRATOS_CLASS_POINTER_DEFINITION(DEM_Inlet);
 
         /// Constructor:
-        DEM_Inlet(ModelPart& inlet_modelpart, int& seed, bool& use_external_seed);
+        DEM_Inlet(ModelPart& inlet_modelpart, int& seed);
 
         /// Destructor.
         virtual ~DEM_Inlet(){}

--- a/applications/DEMApplication/custom_utilities/inlet.h
+++ b/applications/DEMApplication/custom_utilities/inlet.h
@@ -46,7 +46,7 @@ namespace Kratos {
         KRATOS_CLASS_POINTER_DEFINITION(DEM_Inlet);
 
         /// Constructor:
-        DEM_Inlet(ModelPart& inlet_modelpart);
+        DEM_Inlet(ModelPart& inlet_modelpart, int& seed, bool& use_external_seed);
 
         /// Destructor.
         virtual ~DEM_Inlet(){}
@@ -96,7 +96,9 @@ namespace Kratos {
         std::vector<int> mNumberOfParticlesInjected;
         std::map<int, std::string> mOriginInletSubmodelPartIndexes;
         double mTotalMassInjected;
+        int mSeed;
         std::vector<double> mMassInjected;
+        std::mt19937 mGenerator;
         // The following two ratios mark the limit indentation (normalized by the radius) for releasing a particle
         // and for allowing a new one to be injected. admissible_indentation_ratio_for_release should be smaller
         // (more strict), since we want to make sure that the particle is taken far enough to avoid interferences

--- a/applications/DEMApplication/custom_utilities/inlet.h
+++ b/applications/DEMApplication/custom_utilities/inlet.h
@@ -9,6 +9,7 @@
 // System includes
 #include <string>
 #include <iostream>
+#include <random>
 
 // External includes
 

--- a/applications/DEMApplication/python_scripts/DEM_analysis_stage.py
+++ b/applications/DEMApplication/python_scripts/DEM_analysis_stage.py
@@ -296,11 +296,10 @@ class DEMAnalysisStage(AnalysisStage):
         self.report.total_steps_expected = int(self.end_time / self._GetSolver().dt)
 
         super().Initialize()
-        
-        self.use_external_seed = self.DEM_parameters["use_external_seed"].GetBool()
+
         self.seed = self.DEM_parameters["seed"].GetInt()
         #Constructing a model part for the DEM inlet. It contains the DEM elements to be released during the simulation
-        #Initializing the DEM solver must be done before creating the DEM Inlet, because the Inlet configures itself according to some options of the DEM model part      
+        #Initializing the DEM solver must be done before creating the DEM Inlet, because the Inlet configures itself according to some options of the DEM model part
         self.SetInlet()
 
         self.SetInitialNodalValues()
@@ -470,7 +469,7 @@ class DEMAnalysisStage(AnalysisStage):
     def SetInlet(self):
         if self.DEM_parameters["dem_inlet_option"].GetBool():
             #Constructing the inlet and initializing it (must be done AFTER the self.spheres_model_part Initialize)
-            self.DEM_inlet = DEM_Inlet(self.dem_inlet_model_part, self.seed, self.use_external_seed)
+            self.DEM_inlet = DEM_Inlet(self.dem_inlet_model_part, self.seed)
             self.DEM_inlet.InitializeDEM_Inlet(self.spheres_model_part, self.creator_destructor, self._GetSolver().continuum_type)
 
     def SetInitialNodalValues(self):

--- a/applications/DEMApplication/python_scripts/DEM_analysis_stage.py
+++ b/applications/DEMApplication/python_scripts/DEM_analysis_stage.py
@@ -296,9 +296,11 @@ class DEMAnalysisStage(AnalysisStage):
         self.report.total_steps_expected = int(self.end_time / self._GetSolver().dt)
 
         super().Initialize()
-
+        
+        self.use_external_seed = self.DEM_parameters["use_external_seed"].GetBool()
+        self.seed = self.DEM_parameters["seed"].GetInt()
         #Constructing a model part for the DEM inlet. It contains the DEM elements to be released during the simulation
-        #Initializing the DEM solver must be done before creating the DEM Inlet, because the Inlet configures itself according to some options of the DEM model part
+        #Initializing the DEM solver must be done before creating the DEM Inlet, because the Inlet configures itself according to some options of the DEM model part      
         self.SetInlet()
 
         self.SetInitialNodalValues()
@@ -468,7 +470,7 @@ class DEMAnalysisStage(AnalysisStage):
     def SetInlet(self):
         if self.DEM_parameters["dem_inlet_option"].GetBool():
             #Constructing the inlet and initializing it (must be done AFTER the self.spheres_model_part Initialize)
-            self.DEM_inlet = DEM_Inlet(self.dem_inlet_model_part)
+            self.DEM_inlet = DEM_Inlet(self.dem_inlet_model_part, self.seed, self.use_external_seed)
             self.DEM_inlet.InitializeDEM_Inlet(self.spheres_model_part, self.creator_destructor, self._GetSolver().continuum_type)
 
     def SetInitialNodalValues(self):

--- a/applications/DEMApplication/python_scripts/dem_default_input_parameters.py
+++ b/applications/DEMApplication/python_scripts/dem_default_input_parameters.py
@@ -20,6 +20,7 @@ def GetDefaultInputParameters():
             "BoundingBoxMinY"                  : -10.0,
             "BoundingBoxMinZ"                  : -10.0,
             "dem_inlet_option"                 : true,
+            "seed"                             : 42,
             "GravityX"                         : 0.0,
             "GravityY"                         : 0.0,
             "GravityZ"                         : -9.81,

--- a/applications/SwimmingDEMApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/SwimmingDEMApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -516,7 +516,7 @@ void  AddCustomUtilitiesToPython(pybind11::module& m){
         ;
 
     py::class_<Bentonite_Force_Based_Inlet, Bentonite_Force_Based_Inlet::Pointer, DEM_Force_Based_Inlet > (m, "Bentonite_Force_Based_Inlet")
-        .def(py::init<ModelPart&, array_1d<double, 3>, int&, bool& >())
+        .def(py::init<ModelPart&, array_1d<double, 3>, int& >())
         ;
 
     py::class_<SwimmingDemInPfemUtils> (m, "SwimmingDemInPfemUtils")

--- a/applications/SwimmingDEMApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/SwimmingDEMApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -516,7 +516,8 @@ void  AddCustomUtilitiesToPython(pybind11::module& m){
         ;
 
     py::class_<Bentonite_Force_Based_Inlet, Bentonite_Force_Based_Inlet::Pointer, DEM_Force_Based_Inlet > (m, "Bentonite_Force_Based_Inlet")
-        .def(py::init<ModelPart&, array_1d<double, 3>, int& >())
+        .def(py::init<ModelPart&, array_1d<double, 3>, const int >())
+        .def(py::init<ModelPart&, array_1d<double, 3>>())
         ;
 
     py::class_<SwimmingDemInPfemUtils> (m, "SwimmingDemInPfemUtils")

--- a/applications/SwimmingDEMApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/SwimmingDEMApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -516,7 +516,7 @@ void  AddCustomUtilitiesToPython(pybind11::module& m){
         ;
 
     py::class_<Bentonite_Force_Based_Inlet, Bentonite_Force_Based_Inlet::Pointer, DEM_Force_Based_Inlet > (m, "Bentonite_Force_Based_Inlet")
-        .def(py::init<ModelPart&, array_1d<double, 3> >())
+        .def(py::init<ModelPart&, array_1d<double, 3>, int&, bool& >())
         ;
 
     py::class_<SwimmingDemInPfemUtils> (m, "SwimmingDemInPfemUtils")

--- a/applications/SwimmingDEMApplication/custom_utilities/inlets/bentonite_force_based_inlet.cpp
+++ b/applications/SwimmingDEMApplication/custom_utilities/inlets/bentonite_force_based_inlet.cpp
@@ -6,7 +6,7 @@
 
 namespace Kratos {
 
-Bentonite_Force_Based_Inlet::Bentonite_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, int& seed):
+Bentonite_Force_Based_Inlet::Bentonite_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, const int seed):
     BaseClass(inlet_modelpart, injection_force, seed)
 {
     // we want to keep only the direction of the input force (mInjectionForce), since its modulus

--- a/applications/SwimmingDEMApplication/custom_utilities/inlets/bentonite_force_based_inlet.cpp
+++ b/applications/SwimmingDEMApplication/custom_utilities/inlets/bentonite_force_based_inlet.cpp
@@ -1,6 +1,5 @@
 // Author: Guillermo Casas (gcasas@cimne.upc.edu)
 
-#include <random>
 #include "../../../DEMApplication/custom_constitutive/DEM_D_Bentonite_Colloid_CL.h"
 #include "../../../DEMApplication/custom_elements/spheric_particle.h"
 #include "bentonite_force_based_inlet.h"

--- a/applications/SwimmingDEMApplication/custom_utilities/inlets/bentonite_force_based_inlet.cpp
+++ b/applications/SwimmingDEMApplication/custom_utilities/inlets/bentonite_force_based_inlet.cpp
@@ -1,5 +1,6 @@
 // Author: Guillermo Casas (gcasas@cimne.upc.edu)
 
+#include <random>
 #include "../../../DEMApplication/custom_constitutive/DEM_D_Bentonite_Colloid_CL.h"
 #include "../../../DEMApplication/custom_elements/spheric_particle.h"
 #include "bentonite_force_based_inlet.h"

--- a/applications/SwimmingDEMApplication/custom_utilities/inlets/bentonite_force_based_inlet.cpp
+++ b/applications/SwimmingDEMApplication/custom_utilities/inlets/bentonite_force_based_inlet.cpp
@@ -6,8 +6,8 @@
 
 namespace Kratos {
 
-Bentonite_Force_Based_Inlet::Bentonite_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, int& seed, bool& use_external_seed):
-    BaseClass(inlet_modelpart, injection_force, seed, use_external_seed)
+Bentonite_Force_Based_Inlet::Bentonite_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, int& seed):
+    BaseClass(inlet_modelpart, injection_force, seed)
 {
     // we want to keep only the direction of the input force (mInjectionForce), since its modulus
     // has to adapt to the prevailing conditions.

--- a/applications/SwimmingDEMApplication/custom_utilities/inlets/bentonite_force_based_inlet.cpp
+++ b/applications/SwimmingDEMApplication/custom_utilities/inlets/bentonite_force_based_inlet.cpp
@@ -6,8 +6,8 @@
 
 namespace Kratos {
 
-Bentonite_Force_Based_Inlet::Bentonite_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force):
-    BaseClass(inlet_modelpart, injection_force)
+Bentonite_Force_Based_Inlet::Bentonite_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, int& seed, bool& use_external_seed):
+    BaseClass(inlet_modelpart, injection_force, seed, use_external_seed)
 {
     // we want to keep only the direction of the input force (mInjectionForce), since its modulus
     // has to adapt to the prevailing conditions.

--- a/applications/SwimmingDEMApplication/custom_utilities/inlets/bentonite_force_based_inlet.h
+++ b/applications/SwimmingDEMApplication/custom_utilities/inlets/bentonite_force_based_inlet.h
@@ -22,7 +22,7 @@ namespace Kratos {
         typedef ModelPart::ElementsContainerType::iterator ElementIteratorType;
 
         /// Constructor:
-        Bentonite_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force);
+        Bentonite_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, int& seed, bool& use_external_seed);
 
         /// Destructor.
         virtual ~Bentonite_Force_Based_Inlet(){}

--- a/applications/SwimmingDEMApplication/custom_utilities/inlets/bentonite_force_based_inlet.h
+++ b/applications/SwimmingDEMApplication/custom_utilities/inlets/bentonite_force_based_inlet.h
@@ -22,7 +22,7 @@ namespace Kratos {
         typedef ModelPart::ElementsContainerType::iterator ElementIteratorType;
 
         /// Constructor:
-        Bentonite_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, int& seed, bool& use_external_seed);
+        Bentonite_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, int& seed);
 
         /// Destructor.
         virtual ~Bentonite_Force_Based_Inlet(){}

--- a/applications/SwimmingDEMApplication/custom_utilities/inlets/bentonite_force_based_inlet.h
+++ b/applications/SwimmingDEMApplication/custom_utilities/inlets/bentonite_force_based_inlet.h
@@ -22,7 +22,7 @@ namespace Kratos {
         typedef ModelPart::ElementsContainerType::iterator ElementIteratorType;
 
         /// Constructor:
-        Bentonite_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, int& seed);
+        Bentonite_Force_Based_Inlet(ModelPart& inlet_modelpart, array_1d<double, 3> injection_force, const int seed=42);
 
         /// Destructor.
         virtual ~Bentonite_Force_Based_Inlet(){}

--- a/applications/SwimmingDEMApplication/python_scripts/swimming_DEM_analysis.py
+++ b/applications/SwimmingDEMApplication/python_scripts/swimming_DEM_analysis.py
@@ -325,9 +325,8 @@ class SwimmingDEMAnalysis(AnalysisStage):
         self.cluster_model_part.ProcessInfo[Kratos.DELTA_TIME] = self.time_step
         self.stationarity = False
 
-        self.use_external_seed = self.project_parameters["dem_parameters"]["use_external_seed"].GetBool()
         self.seed = self.project_parameters["dem_parameters"]["seed"].GetInt()
-        
+
         # setting up loop counters:
         self.DEM_to_fluid_counter = self.GetBackwardCouplingCounter()
         self.stationarity_counter = self.GetStationarityCounter()
@@ -553,9 +552,9 @@ class SwimmingDEMAnalysis(AnalysisStage):
             # Note that right now only inlets of a single type are possible.
             # This should be generalized.
             if self.project_parameters["type_of_inlet"].GetString() == 'VelocityImposed':
-                self.DEM_inlet = DEM_Inlet(self.dem_inlet_model_part, self.seed, self.use_external_seed)
+                self.DEM_inlet = DEM_Inlet(self.dem_inlet_model_part, self.seed)
             elif self.project_parameters["type_of_inlet"].GetString() == 'ForceImposed':
-                self.DEM_inlet = DEM_Force_Based_Inlet(self.dem_inlet_model_part, self.project_parameters["inlet_force_vector"].GetVector(), self.seed, self.use_external_seed)
+                self.DEM_inlet = DEM_Force_Based_Inlet(self.dem_inlet_model_part, self.project_parameters["inlet_force_vector"].GetVector(), self.seed)
 
             self._GetDEMAnalysis().DEM_inlet = self.DEM_inlet
             self.DEM_inlet.InitializeDEM_Inlet(self.spheres_model_part, self._GetDEMAnalysis().creator_destructor)

--- a/applications/SwimmingDEMApplication/python_scripts/swimming_DEM_analysis.py
+++ b/applications/SwimmingDEMApplication/python_scripts/swimming_DEM_analysis.py
@@ -325,6 +325,9 @@ class SwimmingDEMAnalysis(AnalysisStage):
         self.cluster_model_part.ProcessInfo[Kratos.DELTA_TIME] = self.time_step
         self.stationarity = False
 
+        self.use_external_seed = self.project_parameters["dem_parameters"]["use_external_seed"].GetBool()
+        self.seed = self.project_parameters["dem_parameters"]["seed"].GetInt()
+        
         # setting up loop counters:
         self.DEM_to_fluid_counter = self.GetBackwardCouplingCounter()
         self.stationarity_counter = self.GetStationarityCounter()
@@ -550,9 +553,9 @@ class SwimmingDEMAnalysis(AnalysisStage):
             # Note that right now only inlets of a single type are possible.
             # This should be generalized.
             if self.project_parameters["type_of_inlet"].GetString() == 'VelocityImposed':
-                self.DEM_inlet = DEM_Inlet(self.dem_inlet_model_part)
+                self.DEM_inlet = DEM_Inlet(self.dem_inlet_model_part, self.seed, self.use_external_seed)
             elif self.project_parameters["type_of_inlet"].GetString() == 'ForceImposed':
-                self.DEM_inlet = DEM_Force_Based_Inlet(self.dem_inlet_model_part, self.project_parameters["inlet_force_vector"].GetVector())
+                self.DEM_inlet = DEM_Force_Based_Inlet(self.dem_inlet_model_part, self.project_parameters["inlet_force_vector"].GetVector(), self.seed, self.use_external_seed)
 
             self._GetDEMAnalysis().DEM_inlet = self.DEM_inlet
             self.DEM_inlet.InitializeDEM_Inlet(self.spheres_model_part, self._GetDEMAnalysis().creator_destructor)

--- a/applications/SwimmingDEMApplication/python_scripts/swimming_dem_default_input_parameters.py
+++ b/applications/SwimmingDEMApplication/python_scripts/swimming_dem_default_input_parameters.py
@@ -166,8 +166,7 @@ def GetDefaultInputParameters():
         },
 
         "dem_parameters" : {
-            "seed" : 42,
-            "use_external_seed" : false
+            "seed" : 42
         },
 
         "custom_dem" : {

--- a/applications/SwimmingDEMApplication/python_scripts/swimming_dem_default_input_parameters.py
+++ b/applications/SwimmingDEMApplication/python_scripts/swimming_dem_default_input_parameters.py
@@ -165,7 +165,10 @@ def GetDefaultInputParameters():
             "fluid_model_type_comment" : " untouched, velocity incremented by 1/fluid_fraction (0), modified mass conservation only (1)"
         },
 
-        "dem_parameters" : {},
+        "dem_parameters" : {
+            "seed" : 42,
+            "use_external_seed" : false
+        },
 
         "custom_dem" : {
             "do_solve_dem" : true,


### PR DESCRIPTION
**Description**
Updated PR from #8520


- Inlet constructor now has a default seed. Pybind has both variants available (default or with seed). Changed to const int since its required for default values with pybind.

- If i'm not wrong, we can skip the creation of the uniform distribution since gen()%list does conceptually the same.
- same goes with the member mSeed; it can be skipped in my opinion.

- the DEM_Force_Based_Inlet or any other new inlet util can be still used as usual (avoid api breaking) . 

tests:
Importing    KratosDEMApplication 

     KRATOS |  _ \| ____|  \/  |  _ \ __ _  ___| | __      
            | | | |  _| | |\/| | |_) / _` |/ __| |/ /      
            | |_| | |___| |  | |  __/ (_| | (__|   <       
            |____/|_____|_|  |_|_|   \__,_|\___|_|\_\      
Importing DEMApplication...  done.
.................
----------------------------------------------------------------------
Ran 17 tests in 2.445s

OK

SWIMMING:
----------------------------------------------------------------------
Ran 13 tests in 3.823s

OK

