### PR TITLE
[CI] running nightly build for Core changes

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -6,6 +6,14 @@ on:
     - '.github/workflows/nightly_build.yml'
     - '.github/workflows/configure.sh'
     - '.github/workflows/configure.cmd'
+    - 'kratos/**'
+    - 'external_libraries/**'
+    - 'cmake_modules/**'
+    - 'CMakeLists.txt'
+    - 'applications/LinearSolversApplication/**'
+    - 'applications/MetisApplication/**'
+    - 'applications/TrilinosApplication/**'
+    
 
   schedule:
     - cron:  '0 1 * * *'


### PR DESCRIPTION
we had and have issues with breaking tests in the nightly build
In this PR I propose to run the nightly tests for changes to the Core (and the backbone apps)

The consequence of this is most probably a bit of congestion on the CI, not sure how much we will notice this

Advantage: More security when changing things in the Core
Disadvantage: Potentially congestion in CI. Not sure if this is soo bad, as rapid changes in the Core have the potential to introduce bugs. Hence slowing it down a bit could even be beneficial

mentioning the devs that were involved in the past
@riccardotosi @loumalouomega @maceligueta 