### PR TITLE
[HDF5] Add single file output for transient simulations

### DIFF
--- a/applications/HDF5Application/custom_io/hdf5_file.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file.cpp
@@ -136,19 +136,21 @@ File::File(Parameters Settings)
         m_file_id = H5Fcreate(m_file_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
     else
     {
-        /* Save old error handler */
+        // Save old error handler
         herr_t (*old_func)(hid_t, void*);
         void *old_client_data;
 
         H5Eget_auto(H5E_DEFAULT, &old_func, &old_client_data);
 
-        /* Turn off error handling */
+        // Turn off error handling
         H5Eset_auto(H5E_DEFAULT, NULL, NULL);
 
-        /* Probe. Likely to fail, but that’s okay */
+        // follwoing will fail if the hdf5 file is not found, and will print a failure msg to the output.
+        // if "file_access_mode" is "read_write", then it is ok to fail the following call because,
+        // if it is failed then the file will be created in the subsequent section.
         htri_t is_hdf5 = H5Fis_hdf5(m_file_name.c_str());
 
-        /* Restore previous error handler */
+        // Restore previous error handler
         H5Eset_auto(H5E_DEFAULT, old_func, old_client_data);
 
         if (file_access_mode == "read_only")
@@ -158,8 +160,10 @@ File::File(Parameters Settings)
         }
         else if (file_access_mode == "read_write") {
             if (is_hdf5 <= 0) {
+                // creates the hdf5 file if the file is not found
                 m_file_id = H5Fcreate(m_file_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl_id);
             } else {
+                // open the existing hdf5 file if file is found
                 m_file_id = H5Fopen(m_file_name.c_str(), H5F_ACC_RDWR, fapl_id);
             }
         }

--- a/applications/HDF5Application/python_scripts/core/operations/model_part.py
+++ b/applications/HDF5Application/python_scripts/core/operations/model_part.py
@@ -79,6 +79,8 @@ class VariableIO:
             prefix = Prefix(self.prefix, model_part, self.time_format)
         else:
             prefix = Prefix(self.prefix, model_part)
+        if '<step>' in prefix and not model_part.ProcessInfo.Has(KratosMultiphysics.STEP):
+            raise RuntimeError("STEP is not defined in {:s} process info, but is used in 'prefix'. Please defined it in process info".format(model_part.Name))
         settings['prefix'] = prefix.replace('<step>', str(model_part.ProcessInfo[KratosMultiphysics.STEP]))
         settings['list_of_variables'] = self.list_of_variables
         return settings

--- a/applications/HDF5Application/python_scripts/core/operations/model_part.py
+++ b/applications/HDF5Application/python_scripts/core/operations/model_part.py
@@ -130,6 +130,16 @@ class ElementFlagValueInput(VariableIO):
             self.GetSettings(model_part).Get(), hdf5_file).ReadElementFlags(model_part.Elements,
                                                                             model_part.GetCommunicator())
 
+class ElementGaussPointOutput(VariableIO):
+    '''Write element integration point values to a file.'''
+
+    def __call__(self, model_part, hdf5_file):
+        KratosHDF5.HDF5ElementGaussPointOutput(
+            self.GetSettings(model_part).Get(), hdf5_file).WriteElementGaussPointValues(
+                model_part.Elements,
+                model_part.GetCommunicator().GetDataCommunicator(),
+                model_part.ProcessInfo)
+
 class ConditionDataValueOutput(VariableIO):
     '''Writes non-historical element data values to a file.'''
 
@@ -173,6 +183,16 @@ class ConditionFlagValueInput(VariableIO):
         KratosHDF5.HDF5ConditionFlagValueIO(
             self.GetSettings(model_part).Get(), hdf5_file).ReadConditionFlags(model_part.Conditions,
                                                                               model_part.GetCommunicator())
+
+class ConditionGaussPointOutput(VariableIO):
+    '''Write condition integration point values to a file.'''
+
+    def __call__(self, model_part, hdf5_file):
+        KratosHDF5.HDF5ConditionGaussPointOutput(
+            self.GetSettings(model_part).Get(), hdf5_file).WriteConditionGaussPointValues(
+                model_part.Conditions,
+                model_part.GetCommunicator().GetDataCommunicator(),
+                model_part.ProcessInfo)
 
 
 class NodalSolutionStepDataOutput(VariableIO):
@@ -318,6 +338,8 @@ def Create(settings):
         return ElementDataValueInput(settings)
     elif operation_type == 'element_flag_value_input':
         return ElementFlagValueInput(settings)
+    elif operation_type == 'element_integration_point_output':
+        return ElementGaussPointOutput(settings)
     elif operation_type == 'condition_data_value_output':
         return ConditionDataValueOutput(settings)
     elif operation_type == 'condition_flag_value_output':
@@ -326,6 +348,8 @@ def Create(settings):
         return ConditionDataValueInput(settings)
     elif operation_type == 'condition_flag_value_input':
         return ConditionFlagValueInput(settings)
+    elif operation_type == 'condition_integration_point_output':
+        return ConditionGaussPointOutput(settings)
     elif operation_type == 'nodal_solution_step_data_output':
         return NodalSolutionStepDataOutput(settings)
     elif operation_type == 'nodal_solution_step_data_input':

--- a/applications/HDF5Application/python_scripts/core/operations/model_part.py
+++ b/applications/HDF5Application/python_scripts/core/operations/model_part.py
@@ -79,7 +79,7 @@ class VariableIO:
             prefix = Prefix(self.prefix, model_part, self.time_format)
         else:
             prefix = Prefix(self.prefix, model_part)
-        settings['prefix'] = prefix
+        settings['prefix'] = prefix.replace('<step>', str(model_part.ProcessInfo[KratosMultiphysics.STEP]))
         settings['list_of_variables'] = self.list_of_variables
         return settings
 

--- a/applications/HDF5Application/python_scripts/core/operations/model_part.py
+++ b/applications/HDF5Application/python_scripts/core/operations/model_part.py
@@ -79,9 +79,12 @@ class VariableIO:
             prefix = Prefix(self.prefix, model_part, self.time_format)
         else:
             prefix = Prefix(self.prefix, model_part)
-        if '<step>' in prefix and not model_part.ProcessInfo.Has(KratosMultiphysics.STEP):
-            raise RuntimeError("STEP is not defined in {:s} process info, but is used in 'prefix'. Please defined it in process info".format(model_part.Name))
-        settings['prefix'] = prefix.replace('<step>', str(model_part.ProcessInfo[KratosMultiphysics.STEP]))
+        if '<step>' in prefix:
+            if model_part.ProcessInfo.Has(KratosMultiphysics.STEP):
+                prefix = prefix.replace('<step>', str(model_part.ProcessInfo[KratosMultiphysics.STEP]))
+            else:
+                raise RuntimeError("STEP is not defined in {:s} process info, but is used in 'prefix'. Please define it in process info.".format(model_part.Name))
+        settings['prefix'] = prefix
         settings['list_of_variables'] = self.list_of_variables
         return settings
 


### PR DESCRIPTION
**Description**
This PR adds the capability to write transient simulation results to the same hdf5 file. Following is an example setup:

```json
            {
                "kratos_module": "KratosMultiphysics.HDF5Application",
                "python_module": "single_mesh_temporal_output_process",
                "Parameters": {
                    "model_part_name": "FluidModelPart",
                    "file_settings": {
                        "file_name": "hdf5_output/example_initialization_file.h5",
                        "file_access_mode": "read_write",
                        "echo_level": 1
                    },
                    "nodal_solution_step_data_settings" : {
                        "prefix": "/ResultsData/<step>",
                        "list_of_variables": [
                            "VELOCITY",
                            "PRESSURE"
                        ]
                    },
                    "output_time_settings": {
                        "step_frequency": 1,
                        "time_frequency":  0.05
                    }                    
                }
            }
```

In the `prefix`, eventhough `<time>` flag is supported, HDF5 does not support writing `"."` in the groupnames, therefore we cannot use `<time>` in the `prefix`, so `<step>` flag is introduced. Since this only changes the `prefix`, it does not change the existing behaviour if `<step>` flag is not used.

HDF5 output structure will look like this:
![image](https://user-images.githubusercontent.com/7856520/116860001-2a539e80-ac01-11eb-8cd1-1651e2d36830.png)


**Changelog**
- Adds the capablity to use single file output for transient simulations
