### PR TITLE
[Fix variable process] Allow to free a dof

### DIFF
--- a/kratos/python_scripts/fix_scalar_variable_process.py
+++ b/kratos/python_scripts/fix_scalar_variable_process.py
@@ -15,10 +15,11 @@ class FixScalarVariableProcess(KratosMultiphysics.Process):
         default_settings = KratosMultiphysics.Parameters(
             """
             {
-                "model_part_name" : "SPECIFY_MODEL_PART_NAME",
-                "variable_name"   : "SPECIFY_VARIABLE_NAME",
-                "interval"        : [0.0, 1e30],
-                "constrained"     : true
+                "model_part_name"       : "SPECIFY_MODEL_PART_NAME",
+                "variable_name"         : "SPECIFY_VARIABLE_NAME",
+                "interval"              : [0.0, 1e30],
+                "constrained"           : true,
+                "free_dof_if_specified" : false
             }
             """
         )
@@ -52,6 +53,9 @@ class FixScalarVariableProcess(KratosMultiphysics.Process):
             is_fixed = self.settings["constrained"].GetBool()
             if is_fixed:
                 self.variable_utils.ApplyFixity(self.variable, is_fixed, self.model_part.Nodes)
+            else:
+                if self.settings["free_dof_if_specified"].GetBool():
+                    self.variable_utils.ApplyFixity(self.variable, is_fixed, self.model_part.Nodes)
 
     def ExecuteFinalizeSolutionStep(self):
         current_time = self.model_part.ProcessInfo[KratosMultiphysics.TIME]

--- a/kratos/python_scripts/fix_vector_variable_process.py
+++ b/kratos/python_scripts/fix_vector_variable_process.py
@@ -18,10 +18,11 @@ class FixVectorVariableProcess(KratosMultiphysics.Process):
         default_settings = KratosMultiphysics.Parameters(
             """
             {
-                "model_part_name" : "SPECIFY_MODEL_PART_NAME",
-                "variable_name"   : "SPECIFY_VARIABLE_NAME",
-                "interval"        : [0.0, 1e30],
-                "constrained"     : [true,true,true]
+                "model_part_name"      : "SPECIFY_MODEL_PART_NAME",
+                "variable_name"        : "SPECIFY_VARIABLE_NAME",
+                "interval"             : [0.0, 1e30],
+                "constrained"          : [true,true,true],
+                "free_dof_if_specified : [false,false,false]
             }
             """
         )
@@ -44,6 +45,7 @@ class FixVectorVariableProcess(KratosMultiphysics.Process):
             i_params.AddEmptyValue("variable_name").SetString(settings["variable_name"].GetString() + component)
             i_params.AddValue("interval", settings["interval"])
             i_params.AddValue("constrained", settings["constrained"][index])
+            i_params.AddValue("free_dof_if_specified", settings["free_dof_if_specified"][index])
             self.aux_processes.append( fix_scalar_variable_process.FixScalarVariableProcess(model, i_params) )
 
     def ExecuteInitialize(self):

--- a/kratos/python_scripts/fix_vector_variable_process.py
+++ b/kratos/python_scripts/fix_vector_variable_process.py
@@ -18,11 +18,11 @@ class FixVectorVariableProcess(KratosMultiphysics.Process):
         default_settings = KratosMultiphysics.Parameters(
             """
             {
-                "model_part_name"      : "SPECIFY_MODEL_PART_NAME",
-                "variable_name"        : "SPECIFY_VARIABLE_NAME",
-                "interval"             : [0.0, 1e30],
-                "constrained"          : [true,true,true],
-                "free_dof_if_specified : [false,false,false]
+                "model_part_name"       : "SPECIFY_MODEL_PART_NAME",
+                "variable_name"         : "SPECIFY_VARIABLE_NAME",
+                "interval"              : [0.0, 1e30],
+                "constrained"           : [true,true,true],
+                "free_dof_if_specified" : [false,false,false]
             }
             """
         )


### PR DESCRIPTION
**Description**
Running an example I realized that I need to free a dof in a corner. Is it possible to do that modification to adapt the existing process?
The default behavior does not change.

**Changelog**
- Allow to free a scalar dof if specified
- Corresponding changes in the vector process to be consistent
