### PR TITLE
[CI] Disable mmg/parmmg warnings and reducing progress outputs

### DIFF
--- a/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
@@ -57,7 +57,7 @@ RUN apt-get update -y && apt-get upgrade -y && \
     mkdir /tmp/mmg_5_4_1/build && \
     mkdir -p /external_libraries/mmg/mmg_5_4_1 && \
     cd /tmp/mmg_5_4_1/build && \
-    cmake .. -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_4_1" -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
+    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_4_1" -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
     make -j2 install && \
     rm -r /tmp/mmg_5_4_1 && \
     cd / && \
@@ -66,7 +66,7 @@ RUN apt-get update -y && apt-get upgrade -y && \
     mkdir /tmp/mmg_5_5_1/build && \
     mkdir -p /external_libraries/mmg/mmg_5_5_1 && \
     cd /tmp/mmg_5_5_1/build && \
-    cmake .. -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_5_1" -DUSE_SCOTCH=OFF -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
+    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_5_1" -DUSE_SCOTCH=OFF -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
     make -j2 install && \
     cd / && \
     # install PARMMG
@@ -74,7 +74,7 @@ RUN apt-get update -y && apt-get upgrade -y && \
     mkdir /tmp/ParMmg_5ffc6ad/build && \
     mkdir -p /external_libraries/ParMmg_5ffc6ad && \
     cd /tmp/ParMmg_5ffc6ad/build && git checkout 5ffc6ada4afb1af50a43e1fa6f4c409cff2ea25c && \
-    cmake .. -DCMAKE_INSTALL_PREFIX="/external_libraries/ParMmg_5ffc6ad" -DUSE_SCOTCH=OFF -DLIBPARMMG_SHARED=ON -DDOWNLOAD_MMG=OFF -DMMG_DIR="/tmp/mmg_5_5_1" -DMMG_BUILDDIR="/tmp/mmg_5_5_1/build" -DDOWNLOAD_METIS=OFF -DMETIS_DIR="/usr/include" && \
+    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/external_libraries/ParMmg_5ffc6ad" -DUSE_SCOTCH=OFF -DLIBPARMMG_SHARED=ON -DDOWNLOAD_MMG=OFF -DMMG_DIR="/tmp/mmg_5_5_1" -DMMG_BUILDDIR="/tmp/mmg_5_5_1/build" -DDOWNLOAD_METIS=OFF -DMETIS_DIR="/usr/include" && \
     make -j2 install && \
     rm -r /tmp/mmg_5_5_1 && \
     rm -r /tmp/ParMmg_5ffc6ad && \


### PR DESCRIPTION
**Description**
Closes #8562


**Changelog**
- Added -w flag to remove warnings
- Added CMAKE_RULE_MESSAGES=OFF to reduce the amount of % messages shown.
