### PR TITLE
[Core][Geometry] Set operator functions non virtual and clean geometry

### DIFF
--- a/applications/IgaApplication/custom_modelers/iga_modeler.cpp
+++ b/applications/IgaApplication/custom_modelers/iga_modeler.cpp
@@ -297,7 +297,7 @@ namespace Kratos
             //                  -1->All nodes in this dimension
             Vector local_coordinates = rParameters["local_parameters"].GetVector();
 
-            auto p_background_geometry = geom.pGetGeometryPart(BrepSurface::SURFACE_INDEX);
+            auto p_background_geometry = geom.pGetGeometryPart(BrepSurface<PointerVector<Node<3>>>::SURFACE_INDEX);
 
             if (rGeometryType == "GeometryCurveNodes") {
                 KRATOS_DEBUG_ERROR_IF(geom.Dimension() != 1) << "Geometry #" << geom.Id()

--- a/applications/IgaApplication/custom_modelers/iga_modeler.cpp
+++ b/applications/IgaApplication/custom_modelers/iga_modeler.cpp
@@ -297,12 +297,14 @@ namespace Kratos
             //                  -1->All nodes in this dimension
             Vector local_coordinates = rParameters["local_parameters"].GetVector();
 
+            auto p_background_geometry = geom.pGetGeometryPart(BrepSurface::SURFACE_INDEX);
+
             if (rGeometryType == "GeometryCurveNodes") {
                 KRATOS_DEBUG_ERROR_IF(geom.Dimension() != 1) << "Geometry #" << geom.Id()
                     << " needs to have a dimension of 1 for type GeometryCurveNodes. Dimension: " << geom.Dimension()
                     << ". Geometry" << geom << std::endl;
 
-                SizeType number_of_cps = geom.size();
+                SizeType number_of_cps = p_background_geometry->size();
 
                 IndexType t_start = 0;
                 IndexType t_end = number_of_cps;
@@ -313,7 +315,7 @@ namespace Kratos
                 }
 
                 for (IndexType i = t_start; i < t_end; ++i) {
-                    rModelPart.AddNode(geom.pGetPoint(i));
+                    rModelPart.AddNode(p_background_geometry->pGetPoint(i));
                 }
             }
             else if (rGeometryType == "GeometryCurveVariationNodes") {
@@ -321,17 +323,17 @@ namespace Kratos
                     << " needs to have a dimension of 1 for type GeometryCurveVariationNodes. Dimension: " << geom.Dimension()
                     << ". Geometry" << geom << std::endl;
 
-                SizeType number_of_cps = geom.size();
+                SizeType number_of_cps = p_background_geometry->size();
 
                 KRATOS_ERROR_IF(number_of_cps < 3)
                     << "GetPointsAt: Not enough control points to get second row of nodes."
                     << std::endl;
 
                 if (local_coordinates[0] == 0) {
-                    rModelPart.AddNode(geom.pGetPoint(1));
+                    rModelPart.AddNode(p_background_geometry->pGetPoint(1));
                 }
                 else if (local_coordinates[0] == 1) {
-                    rModelPart.AddNode(geom.pGetPoint(number_of_cps - 1));
+                    rModelPart.AddNode(p_background_geometry->pGetPoint(number_of_cps - 1));
                 }
                 else {
                     KRATOS_ERROR << "GetPointsAt: GeometrySurfaceVariationNodes and local coordinates: " << local_coordinates[0]
@@ -383,7 +385,7 @@ namespace Kratos
 
                 for (IndexType i = u_start; i < u_end; ++i) {
                     for (IndexType j = v_start; j < v_end; ++j) {
-                        rModelPart.AddNode(geom(i + j * number_of_cps_u));
+                        rModelPart.AddNode(p_background_geometry->pGetPoint(i + j * number_of_cps_u));
                     }
                 }
             }

--- a/applications/IgaApplication/custom_modelers/iga_modeler.h
+++ b/applications/IgaApplication/custom_modelers/iga_modeler.h
@@ -22,7 +22,7 @@
 #include "modeler/modeler.h"
 #include "includes/properties.h"
 #include "includes/define.h"
-
+#include "geometries/brep_surface.h"
 
 namespace Kratos
 {

--- a/kratos/geometries/brep_surface.h
+++ b/kratos/geometries/brep_surface.h
@@ -181,35 +181,6 @@ public:
     }
 
     ///@}
-    ///@name Point Access
-    ///@{
-
-    PointType& operator[](const SizeType& i) override
-    {
-        return (*mpNurbsSurface)[i];
-    }
-
-    PointType const& operator[](const SizeType& i) const override
-    {
-        return (*mpNurbsSurface)[i];
-    }
-
-    typename PointType::Pointer& operator()(const SizeType& i) override
-    {
-        return (*mpNurbsSurface)(i);
-    }
-
-    const typename PointType::Pointer& operator()(const SizeType& i) const override
-    {
-        return (*mpNurbsSurface)(i);
-    }
-
-    SizeType size() const override
-    {
-        return mpNurbsSurface->size();
-    }
-
-    ///@}
     ///@name Access to Geometry Parts
     ///@{
 

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -3045,8 +3045,6 @@ public:
         return rResult;
     }
 
-
-
     ///@}
     ///@name Shape Function
     ///@{
@@ -3516,37 +3514,7 @@ public:
 
         rOStream << std::endl;
         rOStream << std::endl;
-        // rOStream << "\tLength\t : " << Length() << std::endl;
-        // rOStream << "\tArea\t : " << Area() << std::endl;
-
-        // Charlie: Volume is not defined by every geometry (2D geometries),
-        // which can cause this call to generate a KRATOS_ERROR while trying
-        // to call the base class Volume() method.
-
-        // rOStream << "\tVolume\t : " << Volume() << std::endl;
-
-        // Charlie: Can this be deleted?
-
-        // for(unsigned int i = 0 ; i < mPoints.size() ; ++i) {
-        //   rOStream << "    Point " << i+1 << "\t            : ";
-        //   mPoints[i].PrintData(rOStream);
-        //   rOStream << std::endl;
-        // }
-        //
-        // rOStream << "    Center\t            : ";
-        // Center().PrintData(rOStream);
-        // rOStream << std::endl;
-        // rOStream << std::endl;
-        // rOStream << "    Length                  : " << Length() << std::endl;
-        // rOStream << "    Area                    : " << Area() << std::endl;
-        // rOStream << "    Volume                  : " << Volume();
     }
-
-
-    ///@}
-    ///@name Friends
-    ///@{
-
 
     ///@}
 
@@ -3760,27 +3728,6 @@ protected:
     }
 
     ///@}
-    ///@name Protected  Access
-    ///@{
-
-
-    ///@}
-    ///@name Protected Inquiry
-    ///@{
-
-
-    ///@}
-    ///@name Protected LifeCycle
-    ///@{
-
-    /** Protected Constructor.
-    Avoids object to be created Except for derived classes
-    */
-
-
-    ///@}
-
-
 
 private:
     ///@name Member Variables

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -1754,76 +1754,6 @@ public:
     }
 
     ///@}
-    ///@name Coordinate transformation
-    ///@{
-
-    /**
-     * Returns a matrix of the local coordinates of all points
-     * @param rResult a Matrix that will be overwritten by the results
-     * @return the coordinates of all points of the current geometry
-     */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const
-    {
-        KRATOS_ERROR << "Calling base class 'PointsLocalCoordinates' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-        return rResult;
-    }
-
-    /**
-     * @brief Returns the local coordinates of a given arbitrary point
-     * @param rResult The vector containing the local coordinates of the point
-     * @param rPoint The point in global coordinates
-     * @return The vector containing the local coordinates of the point
-     */
-    virtual CoordinatesArrayType& PointLocalCoordinates(
-            CoordinatesArrayType& rResult,
-            const CoordinatesArrayType& rPoint
-            ) const
-    {
-        KRATOS_ERROR_IF(WorkingSpaceDimension() != LocalSpaceDimension()) << "ERROR:: Attention, the Point Local Coordinates must be specialized for the current geometry" << std::endl;
-
-        Matrix J = ZeroMatrix( WorkingSpaceDimension(), LocalSpaceDimension() );
-
-        rResult.clear();
-
-        Vector DeltaXi = ZeroVector( LocalSpaceDimension() );
-
-        CoordinatesArrayType CurrentGlobalCoords( ZeroVector( 3 ) );
-
-        static constexpr double MaxNormPointLocalCoordinates = 30.0;
-        static constexpr std::size_t MaxIteratioNumberPointLocalCoordinates = 1000;
-        static constexpr double MaxTolerancePointLocalCoordinates = 1.0e-8;
-
-        //Newton iteration:
-        for(std::size_t k = 0; k < MaxIteratioNumberPointLocalCoordinates; k++) {
-            CurrentGlobalCoords.clear();
-            DeltaXi.clear();
-
-            GlobalCoordinates( CurrentGlobalCoords, rResult );
-            noalias( CurrentGlobalCoords ) = rPoint - CurrentGlobalCoords;
-            InverseOfJacobian( J, rResult );
-            for(unsigned int i = 0; i < WorkingSpaceDimension(); i++) {
-                for(unsigned int j = 0; j < WorkingSpaceDimension(); j++) {
-                    DeltaXi[i] += J(i,j)*CurrentGlobalCoords[j];
-                }
-                rResult[i] += DeltaXi[i];
-            }
-
-            const double norm2DXi = norm_2(DeltaXi);
-
-            if(norm2DXi > MaxNormPointLocalCoordinates) {
-                KRATOS_WARNING("Geometry") << "Computation of local coordinates failed at iteration " << k << std::endl;
-                break;
-            }
-
-            if(norm2DXi < MaxTolerancePointLocalCoordinates) {
-                break;
-            }
-        }
-
-        return rResult;
-    }
-
-    ///@}
     ///@name IsInside
     ///@{
 
@@ -1875,34 +1805,6 @@ public:
             << " Please check the definition of derived class. "
             << *this << std::endl;
         return 0;
-    }
-
-    ///@}
-    ///@name Integration
-    ///@{
-
-    /** This method confirm you if this geometry has a specific
-    integration method or not. This method will be usefull to
-    control the geometry before intagrating using a specific
-    method. In Geometry class this method controls if the
-    integration points vector respecting to this method is empty
-    or not.
-
-    @return bool true if this integration method exist and false if this
-    method is not imeplemented for this geometry.
-    */
-    bool HasIntegrationMethod( IntegrationMethod ThisMethod ) const
-    {
-        return ( mpGeometryData->HasIntegrationMethod( ThisMethod ) );
-    }
-
-    /**
-    * @return default integration method
-    */
-
-    IntegrationMethod GetDefaultIntegrationMethod() const
-    {
-        return mpGeometryData->DefaultIntegrationMethod();
     }
 
     /** This method is to know if this geometry is symmetric or
@@ -2046,6 +1948,34 @@ public:
     virtual void NodesInFaces (DenseMatrix<unsigned int>& rNodesInFaces) const
     {
         KRATOS_ERROR << "Calling base class NodesInFaces method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+    }
+
+    ///@}
+    ///@name Integration
+    ///@{
+
+    /** This method confirm you if this geometry has a specific
+    integration method or not. This method will be usefull to
+    control the geometry before intagrating using a specific
+    method. In Geometry class this method controls if the
+    integration points vector respecting to this method is empty
+    or not.
+
+    @return bool true if this integration method exist and false if this
+    method is not imeplemented for this geometry.
+    */
+    bool HasIntegrationMethod(IntegrationMethod ThisMethod) const
+    {
+        return (mpGeometryData->HasIntegrationMethod(ThisMethod));
+    }
+
+    /**
+    * @return default integration method
+    */
+
+    IntegrationMethod GetDefaultIntegrationMethod() const
+    {
+        return mpGeometryData->DefaultIntegrationMethod();
     }
 
     ///@}
@@ -2362,6 +2292,76 @@ public:
                 << " Please check the definition within derived class. "
                 << *this << std::endl;
         }
+    }
+
+    ///@}
+    ///@name Coordinate transformation
+    ///@{
+
+    /**
+     * Returns a matrix of the local coordinates of all points
+     * @param rResult a Matrix that will be overwritten by the results
+     * @return the coordinates of all points of the current geometry
+     */
+    virtual Matrix& PointsLocalCoordinates(Matrix& rResult) const
+    {
+        KRATOS_ERROR << "Calling base class 'PointsLocalCoordinates' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+        return rResult;
+    }
+
+    /**
+     * @brief Returns the local coordinates of a given arbitrary point
+     * @param rResult The vector containing the local coordinates of the point
+     * @param rPoint The point in global coordinates
+     * @return The vector containing the local coordinates of the point
+     */
+    virtual CoordinatesArrayType& PointLocalCoordinates(
+        CoordinatesArrayType& rResult,
+        const CoordinatesArrayType& rPoint
+    ) const
+    {
+        KRATOS_ERROR_IF(WorkingSpaceDimension() != LocalSpaceDimension()) << "ERROR:: Attention, the Point Local Coordinates must be specialized for the current geometry" << std::endl;
+
+        Matrix J = ZeroMatrix(WorkingSpaceDimension(), LocalSpaceDimension());
+
+        rResult.clear();
+
+        Vector DeltaXi = ZeroVector(LocalSpaceDimension());
+
+        CoordinatesArrayType CurrentGlobalCoords(ZeroVector(3));
+
+        static constexpr double MaxNormPointLocalCoordinates = 30.0;
+        static constexpr std::size_t MaxIteratioNumberPointLocalCoordinates = 1000;
+        static constexpr double MaxTolerancePointLocalCoordinates = 1.0e-8;
+
+        //Newton iteration:
+        for (std::size_t k = 0; k < MaxIteratioNumberPointLocalCoordinates; k++) {
+            CurrentGlobalCoords.clear();
+            DeltaXi.clear();
+
+            GlobalCoordinates(CurrentGlobalCoords, rResult);
+            noalias(CurrentGlobalCoords) = rPoint - CurrentGlobalCoords;
+            InverseOfJacobian(J, rResult);
+            for (unsigned int i = 0; i < WorkingSpaceDimension(); i++) {
+                for (unsigned int j = 0; j < WorkingSpaceDimension(); j++) {
+                    DeltaXi[i] += J(i, j) * CurrentGlobalCoords[j];
+                }
+                rResult[i] += DeltaXi[i];
+            }
+
+            const double norm2DXi = norm_2(DeltaXi);
+
+            if (norm2DXi > MaxNormPointLocalCoordinates) {
+                KRATOS_WARNING("Geometry") << "Computation of local coordinates failed at iteration " << k << std::endl;
+                break;
+            }
+
+            if (norm2DXi < MaxTolerancePointLocalCoordinates) {
+                break;
+            }
+        }
+
+        return rResult;
     }
 
     ///@}

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -623,6 +623,25 @@ public:
         return mPoints;
     }
 
+    /* @brief This method returns a copy of all points of this geometry.
+     * @return GeometriesArrayType contains this geometry points.
+     * @see Points()
+     */
+    virtual GeometriesArrayType GeneratePoints() const
+    {
+        GeometriesArrayType points;
+
+        const auto& p_points = this->Points();
+        for (IndexType i_point = 0; i_point < p_points.size(); ++i_point) {
+            PointsArrayType point_array;
+            point_array.push_back(p_points(i_point));
+            auto p_point_geometry = Kratos::make_shared<Geometry<TPointType>>(point_array);
+            points.push_back(p_point_geometry);
+        }
+
+        return points;
+    }
+
     ///@}
     ///@name Data Container
     ///@{
@@ -1927,31 +1946,6 @@ public:
         } else { // Let's assume is one
             return this->GeneratePoints();
         }
-    }
-
-    ///@}
-    ///@name Points
-    ///@{
-
-    /**
-     * @brief This method gives you all points of this geometry.
-     * @details This method will gives you all the points
-     * @return GeometriesArrayType containes this geometry points.
-     * @see Points()
-     */
-    virtual GeometriesArrayType GeneratePoints() const
-    {
-        GeometriesArrayType points;
-
-        const auto& p_points = this->Points();
-        for (IndexType i_point = 0; i_point < p_points.size(); ++i_point) {
-            PointsArrayType point_array;
-            point_array.push_back(p_points(i_point));
-            auto p_point_geometry = Kratos::make_shared<Geometry<TPointType>>(point_array);
-            points.push_back(p_point_geometry);
-        }
-
-        return points;
     }
 
     ///@}

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -3833,12 +3833,6 @@ private:
     ///@name Private Operations
     ///@{
 
-    /// Sets Id of this Geometry (avoids checks, can be used only as private)
-    void SetIdWithoutCheck(const IndexType Id)
-    {
-        mId = Id;
-    }
-
     static const GeometryData& GeometryDataInstance()
     {
         IntegrationPointsContainerType integration_points = {};

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -1753,60 +1753,6 @@ public:
         KRATOS_ERROR << "Called the virtual function for ComputeDihedralAngles " << *this << std::endl;
     }
 
-    ///@}
-    ///@name IsInside
-    ///@{
-
-    /**
-    * @brief Checks if given point in global space coordinates
-    *        is inside the geometry boundaries. This function
-    *        computes the local coordinates and checks then if
-    *        this point lays within the boundaries.
-    * @param rPointGlobalCoordinates the global coordinates of the
-    *        external point.
-    * @param rResult the local coordinates of the point.
-    * @param Tolerance the tolerance to the boundary.
-    * @return true if the point is inside, false otherwise
-    */
-    virtual bool IsInside(
-        const CoordinatesArrayType& rPointGlobalCoordinates,
-        CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
-        ) const
-    {
-        PointLocalCoordinates(
-            rResult,
-            rPointGlobalCoordinates);
-
-        if (IsInsideLocalSpace(rResult, Tolerance) == 0) {
-            return false;
-        }
-        return true;
-    }
-
-    /**
-    * @brief Checks if given point in local space coordinates of this geometry
-    *        is inside the geometry boundaries.
-    * @param rPointLocalCoordinates the point on the geometry,
-    *        which shall be checked if it lays within
-    *        the boundaries.
-    * @param Tolerance the tolerance to the boundary.
-    * @return -1 -> failed
-    *          0 -> outside
-    *          1 -> inside
-    *          2 -> on the boundary
-    */
-    virtual int IsInsideLocalSpace(
-        const CoordinatesArrayType& rPointLocalCoordinates,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
-    ) const
-    {
-        KRATOS_ERROR << "Calling IsInsideLocalSpace from base class."
-            << " Please check the definition of derived class. "
-            << *this << std::endl;
-        return 0;
-    }
-
     /** This method is to know if this geometry is symmetric or
     not.
 
@@ -2556,6 +2502,60 @@ public:
 
         // Distance to projected point
         return norm_2(rPointGlobalCoordinates - global_coordinates);
+    }
+
+    ///@}
+    ///@name IsInside
+    ///@{
+
+    /**
+    * @brief Checks if given point in global space coordinates
+    *        is inside the geometry boundaries. This function
+    *        computes the local coordinates and checks then if
+    *        this point lays within the boundaries.
+    * @param rPointGlobalCoordinates the global coordinates of the
+    *        external point.
+    * @param rResult the local coordinates of the point.
+    * @param Tolerance the tolerance to the boundary.
+    * @return true if the point is inside, false otherwise
+    */
+    virtual bool IsInside(
+        const CoordinatesArrayType& rPointGlobalCoordinates,
+        CoordinatesArrayType& rResult,
+        const double Tolerance = std::numeric_limits<double>::epsilon()
+    ) const
+    {
+        PointLocalCoordinates(
+            rResult,
+            rPointGlobalCoordinates);
+
+        if (IsInsideLocalSpace(rResult, Tolerance) == 0) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+    * @brief Checks if given point in local space coordinates of this geometry
+    *        is inside the geometry boundaries.
+    * @param rPointLocalCoordinates the point on the geometry,
+    *        which shall be checked if it lays within
+    *        the boundaries.
+    * @param Tolerance the tolerance to the boundary.
+    * @return -1 -> failed
+    *          0 -> outside
+    *          1 -> inside
+    *          2 -> on the boundary
+    */
+    virtual int IsInsideLocalSpace(
+        const CoordinatesArrayType& rPointLocalCoordinates,
+        const double Tolerance = std::numeric_limits<double>::epsilon()
+    ) const
+    {
+        KRATOS_ERROR << "Calling IsInsideLocalSpace from base class."
+            << " Please check the definition of derived class. "
+            << *this << std::endl;
+        return 0;
     }
 
     ///@}

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -371,16 +371,6 @@ public:
     /// Destructor. Do nothing!!!
     virtual ~Geometry() {}
 
-    virtual GeometryData::KratosGeometryFamily GetGeometryFamily() const
-    {
-        return GeometryData::Kratos_generic_family;
-    }
-
-    virtual GeometryData::KratosGeometryType GetGeometryType() const
-    {
-        return GeometryData::Kratos_generic_type;
-    }
-
     ///@}
     ///@name Operators
     ///@{
@@ -585,6 +575,20 @@ public:
         KRATOS_ERROR <<
             "Calling SetGeometryShapeFunctionContainer from base geometry class."
             << std::endl;
+    }
+
+    ///@}
+    ///@name Geometry family and type
+    ///@{
+
+    virtual GeometryData::KratosGeometryFamily GetGeometryFamily() const
+    {
+        return GeometryData::Kratos_generic_family;
+    }
+
+    virtual GeometryData::KratosGeometryType GetGeometryType() const
+    {
+        return GeometryData::Kratos_generic_type;
     }
 
     ///@}

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -3848,17 +3848,6 @@ private:
         return s_geometry_data;
     }
 
-
-    ///@}
-    ///@name Private  Access
-    ///@{
-
-
-    ///@}
-    ///@name Private Inquiry
-    ///@{
-
-
     ///@}
     ///@name Private Friends
     ///@{
@@ -3866,24 +3855,12 @@ private:
     template<class TOtherPointType> friend class Geometry;
 
     ///@}
-    ///@name Un accessible methods
-    ///@{
-
-
-    ///@}
 
 }; // Class Geometry
 
 ///@}
-
-///@name Type Definitions
+///@name Input and output streams
 ///@{
-
-
-///@}
-///@name Input and output
-///@{
-
 
 /// input stream function
 template<class TPointType>

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -427,7 +427,7 @@ public:
         return *this;
     }
 
-     operator PointsArrayType&()
+    operator PointsArrayType&()
     {
         return mPoints;
     }
@@ -436,94 +436,126 @@ public:
     ///@name PointerVector Operators
     ///@{
 
-     virtual TPointType& operator[](const SizeType& i)
+    TPointType& operator[](const SizeType& i)
     {
         return mPoints[i];
     }
 
-    virtual TPointType const& operator[](const SizeType& i) const
+    TPointType const& operator[](const SizeType& i) const
     {
         return mPoints[i];
     }
 
-    virtual PointPointerType& operator()(const SizeType& i)
+    PointPointerType& operator()(const SizeType& i)
     {
         return mPoints(i);
     }
 
-    virtual ConstPointPointerType& operator()(const SizeType& i) const
+    ConstPointPointerType& operator()(const SizeType& i) const
     {
         return mPoints(i);
+    }
+
+    ///@}
+    ///@name Point Access
+    ///@{
+
+    /// Const access to the i'th point.
+    const typename TPointType::Pointer pGetPoint(const int Index) const
+    {
+        KRATOS_TRY
+        return mPoints(Index);
+        KRATOS_CATCH(mPoints)
+    }
+
+    /// Access to the i'th point.
+    typename TPointType::Pointer pGetPoint(const int Index)
+    {
+        KRATOS_TRY
+        return mPoints(Index);
+        KRATOS_CATCH(mPoints);
+    }
+
+    /// Const access to the i'th point.
+    TPointType const& GetPoint(const int Index) const
+    {
+        KRATOS_TRY
+        return mPoints[Index];
+        KRATOS_CATCH(mPoints);
+    }
+
+    /// Access to the i'th point.
+    TPointType& GetPoint(const int Index)
+    {
+        KRATOS_TRY
+        return mPoints[Index];
+        KRATOS_CATCH(mPoints);
     }
 
     ///@}
     ///@name PointerVector Operations
     ///@{
 
-    virtual iterator                   begin()
+    iterator begin()
     {
         return iterator(mPoints.begin());
     }
-    virtual const_iterator             begin() const
+    const_iterator begin() const
     {
         return const_iterator(mPoints.begin());
     }
-    virtual iterator                   end()
+    iterator end()
     {
         return iterator(mPoints.end());
     }
-    virtual const_iterator             end() const
+    const_iterator end() const
     {
         return const_iterator(mPoints.end());
     }
-    virtual ptr_iterator               ptr_begin()
+    ptr_iterator ptr_begin()
     {
         return mPoints.ptr_begin();
     }
-    virtual ptr_const_iterator         ptr_begin() const
+    ptr_const_iterator ptr_begin() const
     {
         return mPoints.ptr_begin();
     }
-    virtual ptr_iterator               ptr_end()
+    ptr_iterator               ptr_end()
     {
         return mPoints.ptr_end();
     }
-    virtual ptr_const_iterator         ptr_end() const
+    ptr_const_iterator ptr_end() const
     {
         return mPoints.ptr_end();
     }
-    virtual PointReferenceType        front()       /* nothrow */
+    PointReferenceType front()       /* nothrow */
     {
         assert(!empty());
         return mPoints.front();
     }
-    virtual ConstPointReferenceType  front() const /* nothrow */
+    ConstPointReferenceType front() const /* nothrow */
     {
         assert(!empty());
         return mPoints.front();
     }
-    virtual PointReferenceType        back()        /* nothrow */
+    PointReferenceType back()        /* nothrow */
     {
         assert(!empty());
         return mPoints.back();
     }
-    virtual ConstPointReferenceType  back() const  /* nothrow */
+    ConstPointReferenceType back() const  /* nothrow */
     {
         assert(!empty());
         return mPoints.back();
     }
 
-    virtual SizeType size() const
+    SizeType size() const
     {
         return mPoints.size();
     }
 
-    /**
-    * @detail Returns the number of the points/ nodes
-    *         belonging to this geometry.
-    * @return Number of points/ nodes.
-    */
-    SizeType PointsNumber() const {
+    /// Returns number of points. Same as size.
+    inline SizeType PointsNumber() const {
         return this->size();
     }
 
@@ -533,59 +565,69 @@ public:
         KRATOS_ERROR << "Trying to access PointsNumberInDirection from geometry base class." << std::endl;
     }
 
-    virtual SizeType max_size() const
+    SizeType max_size() const
     {
         return mPoints.max_size();
     }
-
-    virtual void swap(GeometryType& rOther)
+    void swap(GeometryType& rOther)
     {
         mPoints.swap(rOther.mPoints);
     }
-
-    virtual void push_back(PointPointerType x)
+    void push_back(PointPointerType x)
     {
         mPoints.push_back(x);
     }
-
-    virtual void clear()
+    void clear()
     {
         mPoints.clear();
     }
-
-    virtual void reserve(int dim)
+    void reserve(int dim)
     {
         mPoints.reserve(dim);
     }
-
-    virtual int capacity()
+    int capacity()
     {
         return mPoints.capacity();
     }
+    bool empty() const
+    {
+        return mPoints.empty();
+    }
 
     /////@}
-    /////@name Access
+    /////@name Access points container
     /////@{
 
-    ///** Gives a reference to underly normal container. */
-    virtual PointPointerContainerType& GetContainer()
+    /// Reference to the point container.
+    PointPointerContainerType& GetContainer()
     {
         return mPoints.GetContainer();
     }
 
-    /** Gives a constant reference to underly normal container. */
-    virtual const PointPointerContainerType& GetContainer() const
+    /// Const reference to the point container.
+    const PointPointerContainerType& GetContainer() const
     {
         return mPoints.GetContainer();
+    }
+
+
+    /// Const access to the Vector of the points.
+    const PointsArrayType& Points() const
+    {
+        return mPoints;
+    }
+
+    /// Access to the Vector of the points.
+    PointsArrayType& Points()
+    {
+        return mPoints;
     }
 
     ///@}
     ///@name Data Container
     ///@{
 
-    /**
-     * Access Data:
-     */
+    /// Access Data
     DataValueContainer& GetData()
     {
       return mData;
@@ -726,15 +768,6 @@ public:
     virtual void Calculate(
         const Variable<Matrix>& rVariable,
         Matrix& rOutput) const {}
-
-    ///@}
-    ///@name Inquiry
-    ///@{
-
-    virtual bool empty() const
-    {
-        return mPoints.empty();
-    }
 
     ///@}
     ///@name Operations
@@ -1706,81 +1739,6 @@ public:
     ///@}
     ///@name Access
     ///@{
-
-    /** A constant access method to the Vector of the points stored in
-    this geometry.
-
-    @return A constant reference to PointsArrayType contains
-    pointers to the points.
-    */
-    const PointsArrayType& Points() const
-    {
-        return mPoints;
-    }
-
-    /** An access method to the Vector of the points stored in
-    this geometry.
-
-    @return A reference to PointsArrayType contains pointers to
-    the points.
-    */
-    PointsArrayType& Points()
-    {
-        return mPoints;
-    }
-
-    /** A constant access method to the i'th points stored in
-    this geometry.
-
-    @return A constant counted pointer to i'th point of
-    geometry.
-    */
-    const typename TPointType::Pointer pGetPoint( const int Index ) const
-    {
-        KRATOS_TRY
-        return mPoints( Index );
-        KRATOS_CATCH(mPoints)
-    }
-
-    /** An access method to the i'th points stored in
-    this geometry.
-
-    @return A counted pointer to i'th point of
-    geometry.
-    */
-    typename TPointType::Pointer pGetPoint( const int Index )
-    {
-        KRATOS_TRY
-        return mPoints( Index );
-        KRATOS_CATCH(mPoints);
-    }
-
-    /** A constant access method to the i'th points stored in
-    this geometry.
-
-    @return A constant counted pointer to i'th point of
-    geometry.
-    */
-    TPointType const& GetPoint( const int Index ) const
-    {
-        KRATOS_TRY
-        return mPoints[Index];
-        KRATOS_CATCH( mPoints);
-    }
-
-
-    /** An access method to the i'th points stored in
-    this geometry.
-
-    @return A counted pointer to i'th point of
-    geometry.
-    */
-    TPointType& GetPoint( const int Index )
-    {
-        KRATOS_TRY
-        return mPoints[Index];
-        KRATOS_CATCH(mPoints);
-    }
 
     /**
      * Returns a matrix of the local coordinates of all points

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -1337,6 +1337,10 @@ public:
       return 0.0;
     }
 
+    ///@}
+    ///@name Intersection and BoundingBox and Center
+    ///@{
+
     /** Test the intersection with another geometry
      *
      * Test if this geometry intersects with other geometry
@@ -1573,20 +1577,6 @@ public:
             << "ERROR: The normal norm is zero or almost zero: "
             << norm_normal << std::endl;
         return normal_vector;
-    }
-
-
-    /** This method is to know if this geometry is symmetric or
-    not.
-
-    @todo Making some method related to symmetry axis and more...
-
-    @return bool true if this geometry is symmetric and false if
-    it's not.
-    */
-    virtual bool IsSymmetric() const
-    {
-        return false;
     }
 
     ///@}
@@ -3471,6 +3461,19 @@ public:
     virtual inline void ComputeSolidAngles(Vector& rSolidAngles)  const
     {
         KRATOS_ERROR << "Called the virtual function for ComputeDihedralAngles " << *this << std::endl;
+    }
+
+    /** This method is to know if this geometry is symmetric or
+    not.
+
+    @todo Making some method related to symmetry axis and more...
+
+    @return bool true if this geometry is symmetric and false if
+    it's not.
+    */
+    virtual bool IsSymmetric() const
+    {
+        return false;
     }
 
     ///@}

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -1469,12 +1469,6 @@ public:
       return false;
     }
 
-    // virtual void BoundingBox(BoundingBoxType& rResult) const
-    // {
-    //
-    //   Bounding_Box(rResult.LowPoint(), rResult.HighPoint());
-    // }
-
     /**
      * @brief Calculates the boundingbox of the geometry.
      * @details Corresponds with the highest and lowest point in space
@@ -1995,23 +1989,6 @@ public:
         KRATOS_ERROR << "Calling base class Edges method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
     }
 
-    /** This method gives you an edge of this geometry which holds
-    given points. This method will gives you an edge with
-    dimension related to given points number. for example a
-    tetrahedral would return a triangle for given three points or
-    return an edge line for given two nodes by this method.
-
-    @return Geometry::Pointer to this geometry specific edge.
-    @see EdgesNumber()
-    @see Edges()
-    */
-    // Commented for possible change in Edge interface of geometry. Pooyan. // NOTE: We should rethink this because is aligned with the current PR
-//       virtual Pointer Edge(const PointsArrayType& EdgePoints)
-//  {
-//    KRATOS_ERROR << "Calling base class Edge method instead of derived class one. Please check the definition of derived class." << *this << std::endl;
-//
-//  }
-
     ///@}
     ///@name Face
     ///@{
@@ -2070,51 +2047,6 @@ public:
     {
         KRATOS_ERROR << "Calling base class NodesInFaces method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
     }
-
-
-    /** This method gives you an edge of this geometry related to
-    given index. The numbering order of each geometries edges is
-    depended to type of that geometry.
-
-    @return Geometry::Pointer to this geometry specific edge.
-    @see EdgesNumber()
-    @see Edges()
-    */
-    // Commented for possible change in Edge interface of geometry. Pooyan. // NOTE: We should rethink this because is aligned with the current PR
-//       virtual Pointer Edge(IndexType EdgeIndex)
-//  {
-//    KRATOS_ERROR << "Calling base class Edge method instead of derived class one. Please check the definition of derived class." << *this << std::endl;
-
-//  }
-
-    /** This method gives you normal edge of this geometry which holds
-    given points.
-
-    @return NormalType which is normal to this geometry specific edge.
-    @see Edge()
-    */
-    // Commented for possible change in Edge interface of geometry. Pooyan. // NOTE: We should rethink this because is aligned with the current PR
-//       virtual NormalType NormalEdge(const PointsArrayType& EdgePoints)
-//  {
-//    KRATOS_ERROR << "Calling base class NormalEdge method instead of derived class one. Please check the definition of derived class." << *this << std::endl
-
-//    return NormalType();
-//  }
-
-    /** This method gives you normal to edge of this geometry related to
-    given index. The numbering order of each geometries edges is
-    depended to type of that geometry.
-
-    @return NormalType which is normal to this geometry specific edge.
-    @see Edge()
-    */
-    // Commented for possible change in Edge interface of geometry. Pooyan. // NOTE: We should rethink this because is aligned with the current PR
-//       virtual NormalType NormalEdge(IndexType EdgeIndex)
-//  {
-//    KRATOS_ERROR << "Calling base class NormalEdge method instead of derived class one. Please check the definition of derived class." << *this << std::endl;
-
-//    return NormalType();
-//  }
 
     ///@}
     ///@name Integration Points

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -3800,6 +3800,16 @@ private:
     }
 
     ///@}
+    ///@name Id
+    ///@{
+
+    /// Sets Id of this Geometry (avoids checks, used from Create functions)
+    void SetIdWithoutCheck(const IndexType Id)
+    {
+        mId = Id;
+    }
+
+    ///@}
     ///@name Serialization
     ///@{
 

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -2559,7 +2559,7 @@ public:
     }
 
     ///@}
-    ///@name Jacobian
+    ///@name Jacobian and Determinant of Jacobian
     ///@{
 
     /** Jacobians for default integration method. This method just

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -1897,149 +1897,6 @@ public:
     }
 
     ///@}
-    ///@name Integration
-    ///@{
-
-    /** This method confirm you if this geometry has a specific
-    integration method or not. This method will be usefull to
-    control the geometry before intagrating using a specific
-    method. In Geometry class this method controls if the
-    integration points vector respecting to this method is empty
-    or not.
-
-    @return bool true if this integration method exist and false if this
-    method is not imeplemented for this geometry.
-    */
-    bool HasIntegrationMethod(IntegrationMethod ThisMethod) const
-    {
-        return (mpGeometryData->HasIntegrationMethod(ThisMethod));
-    }
-
-    /**
-    * @return default integration method
-    */
-
-    IntegrationMethod GetDefaultIntegrationMethod() const
-    {
-        return mpGeometryData->DefaultIntegrationMethod();
-    }
-
-    ///@}
-    ///@name Integration Points
-    ///@{
-
-    /** Number of integtation points for default integration
-    method. This method just call IntegrationPointsNumber(enum
-    IntegrationMethod ThisMethod) with default integration
-    method.
-
-    @return SizeType which is the number of integration points
-    for default integrating method.
-    */
-    SizeType IntegrationPointsNumber() const
-    {
-        return mpGeometryData->IntegrationPoints().size();
-    }
-
-    /** Number of integtation points for given integration
-    method. This method use integration points data base to
-    obtain size of the integration points Vector respected to
-    given method.
-
-    @return SizeType which is the number of integration points
-    for given integrating method.
-    */
-    SizeType IntegrationPointsNumber( IntegrationMethod ThisMethod ) const
-    {
-        return mpGeometryData->IntegrationPointsNumber( ThisMethod );
-    }
-
-
-    /** Integtation points for default integration
-    method. This method just call IntegrationPoints(enum
-    IntegrationMethod ThisMethod) with default integration
-    method.
-
-    @return const IntegrationPointsArrayType which is Vector of integration points
-    for default integrating method.
-    */
-    const IntegrationPointsArrayType& IntegrationPoints() const
-    {
-        return mpGeometryData->IntegrationPoints();
-    }
-
-    /** Integtation points for given integration
-    method. This method use integration points data base to
-    obtain integration points Vector respected to
-    given method.
-
-    @return const IntegrationPointsArrayType which is Vector of integration points
-    for default integrating method.
-    */
-    const IntegrationPointsArrayType& IntegrationPoints( IntegrationMethod ThisMethod ) const
-    {
-        return mpGeometryData->IntegrationPoints( ThisMethod );
-    }
-
-    /* Creates integration points according to its quadrature rule.
-     * @return integration points.
-     */
-    virtual void CreateIntegrationPoints(
-        IntegrationPointsArrayType& rIntegrationPoints) const
-    {
-        KRATOS_ERROR << "Calling CreateIntegrationPoints from geometry base class."
-            << " Please check the definition of derived class. "
-            << *this << std::endl;
-    }
-
-    ///@}
-    ///@name Quadrature Point Geometries
-    ///@{
-
-    /* @brief This method creates a list of quadrature point geometries
-     *        from a list of integration points.
-     *
-     * @param rResultGeometries list of quadrature point geometries.
-     * @param rIntegrationPoints list of integration points.
-     * @param NumberOfShapeFunctionDerivatives the number of evaluated
-     *        derivatives of shape functions at the quadrature point geometries.
-     *
-     * @see quadrature_point_geometry.h
-     */
-    virtual void CreateQuadraturePointGeometries(
-        GeometriesArrayType& rResultGeometries,
-        IndexType NumberOfShapeFunctionDerivatives,
-        const IntegrationPointsArrayType& rIntegrationPoints)
-    {
-        KRATOS_ERROR << "Calling CreateQuadraturePointGeometries from geometry base class."
-            << " Please check the definition of derived class. "
-            << *this << std::endl;
-    }
-
-    /* @brief This method creates a list of quadrature point geometries
-     *        from a list of integration points. It creates the list of
-     *        integration points byitself.
-     *
-     * @param rResultGeometries list of quadrature point geometries.
-     * @param NumberOfShapeFunctionDerivatives the number of evaluated
-     *        derivatives of shape functions at the quadrature point geometries.
-     *
-     * @see quadrature_point_geometry.h
-     */
-    virtual void CreateQuadraturePointGeometries(
-        GeometriesArrayType& rResultGeometries,
-        IndexType NumberOfShapeFunctionDerivatives)
-    {
-        IntegrationPointsArrayType IntegrationPoints;
-        CreateIntegrationPoints(IntegrationPoints);
-
-        this->CreateQuadraturePointGeometries(
-            rResultGeometries,
-            NumberOfShapeFunctionDerivatives,
-            IntegrationPoints);
-    }
-
-    ///@}
     ///@name Operation within Global Space
     ///@{
 
@@ -2502,6 +2359,149 @@ public:
 
         // Distance to projected point
         return norm_2(rPointGlobalCoordinates - global_coordinates);
+    }
+
+    ///@}
+    ///@name Integration
+    ///@{
+
+    /** This method confirm you if this geometry has a specific
+    integration method or not. This method will be usefull to
+    control the geometry before intagrating using a specific
+    method. In Geometry class this method controls if the
+    integration points vector respecting to this method is empty
+    or not.
+
+    @return bool true if this integration method exist and false if this
+    method is not imeplemented for this geometry.
+    */
+    bool HasIntegrationMethod(IntegrationMethod ThisMethod) const
+    {
+        return (mpGeometryData->HasIntegrationMethod(ThisMethod));
+    }
+
+    /**
+    * @return default integration method
+    */
+
+    IntegrationMethod GetDefaultIntegrationMethod() const
+    {
+        return mpGeometryData->DefaultIntegrationMethod();
+    }
+
+    ///@}
+    ///@name Integration Points
+    ///@{
+
+    /** Number of integtation points for default integration
+    method. This method just call IntegrationPointsNumber(enum
+    IntegrationMethod ThisMethod) with default integration
+    method.
+
+    @return SizeType which is the number of integration points
+    for default integrating method.
+    */
+    SizeType IntegrationPointsNumber() const
+    {
+        return mpGeometryData->IntegrationPoints().size();
+    }
+
+    /** Number of integtation points for given integration
+    method. This method use integration points data base to
+    obtain size of the integration points Vector respected to
+    given method.
+
+    @return SizeType which is the number of integration points
+    for given integrating method.
+    */
+    SizeType IntegrationPointsNumber(IntegrationMethod ThisMethod) const
+    {
+        return mpGeometryData->IntegrationPointsNumber(ThisMethod);
+    }
+
+
+    /** Integtation points for default integration
+    method. This method just call IntegrationPoints(enum
+    IntegrationMethod ThisMethod) with default integration
+    method.
+
+    @return const IntegrationPointsArrayType which is Vector of integration points
+    for default integrating method.
+    */
+    const IntegrationPointsArrayType& IntegrationPoints() const
+    {
+        return mpGeometryData->IntegrationPoints();
+    }
+
+    /** Integtation points for given integration
+    method. This method use integration points data base to
+    obtain integration points Vector respected to
+    given method.
+
+    @return const IntegrationPointsArrayType which is Vector of integration points
+    for default integrating method.
+    */
+    const IntegrationPointsArrayType& IntegrationPoints(IntegrationMethod ThisMethod) const
+    {
+        return mpGeometryData->IntegrationPoints(ThisMethod);
+    }
+
+    /* Creates integration points according to its quadrature rule.
+     * @return integration points.
+     */
+    virtual void CreateIntegrationPoints(
+        IntegrationPointsArrayType& rIntegrationPoints) const
+    {
+        KRATOS_ERROR << "Calling CreateIntegrationPoints from geometry base class."
+            << " Please check the definition of derived class. "
+            << *this << std::endl;
+    }
+
+    ///@}
+    ///@name Quadrature Point Geometries
+    ///@{
+
+    /* @brief This method creates a list of quadrature point geometries
+     *        from a list of integration points.
+     *
+     * @param rResultGeometries list of quadrature point geometries.
+     * @param rIntegrationPoints list of integration points.
+     * @param NumberOfShapeFunctionDerivatives the number of evaluated
+     *        derivatives of shape functions at the quadrature point geometries.
+     *
+     * @see quadrature_point_geometry.h
+     */
+    virtual void CreateQuadraturePointGeometries(
+        GeometriesArrayType& rResultGeometries,
+        IndexType NumberOfShapeFunctionDerivatives,
+        const IntegrationPointsArrayType& rIntegrationPoints)
+    {
+        KRATOS_ERROR << "Calling CreateQuadraturePointGeometries from geometry base class."
+            << " Please check the definition of derived class. "
+            << *this << std::endl;
+    }
+
+    /* @brief This method creates a list of quadrature point geometries
+     *        from a list of integration points. It creates the list of
+     *        integration points byitself.
+     *
+     * @param rResultGeometries list of quadrature point geometries.
+     * @param NumberOfShapeFunctionDerivatives the number of evaluated
+     *        derivatives of shape functions at the quadrature point geometries.
+     *
+     * @see quadrature_point_geometry.h
+     */
+    virtual void CreateQuadraturePointGeometries(
+        GeometriesArrayType& rResultGeometries,
+        IndexType NumberOfShapeFunctionDerivatives)
+    {
+        IntegrationPointsArrayType IntegrationPoints;
+        CreateIntegrationPoints(IntegrationPoints);
+
+        this->CreateQuadraturePointGeometries(
+            rResultGeometries,
+            NumberOfShapeFunctionDerivatives,
+            IntegrationPoints);
     }
 
     ///@}

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -1241,7 +1241,7 @@ public:
     }
 
     ///@}
-    ///@name Informations
+    ///@name Dimension Informations
     ///@{
 
     /** Dimension of the geometry for example a triangle2d is a 2
@@ -1516,6 +1516,10 @@ public:
         return result;
     }
 
+    ///@}
+    ///@name Normal and UnitNormal
+    ///@{
+
     /**
      * @brief It returns a vector that is normal to its corresponding geometry in the given local point
      * @param rPointLocalCoordinates Reference to the local coordinates of the point in where the normal is to be computed
@@ -1737,7 +1741,7 @@ public:
     }
 
     ///@}
-    ///@name Access
+    ///@name Coordinate transformation
     ///@{
 
     /**
@@ -1861,7 +1865,7 @@ public:
     }
 
     ///@}
-    ///@name Inquiry
+    ///@name Integration
     ///@{
 
     /** This method confirm you if this geometry has a specific

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -1428,6 +1428,139 @@ public:
     }
 
     ///@}
+    ///@name Boundaries
+    ///@{
+
+    /**
+     * @brief This method gives you all boundaries entities of this geometry.
+     * @details This method will gives you all the boundaries entities
+     * @return GeometriesArrayType containes this geometry boundaries entities.
+     * @see GeneratePoints()
+     * @see GenerateEdges()
+     * @see GenerateFaces()
+     */
+    virtual GeometriesArrayType GenerateBoundariesEntities() const
+    {
+        const SizeType dimension = this->LocalSpaceDimension();
+        if (dimension == 3) {
+            return this->GenerateFaces();
+        }
+        else if (dimension == 2) {
+            return this->GenerateEdges();
+        }
+        else { // Let's assume is one
+            return this->GeneratePoints();
+        }
+    }
+
+    ///@}
+    ///@name Edge
+    ///@{
+
+    /**
+     * @brief This method gives you number of all edges of this geometry.
+     * @details For example, for a hexahedron, this would be 12
+     * @return SizeType containes number of this geometry edges.
+     * @see EdgesNumber()
+     * @see Edges()
+     * @see GenerateEdges()
+     * @see FacesNumber()
+     * @see Faces()
+     * @see GenerateFaces()
+     */
+    virtual SizeType EdgesNumber() const
+    {
+        KRATOS_ERROR << "Calling base class EdgesNumber method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+    }
+
+    /**
+     * @brief This method gives you all edges of this geometry.
+     * @details This method will gives you all the edges with one dimension less than this geometry.
+     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangle as its edges but won't return its six edge lines by this method.
+     * @return GeometriesArrayType containes this geometry edges.
+     * @deprecated This is legacy version, move to GenerateFaces
+     * @see EdgesNumber()
+     * @see Edge()
+     */
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version (use GenerateEdgesInstead)") virtual GeometriesArrayType Edges(void)
+    {
+        return this->GenerateEdges();
+    }
+
+    /**
+     * @brief This method gives you all edges of this geometry.
+     * @details This method will gives you all the edges with one dimension less than this geometry.
+     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangle as its edges but won't return its six edge lines by this method.
+     * @return GeometriesArrayType containes this geometry edges.
+     * @see EdgesNumber()
+     * @see Edge()
+     */
+    virtual GeometriesArrayType GenerateEdges() const
+    {
+        KRATOS_ERROR << "Calling base class Edges method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+    }
+
+    ///@}
+    ///@name Face
+    ///@{
+
+    /**
+     * @brief Returns the number of faces of the current geometry.
+     * @details This is only implemented for 3D geometries, since 2D geometries only have edges but no faces
+     * @see EdgesNumber
+     * @see Edges
+     * @see Faces
+     */
+    virtual SizeType FacesNumber() const
+    {
+        KRATOS_ERROR << "Calling base class FacesNumber method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+    }
+
+    /**
+     * @brief Returns all faces of the current geometry.
+     * @details This is only implemented for 3D geometries, since 2D geometries only have edges but no faces
+     * @return GeometriesArrayType containes this geometry faces.
+     * @deprecated This is legacy version, move to GenerateFaces
+     * @see EdgesNumber
+     * @see Edges
+     * @see FacesNumber
+     */
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version (use GenerateEdgesInstead)") virtual GeometriesArrayType Faces(void)
+    {
+        const SizeType dimension = this->LocalSpaceDimension();
+        if (dimension == 3) {
+            return this->GenerateFaces();
+        }
+        else {
+            return this->GenerateEdges();
+        }
+    }
+
+    /**
+     * @brief Returns all faces of the current geometry.
+     * @details This is only implemented for 3D geometries, since 2D geometries only have edges but no faces
+     * @return GeometriesArrayType containes this geometry faces.
+     * @see EdgesNumber
+     * @see GenerateEdges
+     * @see FacesNumber
+     */
+    virtual GeometriesArrayType GenerateFaces() const
+    {
+        KRATOS_ERROR << "Calling base class GenerateFaces method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+    }
+
+    //Connectivities of faces required
+    virtual void NumberNodesInFaces(DenseVector<unsigned int>& rNumberNodesInFaces) const
+    {
+        KRATOS_ERROR << "Calling base class NumberNodesInFaces method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+    }
+
+    virtual void NodesInFaces(DenseMatrix<unsigned int>& rNodesInFaces) const
+    {
+        KRATOS_ERROR << "Calling base class NodesInFaces method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+    }
+
+    ///@}
     ///@name Normal and UnitNormal
     ///@{
 
@@ -1577,136 +1710,6 @@ public:
             << "ERROR: The normal norm is zero or almost zero: "
             << norm_normal << std::endl;
         return normal_vector;
-    }
-
-    ///@}
-    ///@name Boundaries
-    ///@{
-
-    /**
-     * @brief This method gives you all boundaries entities of this geometry.
-     * @details This method will gives you all the boundaries entities
-     * @return GeometriesArrayType containes this geometry boundaries entities.
-     * @see GeneratePoints()
-     * @see GenerateEdges()
-     * @see GenerateFaces()
-     */
-    virtual GeometriesArrayType GenerateBoundariesEntities() const
-    {
-        const SizeType dimension = this->LocalSpaceDimension();
-        if (dimension == 3) {
-            return this->GenerateFaces();
-        } else if (dimension == 2) {
-            return this->GenerateEdges();
-        } else { // Let's assume is one
-            return this->GeneratePoints();
-        }
-    }
-
-    ///@}
-    ///@name Edge
-    ///@{
-
-    /**
-     * @brief This method gives you number of all edges of this geometry.
-     * @details For example, for a hexahedron, this would be 12
-     * @return SizeType containes number of this geometry edges.
-     * @see EdgesNumber()
-     * @see Edges()
-     * @see GenerateEdges()
-     * @see FacesNumber()
-     * @see Faces()
-     * @see GenerateFaces()
-     */
-    virtual SizeType EdgesNumber() const
-    {
-        KRATOS_ERROR << "Calling base class EdgesNumber method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-    }
-
-    /**
-     * @brief This method gives you all edges of this geometry.
-     * @details This method will gives you all the edges with one dimension less than this geometry.
-     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangle as its edges but won't return its six edge lines by this method.
-     * @return GeometriesArrayType containes this geometry edges.
-     * @deprecated This is legacy version, move to GenerateFaces
-     * @see EdgesNumber()
-     * @see Edge()
-     */
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version (use GenerateEdgesInstead)") virtual GeometriesArrayType Edges( void )
-    {
-        return this->GenerateEdges();
-    }
-
-    /**
-     * @brief This method gives you all edges of this geometry.
-     * @details This method will gives you all the edges with one dimension less than this geometry.
-     * For example a triangle would return three lines as its edges or a tetrahedral would return four triangle as its edges but won't return its six edge lines by this method.
-     * @return GeometriesArrayType containes this geometry edges.
-     * @see EdgesNumber()
-     * @see Edge()
-     */
-    virtual GeometriesArrayType GenerateEdges() const
-    {
-        KRATOS_ERROR << "Calling base class Edges method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-    }
-
-    ///@}
-    ///@name Face
-    ///@{
-
-    /**
-     * @brief Returns the number of faces of the current geometry.
-     * @details This is only implemented for 3D geometries, since 2D geometries only have edges but no faces
-     * @see EdgesNumber
-     * @see Edges
-     * @see Faces
-     */
-    virtual SizeType FacesNumber() const
-    {
-        KRATOS_ERROR << "Calling base class FacesNumber method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-    }
-
-    /**
-     * @brief Returns all faces of the current geometry.
-     * @details This is only implemented for 3D geometries, since 2D geometries only have edges but no faces
-     * @return GeometriesArrayType containes this geometry faces.
-     * @deprecated This is legacy version, move to GenerateFaces
-     * @see EdgesNumber
-     * @see Edges
-     * @see FacesNumber
-     */
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version (use GenerateEdgesInstead)") virtual GeometriesArrayType Faces( void )
-    {
-        const SizeType dimension = this->LocalSpaceDimension();
-        if (dimension == 3) {
-            return this->GenerateFaces();
-        } else {
-            return this->GenerateEdges();
-        }
-    }
-
-    /**
-     * @brief Returns all faces of the current geometry.
-     * @details This is only implemented for 3D geometries, since 2D geometries only have edges but no faces
-     * @return GeometriesArrayType containes this geometry faces.
-     * @see EdgesNumber
-     * @see GenerateEdges
-     * @see FacesNumber
-     */
-    virtual GeometriesArrayType GenerateFaces() const
-    {
-        KRATOS_ERROR << "Calling base class GenerateFaces method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-    }
-
-    //Connectivities of faces required
-    virtual void NumberNodesInFaces (DenseVector<unsigned int>& rNumberNodesInFaces) const
-    {
-        KRATOS_ERROR << "Calling base class NumberNodesInFaces method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-    }
-
-    virtual void NodesInFaces (DenseMatrix<unsigned int>& rNodesInFaces) const
-    {
-        KRATOS_ERROR << "Calling base class NodesInFaces method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
     }
 
     ///@}


### PR DESCRIPTION
Dear all,

our beloved geometry base class was touched by many throughout its creation. With this PR I want to put a little bit of structure in it. Furthermore, all operator and iterator functions were accidentally virtual, which shall be fixed with this PR.

The structure would be as following then:
**Geometry Structure**
- Constructors
- Copy Constructors
- Assignment Operators
- Create and Clone
- GeometryData and GeometryShapeFunctionContainer interfaces
- Geometry Family and Type
- Id functions
- Point accesses
    - Point operators
    - Point access
    - Point iterators
    - PointerVector functions
- Data Container
- Assign and Calculate
- Geometry Parent
- Geometry Part
- Dimensions
- Geometrical Information
- Intersection and BoundingBox and Center
- Boundaries
- Normal and UnitNormal
- Coordinate Transformations
- Projection and ClosestPoint
- Integration/ Integration Points/ Quadrature Point Geometries
- IsInside
- Jacobian/ Determinant of Jacobian
- Shape Functions
- Lamping Factors
- Quality
- Input and output
