### PR TITLE
[Core][ParallelUtils] adding test for "continue"

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
@@ -271,6 +271,29 @@ KRATOS_TEST_CASE_IN_SUITE(IndexPartitionerThreadLocalStorage, KratosCoreFastSuit
     KRATOS_CHECK_NEAR(final_sum, exp_sum, tol);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(ParallelUtilsContinue, KratosCoreFastSuite)
+{
+    int nsize = 1e3;
+    std::vector<double> data_vector(nsize, -1.0), output(nsize, 3.3);
+
+    IndexPartition<unsigned int>(data_vector.size()).for_each(
+        [&](unsigned int i){
+            if (i>500) return; // this is the equivalent of "continue" in a regular loop
+
+            output[i] = 2.0*data_vector[i];
+            }
+        );
+
+    for(unsigned int i=0; i<output.size(); ++i) {
+        std::cout << "i=" << i << " ; " << output[i] << std::endl;
+        if (i>500) {
+            KRATOS_CHECK_DOUBLE_EQUAL(output[i], 3.3);
+        } else {
+            KRATOS_CHECK_DOUBLE_EQUAL(output[i], -2.0);
+        }
+    }
+}
+
 KRATOS_TEST_CASE_IN_SUITE(AccumReductionVector, KratosCoreFastSuite)
 {
     int nsize = 1e3;

--- a/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
@@ -278,15 +278,14 @@ KRATOS_TEST_CASE_IN_SUITE(ParallelUtilsContinue, KratosCoreFastSuite)
 
     IndexPartition<unsigned int>(data_vector.size()).for_each(
         [&](unsigned int i){
-            if (i>500) return; // this is the equivalent of "continue" in a regular loop
+            if (i%4 == 0) return; // this is the equivalent of "continue" in a regular loop
 
             output[i] = 2.0*data_vector[i];
             }
         );
 
     for(unsigned int i=0; i<output.size(); ++i) {
-        std::cout << "i=" << i << " ; " << output[i] << std::endl;
-        if (i>500) {
+        if (i%4 == 0) {
             KRATOS_CHECK_DOUBLE_EQUAL(output[i], 3.3);
         } else {
             KRATOS_CHECK_DOUBLE_EQUAL(output[i], -2.0);


### PR DESCRIPTION
**Description**
This PR adds a test for using `continue` with the ParallelUtilites

in a regular loop one can do:
~~~c++
for (...) {
    if (...) continue // this skips the rest of this loop iteration
}
~~~

however with the parallel utilities this is not possible as we pass a lambda which is executed once per loop index. Hence for doing the same we need to use `return` instead of `continue`.
~~~c++
IndexPartition.for_each(
    [](i){
        if (...) return; // this is the equivalent of "continue" in a regular loop
        }
    );
~~~


I see that this is not intuitive but this is how it needs to be done
Same for the standard library functions BTW (e.g. https://stackoverflow.com/questions/56232059/skip-iteration-in-stdfor-each-on-specific-condition)