### PR TITLE
[Core][LockObject] deprecating move constructor

### DIFF
--- a/.github/workflows/configure.cmd
+++ b/.github/workflows/configure.cmd
@@ -32,14 +32,14 @@ del /F /Q "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%\cmake_install.cmake"
 del /F /Q "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%\CMakeCache.txt"
 del /F /Q "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%\CMakeFiles"
 
-cmake                                                ^
-  -G"Visual Studio 16 2019"                          ^
-  -H"%KRATOS_SOURCE%"                                ^
-  -B"%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%"             ^
-  -DBOOST_ROOT="%TEMP%\boost"                        ^
-  -DINSTALL_RUNKRATOS=OFF                            ^
-  -DCMAKE_CXX_FLAGS="/Od /we4661 /we4804 /WX"        ^
-  -DFORCE_LOCAL_ZLIB_COMPILATION=ON                  ^
+cmake                                                 ^
+  -G"Visual Studio 16 2019"                           ^
+  -H"%KRATOS_SOURCE%"                                 ^
+  -B"%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%"              ^
+  -DBOOST_ROOT="%TEMP%\boost"                         ^
+  -DINSTALL_RUNKRATOS=OFF                             ^
+  -DCMAKE_CXX_FLAGS="/Od /we4661 /we4804 /WX /wd4996" ^
+  -DFORCE_LOCAL_ZLIB_COMPILATION=ON                   ^
   -DCMAKE_UNITY_BUILD=ON                                    || goto :error
 
 cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target all_build -- /property:configuration=%KRATOS_BUILD_TYPE% /p:Platform=x64 || goto :error

--- a/kratos/includes/lock_object.h
+++ b/kratos/includes/lock_object.h
@@ -55,6 +55,7 @@ public:
     LockObject(LockObject const& rOther) = delete;
 
     /// Move constructor.
+    KRATOS_DEPRECATED_MESSAGE("The move constructor is deprecated and will be removed in the future!")
     LockObject(LockObject&& rOther) noexcept
 #ifdef KRATOS_SMP_OPENMP
 			: mLock(rOther.mLock)


### PR DESCRIPTION
**Description**
This PR deprecates the Move-Ctor of the `LockObject`. This is necessary as we can no longer support it when we move to C++ based parallelism. Even now the usage is questionable and we are not really sure if it is correct.
For context, `std::mutex` also deletes its move-ctor

@pooyan-dadvand after this is in can you please update your code? This is what we discussed several times already
