### PR TITLE
[Solid] corrections for a correct compilation

### DIFF
--- a/applications/ConstitutiveModelsApplication/custom_processes/non_local_plasticity_process.cpp
+++ b/applications/ConstitutiveModelsApplication/custom_processes/non_local_plasticity_process.cpp
@@ -34,11 +34,11 @@ namespace Kratos
          "echo_level": 1,
          "model_part_name": "Main_Domain",
          "characteristic_length": 0.0,
-         "local_variables": ["PLASTIC_VOL_DEF", 
-                             "PLASTIC_VOL_DEF_ABS", 
+         "local_variables": ["PLASTIC_VOL_DEF",
+                             "PLASTIC_VOL_DEF_ABS",
                              "PLASTIC_DEV_DEF"],
          "non_local_variables": ["NONLOCAL_PLASTIC_VOL_DEF",
-                                 "NONLOCAL_PLASTIC_VOL_DEF_ABS", 
+                                 "NONLOCAL_PLASTIC_VOL_DEF_ABS",
                                  "NONLOCAL_PLASTIC_DEV_DEF"]
       } )" );
 
@@ -92,10 +92,10 @@ namespace Kratos
       std::vector< GaussPoint > GaussPointsVector;
 
 
-      double start = OpenMPUtils::GetCurrentTime();
+      //double start = OpenMPUtils::GetCurrentTime();
 
       this->PerformGaussPointSearch( GaussPointsVector, 3.0*CharacteristicLength);
-      double start2 = OpenMPUtils::GetCurrentTime();
+      // double start2 = OpenMPUtils::GetCurrentTime();
 
 
 
@@ -121,7 +121,7 @@ namespace Kratos
 
             if ( rGP.NeighbourWeight.size() > 1) {
                for (unsigned int nei = 0; nei < rGP.NeighbourWeight.size(); nei++) {
-                  numerator +=  LocalVariableVector[ rGP.NeighbourGP[nei] ] * rGP.NeighbourWeight[nei]; 
+                  numerator +=  LocalVariableVector[ rGP.NeighbourGP[nei] ] * rGP.NeighbourWeight[nei];
                   denominator += rGP.NeighbourWeight[nei];
                }
             }
@@ -139,9 +139,9 @@ namespace Kratos
       }
 
 
-      double start3 = OpenMPUtils::GetCurrentTime();
+      //double start3 = OpenMPUtils::GetCurrentTime();
 
-      std::cout << "        SearchTime " << start2-start << " smooothing " << start3-start2 << " totalTime " << start3-start << std::endl;
+      //std::cout << "        SearchTime " << start2-start << " smooothing " << start3-start2 << " totalTime " << start3-start << std::endl;
 
 
 
@@ -167,7 +167,7 @@ namespace Kratos
 
    //*********************************************************************************************
    // create  a list of the nodes that have an influence
-   void NonLocalPlasticityProcess::PerformGaussPointSearch( std::vector< GaussPoint > & rGPVector, 
+   void NonLocalPlasticityProcess::PerformGaussPointSearch( std::vector< GaussPoint > & rGPVector,
          const double CharacteristicLength)
    {
       KRATOS_TRY
@@ -226,7 +226,7 @@ namespace Kratos
             distance = pow(distance, 0.5);
 
             if ( distance < CharacteristicLength) {
-               alpha = ComputeWeightFunction( distance, mCharacteristicLength, alpha); 
+               alpha = ComputeWeightFunction( distance, mCharacteristicLength, alpha);
                rGPVector[ii].AddNeighbour( jj, alpha);
                rGPVector[jj].AddNeighbour( ii, alpha);
             }

--- a/applications/ContactMechanicsApplication/custom_bounding/compound_noses_bounding_box.hpp
+++ b/applications/ContactMechanicsApplication/custom_bounding/compound_noses_bounding_box.hpp
@@ -77,7 +77,7 @@ private:
 
 protected:
 
-   typedef struct
+   struct BoxNoseVariables
    {
      int    Convexity;      //1 or -1 if "in" is inside or outside respectively
 
@@ -119,7 +119,7 @@ protected:
      }
 
 
-   } BoxNoseVariables;
+   };
 
 
 public:

--- a/applications/ContactMechanicsApplication/custom_bounding/plane_bounding_box.hpp
+++ b/applications/ContactMechanicsApplication/custom_bounding/plane_bounding_box.hpp
@@ -68,7 +68,7 @@ public:
 
 protected:
 
-    typedef struct
+    struct PlaneVariables
     {
 
       PointType  Point;      // plane point
@@ -85,7 +85,7 @@ protected:
 
       }
 
-    } PlaneVariables;
+    };
 
 
 public:

--- a/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/axisym_contact_domain_LM_2D_condition.cpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/axisym_contact_domain_LM_2D_condition.cpp
@@ -185,7 +185,7 @@ void AxisymContactDomainLM2DCondition::CalculateRadius(double & rCurrentRadius,
 //************************************************************************************
 
 
-void AxisymContactDomainLM2DCondition::CalculateKinematics( ConditionVariables& rVariables, ProcessInfo& rCurrentProcessInfo, const unsigned int& rPointNumber )
+void AxisymContactDomainLM2DCondition::CalculateKinematics( ConditionVariables& rVariables, const ProcessInfo& rCurrentProcessInfo, const unsigned int& rPointNumber )
 {
     KRATOS_TRY
 
@@ -232,7 +232,7 @@ void AxisymContactDomainLM2DCondition::CalculateKinematics( ConditionVariables& 
     //Get Current DeformationGradient
     std::vector<Matrix> DeformationGradientVector ( integration_points_number );
     DeformationGradientVector[rPointNumber]=IdentityMatrix(dimension);
-    MasterElement.GetValueOnIntegrationPoints(DEFORMATION_GRADIENT,DeformationGradientVector,rCurrentProcessInfo);
+    MasterElement.CalculateOnIntegrationPoints(DEFORMATION_GRADIENT,DeformationGradientVector,rCurrentProcessInfo);
     rVariables.F = DeformationGradientVector[rPointNumber];
 
     rVariables.detF = MathUtils<double>::Det(rVariables.F);
@@ -241,7 +241,7 @@ void AxisymContactDomainLM2DCondition::CalculateKinematics( ConditionVariables& 
     std::vector<Vector> StressVector ( integration_points_number );
     StressVector[rPointNumber]=ZeroVector(voigtsize);
     //MasterElement.GetValueOnIntegrationPoints(PK2_STRESS_VECTOR,StressVector,rCurrentProcessInfo);
-    MasterElement.GetValueOnIntegrationPoints(CAUCHY_STRESS_VECTOR,StressVector,rCurrentProcessInfo);
+    MasterElement.CalculateOnIntegrationPoints(CAUCHY_STRESS_VECTOR,StressVector,rCurrentProcessInfo);
 
     // ConstitutiveLaw Constitutive;
     // for( unsigned int i=0; i<StressVector.size(); i++)
@@ -257,7 +257,7 @@ void AxisymContactDomainLM2DCondition::CalculateKinematics( ConditionVariables& 
     //Get Current Strain
     std::vector<Matrix> StrainTensor ( integration_points_number );
     StrainTensor[rPointNumber]=ZeroMatrix(dimension,dimension);
-    MasterElement.GetValueOnIntegrationPoints(GREEN_LAGRANGE_STRAIN_TENSOR,StrainTensor,rCurrentProcessInfo);
+    MasterElement.CalculateOnIntegrationPoints(GREEN_LAGRANGE_STRAIN_TENSOR,StrainTensor,rCurrentProcessInfo);
     std::vector<Vector> StrainVector ( integration_points_number );
     for(unsigned int i=1; i<integration_points_number; i++)
     {

--- a/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/axisym_contact_domain_LM_2D_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/axisym_contact_domain_LM_2D_condition.hpp
@@ -175,13 +175,13 @@ protected:
      * Initialize Variables
      */
     void InitializeConditionVariables (ConditionVariables& rVariables,
-				     const ProcessInfo& rCurrentProcessInfo) override;
+                                       const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Calculate Condition Kinematics
      */
     void CalculateKinematics(ConditionVariables& rVariables,
-			     ProcessInfo& rCurrentProcessInfo,
+			     const ProcessInfo& rCurrentProcessInfo,
 			     const unsigned int& rPointNumber) override;
 
     /**

--- a/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/axisym_contact_domain_penalty_2D_condition.cpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/axisym_contact_domain_penalty_2D_condition.cpp
@@ -182,7 +182,7 @@ void AxisymContactDomainPenalty2DCondition::CalculateRadius(double & rCurrentRad
 //************************************************************************************
 
 
-void AxisymContactDomainPenalty2DCondition::CalculateKinematics( ConditionVariables& rVariables, ProcessInfo& rCurrentProcessInfo, const unsigned int& rPointNumber )
+void AxisymContactDomainPenalty2DCondition::CalculateKinematics( ConditionVariables& rVariables, const ProcessInfo& rCurrentProcessInfo, const unsigned int& rPointNumber )
 {
     KRATOS_TRY
 
@@ -230,7 +230,7 @@ void AxisymContactDomainPenalty2DCondition::CalculateKinematics( ConditionVariab
     //Get Current DeformationGradient
     std::vector<Matrix> DeformationGradientVector(integration_points_number);
     DeformationGradientVector[rPointNumber]=IdentityMatrix(dimension);
-    MasterElement.GetValueOnIntegrationPoints(DEFORMATION_GRADIENT,DeformationGradientVector,rCurrentProcessInfo);
+    MasterElement.CalculateOnIntegrationPoints(DEFORMATION_GRADIENT,DeformationGradientVector,rCurrentProcessInfo);
     rVariables.F = DeformationGradientVector[rPointNumber];
 
     rVariables.detF = MathUtils<double>::Det(rVariables.F);
@@ -239,7 +239,7 @@ void AxisymContactDomainPenalty2DCondition::CalculateKinematics( ConditionVariab
     std::vector<Vector> StressVector ( integration_points_number );
     StressVector[rPointNumber]=ZeroVector(voigtsize);
     //MasterElement.GetValueOnIntegrationPoints(PK2_STRESS_VECTOR,StressVector,rCurrentProcessInfo);
-    MasterElement.GetValueOnIntegrationPoints(CAUCHY_STRESS_VECTOR,StressVector,rCurrentProcessInfo);
+    MasterElement.CalculateOnIntegrationPoints(CAUCHY_STRESS_VECTOR,StressVector,rCurrentProcessInfo);
 
     // ConstitutiveLaw Constitutive;
     // for( unsigned int i=0; i<StressVector.size(); i++)
@@ -255,7 +255,7 @@ void AxisymContactDomainPenalty2DCondition::CalculateKinematics( ConditionVariab
     //Get Current Strain
     std::vector<Matrix> StrainTensor ( integration_points_number );
     StrainTensor[rPointNumber]=ZeroMatrix(dimension,dimension);
-    MasterElement.GetValueOnIntegrationPoints(GREEN_LAGRANGE_STRAIN_TENSOR,StrainTensor,rCurrentProcessInfo);
+    MasterElement.CalculateOnIntegrationPoints(GREEN_LAGRANGE_STRAIN_TENSOR,StrainTensor,rCurrentProcessInfo);
     std::vector<Vector> StrainVector ( integration_points_number );
     for(unsigned int i=1; i<integration_points_number; i++)
     {

--- a/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/axisym_contact_domain_penalty_2D_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/axisym_contact_domain_penalty_2D_condition.hpp
@@ -186,7 +186,7 @@ protected:
      * Calculate Condition Kinematics
      */
     void CalculateKinematics(ConditionVariables& rVariables,
-			     ProcessInfo& rCurrentProcessInfo,
+			     const ProcessInfo& rCurrentProcessInfo,
 			     const unsigned int& rPointNumber) override;
 
     /**

--- a/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/contact_domain_LM_2D_condition.cpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/contact_domain_LM_2D_condition.cpp
@@ -368,7 +368,7 @@ void ContactDomainLM2DCondition::CalculatePreviousGap() //prediction of the lagr
 //************************************************************************************
 
 
-void ContactDomainLM2DCondition::CalculateContactFactor( ProcessInfo& rCurrentProcessInfo )
+void ContactDomainLM2DCondition::CalculateContactFactor(const ProcessInfo& rCurrentProcessInfo )
 {
     //Initilialize Tau for the stabilization
     double alpha_stab = 0.1;
@@ -445,7 +445,7 @@ void ContactDomainLM2DCondition::CalculateContactFactor( ProcessInfo& rCurrentPr
 //********************************CALCULATE EXPLICIT MULTIPLIERS**********************
 //************************************************************************************
 
-void ContactDomainLM2DCondition::CalculateExplicitFactors(ConditionVariables& rVariables, ProcessInfo& rCurrentProcessInfo)
+void ContactDomainLM2DCondition::CalculateExplicitFactors(ConditionVariables& rVariables, const ProcessInfo& rCurrentProcessInfo)
 {
 
     const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
@@ -666,7 +666,7 @@ void ContactDomainLM2DCondition::CalculateExplicitFactors(ConditionVariables& rV
     double EffectiveGapT = ReferenceGapT;
 
     double CurrentTimeStep  = rCurrentProcessInfo[DELTA_TIME];
-    ProcessInfo& rPreviousProcessInfo = rCurrentProcessInfo.GetPreviousSolutionStepInfo();
+    const ProcessInfo& rPreviousProcessInfo = rCurrentProcessInfo.GetPreviousSolutionStepInfo();
     double PreviousTimeStep = rPreviousProcessInfo[DELTA_TIME];
 
 

--- a/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/contact_domain_LM_2D_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/contact_domain_LM_2D_condition.hpp
@@ -178,7 +178,7 @@ protected:
     /**
      * Calculate Tau stabilization or Penalty factor
      */
-    void CalculateContactFactor(ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateContactFactor(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -191,7 +191,7 @@ protected:
      * Calculation of the Contact Multipliers or Penalty Factors
      */
     void CalculateExplicitFactors(ConditionVariables& rVariables,
-					  ProcessInfo& rCurrentProcessInfo) override;
+				  const ProcessInfo& rCurrentProcessInfo) override;
     /**
      * Tangent Matrix construction methods:
      */

--- a/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/contact_domain_LM_3D_condition.cpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/contact_domain_LM_3D_condition.cpp
@@ -840,7 +840,7 @@ namespace Kratos
   //************************************************************************************
 
 
-  void ContactDomainLM3DCondition::CalculateContactFactor( ProcessInfo& rCurrentProcessInfo )
+  void ContactDomainLM3DCondition::CalculateContactFactor(const ProcessInfo& rCurrentProcessInfo )
   {
     //Initilialize Tau for the stabilization
     double alpha_stab = 0.1;
@@ -919,7 +919,7 @@ namespace Kratos
   //********************************CALCULATE EXPLICIT MULTIPLIERS**********************
   //************************************************************************************
 
-  void ContactDomainLM3DCondition::CalculateExplicitFactors(ConditionVariables& rVariables, ProcessInfo& rCurrentProcessInfo)
+  void ContactDomainLM3DCondition::CalculateExplicitFactors(ConditionVariables& rVariables, const ProcessInfo& rCurrentProcessInfo)
   {
 
     // std::cout<<" Master Nodes "<<GetValue(MASTER_NODES).size()<<std::endl;
@@ -973,7 +973,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void ContactDomainLM3DCondition::CalculateExplicitFactorsFaceType(ConditionVariables& rVariables, ProcessInfo& rCurrentProcessInfo)
+  void ContactDomainLM3DCondition::CalculateExplicitFactorsFaceType(ConditionVariables& rVariables, const ProcessInfo& rCurrentProcessInfo)
   {
 
     //Contact face node1-node2-node3
@@ -1177,7 +1177,7 @@ namespace Kratos
 
 
     double CurrentTimeStep  = rCurrentProcessInfo[DELTA_TIME];
-    ProcessInfo& rPreviousProcessInfo = rCurrentProcessInfo.GetPreviousSolutionStepInfo();
+    const ProcessInfo& rPreviousProcessInfo = rCurrentProcessInfo.GetPreviousSolutionStepInfo();
     double PreviousTimeStep = rPreviousProcessInfo[DELTA_TIME];
 
 
@@ -1312,7 +1312,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void ContactDomainLM3DCondition::CalculateExplicitFactorsEdgeType(ConditionVariables& rVariables, ProcessInfo& rCurrentProcessInfo)
+  void ContactDomainLM3DCondition::CalculateExplicitFactorsEdgeType(ConditionVariables& rVariables, const ProcessInfo& rCurrentProcessInfo)
   {
 
     //Contact face node1-node2-node3
@@ -1530,7 +1530,7 @@ namespace Kratos
 
 
     double CurrentTimeStep  = rCurrentProcessInfo[DELTA_TIME];
-    ProcessInfo& rPreviousProcessInfo = rCurrentProcessInfo.GetPreviousSolutionStepInfo();
+    const ProcessInfo& rPreviousProcessInfo = rCurrentProcessInfo.GetPreviousSolutionStepInfo();
     double PreviousTimeStep = rPreviousProcessInfo[DELTA_TIME];
 
 

--- a/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/contact_domain_LM_3D_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/contact_domain_LM_3D_condition.hpp
@@ -187,7 +187,7 @@ protected:
     /**
      * Calculate Tau stabilization or Penalty factor
      */
-    void CalculateContactFactor(ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateContactFactor(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -209,19 +209,19 @@ protected:
      * Calculation of the Contact Multipliers or Penalty Factors
      */
     void CalculateExplicitFactors(ConditionVariables& rVariables,
-                                  ProcessInfo& rCurrentProcessInfo) override;
+                                  const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Calculation of the Contact Multipliers or Penalty Factors EdgeType element
      */
     virtual void CalculateExplicitFactorsEdgeType(ConditionVariables& rVariables,
-						  ProcessInfo& rCurrentProcessInfo);
+						  const ProcessInfo& rCurrentProcessInfo);
 
     /**
      * Calculation of the Contact Multipliers or Penalty Factors EdgeType element
      */
     virtual void CalculateExplicitFactorsFaceType(ConditionVariables& rVariables,
-						  ProcessInfo& rCurrentProcessInfo);
+						  const ProcessInfo& rCurrentProcessInfo);
 
 
     /**

--- a/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/contact_domain_condition.cpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/contact_domain_condition.cpp
@@ -112,7 +112,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void ContactDomainCondition::GetDofList( DofsVectorType& rConditionalDofList, ProcessInfo& rCurrentProcessInfo )
+  void ContactDomainCondition::GetDofList( DofsVectorType& rConditionalDofList, const ProcessInfo& rCurrentProcessInfo ) const
   {
     rConditionalDofList.resize( 0 );
 
@@ -130,7 +130,7 @@ namespace Kratos
     //ADD MASTER NODES
     for ( unsigned int i = 0; i < GetValue(MASTER_NODES).size(); i++ )
       {
-	Element::NodeType& MasterNode = GetValue(MASTER_NODES)[i];
+	const Element::NodeType& MasterNode = GetValue(MASTER_NODES)[i];
 
 	rConditionalDofList.push_back( MasterNode.pGetDof( DISPLACEMENT_X ) );
 	rConditionalDofList.push_back( MasterNode.pGetDof( DISPLACEMENT_Y ) );
@@ -142,7 +142,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void ContactDomainCondition::EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo )
+  void ContactDomainCondition::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo ) const
   {
     unsigned int number_of_nodes = GetGeometry().size();
     unsigned int dimension = GetGeometry().WorkingSpaceDimension();
@@ -166,7 +166,7 @@ namespace Kratos
     for ( unsigned int i = 0; i < number_master_nodes; i++ )
       {
 	int index = (number_of_nodes + i) * dimension;
-	Element::NodeType& MasterNode = GetValue(MASTER_NODES)[i];
+	const Element::NodeType& MasterNode = GetValue(MASTER_NODES)[i];
 
 	rResult[index]   = MasterNode.GetDof( DISPLACEMENT_X ).EquationId();
 	rResult[index+1] = MasterNode.GetDof( DISPLACEMENT_Y ).EquationId();
@@ -325,41 +325,11 @@ namespace Kratos
 
   }
 
-  //*********************************GET DOUBLE VALUE***********************************
-  //************************************************************************************
-
-  void ContactDomainCondition::GetValueOnIntegrationPoints( const Variable<double>& rVariable,
-                                                            std::vector<double>& rValues,
-                                                            const ProcessInfo& rCurrentProcessInfo )
-  {
-    this->CalculateOnIntegrationPoints(rVariable,rValues,rCurrentProcessInfo);
-  }
-
-  //**********************************GET VECTOR VALUE**********************************
-  //************************************************************************************
-
-  void ContactDomainCondition::GetValueOnIntegrationPoints( const Variable<Vector>& rVariable,
-                                                            std::vector<Vector>& rValues,
-                                                            const ProcessInfo& rCurrentProcessInfo )
-  {
-    this->CalculateOnIntegrationPoints(rVariable,rValues,rCurrentProcessInfo);
-  }
-
-  //***********************************GET MATRIX VALUE*********************************
-  //************************************************************************************
-
-  void ContactDomainCondition::GetValueOnIntegrationPoints( const Variable<Matrix>& rVariable,
-                                                            std::vector<Matrix>& rValues,
-                                                            const ProcessInfo& rCurrentProcessInfo )
-  {
-    this->CalculateOnIntegrationPoints(rVariable,rValues,rCurrentProcessInfo);
-  }
-
 
   //************************************************************************************
   //************************************************************************************
 
-  void ContactDomainCondition::Initialize()
+  void ContactDomainCondition::Initialize(const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -370,7 +340,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void ContactDomainCondition::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+  void ContactDomainCondition::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
   {
 
     //0.- Initialize Iteration Counter
@@ -399,7 +369,7 @@ namespace Kratos
   ////************************************************************************************
   ////************************************************************************************
 
-  void ContactDomainCondition::InitializeNonLinearIteration( ProcessInfo& CurrentProcessInfo )
+  void ContactDomainCondition::InitializeNonLinearIteration(const ProcessInfo& CurrentProcessInfo)
   {
     //Clear nodal contact forces
     ClearNodalForces();
@@ -410,7 +380,7 @@ namespace Kratos
   ////************************************************************************************
   ////************************************************************************************
 
-  void ContactDomainCondition::FinalizeNonLinearIteration( ProcessInfo& CurrentProcessInfo )
+  void ContactDomainCondition::FinalizeNonLinearIteration(const ProcessInfo& CurrentProcessInfo)
   {
     //Calculte nodal contact forces
     CalculateNodalForces(CurrentProcessInfo);
@@ -423,7 +393,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void ContactDomainCondition::FinalizeSolutionStep( ProcessInfo& CurrentProcessInfo )
+  void ContactDomainCondition::FinalizeSolutionStep(const ProcessInfo& CurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -468,7 +438,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void ContactDomainCondition::CalculateNodalForces(ProcessInfo& CurrentProcessInfo)
+  void ContactDomainCondition::CalculateNodalForces(const ProcessInfo& CurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -638,7 +608,7 @@ namespace Kratos
   //************************************************************************************
 
 
-  void ContactDomainCondition::CalculateKinematics( ConditionVariables& rVariables, ProcessInfo& rCurrentProcessInfo, const unsigned int& rPointNumber )
+  void ContactDomainCondition::CalculateKinematics( ConditionVariables& rVariables, const ProcessInfo& rCurrentProcessInfo, const unsigned int& rPointNumber )
   {
     KRATOS_TRY
 
@@ -683,7 +653,7 @@ namespace Kratos
     //Get Current DeformationGradient
     std::vector<Matrix> DeformationGradientVector ( integration_points_number );
     DeformationGradientVector[rPointNumber]=IdentityMatrix(dimension);
-    MasterElement.GetValueOnIntegrationPoints(DEFORMATION_GRADIENT,DeformationGradientVector,rCurrentProcessInfo);
+    MasterElement.CalculateOnIntegrationPoints(DEFORMATION_GRADIENT,DeformationGradientVector,rCurrentProcessInfo);
     rVariables.F = DeformationGradientVector[rPointNumber];
 
     rVariables.detF = MathUtils<double>::Det(rVariables.F);
@@ -691,7 +661,7 @@ namespace Kratos
     //Get Current Stress
     std::vector<Vector> StressVector ( integration_points_number );
     StressVector[rPointNumber]=ZeroVector(voigtsize);
-    MasterElement.GetValueOnIntegrationPoints(CAUCHY_STRESS_VECTOR,StressVector,rCurrentProcessInfo);
+    MasterElement.CalculateOnIntegrationPoints(CAUCHY_STRESS_VECTOR,StressVector,rCurrentProcessInfo);
 
     // UL
     // ConstitutiveLaw Constitutive;
@@ -753,7 +723,7 @@ namespace Kratos
   //***********************COMPUTE LOCAL SYSTEM CONTRIBUTIONS***************************
   //************************************************************************************
 
-  void ContactDomainCondition::CalculateRightHandSide( VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+  void ContactDomainCondition::CalculateRightHandSide( VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
   {
     //std::cout<<" CalculateRightHandSide "<<std::endl;
 
@@ -780,7 +750,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void ContactDomainCondition::CalculateRightHandSide( std::vector< VectorType >& rRightHandSideVectors, const std::vector< Variable< VectorType > >& rRHSVariables, ProcessInfo& rCurrentProcessInfo )
+  void ContactDomainCondition::CalculateRightHandSide( std::vector< VectorType >& rRightHandSideVectors, const std::vector< Variable< VectorType > >& rRHSVariables, const ProcessInfo& rCurrentProcessInfo )
   {
     //create local system components
     LocalSystemComponents LocalSystem;
@@ -817,7 +787,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void ContactDomainCondition::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+  void ContactDomainCondition::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
   {
     //std::cout<<" CalculateLocalSystem "<<std::endl;
 
@@ -871,7 +841,7 @@ namespace Kratos
   //************************************************************************************
 
 
-  void ContactDomainCondition::CalculatePerturbedLeftHandSide( MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo )
+  void ContactDomainCondition::CalculatePerturbedLeftHandSide( MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo )
   {
     KRATOS_TRY
 
@@ -943,7 +913,7 @@ namespace Kratos
 						     const std::vector< Variable< MatrixType > >& rLHSVariables,
 						     std::vector< VectorType >& rRightHandSideVectors,
 						     const std::vector< Variable< VectorType > >& rRHSVariables,
-						     ProcessInfo& rCurrentProcessInfo )
+						     const ProcessInfo& rCurrentProcessInfo )
   {
     //create local system components
     LocalSystemComponents LocalSystem;
@@ -994,7 +964,7 @@ namespace Kratos
   //************************************************************************************
 
 
-  void ContactDomainCondition::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo )
+  void ContactDomainCondition::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo )
   {
     //std::cout<<" CalculateLeftHandSide "<<std::endl;
 
@@ -1152,7 +1122,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void ContactDomainCondition::CalculateRelativeVelocity (ConditionVariables& rVariables, PointType & TangentVelocity, ProcessInfo& rCurrentProcessInfo)
+  void ContactDomainCondition::CalculateRelativeVelocity (ConditionVariables& rVariables, PointType & TangentVelocity, const ProcessInfo& rCurrentProcessInfo)
   {
     //if current tangent is not previously computed, do it here.
     rVariables.Contact.CurrentSurface.Tangent = this->CalculateCurrentTangent( rVariables.Contact.CurrentSurface.Tangent );
@@ -1216,7 +1186,7 @@ namespace Kratos
   //************************************************************************************
 
 
-  void ContactDomainCondition::CalculateRelativeDisplacement (ConditionVariables& rVariables, PointType & TangentDisplacement, ProcessInfo& rCurrentProcessInfo)
+  void ContactDomainCondition::CalculateRelativeDisplacement (ConditionVariables& rVariables, PointType & TangentDisplacement, const ProcessInfo& rCurrentProcessInfo)
   {
 
     // (Tangent vector previously computed)
@@ -1301,7 +1271,7 @@ namespace Kratos
   //************************************************************************************
 
   void ContactDomainCondition::CalculateConditionSystem(LocalSystemComponents& rLocalSystem,
-							ProcessInfo& rCurrentProcessInfo)
+							const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -1686,7 +1656,7 @@ namespace Kratos
    * or that no common error is found.
    * @param rCurrentProcessInfo
    */
-  int  ContactDomainCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int  ContactDomainCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
     KRATOS_TRY
 
@@ -1704,7 +1674,7 @@ namespace Kratos
     for(unsigned int i=0; i<this->GetGeometry().size(); ++i)
       {
 	// Nodal data
-	Node<3> &rNode = this->GetGeometry()[i];
+	const Node<3> &rNode = this->GetGeometry()[i];
 	KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISPLACEMENT,rNode);
 
 	// Nodal dofs

--- a/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/contact_domain_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/contact_domain_condition.hpp
@@ -186,7 +186,7 @@ protected:
   } ContactTangentVariables;
 
 
-  typedef struct
+  struct ConditionVariables
   {
     double  detF;
     double  detJ;
@@ -240,10 +240,10 @@ protected:
       return *pNcontainer;
     };
 
-  } ConditionVariables;
+  };
 
 
-  typedef struct
+  struct ContactVariables
   {
 
     //Iteration counter:
@@ -296,7 +296,7 @@ protected:
     NodeType& GetMasterNode()           { return (*mpMasterNode); }
 
 
-  } ContactVariables;
+  };
 
 
 
@@ -425,12 +425,12 @@ public:
   /**
    * Sets on rConditionalDofList the degrees of freedom of the considered element geometry
    */
-  void GetDofList(DofsVectorType& rConditionalDofList, ProcessInfo& rCurrentProcessInfo) override;
+  void GetDofList(DofsVectorType& rConditionalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
   /**
    * Sets on rResult the ID's of the element degrees of freedom
    */
-  void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+  void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
   /**
    * Sets on rValues the nodal displacements
@@ -476,22 +476,6 @@ public:
    */
   void SetValuesOnIntegrationPoints(const Variable<Matrix>& rVariable, const std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
-  //GET:
-  /**
-   * Set on rVariable a double Value from the Condition Constitutive Law
-   */
-  void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-  /**
-   * Set on rVariable a Vector Value from the Condition Constitutive Law
-   */
-  void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-  /**
-   * Set on rVariable a Matrix Value from the Condition Constitutive Law
-   */
-  void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
 
 
   //************* STARTING - ENDING  METHODS
@@ -500,30 +484,30 @@ public:
    * Called to initialize the element.
    * Must be called before any calculation is done
    */
-  void Initialize() override;
+  void Initialize(const ProcessInfo& CurrentProcessInfo) override;
 
 
   /**
    * Called at the beginning of each solution step
    */
-  void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+  void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
   /**
    * this is called for non-linear analysis at the beginning of the iteration process
    */
-  void InitializeNonLinearIteration(ProcessInfo& CurrentProcessInfo) override;
+  void InitializeNonLinearIteration(const ProcessInfo& CurrentProcessInfo) override;
 
 
   /**
    * this is called for non-linear analysis at the end of the iteration process
    */
-  void FinalizeNonLinearIteration(ProcessInfo& CurrentProcessInfo) override;
+  void FinalizeNonLinearIteration(const ProcessInfo& CurrentProcessInfo) override;
 
 
   /**
    * Called at the end of eahc solution step
    */
-  void FinalizeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+  void FinalizeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
 
 
@@ -538,7 +522,7 @@ public:
    * @param rCurrentProcessInfo: the current process info instance
    */
 
-  void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector,const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * this function provides a more general interface to the condition.
@@ -553,7 +537,7 @@ public:
                             const std::vector< Variable< MatrixType > >& rLHSVariables,
                             std::vector< VectorType >& rRightHandSideVectors,
                             const std::vector< Variable< VectorType > >& rRHSVariables,
-                            ProcessInfo& rCurrentProcessInfo) override;
+                            const ProcessInfo& rCurrentProcessInfo);
 
   /**
    * this is called during the assembling process in order
@@ -561,7 +545,7 @@ public:
    * @param rRightHandSideVector: the elemental right hand side vector
    * @param rCurrentProcessInfo: the current process info instance
    */
-  void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateRightHandSide(VectorType& rRightHandSideVector,const ProcessInfo& rCurrentProcessInfo) override;
 
 
   /**
@@ -573,7 +557,7 @@ public:
    */
   void CalculateRightHandSide(std::vector< VectorType >& rRightHandSideVectors,
                               const std::vector< Variable< VectorType > >& rRHSVariables,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo);
 
   /**
    * this is called during the assembling process in order
@@ -581,7 +565,7 @@ public:
    * @param rLeftHandSideVector: the elemental left hand side vector
    * @param rCurrentProcessInfo: the current process info instance
    */
-  void CalculateLeftHandSide (MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateLeftHandSide (MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
 
   /**
@@ -625,7 +609,7 @@ public:
    * or that no common error is found.
    * @param rCurrentProcessInfo
    */
-  int Check(const ProcessInfo& rCurrentProcessInfo) override;
+  int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
   //std::string Info() const;
 
@@ -691,7 +675,7 @@ protected:
   /**
    * Calculate Tau stabilization or Penalty factor
    */
-  virtual void CalculateContactFactor(ProcessInfo& rCurrentProcessInfo)
+  virtual void CalculateContactFactor(const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_THROW_ERROR( std::invalid_argument, "Calling base class in contact domain", "" )
   };
@@ -716,7 +700,7 @@ protected:
    * Calculates the condition contributions
    */
   virtual void CalculateConditionSystem(LocalSystemComponents& rLocalSystem,
-                                        ProcessInfo& rCurrentProcessInfo);
+                                        const ProcessInfo& rCurrentProcessInfo);
   /**
    * Clear Nodal Forces
    */
@@ -726,7 +710,7 @@ protected:
   /**
    * Calculate Nodal Forces
    */
-  void CalculateNodalForces (ProcessInfo& CurrentProcessInfo);
+  void CalculateNodalForces (const ProcessInfo& CurrentProcessInfo);
 
 
   /**
@@ -746,7 +730,7 @@ protected:
    * Calculate Condition Kinematics
    */
   virtual void CalculateKinematics(ConditionVariables& rVariables,
-                                   ProcessInfo& rCurrentProcessInfo,
+                                   const ProcessInfo& rCurrentProcessInfo,
                                    const unsigned int& rPointNumber);
 
   /**
@@ -758,7 +742,7 @@ protected:
    * Calculation of the Contact Multipliers or Penalty Factors
    */
   virtual void CalculateExplicitFactors(ConditionVariables& rVariables,
-                                        ProcessInfo& rCurrentProcessInfo)
+                                        const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_THROW_ERROR( std::invalid_argument, "Calling base class in contact domain", "" )
 
@@ -779,14 +763,14 @@ protected:
    */
   virtual void CalculateRelativeVelocity(ConditionVariables& rVariables,
                                          PointType & TangentVelocity,
-                                         ProcessInfo& rCurrentProcessInfo);
+                                         const ProcessInfo& rCurrentProcessInfo);
 
   /**
    *  Parameters for friction law Relative Tangent Displacement:
    */
   virtual void CalculateRelativeDisplacement(ConditionVariables& rVariables,
                                              PointType & TangentDisplacement,
-                                             ProcessInfo& rCurrentProcessInfo);
+                                             const ProcessInfo& rCurrentProcessInfo);
 
   /**
    * Calculate current tangent vector
@@ -823,7 +807,7 @@ protected:
    * Calculation of the tangent via perturbation of the dofs variables : testing purposes
    */
   void CalculatePerturbedLeftHandSide (MatrixType& rLeftHandSideMatrix,
-                                       ProcessInfo& rCurrentProcessInfo);
+                                       const ProcessInfo& rCurrentProcessInfo);
 
   /**
    * Calculate LHS

--- a/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/contact_domain_penalty_2D_condition.cpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/contact_domain_penalty_2D_condition.cpp
@@ -94,7 +94,7 @@ namespace Kratos
   //*****************************COMPUTE PENALTY FACTOR*********************************
   //************************************************************************************
 
-  void ContactDomainPenalty2DCondition::CalculateContactFactor( ProcessInfo& rCurrentProcessInfo )
+  void ContactDomainPenalty2DCondition::CalculateContactFactor(const ProcessInfo& rCurrentProcessInfo )
   {
     //Initilialize penalty parameter
     double penalty_parameter = 1000;
@@ -145,7 +145,7 @@ namespace Kratos
   //****************************CALCULATE EXPLICIT PENALTY PARAMETERS*******************
   //************************************************************************************
 
-  void ContactDomainPenalty2DCondition::CalculateExplicitFactors(ConditionVariables& rVariables, ProcessInfo& rCurrentProcessInfo)
+  void ContactDomainPenalty2DCondition::CalculateExplicitFactors(ConditionVariables& rVariables, const ProcessInfo& rCurrentProcessInfo)
   {
 
 

--- a/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/contact_domain_penalty_2D_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/deformable_contact/contact_domain_penalty_2D_condition.hpp
@@ -174,14 +174,14 @@ protected:
     /**
      * Calculate Tau stabilization or Penalty factor
      */
-    void CalculateContactFactor(ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateContactFactor(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
      * Calculation of the Contact Multipliers or Penalty Factors
      */
     void CalculateExplicitFactors(ConditionVariables& rVariables,
-				  ProcessInfo& rCurrentProcessInfo) override;
+				  const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**

--- a/applications/ContactMechanicsApplication/custom_conditions/hydraulic_contact/hydraulic_rigid_contact_penalty_3D_condition.cpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/hydraulic_contact/hydraulic_rigid_contact_penalty_3D_condition.cpp
@@ -83,7 +83,7 @@ namespace Kratos
 
    }
 
-   void HydraulicRigidContactPenalty3DCondition::InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
+   void HydraulicRigidContactPenalty3DCondition::InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
    {
       KRATOS_TRY
 
@@ -106,7 +106,7 @@ namespace Kratos
    //***********************************************************************************
 
    void HydraulicRigidContactPenalty3DCondition::GetDofList(DofsVectorType& rConditionDofList,
-         ProcessInfo& rCurrentProcessInfo)
+         const ProcessInfo& rCurrentProcessInfo) const
    {
       KRATOS_TRY
 
@@ -130,7 +130,7 @@ namespace Kratos
    //***********************************************************************************
 
    void HydraulicRigidContactPenalty3DCondition::EquationIdVector(EquationIdVectorType& rResult,
-         ProcessInfo& rCurrentProcessInfo)
+         const ProcessInfo& rCurrentProcessInfo) const
    {
       KRATOS_TRY
 

--- a/applications/ContactMechanicsApplication/custom_conditions/hydraulic_contact/hydraulic_rigid_contact_penalty_3D_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/hydraulic_contact/hydraulic_rigid_contact_penalty_3D_condition.hpp
@@ -113,7 +113,7 @@ public:
     /**
      * Called at the beginning of each iteration
      */
-    virtual void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    virtual void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     //************* GETTING METHODS
 
@@ -121,13 +121,13 @@ public:
      * Sets on rConditionDofList the degrees of freedom of the considered element geometry
      */
     void GetDofList(DofsVectorType& rConditionDofList,
-		    ProcessInfo& rCurrentProcessInfo ) override;
+		    const ProcessInfo& rCurrentProcessInfo ) const override;
 
     /**
      * Sets on rResult the ID's of the element degrees of freedom
      */
     void EquationIdVector(EquationIdVectorType& rResult,
-			  ProcessInfo& rCurrentProcessInfo ) override;
+			  const ProcessInfo& rCurrentProcessInfo ) const override;
 
     /**
      * Sets on rValues the nodal displacements

--- a/applications/ContactMechanicsApplication/custom_conditions/rigid_body_links/rigid_body_point_link_condition.cpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/rigid_body_links/rigid_body_point_link_condition.cpp
@@ -76,7 +76,7 @@ RigidBodyPointLinkCondition::~RigidBodyPointLinkCondition()
 //***********************************************************************************
 
 void RigidBodyPointLinkCondition::GetDofList(DofsVectorType& rConditionDofList,
-					     ProcessInfo& rCurrentProcessInfo)
+					     const ProcessInfo& rCurrentProcessInfo) const
 {
   KRATOS_TRY
 
@@ -84,18 +84,17 @@ void RigidBodyPointLinkCondition::GetDofList(DofsVectorType& rConditionDofList,
 
   const SizeType inode = GetGeometry().PointsNumber()-1;
 
-  ElementWeakPtrVectorType& SlaveElements  = (GetGeometry()[inode].GetValue(NEIGHBOUR_ELEMENTS));
+  const ElementWeakPtrVectorType& SlaveElements = (GetGeometry()[inode].GetValue(NEIGHBOUR_ELEMENTS));
 
-  for(auto& ie : SlaveElements)
+  for (SizeType ie = 0; ie < SlaveElements.size(); ie++)
   {
     DofsVectorType SlaveDofList;
-    ie.GetDofList(SlaveDofList, rCurrentProcessInfo);
-
-    for(SizeType i=0; i<SlaveDofList.size(); i++)
+    SlaveElements[ie].GetDofList(SlaveDofList, rCurrentProcessInfo);
+    for (SizeType i = 0; i < SlaveDofList.size(); i++)
       rConditionDofList.push_back(SlaveDofList[i]);
   }
 
-  Element& MasterElement = GetGeometry()[inode].GetValue(MASTER_ELEMENTS).back();
+  const Element& MasterElement = GetGeometry()[inode].GetValue(MASTER_ELEMENTS).back();
 
   DofsVectorType MasterDofList;
   MasterElement.GetDofList(MasterDofList, rCurrentProcessInfo);
@@ -110,7 +109,7 @@ void RigidBodyPointLinkCondition::GetDofList(DofsVectorType& rConditionDofList,
 //***********************************************************************************
 
 void RigidBodyPointLinkCondition::EquationIdVector(EquationIdVectorType& rResult,
-						   ProcessInfo& rCurrentProcessInfo)
+						   const ProcessInfo& rCurrentProcessInfo) const
 {
   KRATOS_TRY
 
@@ -118,18 +117,18 @@ void RigidBodyPointLinkCondition::EquationIdVector(EquationIdVectorType& rResult
 
   const SizeType inode = GetGeometry().PointsNumber()-1;
 
-  ElementWeakPtrVectorType& SlaveElements  = (GetGeometry()[inode].GetValue(NEIGHBOUR_ELEMENTS));
+  const ElementWeakPtrVectorType& SlaveElements  = (GetGeometry()[inode].GetValue(NEIGHBOUR_ELEMENTS));
 
-  for(auto& ie : SlaveElements)
+  for (SizeType ie = 0; ie < SlaveElements.size(); ie++)
   {
     EquationIdVectorType SlaveResult;
-    ie.EquationIdVector(SlaveResult, rCurrentProcessInfo);
+    SlaveElements[ie].EquationIdVector(SlaveResult, rCurrentProcessInfo);
 
     for(SizeType i=0; i<SlaveResult.size(); i++)
       rResult.push_back(SlaveResult[i]);
   }
 
-  Element& MasterElement = GetGeometry()[inode].GetValue(MASTER_ELEMENTS).back();
+  const Element& MasterElement = GetGeometry()[inode].GetValue(MASTER_ELEMENTS).back();
 
   EquationIdVectorType MasterResult;
   MasterElement.EquationIdVector(MasterResult, rCurrentProcessInfo);
@@ -276,7 +275,7 @@ void RigidBodyPointLinkCondition::GetSecondDerivativesVector( Vector& rValues, i
 //***********************************************************************************
 //***********************************************************************************
 
-void RigidBodyPointLinkCondition::Initialize()
+void RigidBodyPointLinkCondition::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -298,7 +297,7 @@ void RigidBodyPointLinkCondition::Initialize()
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodyPointLinkCondition::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void RigidBodyPointLinkCondition::InitializeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -308,7 +307,7 @@ void RigidBodyPointLinkCondition::InitializeSolutionStep( ProcessInfo& rCurrentP
 
 //************************************************************************************
 //************************************************************************************
-void RigidBodyPointLinkCondition::InitializeNonLinearIteration(ProcessInfo& CurrentProcessInfo)
+void RigidBodyPointLinkCondition::InitializeNonLinearIteration(const ProcessInfo& CurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -318,7 +317,7 @@ void RigidBodyPointLinkCondition::InitializeNonLinearIteration(ProcessInfo& Curr
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodyPointLinkCondition::FinalizeNonLinearIteration(ProcessInfo& CurrentProcessInfo)
+void RigidBodyPointLinkCondition::FinalizeNonLinearIteration(const ProcessInfo& CurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -328,7 +327,7 @@ void RigidBodyPointLinkCondition::FinalizeNonLinearIteration(ProcessInfo& Curren
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodyPointLinkCondition::FinalizeSolutionStep( ProcessInfo& CurrentProcessInfo )
+void RigidBodyPointLinkCondition::FinalizeSolutionStep( const ProcessInfo& CurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -369,7 +368,7 @@ void RigidBodyPointLinkCondition::InitializeSystemMatrices(MatrixType& rLeftHand
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodyPointLinkCondition::InitializeGeneralVariables(GeneralVariables& rVariables, ProcessInfo& rCurrentProcessInfo)
+void RigidBodyPointLinkCondition::InitializeGeneralVariables(GeneralVariables& rVariables, const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -467,7 +466,7 @@ void RigidBodyPointLinkCondition::InitializeGeneralVariables(GeneralVariables& r
 void RigidBodyPointLinkCondition::CalculateConditionSystem(LocalSystemComponents& rLocalSystem,
 							   LocalSystemComponents& rLinkedSystem,
 							   Element* pSlaveElement,
-							   ProcessInfo& rCurrentProcessInfo)
+							   const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -558,7 +557,7 @@ void RigidBodyPointLinkCondition::CalculateAndAddRHS(LocalSystemComponents& rLoc
 
 void RigidBodyPointLinkCondition::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix,
 							VectorType& rRightHandSideVector,
-							ProcessInfo& rCurrentProcessInfo )
+							const ProcessInfo& rCurrentProcessInfo )
 {
   //Ask to the linked deformable element the LocalRightHandSide (only one element link)
   const SizeType inode = GetGeometry().PointsNumber()-1;
@@ -721,7 +720,7 @@ void RigidBodyPointLinkCondition::AssembleLocalRHS(VectorType& rRightHandSideVec
 
 void RigidBodyPointLinkCondition::CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix,
 									  VectorType& rRightHandSideVector,
-									  ProcessInfo& rCurrentProcessInfo)
+									  const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -805,7 +804,7 @@ void RigidBodyPointLinkCondition::CalculateSecondDerivativesContributions(Matrix
 //************************************************************************************
 
 void RigidBodyPointLinkCondition::CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                                         ProcessInfo& rCurrentProcessInfo)
+                                                        const  ProcessInfo& rCurrentProcessInfo)
 {
   //set sizes to zero
   MatrixType LocalLeftHandSideMatrix = Matrix();
@@ -874,7 +873,7 @@ void RigidBodyPointLinkCondition::CalculateRightHandSide(VectorType& rRightHandS
 //************************************************************************************
 
 void RigidBodyPointLinkCondition::CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix,
-								ProcessInfo& rCurrentProcessInfo)
+								const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -947,7 +946,7 @@ void RigidBodyPointLinkCondition::CalculateSecondDerivativesLHS(MatrixType& rLef
 //************************************************************************************
 
 void RigidBodyPointLinkCondition::CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector,
-								ProcessInfo& rCurrentProcessInfo)
+								const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -1016,7 +1015,7 @@ void RigidBodyPointLinkCondition::CalculateSecondDerivativesRHS(VectorType& rRig
 //***********************************************************************************
 //***********************************************************************************
 
-void RigidBodyPointLinkCondition::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+void RigidBodyPointLinkCondition::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -1030,7 +1029,7 @@ void RigidBodyPointLinkCondition::CalculateMassMatrix( MatrixType& rMassMatrix, 
 //***********************************************************************************
 //***********************************************************************************
 
-void RigidBodyPointLinkCondition::CalculateDampingMatrix( MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo)
+void RigidBodyPointLinkCondition::CalculateDampingMatrix( MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -1729,7 +1728,7 @@ void RigidBodyPointLinkCondition::WriteMatrixInRows( std::string MatrixName, con
 //***********************************************************************************
 //***********************************************************************************
 
-int RigidBodyPointLinkCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+int RigidBodyPointLinkCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
   return 0;
 }

--- a/applications/ContactMechanicsApplication/custom_conditions/rigid_body_links/rigid_body_point_link_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/rigid_body_links/rigid_body_point_link_condition.hpp
@@ -182,27 +182,27 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkCondition
    * if the condition needs to perform any operation before any calculation is done
    * the condition variables will be initialized and set using this method
    */
-  void Initialize() override;
+  void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * Called at the beginning of each iteration
    */
-  void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+  void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * Called at the end of each iteration
    */
-  void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+  void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * Called at the beginning of each solution step
    */
-  void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+  void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * Called at the end of each solution step
    */
-  void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+  void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
   //************* GETTING METHODS
 
@@ -210,13 +210,13 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkCondition
    * Sets on rConditionDofList the degrees of freedom of the considered element geometry
    */
   void GetDofList(DofsVectorType& rConditionDofList,
-                  ProcessInfo& rCurrentProcessInfo ) override;
+                  const ProcessInfo& rCurrentProcessInfo ) const override;
 
   /**
    * Sets on rResult the ID's of the element degrees of freedom
    */
   void EquationIdVector(EquationIdVectorType& rResult,
-                        ProcessInfo& rCurrentProcessInfo ) override;
+                        const ProcessInfo& rCurrentProcessInfo ) const override;
 
   /**
    * Sets on rValues the nodal displacements
@@ -249,7 +249,7 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkCondition
    */
   void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                             VectorType& rRightHandSideVector,
-                            ProcessInfo& rCurrentProcessInfo) override;
+                            const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * this is called during the assembling process in order
@@ -258,7 +258,7 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkCondition
    * @param rCurrentProcessInfo: the current process info instance
    */
   void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * this is called during the assembling process in order
@@ -269,7 +269,7 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkCondition
    */
   void CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix,
                                                VectorType& rRightHandSideVector,
-                                               ProcessInfo& rCurrentProcessInfo) override;
+                                               const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * this is called during the assembling process in order
@@ -278,7 +278,7 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkCondition
    * @param rCurrentProcessInfo: the current process info instance
    */
   void CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix,
-                                     ProcessInfo& rCurrentProcessInfo) override;
+                                     const ProcessInfo& rCurrentProcessInfo) override;
 
 
   /**
@@ -288,7 +288,7 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkCondition
    * @param rCurrentProcessInfo: the current process info instance
    */
   void CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector,
-                                     ProcessInfo& rCurrentProcessInfo) override;
+                                     const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * this is called during the assembling process in order
@@ -297,7 +297,7 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkCondition
    * @param rCurrentProcessInfo: the current process info instance
    */
   void CalculateMassMatrix(MatrixType& rMassMatrix,
-                           ProcessInfo& rCurrentProcessInfo) override;
+                           const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * this is called during the assembling process in order
@@ -306,7 +306,7 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkCondition
    * @param rCurrentProcessInfo: the current process info instance
    */
   void CalculateDampingMatrix(MatrixType& rDampingMatrix,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * This function provides the place to perform checks on the completeness of the input.
@@ -315,7 +315,7 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkCondition
    * or that no common error is found.
    * @param rCurrentProcessInfo
    */
-  virtual int Check(const ProcessInfo& rCurrentProcessInfo) override;
+  virtual int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
 
   ///@}
@@ -361,14 +361,14 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkCondition
    * Initialize General Variables
    */
   virtual void InitializeGeneralVariables(GeneralVariables& rVariables,
-                                          ProcessInfo& rCurrentProcessInfo);
+                                          const ProcessInfo& rCurrentProcessInfo);
   /**
    * Calculates the condition contributions
    */
   virtual void CalculateConditionSystem(LocalSystemComponents& rLocalSystem,
                                         LocalSystemComponents& rLinkedSystem,
                                         Element* rSlaveElement,
-                                        ProcessInfo& rCurrentProcessInfo);
+                                        const ProcessInfo& rCurrentProcessInfo);
   /**
    * Calculation and addition of the matrices of the LHS
    */

--- a/applications/ContactMechanicsApplication/custom_conditions/rigid_body_links/rigid_body_point_link_segregated_V_condition.cpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/rigid_body_links/rigid_body_point_link_segregated_V_condition.cpp
@@ -70,7 +70,7 @@ RigidBodyPointLinkSegregatedVCondition::~RigidBodyPointLinkSegregatedVCondition(
 //***********************************************************************************
 //***********************************************************************************
 
-void RigidBodyPointLinkSegregatedVCondition::GetDofList(DofsVectorType& rConditionDofList, ProcessInfo& rCurrentProcessInfo)
+void RigidBodyPointLinkSegregatedVCondition::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo) const
 {
   KRATOS_TRY
 
@@ -97,7 +97,7 @@ void RigidBodyPointLinkSegregatedVCondition::GetDofList(DofsVectorType& rConditi
 //***********************************************************************************
 //***********************************************************************************
 
-void RigidBodyPointLinkSegregatedVCondition::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo)
+void RigidBodyPointLinkSegregatedVCondition::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const
 {
   KRATOS_TRY
 
@@ -206,11 +206,11 @@ void RigidBodyPointLinkSegregatedVCondition::GetSecondDerivativesVector( Vector&
 //***********************************************************************************
 //***********************************************************************************
 
-void RigidBodyPointLinkSegregatedVCondition::Initialize()
+void RigidBodyPointLinkSegregatedVCondition::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
-  RigidBodyPointLinkCondition::Initialize();
+  RigidBodyPointLinkCondition::Initialize(rCurrentProcessInfo);
 
   KRATOS_CATCH("")
 }
@@ -218,7 +218,7 @@ void RigidBodyPointLinkSegregatedVCondition::Initialize()
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodyPointLinkSegregatedVCondition::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void RigidBodyPointLinkSegregatedVCondition::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -248,7 +248,7 @@ void RigidBodyPointLinkSegregatedVCondition::InitializeSolutionStep( ProcessInfo
 
 void RigidBodyPointLinkSegregatedVCondition::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix,
                                                                    VectorType& rRightHandSideVector,
-                                                                   ProcessInfo& rCurrentProcessInfo )
+                                                                   const ProcessInfo& rCurrentProcessInfo )
 {
   //process information
   this->SetProcessInformation(rCurrentProcessInfo);
@@ -279,7 +279,7 @@ void RigidBodyPointLinkSegregatedVCondition::CalculateLocalSystem( MatrixType& r
 
 void RigidBodyPointLinkSegregatedVCondition::CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix,
                                                                                      VectorType& rRightHandSideVector,
-                                                                                     ProcessInfo& rCurrentProcessInfo)
+                                                                                     const ProcessInfo& rCurrentProcessInfo)
 {
   //process information
   this->SetProcessInformation(rCurrentProcessInfo);
@@ -308,7 +308,7 @@ void RigidBodyPointLinkSegregatedVCondition::CalculateSecondDerivativesContribut
 //************************************************************************************
 
 void RigidBodyPointLinkSegregatedVCondition::CalculateRightHandSide( VectorType& rRightHandSideVector,
-                                                                     ProcessInfo& rCurrentProcessInfo )
+                                                                     const ProcessInfo& rCurrentProcessInfo )
 {
 
   //process information
@@ -336,7 +336,7 @@ void RigidBodyPointLinkSegregatedVCondition::CalculateRightHandSide( VectorType&
 //************************************************************************************
 
 void RigidBodyPointLinkSegregatedVCondition::CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix,
-                                                                           ProcessInfo& rCurrentProcessInfo)
+                                                                           const ProcessInfo& rCurrentProcessInfo)
 {
 
   //process information
@@ -364,7 +364,7 @@ void RigidBodyPointLinkSegregatedVCondition::CalculateSecondDerivativesLHS(Matri
 //************************************************************************************
 
 void RigidBodyPointLinkSegregatedVCondition::CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector,
-                                                                           ProcessInfo& rCurrentProcessInfo)
+                                                                           const ProcessInfo& rCurrentProcessInfo)
 {
   //process information
   this->SetProcessInformation(rCurrentProcessInfo);
@@ -432,7 +432,7 @@ void RigidBodyPointLinkSegregatedVCondition::SetProcessInformation(const Process
 //***********************************************************************************
 //***********************************************************************************
 
-int RigidBodyPointLinkSegregatedVCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+int RigidBodyPointLinkSegregatedVCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
   return 0;
 }

--- a/applications/ContactMechanicsApplication/custom_conditions/rigid_body_links/rigid_body_point_link_segregated_V_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/rigid_body_links/rigid_body_point_link_segregated_V_condition.hpp
@@ -112,12 +112,12 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkSegregatedVCon
    * if the condition needs to perform any operation before any calculation is done
    * the condition variables will be initialized and set using this method
    */
-  void Initialize() override;
+  void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * Called at the beginning of each solution step
    */
-  void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+  void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 
   //************* GETTING METHODS
@@ -126,13 +126,13 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkSegregatedVCon
    * Sets on rConditionDofList the degrees of freedom of the considered element geometry
    */
   void GetDofList(DofsVectorType& rConditionDofList,
-                  ProcessInfo& rCurrentProcessInfo ) override;
+                  const ProcessInfo& rCurrentProcessInfo ) const override;
 
   /**
    * Sets on rResult the ID's of the element degrees of freedom
    */
   void EquationIdVector(EquationIdVectorType& rResult,
-                        ProcessInfo& rCurrentProcessInfo ) override;
+                        const ProcessInfo& rCurrentProcessInfo ) const override;
 
   /**
    * Sets on rValues the nodal displacements
@@ -165,7 +165,7 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkSegregatedVCon
    */
   void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                             VectorType& rRightHandSideVector,
-                            ProcessInfo& rCurrentProcessInfo) override;
+                            const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * this is called during the assembling process in order
@@ -174,7 +174,7 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkSegregatedVCon
    * @param rCurrentProcessInfo: the current process info instance
    */
   void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * this is called during the assembling process in order
@@ -185,7 +185,7 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkSegregatedVCon
    */
   void CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix,
                                                VectorType& rRightHandSideVector,
-                                               ProcessInfo& rCurrentProcessInfo) override;
+                                               const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * this is called during the assembling process in order
@@ -194,7 +194,7 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkSegregatedVCon
    * @param rCurrentProcessInfo: the current process info instance
    */
   void CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix,
-                                     ProcessInfo& rCurrentProcessInfo) override;
+                                     const ProcessInfo& rCurrentProcessInfo) override;
 
 
   /**
@@ -204,7 +204,7 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkSegregatedVCon
    * @param rCurrentProcessInfo: the current process info instance
    */
   void CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector,
-                                     ProcessInfo& rCurrentProcessInfo) override;
+                                     const ProcessInfo& rCurrentProcessInfo) override;
 
 
   /**
@@ -214,7 +214,7 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) RigidBodyPointLinkSegregatedVCon
    * or that no common error is found.
    * @param rCurrentProcessInfo
    */
-  virtual int Check(const ProcessInfo& rCurrentProcessInfo) override;
+  virtual int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
 
   ///@}

--- a/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/EP_point_rigid_contact_penalty_3D_condition.cpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/EP_point_rigid_contact_penalty_3D_condition.cpp
@@ -96,7 +96,7 @@ namespace Kratos
 
    //************************************************************************************
    //************************************************************************************
-   void EPPointRigidContactPenalty3DCondition::InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
+   void EPPointRigidContactPenalty3DCondition::InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
    {
       KRATOS_TRY
 
@@ -147,7 +147,7 @@ namespace Kratos
    //************************************************************************************
    //************************************************************************************
 
-   void EPPointRigidContactPenalty3DCondition::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+   void EPPointRigidContactPenalty3DCondition::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo )
    {
       KRATOS_TRY
 
@@ -171,7 +171,7 @@ namespace Kratos
    //************************************************************************************
    //************************************************************************************
 
-   void EPPointRigidContactPenalty3DCondition::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+   void EPPointRigidContactPenalty3DCondition::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo )
    {
       KRATOS_TRY
 
@@ -475,7 +475,7 @@ namespace Kratos
          }
       }
 
-      if ( GetGeometry()[0].SolutionStepsDataHas( EFFECTIVE_CONTACT_STRESS) && 
+      if ( GetGeometry()[0].SolutionStepsDataHas( EFFECTIVE_CONTACT_STRESS) &&
             GetGeometry()[0].SolutionStepsDataHas(EFFECTIVE_CONTACT_FORCE) ) {
          double Area = this->CalculateSomeSortOfArea();
          array_1d<double, 3 >& ECF = GetGeometry()[0].FastGetSolutionStepValue(EFFECTIVE_CONTACT_FORCE);

--- a/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/EP_point_rigid_contact_penalty_3D_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/EP_point_rigid_contact_penalty_3D_condition.hpp
@@ -130,18 +130,18 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) EPPointRigidContactPenalty3DCond
     /**
      * Called at the end of each solution step
      */
-    virtual void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    virtual void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Called at the end of each solution step
      */
-    virtual void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    virtual void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
      * Called at the beginning of each iteration
      */
-    virtual void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    virtual void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     ///@name Access
     ///@{

--- a/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/EP_point_rigid_contact_penalty_wP_3D_condition.cpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/EP_point_rigid_contact_penalty_wP_3D_condition.cpp
@@ -79,7 +79,7 @@ namespace Kratos
 
    // ADD A NEW DOF DUE TO THE WATER
    void EPPointRigidContactPenaltywP3DCondition::GetDofList(DofsVectorType& rConditionDofList,
-         ProcessInfo& rCurrentProcessInfo)
+         const ProcessInfo& rCurrentProcessInfo) const
    {
       KRATOS_TRY
 
@@ -104,7 +104,7 @@ namespace Kratos
    //***********************************************************************************
 
    void EPPointRigidContactPenaltywP3DCondition::EquationIdVector(EquationIdVectorType& rResult,
-         ProcessInfo& rCurrentProcessInfo)
+         const ProcessInfo& rCurrentProcessInfo) const
    {
       KRATOS_TRY
 

--- a/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/EP_point_rigid_contact_penalty_wP_3D_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/EP_point_rigid_contact_penalty_wP_3D_condition.hpp
@@ -63,13 +63,13 @@ class KRATOS_API(CONTACT_MECHANICS_APPLICATION) EPPointRigidContactPenaltywP3DCo
                            NodesArrayType const& ThisNodes) const override;
 
   void GetDofList(DofsVectorType& rConditionDofList,
-                  ProcessInfo& rCurrentProcessInfo ) override;
+                  const ProcessInfo& rCurrentProcessInfo ) const override;
 
   /**
    * Sets on rResult the ID's of the element degrees of freedom
    */
   void EquationIdVector(EquationIdVectorType& rResult,
-                        ProcessInfo& rCurrentProcessInfo ) override;
+                        const ProcessInfo& rCurrentProcessInfo ) const override;
 
   /**
    * Sets on rValues the nodal displacements

--- a/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/point_rigid_contact_condition.cpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/point_rigid_contact_condition.cpp
@@ -102,7 +102,7 @@ namespace Kratos
    //***********************************************************************************
 
    void PointRigidContactCondition::GetDofList(DofsVectorType& rConditionDofList,
-         ProcessInfo& rCurrentProcessInfo)
+         const ProcessInfo& rCurrentProcessInfo) const
    {
       KRATOS_TRY
 
@@ -126,7 +126,7 @@ namespace Kratos
    //***********************************************************************************
 
    void PointRigidContactCondition::EquationIdVector(EquationIdVectorType& rResult,
-         ProcessInfo& rCurrentProcessInfo)
+         const ProcessInfo& rCurrentProcessInfo) const
    {
       KRATOS_TRY
 
@@ -303,7 +303,7 @@ namespace Kratos
    //***********************************************************************************
    //***********************************************************************************
 
-   void PointRigidContactCondition::Initialize()
+   void PointRigidContactCondition::Initialize(const ProcessInfo& rCurrentProcessInfo)
    {
       KRATOS_TRY
 
@@ -323,7 +323,7 @@ namespace Kratos
    //************************************************************************************
    //************************************************************************************
 
-   void PointRigidContactCondition::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+   void PointRigidContactCondition::InitializeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
    {
       KRATOS_TRY
 
@@ -340,7 +340,7 @@ namespace Kratos
 
    //************************************************************************************
    //************************************************************************************
-   void PointRigidContactCondition::InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
+   void PointRigidContactCondition::InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
    {
       KRATOS_TRY
 
@@ -352,14 +352,14 @@ namespace Kratos
    //************************************************************************************
    //************************************************************************************
 
-   void PointRigidContactCondition::FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
+   void PointRigidContactCondition::FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
    {
    }
 
    //************************************************************************************
    //************************************************************************************
 
-   void PointRigidContactCondition::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+   void PointRigidContactCondition::FinalizeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
    {
       KRATOS_TRY
 
@@ -437,7 +437,7 @@ namespace Kratos
    //************************************************************************************
 
    void PointRigidContactCondition::CalculateConditionSystem(LocalSystemComponents& rLocalSystem,
-         ProcessInfo& rCurrentProcessInfo)
+         const ProcessInfo& rCurrentProcessInfo)
    {
       KRATOS_TRY
 
@@ -577,7 +577,7 @@ namespace Kratos
    //************************************************************************************
    //************************************************************************************
 
-   void PointRigidContactCondition::CalculateRightHandSide( VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+   void PointRigidContactCondition::CalculateRightHandSide( VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
    {
       //create local system components
       LocalSystemComponents LocalSystem;
@@ -602,7 +602,7 @@ namespace Kratos
    //************************************************************************************
    //************************************************************************************
 
-   void PointRigidContactCondition::CalculateRightHandSide( std::vector< VectorType >& rRightHandSideVectors, const std::vector< Variable< VectorType > >& rRHSVariables, ProcessInfo& rCurrentProcessInfo )
+   void PointRigidContactCondition::CalculateRightHandSide( std::vector< VectorType >& rRightHandSideVectors, const std::vector< Variable< VectorType > >& rRHSVariables, const ProcessInfo& rCurrentProcessInfo )
    {
       //create local system components
       LocalSystemComponents LocalSystem;
@@ -639,7 +639,7 @@ namespace Kratos
    //************************************************************************************
    //************************************************************************************
 
-   void PointRigidContactCondition::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+   void PointRigidContactCondition::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
    {
       //create local system components
       LocalSystemComponents LocalSystem;
@@ -670,7 +670,7 @@ namespace Kratos
          const std::vector< Variable< MatrixType > >& rLHSVariables,
          std::vector< VectorType >& rRightHandSideVectors,
          const std::vector< Variable< VectorType > >& rRHSVariables,
-         ProcessInfo& rCurrentProcessInfo )
+         const ProcessInfo& rCurrentProcessInfo )
    {
       //create local system components
       LocalSystemComponents LocalSystem;
@@ -721,7 +721,7 @@ namespace Kratos
    //***********************************************************************************
    //***********************************************************************************
 
-   void PointRigidContactCondition::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+   void PointRigidContactCondition::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
    {
       KRATOS_TRY
 
@@ -733,7 +733,7 @@ namespace Kratos
    //***********************************************************************************
    //***********************************************************************************
 
-   void PointRigidContactCondition::CalculateDampingMatrix( MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo)
+   void PointRigidContactCondition::CalculateDampingMatrix( MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo)
    {
       KRATOS_TRY
 
@@ -778,7 +778,7 @@ namespace Kratos
    //***********************************************************************************
 
 
-   int PointRigidContactCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+   int PointRigidContactCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
    {
       return 0;
    }

--- a/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/point_rigid_contact_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/point_rigid_contact_condition.hpp
@@ -279,27 +279,27 @@ public:
     /**
      * Called at the beginning of each iteration
      */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Called at the end of each solution step
      */
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Called at the beginning of each iteration
      */
-    void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Called at the end of each iteration
      */
-    void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Called at the end of each solution step
      */
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //************* GETTING METHODS
@@ -308,13 +308,13 @@ public:
      * Sets on rConditionDofList the degrees of freedom of the considered element geometry
      */
     void GetDofList(DofsVectorType& rConditionDofList,
-		    ProcessInfo& rCurrentProcessInfo ) override;
+		    const ProcessInfo& rCurrentProcessInfo ) const override;
 
     /**
      * Sets on rResult the ID's of the element degrees of freedom
      */
     void EquationIdVector(EquationIdVectorType& rResult,
-			  ProcessInfo& rCurrentProcessInfo ) override;
+			  const ProcessInfo& rCurrentProcessInfo ) const override;
 
     /**
      * Sets on rValues the nodal displacements
@@ -347,7 +347,7 @@ public:
      */
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
 			      VectorType& rRightHandSideVector,
-			      ProcessInfo& rCurrentProcessInfo ) override;
+			      const ProcessInfo& rCurrentProcessInfo ) override;
 
 
     /**
@@ -363,7 +363,7 @@ public:
 			      const std::vector< Variable< MatrixType > >& rLHSVariables,
 			      std::vector< VectorType >& rRightHandSideVectors,
 			      const std::vector< Variable< VectorType > >& rRHSVariables,
-			      ProcessInfo& rCurrentProcessInfo) override;
+			      const ProcessInfo& rCurrentProcessInfo);
 
     /**
       * this is called during the assembling process in order
@@ -372,7 +372,7 @@ public:
       * @param rCurrentProcessInfo: the current process info instance
       */
     void CalculateRightHandSide(VectorType& rRightHandSideVector,
-				ProcessInfo& rCurrentProcessInfo ) override;
+				const ProcessInfo& rCurrentProcessInfo ) override;
 
 
     /**
@@ -384,7 +384,7 @@ public:
      */
     void CalculateRightHandSide(std::vector< VectorType >& rRightHandSideVectors,
 				const std::vector< Variable< VectorType > >& rRHSVariables,
-				ProcessInfo& rCurrentProcessInfo) override;
+				const ProcessInfo& rCurrentProcessInfo);
 
     /**
       * this is called during the assembling process in order
@@ -394,7 +394,7 @@ public:
       */
     void CalculateMassMatrix(
         MatrixType& rMassMatrix,
-        ProcessInfo& rCurrentProcessInfo ) override;
+        const ProcessInfo& rCurrentProcessInfo ) override;
 
     /**
       * this is called during the assembling process in order
@@ -404,7 +404,7 @@ public:
       */
     void CalculateDampingMatrix(
         MatrixType& rDampingMatrix,
-        ProcessInfo& rCurrentProcessInfo ) override;
+        const ProcessInfo& rCurrentProcessInfo ) override;
 
 
     /**
@@ -430,7 +430,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
 
     /**
@@ -527,7 +527,7 @@ protected:
      * Calculates the condition contributions
      */
     virtual void CalculateConditionSystem(LocalSystemComponents& rLocalSystem,
-					  ProcessInfo& rCurrentProcessInfo);
+					  const ProcessInfo& rCurrentProcessInfo);
 
 
     /**

--- a/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/rigid_body_point_rigid_contact_condition.cpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/rigid_body_point_rigid_contact_condition.cpp
@@ -93,13 +93,13 @@ RigidBodyPointRigidContactCondition::~RigidBodyPointRigidContactCondition()
 //***********************************************************************************
 
 void RigidBodyPointRigidContactCondition::GetDofList(DofsVectorType& rConditionDofList,
-				    ProcessInfo& rCurrentProcessInfo)
+				    const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 
     rConditionDofList.resize(0);
 
-    Element& MasterElement = mMasterElements.back();
+    const Element& MasterElement = mMasterElements.back();
     MasterElement.GetDofList(rConditionDofList, rCurrentProcessInfo);
 
     KRATOS_CATCH( "" )
@@ -109,13 +109,13 @@ void RigidBodyPointRigidContactCondition::GetDofList(DofsVectorType& rConditionD
 //***********************************************************************************
 
 void RigidBodyPointRigidContactCondition::EquationIdVector(EquationIdVectorType& rResult,
-					  ProcessInfo& rCurrentProcessInfo)
+					  const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 
     rResult.resize( 0, false );
 
-    Element& MasterElement = mMasterElements.back();
+    const Element& MasterElement = mMasterElements.back();
     MasterElement.EquationIdVector(rResult, rCurrentProcessInfo);
 
     KRATOS_CATCH( "" )
@@ -794,7 +794,7 @@ void RigidBodyPointRigidContactCondition::VectorToSkewSymmetricTensor( const Vec
 //***********************************************************************************
 
 
-int RigidBodyPointRigidContactCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+int RigidBodyPointRigidContactCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
   return 0;
 }

--- a/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/rigid_body_point_rigid_contact_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/rigid_contact/rigid_body_point_rigid_contact_condition.hpp
@@ -110,13 +110,13 @@ public:
      * Sets on rConditionDofList the degrees of freedom of the considered element geometry
      */
     void GetDofList(DofsVectorType& rConditionDofList,
-		    ProcessInfo& rCurrentProcessInfo ) override;
+		    const ProcessInfo& rCurrentProcessInfo ) const override;
 
     /**
      * Sets on rResult the ID's of the element degrees of freedom
      */
     void EquationIdVector(EquationIdVectorType& rResult,
-			  ProcessInfo& rCurrentProcessInfo ) override;
+			  const ProcessInfo& rCurrentProcessInfo ) const override;
 
     /**
      * Sets on rValues the nodal displacements
@@ -160,7 +160,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/ContactMechanicsApplication/custom_conditions/thermal_contact/axisym_thermal_contact_domain_penalty_2D_condition.cpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/thermal_contact/axisym_thermal_contact_domain_penalty_2D_condition.cpp
@@ -144,7 +144,7 @@ void AxisymThermalContactDomainPenalty2DCondition::CalculateRadius(double & rCur
 
 
 void AxisymThermalContactDomainPenalty2DCondition::CalculateKinematics(GeneralVariables& rVariables,
-						    ProcessInfo& rCurrentProcessInfo,
+						    const ProcessInfo& rCurrentProcessInfo,
 						    const unsigned int& rPointNumber)
 {
     KRATOS_TRY
@@ -215,7 +215,7 @@ void AxisymThermalContactDomainPenalty2DCondition::CalculateAndAddRHS(VectorType
  * or that no common error is found.
  * @param rCurrentProcessInfo
  */
-int  AxisymThermalContactDomainPenalty2DCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+int  AxisymThermalContactDomainPenalty2DCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 

--- a/applications/ContactMechanicsApplication/custom_conditions/thermal_contact/axisym_thermal_contact_domain_penalty_2D_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/thermal_contact/axisym_thermal_contact_domain_penalty_2D_condition.hpp
@@ -127,7 +127,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     //std::string Info() const;
 
@@ -169,7 +169,7 @@ protected:
      * Calculate Condition Kinematics
      */
     void CalculateKinematics(GeneralVariables& rVariables,
-			     ProcessInfo& rCurrentProcessInfo,
+			     const ProcessInfo& rCurrentProcessInfo,
 			     const unsigned int& rPointNumber) override;
 
     /**

--- a/applications/ContactMechanicsApplication/custom_conditions/thermal_contact/thermal_contact_domain_condition.cpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/thermal_contact/thermal_contact_domain_condition.cpp
@@ -104,7 +104,7 @@ ThermalContactDomainCondition::IntegrationMethod ThermalContactDomainCondition::
 //************************************************************************************
 //************************************************************************************
 
-void ThermalContactDomainCondition::GetDofList( DofsVectorType& rConditionalDofList, ProcessInfo& rCurrentProcessInfo )
+void ThermalContactDomainCondition::GetDofList( DofsVectorType& rConditionalDofList, const ProcessInfo& rCurrentProcessInfo ) const
 {
   rConditionalDofList.resize( 0 );
 
@@ -117,7 +117,7 @@ void ThermalContactDomainCondition::GetDofList( DofsVectorType& rConditionalDofL
 //************************************************************************************
 //************************************************************************************
 
-void ThermalContactDomainCondition::EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo )
+void ThermalContactDomainCondition::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo ) const
 {
   int number_of_nodes = GetGeometry().size();
   unsigned int elementdimension = number_of_nodes;
@@ -217,44 +217,12 @@ void ThermalContactDomainCondition::SetValuesOnIntegrationPoints( const Variable
 
 }
 
-//*********************************GET DOUBLE VALUE***********************************
-//************************************************************************************
-
-void ThermalContactDomainCondition::GetValueOnIntegrationPoints( const Variable<double>& rVariable,
-                                                                 std::vector<double>& rValues,
-                                                                 const ProcessInfo& rCurrentProcessInfo )
-{
-  this->CalculateOnIntegrationPoints(rVariable,rValues,rCurrentProcessInfo);
-}
-
-
-//**********************************GET VECTOR VALUE**********************************
-//************************************************************************************
-
-void ThermalContactDomainCondition::GetValueOnIntegrationPoints( const Variable<Vector>& rVariable,
-                                                                 std::vector<Vector>& rValues,
-                                                                 const ProcessInfo& rCurrentProcessInfo )
-{
-  this->CalculateOnIntegrationPoints(rVariable,rValues,rCurrentProcessInfo);
-
-}
-
-//***********************************GET MATRIX VALUE*********************************
-//************************************************************************************
-
-void ThermalContactDomainCondition::GetValueOnIntegrationPoints( const Variable<Matrix>& rVariable,
-                                                                 std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo )
-{
-  this->CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
-}
-
-
 
 //************* STARTING - ENDING  METHODS
 //************************************************************************************
 //************************************************************************************
 
-void ThermalContactDomainCondition::Initialize()
+void ThermalContactDomainCondition::Initialize(const ProcessInfo& CurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -268,7 +236,7 @@ void ThermalContactDomainCondition::Initialize()
 ////************************************************************************************
 ////************************************************************************************
 
-void ThermalContactDomainCondition::InitializeSolutionStep( ProcessInfo& CurrentProcessInfo )
+void ThermalContactDomainCondition::InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo)
 {
 
   //0.- Initialize Iteration Counter
@@ -284,7 +252,7 @@ void ThermalContactDomainCondition::InitializeSolutionStep( ProcessInfo& Current
 ////************************************************************************************
 ////************************************************************************************
 
-void ThermalContactDomainCondition::InitializeNonLinearIteration( ProcessInfo& CurrentProcessInfo )
+void ThermalContactDomainCondition::InitializeNonLinearIteration(const ProcessInfo& CurrentProcessInfo)
 {
 }
 
@@ -292,7 +260,7 @@ void ThermalContactDomainCondition::InitializeNonLinearIteration( ProcessInfo& C
 //************************************************************************************
 //************************************************************************************
 
-void ThermalContactDomainCondition::FinalizeSolutionStep( ProcessInfo& CurrentProcessInfo )
+void ThermalContactDomainCondition::FinalizeSolutionStep(const ProcessInfo& CurrentProcessInfo)
 {
 }
 
@@ -346,7 +314,7 @@ void ThermalContactDomainCondition::CalculateHeatConductivity()
 //************************************************************************************
 
 
-void ThermalContactDomainCondition::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void ThermalContactDomainCondition::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
   //calculation flags
   Flags CalculationFlags;
@@ -366,7 +334,7 @@ void ThermalContactDomainCondition::CalculateLocalSystem( MatrixType& rLeftHandS
 //************************************************************************************
 
 
-void ThermalContactDomainCondition::CalculateRightHandSide( VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void ThermalContactDomainCondition::CalculateRightHandSide( VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
   //calculation flags
   Flags CalculationFlags;
@@ -387,7 +355,7 @@ void ThermalContactDomainCondition::CalculateRightHandSide( VectorType& rRightHa
 //************************************************************************************
 
 
-void ThermalContactDomainCondition::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo )
+void ThermalContactDomainCondition::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
   //calculation flags
   Flags CalculationFlags;
@@ -445,7 +413,7 @@ void ThermalContactDomainCondition::InitializeSystemMatrices(MatrixType& rLeftHa
 
 void ThermalContactDomainCondition::CalculateConditionalSystem( MatrixType& rLeftHandSideMatrix,
 								VectorType& rRightHandSideVector,
-								ProcessInfo& rCurrentProcessInfo,
+								const ProcessInfo& rCurrentProcessInfo,
 								Flags& rCalculationFlags )
 {
   KRATOS_TRY
@@ -616,7 +584,7 @@ void ThermalContactDomainCondition::CalculateOnIntegrationPoints( const Variable
 //************************************************************************************
 //************************************************************************************
 
-void ThermalContactDomainCondition::CalculateRelativeVelocity(GeneralVariables& rVariables, PointType & TangentVelocity, ProcessInfo& rCurrentProcessInfo)
+void ThermalContactDomainCondition::CalculateRelativeVelocity(GeneralVariables& rVariables, PointType & TangentVelocity, const ProcessInfo& rCurrentProcessInfo)
 {
   //if current tangent is not previously computed, do it here.
   rVariables.CurrentSurface.Tangent = this->CalculateCurrentTangent( rVariables.CurrentSurface.Tangent );
@@ -653,7 +621,7 @@ void ThermalContactDomainCondition::CalculateRelativeVelocity(GeneralVariables& 
 
   //Filter for low velocities (relatives to dynamic waves)
   CurrentVelocity.clear();
-  CalculateRelativeDisplacement(rVariables, CurrentVelocity,rCurrentProcessInfo);
+  CalculateRelativeDisplacement(rVariables, CurrentVelocity, rCurrentProcessInfo);
 
   if( norm_2(TangentVelocity)>0 ){
 
@@ -672,7 +640,7 @@ void ThermalContactDomainCondition::CalculateRelativeVelocity(GeneralVariables& 
 //************************************************************************************
 
 
-void ThermalContactDomainCondition::CalculateRelativeDisplacement(GeneralVariables& rVariables, PointType & TangentDisplacement, ProcessInfo& rCurrentProcessInfo)
+void ThermalContactDomainCondition::CalculateRelativeDisplacement(GeneralVariables& rVariables, PointType & TangentDisplacement, const ProcessInfo& rCurrentProcessInfo)
 {
 
   // (Tangent vector previously computed)
@@ -710,7 +678,7 @@ void ThermalContactDomainCondition::CalculateRelativeDisplacement(GeneralVariabl
  * or that no common error is found.
  * @param rCurrentProcessInfo
  */
-int  ThermalContactDomainCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+int  ThermalContactDomainCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
   KRATOS_TRY
 

--- a/applications/ContactMechanicsApplication/custom_conditions/thermal_contact/thermal_contact_domain_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/thermal_contact/thermal_contact_domain_condition.hpp
@@ -119,7 +119,7 @@ protected:
     } GeneralVariables;
 
 
-    typedef struct
+    struct ContactVariables
     {
 
        //The stabilization parameter and penalty parameter
@@ -155,7 +155,7 @@ protected:
 	NodeType& GetMasterNode()           { return (*mpMasterNode); }
 
 
-    } ContactVariables;
+    };
 
 
 
@@ -224,12 +224,12 @@ public:
     /**
      * Sets on rConditionalDofList the degrees of freedom of the considered condition geometry
      */
-    void GetDofList(DofsVectorType& rConditionalDofList, ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rConditionalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rResult the ID's of the condition degrees of freedom
      */
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rValues the nodal displacements
@@ -275,23 +275,6 @@ public:
      */
     void SetValuesOnIntegrationPoints(const Variable<Matrix>& rVariable, const std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
-    //GET:
-    /**
-     * Set on rVariable a double Value from the Condition Constitutive Law
-     */
-    void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    /**
-     * Set on rVariable a Vector Value from the Condition Constitutive Law
-     */
-    void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    /**
-     * Set on rVariable a Matrix Value from the Condition Constitutive Law
-     */
-    void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-
 
     //************* STARTING - ENDING  METHODS
 
@@ -299,23 +282,23 @@ public:
      * Called to initialize the condition.
      * Must be called before any calculation is done
      */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& CurrentProcessInfo) override;
 
 
     /**
      * Called at the beginning of each solution step
      */
-    void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void InitializeNonLinearIteration(ProcessInfo& CurrentProcessInfo) override;
+    void InitializeNonLinearIteration(const ProcessInfo& CurrentProcessInfo) override;
 
     /**
      * Called at the end of eahc solution step
      */
-    void FinalizeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
 
 
@@ -330,7 +313,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -338,7 +321,7 @@ public:
      * @param rRightHandSideVector: the conditional right hand side vector
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -346,7 +329,7 @@ public:
      * @param rLeftHandSideVector: the conditional left hand side vector
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateLeftHandSide (MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLeftHandSide (MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //on integration points:
@@ -376,7 +359,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     //std::string Info() const;
 
@@ -463,7 +446,7 @@ protected:
      */
     virtual void CalculateConditionalSystem(MatrixType& rLeftHandSideMatrix,
                                             VectorType& rRightHandSideVector,
-                                            ProcessInfo& rCurrentProcessInfo,
+                                            const ProcessInfo& rCurrentProcessInfo,
 					    Flags& rCalculationFlags);
 
 
@@ -472,7 +455,7 @@ protected:
      * Calculate Condition Kinematics
      */
     virtual void CalculateKinematics(GeneralVariables& rVariables,
-				     ProcessInfo& rCurrentProcessInfo,
+				     const ProcessInfo& rCurrentProcessInfo,
 				     const unsigned int& rPointNumber)
     {
       KRATOS_THROW_ERROR( std::invalid_argument, "Calling base class in contact domain", "" );
@@ -553,13 +536,13 @@ protected:
     /**
      * Calculate Relative Velocity:
      */
-    void CalculateRelativeVelocity(GeneralVariables& rVariables, PointType& TangentVelocity, ProcessInfo& rCurrentProcessInfo);
+    void CalculateRelativeVelocity(GeneralVariables& rVariables, PointType& TangentVelocity, const ProcessInfo& rCurrentProcessInfo);
 
 
     /**
      * Calculate Relative Displacement:
      */
-    void CalculateRelativeDisplacement(GeneralVariables& rVariables, PointType & TangentDisplacement, ProcessInfo& rCurrentProcessInfo);
+    void CalculateRelativeDisplacement(GeneralVariables& rVariables, PointType & TangentDisplacement, const ProcessInfo& rCurrentProcessInfo);
 
 
     /**

--- a/applications/ContactMechanicsApplication/custom_conditions/thermal_contact/thermal_contact_domain_penalty_2D_condition.cpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/thermal_contact/thermal_contact_domain_penalty_2D_condition.cpp
@@ -186,7 +186,7 @@ void ThermalContactDomainPenalty2DCondition::SetMasterGeometry()
 
 
 void ThermalContactDomainPenalty2DCondition::CalculateKinematics(GeneralVariables& rVariables,
-						    ProcessInfo& rCurrentProcessInfo,
+						    const ProcessInfo& rCurrentProcessInfo,
 						    const unsigned int& rPointNumber)
 {
     KRATOS_TRY
@@ -202,7 +202,7 @@ void ThermalContactDomainPenalty2DCondition::CalculateKinematics(GeneralVariable
 //************************************************************************************
 //************************************************************************************
 
-void ThermalContactDomainPenalty2DCondition::CalcProjections(GeneralVariables & rVariables, ProcessInfo& rCurrentProcessInfo)
+void ThermalContactDomainPenalty2DCondition::CalcProjections(GeneralVariables & rVariables, const ProcessInfo& rCurrentProcessInfo)
 {
 
     //Contact face segment node1-node2
@@ -421,7 +421,7 @@ ContactDomainUtilities::PointType & ThermalContactDomainPenalty2DCondition::Calc
  * or that no common error is found.
  * @param rCurrentProcessInfo
  */
-int  ThermalContactDomainPenalty2DCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+int  ThermalContactDomainPenalty2DCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 

--- a/applications/ContactMechanicsApplication/custom_conditions/thermal_contact/thermal_contact_domain_penalty_2D_condition.hpp
+++ b/applications/ContactMechanicsApplication/custom_conditions/thermal_contact/thermal_contact_domain_penalty_2D_condition.hpp
@@ -119,7 +119,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     //std::string Info() const;
 
@@ -178,13 +178,13 @@ protected:
      * Calculate Condition Kinematics
      */
     void CalculateKinematics(GeneralVariables& rVariables,
-                             ProcessInfo& rCurrentProcessInfo,
+                             const ProcessInfo& rCurrentProcessInfo,
                              const unsigned int& rPointNumber) override;
 
     /**
      * Calculate Contact Element Projections
      */
-    void CalcProjections(GeneralVariables& rVariables, ProcessInfo& rCurrentProcessInfo);
+    void CalcProjections(GeneralVariables& rVariables, const ProcessInfo& rCurrentProcessInfo);
 
     /**
      * Calculate Integration Weight:

--- a/applications/ContactMechanicsApplication/custom_elements/rigid_body_element.cpp
+++ b/applications/ContactMechanicsApplication/custom_elements/rigid_body_element.cpp
@@ -103,7 +103,7 @@ RigidBodyElement::~RigidBodyElement()
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodyElement::GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo)
+void RigidBodyElement::GetDofList(DofsVectorType& ElementalDofList, const ProcessInfo& CurrentProcessInfo) const
 {
     ElementalDofList.resize(0);
     const SizeType dimension       = GetGeometry().WorkingSpaceDimension();
@@ -124,7 +124,7 @@ void RigidBodyElement::GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& 
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodyElement::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo)
+void RigidBodyElement::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const
 {
     const SizeType dimension = GetGeometry().WorkingSpaceDimension();
     const SizeType dofs_size = this->GetDofsSize();
@@ -177,7 +177,7 @@ void RigidBodyElement::GetValuesVector(Vector& rValues, int Step) const
 //************************************VELOCITY****************************************
 //************************************************************************************
 
-void RigidBodyElement::GetFirstDerivativesVector(Vector& rValues, int Step) const 
+void RigidBodyElement::GetFirstDerivativesVector(Vector& rValues, int Step) const
 {
     KRATOS_TRY
 
@@ -234,7 +234,7 @@ void RigidBodyElement::GetSecondDerivativesVector(Vector& rValues, int Step) con
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodyElement::Initialize()
+void RigidBodyElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -248,7 +248,7 @@ void RigidBodyElement::Initialize()
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodyElement::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+void RigidBodyElement::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -259,7 +259,7 @@ void RigidBodyElement::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodyElement::InitializeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+void RigidBodyElement::InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
 {
      KRATOS_TRY
 
@@ -271,7 +271,7 @@ void RigidBodyElement::InitializeNonLinearIteration( ProcessInfo& rCurrentProces
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodyElement::FinalizeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+void RigidBodyElement::FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
 {
      KRATOS_TRY
 
@@ -285,7 +285,7 @@ void RigidBodyElement::FinalizeNonLinearIteration( ProcessInfo& rCurrentProcessI
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodyElement::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+void RigidBodyElement::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
      KRATOS_TRY
 
@@ -353,7 +353,7 @@ void RigidBodyElement::CalculateRigidBodyProperties(RigidBodyProperties & rRigid
 //************************************************************************************
 
 void RigidBodyElement::CalculateRightHandSide(VectorType& rRightHandSideVector,
-					      ProcessInfo& rCurrentProcessInfo)
+					      const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -376,7 +376,7 @@ void RigidBodyElement::CalculateRightHandSide(VectorType& rRightHandSideVector,
 //************************************************************************************
 
 void RigidBodyElement::CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                                             ProcessInfo& rCurrentProcessInfo)
+                                             const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -400,7 +400,7 @@ void RigidBodyElement::CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
 
 void RigidBodyElement::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                             VectorType& rRightHandSideVector,
-                                            ProcessInfo& rCurrentProcessInfo)
+                                            const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -422,7 +422,7 @@ void RigidBodyElement::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
 //************************************************************************************
 
 void RigidBodyElement::CalculateDynamicSystem(LocalSystemComponents& rLocalSystem,
-                                              ProcessInfo& rCurrentProcessInfo)
+                                              const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -634,7 +634,7 @@ RigidBodyElement::ArrayType& RigidBodyElement::CalculateVolumeForce(ArrayType& r
 
 void RigidBodyElement::CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix,
                                                                VectorType& rRightHandSideVector,
-                                                               ProcessInfo& rCurrentProcessInfo)
+                                                               const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -691,7 +691,7 @@ void RigidBodyElement::CalculateSecondDerivativesContributions(MatrixType& rLeft
 //************************************************************************************
 
 void RigidBodyElement::CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix,
-                                                     ProcessInfo& rCurrentProcessInfo)
+                                                     const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -735,7 +735,7 @@ void RigidBodyElement::CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMa
 //************************************************************************************
 
 void RigidBodyElement::CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector,
-                                                     ProcessInfo& rCurrentProcessInfo)
+                                                     const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -1220,7 +1220,7 @@ void RigidBodyElement::CalculateAndAddInertiaRHS(VectorType& rRightHandSideVecto
 //************************************************************************************
 
 void RigidBodyElement::CalculateMassMatrix(MatrixType& rMassMatrix,
-                                           ProcessInfo& rCurrentProcessInfo)
+                                           const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -1308,7 +1308,7 @@ void RigidBodyElement::CalculateRotationLinearPartTensor(ArrayType& rRotationVec
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodyElement::UpdateRigidBodyNodes(ProcessInfo& rCurrentProcessInfo)
+void RigidBodyElement::UpdateRigidBodyNodes(const ProcessInfo& rCurrentProcessInfo)
 {
 
      KRATOS_TRY
@@ -1428,7 +1428,7 @@ RigidBodyElement::SizeType RigidBodyElement::GetDofsSize() const
  * or that no common error is found.
  * @param rCurrentProcessInfo
  */
-int  RigidBodyElement::Check(const ProcessInfo& rCurrentProcessInfo)
+int  RigidBodyElement::Check(const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 

--- a/applications/ContactMechanicsApplication/custom_elements/rigid_body_element.hpp
+++ b/applications/ContactMechanicsApplication/custom_elements/rigid_body_element.hpp
@@ -214,12 +214,12 @@ public:
     /**
      * Sets on rElementalDofList the degrees of freedom of the considered element geometry
      */
-    void GetDofList(DofsVectorType& rElementalDofList,ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rResult the ID's of the element degrees of freedom
      */
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rValues the nodal displacements
@@ -243,28 +243,28 @@ public:
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
       /**
      * Called at the beginning of each solution step
      */
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
      * Called at the end of eahc solution step
      */
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     //************* COMPUTING  METHODS
 
@@ -276,7 +276,7 @@ public:
      * @param rRightHandSideVector: the elemental right hand side
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -284,7 +284,7 @@ public:
      * @param rRightHandSideVector: the elemental right hand side vector
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -293,7 +293,7 @@ public:
      * @param rLeftHandSideVector: the elemental left hand side vector
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -305,7 +305,7 @@ public:
      */
     void CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix,
 						VectorType& rRightHandSideVector,
-						ProcessInfo& rCurrentProcessInfo) override;
+						const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -314,7 +314,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix,
-				       ProcessInfo& rCurrentProcessInfo) override;
+				       const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -324,7 +324,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector,
-				       ProcessInfo& rCurrentProcessInfo) override;
+				       const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -332,7 +332,7 @@ public:
      * @param rMassMatrix: the elemental mass matrix
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -357,7 +357,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access
@@ -423,7 +423,7 @@ protected:
      * Calculates the elemental dynamic contributions
      */
     void CalculateDynamicSystem(LocalSystemComponents& rLocalSystem,
-                                ProcessInfo& rCurrentProcessInfo);
+                                const ProcessInfo& rCurrentProcessInfo);
 
     /**
      * Initialize System Matrices
@@ -496,7 +496,7 @@ protected:
     /**
       * Update rigid body nodes and positions
       */
-    virtual void UpdateRigidBodyNodes(ProcessInfo& rCurrentProcessInfo);
+    virtual void UpdateRigidBodyNodes(const ProcessInfo& rCurrentProcessInfo);
 
     /**
      * Get element size from the dofs

--- a/applications/ContactMechanicsApplication/custom_elements/rigid_body_segregated_V_element.cpp
+++ b/applications/ContactMechanicsApplication/custom_elements/rigid_body_segregated_V_element.cpp
@@ -87,7 +87,7 @@ RigidBodySegregatedVElement::~RigidBodySegregatedVElement()
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodySegregatedVElement::GetDofList(DofsVectorType& rElementalDofList,ProcessInfo& rCurrentProcessInfo)
+void RigidBodySegregatedVElement::GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const
 {
   rElementalDofList.resize(0);
 
@@ -126,9 +126,9 @@ void RigidBodySegregatedVElement::GetDofList(DofsVectorType& rElementalDofList,P
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodySegregatedVElement::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo)
+void RigidBodySegregatedVElement::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const
 {
-  this->SetProcessInformation(rCurrentProcessInfo);
+  //this->SetProcessInformation(rCurrentProcessInfo);
 
   switch(StepType(rCurrentProcessInfo[SEGREGATED_STEP]))
   {
@@ -202,7 +202,7 @@ void RigidBodySegregatedVElement::GetValuesVector(Vector& rValues, int Step) con
 //************************************VELOCITY****************************************
 //************************************************************************************
 
-void RigidBodySegregatedVElement::GetFirstDerivativesVector(Vector& rValues, int Step) const 
+void RigidBodySegregatedVElement::GetFirstDerivativesVector(Vector& rValues, int Step) const
 {
   KRATOS_TRY
 
@@ -258,11 +258,11 @@ void RigidBodySegregatedVElement::GetSecondDerivativesVector(Vector& rValues, in
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodySegregatedVElement::Initialize()
+void RigidBodySegregatedVElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
-  RigidBodyElement::Initialize();
+  RigidBodyElement::Initialize(rCurrentProcessInfo);
 
   KRATOS_CATCH("")
 }
@@ -270,7 +270,7 @@ void RigidBodySegregatedVElement::Initialize()
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodySegregatedVElement::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+void RigidBodySegregatedVElement::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -298,7 +298,7 @@ void RigidBodySegregatedVElement::InitializeSolutionStep(ProcessInfo& rCurrentPr
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodySegregatedVElement::InitializeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+void RigidBodySegregatedVElement::InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -312,7 +312,7 @@ void RigidBodySegregatedVElement::InitializeNonLinearIteration( ProcessInfo& rCu
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodySegregatedVElement::FinalizeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+void RigidBodySegregatedVElement::FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -340,7 +340,7 @@ void RigidBodySegregatedVElement::FinalizeNonLinearIteration( ProcessInfo& rCurr
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodySegregatedVElement::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void RigidBodySegregatedVElement::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -371,7 +371,7 @@ void RigidBodySegregatedVElement::FinalizeSolutionStep( ProcessInfo& rCurrentPro
 //************************************************************************************
 
 void RigidBodySegregatedVElement::CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                                         ProcessInfo& rCurrentProcessInfo)
+                                                         const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -388,7 +388,7 @@ void RigidBodySegregatedVElement::CalculateRightHandSide(VectorType& rRightHandS
 //************************************************************************************
 
 void RigidBodySegregatedVElement::CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                                                        ProcessInfo& rCurrentProcessInfo)
+                                                        const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -406,7 +406,7 @@ void RigidBodySegregatedVElement::CalculateLeftHandSide(MatrixType& rLeftHandSid
 
 void RigidBodySegregatedVElement::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                                        VectorType& rRightHandSideVector,
-                                                       ProcessInfo& rCurrentProcessInfo)
+                                                       const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -424,7 +424,7 @@ void RigidBodySegregatedVElement::CalculateLocalSystem(MatrixType& rLeftHandSide
 
 void RigidBodySegregatedVElement::CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix,
                                                                           VectorType& rRightHandSideVector,
-                                                                          ProcessInfo& rCurrentProcessInfo)
+                                                                          const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -454,7 +454,7 @@ void RigidBodySegregatedVElement::CalculateSecondDerivativesContributions(Matrix
 //************************************************************************************
 
 void RigidBodySegregatedVElement::CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix,
-                                                                ProcessInfo& rCurrentProcessInfo)
+                                                                const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -484,7 +484,7 @@ void RigidBodySegregatedVElement::CalculateSecondDerivativesLHS(MatrixType& rLef
 //************************************************************************************
 
 void RigidBodySegregatedVElement::CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector,
-                                                                ProcessInfo& rCurrentProcessInfo)
+                                                                const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -512,7 +512,7 @@ void RigidBodySegregatedVElement::CalculateSecondDerivativesRHS(VectorType& rRig
 //************************************************************************************
 //************************************************************************************
 
-void RigidBodySegregatedVElement::CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+void RigidBodySegregatedVElement::CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -591,7 +591,7 @@ RigidBodySegregatedVElement::SizeType RigidBodySegregatedVElement::GetDofsSize()
 //***********************************************************************************
 //***********************************************************************************
 
-void RigidBodySegregatedVElement::UpdateRigidBodyNodes(ProcessInfo& rCurrentProcessInfo)
+void RigidBodySegregatedVElement::UpdateRigidBodyNodes(const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -631,7 +631,7 @@ void RigidBodySegregatedVElement::SetProcessInformation(const ProcessInfo& rCurr
 //************************************************************************************
 //************************************************************************************
 
-int RigidBodySegregatedVElement::Check(const ProcessInfo& rCurrentProcessInfo)
+int RigidBodySegregatedVElement::Check(const ProcessInfo& rCurrentProcessInfo) const
 {
   KRATOS_TRY
 

--- a/applications/ContactMechanicsApplication/custom_elements/rigid_body_segregated_V_element.hpp
+++ b/applications/ContactMechanicsApplication/custom_elements/rigid_body_segregated_V_element.hpp
@@ -114,12 +114,12 @@ public:
     /**
      * Sets on rElementalDofList the degrees of freedom of the considered element geometry
      */
-    void GetDofList(DofsVectorType& rElementalDofList,ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rResult the ID's of the element degrees of freedom
      */
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rValues the nodal displacements
@@ -143,28 +143,28 @@ public:
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
       /**
      * Called at the beginning of each solution step
      */
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
      * Called at the end of eahc solution step
      */
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //************* COMPUTING  METHODS
@@ -177,7 +177,7 @@ public:
      * @param rRightHandSideVector: the elemental right hand side
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -185,7 +185,7 @@ public:
      * @param rRightHandSideVector: the elemental right hand side vector
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -194,7 +194,7 @@ public:
      * @param rLeftHandSideVector: the elemental left hand side vector
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -206,7 +206,7 @@ public:
      */
     void CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix,
 						VectorType& rRightHandSideVector,
-						ProcessInfo& rCurrentProcessInfo) override;
+						const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -215,7 +215,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix,
-				       ProcessInfo& rCurrentProcessInfo) override;
+				       const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -225,7 +225,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector,
-				       ProcessInfo& rCurrentProcessInfo) override;
+				       const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -234,7 +234,7 @@ public:
      * @param rMassMatrix: the elemental mass matrix
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -244,7 +244,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access
@@ -319,7 +319,7 @@ protected:
     /**
       * Update rigid body nodes and positions
       */
-    void UpdateRigidBodyNodes(ProcessInfo& rCurrentProcessInfo) override;
+    void UpdateRigidBodyNodes(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     ///@}

--- a/applications/ContactMechanicsApplication/custom_elements/translatory_rigid_body_element.cpp
+++ b/applications/ContactMechanicsApplication/custom_elements/translatory_rigid_body_element.cpp
@@ -102,7 +102,7 @@ TranslatoryRigidBodyElement::~TranslatoryRigidBodyElement()
 //************************************************************************************
 
 
-void TranslatoryRigidBodyElement::GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo)
+void TranslatoryRigidBodyElement::GetDofList(DofsVectorType& ElementalDofList, const ProcessInfo& CurrentProcessInfo) const
 {
 
     ElementalDofList.resize(0);
@@ -123,7 +123,7 @@ void TranslatoryRigidBodyElement::GetDofList(DofsVectorType& ElementalDofList,Pr
 //************************************************************************************
 //************************************************************************************
 
-void TranslatoryRigidBodyElement::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo)
+void TranslatoryRigidBodyElement::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const
 {
 
     const unsigned int number_of_nodes = GetGeometry().size();
@@ -233,7 +233,7 @@ void TranslatoryRigidBodyElement::GetSecondDerivativesVector(Vector& rValues, in
 //************************************************************************************
 //************************************************************************************
 
-void TranslatoryRigidBodyElement::Initialize()
+void TranslatoryRigidBodyElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -339,7 +339,7 @@ void TranslatoryRigidBodyElement::CalculateAndAddInertiaLHS(MatrixType& rLeftHan
 
     //rCurrentProcessInfo must give it:
     double AlphaM = rCurrentProcessInfo[BOSSAK_ALPHA];
-    
+
     double Newmark0 = 0;
     double Newmark1 = 0;
     double Newmark2 = 0;
@@ -351,7 +351,7 @@ void TranslatoryRigidBodyElement::CalculateAndAddInertiaLHS(MatrixType& rLeftHan
     MatrixType m11(dimension, dimension);
     noalias(m11) = IdentityMatrix(dimension);
     m11 *= (1.0-AlphaM) * Newmark1 * rVariables.RigidBody.Mass;
-    
+
     //Building the Local Tangent Inertia Matrix
     BeamMathUtilsType::AddMatrix(rLeftHandSideMatrix, m11, 0, 0);
 
@@ -379,7 +379,7 @@ void TranslatoryRigidBodyElement::CalculateAndAddInertiaRHS(VectorType& rRightHa
       rRightHandSideVector.resize(dofs_size, false);
 
     noalias(rRightHandSideVector) = ZeroVector( dofs_size );
-    
+
     ArrayType CurrentLinearAccelerationVector = GetGeometry()[0].FastGetSolutionStepValue(ACCELERATION);
     CurrentLinearAccelerationVector = MapToInitialLocalFrame(CurrentLinearAccelerationVector);
     ArrayType PreviousLinearAccelerationVector = GetGeometry()[0].FastGetSolutionStepValue(ACCELERATION,1);
@@ -409,7 +409,7 @@ void TranslatoryRigidBodyElement::CalculateAndAddInertiaRHS(VectorType& rRightHa
 //************************************************************************************
 //************************************************************************************
 
-void TranslatoryRigidBodyElement::CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+void TranslatoryRigidBodyElement::CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
 
     KRATOS_TRY
@@ -442,7 +442,7 @@ void TranslatoryRigidBodyElement::CalculateMassMatrix(MatrixType& rMassMatrix, P
 //************************************************************************************
 //************************************************************************************
 
-void TranslatoryRigidBodyElement::UpdateRigidBodyNodes(ProcessInfo& rCurrentProcessInfo)
+void TranslatoryRigidBodyElement::UpdateRigidBodyNodes(const ProcessInfo& rCurrentProcessInfo)
 {
 
      KRATOS_TRY
@@ -484,7 +484,7 @@ TranslatoryRigidBodyElement::SizeType TranslatoryRigidBodyElement::GetDofsSize()
 //************************************************************************************
 //************************************************************************************
 
-int TranslatoryRigidBodyElement::Check(const ProcessInfo& rCurrentProcessInfo)
+int TranslatoryRigidBodyElement::Check(const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 

--- a/applications/ContactMechanicsApplication/custom_elements/translatory_rigid_body_element.hpp
+++ b/applications/ContactMechanicsApplication/custom_elements/translatory_rigid_body_element.hpp
@@ -125,12 +125,12 @@ public:
     /**
      * Sets on rElementalDofList the degrees of freedom of the considered element geometry
      */
-    void GetDofList(DofsVectorType& rElementalDofList,ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rResult the ID's of the element degrees of freedom
      */
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rValues the nodal displacements
@@ -154,7 +154,7 @@ public:
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //************* COMPUTING  METHODS
@@ -165,7 +165,7 @@ public:
      * @param rMassMatrix: the elemental mass matrix
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -175,7 +175,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access
@@ -256,7 +256,7 @@ protected:
     /**
       * Update rigid body nodes and positions
       */
-    void UpdateRigidBodyNodes(ProcessInfo& rCurrentProcessInfo) override;
+    void UpdateRigidBodyNodes(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Get element size from the dofs

--- a/applications/ContactMechanicsApplication/custom_elements/translatory_rigid_body_segregated_V_element.cpp
+++ b/applications/ContactMechanicsApplication/custom_elements/translatory_rigid_body_segregated_V_element.cpp
@@ -93,7 +93,7 @@ TranslatoryRigidBodySegregatedVElement::~TranslatoryRigidBodySegregatedVElement(
 //************************************************************************************
 //************************************************************************************
 
-void TranslatoryRigidBodySegregatedVElement::GetDofList(DofsVectorType& rElementalDofList,ProcessInfo& rCurrentProcessInfo)
+void TranslatoryRigidBodySegregatedVElement::GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const
 {
   rElementalDofList.resize(0);
 
@@ -126,9 +126,9 @@ void TranslatoryRigidBodySegregatedVElement::GetDofList(DofsVectorType& rElement
 //************************************************************************************
 //************************************************************************************
 
-void TranslatoryRigidBodySegregatedVElement::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo)
+void TranslatoryRigidBodySegregatedVElement::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const
 {
-  this->SetProcessInformation(rCurrentProcessInfo);
+  //this->SetProcessInformation(rCurrentProcessInfo);
 
   switch(StepType(rCurrentProcessInfo[SEGREGATED_STEP]))
   {
@@ -256,11 +256,11 @@ void TranslatoryRigidBodySegregatedVElement::GetSecondDerivativesVector(Vector& 
 //************************************************************************************
 //************************************************************************************
 
-void TranslatoryRigidBodySegregatedVElement::Initialize()
+void TranslatoryRigidBodySegregatedVElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
-    TranslatoryRigidBodyElement::Initialize();
+    TranslatoryRigidBodyElement::Initialize(rCurrentProcessInfo);
 
     KRATOS_CATCH( "" )
 }
@@ -268,7 +268,7 @@ void TranslatoryRigidBodySegregatedVElement::Initialize()
 //************************************************************************************
 //************************************************************************************
 
-void TranslatoryRigidBodySegregatedVElement::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+void TranslatoryRigidBodySegregatedVElement::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -295,7 +295,7 @@ void TranslatoryRigidBodySegregatedVElement::InitializeSolutionStep(ProcessInfo&
 //************************************************************************************
 //************************************************************************************
 
-void TranslatoryRigidBodySegregatedVElement::InitializeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+void TranslatoryRigidBodySegregatedVElement::InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -309,7 +309,7 @@ void TranslatoryRigidBodySegregatedVElement::InitializeNonLinearIteration( Proce
 //************************************************************************************
 //************************************************************************************
 
-void TranslatoryRigidBodySegregatedVElement::FinalizeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+void TranslatoryRigidBodySegregatedVElement::FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -336,7 +336,7 @@ void TranslatoryRigidBodySegregatedVElement::FinalizeNonLinearIteration( Process
 //************************************************************************************
 //************************************************************************************
 
-void TranslatoryRigidBodySegregatedVElement::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void TranslatoryRigidBodySegregatedVElement::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -366,7 +366,7 @@ void TranslatoryRigidBodySegregatedVElement::FinalizeSolutionStep( ProcessInfo& 
 //************************************************************************************
 
 void TranslatoryRigidBodySegregatedVElement::CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                                                    ProcessInfo& rCurrentProcessInfo)
+                                                                    const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -383,7 +383,7 @@ void TranslatoryRigidBodySegregatedVElement::CalculateRightHandSide(VectorType& 
 //************************************************************************************
 
 void TranslatoryRigidBodySegregatedVElement::CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                                                                   ProcessInfo& rCurrentProcessInfo)
+                                                                   const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -401,7 +401,7 @@ void TranslatoryRigidBodySegregatedVElement::CalculateLeftHandSide(MatrixType& r
 
 void TranslatoryRigidBodySegregatedVElement::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                                                   VectorType& rRightHandSideVector,
-                                                                  ProcessInfo& rCurrentProcessInfo)
+                                                                  const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -421,7 +421,7 @@ void TranslatoryRigidBodySegregatedVElement::CalculateLocalSystem(MatrixType& rL
 
 void TranslatoryRigidBodySegregatedVElement::CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix,
                                                                                      VectorType& rRightHandSideVector,
-                                                                                     ProcessInfo& rCurrentProcessInfo)
+                                                                                     const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -453,7 +453,7 @@ void TranslatoryRigidBodySegregatedVElement::CalculateSecondDerivativesContribut
 //************************************************************************************
 
 void TranslatoryRigidBodySegregatedVElement::CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix,
-                                                                           ProcessInfo& rCurrentProcessInfo)
+                                                                           const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -483,7 +483,7 @@ void TranslatoryRigidBodySegregatedVElement::CalculateSecondDerivativesLHS(Matri
 //************************************************************************************
 
 void TranslatoryRigidBodySegregatedVElement::CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector,
-                                                                           ProcessInfo& rCurrentProcessInfo)
+                                                                           const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -511,7 +511,7 @@ void TranslatoryRigidBodySegregatedVElement::CalculateSecondDerivativesRHS(Vecto
 //************************************************************************************
 //************************************************************************************
 
-void TranslatoryRigidBodySegregatedVElement::CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+void TranslatoryRigidBodySegregatedVElement::CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -585,7 +585,7 @@ TranslatoryRigidBodySegregatedVElement::SizeType TranslatoryRigidBodySegregatedV
 //***********************************************************************************
 //***********************************************************************************
 
-void TranslatoryRigidBodySegregatedVElement::UpdateRigidBodyNodes(ProcessInfo& rCurrentProcessInfo)
+void TranslatoryRigidBodySegregatedVElement::UpdateRigidBodyNodes(const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -624,7 +624,7 @@ void TranslatoryRigidBodySegregatedVElement::SetProcessInformation(const Process
 //************************************************************************************
 //************************************************************************************
 
-int TranslatoryRigidBodySegregatedVElement::Check(const ProcessInfo& rCurrentProcessInfo)
+int TranslatoryRigidBodySegregatedVElement::Check(const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 

--- a/applications/ContactMechanicsApplication/custom_elements/translatory_rigid_body_segregated_V_element.hpp
+++ b/applications/ContactMechanicsApplication/custom_elements/translatory_rigid_body_segregated_V_element.hpp
@@ -114,12 +114,12 @@ public:
     /**
      * Sets on rElementalDofList the degrees of freedom of the considered element geometry
      */
-    void GetDofList(DofsVectorType& rElementalDofList,ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rResult the ID's of the element degrees of freedom
      */
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rValues the nodal displacements
@@ -143,28 +143,28 @@ public:
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
       /**
      * Called at the beginning of each solution step
      */
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
      * Called at the end of eahc solution step
      */
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //************* COMPUTING  METHODS
@@ -177,7 +177,7 @@ public:
      * @param rRightHandSideVector: the elemental right hand side
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -185,7 +185,7 @@ public:
      * @param rRightHandSideVector: the elemental right hand side vector
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -194,7 +194,7 @@ public:
      * @param rLeftHandSideVector: the elemental left hand side vector
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -206,7 +206,7 @@ public:
      */
     void CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix,
 						VectorType& rRightHandSideVector,
-						ProcessInfo& rCurrentProcessInfo) override;
+						const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -215,7 +215,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix,
-				       ProcessInfo& rCurrentProcessInfo) override;
+				       const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -225,7 +225,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector,
-				       ProcessInfo& rCurrentProcessInfo) override;
+				       const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -233,7 +233,7 @@ public:
      * @param rMassMatrix: the elemental mass matrix
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
     //************************************************************************************
     //************************************************************************************
@@ -244,7 +244,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access
@@ -318,7 +318,7 @@ protected:
     /**
       * Update rigid body nodes and positions
       */
-    void UpdateRigidBodyNodes(ProcessInfo& rCurrentProcessInfo) override;
+    void UpdateRigidBodyNodes(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     ///@}

--- a/applications/DelaunayMeshingApplication/custom_bounding/spatial_bounding_box.hpp
+++ b/applications/DelaunayMeshingApplication/custom_bounding/spatial_bounding_box.hpp
@@ -202,7 +202,7 @@ public:
 protected:
 
 
-  typedef struct
+  struct BoundingBoxVariables
   {
 
     int        Dimension;          // 2D or 3D
@@ -274,7 +274,7 @@ protected:
     }
 
 
-  } BoundingBoxVariables;
+  };
 
 
 

--- a/applications/PfemApplication/custom_elements/fluid_elements/fluid_element.cpp
+++ b/applications/PfemApplication/custom_elements/fluid_elements/fluid_element.cpp
@@ -160,7 +160,7 @@ void FluidElement::IncreaseIntegrationMethod(IntegrationMethod& rThisIntegration
 //************************************************************************************
 //************************************************************************************
 
-void FluidElement::GetDofList( DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo )
+void FluidElement::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_ERROR << " calling the default method GetDofList for a fluid element " << std::endl;
 }
@@ -179,7 +179,7 @@ void FluidElement::SetProcessInformation(const ProcessInfo& rCurrentProcessInfo)
 //************************************************************************************
 //************************************************************************************
 
-void FluidElement::EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo )
+void FluidElement::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_ERROR << " calling the default method EquationIdVector for a fluid element " << std::endl;
 }
@@ -279,126 +279,10 @@ void FluidElement::SetValuesOnIntegrationPoints( const Variable<ConstitutiveLaw:
 
 }
 
-//*********************************GET DOUBLE VALUE***********************************
-//************************************************************************************
-
-
-void FluidElement::GetValueOnIntegrationPoints( const Variable<double>& rVariable,
-						std::vector<double>& rValues,
-						const ProcessInfo& rCurrentProcessInfo )
-{
-    if ( rVariable == PRESSURE )
-    {
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-    }
-    else
-    {
-      const unsigned int& integration_points_number = GetGeometry().IntegrationPointsNumber( mThisIntegrationMethod );
-
-      if ( rValues.size() != integration_points_number )
-      {
-        rValues.resize( integration_points_number );
-      }
-
-      for ( unsigned int ii = 0; ii < integration_points_number; ii++ )
-      {
-        rValues[ii] = mConstitutiveLawVector[ii]->GetValue( rVariable, rValues[ii] );
-      }
-    }
-}
-
-//**********************************GET VECTOR VALUE**********************************
-//************************************************************************************
-
-
-void FluidElement::GetValueOnIntegrationPoints( const Variable<Vector>& rVariable,
-						std::vector<Vector>& rValues,
-						const ProcessInfo& rCurrentProcessInfo )
-{
-    const unsigned int& integration_points_number = mConstitutiveLawVector.size();
-
-    if ( rValues.size() != integration_points_number )
-        rValues.resize( integration_points_number );
-
-
-    if ( rVariable == PK2_STRESS_TENSOR ||  rVariable == CAUCHY_STRESS_TENSOR )
-    {
-
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-
-    }
-    else if ( rVariable == PK2_STRESS_VECTOR ||  rVariable == CAUCHY_STRESS_VECTOR )
-    {
-
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-
-    }
-    else if ( rVariable == GREEN_LAGRANGE_STRAIN_TENSOR ||  rVariable == ALMANSI_STRAIN_TENSOR )
-    {
-
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-
-    }
-    else
-    {
-
-        for ( unsigned int PointNumber = 0;  PointNumber < integration_points_number; PointNumber++ )
-        {
-            rValues[PointNumber] = mConstitutiveLawVector[PointNumber]->GetValue( rVariable, rValues[PointNumber] );
-        }
-
-    }
-
-}
-
-//***********************************GET MATRIX VALUE*********************************
-//************************************************************************************
-
-void FluidElement::GetValueOnIntegrationPoints( const Variable<Matrix>& rVariable,
-						std::vector<Matrix>& rValues,
-						const ProcessInfo& rCurrentProcessInfo )
-{
-
-    const unsigned int& integration_points_number = mConstitutiveLawVector.size();
-
-    if ( rValues.size() != integration_points_number )
-        rValues.resize( integration_points_number );
-
-    if ( rVariable == PK2_STRESS_TENSOR ||  rVariable == CAUCHY_STRESS_TENSOR )
-    {
-
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-
-    }
-    else if ( rVariable == GREEN_LAGRANGE_STRAIN_TENSOR ||  rVariable == ALMANSI_STRAIN_TENSOR )
-    {
-
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-
-    }
-    else if ( rVariable == DEFORMATION_GRADIENT )
-    {
-
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-
-    }
-    else
-    {
-
-        for ( unsigned int PointNumber = 0;  PointNumber < integration_points_number; PointNumber++ )
-        {
-            rValues[PointNumber] = mConstitutiveLawVector[PointNumber]->GetValue( rVariable, rValues[PointNumber] );
-        }
-
-    }
-
-
-}
-
 //********************************GET CONSTITUTIVE VALUE******************************
 //************************************************************************************
 
-void FluidElement::GetValueOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable,
+void FluidElement::CalculateOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable,
 						std::vector<ConstitutiveLaw::Pointer>& rValues,
 						const ProcessInfo& rCurrentProcessInfo )
 {
@@ -423,7 +307,7 @@ void FluidElement::GetValueOnIntegrationPoints( const Variable<ConstitutiveLaw::
 //************************************************************************************
 
 
-void FluidElement::Initialize()
+void FluidElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -625,7 +509,7 @@ void FluidElement::CalculateMaterialResponse(ElementDataType& rVariables,
 //************************************************************************************
 
 void FluidElement::CalculateElementalSystem( LocalSystemComponents& rLocalSystem,
-                                             ProcessInfo& rCurrentProcessInfo )
+                                             const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -690,7 +574,7 @@ void FluidElement::CalculateElementalSystem( LocalSystemComponents& rLocalSystem
 //************************************************************************************
 
 void FluidElement::CalculateDynamicSystem( LocalSystemComponents& rLocalSystem,
-					   ProcessInfo& rCurrentProcessInfo )
+					   const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -942,7 +826,7 @@ double& FluidElement::CalculateIntegrationWeight(double& rIntegrationWeight)
 //************************************************************************************
 //************************************************************************************
 
-void FluidElement::CalculateRightHandSide( VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void FluidElement::CalculateRightHandSide( VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -975,7 +859,7 @@ void FluidElement::CalculateRightHandSide( VectorType& rRightHandSideVector, Pro
 //************************************************************************************
 
 
-void FluidElement::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo )
+void FluidElement::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1007,7 +891,7 @@ void FluidElement::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, Proce
 //************************************************************************************
 //************************************************************************************
 
-void FluidElement::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void FluidElement::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1057,7 +941,7 @@ void FluidElement::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, Vector
 //************************************************************************************
 
 
-void FluidElement::CalculatePerturbedLeftHandSide( MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo )
+void FluidElement::CalculatePerturbedLeftHandSide( MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1125,7 +1009,7 @@ void FluidElement::CalculatePerturbedLeftHandSide( MatrixType& rLeftHandSideMatr
 //************************************************************************************
 //************************************************************************************
 
-void FluidElement::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void FluidElement::InitializeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1139,7 +1023,7 @@ void FluidElement::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo )
 
 //************************************************************************************
 //************************************************************************************
-void FluidElement::InitializeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+void FluidElement::InitializeNonLinearIteration( const ProcessInfo& rCurrentProcessInfo )
 {
     InitializeExplicitContributions();
 }
@@ -1147,7 +1031,7 @@ void FluidElement::InitializeNonLinearIteration( ProcessInfo& rCurrentProcessInf
 //************************************************************************************
 //************************************************************************************
 
-void FluidElement::FinalizeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+void FluidElement::FinalizeNonLinearIteration( const ProcessInfo& rCurrentProcessInfo )
 {
 
 }
@@ -1155,7 +1039,7 @@ void FluidElement::FinalizeNonLinearIteration( ProcessInfo& rCurrentProcessInfo 
 //************************************************************************************
 //************************************************************************************
 
-void FluidElement::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void FluidElement::FinalizeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1745,7 +1629,7 @@ Vector& FluidElement::CalculateVolumeForce( Vector& rVolumeForce, ElementDataTyp
 //************************************************************************************
 //************************************************************************************
 
-void FluidElement::CalculateFirstDerivativesContributions(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+void FluidElement::CalculateFirstDerivativesContributions(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -1774,7 +1658,7 @@ void FluidElement::CalculateFirstDerivativesContributions(MatrixType& rLeftHandS
 //************************************************************************************
 //************************************************************************************
 
-void FluidElement::CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+void FluidElement::CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -1856,7 +1740,7 @@ void FluidElement::CalculateSecondDerivativesContributions(MatrixType& rLeftHand
 //************************************************************************************
 //************************************************************************************
 
-void FluidElement::CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo)
+void FluidElement::CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -1908,7 +1792,7 @@ void FluidElement::CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix
 //************************************************************************************
 //************************************************************************************
 
-void FluidElement::CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+void FluidElement::CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -1979,7 +1863,7 @@ void FluidElement::CalculateSecondDerivativesRHS(VectorType& rRightHandSideVecto
 //************************************************************************************
 //************************************************************************************
 
-void FluidElement::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo )
+void FluidElement::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -2050,7 +1934,7 @@ void FluidElement::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rC
 //************************************************************************************
 //************************************************************************************
 
-void FluidElement::CalculateDampingMatrix( MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo )
+void FluidElement::CalculateDampingMatrix( MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 

--- a/applications/PfemApplication/custom_elements/fluid_elements/fluid_element.hpp
+++ b/applications/PfemApplication/custom_elements/fluid_elements/fluid_element.hpp
@@ -318,12 +318,12 @@ public:
     /**
      * Sets on rElementalDofList the degrees of freedom of the considered element geometry
      */
-    void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rResult the ID's of the element degrees of freedom
      */
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rValues the nodal displacements
@@ -379,27 +379,13 @@ public:
 
 
     //GET:
-    /**
-     * Get on rVariable a double Value from the Element Constitutive Law
-     */
-    virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    /**
-     * Get on rVariable a Vector Value from the Element Constitutive Law
-     */
-    virtual void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    /**
-     * Get on rVariable a Matrix Value from the Element Constitutive Law
-     */
-    virtual void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Get a Constitutive Law Value
      */
-    void GetValueOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable,
-                                      std::vector<ConstitutiveLaw::Pointer>& rValues,
-                                      const ProcessInfo& rCurrentProcessInfo ) override;
+    void CalculateOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable,
+                                       std::vector<ConstitutiveLaw::Pointer>& rValues,
+                                       const ProcessInfo& rCurrentProcessInfo ) override;
 
 
 
@@ -409,27 +395,27 @@ public:
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    virtual void Initialize() override;
+    virtual void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Called at the beginning of each solution step
      */
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Called at the end of eahc solution step
      */
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //************* COMPUTING  METHODS
@@ -446,7 +432,7 @@ public:
 
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
 			      VectorType& rRightHandSideVector,
-			      ProcessInfo& rCurrentProcessInfo) override;
+			      const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -456,7 +442,7 @@ public:
       * @param rCurrentProcessInfo: the current process info instance
       */
     void CalculateRightHandSide(VectorType& rRightHandSideVector,
-				ProcessInfo& rCurrentProcessInfo) override;
+				const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -466,7 +452,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateLeftHandSide (MatrixType& rLeftHandSideMatrix,
-				ProcessInfo& rCurrentProcessInfo) override;
+				const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -477,7 +463,7 @@ public:
      */
     void CalculateFirstDerivativesContributions(MatrixType& rLeftHandSideMatrix,
 						VectorType& rRightHandSideVector,
-						ProcessInfo& rCurrentProcessInfo) override;
+						const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -488,7 +474,7 @@ public:
      */
     void CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix,
 						VectorType& rRightHandSideVector,
-						ProcessInfo& rCurrentProcessInfo) override;
+						const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -497,7 +483,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix,
-				       ProcessInfo& rCurrentProcessInfo) override;
+				       const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -507,7 +493,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector,
-				       ProcessInfo& rCurrentProcessInfo) override;
+				       const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
       * this is called during the assembling process in order
@@ -516,7 +502,7 @@ public:
       * @param rCurrentProcessInfo: the current process info instance
       */
     void CalculateMassMatrix(MatrixType& rMassMatrix,
-		    ProcessInfo& rCurrentProcessInfo) override;
+                             const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
       * this is called during the assembling process in order
@@ -525,7 +511,7 @@ public:
       * @param rCurrentProcessInfo: the current process info instance
       */
     void CalculateDampingMatrix(MatrixType& rDampingMatrix,
-		    ProcessInfo& rCurrentProcessInfo) override;
+                                const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -644,13 +630,13 @@ protected:
      * Calculates the elemental contributions
      */
     virtual void CalculateElementalSystem(LocalSystemComponents& rLocalSystem,
-                                          ProcessInfo& rCurrentProcessInfo);
+                                          const ProcessInfo& rCurrentProcessInfo);
 
     /**
      * Calculates the elemental dynamic contributions
      */
     virtual void CalculateDynamicSystem(LocalSystemComponents& rLocalSystem,
-					ProcessInfo& rCurrentProcessInfo);
+					const ProcessInfo& rCurrentProcessInfo);
 
     /**
      * Prints element information for each gauss point (debugging purposes)
@@ -662,7 +648,7 @@ protected:
      * Calculation of the tangent via perturbation of the dofs variables : testing purposes
      */
     void CalculatePerturbedLeftHandSide (MatrixType& rLeftHandSideMatrix,
-					 ProcessInfo& rCurrentProcessInfo);
+					 const ProcessInfo& rCurrentProcessInfo);
 
     /**
      * Calculation and addition of the matrices of the LHS
@@ -786,7 +772,7 @@ protected:
      * Initialize Element General Variables
      */
     virtual void InitializeElementData(ElementDataType & rVariables,
-					    const ProcessInfo& rCurrentProcessInfo);
+                                       const ProcessInfo& rCurrentProcessInfo);
 
     /**
      * Transform Element General Variables

--- a/applications/PfemApplication/custom_elements/fluid_elements/updated_lagrangian_segregated_fluid_element.cpp
+++ b/applications/PfemApplication/custom_elements/fluid_elements/updated_lagrangian_segregated_fluid_element.cpp
@@ -125,7 +125,7 @@ UpdatedLagrangianSegregatedFluidElement::~UpdatedLagrangianSegregatedFluidElemen
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianSegregatedFluidElement::GetDofList( DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo )
+void UpdatedLagrangianSegregatedFluidElement::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo ) const
 {
   rElementalDofList.resize( 0 );
 
@@ -162,9 +162,9 @@ void UpdatedLagrangianSegregatedFluidElement::GetDofList( DofsVectorType& rEleme
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianSegregatedFluidElement::EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo )
+void UpdatedLagrangianSegregatedFluidElement::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo ) const
 {
-  this->SetProcessInformation(rCurrentProcessInfo);
+  //this->SetProcessInformation(rCurrentProcessInfo);
 
   const SizeType number_of_nodes = GetGeometry().size();
   const SizeType dimension       = GetGeometry().WorkingSpaceDimension();
@@ -205,7 +205,7 @@ void UpdatedLagrangianSegregatedFluidElement::EquationIdVector( EquationIdVector
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianSegregatedFluidElement::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void UpdatedLagrangianSegregatedFluidElement::InitializeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -220,7 +220,7 @@ void UpdatedLagrangianSegregatedFluidElement::InitializeSolutionStep( ProcessInf
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianSegregatedFluidElement::InitializeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+void UpdatedLagrangianSegregatedFluidElement::InitializeNonLinearIteration( const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -232,7 +232,7 @@ void UpdatedLagrangianSegregatedFluidElement::InitializeNonLinearIteration( Proc
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianSegregatedFluidElement::FinalizeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+void UpdatedLagrangianSegregatedFluidElement::FinalizeNonLinearIteration( const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -243,7 +243,7 @@ void UpdatedLagrangianSegregatedFluidElement::FinalizeNonLinearIteration( Proces
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianSegregatedFluidElement::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void UpdatedLagrangianSegregatedFluidElement::FinalizeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -828,7 +828,7 @@ void UpdatedLagrangianSegregatedFluidElement::CalculateAndAddInternalForces(Vect
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianSegregatedFluidElement::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo )
+void UpdatedLagrangianSegregatedFluidElement::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -862,7 +862,7 @@ void UpdatedLagrangianSegregatedFluidElement::CalculateMassMatrix( MatrixType& r
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianSegregatedFluidElement::CalculateDampingMatrix( MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo )
+void UpdatedLagrangianSegregatedFluidElement::CalculateDampingMatrix( MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 

--- a/applications/PfemApplication/custom_elements/fluid_elements/updated_lagrangian_segregated_fluid_element.hpp
+++ b/applications/PfemApplication/custom_elements/fluid_elements/updated_lagrangian_segregated_fluid_element.hpp
@@ -122,34 +122,34 @@ public:
   /**
    * Called at the beginning of each solution step
    */
-  void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+  void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * Called at the end of eahc solution step
    */
-  void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+  void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * this is called for non-linear analysis at the beginning of the iteration process
    */
-  void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+  void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * this is called for non-linear analysis at the beginning of the iteration process
    */
-  void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+  void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
   //************* GETTING METHODS
 
   /**
    * Sets on rElementalDofList the degrees of freedom of the considered element geometry
    */
-  void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
+  void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
   /**
    * Sets on rResult the ID's of the element degrees of freedom
    */
-  void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+  void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
   /**
    * Sets on rValues the nodal displacements
@@ -174,7 +174,7 @@ public:
    * @param rCurrentProcessInfo: the current process info instance
    */
   void CalculateMassMatrix(MatrixType& rMassMatrix,
-                           ProcessInfo& rCurrentProcessInfo) override;
+                           const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * this is called during the assembling process in order
@@ -183,7 +183,7 @@ public:
    * @param rCurrentProcessInfo: the current process info instance
    */
   void CalculateDampingMatrix(MatrixType& rDampingMatrix,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
 
 
 

--- a/applications/SolidMechanicsApplication/custom_conditions/boundary_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/boundary_condition.cpp
@@ -155,7 +155,7 @@ namespace Kratos
   //***********************************************************************************
 
   void BoundaryCondition::GetDofList(DofsVectorType& rConditionDofList,
-				     ProcessInfo& rCurrentProcessInfo)
+				     const ProcessInfo& rCurrentProcessInfo) const
   {
     KRATOS_TRY
 
@@ -199,7 +199,7 @@ namespace Kratos
   //***********************************************************************************
 
   void BoundaryCondition::EquationIdVector(EquationIdVectorType& rResult,
-					   ProcessInfo& rCurrentProcessInfo)
+					   const ProcessInfo& rCurrentProcessInfo) const
   {
     KRATOS_TRY
 
@@ -585,7 +585,7 @@ namespace Kratos
   //***********************************************************************************
   //***********************************************************************************
 
-  void BoundaryCondition::Initialize()
+  void BoundaryCondition::Initialize( const ProcessInfo& rCurrentProcessInfo )
   {
     KRATOS_TRY
 
@@ -596,7 +596,7 @@ namespace Kratos
   //***********************************************************************************
   //***********************************************************************************
 
-  void BoundaryCondition::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+  void BoundaryCondition::InitializeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
   {
     KRATOS_TRY
 
@@ -608,7 +608,7 @@ namespace Kratos
   //***********************************************************************************
   //***********************************************************************************
 
-  void BoundaryCondition::InitializeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+  void BoundaryCondition::InitializeNonLinearIteration( const ProcessInfo& rCurrentProcessInfo )
   {
     KRATOS_TRY
 
@@ -775,7 +775,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void BoundaryCondition::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo )
+  void BoundaryCondition::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo )
   {
     //create local system components
     LocalSystemComponents LocalSystem;
@@ -802,7 +802,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void BoundaryCondition::CalculateRightHandSide( VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+  void BoundaryCondition::CalculateRightHandSide( VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
   {
     //create local system components
     LocalSystemComponents LocalSystem;
@@ -828,7 +828,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void BoundaryCondition::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+  void BoundaryCondition::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
   {
     //create local system components
     LocalSystemComponents LocalSystem;
@@ -853,7 +853,7 @@ namespace Kratos
   //***********************************************************************************
   //***********************************************************************************
 
-  void BoundaryCondition::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+  void BoundaryCondition::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -865,7 +865,7 @@ namespace Kratos
   //***********************************************************************************
   //***********************************************************************************
 
-  void BoundaryCondition::CalculateDampingMatrix( MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo)
+  void BoundaryCondition::CalculateDampingMatrix( MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -1003,16 +1003,6 @@ namespace Kratos
   }
 
 
-  //*********************************GET DOUBLE VALUE***********************************
-  //************************************************************************************
-
-  void BoundaryCondition::GetValueOnIntegrationPoints( const Variable<double>& rVariable,
-						       std::vector<double>& rValues,
-						       const ProcessInfo& rCurrentProcessInfo )
-  {
-    this->CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-  }
-
   //************************************************************************************
   //************************************************************************************
 
@@ -1067,7 +1057,7 @@ namespace Kratos
   //***********************************************************************************
 
 
-  int BoundaryCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int BoundaryCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
 
     // Perform base element checks

--- a/applications/SolidMechanicsApplication/custom_conditions/boundary_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/boundary_condition.hpp
@@ -274,17 +274,17 @@ public:
     /**
      * Called at the beginning of each solution step
      */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Called at the beginning of each solution step
      */
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Called at the beginning of each iteration
      */
-    void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //************* GETTING METHODS
@@ -293,13 +293,13 @@ public:
      * Sets on rConditionDofList the degrees of freedom of the considered element geometry
      */
     void GetDofList(DofsVectorType& rConditionDofList,
-		    ProcessInfo& rCurrentProcessInfo ) override;
+		    const ProcessInfo& rCurrentProcessInfo ) const override;
 
     /**
      * Sets on rResult the ID's of the element degrees of freedom
      */
     void EquationIdVector(EquationIdVectorType& rResult,
-			  ProcessInfo& rCurrentProcessInfo ) override;
+			  const ProcessInfo& rCurrentProcessInfo ) const override;
 
     /**
      * Sets on rValues the nodal displacements
@@ -332,7 +332,7 @@ public:
      */
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
 			      VectorType& rRightHandSideVector,
-			      ProcessInfo& rCurrentProcessInfo ) override;
+			      const ProcessInfo& rCurrentProcessInfo ) override;
 
     /**
       * this is called during the assembling process in order
@@ -341,7 +341,7 @@ public:
       * @param rCurrentProcessInfo: the current process info instance
       */
     void CalculateRightHandSide(VectorType& rRightHandSideVector,
-				ProcessInfo& rCurrentProcessInfo ) override;
+				const ProcessInfo& rCurrentProcessInfo ) override;
 
     /**
      * this is called during the assembling process in order
@@ -350,7 +350,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-			       ProcessInfo& rCurrentProcessInfo) override;
+			       const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
       * this is called during the assembling process in order
@@ -359,7 +359,7 @@ public:
       * @param rCurrentProcessInfo: the current process info instance
       */
     void CalculateMassMatrix(MatrixType& rMassMatrix,
-			     ProcessInfo& rCurrentProcessInfo ) override;
+			     const ProcessInfo& rCurrentProcessInfo ) override;
 
     /**
       * this is called during the assembling process in order
@@ -368,7 +368,7 @@ public:
       * @param rCurrentProcessInfo: the current process info instance
       */
     void CalculateDampingMatrix(MatrixType& rDampingMatrix,
-				ProcessInfo& rCurrentProcessInfo ) override;
+				const ProcessInfo& rCurrentProcessInfo ) override;
 
 
     /**
@@ -385,13 +385,6 @@ public:
 					 const Variable<array_1d<double,3> >& rDestinationVariable,
 					 const ProcessInfo& rCurrentProcessInfo) override;
 
-
-    /**
-     * Get on rVariable a double Value
-     */
-    void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
-				     std::vector<double>& rValues,
-				     const ProcessInfo& rCurrentProcessInfo ) override;
 
     /**
      * Calculate a double Variable
@@ -411,7 +404,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/axisymmetric_line_elastic_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/axisymmetric_line_elastic_condition.cpp
@@ -198,7 +198,7 @@ namespace Kratos
   //***********************************************************************************
   //***********************************************************************************
 
-  int AxisymmetricLineElasticCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int AxisymmetricLineElasticCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/axisymmetric_line_elastic_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/axisymmetric_line_elastic_condition.hpp
@@ -108,7 +108,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/axisymmetric_point_elastic_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/axisymmetric_point_elastic_condition.cpp
@@ -155,7 +155,7 @@ namespace Kratos
   //***********************************************************************************
 
 
-  int AxisymmetricPointElasticCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int AxisymmetricPointElasticCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/axisymmetric_point_elastic_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/axisymmetric_point_elastic_condition.hpp
@@ -103,7 +103,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/elastic_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/elastic_condition.cpp
@@ -233,7 +233,7 @@ namespace Kratos
   //***********************************************************************************
 
 
-  int ElasticCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int ElasticCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/elastic_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/elastic_condition.hpp
@@ -112,7 +112,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/line_elastic_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/line_elastic_condition.cpp
@@ -322,7 +322,7 @@ namespace Kratos
   //***********************************************************************************
 
 
-  int LineElasticCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int LineElasticCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/line_elastic_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/line_elastic_condition.hpp
@@ -104,7 +104,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/point_elastic_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/point_elastic_condition.cpp
@@ -211,7 +211,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  int PointElasticCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int PointElasticCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/point_elastic_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/point_elastic_condition.hpp
@@ -103,7 +103,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/surface_elastic_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/surface_elastic_condition.cpp
@@ -320,7 +320,7 @@ namespace Kratos
   //***********************************************************************************
 
 
-  int SurfaceElasticCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int SurfaceElasticCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/surface_elastic_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/elastic_conditions/surface_elastic_condition.hpp
@@ -104,7 +104,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_conditions/load_conditions/axisymmetric_line_load_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/load_conditions/axisymmetric_line_load_condition.cpp
@@ -199,7 +199,7 @@ namespace Kratos
   //***********************************************************************************
   //***********************************************************************************
 
-  int AxisymmetricLineLoadCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int AxisymmetricLineLoadCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_conditions/load_conditions/axisymmetric_line_load_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/load_conditions/axisymmetric_line_load_condition.hpp
@@ -108,7 +108,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_conditions/load_conditions/axisymmetric_point_load_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/load_conditions/axisymmetric_point_load_condition.cpp
@@ -154,7 +154,7 @@ namespace Kratos
   //***********************************************************************************
 
 
-  int AxisymmetricPointLoadCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int AxisymmetricPointLoadCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_conditions/load_conditions/axisymmetric_point_load_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/load_conditions/axisymmetric_point_load_condition.hpp
@@ -103,7 +103,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_conditions/load_conditions/line_load_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/load_conditions/line_load_condition.cpp
@@ -341,7 +341,7 @@ namespace Kratos
   //***********************************************************************************
 
 
-  int LineLoadCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int LineLoadCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_conditions/load_conditions/line_load_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/load_conditions/line_load_condition.hpp
@@ -104,7 +104,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_conditions/load_conditions/load_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/load_conditions/load_condition.cpp
@@ -234,7 +234,7 @@ namespace Kratos
   //***********************************************************************************
 
 
-  int LoadCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int LoadCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_conditions/load_conditions/load_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/load_conditions/load_condition.hpp
@@ -115,7 +115,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_conditions/load_conditions/point_load_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/load_conditions/point_load_condition.cpp
@@ -223,7 +223,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  int PointLoadCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int PointLoadCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_conditions/load_conditions/point_load_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/load_conditions/point_load_condition.hpp
@@ -103,7 +103,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_conditions/load_conditions/surface_load_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/load_conditions/surface_load_condition.cpp
@@ -336,7 +336,7 @@ namespace Kratos
   //***********************************************************************************
 
 
-  int SurfaceLoadCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int SurfaceLoadCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_conditions/load_conditions/surface_load_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/load_conditions/surface_load_condition.hpp
@@ -104,7 +104,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_conditions/moment_conditions/line_moment_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/moment_conditions/line_moment_condition.cpp
@@ -251,7 +251,7 @@ namespace Kratos
   //***********************************************************************************
 
 
-  int LineMomentCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int LineMomentCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_conditions/moment_conditions/line_moment_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/moment_conditions/line_moment_condition.hpp
@@ -104,7 +104,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_conditions/moment_conditions/moment_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/moment_conditions/moment_condition.cpp
@@ -107,7 +107,7 @@ namespace Kratos
   //***********************************************************************************
 
   void MomentCondition::GetDofList(DofsVectorType& rConditionDofList,
-				     ProcessInfo& rCurrentProcessInfo)
+				   const ProcessInfo& rCurrentProcessInfo) const
   {
     KRATOS_TRY
 
@@ -135,7 +135,7 @@ namespace Kratos
   //***********************************************************************************
 
   void MomentCondition::EquationIdVector(EquationIdVectorType& rResult,
-					  ProcessInfo& rCurrentProcessInfo)
+					 const  ProcessInfo& rCurrentProcessInfo) const
   {
     KRATOS_TRY
 
@@ -509,7 +509,7 @@ namespace Kratos
   //***********************************************************************************
 
 
-  int MomentCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int MomentCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_conditions/moment_conditions/moment_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/moment_conditions/moment_condition.hpp
@@ -108,13 +108,13 @@ public:
      * Sets on rConditionDofList the degrees of freedom of the considered element geometry
      */
     void GetDofList(DofsVectorType& rConditionDofList,
-		    ProcessInfo& rCurrentProcessInfo) override;
+		    const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rResult the ID's of the element degrees of freedom
      */
     void EquationIdVector(EquationIdVectorType& rResult,
-			  ProcessInfo& rCurrentProcessInfo) override;
+			  const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rValues the nodal displacements
@@ -157,7 +157,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_conditions/moment_conditions/point_moment_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/moment_conditions/point_moment_condition.cpp
@@ -246,7 +246,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  int PointMomentCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int PointMomentCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_conditions/moment_conditions/point_moment_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/moment_conditions/point_moment_condition.hpp
@@ -103,7 +103,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_conditions/moment_conditions/surface_moment_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/moment_conditions/surface_moment_condition.cpp
@@ -293,7 +293,7 @@ namespace Kratos
   //***********************************************************************************
 
 
-  int SurfaceMomentCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+  int SurfaceMomentCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_conditions/moment_conditions/surface_moment_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/moment_conditions/surface_moment_condition.hpp
@@ -103,7 +103,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_conditions/thermal_conditions/line_heat_flux_condition.cpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/thermal_conditions/line_heat_flux_condition.cpp
@@ -46,7 +46,7 @@ LineHeatFluxCondition::~LineHeatFluxCondition()
 
 //************************************************************************************
 //************************************************************************************
-void LineHeatFluxCondition::CalculateRightHandSide( VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void LineHeatFluxCondition::CalculateRightHandSide( VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
   //calculation flags
   bool CalculateStiffnessMatrixFlag = false;
@@ -58,7 +58,7 @@ void LineHeatFluxCondition::CalculateRightHandSide( VectorType& rRightHandSideVe
 
 //************************************************************************************
 //************************************************************************************
-void LineHeatFluxCondition::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void LineHeatFluxCondition::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
   //calculation flags
   bool CalculateStiffnessMatrixFlag = true;
@@ -71,7 +71,7 @@ void LineHeatFluxCondition::CalculateLocalSystem( MatrixType& rLeftHandSideMatri
 //************************************************************************************
 //************************************************************************************
 void LineHeatFluxCondition::CalculateElementalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector,
-                                                    ProcessInfo& rCurrentProcessInfo,
+                                                    const ProcessInfo& rCurrentProcessInfo,
                                                     bool CalculateStiffnessMatrixFlag,
                                                     bool CalculateResidualVectorFlag )
 {
@@ -231,7 +231,7 @@ void LineHeatFluxCondition::CalculateAndAddFaceHeatFlux(Vector& rF,
 
 //************************************************************************************
 //************************************************************************************
-void LineHeatFluxCondition::EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo )
+void LineHeatFluxCondition::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo ) const
 {
   int number_of_nodes     = GetGeometry().PointsNumber(); //=Geometry().size();
 
@@ -249,7 +249,7 @@ void LineHeatFluxCondition::EquationIdVector( EquationIdVectorType& rResult, Pro
 
 //************************************************************************************
 //************************************************************************************
-void LineHeatFluxCondition::GetDofList( DofsVectorType& rConditionalDofList, ProcessInfo& rCurrentProcessInfo )
+void LineHeatFluxCondition::GetDofList( DofsVectorType& rConditionalDofList, const ProcessInfo& rCurrentProcessInfo ) const
 {
   rConditionalDofList.resize( 0 );
   for ( unsigned int i = 0; i < GetGeometry().size(); i++ )
@@ -260,7 +260,7 @@ void LineHeatFluxCondition::GetDofList( DofsVectorType& rConditionalDofList, Pro
 
 //************************************************************************************
 //************************************************************************************
-void  LineHeatFluxCondition::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo )
+void  LineHeatFluxCondition::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -272,7 +272,7 @@ void  LineHeatFluxCondition::CalculateMassMatrix( MatrixType& rMassMatrix, Proce
 
 //************************************************************************************
 //************************************************************************************
-void  LineHeatFluxCondition::CalculateDampingMatrix( MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo )
+void  LineHeatFluxCondition::CalculateDampingMatrix( MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -282,11 +282,9 @@ void  LineHeatFluxCondition::CalculateDampingMatrix( MatrixType& rDampingMatrix,
   KRATOS_CATCH( "" )
 }
 
-int LineHeatFluxCondition::Check( const ProcessInfo& rCurrentProcessInfo )
+int LineHeatFluxCondition::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
   return 0;
 }
 
 } // Namespace Kratos
-
-

--- a/applications/SolidMechanicsApplication/custom_conditions/thermal_conditions/line_heat_flux_condition.hpp
+++ b/applications/SolidMechanicsApplication/custom_conditions/thermal_conditions/line_heat_flux_condition.hpp
@@ -75,17 +75,17 @@ public:
 
     Condition::Pointer Create( IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties ) const override;
 
-    void CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo ) override;
+    void CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo ) override;
 
-    void CalculateRightHandSide( VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo ) override;
+    void CalculateRightHandSide( VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo ) override;
 
-    void EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo ) override;
+    void EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo ) const override;
 
-    void GetDofList( DofsVectorType& rConditionalDofList, ProcessInfo& rCurrentProcessInfo ) override;
+    void GetDofList( DofsVectorType& rConditionalDofList, const ProcessInfo& rCurrentProcessInfo ) const override;
 
-    void CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo ) override;
+    void CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo ) override;
 
-    void CalculateDampingMatrix( MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo ) override;
+    void CalculateDampingMatrix( MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo ) override;
 
     /**
      * This function provides the place to perform checks on the completeness of the input.
@@ -94,7 +94,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check( const ProcessInfo& rCurrentProcessInfo ) override;
+    int Check( const ProcessInfo& rCurrentProcessInfo ) const override;
     ///@}
     ///@name Access
     ///@{
@@ -143,7 +143,7 @@ private:
     ///@{
 
     void CalculateElementalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector,
-                                   ProcessInfo& rCurrentProcessInfo,
+                                   const ProcessInfo& rCurrentProcessInfo,
                                    bool CalculateStiffnessMatrixFlag,
                                    bool CalculateResidualVectorFlag);
 
@@ -222,5 +222,3 @@ private:
 }  // namespace Kratos.
 
 #endif // KRATOS_LINE_HEAT_FLUX_CONDITION_H_INCLUDED  defined
-
-

--- a/applications/SolidMechanicsApplication/custom_elements/beam_elements/beam_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/beam_elements/beam_element.cpp
@@ -95,7 +95,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void BeamElement::GetDofList(DofsVectorType& rElementalDofList,ProcessInfo& rCurrentProcessInfo)
+  void BeamElement::GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const
   {
     const SizeType dimension  = GetGeometry().WorkingSpaceDimension();
 
@@ -123,7 +123,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void BeamElement::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo)
+  void BeamElement::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const
   {
 
     const SizeType number_of_nodes  = GetGeometry().size();
@@ -286,30 +286,11 @@ namespace Kratos
   }
 
 
-  //*********************************GET DOUBLE VALUE***********************************
-  //************************************************************************************
-
-  void  BeamElement::GetValueOnIntegrationPoints( const Variable<double>& rVariable,
-						  std::vector<double>& rValues,
-						  const ProcessInfo& rCurrentProcessInfo )
-  {
-    this->CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-  }
-
-  //**********************************GET VECTOR VALUE**********************************
-  //************************************************************************************
-
-  void BeamElement::GetValueOnIntegrationPoints( const Variable<array_1d<double, 3 > >& rVariable,
-						 std::vector< array_1d<double, 3 > >& rValues,
-						 const ProcessInfo& rCurrentProcessInfo )
-  {
-    this->CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
-  }
 
   //************************************************************************************
   //************************************************************************************
 
-  void BeamElement::Initialize()
+  void BeamElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -329,7 +310,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void BeamElement::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+  void BeamElement::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -342,7 +323,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void BeamElement::InitializeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+  void BeamElement::InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo )
   {
     KRATOS_TRY
 
@@ -352,7 +333,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void BeamElement::FinalizeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+  void BeamElement::FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo )
   {
     KRATOS_TRY
 
@@ -363,7 +344,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void BeamElement::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+  void BeamElement::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -633,7 +614,7 @@ namespace Kratos
 
 
   void BeamElement::CalculateElementalSystem( LocalSystemComponents& rLocalSystem,
-					      ProcessInfo& rCurrentProcessInfo )
+					      const ProcessInfo& rCurrentProcessInfo )
   {
     KRATOS_TRY
 
@@ -693,7 +674,7 @@ namespace Kratos
   //************************************************************************************
 
   void BeamElement::CalculateDynamicSystem( LocalSystemComponents& rLocalSystem,
-					    ProcessInfo& rCurrentProcessInfo )
+					    const ProcessInfo& rCurrentProcessInfo )
   {
     KRATOS_TRY
 
@@ -963,7 +944,7 @@ namespace Kratos
   //************************************************************************************
 
   void  BeamElement::CalculateRightHandSide(VectorType& rRightHandSideVector,
-					    ProcessInfo& rCurrentProcessInfo)
+					    const ProcessInfo& rCurrentProcessInfo)
   {
 
     KRATOS_TRY
@@ -994,7 +975,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void BeamElement::CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo)
+  void BeamElement::CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -1024,7 +1005,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void BeamElement::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+  void BeamElement::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -1308,7 +1289,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void BeamElement::CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+  void BeamElement::CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -1361,7 +1342,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void BeamElement::CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo)
+  void BeamElement::CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -1406,7 +1387,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void BeamElement::CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+  void BeamElement::CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -1454,7 +1435,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void BeamElement::CalculateAndAddInertiaLHS(MatrixType& rLeftHandSideMatrix, ElementDataType& rVariables, ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight )
+  void BeamElement::CalculateAndAddInertiaLHS(MatrixType& rLeftHandSideMatrix, ElementDataType& rVariables, const ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight )
   {
 
     KRATOS_TRY
@@ -1467,7 +1448,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void BeamElement::CalculateAndAddInertiaRHS(VectorType& rRightHandSideVector, ElementDataType& rVariables, ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
+  void BeamElement::CalculateAndAddInertiaRHS(VectorType& rRightHandSideVector, ElementDataType& rVariables, const ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
   {
     KRATOS_TRY
 
@@ -1479,7 +1460,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void BeamElement::CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+  void BeamElement::CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -1576,7 +1557,7 @@ namespace Kratos
    * or that no common error is found.
    * @param rCurrentProcessInfo
    */
-  int  BeamElement::Check(const ProcessInfo& rCurrentProcessInfo)
+  int  BeamElement::Check(const ProcessInfo& rCurrentProcessInfo) const
   {
     KRATOS_TRY
 
@@ -1588,7 +1569,7 @@ namespace Kratos
     for(SizeType i=0; i<this->GetGeometry().size(); ++i)
       {
 	// Nodal data
-	Node<3> &rNode = this->GetGeometry()[i];
+	const Node<3> &rNode = this->GetGeometry()[i];
 	KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISPLACEMENT,rNode);
 	KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(ROTATION,rNode);
 	//KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VOLUME_ACCELERATION,rNode);

--- a/applications/SolidMechanicsApplication/custom_elements/beam_elements/beam_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/beam_elements/beam_element.hpp
@@ -361,12 +361,12 @@ public:
     /**
      * Sets on rElementalDofList the degrees of freedom of the considered element geometry
      */
-    void GetDofList(DofsVectorType& rElementalDofList,ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rResult the ID's of the element degrees of freedom
      */
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rValues the nodal displacements
@@ -383,33 +383,6 @@ public:
      */
     void GetSecondDerivativesVector(Vector& rValues, int Step = 0) const override;
 
-    //on integration points:
-    /**
-     * Access for variables on Integration points.
-     * This gives access to variables stored in the constitutive law on each integration point.
-     * Specialisations of element.h (e.g. the TotalLagrangian) must specify the actual
-     * interface to the constitutive law!
-     * Note, that these functions expect a std::vector of values for the
-     * specified variable type that contains a value for each integration point!
-     * SetValuesOnIntegrationPoints: set the values for given Variable.
-     * GetValueOnIntegrationPoints: get the values for given Variable.
-     */
-
-    //GET:
-    /**
-     * Get on rVariable a double Value from the Element Constitutive Law
-     */
-    void GetValueOnIntegrationPoints( const Variable<double>& rVariable,
-				      std::vector<double>& rValues,
-				      const ProcessInfo& rCurrentProcessInfo ) override;
-
-    /**
-     * Get on rVariable a Vector Value from the Element Constitutive Law
-     */
-    void GetValueOnIntegrationPoints( const Variable< array_1d<double, 3 > >& rVariable,
-				      std::vector< array_1d<double, 3 > >& rValues,
-				      const ProcessInfo& rCurrentProcessInfo ) override;
-
 
     //************* STARTING - ENDING  METHODS
 
@@ -417,28 +390,27 @@ public:
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
       /**
      * Called at the beginning of each solution step
      */
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
-
+    void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Called at the end of eahc solution step
      */
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     //************* COMPUTING  METHODS
 
@@ -451,7 +423,7 @@ public:
      * @param rRightHandSideVector: the elemental right hand side
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -459,7 +431,7 @@ public:
      * @param rRightHandSideVector: the elemental right hand side vector
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -468,7 +440,7 @@ public:
      * @param rLeftHandSideVector: the elemental left hand side vector
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -480,7 +452,7 @@ public:
      */
     void CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix,
 						VectorType& rRightHandSideVector,
-						ProcessInfo& rCurrentProcessInfo) override;
+						const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -489,7 +461,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix,
-				       ProcessInfo& rCurrentProcessInfo) override;
+				       const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -499,7 +471,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector,
-				       ProcessInfo& rCurrentProcessInfo) override;
+				       const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -507,7 +479,7 @@ public:
      * @param rMassMatrix: the elemental mass matrix
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -551,7 +523,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access
@@ -630,14 +602,14 @@ protected:
      */
 
     virtual void CalculateElementalSystem( LocalSystemComponents& rLocalSystem,
-					   ProcessInfo& rCurrentProcessInfo );
+					   const ProcessInfo& rCurrentProcessInfo );
 
 
     /**
      * Calculates the elemental dynamic contributions
       */
     virtual void CalculateDynamicSystem( LocalSystemComponents& rLocalSystem,
-					 ProcessInfo& rCurrentProcessInfo );
+					 const ProcessInfo& rCurrentProcessInfo );
 
     /**
      * Get element size from the dofs
@@ -779,7 +751,7 @@ protected:
       */
     virtual void CalculateAndAddInertiaLHS(MatrixType& rLeftHandSideMatrix,
 					   ElementDataType& rVariables,
-					   ProcessInfo& rCurrentProcessInfo,
+					   const ProcessInfo& rCurrentProcessInfo,
 					   double& rIntegrationWeight);
 
     /**
@@ -787,7 +759,7 @@ protected:
       */
     virtual void CalculateAndAddInertiaRHS(VectorType& rRightHandSideVector,
 					   ElementDataType& rVariables,
-					   ProcessInfo& rCurrentProcessInfo,
+					   const ProcessInfo& rCurrentProcessInfo,
 					   double& rIntegrationWeight);
 
     /**

--- a/applications/SolidMechanicsApplication/custom_elements/beam_elements/geometrically_exact_rod_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/beam_elements/geometrically_exact_rod_element.cpp
@@ -72,11 +72,11 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void GeometricallyExactRodElement::Initialize()
+  void GeometricallyExactRodElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
-    LargeDisplacementBeamEMCElement::Initialize();
+    LargeDisplacementBeamEMCElement::Initialize(rCurrentProcessInfo);
 
     const SizeType dimension        = GetGeometry().WorkingSpaceDimension();
     const SizeType number_of_nodes  = GetGeometry().size();
@@ -145,7 +145,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void GeometricallyExactRodElement::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+  void GeometricallyExactRodElement::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -558,7 +558,7 @@ namespace Kratos
 
 
   void GeometricallyExactRodElement::CalculateElementalSystem( LocalSystemComponents& rLocalSystem,
-							       ProcessInfo& rCurrentProcessInfo )
+							       const ProcessInfo& rCurrentProcessInfo )
   {
     KRATOS_TRY
 
@@ -629,7 +629,7 @@ namespace Kratos
 
 
   void GeometricallyExactRodElement::CalculateDynamicSystem( LocalSystemComponents& rLocalSystem,
-							     ProcessInfo& rCurrentProcessInfo )
+							     const ProcessInfo& rCurrentProcessInfo )
   {
     KRATOS_TRY
 
@@ -1818,7 +1818,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void GeometricallyExactRodElement::CalculateAndAddInertiaLHS(MatrixType& rLeftHandSideMatrix, ElementDataType& rVariables, ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight )
+  void GeometricallyExactRodElement::CalculateAndAddInertiaLHS(MatrixType& rLeftHandSideMatrix, ElementDataType& rVariables, const ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight )
   {
 
     KRATOS_TRY
@@ -1910,7 +1910,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void GeometricallyExactRodElement::CalculateAndAddInertiaRHS(VectorType& rRightHandSideVector, ElementDataType& rVariables, ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
+  void GeometricallyExactRodElement::CalculateAndAddInertiaRHS(VectorType& rRightHandSideVector, ElementDataType& rVariables, const ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
   {
     KRATOS_TRY
 
@@ -2120,7 +2120,7 @@ namespace Kratos
    * or that no common error is found.
    * @param rCurrentProcessInfo
    */
-  int  GeometricallyExactRodElement::Check(const ProcessInfo& rCurrentProcessInfo)
+  int  GeometricallyExactRodElement::Check(const ProcessInfo& rCurrentProcessInfo) const
   {
     KRATOS_TRY
 
@@ -2163,5 +2163,3 @@ namespace Kratos
 
 
 } // Namespace Kratos
-
-

--- a/applications/SolidMechanicsApplication/custom_elements/beam_elements/geometrically_exact_rod_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/beam_elements/geometrically_exact_rod_element.hpp
@@ -107,12 +107,12 @@ public:
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
       /**
      * Called at the beginning of each solution step
      */
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //************************************************************************************
@@ -124,7 +124,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access
@@ -215,14 +215,14 @@ protected:
      */
 
     void CalculateElementalSystem( LocalSystemComponents& rLocalSystem,
-				   ProcessInfo& rCurrentProcessInfo ) override;
+				   const ProcessInfo& rCurrentProcessInfo ) override;
 
 
     /**
      * Calculates the elemental dynamic contributions
       */
     void CalculateDynamicSystem( LocalSystemComponents& rLocalSystem,
-				 ProcessInfo& rCurrentProcessInfo ) override;
+				 const ProcessInfo& rCurrentProcessInfo ) override;
 
 
 
@@ -335,7 +335,7 @@ protected:
       */
     void CalculateAndAddInertiaLHS(MatrixType& rLeftHandSideMatrix,
 				   ElementDataType& rVariables,
-				   ProcessInfo& rCurrentProcessInfo,
+				   const ProcessInfo& rCurrentProcessInfo,
 				   double& rIntegrationWeight) override;
 
 
@@ -344,7 +344,7 @@ protected:
       */
     void CalculateAndAddInertiaRHS(VectorType& rRightHandSideVector,
 				   ElementDataType& rVariables,
-				   ProcessInfo& rCurrentProcessInfo,
+				   const ProcessInfo& rCurrentProcessInfo,
 				   double& rIntegrationWeight) override;
 
 
@@ -471,4 +471,3 @@ private:
 
 } // namespace Kratos.
 #endif //  KRATOS_GEOMETRICALLY_EXACT_ROD_ELEMENT_H_INCLUDED defined
-

--- a/applications/SolidMechanicsApplication/custom_elements/beam_elements/large_displacement_beam_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/beam_elements/large_displacement_beam_element.cpp
@@ -101,11 +101,11 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void LargeDisplacementBeamElement::Initialize()
+  void LargeDisplacementBeamElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
-    BeamElement::Initialize();
+    BeamElement::Initialize(rCurrentProcessInfo);
 
     //------------- REDUCED QUADRATURE INTEGRATION
 
@@ -202,7 +202,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void LargeDisplacementBeamElement::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+  void LargeDisplacementBeamElement::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -276,7 +276,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void LargeDisplacementBeamElement::InitializeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+  void LargeDisplacementBeamElement::InitializeNonLinearIteration( const ProcessInfo& rCurrentProcessInfo )
   {
     KRATOS_TRY
 
@@ -287,7 +287,7 @@ namespace Kratos
   ////************************************************************************************
   ////************************************************************************************
 
-  void LargeDisplacementBeamElement::FinalizeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+  void LargeDisplacementBeamElement::FinalizeNonLinearIteration( const ProcessInfo& rCurrentProcessInfo )
   {
     KRATOS_TRY
 
@@ -300,7 +300,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void LargeDisplacementBeamElement::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+  void LargeDisplacementBeamElement::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -629,7 +629,7 @@ namespace Kratos
 
 
   void LargeDisplacementBeamElement::CalculateDynamicSystem( LocalSystemComponents& rLocalSystem,
-							     ProcessInfo& rCurrentProcessInfo )
+							     const ProcessInfo& rCurrentProcessInfo )
   {
     KRATOS_TRY
 
@@ -1679,7 +1679,7 @@ namespace Kratos
   //************************************************************************************
 
   //Inertia in the SPATIAL configuration
-  void LargeDisplacementBeamElement::CalculateAndAddInertiaLHS(MatrixType& rLeftHandSideMatrix, ElementDataType& rVariables, ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight )
+  void LargeDisplacementBeamElement::CalculateAndAddInertiaLHS(MatrixType& rLeftHandSideMatrix, ElementDataType& rVariables, const ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight )
   {
 
     KRATOS_TRY
@@ -1919,7 +1919,7 @@ namespace Kratos
   //************************************************************************************
 
   //Inertia in the SPATIAL configuration
-  void LargeDisplacementBeamElement::CalculateAndAddInertiaRHS(VectorType& rRightHandSideVector, ElementDataType& rVariables, ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
+  void LargeDisplacementBeamElement::CalculateAndAddInertiaRHS(VectorType& rRightHandSideVector, ElementDataType& rVariables, const ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
   {
     KRATOS_TRY
 
@@ -2339,7 +2339,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void LargeDisplacementBeamElement::CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+  void LargeDisplacementBeamElement::CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
   {
 
     KRATOS_TRY
@@ -2751,7 +2751,7 @@ namespace Kratos
    * or that no common error is found.
    * @param rCurrentProcessInfo
    */
-  int  LargeDisplacementBeamElement::Check(const ProcessInfo& rCurrentProcessInfo)
+  int  LargeDisplacementBeamElement::Check(const ProcessInfo& rCurrentProcessInfo) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_elements/beam_elements/large_displacement_beam_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/beam_elements/large_displacement_beam_element.hpp
@@ -105,28 +105,28 @@ public:
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
       /**
      * Called at the beginning of each solution step
      */
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
      * Called at the end of eahc solution step
      */
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //************* COMPUTING  METHODS
@@ -138,7 +138,7 @@ public:
      * @param rMassMatrix: the elemental mass matrix
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //on integration points:
@@ -167,7 +167,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access
@@ -278,7 +278,7 @@ protected:
      * Calculates the elemental dynamic contributions
       */
     void CalculateDynamicSystem( LocalSystemComponents& rLocalSystem,
-					 ProcessInfo& rCurrentProcessInfo ) override;
+			 	 const ProcessInfo& rCurrentProcessInfo ) override;
 
     /**
      * Transform Vector Variable form Material Frame to the Spatial Frame
@@ -376,7 +376,7 @@ protected:
       */
     void CalculateAndAddInertiaLHS(MatrixType& rLeftHandSideMatrix,
 					   ElementDataType& rVariables,
-					   ProcessInfo& rCurrentProcessInfo,
+					   const ProcessInfo& rCurrentProcessInfo,
 					   double& rIntegrationWeight) override;
 
     /**
@@ -384,7 +384,7 @@ protected:
       */
     void CalculateAndAddInertiaRHS(VectorType& rRightHandSideVector,
 					   ElementDataType& rVariables,
-					   ProcessInfo& rCurrentProcessInfo,
+					   const ProcessInfo& rCurrentProcessInfo,
 					   double& rIntegrationWeight) override;
 
     /**
@@ -535,4 +535,3 @@ private:
 
 } // namespace Kratos.
 #endif //  KRATOS_LARGE_DISPLACEMENT_BEAM_ELEMENT_H_INCLUDED defined
-

--- a/applications/SolidMechanicsApplication/custom_elements/beam_elements/large_displacement_beam_emc_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/beam_elements/large_displacement_beam_emc_element.cpp
@@ -71,11 +71,11 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void LargeDisplacementBeamEMCElement::Initialize()
+  void LargeDisplacementBeamEMCElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
-    LargeDisplacementBeamElement::Initialize();
+    LargeDisplacementBeamElement::Initialize(rCurrentProcessInfo);
 
     //------------- REDUCED QUADRATURE INTEGRATION
 
@@ -116,7 +116,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void LargeDisplacementBeamEMCElement::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+  void LargeDisplacementBeamEMCElement::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
   {
     KRATOS_TRY
 
@@ -1113,7 +1113,7 @@ namespace Kratos
   //************************************************************************************
 
   //Inertia in the SPATIAL configuration
-  void LargeDisplacementBeamEMCElement::CalculateAndAddInertiaLHS(MatrixType& rLeftHandSideMatrix, ElementDataType& rVariables, ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight )
+  void LargeDisplacementBeamEMCElement::CalculateAndAddInertiaLHS(MatrixType& rLeftHandSideMatrix, ElementDataType& rVariables, const ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight )
   {
 
     KRATOS_TRY
@@ -1254,7 +1254,7 @@ namespace Kratos
   //************************************************************************************
 
   //Inertia in the SPATIAL configuration
-  void LargeDisplacementBeamEMCElement::CalculateAndAddInertiaRHS(VectorType& rRightHandSideVector, ElementDataType& rVariables, ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
+  void LargeDisplacementBeamEMCElement::CalculateAndAddInertiaRHS(VectorType& rRightHandSideVector, ElementDataType& rVariables, const ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
   {
     KRATOS_TRY
 
@@ -1422,7 +1422,7 @@ namespace Kratos
    * or that no common error is found.
    * @param rCurrentProcessInfo
    */
-  int LargeDisplacementBeamEMCElement::Check(const ProcessInfo& rCurrentProcessInfo)
+  int LargeDisplacementBeamEMCElement::Check(const ProcessInfo& rCurrentProcessInfo) const
   {
     KRATOS_TRY
 
@@ -1457,5 +1457,3 @@ namespace Kratos
 
 
 } // Namespace Kratos
-
-

--- a/applications/SolidMechanicsApplication/custom_elements/beam_elements/large_displacement_beam_emc_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/beam_elements/large_displacement_beam_emc_element.hpp
@@ -108,12 +108,12 @@ public:
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
       /**
      * Called at the beginning of each solution step
      */
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //************************************************************************************
@@ -125,7 +125,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access
@@ -306,7 +306,7 @@ protected:
       */
     void CalculateAndAddInertiaLHS(MatrixType& rLeftHandSideMatrix,
 					   ElementDataType& rVariables,
-					   ProcessInfo& rCurrentProcessInfo,
+					   const ProcessInfo& rCurrentProcessInfo,
 					   double& rIntegrationWeight) override;
 
 
@@ -315,7 +315,7 @@ protected:
       */
     void CalculateAndAddInertiaRHS(VectorType& rRightHandSideVector,
 					   ElementDataType& rVariables,
-					   ProcessInfo& rCurrentProcessInfo,
+					   const ProcessInfo& rCurrentProcessInfo,
 					   double& rIntegrationWeight) override;
 
     /**
@@ -390,4 +390,3 @@ private:
 
 } // namespace Kratos.
 #endif //  KRATOS_LARGE_DISPLACEMENT_BEAM_EMC_ELEMENT_H_INCLUDED defined
-

--- a/applications/SolidMechanicsApplication/custom_elements/beam_elements/large_displacement_beam_semc_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/beam_elements/large_displacement_beam_semc_element.cpp
@@ -276,7 +276,7 @@ namespace Kratos
   //************************************************************************************
   //************************************************************************************
 
-  void LargeDisplacementBeamSEMCElement::CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+  void LargeDisplacementBeamSEMCElement::CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
   {
 
     KRATOS_TRY
@@ -431,7 +431,7 @@ namespace Kratos
   //************************************************************************************
 
   //Inertia in the SPATIAL configuration
-  void LargeDisplacementBeamSEMCElement::CalculateAndAddInertiaLHS(MatrixType& rLeftHandSideMatrix, ElementDataType& rVariables, ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight )
+  void LargeDisplacementBeamSEMCElement::CalculateAndAddInertiaLHS(MatrixType& rLeftHandSideMatrix, ElementDataType& rVariables, const ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight )
   {
 
     KRATOS_TRY
@@ -569,7 +569,7 @@ namespace Kratos
   //************************************************************************************
 
   //Inertia in the SPATIAL configuration
-  void LargeDisplacementBeamSEMCElement::CalculateAndAddInertiaRHS(VectorType& rRightHandSideVector, ElementDataType& rVariables, ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
+  void LargeDisplacementBeamSEMCElement::CalculateAndAddInertiaRHS(VectorType& rRightHandSideVector, ElementDataType& rVariables, const ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
   {
     KRATOS_TRY
 
@@ -791,7 +791,7 @@ namespace Kratos
    * or that no common error is found.
    * @param rCurrentProcessInfo
    */
-  int LargeDisplacementBeamSEMCElement::Check(const ProcessInfo& rCurrentProcessInfo)
+  int LargeDisplacementBeamSEMCElement::Check(const ProcessInfo& rCurrentProcessInfo) const
   {
     KRATOS_TRY
 
@@ -821,5 +821,3 @@ namespace Kratos
 
 
 } // Namespace Kratos
-
-

--- a/applications/SolidMechanicsApplication/custom_elements/beam_elements/large_displacement_beam_semc_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/beam_elements/large_displacement_beam_semc_element.hpp
@@ -109,7 +109,7 @@ public:
      * @param rMassMatrix: the elemental mass matrix
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this function is designed to make the element to assemble an rRHS vector
@@ -138,7 +138,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access
@@ -217,7 +217,7 @@ protected:
       */
     void CalculateAndAddInertiaLHS(MatrixType& rLeftHandSideMatrix,
 					   ElementDataType& rVariables,
-					   ProcessInfo& rCurrentProcessInfo,
+					   const ProcessInfo& rCurrentProcessInfo,
 					   double& rIntegrationWeight) override;
 
 
@@ -226,7 +226,7 @@ protected:
       */
     void CalculateAndAddInertiaRHS(VectorType& rRightHandSideVector,
 					   ElementDataType& rVariables,
-					   ProcessInfo& rCurrentProcessInfo,
+					   const ProcessInfo& rCurrentProcessInfo,
 					   double& rIntegrationWeight) override;
 
 
@@ -289,4 +289,3 @@ private:
 
 } // namespace Kratos.
 #endif //  KRATOS_LARGE_DISPLACEMENT_BEAM_SEMC_ELEMENT_H_INCLUDED defined
-

--- a/applications/SolidMechanicsApplication/custom_elements/beam_elements/small_displacement_beam_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/beam_elements/small_displacement_beam_element.cpp
@@ -427,7 +427,7 @@ namespace Kratos
    * or that no common error is found.
    * @param rCurrentProcessInfo
    */
-  int  SmallDisplacementBeamElement::Check(const ProcessInfo& rCurrentProcessInfo)
+  int  SmallDisplacementBeamElement::Check(const ProcessInfo& rCurrentProcessInfo) const
   {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_elements/beam_elements/small_displacement_beam_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/beam_elements/small_displacement_beam_element.hpp
@@ -90,7 +90,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
     ///@}
     ///@name Access
     ///@{
@@ -271,4 +271,3 @@ private:
 
 } // namespace Kratos.
 #endif //  KRATOS_SMALL_DISPLACEMENT_BEAM_ELEMENT_H_INCLUDED defined
-

--- a/applications/SolidMechanicsApplication/custom_elements/beam_elements/small_displacement_beam_element_3D2N.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/beam_elements/small_displacement_beam_element_3D2N.cpp
@@ -93,8 +93,8 @@ SmallDisplacementBeamElement3D2N::IntegrationMethod  SmallDisplacementBeamElemen
 //************************************************************************************
 //************************************************************************************
 
-void SmallDisplacementBeamElement3D2N::GetDofList(DofsVectorType& ElementalDofList,ProcessInfo&
-                             CurrentProcessInfo)
+void SmallDisplacementBeamElement3D2N::GetDofList(DofsVectorType& ElementalDofList,const ProcessInfo&
+                             CurrentProcessInfo) const
 {
     ElementalDofList.resize(0);
 
@@ -114,7 +114,7 @@ void SmallDisplacementBeamElement3D2N::GetDofList(DofsVectorType& ElementalDofLi
 //************************************************************************************
 
 void SmallDisplacementBeamElement3D2N::EquationIdVector(EquationIdVectorType& rResult,
-                                   ProcessInfo& CurrentProcessInfo)
+                                   const ProcessInfo& CurrentProcessInfo) const
 {
 
     const SizeType number_of_nodes  = GetGeometry().size();
@@ -232,24 +232,11 @@ void SmallDisplacementBeamElement3D2N::GetSecondDerivativesVector(Vector& rValue
 //************************************************************************************
 //************************************************************************************
 
-//**********************************GET VECTOR VALUE**********************************
-//************************************************************************************
-
-void SmallDisplacementBeamElement3D2N::GetValueOnIntegrationPoints( const Variable<array_1d<double, 3 > >& rVariable,
-								    std::vector< array_1d<double, 3 > >& rValues,
-								    const ProcessInfo& rCurrentProcessInfo )
-{
-
-    this->CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
-
-}
-
-
 //************* STARTING - ENDING  METHODS
 //************************************************************************************
 //************************************************************************************
 
-void SmallDisplacementBeamElement3D2N::Initialize()
+void SmallDisplacementBeamElement3D2N::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -263,7 +250,7 @@ void SmallDisplacementBeamElement3D2N::Initialize()
 //************************************************************************************
 //************************************************************************************
 
-void SmallDisplacementBeamElement3D2N::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+void SmallDisplacementBeamElement3D2N::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -273,7 +260,7 @@ void SmallDisplacementBeamElement3D2N::InitializeSolutionStep(ProcessInfo& rCurr
 //************************************************************************************
 //************************************************************************************
 
-void SmallDisplacementBeamElement3D2N::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+void SmallDisplacementBeamElement3D2N::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -372,7 +359,7 @@ void SmallDisplacementBeamElement3D2N::CalculateSectionProperties()
 
 
 void SmallDisplacementBeamElement3D2N::CalculateElementalSystem( LocalSystemComponents& rLocalSystem,
-								 ProcessInfo& rCurrentProcessInfo )
+								 const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -519,7 +506,7 @@ void SmallDisplacementBeamElement3D2N::CalculateAndAddRHS(LocalSystemComponents&
 //************************************************************************************
 
 void  SmallDisplacementBeamElement3D2N::CalculateRightHandSide(VectorType& rRightHandSideVector,
-					  ProcessInfo& rCurrentProcessInfo)
+					  const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -548,7 +535,7 @@ void  SmallDisplacementBeamElement3D2N::CalculateRightHandSide(VectorType& rRigh
 //************************************************************************************
 //************************************************************************************
 
-void SmallDisplacementBeamElement3D2N::CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo)
+void SmallDisplacementBeamElement3D2N::CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -577,7 +564,7 @@ void SmallDisplacementBeamElement3D2N::CalculateLeftHandSide(MatrixType& rLeftHa
 //************************************************************************************
 //************************************************************************************
 
-void SmallDisplacementBeamElement3D2N::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+void SmallDisplacementBeamElement3D2N::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -1068,7 +1055,7 @@ void SmallDisplacementBeamElement3D2N::CalculateGlobalBodyForce( Vector& rGlobal
 //************************************************************************************
 //************************************************************************************
 
-void SmallDisplacementBeamElement3D2N::CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+void SmallDisplacementBeamElement3D2N::CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
 
     KRATOS_TRY
@@ -1463,7 +1450,7 @@ void SmallDisplacementBeamElement3D2N::CalculateLocalNodalStress(Vector& Stress,
  * or that no common error is found.
  * @param rCurrentProcessInfo
  */
-int  SmallDisplacementBeamElement3D2N::Check(const ProcessInfo& rCurrentProcessInfo)
+int  SmallDisplacementBeamElement3D2N::Check(const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 
@@ -1475,7 +1462,7 @@ int  SmallDisplacementBeamElement3D2N::Check(const ProcessInfo& rCurrentProcessI
     for(unsigned int i=0; i<this->GetGeometry().size(); ++i)
       {
 	// Nodal data
-	Node<3> &rNode = this->GetGeometry()[i];
+	const Node<3> &rNode = this->GetGeometry()[i];
 	KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISPLACEMENT,rNode);
 	KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(ROTATION,rNode);
 
@@ -1525,5 +1512,3 @@ int  SmallDisplacementBeamElement3D2N::Check(const ProcessInfo& rCurrentProcessI
 
 
 } // Namespace Kratos
-
-

--- a/applications/SolidMechanicsApplication/custom_elements/beam_elements/small_displacement_beam_element_3D2N.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/beam_elements/small_displacement_beam_element_3D2N.hpp
@@ -161,12 +161,12 @@ public:
     /**
      * Sets on rElementalDofList the degrees of freedom of the considered element geometry
      */
-    void GetDofList(DofsVectorType& rElementalDofList,ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rResult the ID's of the element degrees of freedom
      */
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rValues the nodal displacements
@@ -195,33 +195,24 @@ public:
      * GetValueOnIntegrationPoints: get the values for given Variable.
      */
 
-    //GET:
-    /**
-     * Get on rVariable a Vector Value from the Element Constitutive Law
-     */
-    void GetValueOnIntegrationPoints( const Variable< array_1d<double, 3 > >& rVariable,
-				      std::vector< array_1d<double, 3 > >& rValues,
-				      const ProcessInfo& rCurrentProcessInfo ) override;
-
-
     //************* STARTING - ENDING  METHODS
 
     /**
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
       /**
      * Called at the beginning of each solution step
      */
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
      * Called at the end of eahc solution step
      */
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     //************* COMPUTING  METHODS
 
@@ -234,7 +225,7 @@ public:
      * @param rRightHandSideVector: the elemental right hand side
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -242,7 +233,7 @@ public:
      * @param rRightHandSideVector: the elemental right hand side vector
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -251,7 +242,7 @@ public:
      * @param rLeftHandSideVector: the elemental left hand side vector
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -260,7 +251,7 @@ public:
      * @param rMassMatrix: the elemental mass matrix
      * @param rCurrentProcessInfo: the current process info instance
      */
-    void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //on integration points:
@@ -281,7 +272,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access
@@ -361,7 +352,7 @@ protected:
      */
 
     void CalculateElementalSystem( LocalSystemComponents& rLocalSystem,
-				   ProcessInfo& rCurrentProcessInfo );
+				   const ProcessInfo& rCurrentProcessInfo );
 
 
     /**
@@ -490,4 +481,3 @@ private:
 
 } // namespace Kratos.
 #endif //  KRATOS_SMALL_DISPLACEMENT_BEAM_ELEMENT_3D2N_H_INCLUDED defined
-

--- a/applications/SolidMechanicsApplication/custom_elements/shell_elements/shell_thick_element_3D4N.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/shell_elements/shell_thick_element_3D4N.hpp
@@ -167,11 +167,11 @@ class KRATOS_API(SOLID_MECHANICS_APPLICATION) ShellThickElement3D4N : public Ele
 
     inline void Initialize(const GeometryType& geom);
 
-    inline void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo);
+    inline void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo);
 
-    inline void FinalizeSolutionStep(ProcessInfo& CurrentProcessInfo);
+    inline void FinalizeSolutionStep(const ProcessInfo& CurrentProcessInfo);
 
-    inline void FinalizeNonLinearIteration(const Vector& displacementVector, ProcessInfo& CurrentProcessInfo);
+    inline void FinalizeNonLinearIteration(const Vector& displacementVector, const ProcessInfo& CurrentProcessInfo);
 
    private:
 
@@ -291,15 +291,15 @@ class KRATOS_API(SOLID_MECHANICS_APPLICATION) ShellThickElement3D4N : public Ele
 
   Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override;
 
-  void Initialize() override;
+  void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
   void ResetConstitutiveLaw() override;
 
-  void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+  void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
-  void GetDofList(DofsVectorType& ElementalDofList, ProcessInfo& CurrentProcessInfo) override;
+  void GetDofList(DofsVectorType& ElementalDofList, const ProcessInfo& CurrentProcessInfo) const override;
 
-  int Check(const ProcessInfo& rCurrentProcessInfo) override;
+  int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
   void GetValuesVector(Vector& values, int Step = 0) const override;
 
@@ -307,36 +307,36 @@ class KRATOS_API(SOLID_MECHANICS_APPLICATION) ShellThickElement3D4N : public Ele
 
   void GetSecondDerivativesVector(Vector& values, int Step = 0) const override;
 
-  void InitializeNonLinearIteration(ProcessInfo& CurrentProcessInfo) override;
+  void InitializeNonLinearIteration(const ProcessInfo& CurrentProcessInfo) override;
 
-  void FinalizeNonLinearIteration(ProcessInfo& CurrentProcessInfo) override;
+  void FinalizeNonLinearIteration(const ProcessInfo& CurrentProcessInfo) override;
 
-  void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+  void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
-  void FinalizeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+  void FinalizeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
-  void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
-  void CalculateDampingMatrix(MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateDampingMatrix(MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
   void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                             VectorType& rRightHandSideVector,
-                            ProcessInfo& rCurrentProcessInfo) override;
+                            const ProcessInfo& rCurrentProcessInfo) override;
 
   void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
 
   // Results calculation on integration points
 
-  void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
-  void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
-  void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
-  void GetValueOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable, std::vector<array_1d<double,3> >& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable, std::vector<array_1d<double,3> >& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
-  void GetValueOnIntegrationPoints(const Variable<array_1d<double,6> >& rVariable, std::vector<array_1d<double,6> >& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateOnIntegrationPoints(const Variable<array_1d<double,6> >& rVariable, std::vector<array_1d<double,6> >& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
   ///@}
 
@@ -377,7 +377,7 @@ class KRATOS_API(SOLID_MECHANICS_APPLICATION) ShellThickElement3D4N : public Ele
 
   void CalculateAll(MatrixType& rLeftHandSideMatrix,
                     VectorType& rRightHandSideVector,
-                    ProcessInfo& rCurrentProcessInfo,
+                    const ProcessInfo& rCurrentProcessInfo,
                     const bool LHSrequired,
                     const bool RHSrequired);
 

--- a/applications/SolidMechanicsApplication/custom_elements/shell_elements/shell_thin_element_3D3N.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/shell_elements/shell_thin_element_3D3N.cpp
@@ -188,7 +188,7 @@ ShellThinElement3D3N::IntegrationMethod ShellThinElement3D3N::GetIntegrationMeth
   return mThisIntegrationMethod;
 }
 
-void ShellThinElement3D3N::Initialize()
+void ShellThinElement3D3N::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
   KRATOS_TRY
 
@@ -229,7 +229,7 @@ void ShellThinElement3D3N::Initialize()
     }
   }
 
-  mpCoordinateTransformation->Initialize();
+  mpCoordinateTransformation->Initialize(rCurrentProcessInfo);
 
   this->SetupOrientationAngles();
 
@@ -250,17 +250,17 @@ void ShellThinElement3D3N::ResetConstitutiveLaw()
   KRATOS_CATCH("")
       }
 
-void ShellThinElement3D3N::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo)
+void ShellThinElement3D3N::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const
 {
   if(rResult.size() != OPT_NUM_DOFS)
     rResult.resize(OPT_NUM_DOFS, false);
 
-  GeometryType & geom = this->GetGeometry();
+  const GeometryType & geom = this->GetGeometry();
 
   for(SizeType i = 0; i < geom.size(); i++)
   {
     int index = i * 6;
-    NodeType & iNode = geom[i];
+    const NodeType & iNode = geom[i];
 
     rResult[index]     = iNode.GetDof(DISPLACEMENT_X).EquationId();
     rResult[index + 1] = iNode.GetDof(DISPLACEMENT_Y).EquationId();
@@ -272,16 +272,16 @@ void ShellThinElement3D3N::EquationIdVector(EquationIdVectorType& rResult, Proce
   }
 }
 
-void ShellThinElement3D3N::GetDofList(DofsVectorType& ElementalDofList, ProcessInfo& CurrentProcessInfo)
+void ShellThinElement3D3N::GetDofList(DofsVectorType& ElementalDofList, const ProcessInfo& CurrentProcessInfo) const
 {
   ElementalDofList.resize(0);
   ElementalDofList.reserve(OPT_NUM_DOFS);
 
-  GeometryType & geom = this->GetGeometry();
+  const GeometryType & geom = this->GetGeometry();
 
   for (SizeType i = 0; i < geom.size(); i++)
   {
-    NodeType & iNode = geom[i];
+    const NodeType & iNode = geom[i];
 
     ElementalDofList.push_back(iNode.pGetDof(DISPLACEMENT_X));
     ElementalDofList.push_back(iNode.pGetDof(DISPLACEMENT_Y));
@@ -293,11 +293,11 @@ void ShellThinElement3D3N::GetDofList(DofsVectorType& ElementalDofList, ProcessI
   }
 }
 
-int ShellThinElement3D3N::Check(const ProcessInfo& rCurrentProcessInfo)
+int ShellThinElement3D3N::Check(const ProcessInfo& rCurrentProcessInfo) const
 {
   KRATOS_TRY
 
-      GeometryType& geom = GetGeometry();
+      const GeometryType& geom = GetGeometry();
 
   // verify that the variables are correctly initialized
   if(DISPLACEMENT.Key() == 0)
@@ -441,7 +441,7 @@ void ShellThinElement3D3N::GetSecondDerivativesVector(Vector& values, int Step) 
   }
 }
 
-void ShellThinElement3D3N::InitializeNonLinearIteration(ProcessInfo& CurrentProcessInfo)
+void ShellThinElement3D3N::InitializeNonLinearIteration(const ProcessInfo& CurrentProcessInfo)
 {
   mpCoordinateTransformation->InitializeNonLinearIteration(CurrentProcessInfo);
 
@@ -451,7 +451,7 @@ void ShellThinElement3D3N::InitializeNonLinearIteration(ProcessInfo& CurrentProc
     mSections[i]->InitializeNonLinearIteration(GetProperties(), geom, row(shapeFunctionsValues, i), CurrentProcessInfo);
 }
 
-void ShellThinElement3D3N::FinalizeNonLinearIteration(ProcessInfo& CurrentProcessInfo)
+void ShellThinElement3D3N::FinalizeNonLinearIteration(const ProcessInfo& CurrentProcessInfo)
 {
   mpCoordinateTransformation->FinalizeNonLinearIteration(CurrentProcessInfo);
 
@@ -461,7 +461,7 @@ void ShellThinElement3D3N::FinalizeNonLinearIteration(ProcessInfo& CurrentProces
     mSections[i]->FinalizeNonLinearIteration(GetProperties(), geom, row(shapeFunctionsValues, i), CurrentProcessInfo);
 }
 
-void ShellThinElement3D3N::InitializeSolutionStep(ProcessInfo& CurrentProcessInfo)
+void ShellThinElement3D3N::InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo)
 {
   const PropertiesType& props = GetProperties();
   const GeometryType & geom = GetGeometry();
@@ -473,7 +473,7 @@ void ShellThinElement3D3N::InitializeSolutionStep(ProcessInfo& CurrentProcessInf
   mpCoordinateTransformation->InitializeSolutionStep(CurrentProcessInfo);
 }
 
-void ShellThinElement3D3N::FinalizeSolutionStep(ProcessInfo& CurrentProcessInfo)
+void ShellThinElement3D3N::FinalizeSolutionStep(const ProcessInfo& CurrentProcessInfo)
 {
   const PropertiesType& props = GetProperties();
   const GeometryType& geom = GetGeometry();
@@ -485,7 +485,7 @@ void ShellThinElement3D3N::FinalizeSolutionStep(ProcessInfo& CurrentProcessInfo)
   mpCoordinateTransformation->FinalizeSolutionStep(CurrentProcessInfo);
 }
 
-void ShellThinElement3D3N::CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+void ShellThinElement3D3N::CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
   if((rMassMatrix.size1() != OPT_NUM_DOFS) || (rMassMatrix.size2() != OPT_NUM_DOFS))
     rMassMatrix.resize(OPT_NUM_DOFS, OPT_NUM_DOFS, false);
@@ -522,7 +522,7 @@ void ShellThinElement3D3N::CalculateMassMatrix(MatrixType& rMassMatrix, ProcessI
   }
 }
 
-void ShellThinElement3D3N::CalculateDampingMatrix(MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo)
+void ShellThinElement3D3N::CalculateDampingMatrix(MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
   if((rDampingMatrix.size1() != OPT_NUM_DOFS) || (rDampingMatrix.size2() != OPT_NUM_DOFS))
     rDampingMatrix.resize(OPT_NUM_DOFS, OPT_NUM_DOFS, false);
@@ -532,13 +532,13 @@ void ShellThinElement3D3N::CalculateDampingMatrix(MatrixType& rDampingMatrix, Pr
 
 void ShellThinElement3D3N::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                                 VectorType& rRightHandSideVector,
-                                                ProcessInfo& rCurrentProcessInfo)
+                                                const ProcessInfo& rCurrentProcessInfo)
 {
   CalculateAll(rLeftHandSideMatrix, rRightHandSideVector, rCurrentProcessInfo, true, true);
 }
 
 void ShellThinElement3D3N::CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                                  ProcessInfo& rCurrentProcessInfo)
+                                                  const ProcessInfo& rCurrentProcessInfo)
 {
   Matrix dummy;
   CalculateAll(dummy, rRightHandSideVector, rCurrentProcessInfo, true, true);
@@ -550,7 +550,7 @@ void ShellThinElement3D3N::CalculateRightHandSide(VectorType& rRightHandSideVect
 //
 // =====================================================================================
 
-void ShellThinElement3D3N::GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<double>& rVariable,
                                                        std::vector<double>& rValues,
                                                        const ProcessInfo& rCurrentProcessInfo)
 {
@@ -563,27 +563,27 @@ void ShellThinElement3D3N::GetValueOnIntegrationPoints(const Variable<double>& r
   OPT_INTERPOLATE_RESULTS_TO_STANDARD_GAUSS_POINTS(rValues);
 }
 
-void ShellThinElement3D3N::GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
+void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
                                                        std::vector<Vector>& rValues,
                                                        const ProcessInfo& rCurrentProcessInfo)
 {
 }
 
-void ShellThinElement3D3N::GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
+void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,
                                                        std::vector<Matrix>& rValues,
                                                        const ProcessInfo& rCurrentProcessInfo)
 {
   if(TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses(rVariable, rValues, rCurrentProcessInfo)) return;
 }
 
-void ShellThinElement3D3N::GetValueOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable,
+void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable,
                                                        std::vector<array_1d<double,3> >& rValues,
                                                        const ProcessInfo& rCurrentProcessInfo)
 {
   if(TryGetValueOnIntegrationPoints_MaterialOrientation(rVariable, rValues, rCurrentProcessInfo)) return;
 }
 
-void ShellThinElement3D3N::GetValueOnIntegrationPoints(const Variable<array_1d<double,6> >& rVariable,
+void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<array_1d<double,6> >& rVariable,
                                                        std::vector<array_1d<double,6> >& rValues,
                                                        const ProcessInfo& rCurrentProcessInfo)
 {
@@ -1236,7 +1236,7 @@ void ShellThinElement3D3N::AddBodyForces(CalculationData& data, VectorType& rRig
 
 void ShellThinElement3D3N::CalculateAll(MatrixType& rLeftHandSideMatrix,
                                         VectorType& rRightHandSideVector,
-                                        ProcessInfo& rCurrentProcessInfo,
+                                        const ProcessInfo& rCurrentProcessInfo,
                                         const bool LHSrequired,
                                         const bool RHSrequired)
 {

--- a/applications/SolidMechanicsApplication/custom_elements/shell_elements/shell_thin_element_3D3N.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/shell_elements/shell_thin_element_3D3N.hpp
@@ -114,15 +114,15 @@ class KRATOS_API(SOLID_MECHANICS_APPLICATION) ShellThinElement3D3N : public Elem
 
   IntegrationMethod GetIntegrationMethod() const override;
 
-  void Initialize() override;
+  void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
   void ResetConstitutiveLaw() override;
 
-  void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+  void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
-  void GetDofList(DofsVectorType& ElementalDofList, ProcessInfo& CurrentProcessInfo) override;
+  void GetDofList(DofsVectorType& ElementalDofList, const ProcessInfo& CurrentProcessInfo) const override;
 
-  int Check(const ProcessInfo& rCurrentProcessInfo) override;
+  int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
   void GetValuesVector(Vector& values, int Step = 0) const override;
 
@@ -130,36 +130,36 @@ class KRATOS_API(SOLID_MECHANICS_APPLICATION) ShellThinElement3D3N : public Elem
 
   void GetSecondDerivativesVector(Vector& values, int Step = 0) const override;
 
-  void InitializeNonLinearIteration(ProcessInfo& CurrentProcessInfo) override;
+  void InitializeNonLinearIteration(const ProcessInfo& CurrentProcessInfo) override;
 
-  void FinalizeNonLinearIteration(ProcessInfo& CurrentProcessInfo) override;
+  void FinalizeNonLinearIteration(const ProcessInfo& CurrentProcessInfo) override;
 
-  void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+  void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
-  void FinalizeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
+  void FinalizeSolutionStep(const ProcessInfo& CurrentProcessInfo) override;
 
-  void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
-  void CalculateDampingMatrix(MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateDampingMatrix(MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
   void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                             VectorType& rRightHandSideVector,
-                            ProcessInfo& rCurrentProcessInfo) override;
+                            const ProcessInfo& rCurrentProcessInfo) override;
 
   void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
 
   // Results calculation on integration points
 
-  void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
-  void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
-  void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
-  void GetValueOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable, std::vector<array_1d<double,3> >& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable, std::vector<array_1d<double,3> >& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
-  void GetValueOnIntegrationPoints(const Variable<array_1d<double,6> >& rVariable, std::vector<array_1d<double,6> >& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateOnIntegrationPoints(const Variable<array_1d<double,6> >& rVariable, std::vector<array_1d<double,6> >& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
   ///@}
 
@@ -302,7 +302,7 @@ class KRATOS_API(SOLID_MECHANICS_APPLICATION) ShellThinElement3D3N : public Elem
 
   void CalculateAll(MatrixType& rLeftHandSideMatrix,
                     VectorType& rRightHandSideVector,
-                    ProcessInfo& rCurrentProcessInfo,
+                    const ProcessInfo& rCurrentProcessInfo,
                     const bool LHSrequired,
                     const bool RHSrequired);
 

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/axisymmetric_small_displacement_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/axisymmetric_small_displacement_element.cpp
@@ -429,7 +429,7 @@ void AxisymmetricSmallDisplacementElement::CalculateInfinitesimalStrain(const Ma
 //************************************************************************************
 //************************************************************************************
 
-int AxisymmetricSmallDisplacementElement::Check( const ProcessInfo& rCurrentProcessInfo )
+int AxisymmetricSmallDisplacementElement::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
@@ -457,5 +457,3 @@ void AxisymmetricSmallDisplacementElement::load( Serializer& rSerializer )
 
 
 } // Namespace Kratos
-
-

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/axisymmetric_small_displacement_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/axisymmetric_small_displacement_element.hpp
@@ -120,7 +120,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
 
     ///@}

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/axisymmetric_updated_lagrangian_U_P_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/axisymmetric_updated_lagrangian_U_P_element.cpp
@@ -175,7 +175,7 @@ void AxisymmetricUpdatedLagrangianUPElement::SetValuesOnIntegrationPoints( const
 //************************************************************************************
 
 
-void AxisymmetricUpdatedLagrangianUPElement::GetValueOnIntegrationPoints( const Variable<double>& rVariable,
+void AxisymmetricUpdatedLagrangianUPElement::CalculateOnIntegrationPoints( const Variable<double>& rVariable,
         std::vector<double>& rValues,
         const ProcessInfo& rCurrentProcessInfo )
 {
@@ -195,7 +195,7 @@ void AxisymmetricUpdatedLagrangianUPElement::GetValueOnIntegrationPoints( const 
   }
   else{
 
-    LargeDisplacementElement::GetValueOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
+    LargeDisplacementElement::CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
 
   }
 
@@ -205,11 +205,11 @@ void AxisymmetricUpdatedLagrangianUPElement::GetValueOnIntegrationPoints( const 
 //************************************************************************************
 //************************************************************************************
 
-void AxisymmetricUpdatedLagrangianUPElement::Initialize()
+void AxisymmetricUpdatedLagrangianUPElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
-    LargeDisplacementElement::Initialize();
+    LargeDisplacementElement::Initialize(rCurrentProcessInfo);
 
     SizeType integration_points_number = GetGeometry().IntegrationPointsNumber( mThisIntegrationMethod );
 
@@ -1145,7 +1145,7 @@ double& AxisymmetricUpdatedLagrangianUPElement::CalculateTotalMass( double& rTot
 //************************************************************************************
 //************************************************************************************
 
-void AxisymmetricUpdatedLagrangianUPElement::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo )
+void AxisymmetricUpdatedLagrangianUPElement::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1263,7 +1263,7 @@ double& AxisymmetricUpdatedLagrangianUPElement::CalculateVolumeChange( double& r
 //************************************************************************************
 //************************************************************************************
 
-int AxisymmetricUpdatedLagrangianUPElement::Check( const ProcessInfo& rCurrentProcessInfo )
+int AxisymmetricUpdatedLagrangianUPElement::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/axisymmetric_updated_lagrangian_U_P_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/axisymmetric_updated_lagrangian_U_P_element.hpp
@@ -128,7 +128,7 @@ public:
     /**
      * Get on rVariable a double Value from the Element Constitutive Law
      */
-    void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //************* STARTING - ENDING  METHODS
@@ -137,7 +137,7 @@ public:
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     //************* COMPUTING  METHODS
 
@@ -148,7 +148,7 @@ public:
       * @param rCurrentProcessInfo: the current process info instance
       */
     void CalculateMassMatrix(MatrixType& rMassMatrix,
-			     ProcessInfo& rCurrentProcessInfo) override;
+			     const ProcessInfo& rCurrentProcessInfo) override;
     //************************************************************************************
     //************************************************************************************
     /**
@@ -158,7 +158,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/axisymmetric_updated_lagrangian_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/axisymmetric_updated_lagrangian_element.cpp
@@ -168,7 +168,7 @@ void AxisymmetricUpdatedLagrangianElement::SetValuesOnIntegrationPoints( const V
 //************************************************************************************
 
 
-void AxisymmetricUpdatedLagrangianElement::GetValueOnIntegrationPoints( const Variable<double>& rVariable,
+void AxisymmetricUpdatedLagrangianElement::CalculateOnIntegrationPoints( const Variable<double>& rVariable,
         std::vector<double>& rValues,
         const ProcessInfo& rCurrentProcessInfo )
 {
@@ -188,7 +188,7 @@ void AxisymmetricUpdatedLagrangianElement::GetValueOnIntegrationPoints( const Va
   }
   else{
 
-    LargeDisplacementElement::GetValueOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
+    LargeDisplacementElement::CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
 
   }
 
@@ -199,11 +199,11 @@ void AxisymmetricUpdatedLagrangianElement::GetValueOnIntegrationPoints( const Va
 //************************************************************************************
 //************************************************************************************
 
-void AxisymmetricUpdatedLagrangianElement::Initialize()
+void AxisymmetricUpdatedLagrangianElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
-    LargeDisplacementElement::Initialize();
+    LargeDisplacementElement::Initialize(rCurrentProcessInfo);
 
     SizeType integration_points_number = GetGeometry().IntegrationPointsNumber( mThisIntegrationMethod );
 
@@ -734,7 +734,7 @@ double& AxisymmetricUpdatedLagrangianElement::CalculateVolumeChange( double& rVo
 //************************************************************************************
 //************************************************************************************
 
-int AxisymmetricUpdatedLagrangianElement::Check( const ProcessInfo& rCurrentProcessInfo )
+int AxisymmetricUpdatedLagrangianElement::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
@@ -746,7 +746,7 @@ int AxisymmetricUpdatedLagrangianElement::Check( const ProcessInfo& rCurrentProc
     for(SizeType i=0; i<this->GetGeometry().size(); ++i)
       {
 	// Nodal data
-	Node<3> &rNode = this->GetGeometry()[i];
+	const Node<3> &rNode = this->GetGeometry()[i];
 	KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISPLACEMENT,rNode);
 	//KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VOLUME_ACCELERATION,rNode);
 

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/axisymmetric_updated_lagrangian_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/axisymmetric_updated_lagrangian_element.hpp
@@ -124,7 +124,7 @@ public:
     /**
      * Get on rVariable a double Value from the Element Constitutive Law
      */
-    void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //************* STARTING - ENDING  METHODS
@@ -133,7 +133,7 @@ public:
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     //************************************************************************************
     //************************************************************************************
@@ -144,7 +144,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/large_displacement_U_P_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/large_displacement_U_P_element.cpp
@@ -122,7 +122,7 @@ LargeDisplacementUPElement::~LargeDisplacementUPElement()
 
 
 
-void LargeDisplacementUPElement::GetDofList( DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementUPElement::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo ) const
 {
     rElementalDofList.resize( 0 );
 
@@ -144,7 +144,7 @@ void LargeDisplacementUPElement::GetDofList( DofsVectorType& rElementalDofList, 
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementUPElement::EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementUPElement::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo ) const
 {
     const SizeType number_of_nodes = GetGeometry().size();
     const SizeType dimension = GetGeometry().WorkingSpaceDimension();
@@ -1020,7 +1020,7 @@ void LargeDisplacementUPElement::CalculateAndAddKppStab (MatrixType& rLeftHandSi
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementUPElement::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementUPElement::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1115,7 +1115,7 @@ void LargeDisplacementUPElement::CalculateMassMatrix( MatrixType& rMassMatrix, P
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementUPElement::CalculateDampingMatrix( MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementUPElement::CalculateDampingMatrix( MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1191,7 +1191,7 @@ void LargeDisplacementUPElement::CalculateDampingMatrix( MatrixType& rDampingMat
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementUPElement::CalculateAndAddDynamicLHS(MatrixType& rLeftHandSideMatrix, ElementDataType& rVariables, ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
+void LargeDisplacementUPElement::CalculateAndAddDynamicLHS(MatrixType& rLeftHandSideMatrix, ElementDataType& rVariables, const ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
 {
   KRATOS_TRY
 
@@ -1206,7 +1206,7 @@ void LargeDisplacementUPElement::CalculateAndAddDynamicLHS(MatrixType& rLeftHand
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementUPElement::CalculateAndAddDynamicRHS(VectorType& rRightHandSideVector, ElementDataType& rVariables, ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
+void LargeDisplacementUPElement::CalculateAndAddDynamicRHS(VectorType& rRightHandSideVector, ElementDataType& rVariables, const ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
 {
   KRATOS_TRY
 
@@ -1239,7 +1239,7 @@ void LargeDisplacementUPElement::CalculateAndAddDynamicRHS(VectorType& rRightHan
 //************************************************************************************
 //************************************************************************************
 
-int LargeDisplacementUPElement::Check( const ProcessInfo& rCurrentProcessInfo )
+int LargeDisplacementUPElement::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
@@ -1251,7 +1251,7 @@ int LargeDisplacementUPElement::Check( const ProcessInfo& rCurrentProcessInfo )
     for(SizeType i=0; i<this->GetGeometry().size(); ++i)
       {
 	// Nodal data
-	Node<3> &rNode = this->GetGeometry()[i];
+	const Node<3> &rNode = this->GetGeometry()[i];
 	KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISPLACEMENT,rNode);
 	//KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VOLUME_ACCELERATION,rNode);
 

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/large_displacement_U_P_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/large_displacement_U_P_element.hpp
@@ -121,12 +121,12 @@ public:
     /**
     * Sets on rElementalDofList the degrees of freedom of the considered element geometry
     */
-    void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rResult the ID's of the element degrees of freedom
      */
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rValues the nodal displacements
@@ -152,7 +152,7 @@ public:
       * @param rMassMatrix: the elemental mass matrix
       * @param rCurrentProcessInfo: the current process info instance
       */
-    void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
       * this is called during the assembling process in order
@@ -160,7 +160,7 @@ public:
       * @param rDampingMatrix: the elemental damping matrix
       * @param rCurrentProcessInfo: the current process info instance
       */
-    void CalculateDampingMatrix(MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateDampingMatrix(MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
 
 
@@ -173,7 +173,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access
@@ -229,7 +229,7 @@ protected:
 
     void CalculateAndAddDynamicLHS(MatrixType& rLeftHandSideMatrix,
                                    ElementDataType& rVariables,
-                                   ProcessInfo& rCurrentProcessInfo,
+                                   const ProcessInfo& rCurrentProcessInfo,
                                    double& rIntegrationWeight) override;
 
     /**
@@ -238,7 +238,7 @@ protected:
 
     void CalculateAndAddDynamicRHS(VectorType& rRightHandSideVector,
                                    ElementDataType& rVariables,
-                                   ProcessInfo& rCurrentProcessInfo,
+                                   const ProcessInfo& rCurrentProcessInfo,
                                    double& rIntegrationWeight) override;
 
     /**

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/large_displacement_V_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/large_displacement_V_element.cpp
@@ -120,7 +120,7 @@ LargeDisplacementVElement::~LargeDisplacementVElement()
 
 
 
-void LargeDisplacementVElement::GetDofList( DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementVElement::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo ) const
 {
     rElementalDofList.resize( 0 );
 
@@ -140,7 +140,7 @@ void LargeDisplacementVElement::GetDofList( DofsVectorType& rElementalDofList, P
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementVElement::EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementVElement::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo ) const
 {
     const SizeType number_of_nodes  = GetGeometry().size();
     const SizeType dimension        = GetGeometry().WorkingSpaceDimension();
@@ -297,7 +297,7 @@ void LargeDisplacementVElement::SetElementData(ElementDataType& rVariables,
 //************************************************************************************
 //************************************************************************************
 
-int  LargeDisplacementVElement::Check( const ProcessInfo& rCurrentProcessInfo )
+int  LargeDisplacementVElement::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
@@ -309,7 +309,7 @@ int  LargeDisplacementVElement::Check( const ProcessInfo& rCurrentProcessInfo )
     for(SizeType i=0; i<this->GetGeometry().size(); ++i)
       {
 	// Nodal data
-	Node<3> &rNode = this->GetGeometry()[i];
+	const Node<3> &rNode = this->GetGeometry()[i];
 	KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VELOCITY,rNode);
 	//KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VOLUME_ACCELERATION,rNode);
 

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/large_displacement_V_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/large_displacement_V_element.hpp
@@ -121,12 +121,12 @@ public:
     /**
     * Sets on rElementalDofList the degrees of freedom of the considered element geometry
     */
-    void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rResult the ID's of the element degrees of freedom
      */
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
 
 
@@ -139,7 +139,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/large_displacement_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/large_displacement_element.cpp
@@ -194,7 +194,7 @@ void LargeDisplacementElement::SetElementData(ElementDataType& rVariables,
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementElement::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementElement::InitializeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -209,7 +209,7 @@ void LargeDisplacementElement::InitializeSolutionStep( ProcessInfo& rCurrentProc
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementElement::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementElement::FinalizeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -434,7 +434,7 @@ void LargeDisplacementElement::CalculateOnIntegrationPoints( const Variable<Matr
 //************************************************************************************
 //************************************************************************************
 
-int LargeDisplacementElement::Check( const ProcessInfo& rCurrentProcessInfo )
+int LargeDisplacementElement::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/large_displacement_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/large_displacement_element.hpp
@@ -116,13 +116,13 @@ public:
     /**
      * Called at the beginning of each solution step
      */
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
      * Called at the end of eahc solution step
      */
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 
 
@@ -154,7 +154,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
 
     ///@}

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/large_displacement_segregated_V_P_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/large_displacement_segregated_V_P_element.cpp
@@ -129,7 +129,7 @@ LargeDisplacementSegregatedVPElement::~LargeDisplacementSegregatedVPElement()
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementSegregatedVPElement::GetDofList( DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementSegregatedVPElement::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo ) const
 {
     rElementalDofList.resize(0);
 
@@ -165,10 +165,10 @@ void LargeDisplacementSegregatedVPElement::GetDofList( DofsVectorType& rElementa
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementSegregatedVPElement::EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementSegregatedVPElement::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo ) const
 {
 
-    this->SetProcessInformation(rCurrentProcessInfo);
+  //this->SetProcessInformation(rCurrentProcessInfo);
 
     const SizeType number_of_nodes = GetGeometry().size();
     const SizeType dimension = GetGeometry().WorkingSpaceDimension();
@@ -210,7 +210,7 @@ void LargeDisplacementSegregatedVPElement::EquationIdVector( EquationIdVectorTyp
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementSegregatedVPElement::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementSegregatedVPElement::InitializeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -227,7 +227,7 @@ void LargeDisplacementSegregatedVPElement::InitializeSolutionStep( ProcessInfo& 
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementSegregatedVPElement::InitializeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementSegregatedVPElement::InitializeNonLinearIteration( const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -239,7 +239,7 @@ void LargeDisplacementSegregatedVPElement::InitializeNonLinearIteration( Process
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementSegregatedVPElement::FinalizeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementSegregatedVPElement::FinalizeNonLinearIteration( const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -250,7 +250,7 @@ void LargeDisplacementSegregatedVPElement::FinalizeNonLinearIteration( ProcessIn
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementSegregatedVPElement::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementSegregatedVPElement::FinalizeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -420,7 +420,7 @@ void LargeDisplacementSegregatedVPElement::GetSecondDerivativesVector( Vector& r
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementSegregatedVPElement::CalculateRightHandSide( VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementSegregatedVPElement::CalculateRightHandSide( VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -436,7 +436,7 @@ void LargeDisplacementSegregatedVPElement::CalculateRightHandSide( VectorType& r
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementSegregatedVPElement::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementSegregatedVPElement::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -452,7 +452,7 @@ void LargeDisplacementSegregatedVPElement::CalculateLeftHandSide( MatrixType& rL
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementSegregatedVPElement::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementSegregatedVPElement::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -566,7 +566,7 @@ void LargeDisplacementSegregatedVPElement::CalculateAndAddPressureForces(VectorT
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementSegregatedVPElement::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementSegregatedVPElement::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -600,7 +600,7 @@ void LargeDisplacementSegregatedVPElement::CalculateMassMatrix( MatrixType& rMas
 //************************************************************************************
 //************************************************************************************
 
-void LargeDisplacementSegregatedVPElement::CalculateDampingMatrix( MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo )
+void LargeDisplacementSegregatedVPElement::CalculateDampingMatrix( MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
   KRATOS_TRY
 
@@ -663,7 +663,7 @@ LargeDisplacementSegregatedVPElement::SizeType LargeDisplacementSegregatedVPElem
 //************************************************************************************
 //************************************************************************************
 
-int  LargeDisplacementSegregatedVPElement::Check( const ProcessInfo& rCurrentProcessInfo )
+int  LargeDisplacementSegregatedVPElement::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
@@ -675,7 +675,7 @@ int  LargeDisplacementSegregatedVPElement::Check( const ProcessInfo& rCurrentPro
     for(SizeType i=0; i<this->GetGeometry().size(); ++i)
       {
 	// Nodal data
-	Node<3> &rNode = this->GetGeometry()[i];
+	const Node<3> &rNode = this->GetGeometry()[i];
 	KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(PRESSURE,rNode);
         //KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(PRESSURE_VELOCITY,rNode);
         //KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(PRESSURE_ACCELERATION,rNode);

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/large_displacement_segregated_V_P_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/large_displacement_segregated_V_P_element.hpp
@@ -123,22 +123,22 @@ public:
     /**
      * Called at the beginning of each solution step
      */
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Called at the end of eahc solution step
      */
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //************* GETTING METHODS
@@ -146,12 +146,12 @@ public:
     /**
     * Sets on rElementalDofList the degrees of freedom of the considered element geometry
     */
-    void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rResult the ID's of the element degrees of freedom
      */
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rValues the nodal displacements
@@ -182,7 +182,7 @@ public:
 
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                               VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
     /**
      * this is called during the assembling process in order
      * to calculate the elemental right hand side vector only
@@ -190,7 +190,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
     /**
      * this is called during the assembling process in order
      * to calculate the elemental left hand side vector only
@@ -198,7 +198,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateLeftHandSide (MatrixType& rLeftHandSideMatrix,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -207,7 +207,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateMassMatrix(MatrixType& rMassMatrix,
-                             ProcessInfo& rCurrentProcessInfo) override;
+                             const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -216,7 +216,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateDampingMatrix(MatrixType& rDampingMatrix,
-                                ProcessInfo& rCurrentProcessInfo) override;
+                                const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //************************************************************************************
@@ -228,7 +228,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/linear_solid_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/linear_solid_element.cpp
@@ -147,7 +147,7 @@ LinearSolidElement::IntegrationMethod LinearSolidElement::GetIntegrationMethod()
 //************************************************************************************
 //************************************************************************************
 
-void LinearSolidElement::GetDofList( DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo )
+void LinearSolidElement::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo ) const
 {
     //NEEDED TO DEFINE THE DOFS OF THE ELEMENT
     rElementalDofList.resize( 0 );
@@ -166,7 +166,7 @@ void LinearSolidElement::GetDofList( DofsVectorType& rElementalDofList, ProcessI
 //************************************************************************************
 //************************************************************************************
 
-void LinearSolidElement::EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo )
+void LinearSolidElement::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo ) const
 {
     //NEEDED TO DEFINE GLOBAL IDS FOR THE CORRECT ASSEMBLY
     const SizeType number_of_nodes  = GetGeometry().size();
@@ -267,24 +267,6 @@ void LinearSolidElement::GetSecondDerivativesVector( Vector& rValues, int Step )
 //************************************************************************************
 //(see element.h)
 
-//*********************************GET VALUE METHODS**********************************
-//************************************************************************************
-//(see element.h)
-
-void LinearSolidElement::GetValueOnIntegrationPoints( const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo )
-{
-  KRATOS_TRY
-
-  if ( rVariable == CAUCHY_STRESS_TENSOR || rVariable == GREEN_LAGRANGE_STRAIN_TENSOR )
-    {
-      CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-    }
-
-  return;
-
-  KRATOS_CATCH( "" )
-
-}
 
 
 //************* STARTING - ENDING  METHODS
@@ -292,7 +274,7 @@ void LinearSolidElement::GetValueOnIntegrationPoints( const Variable<Matrix>& rV
 //************************************************************************************
 
 
-void LinearSolidElement::Initialize()
+void LinearSolidElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -327,7 +309,7 @@ void LinearSolidElement::Initialize()
 ////************************************************************************************
 ////************************************************************************************
 
-void LinearSolidElement::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void LinearSolidElement::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
 
 }
@@ -335,7 +317,7 @@ void LinearSolidElement::InitializeSolutionStep( ProcessInfo& rCurrentProcessInf
 
 ////************************************************************************************
 ////************************************************************************************
-void LinearSolidElement::InitializeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+void LinearSolidElement::InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo )
 {
 
 }
@@ -343,7 +325,7 @@ void LinearSolidElement::InitializeNonLinearIteration( ProcessInfo& rCurrentProc
 ////************************************************************************************
 ////************************************************************************************
 
-void LinearSolidElement::FinalizeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+void LinearSolidElement::FinalizeNonLinearIteration( const ProcessInfo& rCurrentProcessInfo )
 {
 
 }
@@ -351,7 +333,7 @@ void LinearSolidElement::FinalizeNonLinearIteration( ProcessInfo& rCurrentProces
 ////************************************************************************************
 ////************************************************************************************
 
-void LinearSolidElement::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void LinearSolidElement::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -376,7 +358,7 @@ void LinearSolidElement::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo 
 //************************************************************************************
 //************************************************************************************
 
-void LinearSolidElement::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void LinearSolidElement::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
 
     KRATOS_TRY
@@ -791,7 +773,7 @@ Vector& LinearSolidElement::CalculateVolumeForce( Vector& rVolumeForce, const Ve
 //************************************************************************************
 //************************************************************************************
 
-void LinearSolidElement::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo )
+void LinearSolidElement::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -834,7 +816,7 @@ void LinearSolidElement::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessIn
 //************************************************************************************
 //************************************************************************************
 
-void LinearSolidElement::CalculateDampingMatrix( MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo )
+void LinearSolidElement::CalculateDampingMatrix( MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1089,7 +1071,7 @@ void LinearSolidElement::CalculateOnIntegrationPoints( const Variable<Matrix>& r
 //************************************************************************************
 //************************************************************************************
 
-int LinearSolidElement::Check( const ProcessInfo& rCurrentProcessInfo )
+int LinearSolidElement::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
@@ -1101,7 +1083,7 @@ int LinearSolidElement::Check( const ProcessInfo& rCurrentProcessInfo )
     for(SizeType i=0; i<this->GetGeometry().size(); ++i)
       {
 	// Nodal data
-	Node<3> &rNode = this->GetGeometry()[i];
+	const Node<3> &rNode = this->GetGeometry()[i];
 	KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISPLACEMENT,rNode);
 	//KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VOLUME_ACCELERATION,rNode);
 

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/linear_solid_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/linear_solid_element.hpp
@@ -121,12 +121,12 @@ public:
     /**
      * Sets on rElementalDofList the degrees of freedom of the considered element geometry
      */
-    void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rResult the ID's of the element degrees of freedom
      */
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rValues the nodal displacements
@@ -151,7 +151,7 @@ public:
     /**
      * Get on rVariable a Matrix Value from the Element Constitutive Law
      */
-    void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //************* STARTING - ENDING  METHODS
@@ -160,27 +160,27 @@ public:
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Called at the beginning of each solution step
      */
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Called at the end of eahc solution step
      */
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //************* COMPUTING  METHODS
@@ -196,7 +196,7 @@ public:
 
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
 			      VectorType& rRightHandSideVector,
-			      ProcessInfo& rCurrentProcessInfo) override;
+			      const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -206,7 +206,7 @@ public:
       * @param rCurrentProcessInfo: the current process info instance
       */
     void CalculateMassMatrix(MatrixType& rMassMatrix,
-		    ProcessInfo& rCurrentProcessInfo) override;
+                             const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
       * this is called during the assembling process in order
@@ -215,7 +215,7 @@ public:
       * @param rCurrentProcessInfo: the current process info instance
       */
     void CalculateDampingMatrix(MatrixType& rDampingMatrix,
-		    ProcessInfo& rCurrentProcessInfo) override;
+                                const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -232,14 +232,6 @@ public:
                                  const Variable<array_1d<double,3> >& rDestinationVariable,
                                  const ProcessInfo& rCurrentProcessInfo) override;
 
-    //on integration points:
-    // see element.h
-
-    /**
-     * Calculate a Vector Variable on the Element Constitutive Law
-     */
-    void CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rOutput, const ProcessInfo& rCurrentProcessInfo) override;
-
 
 
     //************************************************************************************
@@ -251,7 +243,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
 
     ///@}

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/small_displacement_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/small_displacement_element.cpp
@@ -391,7 +391,7 @@ void SmallDisplacementElement::CalculateOnIntegrationPoints( const Variable<Matr
 //************************************************************************************
 //************************************************************************************
 
-int SmallDisplacementElement::Check( const ProcessInfo& rCurrentProcessInfo )
+int SmallDisplacementElement::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
@@ -403,7 +403,7 @@ int SmallDisplacementElement::Check( const ProcessInfo& rCurrentProcessInfo )
     for(SizeType i=0; i<this->GetGeometry().size(); ++i)
       {
 	// Nodal data
-	Node<3> &rNode = this->GetGeometry()[i];
+	const Node<3> &rNode = this->GetGeometry()[i];
 	KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISPLACEMENT,rNode);
 	//KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VOLUME_ACCELERATION,rNode);
 

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/small_displacement_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/small_displacement_element.hpp
@@ -143,7 +143,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/solid_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/solid_element.cpp
@@ -161,7 +161,7 @@ void SolidElement::IncreaseIntegrationMethod(IntegrationMethod& rThisIntegration
 //************************************************************************************
 //************************************************************************************
 
-void SolidElement::GetDofList( DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo )
+void SolidElement::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo ) const
 {
     rElementalDofList.resize( 0 );
     const SizeType dimension  = GetGeometry().WorkingSpaceDimension();
@@ -179,7 +179,7 @@ void SolidElement::GetDofList( DofsVectorType& rElementalDofList, ProcessInfo& r
 //************************************************************************************
 //************************************************************************************
 
-void SolidElement::EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo )
+void SolidElement::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo ) const
 {
     const SizeType number_of_nodes = GetGeometry().size();
     const SizeType dimension = GetGeometry().WorkingSpaceDimension();
@@ -345,126 +345,11 @@ void SolidElement::SetValuesOnIntegrationPoints( const Variable<ConstitutiveLaw:
 
 }
 
-//*********************************GET DOUBLE VALUE***********************************
-//************************************************************************************
-
-
-void SolidElement::GetValueOnIntegrationPoints( const Variable<double>& rVariable,
-						std::vector<double>& rValues,
-						const ProcessInfo& rCurrentProcessInfo )
-{
-    if ( rVariable == VON_MISES_STRESS || rVariable == NORM_ISOCHORIC_STRESS || rVariable == PRESSURE || DAMAGE_VARIABLE)
-    {
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-    }
-    else
-    {
-      const SizeType& integration_points_number = GetGeometry().IntegrationPointsNumber( mThisIntegrationMethod );
-
-      if ( rValues.size() != integration_points_number )
-      {
-        rValues.resize( integration_points_number );
-      }
-
-      for ( SizeType ii = 0; ii < integration_points_number; ii++ )
-      {
-        rValues[ii] = mConstitutiveLawVector[ii]->GetValue( rVariable, rValues[ii] );
-      }
-    }
-}
-
-//**********************************GET VECTOR VALUE**********************************
-//************************************************************************************
-
-
-void SolidElement::GetValueOnIntegrationPoints( const Variable<Vector>& rVariable,
-						std::vector<Vector>& rValues,
-						const ProcessInfo& rCurrentProcessInfo )
-{
-    const SizeType& integration_points_number = mConstitutiveLawVector.size();
-
-    if ( rValues.size() != integration_points_number )
-        rValues.resize( integration_points_number );
-
-
-    if ( rVariable == PK2_STRESS_TENSOR ||  rVariable == CAUCHY_STRESS_TENSOR )
-    {
-
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-
-    }
-    else if ( rVariable == PK2_STRESS_VECTOR ||  rVariable == CAUCHY_STRESS_VECTOR )
-    {
-
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-
-    }
-    else if ( rVariable == GREEN_LAGRANGE_STRAIN_TENSOR ||  rVariable == ALMANSI_STRAIN_TENSOR )
-    {
-
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-
-    }
-    else
-    {
-
-        for ( SizeType PointNumber = 0;  PointNumber < integration_points_number; PointNumber++ )
-        {
-            rValues[PointNumber] = mConstitutiveLawVector[PointNumber]->GetValue( rVariable, rValues[PointNumber] );
-        }
-
-    }
-
-}
-
-//***********************************GET MATRIX VALUE*********************************
-//************************************************************************************
-
-void SolidElement::GetValueOnIntegrationPoints( const Variable<Matrix>& rVariable,
-						std::vector<Matrix>& rValues,
-						const ProcessInfo& rCurrentProcessInfo )
-{
-
-    const SizeType& integration_points_number = mConstitutiveLawVector.size();
-
-    if ( rValues.size() != integration_points_number )
-        rValues.resize( integration_points_number );
-
-    if ( rVariable == PK2_STRESS_TENSOR ||  rVariable == CAUCHY_STRESS_TENSOR )
-    {
-
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-
-    }
-    else if ( rVariable == GREEN_LAGRANGE_STRAIN_TENSOR ||  rVariable == ALMANSI_STRAIN_TENSOR )
-    {
-
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-
-    }
-    else if ( rVariable == DEFORMATION_GRADIENT )
-    {
-
-        CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
-
-    }
-    else
-    {
-
-        for ( SizeType PointNumber = 0;  PointNumber < integration_points_number; PointNumber++ )
-        {
-            rValues[PointNumber] = mConstitutiveLawVector[PointNumber]->GetValue( rVariable, rValues[PointNumber] );
-        }
-
-    }
-
-
-}
 
 //********************************GET CONSTITUTIVE VALUE******************************
 //************************************************************************************
 
-void SolidElement::GetValueOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable,
+void SolidElement::CalculateOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable,
 						std::vector<ConstitutiveLaw::Pointer>& rValues,
 						const ProcessInfo& rCurrentProcessInfo )
 {
@@ -488,7 +373,7 @@ void SolidElement::GetValueOnIntegrationPoints( const Variable<ConstitutiveLaw::
 //************************************************************************************
 //************************************************************************************
 
-void SolidElement::Initialize()
+void SolidElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -680,7 +565,7 @@ void SolidElement::CalculateMaterialResponse(ElementDataType& rVariables,
 //************************************************************************************
 
 void SolidElement::CalculateElementalSystem( LocalSystemComponents& rLocalSystem,
-                                             ProcessInfo& rCurrentProcessInfo)
+                                             const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -753,7 +638,7 @@ void SolidElement::CalculateElementalSystem( LocalSystemComponents& rLocalSystem
 //************************************************************************************
 
 void SolidElement::CalculateDynamicSystem( LocalSystemComponents& rLocalSystem,
-					   ProcessInfo& rCurrentProcessInfo)
+					   const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -901,7 +786,7 @@ void SolidElement::CalculateAndAddRHS(LocalSystemComponents& rLocalSystem, Eleme
 //************************************************************************************
 //************************************************************************************
 
-void SolidElement::CalculateAndAddDynamicLHS(MatrixType& rLeftHandSideMatrix, ElementDataType& rVariables, ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
+void SolidElement::CalculateAndAddDynamicLHS(MatrixType& rLeftHandSideMatrix, ElementDataType& rVariables, const ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
 {
   KRATOS_TRY
 
@@ -948,7 +833,7 @@ void SolidElement::CalculateAndAddDynamicLHS(MatrixType& rLeftHandSideMatrix, El
 //************************************************************************************
 //************************************************************************************
 
-void SolidElement::CalculateAndAddDynamicRHS(VectorType& rRightHandSideVector, ElementDataType& rVariables, ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
+void SolidElement::CalculateAndAddDynamicRHS(VectorType& rRightHandSideVector, ElementDataType& rVariables, const ProcessInfo& rCurrentProcessInfo, double& rIntegrationWeight)
 {
   KRATOS_TRY
 
@@ -1031,7 +916,7 @@ double& SolidElement::CalculateIntegrationWeight(double& rIntegrationWeight)
 //************************************************************************************
 //************************************************************************************
 
-void SolidElement::CalculateRightHandSide( VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void SolidElement::CalculateRightHandSide( VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1061,7 +946,7 @@ void SolidElement::CalculateRightHandSide( VectorType& rRightHandSideVector, Pro
 //************************************************************************************
 
 
-void SolidElement::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo )
+void SolidElement::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1090,7 +975,7 @@ void SolidElement::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, Proce
 //************************************************************************************
 //************************************************************************************
 
-void SolidElement::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void SolidElement::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1137,7 +1022,7 @@ void SolidElement::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, Vector
 //************************************************************************************
 
 
-void SolidElement::CalculatePerturbedLeftHandSide( MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo )
+void SolidElement::CalculatePerturbedLeftHandSide( MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1205,7 +1090,7 @@ void SolidElement::CalculatePerturbedLeftHandSide( MatrixType& rLeftHandSideMatr
 //************************************************************************************
 //************************************************************************************
 
-void SolidElement::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void SolidElement::InitializeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1220,7 +1105,7 @@ void SolidElement::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo )
 
 //************************************************************************************
 //************************************************************************************
-void SolidElement::InitializeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+void SolidElement::InitializeNonLinearIteration( const ProcessInfo& rCurrentProcessInfo )
 {
     InitializeExplicitContributions();
 }
@@ -1228,7 +1113,7 @@ void SolidElement::InitializeNonLinearIteration( ProcessInfo& rCurrentProcessInf
 //************************************************************************************
 //************************************************************************************
 
-void SolidElement::FinalizeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
+void SolidElement::FinalizeNonLinearIteration( const ProcessInfo& rCurrentProcessInfo )
 {
 
 }
@@ -1236,7 +1121,7 @@ void SolidElement::FinalizeNonLinearIteration( ProcessInfo& rCurrentProcessInfo 
 //************************************************************************************
 //************************************************************************************
 
-void SolidElement::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void SolidElement::FinalizeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1608,7 +1493,7 @@ Vector& SolidElement::CalculateVolumeForce( Vector& rVolumeForce, ElementDataTyp
 //************************************************************************************
 //************************************************************************************
 
-void SolidElement::CalculateFirstDerivativesContributions(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+void SolidElement::CalculateFirstDerivativesContributions(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -1637,7 +1522,7 @@ void SolidElement::CalculateFirstDerivativesContributions(MatrixType& rLeftHandS
 //************************************************************************************
 //************************************************************************************
 
-void SolidElement::CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+void SolidElement::CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -1719,7 +1604,7 @@ void SolidElement::CalculateSecondDerivativesContributions(MatrixType& rLeftHand
 //************************************************************************************
 //************************************************************************************
 
-void SolidElement::CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo)
+void SolidElement::CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -1769,7 +1654,7 @@ void SolidElement::CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix
 //************************************************************************************
 //************************************************************************************
 
-void SolidElement::CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+void SolidElement::CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -1840,7 +1725,7 @@ void SolidElement::CalculateSecondDerivativesRHS(VectorType& rRightHandSideVecto
 //************************************************************************************
 //************************************************************************************
 
-void SolidElement::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo )
+void SolidElement::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1910,7 +1795,7 @@ void SolidElement::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rC
 //************************************************************************************
 //************************************************************************************
 
-void SolidElement::CalculateDampingMatrix( MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo )
+void SolidElement::CalculateDampingMatrix( MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -2342,7 +2227,7 @@ void SolidElement::CalculateOnIntegrationPoints( const Variable<Matrix >& rVaria
 //************************************************************************************
 //************************************************************************************
 
-int  SolidElement::Check( const ProcessInfo& rCurrentProcessInfo )
+int  SolidElement::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/solid_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/solid_element.hpp
@@ -326,12 +326,12 @@ public:
     /**
      * Sets on rElementalDofList the degrees of freedom of the considered element geometry
      */
-    void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rResult the ID's of the element degrees of freedom
      */
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Sets on rValues the nodal displacements
@@ -387,25 +387,11 @@ public:
 
 
     //GET:
-    /**
-     * Get on rVariable a double Value from the Element Constitutive Law
-     */
-    void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    /**
-     * Get on rVariable a Vector Value from the Element Constitutive Law
-     */
-    void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    /**
-     * Get on rVariable a Matrix Value from the Element Constitutive Law
-     */
-    void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Get a Constitutive Law Value
      */
-    void GetValueOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable,
+    void CalculateOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable,
                                       std::vector<ConstitutiveLaw::Pointer>& rValues,
                                       const ProcessInfo& rCurrentProcessInfo ) override;
 
@@ -417,27 +403,27 @@ public:
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Called at the beginning of each solution step
      */
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called for non-linear analysis at the beginning of the iteration process
      */
-    void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Called at the end of eahc solution step
      */
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //************* COMPUTING  METHODS
@@ -454,7 +440,7 @@ public:
 
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
 			      VectorType& rRightHandSideVector,
-			      ProcessInfo& rCurrentProcessInfo) override;
+			      const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -464,7 +450,7 @@ public:
       * @param rCurrentProcessInfo: the current process info instance
       */
     void CalculateRightHandSide(VectorType& rRightHandSideVector,
-				ProcessInfo& rCurrentProcessInfo) override;
+				const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -474,7 +460,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateLeftHandSide (MatrixType& rLeftHandSideMatrix,
-				ProcessInfo& rCurrentProcessInfo) override;
+				const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -485,7 +471,7 @@ public:
      */
     void CalculateFirstDerivativesContributions(MatrixType& rLeftHandSideMatrix,
 						VectorType& rRightHandSideVector,
-						ProcessInfo& rCurrentProcessInfo) override;
+						const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -496,7 +482,7 @@ public:
      */
     void CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix,
 						VectorType& rRightHandSideVector,
-						ProcessInfo& rCurrentProcessInfo) override;
+						const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * this is called during the assembling process in order
@@ -505,7 +491,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix,
-				       ProcessInfo& rCurrentProcessInfo) override;
+				       const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -515,7 +501,7 @@ public:
      * @param rCurrentProcessInfo: the current process info instance
      */
     void CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector,
-				       ProcessInfo& rCurrentProcessInfo) override;
+				       const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
       * this is called during the assembling process in order
@@ -524,7 +510,7 @@ public:
       * @param rCurrentProcessInfo: the current process info instance
       */
     void CalculateMassMatrix(MatrixType& rMassMatrix,
-		    ProcessInfo& rCurrentProcessInfo) override;
+                             const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
       * this is called during the assembling process in order
@@ -533,7 +519,7 @@ public:
       * @param rCurrentProcessInfo: the current process info instance
       */
     void CalculateDampingMatrix(MatrixType& rDampingMatrix,
-		    ProcessInfo& rCurrentProcessInfo) override;
+                                const ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -576,7 +562,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access
@@ -650,13 +636,13 @@ protected:
      * Calculates the elemental contributions
      */
     virtual void CalculateElementalSystem(LocalSystemComponents& rLocalSystem,
-                                          ProcessInfo& rCurrentProcessInfo);
+                                          const ProcessInfo& rCurrentProcessInfo);
 
     /**
      * Calculates the elemental dynamic contributions
      */
     virtual void CalculateDynamicSystem(LocalSystemComponents& rLocalSystem,
-					ProcessInfo& rCurrentProcessInfo);
+					const ProcessInfo& rCurrentProcessInfo);
 
     /**
      * Prints element information for each gauss point (debugging purposes)
@@ -668,7 +654,7 @@ protected:
      * Calculation of the tangent via perturbation of the dofs variables : testing purposes
      */
     void CalculatePerturbedLeftHandSide (MatrixType& rLeftHandSideMatrix,
-					 ProcessInfo& rCurrentProcessInfo);
+					 const ProcessInfo& rCurrentProcessInfo);
 
     /**
      * Calculation and addition of the matrices of the LHS
@@ -695,7 +681,7 @@ protected:
 
     virtual void CalculateAndAddDynamicLHS(MatrixType& rLeftHandSideMatrix,
 					   ElementDataType& rVariables,
-					   ProcessInfo& rCurrentProcessInfo,
+					   const ProcessInfo& rCurrentProcessInfo,
 					   double& rIntegrationWeight);
 
     /**
@@ -704,7 +690,7 @@ protected:
 
     virtual void CalculateAndAddDynamicRHS(VectorType& rRightHandSideVector,
 					   ElementDataType& rVariables,
-					   ProcessInfo& rCurrentProcessInfo,
+					   const ProcessInfo& rCurrentProcessInfo,
 					   double& rIntegrationWeight);
 
 

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/total_lagrangian_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/total_lagrangian_element.cpp
@@ -143,11 +143,11 @@ TotalLagrangianElement::~TotalLagrangianElement()
 //************************************************************************************
 
 
-void TotalLagrangianElement::Initialize()
+void TotalLagrangianElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
-    LargeDisplacementElement::Initialize();
+    LargeDisplacementElement::Initialize(rCurrentProcessInfo);
 
     const GeometryType::IntegrationPointsArrayType& integration_points = GetGeometry().IntegrationPoints( mThisIntegrationMethod );
 
@@ -404,7 +404,7 @@ double& TotalLagrangianElement::CalculateVolumeChange( double& rVolumeChange, El
 //************************************************************************************
 //************************************************************************************
 
-int TotalLagrangianElement::Check( const ProcessInfo& rCurrentProcessInfo )
+int TotalLagrangianElement::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
@@ -430,7 +430,7 @@ int TotalLagrangianElement::Check( const ProcessInfo& rCurrentProcessInfo )
     for(SizeType i=0; i<this->GetGeometry().size(); ++i)
       {
 	// Nodal data
-	Node<3> &rNode = this->GetGeometry()[i];
+	const Node<3> &rNode = this->GetGeometry()[i];
 	KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISPLACEMENT,rNode);
 	//KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VOLUME_ACCELERATION,rNode);
 

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/total_lagrangian_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/total_lagrangian_element.hpp
@@ -116,7 +116,7 @@ public:
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     //************************************************************************************
@@ -128,7 +128,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/updated_lagrangian_U_P_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/updated_lagrangian_U_P_element.cpp
@@ -173,7 +173,7 @@ void UpdatedLagrangianUPElement::SetValuesOnIntegrationPoints( const Variable<do
 //************************************************************************************
 
 
-void UpdatedLagrangianUPElement::GetValueOnIntegrationPoints( const Variable<double>& rVariable,
+void UpdatedLagrangianUPElement::CalculateOnIntegrationPoints( const Variable<double>& rVariable,
         std::vector<double>& rValues,
         const ProcessInfo& rCurrentProcessInfo )
 {
@@ -193,7 +193,7 @@ void UpdatedLagrangianUPElement::GetValueOnIntegrationPoints( const Variable<dou
   }
   else{
 
-    LargeDisplacementElement::GetValueOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
+    LargeDisplacementElement::CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
 
   }
 
@@ -203,11 +203,11 @@ void UpdatedLagrangianUPElement::GetValueOnIntegrationPoints( const Variable<dou
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUPElement::Initialize()
+void UpdatedLagrangianUPElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
-    LargeDisplacementElement::Initialize();
+    LargeDisplacementElement::Initialize(rCurrentProcessInfo);
 
     SizeType integration_points_number = GetGeometry().IntegrationPointsNumber( mThisIntegrationMethod );
     const SizeType dimension        = GetGeometry().WorkingSpaceDimension();

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/updated_lagrangian_U_P_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/updated_lagrangian_U_P_element.hpp
@@ -128,7 +128,7 @@ public:
     /**
      * Get on rVariable a double Value from the Element Constitutive Law
      */
-    void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
 
 
@@ -138,7 +138,7 @@ public:
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     //************************************************************************************
     //************************************************************************************

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/updated_lagrangian_V_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/updated_lagrangian_V_element.cpp
@@ -167,7 +167,7 @@ void UpdatedLagrangianVElement::SetValuesOnIntegrationPoints( const Variable<dou
 //************************************************************************************
 
 
-void UpdatedLagrangianVElement::GetValueOnIntegrationPoints( const Variable<double>& rVariable,
+void UpdatedLagrangianVElement::CalculateOnIntegrationPoints( const Variable<double>& rVariable,
         std::vector<double>& rValues,
         const ProcessInfo& rCurrentProcessInfo )
 {
@@ -187,7 +187,7 @@ void UpdatedLagrangianVElement::GetValueOnIntegrationPoints( const Variable<doub
   }
   else{
 
-    LargeDisplacementVElement::GetValueOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
+    LargeDisplacementVElement::CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
 
   }
 
@@ -197,11 +197,11 @@ void UpdatedLagrangianVElement::GetValueOnIntegrationPoints( const Variable<doub
 //************************************************************************************
 
 
-void UpdatedLagrangianVElement::Initialize()
+void UpdatedLagrangianVElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
-    LargeDisplacementVElement::Initialize();
+    LargeDisplacementVElement::Initialize(rCurrentProcessInfo);
 
     SizeType integration_points_number = GetGeometry().IntegrationPointsNumber( mThisIntegrationMethod );
     const SizeType dimension        = GetGeometry().WorkingSpaceDimension();
@@ -381,7 +381,7 @@ double& UpdatedLagrangianVElement::CalculateVolumeChange( double& rVolumeChange,
 //************************************************************************************
 //************************************************************************************
 
-int UpdatedLagrangianVElement::Check( const ProcessInfo& rCurrentProcessInfo )
+int UpdatedLagrangianVElement::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/updated_lagrangian_V_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/updated_lagrangian_V_element.hpp
@@ -122,14 +122,14 @@ public:
     /**
      * Get on rVariable a double Value from the Element Constitutive Law
      */
-    void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
     //************* STARTING - ENDING  METHODS
     /**
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     //************************************************************************************
     //************************************************************************************
@@ -140,7 +140,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/updated_lagrangian_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/updated_lagrangian_element.cpp
@@ -144,8 +144,8 @@ UpdatedLagrangianElement::~UpdatedLagrangianElement()
 //************************************************************************************
 
 void UpdatedLagrangianElement::SetValuesOnIntegrationPoints( const Variable<double>& rVariable,
-        std::vector<double>& rValues,
-        const ProcessInfo& rCurrentProcessInfo )
+                                                             const std::vector<double>& rValues,
+                                                             const ProcessInfo& rCurrentProcessInfo )
 {
 
   if (rVariable == DETERMINANT_F){
@@ -178,7 +178,7 @@ void UpdatedLagrangianElement::SetValuesOnIntegrationPoints( const Variable<doub
 //************************************************************************************
 
 
-void UpdatedLagrangianElement::GetValueOnIntegrationPoints( const Variable<double>& rVariable,
+void UpdatedLagrangianElement::CalculateOnIntegrationPoints( const Variable<double>& rVariable,
         std::vector<double>& rValues,
         const ProcessInfo& rCurrentProcessInfo )
 {
@@ -198,7 +198,7 @@ void UpdatedLagrangianElement::GetValueOnIntegrationPoints( const Variable<doubl
   }
   else{
 
-    LargeDisplacementElement::GetValueOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
+    LargeDisplacementElement::CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
 
   }
 
@@ -210,11 +210,11 @@ void UpdatedLagrangianElement::GetValueOnIntegrationPoints( const Variable<doubl
 //************************************************************************************
 
 
-void UpdatedLagrangianElement::Initialize()
+void UpdatedLagrangianElement::Initialize( const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
-    LargeDisplacementElement::Initialize();
+    LargeDisplacementElement::Initialize(rCurrentProcessInfo);
 
     SizeType integration_points_number = GetGeometry().IntegrationPointsNumber( mThisIntegrationMethod );
     const SizeType dimension        = GetGeometry().WorkingSpaceDimension();
@@ -456,7 +456,7 @@ double& UpdatedLagrangianElement::CalculateVolumeChange( double& rVolumeChange, 
 //************************************************************************************
 //************************************************************************************
 
-int UpdatedLagrangianElement::Check( const ProcessInfo& rCurrentProcessInfo )
+int UpdatedLagrangianElement::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
@@ -483,7 +483,7 @@ int UpdatedLagrangianElement::Check( const ProcessInfo& rCurrentProcessInfo )
     for(SizeType i=0; i<this->GetGeometry().size(); ++i)
       {
 	// Nodal data
-	Node<3> &rNode = this->GetGeometry()[i];
+	const Node<3> &rNode = this->GetGeometry()[i];
 	KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISPLACEMENT,rNode);
 	//KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VOLUME_ACCELERATION,rNode);
 

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/updated_lagrangian_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/updated_lagrangian_element.hpp
@@ -126,7 +126,7 @@ public:
     /**
      * Get on rVariable a double Value from the Element Constitutive Law
      */
-    void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
 
 
@@ -136,7 +136,7 @@ public:
       * Called to initialize the element.
       * Must be called before any calculation is done
       */
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     //************************************************************************************
     //************************************************************************************
@@ -147,7 +147,7 @@ public:
      * or that no common error is found.
      * @param rCurrentProcessInfo
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/updated_lagrangian_segregated_V_P_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/updated_lagrangian_segregated_V_P_element.cpp
@@ -159,7 +159,7 @@ void UpdatedLagrangianSegregatedVPElement::SetValuesOnIntegrationPoints( const V
 //************************************************************************************
 
 
-void UpdatedLagrangianSegregatedVPElement::GetValueOnIntegrationPoints( const Variable<double>& rVariable,
+void UpdatedLagrangianSegregatedVPElement::CalculateOnIntegrationPoints( const Variable<double>& rVariable,
                                                                         std::vector<double>& rValues,
                                                                         const ProcessInfo& rCurrentProcessInfo )
 {
@@ -179,7 +179,7 @@ void UpdatedLagrangianSegregatedVPElement::GetValueOnIntegrationPoints( const Va
   }
   else{
 
-    LargeDisplacementSegregatedVPElement::GetValueOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
+    LargeDisplacementSegregatedVPElement::CalculateOnIntegrationPoints( rVariable, rValues, rCurrentProcessInfo );
 
   }
 
@@ -188,11 +188,11 @@ void UpdatedLagrangianSegregatedVPElement::GetValueOnIntegrationPoints( const Va
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianSegregatedVPElement::Initialize()
+void UpdatedLagrangianSegregatedVPElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
-    LargeDisplacementSegregatedVPElement::Initialize();
+    LargeDisplacementSegregatedVPElement::Initialize(rCurrentProcessInfo);
 
     SizeType integration_points_number = GetGeometry().IntegrationPointsNumber( mThisIntegrationMethod );
     const SizeType dimension        = GetGeometry().WorkingSpaceDimension();
@@ -944,7 +944,7 @@ double& UpdatedLagrangianSegregatedVPElement::CalculateVolumeChange( double& rVo
 //************************************************************************************
 //************************************************************************************
 
-int  UpdatedLagrangianSegregatedVPElement::Check( const ProcessInfo& rCurrentProcessInfo )
+int  UpdatedLagrangianSegregatedVPElement::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
   KRATOS_TRY
 
@@ -968,7 +968,7 @@ int  UpdatedLagrangianSegregatedVPElement::Check( const ProcessInfo& rCurrentPro
   for(SizeType i=0; i<this->GetGeometry().size(); ++i)
   {
     // Nodal data
-    Node<3> &rNode = this->GetGeometry()[i];
+    const Node<3> &rNode = this->GetGeometry()[i];
     KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(PRESSURE,rNode);
     KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(PRESSURE_VELOCITY,rNode);
     KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(PRESSURE_ACCELERATION,rNode);

--- a/applications/SolidMechanicsApplication/custom_elements/solid_elements/updated_lagrangian_segregated_V_P_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/solid_elements/updated_lagrangian_segregated_V_P_element.hpp
@@ -126,14 +126,14 @@ public:
   /**
    * Get on rVariable a double Value from the Element Constitutive Law
    */
-  void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
   //************* STARTING - ENDING  METHODS
   /**
    * Called to initialize the element.
    * Must be called before any calculation is done
    */
-  void Initialize() override;
+  void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
   //************************************************************************************
   //************************************************************************************
@@ -144,7 +144,7 @@ public:
    * or that no common error is found.
    * @param rCurrentProcessInfo
    */
-  int Check(const ProcessInfo& rCurrentProcessInfo) override;
+  int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
   ///@}
   ///@name Access

--- a/applications/SolidMechanicsApplication/custom_elements/thermal_elements/thermal_element.cpp
+++ b/applications/SolidMechanicsApplication/custom_elements/thermal_elements/thermal_element.cpp
@@ -93,7 +93,7 @@ ThermalElement::IntegrationMethod ThermalElement::GetIntegrationMethod() const
 //************************************************************************************
 //************************************************************************************
 
-void ThermalElement::GetDofList( DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo )
+void ThermalElement::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo ) const
 {
     rElementalDofList.resize( 0 );
 
@@ -107,7 +107,7 @@ void ThermalElement::GetDofList( DofsVectorType& rElementalDofList, ProcessInfo&
 //************************************************************************************
 //************************************************************************************
 
-void ThermalElement::EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo )
+void ThermalElement::EquationIdVector( EquationIdVectorType& rResult,const  ProcessInfo& rCurrentProcessInfo ) const
 {
     unsigned int number_of_nodes  = GetGeometry().size();
 
@@ -205,47 +205,13 @@ void ThermalElement::SetValuesOnIntegrationPoints( const Variable<Matrix>& rVari
     KRATOS_CATCH( "" )
 }
 
-//*********************************GET DOUBLE VALUE***********************************
-//************************************************************************************
 
-void ThermalElement::GetValueOnIntegrationPoints( const Variable<double>& rVariable,
-                                                  std::vector<double>& rValues,
-                                                  const ProcessInfo& rCurrentProcessInfo )
-{
-    KRATOS_TRY
-
-    KRATOS_CATCH( "" )
-}
-
-//**********************************GET VECTOR VALUE**********************************
-//************************************************************************************
-
-void ThermalElement::GetValueOnIntegrationPoints( const Variable<Vector>& rVariable,
-                                                  std::vector<Vector>& rValues,
-                                                  const ProcessInfo& rCurrentProcessInfo )
-{
-    KRATOS_TRY
-
-    KRATOS_CATCH( "" )
-}
-
-//***********************************GET MATRIX VALUE*********************************
-//************************************************************************************
-
-void ThermalElement::GetValueOnIntegrationPoints( const Variable<Matrix>& rVariable,
-                                                  std::vector<Matrix>& rValues,
-                                                  const ProcessInfo& rCurrentProcessInfo )
-{
-    KRATOS_TRY
-
-    KRATOS_CATCH( "" )
-}
 
 //************* STARTING - ENDING  METHODS
 //************************************************************************************
 //************************************************************************************
 
-void ThermalElement::Initialize()
+void ThermalElement::Initialize( const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -258,7 +224,7 @@ void ThermalElement::Initialize()
 //************************************************************************************
 //************************************************************************************
 
-void ThermalElement::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void ThermalElement::InitializeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -270,7 +236,7 @@ void ThermalElement::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo )
 //************************************************************************************
 //************************************************************************************
 
-void ThermalElement::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void ThermalElement::FinalizeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -441,7 +407,7 @@ void ThermalElement::InitializeSystemMatrices(MatrixType& rLeftHandSideMatrix,
 
 void ThermalElement::CalculateElementalSystem( MatrixType& rLeftHandSideMatrix,
 					       VectorType& rRightHandSideVector,
-					       ProcessInfo& rCurrentProcessInfo,
+					       const ProcessInfo& rCurrentProcessInfo,
 					       Flags& rCalculationFlags )
 {
     KRATOS_TRY
@@ -468,7 +434,7 @@ void ThermalElement::CalculateElementalSystem( MatrixType& rLeftHandSideMatrix,
 
       MechanicalElement.CalculateOnIntegrationPoints(CAUCHY_STRESS_VECTOR, StressVector, rCurrentProcessInfo);
 
-      MechanicalElement.GetValueOnIntegrationPoints(CONSTITUTIVE_LAW, ConstitutiveLawVector, rCurrentProcessInfo);
+      MechanicalElement.CalculateOnIntegrationPoints(CONSTITUTIVE_LAW, ConstitutiveLawVector, rCurrentProcessInfo);
 
     }
     else {
@@ -591,7 +557,7 @@ void ThermalElement::CalculateAndAddRHS(VectorType& rRightHandSideVector, Genera
 //************************************************************************************
 //************************************************************************************
 
-void ThermalElement::CalculateRightHandSide( VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void ThermalElement::CalculateRightHandSide( VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
     //calculation flags
     Flags CalculationFlags;
@@ -612,7 +578,7 @@ void ThermalElement::CalculateRightHandSide( VectorType& rRightHandSideVector, P
 //************************************************************************************
 
 
-void ThermalElement::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo )
+void ThermalElement::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     //calculation flags
     Flags CalculationFlags;
@@ -632,7 +598,7 @@ void ThermalElement::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, Pro
 //************************************************************************************
 
 
-void ThermalElement::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void ThermalElement::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
 
     //calculation flags
@@ -652,7 +618,7 @@ void ThermalElement::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, Vect
 //************************************************************************************
 //************************************************************************************
 
-void ThermalElement::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo )
+void ThermalElement::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -662,7 +628,7 @@ void ThermalElement::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& 
 //************************************************************************************
 //************************************************************************************
 
-void ThermalElement::CalculateDampingMatrix( MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo )
+void ThermalElement::CalculateDampingMatrix( MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -917,7 +883,7 @@ void ThermalElement::CalculateOnIntegrationPoints( const Variable<Matrix >& rVar
  * or that no common error is found.
  * @param rCurrentProcessInfo
  */
-int  ThermalElement::Check( const ProcessInfo& rCurrentProcessInfo )
+int  ThermalElement::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
      KRATOS_TRY
 

--- a/applications/SolidMechanicsApplication/custom_elements/thermal_elements/thermal_element.hpp
+++ b/applications/SolidMechanicsApplication/custom_elements/thermal_elements/thermal_element.hpp
@@ -189,12 +189,12 @@ class KRATOS_API(SOLID_MECHANICS_APPLICATION) ThermalElement
   /**
    * Sets on rElementalDofList the degrees of freedom of the considered element geometry
    */
-  void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
+  void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
   /**
    * Sets on rResult the ID's of the element degrees of freedom
    */
-  void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+  void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
   /**
    * Sets on rValues the nodal displacements
@@ -241,42 +241,25 @@ class KRATOS_API(SOLID_MECHANICS_APPLICATION) ThermalElement
   void SetValuesOnIntegrationPoints(const Variable<Matrix>& rVariable, const std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
 
-  //GET:
-  /**
-   * Get on rVariable a double Value from the Element Constitutive Law
-   */
-  void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-  /**
-   * Get on rVariable a Vector Value from the Element Constitutive Law
-   */
-  void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-  /**
-   * Get on rVariable a Matrix Value from the Element Constitutive Law
-   */
-  void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-
   //************* STARTING - ENDING  METHODS
 
   /**
    * Called to initialize the element.
    * Must be called before any calculation is done
    */
-  void Initialize() override;
+  void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
 
   /**
    * Called at the beginning of each solution step
    */
-  void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+  void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 
   /**
    * Called at the end of each solution step
    */
-  void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+  void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 
 
@@ -291,7 +274,7 @@ class KRATOS_API(SOLID_MECHANICS_APPLICATION) ThermalElement
    * @param rCurrentProcessInfo: the current process info instance
    */
 
-  void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * this is called during the assembling process in order
@@ -299,7 +282,7 @@ class KRATOS_API(SOLID_MECHANICS_APPLICATION) ThermalElement
    * @param rRightHandSideVector: the elemental right hand side vector
    * @param rCurrentProcessInfo: the current process info instance
    */
-  void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * this is called during the assembling process in order
@@ -307,7 +290,7 @@ class KRATOS_API(SOLID_MECHANICS_APPLICATION) ThermalElement
    * @param rLeftHandSideVector: the elemental left hand side vector
    * @param rCurrentProcessInfo: the current process info instance
    */
-  void CalculateLeftHandSide (MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateLeftHandSide (MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * this is called during the assembling process in order
@@ -315,7 +298,7 @@ class KRATOS_API(SOLID_MECHANICS_APPLICATION) ThermalElement
    * @param rMassMatrix: the elemental mass matrix
    * @param rCurrentProcessInfo: the current process info instance
    */
-  void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
   /**
    * this is called during the assembling process in order
@@ -323,7 +306,7 @@ class KRATOS_API(SOLID_MECHANICS_APPLICATION) ThermalElement
    * @param rDampingMatrix: the elemental damping matrix
    * @param rCurrentProcessInfo: the current process info instance
    */
-  void CalculateDampingMatrix(MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo) override;
+  void CalculateDampingMatrix(MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
 
   //on integration points:
@@ -352,7 +335,7 @@ class KRATOS_API(SOLID_MECHANICS_APPLICATION) ThermalElement
    * or that no common error is found.
    * @param rCurrentProcessInfo
    */
-  int Check(const ProcessInfo& rCurrentProcessInfo) override;
+  int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
   //std::string Info() const;
 
@@ -406,7 +389,7 @@ class KRATOS_API(SOLID_MECHANICS_APPLICATION) ThermalElement
    */
   virtual void CalculateElementalSystem(MatrixType& rLeftHandSideMatrix,
                                         VectorType& rRightHandSideVector,
-                                        ProcessInfo& rCurrentProcessInfo,
+                                        const ProcessInfo& rCurrentProcessInfo,
                                         Flags & rCalculationFlags);
   ///@}
   ///@name Protected Operations

--- a/applications/SolidMechanicsApplication/custom_solvers/solution_builders_and_solvers/block_builder_and_solver.hpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/solution_builders_and_solvers/block_builder_and_solver.hpp
@@ -206,7 +206,7 @@ class BlockBuilderAndSolver : public SolutionBuilderAndSolver< TSparseSpace, TDe
     Element::EquationIdVectorType EquationId;
 
     // assemble all elements
-    double start_build = OpenMPUtils::GetCurrentTime();
+    // double start_build = OpenMPUtils::GetCurrentTime();
 
 #pragma omp parallel firstprivate(nelements,nconditions, LHS_Contribution, RHS_Contribution, EquationId )
     {
@@ -269,13 +269,13 @@ class BlockBuilderAndSolver : public SolutionBuilderAndSolver< TSparseSpace, TDe
       }
     }
 
-    double stop_build = OpenMPUtils::GetCurrentTime();
-    if (this->mEchoLevel > 2 && rModelPart.GetCommunicator().MyPID() == 0)
-      KRATOS_INFO("parallel_build_time") << stop_build - start_build << std::endl;
+    // double stop_build = OpenMPUtils::GetCurrentTime();
+    // if (this->mEchoLevel > 2 && rModelPart.GetCommunicator().MyPID() == 0)
+    //   KRATOS_INFO("parallel_build_time") << stop_build - start_build << std::endl;
 
-    if (this->mEchoLevel > 2 && rModelPart.GetCommunicator().MyPID() == 0){
-      KRATOS_INFO("parallel_build") << "finished" << std::endl;
-    }
+    // if (this->mEchoLevel > 2 && rModelPart.GetCommunicator().MyPID() == 0){
+    //   KRATOS_INFO("parallel_build") << "finished" << std::endl;
+    // }
 
     KRATOS_CATCH("")
 
@@ -325,12 +325,12 @@ class BlockBuilderAndSolver : public SolutionBuilderAndSolver< TSparseSpace, TDe
   {
     KRATOS_TRY
 
-    double begin_time = OpenMPUtils::GetCurrentTime();
+    // double begin_time = OpenMPUtils::GetCurrentTime();
     Build(pScheme, rModelPart, rA, rb);
-    double end_time = OpenMPUtils::GetCurrentTime();
+    // double end_time = OpenMPUtils::GetCurrentTime();
 
-    if (this->mEchoLevel > 1 && rModelPart.GetCommunicator().MyPID() == 0)
-      KRATOS_INFO("system_build_time") << end_time - begin_time << std::endl;
+    // if (this->mEchoLevel > 1 && rModelPart.GetCommunicator().MyPID() == 0)
+    //   KRATOS_INFO("system_build_time") << end_time - begin_time << std::endl;
 
     ApplyDirichletConditions(pScheme, rModelPart, rA, rDx, rb);
 
@@ -341,13 +341,13 @@ class BlockBuilderAndSolver : public SolutionBuilderAndSolver< TSparseSpace, TDe
       KRATOS_INFO("RHS before solve") << "Vector = " << rb << std::endl;
     }
 
-    begin_time = OpenMPUtils::GetCurrentTime();
+    // begin_time = OpenMPUtils::GetCurrentTime();
     SystemSolveWithPhysics(rA, rDx, rb, rModelPart);
-    end_time = OpenMPUtils::GetCurrentTime();
+    // end_time = OpenMPUtils::GetCurrentTime();
 
 
-    if (this->mEchoLevel > 1 && rModelPart.GetCommunicator().MyPID() == 0)
-      KRATOS_INFO("system_solve_time") << end_time - begin_time << std::endl;
+    // if (this->mEchoLevel > 1 && rModelPart.GetCommunicator().MyPID() == 0)
+    //   KRATOS_INFO("system_solve_time") << end_time - begin_time << std::endl;
 
     if (this->mEchoLevel == 3)
     {
@@ -483,7 +483,7 @@ class BlockBuilderAndSolver : public SolutionBuilderAndSolver< TSparseSpace, TDe
 
     ProcessInfo& rCurrentProcessInfo = rModelPart.GetProcessInfo();
 
-    unsigned int nthreads = OpenMPUtils::GetNumThreads();
+    unsigned int nthreads = ParallelUtilities::GetNumThreads();
 
 #ifdef USE_GOOGLE_HASH
     typedef google::dense_hash_set < Node<3>::DofType::Pointer, dof_iterator_hash>  set_type;
@@ -918,7 +918,7 @@ class BlockBuilderAndSolver : public SolutionBuilderAndSolver< TSparseSpace, TDe
                                         ProcessInfo& rCurrentProcessInfo)
   {
     //filling with zero the matrix (creating the structure)
-    double begin_time = OpenMPUtils::GetCurrentTime();
+    // double begin_time = OpenMPUtils::GetCurrentTime();
 
     const std::size_t equation_size = this->mEquationSystemSize;
 
@@ -1019,9 +1019,9 @@ class BlockBuilderAndSolver : public SolutionBuilderAndSolver< TSparseSpace, TDe
 
     rA.set_filled(indices.size()+1, nnz);
 
-    double end_time = OpenMPUtils::GetCurrentTime();
-    if (this->mEchoLevel >= 2)
-      KRATOS_INFO("BlockBuilderAndSolver") << "construct matrix structure time:" << end_time - begin_time << "\n" << LoggerMessage::Category::STATISTICS;
+    // double end_time = OpenMPUtils::GetCurrentTime();
+    // if (this->mEchoLevel >= 2)
+    //   KRATOS_INFO("BlockBuilderAndSolver") << "construct matrix structure time:" << end_time - begin_time << "\n" << LoggerMessage::Category::STATISTICS;
 
   }
 

--- a/applications/SolidMechanicsApplication/custom_solvers/solution_builders_and_solvers/reduction_builder_and_solver.hpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/solution_builders_and_solvers/reduction_builder_and_solver.hpp
@@ -296,7 +296,7 @@ class ReductionBuilderAndSolver : public SolutionBuilderAndSolver< TSparseSpace,
     Element::EquationIdVectorType EquationId;
 
     // assemble all elements
-    double start_build = OpenMPUtils::GetCurrentTime();
+    // double start_build = OpenMPUtils::GetCurrentTime();
 
 #pragma omp parallel firstprivate(nelements, nconditions,  LHS_Contribution, RHS_Contribution, EquationId )
     {
@@ -357,9 +357,9 @@ class ReductionBuilderAndSolver : public SolutionBuilderAndSolver< TSparseSpace,
       }
     }
 
-    double stop_build = OpenMPUtils::GetCurrentTime();
-    if (this->mEchoLevel > 2 && rModelPart.GetCommunicator().MyPID() == 0)
-      KRATOS_INFO("parallel_build_time") << stop_build - start_build << std::endl;
+    // double stop_build = OpenMPUtils::GetCurrentTime();
+    // if (this->mEchoLevel > 2 && rModelPart.GetCommunicator().MyPID() == 0)
+    //   KRATOS_INFO("parallel_build_time") << stop_build - start_build << std::endl;
 
     if (this->mEchoLevel > 2 && rModelPart.GetCommunicator().MyPID() == 0){
       KRATOS_INFO("parallel_build") << "finished" << std::endl;
@@ -414,12 +414,12 @@ class ReductionBuilderAndSolver : public SolutionBuilderAndSolver< TSparseSpace,
   {
     KRATOS_TRY
 
-    double begin_time = OpenMPUtils::GetCurrentTime();
+    // double begin_time = OpenMPUtils::GetCurrentTime();
     Build(pScheme, rModelPart, rA, rb);
-    double end_time = OpenMPUtils::GetCurrentTime();
+    // double end_time = OpenMPUtils::GetCurrentTime();
 
-    if (this->mEchoLevel > 1 && rModelPart.GetCommunicator().MyPID() == 0)
-      KRATOS_INFO("system_build_time") << end_time - begin_time << std::endl;
+    // if (this->mEchoLevel > 1 && rModelPart.GetCommunicator().MyPID() == 0)
+    //   KRATOS_INFO("system_build_time") << end_time - begin_time << std::endl;
 
     ApplyDirichletConditions(pScheme, rModelPart, rA, rDx, rb);
 
@@ -430,13 +430,13 @@ class ReductionBuilderAndSolver : public SolutionBuilderAndSolver< TSparseSpace,
       KRATOS_INFO("RHS before solve") << "Vector = " << rb << std::endl;
     }
 
-    begin_time = OpenMPUtils::GetCurrentTime();
+    // begin_time = OpenMPUtils::GetCurrentTime();
     SystemSolveWithPhysics(rA, rDx, rb, rModelPart);
-    end_time = OpenMPUtils::GetCurrentTime();
+    // end_time = OpenMPUtils::GetCurrentTime();
 
 
-    if (this->mEchoLevel > 1 && rModelPart.GetCommunicator().MyPID() == 0)
-      KRATOS_INFO("system_solve_time") << end_time - begin_time << std::endl;
+    // if (this->mEchoLevel > 1 && rModelPart.GetCommunicator().MyPID() == 0)
+    //   KRATOS_INFO("system_solve_time") << end_time - begin_time << std::endl;
 
     if (this->mEchoLevel == 3)
     {
@@ -504,7 +504,7 @@ class ReductionBuilderAndSolver : public SolutionBuilderAndSolver< TSparseSpace,
 
     ProcessInfo& rCurrentProcessInfo = rModelPart.GetProcessInfo();
 
-    unsigned int nthreads = OpenMPUtils::GetNumThreads();
+    unsigned int nthreads = ParallelUtilities::GetNumThreads();
 
 #ifdef USE_GOOGLE_HASH
     typedef google::dense_hash_set < Node<3>::DofType::Pointer, dof_iterator_hash>  set_type;
@@ -948,7 +948,7 @@ class ReductionBuilderAndSolver : public SolutionBuilderAndSolver< TSparseSpace,
                                         ProcessInfo& rCurrentProcessInfo)
   {
     //filling with zero the matrix (creating the structure)
-    double begin_time = OpenMPUtils::GetCurrentTime();
+    // double begin_time = OpenMPUtils::GetCurrentTime();
 
     const std::size_t equation_size = this->mEquationSystemSize;
 
@@ -1063,9 +1063,9 @@ class ReductionBuilderAndSolver : public SolutionBuilderAndSolver< TSparseSpace,
 
     rA.set_filled(indices.size() + 1, nnz);
 
-    double end_time = OpenMPUtils::GetCurrentTime();
-    if (this->mEchoLevel >= 2)
-      KRATOS_INFO("BlockBuilderAndSolver") << "construct matrix structure time:" << end_time - begin_time << "\n" << LoggerMessage::Category::STATISTICS;
+    // double end_time = OpenMPUtils::GetCurrentTime();
+    // if (this->mEchoLevel >= 2)
+    //   KRATOS_INFO("BlockBuilderAndSolver") << "construct matrix structure time:" << end_time - begin_time << "\n" << LoggerMessage::Category::STATISTICS;
 
   }
 

--- a/applications/SolidMechanicsApplication/custom_solvers/solution_schemes/dynamic_scheme.hpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/solution_schemes/dynamic_scheme.hpp
@@ -167,7 +167,7 @@ namespace Kratos
 	DerivedType::Initialize(rModelPart);
 
 	// Allocate auxiliary memory
-	const unsigned int NumThreads = OpenMPUtils::GetNumThreads();
+	const unsigned int NumThreads = ParallelUtilities::GetNumThreads();
 
 	mMatrix.M.resize(NumThreads);
 	mMatrix.D.resize(NumThreads);

--- a/applications/SolidMechanicsApplication/custom_solvers/solution_schemes/explicit_central_differences_scheme.hpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/solution_schemes/explicit_central_differences_scheme.hpp
@@ -103,7 +103,7 @@ namespace Kratos
       mDeltaTime.Fraction         = rDeltaTimeFraction;
 
       // Allocate auxiliary memory
-      const unsigned int NumThreads = OpenMPUtils::GetNumThreads();
+      const unsigned int NumThreads = ParallelUtilities::GetNumThreads();
 
       mMatrix.resize(NumThreads);
       mVector.resize(NumThreads);
@@ -215,7 +215,7 @@ namespace Kratos
       mTime.Delta     = rCurrentProcessInfo[DELTA_TIME];
       mTime.Middle    = 0.5 * ( mTime.Previous + mTime.Current );
 
-      const unsigned int NumThreads = OpenMPUtils::GetNumThreads();
+      const unsigned int NumThreads = ParallelUtilities::GetNumThreads();
 
       OpenMPUtils::PartitionVector NodePartition;
       OpenMPUtils::DivideInPartitions(rModelPart.Nodes().size(), NumThreads, NodePartition);
@@ -457,7 +457,7 @@ namespace Kratos
     {
       KRATOS_TRY
 
-      const unsigned int NumThreads = OpenMPUtils::GetNumThreads();
+      const unsigned int NumThreads = ParallelUtilities::GetNumThreads();
 
       OpenMPUtils::PartitionVector NodePartition;
       OpenMPUtils::DivideInPartitions(rModelPart.Nodes().size(), NumThreads, NodePartition);
@@ -482,7 +482,7 @@ namespace Kratos
 
       ProcessInfo& rCurrentProcessInfo= rModelPart.GetProcessInfo();
 
-      const unsigned int NumThreads = OpenMPUtils::GetNumThreads();
+      const unsigned int NumThreads = ParallelUtilities::GetNumThreads();
 
       //most autors recommend a value near 0.80 (Belytschko - Nonlinear FE.. 2000. chap 6. pag. 315)
       double safety_factor     = 0.5;
@@ -553,7 +553,7 @@ namespace Kratos
     {
       KRATOS_TRY
 
-      const unsigned int NumThreads = OpenMPUtils::GetNumThreads();
+      const unsigned int NumThreads = ParallelUtilities::GetNumThreads();
 
       OpenMPUtils::PartitionVector NodePartition;
       OpenMPUtils::DivideInPartitions(rModelPart.Nodes().size(), NumThreads, NodePartition);
@@ -584,7 +584,7 @@ namespace Kratos
     {
       KRATOS_TRY
 
-      const unsigned int NumThreads = OpenMPUtils::GetNumThreads();
+      const unsigned int NumThreads = ParallelUtilities::GetNumThreads();
 
       OpenMPUtils::PartitionVector NodePartition;
       OpenMPUtils::DivideInPartitions(rModelPart.Nodes().size(), NumThreads, NodePartition);
@@ -822,4 +822,3 @@ namespace Kratos
 }  //namespace Kratos.
 
 #endif // KRATOS_EXPLICIT_CENTRAL_DIFFERENCES_SCHEME_H_INCLUDED  defined
-

--- a/applications/SolidMechanicsApplication/custom_solvers/solution_schemes/explicit_hamilton_scheme.hpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/solution_schemes/explicit_hamilton_scheme.hpp
@@ -111,7 +111,7 @@ namespace Kratos
       mRayleighDamping            = rRayleighDamping;
 
       //Allocate auxiliary memory
-      int NumThreads = OpenMPUtils::GetNumThreads();
+      int NumThreads = ParallelUtilities::GetNumThreads();
 
 
       mMatrix.D.resize(NumThreads);
@@ -155,8 +155,6 @@ namespace Kratos
     virtual void Initialize(ModelPart& r_model_part)
     {
       KRATOS_TRY
-
-        mModelPart = r_model_part;
 
       if(mDeltaTime.PredictionLevel>0)
         {
@@ -297,7 +295,7 @@ namespace Kratos
         ElementsArrayType& rElements = rModelPart.Elements();
         ProcessInfo& CurrentProcessInfo = rModelPart.GetProcessInfo();
 
-        int NumThreads = OpenMPUtils::GetNumThreads();
+        int NumThreads = ParallelUtilities::GetNumThreads();
         OpenMPUtils::PartitionVector ElementPartition;
         OpenMPUtils::DivideInPartitions(rElements.size(), NumThreads, ElementPartition);
 
@@ -997,8 +995,6 @@ namespace Kratos
 
     bool                mSchemeIsInitialized;
 
-    ModelPart           mModelPart;
-
 
     TimeVariables       mTime;
     DeltaTimeParameters mDeltaTime;
@@ -1124,4 +1120,3 @@ namespace Kratos
 }  /* namespace Kratos.*/
 
 #endif /* KRATOS_EXPLICIT_HAMILTON_SCHEME_H_INCLUDED  defined */
-

--- a/applications/SolidMechanicsApplication/custom_solvers/solution_schemes/solution_scheme.hpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/solution_schemes/solution_scheme.hpp
@@ -357,7 +357,7 @@ class SolutionScheme : public Flags
   {
     KRATOS_TRY
 
-    const unsigned int NumThreads = OpenMPUtils::GetNumThreads();
+    const unsigned int NumThreads = ParallelUtilities::GetNumThreads();
 
     // Update of displacement (by DOF)
     OpenMPUtils::PartitionVector DofPartition;
@@ -391,7 +391,7 @@ class SolutionScheme : public Flags
   {
     KRATOS_TRY
 
-    const unsigned int NumThreads = OpenMPUtils::GetNumThreads();
+    const unsigned int NumThreads = ParallelUtilities::GetNumThreads();
 
     // Update of displacement (by DOF)
     OpenMPUtils::PartitionVector DofPartition;
@@ -445,7 +445,7 @@ class SolutionScheme : public Flags
     if( this->mOptions.Is(LocalFlagType::UPDATE_VARIABLES) ){
 
       // Updating time derivatives (nodally for efficiency)
-      const unsigned int NumThreads = OpenMPUtils::GetNumThreads();
+      const unsigned int NumThreads = ParallelUtilities::GetNumThreads();
       OpenMPUtils::PartitionVector NodePartition;
       OpenMPUtils::DivideInPartitions(rModelPart.Nodes().size(), NumThreads, NodePartition);
 
@@ -473,7 +473,7 @@ class SolutionScheme : public Flags
     KRATOS_TRY
 
     // Updating time derivatives (nodally for efficiency)
-    const unsigned int NumThreads = OpenMPUtils::GetNumThreads();
+    const unsigned int NumThreads = ParallelUtilities::GetNumThreads();
     OpenMPUtils::PartitionVector NodePartition;
     OpenMPUtils::DivideInPartitions(rModelPart.Nodes().size(), NumThreads, NodePartition);
 
@@ -825,7 +825,7 @@ class SolutionScheme : public Flags
       for(int i=0; i<static_cast<int>(rModelPart.Elements().size()); i++)
       {
         auto itElem = rModelPart.ElementsBegin() + i;
-        itElem->Initialize();
+        itElem->Initialize(rModelPart.GetProcessInfo());
       }
 
     this->Set(LocalFlagType::ELEMENTS_INITIALIZED, true);
@@ -852,7 +852,7 @@ class SolutionScheme : public Flags
       for(int i=0; i<static_cast<int>(rModelPart.Conditions().size()); i++)
       {
         auto itCond = rModelPart.ConditionsBegin() + i;
-        itCond->Initialize();
+        itCond->Initialize(rModelPart.GetProcessInfo());
       }
 
       this->Set(LocalFlagType::CONDITIONS_INITIALIZED, true);

--- a/applications/SolidMechanicsApplication/custom_solvers/solution_strategies/eigensolver_strategy.hpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/solution_strategies/eigensolver_strategy.hpp
@@ -427,18 +427,18 @@ class EigensolverStrategy
     //set up the system, operation performed just once unless it is required to reform the dof set at each iteration
 
     //setting up the list of the DOFs to be solved
-    double begin_time = OpenMPUtils::GetCurrentTime();
+    // double begin_time = OpenMPUtils::GetCurrentTime();
     mpBuilderAndSolver->SetUpDofSet(mpScheme, this->GetModelPart());
-    double end_time = OpenMPUtils::GetCurrentTime();
-    if (this->mEchoLevel >= 2)
-      KRATOS_INFO("setup_dofs_time") << "setup_dofs_time : " << end_time - begin_time << "\n" << LoggerMessage::Category::STATISTICS;
+    // double end_time = OpenMPUtils::GetCurrentTime();
+    // if (this->mEchoLevel >= 2)
+    //   KRATOS_INFO("setup_dofs_time") << "setup_dofs_time : " << end_time - begin_time << "\n" << LoggerMessage::Category::STATISTICS;
 
     //shaping correctly the system
-    begin_time = OpenMPUtils::GetCurrentTime();
+    // begin_time = OpenMPUtils::GetCurrentTime();
     mpBuilderAndSolver->SetUpSystem();
-    end_time = OpenMPUtils::GetCurrentTime();
-    if (this->mEchoLevel >= 2)
-      KRATOS_INFO("setup_system_time") << ": setup_system_time : " << end_time - begin_time << "\n" << LoggerMessage::Category::STATISTICS;
+    // end_time = OpenMPUtils::GetCurrentTime();
+    // if (this->mEchoLevel >= 2)
+    //   KRATOS_INFO("setup_system_time") << ": setup_system_time : " << end_time - begin_time << "\n" << LoggerMessage::Category::STATISTICS;
 
     KRATOS_CATCH("")
   }

--- a/applications/SolidMechanicsApplication/custom_solvers/solution_strategies/linear_strategy.hpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/solution_strategies/linear_strategy.hpp
@@ -181,12 +181,12 @@ class LinearStrategy : public SolutionStrategy<TSparseSpace, TDenseSpace, TLinea
     }
 
     //setting up the vectors involved to the correct size
-    double begin_time = OpenMPUtils::GetCurrentTime();
-    mpBuilderAndSolver->SetUpSystemMatrices(mpScheme, this->GetModelPart(), mpA, mpDx, mpb);
-    double end_time = OpenMPUtils::GetCurrentTime();
+    // // double begin_time = OpenMPUtils::GetCurrentTime();
+    // mpBuilderAndSolver->SetUpSystemMatrices(mpScheme, this->GetModelPart(), mpA, mpDx, mpb);
+    // double end_time = OpenMPUtils::GetCurrentTime();
 
-    if (this->mEchoLevel >= 2)
-      KRATOS_INFO("system_resize_time") << ": system_resize_time : " << end_time - begin_time << "\n" << LoggerMessage::Category::STATISTICS;
+    // if (this->mEchoLevel >= 2)
+    //   KRATOS_INFO("system_resize_time") << ": system_resize_time : " << end_time - begin_time << "\n" << LoggerMessage::Category::STATISTICS;
 
     //initial operations ... things that are constant over the Solution Step
     mpBuilderAndSolver->InitializeSolutionStep(mpScheme, this->GetModelPart(), mpA, mpDx, mpb);
@@ -503,18 +503,18 @@ class LinearStrategy : public SolutionStrategy<TSparseSpace, TDenseSpace, TLinea
     //set up the system, operation performed just once unless it is required to reform the dof set at each iteration
 
     //setting up the list of the DOFs to be solved
-    double begin_time = OpenMPUtils::GetCurrentTime();
+    // double begin_time = OpenMPUtils::GetCurrentTime();
     mpBuilderAndSolver->SetUpDofSet(mpScheme, this->GetModelPart());
-    double end_time = OpenMPUtils::GetCurrentTime();
-    if (this->mEchoLevel >= 2)
-      KRATOS_INFO("setup_dofs_time") << "setup_dofs_time : " << end_time - begin_time << "\n" << LoggerMessage::Category::STATISTICS;
+    // double end_time = OpenMPUtils::GetCurrentTime();
+    // if (this->mEchoLevel >= 2)
+    //   KRATOS_INFO("setup_dofs_time") << "setup_dofs_time : " << end_time - begin_time << "\n" << LoggerMessage::Category::STATISTICS;
 
     //shaping correctly the system
-    begin_time = OpenMPUtils::GetCurrentTime();
+    // begin_time = OpenMPUtils::GetCurrentTime();
     mpBuilderAndSolver->SetUpSystem();
-    end_time = OpenMPUtils::GetCurrentTime();
-    if (this->mEchoLevel >= 2)
-      KRATOS_INFO("setup_system_time") << ": setup_system_time : " << end_time - begin_time << "\n" << LoggerMessage::Category::STATISTICS;    //set up the system, operation performed just once unless it is required to reform the dof set at each iteration
+    // end_time = OpenMPUtils::GetCurrentTime();
+    // if (this->mEchoLevel >= 2)
+    //   KRATOS_INFO("setup_system_time") << ": setup_system_time : " << end_time - begin_time << "\n" << LoggerMessage::Category::STATISTICS;    //set up the system, operation performed just once unless it is required to reform the dof set at each iteration
 
     KRATOS_CATCH("")
   }

--- a/applications/SolidMechanicsApplication/custom_utilities/shellq4_coordinate_transformation.hpp
+++ b/applications/SolidMechanicsApplication/custom_utilities/shellq4_coordinate_transformation.hpp
@@ -61,23 +61,23 @@ class ShellQ4_CoordinateTransformation
     return ShellQ4_CoordinateTransformation::Pointer( new ShellQ4_CoordinateTransformation( pGeometry ) );
   }
 
-  virtual void Initialize()
+  virtual void Initialize(const ProcessInfo& CurrentProcessInfo)
   {
   }
 
-  virtual void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo)
+  virtual void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo)
   {
   }
 
-  virtual void FinalizeSolutionStep(ProcessInfo& CurrentProcessInfo)
+  virtual void FinalizeSolutionStep(const ProcessInfo& CurrentProcessInfo)
   {
   }
 
-  virtual void InitializeNonLinearIteration(ProcessInfo& CurrentProcessInfo)
+  virtual void InitializeNonLinearIteration(const ProcessInfo& CurrentProcessInfo)
   {
   }
 
-  virtual void FinalizeNonLinearIteration(ProcessInfo& CurrentProcessInfo)
+  virtual void FinalizeNonLinearIteration(const ProcessInfo& CurrentProcessInfo)
   {
   }
 

--- a/applications/SolidMechanicsApplication/custom_utilities/shellq4_corotational_coordinate_transformation.hpp
+++ b/applications/SolidMechanicsApplication/custom_utilities/shellq4_corotational_coordinate_transformation.hpp
@@ -79,7 +79,7 @@ class ShellQ4_CorotationalCoordinateTransformation : public ShellQ4_CoordinateTr
     return ShellQ4_CorotationalCoordinateTransformation::Pointer( new ShellQ4_CorotationalCoordinateTransformation( pGeometry ) );
   }
 
-  void Initialize() override
+  void Initialize(const ProcessInfo& CurrentProcessInfo) override
   {
     KRATOS_TRY
 
@@ -107,7 +107,7 @@ class ShellQ4_CorotationalCoordinateTransformation : public ShellQ4_CoordinateTr
     KRATOS_CATCH("")
         }
 
-  void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override
+  void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo) override
   {
     for(int i = 0; i < 4; i++)
     {
@@ -116,7 +116,7 @@ class ShellQ4_CorotationalCoordinateTransformation : public ShellQ4_CoordinateTr
     }
   }
 
-  void FinalizeSolutionStep(ProcessInfo& CurrentProcessInfo) override
+  void FinalizeSolutionStep(const ProcessInfo& CurrentProcessInfo) override
   {
     for(int i = 0; i < 4; i++)
     {
@@ -125,11 +125,11 @@ class ShellQ4_CorotationalCoordinateTransformation : public ShellQ4_CoordinateTr
     }
   }
 
-  void InitializeNonLinearIteration(ProcessInfo& CurrentProcessInfo) override
+  void InitializeNonLinearIteration(const ProcessInfo& CurrentProcessInfo) override
   {
   }
 
-  void FinalizeNonLinearIteration(ProcessInfo& CurrentProcessInfo) override
+  void FinalizeNonLinearIteration(const ProcessInfo& CurrentProcessInfo) override
   {
     const GeometryType & geom = GetGeometry();
     Vector3Type incrementalRotation;

--- a/applications/SolidMechanicsApplication/custom_utilities/shellt3_coordinate_transformation.hpp
+++ b/applications/SolidMechanicsApplication/custom_utilities/shellt3_coordinate_transformation.hpp
@@ -61,23 +61,23 @@ class ShellT3_CoordinateTransformation
     return ShellT3_CoordinateTransformation::Pointer( new ShellT3_CoordinateTransformation( pGeometry ) );
   }
 
-  virtual void Initialize()
+  virtual void Initialize(const ProcessInfo& CurrentProcessInfo)
   {
   }
 
-  virtual void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo)
+  virtual void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo)
   {
   }
 
-  virtual void FinalizeSolutionStep(ProcessInfo& CurrentProcessInfo)
+  virtual void FinalizeSolutionStep(const ProcessInfo& CurrentProcessInfo)
   {
   }
 
-  virtual void InitializeNonLinearIteration(ProcessInfo& CurrentProcessInfo)
+  virtual void InitializeNonLinearIteration(const ProcessInfo& CurrentProcessInfo)
   {
   }
 
-  virtual void FinalizeNonLinearIteration(ProcessInfo& CurrentProcessInfo)
+  virtual void FinalizeNonLinearIteration(const ProcessInfo& CurrentProcessInfo)
   {
   }
 

--- a/applications/SolidMechanicsApplication/custom_utilities/shellt3_corotational_coordinate_transformation.hpp
+++ b/applications/SolidMechanicsApplication/custom_utilities/shellt3_corotational_coordinate_transformation.hpp
@@ -80,7 +80,7 @@ class ShellT3_CorotationalCoordinateTransformation : public ShellT3_CoordinateTr
     return ShellT3_CorotationalCoordinateTransformation::Pointer( new ShellT3_CorotationalCoordinateTransformation( pGeometry ) );
   }
 
-  void Initialize() override
+  void Initialize(const ProcessInfo& CurrentProcessInfo) override
   {
     KRATOS_TRY
 
@@ -108,7 +108,7 @@ class ShellT3_CorotationalCoordinateTransformation : public ShellT3_CoordinateTr
     KRATOS_CATCH("")
         }
 
-  void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override
+  void InitializeSolutionStep(const ProcessInfo& CurrentProcessInfo) override
   {
     for(int i = 0; i < 3; i++)
     {
@@ -117,7 +117,7 @@ class ShellT3_CorotationalCoordinateTransformation : public ShellT3_CoordinateTr
     }
   }
 
-  void FinalizeSolutionStep(ProcessInfo& CurrentProcessInfo) override
+  void FinalizeSolutionStep(const ProcessInfo& CurrentProcessInfo) override
   {
     for(int i = 0; i < 3; i++)
     {
@@ -126,11 +126,11 @@ class ShellT3_CorotationalCoordinateTransformation : public ShellT3_CoordinateTr
     }
   }
 
-  void InitializeNonLinearIteration(ProcessInfo& CurrentProcessInfo) override
+  void InitializeNonLinearIteration(const ProcessInfo& CurrentProcessInfo) override
   {
   }
 
-  void FinalizeNonLinearIteration(ProcessInfo& CurrentProcessInfo) override
+  void FinalizeNonLinearIteration(const ProcessInfo& CurrentProcessInfo) override
   {
     const GeometryType & geom = GetGeometry();
     Vector3Type incrementalRotation;


### PR DESCRIPTION
**Description**
Adding "const" to methods and method arguments of elements and conditions for a correct override
in SolidMechanicsApplication, ContactMechanicsApplication and PfemApplication.

**Changelog**
No new features added. Addressing errors reported in issue #8734

