### PR TITLE
[Core][Fluid] Add ComputeLevelForceProcess

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/compute_level_force_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/compute_level_force_process.py
@@ -1,0 +1,121 @@
+# Kratos imports
+import KratosMultiphysics
+from KratosMultiphysics.time_based_ascii_file_writer_utility import TimeBasedAsciiFileWriterUtility
+
+# STL imports
+import pathlib
+
+
+class ComputeLevelForceProcess(KratosMultiphysics.Process):
+    """
+    Reduce nodal reaction forces and torques on stacked slab domains.
+
+    A region of space between 'bottom_point' and 'top_point' is subdivided into 'number_of_slabs'
+    parallel slabs. Then, nodes from the specified model part are sorted into sub model parts
+    based on which slab they are located in. Finally, for each sub model part, the reaction forces
+    are summed up, and their torque (plus MOMENT if applicable) is reduced to 'moment_reference_point'.
+    The reduced values are written to output files for each sub model part.
+
+    Default parameters:
+    {
+        "moment_reference_point" : [0.0, 0.0, 0.0],
+        "bottom_point" : [0.0, 0.0, 0.0],
+        "top_point" : [0.0, 0.0, 0.0],
+        "number_of_slabs" : 1,
+        "open_domain" : false,
+        "time_domain" : [0.0, 1e100],
+        "output_name_stub" : "slab_"
+    }
+    """
+    def __init__(self, modelPart: KratosMultiphysics.ModelPart, parameters: KratosMultiphysics.Parameters):
+        super().__init__()
+        self.model_part = modelPart
+        
+        parameters.ValidateAndAssignDefaults(self.GetDefaultParameters())
+        self.moment_reference_point = parameters["moment_reference_point"].GetVector()
+        self.bottom_point = parameters["bottom_point"].GetVector()
+        self.top_point = parameters["top_point"].GetVector()
+        self.time_domain = parameters["time_domain"].GetVector()
+        self.number_of_slabs = parameters["number_of_slabs"].GetInt()
+        self.is_open_domain = parameters["open_domain"].GetBool()
+        self.output_name_stub = pathlib.Path(parameters["output_name_stub"].GetString())
+
+    
+    def ExecuteFinalizeSolutionStep(self):
+        time = self.model_part.ProcessInfo[KratosMultiphysics.TIME]
+
+        if self.time_domain[0] <= time and time <= self.time_domain[1]:
+            sub_model_parts = KratosMultiphysics.ModelSubdivisionUtilities.SortNodesBySlabs(
+                self.model_part,
+                self.bottom_point,
+                self.top_point,
+                self.number_of_slabs,
+                self.is_open_domain
+            )
+
+            for model_part_index, model_part in enumerate(sub_model_parts):
+                force, torque = KratosMultiphysics.ForceAndTorqueUtils.ComputeEquivalentForceAndTorque(
+                    model_part,
+                    self.moment_reference_point,
+                    KratosMultiphysics.REACTION,
+                    KratosMultiphysics.MOMENT
+                )
+
+                output_params = KratosMultiphysics.Parameters("""
+                {
+                    "output_path" : "",
+                    "file_name" : ""
+                }
+                """)
+
+                output_params["output_path"].SetString(str(self.output_name_stub.parent))
+                output_params["file_name"].SetString("{}{}".format(self.output_name_stub.name, str(model_part_index)))
+
+                # TODO: this is a barebone output, implement something more user friendly
+                output_header = ""
+
+                output_file = TimeBasedAsciiFileWriterUtility(
+                    model_part,
+                    output_params,
+                    output_header
+                ).file
+
+                output_file.write("force:\t{}\ntorque:\t{}".format(force, torque))
+                output_file.flush()
+                output_file.close()
+
+
+    def GetDefaultParameters(self):
+        return KratosMultiphysics.Parameters("""
+        {
+            "moment_reference_point" : [0.0, 0.0, 0.0],
+            "bottom_point" : [0.0, 0.0, 0.0],
+            "top_point" : [0.0, 0.0, 0.0],
+            "number_of_slabs" : 1,
+            "open_domain" : false,
+            "time_domain" : [0.0, 1e100],
+            "output_name_stub" : "slab_"
+        }
+        """)
+
+
+    @staticmethod
+    def ParseOutput(fileName: pathlib.Path):
+        """Get output values from a file written by this process (temporary implementation)"""
+
+        def ParseList(line: str):
+            begin = line.index('(') + 1
+            end = line.index(')')
+            values = [float(component.strip()) for component in line[begin:end].split(',') if component ]
+            return values
+
+        force = []
+        torque = []
+        with open(fileName, 'r') as file:
+            for line in file:
+                if "force" in line:
+                    force = ParseList(line)
+                elif "torque" in line:
+                    torque = ParseList(line)
+
+        return force, torque

--- a/applications/FluidDynamicsApplication/python_scripts/compute_level_force_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/compute_level_force_process.py
@@ -7,30 +7,28 @@ import pathlib
 
 
 class ComputeLevelForceProcess(KratosMultiphysics.Process):
-    """
-    Reduce nodal reaction forces and torques on stacked slab domains.
-
-    A region of space between 'bottom_point' and 'top_point' is subdivided into 'number_of_slabs'
-    parallel slabs. Then, nodes from the specified model part are sorted into sub model parts
-    based on which slab they are located in. Finally, for each sub model part, the reaction forces
-    are summed up, and their torque (plus MOMENT if applicable) is reduced to 'moment_reference_point'.
-    The reduced values are written to output files for each sub model part.
-
-    Default parameters:
-    {
-        "moment_reference_point" : [0.0, 0.0, 0.0],
-        "bottom_point" : [0.0, 0.0, 0.0],
-        "top_point" : [0.0, 0.0, 0.0],
-        "number_of_slabs" : 1,
-        "open_domain" : false,
-        "time_domain" : [0.0, 1e100],
-        "output_name_stub" : "slab_"
-    }
-    """
     def __init__(self, modelPart: KratosMultiphysics.ModelPart, parameters: KratosMultiphysics.Parameters):
+        """Reduce nodal reaction forces and torques on stacked slab domains.
+        A region of space between 'bottom_point' and 'top_point' is subdivided into 'number_of_slabs'
+        parallel slabs. Then, nodes from the specified model part are sorted into sub model parts
+        based on which slab they are located in. Finally, for each sub model part, the reaction forces
+        are summed up, and their torque (plus MOMENT if applicable) is reduced to 'moment_reference_point'.
+        The reduced values are written to output files for each sub model part.
+
+        Default parameters:
+        {
+            "moment_reference_point" : [0.0, 0.0, 0.0],
+            "bottom_point" : [0.0, 0.0, 0.0],
+            "top_point" : [0.0, 0.0, 0.0],
+            "number_of_slabs" : 1,
+            "open_domain" : false,
+            "time_domain" : [0.0, 1e100],
+            "output_name_stub" : "slab_"
+        }"""
+
         super().__init__()
         self.model_part = modelPart
-        
+
         parameters.ValidateAndAssignDefaults(self.GetDefaultParameters())
         self.moment_reference_point = parameters["moment_reference_point"].GetVector()
         self.bottom_point = parameters["bottom_point"].GetVector()
@@ -85,7 +83,8 @@ class ComputeLevelForceProcess(KratosMultiphysics.Process):
                 output_file.close()
 
 
-    def GetDefaultParameters(self):
+    @staticmethod
+    def GetDefaultParameters():
         return KratosMultiphysics.Parameters("""
         {
             "moment_reference_point" : [0.0, 0.0, 0.0],
@@ -101,7 +100,7 @@ class ComputeLevelForceProcess(KratosMultiphysics.Process):
 
     @staticmethod
     def ParseOutput(fileName: pathlib.Path):
-        """Get output values from a file written by this process (temporary implementation)"""
+        """Get output values from a file written by this process (temporary implementation)."""
 
         def ParseList(line: str):
             begin = line.index('(') + 1

--- a/applications/FluidDynamicsApplication/tests/test_compute_level_force_process.py
+++ b/applications/FluidDynamicsApplication/tests/test_compute_level_force_process.py
@@ -3,7 +3,6 @@ import numpy
 
 # Kratos imports
 import KratosMultiphysics
-import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 from KratosMultiphysics.FluidDynamicsApplication.compute_level_force_process import ComputeLevelForceProcess
 import KratosMultiphysics.KratosUnittest as UnitTest
 import KratosMultiphysics.kratos_utilities as KratosUtils
@@ -55,19 +54,29 @@ class ComputeLevelForceProcessTest(UnitTest.TestCase):
         self.assertAlmostEqual(force[0], 7.2)
         self.assertAlmostEqual(force[1], -36.0)
         self.assertAlmostEqual(force[2], 36.0)
+        self.assertAlmostEqual(torque[0], 52.8)
+        self.assertAlmostEqual(torque[1], 0.84)
+        self.assertAlmostEqual(torque[2], -8.04)
 
         force, torque = ComputeLevelForceProcess.ParseOutput(GetFilePath("test_compute_level_force_process_1.dat"))
         self.assertAlmostEqual(force[0], 14.4)
         self.assertAlmostEqual(force[1], -18.0)
         self.assertAlmostEqual(force[2], 18.0)
+        self.assertAlmostEqual(torque[0], 26.4)
+        self.assertAlmostEqual(torque[1], 1.68)
+        self.assertAlmostEqual(torque[2], -16.08)
 
         force, torque = ComputeLevelForceProcess.ParseOutput(GetFilePath("test_compute_level_force_process_2.dat"))
         self.assertAlmostEqual(force[0], 50.4)
         self.assertAlmostEqual(force[1], -36.0)
         self.assertAlmostEqual(force[2], 36.0)
+        self.assertAlmostEqual(torque[0], 52.8)
+        self.assertAlmostEqual(torque[1], 5.88)
+        self.assertAlmostEqual(torque[2], -56.28)
 
 
-    def tearDown(self):
+    @classmethod
+    def tearDown(cls):
         KratosUtils.DeleteFileIfExisting(GetFilePath("test_compute_level_force_process_0.dat"))
         KratosUtils.DeleteFileIfExisting(GetFilePath("test_compute_level_force_process_1.dat"))
         KratosUtils.DeleteFileIfExisting(GetFilePath("test_compute_level_force_process_2.dat"))

--- a/applications/FluidDynamicsApplication/tests/test_compute_level_force_process.py
+++ b/applications/FluidDynamicsApplication/tests/test_compute_level_force_process.py
@@ -1,0 +1,77 @@
+# External imports
+import numpy
+
+# Kratos imports
+import KratosMultiphysics
+import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
+from KratosMultiphysics.FluidDynamicsApplication.compute_level_force_process import ComputeLevelForceProcess
+import KratosMultiphysics.KratosUnittest as UnitTest
+import KratosMultiphysics.kratos_utilities as KratosUtils
+
+# STL imports
+import pathlib
+
+
+def GetFilePath(fileName):
+    return pathlib.Path(__file__).absolute().parent / fileName
+
+
+class ComputeLevelForceProcessTest(UnitTest.TestCase):
+
+    def GenerateModelPart(self):
+        model = KratosMultiphysics.Model()
+        model_part = model.CreateModelPart("main")
+
+        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.REACTION)
+
+        # Fill a unit cube with nodes and assign reactions to them
+        coordinates = numpy.linspace(0.0, 1.0, num=6)
+        node_counter = 0
+        for x in coordinates:
+            for y in coordinates:
+                for z in coordinates:
+                    node_counter += 1
+                    node = model_part.CreateNewNode(node_counter, x, y, z)
+                    node.SetSolutionStepValue(KratosMultiphysics.REACTION, [x*(y+z), -z, y])
+
+        return model_part
+
+    def testComputeLevelForceProcess(self):
+        parameters = KratosMultiphysics.Parameters("""
+        {
+            "bottom_point" : [0.0, 0.0, 0.0],
+            "top_point" : [0.9, 0.0, 0.0],
+            "number_of_slabs" : 3,
+            "output_name_stub" : ""
+        }
+        """)
+        parameters["output_name_stub"].SetString(str(GetFilePath("test_compute_level_force_process_")))
+        model_part = self.GenerateModelPart()
+        ComputeLevelForceProcess(
+            model_part,
+            parameters).ExecuteFinalizeSolutionStep()
+
+        force, torque = ComputeLevelForceProcess.ParseOutput(GetFilePath("test_compute_level_force_process_0.dat"))
+        self.assertAlmostEqual(force[0], 7.2)
+        self.assertAlmostEqual(force[1], -36.0)
+        self.assertAlmostEqual(force[2], 36.0)
+
+        force, torque = ComputeLevelForceProcess.ParseOutput(GetFilePath("test_compute_level_force_process_1.dat"))
+        self.assertAlmostEqual(force[0], 14.4)
+        self.assertAlmostEqual(force[1], -18.0)
+        self.assertAlmostEqual(force[2], 18.0)
+
+        force, torque = ComputeLevelForceProcess.ParseOutput(GetFilePath("test_compute_level_force_process_2.dat"))
+        self.assertAlmostEqual(force[0], 50.4)
+        self.assertAlmostEqual(force[1], -36.0)
+        self.assertAlmostEqual(force[2], 36.0)
+
+
+    def tearDown(self):
+        KratosUtils.DeleteFileIfExisting(GetFilePath("test_compute_level_force_process_0.dat"))
+        KratosUtils.DeleteFileIfExisting(GetFilePath("test_compute_level_force_process_1.dat"))
+        KratosUtils.DeleteFileIfExisting(GetFilePath("test_compute_level_force_process_2.dat"))
+
+
+if __name__ == "__main__":
+    UnitTest.main()

--- a/kratos/python/add_other_utilities_to_python.cpp
+++ b/kratos/python/add_other_utilities_to_python.cpp
@@ -58,6 +58,7 @@
 #include "utilities/dense_svd_decomposition.h"
 #include "utilities/force_and_torque_utils.h"
 #include "utilities/sub_model_part_entities_boolean_operation_utility.h"
+#include "utilities/model_subdivision_utilities.h"
 
 namespace Kratos {
 namespace Python {
@@ -666,6 +667,9 @@ void AddOtherUtilitiesToPython(pybind11::module &m)
     AddSubModelPartEntitiesBooleanOperationToPython<MasterSlaveConstraint,ModelPart::MasterSlaveConstraintContainerType>(
         m, "SubModelPartConstraintsBooleanOperationUtility");
 
+    py::class_<ModelSubdivisionUtilities>(m, "ModelSubdivisionUtilities")
+        .def_static("SortNodesBySlabs", &ModelSubdivisionUtilities::SortNodesBySlabs)
+        ;
 }
 
 } // namespace Python.

--- a/kratos/tests/cpp_tests/utilities/test_model_subdivision_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_model_subdivision_utilities.cpp
@@ -1,0 +1,185 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Máté Kelemen
+//
+
+// Project Includes
+#include "containers/model.h"
+#include "testing/testing.h"
+
+// Utility includes
+#include "utilities/model_subdivision_utilities.h"
+
+
+namespace Kratos
+{
+namespace Testing
+{
+
+
+KRATOS_TEST_CASE_IN_SUITE(ModelSubdivisionUtilitiesSortNodesBySlabs, KratosCoreFastSuite)
+{
+    Model model;
+    ModelPart& r_model_part = model.CreateModelPart("main");
+
+    // Fill a cartesian domain with nodes
+    // Domain corners: {-2.0, -2.0, -2.0} {2.0, 2.0, 2.0}
+    const std::size_t resolution = 6;
+    const double distance = 4.0 / (resolution - 1);
+    std::size_t node_counter = 0;
+    
+    for (std::size_t i=0; i<resolution; ++i) {
+        for (std::size_t j=0; j<resolution; ++j) {
+            for (std::size_t k=0; k<resolution; ++k) {
+                r_model_part.CreateNewNode(
+                    ++node_counter,
+                    -2.0 + i * distance,
+                    -2.0 + j * distance,
+                    -2.0 + k * distance
+                );
+            }
+        }
+    }
+
+    // Sort nodes by z:
+    //  z in [-1, -1/3[     -> 0
+    //  z in [-1/3, 1/3[    -> 1 (empty)
+    //  z in [1/3, 1]       -> 2
+    auto sub_model_parts = ModelSubdivisionUtilities::SortNodesBySlabs(
+        r_model_part,
+        array_1d<double,3>({0.0, 0.0, -1.0}),
+        array_1d<double,3>({0.0, 0.0, 1.0}),
+        3,
+        false
+    );
+
+    KRATOS_CHECK_EQUAL(sub_model_parts.size(), 3);
+
+    KRATOS_CHECK_NOT_EQUAL(sub_model_parts[0], nullptr);
+    KRATOS_CHECK_EQUAL(sub_model_parts[0]->Nodes().size(), resolution * resolution);
+    for (const auto& r_node : sub_model_parts[0]->Nodes()) {
+        KRATOS_CHECK(-1.0 <= r_node.Z());
+        KRATOS_CHECK(r_node.Z() < -1.0/3.0);
+    }
+
+    KRATOS_CHECK_NOT_EQUAL(sub_model_parts[1], nullptr);
+    KRATOS_CHECK_EQUAL(sub_model_parts[1]->Nodes().size(), 0);
+
+    KRATOS_CHECK_NOT_EQUAL(sub_model_parts[2], nullptr);
+    KRATOS_CHECK_EQUAL(sub_model_parts[2]->Nodes().size(), resolution * resolution);
+    for (const auto& r_node : sub_model_parts[2]->Nodes()) {
+        KRATOS_CHECK(1.0/3.0 <= r_node.Z());
+        KRATOS_CHECK(r_node.Z() <= 1.0);
+    }
+}
+
+
+// Make protected content accessible
+struct MockUtility : public ModelSubdivisionUtilities
+{
+    using ModelSubdivisionUtilities::Slab;
+    using ModelSubdivisionUtilities::SlabStack;
+};
+
+
+KRATOS_TEST_CASE_IN_SUITE(ModelSubdivisionUtilitiesSlab, KratosCoreFastSuite)
+{
+    const array_1d<double,3> bottom({-1.0, -1.0, 0.0});
+    const array_1d<double,3> top({1.0, 1.0, 0.0});
+
+    // Check invalid construction
+    auto make_degenerate_slab = [&](){MockUtility::Slab {bottom, bottom, false};};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(make_degenerate_slab(), "Degenerate slab!");
+
+    // Check point location
+    const MockUtility::Slab closed_slab {bottom, top, false};
+    const MockUtility::Slab open_slab {bottom, top, true};
+
+    const array_1d<double,3> test_below({-1.0, -2.0, 100.0});
+    const array_1d<double,3> test_bottom_boundary = bottom;
+    const array_1d<double,3> test_inside({0.0, 0.0, 100.0});
+    const array_1d<double,3> test_top_boundary = top;
+    const array_1d<double,3> test_above({1.0, 2.0, 100.0});
+
+    // Closed slab
+    KRATOS_CHECK(closed_slab.IsBelow(test_below));
+    KRATOS_CHECK(!closed_slab.IsInside(test_below));
+    KRATOS_CHECK(!closed_slab.IsAbove(test_below));
+
+    KRATOS_CHECK(!closed_slab.IsBelow(test_bottom_boundary));
+    KRATOS_CHECK(closed_slab.IsInside(test_bottom_boundary));
+    KRATOS_CHECK(!closed_slab.IsAbove(test_bottom_boundary));
+
+    KRATOS_CHECK(!closed_slab.IsBelow(test_inside));
+    KRATOS_CHECK(closed_slab.IsInside(test_inside));
+    KRATOS_CHECK(!closed_slab.IsAbove(test_inside));
+
+    KRATOS_CHECK(!closed_slab.IsBelow(test_top_boundary));
+    KRATOS_CHECK(closed_slab.IsInside(test_top_boundary));
+    KRATOS_CHECK(!closed_slab.IsAbove(test_top_boundary));
+
+    KRATOS_CHECK(!closed_slab.IsBelow(test_above));
+    KRATOS_CHECK(!closed_slab.IsInside(test_above));
+    KRATOS_CHECK(closed_slab.IsAbove(test_above));
+
+    // Open slab
+    KRATOS_CHECK(open_slab.IsBelow(test_below));
+    KRATOS_CHECK(!open_slab.IsInside(test_below));
+    KRATOS_CHECK(!open_slab.IsAbove(test_below));
+
+    KRATOS_CHECK(open_slab.IsBelow(test_bottom_boundary));
+    KRATOS_CHECK(!open_slab.IsInside(test_bottom_boundary));
+    KRATOS_CHECK(!open_slab.IsAbove(test_bottom_boundary));
+
+    KRATOS_CHECK(!open_slab.IsBelow(test_inside));
+    KRATOS_CHECK(open_slab.IsInside(test_inside));
+    KRATOS_CHECK(!open_slab.IsAbove(test_inside));
+
+    KRATOS_CHECK(!open_slab.IsBelow(test_top_boundary));
+    KRATOS_CHECK(!open_slab.IsInside(test_top_boundary));
+    KRATOS_CHECK(open_slab.IsAbove(test_top_boundary));
+
+    KRATOS_CHECK(!open_slab.IsBelow(test_above));
+    KRATOS_CHECK(!open_slab.IsInside(test_above));
+    KRATOS_CHECK(open_slab.IsAbove(test_above));
+}
+
+
+KRATOS_TEST_CASE_IN_SUITE(ModelSubdivisionUtilitiesSlabStack, KratosCoreFastSuite)
+{
+    const array_1d<double,3> bottom({-1.0, -1.0, 0.0});
+    const array_1d<double,3> top({1.0, 1.0, 0.0});
+
+    // Check invalid construction
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(MockUtility::SlabStack(bottom, top, 0, false), "Number of slabs in a stack must be at least 1");
+
+    // Check point location
+    const MockUtility::SlabStack slab_stack(bottom, top, 4, false);
+
+    KRATOS_CHECK_EQUAL(slab_stack.size(), 4);
+
+    const array_1d<double,3> test_below({-1.0, -3.0, 100.0});
+    const array_1d<double,3> test_in_0({-7.0/4.0, 1.0/4.0, 100.0});
+    const array_1d<double,3> test_in_1({-1.0/4.0, -1.0/4.0, 100.0});
+    const array_1d<double,3> test_in_2({1.0/4.0, 1.0/4.0, 100.0});
+    const array_1d<double,3> test_in_3({7.0/4.0, -1.0/4.0, 100.0});
+    const array_1d<double,3> test_above({1.0, 3.0, 100.0});
+
+    //KRATOS_CHECK_EXCEPTION_IS_THROWN(slab_stack.SlabIndex(test_below), "");
+    KRATOS_CHECK_EQUAL(slab_stack.SlabIndex(test_in_0), 0);
+    KRATOS_CHECK_EQUAL(slab_stack.SlabIndex(test_in_1), 1);
+    KRATOS_CHECK_EQUAL(slab_stack.SlabIndex(test_in_2), 2);
+    KRATOS_CHECK_EQUAL(slab_stack.SlabIndex(test_in_3), 3);
+    //KRATOS_CHECK_EXCEPTION_IS_THROWN(slab_stack.SlabIndex(test_above), "");
+}
+
+
+} // namespace Testing
+} // namespace Kratos

--- a/kratos/utilities/model_subdivision_utilities.cpp
+++ b/kratos/utilities/model_subdivision_utilities.cpp
@@ -1,0 +1,264 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Máté Kelemen
+//
+
+// Project includes
+#include "model_subdivision_utilities.h"
+#include "parallel_utilities.h"
+
+
+namespace Kratos
+{
+
+
+std::vector<shared_ptr<ModelPart>> ModelSubdivisionUtilities::SortNodesBySlabs(
+    ModelPart& rModelPart,
+    const array_1d<double,3>& rBottomPoint,
+    const array_1d<double,3>& rTopPoint,
+    std::size_t numberOfSlabs,
+    bool isRootSlabOpen)
+{
+    KRATOS_TRY
+
+    // Construct slabs
+    const ModelSubdivisionUtilities::SlabStack slabs(rBottomPoint, rTopPoint, numberOfSlabs, isRootSlabOpen);
+    
+    // Construct sub model parts
+    std::vector<ModelPart*> sub_model_parts;
+    sub_model_parts.reserve(slabs.size());
+    for (std::size_t i_slab=0; i_slab<slabs.size(); ++i_slab) {
+        sub_model_parts.push_back(&rModelPart.CreateSubModelPart(
+            rModelPart.Name() + "_slab_" + std::to_string(i_slab)
+        ));
+    }
+
+    // Assign nodes to sub model parts
+    auto sort_function = [&slabs, &sub_model_parts](const Node<3>& rNode) -> ModelPart*
+    {
+        KRATOS_TRY
+        return slabs.IsInside(rNode) ?
+            sub_model_parts[slabs.SlabIndex(rNode)]
+            :
+            nullptr;
+        KRATOS_CATCH("");
+    };
+
+    ModelSubdivisionUtilities::SortNodes(
+        rModelPart,
+        sort_function,
+        sub_model_parts
+    );
+
+    // Convert raw pointers to smart ones
+    std::vector<shared_ptr<ModelPart>> output;
+    output.reserve(sub_model_parts.size());
+
+    for (std::size_t i_model_part=0; i_model_part<sub_model_parts.size(); ++i_model_part) {
+        output.push_back(rModelPart.SubModelParts()(sub_model_parts[i_model_part]->Name()));
+    }
+
+    return output;
+
+    KRATOS_CATCH("");
+}
+
+
+void ModelSubdivisionUtilities::SortNodes(
+    ModelPart& rModelPart,
+    std::function<ModelPart*(const Node<3>&)> sortFunction,
+    std::vector<ModelPart*>& rSubModelParts)
+{
+    KRATOS_TRY
+
+    ModelSubdivisionUtilities::ThreadSafeIndexSet index_sets(rSubModelParts);
+
+    block_for_each(rModelPart.Nodes(),
+        [&](const Node<3>& rNode)
+        {
+            index_sets.Push(
+                sortFunction(rNode),
+                rNode.Id()
+            );
+        }
+    );
+
+    void (ModelPart::*AddNodes)(const std::vector<ModelPart::IndexType>&, ModelPart::IndexType) = &ModelPart::AddNodes;
+    index_sets.Apply(AddNodes);
+
+    KRATOS_CATCH("");
+}
+
+
+void ModelSubdivisionUtilities::SortElements(
+    ModelPart& rModelPart,
+    std::function<ModelPart*(const Element&)> sortFunction,
+    std::vector<ModelPart*>& rSubModelParts)
+{
+    KRATOS_TRY
+
+    ModelSubdivisionUtilities::ThreadSafeIndexSet index_sets(rSubModelParts);
+
+    block_for_each(rModelPart.Elements(),
+        [&](const Element& rElement)
+        {
+            index_sets.Push(
+                sortFunction(rElement),
+                rElement.Id()
+            );
+        }
+    );
+
+    void (ModelPart::*AddElements)(const std::vector<ModelPart::IndexType>&, ModelPart::IndexType) = &ModelPart::AddElements;
+    index_sets.Apply(AddElements);
+
+    KRATOS_CATCH("");
+}
+
+
+void ModelSubdivisionUtilities::SortConditions(
+    ModelPart& rModelPart,
+    std::function<ModelPart*(const Condition&)> sortFunction,
+    std::vector<ModelPart*>& rSubModelParts)
+{
+    KRATOS_TRY
+
+    ModelSubdivisionUtilities::ThreadSafeIndexSet index_sets(rSubModelParts);
+
+    block_for_each(rModelPart.Conditions(),
+        [&](const Condition& rCondition)
+        {
+            index_sets.Push(
+                sortFunction(rCondition),
+                rCondition.Id()
+            );
+        }
+    );
+
+    void (ModelPart::*AddConditions)(const std::vector<ModelPart::IndexType>&, ModelPart::IndexType) = &ModelPart::AddConditions;
+    index_sets.Apply(AddConditions);
+
+    KRATOS_CATCH("");
+}
+
+
+ModelSubdivisionUtilities::ThreadSafeIndexSet::ThreadSafeIndexSet(std::vector<ModelPart*>& rSubModelParts)
+{
+    for (ModelPart* p_model_part : rSubModelParts) {
+        mIndexSets.emplace(std::make_pair(
+            p_model_part,
+            std::make_pair(std::vector<IndexType>(), make_unique<std::mutex>())
+        ));
+    }
+}
+
+
+ModelSubdivisionUtilities::Slab::Slab(
+    const array_1d<double,3>& rBottomPoint,
+    const array_1d<double,3>& rTopPoint,
+    bool isOpen) :
+        mBottomPlane {rBottomPoint, rBottomPoint - rTopPoint},
+        mTopPlane {rTopPoint, rTopPoint - rBottomPoint},
+        mIsOpen(isOpen)
+{
+    if (MathUtils<double>::Norm(this->Normal()) < 1e-15) {
+        KRATOS_ERROR << "Degenerate slab!";
+    }
+}
+
+
+ModelSubdivisionUtilities::SlabStack::SlabStack(
+    const array_1d<double,3> rBottomPoint,
+    const array_1d<double,3> rTopPoint,
+    std::size_t numberOfSlabs,
+    bool isOpen) :
+        ModelSubdivisionUtilities::Slab(
+            rBottomPoint,
+            rTopPoint,
+            isOpen)
+{
+    KRATOS_TRY
+
+    if (numberOfSlabs == 0) {
+        KRATOS_ERROR << "Number of slabs in a stack must be at least 1";
+    }
+    else if (1 < numberOfSlabs) {
+        mInnerPlanes.reserve(numberOfSlabs - 1);
+
+        // Compute the vector by which the inner planes are offset from each other
+        const double normal_length = MathUtils<double>::Norm(this->Normal());
+        const double slab_height = MathUtils<double>::Dot(rTopPoint - rBottomPoint, this->Normal()) / normal_length / numberOfSlabs;
+        const array_1d<double,3> normal_segment = (slab_height / normal_length) * this->Normal();
+
+        // Generate inner planes (boundaries are not included)
+        for (std::size_t i_slab=0; i_slab<numberOfSlabs-1; ++i_slab) {
+            mInnerPlanes.emplace_back( ModelSubdivisionUtilities::Slab::Plane {
+                rBottomPoint + (i_slab + 1) * normal_segment,
+                this->Normal()
+            } );
+        }
+    }
+
+    KRATOS_CATCH("");
+}
+
+
+std::size_t ModelSubdivisionUtilities::SlabStack::SlabIndex(const array_1d<double,3>& rPoint) const
+{
+    KRATOS_TRY
+
+    // Perform a binary search on the inner planes
+    auto it_top_plane = std::upper_bound(
+        mInnerPlanes.begin(),
+        mInnerPlanes.end(),
+        rPoint,
+        [](const array_1d<double,3>& r_point, const Plane& r_plane)
+        {
+            return !r_plane.IsOnPositiveSide(r_point, false);
+        }
+    );
+    
+    std::size_t slab_index = std::numeric_limits<std::size_t>::max();
+
+    // The inner planes do not contain the boundaries, so those
+    // cases have to be checked separately
+    if (it_top_plane == mInnerPlanes.begin()) {
+        if (this->IsBelow(rPoint)) {
+            KRATOS_ERROR << rPoint << " is below the slab stack!";
+        }
+        else {
+            slab_index = 0;
+        }
+    }
+    else if (it_top_plane == mInnerPlanes.end()) {
+        if (this->IsAbove(rPoint)) {
+            KRATOS_ERROR << rPoint << " is above the slab stack!";
+        }
+        else {
+            slab_index = mInnerPlanes.size();
+        }
+    }
+    else {
+        slab_index = std::distance(mInnerPlanes.begin(), it_top_plane);
+    }
+
+    return slab_index;
+
+    KRATOS_CATCH("");
+}
+
+
+std::size_t ModelSubdivisionUtilities::SlabStack::size() const
+{
+    return mInnerPlanes.size() + 1;
+}
+
+
+} // namespace Kratos

--- a/kratos/utilities/model_subdivision_utilities.h
+++ b/kratos/utilities/model_subdivision_utilities.h
@@ -32,7 +32,7 @@ namespace Kratos
  * @ingroup KratosCore
  * @brief Utility for populating sub model parts
  */
-class ModelSubdivisionUtilities
+class KRATOS_API(KRATOS_CORE) ModelSubdivisionUtilities
 {
 public:
     /** Sort nodes in a model part depending on their location within a stack of slabs

--- a/kratos/utilities/model_subdivision_utilities.h
+++ b/kratos/utilities/model_subdivision_utilities.h
@@ -1,0 +1,238 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Máté Kelemen
+//
+
+#ifndef KRATOS_MODEL_SUBDIVISION_UTILITIES
+#define KRATOS_MODEL_SUBDIVISION_UTILITIES
+
+// Project includes
+#include "includes/model_part.h"
+#include "math_utils.h"
+
+// System includes
+#include <mutex>
+
+
+namespace Kratos
+{
+
+///@name Kratos Classes
+///@{
+
+/**
+ * @class ModelSubdivisionUtilities
+ * @ingroup KratosCore
+ * @brief Utility for populating sub model parts
+ */
+class ModelSubdivisionUtilities
+{
+public:
+    /** Sort nodes in a model part depending on their location within a stack of slabs
+     *  @details construct a set of slabs of equal height between the two specified points.
+     *  Nodes in the model part are then assigned to newly created sub model parts, based on
+     *  which constructed slab they are located in.
+     *  @param rModelPart model part containing nodes to sort
+     *  @param rBottomPoint point on the bottom plane of the bottom slab
+     *  @param rTopPoint point on the top plane of the top slab
+     *  @param numberOfSlabs number of slabs to construct between the two points
+     *  (an equal number of sub model parts are created as well)
+     *  @param isRootSlabOpen defines whether the top and bottom planes of the top and bottom
+     *  slabs respectively are considered to be inside the domain (true: not considered inside).
+     */
+    static std::vector<shared_ptr<ModelPart>> SortNodesBySlabs(
+        ModelPart& rModelPart,
+        const array_1d<double,3>& rBottomPoint,
+        const array_1d<double,3>& rTopPoint,
+        std::size_t numberOfSlabs,
+        bool isRootSlabOpen);
+
+    /** Sort nodes into sub model parts
+     *  @param rModelPart model part containing nodes to sort
+     *  @param sortFunction function that decides which sub model part a node is added to (NULL means it is skipped)
+     *  @param rSubModelParts set of sub model parts to sort nodes into
+     *  @details calls sortFunction for every node in rModelPart, and adds each of them to a sub model part
+     *  in rSubModelParts. If sortFunction returns NULL, the node is skipped and is not added to any of the model parts. 
+     */
+    static void SortNodes(
+        ModelPart& rModelPart,
+        std::function<ModelPart*(const Node<3>&)> sortFunction,
+        std::vector<ModelPart*>& rSubModelParts);
+
+    /** Sort elements into sub model parts
+     *  @param rModelPart model part containing elements to sort
+     *  @param sortFunction function that decides which sub model part a element is added to (NULL means it is skipped)
+     *  @param rSubModelParts set of sub model parts to sort elements into
+     *  @details calls sortFunction for every element in rModelPart, and adds each of them to a sub model part
+     *  in rSubModelParts. If sortFunction returns NULL, the element is skipped and is not added to any of the model parts. 
+     */
+    static void SortElements(
+        ModelPart& rModelPart,
+        std::function<ModelPart*(const Element&)> sortFunction,
+        std::vector<ModelPart*>& rSubModelParts);
+
+    /** Sort conditions into sub model parts
+     *  @param rModelPart model part containing conditions to sort
+     *  @param sortFunction function that decides which sub model part a condition is added to (NULL means it is skipped)
+     *  @param rSubModelParts set of sub model parts to sort conditions into
+     *  @details calls sortFunction for every condition in rModelPart, and adds each of them to a sub model part
+     *  in rSubModelParts. If sortFunction returns NULL, the condition is skipped and is not added to any of the model parts. 
+     */
+    static void SortConditions(
+        ModelPart& rModelPart,
+        std::function<ModelPart*(const Condition&)> sortFunction,
+        std::vector<ModelPart*>& rSubModelParts);
+
+protected:
+    /** A set of integer vectors that can be pushed to in parallel
+     *  @details each vector is assigned to a sub model part and has their own mutex.
+     */
+    class ThreadSafeIndexSet
+    {
+    public:
+        using IndexType = ModelPart::IndexType;
+
+        ThreadSafeIndexSet(std::vector<ModelPart*>& rSubModelParts);
+
+        /** Push to a vector that is assigned to a specific model part
+         *  @param pSubModelPart pointer to the desired model part (NULL is valid too)
+         *  @param value integer to be pushed
+         *  @note pSubModelPart==NULL is valid and means value will not be pushed anywhere
+         */
+        void Push(ModelPart* pSubModelPart, IndexType value)
+        {
+            KRATOS_TRY
+
+            // Push index to the corresponding container of the model part pointer
+            // Note: the case where pSubModelPart==NULL is valid, and means the value will not be pushed anywhere
+            if (pSubModelPart) {
+                auto& rPair = mIndexSets[pSubModelPart];
+                std::lock_guard<std::mutex> lock(*rPair.second); // replace with std::scoped_lock (c++17)
+                rPair.first.push_back(value);
+            }
+
+            KRATOS_CATCH("");
+        }
+
+        /// Only to be used with ModelPart::AddNodes, ModelPart::AddElements, and ModelPart::AddConditions
+        template <class TFunction = std::function<void(ModelPart*, const std::vector<IndexType>&, IndexType)>>
+        void Apply(TFunction function)
+        {
+            for (auto& rPair : mIndexSets) {
+                (rPair.first->*function)(rPair.second.first, 0);
+            }
+        }
+
+    private:
+        std::map<
+            ModelPart*,
+            std::pair<std::vector<IndexType>, unique_ptr<std::mutex>>> mIndexSets;
+    };
+
+
+    /// A subset of R^3 between two parallel planes
+    class Slab
+    {
+    public:
+        Slab(
+            const array_1d<double,3>& rBottomPoint,
+            const array_1d<double,3>& rTopPoint,
+            bool isOpen = false);
+
+        bool IsBelow(const array_1d<double,3>& rPoint) const
+        {
+            return mBottomPlane.IsOnPositiveSide(rPoint, mIsOpen);
+        }
+
+        bool IsAbove(const array_1d<double,3>& rPoint) const
+        {
+            return mTopPlane.IsOnPositiveSide(rPoint, mIsOpen);
+        }
+
+        bool IsInside(const array_1d<double,3>& rPoint) const
+        {
+            return (!IsBelow(rPoint)) && (!IsAbove(rPoint));
+        }
+
+    protected:
+        struct Plane
+        {
+            /** Return true if the normal points toward the halfspace in which the specified point is located
+             *  @note if the plane is open, points on the plane are considered to be on the positive side
+             */
+            bool IsOnPositiveSide(const array_1d<double,3>& rPoint, bool open) const
+            {
+                const double product = MathUtils<double>::Dot(rPoint - mReferencePoint, mNormal);
+                if (product < 0) {
+                    return false;
+                }
+                else if (0 < product) {
+                    return true;
+                }
+                else if (open) {
+                    return true;
+                }
+                else {
+                    return false;
+                }
+            }
+
+            array_1d<double,3> mReferencePoint;
+            array_1d<double,3> mNormal;
+        }; // struct Plane
+
+        const array_1d<double,3>& Normal() const
+        {
+            return mTopPlane.mNormal;
+        }
+
+        const Plane mBottomPlane;
+        const Plane mTopPlane;
+        const bool  mIsOpen;
+    }; // class Slab
+
+    class SlabStack : public Slab
+    {
+    public:
+
+        /** Construct a stack of slabs of identical heights.
+         *  @param rBottomPoint point on the bottom plane of the bottom slab
+         *  @param rTopPoint point on the top plane of the top slab
+         *  @param numberOfSlabs number of slabs to generate between the bottom and top points (>1)
+         *  @param isOpen if true, points on the outer slab boundaries are not considered to be inside it
+         *  (inner slabs will always be closed regardless)
+         */
+        SlabStack(
+            const array_1d<double,3> rBottomPoint,
+            const array_1d<double,3> rTopPoint,
+            std::size_t numberOfSlabs,
+            bool isOpen);
+
+        /** Find the index of the inner slab containing a specified point
+         *  @param rPoint point to be located
+         *  @note the specified point must be inside the slab stack, which can
+         *  be checked with @ref{SlabStack::IsInside}. An exception is thrown
+         *  if the point is outisde the stack.
+         */
+        std::size_t SlabIndex(const array_1d<double,3>& rPoint) const;
+
+        /// Get the number of internal slabs
+        std::size_t size() const;
+
+    private:
+        std::vector<Slab::Plane> mInnerPlanes;
+    }; // class SlabStack
+}; // class ModelSubdivisionUtilities
+
+///@}
+
+} // namespace Kratos
+
+#endif // KRATOS_MODEL_SUBDIVISION_UTILITIES


### PR DESCRIPTION
**Description**
Add a process for computing reduced nodal forces and torques in a region subdivided by parallel slabs.

- a region defined between a bottom and top point is subdivided into a number of parallel slabs
- nodes from each region are collected into sub model parts
- nodal forces and torques for each sub model part are reduced to a reference point

**Changelog**
- add ```ModelSubdivisionUtilities``` to core utilities (and its related cpp tests)
- add ```ComputeLevelForceProcess``` to fluid dynamics processes (and its related python tests)

**Discussion**
- *This could be done in a single function, why the extra infrastructure?*
This task breaks down nicely into sub tasks that I imagine could be commonly used (example: sort nodes/elements/conditions from a model part to sub model parts based on some criterion). ```ModelSubdivisionUtilities``` and [SubModelPartEntitiesBooleanOperationUtility](https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/utilities/sub_model_part_entities_boolean_operation_utility.h) could probably be merged with a bit of renaming, since they are doing rather similar things.
- The output from ```ComputeLevelForceProcess``` is rather barebones right now, so suggestions on what the output files should contain are welcome. The current output looks somthing like this:
```
force:      [3](0.0, 0.0, 0.0)
moment: [3](0.0, 0.0, 0.0)
```