### PR TITLE
[FastPR][MPI] Quaternion synchronization

### DIFF
--- a/kratos/includes/communicator.h
+++ b/kratos/includes/communicator.h
@@ -325,6 +325,8 @@ public:
 
     virtual bool SynchronizeVariable(Variable<Matrix> const& rThisVariable);
 
+    virtual bool SynchronizeVariable(Variable<Quaternion<double>> const& rThisVariable);
+
     virtual bool SynchronizeNonHistoricalVariable(Variable<int> const& rThisVariable);
 
     virtual bool SynchronizeNonHistoricalVariable(Variable<double> const& rThisVariable);
@@ -342,6 +344,8 @@ public:
     virtual bool SynchronizeNonHistoricalVariable(Variable<Vector> const& rThisVariable);
 
     virtual bool SynchronizeNonHistoricalVariable(Variable<Matrix> const& rThisVariable);
+
+    virtual bool SynchronizeNonHistoricalVariable(Variable<Quaternion<double>> const& rThisVariable);
 
     /// Synchronize variable in nodal solution step data to the minimum value across all processes.
     /** @param ThisVariable The variable to be synchronized.
@@ -568,5 +572,3 @@ inline std::ostream & operator <<(std::ostream& rOStream,
 } // namespace Kratos.
 
 #endif // KRATOS_COMMUNICATOR_H_INCLUDED  defined
-
-

--- a/kratos/mpi/includes/mpi_communicator.h
+++ b/kratos/mpi/includes/mpi_communicator.h
@@ -135,6 +135,13 @@ template<> struct SendTraits< Matrix >
     }
 };
 
+template<> struct SendTraits< Quaternion<double> >
+{
+    using SendType = double;
+    using BufferType = std::vector<SendType>;
+    constexpr static bool IsFixedSize = true;
+    constexpr static std::size_t BlockSize = 4;
+};
 
 template<typename TVectorValue> struct SendTraits< DenseVector<TVectorValue> >
 {
@@ -225,6 +232,31 @@ struct SendTools< Vector >: public DynamicArrayTypeTransfer<Vector> {};
 
 template<>
 struct SendTools< Matrix >: public DynamicArrayTypeTransfer<Matrix> {};
+
+// template<>
+// struct SendTools< Quaternion<double> >: public DirectCopyTransfer<Quaternion<double>> {};
+
+template<>
+struct SendTools< Quaternion<double> >
+{
+    using SendType = SendTraits< Quaternion<double> >::SendType;
+
+    static inline void WriteBuffer(const Quaternion<double>& rValue, SendType* pBuffer)
+    {
+        *(pBuffer) = rValue.X();
+        *(pBuffer + 1) = rValue.Y();
+        *(pBuffer + 2) = rValue.Z();
+        *(pBuffer + 3) = rValue.W();
+    }
+
+    static inline void ReadBuffer(const SendType* pBuffer, Quaternion<double>& rValue)
+    {
+        rValue.SetX(*(pBuffer));
+        rValue.SetY(*(pBuffer + 1));
+        rValue.SetZ(*(pBuffer + 2));
+        rValue.SetW(*(pBuffer + 3));
+    }
+};
 
 template<typename TVectorValue>
 struct SendTools< DenseVector<TVectorValue> >
@@ -814,6 +846,13 @@ public:
         return true;
     }
 
+    bool SynchronizeVariable(Variable<Quaternion<double>> const& rThisVariable) override
+    {
+        MPIInternals::NodalSolutionStepValueAccess<Quaternion<double>> solution_step_value_access(rThisVariable);
+        SynchronizeFixedSizeValues(solution_step_value_access);
+        return true;
+    }
+
     bool SynchronizeNonHistoricalVariable(Variable<int> const& rThisVariable) override
     {
         MPIInternals::NodalDataAccess<int> nodal_data_access(rThisVariable);
@@ -874,6 +913,13 @@ public:
     {
         MPIInternals::NodalDataAccess<Matrix> nodal_data_access(rThisVariable);
         SynchronizeDynamicMatrixValues(nodal_data_access);
+        return true;
+    }
+
+    bool SynchronizeNonHistoricalVariable(Variable<Quaternion<double>> const& rThisVariable) override
+    {
+        MPIInternals::NodalDataAccess<Quaternion<double>> nodal_data_access(rThisVariable);
+        SynchronizeFixedSizeValues(nodal_data_access);
         return true;
     }
 

--- a/kratos/mpi/tests/sources/test_mpi_communicator.cpp
+++ b/kratos/mpi/tests/sources/test_mpi_communicator.cpp
@@ -323,6 +323,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSy
     r_model_part.AddNodalSolutionStepVariable(VELOCITY);              // Variable< array_1d<double,3> >
     r_model_part.AddNodalSolutionStepVariable(CAUCHY_STRESS_VECTOR);  // Variable<Vector>
     r_model_part.AddNodalSolutionStepVariable(DEFORMATION_GRADIENT);  // Variable<Matrix>
+    r_model_part.AddNodalSolutionStepVariable(ORIENTATION);           // Variable<Quaternion<double>>
 
     MPIDataCommunicator comm_world(MPI_COMM_WORLD);
     Internals::ModelPartForMPICommunicatorTests(r_model_part, comm_world);
@@ -344,6 +345,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSy
         r_deformation_gradient.resize(3,2,false);
         r_deformation_gradient = ZeroMatrix(3,2);
         r_deformation_gradient(2,1) = 1.0;
+        i_node->FastGetSolutionStepValue(ORIENTATION) = Quaternion<double>(4.0,1.0,2.0,3.0);
     }
 
     r_comm.SynchronizeVariable(DOMAIN_SIZE);
@@ -389,6 +391,15 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSy
         KRATOS_CHECK_EQUAL(r_matrix.size2(), 2);
         KRATOS_CHECK_EQUAL(r_matrix(0,0), 0.0);
         KRATOS_CHECK_EQUAL(r_matrix(2,1), 1.0);
+    }
+
+    r_comm.SynchronizeVariable(ORIENTATION);
+    for (const auto& r_node : r_model_part.Nodes()) {
+        const auto& r_quaternion = r_node.FastGetSolutionStepValue(ORIENTATION);
+        KRATOS_CHECK_EQUAL(r_quaternion.X(), 1.0);
+        KRATOS_CHECK_EQUAL(r_quaternion.Y(), 2.0);
+        KRATOS_CHECK_EQUAL(r_quaternion.Z(), 3.0);
+        KRATOS_CHECK_EQUAL(r_quaternion.W(), 4.0);
     }
 }
 
@@ -516,6 +527,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataSynchronize, Krato
         r_deformation_gradient.resize(3,2,false);
         r_deformation_gradient = ZeroMatrix(3,2);
         r_deformation_gradient(2,1) = 1.0;
+        i_node->SetValue(ORIENTATION, Quaternion<double>(4.0,1.0,2.0,3.0));
     }
 
     r_comm.SynchronizeNonHistoricalVariable(DOMAIN_SIZE);
@@ -561,6 +573,15 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataSynchronize, Krato
         KRATOS_CHECK_EQUAL(r_matrix.size2(), 2);
         KRATOS_CHECK_EQUAL(r_matrix(0,0), 0.0);
         KRATOS_CHECK_EQUAL(r_matrix(2,1), 1.0);
+    }
+
+    r_comm.SynchronizeNonHistoricalVariable(ORIENTATION);
+    for (const auto& r_node : r_model_part.Nodes()) {
+        const auto& r_quaternion = r_node.GetValue(ORIENTATION);
+        KRATOS_CHECK_EQUAL(r_quaternion.X(), 1.0);
+        KRATOS_CHECK_EQUAL(r_quaternion.Y(), 2.0);
+        KRATOS_CHECK_EQUAL(r_quaternion.Z(), 3.0);
+        KRATOS_CHECK_EQUAL(r_quaternion.W(), 4.0);
     }
 }
 

--- a/kratos/sources/communicator.cpp
+++ b/kratos/sources/communicator.cpp
@@ -389,6 +389,11 @@ bool Communicator::SynchronizeVariable(Variable<Matrix> const& rThisVariable)
     return true;
 }
 
+bool Communicator::SynchronizeVariable(Variable<Quaternion<double>> const& rThisVariable)
+{
+    return true;
+}
+
 bool Communicator::SynchronizeNonHistoricalVariable(Variable<int> const& rThisVariable)
 {
     return true;
@@ -430,6 +435,11 @@ bool Communicator::SynchronizeNonHistoricalVariable(Variable<Vector> const& rThi
 }
 
 bool Communicator::SynchronizeNonHistoricalVariable(Variable<Matrix> const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeNonHistoricalVariable(Variable<Quaternion<double>> const& rThisVariable)
 {
     return true;
 }

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -130,9 +130,10 @@ public:
         const int n_orig_nodes = rOriginModelPart.NumberOfNodes();
         const int n_dest_nodes = rDestinationModelPart.NumberOfNodes();
 
-        KRATOS_ERROR_IF_NOT(n_orig_nodes == n_dest_nodes) << "Origin and destination model parts have different number of nodes."
-                                                        << "\n\t- Number of origin nodes: " << n_orig_nodes
-                                                        << "\n\t- Number of destination nodes: " << n_dest_nodes << std::endl;
+        KRATOS_ERROR_IF_NOT(n_orig_nodes == n_dest_nodes)
+            << "Origin and destination model parts have different number of nodes."
+            << "\n\t- Number of origin nodes: " << n_orig_nodes
+            << "\n\t- Number of destination nodes: " << n_dest_nodes << std::endl;
 
         IndexPartition<std::size_t>(n_orig_nodes).for_each([&](std::size_t index){
             auto it_dest_node = rDestinationModelPart.NodesBegin() + index;
@@ -140,6 +141,8 @@ public:
             const auto& r_value = it_orig_node->GetSolutionStepValue(rVariable, BuffStep);
             it_dest_node->FastGetSolutionStepValue(rDestinationVariable, BuffStep) = r_value;
         });
+
+        rDestinationModelPart.GetCommunicator().SynchronizeVariable(rDestinationVariable);
     }
 
     /**
@@ -183,6 +186,8 @@ public:
             const auto& r_value = it_orig_node->GetSolutionStepValue(rVariable, BuffStep);
             it_dest_node->GetValue(rDestinationVariable) = r_value;
         });
+
+        rDestinationModelPart.GetCommunicator().SynchronizeNonHistoricalVariable(rDestinationVariable);
     }
 
     template< class TVarType >


### PR DESCRIPTION
**Description**
This adds missing historical and non-historical variable synchronization for the `Quaternion<double>` type.

As this raised from a bugfix in the `VariableUtils` I also took the chance to fix it in here. Long story short, the `CopyModelPartNodalVar` methods were not synchronizing the copied data.
