### PR TITLE
A minor bug in BFECC has been fixed

### DIFF
--- a/applications/ConvectionDiffusionApplication/custom_utilities/bfecc_convection.h
+++ b/applications/ConvectionDiffusionApplication/custom_utilities/bfecc_convection.h
@@ -230,7 +230,7 @@ public:
         {
             noalias(position) += small_dt*initial_velocity;
             unsigned int substep=0;
-            while(substep++ < subdivisions)
+            while(++substep < subdivisions)
             {
                 is_found = mpSearchStructure->FindPointOnMesh(position, N, pelement, result_begin, max_results);
 
@@ -260,7 +260,7 @@ public:
         {
             noalias(position) -= small_dt*initial_velocity;
             unsigned int substep=0;
-            while(substep++ < subdivisions)
+            while(++substep < subdivisions)
             {
                 is_found = mpSearchStructure->FindPointOnMesh(position, N, pelement, result_begin, max_results);
 


### PR DESCRIPTION
**Description**
The substepping scheme in the Bfecc utility in the ConvectionDiffusionApplication had a minor bug. The previous version of the code was surpassing the timestep due to the fact that a while(substep++ < subdivisions) statement checks if substep < subdivisions first and then increments the substep. This bug could be circumvented simply by replacing the substep++ with ++substep.


