### PR TITLE
[RANS] Fix negative wall distance issue for some cases

### DIFF
--- a/applications/RANSApplication/custom_processes/rans_wall_distance_calculation_process.cpp
+++ b/applications/RANSApplication/custom_processes/rans_wall_distance_calculation_process.cpp
@@ -50,9 +50,11 @@ void CalculateAndUpdateNodalMinimumWallDistance(
     const array_1d<double, 3>& rUnitNormal,
     const Variable<double>& rDistanceVariable)
 {
-    // rUnitNormal is assumed to be outward pointing, hence wall_distance will be always positive.
+    // Even if the rUnitNormal is outward pointing, there are situations (such as trailing edge point)
+    // where the nodal averaged unit normal will be outward pointing, but the nodal location of interest
+    // may give negative wall distances. So std::abs is used in here to avoid that.
     const double wall_distance =
-        inner_prod(rWallLocation - rNode.Coordinates(), rUnitNormal);
+        std::abs(inner_prod(rWallLocation - rNode.Coordinates(), rUnitNormal));
 
     rNode.SetLock();
     double& current_distance = rNode.FastGetSolutionStepValue(rDistanceVariable);


### PR DESCRIPTION
**Description**
I found out that, wall distance of neighbouring nodes become negative (such as trailing edge point of a aerofoil) due to normal averaging, and the adjacent domain node falling in such a way that distance is negative in the normal manner. So this fixes it by making use of `std::abs`. This does not change the behaviour of the existing tests so, no tests were modified.

**Changelog**
- Adding `std::abs` to circumvent negative wall distances