### PR TITLE
[PotentialFlow] Add process to compute quantities on wing sections

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_wing_section_variable_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_wing_section_variable_process.cpp
@@ -67,6 +67,8 @@ void ComputeWingSectionVariableProcess::Execute()
 {
     KRATOS_TRY;
 
+    ExecuteInitialize();
+
     block_for_each(mrModelPart.Nodes(), [&](Node<3>& rNode)
     {
         auto direction = rNode.Coordinates() - mrOrigin;

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_wing_section_variable_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_wing_section_variable_process.cpp
@@ -1,0 +1,137 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Marc Nunez
+//
+//
+//
+#include "compute_wing_section_variable_process.h"
+#include "includes/cfd_variables.h"
+#include "utilities/variable_utils.h"
+
+namespace Kratos
+{
+
+ComputeWingSectionVariableProcess::ComputeWingSectionVariableProcess(
+    ModelPart& rModelPart,
+    ModelPart& rSectionModelPart,
+    const array_1d<double,3>& rVersor,
+    const array_1d<double,3>& rOrigin,
+    const std::vector<std::string>& rVariableStringArray)
+    :mrModelPart(rModelPart),
+    mrSectionModelPart(rSectionModelPart),
+    mrVersor(rVersor),
+    mrOrigin(rOrigin)
+{
+    KRATOS_TRY
+
+    KRATOS_ERROR_IF( rVariableStringArray.size() < 1 ) <<
+    " ComputeNodalValueProcess: The variables list is empty " << std::endl;
+
+    StoreVariableList(rVariableStringArray);
+
+    KRATOS_CATCH("")
+}
+
+ComputeWingSectionVariableProcess::ComputeWingSectionVariableProcess(
+    ModelPart& rModelPart,
+    ModelPart& rSectionModelPart,
+    const array_1d<double,3>& rVersor,
+    const array_1d<double,3>& rOrigin)
+    :mrModelPart(rModelPart),
+    mrSectionModelPart(rSectionModelPart),
+    mrVersor(rVersor),
+    mrOrigin(rOrigin)
+{
+    KRATOS_TRY
+
+    const auto& r_double_var  = KratosComponents<Variable<double>>::Get("PRESSURE_COEFFICIENT");
+    mDoubleVariablesList.push_back(&r_double_var);
+
+    KRATOS_CATCH("")
+}
+
+void ComputeWingSectionVariableProcess::Execute()
+{
+    KRATOS_TRY;
+
+    for (auto& r_node : mrModelPart.Nodes()) {
+        auto direction = r_node.Coordinates() - mrOrigin;
+        auto distance = inner_prod(direction, mrVersor);
+        if (std::abs(distance) < 1e-9) {
+            r_node.SetValue(DISTANCE, 1e-9);
+        } else {
+            r_node.SetValue(DISTANCE, distance);
+        }
+    }
+    IndexType node_index = 0;
+
+    for (auto& r_cond : mrModelPart.Conditions()) {
+        auto& r_geometry = r_cond.GetGeometry();
+        IndexType n_pos = 0;
+        IndexType n_neg = 0;
+
+        for (auto& r_node : r_geometry) {
+            auto distance = r_node.GetValue(DISTANCE);
+            if (distance > 0.0) {
+                n_pos++;
+            }
+            else {
+                n_neg++;
+            }
+
+        }
+
+        if (n_neg > 0 && n_pos > 0) {
+            node_index++;
+            auto p_node = mrSectionModelPart.CreateNewNode(node_index, r_geometry.Center().X(), r_geometry.Center().Y(), r_geometry.Center().Z());
+            p_node->SetValue(PRESSURE_COEFFICIENT, r_cond.GetValue(PRESSURE_COEFFICIENT));
+        }
+    }
+
+    KRATOS_CATCH("")
+}
+
+void ComputeWingSectionVariableProcess::ExecuteInitialize()
+{
+    auto& r_nodes = mrModelPart.Nodes();
+
+    VariableUtils().SetNonHistoricalVariable(DISTANCE, 0.0, r_nodes);
+
+    const array_1d<double,3> zero_vector = ZeroVector(3);
+    for (IndexType i_var = 0; i_var < mArrayVariablesList.size(); i_var++){
+        const auto& r_array_var = *mArrayVariablesList[i_var];
+        VariableUtils().SetNonHistoricalVariable(r_array_var, zero_vector, r_nodes);
+    }
+
+    for (IndexType i_var = 0; i_var < mDoubleVariablesList.size(); i_var++){
+        const auto& r_double_var = *mDoubleVariablesList[i_var];
+        VariableUtils().SetNonHistoricalVariable(r_double_var, 0.0, r_nodes);
+    }
+}
+
+void ComputeWingSectionVariableProcess::StoreVariableList(const std::vector<std::string>& rVariableStringArray)
+{
+    // Storing variable list
+    for (IndexType i_variable=0; i_variable < rVariableStringArray.size(); i_variable++){
+        if (KratosComponents<Variable<double>>::Has(rVariableStringArray[i_variable])) {
+            const auto& r_double_var  = KratosComponents<Variable<double>>::Get(rVariableStringArray[i_variable]);
+            mDoubleVariablesList.push_back(&r_double_var);
+        }
+        else if (KratosComponents<Variable<array_1d<double,3>>>::Has(rVariableStringArray[i_variable])){
+            const auto& r_array_var = KratosComponents<Variable<array_1d<double,3>>>::Get(rVariableStringArray[i_variable]);
+            mArrayVariablesList.push_back(&r_array_var);
+        }
+        else {
+            KRATOS_ERROR << "The variable defined in the list is not a double variable nor an array variable. Given variable: " << rVariableStringArray[i_variable] << std::endl;
+        }
+    }
+
+}
+} /* namespace Kratos.*/

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_wing_section_variable_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_wing_section_variable_process.cpp
@@ -87,7 +87,7 @@ void ComputeWingSectionVariableProcess::Execute()
             cond_distances[i]= r_geometry[i].GetValue(DISTANCE);
         }
 
-        if (PotentialFlowUtilities::CheckIfElementIsCutByDistance<3,3>(cond_distances)) {
+        if (PotentialFlowUtilities::CheckIfElementIsCutByDistance<2,3>(cond_distances)) {
             auto p_node = mrSectionModelPart.CreateNewNode(++node_index, r_geometry.Center().X(), r_geometry.Center().Y(), r_geometry.Center().Z());
             for (IndexType i_var = 0; i_var < mArrayVariablesList.size(); i_var++){
                 const auto& r_array_var = *mArrayVariablesList[i_var];

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_wing_section_variable_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_wing_section_variable_process.cpp
@@ -87,7 +87,7 @@ void ComputeWingSectionVariableProcess::Execute()
             cond_distances[i]= r_geometry[i].GetValue(DISTANCE);
         }
 
-        if (PotentialFlowUtilities::CheckIfElementIsCutByDistance<3,4>(cond_distances)) {
+        if (PotentialFlowUtilities::CheckIfElementIsCutByDistance<3,3>(cond_distances)) {
             auto p_node = mrSectionModelPart.CreateNewNode(++node_index, r_geometry.Center().X(), r_geometry.Center().Y(), r_geometry.Center().Z());
             for (IndexType i_var = 0; i_var < mArrayVariablesList.size(); i_var++){
                 const auto& r_array_var = *mArrayVariablesList[i_var];

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_wing_section_variable_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_wing_section_variable_process.cpp
@@ -63,7 +63,7 @@ void ComputeWingSectionVariableProcess::Execute()
 
     for (auto& r_node : mrModelPart.Nodes()) {
         auto direction = r_node.Coordinates() - mrOrigin;
-        auto distance = inner_prod(direction, mrVersor);
+        double distance = inner_prod(direction, mrVersor);
         if (std::abs(distance) < 1e-9) {
             r_node.SetValue(DISTANCE, 1e-9);
         } else {
@@ -89,9 +89,17 @@ void ComputeWingSectionVariableProcess::Execute()
         }
 
         if (n_neg > 0 && n_pos > 0) {
-            node_index++;
-            auto p_node = mrSectionModelPart.CreateNewNode(node_index, r_geometry.Center().X(), r_geometry.Center().Y(), r_geometry.Center().Z());
-            p_node->SetValue(PRESSURE_COEFFICIENT, r_cond.GetValue(PRESSURE_COEFFICIENT));
+            auto p_node = mrSectionModelPart.CreateNewNode(++node_index, r_geometry.Center().X(), r_geometry.Center().Y(), r_geometry.Center().Z());
+            for (IndexType i_var = 0; i_var < mArrayVariablesList.size(); i_var++){
+                const auto& r_array_var = *mArrayVariablesList[i_var];
+                const auto& r_array_value = r_cond.GetValue(r_array_var);
+                p_node->SetValue(r_array_var, r_array_value);
+            }
+            for (IndexType i_var = 0; i_var < mDoubleVariablesList.size(); i_var++){
+                const auto& r_double_var = *mDoubleVariablesList[i_var];
+                const auto& r_double_value = r_cond.GetValue(r_double_var);
+                p_node->SetValue(r_double_var, r_double_value);
+            }
         }
     }
 

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_wing_section_variable_process.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_wing_section_variable_process.h
@@ -107,8 +107,8 @@ private:
 
     ModelPart& mrModelPart; // The main model part
     ModelPart& mrSectionModelPart; // The newly crated section model part
-    const array_1d<double,3>& mrVersor; // The plane normal
-    const array_1d<double,3>& mrOrigin; // A point of the plane
+    array_1d<double,3> mrVersor; // The plane normal
+    array_1d<double,3> mrOrigin; // A point of the plane
     std::vector<const Variable<array_1d<double, 3>>*>    mArrayVariablesList;
     std::vector<const Variable<double>*>                 mDoubleVariablesList;
 

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_wing_section_variable_process.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_wing_section_variable_process.h
@@ -1,0 +1,144 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Marc Nunez
+//
+//
+
+#if !defined(KRATOS_COMPUTE_WING_SECTION_VARIABLE_PROCESS_INCLUDED)
+#define  KRATOS_COMPUTE_WING_SECTION_VARIABLE_PROCESS_INCLUDED
+
+// Project includes
+#include "includes/define.h"
+#include "processes/process.h"
+#include "includes/model_part.h"
+
+namespace Kratos
+{
+
+///@name Kratos Classes
+///@{
+
+
+class KRATOS_API(COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION) ComputeWingSectionVariableProcess
+    : public Process
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of ComputeWingSectionVariableProcess
+    KRATOS_CLASS_POINTER_DEFINITION(ComputeWingSectionVariableProcess);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor
+    ComputeWingSectionVariableProcess(
+        ModelPart& rModelPart,
+        ModelPart& rSectionModelPart,
+        const array_1d<double,3>& rVersor,
+        const array_1d<double,3>& rOrigin,
+        const std::vector<std::string>& rVariableStringArray);
+
+    ComputeWingSectionVariableProcess(
+        ModelPart& rModelPart,
+        ModelPart& rSectionModelPart,
+        const array_1d<double,3>& rVersor,
+        const array_1d<double,3>& rOrigin);
+
+    /// Destructor.
+    ~ComputeWingSectionVariableProcess() override
+    {
+    }
+
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /// This operator is provided to call the process as a function and simply calls the Execute method.
+    void operator()()
+    {
+        Execute();
+    }
+
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    void Execute() override;
+
+    void ExecuteInitialize() override;
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        return "ComputeWingSectionVariableProcess";
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const override
+    {
+        rOStream << "ComputeWingSectionVariableProcess";
+    }
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const override
+    {
+    }
+    ///@}
+
+private:
+    ///@name Member Variables
+    ///@{
+
+    ModelPart& mrModelPart; // The main model part
+    ModelPart& mrSectionModelPart; // The newly crated section model part
+    const array_1d<double,3>& mrVersor; // The plane normal
+    const array_1d<double,3>& mrOrigin; // A point of the plane
+    std::vector<const Variable<array_1d<double, 3>>*>    mArrayVariablesList;
+    std::vector<const Variable<double>*>                 mDoubleVariablesList;
+
+    ///@}
+
+    ///@name Un accessible methods
+    ///@{
+
+    /**
+     * @brief Reads the variables list specified in the input and stores them
+     * in the mDoubleVariablesList and the mComponentVariablesList.
+     * @param rVariableStringArray Array containing the variables whose value
+     * is transfered from elements to nodes
+    */
+    void StoreVariableList(const std::vector<std::string>& rVariableStringArray);
+
+    /// Assignment operator.
+    ComputeWingSectionVariableProcess& operator=(ComputeWingSectionVariableProcess const& rOther);
+
+    /// Copy constructor.
+    //ComputeWingSectionVariableProcess(ComputeWingSectionVariableProcess const& rOther);
+
+
+    ///@}
+
+}; // Class ComputeWingSectionVariableProcess
+
+///@}
+}  // namespace Kratos.
+
+#endif // KRATOS_COMPUTE_NODAL_VALUE_PROCESS_INCLUDED  defined
+
+

--- a/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_processes_to_python.cpp
@@ -25,6 +25,7 @@
 #include "custom_processes/compute_embedded_lift_process.h"
 #include "custom_processes/define_embedded_wake_process.h"
 #include "custom_processes/compute_nodal_value_process.h"
+#include "custom_processes/compute_wing_section_variable_process.h"
 
 namespace Kratos {
 namespace Python {
@@ -71,6 +72,12 @@ void  AddCustomProcessesToPython(pybind11::module& m)
     py::class_<ComputeNodalValueProcess, ComputeNodalValueProcess::Pointer, Process>
         (m,"ComputeNodalValueProcess")
         .def(py::init<ModelPart&, const std::vector<std::string>&>())
+    ;
+
+    py::class_<ComputeWingSectionVariableProcess, ComputeWingSectionVariableProcess::Pointer, Process>
+        (m,"ComputeWingSectionVariableProcess")
+        .def(py::init<ModelPart&, ModelPart&, const array_1d<double, 3>&, const array_1d<double, 3>&>())
+        .def(py::init<ModelPart&, ModelPart&, const array_1d<double, 3>&, const array_1d<double, 3>&, const std::vector<std::string>& >())
     ;
 }
 

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_processes.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_processes.cpp
@@ -351,7 +351,6 @@ namespace Kratos {
         auto nodal_velocity = r_node.GetValue(VELOCITY);
         KRATOS_CHECK_NEAR(nodal_velocity[0], 1, 1e-6);
         KRATOS_CHECK_NEAR(nodal_velocity[1], 1, 1e-6);
-
         KRATOS_CHECK_NEAR(nodal_velocity[2], 0, 1e-6);
         auto nodal_pressure = r_node.GetValue(PRESSURE_COEFFICIENT);
         KRATOS_CHECK_NEAR(nodal_pressure, 0.98, 1e-6);

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_processes.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_processes.cpp
@@ -20,6 +20,7 @@
 #include "custom_processes/define_2d_wake_process.h"
 #include "custom_processes/apply_far_field_process.h"
 #include "custom_processes/compute_nodal_value_process.h"
+#include "custom_processes/compute_wing_section_variable_process.h"
 
 namespace Kratos {
   namespace Testing {
@@ -350,10 +351,81 @@ namespace Kratos {
         auto nodal_velocity = r_node.GetValue(VELOCITY);
         KRATOS_CHECK_NEAR(nodal_velocity[0], 1, 1e-6);
         KRATOS_CHECK_NEAR(nodal_velocity[1], 1, 1e-6);
+
         KRATOS_CHECK_NEAR(nodal_velocity[2], 0, 1e-6);
         auto nodal_pressure = r_node.GetValue(PRESSURE_COEFFICIENT);
         KRATOS_CHECK_NEAR(nodal_pressure, 0.98, 1e-6);
       }
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(ComputeWingSectionVariableProcess, CompressiblePotentialApplicationFastSuite)
+    {
+      // Create model_part
+      Model this_model;
+      ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+      model_part.GetProcessInfo()[DOMAIN_SIZE] = 3;
+
+      // Set model_part properties
+      BoundedVector<double, 3> free_stream_velocity = ZeroVector(3);
+      free_stream_velocity(0) = 10.0;
+      model_part.GetProcessInfo()[FREE_STREAM_VELOCITY] = free_stream_velocity;
+
+      // Variables addition
+      model_part.AddNodalSolutionStepVariable(VELOCITY_POTENTIAL);
+
+      // Set the element properties
+      model_part.CreateNewProperties(0);
+      Properties::Pointer p_cond_prop = model_part.pGetProperties(0);
+
+      // Geometry creation
+      model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+      model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+      model_part.CreateNewNode(3, 1.0, 1.0, 0.0);
+      std::vector<ModelPart::IndexType> cond_nodes_1{ 1, 2, 3 };
+      model_part.CreateNewCondition("SurfaceCondition3D3N", 1, cond_nodes_1, p_cond_prop);
+
+      auto& r_condition = model_part.GetCondition(1);
+
+      r_condition.SetValue(PRESSURE_COEFFICIENT, 0.5);
+
+      Vector velocity(3);
+      velocity(0) = 1.0;
+      velocity(1) = 2.0;
+      velocity(2) = 3.0;
+      r_condition.SetValue(VELOCITY, velocity);
+
+      ModelPart& section_model_part_1 = this_model.CreateModelPart("section_1", 3);
+
+      Vector origin(3, 0.0);
+      origin(0) = 1.0/3.0;
+      origin(1) = 1.0/3.0;
+
+      Vector versor(3, 0.0);
+      versor(1) = 1.0;
+
+      ComputeWingSectionVariableProcess ComputeWingSectionVariableProcessDefault(
+                                      model_part,
+                                      section_model_part_1,
+                                      versor,
+                                      origin);
+      ComputeWingSectionVariableProcessDefault.Execute();
+
+      auto& r_node_section_1 = section_model_part_1.GetNode(1);
+      KRATOS_CHECK_NEAR(r_node_section_1.GetValue(PRESSURE_COEFFICIENT), 0.5, 1e-6);
+
+      const std::vector<std::string> variable_array = {"VELOCITY","PRESSURE_COEFFICIENT"};
+      ModelPart& section_model_part_2 = this_model.CreateModelPart("section_2", 3);
+      ComputeWingSectionVariableProcess ComputeWingSectionVariableProcessWithArray(
+                                      model_part,
+                                      section_model_part_2,
+                                      versor,
+                                      origin,
+                                      variable_array);
+      ComputeWingSectionVariableProcessWithArray.Execute();
+
+      auto& r_node_section_2 = section_model_part_2.GetNode(1);
+      KRATOS_CHECK_NEAR(r_node_section_2.GetValue(PRESSURE_COEFFICIENT), 0.5, 1e-6);
+      KRATOS_CHECK_VECTOR_NEAR(r_node_section_2.GetValue(VELOCITY), velocity, 1e-6);
     }
   } // namespace Testing
 }  // namespace Kratos.


### PR DESCRIPTION
**Description**
This process finds the section of a wing for a given plane (geometrical plane defined with its normal vector and a point, not an aircraft 😄 ) and computes a given set of variables on the section in a new model part. 

Very useful to plot typical pressure distribution plots. 

@inigolcanalejo I changed the name and generalised the process to use any variable.

**Changelog**
- Adding new wing section process and cpp tests.
