### PR TITLE
[not to merge] Mdpa modeler

### DIFF
--- a/kratos/includes/kratos_application.h
+++ b/kratos/includes/kratos_application.h
@@ -66,6 +66,7 @@
 #include "modeler/modeler.h"
 #include "modeler/cad_io_modeler.h"
 #include "modeler/cad_tessellation_modeler.h"
+#include "modeler/mdpa_io_modeler.h"
 
 namespace Kratos {
 ///@name Kratos Classes
@@ -465,6 +466,7 @@ class KRATOS_API(KRATOS_CORE) KratosApplication {
     const Modeler mModeler;
     const CadIoModeler mCadIoModeler;
     const CadTessellationModeler mCadTessellationModeler;
+    const MdpaIoModeler mMdpaIoModeler;
 
     // Base constitutive law definition
     const ConstitutiveLaw mConstitutiveLaw;

--- a/kratos/modeler/mdpa_io_modeler.cpp
+++ b/kratos/modeler/mdpa_io_modeler.cpp
@@ -7,6 +7,8 @@
 //  License:         BSD License 
 //                   Kratos default license: kratos/license.txt
 //
+//  Main authors:    Miguel Maso Sotomayor
+//
 
 
 // Project includes

--- a/kratos/modeler/mdpa_io_modeler.cpp
+++ b/kratos/modeler/mdpa_io_modeler.cpp
@@ -26,6 +26,7 @@ namespace Kratos
     const Parameters MdpaIoModeler::GetDefaultParameters() const
     {
         const Parameters default_parameters = Parameters(R"({
+            "echo_level"                                 : 0,
             "input_file_name"                            : "",
             "model_part_name"                            : "model_part",
             "skip_timer"                                 : true,
@@ -36,8 +37,8 @@ namespace Kratos
 
     void MdpaIoModeler::SetupGeometryModel()
     {
-        auto input_file_name = mParameters["input_file_name"].GetString();
-        auto model_part_name = mParameters["model_part_name"].GetString();
+        const auto input_file_name = mParameters["input_file_name"].GetString();
+        const auto model_part_name = mParameters["model_part_name"].GetString();
         ModelPart& model_part =
             mpModel->HasModelPart(model_part_name) ?
             mpModel->GetModelPart(model_part_name) :
@@ -47,6 +48,7 @@ namespace Kratos
             options = IO::SKIP_TIMER | options;
         if (mParameters["ignore_variables_not_in_solution_step_data"].GetBool())
             options = IO::IGNORE_VARIABLES_ERROR | options;
+        KRATOS_INFO_IF("::[MdpaIoModeler]::", mParameters["echo_level"].GetInt() > 0) << "Importing mdpa from: " << input_file_name << std::endl;
         ModelPartIO(input_file_name, options).ReadModelPart(model_part);
     }
 }

--- a/kratos/modeler/mdpa_io_modeler.cpp
+++ b/kratos/modeler/mdpa_io_modeler.cpp
@@ -11,6 +11,10 @@
 //
 
 
+// System includes
+      
+// External includes
+      
 // Project includes
 #include "mdpa_io_modeler.h"
 #include "includes/model_part_io.h"

--- a/kratos/modeler/mdpa_io_modeler.cpp
+++ b/kratos/modeler/mdpa_io_modeler.cpp
@@ -16,39 +16,41 @@
 
 namespace Kratos
 {
-    MdpaIoModeler::MdpaIoModeler(Model& rModel, Parameters ModelerParameters)
-        : Modeler(rModel, ModelerParameters)
-        , mpModel(&rModel)
-    {
-        mParameters.ValidateAndAssignDefaults(GetDefaultParameters());
-    }
 
-    const Parameters MdpaIoModeler::GetDefaultParameters() const
-    {
-        const Parameters default_parameters = Parameters(R"({
-            "echo_level"                                 : 0,
-            "input_file_name"                            : "",
-            "model_part_name"                            : "model_part",
-            "skip_timer"                                 : true,
-            "ignore_variables_not_in_solution_step_data" : false
-        })");
-        return default_parameters;
-    }
+MdpaIoModeler::MdpaIoModeler(Model& rModel, Parameters ModelerParameters)
+    : Modeler(rModel, ModelerParameters)
+    , mpModel(&rModel)
+{
+    mParameters.ValidateAndAssignDefaults(GetDefaultParameters());
+}
 
-    void MdpaIoModeler::SetupGeometryModel()
-    {
-        const auto input_file_name = mParameters["input_file_name"].GetString();
-        const auto model_part_name = mParameters["model_part_name"].GetString();
-        ModelPart& model_part =
-            mpModel->HasModelPart(model_part_name) ?
-            mpModel->GetModelPart(model_part_name) :
-            mpModel->CreateModelPart(model_part_name);
-        Flags options = IO::READ;
-        if (mParameters["skip_timer"].GetBool())
-            options = IO::SKIP_TIMER | options;
-        if (mParameters["ignore_variables_not_in_solution_step_data"].GetBool())
-            options = IO::IGNORE_VARIABLES_ERROR | options;
-        KRATOS_INFO_IF("::[MdpaIoModeler]::", mParameters["echo_level"].GetInt() > 0) << "Importing mdpa from: " << input_file_name << std::endl;
-        ModelPartIO(input_file_name, options).ReadModelPart(model_part);
-    }
+const Parameters MdpaIoModeler::GetDefaultParameters() const
+{
+    const Parameters default_parameters = Parameters(R"({
+        "echo_level"                                 : 0,
+        "input_file_name"                            : "",
+        "model_part_name"                            : "model_part",
+        "skip_timer"                                 : true,
+        "ignore_variables_not_in_solution_step_data" : false
+    })");
+    return default_parameters;
+}
+
+void MdpaIoModeler::SetupGeometryModel()
+{
+    const auto input_file_name = mParameters["input_file_name"].GetString();
+    const auto model_part_name = mParameters["model_part_name"].GetString();
+    ModelPart& model_part =
+        mpModel->HasModelPart(model_part_name) ?
+        mpModel->GetModelPart(model_part_name) :
+        mpModel->CreateModelPart(model_part_name);
+    Flags options = IO::READ;
+    if (mParameters["skip_timer"].GetBool())
+        options = IO::SKIP_TIMER | options;
+    if (mParameters["ignore_variables_not_in_solution_step_data"].GetBool())
+        options = IO::IGNORE_VARIABLES_ERROR | options;
+    KRATOS_INFO_IF("::[MdpaIoModeler]::", mParameters["echo_level"].GetInt() > 0) << "Importing mdpa from: " << input_file_name << std::endl;
+    ModelPartIO(input_file_name, options).ReadModelPart(model_part);
+}
+
 }

--- a/kratos/modeler/mdpa_io_modeler.cpp
+++ b/kratos/modeler/mdpa_io_modeler.cpp
@@ -1,0 +1,52 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License 
+//                   Kratos default license: kratos/license.txt
+//
+
+
+// Project includes
+#include "mdpa_io_modeler.h"
+#include "includes/model_part_io.h"
+
+
+namespace Kratos
+{
+    MdpaIoModeler::MdpaIoModeler(Model& rModel, Parameters ModelerParameters)
+        : Modeler(rModel, ModelerParameters)
+        , mpModel(&rModel)
+    {
+        mParameters.ValidateAndAssignDefaults(GetDefaultParameters());
+    }
+
+    const Parameters MdpaIoModeler::GetDefaultParameters() const
+    {
+        const Parameters default_parameters = Parameters(R"({
+            "input_file_name"                            : "",
+            "model_part_name"                            : "model_part",
+            "skip_timer"                                 : true,
+            "ignore_variables_not_in_solution_step_data" : false
+        })");
+        return default_parameters;
+    }
+
+    void MdpaIoModeler::SetupGeometryModel()
+    {
+        auto input_file_name = mParameters["input_file_name"].GetString();
+        auto model_part_name = mParameters["model_part_name"].GetString();
+        ModelPart& model_part =
+            mpModel->HasModelPart(model_part_name) ?
+            mpModel->GetModelPart(model_part_name) :
+            mpModel->CreateModelPart(model_part_name);
+        Flags options = IO::READ;
+        if (mParameters["skip_timer"].GetBool())
+            options = IO::SKIP_TIMER | options;
+        if (mParameters["ignore_variables_not_in_solution_step_data"].GetBool())
+            options = IO::IGNORE_VARIABLES_ERROR | options;
+        ModelPartIO(input_file_name, options).ReadModelPart(model_part);
+    }
+}

--- a/kratos/modeler/mdpa_io_modeler.h
+++ b/kratos/modeler/mdpa_io_modeler.h
@@ -8,6 +8,8 @@
 //                   Kratos default license: kratos/license.txt
 //
 //
+//  Main authors:    Miguel Maso Sotomayor
+//
 
 
 #ifndef KRATOS_MDPA_IO_MODELER_H_INCLUDED

--- a/kratos/modeler/mdpa_io_modeler.h
+++ b/kratos/modeler/mdpa_io_modeler.h
@@ -1,0 +1,151 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//
+
+
+#ifndef KRATOS_MDPA_IO_MODELER_H_INCLUDED
+#define KRATOS_MDPA_IO_MODELER_H_INCLUDED
+
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "modeler.h"
+
+namespace Kratos
+{
+
+///@name Kratos Classes
+///@{
+
+/**
+ * @class MdpaIoModeler
+ * @ingroup KratosCore
+ * @brief Mdpa file reading
+ * @details Import a model part from an mdpa file
+ * @author Miguel Maso Sotomayor
+ */
+class KRATOS_API(KRATOS_CORE) MdpaIoModeler : public Modeler
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of Modeler
+    KRATOS_CLASS_POINTER_DEFINITION(MdpaIoModeler);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /**
+     * @brief Default constructor
+     */
+    MdpaIoModeler() : Modeler()
+    {
+    }
+
+    /**
+     * @brief Constructor with Model and Parameters
+     */
+    MdpaIoModeler(Model& rModel, Parameters ModelerParameters = Parameters());
+
+    /**
+     * @brief Destructor
+     */
+    virtual ~MdpaIoModeler() = default;
+
+    /**
+     * @brief Creates the Modeler Pointer
+     */
+    Modeler::Pointer Create(Model& rModel, const Parameters ModelParameters) const override
+    {
+        return Kratos::make_shared<MdpaIoModeler>(rModel, ModelParameters);
+    }
+
+    ///@}
+    ///@name Stages
+    ///@{
+
+    void SetupGeometryModel() override;
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        return "MdpaIoModeler";
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream & rOStream) const override
+    {
+        rOStream << Info();
+    }
+
+    /// Print object's data.
+    void PrintData(std::ostream & rOStream) const override
+    {
+    }
+
+    ///@}
+
+private:
+    ///@name Member variables
+    ///@{
+
+    Model* mpModel = nullptr;
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+    const Parameters GetDefaultParameters() const;
+
+    ///@}
+    ///@name Serializer
+    ///@{
+
+    friend class Serializer;
+
+    ///@}
+
+}; // Class MdpaIoModeler
+
+///@}
+///@name Input and output
+///@{
+
+/// input stream function
+inline std::istream& operator >> (
+    std::istream& rIStream,
+    MdpaIoModeler& rThis);
+
+/// output stream function
+inline std::ostream& operator << (
+    std::ostream& rOStream,
+    const MdpaIoModeler& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+
+///@}
+
+}  // namespace Kratos.
+
+#endif // KRATOS_MDPA_IO_MODELER_H_INCLUDED  defined

--- a/kratos/sources/kratos_application.cpp
+++ b/kratos/sources/kratos_application.cpp
@@ -185,6 +185,7 @@ void KratosApplication::RegisterKratosCore() {
     KRATOS_REGISTER_MODELER("Modeler", mModeler);
     KRATOS_REGISTER_MODELER("CadIoModeler", mCadIoModeler);
     KRATOS_REGISTER_MODELER("CadTessellationModeler", mCadTessellationModeler);
+    KRATOS_REGISTER_MODELER("MdpaIoModeler", mMdpaIoModeler);
 
     // Register general geometries:
     // Point register:

--- a/kratos/tests/test_modelers.py
+++ b/kratos/tests/test_modelers.py
@@ -1,0 +1,58 @@
+import KratosMultiphysics as KM
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+from KratosMultiphysics.modeler_factory import KratosModelerFactory
+
+
+def run_modelers(current_model, modelers_list):
+    factory = KratosModelerFactory()
+    list_of_modelers = factory.ConstructListOfModelers(
+        current_model,
+        modelers_list)
+
+    for modeler in list_of_modelers:
+        modeler.SetupGeometryModel()
+
+    for modeler in list_of_modelers:
+        modeler.PrepareGeometryModel()
+
+    for modeler in list_of_modelers:
+        modeler.SetupModelPart()
+
+
+class TestModelers(KratosUnittest.TestCase):
+    def test_mdpa_io_modeler(self):
+
+        modelers_list = KM.Parameters(
+        """ [{
+            "modeler_name": "MdpaIoModeler",
+            "Parameters": {
+                "echo_level"                                 : 0,
+                "input_file_name"                            : "auxiliar_files_for_python_unittest/mdpa_files/test_model_part_io_read",
+                "model_part_name"                            : "model_part",
+                "skip_timer"                                 : true,
+                "ignore_variables_not_in_solution_step_data" : false
+            }
+        }] """)
+
+        current_model = KM.Model()
+
+        model_part = current_model.CreateModelPart("model_part")
+        model_part.AddNodalSolutionStepVariable(KM.DISPLACEMENT)
+        model_part.AddNodalSolutionStepVariable(KM.VISCOSITY)
+        model_part.AddNodalSolutionStepVariable(KM.VELOCITY)
+
+        run_modelers(current_model, modelers_list)
+
+        self.assertEqual(model_part.NumberOfSubModelParts(), 2)
+        self.assertEqual(model_part.NumberOfTables(), 1)
+        self.assertEqual(model_part.NumberOfProperties(), 1)
+        self.assertEqual(model_part.NumberOfNodes(), 6)
+        self.assertEqual(model_part.NumberOfElements(), 4)
+        self.assertEqual(model_part.NumberOfConditions(), 5)
+
+        self.assertEqual(model_part.GetNode(974).GetSolutionStepValue(KM.DISPLACEMENT_Y), 0.000974)
+
+        # The other features of the model part import are tested in test_model_part_io.py
+
+if __name__ == '__main__':
+    KratosUnittest.main()


### PR DESCRIPTION
**Description**
Recently I've discovered the modelers. I think they are a nice feature and a good alternative to the `PythonSolver.ImportModelPart` because of its modularity.

If I had known the modelers existed, I would have implemented #8608 as a modeler in conjunction with this. Maybe it is interesting for special needs in the import stage, like #8806

This is to start a discussion about the import stage. Is it the intended usage of the modelers?

**Changelog**
- Add mdpa io modeler
