### PR TITLE
Adding pydocstyle config file

### DIFF
--- a/.pydocstyle
+++ b/.pydocstyle
@@ -1,0 +1,4 @@
+[pydocstyle]
+inherit = false
+ignore = D212
+match = .*\.py


### PR DESCRIPTION
**Description**
Trying to adapt the codacy config for the pydocstyle tool (see #8816).

I've changed Kratos codacy to use the python tools for python3 (we were using the ones for python2) as well. Let's see if this solves the problem

**Changelog**
- Ignoring D212 from pep257
