### PR TITLE
[Core] adding Testing::GetDefaultDataCommunicator

### DIFF
--- a/kratos/input_output/logger_table_output.cpp
+++ b/kratos/input_output/logger_table_output.cpp
@@ -19,7 +19,7 @@
 
 
 // Project includes
-#include "includes/data_communicator.h"
+#include "includes/parallel_environment.h"
 #include "input_output/logger_table_output.h"
 
 namespace Kratos
@@ -30,7 +30,7 @@ namespace Kratos
       column_name.erase(column_name.find_last_not_of(" ") + 1);
     }
 
-    const DataCommunicator& r_communicator = DataCommunicator::GetDefault();
+    const DataCommunicator& r_communicator = ParallelEnvironment::GetDefaultDataCommunicator();
     if (r_communicator.Rank() == 0) {
       WriteHeader();
     }

--- a/kratos/mpi/tests/sources/test_mpi_assign_unique_model_part_collection_tag_utility.cpp
+++ b/kratos/mpi/tests/sources/test_mpi_assign_unique_model_part_collection_tag_utility.cpp
@@ -48,7 +48,7 @@ namespace Kratos
             ModelPart& r_sub_modelpart_3 = r_model_part.CreateSubModelPart("ZSubModelPart3");
             ModelPart& r_sub_modelpart_4 = r_model_part.CreateSubModelPart("YSubModelPart4");
 
-            Communicator::Pointer pnew_comm = Kratos::make_shared< MPICommunicator >(&r_model_part.GetNodalSolutionStepVariablesList(), DataCommunicator::GetDefault());
+            Communicator::Pointer pnew_comm = Kratos::make_shared< MPICommunicator >(&r_model_part.GetNodalSolutionStepVariablesList(), Testing::GetDefaultDataCommunicator());
             r_model_part.SetCommunicator(pnew_comm);
             auto& r_data_communicator = r_model_part.GetCommunicator().GetDataCommunicator();
             auto rank = r_data_communicator.Rank();

--- a/kratos/python/add_logger_to_python.cpp
+++ b/kratos/python/add_logger_to_python.cpp
@@ -15,7 +15,7 @@
 
 // Project includes
 #include "includes/define_python.h"
-#include "includes/data_communicator.h"
+#include "includes/parallel_environment.h"
 #include "input_output/logger.h"
 #include "input_output/file_logger_output.h"
 
@@ -31,7 +31,7 @@ const DataCommunicator& getDataCommunicator(pybind11::kwargs kwargs) {
         return r_data_communicator;
     }
     else {
-        return DataCommunicator::GetDefault();
+        return ParallelEnvironment::GetDefaultDataCommunicator();
     }
 }
 

--- a/kratos/testing/distributed_test_case.cpp
+++ b/kratos/testing/distributed_test_case.cpp
@@ -17,7 +17,7 @@
 
 // Project includes
 #include "includes/kernel.h"
-#include "includes/data_communicator.h"
+#include "includes/parallel_environment.h"
 #include "testing/distributed_test_case.h"
 
 namespace Kratos {
@@ -59,7 +59,7 @@ std::string DistributedTestCase::Info() const
 void DistributedTestCase::CheckRemoteFailure()
 {
     bool success_on_this_rank = GetResult().IsSucceed();
-    const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+    const DataCommunicator& r_comm = ParallelEnvironment::GetDefaultDataCommunicator();
     bool global_success = r_comm.AndReduceAll(success_on_this_rank);
     if (success_on_this_rank && !global_success)
     {

--- a/kratos/testing/testing.cpp
+++ b/kratos/testing/testing.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //

--- a/kratos/testing/testing.cpp
+++ b/kratos/testing/testing.cpp
@@ -1,0 +1,26 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//
+//
+
+#include "testing.h"
+#include "includes/parallel_environment.h"
+
+namespace Kratos {
+namespace Testing {
+
+DataCommunicator& GetDefaultDataCommunicator()
+{
+    return ParallelEnvironment::GetDefaultDataCommunicator();
+}
+
+}
+}

--- a/kratos/testing/testing.h
+++ b/kratos/testing/testing.h
@@ -16,6 +16,15 @@
 
 #include "testing/test_suite.h" // This includes the test_case.h which includes tester.h
 #include "includes/checks.h"  // It is almost always necessary. includes the exception
+#include "includes/data_communicator.h"
 #include "testing/test_skipped_exception.h" // Macros and exception class used to skip tests.
+
+namespace Kratos {
+namespace Testing {
+
+DataCommunicator& GetDefaultDataCommunicator();
+
+}
+}
 
 #endif // KRATOS_TEST_SUITE_H_INCLUDED  defined


### PR DESCRIPTION
**Description**
After #8612, making C++ consistent with Python

Also fixed the deprecation warnings in the Core
I plan to fix the deprecation warnings in the remaining Core-C++-Tests after this PR
