### PR TITLE
[Core] Geometry remove virtual from point access operators

### DIFF
--- a/applications/IgaApplication/custom_modelers/iga_modeler.cpp
+++ b/applications/IgaApplication/custom_modelers/iga_modeler.cpp
@@ -297,12 +297,14 @@ namespace Kratos
             //                  -1->All nodes in this dimension
             Vector local_coordinates = rParameters["local_parameters"].GetVector();
 
+            auto p_background_geometry = geom.pGetGeometryPart(BrepSurface<PointerVector<Node<3>>>::SURFACE_INDEX);
+
             if (rGeometryType == "GeometryCurveNodes") {
                 KRATOS_DEBUG_ERROR_IF(geom.Dimension() != 1) << "Geometry #" << geom.Id()
                     << " needs to have a dimension of 1 for type GeometryCurveNodes. Dimension: " << geom.Dimension()
                     << ". Geometry" << geom << std::endl;
 
-                SizeType number_of_cps = geom.size();
+                SizeType number_of_cps = p_background_geometry->size();
 
                 IndexType t_start = 0;
                 IndexType t_end = number_of_cps;
@@ -313,7 +315,7 @@ namespace Kratos
                 }
 
                 for (IndexType i = t_start; i < t_end; ++i) {
-                    rModelPart.AddNode(geom.pGetPoint(i));
+                    rModelPart.AddNode(p_background_geometry->pGetPoint(i));
                 }
             }
             else if (rGeometryType == "GeometryCurveVariationNodes") {
@@ -321,17 +323,17 @@ namespace Kratos
                     << " needs to have a dimension of 1 for type GeometryCurveVariationNodes. Dimension: " << geom.Dimension()
                     << ". Geometry" << geom << std::endl;
 
-                SizeType number_of_cps = geom.size();
+                SizeType number_of_cps = p_background_geometry->size();
 
                 KRATOS_ERROR_IF(number_of_cps < 3)
                     << "GetPointsAt: Not enough control points to get second row of nodes."
                     << std::endl;
 
                 if (local_coordinates[0] == 0) {
-                    rModelPart.AddNode(geom.pGetPoint(1));
+                    rModelPart.AddNode(p_background_geometry->pGetPoint(1));
                 }
                 else if (local_coordinates[0] == 1) {
-                    rModelPart.AddNode(geom.pGetPoint(number_of_cps - 1));
+                    rModelPart.AddNode(p_background_geometry->pGetPoint(number_of_cps - 1));
                 }
                 else {
                     KRATOS_ERROR << "GetPointsAt: GeometrySurfaceVariationNodes and local coordinates: " << local_coordinates[0]
@@ -383,7 +385,7 @@ namespace Kratos
 
                 for (IndexType i = u_start; i < u_end; ++i) {
                     for (IndexType j = v_start; j < v_end; ++j) {
-                        rModelPart.AddNode(geom(i + j * number_of_cps_u));
+                        rModelPart.AddNode(p_background_geometry->pGetPoint(i + j * number_of_cps_u));
                     }
                 }
             }

--- a/applications/IgaApplication/custom_modelers/iga_modeler.h
+++ b/applications/IgaApplication/custom_modelers/iga_modeler.h
@@ -23,6 +23,8 @@
 #include "includes/properties.h"
 #include "includes/define.h"
 
+// brep surface for constexpression of SURFACE_INDEX
+#include "geometries/brep_surface.h"
 
 namespace Kratos
 {

--- a/kratos/geometries/brep_surface.h
+++ b/kratos/geometries/brep_surface.h
@@ -181,35 +181,6 @@ public:
     }
 
     ///@}
-    ///@name Point Access
-    ///@{
-
-    PointType& operator[](const SizeType& i) override
-    {
-        return (*mpNurbsSurface)[i];
-    }
-
-    PointType const& operator[](const SizeType& i) const override
-    {
-        return (*mpNurbsSurface)[i];
-    }
-
-    typename PointType::Pointer& operator()(const SizeType& i) override
-    {
-        return (*mpNurbsSurface)(i);
-    }
-
-    const typename PointType::Pointer& operator()(const SizeType& i) const override
-    {
-        return (*mpNurbsSurface)(i);
-    }
-
-    SizeType size() const override
-    {
-        return mpNurbsSurface->size();
-    }
-
-    ///@}
     ///@name Access to Geometry Parts
     ///@{
 

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -436,22 +436,22 @@ public:
     ///@name PointerVector Operators
     ///@{
 
-     virtual TPointType& operator[](const SizeType& i)
+    TPointType& operator[](const SizeType& i)
     {
         return mPoints[i];
     }
 
-    virtual TPointType const& operator[](const SizeType& i) const
+    TPointType const& operator[](const SizeType& i) const
     {
         return mPoints[i];
     }
 
-    virtual PointPointerType& operator()(const SizeType& i)
+    PointPointerType& operator()(const SizeType& i)
     {
         return mPoints(i);
     }
 
-    virtual ConstPointPointerType& operator()(const SizeType& i) const
+    ConstPointPointerType& operator()(const SizeType& i) const
     {
         return mPoints(i);
     }
@@ -460,60 +460,60 @@ public:
     ///@name PointerVector Operations
     ///@{
 
-    virtual iterator                   begin()
+    iterator                   begin()
     {
         return iterator(mPoints.begin());
     }
-    virtual const_iterator             begin() const
+    const_iterator             begin() const
     {
         return const_iterator(mPoints.begin());
     }
-    virtual iterator                   end()
+    iterator                   end()
     {
         return iterator(mPoints.end());
     }
-    virtual const_iterator             end() const
+    const_iterator             end() const
     {
         return const_iterator(mPoints.end());
     }
-    virtual ptr_iterator               ptr_begin()
+    ptr_iterator               ptr_begin()
     {
         return mPoints.ptr_begin();
     }
-    virtual ptr_const_iterator         ptr_begin() const
+    ptr_const_iterator         ptr_begin() const
     {
         return mPoints.ptr_begin();
     }
-    virtual ptr_iterator               ptr_end()
+    ptr_iterator               ptr_end()
     {
         return mPoints.ptr_end();
     }
-    virtual ptr_const_iterator         ptr_end() const
+    ptr_const_iterator         ptr_end() const
     {
         return mPoints.ptr_end();
     }
-    virtual PointReferenceType        front()       /* nothrow */
+    PointReferenceType        front()       /* nothrow */
     {
         assert(!empty());
         return mPoints.front();
     }
-    virtual ConstPointReferenceType  front() const /* nothrow */
+    ConstPointReferenceType  front() const /* nothrow */
     {
         assert(!empty());
         return mPoints.front();
     }
-    virtual PointReferenceType        back()        /* nothrow */
+    PointReferenceType        back()        /* nothrow */
     {
         assert(!empty());
         return mPoints.back();
     }
-    virtual ConstPointReferenceType  back() const  /* nothrow */
+    ConstPointReferenceType  back() const  /* nothrow */
     {
         assert(!empty());
         return mPoints.back();
     }
 
-    virtual SizeType size() const
+    SizeType size() const
     {
         return mPoints.size();
     }
@@ -533,32 +533,32 @@ public:
         KRATOS_ERROR << "Trying to access PointsNumberInDirection from geometry base class." << std::endl;
     }
 
-    virtual SizeType max_size() const
+    SizeType max_size() const
     {
         return mPoints.max_size();
     }
 
-    virtual void swap(GeometryType& rOther)
+    void swap(GeometryType& rOther)
     {
         mPoints.swap(rOther.mPoints);
     }
 
-    virtual void push_back(PointPointerType x)
+    void push_back(PointPointerType x)
     {
         mPoints.push_back(x);
     }
 
-    virtual void clear()
+    void clear()
     {
         mPoints.clear();
     }
 
-    virtual void reserve(int dim)
+    void reserve(int dim)
     {
         mPoints.reserve(dim);
     }
 
-    virtual int capacity()
+    int capacity()
     {
         return mPoints.capacity();
     }
@@ -568,13 +568,13 @@ public:
     /////@{
 
     ///** Gives a reference to underly normal container. */
-    virtual PointPointerContainerType& GetContainer()
+    PointPointerContainerType& GetContainer()
     {
         return mPoints.GetContainer();
     }
 
     /** Gives a constant reference to underly normal container. */
-    virtual const PointPointerContainerType& GetContainer() const
+    const PointPointerContainerType& GetContainer() const
     {
         return mPoints.GetContainer();
     }
@@ -731,7 +731,7 @@ public:
     ///@name Inquiry
     ///@{
 
-    virtual bool empty() const
+    bool empty() const
     {
         return mPoints.empty();
     }


### PR DESCRIPTION
As #8627 became a bit to big with too many changes, I split it up. This PR is now purely focusing on removing the virtual from all Point access functions, which shall speed up the calls.