### PR TITLE
change Kratos_generic_type to the end of enum, then Kratos_generic_ty…

### DIFF
--- a/kratos/geometries/geometry_data.h
+++ b/kratos/geometries/geometry_data.h
@@ -103,7 +103,6 @@ public:
 
     enum KratosGeometryType
     {
-        Kratos_generic_type,
         Kratos_Hexahedra3D20,
         Kratos_Hexahedra3D27,
         Kratos_Hexahedra3D8,
@@ -129,7 +128,8 @@ public:
         Kratos_Point3D,
         Kratos_Sphere3D1,
         Kratos_Brep_Surface,
-        Kratos_Brep_Curve
+        Kratos_Brep_Curve,
+        Kratos_generic_type
     };
 
     ///@}


### PR DESCRIPTION
**Description**
change Kratos_generic_type to the end of enum, then Kratos_generic_type can be used to get the number of supported geometries in the kernel

Please mark the PR with appropriate tags: 
- kernel enhancement

