### PR TITLE
[Core] deprecate access to default DataCommunicator

### DIFF
--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -637,6 +637,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     /// Convenience function to retireve the current default DataCommunicator.
     /** @return A reference to the DataCommunicator instance registered as default in ParallelEnvironment.
      */
+    KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator through the ModelPart or by name")
     static DataCommunicator& GetDefault();
 
     ///@}

--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -637,7 +637,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     /// Convenience function to retireve the current default DataCommunicator.
     /** @return A reference to the DataCommunicator instance registered as default in ParallelEnvironment.
      */
-    KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator through the ModelPart or by name")
+    KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator through the ModelPart (or by name in special cases)")
     static DataCommunicator& GetDefault();
 
     ///@}

--- a/kratos/python/add_data_communicator_to_python.cpp
+++ b/kratos/python/add_data_communicator_to_python.cpp
@@ -137,7 +137,7 @@ void AddDataCommunicatorToPython(pybind11::module &m)
     .def("IsDefinedOnThisRank", &DataCommunicator::IsDefinedOnThisRank)
     .def("IsNullOnThisRank", &DataCommunicator::IsNullOnThisRank)
     .def_static("GetDefault", []() -> DataCommunicator& {
-        KRATOS_WARNING("DataCommunicator") << "This function is deprecated, please retrieve the DataCommunicator through the ModelPart or by name" << std::endl;
+        KRATOS_WARNING("DataCommunicator") << "This function is deprecated, please retrieve the DataCommunicator through the ModelPart (or by name in special cases)" << std::endl;
         return ParallelEnvironment::GetDefaultDataCommunicator();
     }, py::return_value_policy::reference)
     .def("__str__", PrintObject<DataCommunicator>);

--- a/kratos/python/add_data_communicator_to_python.cpp
+++ b/kratos/python/add_data_communicator_to_python.cpp
@@ -19,6 +19,7 @@
 #include "add_data_communicator_to_python.h"
 #include "includes/define_python.h"
 #include "includes/data_communicator.h"
+#include "includes/parallel_environment.h"
 
 namespace Kratos {
 
@@ -135,7 +136,10 @@ void AddDataCommunicatorToPython(pybind11::module &m)
     .def("IsDistributed", &DataCommunicator::IsDistributed)
     .def("IsDefinedOnThisRank", &DataCommunicator::IsDefinedOnThisRank)
     .def("IsNullOnThisRank", &DataCommunicator::IsNullOnThisRank)
-    .def_static("GetDefault", &DataCommunicator::GetDefault, py::return_value_policy::reference)
+    .def_static("GetDefault", []() -> DataCommunicator& {
+        KRATOS_WARNING("DataCommunicator") << "This function is deprecated, please retrieve the DataCommunicator through the ModelPart or by name" << std::endl;
+        return ParallelEnvironment::GetDefaultDataCommunicator();
+    }, py::return_value_policy::reference)
     .def("__str__", PrintObject<DataCommunicator>);
 }
 

--- a/kratos/python/add_testing_to_python.cpp
+++ b/kratos/python/add_testing_to_python.cpp
@@ -15,6 +15,7 @@
 
 // Project includes
 #include "includes/define_python.h"
+#include "includes/parallel_environment.h"
 #include "testing/testing.h"
 #include "add_testing_to_python.h"
 
@@ -61,6 +62,11 @@ void  AddTestingToPython(pybind11::module& m) {
         .value("FAILED_TESTS_OUTPUTS", Testing::Tester::Verbosity::FAILED_TESTS_OUTPUTS)
         .value("TESTS_OUTPUTS", Testing::Tester::Verbosity::TESTS_OUTPUTS)
     ;
+
+    auto m_testing = m.def_submodule("Testing");
+    m_testing.def("GetDefaultDataCommunicator", []() -> DataCommunicator& {
+        return ParallelEnvironment::GetDefaultDataCommunicator();
+    });
 }
 
 }  // namespace Python.


### PR DESCRIPTION
**Description**
This is dangerous is used in the wrong way. Basically this can lead to deadlocks in MPI when we are using a subset of MPI-Processes for e.g. a solver

The preferred way is to use the `DataCommunicator` of the `ModelPart`, alternatively in special cases it could be accessed by name.

EDIT:
Note that for testing this is ok to be used, hence I added the same function but in the `Testing` namespace.
I.e. in the tests we can replace 
`KratosMultiphysics.DataCommunicator.GetDefault()` 
with 
`KratosMultiphysics.Testing.GetDefaultDataCommunicator()`
