### PR TITLE
[dem] Bugfix for restart tests, spoiling nightly runs

### DIFF
--- a/applications/DEMApplication/tests/restart_files/ball_and_wallProjectParametersDEM.json
+++ b/applications/DEMApplication/tests/restart_files/ball_and_wallProjectParametersDEM.json
@@ -28,7 +28,7 @@
             "restart_load_file_label" : "0.03001"
         },
         "material_import_settings"           : {
-            "materials_filename" : "MaterialsDEM.json"
+            "materials_filename" : "ball_and_wall_MaterialsDEM.json"
         }
     },
     "VirtualMassCoefficient"         : 1.0,

--- a/applications/DEMApplication/tests/restart_files/ball_and_wall_MaterialsDEM.json
+++ b/applications/DEMApplication/tests/restart_files/ball_and_wall_MaterialsDEM.json
@@ -1,0 +1,28 @@
+{
+    "materials":[{
+        "material_name": "mat1",
+        "material_id": 1,
+        "Variables":{
+            "PARTICLE_DENSITY": 2500.0,
+            "YOUNG_MODULUS": 100000.0,
+            "POISSON_RATIO": 0.20
+        }
+    }],
+    "material_relations":[{
+        "material_names_list":["mat1", "mat1"],
+        "material_ids_list":[1, 1],
+        "Variables":{
+            "COEFFICIENT_OF_RESTITUTION": 0.2,
+            "STATIC_FRICTION": 1.0,
+            "DYNAMIC_FRICTION": 1.0,
+            "FRICTION_DECAY": 500,
+            "ROLLING_FRICTION": 0.01,
+            "ROLLING_FRICTION_WITH_WALLS": 0.01,
+            "DEM_DISCONTINUUM_CONSTITUTIVE_LAW_NAME": "DEM_D_Hertz_viscous_Coulomb"
+        }
+    }],
+    "material_assignation_table":[
+        ["SpheresPart", "mat1"],
+        ["RigidFacePart","mat1"]
+    ]
+}

--- a/applications/DEMApplication/tests/test_restart.py
+++ b/applications/DEMApplication/tests/test_restart.py
@@ -8,11 +8,9 @@ import os
 class DEMRestartTestFactory():
 
     def setUp(self, case_name=""):
-        with KratosUnittest.WorkFolderScope(".", __file__):
-            with open(os.path.join('restart_files', case_name + 'ProjectParametersDEM.json'), 'r') as parameter_file:
+        with KratosUnittest.WorkFolderScope("restart_files", __file__):
+            with open(os.path.join(case_name + 'ProjectParametersDEM.json'), 'r') as parameter_file:
                 self.project_parameters_save = Kratos.Parameters(parameter_file.read())
-            with open(os.path.join('restart_files', 'MaterialsDEM.json'), 'r') as materials_file:
-                self.materials_parameters = Kratos.Parameters(materials_file.read())
 
         # Now clone the settings after the common settings are set
         self.project_parameters_load = self.project_parameters_save.Clone()
@@ -21,12 +19,11 @@ class DEMRestartTestFactory():
     def test_execution(self):
         # Within this location context:
 
-        with KratosUnittest.WorkFolderScope(".", __file__):
+        with KratosUnittest.WorkFolderScope("restart_files", __file__):
             model_save = Kratos.Model()
             model_load = Kratos.Model()
-            save_analysis = DEM_analysis_stage.DEMAnalysisStage(model_save, self.project_parameters_save, self.materials_parameters)
-            save_analysis.mdpas_folder_path = os.path.join(save_analysis.main_path, 'restart_files')
-            load_analysis = DEM_analysis_stage.DEMAnalysisStage(model_load, self.project_parameters_load, self.materials_parameters)
+            save_analysis = DEM_analysis_stage.DEMAnalysisStage(model_save, self.project_parameters_save)
+            load_analysis = DEM_analysis_stage.DEMAnalysisStage(model_load, self.project_parameters_load)
             self.project_parameters_load["output_processes"].RemoveValue("restart_processes")
             def NullFunction():
                 pass
@@ -68,7 +65,7 @@ class TestRestartBallAndWall(DEMRestartTestFactory, KratosUnittest.TestCase):
 
 if __name__ == '__main__':
     Kratos.Logger.GetDefaultOutput().SetSeverity(Kratos.Logger.Severity.WARNING)
-    
+
     suites = KratosUnittest.KratosSuites
 
     smallSuite = suites['small'] # These tests are executed by the continuous integration tool


### PR DESCRIPTION
**Description**
The relative paths were not correct. 
Also, it was missing the assignation of material to one wall.



