### PR TITLE
[Core][Geometry] Add GlobalSpaceDerivatives to BrepCurveOnSurface

### DIFF
--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -382,6 +382,27 @@ public:
      {
         return mpCurveOnSurface->GlobalCoordinates(rResult, rLocalCoordinates);
     }
+    
+    /**
+    * @brief This method maps from local space to global/working space and computes the
+    *        number of derivatives at the underlying nurbs curve on surface
+    *        at the parameter rLocalCoordinates[0].
+    *
+    * @param LocalCoordinates The local coordinates in paramater space
+    * @param Derivative Number of computed derivatives
+    *        0 -> Location = PointLocalCoordinates
+    *        1 -> Tangent
+    *        2 -> Curvature
+    *        ...
+    * @return std::vector<array_1d<double, 3>> with the global space derivatives
+    */
+    void GlobalSpaceDerivatives(
+        std::vector<CoordinatesArrayType>& rGlobalSpaceDerivatives,
+        const CoordinatesArrayType& rLocalCoordinates,
+        const SizeType DerivativeOrder) const override
+    {
+        return mpCurveOnSurface->GlobalSpaceDerivatives(rGlobalSpaceDerivatives, rLocalCoordinates, DerivativeOrder);
+    }
 
     /**
     * Returns whether given arbitrary point is inside the Geometry and the respective


### PR DESCRIPTION
**Description**
Just completes the GlobalSpaceDerivatives interface on the BrepCurveOnSurface.

Thank you very much, @rickyaristio for pointing this out!