### PR TITLE
Using unique ptr for csr matrix data

### DIFF
--- a/kratos/containers/csr_matrix.h
+++ b/kratos/containers/csr_matrix.h
@@ -83,8 +83,8 @@ public:
         TIndexType row_data_size=0;
         TIndexType col_data_size=0;
         rSparseGraph.ExportCSRArrays(mpRowIndicesData,row_data_size,mpColIndicesData, col_data_size);
-        mRowIndices = Kratos::span<TIndexType>(mpRowIndicesData, row_data_size); //no copying of data happening here
-        mColIndices = Kratos::span<TIndexType>(mpColIndicesData, col_data_size);
+        mRowIndices = Kratos::span<TIndexType>(mpRowIndicesData.get(), row_data_size); //no copying of data happening here
+        mColIndices = Kratos::span<TIndexType>(mpColIndicesData.get(), col_data_size);
 
         mNrows = size1();
 
@@ -140,9 +140,7 @@ public:
 
     /// Destructor.
     virtual ~CsrMatrix(){
-        AssignIndex1Data(nullptr,0);
-        AssignIndex2Data(nullptr,0);
-        AssignValueData(nullptr,0);        
+      
     }
 
     /// Assignment operator. 
@@ -247,58 +245,53 @@ public:
         mNcols = max_col+1; //note that we must add 1 to the greatest column id
     }
 
-    void AssignIndex1Data(TIndexType* pExternalData, TIndexType DataSize){
-        if(IsOwnerOfData() && mpRowIndicesData != nullptr)
-            delete [] mpRowIndicesData;
-        mpRowIndicesData = pExternalData;
+    void AssignIndex1Data(Kratos::unique_ptr<IndexType[]>& pExternalData, TIndexType DataSize){
         if(DataSize!=0)
-            mRowIndices = Kratos::span<TIndexType>(mpRowIndicesData, DataSize);
+            mRowIndices = Kratos::span<TIndexType>(pExternalData.get(), DataSize);
         else
             mRowIndices = Kratos::span<TIndexType>();
+
+        if(IsOwnerOfData()){
+            mpRowIndicesData = std::move(pExternalData);
+        }
     }
 
-    void AssignIndex2Data(TIndexType* pExternalData, TIndexType DataSize){
-        if(IsOwnerOfData() && mpColIndicesData != nullptr)
-            delete [] mpColIndicesData;
-        mpColIndicesData = pExternalData;
+    void AssignIndex2Data(Kratos::unique_ptr<IndexType[]>& pExternalData, TIndexType DataSize){
+        
         if(DataSize!=0)
-            mColIndices = Kratos::span<TIndexType>(mpColIndicesData, DataSize);
+            mColIndices = Kratos::span<TIndexType>(pExternalData.get(), DataSize);
         else
             mColIndices = Kratos::span<TIndexType>();
+
+        if(IsOwnerOfData())
+            mpColIndicesData = std::move(pExternalData);
     }
 
-    void AssignValueData(TDataType* pExternalData, TIndexType DataSize){
-        if(IsOwnerOfData() && mpValuesVectorData != nullptr)
-            delete [] mpValuesVectorData;
-        mpValuesVectorData = pExternalData;
+    void AssignValueData(Kratos::unique_ptr<TDataType[]>& pExternalData, TIndexType DataSize){
         if(DataSize!=0)
-            mValuesVector = Kratos::span<TDataType>(mpValuesVectorData, DataSize);
+            mValuesVector = Kratos::span<TDataType>(pExternalData.get(), DataSize);
         else
             mValuesVector = Kratos::span<TDataType>();
+        if(IsOwnerOfData())
+            mpValuesVectorData = std::move(pExternalData);
     }
 
     void ResizeIndex1Data(TIndexType DataSize){
         KRATOS_ERROR_IF_NOT(IsOwnerOfData()) << "ResizeIndex1Data is only allowed if the data are locally owned" << std::endl;
-        if(mpRowIndicesData != nullptr)
-            delete [] mpRowIndicesData;
-        mpRowIndicesData = new TIndexType[DataSize];
-        mRowIndices = Kratos::span<TIndexType>(mpRowIndicesData, DataSize);
+        mpRowIndicesData = std::move(Kratos::unique_ptr<IndexType[]>(new TIndexType[DataSize]));
+        mRowIndices = Kratos::span<TIndexType>(mpRowIndicesData.get(), DataSize);
     }
 
     void ResizeIndex2Data(TIndexType DataSize){
         KRATOS_ERROR_IF_NOT(IsOwnerOfData()) << "ResizeIndex2Data is only allowed if the data are locally owned" << std::endl;
-        if(mpColIndicesData != nullptr)
-            delete [] mpColIndicesData;
-        mpColIndicesData = new TIndexType[DataSize];
-        mColIndices = Kratos::span<TIndexType>(mpColIndicesData, DataSize);
+        mpColIndicesData = std::move(Kratos::unique_ptr<IndexType[]>(new TIndexType[DataSize]));
+        mColIndices = Kratos::span<TIndexType>(mpColIndicesData.get(), DataSize);
     }
 
     void ResizeValueData(TIndexType DataSize){
         KRATOS_ERROR_IF_NOT(IsOwnerOfData()) << "ResizeValueData is only allowed if the data are locally owned" << std::endl;
-        if(mpValuesVectorData != nullptr)
-            delete [] mpValuesVectorData;
-        mpValuesVectorData = new TDataType[DataSize];
-        mValuesVector = Kratos::span<TDataType>(mpValuesVectorData, DataSize);
+        mpValuesVectorData = std::move(Kratos::unique_ptr<TDataType[]>(new TDataType[DataSize]));
+        mValuesVector = Kratos::span<TDataType>(mpValuesVectorData.get(), DataSize);
     }
 
 
@@ -696,9 +689,9 @@ private:
     ///@name Member Variables
     ///@{
     bool mIsOwnerOfData = true;
-    IndexType* mpRowIndicesData = nullptr;
-    IndexType* mpColIndicesData = nullptr;
-    TDataType* mpValuesVectorData = nullptr;
+    Kratos::unique_ptr<IndexType[]> mpRowIndicesData;
+    Kratos::unique_ptr<IndexType[]> mpColIndicesData;
+    Kratos::unique_ptr<TDataType[]> mpValuesVectorData;
     Kratos::span<IndexType> mRowIndices;
     Kratos::span<IndexType> mColIndices;
     Kratos::span<TDataType> mValuesVector;

--- a/kratos/containers/csr_matrix.h
+++ b/kratos/containers/csr_matrix.h
@@ -124,9 +124,9 @@ public:
         rOtherMatrix.mIsOwnerOfData=false;
 
         //swap the pointers to take owership of data
-        mpRowIndicesData = rOtherMatrix.mpRowIndicesData;
-        mpColIndicesData = rOtherMatrix.mpColIndicesData;
-        mpValuesVectorData = rOtherMatrix.mpValuesVectorData;
+        mpRowIndicesData = std::move(rOtherMatrix.mpRowIndicesData);
+        mpColIndicesData = std::move(rOtherMatrix.mpColIndicesData);
+        mpValuesVectorData = std::move(rOtherMatrix.mpValuesVectorData);
 
         //here we assign the span
         mRowIndices = rOtherMatrix.mRowIndices;
@@ -689,9 +689,9 @@ private:
     ///@name Member Variables
     ///@{
     bool mIsOwnerOfData = true;
-    Kratos::unique_ptr<IndexType[]> mpRowIndicesData;
-    Kratos::unique_ptr<IndexType[]> mpColIndicesData;
-    Kratos::unique_ptr<TDataType[]> mpValuesVectorData;
+    Kratos::unique_ptr<IndexType[]> mpRowIndicesData; //this is the pointer who "owns" the data. DO NOT USE IT as such (it may be uninitialized if data is not owned), only use the span wrapper just below
+    Kratos::unique_ptr<IndexType[]> mpColIndicesData; //this is the pointer who "owns" the data. DO NOT USE IT as such (it may be uninitialized if data is not owned), only use the span wrapper just below
+    Kratos::unique_ptr<TDataType[]> mpValuesVectorData; //this is the pointer who "owns" the data. DO NOT USE IT as such (it may be uninitialized if data is not owned), only use the span wrapper just below
     Kratos::span<IndexType> mRowIndices;
     Kratos::span<IndexType> mColIndices;
     Kratos::span<TDataType> mValuesVector;

--- a/kratos/containers/sparse_contiguous_row_graph.h
+++ b/kratos/containers/sparse_contiguous_row_graph.h
@@ -216,9 +216,9 @@ public:
         TVectorType& rColIndices
     ) const
     {
-        IndexType* pRowIndicesData=nullptr;
+        Kratos::unique_ptr<IndexType[]> pRowIndicesData;
         IndexType RowIndicesDataSize=0;
-        IndexType* pColIndicesData=nullptr;
+        Kratos::unique_ptr<IndexType[]> pColIndicesData;
         IndexType ColIndicesDataSize=0;
         ExportCSRArrays(pRowIndicesData,RowIndicesDataSize,pColIndicesData,ColIndicesDataSize);
         if(rRowIndices.size() != RowIndicesDataSize)
@@ -227,13 +227,13 @@ public:
             [&](IndexType i){rRowIndices[i] = pRowIndicesData[i];}
         );
         
-        delete [] pRowIndicesData;
+        pRowIndicesData.reset();
         if(rColIndices.size() != ColIndicesDataSize)
             rColIndices.resize(ColIndicesDataSize);
         IndexPartition<IndexType>(ColIndicesDataSize).for_each( 
             [&](IndexType i){rColIndices[i] = pColIndicesData[i];}
         );
-        delete [] pColIndicesData;
+        pColIndicesData.reset();
 
         return rRowIndices.size();
     }
@@ -243,8 +243,6 @@ public:
         Kratos::span<IndexType>& rColIndices
     ) const = delete;
 
-    //NOTE this function will transfer ownership of pRowIndicesData and pColIndicesData to the caller
-    //hence the caller will be in charge of deleting that array
     IndexType ExportCSRArrays(
         Kratos::unique_ptr<IndexType[]>& pRowIndicesData,
         IndexType& rRowDataSize,

--- a/kratos/containers/sparse_contiguous_row_graph.h
+++ b/kratos/containers/sparse_contiguous_row_graph.h
@@ -246,18 +246,18 @@ public:
     //NOTE this function will transfer ownership of pRowIndicesData and pColIndicesData to the caller
     //hence the caller will be in charge of deleting that array
     IndexType ExportCSRArrays(
-        IndexType*& pRowIndicesData,
+        Kratos::unique_ptr<IndexType[]>& pRowIndicesData,
         IndexType& rRowDataSize,
-        IndexType*& pColIndicesData,
+        Kratos::unique_ptr<IndexType[]>& pColIndicesData,
         IndexType& rColDataSize
     ) const
     {
         //need to detect the number of rows this way since there may be gaps
         IndexType nrows=Size();
 
-        pRowIndicesData = new IndexType[nrows+1];
+        pRowIndicesData = std::move(Kratos::unique_ptr<IndexType[]>(new IndexType[nrows+1]));
         rRowDataSize=nrows+1;
-        Kratos::span<IndexType> row_indices(pRowIndicesData, nrows+1);
+        Kratos::span<IndexType> row_indices(pRowIndicesData.get(), nrows+1);
 
         if(nrows == 0) //empty
         {
@@ -283,8 +283,8 @@ public:
 
         IndexType nnz = row_indices[nrows];
         rColDataSize=nnz;
-        pColIndicesData = new IndexType[nnz];
-        Kratos::span<IndexType> col_indices(pColIndicesData,nnz);
+        pColIndicesData = std::move(Kratos::unique_ptr<IndexType[]>(new IndexType[nnz]));
+        Kratos::span<IndexType> col_indices(pColIndicesData.get(),nnz);
 
         //set it to zero in parallel to allow first touching
         IndexPartition<IndexType>(col_indices.size()).for_each([&](IndexType i){

--- a/kratos/containers/sparse_graph.h
+++ b/kratos/containers/sparse_graph.h
@@ -223,8 +223,6 @@ public:
         Kratos::span<IndexType>& rColIndices
     ) const = delete;
 
-    //NOTE this function will transfer ownership of pRowIndicesData and pColIndicesData to the caller
-    //hence the caller will be in charge of deleting that array
     IndexType ExportCSRArrays(
         Kratos::unique_ptr<IndexType[]>& pRowIndicesData,
         IndexType& rRowDataSize,

--- a/kratos/containers/sparse_graph.h
+++ b/kratos/containers/sparse_graph.h
@@ -196,9 +196,9 @@ public:
         TVectorType& rColIndices
     ) const
     {
-        IndexType* pRowIndicesData=nullptr;
+        Kratos::unique_ptr<IndexType[]> pRowIndicesData;
         IndexType RowIndicesDataSize=0;
-        IndexType* pColIndicesData=nullptr;
+        Kratos::unique_ptr<IndexType[]> pColIndicesData;
         IndexType ColIndicesDataSize=0;
         ExportCSRArrays(pRowIndicesData,RowIndicesDataSize,pColIndicesData,ColIndicesDataSize);
         if(rRowIndices.size() != RowIndicesDataSize)
@@ -207,13 +207,13 @@ public:
             [&](IndexType i){rRowIndices[i] = pRowIndicesData[i];}
         );
         
-        delete [] pRowIndicesData;
+        pRowIndicesData.reset();
         if(rColIndices.size() != ColIndicesDataSize)
             rColIndices.resize(ColIndicesDataSize);
         IndexPartition<IndexType>(ColIndicesDataSize).for_each( 
             [&](IndexType i){rColIndices[i] = pColIndicesData[i];}
         );
-        delete [] pColIndicesData;
+        pColIndicesData.reset();
 
         return rRowIndices.size();
     }
@@ -226,18 +226,18 @@ public:
     //NOTE this function will transfer ownership of pRowIndicesData and pColIndicesData to the caller
     //hence the caller will be in charge of deleting that array
     IndexType ExportCSRArrays(
-        IndexType*& pRowIndicesData,
+        Kratos::unique_ptr<IndexType[]>& pRowIndicesData,
         IndexType& rRowDataSize,
-        IndexType*& pColIndicesData,
+        Kratos::unique_ptr<IndexType[]>& pColIndicesData,
         IndexType& rColDataSize
     ) const
     {
         //need to detect the number of rows this way since there may be gaps
         IndexType nrows=this->Size();
 
-        pRowIndicesData = new IndexType[nrows+1];
+        pRowIndicesData = std::move(Kratos::unique_ptr<IndexType[]>(new IndexType[nrows+1]));
         rRowDataSize = nrows+1;
-        Kratos::span<IndexType> row_indices(pRowIndicesData, nrows+1);
+        Kratos::span<IndexType> row_indices(pRowIndicesData.get(), nrows+1);
         
         //set it to zero in parallel to allow first touching
         IndexPartition<IndexType>(row_indices.size()).for_each([&](IndexType i){
@@ -258,8 +258,8 @@ public:
 
         IndexType nnz = row_indices[nrows];
         rColDataSize = nnz;
-        pColIndicesData = new IndexType[nnz];
-        Kratos::span<IndexType> col_indices(pColIndicesData, nnz);
+        pColIndicesData = std::move(Kratos::unique_ptr<IndexType[]>(new IndexType[nnz]));
+        Kratos::span<IndexType> col_indices(pColIndicesData.get(), nnz);
         
         //set it to zero in parallel to allow first touching
         IndexPartition<IndexType>(col_indices.size()).for_each([&](IndexType i){


### PR DESCRIPTION
**Description**
avoids explicit delte by using unique_ptr

Please mark the PR with appropriate tags: 

**Changelog**
avoids explicit delete in managing csr internals. note however that a hacky use of pointer release and reset must be made
