### PR TITLE
[Core] CAD Tessellation Modeler 1/2

### DIFF
--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -81,7 +81,7 @@ public:
     ///@{
 
     /// constructor for untrimmed surface
-    BrepCurveOnSurface( 
+    BrepCurveOnSurface(
         typename NurbsSurfaceType::Pointer pSurface,
         typename NurbsCurveType::Pointer pCurve,
         bool SameCurveDirection = true)
@@ -451,6 +451,15 @@ public:
         return mpCurveOnSurface->ShapeFunctionsLocalGradients(rResult, rCoordinates);
     }
 
+    GeometryData::KratosGeometryFamily GetGeometryFamily() const override
+    {
+        return GeometryData::Kratos_Brep;
+    }
+
+    GeometryData::KratosGeometryType GetGeometryType() const override
+    {
+        return GeometryData::Kratos_Brep_Curve;
+    }
     ///@}
     ///@name Input and output
     ///@{

--- a/kratos/geometries/brep_surface.h
+++ b/kratos/geometries/brep_surface.h
@@ -489,6 +489,16 @@ public:
         return rResult;
     }
 
+    GeometryData::KratosGeometryFamily GetGeometryFamily() const override
+    {
+        return GeometryData::Kratos_Brep;
+    }
+
+    GeometryData::KratosGeometryType GetGeometryType() const override
+    {
+        return GeometryData::Kratos_Brep_Surface;
+    }
+
     ///@}
     ///@name Information
     ///@{

--- a/kratos/geometries/geometry_data.h
+++ b/kratos/geometries/geometry_data.h
@@ -97,7 +97,8 @@ public:
         Kratos_Tetrahedra,
         Kratos_Hexahedra,
         Kratos_Prism,
-        Kratos_generic_family
+        Kratos_generic_family,
+        Kratos_Brep
     };
 
     enum KratosGeometryType
@@ -126,9 +127,10 @@ public:
         Kratos_Line3D3,
         Kratos_Point2D,
         Kratos_Point3D,
-        Kratos_Sphere3D1
+        Kratos_Sphere3D1,
+        Kratos_Brep_Surface,
+        Kratos_Brep_Curve
     };
-
 
     ///@}
     ///@name Type Definitions
@@ -277,7 +279,7 @@ public:
     * Constructor which has a precomputed shape function container.
     * @param pThisGeometryDimension pointer to the dimensional data
     * @param ThisGeometryShapeFunctionContainer including the evaluated
-    *        values for the shape functions, it's derivatives and the 
+    *        values for the shape functions, it's derivatives and the
     *        integration points.
     */
     GeometryData(GeometryDimension const *pThisGeometryDimension,
@@ -787,5 +789,3 @@ inline std::ostream& operator << ( std::ostream& rOStream,
 }  // namespace Kratos.
 
 #endif // KRATOS_GEOMETRY_DATA_H_INCLUDED  defined
-
-

--- a/kratos/geometries/nurbs_curve_on_surface_geometry.h
+++ b/kratos/geometries/nurbs_curve_on_surface_geometry.h
@@ -49,6 +49,7 @@ public:
 
     typedef NurbsSurfaceGeometry<3, TSurfaceContainerPointType> NurbsSurfaceType;
     typedef NurbsCurveGeometry<2, TCurveContainerPointType> NurbsCurveType;
+    typedef typename NurbsCurveType::Pointer NurbsCurvePointerType;
 
     typedef typename BaseType::CoordinatesArrayType CoordinatesArrayType;
     typedef typename BaseType::PointsArrayType PointsArrayType;
@@ -230,6 +231,21 @@ public:
     SizeType PolynomialDegree(IndexType LocalDirectionIndex) const override
     {
         return mpNurbsSurface->PolynomialDegree(0) + mpNurbsSurface->PolynomialDegree(1);
+    }
+
+    ///@}
+    ///@name Set/ Get functions
+    ///@{
+    /// Returns the NurbsCurve::Pointer of this CurveOnSurface.
+    NurbsCurvePointerType pGetCurve()
+    {
+        return mpNurbsCurve;
+    }
+
+    /// Returns the const NurbsCurveOnSurface::Pointer of this brep.
+    const NurbsCurvePointerType pGetCurve() const
+    {
+        return mpNurbsCurve;
     }
 
     ///@}
@@ -458,12 +474,12 @@ public:
     {
         // Compute the coordinates of the embedded curve in the parametric space of the surface
         CoordinatesArrayType result_local = mpNurbsCurve->GlobalCoordinates(rResult, rLocalCoordinates);
-        
+
         // Compute and return the coordinates of the surface in the geometric space
         return mpNurbsSurface->GlobalCoordinates(rResult, result_local);
     }
 
-    /** 
+    /**
     * @brief This method maps from dimension space to working space and computes the
     *        number of derivatives at the dimension parameter.
     * From ANurbs library (https://github.com/oberbichler/ANurbs)
@@ -485,7 +501,7 @@ public:
         // Compute the gradients of the embedded curve in the parametric space of the surface
         std::vector<array_1d<double, 3>> curve_derivatives;
         mpNurbsCurve->GlobalSpaceDerivatives(curve_derivatives, rCoordinates, DerivativeOrder);
-        
+
         // Compute the gradients of the surface in the geometric space
         array_1d<double, 3> surface_coordinates =  ZeroVector(3);
         surface_coordinates[0] = curve_derivatives[0][0];

--- a/kratos/tests/cpp_tests/geometries/test_geometry.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_geometry.cpp
@@ -127,6 +127,10 @@ namespace Testing {
           return "Kratos_Point3D";
         case GeometryData::Kratos_Sphere3D1 :
           return "Kratos_Sphere3D1";
+        case GeometryData::Kratos_Brep_Surface:
+          return "Kratos_Brep_Surface";
+        case GeometryData::Kratos_Brep_Curve:
+          return "Kratos_Brep_Curve";
       };
 
       return "UnknownGeometry";

--- a/kratos/utilities/geometry_tester.h
+++ b/kratos/utilities/geometry_tester.h
@@ -408,7 +408,7 @@ public:
 
         if(std::abs(geom.Area() - expected_area) > 1e-14)
         {
-            error_msg << "Geometry Type = " << "Kratos_QuadrilateralInterface3D4" << " --> " 
+            error_msg << "Geometry Type = " << "Kratos_QuadrilateralInterface3D4" << " --> "
                       << " error: area returned by the function geom.Area() does not deliver the correct result " << std::endl;
             succesful=false;
         }
@@ -577,7 +577,7 @@ public:
 
         if(std::abs(geom.Volume() - expected_vol) > 1e-14)
         {
-            error_msg << "Geometry Type = " << "Kratos_HexahedraInterface3D8" << " --> " 
+            error_msg << "Geometry Type = " << "Kratos_HexahedraInterface3D8" << " --> "
                       << " error: volume returned by the function geom.Volume() does not deliver the correct result " << std::endl;
             succesful=false;
         }
@@ -679,7 +679,7 @@ public:
 
         if(std::abs(geom.Volume() - expected_vol) > 1e-14)
         {
-            error_msg << "Geometry Type = " << "Kratos_PrismInterface3D6" << " --> " 
+            error_msg << "Geometry Type = " << "Kratos_PrismInterface3D6" << " --> "
                       << " error: volume returned by the function geom.Volume() does not deliver the correct result " << std::endl;
             succesful=false;
         }
@@ -1192,6 +1192,10 @@ private:
             return std::string("Kratos_Point3D");
         case GeometryData::Kratos_Sphere3D1 :
             return std::string("Kratos_Sphere3D1");
+        case GeometryData::Kratos_Brep_Surface:
+            return std::string("Kratos_Brep_Surface");
+        case GeometryData::Kratos_Brep_Curve:
+            return std::string("Kratos_Brep_Curve");
         };
 
         return std::string("UnknownGeometry");

--- a/kratos/utilities/nurbs_curve_tessellation.h
+++ b/kratos/utilities/nurbs_curve_tessellation.h
@@ -10,7 +10,7 @@
 //  Main authors:    Andreas Apostolatos
 //					 Tobias Teschemacher
 //					 Thomas Oberbichler
-//					
+//
 //
 //  Ported from the ANurbs library (https://github.com/oberbichler/ANurbs)
 //
@@ -48,7 +48,7 @@ private:
     ///@{
 
     static double DistanceToLine(
-        const typename GeometryType::CoordinatesArrayType& rPoint, 
+        const typename GeometryType::CoordinatesArrayType& rPoint,
         const typename GeometryType::CoordinatesArrayType& rLineA,
         const typename GeometryType::CoordinatesArrayType& rLineB
         )
@@ -69,17 +69,17 @@ public:
     {
     }
 
-    /** 
+    /**
     * @brief This method tessellates a curve and stores the tessellation in the class
     * @param rGeometry Reference to the geometry
     * @param PolynomialDegree The polynomial degree of the curve
     * @param DomainInterval The curve interval which is to be tessellated
     * @param rKnotSpanIntervals Reference to the knot span intervals laying in the DomainInterval
-    * @param Tolerance Tolerance for the choral error
+    * @param Tolerance Tolerance for the chordal error
     * @see ComputeTessellation
     */
     void Tessellate(
-        const GeometryType& rGeometry, 
+        const GeometryType& rGeometry,
         const int PolynomialDegree,
         const NurbsInterval DomainInterval,
         const std::vector<NurbsInterval>& rKnotSpanIntervals,
@@ -93,7 +93,7 @@ public:
             Tolerance);
     }
 
-    /** 
+    /**
     * @brief This method returns the tessellation of a curve
     * @param pGeometry Pointer to the geometry
     * @param PolynomialDegree The polynomial degree of the curve
@@ -254,7 +254,7 @@ public:
         return points;
     }
 
-    /** 
+    /**
     * @brief This method returns the already computed tessellation of a curve
     * @return return std::vector<std::pair<double, Vector>> tessellation
     */


### PR DESCRIPTION
**Description**

The Cad Tessellation Modeler PR https://github.com/KratosMultiphysics/Kratos/pull/8458 is split into two PRS. This is the first of two PRs. 

This PR introduces the geometry-related changes of the Cad Tessellation Modeler.  The Cad Tessellation Modeler can be used for the tessellation of exact  NURBS-based geometries. 

A subsequent PR with the Modeler itself will follow as soon as this PR is approved. 

