### PR TITLE
[SMA] Minor bug in Updated Lagrangian Element

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -108,15 +108,18 @@ void UpdatedLagrangian::InitializeSolutionStep(const ProcessInfo& rCurrentProces
 void UpdatedLagrangian::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo )
 {
     // Create and initialize element variables:
-    const SizeType number_of_nodes = GetGeometry().size();
-    const SizeType dimension = GetGeometry().WorkingSpaceDimension();
+    const auto& r_geometry = GetGeometry();
+    const SizeType number_of_nodes = r_geometry.size();
+    const SizeType dimension = r_geometry.WorkingSpaceDimension();
     const SizeType strain_size = mConstitutiveLawVector[0]->GetStrainSize();
+    // Reading integration points
+    const GeometryType::IntegrationPointsArrayType& integration_points = r_geometry.IntegrationPoints(mThisIntegrationMethod);
 
     KinematicVariables this_kinematic_variables(strain_size, dimension, number_of_nodes);
     ConstitutiveVariables this_constitutive_variables(strain_size);
 
     // Create constitutive law parameters:
-    ConstitutiveLaw::Parameters Values(GetGeometry(),GetProperties(),rCurrentProcessInfo);
+    ConstitutiveLaw::Parameters Values(r_geometry,GetProperties(),rCurrentProcessInfo);
 
     // Set constitutive law flags:
     Flags& ConstitutiveLawOptions=Values.GetOptions();
@@ -135,13 +138,16 @@ void UpdatedLagrangian::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessI
         // Compute element kinematics B, F, DN_DX ...
         this->CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
 
+        // Setting the variables for the CL
+        SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
+
         // Call the constitutive law to update material variables
         mConstitutiveLawVector[point_number]->FinalizeMaterialResponse(Values, GetStressMeasure());
 
         mConstitutiveLawVector[point_number]->FinalizeSolutionStep(
         GetProperties(),
-        GetGeometry(),
-        row( GetGeometry().ShapeFunctionsValues(  ), point_number ),
+        r_geometry,
+        row( r_geometry.ShapeFunctionsValues(  ), point_number ),
         rCurrentProcessInfo
         );
 

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -144,13 +144,6 @@ void UpdatedLagrangian::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessI
         // Call the constitutive law to update material variables
         mConstitutiveLawVector[point_number]->FinalizeMaterialResponse(Values, GetStressMeasure());
 
-        mConstitutiveLawVector[point_number]->FinalizeSolutionStep(
-        GetProperties(),
-        r_geometry,
-        row( r_geometry.ShapeFunctionsValues(  ), point_number ),
-        rCurrentProcessInfo
-        );
-
         // Update the element internal variables
         this->UpdateHistoricalDatabase(this_kinematic_variables, point_number);
     }


### PR DESCRIPTION
A missing `SetConstitutiveVariables ` has been added, otherwise the **F** is not set and a `SegFault `occurs in the `FinalizeSolutionStep `of the CL