### PR TITLE
[Structural][EigenPost] improve ordering in Paraview

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_processes/postprocess_eigenvalues_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/postprocess_eigenvalues_process.cpp
@@ -7,10 +7,12 @@
 //  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
-//  Main authors:    Philipp Bucher
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
 //
 
 // System includes
+#include <cmath>
+#include <iomanip>
 
 // External includes
 
@@ -190,7 +192,7 @@ void PostprocessEigenvaluesProcess::ExecuteFinalizeSolutionStep()
         const double cos_angle = std::cos(2 * Globals::Pi * i / num_animation_steps);
 
         for (SizeType j=0; j<num_eigenvalues; ++j) {
-            const std::string label = GetLabel(j, eigenvalue_vector[j]);
+            const std::string label = GetLabel(j, num_eigenvalues, eigenvalue_vector[j]);
 
             #pragma omp parallel for
             for (int k=0; k<static_cast<int>(mrModelPart.NumberOfNodes()); ++k) {
@@ -241,12 +243,13 @@ void PostprocessEigenvaluesProcess::GetVariables(std::vector<Variable<double>>& 
 }
 
 std::string PostprocessEigenvaluesProcess::GetLabel(const int NumberOfEigenvalue,
+                                                    const int NumberOfEigenvalues,
                                                     const double EigenvalueSolution) const
 {
     double label_number;
 
     std::stringstream parser;
-    parser << (NumberOfEigenvalue + 1);
+    parser << std::setfill('0') << std::setw(std::floor(std::log10(NumberOfEigenvalues))+1) << (NumberOfEigenvalue + 1);
     std::string label = parser.str();
 
     const std::string lable_type = mOutputParameters["label_type"].GetString();

--- a/applications/StructuralMechanicsApplication/custom_processes/postprocess_eigenvalues_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/postprocess_eigenvalues_process.h
@@ -7,7 +7,7 @@
 //  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
-//  Main authors:    Philipp Bucher
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
 //
 
 #if !defined(KRATOS_POSTPROCESS_EIGENVALUES_H_INCLUDED )
@@ -97,6 +97,7 @@ private:
     ///@{
 
     std::string GetLabel(const int NumberOfEigenValue,
+                         const int NumberOfEigenvalues,
                          const double EigenValueSolution) const;
 
     void GetVariables(std::vector<Variable<double>>& rRequestedDoubleResults,


### PR DESCRIPTION
**Description**
This PR improves the ordering of the EigenValues in Paraview (it uses lexicographic order), see the following pics

<img src="https://user-images.githubusercontent.com/25484702/114171081-15525b00-9934-11eb-86e4-1a08178e057d.jpeg" width="400">

<img src="https://user-images.githubusercontent.com/25484702/114171042-08ce0280-9934-11eb-8ecc-d24f018fb014.jpeg" width="400">