### PR TITLE
[PotentialFlow] Add definition of adjoint perturbation incompressible 2d and 3d elements

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.cpp
+++ b/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.cpp
@@ -39,6 +39,8 @@ KratosCompressiblePotentialFlowApplication::KratosCompressiblePotentialFlowAppli
     mTransonicPerturbationPotentialFlowElement3D4N(0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
     mAdjointAnalyticalIncompressiblePotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
     mAdjointIncompressiblePotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+    mAdjointIncompressiblePerturbationPotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+    mAdjointIncompressiblePerturbationPotentialFlowElement3D4N(0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
     mAdjointCompressiblePotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
     mEmbeddedIncompressiblePotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
     mEmbeddedIncompressiblePotentialFlowElement3D4N(0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
@@ -48,7 +50,8 @@ KratosCompressiblePotentialFlowApplication::KratosCompressiblePotentialFlowAppli
     mAdjointEmbeddedCompressiblePotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
     mPotentialWallCondition2D2N(0, Element::GeometryType::Pointer(new Line2D2<Node<3> >(Element::GeometryType::PointsArrayType(2)))),
     mPotentialWallCondition3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
-    mAdjointPotentialWallCondition2D2N(0, Element::GeometryType::Pointer(new Line2D2<Node<3> >(Element::GeometryType::PointsArrayType(2))))
+    mAdjointPotentialWallCondition2D2N(0, Element::GeometryType::Pointer(new Line2D2<Node<3> >(Element::GeometryType::PointsArrayType(2)))),
+    mAdjointPotentialWallCondition3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3))))
   {}
 
 void KratosCompressiblePotentialFlowApplication::Register()
@@ -139,6 +142,8 @@ void KratosCompressiblePotentialFlowApplication::Register()
   KRATOS_REGISTER_ELEMENT("TransonicPerturbationPotentialFlowElement3D4N", mTransonicPerturbationPotentialFlowElement3D4N);
   KRATOS_REGISTER_ELEMENT("AdjointAnalyticalIncompressiblePotentialFlowElement2D3N", mAdjointAnalyticalIncompressiblePotentialFlowElement2D3N);
   KRATOS_REGISTER_ELEMENT("AdjointIncompressiblePotentialFlowElement2D3N", mAdjointIncompressiblePotentialFlowElement2D3N);
+  KRATOS_REGISTER_ELEMENT("AdjointIncompressiblePerturbationPotentialFlowElement2D3N", mAdjointIncompressiblePerturbationPotentialFlowElement2D3N);
+  KRATOS_REGISTER_ELEMENT("AdjointIncompressiblePerturbationPotentialFlowElement3D4N", mAdjointIncompressiblePerturbationPotentialFlowElement3D4N);
   KRATOS_REGISTER_ELEMENT("AdjointCompressiblePotentialFlowElement2D3N", mAdjointCompressiblePotentialFlowElement2D3N);
   KRATOS_REGISTER_ELEMENT("EmbeddedIncompressiblePotentialFlowElement2D3N", mEmbeddedIncompressiblePotentialFlowElement2D3N);
   KRATOS_REGISTER_ELEMENT("EmbeddedIncompressiblePotentialFlowElement3D4N", mEmbeddedIncompressiblePotentialFlowElement3D4N);
@@ -151,6 +156,7 @@ void KratosCompressiblePotentialFlowApplication::Register()
   KRATOS_REGISTER_CONDITION("PotentialWallCondition2D2N", mPotentialWallCondition2D2N);
   KRATOS_REGISTER_CONDITION("PotentialWallCondition3D3N", mPotentialWallCondition3D3N);
   KRATOS_REGISTER_CONDITION("AdjointPotentialWallCondition2D2N", mAdjointPotentialWallCondition2D2N);
+  KRATOS_REGISTER_CONDITION("AdjointPotentialWallCondition3D3N", mAdjointPotentialWallCondition3D3N);
 }
 
 }  // namespace Kratos.

--- a/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.h
+++ b/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.h
@@ -116,6 +116,8 @@ private:
     const TransonicPerturbationPotentialFlowElement<3, 4> mTransonicPerturbationPotentialFlowElement3D4N;
     const AdjointAnalyticalIncompressiblePotentialFlowElement<IncompressiblePotentialFlowElement<2, 3>> mAdjointAnalyticalIncompressiblePotentialFlowElement2D3N;
     const AdjointFiniteDifferencePotentialFlowElement<IncompressiblePotentialFlowElement<2,3>> mAdjointIncompressiblePotentialFlowElement2D3N;
+    const AdjointFiniteDifferencePotentialFlowElement<IncompressiblePerturbationPotentialFlowElement<2,3>> mAdjointIncompressiblePerturbationPotentialFlowElement2D3N;
+    const AdjointFiniteDifferencePotentialFlowElement<IncompressiblePerturbationPotentialFlowElement<3,4>> mAdjointIncompressiblePerturbationPotentialFlowElement3D4N;
     const AdjointFiniteDifferencePotentialFlowElement<CompressiblePotentialFlowElement<2,3>> mAdjointCompressiblePotentialFlowElement2D3N;
     const EmbeddedIncompressiblePotentialFlowElement<2,3> mEmbeddedIncompressiblePotentialFlowElement2D3N;
     const EmbeddedIncompressiblePotentialFlowElement<3,4> mEmbeddedIncompressiblePotentialFlowElement3D4N;
@@ -128,6 +130,7 @@ private:
     const PotentialWallCondition<2,2> mPotentialWallCondition2D2N;
     const PotentialWallCondition<3,3> mPotentialWallCondition3D3N;
     const AdjointPotentialWallCondition<PotentialWallCondition<2,2>> mAdjointPotentialWallCondition2D2N;
+    const AdjointPotentialWallCondition<PotentialWallCondition<3,3>> mAdjointPotentialWallCondition3D3N;
 
     ///@}
     ///@name Un accessible methods

--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/adjoint_potential_wall_condition.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/adjoint_potential_wall_condition.cpp
@@ -262,6 +262,7 @@ void AdjointPotentialWallCondition<TPrimalCondition>::load(Serializer& rSerializ
 }
 
 template class AdjointPotentialWallCondition<PotentialWallCondition<2,2>>;
+template class AdjointPotentialWallCondition<PotentialWallCondition<3,3>>;
 
 
 }  // namespace Kratos.

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_base_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_base_potential_flow_element.cpp
@@ -12,6 +12,7 @@
 //
 #include "compressible_potential_flow_application_variables.h"
 #include "incompressible_potential_flow_element.h"
+#include "incompressible_perturbation_potential_flow_element.h"
 #include "compressible_potential_flow_element.h"
 #include "embedded_incompressible_potential_flow_element.h"
 #include "embedded_compressible_potential_flow_element.h"
@@ -360,6 +361,8 @@ namespace Kratos
     // Template class instantiation
 
     template class AdjointBasePotentialFlowElement<IncompressiblePotentialFlowElement<2,3>>;
+    template class AdjointBasePotentialFlowElement<IncompressiblePerturbationPotentialFlowElement<2,3>>;
+    template class AdjointBasePotentialFlowElement<IncompressiblePerturbationPotentialFlowElement<3,4>>;
     template class AdjointBasePotentialFlowElement<CompressiblePotentialFlowElement<2,3>>;
     template class AdjointBasePotentialFlowElement<EmbeddedIncompressiblePotentialFlowElement<2,3>>;
     template class AdjointBasePotentialFlowElement<EmbeddedCompressiblePotentialFlowElement<2,3>>;

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_finite_difference_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_finite_difference_potential_flow_element.cpp
@@ -12,6 +12,7 @@
 //
 #include "compressible_potential_flow_application_variables.h"
 #include "incompressible_potential_flow_element.h"
+#include "incompressible_perturbation_potential_flow_element.h"
 #include "compressible_potential_flow_element.h"
 #include "embedded_incompressible_potential_flow_element.h"
 #include "embedded_compressible_potential_flow_element.h"
@@ -185,5 +186,7 @@ namespace Kratos
     template class AdjointFiniteDifferencePotentialFlowElement<CompressiblePotentialFlowElement<2,3>>;
     template class AdjointFiniteDifferencePotentialFlowElement<EmbeddedIncompressiblePotentialFlowElement<2,3>>;
     template class AdjointFiniteDifferencePotentialFlowElement<EmbeddedCompressiblePotentialFlowElement<2,3>>;
+    template class AdjointFiniteDifferencePotentialFlowElement<IncompressiblePerturbationPotentialFlowElement<2,3>>;
+    template class AdjointFiniteDifferencePotentialFlowElement<IncompressiblePerturbationPotentialFlowElement<3,4>>;
 } // namespace Kratos.
 

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_adjoint_solver.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_adjoint_solver.py
@@ -55,6 +55,16 @@ class PotentialFlowAdjointFormulation(PotentialFlowFormulation):
         self.element_name = "AdjointEmbeddedCompressiblePotentialFlowElement"
         self.condition_name = "AdjointPotentialWallCondition"
 
+    def _SetUpIncompressiblePerturbationElement(self, formulation_settings):
+        default_settings = KratosMultiphysics.Parameters(r"""{
+            "element_type": "",
+            "gradient_mode": ""
+        }""")
+        formulation_settings.ValidateAndAssignDefaults(default_settings)
+
+        self.element_name = "AdjointIncompressiblePerturbationPotentialFlowElement"
+        self.condition_name = "AdjointPotentialWallCondition"
+
 def CreateSolver(model, custom_settings):
     return PotentialFlowAdjointSolver(model, custom_settings)
 


### PR DESCRIPTION
**Description**
This just adds the definition of the adjoint elements using the incompressible pertubation elements in 2D and 3D.


**Changelog**
- Add definition of AdjointIncompressiblePerturbation elements.

