### PR TITLE
[CoSim] minor bugfix related to echo level

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
@@ -88,7 +88,7 @@ class CoSimulationSolverWrapper:
         io_settings = self.settings["io_settings"]
 
         if not io_settings.Has("echo_level"):
-            io_settings.AddEmptyValue("echo_level").SetInt(self.echo_level)
+            io_settings.AddEmptyValue("echo_level").SetInt(io_echo_level)
 
         self.__io = io_factory.CreateIO(self.settings["io_settings"], self.model, self.name, self._GetIOType())
 


### PR DESCRIPTION
Minor bugfix:
The `IO` currently uses the echo level of the solver it belongs to, but we decided that it should use the echo level of the coupled solver. This PR fixes this

see:
https://github.com/KratosMultiphysics/Kratos/blob/56289ed83761d8c7fe27de12acc0dd2624219456/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py#L67-L68