### PR TITLE
Adding comm to serial matrix

### DIFF
--- a/kratos/containers/csr_matrix.h
+++ b/kratos/containers/csr_matrix.h
@@ -24,6 +24,7 @@
 #include "utilities/parallel_utilities.h"
 #include "utilities/atomic_utilities.h"
 #include "includes/key_hash.h"
+#include "includes/parallel_environment.h"
 
 // Project includes
 #include "includes/define.h"
@@ -74,12 +75,23 @@ public:
     ///@{
     CsrMatrix() //needs to be public, since one could use the low level API to construc the CSR matrix
     {
+        mpComm = &ParallelEnvironment::GetDataCommunicator("Serial");
     }
+
+    CsrMatrix(const DataCommunicator& rComm) //needs to be public, since one could use the low level API to construc the CSR matrix
+    {
+        if(rComm.IsDistributed())
+            KRATOS_ERROR << "Attempting to construct a serial CsrMatrix with a distributed communicator" << std::endl;
+
+        mpComm = &rComm;
+    }
+    
 
     /// constructor.
     template<class TGraphType>
     CsrMatrix(const TGraphType& rSparseGraph)
     {
+        mpComm = rSparseGraph.pGetComm();
         TIndexType row_data_size=0;
         TIndexType col_data_size=0;
         rSparseGraph.ExportCSRArrays(mpRowIndicesData,row_data_size,mpColIndicesData, col_data_size);
@@ -97,6 +109,7 @@ public:
 
     explicit CsrMatrix(const CsrMatrix<TDataType,TIndexType>& rOtherMatrix)
     {
+        mpComm = rOtherMatrix.mpComm;
         ResizeIndex1Data(rOtherMatrix.mRowIndices.size());
         ResizeIndex2Data(rOtherMatrix.mColIndices.size());
         ResizeValueData(rOtherMatrix.mValuesVector.size());
@@ -151,6 +164,7 @@ public:
     //move assignement operator
     CsrMatrix& operator=(CsrMatrix&& rOtherMatrix)
     {
+        mpComm = rOtherMatrix.mpComm;
         mIsOwnerOfData=rOtherMatrix.mIsOwnerOfData;
         rOtherMatrix.mIsOwnerOfData=false;
 
@@ -178,6 +192,16 @@ public:
         AssignValueData(nullptr,0);
         mNrows=0;
         mNcols=0;
+    }
+
+    DataCommunicator& GetComm() const
+    {
+        return *mpComm;
+    }
+
+    DataCommunicator* pGetComm() const
+    {
+        return mpComm;
     }
 
     void SetValue(const TDataType value)
@@ -695,6 +719,7 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
+    DataCommunicator* mpComm;
     bool mIsOwnerOfData = true;
     IndexType* mpRowIndicesData = nullptr;
     IndexType* mpColIndicesData = nullptr;

--- a/kratos/containers/csr_matrix.h
+++ b/kratos/containers/csr_matrix.h
@@ -194,12 +194,12 @@ public:
         mNcols=0;
     }
 
-    DataCommunicator& GetComm() const
+    const DataCommunicator& GetComm() const
     {
         return *mpComm;
     }
 
-    DataCommunicator* pGetComm() const
+    const DataCommunicator* pGetComm() const
     {
         return mpComm;
     }
@@ -719,7 +719,7 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
-    DataCommunicator* mpComm;
+    const DataCommunicator* mpComm;
     bool mIsOwnerOfData = true;
     IndexType* mpRowIndicesData = nullptr;
     IndexType* mpColIndicesData = nullptr;

--- a/kratos/containers/distributed_system_vector.h
+++ b/kratos/containers/distributed_system_vector.h
@@ -75,7 +75,7 @@ public:
 
     DistributedSystemVector(const DistributedSparseGraph<IndexType>& rGraph)
             :
-            mrComm(rGraph.GetComm())
+            mpComm(&rGraph.GetComm())
     {
         mpNumbering = Kratos::make_unique< DistributedNumbering<IndexType> >( rGraph.GetRowNumbering());
 
@@ -98,7 +98,7 @@ public:
     /// Copy constructor.
     explicit DistributedSystemVector(DistributedSystemVector const& rOther)
     :
-    mrComm(rOther.GetComm())
+    mpComm(&rOther.GetComm())
     {
         mpNumbering = Kratos::make_unique<DistributedNumbering<IndexType>>(rOther.GetNumbering());
         KRATOS_ERROR_IF(LocalSize() != rOther.LocalSize());
@@ -116,7 +116,7 @@ public:
     //WARNING: if a Distributed vector is constructed using this constructor, it cannot be used for assembly (non local entries are not precomputed)
     DistributedSystemVector(const DistributedNumbering<IndexType>& rNumbering)
             :
-            mrComm(rNumbering.GetComm())
+            mpComm(&rNumbering.GetComm())
     {
         mpNumbering = Kratos::make_unique< DistributedNumbering<IndexType> >( rNumbering );
         mLocalData.resize(rNumbering.LocalSize(),false);
@@ -129,7 +129,11 @@ public:
     ///@name Operators
     ///@{
     const DataCommunicator& GetComm() const{
-        return mrComm;
+        return *mpComm;
+    }
+
+    const DataCommunicator* pGetComm() const{
+        return mpComm;
     }
 
     const DistributedNumbering<IndexType>& GetNumbering() const
@@ -401,7 +405,7 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
-    const DataCommunicator& mrComm;
+    const DataCommunicator* mpComm;
     typename DistributedNumbering<IndexType>::UniquePointer mpNumbering;
 
     DenseVector<TDataType> mLocalData; //contains the local data

--- a/kratos/containers/sparse_contiguous_row_graph.h
+++ b/kratos/containers/sparse_contiguous_row_graph.h
@@ -27,6 +27,7 @@
 #include "includes/ublas_interface.h"
 #include "includes/serializer.h"
 #include "includes/lock_object.h"
+#include "includes/parallel_environment.h"
 #include "utilities/parallel_utilities.h"
 
 namespace Kratos
@@ -81,10 +82,12 @@ public:
     /// Default constructor. - needs to be public for communicator, but it will fail if used in any other mode
     SparseContiguousRowGraph()
     {
+        mpComm = &ParallelEnvironment::GetDataCommunicator("Serial");
     }
 
     SparseContiguousRowGraph(IndexType GraphSize)
     {
+        mpComm = &ParallelEnvironment::GetDataCommunicator("Serial");
         mGraph.resize(GraphSize,false);
         mLocks.resize(GraphSize);
 
@@ -109,7 +112,18 @@ public:
     /// Copy constructor.
     SparseContiguousRowGraph(const SparseContiguousRowGraph& rOther)
     {
+        mpComm = rOther.mpComm;
         this->AddEntries(rOther);
+    }
+
+    DataCommunicator& GetComm() const
+    {
+        return *mpComm;
+    }
+
+    DataCommunicator* pGetComm() const
+    {
+        return mpComm;
     }
 
     ///@}
@@ -464,6 +478,7 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
+    DataCommunicator* mpComm;
     GraphType mGraph;
     std::vector<LockObject> mLocks;
 

--- a/kratos/containers/sparse_contiguous_row_graph.h
+++ b/kratos/containers/sparse_contiguous_row_graph.h
@@ -116,12 +116,12 @@ public:
         this->AddEntries(rOther);
     }
 
-    DataCommunicator& GetComm() const
+    const DataCommunicator& GetComm() const
     {
         return *mpComm;
     }
 
-    DataCommunicator* pGetComm() const
+    const DataCommunicator* pGetComm() const
     {
         return mpComm;
     }

--- a/kratos/containers/sparse_graph.h
+++ b/kratos/containers/sparse_graph.h
@@ -27,6 +27,7 @@
 #include "utilities/parallel_utilities.h"
 #include "includes/ublas_interface.h"
 #include "includes/serializer.h"
+#include "includes/parallel_environment.h"
 
 namespace Kratos
 {
@@ -79,11 +80,21 @@ public:
 
     SparseGraph(IndexType N)
     {
+        mpComm = &ParallelEnvironment::GetDataCommunicator("Serial"); //that's the only option
     }
 
     /// Default constructor.
     SparseGraph()
     {
+        mpComm = &ParallelEnvironment::GetDataCommunicator("Serial"); //thats the only option
+    }
+
+    SparseGraph(DataCommunicator& rComm)
+    {
+        if(rComm.IsDistributed())
+            KRATOS_ERROR << "Attempting to construct a serial CsrMatrix with a distributed communicator" << std::endl;
+
+        mpComm = &rComm;
     }
 
     /// Destructor.
@@ -92,6 +103,7 @@ public:
     /// Copy constructor. 
     SparseGraph(const SparseGraph& rOther)
     :
+        mpComm(rOther.mpComm),
         mGraph(rOther.mGraph)
     {
     }
@@ -104,6 +116,15 @@ public:
     ///@}
     ///@name Operators
     ///@{
+    DataCommunicator& GetComm() const
+    {
+        return *mpComm;
+    }
+
+    DataCommunicator* pGetComm() const
+    {
+        return mpComm;
+    }
 
     IndexType Size() const
     {
@@ -445,6 +466,7 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
+    DataCommunicator* mpComm;
     GraphType mGraph;
 
 

--- a/kratos/containers/sparse_graph.h
+++ b/kratos/containers/sparse_graph.h
@@ -116,12 +116,12 @@ public:
     ///@}
     ///@name Operators
     ///@{
-    DataCommunicator& GetComm() const
+    const DataCommunicator& GetComm() const
     {
         return *mpComm;
     }
 
-    DataCommunicator* pGetComm() const
+    const DataCommunicator* pGetComm() const
     {
         return mpComm;
     }

--- a/kratos/containers/system_vector.h
+++ b/kratos/containers/system_vector.h
@@ -69,19 +69,25 @@ public:
     ///@{
 
     SystemVector(const SparseGraph<IndexType>& rGraph){
+        mpComm = rGraph.pGetComm();
         mData.resize(rGraph.Size(),false);
     }
 
     SystemVector(const SparseContiguousRowGraph<IndexType>& rGraph){
+        mpComm = rGraph.pGetComm();
         mData.resize(rGraph.Size(),false);
     }
 
-    SystemVector(IndexType size){
+    SystemVector(IndexType size, DataCommunicator& rComm=ParallelEnvironment::GetDataCommunicator("Serial")){
+        if(rComm.IsDistributed())
+            KRATOS_ERROR << "Attempting to construct a serial system_vector with a distributed communicator" << std::endl;
+        mpComm = &rComm;
         mData.resize(size,false);
     }
 
     /// Copy constructor.
     explicit SystemVector(const SystemVector<TDataType,TIndexType>& rOtherVector){
+        mpComm = rOtherVector.mpComm;
         mData.resize(rOtherVector.size(),false);
 
         IndexPartition<IndexType>(size()).for_each([&](IndexType i){
@@ -91,6 +97,16 @@ public:
 
     /// Destructor.
     virtual ~SystemVector(){}
+
+    const DataCommunicator& GetComm() const
+    {
+        return *mpComm;
+    }
+
+    const DataCommunicator* pGetComm() const
+    {
+        return mpComm;
+    }
 
     ///@}
     ///@name Operators
@@ -281,6 +297,7 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
+    const DataCommunicator* mpComm;
     DenseVector<TDataType> mData;
 
     ///@}


### PR DESCRIPTION
**Description**
the main purpose of this PR is to add communicator (serial) to csr_matrix and related objects.
The objective is to ensure that serial and distributed versions are really a drop in replacement one of the other, even in the constructor

Please mark the PR with appropriate tags: 


**Changelog**
adding Comm to serial system related objects