### PR TITLE
[Structural][ConstitutiveLaws] Use InitialState for strain in SmallStrainIsotropicDamage - 2nd try

### DIFF
--- a/applications/ConstitutiveLawsApplication/custom_constitutive/small_strain_isotropic_damage_3d.cpp
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/small_strain_isotropic_damage_3d.cpp
@@ -54,12 +54,12 @@ SmallStrainIsotropicDamage3D::~SmallStrainIsotropicDamage3D()
 bool SmallStrainIsotropicDamage3D::Has(const Variable<double>& rThisVariable)
 {
     if(rThisVariable == STRAIN_ENERGY){
-        // explicitly returning "false", so we know we must call CalculateValue(...)
+        // explicitly returning "false", so the element calls CalculateValue(...)
         return false;
-    }
-    if(rThisVariable == DAMAGE_VARIABLE){
-        // explicitly returning "false", so we know we must call CalculateValue(...)
+    } else if(rThisVariable == DAMAGE_VARIABLE){
+        // explicitly returning "false", so the element calls CalculateValue(...)
         return false;
+
     }
 
     return false;
@@ -72,6 +72,9 @@ bool SmallStrainIsotropicDamage3D::Has(const Variable<Vector>& rThisVariable)
 {
     if(rThisVariable == INTERNAL_VARIABLES){
         return true;
+    } else if(rThisVariable == STRAIN){
+        // explicitly returning "false", so the element calls CalculateValue(...)
+        return false;
     }
 
     return false;
@@ -124,59 +127,49 @@ void SmallStrainIsotropicDamage3D::InitializeMaterial(
 //************************************************************************************
 //************************************************************************************
 
-void SmallStrainIsotropicDamage3D::InitializeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues)
-{
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void SmallStrainIsotropicDamage3D::FinalizeMaterialResponseCauchy(Parameters& rValues)
+void SmallStrainIsotropicDamage3D::FinalizeMaterialResponseCauchy(
+    ConstitutiveLaw::Parameters& rParametersValues)
 {
     Vector internal_variables(1);
-    this->CalculateStressResponse(rValues, internal_variables);
+    this->CalculateStressResponse(rParametersValues, internal_variables);
     mStrainVariable = internal_variables[0];
 }
 
 //************************************************************************************
 //************************************************************************************
 
-void SmallStrainIsotropicDamage3D::CalculateMaterialResponsePK2(Parameters& rValues)
+void SmallStrainIsotropicDamage3D::CalculateMaterialResponsePK2(
+    ConstitutiveLaw::Parameters& rParametersValues)
 {
     Vector internal_variables(1);
-    this->CalculateStressResponse(rValues, internal_variables);
+    CalculateStressResponse(rParametersValues, internal_variables);
 }
 
 //************************************************************************************
 //************************************************************************************
 
 void SmallStrainIsotropicDamage3D::CalculateStressResponse(
-        Parameters &rValues,
-        Vector& rInternalVariables)
+    ConstitutiveLaw::Parameters& rParametersValues,
+    Vector& rInternalVariables)
 {
     double strain_variable = mStrainVariable;
-    const Properties& rMaterialProperties = rValues.GetMaterialProperties();
-    Flags & r_constitutive_law_options = rValues.GetOptions();
-    Vector& r_strain_vector = rValues.GetStrainVector();
-    if (rValues.GetProcessInfo().Has(INITIAL_STRAIN)) {
-        noalias(r_strain_vector) += rValues.GetProcessInfo()[INITIAL_STRAIN];
-    }
-
-    if( r_constitutive_law_options.IsNot( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
-        //this->CalculateValue(rValues, STRAIN, r_strain_vector);
-    }
+    const Properties& r_material_properties = rParametersValues.GetMaterialProperties();
+    Flags& r_constitutive_law_options = rParametersValues.GetOptions();
+    Vector& r_strain_vector = rParametersValues.GetStrainVector();
+    CalculateValue(rParametersValues, STRAIN, r_strain_vector);
 
     // If we compute the tangent moduli or the stress
     if( r_constitutive_law_options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ||
         r_constitutive_law_options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR )) {
-        Vector& r_stress_vector = rValues.GetStressVector();
-        Matrix& r_constitutive_matrix = rValues.GetConstitutiveMatrix();
-        CalculateElasticMatrix(r_constitutive_matrix, rValues);
+        Vector& r_stress_vector = rParametersValues.GetStressVector();
+        Matrix& r_constitutive_matrix = rParametersValues.GetConstitutiveMatrix();
+        CalculateElasticMatrix(r_constitutive_matrix, rParametersValues);
         noalias(r_stress_vector) = prod(r_constitutive_matrix, r_strain_vector);
 
-        // Auxiliary stress vector to allow derived models (e.g. traction-only damage) to set
-        // a different value of r_stress_vector_pos with ComputePositiveStressVector function
-        // In the symmetric model, ComputePositiveStressVector does not do anything.
+        // Auxiliary stress vector to allow derived models (e.g. traction-only damage)
+        // to set the value of r_stress_vector_pos with the ComputePositiveStressVector
+        // function.
+        // In the symmetric model, ComputePositiveStressVector does nothing.
         Vector r_stress_vector_pos = r_stress_vector;
         ComputePositiveStressVector(r_stress_vector_pos, r_stress_vector);
 
@@ -187,7 +180,7 @@ void SmallStrainIsotropicDamage3D::CalculateStressResponse(
         {
             // ELASTIC
             strain_variable = mStrainVariable;
-            const double stress_variable = EvaluateHardeningLaw(strain_variable, rMaterialProperties);
+            const double stress_variable = EvaluateHardeningLaw(strain_variable, r_material_properties);
             const double damage_variable = 1. - stress_variable / strain_variable;
             r_constitutive_matrix *= (1 - damage_variable);
             r_stress_vector *= (1 - damage_variable);
@@ -196,9 +189,9 @@ void SmallStrainIsotropicDamage3D::CalculateStressResponse(
         {
             // INELASTIC
             strain_variable = strain_norm;
-            const double stress_variable = EvaluateHardeningLaw(strain_variable, rMaterialProperties);
+            const double stress_variable = EvaluateHardeningLaw(strain_variable, r_material_properties);
             const double damage_variable = 1. - stress_variable / strain_variable;
-            const double hardening_modulus = EvaluateHardeningModulus(strain_variable, rMaterialProperties);
+            const double hardening_modulus = EvaluateHardeningModulus(strain_variable, r_material_properties);
             const double damage_rate = (stress_variable - hardening_modulus * strain_variable)
                                        / (strain_variable * strain_variable * strain_variable);
             r_constitutive_matrix *= (1. - damage_variable);
@@ -216,6 +209,7 @@ void SmallStrainIsotropicDamage3D::CalculateStressResponse(
 void SmallStrainIsotropicDamage3D::ComputePositiveStressVector(
             Vector& rStressVectorPos, Vector& rStressVector)
 {
+    // explicit pass for the symmetric model
 }
 
 //************************************************************************************
@@ -237,7 +231,7 @@ double SmallStrainIsotropicDamage3D::EvaluateHardeningModulus(
     const double q1 = inf_yield_stress / std::sqrt(young_modulus);  // stress_variable_inf
     const double r1 = r0 + (q1 - q0) / H0;
 
-     if (r < r0)
+    if (r < r0)
         return 0.;
     if (r >= r0 && r < r1)
         return H0;
@@ -249,8 +243,8 @@ double SmallStrainIsotropicDamage3D::EvaluateHardeningModulus(
 //************************************************************************************
 
 double SmallStrainIsotropicDamage3D::EvaluateHardeningLaw(
-        double r,
-        const Properties &rMaterialProperties)
+    double r,
+    const Properties &rMaterialProperties)
 {
     const double yield_stress = rMaterialProperties[YIELD_STRESS];
     const double inf_yield_stress = rMaterialProperties[INFINITY_YIELD_STRESS];
@@ -275,33 +269,52 @@ double SmallStrainIsotropicDamage3D::EvaluateHardeningLaw(
 //************************************************************************************
 
 double& SmallStrainIsotropicDamage3D::CalculateValue(
-    Parameters& rValues,
+    ConstitutiveLaw::Parameters& rParametersValues,
     const Variable<double>& rThisVariable,
     double& rValue
     )
 {
     if (rThisVariable == STRAIN_ENERGY){
-        Vector& r_strain_vector = rValues.GetStrainVector();
-        if (rValues.GetProcessInfo().Has(INITIAL_STRAIN)) {
-            noalias(r_strain_vector) += rValues.GetProcessInfo()[INITIAL_STRAIN];
-        }
-        const Properties& rMaterialProperties = rValues.GetMaterialProperties();
+        Vector& r_strain_vector = rParametersValues.GetStrainVector();
+        this->CalculateValue(rParametersValues, STRAIN, r_strain_vector);
+        const Properties& r_material_properties = rParametersValues.GetMaterialProperties();
         Matrix constitutive_matrix;
-        CalculateElasticMatrix(constitutive_matrix, rValues);
-        const double stress_like_variable = EvaluateHardeningLaw(mStrainVariable, rMaterialProperties);
+        CalculateElasticMatrix(constitutive_matrix, rParametersValues);
+        const double stress_like_variable = EvaluateHardeningLaw(
+                                                mStrainVariable,
+                                                r_material_properties);
         const double damage_variable = 1. - stress_like_variable / mStrainVariable;
 
         rValue = 0.5 * ((1. - damage_variable) * inner_prod(r_strain_vector,
-                                              prod(constitutive_matrix, r_strain_vector)));
-    }
+                                        prod(constitutive_matrix, r_strain_vector)));
 
-    if (rThisVariable == DAMAGE_VARIABLE){
-        const Properties& rMaterialProperties = rValues.GetMaterialProperties();
-        const double stress_like_variable = EvaluateHardeningLaw(mStrainVariable, rMaterialProperties);
+    } else if (rThisVariable == DAMAGE_VARIABLE){
+        const Properties& r_material_properties = rParametersValues.GetMaterialProperties();
+        const double stress_like_variable = EvaluateHardeningLaw(
+                                                mStrainVariable,
+                                                r_material_properties);
 
         rValue = 1. - stress_like_variable / mStrainVariable;
+
+    } else {
+        ElasticIsotropic3D::CalculateValue(rParametersValues, rThisVariable, rValue);
+
     }
 
+    return(rValue);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+Vector& SmallStrainIsotropicDamage3D::CalculateValue(
+    ConstitutiveLaw::Parameters& rParametersValues,
+    const Variable<Vector>& rThisVariable,
+    Vector& rValue
+    )
+{
+    //Explicitly having STRAIN and INITAL_STRAIN_VECTOR calculated in base class
+    ElasticIsotropic3D::CalculateValue(rParametersValues, rThisVariable, rValue);
     return(rValue);
 }
 

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/small_strain_isotropic_damage_3d.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/small_strain_isotropic_damage_3d.h
@@ -56,7 +56,6 @@ namespace Kratos
  */
 class KRATOS_API(CONSTITUTIVE_LAWS_APPLICATION) SmallStrainIsotropicDamage3D
     : public ElasticIsotropic3D
-
 {
 public:
 
@@ -66,7 +65,7 @@ public:
     typedef ConstitutiveLaw BaseType;
     typedef std::size_t SizeType;
 
-    // Counted pointer of LinearIsotropicDamage3DLaw
+    // Counted pointer
     KRATOS_CLASS_POINTER_DEFINITION(SmallStrainIsotropicDamage3D);
 
     ///@}
@@ -79,12 +78,12 @@ public:
     SmallStrainIsotropicDamage3D();
 
     /**
-     * @brief Default constructor.
+     * @brief Copy constructor.
      */
     SmallStrainIsotropicDamage3D(const SmallStrainIsotropicDamage3D& rOther);
 
     /**
-     * @brief Default constructor.
+     * @brief Destructor.
      */
     ~SmallStrainIsotropicDamage3D() override;
 
@@ -116,13 +115,13 @@ public:
     bool Has(const Variable<double>& rThisVariable) override;
 
     /**
-     * @brief Returns whether this constitutive Law has specified variable (double)
+     * @brief Returns whether this constitutive Law has specified variable (Vector)
      * @param rThisVariable the variable to be checked for
      * @return true if the variable is defined in the constitutive law
      */
     bool Has(const Variable<Vector>& rThisVariable) override;
 
-     /**
+    /**
      * @brief Returns the value of a specified variable (Vector)
      * @param rThisVariable the variable to be returned
      * @param rValue a reference to the returned value
@@ -133,10 +132,10 @@ public:
         Vector& rValue
         ) override;
 
-     /**
-     * @brief Returns the value of a specified variable (Vector)
-     * @param rThisVariable the variable requested
-     * @param rValue new value of the specified variable
+    /**
+     * @brief Sets the value of a specified variable (Vector)
+     * @param rThisVariable The variable to be returned
+     * @param rValue New value of the specified variable
      * @param rCurrentProcessInfo the process info
      */
     void SetValue(
@@ -157,7 +156,15 @@ public:
                             const Vector& rShapeFunctionsValues) override;
 
     /**
-     * @brief Computes the material response in terms of 2nd Piola-Kirchhoff stresses and constitutive tensor
+     * @brief This method computes the stress and constitutive tensor
+     * @param rValues The norm of the deviation stress
+     * @param rStrainVariable
+     */
+    void CalculateStressResponse(ConstitutiveLaw::Parameters& rValues,
+                                 Vector& rInternalVariables) override;
+
+    /**
+     * @brief Computes the material response in terms of 2nd Piola-Kirchhoff stress
      * @param rValues The specific parameters of the current constitutive law
      * @see Parameters
      */
@@ -165,7 +172,7 @@ public:
 
     /**
      * @brief Indicates if this CL requires initialization of the material response,
-     * called by the element in InitializeSolutionStep.
+     * called by the element in InitializeMaterialResponse.
      */
     bool RequiresInitializeMaterialResponse() override
     {
@@ -173,16 +180,8 @@ public:
     }
 
     /**
-     * @brief Initialize the material response in terms of Cauchy stresses
-     * @param rValues The specific parameters of the current constitutive law
-     * @see Parameters
-     */
-    void InitializeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues) override;
-
-    /**
-     * @brief Indicates if this CL requires finalization step the material
-     * response (e.g. update of the internal variables), called by the element
-     * in FinalizeSolutionStep.
+     * @brief Indicates if this CL requires finalization of the material response,
+     * called by the element in FinalizeMaterialResponse.
      */
     bool RequiresFinalizeMaterialResponse() override
     {
@@ -197,7 +196,7 @@ public:
     void FinalizeMaterialResponseCauchy(Parameters& rValues) override;
 
     /**
-     * @brief calculates the value of a specified variable
+     * @brief calculates the value of a specified variable (double)
      * @param rValues the needed parameters for the CL calculation
      * @param rThisVariable the variable to be returned
      * @param rValue a reference to the returned value
@@ -206,6 +205,17 @@ public:
     double& CalculateValue(Parameters& rValues,
                            const Variable<double>& rThisVariable,
                            double& rValue) override;
+
+    /**
+     * @brief calculates the value of a specified variable (Vector)
+     * @param rValues the needed parameters for the CL calculation
+     * @param rThisVariable the variable to be returned
+     * @param rValue a reference to the returned value
+     * @return rValue output: the value of the specified variable
+     */
+     Vector& CalculateValue(Parameters& rValues,
+                            const Variable<Vector>& rThisVariable,
+                            Vector& rValue) override;
 
     /**
      * @brief This function provides the place to perform checks on the completeness of the input.
@@ -232,13 +242,6 @@ public:
     void PrintData(std::ostream& rOStream) const override {
         rOStream << "Small Strain Isotropic Damage 3D constitutive law\n";
     };
-
-    /**
-     * @brief This method computes the stress and constitutive tensor
-     * @param rValues The norm of the deviation stress
-     * @param rStrainVariable
-     */
-    void CalculateStressResponse(ConstitutiveLaw::Parameters& rValues, Vector& rInternalVariables) override;
 
 protected:
 
@@ -322,6 +325,6 @@ private:
 
     void load(Serializer& rSerializer) override;
 
-}; // class LinearIsotropicDamage3DLaw
+}; // class SmallStrainIsotropicDamage3D
 } // namespace Kratos
 #endif


### PR DESCRIPTION
(2nd try, I messed up previous PR. Comments from previous attempt copied below.)

**Description**                                                                         
 Add usage of InitialState for strain to SmallStrainIsotropicDamage3D.                   
                                                                                          
 **Changelog**                                                                           
 - ElasticIsotropic3D: Add CalculateValue(INITIAL_STRAIN_VECTOR)                         
 - ElasticIsotropic3D: Compute STRAIN via CalculateMaterialResponsePK2                   
 - SmallStrainIsotropicDamage3D: Add AddInitialStrainContibution to CalculateMaterialResponse
  - SmallStrainIsotropicDamage3D: Compute STRAIN and INITIAL_STRAIN_VECTOR via ElasticIsotropic3D
  - SmallStrainIsotropicDamage3D: Add other stress measures to FinalizeMaterialResponse and CalculateMa    terialResponse
  - Fix doc strings                                                                       
  - Minor: rename of variables, enhancement of the comments, code format

