### PR TITLE
[CI] improve name of runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   ubuntu:
     runs-on: ubuntu-latest
+    name: "Build type: ${{ matrix.build-type }}, Compiler: ${{ matrix.compiler }}"
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   ubuntu:
     runs-on: ubuntu-latest
-    name: "Build type: ${{ matrix.build-type }}, Compiler: ${{ matrix.compiler }}"
+    name: "Ubuntu; Build type: ${{ matrix.build-type }}, Compiler: ${{ matrix.compiler }}"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This improves the name of the runs
before:
![image](https://user-images.githubusercontent.com/25484702/115684483-af180000-a357-11eb-9843-b1ddef5feeec.png)

after:
![image](https://user-images.githubusercontent.com/25484702/115684716-e5557f80-a357-11eb-8e8b-a64e058a31a6.png)