### PR TITLE
[CFD] Adding default output file name for CFL

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/cfl_output_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/cfl_output_process.py
@@ -81,8 +81,20 @@ class CFLOutputProcess(KratosMultiphysics.Process):
 
         if (self.model_part.GetCommunicator().MyPID() == 0):
             if (self.write_output_file):
+
+                output_file_name = params["model_part_name"].GetString() + "_cfl.dat"
+
                 file_handler_params = KratosMultiphysics.Parameters(
                     params["output_file_settings"])
+
+                if file_handler_params.Has("file_name"):
+                    warn_msg  = 'Unexpected user-specified entry found in "output_file_settings": {"file_name": '
+                    warn_msg += '"' + file_handler_params["file_name"].GetString() + '"}\n'
+                    warn_msg += 'Using this specififed file name instead of the default "' + output_file_name + '"'
+                    KratosMultiphysics.Logger.PrintWarning("CFLOutputProcess", warn_msg)
+                else:
+                    file_handler_params.AddEmptyValue("file_name")
+                    file_handler_params["file_name"].SetString(output_file_name)
 
                 file_header = self._GetFileHeader()
                 self.output_file = TimeBasedAsciiFileWriterUtility(self.model_part,


### PR DESCRIPTION
Fixes #8671

Similarly to the [`compute_drag_process.py`](https://github.com/KratosMultiphysics/Kratos/blob/da28d65ea7b158510ab7ccfce79b836696690f81/applications/FluidDynamicsApplication/python_scripts/compute_drag_process.py#L70)