### PR TITLE
Shape opt opt utils

### DIFF
--- a/applications/ShapeOptimizationApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/ShapeOptimizationApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -72,28 +72,27 @@ inline void InverseMapScalar(TMapper& mapper,
     mapper.InverseMap(origin_variable, destination_variable);
 }
 
-inline double ComputeL2NormScalar(OptimizationUtilities& utils, ModelPart& rModelPart, const Variable< double >& variable)
+inline double ComputeL2NormScalar(ModelPart& rModelPart, const Variable< double >& variable)
 {
-    return utils.ComputeL2NormOfNodalVariable(rModelPart, variable);
+    return OptimizationUtilities::ComputeL2NormOfNodalVariable(rModelPart, variable);
 }
 
-inline double ComputeL2NormVector(OptimizationUtilities& utils, ModelPart& rModelPart, const Variable< array_1d<double, 3> >& variable)
+inline double ComputeL2NormVector(ModelPart& rModelPart, const Variable< array_1d<double, 3> >& variable)
 {
-    return utils.ComputeL2NormOfNodalVariable(rModelPart, variable);
+    return OptimizationUtilities::ComputeL2NormOfNodalVariable(rModelPart, variable);
 }
 
-inline double ComputeMaxNormScalar(OptimizationUtilities& utils, ModelPart& rModelPart, const Variable< double >& variable)
+inline double ComputeMaxNormScalar( ModelPart& rModelPart, const Variable< double >& variable)
 {
-    return utils.ComputeMaxNormOfNodalVariable(rModelPart, variable);
+    return OptimizationUtilities::ComputeMaxNormOfNodalVariable(rModelPart, variable);
 }
 
-inline double ComputeMaxNormVector(OptimizationUtilities& utils, ModelPart& rModelPart, const Variable< array_1d<double, 3> >& variable)
+inline double ComputeMaxNormVector(ModelPart& rModelPart, const Variable< array_1d<double, 3> >& variable)
 {
-    return utils.ComputeMaxNormOfNodalVariable(rModelPart, variable);
+    return OptimizationUtilities::ComputeMaxNormOfNodalVariable(rModelPart, variable);
 }
 
 inline void AssembleMatrixForVariableList(
-    OptimizationUtilities& utils,
     ModelPart& rModelPart,
     Matrix& rMatrix,
     pybind11::list& rVariables)
@@ -104,7 +103,7 @@ inline void AssembleMatrixForVariableList(
     {
         variables_vector[i] = (rVariables[i]).cast<Variable<OptimizationUtilities::array_3d>*>();
     }
-    return utils.AssembleMatrix(rModelPart, rMatrix, variables_vector);
+    return OptimizationUtilities::AssembleMatrix(rModelPart, rMatrix, variables_vector);
 }
 
 // ==============================================================================
@@ -168,25 +167,25 @@ void  AddCustomUtilitiesToPython(pybind11::module& m)
         // ----------------------------------------------------------------
         // For running unconstrained descent methods
         // ----------------------------------------------------------------
-        .def("ComputeSearchDirectionSteepestDescent", &OptimizationUtilities::ComputeSearchDirectionSteepestDescent)
+        .def_static("ComputeSearchDirectionSteepestDescent", &OptimizationUtilities::ComputeSearchDirectionSteepestDescent)
         // ----------------------------------------------------------------
         // For running penalized projection method
         // ----------------------------------------------------------------
-        .def("ComputeProjectedSearchDirection", &OptimizationUtilities::ComputeProjectedSearchDirection)
-        .def("CorrectProjectedSearchDirection", &OptimizationUtilities::CorrectProjectedSearchDirection)
+        .def_static("ComputeProjectedSearchDirection", &OptimizationUtilities::ComputeProjectedSearchDirection)
+        .def_static("CorrectProjectedSearchDirection", &OptimizationUtilities::CorrectProjectedSearchDirection)
         // ----------------------------------------------------------------
         // General optimization operations
         // ----------------------------------------------------------------
-        .def("ComputeControlPointUpdate", &OptimizationUtilities::ComputeControlPointUpdate)
-        .def("AddFirstVariableToSecondVariable", &OptimizationUtilities::AddFirstVariableToSecondVariable)
-        .def("ComputeL2NormOfNodalVariable", ComputeL2NormScalar)
-        .def("ComputeL2NormOfNodalVariable", ComputeL2NormVector)
-        .def("ComputeMaxNormOfNodalVariable", ComputeMaxNormScalar)
-        .def("ComputeMaxNormOfNodalVariable", ComputeMaxNormVector)
-        .def("AssembleVector", &OptimizationUtilities::AssembleVector)
-        .def("AssignVectorToVariable", &OptimizationUtilities::AssignVectorToVariable)
-        .def("AssembleMatrix", &AssembleMatrixForVariableList)
-        .def("CalculateProjectedSearchDirectionAndCorrection", &OptimizationUtilities::CalculateProjectedSearchDirectionAndCorrection)
+        .def_static("ComputeControlPointUpdate", &OptimizationUtilities::ComputeControlPointUpdate)
+        .def_static("AddFirstVariableToSecondVariable", &OptimizationUtilities::AddFirstVariableToSecondVariable)
+        .def_static("ComputeL2NormOfNodalVariable", ComputeL2NormScalar)
+        .def_static("ComputeL2NormOfNodalVariable", ComputeL2NormVector)
+        .def_static("ComputeMaxNormOfNodalVariable", ComputeMaxNormScalar)
+        .def_static("ComputeMaxNormOfNodalVariable", ComputeMaxNormVector)
+        .def_static("AssembleVector", &OptimizationUtilities::AssembleVector)
+        .def_static("AssignVectorToVariable", &OptimizationUtilities::AssignVectorToVariable)
+        .def_static("AssembleMatrix", &AssembleMatrixForVariableList)
+        .def_static("CalculateProjectedSearchDirectionAndCorrection", &OptimizationUtilities::CalculateProjectedSearchDirectionAndCorrection)
         ;
 
     // ========================================================================

--- a/applications/ShapeOptimizationApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/ShapeOptimizationApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -164,7 +164,7 @@ void  AddCustomUtilitiesToPython(pybind11::module& m)
     // For performing individual steps of an optimization algorithm
     // ========================================================================
     py::class_<OptimizationUtilities >(m, "OptimizationUtilities")
-        .def(py::init<Parameters>())
+        .def(py::init<>())
         // ----------------------------------------------------------------
         // For running unconstrained descent methods
         // ----------------------------------------------------------------
@@ -174,7 +174,6 @@ void  AddCustomUtilitiesToPython(pybind11::module& m)
         // ----------------------------------------------------------------
         .def("ComputeProjectedSearchDirection", &OptimizationUtilities::ComputeProjectedSearchDirection)
         .def("CorrectProjectedSearchDirection", &OptimizationUtilities::CorrectProjectedSearchDirection)
-        .def("GetCorrectionScaling", &OptimizationUtilities::GetCorrectionScaling)
         // ----------------------------------------------------------------
         // General optimization operations
         // ----------------------------------------------------------------

--- a/applications/ShapeOptimizationApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/ShapeOptimizationApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -72,28 +72,29 @@ inline void InverseMapScalar(TMapper& mapper,
     mapper.InverseMap(origin_variable, destination_variable);
 }
 
-inline double ComputeL2NormScalar(OptimizationUtilities& utils, const Variable< double >& variable)
+inline double ComputeL2NormScalar(OptimizationUtilities& utils, ModelPart& rModelPart, const Variable< double >& variable)
 {
-    return utils.ComputeL2NormOfNodalVariable(variable);
+    return utils.ComputeL2NormOfNodalVariable(rModelPart, variable);
 }
 
-inline double ComputeL2NormVector(OptimizationUtilities& utils, const Variable< array_1d<double, 3> >& variable)
+inline double ComputeL2NormVector(OptimizationUtilities& utils, ModelPart& rModelPart, const Variable< array_1d<double, 3> >& variable)
 {
-    return utils.ComputeL2NormOfNodalVariable(variable);
+    return utils.ComputeL2NormOfNodalVariable(rModelPart, variable);
 }
 
-inline double ComputeMaxNormScalar(OptimizationUtilities& utils, const Variable< double >& variable)
+inline double ComputeMaxNormScalar(OptimizationUtilities& utils, ModelPart& rModelPart, const Variable< double >& variable)
 {
-    return utils.ComputeMaxNormOfNodalVariable(variable);
+    return utils.ComputeMaxNormOfNodalVariable(rModelPart, variable);
 }
 
-inline double ComputeMaxNormVector(OptimizationUtilities& utils, const Variable< array_1d<double, 3> >& variable)
+inline double ComputeMaxNormVector(OptimizationUtilities& utils, ModelPart& rModelPart, const Variable< array_1d<double, 3> >& variable)
 {
-    return utils.ComputeMaxNormOfNodalVariable(variable);
+    return utils.ComputeMaxNormOfNodalVariable(rModelPart, variable);
 }
 
 inline void AssembleMatrixForVariableList(
     OptimizationUtilities& utils,
+    ModelPart& rModelPart,
     Matrix& rMatrix,
     pybind11::list& rVariables)
 {
@@ -103,7 +104,7 @@ inline void AssembleMatrixForVariableList(
     {
         variables_vector[i] = (rVariables[i]).cast<Variable<OptimizationUtilities::array_3d>*>();
     }
-    return utils.AssembleMatrix(rMatrix, variables_vector);
+    return utils.AssembleMatrix(rModelPart, rMatrix, variables_vector);
 }
 
 // ==============================================================================
@@ -163,7 +164,7 @@ void  AddCustomUtilitiesToPython(pybind11::module& m)
     // For performing individual steps of an optimization algorithm
     // ========================================================================
     py::class_<OptimizationUtilities >(m, "OptimizationUtilities")
-        .def(py::init<ModelPart&, Parameters>())
+        .def(py::init<Parameters>())
         // ----------------------------------------------------------------
         // For running unconstrained descent methods
         // ----------------------------------------------------------------

--- a/applications/ShapeOptimizationApplication/custom_utilities/optimization_utilities.h
+++ b/applications/ShapeOptimizationApplication/custom_utilities/optimization_utilities.h
@@ -416,23 +416,6 @@ public:
     ///@name Input and output
     ///@{
 
-    /// Turn back information as a string.
-    virtual std::string Info() const
-    {
-        return "OptimizationUtilities";
-    }
-
-    /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
-    {
-        rOStream << "OptimizationUtilities";
-    }
-
-    /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const
-    {
-    }
-
 
     ///@}
     ///@name Friends

--- a/applications/ShapeOptimizationApplication/custom_utilities/optimization_utilities.h
+++ b/applications/ShapeOptimizationApplication/custom_utilities/optimization_utilities.h
@@ -73,18 +73,6 @@ public:
     ///@name Life Cycle
     ///@{
 
-    /// Default constructor.
-    OptimizationUtilities()
-    {
-
-    }
-
-    /// Destructor.
-    virtual ~OptimizationUtilities()
-    {
-    }
-
-
     ///@}
     ///@name Operators
     ///@{
@@ -97,7 +85,7 @@ public:
     // ==============================================================================
     // General optimization operations
     // ==============================================================================
-    void ComputeControlPointUpdate(ModelPart& rModelPart, const double StepSize, const bool Normalize)
+    static void ComputeControlPointUpdate(ModelPart& rModelPart, const double StepSize, const bool Normalize)
     {
         KRATOS_TRY;
 
@@ -123,14 +111,14 @@ public:
     }
 
     // --------------------------------------------------------------------------
-    void AddFirstVariableToSecondVariable( ModelPart& rModelPart, const Variable<array_3d> &rFirstVariable, const Variable<array_3d> &rSecondVariable )
+    static void AddFirstVariableToSecondVariable( ModelPart& rModelPart, const Variable<array_3d> &rFirstVariable, const Variable<array_3d> &rSecondVariable )
     {
         for (auto & node_i : rModelPart.Nodes())
             noalias(node_i.FastGetSolutionStepValue(rSecondVariable)) += node_i.FastGetSolutionStepValue(rFirstVariable);
     }
 
     // --------------------------------------------------------------------------
-    double ComputeL2NormOfNodalVariable( ModelPart& rModelPart, const Variable<array_3d> &rVariable)
+    static double ComputeL2NormOfNodalVariable( ModelPart& rModelPart, const Variable<array_3d> &rVariable)
     {
         double l2_norm = 0.0;
         for (auto & node_i : rModelPart.Nodes())
@@ -142,7 +130,7 @@ public:
     }
 
     // --------------------------------------------------------------------------
-    double ComputeL2NormOfNodalVariable(ModelPart& rModelPart, const Variable<double> &rVariable)
+    static double ComputeL2NormOfNodalVariable(ModelPart& rModelPart, const Variable<double> &rVariable)
     {
         double l2_norm = 0.0;
         for (auto & node_i : rModelPart.Nodes())
@@ -154,7 +142,7 @@ public:
     }
 
     // --------------------------------------------------------------------------
-    double ComputeMaxNormOfNodalVariable(ModelPart& rModelPart, const Variable<array_3d> &rVariable)
+    static double ComputeMaxNormOfNodalVariable(ModelPart& rModelPart, const Variable<array_3d> &rVariable)
     {
         double max_norm = 0.0;
         for (auto & node_i : rModelPart.Nodes())
@@ -168,7 +156,7 @@ public:
     }
 
     // --------------------------------------------------------------------------
-    double ComputeMaxNormOfNodalVariable(ModelPart& rModelPart, const Variable<double> &rVariable)
+    static double ComputeMaxNormOfNodalVariable(ModelPart& rModelPart, const Variable<double> &rVariable)
     {
         double max_norm = 0.0;
         for (auto & node_i : rModelPart.Nodes())
@@ -184,7 +172,7 @@ public:
     // ==============================================================================
     // For running unconstrained descent methods
     // ==============================================================================
-    void ComputeSearchDirectionSteepestDescent(ModelPart& rModelPart)
+    static void ComputeSearchDirectionSteepestDescent(ModelPart& rModelPart)
     {
         KRATOS_TRY;
 
@@ -204,7 +192,7 @@ public:
     // ==============================================================================
     // For running penalized projection method
     // ==============================================================================
-    void ComputeProjectedSearchDirection(ModelPart& rModelPart)
+    static void ComputeProjectedSearchDirection(ModelPart& rModelPart)
     {
         KRATOS_TRY;
 
@@ -249,7 +237,7 @@ public:
     }
 
     // --------------------------------------------------------------------------
-    double CorrectProjectedSearchDirection(ModelPart& rModelPart, const double PrevConstraintValue, const double ConstraintValue, const double CorrectionScaling, const bool IsAdaptive )
+    static double CorrectProjectedSearchDirection(ModelPart& rModelPart, const double PrevConstraintValue, const double ConstraintValue, const double CorrectionScaling, const bool IsAdaptive )
     {
         // Check correction necessary
         if(ConstraintValue==0)
@@ -268,7 +256,7 @@ public:
     }
 
     // --------------------------------------------------------------------------
-    double ComputeCorrectionFactor(ModelPart& rModelPart, const double PrevConstraintValue, const double ConstraintValue, double& CorrectionScaling, const bool IsAdaptive)
+    static double ComputeCorrectionFactor(ModelPart& rModelPart, const double PrevConstraintValue, const double ConstraintValue, double& CorrectionScaling, const bool IsAdaptive)
     {
     	double norm_correction_term = 0.0;
     	double norm_search_direction = 0.0;
@@ -309,7 +297,7 @@ public:
     /**
      * Assemble the values of the nodal vector variable into a vector
      */
-    void AssembleVector( ModelPart& rModelPart,
+    static void AssembleVector( ModelPart& rModelPart,
         Vector& rVector,
         const Variable<array_3d> &rVariable)
     {
@@ -331,7 +319,7 @@ public:
     /**
      * Assigns the values of a vector to the nodal vector variables
      */
-    void AssignVectorToVariable(ModelPart& rModelPart,
+    static void AssignVectorToVariable(ModelPart& rModelPart,
         const Vector& rVector,
         const Variable<array_3d> &rVariable)
     {
@@ -353,10 +341,10 @@ public:
      * Assemble the values of the nodal vector variables into a dense matrix.
      * One column per variable is created.
      */
-    void AssembleMatrix(ModelPart& rModelPart,
+    static void AssembleMatrix(ModelPart& rModelPart,
         Matrix& rMatrix,
         const std::vector<Variable<array_3d>*>& rVariables
-    ) const
+    )
     {
         if ((rMatrix.size1() != rModelPart.NumberOfNodes()*3 || rMatrix.size2() !=  rVariables.size())){
             rMatrix.resize(rModelPart.NumberOfNodes()*3, rVariables.size());
@@ -386,7 +374,7 @@ public:
      * In a second step, calculate the restoration move accounting for the current violation of the constraints.
      * Variable naming and implementation based on https://msulaiman.org/onewebmedia/GradProj_2.pdf
      */
-    void CalculateProjectedSearchDirectionAndCorrection(
+    static void CalculateProjectedSearchDirectionAndCorrection(
         Vector& rObjectiveGradient,
         Matrix& rConstraintGradients,
         Vector& rConstraintValues,

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
@@ -132,7 +132,7 @@ class AlgorithmBeadOptimization(OptimizationAlgorithm):
         self.data_logger = data_logger_factory.CreateDataLogger(self.model_part_controller, self.communicator, self.optimization_settings)
         self.data_logger.InitializeDataLogging()
 
-        self.optimization_utilities = KSO.OptimizationUtilities()
+        self.optimization_utilities = KSO.OptimizationUtilities
 
         # Identify fixed design areas
         KM.VariableUtils().SetFlag(KM.BOUNDARY, False, self.optimization_model_part.Nodes)

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
@@ -132,7 +132,7 @@ class AlgorithmBeadOptimization(OptimizationAlgorithm):
         self.data_logger = data_logger_factory.CreateDataLogger(self.model_part_controller, self.communicator, self.optimization_settings)
         self.data_logger.InitializeDataLogging()
 
-        self.optimization_utilities = KSO.OptimizationUtilities(self.design_surface, self.optimization_settings)
+        self.optimization_utilities = KSO.OptimizationUtilities(self.optimization_settings)
 
         # Identify fixed design areas
         KM.VariableUtils().SetFlag(KM.BOUNDARY, False, self.optimization_model_part.Nodes)
@@ -244,7 +244,7 @@ class AlgorithmBeadOptimization(OptimizationAlgorithm):
                 self.mapper.InverseMap(KSO.DF1DALPHA, KSO.DF1DALPHA_MAPPED)
 
                 # Compute scaling
-                max_norm_objective_gradient = self.optimization_utilities.ComputeMaxNormOfNodalVariable(KSO.DF1DALPHA_MAPPED)
+                max_norm_objective_gradient = self.optimization_utilities.ComputeMaxNormOfNodalVariable(self.design_surface, KSO.DF1DALPHA_MAPPED)
 
                 if outer_iteration == 1 and inner_iteration == min(3,self.max_inner_iterations):
                     if self.bead_side == "positive" or self.bead_side == "negative":

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
@@ -132,7 +132,7 @@ class AlgorithmBeadOptimization(OptimizationAlgorithm):
         self.data_logger = data_logger_factory.CreateDataLogger(self.model_part_controller, self.communicator, self.optimization_settings)
         self.data_logger.InitializeDataLogging()
 
-        self.optimization_utilities = KSO.OptimizationUtilities(self.optimization_settings)
+        self.optimization_utilities = KSO.OptimizationUtilities()
 
         # Identify fixed design areas
         KM.VariableUtils().SetFlag(KM.BOUNDARY, False, self.optimization_model_part.Nodes)

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_gradient_projection.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_gradient_projection.py
@@ -96,7 +96,7 @@ class AlgorithmGradientProjection(OptimizationAlgorithm):
         self.data_logger = data_logger_factory.CreateDataLogger(self.model_part_controller, self.communicator, self.optimization_settings)
         self.data_logger.InitializeDataLogging()
 
-        self.optimization_utilities = KSO.OptimizationUtilities()
+        self.optimization_utilities = KSO.OptimizationUtilities
 
     # --------------------------------------------------------------------------
     def RunOptimizationLoop(self):

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_gradient_projection.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_gradient_projection.py
@@ -96,7 +96,7 @@ class AlgorithmGradientProjection(OptimizationAlgorithm):
         self.data_logger = data_logger_factory.CreateDataLogger(self.model_part_controller, self.communicator, self.optimization_settings)
         self.data_logger.InitializeDataLogging()
 
-        self.optimization_utilities = KSO.OptimizationUtilities(self.optimization_settings)
+        self.optimization_utilities = KSO.OptimizationUtilities()
 
     # --------------------------------------------------------------------------
     def RunOptimizationLoop(self):

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_gradient_projection.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_gradient_projection.py
@@ -96,7 +96,7 @@ class AlgorithmGradientProjection(OptimizationAlgorithm):
         self.data_logger = data_logger_factory.CreateDataLogger(self.model_part_controller, self.communicator, self.optimization_settings)
         self.data_logger.InitializeDataLogging()
 
-        self.optimization_utilities = KSO.OptimizationUtilities(self.design_surface, self.optimization_settings)
+        self.optimization_utilities = KSO.OptimizationUtilities(self.optimization_settings)
 
     # --------------------------------------------------------------------------
     def RunOptimizationLoop(self):
@@ -201,35 +201,33 @@ class AlgorithmGradientProjection(OptimizationAlgorithm):
     # --------------------------------------------------------------------------
     def __computeControlPointUpdate(self):
         """adapted from https://msulaiman.org/onewebmedia/GradProj_2.pdf"""
-        gp_utilities = self.optimization_utilities
-
         g_a, g_a_variables = self.__getActiveConstraints()
 
         KM.Logger.PrintInfo("ShapeOpt", "Assemble vector of objective gradient.")
         nabla_f = KM.Vector()
         s = KM.Vector()
-        gp_utilities.AssembleVector(nabla_f, KSO.DF1DX_MAPPED)
+        self.optimization_utilities.AssembleVector(self.design_surface, nabla_f, KSO.DF1DX_MAPPED)
 
         if len(g_a) == 0:
             KM.Logger.PrintInfo("ShapeOpt", "No constraints active, use negative objective gradient as search direction.")
             s = nabla_f * (-1.0)
             s *= self.step_size / s.norm_inf()
-            gp_utilities.AssignVectorToVariable(s, KSO.SEARCH_DIRECTION)
-            gp_utilities.AssignVectorToVariable([0.0]*len(s), KSO.CORRECTION)
-            gp_utilities.AssignVectorToVariable(s, KSO.CONTROL_POINT_UPDATE)
+            self.optimization_utilities.AssignVectorToVariable(self.design_surface, s, KSO.SEARCH_DIRECTION)
+            self.optimization_utilities.AssignVectorToVariable(self.design_surface, [0.0]*len(s), KSO.CORRECTION)
+            self.optimization_utilities.AssignVectorToVariable(self.design_surface, s, KSO.CONTROL_POINT_UPDATE)
             return
 
 
         KM.Logger.PrintInfo("ShapeOpt", "Assemble matrix of constraint gradient.")
         N = KM.Matrix()
-        gp_utilities.AssembleMatrix(N, g_a_variables)  # TODO check if gradients are 0.0! - in cpp
+        self.optimization_utilities.AssembleMatrix(self.design_surface, N, g_a_variables)  # TODO check if gradients are 0.0! - in cpp
 
         settings = KM.Parameters('{ "solver_type" : "LinearSolversApplication.dense_col_piv_householder_qr" }')
         solver = dense_linear_solver_factory.ConstructSolver(settings)
 
         KM.Logger.PrintInfo("ShapeOpt", "Calculate projected search direction and correction.")
         c = KM.Vector()
-        gp_utilities.CalculateProjectedSearchDirectionAndCorrection(
+        self.optimization_utilities.CalculateProjectedSearchDirectionAndCorrection(
             nabla_f,
             N,
             g_a,
@@ -248,9 +246,9 @@ class AlgorithmGradientProjection(OptimizationAlgorithm):
         else:
             s *= self.step_size / s.norm_inf()
 
-        gp_utilities.AssignVectorToVariable(s, KSO.SEARCH_DIRECTION)
-        gp_utilities.AssignVectorToVariable(c, KSO.CORRECTION)
-        gp_utilities.AssignVectorToVariable(s+c, KSO.CONTROL_POINT_UPDATE)
+        self.optimization_utilities.AssignVectorToVariable(self.design_surface, s, KSO.SEARCH_DIRECTION)
+        self.optimization_utilities.AssignVectorToVariable(self.design_surface, c, KSO.CORRECTION)
+        self.optimization_utilities.AssignVectorToVariable(self.design_surface, s+c, KSO.CONTROL_POINT_UPDATE)
 
     # --------------------------------------------------------------------------
     def __getActiveConstraints(self):
@@ -282,8 +280,8 @@ class AlgorithmGradientProjection(OptimizationAlgorithm):
     def __logCurrentOptimizationStep(self):
         additional_values_to_log = {}
         additional_values_to_log["step_size"] = self.step_size
-        additional_values_to_log["inf_norm_s"] = self.optimization_utilities.ComputeMaxNormOfNodalVariable(KSO.SEARCH_DIRECTION)
-        additional_values_to_log["inf_norm_c"] = self.optimization_utilities.ComputeMaxNormOfNodalVariable(KSO.CORRECTION)
+        additional_values_to_log["inf_norm_s"] = self.optimization_utilities.ComputeMaxNormOfNodalVariable(self.design_surface, KSO.SEARCH_DIRECTION)
+        additional_values_to_log["inf_norm_c"] = self.optimization_utilities.ComputeMaxNormOfNodalVariable(self.design_surface, KSO.CORRECTION)
         self.data_logger.LogCurrentValues(self.optimization_iteration, additional_values_to_log)
         self.data_logger.LogCurrentDesign(self.optimization_iteration)
 
@@ -307,7 +305,7 @@ class AlgorithmGradientProjection(OptimizationAlgorithm):
 
     # --------------------------------------------------------------------------
     def __determineAbsoluteChanges(self):
-        self.optimization_utilities.AddFirstVariableToSecondVariable(KSO.CONTROL_POINT_UPDATE, KSO.CONTROL_POINT_CHANGE)
-        self.optimization_utilities.AddFirstVariableToSecondVariable(KSO.SHAPE_UPDATE, KSO.SHAPE_CHANGE)
+        self.optimization_utilities.AddFirstVariableToSecondVariable(self.design_surface, KSO.CONTROL_POINT_UPDATE, KSO.CONTROL_POINT_CHANGE)
+        self.optimization_utilities.AddFirstVariableToSecondVariable(self.design_surface, KSO.SHAPE_UPDATE, KSO.SHAPE_CHANGE)
 
 # ==============================================================================

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_penalized_projection.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_penalized_projection.py
@@ -54,6 +54,8 @@ class AlgorithmPenalizedProjection(OptimizationAlgorithm):
         self.mapper = None
         self.data_logger = None
         self.optimization_utilities = None
+        self.constraint_value = 0.0
+        self.correction_scaling = optimization_settings["optimization_algorithm"]["correction_scaling"].GetDouble()
 
         self.objectives = optimization_settings["objectives"]
         self.constraints = optimization_settings["constraints"]
@@ -88,7 +90,7 @@ class AlgorithmPenalizedProjection(OptimizationAlgorithm):
         self.data_logger = data_logger_factory.CreateDataLogger(self.model_part_controller, self.communicator, self.optimization_settings)
         self.data_logger.InitializeDataLogging()
 
-        self.optimization_utilities = KSO.OptimizationUtilities(self.optimization_settings)
+        self.optimization_utilities = KSO.OptimizationUtilities()
 
     # --------------------------------------------------------------------------
     def RunOptimizationLoop(self):
@@ -164,14 +166,18 @@ class AlgorithmPenalizedProjection(OptimizationAlgorithm):
         self.mapper.Update()
         self.mapper.InverseMap(KSO.DF1DX, KSO.DF1DX_MAPPED)
         self.mapper.InverseMap(KSO.DC1DX, KSO.DC1DX_MAPPED)
+        is_adaptive = self.algorithm_settings["use_adaptive_correction"].GetBool()
 
         constraint_value = self.communicator.getStandardizedValue(self.constraints[0]["identifier"].GetString())
         if self.__isConstraintActive(constraint_value):
             self.optimization_utilities.ComputeProjectedSearchDirection(self.design_surface)
-            self.optimization_utilities.CorrectProjectedSearchDirection(self.design_surface, constraint_value)
+            self.correction_scaling = self.optimization_utilities.CorrectProjectedSearchDirection(self.design_surface, self.constraint_value, constraint_value, self.correction_scaling, is_adaptive)
+            self.constraint_value = constraint_value
         else:
             self.optimization_utilities.ComputeSearchDirectionSteepestDescent(self.design_surface)
-        self.optimization_utilities.ComputeControlPointUpdate(self.design_surface, self.step_size)
+
+        normalize = self.algorithm_settings["line_search"]["normalize_search_direction"].GetBool()
+        self.optimization_utilities.ComputeControlPointUpdate(self.design_surface, self.step_size, normalize)
 
         self.mapper.Map(KSO.CONTROL_POINT_UPDATE, KSO.SHAPE_UPDATE)
         self.model_part_controller.DampNodalVariableIfSpecified(KSO.SHAPE_UPDATE)
@@ -188,7 +194,7 @@ class AlgorithmPenalizedProjection(OptimizationAlgorithm):
     # --------------------------------------------------------------------------
     def __logCurrentOptimizationStep(self):
         additional_values_to_log = {}
-        additional_values_to_log["correction_scaling"] = self.optimization_utilities.GetCorrectionScaling()
+        additional_values_to_log["correction_scaling"] = self.correction_scaling
         additional_values_to_log["step_size"] = self.step_size
         self.data_logger.LogCurrentValues(self.optimization_iteration, additional_values_to_log)
         self.data_logger.LogCurrentDesign(self.optimization_iteration)

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_penalized_projection.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_penalized_projection.py
@@ -88,7 +88,7 @@ class AlgorithmPenalizedProjection(OptimizationAlgorithm):
         self.data_logger = data_logger_factory.CreateDataLogger(self.model_part_controller, self.communicator, self.optimization_settings)
         self.data_logger.InitializeDataLogging()
 
-        self.optimization_utilities = KSO.OptimizationUtilities(self.design_surface, self.optimization_settings)
+        self.optimization_utilities = KSO.OptimizationUtilities(self.optimization_settings)
 
     # --------------------------------------------------------------------------
     def RunOptimizationLoop(self):
@@ -167,11 +167,11 @@ class AlgorithmPenalizedProjection(OptimizationAlgorithm):
 
         constraint_value = self.communicator.getStandardizedValue(self.constraints[0]["identifier"].GetString())
         if self.__isConstraintActive(constraint_value):
-            self.optimization_utilities.ComputeProjectedSearchDirection()
-            self.optimization_utilities.CorrectProjectedSearchDirection(constraint_value)
+            self.optimization_utilities.ComputeProjectedSearchDirection(self.design_surface)
+            self.optimization_utilities.CorrectProjectedSearchDirection(self.design_surface, constraint_value)
         else:
-            self.optimization_utilities.ComputeSearchDirectionSteepestDescent()
-        self.optimization_utilities.ComputeControlPointUpdate(self.step_size)
+            self.optimization_utilities.ComputeSearchDirectionSteepestDescent(self.design_surface)
+        self.optimization_utilities.ComputeControlPointUpdate(self.design_surface, self.step_size)
 
         self.mapper.Map(KSO.CONTROL_POINT_UPDATE, KSO.SHAPE_UPDATE)
         self.model_part_controller.DampNodalVariableIfSpecified(KSO.SHAPE_UPDATE)
@@ -213,7 +213,7 @@ class AlgorithmPenalizedProjection(OptimizationAlgorithm):
 
     # --------------------------------------------------------------------------
     def __determineAbsoluteChanges(self):
-        self.optimization_utilities.AddFirstVariableToSecondVariable(KSO.CONTROL_POINT_UPDATE, KSO.CONTROL_POINT_CHANGE)
-        self.optimization_utilities.AddFirstVariableToSecondVariable(KSO.SHAPE_UPDATE, KSO.SHAPE_CHANGE)
+        self.optimization_utilities.AddFirstVariableToSecondVariable(self.design_surface, KSO.CONTROL_POINT_UPDATE, KSO.CONTROL_POINT_CHANGE)
+        self.optimization_utilities.AddFirstVariableToSecondVariable(self.design_surface, KSO.SHAPE_UPDATE, KSO.SHAPE_CHANGE)
 
 # ==============================================================================

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_penalized_projection.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_penalized_projection.py
@@ -90,7 +90,7 @@ class AlgorithmPenalizedProjection(OptimizationAlgorithm):
         self.data_logger = data_logger_factory.CreateDataLogger(self.model_part_controller, self.communicator, self.optimization_settings)
         self.data_logger.InitializeDataLogging()
 
-        self.optimization_utilities = KSO.OptimizationUtilities()
+        self.optimization_utilities = KSO.OptimizationUtilities
 
     # --------------------------------------------------------------------------
     def RunOptimizationLoop(self):

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_steepest_descent.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_steepest_descent.py
@@ -95,7 +95,7 @@ class AlgorithmSteepestDescent(OptimizationAlgorithm):
         self.data_logger = data_logger_factory.CreateDataLogger(self.model_part_controller, self.communicator, self.optimization_settings)
         self.data_logger.InitializeDataLogging()
 
-        self.optimization_utilities = KSO.OptimizationUtilities(self.design_surface, self.optimization_settings)
+        self.optimization_utilities = KSO.OptimizationUtilities(self.optimization_settings)
 
     # --------------------------------------------------------------------------
     def RunOptimizationLoop(self):
@@ -202,8 +202,8 @@ class AlgorithmSteepestDescent(OptimizationAlgorithm):
         self.mapper.Update()
         self.mapper.InverseMap(KSO.DF1DX, KSO.DF1DX_MAPPED)
 
-        self.optimization_utilities.ComputeSearchDirectionSteepestDescent()
-        self.optimization_utilities.ComputeControlPointUpdate(self.step_size)
+        self.optimization_utilities.ComputeSearchDirectionSteepestDescent(self.design_surface)
+        self.optimization_utilities.ComputeControlPointUpdate(self.design_surface, self.step_size)
 
         self.mapper.Map(KSO.CONTROL_POINT_UPDATE, KSO.SHAPE_UPDATE)
         self.model_part_controller.DampNodalVariableIfSpecified(KSO.SHAPE_UPDATE)
@@ -211,7 +211,7 @@ class AlgorithmSteepestDescent(OptimizationAlgorithm):
     # --------------------------------------------------------------------------
     def __logCurrentOptimizationStep(self):
         self.previos_objective_value = self.communicator.getStandardizedValue(self.objectives[0]["identifier"].GetString())
-        self.norm_objective_gradient = self.optimization_utilities.ComputeL2NormOfNodalVariable(KSO.DF1DX_MAPPED)
+        self.norm_objective_gradient = self.optimization_utilities.ComputeL2NormOfNodalVariable(self.design_surface, KSO.DF1DX_MAPPED)
 
         additional_values_to_log = {}
         additional_values_to_log["step_size"] = self.step_size
@@ -247,7 +247,7 @@ class AlgorithmSteepestDescent(OptimizationAlgorithm):
 
     # --------------------------------------------------------------------------
     def __determineAbsoluteChanges(self):
-        self.optimization_utilities.AddFirstVariableToSecondVariable(KSO.CONTROL_POINT_UPDATE, KSO.CONTROL_POINT_CHANGE)
-        self.optimization_utilities.AddFirstVariableToSecondVariable(KSO.SHAPE_UPDATE, KSO.SHAPE_CHANGE)
+        self.optimization_utilities.AddFirstVariableToSecondVariable(self.design_surface, KSO.CONTROL_POINT_UPDATE, KSO.CONTROL_POINT_CHANGE)
+        self.optimization_utilities.AddFirstVariableToSecondVariable(self.design_surface, KSO.SHAPE_UPDATE, KSO.SHAPE_CHANGE)
 
 # ==============================================================================

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_steepest_descent.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_steepest_descent.py
@@ -95,7 +95,7 @@ class AlgorithmSteepestDescent(OptimizationAlgorithm):
         self.data_logger = data_logger_factory.CreateDataLogger(self.model_part_controller, self.communicator, self.optimization_settings)
         self.data_logger.InitializeDataLogging()
 
-        self.optimization_utilities = KSO.OptimizationUtilities(self.optimization_settings)
+        self.optimization_utilities = KSO.OptimizationUtilities()
 
     # --------------------------------------------------------------------------
     def RunOptimizationLoop(self):
@@ -203,7 +203,8 @@ class AlgorithmSteepestDescent(OptimizationAlgorithm):
         self.mapper.InverseMap(KSO.DF1DX, KSO.DF1DX_MAPPED)
 
         self.optimization_utilities.ComputeSearchDirectionSteepestDescent(self.design_surface)
-        self.optimization_utilities.ComputeControlPointUpdate(self.design_surface, self.step_size)
+        normalize = self.algorithm_settings["line_search"]["normalize_search_direction"].GetBool()
+        self.optimization_utilities.ComputeControlPointUpdate(self.design_surface, self.step_size, normalize)
 
         self.mapper.Map(KSO.CONTROL_POINT_UPDATE, KSO.SHAPE_UPDATE)
         self.model_part_controller.DampNodalVariableIfSpecified(KSO.SHAPE_UPDATE)

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_steepest_descent.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_steepest_descent.py
@@ -95,7 +95,7 @@ class AlgorithmSteepestDescent(OptimizationAlgorithm):
         self.data_logger = data_logger_factory.CreateDataLogger(self.model_part_controller, self.communicator, self.optimization_settings)
         self.data_logger.InitializeDataLogging()
 
-        self.optimization_utilities = KSO.OptimizationUtilities()
+        self.optimization_utilities = KSO.OptimizationUtilities
 
     # --------------------------------------------------------------------------
     def RunOptimizationLoop(self):

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_trust_region.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_trust_region.py
@@ -82,7 +82,7 @@ class AlgorithmTrustRegion(OptimizationAlgorithm):
         self.data_logger = data_logger_factory.CreateDataLogger(self.model_part_controller, self.communicator, self.optimization_settings)
         self.data_logger.InitializeDataLogging()
 
-        self.optimization_utilities = KSO.OptimizationUtilities(self.design_surface, self.optimization_settings)
+        self.optimization_utilities = KSO.OptimizationUtilities(self.optimization_settings)
 
     # --------------------------------------------------------------------------
     def RunOptimizationLoop(self):
@@ -398,7 +398,7 @@ class AlgorithmTrustRegion(OptimizationAlgorithm):
         dX = cm.ScalarVectorProduct(step_length,dX_bar)
 
         WriteListToNodalVariable(dX, self.design_surface, KSO.SHAPE_UPDATE)
-        self.optimization_utilities.AddFirstVariableToSecondVariable(KSO.SHAPE_UPDATE, KSO.SHAPE_CHANGE)
+        self.optimization_utilities.AddFirstVariableToSecondVariable(self.design_surface, KSO.SHAPE_UPDATE, KSO.SHAPE_CHANGE)
 
         return dX
 

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_trust_region.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_trust_region.py
@@ -82,7 +82,7 @@ class AlgorithmTrustRegion(OptimizationAlgorithm):
         self.data_logger = data_logger_factory.CreateDataLogger(self.model_part_controller, self.communicator, self.optimization_settings)
         self.data_logger.InitializeDataLogging()
 
-        self.optimization_utilities = KSO.OptimizationUtilities()
+        self.optimization_utilities = KSO.OptimizationUtilities
 
     # --------------------------------------------------------------------------
     def RunOptimizationLoop(self):

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_trust_region.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_trust_region.py
@@ -82,7 +82,7 @@ class AlgorithmTrustRegion(OptimizationAlgorithm):
         self.data_logger = data_logger_factory.CreateDataLogger(self.model_part_controller, self.communicator, self.optimization_settings)
         self.data_logger.InitializeDataLogging()
 
-        self.optimization_utilities = KSO.OptimizationUtilities(self.optimization_settings)
+        self.optimization_utilities = KSO.OptimizationUtilities()
 
     # --------------------------------------------------------------------------
     def RunOptimizationLoop(self):


### PR DESCRIPTION
**Description**
This is the first of a series of changes that will follow to make it possible that shape optimization application can deal with multiple design surfaces with different VertexMorphing parameters. 


**Changelog**
Modifies the optimization_utilities.h so no design surface and parameters are required in the constructor. 
Changes necessary files to make the above change possible. 

All the tests in ShapeOptApp pass locally. 
