### PR TITLE
[UnityBuild?] Fix compilation error due to missing parallel utils include 

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
@@ -13,6 +13,7 @@
 #include "compressible_potential_flow_application_variables.h"
 #include "fluid_dynamics_application_variables.h"
 #include "includes/model_part.h"
+#include "utilities/parallel_utilities.h"
 
 namespace Kratos {
 namespace PotentialFlowUtilities {

--- a/applications/ShapeOptimizationApplication/custom_utilities/mapping/symmetry_revolution.cpp
+++ b/applications/ShapeOptimizationApplication/custom_utilities/mapping/symmetry_revolution.cpp
@@ -17,6 +17,7 @@
 #include "includes/define.h"
 #include "includes/model_part.h"
 #include "utilities/math_utils.h"
+#include "utilities/parallel_utilities.h"
 #include "shape_optimization_application.h"
 #include "symmetry_base.h"
 #include "symmetry_revolution.h"


### PR DESCRIPTION
**Description**
Current master fails to compile for me for the PotentialFlow and ShapeOptApp due to missing includes.

After doing git bisect I have seen it is due to this change:

https://github.com/KratosMultiphysics/Kratos/commit/f26f571ebcc3f0e793f3cbfdf17ac227b6d82836

which I guess was doing the include of parallel_utilities implicitly for the utilities in this PR.

This was for some reason not detected by the non-unity CI. Any clue why? @philbucher 

**Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Add missing include in potential flow app
- Add missing include in shape opt app