### PR TITLE
[Core] improve neighbor processes

### DIFF
--- a/kratos/processes/find_global_nodal_elemental_neighbours_process.h
+++ b/kratos/processes/find_global_nodal_elemental_neighbours_process.h
@@ -81,9 +81,16 @@ public:
 
     /// Default constructor.
     /// the better the guess for the quantities above the less memory occupied and the fastest the algorithm
-    FindGlobalNodalElementalNeighboursProcess(const DataCommunicator& rComm, 
+    FindGlobalNodalElementalNeighboursProcess(ModelPart& model_part)
+        : mr_model_part(model_part),
+          mrComm(model_part.GetCommunicator().GetDataCommunicator())
+    {
+    }
+
+    KRATOS_DEPRECATED_MESSAGE("Use of DataCommunicator is deprecated. Please use constructor without it.")
+    FindGlobalNodalElementalNeighboursProcess(const DataCommunicator& rComm,
                                               ModelPart& model_part)
-        : mrComm(rComm),mr_model_part(model_part)
+        : FindGlobalNodalElementalNeighboursProcess(model_part)
     {
     }
 
@@ -199,8 +206,8 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
-    const DataCommunicator& mrComm;
     ModelPart& mr_model_part;
+    const DataCommunicator& mrComm;
     unsigned int mavg_nodes;
 
 
@@ -269,6 +276,6 @@ inline std::ostream& operator << (std::ostream& rOStream,
 
 }  // namespace Kratos.
 
-#endif // KRATOS_FIND_GLOBAL_NODAL_ELEMENTAL_NEIGHBOURS_PROCESS_H_INCLUDED  defined 
+#endif // KRATOS_FIND_GLOBAL_NODAL_ELEMENTAL_NEIGHBOURS_PROCESS_H_INCLUDED  defined
 
 

--- a/kratos/processes/find_global_nodal_neighbours_for_entities_process.h
+++ b/kratos/processes/find_global_nodal_neighbours_for_entities_process.h
@@ -55,12 +55,20 @@ public:
 
     /// Constructor
     FindNodalNeighboursForEntitiesProcess(
-        const DataCommunicator& rDataCommunicator,
         ModelPart& rModelPart,
         const Variable<GlobalPointersVector<NodeType>>& rOutputVariable)
         : mrModelPart(rModelPart),
-          mrDataCommunicator(rDataCommunicator),
+          mrDataCommunicator(rModelPart.GetCommunicator().GetDataCommunicator()),
           mrOutputVariable(rOutputVariable)
+    {
+    }
+
+    KRATOS_DEPRECATED_MESSAGE("Use of DataCommunicator is deprecated. Please use constructor without it.")
+    FindNodalNeighboursForEntitiesProcess(
+        const DataCommunicator& rDataCommunicator,
+        ModelPart& rModelPart,
+        const Variable<GlobalPointersVector<NodeType>>& rOutputVariable)
+        : FindNodalNeighboursForEntitiesProcess(rModelPart, rOutputVariable)
     {
     }
 

--- a/kratos/processes/find_global_nodal_neighbours_process.h
+++ b/kratos/processes/find_global_nodal_neighbours_process.h
@@ -52,6 +52,12 @@ public:
     ///@{
 
     /// Default constructor.
+    FindGlobalNodalNeighboursProcess(
+        ModelPart& rModelPart)
+        : BaseType(rModelPart, NEIGHBOUR_NODES)
+    {
+    }
+
     /// avg_elems ------ expected number of neighbour elements per node.,
     /// avg_nodes ------ expected number of neighbour Nodes
     /// the better the guess for the quantities above the less memory occupied and the fastest the algorithm
@@ -61,14 +67,15 @@ public:
         const DataCommunicator& rDataCommunicator,
         ModelPart& rModelPart,
         unsigned int avg_nodes)
-        : BaseType(rDataCommunicator, rModelPart, NEIGHBOUR_NODES)
+        : FindGlobalNodalNeighboursProcess(rModelPart)
     {
     }
 
+    KRATOS_DEPRECATED_MESSAGE("Use of DataCommunicator is deprecated. Please use constructor without it.")
     FindGlobalNodalNeighboursProcess(
         const DataCommunicator& rDataCommunicator,
         ModelPart& rModelPart)
-        : BaseType(rDataCommunicator, rModelPart, NEIGHBOUR_NODES)
+        : FindGlobalNodalNeighboursProcess(rModelPart)
     {
     }
 

--- a/kratos/processes/find_nodal_neighbours_process.cpp
+++ b/kratos/processes/find_nodal_neighbours_process.cpp
@@ -21,16 +21,15 @@
 namespace Kratos
 {
 
-FindNodalNeighboursProcess::FindNodalNeighboursProcess(ModelPart& rModelPart) 
+FindNodalNeighboursProcess::FindNodalNeighboursProcess(ModelPart& rModelPart)
     : mrModelPart(rModelPart)
 {
-    auto& r_comm = mrModelPart.GetCommunicator().GetDataCommunicator();
-    mpNodeNeighboursCalculator = Kratos::make_unique<FindGlobalNodalNeighboursProcess>(r_comm, mrModelPart);
-    mpElemNeighboursCalculator = Kratos::make_unique<FindGlobalNodalElementalNeighboursProcess>(r_comm, mrModelPart);
+    mpNodeNeighboursCalculator = Kratos::make_unique<FindGlobalNodalNeighboursProcess>(mrModelPart);
+    mpElemNeighboursCalculator = Kratos::make_unique<FindGlobalNodalElementalNeighboursProcess>(mrModelPart);
 
-    KRATOS_INFO("FindNodalNeighboursProcess") << 
-        R"(please call separetely FindGlobalNodalNeighboursProcess 
-        and FindGlobalNodalElementalNeighboursProcess. 
+    KRATOS_INFO("FindNodalNeighboursProcess") <<
+        R"(please call separetely FindGlobalNodalNeighboursProcess
+        and FindGlobalNodalElementalNeighboursProcess.
         The two calculations are currently independent,
             hence memory savings can be achieved)" << std::endl;
 }
@@ -39,8 +38,8 @@ FindNodalNeighboursProcess::FindNodalNeighboursProcess(ModelPart& rModelPart)
 /***********************************************************************************/
 
 FindNodalNeighboursProcess::FindNodalNeighboursProcess(
-    ModelPart& rModelPart, 
-    const SizeType AverageElements, 
+    ModelPart& rModelPart,
+    const SizeType AverageElements,
     const SizeType AverageNodes
     ) : FindNodalNeighboursProcess(rModelPart)
 {
@@ -64,7 +63,7 @@ void FindNodalNeighboursProcess::ClearNeighbours()
     mpNodeNeighboursCalculator->ClearNeighbours();
     mpElemNeighboursCalculator->ClearNeighbours();
 }
-  
+
 }  // namespace Kratos.
 
 

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -150,7 +150,13 @@ void  AddProcessesToPython(pybind11::module& m)
 
     py::class_<FindGlobalNodalNeighboursProcess, FindGlobalNodalNeighboursProcess::Pointer, Process>
         (m,"FindGlobalNodalNeighboursProcess")
-            .def(py::init<const DataCommunicator&, ModelPart&>())
+    .def(py::init([](const DataCommunicator& rDataComm, ModelPart& rModelPart) {
+        KRATOS_WARNING("FindGlobalNodalNeighboursProcess") << "Using deprecated constructor. Please use constructor without DataCommunicator.";
+        return Kratos::make_shared<FindGlobalNodalNeighboursProcess>(rModelPart);
+    }))
+    .def(py::init([](ModelPart& rModelPart) {
+        return Kratos::make_shared<FindGlobalNodalNeighboursProcess>(rModelPart);
+    }))
     .def("ClearNeighbours",&FindGlobalNodalNeighboursProcess::ClearNeighbours)
     .def("GetNeighbourIds",&FindGlobalNodalNeighboursProcess::GetNeighbourIds)
     ;
@@ -159,7 +165,11 @@ void  AddProcessesToPython(pybind11::module& m)
     py::class_<FindGlobalNodalNeighboursForConditionsProcess, FindGlobalNodalNeighboursForConditionsProcess::Pointer, Process>
         (m,"FindGlobalNodalNeighboursForConditionsProcess")
     .def(py::init([](const DataCommunicator& rDataComm, ModelPart& rModelPart) {
-        return std::unique_ptr<FindGlobalNodalNeighboursForConditionsProcess>(new FindGlobalNodalNeighboursForConditionsProcess(rDataComm, rModelPart, NEIGHBOUR_CONDITION_NODES));
+        KRATOS_WARNING("FindGlobalNodalNeighboursForConditionsProcess") << "Using deprecated constructor. Please use constructor without DataCommunicator.";
+        return Kratos::make_shared<FindGlobalNodalNeighboursForConditionsProcess>(rModelPart, NEIGHBOUR_CONDITION_NODES);
+    }))
+    .def(py::init([](ModelPart& rModelPart) {
+        return Kratos::make_shared<FindGlobalNodalNeighboursForConditionsProcess>(rModelPart, NEIGHBOUR_CONDITION_NODES);
     }))
     .def("ClearNeighbours",&FindGlobalNodalNeighboursForConditionsProcess::ClearNeighbours)
     .def("GetNeighbourIds",&FindGlobalNodalNeighboursForConditionsProcess::GetNeighbourIds)
@@ -167,7 +177,13 @@ void  AddProcessesToPython(pybind11::module& m)
 
     py::class_<FindGlobalNodalElementalNeighboursProcess, FindGlobalNodalElementalNeighboursProcess::Pointer, Process>
         (m,"FindGlobalNodalElementalNeighboursProcess")
-            .def(py::init<const DataCommunicator&, ModelPart&>())
+    .def(py::init([](const DataCommunicator& rDataComm, ModelPart& rModelPart) {
+        KRATOS_WARNING("FindGlobalNodalElementalNeighboursProcess") << "Using deprecated constructor. Please use constructor without DataCommunicator.";
+        return Kratos::make_shared<FindGlobalNodalElementalNeighboursProcess>(rModelPart);
+    }))
+    .def(py::init([](ModelPart& rModelPart) {
+        return Kratos::make_shared<FindGlobalNodalElementalNeighboursProcess>(rModelPart);
+    }))
     .def("ClearNeighbours",&FindGlobalNodalElementalNeighboursProcess::ClearNeighbours)
     .def("GetNeighbourIds",&FindGlobalNodalElementalNeighboursProcess::GetNeighbourIds)
     ;


### PR DESCRIPTION
**Description**
I noticed that the neighbor computation processes require to pass a `DataCommunicator` even thought they also get a `ModelPart`
This can lead to misusages of the Default Data Communicator

IMO these processes should use the `DataCommunicator` of the `ModelPart` (which as you can see from the changes was even done in some cases)

Hence I am changing the interface to no longer require to pass the DataComm but instead use the one of the ModelPart

The changes are done backward compatible with deprecation warnings