### PR TITLE
Adding missing dependency for ExaquteApp

### DIFF
--- a/applications/ExaquteSandboxApplication/CMakeLists.txt
+++ b/applications/ExaquteSandboxApplication/CMakeLists.txt
@@ -2,6 +2,8 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 message("**** configuring KratosExaquteSandboxApplication ****")
 
+kratos_add_dependency(${KRATOS_SOURCE_DIR}/applications/MeshingApplication)
+
 ################### PYBIND11
 include(pybind11Tools)
 


### PR DESCRIPTION
**Description**
Adds a missing dependency.
This enables the app to be compiled automatically if not enabled by the user, in the line with the others.

**Changelog**
- Added MeshingApplication as compile dependency of ExaquteApplication
