### PR TITLE
Added ListImportedApp and MapImportedApps utilities

### DIFF
--- a/kratos/python_scripts/kratos_utilities.py
+++ b/kratos/python_scripts/kratos_utilities.py
@@ -1,5 +1,5 @@
+import os, sys, shutil, re
 import KratosMultiphysics as KM
-import os, shutil, re
 
 def IssueDeprecationWarning(label, *message):
     KM.Logger.PrintWarning('DEPRECATION-Warning; '+label, ' '.join(map(str,message)))
@@ -45,6 +45,35 @@ def GetListOfAvailableApplications():
     ])
 
     return apps
+
+def GetListOfImportedApplications():
+    """Returns the list of applications that are or were imported at
+    call time, including the main KratosMultiphysics module.
+    """
+    loaded_modules = [mod for mod in sys.modules.keys() if '__file__' in dir(sys.modules[mod]) and sys.modules[mod].__file__]
+    kratos_modules = [mod for mod in loaded_modules if "KratosMultiphysics" in sys.modules[mod].__file__]
+
+    kratos_apps = [mod for mod in kratos_modules if os.path.basename(sys.modules[mod].__file__) == "__init__.py"]
+
+    return kratos_apps
+
+def GetMapOfImportedApplications():
+    """Returns the tree of application modules that are or were imported at
+    call time, including the main KratosMultiphysics module.
+    """
+    import_map = {}
+    imported_apps = GetListOfImportedApplications()
+
+    for app in imported_apps:
+        names = app.split(".")
+
+        entry_point = import_map
+        for part in names:
+            if part not in entry_point:
+                entry_point[part] = {}
+            entry_point = entry_point[part]
+
+    return import_map
 
 def IsMPIAvailable():
     """Check if the KratosMPI module (the MPI core) is available.

--- a/kratos/python_scripts/kratos_utilities.py
+++ b/kratos/python_scripts/kratos_utilities.py
@@ -46,23 +46,23 @@ def GetListOfAvailableApplications():
 
     return apps
 
-def GetListOfImportedApplications():
-    """Returns the list of applications that are or were imported at
-    call time, including the main KratosMultiphysics module.
+def GetListOfImportedApplications(module_name="KratosMultiphysics"):
+    """Returns the list of moldules that are or were imported at
+    call time, including the main module_name module.
     """
     loaded_modules = [mod for mod in sys.modules.keys() if '__file__' in dir(sys.modules[mod]) and sys.modules[mod].__file__]
-    kratos_modules = [mod for mod in loaded_modules if "KratosMultiphysics" in sys.modules[mod].__file__]
+    kratos_modules = [mod for mod in loaded_modules if module_name in sys.modules[mod].__file__]
 
     kratos_apps = [mod for mod in kratos_modules if os.path.basename(sys.modules[mod].__file__) == "__init__.py"]
 
     return kratos_apps
 
-def GetMapOfImportedApplications():
-    """Returns the tree of application modules that are or were imported at
-    call time, including the main KratosMultiphysics module.
+def GetMapOfImportedApplications(module_name="KratosMultiphysics"):
+    """Returns the tree of modules that are or were imported at
+    call time, including the main "module_name" module.
     """
     import_map = {}
-    imported_apps = GetListOfImportedApplications()
+    imported_apps = GetListOfImportedApplications(module_name)
 
     for app in imported_apps:
         names = app.split(".")


### PR DESCRIPTION
**Description**
Adds a couple of utilities to retrieve the list of applications that are loaded or have been loaded through an execution. 
It also adds a utility to retrieve it in form of a map with nested dependencies.

It detects applications automatically imported from process by the stage, but does not resolve third party dependencies.

It can be expanded to list all symbols and not only modules if needed.

**Example** (a fluid script that prints in hdf5):

List:
```
['KratosMultiphysics', 'KratosMultiphysics.FluidDynamicsApplication', 'KratosMultiphysics.HDF5Application', 'KratosMultiphysics.HDF5Application.core.operations', 'KratosMultiphysics.HDF5Application.core']
```

Map:
```json
{
	"KratosMultiphysics": {
		"FluidDynamicsApplication": {},
		"HDF5Application": {
			"core": {
				"operations": {}
			}
		}
	}
}
```

**Note**
Tests are missing because I cannot tests this in the core without importing an app, which is the solo purpose of this utility

**Changelog**
- Added GetListOfImportedApplications utility
- Added GetMapOfImportedApplications utility
