### PR TITLE
[Trilinos] B&S - remove echo level in timers - unify with serial version

### DIFF
--- a/applications/TrilinosApplication/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
+++ b/applications/TrilinosApplication/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
@@ -372,13 +372,11 @@ public:
     {
         KRATOS_TRY
 
-        if (BaseType::GetEchoLevel() > 0)
-            START_TIMER("Build", 0)
+        START_TIMER("Build", 0)
 
         Build(pScheme, rModelPart, rA, rb);
 
-        if (BaseType::GetEchoLevel() > 0)
-            STOP_TIMER("Build", 0)
+        STOP_TIMER("Build", 0)
 
         // apply dirichlet conditions
         ApplyDirichletConditions(pScheme, rModelPart, rA, rDx, rb);
@@ -388,8 +386,7 @@ public:
             << "\nSystem Matrix = " << rA << "\nunknowns vector = " << rDx
             << "\nRHS vector = " << rb << std::endl;
 
-        if (BaseType::GetEchoLevel() > 0)
-            START_TIMER("System solve time ", 0)
+        START_TIMER("Solve", 0)
 
         BuiltinTimer solve_timer;
 
@@ -397,8 +394,7 @@ public:
 
         KRATOS_INFO_IF("TrilinosBlockBuilderAndSolver", BaseType::GetEchoLevel() >=1) << "System solve time: " << solve_timer.ElapsedSeconds() << std::endl;
 
-        if (BaseType::GetEchoLevel() > 0)
-            STOP_TIMER("System solve time ", 0)
+        STOP_TIMER("Solve", 0)
 
         KRATOS_INFO_IF("TrilinosBlockBuilderAndSolver", BaseType::GetEchoLevel() == 3)
             << "\nAfter the solution of the system"
@@ -447,9 +443,8 @@ public:
                   TSystemVectorType& rb) override
     {
         KRATOS_TRY
-        if (BaseType::GetEchoLevel() > 0) {
-            START_TIMER("BuildRHS ", 0)
-        }
+        
+        START_TIMER("BuildRHS ", 0)
         // Resetting to zero the vector of reactions
         TSparseSpace::SetToZero(*BaseType::mpReactionsVector);
 
@@ -486,9 +481,8 @@ public:
         // finalizing the assembly
         rb.GlobalAssemble();
 
-        if (BaseType::GetEchoLevel() > 0) {
-            STOP_TIMER("BuildRHS ", 0)
-        }
+        STOP_TIMER("BuildRHS ", 0)
+        
         KRATOS_CATCH("")
     }
 


### PR DESCRIPTION
The point is to unify timers print in serial Builder and Solver and in trilinos one.

https://github.com/KratosMultiphysics/Kratos/blob/f15ad6a44f9d2897ca920310041725bf79dfe90a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h#L518

I think that if you add the timer process you want to see these results, independently of the echo level, thats why I removed the if condition.

Also, label for "Solve" is now the same for both B&S.

FYI @jrubiogonzalez 