### PR TITLE
[Trilinos] test linear solver with subcomms

### DIFF
--- a/applications/TrilinosApplication/tests/test_trilinos_linear_solvers.py
+++ b/applications/TrilinosApplication/tests/test_trilinos_linear_solvers.py
@@ -18,7 +18,7 @@ class TestLinearSolvers(KratosUnittest.TestCase):
             self._auxiliary_test_function(settings)
 
     def _auxiliary_test_function(self, settings, matrix_name="A.mm", absolute_norm=False):
-        comm = KratosMultiphysics.TrilinosApplication.CreateEpetraCommunicator(KratosMultiphysics.DataCommunicator.GetDefault())
+        comm = KratosMultiphysics.TrilinosApplication.CreateEpetraCommunicator(KratosMultiphysics.Testing.GetDefaultDataCommunicator())
         space = KratosMultiphysics.TrilinosApplication.TrilinosSparseSpace()
 
         #read the matrices
@@ -69,7 +69,7 @@ class TestLinearSolvers(KratosUnittest.TestCase):
         if(settings.Has("tolerance")):
             tolerance = settings["tolerance"].GetDouble()
 
-        nproc = KratosMultiphysics.DataCommunicator.GetDefault().Size()
+        nproc = KratosMultiphysics.Testing.GetDefaultDataCommunicator().Size()
         target_norm = tolerance*space.TwoNorm(pboriginal.GetReference())*nproc #multiplying by nproc the target tolerance to give some slack. Not really nice :-(
 
         if(achieved_norm > target_norm):

--- a/applications/TrilinosApplication/tests/test_trilinos_linear_solvers.py
+++ b/applications/TrilinosApplication/tests/test_trilinos_linear_solvers.py
@@ -17,6 +17,13 @@ class TestLinearSolvers(KratosUnittest.TestCase):
             settings = all_settings["test_list"][i]
             self._auxiliary_test_function(settings)
 
+    def _RunParametrizedWithSubComm(self, my_params_string ):
+        all_settings = KratosMultiphysics.Parameters( my_params_string )
+
+        for i in range(all_settings["test_list"].size()):
+            settings = all_settings["test_list"][i]
+            self._auxiliary_test_function(settings, KratosMultiphysics.Testing.GetDefaultDataCommunicator())
+
     def _auxiliary_test_function(self, settings, data_comm=KratosMultiphysics.Testing.GetDefaultDataCommunicator(), matrix_name="A.mm", absolute_norm=False):
         comm = KratosMultiphysics.TrilinosApplication.CreateEpetraCommunicator(data_comm)
         space = KratosMultiphysics.TrilinosApplication.TrilinosSparseSpace()
@@ -86,7 +93,7 @@ class TestAmesosLinearSolvers(TestLinearSolvers):
         if( not KratosMultiphysics.TrilinosApplication.AmesosSolver.HasSolver("Amesos_Superludist") ):
             self.skipTest("Amesos_Superludist is not among the available Amesos Solvers")
 
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -95,13 +102,19 @@ class TestAmesosLinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_amesos_mumps(self):
         if( not KratosMultiphysics.TrilinosApplication.AmesosSolver.HasSolver("Amesos_Mumps") ):
             self.skipTest("Amesos_Mumps is not among the available Amesos Solvers")
 
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -110,14 +123,20 @@ class TestAmesosLinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
 
     def test_amesos_klu(self):
         if( not KratosMultiphysics.TrilinosApplication.AmesosSolver.HasSolver("Amesos_Klu") ):
             self.skipTest("Amesos_Klu is not among the available Amesos Solvers")
 
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -126,13 +145,19 @@ class TestAmesosLinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_amesos_superludist_2(self):
         if( not KratosMultiphysics.TrilinosApplication.AmesosSolver.HasSolver("Amesos_Superludist") ):
             self.skipTest("Amesos_Superludist is not among the available Amesos Solvers")
 
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -140,13 +165,19 @@ class TestAmesosLinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_amesos_mumps_2(self):
         if( not KratosMultiphysics.TrilinosApplication.AmesosSolver.HasSolver("Amesos_Mumps") ):
             self.skipTest("Amesos_Mumps is not among the available Amesos Solvers")
 
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -154,13 +185,19 @@ class TestAmesosLinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_amesos_klu_2(self):
         if( not KratosMultiphysics.TrilinosApplication.AmesosSolver.HasSolver("Amesos_Klu") ):
             self.skipTest("Amesos_Klu is not among the available Amesos Solvers")
 
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -168,7 +205,13 @@ class TestAmesosLinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
 class TestAmesos2LinearSolvers(TestLinearSolvers):
     def setUp(self):

--- a/applications/TrilinosApplication/tests/test_trilinos_linear_solvers.py
+++ b/applications/TrilinosApplication/tests/test_trilinos_linear_solvers.py
@@ -88,6 +88,7 @@ class TestLinearSolvers(KratosUnittest.TestCase):
         del linear_solver
 
 
+@KratosUnittest.skipUnless(hasattr(KratosMultiphysics.TrilinosApplication, 'AmesosSolver'), "AmesosSolver was explicitly disabled.")
 class TestAmesosLinearSolvers(TestLinearSolvers):
     def test_amesos_superludist(self):
         if( not KratosMultiphysics.TrilinosApplication.AmesosSolver.HasSolver("Amesos_Superludist") ):
@@ -213,12 +214,8 @@ class TestAmesosLinearSolvers(TestLinearSolvers):
         with self.subTest('SubComm'):
             self._RunParametrizedWithSubComm(params_string)
 
+@KratosUnittest.skipUnless(hasattr(KratosMultiphysics.TrilinosApplication, 'Amesos2Solver'), "Amesos2Solver is not included in the compilation.")
 class TestAmesos2LinearSolvers(TestLinearSolvers):
-    def setUp(self):
-        if not hasattr(KratosMultiphysics.TrilinosApplication, "Amesos2Solver"):
-            self.skipTest("Amesos2Solver is not available")
-        super().setUp()
-
     def test_amesos2_superludist(self):
         if( not KratosMultiphysics.TrilinosApplication.Amesos2Solver.HasSolver("amesos2_superludist") ):
             self.skipTest("amesos2_superludist is not among the available Amesos2 Solvers")

--- a/applications/TrilinosApplication/tests/test_trilinos_linear_solvers.py
+++ b/applications/TrilinosApplication/tests/test_trilinos_linear_solvers.py
@@ -223,7 +223,7 @@ class TestAmesos2LinearSolvers(TestLinearSolvers):
         if( not KratosMultiphysics.TrilinosApplication.Amesos2Solver.HasSolver("amesos2_superludist") ):
             self.skipTest("amesos2_superludist is not among the available Amesos2 Solvers")
 
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -232,13 +232,19 @@ class TestAmesos2LinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_amesos2_mumps(self):
         if( not KratosMultiphysics.TrilinosApplication.Amesos2Solver.HasSolver("amesos2_mumps") ):
             self.skipTest("amesos2_mumps is not among the available Amesos2 Solvers")
 
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -247,13 +253,19 @@ class TestAmesos2LinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_amesos2_klu(self):
         if( not KratosMultiphysics.TrilinosApplication.Amesos2Solver.HasSolver("amesos2_klu2") ):
             self.skipTest("amesos2_klu2 is not among the available Amesos2 Solvers")
 
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -262,13 +274,19 @@ class TestAmesos2LinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_amesos2_basker(self):
         if( not KratosMultiphysics.TrilinosApplication.Amesos2Solver.HasSolver("basker") ):
             self.skipTest("basker is not among the available Amesos2 Solvers")
 
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -277,13 +295,19 @@ class TestAmesos2LinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_amesos2_superludist_2(self):
         if( not KratosMultiphysics.TrilinosApplication.Amesos2Solver.HasSolver("amesos2_superludist") ):
             self.skipTest("amesos2_superludist is not among the available Amesos2 Solvers")
 
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -291,13 +315,19 @@ class TestAmesos2LinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_amesos2_mumps_2(self):
         if( not KratosMultiphysics.TrilinosApplication.Amesos2Solver.HasSolver("amesos2_mumps") ):
             self.skipTest("amesos2_mumps is not among the available Amesos2 Solvers")
 
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -305,13 +335,19 @@ class TestAmesos2LinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_amesos2_klu_2(self):
         if( not KratosMultiphysics.TrilinosApplication.Amesos2Solver.HasSolver("amesos2_klu2") ):
             self.skipTest("amesos2_klu2 is not among the available Amesos2 Solvers")
 
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -319,13 +355,19 @@ class TestAmesos2LinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_amesos2_basker_2(self):
         if( not KratosMultiphysics.TrilinosApplication.Amesos2Solver.HasSolver("basker") ):
             self.skipTest("basker is not among the available Amesos2 Solvers")
 
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -333,12 +375,18 @@ class TestAmesos2LinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
 @KratosUnittest.skipUnless(hasattr(KratosMultiphysics.TrilinosApplication, 'AztecSolver'), "AztecSolver was explicitly disabled.")
 class TestAztecLinearSolvers(TestLinearSolvers):
     def test_aztec_cg(self):
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -376,10 +424,16 @@ class TestAztecLinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_aztec_gmres(self):
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -417,12 +471,19 @@ class TestAztecLinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
+
 
 @KratosUnittest.skipUnless(hasattr(KratosMultiphysics.TrilinosApplication, 'MultiLevelSolver'), "MultiLevelSolver was explicitly disabled.")
 class TestMLLinearSolvers(TestLinearSolvers):
     def test_ml_symmetric(self):
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -439,10 +500,16 @@ class TestMLLinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_ml_symmetric_scaling(self):
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -459,10 +526,16 @@ class TestMLLinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_ml_nonsymmetric(self):
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -479,10 +552,16 @@ class TestMLLinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_ml_nonsymmetric_scaling(self):
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -499,11 +578,17 @@ class TestMLLinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
 class TestAMGCLMPILinearSolvers(TestLinearSolvers):
     def test_amgcl_mpi_solver_cg(self):
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -515,10 +600,16 @@ class TestAMGCLMPILinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_amgcl_mpi_solver_bicgstab(self):
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -530,10 +621,16 @@ class TestAMGCLMPILinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_amgcl_mpi_solver_bicgstabl(self):
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -545,10 +642,16 @@ class TestAMGCLMPILinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
     def test_amgcl_mpi_solver_gmres(self):
-        self._RunParametrized("""
+        params_string = """
             {
                 "test_list" : [
                     {
@@ -560,7 +663,13 @@ class TestAMGCLMPILinearSolvers(TestLinearSolvers):
                     }
                 ]
             }
-            """)
+            """
+
+        with self.subTest('All ranks (MPI_COMM_WORLD)'):
+            self._RunParametrized(params_string)
+
+        with self.subTest('SubComm'):
+            self._RunParametrizedWithSubComm(params_string)
 
 
 if __name__ == '__main__':

--- a/applications/TrilinosApplication/tests/test_trilinos_linear_solvers.py
+++ b/applications/TrilinosApplication/tests/test_trilinos_linear_solvers.py
@@ -17,8 +17,8 @@ class TestLinearSolvers(KratosUnittest.TestCase):
             settings = all_settings["test_list"][i]
             self._auxiliary_test_function(settings)
 
-    def _auxiliary_test_function(self, settings, matrix_name="A.mm", absolute_norm=False):
-        comm = KratosMultiphysics.TrilinosApplication.CreateEpetraCommunicator(KratosMultiphysics.Testing.GetDefaultDataCommunicator())
+    def _auxiliary_test_function(self, settings, data_comm=KratosMultiphysics.Testing.GetDefaultDataCommunicator(), matrix_name="A.mm", absolute_norm=False):
+        comm = KratosMultiphysics.TrilinosApplication.CreateEpetraCommunicator(data_comm)
         space = KratosMultiphysics.TrilinosApplication.TrilinosSparseSpace()
 
         #read the matrices
@@ -69,7 +69,7 @@ class TestLinearSolvers(KratosUnittest.TestCase):
         if(settings.Has("tolerance")):
             tolerance = settings["tolerance"].GetDouble()
 
-        nproc = KratosMultiphysics.Testing.GetDefaultDataCommunicator().Size()
+        nproc = data_comm.Size()
         target_norm = tolerance*space.TwoNorm(pboriginal.GetReference())*nproc #multiplying by nproc the target tolerance to give some slack. Not really nice :-(
 
         if(achieved_norm > target_norm):


### PR DESCRIPTION
**Description**
This PR adds tests for the trilinos linear solvers with SubCommunicators (i.e. `MPI_Comm` that is a subset of ranks from `MPI_COMM_WORLD`)

I use the `subTest` feature of the python testing, which I think is not that known but can be quite handy in situations such as this one