### PR TITLE
[PotentialFlow] Reduce different warnings in tests

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
@@ -894,7 +894,7 @@ void CheckIfWakeConditionsAreFulfilled(const ModelPart& rWakeModelPart, const do
             number_of_unfulfilled_wake_conditions += 1;
         }
     }
-    KRATOS_WARNING_IF("CheckIfWakeConditionsAreFulfilled", number_of_unfulfilled_wake_conditions > 0)
+    KRATOS_WARNING_IF("CheckIfWakeConditionsAreFulfilled", number_of_unfulfilled_wake_conditions > 0 && rEchoLevel > 0)
         << "THE WAKE CONDITION IS NOT FULFILLED IN " << number_of_unfulfilled_wake_conditions
         << " ELEMENTS WITH AN ABSOLUTE TOLERANCE OF " << rTolerance << std::endl;
 }

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_3d.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_3d.py
@@ -27,6 +27,7 @@ class DefineWakeProcess3D(KratosMultiphysics.Process):
             "wake_stl_file_name" : "",
             "wake_normal": [0.0,0.0,1.0],
             "output_wake": false,
+            "echo_level": 1,
             "epsilon": 1e-9
         }''')
         settings.ValidateAndAssignDefaults(default_settings)
@@ -55,6 +56,7 @@ class DefineWakeProcess3D(KratosMultiphysics.Process):
 
         self.epsilon = settings["epsilon"].GetDouble()
         self.output_wake = settings["output_wake"].GetBool()
+        self.echo_level = settings["echo_level"].GetInt()
 
         # For now plane wake surfaces are considered.
         # TODO: Generalize this to curved wake surfaces
@@ -398,4 +400,4 @@ class DefineWakeProcess3D(KratosMultiphysics.Process):
         gid_output.ExecuteFinalize()
 
     def ExecuteFinalizeSolutionStep(self):
-        CPFApp.PotentialFlowUtilities.CheckIfWakeConditionsAreFulfilled3D(self.wake_sub_model_part, 1e-1, 0)
+        CPFApp.PotentialFlowUtilities.CheckIfWakeConditionsAreFulfilled3D(self.wake_sub_model_part, 1e-1, self.echo_level)

--- a/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
@@ -151,7 +151,7 @@ class PotentialFlowTests(UnitTest.TestCase):
         work_folder = "wake_process_3d_tests/15_elements_small_test"
 
         with WorkFolderScope(work_folder):
-            self._runTest(settings_file_name)
+            self._runTest(settings_file_name, True)
             reference_wake_elements_id_list = [2, 4, 9, 13, 15]
             self._validateWakeProcess(reference_wake_elements_id_list, "WAKE")
             reference_kutta_elements_id_list = [1, 10, 14]
@@ -165,7 +165,7 @@ class PotentialFlowTests(UnitTest.TestCase):
         work_folder = "wake_process_3d_tests/25_elements_nodes_on_wake_test"
 
         with WorkFolderScope(work_folder):
-            self._runTest(settings_file_name)
+            self._runTest(settings_file_name, True)
             reference_wake_elements_id_list = [1, 2, 3, 4, 5, 6]
             self._validateWakeProcess(reference_wake_elements_id_list, "WAKE")
             reference_kutta_elements_id_list = [13, 14, 15, 17, 18, 19, 20, 21, 22, 23]
@@ -179,7 +179,7 @@ class PotentialFlowTests(UnitTest.TestCase):
         work_folder = "wake_process_3d_tests/24_elements_kutta_node_above_wake_test"
 
         with WorkFolderScope(work_folder):
-            self._runTest(settings_file_name)
+            self._runTest(settings_file_name, True)
             reference_wake_elements_id_list = [2, 4, 8, 16, 17, 19, 20]
             self._validateWakeProcess(reference_wake_elements_id_list, "WAKE")
             reference_kutta_elements_id_list = [10, 11, 12, 13, 14, 15, 18, 23, 24]
@@ -216,7 +216,7 @@ class PotentialFlowTests(UnitTest.TestCase):
             for i in range(len(reference_element_id_list)):
                 self._check_results(solution_element_id_list[i], reference_element_id_list[i], 0.0, 1e-9)
 
-    def _runTest(self,settings_file_name):
+    def _runTest(self,settings_file_name, initialize_only = False):
         model = KratosMultiphysics.Model()
         with open(settings_file_name,'r') as settings_file:
             settings = KratosMultiphysics.Parameters(settings_file.read())
@@ -294,7 +294,10 @@ class PotentialFlowTests(UnitTest.TestCase):
                 }'''))
 
         potential_flow_analysis = PotentialFlowAnalysis(model, settings)
-        potential_flow_analysis.Run()
+        potential_flow_analysis.Initialize()
+        if not initialize_only:
+            potential_flow_analysis.RunSolutionLoop()
+            potential_flow_analysis.Finalize()
         self.main_model_part = model.GetModelPart(settings["solver_settings"]["model_part_name"].GetString())
 
     def _check_results(self, result, reference, rel_tol, abs_tol):

--- a/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
@@ -151,7 +151,7 @@ class PotentialFlowTests(UnitTest.TestCase):
         work_folder = "wake_process_3d_tests/15_elements_small_test"
 
         with WorkFolderScope(work_folder):
-            self._runTest(settings_file_name, True)
+            self._runTest(settings_file_name, initialize_only=True)
             reference_wake_elements_id_list = [2, 4, 9, 13, 15]
             self._validateWakeProcess(reference_wake_elements_id_list, "WAKE")
             reference_kutta_elements_id_list = [1, 10, 14]
@@ -165,7 +165,7 @@ class PotentialFlowTests(UnitTest.TestCase):
         work_folder = "wake_process_3d_tests/25_elements_nodes_on_wake_test"
 
         with WorkFolderScope(work_folder):
-            self._runTest(settings_file_name, True)
+            self._runTest(settings_file_name, initialize_only=True)
             reference_wake_elements_id_list = [1, 2, 3, 4, 5, 6]
             self._validateWakeProcess(reference_wake_elements_id_list, "WAKE")
             reference_kutta_elements_id_list = [13, 14, 15, 17, 18, 19, 20, 21, 22, 23]
@@ -179,7 +179,7 @@ class PotentialFlowTests(UnitTest.TestCase):
         work_folder = "wake_process_3d_tests/24_elements_kutta_node_above_wake_test"
 
         with WorkFolderScope(work_folder):
-            self._runTest(settings_file_name, True)
+            self._runTest(settings_file_name, initialize_only=True)
             reference_wake_elements_id_list = [2, 4, 8, 16, 17, 19, 20]
             self._validateWakeProcess(reference_wake_elements_id_list, "WAKE")
             reference_kutta_elements_id_list = [10, 11, 12, 13, 14, 15, 18, 23, 24]

--- a/applications/CompressiblePotentialFlowApplication/tests/rhombus_3d/rhombus_3d.mdpa
+++ b/applications/CompressiblePotentialFlowApplication/tests/rhombus_3d/rhombus_3d.mdpa
@@ -761,7 +761,7 @@ Begin Conditions SurfaceCondition3D3N// GUI group identifier: _HIDDEN__SKIN_
     216 0 17 8 3
 End Conditions
 
-Begin Conditions LineCondition3D2N
+Begin Conditions LineCondition2D2N
     217 0 109 87
     218 0 87 56
     219 0 56 49

--- a/applications/CompressiblePotentialFlowApplication/tests/rhombus_3d/rhombus_3d_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/rhombus_3d/rhombus_3d_parameters.json
@@ -38,6 +38,7 @@
                 "model_part_name" : "MainModelPart.Wake3D_Wake_Auto1",
                 "body_model_part_name": "MainModelPart.Body3D_Body_Auto1",
                 "wake_stl_file_name" : "wake_stl.stl",
+                "echo_level"   : 0,
                 "epsilon"         : 1e-6
             }
         },{


### PR DESCRIPTION
**Description**
There are some warnings appearing during test execution that clutter the log output. See changelog below

**Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Do only Initialize() in tests where only Initialize() is requried
- Add option to set echo level in 3D wake process for the CheckWakeCondition()
- Change geometry type accepted by octree_binary.h
