### PR TITLE
[Core] Deprecate duplicated Initialize method in find intersected geometrical objects

### DIFF
--- a/kratos/processes/apply_ray_casting_process.cpp
+++ b/kratos/processes/apply_ray_casting_process.cpp
@@ -65,7 +65,7 @@ namespace Kratos
 	void ApplyRayCastingProcess<TDim>::Execute()
 	{
         if(mIsSearchStructureAllocated) // we have not initialized it yet
-            mpFindIntersectedObjectsProcess->Initialize();
+            mpFindIntersectedObjectsProcess->ExecuteInitialize();
 
 		this->SetRayCastingTolerances();
 

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
@@ -67,7 +67,7 @@ namespace Kratos
     void CalculateDiscontinuousDistanceToSkinProcess<TDim>::Initialize()
     {
         // Initialize the intersected objects process
-        mFindIntersectedObjectsProcess.Initialize();
+        mFindIntersectedObjectsProcess.ExecuteInitialize();
 
         // Initialize the elemental distances to the domain characteristic length
         const double initial_distance = this->CalculateCharacteristicLength();

--- a/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
+++ b/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
@@ -679,7 +679,7 @@ private:
     void CalculateIntersections()
     {
         mpFindIntersectedGeometricalObjectsProcess = Kratos::make_unique<FindIntersectedGeometricalObjectsProcess>(mrBaseModelPart, mrSkinModelPart);
-        mpFindIntersectedGeometricalObjectsProcess->Initialize();
+        mpFindIntersectedGeometricalObjectsProcess->ExecuteInitialize();
         mpFindIntersectedGeometricalObjectsProcess->FindIntersections();
     }
 

--- a/kratos/processes/find_intersected_geometrical_objects_process.cpp
+++ b/kratos/processes/find_intersected_geometrical_objects_process.cpp
@@ -79,14 +79,6 @@ FindIntersectedGeometricalObjectsProcess::FindIntersectedGeometricalObjectsProce
 /***********************************************************************************/
 /***********************************************************************************/
 
-void FindIntersectedGeometricalObjectsProcess::Initialize()
-{
-    GenerateOctree();
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
 void FindIntersectedGeometricalObjectsProcess::FindIntersectedSkinObjects(std::vector<PointerVector<GeometricalObject>>& rResults)
 {
     auto& r_elements_array = mrModelPartIntersected.ElementsArray();

--- a/kratos/processes/find_intersected_geometrical_objects_process.cpp
+++ b/kratos/processes/find_intersected_geometrical_objects_process.cpp
@@ -82,9 +82,7 @@ FindIntersectedGeometricalObjectsProcess::FindIntersectedGeometricalObjectsProce
 void FindIntersectedGeometricalObjectsProcess::Initialize()
 {
     KRATOS_WARNING("Using FindIntersectedGeometricalObjectsProcess.Initialize() method is deprecated. Please use the ExecuteInitialize() method instead.");
-    if (mrModelPartIntersected.NumberOfNodes() > 0) {
-        GenerateOctree();
-    }
+    this->ExecuteInitialize();
 }
 
 /***********************************************************************************/

--- a/kratos/processes/find_intersected_geometrical_objects_process.cpp
+++ b/kratos/processes/find_intersected_geometrical_objects_process.cpp
@@ -79,6 +79,14 @@ FindIntersectedGeometricalObjectsProcess::FindIntersectedGeometricalObjectsProce
 /***********************************************************************************/
 /***********************************************************************************/
 
+void FindIntersectedGeometricalObjectsProcess::Initialize()
+{
+    GenerateOctree();
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
 void FindIntersectedGeometricalObjectsProcess::FindIntersectedSkinObjects(std::vector<PointerVector<GeometricalObject>>& rResults)
 {
     auto& r_elements_array = mrModelPartIntersected.ElementsArray();

--- a/kratos/processes/find_intersected_geometrical_objects_process.cpp
+++ b/kratos/processes/find_intersected_geometrical_objects_process.cpp
@@ -81,6 +81,7 @@ FindIntersectedGeometricalObjectsProcess::FindIntersectedGeometricalObjectsProce
 
 void FindIntersectedGeometricalObjectsProcess::Initialize()
 {
+    KRATOS_WARNING("Using FindIntersectedGeometricalObjectsProcess.Initialize() method is deprecated. Please use the ExecuteInitialize() method intead.");
     if (mrModelPartIntersected.NumberOfNodes() > 0) {
         GenerateOctree();
     }

--- a/kratos/processes/find_intersected_geometrical_objects_process.cpp
+++ b/kratos/processes/find_intersected_geometrical_objects_process.cpp
@@ -81,7 +81,7 @@ FindIntersectedGeometricalObjectsProcess::FindIntersectedGeometricalObjectsProce
 
 void FindIntersectedGeometricalObjectsProcess::Initialize()
 {
-    KRATOS_WARNING("Using FindIntersectedGeometricalObjectsProcess.Initialize() method is deprecated. Please use the ExecuteInitialize() method intead.");
+    KRATOS_WARNING("Using FindIntersectedGeometricalObjectsProcess.Initialize() method is deprecated. Please use the ExecuteInitialize() method instead.");
     if (mrModelPartIntersected.NumberOfNodes() > 0) {
         GenerateOctree();
     }

--- a/kratos/processes/find_intersected_geometrical_objects_process.h
+++ b/kratos/processes/find_intersected_geometrical_objects_process.h
@@ -402,6 +402,13 @@ public:
     ///@{
 
     /**
+     * @brief This function is designed for being called at the beginning of the computations right after reading the model and the groups
+     * @todo This should be moved to ExecuteInitialize (base class of Process)
+     */
+    KRATOS_DEPRECATED_MESSAGE("Please do not use this method - Use ExecuteInitialize instead\"")
+    virtual void Initialize();
+
+    /**
      * @brief This method finds the intersected objects with the skin
      * @param rResults The vector containing the intersected objects with the skin
      */

--- a/kratos/processes/find_intersected_geometrical_objects_process.h
+++ b/kratos/processes/find_intersected_geometrical_objects_process.h
@@ -402,12 +402,6 @@ public:
     ///@{
 
     /**
-     * @brief This function is designed for being called at the beginning of the computations right after reading the model and the groups
-     * @todo This should be moved to ExecuteInitialize (base class of Process)
-     */
-    virtual void Initialize();
-
-    /**
      * @brief This method finds the intersected objects with the skin
      * @param rResults The vector containing the intersected objects with the skin
      */


### PR DESCRIPTION
**Description**
The find_intersectred_geometrical_objects_process has two identical intialize methods:

https://github.com/KratosMultiphysics/Kratos/blob/7adf1e3266df392298a517af77f96836e854affd/kratos/processes/find_intersected_geometrical_objects_process.cpp#L82-L85

https://github.com/KratosMultiphysics/Kratos/blob/7adf1e3266df392298a517af77f96836e854affd/kratos/processes/find_intersected_geometrical_objects_process.cpp#L213-L216

This replaces all usages in the core of the Initialize() version and deprecates it. 

**Changelog**
- Replace Initiliaze usages with ExecuteInitialize() in the core
- Deprecate Initialize() method
