### PR TITLE
[HDF5App] Replace deprecated data comm calls GetDefault()

### DIFF
--- a/applications/HDF5Application/python_scripts/core/__init__.py
+++ b/applications/HDF5Application/python_scripts/core/__init__.py
@@ -24,8 +24,9 @@ def CreateControllerWithFileIO(settings, model):
     if len(settings['list_of_operations']) == 0:
         settings['list_of_operations'].Append(KratosMultiphysics.Parameters())
     model_part = model[settings['model_part_name']]
+    data_comm = model_part.GetCommunicator().GetDataCommunicator()
     return controllers.Create(
-        model_part, file_io.Create(settings['io_settings']),
+        model_part, file_io.Create(settings['io_settings'], data_comm),
         settings['controller_settings'])
 
 

--- a/applications/HDF5Application/python_scripts/core/file_io.py
+++ b/applications/HDF5Application/python_scripts/core/file_io.py
@@ -124,24 +124,24 @@ class _FilenameGetter(object):
 
 class _FilenameGetterWithDirectoryInitialization(object):
 
-    def __init__(self, settings):
+    def __init__(self, settings, data_comm):
         self.filename_getter = _FilenameGetter(settings)
+        self.data_comm = data_comm
 
     def Get(self, model_part=None):
         file_name = self.filename_getter.Get(model_part)
-        self._InitializeDirectory(file_name, model_part.GetCommunicator().GetDataCommunicator())
+        self._InitializeDirectory(file_name)
         return file_name
 
-    @staticmethod
-    def _InitializeDirectory(file_name, data_comm):
+    def _InitializeDirectory(self, file_name):
         dirname = os.path.dirname(file_name)
         if dirname != '' and not os.path.exists(dirname):
-            if data_comm.Rank() == 0:
+            if self.data_comm.Rank() == 0:
                 os.makedirs(dirname)
-            data_comm.Barrier()
+            self.data_comm.Barrier()
 
 
-def Create(settings):
+def Create(settings, data_comm):
     '''Return the IO object specified by the setting 'io_type'.
 
     Empty settings will contain default values after returning from the
@@ -149,7 +149,7 @@ def Create(settings):
     '''
     _SetDefaults(settings)
     io = _GetIO(settings['io_type'])
-    io.filename_getter = _FilenameGetterWithDirectoryInitialization(settings)
+    io.filename_getter = _FilenameGetterWithDirectoryInitialization(settings, data_comm)
     io.file_access_mode = settings['file_access_mode']
     io.file_driver = settings['file_driver']
     io.echo_level = settings['echo_level']

--- a/applications/HDF5Application/python_scripts/core/file_io.py
+++ b/applications/HDF5Application/python_scripts/core/file_io.py
@@ -136,9 +136,9 @@ class _FilenameGetterWithDirectoryInitialization(object):
     def _InitializeDirectory(file_name):
         dirname = os.path.dirname(file_name)
         if dirname != '' and not os.path.exists(dirname):
-            if KratosMultiphysics.DataCommunicator.GetDefault().Rank() == 0:
+            if KratosMultiphysics.Testing.GetDefaultDataCommunicator().Rank() == 0:
                 os.makedirs(dirname)
-            KratosMultiphysics.DataCommunicator.GetDefault().Barrier()
+            KratosMultiphysics.Testing.GetDefaultDataCommunicator().Barrier()
 
 
 def Create(settings):

--- a/applications/HDF5Application/python_scripts/core/file_io.py
+++ b/applications/HDF5Application/python_scripts/core/file_io.py
@@ -129,16 +129,16 @@ class _FilenameGetterWithDirectoryInitialization(object):
 
     def Get(self, model_part=None):
         file_name = self.filename_getter.Get(model_part)
-        self._InitializeDirectory(file_name)
+        self._InitializeDirectory(file_name, model_part.GetCommunicator().GetDataCommunicator())
         return file_name
 
     @staticmethod
-    def _InitializeDirectory(file_name):
+    def _InitializeDirectory(file_name, data_comm):
         dirname = os.path.dirname(file_name)
         if dirname != '' and not os.path.exists(dirname):
-            if KratosMultiphysics.Testing.GetDefaultDataCommunicator().Rank() == 0:
+            if data_comm.Rank() == 0:
                 os.makedirs(dirname)
-            KratosMultiphysics.Testing.GetDefaultDataCommunicator().Barrier()
+            data_comm.Barrier()
 
 
 def Create(settings):

--- a/applications/HDF5Application/python_scripts/initialization_from_hdf5_process.py
+++ b/applications/HDF5Application/python_scripts/initialization_from_hdf5_process.py
@@ -10,7 +10,6 @@ __all__ = ["Factory"]
 import KratosMultiphysics
 import KratosMultiphysics.HDF5Application.core as core
 from KratosMultiphysics.HDF5Application.utils import ParametersWrapper
-from KratosMultiphysics.HDF5Application.utils import IsDistributed
 from KratosMultiphysics.HDF5Application.utils import CreateOperationSettings
 
 
@@ -48,7 +47,7 @@ def Factory(settings, Model):
     |                                     |            | "list_of_variables": []         |
     +-------------------------------------+------------+---------------------------------+
     """
-    core_settings = CreateCoreSettings(settings["Parameters"])
+    core_settings = CreateCoreSettings(settings["Parameters"], Model)
     return InitializationFromHDF5ProcessFactory(core_settings, Model)
 
 
@@ -56,7 +55,7 @@ def InitializationFromHDF5ProcessFactory(core_settings, Model):
     return core.Factory(core_settings, Model)
 
 
-def CreateCoreSettings(user_settings):
+def CreateCoreSettings(user_settings, model):
     """Return the core settings."""
     # Configure the defaults:
     core_settings = ParametersWrapper("""
@@ -91,7 +90,8 @@ def CreateCoreSettings(user_settings):
     for key in user_settings["file_settings"]:
         core_settings[0]["io_settings"][key] = user_settings["file_settings"][key]
     core_settings[0]["file_access_mode"] = "read_only"
-    if IsDistributed():
+    model_part_name = user_settings["model_part_name"]
+    if model[model_part_name].IsDistributed():
         core_settings[0]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
     else:
         core_settings[0]["io_settings"]["io_type"] = "serial_hdf5_file_io"

--- a/applications/HDF5Application/python_scripts/multiple_mesh_temporal_output_process.py
+++ b/applications/HDF5Application/python_scripts/multiple_mesh_temporal_output_process.py
@@ -17,7 +17,6 @@ __all__ = ["Factory"]
 import KratosMultiphysics
 from KratosMultiphysics.HDF5Application import core
 from KratosMultiphysics.HDF5Application.utils import ParametersWrapper
-from KratosMultiphysics.HDF5Application.utils import IsDistributed
 from KratosMultiphysics.HDF5Application.utils import CreateOperationSettings
 
 
@@ -69,7 +68,7 @@ def Factory(settings, Model):
     |                                             |            | "list_of_variables": []         |
     +---------------------------------------------+------------+---------------------------------+
     """
-    core_settings = CreateCoreSettings(settings["Parameters"])
+    core_settings = CreateCoreSettings(settings["Parameters"], Model)
     return MultipleMeshTemporalOutputProcessFactory(core_settings, Model)
 
 
@@ -77,7 +76,7 @@ def MultipleMeshTemporalOutputProcessFactory(core_settings, Model):
     return core.Factory(core_settings, Model)
 
 
-def CreateCoreSettings(user_settings):
+def CreateCoreSettings(user_settings, model):
     """Return the core settings.
 
     The core setting "io_type" cannot be overwritten by the user. It is
@@ -131,7 +130,8 @@ def CreateCoreSettings(user_settings):
         core_settings[i]["model_part_name"] = user_settings["model_part_name"]
         for key in user_settings["file_settings"]:
             core_settings[i]["io_settings"][key] = user_settings["file_settings"][key]
-        if IsDistributed():
+        model_part_name = user_settings["model_part_name"]
+        if model[model_part_name].IsDistributed():
             model_part_output_type = "partitioned_model_part_output"
             core_settings[i]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
         else:

--- a/applications/HDF5Application/python_scripts/single_mesh_primal_output_process.py
+++ b/applications/HDF5Application/python_scripts/single_mesh_primal_output_process.py
@@ -18,7 +18,6 @@ __all__ = ["Factory"]
 import KratosMultiphysics
 import KratosMultiphysics.HDF5Application.core as core
 from KratosMultiphysics.HDF5Application.utils import ParametersWrapper
-from KratosMultiphysics.HDF5Application.utils import IsDistributed
 from KratosMultiphysics.HDF5Application.utils import CreateOperationSettings
 
 
@@ -71,7 +70,7 @@ def Factory(settings, Model):
     |                                             |            | "list_of_variables": []         |
     +---------------------------------------------+------------+---------------------------------+
     """
-    core_settings = CreateCoreSettings(settings["Parameters"])
+    core_settings = CreateCoreSettings(settings["Parameters"], Model)
     return SingleMeshPrimalOutputProcessFactory(core_settings, Model)
 
 
@@ -79,7 +78,7 @@ def SingleMeshPrimalOutputProcessFactory(core_settings, Model):
     return core.Factory(core_settings, Model)
 
 
-def CreateCoreSettings(user_settings):
+def CreateCoreSettings(user_settings, model):
     """Return the core settings.
 
     The core setting "io_type" cannot be overwritten by the user. It is
@@ -132,7 +131,8 @@ def CreateCoreSettings(user_settings):
         core_settings[i]["model_part_name"] = user_settings["model_part_name"]
         for key in user_settings["file_settings"]:
             core_settings[i]["io_settings"][key] = user_settings["file_settings"][key]
-    if IsDistributed():
+    model_part_name = user_settings["model_part_name"]
+    if model[model_part_name].IsDistributed():
         model_part_output_type = "partitioned_model_part_output"
         core_settings[0]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
         core_settings[1]["io_settings"]["io_type"] = "parallel_hdf5_file_io"

--- a/applications/HDF5Application/python_scripts/single_mesh_temporal_input_process.py
+++ b/applications/HDF5Application/python_scripts/single_mesh_temporal_input_process.py
@@ -12,7 +12,6 @@ __all__ = ["Factory"]
 import KratosMultiphysics
 import KratosMultiphysics.HDF5Application.core as core
 from KratosMultiphysics.HDF5Application.utils import ParametersWrapper
-from KratosMultiphysics.HDF5Application.utils import IsDistributed
 from KratosMultiphysics.HDF5Application.utils import CreateOperationSettings
 
 
@@ -51,7 +50,7 @@ def Factory(settings, Model):
     |                                     |            | "list_of_variables": []                 |
     +-------------------------------------+------------+-----------------------------------------+
     """
-    core_settings = CreateCoreSettings(settings["Parameters"])
+    core_settings = CreateCoreSettings(settings["Parameters"], Model)
     return SingleMeshTemporalInputProcessFactory(core_settings, Model)
 
 
@@ -59,7 +58,7 @@ def SingleMeshTemporalInputProcessFactory(core_settings, Model):
     return core.Factory(core_settings, Model)
 
 
-def CreateCoreSettings(user_settings):
+def CreateCoreSettings(user_settings, model):
     """Return the core settings."""
     # Configure the defaults:
     core_settings = ParametersWrapper("""
@@ -94,7 +93,8 @@ def CreateCoreSettings(user_settings):
     core_settings[0]["model_part_name"] = user_settings["model_part_name"]
     for key in user_settings["file_settings"]:
         core_settings[0]["io_settings"][key] = user_settings["file_settings"][key]
-    if IsDistributed():
+    model_part_name = user_settings["model_part_name"]
+    if model[model_part_name].IsDistributed():
         core_settings[0]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
     else:
         core_settings[0]["io_settings"]["io_type"] = "serial_hdf5_file_io"

--- a/applications/HDF5Application/python_scripts/single_mesh_temporal_output_process.py
+++ b/applications/HDF5Application/python_scripts/single_mesh_temporal_output_process.py
@@ -16,7 +16,6 @@ __all__ = ["Factory"]
 import KratosMultiphysics
 import KratosMultiphysics.HDF5Application.core as core
 from KratosMultiphysics.HDF5Application.utils import ParametersWrapper
-from KratosMultiphysics.HDF5Application.utils import IsDistributed
 from KratosMultiphysics.HDF5Application.utils import CreateOperationSettings
 
 
@@ -65,7 +64,7 @@ def Factory(settings, Model):
     |                                             |            | "list_of_variables": []            |
     +---------------------------------------------+------------+------------------------------------+
     """
-    core_settings = CreateCoreSettings(settings["Parameters"])
+    core_settings = CreateCoreSettings(settings["Parameters"], Model)
     return SingleMeshTemporalOutputProcessFactory(core_settings, Model)
 
 
@@ -73,7 +72,7 @@ def SingleMeshTemporalOutputProcessFactory(core_settings, Model):
     return core.Factory(core_settings, Model)
 
 
-def CreateCoreSettings(user_settings):
+def CreateCoreSettings(user_settings, model):
     """Return the core settings.
 
     The core setting "io_type" cannot be overwritten by the user. It is
@@ -126,7 +125,8 @@ def CreateCoreSettings(user_settings):
         core_settings[i]["model_part_name"] = user_settings["model_part_name"]
         for key in user_settings["file_settings"]:
             core_settings[i]["io_settings"][key] = user_settings["file_settings"][key]
-        if IsDistributed():
+        model_part_name = user_settings["model_part_name"]
+        if model[model_part_name].IsDistributed():
             model_part_output_type = "partitioned_model_part_output"
             core_settings[i]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
         else:

--- a/applications/HDF5Application/python_scripts/single_mesh_xdmf_output_process.py
+++ b/applications/HDF5Application/python_scripts/single_mesh_xdmf_output_process.py
@@ -22,7 +22,6 @@ __all__ = ["Factory"]
 import KratosMultiphysics
 from KratosMultiphysics.HDF5Application import core
 from KratosMultiphysics.HDF5Application.utils import ParametersWrapper
-from KratosMultiphysics.HDF5Application.utils import IsDistributed
 from KratosMultiphysics.HDF5Application.utils import CreateOperationSettings
 
 def Factory(settings, Model):
@@ -68,7 +67,7 @@ def Factory(settings, Model):
     +-------------------------------------+------------+---------------------------------+
 
     """
-    core_settings = CreateCoreSettings(settings["Parameters"])
+    core_settings = CreateCoreSettings(settings["Parameters"], Model)
     return SingleMeshXdmfOutputProcessFactory(core_settings, Model)
 
 
@@ -76,7 +75,7 @@ def SingleMeshXdmfOutputProcessFactory(core_settings, Model):
     return core.Factory(core_settings, Model)
 
 
-def CreateCoreSettings(user_settings):
+def CreateCoreSettings(user_settings, model):
     """Return the core settings.
 
     The core setting "io_type" cannot be overwritten by the user. It is
@@ -156,7 +155,8 @@ def CreateCoreSettings(user_settings):
             core_settings[i]["io_settings"][key] = user_settings["file_settings"][key]
     core_settings[0]["io_settings"]["io_type"] = "mock_hdf5_file_io"
     core_settings[3]["io_settings"]["io_type"] = "mock_hdf5_file_io"
-    if IsDistributed():
+    model_part_name = user_settings["model_part_name"]
+    if model[model_part_name].IsDistributed():
         model_part_output_type = "partitioned_model_part_output"
         core_settings[1]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
         core_settings[2]["io_settings"]["io_type"] = "parallel_hdf5_file_io"

--- a/applications/HDF5Application/python_scripts/utils.py
+++ b/applications/HDF5Application/python_scripts/utils.py
@@ -15,10 +15,6 @@ import KratosMultiphysics
 from KratosMultiphysics.HDF5Application.core.utils import ParametersWrapper
 
 
-def IsDistributed():
-    return KratosMultiphysics.IsDitributedRun()
-
-
 def CreateOperationSettings(operation_type, user_settings):
     """Return core settings for an operation type.
 

--- a/applications/HDF5Application/python_scripts/utils.py
+++ b/applications/HDF5Application/python_scripts/utils.py
@@ -16,7 +16,7 @@ from KratosMultiphysics.HDF5Application.core.utils import ParametersWrapper
 
 
 def IsDistributed():
-    return KratosMultiphysics.DataCommunicator.GetDefault().IsDistributed()
+    return KratosMultiphysics.Testing.GetDefaultDataCommunicator().IsDistributed()
 
 
 def CreateOperationSettings(operation_type, user_settings):

--- a/applications/HDF5Application/python_scripts/utils.py
+++ b/applications/HDF5Application/python_scripts/utils.py
@@ -16,7 +16,7 @@ from KratosMultiphysics.HDF5Application.core.utils import ParametersWrapper
 
 
 def IsDistributed():
-    return KratosMultiphysics.Testing.GetDefaultDataCommunicator().IsDistributed()
+    return KratosMultiphysics.IsDitributedRun()
 
 
 def CreateOperationSettings(operation_type, user_settings):


### PR DESCRIPTION
**Description**
Avoid using the deprecated GetDefault() DataCommunicator by passing it from the model part.

**Changelog**
- Replaced deprecated GetDefault() calls