### PR TITLE
[Core] Move Array3Reduction to reduction utilities

### DIFF
--- a/kratos/utilities/reduction_utilities.h
+++ b/kratos/utilities/reduction_utilities.h
@@ -28,7 +28,34 @@
 
 namespace Kratos
 {
+
+/** @brief Helper class for null-initializiation
+ */
+template <class TObjectType>
+struct NullInitialized
+{
+    static TObjectType Get()
+    {
+        return TObjectType();
+    }
+};
+
+template <class TValueType, std::size_t ArraySize>
+struct NullInitialized<array_1d<TValueType,ArraySize>>
+{
+    static array_1d<TValueType,ArraySize> Get()
+    {
+        array_1d<TValueType,ArraySize> array;
+        std::fill_n(array.begin(), ArraySize, 0);
+        return array;
+    }
+};
+
 ///@addtogroup KratosCore
+
+//***********************************************************************************
+//***********************************************************************************
+//***********************************************************************************
 
 /** @brief utility function to do a sum reduction
  */
@@ -39,7 +66,7 @@ public:
     typedef TDataType   value_type;
     typedef TReturnType return_type;
 
-    TReturnType mValue = TReturnType(); // deliberately making the member value public, to allow one to change it as needed
+    TReturnType mValue = NullInitialized<TReturnType>::Get(); // deliberately making the member value public, to allow one to change it as needed
 
     /// access to reduced value
     TReturnType GetValue() const
@@ -69,7 +96,7 @@ public:
     typedef TDataType   value_type;
     typedef TReturnType return_type;
 
-    TReturnType mValue = TReturnType(); // deliberately making the member value public, to allow one to change it as needed
+    TReturnType mValue = NullInitialized<TReturnType>::Get(); // deliberately making the member value public, to allow one to change it as needed
 
     /// access to reduced value
     TReturnType GetValue() const

--- a/kratos/utilities/reduction_utilities.h
+++ b/kratos/utilities/reduction_utilities.h
@@ -29,6 +29,8 @@
 namespace Kratos
 {
 
+namespace Internals
+{
 /** @brief Helper class for null-initializiation
  */
 template <class TObjectType>
@@ -46,10 +48,11 @@ struct NullInitialized<array_1d<TValueType,ArraySize>>
     static array_1d<TValueType,ArraySize> Get()
     {
         array_1d<TValueType,ArraySize> array;
-        std::fill_n(array.begin(), ArraySize, 0);
+        std::fill_n(array.begin(), ArraySize, NullInitialized<TValueType>::Get());
         return array;
     }
 };
+} // namespace Internals
 
 ///@addtogroup KratosCore
 
@@ -66,7 +69,7 @@ public:
     typedef TDataType   value_type;
     typedef TReturnType return_type;
 
-    TReturnType mValue = NullInitialized<TReturnType>::Get(); // deliberately making the member value public, to allow one to change it as needed
+    TReturnType mValue = Internals::NullInitialized<TReturnType>::Get(); // deliberately making the member value public, to allow one to change it as needed
 
     /// access to reduced value
     TReturnType GetValue() const
@@ -96,7 +99,7 @@ public:
     typedef TDataType   value_type;
     typedef TReturnType return_type;
 
-    TReturnType mValue = NullInitialized<TReturnType>::Get(); // deliberately making the member value public, to allow one to change it as needed
+    TReturnType mValue = Internals::NullInitialized<TReturnType>::Get(); // deliberately making the member value public, to allow one to change it as needed
 
     /// access to reduced value
     TReturnType GetValue() const

--- a/kratos/utilities/variable_utils.cpp
+++ b/kratos/utilities/variable_utils.cpp
@@ -59,7 +59,7 @@ array_1d<double, 3> VariableUtils::SumNonHistoricalNodeVectorVariable(
     array_1d<double, 3> sum_value = ZeroVector(3);
     auto& r_comm = rModelPart.GetCommunicator();
 
-    sum_value = block_for_each<Array3Reduction>(r_comm.LocalMesh().Nodes(),[&](NodeType& rNode){
+    sum_value = block_for_each<SumReduction<array_1d<double,3>>>(r_comm.LocalMesh().Nodes(),[&](NodeType& rNode){
         return rNode.GetValue(rVar);
     });
 
@@ -81,7 +81,7 @@ array_1d<double, 3> VariableUtils::SumConditionVectorVariable(
     array_1d<double, 3> sum_value = ZeroVector(3);
     auto& r_comm = rModelPart.GetCommunicator();
 
-    sum_value = block_for_each<Array3Reduction>(r_comm.LocalMesh().Conditions(),[&](ConditionType& rCond){
+    sum_value = block_for_each<SumReduction<array_1d<double,3>>>(r_comm.LocalMesh().Conditions(),[&](ConditionType& rCond){
         return rCond.GetValue(rVar);
     });
 
@@ -103,7 +103,7 @@ array_1d<double, 3> VariableUtils::SumElementVectorVariable(
     array_1d<double, 3> sum_value = ZeroVector(3);
     auto& r_comm = rModelPart.GetCommunicator();
 
-    sum_value = block_for_each<Array3Reduction>(r_comm.LocalMesh().Elements(),[&](ElementType& rElem){
+    sum_value = block_for_each<SumReduction<array_1d<double,3>>>(r_comm.LocalMesh().Elements(),[&](ElementType& rElem){
         return rElem.GetValue(rVar);
     });
 

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -1177,9 +1177,7 @@ public:
 
         const auto &r_communicator = rModelPart.GetCommunicator();
 
-        using ReductionType = typename std::conditional< std::is_scalar<TDataType>::value , SumReduction<double> , SumReduction<array_1d<double,3>> >::type;
-
-        TDataType sum_value = block_for_each<ReductionType>(r_communicator.LocalMesh().Nodes(),[&](Node<3>& rNode){
+        TDataType sum_value = block_for_each<SumReduction<TDataType>>(r_communicator.LocalMesh().Nodes(),[&](Node<3>& rNode){
             return rNode.GetSolutionStepValue(rVariable, BuffStep);
         });
 

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -1177,7 +1177,7 @@ public:
 
         const auto &r_communicator = rModelPart.GetCommunicator();
 
-        using ReductionType = typename std::conditional< std::is_scalar<TDataType>::value , SumReduction<double> , Array3Reduction >::type;
+        using ReductionType = typename std::conditional< std::is_scalar<TDataType>::value , SumReduction<double> , SumReduction<array_1d<double,3>> >::type;
 
         TDataType sum_value = block_for_each<ReductionType>(r_communicator.LocalMesh().Nodes(),[&](Node<3>& rNode){
             return rNode.GetSolutionStepValue(rVariable, BuffStep);
@@ -1387,33 +1387,6 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
-
-    // TODO use SumReduction once it supports array3 (- Philipp)
-    class Array3Reduction
-    {
-    public:
-        typedef array_1d<double,3> value_type;
-        typedef array_1d<double,3> return_type;
-
-        return_type mValue = ZeroVector(3);
-
-        /// access to reduced value
-        return_type GetValue() const
-        {
-            return mValue;
-        }
-
-        void LocalReduce(const value_type& value)
-        {
-            mValue += value;
-        }
-
-        void ThreadSafeReduce(const Array3Reduction& rOther)
-        {
-            AtomicAdd(mValue, rOther.mValue);
-        }
-    };
-
 
     ///@}
     ///@name Private Operators


### PR DESCRIPTION
**Description**
Remove ```Array3Reduction``` from _variable_utils_ and add a ```NullInitialized``` class to _reduction_utils_ responsible for initializing objects in ```SumReduction``` and ```SubReduction```. Further specializations to this class can be added to handle the initialization of other types as needed.

Addresses #8577