### PR TITLE
[CI] adding backbone apps to non-unity build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,8 +220,17 @@ jobs:
 
         export KRATOS_SOURCE="${KRATOS_SOURCE:-${PWD}}"
         export KRATOS_BUILD="${KRATOS_SOURCE}/build"
+        export KRATOS_APP_DIR="${KRATOS_SOURCE}/applications"
         export PYTHON_EXECUTABLE="/usr/bin/python3.8"
         export KRATOS_INSTALL_PYTHON_USING_LINKS=ON
+
+        add_app () {
+            export KRATOS_APPLICATIONS="${KRATOS_APPLICATIONS}$1;"
+        }
+
+        add_app ${KRATOS_APP_DIR}/LinearSolversApplication;
+        add_app ${KRATOS_APP_DIR}/MetisApplication;
+        add_app ${KRATOS_APP_DIR}/TrilinosApplication;
 
         source /opt/intel/oneapi/setvars.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,8 +241,6 @@ jobs:
         -DTRILINOS_INCLUDE_DIR="/usr/include/trilinos" \
         -DTRILINOS_LIBRARY_DIR="/usr/lib/x86_64-linux-gnu" \
         -DTRILINOS_LIBRARY_PREFIX="trilinos_" \
-        -DUSE_EIGEN_MKL=ON \
-        -DUSE_EIGEN_FEAST=ON \
         -DINSTALL_RUNKRATOS=OFF
 
         # Buid

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,11 @@ jobs:
         cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
         -DUSE_MPI=ON \
         -DPYBIND11_PYTHON_VERSION="3.8" \
+        -DTRILINOS_INCLUDE_DIR="/usr/include/trilinos" \
+        -DTRILINOS_LIBRARY_DIR="/usr/lib/x86_64-linux-gnu" \
+        -DTRILINOS_LIBRARY_PREFIX="trilinos_" \
+        -DUSE_EIGEN_MKL=ON \
+        -DUSE_EIGEN_FEAST=ON \
         -DINSTALL_RUNKRATOS=OFF
 
         # Buid


### PR DESCRIPTION
This PR adds the apps to the non-unity CI that are crucial for the operation of Kratos, they are the backbone (and are managed by the technical committee):
- MetisApp
- TrilinosApp
- LinearSolversApp

I want to restrict the non unity build to those apps and those only to not have the build times explode and to be able to use ccache (which with more apps we will run out of memory)