### PR TITLE
[core] Windows warning fixed. 'dllexport' instead of 'dllimport' 

### DIFF
--- a/kratos/includes/kratos_version.h
+++ b/kratos/includes/kratos_version.h
@@ -55,9 +55,9 @@ constexpr int GetMinorVersion() {
     return KRATOS_MINOR_VERSION;
 }
 
-KRATOS_API(KRATOS_VERSION) std::string GetPatchVersion();
-KRATOS_API(KRATOS_VERSION) std::string GetCommit();
-KRATOS_API(KRATOS_VERSION) std::string GetBuildType();
-KRATOS_API(KRATOS_VERSION) std::string GetVersionString();
+KRATOS_API_EXPORT std::string GetPatchVersion();
+KRATOS_API_EXPORT std::string GetCommit();
+KRATOS_API_EXPORT std::string GetBuildType();
+KRATOS_API_EXPORT std::string GetVersionString();
 
 } // namespace Kratos


### PR DESCRIPTION
**Description**
Just trying to get rid of a warning in Windows. It has been there for very long and maybe it was there for a reason. I ignore it, so I tried. The expansion of the macro was leading to 'import' when it should in principle be 'export'. I hope it does not break the Mac or Linux distribution.


