### PR TITLE
[CLA][SMA] Fix missing resize when getting initial strain vector

### DIFF
--- a/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_small_strain_isotropic_damage_3d.cpp
+++ b/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_small_strain_isotropic_damage_3d.cpp
@@ -102,6 +102,23 @@ KRATOS_TEST_CASE_IN_SUITE(_ConstitutiveLaw_SmallStrainIsotropicDamage3D, KratosC
     KRATOS_CHECK_NEAR(internal_variables_r.size(), 1., 1.e-5);  // = True
     KRATOS_CHECK_NEAR(internal_variables_r[0], 0.123, 1.e-5);  // = True
 
+    Vector initial_strain_w(6);
+    initial_strain_w(0) = 0.000000;
+    initial_strain_w(1) = 0.000001;
+    initial_strain_w(2) = 0.000002;
+    initial_strain_w(3) = 0.000003;
+    initial_strain_w(4) = 0.000004;
+    initial_strain_w(5) = 0.000005;
+    InitialState::Pointer p_initial_state = Kratos::make_intrusive<InitialState>
+	    (initial_strain_w, InitialState::InitialImposingType::STRAIN_ONLY);
+    cl.SetInitialState(p_initial_state);
+    Vector initial_strain_r;  // Should be accordingly resized in the CL
+    cl.CalculateValue(cl_parameters, INITIAL_STRAIN_VECTOR, initial_strain_r);
+    KRATOS_CHECK_VECTOR_NEAR(initial_strain_r, initial_strain_w, 1e-8);
+    p_initial_state->SetInitialStrainVector(ZeroVector(6));
+    cl.CalculateValue(cl_parameters, INITIAL_STRAIN_VECTOR, initial_strain_r);
+    KRATOS_CHECK_VECTOR_NEAR(initial_strain_r, ZeroVector(6), 1e-8);
+
     //
     // Test: exponential hardening model, load in traction
     //

--- a/applications/StructuralMechanicsApplication/custom_constitutive/elastic_isotropic_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/elastic_isotropic_3d.cpp
@@ -254,7 +254,10 @@ Vector& ElasticIsotropic3D::CalculateValue(
 
     } else if (rThisVariable == INITIAL_STRAIN_VECTOR) {
         if (this->HasInitialState()) {
-            noalias(rValue) = GetInitialState().GetInitialStrainVector();
+	    if (rValue.size() != GetStrainSize()) {
+	        rValue.resize(GetStrainSize());
+	    }
+	    noalias(rValue) = GetInitialState().GetInitialStrainVector();
         } else {
             noalias(rValue) = ZeroVector(0);
         }


### PR DESCRIPTION
**Description**
Fix missing resize when getting initial strain vector. Without it, CalculateValue(INITIAL_STRAIN_VECTOR) returns an empty vector.

**Changelog**
- resize rValue vector to the expected size, required by "noalias"
- added co block to cpp test, to check the fix