### PR TITLE
[HDF5] Extends XDMF creation support for single file temporal output

### DIFF
--- a/applications/HDF5Application/python_scripts/create_xdmf_file.py
+++ b/applications/HDF5Application/python_scripts/create_xdmf_file.py
@@ -8,6 +8,7 @@ from argparse import ArgumentParser
 
 
 from KratosMultiphysics.HDF5Application.xdmf_utils import WriteMultifileTemporalAnalysisToXdmf
+from KratosMultiphysics.HDF5Application.xdmf_utils import WriteSinglefileTemporalAnalysisToXdmf
 
 
 def main():
@@ -29,6 +30,9 @@ def main():
     if args.type == "multiple" and args.analysis == "temporal":
         WriteMultifileTemporalAnalysisToXdmf(
             args.file_name, args.mesh_path, args.results_path)
+    elif args.type == "single" and args.analysis == "temporal":
+        WriteSinglefileTemporalAnalysisToXdmf(
+            args.file_name, args.mesh_path, args.results_path)        
     else:
         raise RuntimeError("Unsupported command line options.")
 


### PR DESCRIPTION
**Description**
This PR extends XDMF creation process to support creating xdmf file created using single file temporal output method. This enables visualizing them in paraview as well.

If an hdf5 file is created using single file temporal output method [ refer #8701 ], then following can be used to create the corresponding xdmf file. First navigate to the folder where you can fidn single "*.h5" file.

```bash
python3 ~/software/kratos/applications/HDF5Application/python_scripts/create_xdmf_file.py your_h5_file.h5 -t single -r "/ResultsData/<step>"
```

In here `-t single` specifies this is made from single file temporal output process, and `-r "/ResultsData/<step>"` specifies the `prefix` pattern used in creating the results. If different meshes are also found for each time step then following can be used.

```bash
python3 ~/software/kratos/applications/HDF5Application/python_scripts/create_xdmf_file.py your_h5_file.h5 -t single -r  "/ResultsData/<step>" -m "/ModelData/<step>""
```

**Changelog**
- Extends xdmf creation process to support files created by single file temporal output method.
