### PR TITLE
[CI] add Core build without Unity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,7 @@ jobs:
 
     container:
       image: kratosmultiphysics/kratos-image-ci-ubuntu-20-04:latest
-      options: --user 1001
-      env:
-        CCACHE_SLOPPINESS: pch_defines,time_macros
-        CCACHE_COMPILERCHECK: content
-        CCACHE_COMPRESS: true
-        CCACHE_NODISABLE: true
-        CCACHE_MAXSIZE: 500M
+      options: --user 1001 
 
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
@@ -36,20 +30,12 @@ jobs:
 
     - uses: actions/checkout@v2
 
-    - name: Cache Build
-      id: cache-build
-      uses: actions/cache@v1
-      with:
-        path: ~/.ccache
-        key: ${{ runner.os }}-${{ matrix.build-type }}-${{ matrix.compiler }}-ccache-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-${{ matrix.build-type }}-${{ matrix.compiler }}-ccache-
-
     - name: Build
       shell: bash
       run: |
         if [ ${{ matrix.compiler }} = gcc ]; then
-          export CC=/usr/lib/ccache/gcc
-          export CXX=/usr/lib/ccache/g++
+          export CC=/usr/bin/gcc
+          export CXX=/usr/bin/g++
           export KRATOS_CMAKE_OPTIONS_FLAGS="-DUSE_EIGEN_MKL=ON -DUSE_EIGEN_FEAST=ON -DTRILINOS_EXCLUDE_AMESOS2_SOLVER=OFF -DMMG_ROOT=/external_libraries/mmg/mmg_5_5_1/ -DPMMG_ROOT=/external_libraries/ParMmg_5ffc6ad -DINCLUDE_PMMG=ON"
           export KRATOS_CMAKE_CXX_FLAGS="-std=c++11 -Werror -Wno-deprecated-declarations -Wignored-qualifiers"
         elif [ ${{ matrix.compiler }} = clang ]; then
@@ -69,7 +55,6 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         cp .github/workflows/configure.sh configure.sh
         bash configure.sh
-        ccache -s
 
     - name: Running small tests
       shell: bash
@@ -140,13 +125,6 @@ jobs:
     - uses: actions/setup-python@v1
       with:
         python-version: '3.6'
-    - name: Cache Build
-      id: cache-build
-      uses: actions/cache@v1
-      with:
-        path: build
-        key: ${{ runner.os }}-build-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-build-
 
     - name: Download boost
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,44 @@ jobs:
         bash centos_configure.sh
 
     - name: Running small tests
+    
+
+ubuntu-without-unity:
+    runs-on: ubuntu-latest
+    strategy:
+    env:
+      KRATOS_BUILD_TYPE: Custom
+
+    container:
+      image: kratosmultiphysics/kratos-image-ci-ubuntu-20-04:latest
+
+    steps:
+    - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+    - uses: actions/checkout@v2
+
+    - name: Build
+      shell: bash
+      run: |
+        export CC=/usr/bin/clang
+        export CXX=/usr/bin/clang++
+
+        export KRATOS_SOURCE="${KRATOS_SOURCE:-${PWD}}"
+        export KRATOS_BUILD="${KRATOS_SOURCE}/build"
+        export PYTHON_EXECUTABLE="/usr/bin/python3.8"
+        export KRATOS_INSTALL_PYTHON_USING_LINKS=ON
+
+        # Configure
+        cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
+        -DUSE_MPI=ON \
+        -DPYBIND11_PYTHON_VERSION="3.8" \
+        -DINSTALL_RUNKRATOS=OFF
+
+        # Buid
+        cmake --build "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" --target install -- -j2
+
       run: |
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,8 +213,8 @@ jobs:
     - name: Build
       shell: bash
       run: |
-        export CC=/usr/lib/ccache/gcc
-        export CXX=/usr/lib/ccache/g++
+        export CC=/usr/lib/ccache/clang
+        export CXX=/usr/lib/ccache/clang++
 
         export KRATOS_SOURCE="${KRATOS_SOURCE:-${PWD}}"
         export KRATOS_BUILD="${KRATOS_SOURCE}/build"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,11 @@ jobs:
         bash centos_configure.sh
 
     - name: Running small tests
-    
+      run: |
+        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
+        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
+        python3.5 kratos/python_scripts/run_tests.py -l small -c python3.5
+
 
 ubuntu-without-unity:
     runs-on: ubuntu-latest
@@ -234,8 +238,3 @@ ubuntu-without-unity:
 
         # Buid
         cmake --build "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" --target install -- -j2
-
-      run: |
-        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
-        python3.5 kratos/python_scripts/run_tests.py -l small -c python3.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,9 +203,8 @@ jobs:
         python3.5 kratos/python_scripts/run_tests.py -l small -c python3.5
 
 
-ubuntu-without-unity:
+  ubuntu-without-unity:
     runs-on: ubuntu-latest
-    strategy:
     env:
       KRATOS_BUILD_TYPE: Custom
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     container:
       image: kratosmultiphysics/kratos-image-ci-ubuntu-20-04:latest
-      options: --user 1001 
+      options: --user 1001
 
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
@@ -188,6 +188,12 @@ jobs:
 
     container:
       image: kratosmultiphysics/kratos-image-ci-ubuntu-20-04:latest
+      env:
+        CCACHE_SLOPPINESS: pch_defines,time_macros
+        CCACHE_COMPILERCHECK: content
+        CCACHE_COMPRESS: true
+        CCACHE_NODISABLE: true
+        CCACHE_MAXSIZE: 500M
 
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
@@ -196,11 +202,19 @@ jobs:
 
     - uses: actions/checkout@v2
 
+    - name: Cache Build
+      id: cache-build
+      uses: actions/cache@v1
+      with:
+        path: ~/.ccache
+        key: ${{ runner.os }}-no-unity-ccache-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-no-unity-ccache-
+
     - name: Build
       shell: bash
       run: |
-        export CC=/usr/bin/clang
-        export CXX=/usr/bin/clang++
+        export CC=/usr/lib/ccache/gcc
+        export CXX=/usr/lib/ccache/g++
 
         export KRATOS_SOURCE="${KRATOS_SOURCE:-${PWD}}"
         export KRATOS_BUILD="${KRATOS_SOURCE}/build"
@@ -215,3 +229,5 @@ jobs:
 
         # Buid
         cmake --build "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" --target install -- -j2
+
+        ccache -s


### PR DESCRIPTION
**Description**
In the past we quite often had the problem that some includes were missing which is often ok when using the unity build but is failing in normal compilations

this PR adds a build of the Core with Clang to prevent this (at least for the Core). I am only adding the Core as this would be too slow when all the apps are added too

Better version of #8485 

closes #8404