### PR TITLE
[PotentialFlow] Update deprecated constructor compute nodal neighbours

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
@@ -196,10 +196,7 @@ class PotentialFlowSolver(FluidSolver):
 
     def _ComputeNodalElementalNeighbours(self):
         # Find nodal neigbours util call
-        data_communicator  = KratosMultiphysics.DataCommunicator.GetDefault()
-        KratosMultiphysics.FindGlobalNodalElementalNeighboursProcess(
-            data_communicator,
-            self.GetComputingModelPart()).Execute()
+        KratosMultiphysics.FindGlobalNodalElementalNeighboursProcess(self.GetComputingModelPart()).Execute()
 
     def _GetStrategyType(self):
         element_type = self.settings["formulation"]["element_type"].GetString()


### PR DESCRIPTION
**Description**
This updates the nodal neighbours call in the potential flow solver with its new constructor without the data communicator.

**Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Updated nodal neighbour process call without  datacomm.
