### PR TITLE
add divide_triangle_3d_3 

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_divide_triangle_3d_3.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_divide_triangle_3d_3.cpp
@@ -4,11 +4,10 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:     BSD License
-//  			 Kratos default license: kratos/license.txt
+//   License:        BSD License
+//                   Kratos default license: kratos/license.txt
 //
-//  Main authors:    Ruben Zorrilla
-//
+//   Main authors:   Pablo Becker
 //
 
 // Project includes
@@ -19,184 +18,256 @@
 
 namespace Kratos
 {
-	namespace Testing
-	{
+namespace Testing
+{
 
-		KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle3D3, KratosCoreFastSuite)
-		{
-			Model current_model;
+KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle3D3, KratosCoreFastSuite)
+{
+    Model current_model;
 
-			// Generate a model part with the previous
-			ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
-			base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
+    base_model_part.AddNodalSolutionStepVariable(DISTANCE);
 
-			// Fill the model part geometry data
-			base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(3, 0.0, 1.0, -1.0);
-			Properties::Pointer p_properties(new Properties(0));
-			base_model_part.CreateNewElement("Element3D3N", 1, {1, 2, 3}, p_properties);
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(3, 0.0, 1.0, -1.0);
+    Properties::Pointer p_properties(new Properties(0));
+    base_model_part.CreateNewElement("Element3D3N", 1, {1, 2, 3}, p_properties);
 
-			// Set the DISTANCE field
-			base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
-			base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
-			base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) =  1.0;
+    // Set the DISTANCE field
+    base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) =  1.0;
 
-			// Set the elemental distances vector
-			Geometry < Node < 3 > >& r_geometry = base_model_part.Elements()[1].GetGeometry();
+    // Set the elemental distances vector
+    Geometry < Node < 3 > >& r_geometry = base_model_part.Elements()[1].GetGeometry();
 
-			array_1d<double, 3> distances_vector;
-			for (unsigned int i = 0; i < r_geometry.size(); ++i) {
-				distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
-			}
+    array_1d<double, 3> distances_vector;
+    for (unsigned int i = 0; i < r_geometry.size(); ++i) {
+        distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
+    }
 
-			base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+    base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
 
-			Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+    Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
 
-			// Build the triangle splitting utility
-			DivideTriangle3D3 triangle_splitter(r_geometry, r_elemental_distances);
+    // Build the triangle splitting utility
+    DivideTriangle3D3 triangle_splitter(r_geometry, r_elemental_distances);
 
-			// Call the divide geometry method
-			triangle_splitter.GenerateDivision();
+    // Call the divide geometry method
+    triangle_splitter.GenerateDivision();
 
 
-			// Call the intersection generation method
-			triangle_splitter.GenerateIntersectionsSkin();
+    // Call the intersection generation method
+    triangle_splitter.GenerateIntersectionsSkin();
 
-			// Call the positive exterior faces generation method
-			std::vector < unsigned int > pos_ext_faces_parent_ids;
-			std::vector < DivideTriangle2D3::IndexedPointGeometryPointerType > pos_ext_faces;
-			triangle_splitter.GenerateExteriorFaces(
-				pos_ext_faces,
-				pos_ext_faces_parent_ids,
-				triangle_splitter.GetPositiveSubdivisions());
+    // Call the positive exterior faces generation method
+    std::vector < unsigned int > pos_ext_faces_parent_ids;
+    std::vector < DivideTriangle2D3::IndexedPointGeometryPointerType > pos_ext_faces;
+    triangle_splitter.GenerateExteriorFaces(
+        pos_ext_faces,
+        pos_ext_faces_parent_ids,
+        triangle_splitter.GetPositiveSubdivisions());
 
-			// Call the negative exterior faces generation method
-			std::vector < unsigned int > neg_ext_faces_parent_ids;
-			std::vector < DivideTriangle2D3::IndexedPointGeometryPointerType > neg_ext_faces;
-			triangle_splitter.GenerateExteriorFaces(
-				neg_ext_faces,
-				neg_ext_faces_parent_ids,
-				triangle_splitter.GetNegativeSubdivisions());
+    // Call the negative exterior faces generation method
+    std::vector < unsigned int > neg_ext_faces_parent_ids;
+    std::vector < DivideTriangle2D3::IndexedPointGeometryPointerType > neg_ext_faces;
+    triangle_splitter.GenerateExteriorFaces(
+        neg_ext_faces,
+        neg_ext_faces_parent_ids,
+        triangle_splitter.GetNegativeSubdivisions());
 
-			const double tolerance = 1e-10;
+    const double tolerance = 1e-10;
 
-			// Check general splitting values
-			KRATOS_CHECK(triangle_splitter.mIsSplit);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mDivisionsNumber, 3);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdgesNumber, 2);
+    // Check general splitting values
+    KRATOS_CHECK(triangle_splitter.mIsSplit);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mDivisionsNumber, 3);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdgesNumber, 2);
 
-			// Check split edges
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[0],  0);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[1],  1);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[2],  2);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[3], -1);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[4],  4);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[5],  5);
+    // Check split edges
+    std::array<int,6> expected_split_edges;
+    expected_split_edges[0]= 0;
+    expected_split_edges[1]= 1;
+    expected_split_edges[2]= 2;
+    expected_split_edges[3]= -1;
+    expected_split_edges[4]= 4;
+    expected_split_edges[5]= 5;
+    for (unsigned int i = 0; i < 6; ++i) {
+        KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[i],  expected_split_edges[i]);
+    }
 
-			// Check subdivisions
-			const auto &r_positive_subdivision_0 = *(triangle_splitter.GetPositiveSubdivisions()[0]);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Z(), -0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Z(), -0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Y(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Z(), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0.Area(), 0.17677669529,tolerance);
+    // Check subdivisions
+    const auto &r_positive_subdivision_0 = *(triangle_splitter.GetPositiveSubdivisions()[0]);
+    
+    Vector positive_subdivision_0_node_0_coordinates(3);
+    positive_subdivision_0_node_0_coordinates[0] = 0.0;
+    positive_subdivision_0_node_0_coordinates[1] = 0.5;
+    positive_subdivision_0_node_0_coordinates[2] = -0.5;
+    KRATOS_CHECK_VECTOR_EQUAL(r_positive_subdivision_0[0],positive_subdivision_0_node_0_coordinates);
 
-			const auto &r_negative_subdivision_0 = *(triangle_splitter.GetNegativeSubdivisions()[0]);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Z(), -0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Z(), -0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0.Area(), 0.17677669529, tolerance);
+    Vector positive_subdivision_0_node_1_coordinates(3);
+    positive_subdivision_0_node_1_coordinates[0] = 0.5;
+    positive_subdivision_0_node_1_coordinates[1] = 0.5;
+    positive_subdivision_0_node_1_coordinates[2] = -0.5;
+    KRATOS_CHECK_VECTOR_EQUAL(r_positive_subdivision_0[1],positive_subdivision_0_node_1_coordinates);
+    
+    Vector positive_subdivision_0_node_2_coordinates(3);
+    positive_subdivision_0_node_2_coordinates[0] = 0.0;
+    positive_subdivision_0_node_2_coordinates[1] = 1.0;
+    positive_subdivision_0_node_2_coordinates[2] = -1.0;
+    KRATOS_CHECK_VECTOR_EQUAL(r_positive_subdivision_0[2],positive_subdivision_0_node_2_coordinates);
+    
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0.Area(), 0.17677669529,tolerance);
 
-			const auto &r_negative_subdivision_1 = *(triangle_splitter.GetNegativeSubdivisions()[1]);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[0].Z(), -0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[2].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[2].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[2].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1.Area(), 0.35355339059, tolerance);
+    const auto &r_negative_subdivision_0 = *(triangle_splitter.GetNegativeSubdivisions()[0]);
 
-			// Check interfaces
-			const auto &r_positive_interface_0 = *(triangle_splitter.GetPositiveInterfaces()[0]);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[0].Z(), -0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[1].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[1].Z(), -0.5, tolerance);
+    Vector negative_subdivision_0_node_0_coordinates(3);
+    negative_subdivision_0_node_0_coordinates[0] = 0.0;
+    negative_subdivision_0_node_0_coordinates[1] = 0.5;
+    negative_subdivision_0_node_0_coordinates[2] = -0.5;
+    KRATOS_CHECK_VECTOR_EQUAL(r_negative_subdivision_0[0],negative_subdivision_0_node_0_coordinates);
 
-			const auto &r_negative_interface_0 = *(triangle_splitter.GetNegativeInterfaces()[0]);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[0].Z(), -0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[1].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[1].Z(), -0.5, tolerance);
+    Vector negative_subdivision_0_node_1_coordinates(3);
+    negative_subdivision_0_node_1_coordinates[0] = 1.0;
+    negative_subdivision_0_node_1_coordinates[1] = 0.0;
+    negative_subdivision_0_node_1_coordinates[2] = 0.0;
+    KRATOS_CHECK_VECTOR_EQUAL(r_negative_subdivision_0[1],negative_subdivision_0_node_1_coordinates);
 
-			KRATOS_CHECK_EQUAL(triangle_splitter.GetPositiveInterfacesParentIds()[0], 0);
-			KRATOS_CHECK_EQUAL(triangle_splitter.GetNegativeInterfacesParentIds()[0], 0);
+    Vector negative_subdivision_0_node_2_coordinates(3);
+    negative_subdivision_0_node_2_coordinates[0] = 0.5;
+    negative_subdivision_0_node_2_coordinates[1] = 0.5;
+    negative_subdivision_0_node_2_coordinates[2] = -0.5;
+    KRATOS_CHECK_VECTOR_EQUAL(r_negative_subdivision_0[2],negative_subdivision_0_node_2_coordinates);
 
-			// Check exterior faces
-			KRATOS_CHECK_EQUAL(pos_ext_faces.size(), 2);
-			KRATOS_CHECK_EQUAL(neg_ext_faces.size(), 3);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0.Area(), 0.17677669529, tolerance);
 
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[0], 0);
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[1], 0);
+    const auto &r_negative_subdivision_1 = *(triangle_splitter.GetNegativeSubdivisions()[1]);
 
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[0], 0);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[1], 1);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[2], 1);
+    Vector negative_subdivision_1_node_0_coordinates(3);
+    negative_subdivision_1_node_0_coordinates[0] = 0.0;
+    negative_subdivision_1_node_0_coordinates[1] = 0.5;
+    negative_subdivision_1_node_0_coordinates[2] = -0.5;
+    KRATOS_CHECK_VECTOR_EQUAL(r_negative_subdivision_1[0],negative_subdivision_1_node_0_coordinates);
 
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Z(), -0.5, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Y(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Z(), -1.0, tolerance);
+    Vector negative_subdivision_1_node_1_coordinates(3);
+    negative_subdivision_1_node_1_coordinates[0] = 0.0;
+    negative_subdivision_1_node_1_coordinates[1] = 0.0;
+    negative_subdivision_1_node_1_coordinates[2] = 0.0;
+    KRATOS_CHECK_VECTOR_EQUAL(r_negative_subdivision_1[1],negative_subdivision_1_node_1_coordinates);
 
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].Y(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].Z(), -1.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].Z(), -0.5, tolerance);
+    Vector negative_subdivision_1_node_2_coordinates(3);
+    negative_subdivision_1_node_2_coordinates[0] = 1.0;
+    negative_subdivision_1_node_2_coordinates[1] = 0.0;
+    negative_subdivision_1_node_2_coordinates[2] = 0.0;
+    KRATOS_CHECK_VECTOR_EQUAL(r_negative_subdivision_1[2],negative_subdivision_1_node_2_coordinates);
 
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Z(), -0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_1.Area(), 0.35355339059, tolerance);
 
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].Z(), -0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].Z(), 0.0, tolerance);
+    // Check interfaces
+    const auto &r_positive_interface_0 = *(triangle_splitter.GetPositiveInterfaces()[0]);
 
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].Z(), 0.0, tolerance);
-		}
-	}
+    Vector positive_interface_0_node_0_coordinates(3);
+    positive_interface_0_node_0_coordinates[0] = 0.0;
+    positive_interface_0_node_0_coordinates[1] = 0.5;
+    positive_interface_0_node_0_coordinates[2] = -0.5;
+    KRATOS_CHECK_VECTOR_EQUAL(r_positive_interface_0[0],positive_interface_0_node_0_coordinates);
+
+    Vector positive_interface_0_node_1_coordinates(3);
+    positive_interface_0_node_1_coordinates[0] = 0.5;
+    positive_interface_0_node_1_coordinates[1] = 0.5;
+    positive_interface_0_node_1_coordinates[2] = -0.5;
+    KRATOS_CHECK_VECTOR_EQUAL(r_positive_interface_0[1],positive_interface_0_node_1_coordinates);
+
+    const auto &r_negative_interface_0 = *(triangle_splitter.GetNegativeInterfaces()[0]);
+
+    Vector negative_interface_0_node_0_coordinates(3);
+    negative_interface_0_node_0_coordinates[0] = 0.5;
+    negative_interface_0_node_0_coordinates[1] = 0.5;
+    negative_interface_0_node_0_coordinates[2] = -0.5;
+    KRATOS_CHECK_VECTOR_EQUAL(r_negative_interface_0[0],negative_interface_0_node_0_coordinates);
+
+    Vector negative_interface_0_node_1_coordinates(3);
+    negative_interface_0_node_1_coordinates[0] = 0.0;
+    negative_interface_0_node_1_coordinates[1] = 0.5;
+    negative_interface_0_node_1_coordinates[2] = -0.5;
+    KRATOS_CHECK_VECTOR_EQUAL(r_negative_interface_0[1],negative_interface_0_node_1_coordinates);
+
+    KRATOS_CHECK_EQUAL(triangle_splitter.GetPositiveInterfacesParentIds()[0], 0);
+    KRATOS_CHECK_EQUAL(triangle_splitter.GetNegativeInterfacesParentIds()[0], 0);
+
+    // Check exterior faces
+    KRATOS_CHECK_EQUAL(pos_ext_faces.size(), 2);
+    KRATOS_CHECK_EQUAL(neg_ext_faces.size(), 3);
+
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[0], 0);
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[1], 0);
+
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[0], 0);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[1], 1);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[2], 1);
+
+    Vector pos_ext_faces_0_node_0_coordinates(3);
+    pos_ext_faces_0_node_0_coordinates[0] = 0.5;
+    pos_ext_faces_0_node_0_coordinates[1] = 0.5;
+    pos_ext_faces_0_node_0_coordinates[2] = -0.5;
+    KRATOS_CHECK_VECTOR_EQUAL((*pos_ext_faces[0])[0],pos_ext_faces_0_node_0_coordinates);
+
+    Vector pos_ext_faces_0_node_1_coordinates(3);
+    pos_ext_faces_0_node_1_coordinates[0] = 0.0;
+    pos_ext_faces_0_node_1_coordinates[1] = 1.0;
+    pos_ext_faces_0_node_1_coordinates[2] = -1.0;
+    KRATOS_CHECK_VECTOR_EQUAL((*pos_ext_faces[0])[1],pos_ext_faces_0_node_1_coordinates);
+
+    Vector pos_ext_faces_1_node_0_coordinates(3);
+    pos_ext_faces_1_node_0_coordinates[0] = 0.0;
+    pos_ext_faces_1_node_0_coordinates[1] = 1.0;
+    pos_ext_faces_1_node_0_coordinates[2] = -1.0;
+    KRATOS_CHECK_VECTOR_EQUAL((*pos_ext_faces[1])[0],pos_ext_faces_1_node_0_coordinates);
+
+    Vector pos_ext_faces_1_node_1_coordinates(3);
+    pos_ext_faces_1_node_1_coordinates[0] = 0.0;
+    pos_ext_faces_1_node_1_coordinates[1] = 0.5;
+    pos_ext_faces_1_node_1_coordinates[2] = -0.5;
+    KRATOS_CHECK_VECTOR_EQUAL((*pos_ext_faces[1])[1],pos_ext_faces_1_node_1_coordinates);
+
+    Vector neg_ext_faces_0_node_0_coordinates(3);
+    neg_ext_faces_0_node_0_coordinates[0] = 1.0;
+    neg_ext_faces_0_node_0_coordinates[1] = 0.0;
+    neg_ext_faces_0_node_0_coordinates[2] = 0.0;
+    KRATOS_CHECK_VECTOR_EQUAL((*neg_ext_faces[0])[0],neg_ext_faces_0_node_0_coordinates);
+
+    Vector neg_ext_faces_0_node_1_coordinates(3);
+    neg_ext_faces_0_node_1_coordinates[0] = 0.5;
+    neg_ext_faces_0_node_1_coordinates[1] = 0.5;
+    neg_ext_faces_0_node_1_coordinates[2] = -0.5;
+    KRATOS_CHECK_VECTOR_EQUAL((*neg_ext_faces[0])[1],neg_ext_faces_0_node_1_coordinates);
+
+    Vector neg_ext_faces_1_node_0_coordinates(3);
+    neg_ext_faces_1_node_0_coordinates[0] = 0.0;
+    neg_ext_faces_1_node_0_coordinates[1] = 0.5;
+    neg_ext_faces_1_node_0_coordinates[2] = -0.5;
+    KRATOS_CHECK_VECTOR_EQUAL((*neg_ext_faces[1])[0],neg_ext_faces_1_node_0_coordinates);
+
+    Vector neg_ext_faces_1_node_1_coordinates(3);
+    neg_ext_faces_1_node_1_coordinates[0] = 0.0;
+    neg_ext_faces_1_node_1_coordinates[1] = 0.0;
+    neg_ext_faces_1_node_1_coordinates[2] = 0.0;
+    KRATOS_CHECK_VECTOR_EQUAL((*neg_ext_faces[1])[1],neg_ext_faces_1_node_1_coordinates);
+
+    Vector neg_ext_faces_2_node_0_coordinates(3);
+    neg_ext_faces_2_node_0_coordinates[0] = 0.0;
+    neg_ext_faces_2_node_0_coordinates[1] = 0.0;
+    neg_ext_faces_2_node_0_coordinates[2] = 0.0;
+    KRATOS_CHECK_VECTOR_EQUAL((*neg_ext_faces[2])[0],neg_ext_faces_2_node_0_coordinates);
+
+    Vector neg_ext_faces_2_node_1_coordinates(3);
+    neg_ext_faces_2_node_1_coordinates[0] = 1.0;
+    neg_ext_faces_2_node_1_coordinates[1] = 0.0;
+    neg_ext_faces_2_node_1_coordinates[2] = 0.0;
+    KRATOS_CHECK_VECTOR_EQUAL((*neg_ext_faces[2])[1],neg_ext_faces_2_node_1_coordinates);
+
+}
+}
 }  // namespace Kratos.

--- a/kratos/tests/cpp_tests/utilities/test_divide_triangle_3d_3.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_divide_triangle_3d_3.cpp
@@ -70,7 +70,7 @@ namespace Kratos
 			triangle_splitter.GenerateExteriorFaces(
 				pos_ext_faces,
 				pos_ext_faces_parent_ids,
-				triangle_splitter.mPositiveSubdivisions);
+				triangle_splitter.GetPositiveSubdivisions());
 
 			// Call the negative exterior faces generation method
 			std::vector < unsigned int > neg_ext_faces_parent_ids;
@@ -78,7 +78,7 @@ namespace Kratos
 			triangle_splitter.GenerateExteriorFaces(
 				neg_ext_faces,
 				neg_ext_faces_parent_ids,
-				triangle_splitter.mNegativeSubdivisions);
+				triangle_splitter.GetNegativeSubdivisions());
 
 			const double tolerance = 1e-10;
 
@@ -96,56 +96,61 @@ namespace Kratos
 			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[5],  5);
 
 			// Check subdivisions
-			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[0].Z(), -0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[1].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[1].Z(), -0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[2].Y(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[2].Z(), -1.0, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0]).Area(), 0.17677669529,tolerance);
+			const auto &r_positive_subdivision_0 = *(triangle_splitter.GetPositiveSubdivisions()[0]);
+			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Z(), -0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].X(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Z(), -0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Y(), 1.0, tolerance);
+			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Z(), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(r_positive_subdivision_0.Area(), 0.17677669529,tolerance);
 
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[0].Z(), -0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[1].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[2].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[2].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[2].Z(), -0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0]).Area(), 0.17677669529, tolerance);
+			const auto &r_negative_subdivision_0 = *(triangle_splitter.GetNegativeSubdivisions()[0]);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Z(), -0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].X(), 1.0, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Y(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Z(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].X(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Z(), -0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_0.Area(), 0.17677669529, tolerance);
 
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[0].Z(), -0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[2].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[2].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[2].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1]).Area(), 0.35355339059, tolerance);
+			const auto &r_negative_subdivision_1 = *(triangle_splitter.GetNegativeSubdivisions()[1]);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_1[0].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_1[0].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_1[0].Z(), -0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_1[1].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_1[1].Y(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_1[1].Z(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_1[2].X(), 1.0, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_1[2].Y(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_1[2].Z(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_subdivision_1.Area(), 0.35355339059, tolerance);
 
 			// Check interfaces
-			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveInterfaces[0])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveInterfaces[0])[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveInterfaces[0])[0].Z(), -0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveInterfaces[0])[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveInterfaces[0])[1].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveInterfaces[0])[1].Z(), -0.5, tolerance);
+			const auto &r_positive_interface_0 = *(triangle_splitter.GetPositiveInterfaces()[0]);
+			KRATOS_CHECK_NEAR(r_positive_interface_0[0].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(r_positive_interface_0[0].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_positive_interface_0[0].Z(), -0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_positive_interface_0[1].X(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_positive_interface_0[1].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_positive_interface_0[1].Z(), -0.5, tolerance);
 
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeInterfaces[0])[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeInterfaces[0])[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeInterfaces[0])[0].Z(), -0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeInterfaces[0])[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeInterfaces[0])[1].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeInterfaces[0])[1].Z(), -0.5, tolerance);
+			const auto &r_negative_interface_0 = *(triangle_splitter.GetNegativeInterfaces()[0]);
+			KRATOS_CHECK_NEAR(r_negative_interface_0[0].X(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_interface_0[0].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_interface_0[0].Z(), -0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_interface_0[1].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_interface_0[1].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(r_negative_interface_0[1].Z(), -0.5, tolerance);
 
-			KRATOS_CHECK_EQUAL(triangle_splitter.mPositiveInterfacesParentIds[0], 0);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mNegativeInterfacesParentIds[0], 0);
+			KRATOS_CHECK_EQUAL(triangle_splitter.GetPositiveInterfacesParentIds()[0], 0);
+			KRATOS_CHECK_EQUAL(triangle_splitter.GetNegativeInterfacesParentIds()[0], 0);
 
 			// Check exterior faces
 			KRATOS_CHECK_EQUAL(pos_ext_faces.size(), 2);

--- a/kratos/tests/cpp_tests/utilities/test_divide_triangle_3d_3.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_divide_triangle_3d_3.cpp
@@ -1,0 +1,197 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:     BSD License
+//  			 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+//
+
+// Project includes
+#include "testing/testing.h"
+#include "containers/model.h"
+#include "includes/checks.h"
+#include "utilities/divide_triangle_3d_3.h"
+
+namespace Kratos
+{
+	namespace Testing
+	{
+
+		KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle3D3, KratosCoreFastSuite)
+		{
+			Model current_model;
+
+			// Generate a model part with the previous
+			ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
+			base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+			// Fill the model part geometry data
+			base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+			base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+			base_model_part.CreateNewNode(3, 0.0, 1.0, -1.0);
+			Properties::Pointer p_properties(new Properties(0));
+			base_model_part.CreateNewElement("Element3D3N", 1, {1, 2, 3}, p_properties);
+
+			// Set the DISTANCE field
+			base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
+			base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
+			base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) =  1.0;
+
+			// Set the elemental distances vector
+			Geometry < Node < 3 > >& r_geometry = base_model_part.Elements()[1].GetGeometry();
+
+			array_1d<double, 3> distances_vector;
+			for (unsigned int i = 0; i < r_geometry.size(); ++i) {
+				distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
+			}
+
+			base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+
+			Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+			// Build the triangle splitting utility
+			DivideTriangle3D3 triangle_splitter(r_geometry, r_elemental_distances);
+
+			// Call the divide geometry method
+			triangle_splitter.GenerateDivision();
+
+
+			// Call the intersection generation method
+			triangle_splitter.GenerateIntersectionsSkin();
+
+			// Call the positive exterior faces generation method
+			std::vector < unsigned int > pos_ext_faces_parent_ids;
+			std::vector < DivideTriangle2D3::IndexedPointGeometryPointerType > pos_ext_faces;
+			triangle_splitter.GenerateExteriorFaces(
+				pos_ext_faces,
+				pos_ext_faces_parent_ids,
+				triangle_splitter.mPositiveSubdivisions);
+
+			// Call the negative exterior faces generation method
+			std::vector < unsigned int > neg_ext_faces_parent_ids;
+			std::vector < DivideTriangle2D3::IndexedPointGeometryPointerType > neg_ext_faces;
+			triangle_splitter.GenerateExteriorFaces(
+				neg_ext_faces,
+				neg_ext_faces_parent_ids,
+				triangle_splitter.mNegativeSubdivisions);
+
+			const double tolerance = 1e-10;
+
+			// Check general splitting values
+			KRATOS_CHECK(triangle_splitter.mIsSplit);
+			KRATOS_CHECK_EQUAL(triangle_splitter.mDivisionsNumber, 3);
+			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdgesNumber, 2);
+
+			// Check split edges
+			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[0],  0);
+			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[1],  1);
+			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[2],  2);
+			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[3], -1);
+			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[4],  4);
+			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[5],  5);
+
+			// Check subdivisions
+			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[0].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[0].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[0].Z(), -0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[1].X(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[1].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[1].Z(), -0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[2].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[2].Y(), 1.0, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0])[2].Z(), -1.0, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveSubdivisions[0]).Area(), 0.17677669529,tolerance);
+
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[0].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[0].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[0].Z(), -0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[1].X(), 1.0, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[1].Y(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[1].Z(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[2].X(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[2].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0])[2].Z(), -0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[0]).Area(), 0.17677669529, tolerance);
+
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[0].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[0].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[0].Z(), -0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[1].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[1].Y(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[1].Z(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[2].X(), 1.0, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[2].Y(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1])[2].Z(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeSubdivisions[1]).Area(), 0.35355339059, tolerance);
+
+			// Check interfaces
+			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveInterfaces[0])[0].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveInterfaces[0])[0].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveInterfaces[0])[0].Z(), -0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveInterfaces[0])[1].X(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveInterfaces[0])[1].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mPositiveInterfaces[0])[1].Z(), -0.5, tolerance);
+
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeInterfaces[0])[0].X(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeInterfaces[0])[0].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeInterfaces[0])[0].Z(), -0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeInterfaces[0])[1].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeInterfaces[0])[1].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*triangle_splitter.mNegativeInterfaces[0])[1].Z(), -0.5, tolerance);
+
+			KRATOS_CHECK_EQUAL(triangle_splitter.mPositiveInterfacesParentIds[0], 0);
+			KRATOS_CHECK_EQUAL(triangle_splitter.mNegativeInterfacesParentIds[0], 0);
+
+			// Check exterior faces
+			KRATOS_CHECK_EQUAL(pos_ext_faces.size(), 2);
+			KRATOS_CHECK_EQUAL(neg_ext_faces.size(), 3);
+
+			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[0], 0);
+			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[1], 0);
+
+			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[0], 0);
+			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[1], 1);
+			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[2], 1);
+
+			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].X(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Z(), -0.5, tolerance);
+			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Y(), 1.0, tolerance);
+			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Z(), -1.0, tolerance);
+
+			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].Y(), 1.0, tolerance);
+			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].Z(), -1.0, tolerance);
+			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].Z(), -0.5, tolerance);
+
+			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].X(), 1.0, tolerance);
+			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Y(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Z(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].X(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Z(), -0.5, tolerance);
+
+			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].Y(), 0.5, tolerance);
+			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].Z(), -0.5, tolerance);
+			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].Y(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].Z(), 0.0, tolerance);
+
+			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].X(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].Y(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].Z(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].X(), 1.0, tolerance);
+			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].Y(), 0.0, tolerance);
+			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].Z(), 0.0, tolerance);
+		}
+	}
+}  // namespace Kratos.

--- a/kratos/utilities/divide_triangle_2d_3.cpp
+++ b/kratos/utilities/divide_triangle_2d_3.cpp
@@ -147,7 +147,7 @@ namespace Kratos
                 TriangleGetNewConnectivityGID(idivision, t.data(), mSplitEdges.data(), &i0, &i1, &i2);
 
                 // Generate a pointer to an auxiliar triangular geometry made with the subdivision points
-                IndexedPointGeometryPointerType p_aux_partition = GenerateTriangle(i0, i1, i2);
+                IndexedPointGeometryPointerType p_aux_partition = GenerateAuxiliaryPartitionTriangle(i0, i1, i2);
 
                 // Determine if the subdivision is wether in the negative or the positive side
                 unsigned int neg = 0, pos = 0;
@@ -211,7 +211,7 @@ namespace Kratos
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
                     if ((node_i_key >= n_nodes) && (node_j_key >= n_nodes)) {
                         // Generate an indexed point line geometry pointer with the two interface nodes
-                        IndexedPointGeometryPointerType p_intersection_line = GenerateLine(node_i_key, node_j_key);
+                        IndexedPointGeometryPointerType p_intersection_line = GenerateIntersectionLine(node_i_key, node_j_key);
                         mPositiveInterfaces.push_back(p_intersection_line);
                         mPositiveInterfacesParentIds.push_back(i_subdivision);
 
@@ -236,7 +236,7 @@ namespace Kratos
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
                     if ((node_i_key >= n_nodes) && (node_j_key >= n_nodes)) {
                         // Generate an indexed point line geometry pointer with the two interface nodes
-                        IndexedPointGeometryPointerType p_intersection_line = GenerateLine(node_i_key ,node_j_key);
+                        IndexedPointGeometryPointerType p_intersection_line = GenerateIntersectionLine(node_i_key ,node_j_key);
                         mNegativeInterfaces.push_back(p_intersection_line);
                         mNegativeInterfacesParentIds.push_back(i_subdivision);
 
@@ -321,7 +321,7 @@ namespace Kratos
                     if (std::find(faces_edge_nodes.begin(), faces_edge_nodes.end(), node_i_key) != faces_edge_nodes.end()) {
                         if (std::find(faces_edge_nodes.begin(), faces_edge_nodes.end(), node_j_key) != faces_edge_nodes.end()) {
                             // If both nodes are in the candidate nodes list, the subface is exterior
-                            IndexedPointGeometryPointerType p_subface_line = GenerateLine(node_i_key, node_j_key);
+                            IndexedPointGeometryPointerType p_subface_line = GenerateIntersectionLine(node_i_key, node_j_key);
 
                             rExteriorFacesVector.push_back(p_subface_line);
                             rExteriorFacesParentSubdivisionsIdsVector.push_back(i_subdivision);
@@ -334,17 +334,24 @@ namespace Kratos
         }
     };
 
-    DivideTriangle2D3::IndexedPointGeometryPointerType DivideTriangle2D3::GenerateTriangle(const int& r_i0,const int& r_i1,const int& r_i2) {
+    DivideTriangle2D3::IndexedPointGeometryPointerType DivideTriangle2D3::GenerateAuxiliaryPartitionTriangle(
+        const int I0,
+        const int I1,
+        const int I2)
+    {
         return Kratos::make_shared<IndexedPointTriangleType>(
-                    mAuxPointsContainer(r_i0),
-                    mAuxPointsContainer(r_i1),
-                    mAuxPointsContainer(r_i2));
+            mAuxPointsContainer(I0),
+            mAuxPointsContainer(I1),
+            mAuxPointsContainer(I2));
     }
 
-    DivideTriangle2D3::IndexedPointGeometryPointerType DivideTriangle2D3::GenerateLine(const int& r_i0,const int& r_i1) {
+    DivideTriangle2D3::IndexedPointGeometryPointerType DivideTriangle2D3::GenerateIntersectionLine(
+        const int I0,
+        const int I1)
+    {
         return Kratos::make_shared<IndexedPointLineType>(
-                    mAuxPointsContainer(r_i0),
-                    mAuxPointsContainer(r_i1));
+            mAuxPointsContainer(I0),
+            mAuxPointsContainer(I1));
     }
 
 };

--- a/kratos/utilities/divide_triangle_2d_3.cpp
+++ b/kratos/utilities/divide_triangle_2d_3.cpp
@@ -147,10 +147,7 @@ namespace Kratos
                 TriangleGetNewConnectivityGID(idivision, t.data(), mSplitEdges.data(), &i0, &i1, &i2);
 
                 // Generate a pointer to an auxiliar triangular geometry made with the subdivision points
-                IndexedPointGeometryPointerType p_aux_partition = Kratos::make_shared<IndexedPointTriangleType>(
-                    mAuxPointsContainer(i0),
-                    mAuxPointsContainer(i1),
-                    mAuxPointsContainer(i2));
+                IndexedPointGeometryPointerType p_aux_partition = GenerateTriangle(i0, i1, i2);
 
                 // Determine if the subdivision is wether in the negative or the positive side
                 unsigned int neg = 0, pos = 0;
@@ -214,8 +211,7 @@ namespace Kratos
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
                     if ((node_i_key >= n_nodes) && (node_j_key >= n_nodes)) {
                         // Generate an indexed point line geometry pointer with the two interface nodes
-                        IndexedPointGeometryPointerType p_intersection_line = Kratos::make_shared<IndexedPointLineType>(mAuxPointsContainer(node_i_key),
-                                                                                                                       mAuxPointsContainer(node_j_key));
+                        IndexedPointGeometryPointerType p_intersection_line = GenerateLine(node_i_key, node_j_key);
                         mPositiveInterfaces.push_back(p_intersection_line);
                         mPositiveInterfacesParentIds.push_back(i_subdivision);
 
@@ -240,8 +236,7 @@ namespace Kratos
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
                     if ((node_i_key >= n_nodes) && (node_j_key >= n_nodes)) {
                         // Generate an indexed point line geometry pointer with the two interface nodes
-                        IndexedPointGeometryPointerType p_intersection_line = Kratos::make_shared<IndexedPointLineType>(mAuxPointsContainer(node_i_key),
-                                                                                                                       mAuxPointsContainer(node_j_key));
+                        IndexedPointGeometryPointerType p_intersection_line = GenerateLine(node_i_key ,node_j_key);
                         mNegativeInterfaces.push_back(p_intersection_line);
                         mNegativeInterfacesParentIds.push_back(i_subdivision);
 
@@ -326,9 +321,7 @@ namespace Kratos
                     if (std::find(faces_edge_nodes.begin(), faces_edge_nodes.end(), node_i_key) != faces_edge_nodes.end()) {
                         if (std::find(faces_edge_nodes.begin(), faces_edge_nodes.end(), node_j_key) != faces_edge_nodes.end()) {
                             // If both nodes are in the candidate nodes list, the subface is exterior
-                            IndexedPointGeometryPointerType p_subface_line = Kratos::make_shared<IndexedPointLineType>(
-                                mAuxPointsContainer(node_i_key),
-                                mAuxPointsContainer(node_j_key));
+                            IndexedPointGeometryPointerType p_subface_line = GenerateLine(node_i_key, node_j_key);
 
                             rExteriorFacesVector.push_back(p_subface_line);
                             rExteriorFacesParentSubdivisionsIdsVector.push_back(i_subdivision);
@@ -340,5 +333,18 @@ namespace Kratos
             KRATOS_ERROR << "Trying to generate the exterior faces in DivideTriangle2D3::GenerateExteriorFaces() for a non-split element.";
         }
     };
+
+    DivideTriangle2D3::IndexedPointGeometryPointerType DivideTriangle2D3::GenerateTriangle(const int& r_i0,const int& r_i1,const int& r_i2) {
+        return Kratos::make_shared<IndexedPointTriangleType>(
+                    mAuxPointsContainer(r_i0),
+                    mAuxPointsContainer(r_i1),
+                    mAuxPointsContainer(r_i2));
+    }
+
+    DivideTriangle2D3::IndexedPointGeometryPointerType DivideTriangle2D3::GenerateLine(const int& r_i0,const int& r_i1) {
+        return Kratos::make_shared<IndexedPointLineType>(
+                    mAuxPointsContainer(r_i0),
+                    mAuxPointsContainer(r_i1));
+    }
 
 };

--- a/kratos/utilities/divide_triangle_2d_3.h
+++ b/kratos/utilities/divide_triangle_2d_3.h
@@ -151,6 +151,10 @@ public:
 
     ///@}
 
+    virtual IndexedPointGeometryPointerType GenerateTriangle(const int& r_i0,const int& r_i1,const int& r_i2);
+
+    virtual IndexedPointGeometryPointerType GenerateLine(const int& r_i0,const int& r_i1 );
+    
 private:
     ///@name Static Member Variables
     ///@{

--- a/kratos/utilities/divide_triangle_2d_3.h
+++ b/kratos/utilities/divide_triangle_2d_3.h
@@ -151,9 +151,14 @@ public:
 
     ///@}
 
-    virtual IndexedPointGeometryPointerType GenerateTriangle(const int& r_i0,const int& r_i1,const int& r_i2);
+    virtual IndexedPointGeometryPointerType GenerateAuxiliaryPartitionTriangle(
+        const int I0,
+        const int I1,
+        const int I2);
 
-    virtual IndexedPointGeometryPointerType GenerateLine(const int& r_i0,const int& r_i1 );
+    virtual IndexedPointGeometryPointerType GenerateIntersectionLine(
+        const int I0,
+        const int I1);
     
 private:
     ///@name Static Member Variables

--- a/kratos/utilities/divide_triangle_3d_3.cpp
+++ b/kratos/utilities/divide_triangle_3d_3.cpp
@@ -1,0 +1,49 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//   License:        BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//   Main authors:   Pablo Becker
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+
+#include "utilities/divide_triangle_3d_3.h"
+
+namespace Kratos
+{
+
+DivideTriangle3D3::DivideTriangle3D3(const GeometryType& rInputGeometry, const Vector& rNodalDistances) :
+    DivideTriangle2D3(rInputGeometry, rNodalDistances) {};
+
+DivideTriangle3D3::~DivideTriangle3D3() {};
+
+DivideTriangle3D3::IndexedPointGeometryPointerType DivideTriangle3D3::GenerateAuxiliaryPartitionTriangle(
+    const int I0,
+    const int I1,
+    const int I2)
+{
+    return Kratos::make_shared<IndexedPointTriangleType>(
+        mAuxPointsContainer(I0),
+        mAuxPointsContainer(I1),
+        mAuxPointsContainer(I2));
+}
+
+DivideTriangle3D3::IndexedPointGeometryPointerType DivideTriangle3D3::GenerateIntersectionLine(
+    const int I0,
+    const int I1)
+{
+    return Kratos::make_shared<IndexedPointLineType>(
+        mAuxPointsContainer(I0),
+        mAuxPointsContainer(I1));
+}
+
+};

--- a/kratos/utilities/divide_triangle_3d_3.h
+++ b/kratos/utilities/divide_triangle_3d_3.h
@@ -1,0 +1,144 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+#if !defined(KRATOS_DIVIDE_TRIANGLE_3D_3_UTILS)
+#define KRATOS_DIVIDE_TRIANGLE_3D_3_UTILS
+
+// System includes
+
+// External includes
+
+// Project includes
+
+#include "geometries/line_3d_2.h"
+#include "geometries/triangle_3d_3.h"
+#include "utilities/divide_geometry.h"
+#include "utilities/divide_triangle_2d_3.h"
+
+namespace Kratos
+{
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+class KRATOS_API(KRATOS_CORE) DivideTriangle3D3 : public DivideTriangle2D3
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    typedef Line3D2 < IndexedPointType >                                IndexedPointLineType;
+    typedef Triangle3D3 < IndexedPointType >                            IndexedPointTriangleType;
+
+    /// Pointer definition of DivideTriangle2D3
+    KRATOS_CLASS_POINTER_DEFINITION(DivideTriangle3D3);
+
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor
+    DivideTriangle3D3(const GeometryType& rInputGeometry, const Vector& rNodalDistances) :
+        DivideTriangle2D3(rInputGeometry, rNodalDistances) {};
+    /// Destructor
+    ~DivideTriangle3D3() {};
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+    ///@}
+    ///@name Operations
+    ///@{
+    IndexedPointGeometryPointerType GenerateTriangle(const int& r_i0,const int& r_i1,const int& r_i2) override {
+    return Kratos::make_shared<IndexedPointTriangleType>(
+                    mAuxPointsContainer(r_i0),
+                    mAuxPointsContainer(r_i1),
+                    mAuxPointsContainer(r_i2));
+    }
+
+    IndexedPointGeometryPointerType GenerateLine(const int& r_i0,const int& r_i1) override {
+    return Kratos::make_shared<IndexedPointLineType>(
+                    mAuxPointsContainer(r_i0),
+                    mAuxPointsContainer(r_i1));
+    }
+    ///@}
+
+private:
+    ///@name Static Member Variables
+    ///@{
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+    ///@}
+    ///@name Serialization
+    ///@{
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+    ///@}
+    ///@name Private Inquiry
+    ///@{
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+    /// Assignment operator.
+    DivideTriangle3D3& operator=(DivideTriangle3D3 const& rOther);
+
+    /// Copy constructor.
+    DivideTriangle3D3(DivideTriangle3D3 const& rOther)
+        : DivideTriangle2D3(rOther.GetInputGeometry(), rOther.GetNodalDistances()) {};
+
+    ///@}
+
+};// class DivideTriangle3D3
+
+}
+#endif /* KRATOS_DIVIDE_TRIANGLE_3D_3_UTILS defined */

--- a/kratos/utilities/divide_triangle_3d_3.h
+++ b/kratos/utilities/divide_triangle_3d_3.h
@@ -4,10 +4,10 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//   License:        BSD License
+//                   Kratos default license: kratos/license.txt
 //
-//  Main authors:    Ruben Zorrilla
+//   Main authors:   Pablo Becker
 //
 
 #if !defined(KRATOS_DIVIDE_TRIANGLE_3D_3_UTILS)
@@ -59,10 +59,10 @@ public:
     ///@{
 
     /// Default constructor
-    DivideTriangle3D3(const GeometryType& rInputGeometry, const Vector& rNodalDistances) :
-        DivideTriangle2D3(rInputGeometry, rNodalDistances) {};
+    DivideTriangle3D3(const GeometryType& rInputGeometry, const Vector& rNodalDistances);
+
     /// Destructor
-    ~DivideTriangle3D3() {};
+    ~DivideTriangle3D3();
 
     ///@}
     ///@name Access
@@ -83,18 +83,14 @@ public:
     ///@}
     ///@name Operations
     ///@{
-    IndexedPointGeometryPointerType GenerateTriangle(const int& r_i0,const int& r_i1,const int& r_i2) override {
-    return Kratos::make_shared<IndexedPointTriangleType>(
-                    mAuxPointsContainer(r_i0),
-                    mAuxPointsContainer(r_i1),
-                    mAuxPointsContainer(r_i2));
-    }
+    IndexedPointGeometryPointerType GenerateAuxiliaryPartitionTriangle(
+        const int I0,
+        const int I1,
+        const int I2) override;
 
-    IndexedPointGeometryPointerType GenerateLine(const int& r_i0,const int& r_i1) override {
-    return Kratos::make_shared<IndexedPointLineType>(
-                    mAuxPointsContainer(r_i0),
-                    mAuxPointsContainer(r_i1));
-    }
+    IndexedPointGeometryPointerType GenerateIntersectionLine(
+        const int I0,
+        const int I1) override;
     ///@}
 
 private:


### PR DESCRIPTION
**Description**
Adds an utility to divide 3d triangles. Derived from the divide triangles 2d

Please mark the PR with appropriate tags: 
core/utilities

**Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Modified the divide_triangle_2d_3 to create triangles and lines in a separate function to allow 2d/3d code with just one function modified
- Added the divide_triangle_3d_3 , derived from divide_triangle_2d_3 . (in reality it's the same, but the function has to be written again to use the modified typedef of triangles and lines
- Added a test to verify it works correctly
- 
