### PR TITLE
[CMake] application switches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,6 +386,8 @@ if(${USE_TETGEN_NONFREE_TPL} MATCHES ON )
   find_package(Tetgen REQUIRED)
 endif(${USE_TETGEN_NONFREE_TPL} MATCHES ON )
 
+set(USE_MPI OFF CACHE BOOL "Build Kratos with MPI")
+
 if(${USE_MPI} MATCHES ON )
   find_package(MPI REQUIRED)
   add_definitions( -DKRATOS_USING_MPI )
@@ -449,27 +451,63 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 add_subdirectory(external_libraries/gidpost)
 add_subdirectory(kratos)
 
+# Collect Kratos applications for the CMake GUI / CMake variables
+set(KRATOS_APPLICATION_DIRECTORIES "${KRATOS_SOURCE_DIR}/applications" CACHE STRING "List of directories with Kratos applications")
+set(KRATOS_APPLICATIONS "")
+
+foreach(application_directory ${KRATOS_APPLICATION_DIRECTORIES})
+    file(GLOB items_in_directory RELATIVE "${application_directory}" "${application_directory}/*")
+    foreach(item ${items_in_directory})
+        if(IS_DIRECTORY "${application_directory}/${item}")
+
+            # Create application switch (off by default)
+            set(KRATOS_BUILD_${item} OFF CACHE BOOL "Build application: ${item}")
+
+            # Register application in the build list
+            if(${KRATOS_BUILD_${item}})
+                list(APPEND KRATOS_APPLICATIONS "${application_directory}/${item}")
+            endif(${KRATOS_BUILD_${item}})
+
+        endif(IS_DIRECTORY "${application_directory}/${item}")
+    endforeach(item ${items_in_directory})
+endforeach(application_directory ${KRATOS_APPLICATION_DIRECTORIES})
+
+# Collect Kratos applications from the environment
+if(DEFINED ENV{KRATOS_APPLICATIONS})
+    foreach(application_path $ENV{KRATOS_APPLICATIONS})
+        get_filename_component(application_name "${application_path}" NAME)
+
+        # Define the application switch if it wasn't already
+        if(NOT DEFINED KRATOS_BUILD_${application_name})
+            set(KRATOS_BUILD_${application_name} ON CACHE BOOL "Build application: ${application_name}")
+        endif(NOT DEFINED KRATOS_BUILD_${application_name})
+
+        # Add application to the build list if it's not in it yet
+        list(FIND ${KRATOS_APPLICATIONS} "KRATOS_BUILD_${application_name}" index) # CMake < 3.3 does not support IN_LIST
+        if(${index} EQUAL -1)
+            list(APPEND KRATOS_APPLICATIONS "${application_path}")
+        endif(${index EQUAL -1})
+
+    endforeach(application_path $ENV{KRATOS_APPLICATIONS})
+endif(DEFINED ENV{KRATOS_APPLICATIONS})
+
 # Configure kratos applications
 message("-- Configuring applications (ENV):")
 set_property(GLOBAL PROPERTY LIST_OF_APPLICATIONS_ADDED_THROUGH_DEPENDENCIES)
-if(DEFINED ENV{KRATOS_APPLICATIONS})
-    foreach(APPLICATION_PATH $ENV{KRATOS_APPLICATIONS})
-        get_filename_component(APPLICATION_NAME ${APPLICATION_PATH} NAME)
-        list(APPEND LIST_OF_APPLICATIONS_TO_BE_COMPILED ${APPLICATION_NAME})
-    endforeach(APPLICATION_PATH $ENV{KRATOS_APPLICATIONS})
-endif(DEFINED ENV{KRATOS_APPLICATIONS})
+foreach(APPLICATION_PATH ${KRATOS_APPLICATIONS})
+    get_filename_component(APPLICATION_NAME ${APPLICATION_PATH} NAME)
+    list(APPEND LIST_OF_APPLICATIONS_TO_BE_COMPILED ${APPLICATION_NAME})
+endforeach(APPLICATION_PATH ${KRATOS_APPLICATIONS})
 
-if(DEFINED ENV{KRATOS_APPLICATIONS})
-    foreach(APPLICATION_PATH $ENV{KRATOS_APPLICATIONS})
-        get_filename_component(APPLICATION_NAME ${APPLICATION_PATH} NAME)
-        if(NOT TARGET Kratos${APPLICATION_NAME})
-            message("Adding application '${APPLICATION_PATH}'")
-            add_subdirectory(${APPLICATION_PATH} ${CMAKE_CURRENT_BINARY_DIR}/applications/${APPLICATION_NAME})
-        else(NOT TARGET Kratos${APPLICATION_NAME})
-            message("[Warning] Application '${APPLICATION_PATH}' was already added")
-        endif(NOT TARGET Kratos${APPLICATION_NAME})
-    endforeach(APPLICATION_PATH $ENV{KRATOS_APPLICATIONS})
-endif(DEFINED ENV{KRATOS_APPLICATIONS})
+foreach(APPLICATION_PATH ${KRATOS_APPLICATIONS})
+    get_filename_component(APPLICATION_NAME ${APPLICATION_PATH} NAME)
+    if(NOT TARGET Kratos${APPLICATION_NAME})
+        message("Adding application '${APPLICATION_PATH}'")
+        add_subdirectory(${APPLICATION_PATH} ${CMAKE_CURRENT_BINARY_DIR}/applications/${APPLICATION_NAME})
+    else(NOT TARGET Kratos${APPLICATION_NAME})
+        message("[Warning] Application '${APPLICATION_PATH}' was already added")
+    endif(NOT TARGET Kratos${APPLICATION_NAME})
+endforeach(APPLICATION_PATH ${KRATOS_APPLICATIONS})
 
 message("")
 message("***********************************************************************")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project (KratosMultiphysics)
-cmake_minimum_required (VERSION 2.8.6)
+cmake_minimum_required (VERSION 3.3)
 set (CMAKE_CXX_STANDARD 11)
 
 # Setting some policies
@@ -483,10 +483,9 @@ if(DEFINED ENV{KRATOS_APPLICATIONS})
         endif(NOT DEFINED KRATOS_BUILD_${application_name})
 
         # Add application to the build list if it's not in it yet
-        list(FIND "${KRATOS_APPLICATIONS}" "KRATOS_BUILD_${application_name}" index) # CMake < 3.3 does not support IN_LIST
-        if(${index} EQUAL -1)
+        if(NOT "KRATOS_BUILD_${application_name}" IN_LIST KRATOS_APPLICATIONS)
             list(APPEND KRATOS_APPLICATIONS "${application_path}")
-        endif(${index EQUAL -1})
+        endif(NOT "KRATOS_BUILD_${application_name}" IN_LIST KRATOS_APPLICATIONS)
 
     endforeach(application_path $ENV{KRATOS_APPLICATIONS})
 endif(DEFINED ENV{KRATOS_APPLICATIONS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,7 +483,7 @@ if(DEFINED ENV{KRATOS_APPLICATIONS})
         endif(NOT DEFINED KRATOS_BUILD_${application_name})
 
         # Add application to the build list if it's not in it yet
-        list(FIND ${KRATOS_APPLICATIONS} "KRATOS_BUILD_${application_name}" index) # CMake < 3.3 does not support IN_LIST
+        list(FIND "${KRATOS_APPLICATIONS}" "KRATOS_BUILD_${application_name}" index) # CMake < 3.3 does not support IN_LIST
         if(${index} EQUAL -1)
             list(APPEND KRATOS_APPLICATIONS "${application_path}")
         endif(${index EQUAL -1})


### PR DESCRIPTION
**Description**
Please note that this PR is just a draft.
(It's a feature no one asked for, but it can be useful for people setting up Kratos for the first time)

Add CMake switches for selecting applications to compile. Now it should be possible to configure Kratos entirely through CMake, without shell scripts.
```
KRATOS_BUILD_${application_name}
```

Following the discussion in #8675, external applications are supported but need an extra step to be discovered. ```KRATOS_APPLICATION_DIRECTORIES``` is a list of directories containing Kratos applications. By default, it's initialized to ```${KRATOS_SOURCE}/applications```, but can be appended with paths containing external ones. All subdirectories in these folders are assumed to be Kratos applications, and get their own switches.

Configuring **with** shell scripts is still possible, but the two approaches shouldn't be mixed.

**Changelog**
Add application switches in the main ```CMakeLists.txt```