### PR TITLE
[PotentialFlow] Adding 3d incompressible wake condition in full potential element

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.cpp
@@ -433,13 +433,12 @@ void IncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLocalSystemWake
     // Calculate shape functions
     GeometryUtils::CalculateGeometryData(GetGeometry(), data.DN_DX, data.N, data.vol);
 
-    const double free_stream_density = rCurrentProcessInfo[FREE_STREAM_DENSITY];
-
     GetWakeDistances(data.distances);
 
     BoundedMatrix<double, NumNodes, NumNodes> lhs_total = ZeroMatrix(NumNodes, NumNodes);
+    BoundedMatrix<double, NumNodes, NumNodes> lhs_wake_condition = ZeroMatrix(NumNodes, NumNodes);
 
-    ComputeLHSGaussPointContribution(data.vol*free_stream_density, lhs_total, data);
+    CalculateBlockLeftHandSideWakeElement(lhs_total, lhs_wake_condition, data, rCurrentProcessInfo);
 
     if (this->Is(STRUCTURE))
     {
@@ -448,15 +447,48 @@ void IncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLocalSystemWake
 
         CalculateLocalSystemSubdividedElement(lhs_positive, lhs_negative, rCurrentProcessInfo);
         AssignLocalSystemSubdividedElement(rLeftHandSideMatrix, lhs_positive,
-                                           lhs_negative, lhs_total, data);
+                                           lhs_negative, lhs_total, lhs_wake_condition, data);
     }
     else
-        AssignLocalSystemWakeElement(rLeftHandSideMatrix, lhs_total, data);
+        AssignLocalSystemWakeElement(rLeftHandSideMatrix, lhs_total, lhs_wake_condition, data);
 
     BoundedVector<double, 2*NumNodes> split_element_values;
     split_element_values = PotentialFlowUtilities::GetPotentialOnWakeElement<Dim, NumNodes>(*this, data.distances);
     noalias(rRightHandSideVector) = -prod(rLeftHandSideMatrix, split_element_values);
 }
+
+// In 2D
+template <>
+void IncompressiblePotentialFlowElement<2, 3>::CalculateBlockLeftHandSideWakeElement( BoundedMatrix<double, 3, 3>& rLhs_total, BoundedMatrix<double, 3, 3>& rLhs_wake_condition, const ElementalData<3, 2>& rData, const ProcessInfo& rCurrentProcessInfo)
+{
+    const double free_stream_density = rCurrentProcessInfo[FREE_STREAM_DENSITY];
+    ComputeLHSGaussPointContribution(rData.vol*free_stream_density, rLhs_total, rData);
+    rLhs_wake_condition = rLhs_total;
+}
+
+// In 3D
+template <>
+void IncompressiblePotentialFlowElement<3, 4>::CalculateBlockLeftHandSideWakeElement( BoundedMatrix<double, 4, 4>& rLhs_total, BoundedMatrix<double, 4, 4>& rLhs_wake_condition, const ElementalData<4, 3>& rData, const ProcessInfo& rCurrentProcessInfo)
+{
+    const double free_stream_density = rCurrentProcessInfo[FREE_STREAM_DENSITY];
+    ComputeLHSGaussPointContribution(rData.vol*free_stream_density, rLhs_total, rData);
+
+    // Computing linearized pressure equality condition lhs
+    const array_1d<double, 3>& free_stream_velocity_direction = rCurrentProcessInfo[FREE_STREAM_VELOCITY_DIRECTION];
+    const BoundedVector<double, 4> DNv = prod(rData.DN_DX, free_stream_velocity_direction);
+    const BoundedMatrix<double, 4, 4> pressure_equality_lhs = outer_prod(DNv,trans(DNv));
+
+    // Computing wake normal condition lhs
+    // Attention: this only works for straight trailing edges
+    // TODO: Make it work for curved trailing edges, i.e., find the way to store the local normal vector of the skin in the element.
+    const array_1d<double, 3>& wake_normal = rCurrentProcessInfo[WAKE_NORMAL];
+    const BoundedVector<double, 4> DNn = prod(rData.DN_DX, wake_normal);
+    const BoundedMatrix<double, 4, 4> normal_condition_lhs = outer_prod(DNn,trans(DNn));
+
+    // Adding contributions
+    rLhs_wake_condition = rData.vol * (pressure_equality_lhs + normal_condition_lhs);
+}
+
 
 template <int Dim, int NumNodes>
 void IncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLocalSystemSubdividedElement(
@@ -521,6 +553,7 @@ void IncompressiblePotentialFlowElement<Dim, NumNodes>::AssignLocalSystemSubdivi
     BoundedMatrix<double, NumNodes, NumNodes>& lhs_positive,
     BoundedMatrix<double, NumNodes, NumNodes>& lhs_negative,
     BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+    BoundedMatrix<double, NumNodes, NumNodes>& rLhs_wake_condition,
     const ElementalData<NumNodes, Dim>& data) const
 {
     for (unsigned int i = 0; i < NumNodes; ++i)
@@ -536,7 +569,7 @@ void IncompressiblePotentialFlowElement<Dim, NumNodes>::AssignLocalSystemSubdivi
             }
         }
         else
-            AssignLocalSystemWakeNode(rLeftHandSideMatrix, lhs_total, data, i);
+            AssignLocalSystemWakeNode(rLeftHandSideMatrix, lhs_total, rLhs_wake_condition, data, i);
     }
 }
 
@@ -544,33 +577,41 @@ template <int Dim, int NumNodes>
 void IncompressiblePotentialFlowElement<Dim, NumNodes>::AssignLocalSystemWakeElement(
     MatrixType& rLeftHandSideMatrix,
     BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+    BoundedMatrix<double, NumNodes, NumNodes>& rLhs_wake_condition,
     const ElementalData<NumNodes, Dim>& data) const
 {
     for (unsigned int row = 0; row < NumNodes; ++row)
-        AssignLocalSystemWakeNode(rLeftHandSideMatrix, lhs_total, data, row);
+        AssignLocalSystemWakeNode(rLeftHandSideMatrix, lhs_total, rLhs_wake_condition, data, row);
 }
 
 template <int Dim, int NumNodes>
 void IncompressiblePotentialFlowElement<Dim, NumNodes>::AssignLocalSystemWakeNode(
     MatrixType& rLeftHandSideMatrix,
     BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+    BoundedMatrix<double, NumNodes, NumNodes>& rLhs_wake_condition,
     const ElementalData<NumNodes, Dim>& data,
     unsigned int& row) const
 {
-    // Filling the diagonal blocks (i.e. decoupling upper and lower dofs)
-    for (unsigned int column = 0; column < NumNodes; ++column)
-    {
-        rLeftHandSideMatrix(row, column) = lhs_total(row, column);
-        rLeftHandSideMatrix(row + NumNodes, column + NumNodes) = lhs_total(row, column);
-    }
+    if (data.distances[row] < 0.0) {
+        for (unsigned int column = 0; column < NumNodes; ++column){
+            // Applying conservation of mass in VELOCITY_POTENTIAL dofs
+            rLeftHandSideMatrix(row + NumNodes, column + NumNodes) = lhs_total(row, column);
 
-    // Applying wake condition on the AUXILIARY_VELOCITY_POTENTIAL dofs
-    if (data.distances[row] < 0.0)
-        for (unsigned int column = 0; column < NumNodes; ++column)
-            rLeftHandSideMatrix(row, column + NumNodes) = -lhs_total(row, column); // Side 1
-    else if (data.distances[row] > 0.0)
-        for (unsigned int column = 0; column < NumNodes; ++column)
-            rLeftHandSideMatrix(row + NumNodes, column) = -lhs_total(row, column); // Side 2
+            // Applying wake condition in AUXILIARY_VELOCITY_POTENTIAL dofs
+            rLeftHandSideMatrix(row, column) = rLhs_wake_condition(row, column);
+            rLeftHandSideMatrix(row, column + NumNodes) = -rLhs_wake_condition(row, column); // Side 1
+        }
+    }
+    else if (data.distances[row] > 0.0)  {
+        for (unsigned int column = 0; column < NumNodes; ++column){
+            // Applying conservation of mass in VELOCITY_POTENTIAL dofs
+            rLeftHandSideMatrix(row, column) = lhs_total(row, column);
+
+            // Applying wake condition in AUXILIARY_VELOCITY_POTENTIAL dofs
+            rLeftHandSideMatrix(row + NumNodes, column + NumNodes) = rLhs_wake_condition(row, column);
+            rLeftHandSideMatrix(row + NumNodes, column) = -rLhs_wake_condition(row, column); // Side 2
+        }
+    }
 }
 
 template <int Dim, int NumNodes>

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.h
@@ -208,18 +208,26 @@ private:
                                           BoundedMatrix<double, NumNodes, NumNodes>& lhs,
                                           const ElementalData<NumNodes, Dim>& data) const;
 
+    void CalculateBlockLeftHandSideWakeElement(BoundedMatrix<double, NumNodes, NumNodes>& rLhs_total,
+                                            BoundedMatrix<double, NumNodes, NumNodes>& rLhs_wake_condition,
+                                            const ElementalData<NumNodes, Dim>& rData,
+                                            const ProcessInfo& rCurrentProcessInfo);
+
     void AssignLocalSystemSubdividedElement(MatrixType& rLeftHandSideMatrix,
                                             BoundedMatrix<double, NumNodes, NumNodes>& lhs_positive,
                                             BoundedMatrix<double, NumNodes, NumNodes>& lhs_negative,
                                             BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+                                            BoundedMatrix<double, NumNodes, NumNodes>& rLhs_wake_condition,
                                             const ElementalData<NumNodes, Dim>& data) const;
 
     void AssignLocalSystemWakeElement(MatrixType& rLeftHandSideMatrix,
                                       BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+                                      BoundedMatrix<double, NumNodes, NumNodes>& rLhs_wake_condition,
                                       const ElementalData<NumNodes, Dim>& data) const;
 
     void AssignLocalSystemWakeNode(MatrixType& rLeftHandSideMatrix,
                                    BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+                                    BoundedMatrix<double, NumNodes, NumNodes>& rLhs_wake_condition,
                                    const ElementalData<NumNodes, Dim>& data,
                                    unsigned int& row) const;
 

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_incompressible_potential_element_3d.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_incompressible_potential_element_3d.cpp
@@ -1,0 +1,232 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Inigo Lopez
+//
+//
+
+// Project includes
+#include "testing/testing.h"
+#include "containers/model.h"
+#include "includes/model_part.h"
+#include "compressible_potential_flow_application_variables.h"
+#include "custom_elements/incompressible_potential_flow_element.h"
+#include "custom_utilities/potential_flow_utilities.h"
+#include "tests/cpp_tests/test_utilities.h"
+
+namespace Kratos {
+  namespace Testing {
+
+    typedef ModelPart::IndexType IndexType;
+    typedef ModelPart::NodeIterator NodeIteratorType;
+
+    void GenerateIncompressibleElement3D(ModelPart& rModelPart)
+    {
+      // Variables addition
+      rModelPart.AddNodalSolutionStepVariable(VELOCITY_POTENTIAL);
+      rModelPart.AddNodalSolutionStepVariable(AUXILIARY_VELOCITY_POTENTIAL);
+
+      // Set the element properties
+      rModelPart.CreateNewProperties(0);
+      Properties::Pointer pElemProp = rModelPart.pGetProperties(0);
+      BoundedVector<double, 3> free_stream_velocity = ZeroVector(3);
+      free_stream_velocity(0) = 10.0;
+
+      BoundedVector<double, 3> free_stream_velocity_direction = ZeroVector(3);
+      free_stream_velocity_direction(0) = 1.0;
+
+      BoundedVector<double, 3> wake_normal = ZeroVector(3);
+      wake_normal(2) = 1.0;
+
+      rModelPart.GetProcessInfo()[FREE_STREAM_VELOCITY] = free_stream_velocity;
+      rModelPart.GetProcessInfo()[FREE_STREAM_DENSITY] = 1.0;
+      rModelPart.GetProcessInfo()[FREE_STREAM_VELOCITY_DIRECTION] = free_stream_velocity_direction;
+      rModelPart.GetProcessInfo()[WAKE_NORMAL] = wake_normal;
+
+      // Geometry creation
+      rModelPart.CreateNewNode(1, 0.0, -0.2, -0.2);
+      rModelPart.CreateNewNode(2, 1.0, 0.0, 0.0);
+      rModelPart.CreateNewNode(3, 0.1, 1.0, 0.0);
+      rModelPart.CreateNewNode(4, -0.1, 0.0, 1.0);
+      std::vector<ModelPart::IndexType> elemNodes{1, 2, 3, 4};
+      rModelPart.CreateNewElement("IncompressiblePotentialFlowElement3D4N", 1, elemNodes, pElemProp);
+    }
+
+    // Checks the LHS of the 3D IncompressiblePotentialFlowElement element.
+    KRATOS_TEST_CASE_IN_SUITE(PingIncompressiblePotentialFlowElementLHS3D,
+                              CompressiblePotentialApplicationFastSuite)
+    {
+        Model this_model;
+        ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+        GenerateIncompressibleElement3D(model_part);
+        Element::Pointer p_element = model_part.pGetElement(1);
+        const unsigned int number_of_nodes = p_element->GetGeometry().size();
+
+        std::array<double, 4> potential{1.39572, 143.39275, 151.1549827, 134.284736};
+        Matrix LHS_finite_diference = ZeroMatrix(number_of_nodes, number_of_nodes);
+        Matrix LHS_analytical = ZeroMatrix(number_of_nodes, number_of_nodes);
+
+        PotentialFlowTestUtilities::ComputeElementalSensitivities<4>(
+            model_part, LHS_finite_diference, LHS_analytical, potential);
+
+        KRATOS_CHECK_MATRIX_NEAR(LHS_finite_diference, LHS_analytical, 1e-10);
+    }
+
+    // Checks the LHS of the 3D Wake IncompressiblePotentialFlowElement element.
+    KRATOS_TEST_CASE_IN_SUITE(PingWakeIncompressiblePotentialFlowElementLHS3D,
+                              CompressiblePotentialApplicationFastSuite)
+    {
+        Model this_model;
+        ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+        GenerateIncompressibleElement3D(model_part);
+        Element::Pointer p_element = model_part.pGetElement(1);
+        const unsigned int number_of_nodes = p_element->GetGeometry().size();
+
+        std::array<double, 8> potential{1.39572,     110.69275, 121.1549827,
+                                        104.284736,  2.39572,   46.69275,
+                                        100.1549827, 102.284736};
+        Matrix LHS_finite_diference = ZeroMatrix(2*number_of_nodes, 2*number_of_nodes);
+        Matrix LHS_analytical = ZeroMatrix(2*number_of_nodes, 2*number_of_nodes);
+
+        PotentialFlowTestUtilities::ComputeWakeElementalSensitivities<4>(
+            model_part, LHS_finite_diference, LHS_analytical, potential);
+
+        KRATOS_CHECK_MATRIX_NEAR(LHS_finite_diference, LHS_analytical, 1e-10);
+    }
+
+    // Checks the RHS of the 3D Wake IncompressiblePotentialFlowElement element.
+    KRATOS_TEST_CASE_IN_SUITE(WakeIncompressiblePotentialFlowElementRHS3D,
+                              CompressiblePotentialApplicationFastSuite)
+    {
+        Model this_model;
+        ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+        GenerateIncompressibleElement3D(model_part);
+        Element::Pointer p_element = model_part.pGetElement(1);
+
+        BoundedVector<double,4> distances = PotentialFlowTestUtilities::AssignDistancesToElement<4>();
+
+        p_element->GetValue(WAKE_ELEMENTAL_DISTANCES) = distances;
+        p_element->GetValue(WAKE) = true;
+
+        std::array<double, 8> potential{1.39572,     110.69275, 121.1549827,
+                                        104.284736,  2.39572,   46.69275,
+                                        100.1549827, 102.284736};
+        PotentialFlowTestUtilities::AssignPotentialsToWakeElement<4>(*p_element,distances,potential);
+
+        // Compute RHS
+        Vector RHS = ZeroVector(4);
+
+        const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+        p_element->CalculateRightHandSide(RHS, r_current_process_info);
+
+        std::vector<double> reference{11.25952380952381,-14.46333333333333,2.251904761904762,-10.51435102035238,26.29551835085714,-3.872345907866666,-10.5883452321619,-0.9519047619047605};
+
+        KRATOS_CHECK_VECTOR_NEAR(RHS, reference, 1e-13);
+    }
+
+    // Checks the LHS of the 3D Wake IncompressiblePotentialFlowElement element.
+    KRATOS_TEST_CASE_IN_SUITE(WakeIncompressiblePotentialFlowElementLHS3D,
+                              CompressiblePotentialApplicationFastSuite)
+    {
+        Model this_model;
+        ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+        GenerateIncompressibleElement3D(model_part);
+        Element::Pointer p_element = model_part.pGetElement(1);
+
+        BoundedVector<double,4> distances = PotentialFlowTestUtilities::AssignDistancesToElement<4>();
+
+        p_element->GetValue(WAKE_ELEMENTAL_DISTANCES) = distances;
+        p_element->GetValue(WAKE) = true;
+
+        std::array<double, 8> potential{1.39572,     110.69275, 121.1549827,
+                                        104.284736,  2.39572,   46.69275,
+                                        100.1549827, 102.284736};
+        PotentialFlowTestUtilities::AssignPotentialsToWakeElement<4>(*p_element,distances,potential);
+
+        // Compute LHS
+        Matrix LHS = ZeroMatrix(4, 4);
+
+        const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+        p_element->CalculateLeftHandSide(LHS, r_current_process_info);
+
+        std::vector<double> reference{0.263095238095238,-0.185,0.05261904761904762,-0.1307142857142857,-0.263095238095238,
+        0.185,-0.05261904761904762,0.1307142857142857,-0.185,0.2356666666666666,-0.03699999999999999,-0.01366666666666666,
+        0.185,-0.2356666666666666,0.03699999999999999,0.01366666666666666,0.05261904761904762,-0.03699999999999999,
+        0.01052380952380952,-0.02614285714285715,-0.05261904761904762,0.03699999999999999,-0.01052380952380952,
+        0.02614285714285715,-0.1114285714285714,-0.01066666666666666,-0.05228571428571429,0.1743809523809524,0,0,0,0,0,
+        0,0,0,0.3595238095238095,-0.17,-0.07809523809523812,-0.1114285714285714,0,0,0,0,-0.17,0.238,-0.05733333333333333,
+        -0.01066666666666666,0,0,0,0,-0.07809523809523812,-0.05733333333333333,0.1877142857142857,-0.05228571428571429,
+        0.1307142857142857,0.01366666666666666,0.02614285714285715,-0.1705238095238095,-0.1307142857142857,
+        -0.01366666666666666,-0.02614285714285715,0.1705238095238095};
+
+        for (unsigned int i = 0; i < LHS.size1(); i++) {
+            for (unsigned int j = 0; j < LHS.size2(); j++) {
+                KRATOS_CHECK_NEAR(LHS(i, j), reference[i * 8 + j], 1e-13);
+            }
+        }
+    }
+
+    // Checks the RHS of the 3D IncompressiblePotentialFlowElement element.
+    KRATOS_TEST_CASE_IN_SUITE(IncompressiblePotentialFlowElementRHS3D,
+                              CompressiblePotentialApplicationFastSuite)
+    {
+        Model this_model;
+        ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+        GenerateIncompressibleElement3D(model_part);
+        Element::Pointer p_element = model_part.pGetElement(1);
+
+        std::array<double, 4> potential{1.39572, 143.39275, 151.1549827, 134.284736};
+        PotentialFlowTestUtilities::AssignPotentialsToNormalElement<4>(*p_element,potential);
+
+        // Compute RHS
+        Vector RHS = ZeroVector(4);
+
+        const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+        p_element->CalculateRightHandSide(RHS, r_current_process_info);
+
+        std::vector<double> reference{50.64261358895238,-23.79161257453333,-13.02259285120952,-13.82840816320952};
+
+        KRATOS_CHECK_VECTOR_NEAR(RHS, reference, 1e-13);
+    }
+
+    // Checks the LHS of the 3D IncompressiblePotentialFlowElement element.
+    KRATOS_TEST_CASE_IN_SUITE(IncompressiblePotentialFlowElementLHS3D,
+                              CompressiblePotentialApplicationFastSuite)
+    {
+        Model this_model;
+        ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+        GenerateIncompressibleElement3D(model_part);
+        Element::Pointer p_element = model_part.pGetElement(1);
+
+        std::array<double, 4> potential{1.39572, 143.39275, 151.1549827, 134.284736};
+        PotentialFlowTestUtilities::AssignPotentialsToNormalElement<4>(*p_element,potential);
+
+        // Compute LHS
+        Matrix LHS = ZeroMatrix(4, 4);
+
+        const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+        p_element->CalculateLeftHandSide(LHS, r_current_process_info);
+
+        std::vector<double> reference{0.3595238095238095,-0.17,-0.07809523809523812,-0.1114285714285714,-0.17,0.238,-0.05733333333333333,-0.01066666666666666,-0.07809523809523812,-0.05733333333333333,0.1877142857142857,-0.05228571428571429,-0.1114285714285714,-0.01066666666666666,-0.05228571428571429,0.1743809523809524};
+
+        for (unsigned int i = 0; i < LHS.size1(); i++) {
+            for (unsigned int j = 0; j < LHS.size2(); j++) {
+                KRATOS_CHECK_NEAR(LHS(i, j), reference[i * 4 + j], 1e-13);
+            }
+        }
+    }
+
+  } // namespace Testing
+}  // namespace Kratos.

--- a/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
@@ -193,11 +193,11 @@ class PotentialFlowTests(UnitTest.TestCase):
 
         with WorkFolderScope(work_folder):
             self._runTest(settings_file_name)
-            self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT], 0.7331131286069874, 0.0, 1e-9)
-            self._check_results(self.main_model_part.ProcessInfo[KratosMultiphysics.DRAG_COEFFICIENT], 0.06480686535448453, 0.0, 1e-9)
-            self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_JUMP], 0.7228720706323188, 0.0, 1e-9)
-            self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_FAR_FIELD], 0.7287060122732945, 0.0, 1e-9)
-            self._check_results(self.main_model_part.ProcessInfo[CPFApp.DRAG_COEFFICIENT_FAR_FIELD], 0.008517301562764179, 0.0, 1e-9)
+            self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT], 0.734548229630418, 0.0, 1e-9)
+            self._check_results(self.main_model_part.ProcessInfo[KratosMultiphysics.DRAG_COEFFICIENT], 0.06493669400120756, 0.0, 1e-9)
+            self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_JUMP], 0.7241685913941622, 0.0, 1e-9)
+            self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_FAR_FIELD], 0.7312296375421161, 0.0, 1e-9)
+            self._check_results(self.main_model_part.ProcessInfo[CPFApp.DRAG_COEFFICIENT_FAR_FIELD], 0.008607693464186337, 0.0, 1e-9)
 
     @UnitTest.skipIfApplicationsNotAvailable("ShapeOptimizationApplication", "LinearSolversApplication")
     def test_ShapeOptimizationLiftConstrainedBodyFitted2D(self):


### PR DESCRIPTION
**Description**
After #8785, adding the linearized BC of the wake to the full potential element as well.

**Changelog**
- Adding linearized computation for the 3D element.
- Adding cpp tests. 