### PR TITLE
[Core][VTKOutput] fix race condition in folder creation

### DIFF
--- a/kratos/input_output/vtk_output.cpp
+++ b/kratos/input_output/vtk_output.cpp
@@ -232,9 +232,13 @@ std::string VtkOutput::GetOutputFileName(const ModelPart& rModelPart, const bool
         const std::string output_path = mOutputSettings["output_path"].GetString();
 
         // create folder if it doesn't exist before
-        if (!Kratos::filesystem::is_directory(output_path)) {
+        if (!Kratos::filesystem::is_directory(output_path) && rModelPart.GetCommunicator().MyPID() == 0) {
             Kratos::filesystem::create_directories(output_path);
         }
+
+        // all ranks must wait until the folder is created otherwise writing might fail
+        // if some ranks are faster and try to create files in a not-yet existing folder
+        rModelPart.GetCommunicator().GetDataCommunicator().Barrier();
 
         output_file_name = Kratos::FilesystemExtensions::JoinPaths({output_path, output_file_name});
     }

--- a/kratos/input_output/vtk_output.cpp
+++ b/kratos/input_output/vtk_output.cpp
@@ -231,12 +231,12 @@ std::string VtkOutput::GetOutputFileName(const ModelPart& rModelPart, const bool
     if (mOutputSettings["save_output_files_in_folder"].GetBool()) {
         const std::string output_path = mOutputSettings["output_path"].GetString();
 
-        // create folder if it doesn't exist before
+        // Create folder if it doesn't exist before
         if (!Kratos::filesystem::is_directory(output_path) && rModelPart.GetCommunicator().MyPID() == 0) {
             Kratos::filesystem::create_directories(output_path);
         }
 
-        // all ranks must wait until the folder is created otherwise writing might fail
+        // All ranks must wait until the folder is created otherwise writing might fail
         // if some ranks are faster and try to create files in a not-yet existing folder
         rModelPart.GetCommunicator().GetDataCommunicator().Barrier();
 


### PR DESCRIPTION
**Description**
Currently all ranks try to create the folder for the output files. This can crash in MPI, I am actually surprised none had this problem yet