### PR TITLE
[FastPR][Core] Add missing create methods to levelset convection elements

### DIFF
--- a/kratos/elements/levelset_convection_element_simplex.h
+++ b/kratos/elements/levelset_convection_element_simplex.h
@@ -100,6 +100,15 @@ public:
         KRATOS_CATCH("");
     }
 
+    Element::Pointer Create(
+        IndexType NewId,
+        GeometryType::Pointer pGeom,
+        PropertiesType::Pointer pProperties) const override
+    {
+        KRATOS_TRY
+        return Element::Pointer(new LevelSetConvectionElementSimplex(NewId, pGeom, pProperties));
+        KRATOS_CATCH("");
+    }
 
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override
     {

--- a/kratos/elements/levelset_convection_element_simplex_algebraic_stabilization.cpp
+++ b/kratos/elements/levelset_convection_element_simplex_algebraic_stabilization.cpp
@@ -24,7 +24,7 @@
 namespace Kratos
 {
     template< unsigned int TDim, unsigned int TNumNodes>
-    LevelSetConvectionElementSimplexAlgebraicStabilization<TDim, TNumNodes>::LevelSetConvectionElementSimplexAlgebraicStabilization() 
+    LevelSetConvectionElementSimplexAlgebraicStabilization<TDim, TNumNodes>::LevelSetConvectionElementSimplexAlgebraicStabilization()
     : LevelSetConvectionElementSimplex<TDim, TNumNodes>::LevelSetConvectionElementSimplex()
     {}
 
@@ -55,6 +55,17 @@ namespace Kratos
     {
         KRATOS_TRY
         return Element::Pointer(new LevelSetConvectionElementSimplexAlgebraicStabilization(NewId, this->GetGeometry().Create(ThisNodes), pProperties));
+        KRATOS_CATCH("");
+    }
+
+    template <unsigned int TDim, unsigned int TNumNodes>
+    Element::Pointer LevelSetConvectionElementSimplexAlgebraicStabilization<TDim, TNumNodes>::Create(
+        IndexType NewId,
+        GeometryType::Pointer pGeom,
+        PropertiesType::Pointer pProperties) const
+    {
+        KRATOS_TRY
+        return Element::Pointer(new LevelSetConvectionElementSimplexAlgebraicStabilization(NewId, pGeom, pProperties));
         KRATOS_CATCH("");
     }
 
@@ -215,7 +226,7 @@ namespace Kratos
         noalias(rRightHandSideVector) -= prod(rLeftHandSideMatrix, phi);
 
         const double gauss_pt_weigth = Volume * aux_weight;
-        
+
         rRightHandSideVector *= gauss_pt_weigth;
         rLeftHandSideMatrix *= gauss_pt_weigth;
 

--- a/kratos/elements/levelset_convection_element_simplex_algebraic_stabilization.h
+++ b/kratos/elements/levelset_convection_element_simplex_algebraic_stabilization.h
@@ -99,6 +99,11 @@ public:
         NodesArrayType const& ThisNodes,
         PropertiesType::Pointer pProperties) const override;
 
+    Element::Pointer Create(
+        IndexType NewId,
+        GeometryType::Pointer pGeom,
+        PropertiesType::Pointer pProperties) const override;
+
     void CalculateLocalSystem(
         MatrixType& rLeftHandSideMatrix,
         VectorType& rRightHandSideVector,


### PR DESCRIPTION
Basically this. We will need these to create the levelset convection elements from a factory one.
