### PR TITLE
[Core][Geometry][NURBS] Ensure unique nurbs entity ids by usage of CadJsonInput utility

### DIFF
--- a/kratos/input_output/cad_json_input.h
+++ b/kratos/input_output/cad_json_input.h
@@ -527,11 +527,13 @@ private:
                     knot_vector,
                     control_point_weights));
         }
-        return Kratos::make_shared<NurbsCurveGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>>(
-            NurbsCurveGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>(
+        typename NurbsCurveGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>::Pointer p_nurbs_curve(
+            new NurbsCurveGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>(
                 control_points,
                 polynomial_degree,
                 knot_vector));
+
+        return p_nurbs_curve;
     }
 
     /* @brief read NurbsSurfaces from the given parameter input.
@@ -601,13 +603,15 @@ private:
                 knot_vector_v,
                 control_point_weights);
         }
-        return Kratos::make_shared<NurbsSurfaceGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>>(
-            NurbsSurfaceGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>(
+        typename NurbsSurfaceGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>::Pointer p_nurbs_surface(
+            new NurbsSurfaceGeometry<TWorkingSpaceDimension, PointerVector<TThisNodeType>>(
                 control_points,
                 p,
                 q,
                 knot_vector_u,
                 knot_vector_v));
+
+        return p_nurbs_surface;
     }
 
     ///@}


### PR DESCRIPTION
To ensure a unique position of the NURBS entities, unfortunately the dodgy creation has to be taken. Otherwise, all similar objects will get the same Id and are thus not differntiable.