### PR TITLE
[Core][Nurbs] Add control_point_weights to NurbsCurve construction in input reader

### DIFF
--- a/kratos/input_output/cad_json_input.h
+++ b/kratos/input_output/cad_json_input.h
@@ -524,7 +524,8 @@ private:
                 NurbsCurveGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>(
                     control_points,
                     polynomial_degree,
-                    knot_vector));
+                    knot_vector,
+                    control_point_weights));
         }
         return Kratos::make_shared<NurbsCurveGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>>(
             NurbsCurveGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>(


### PR DESCRIPTION
Thank you @rickyaristio very much for detecting and reporting this bug. 

It actually does not include the weights within the input reading which could result in very difficult problems in the debugging.