### PR TITLE
[PotentialFlow] Return true in SetPhysicalProperies to avoid material warning

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
@@ -261,3 +261,7 @@ class PotentialFlowSolver(FluidSolver):
             err_msg = "Unknown strategy type: \'" + strategy_type + "\'. Valid options are \'linear\' and \'non_linear\'."
             raise Exception(err_msg)
         return solution_strategy
+
+    def _SetPhysicalProperties(self):
+        # There are no properties in the potential flow solver. Free stream quantities are defined in the apply_far_field_process.py
+        return True


### PR DESCRIPTION
**Description**
Currently the potential flow solver, that depends on the fluid, gives the warning:

```
[WARNING] PotentialFlowSolver: Material properties have not been imported. Check 'material_import_settings'
 in your ProjectParameters.json.
```

As no material properties are imported. However, there is no use of elemental or condition properties, as the quantities that define the system are free-stream quantities that are defined in a separate process in the ProcessInfo.

https://github.com/KratosMultiphysics/Kratos/blob/7a188d1cc11792d975646e9b9a481fe8ed430150/applications/CompressiblePotentialFlowApplication/python_scripts/apply_far_field_process.py#L66-L74


I understand this still could be added in the properties, but it is adding kind of more complexity and the requirement to read an extra file. 

**Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Return true in _SetPhysicalPropties() of the fluid solver to avoid material warning
