### PR TITLE
[PotentialFlow] Move potential jump computation to utilities

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
@@ -141,22 +141,6 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetDofList(Dof
     }
 }
 
-template <int Dim, int NumNodes>
-void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
-{
-    bool active = true;
-    if ((this)->IsDefined(ACTIVE))
-        active = (this)->Is(ACTIVE);
-
-    const CompressiblePerturbationPotentialFlowElement& r_this = *this;
-    const int wake = r_this.GetValue(WAKE);
-
-    if (wake != 0 && active == true)
-    {
-        ComputePotentialJump(rCurrentProcessInfo);
-    }
-}
-
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Inquiry
 
@@ -873,37 +857,6 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::AssignRightHan
     else{
         rRightHandSideVector[rRow] = rWake_rhs(rRow);
         rRightHandSideVector[rRow + NumNodes] = rLower_rhs(rRow);
-    }
-}
-
-template <int Dim, int NumNodes>
-void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo)
-{
-    const array_1d<double, 3>& vinfinity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
-    const double vinfinity_norm = sqrt(inner_prod(vinfinity, vinfinity));
-
-    array_1d<double, NumNodes> distances;
-    GetWakeDistances(distances);
-
-    auto& r_geometry = GetGeometry();
-    for (unsigned int i = 0; i < NumNodes; i++)
-    {
-        double aux_potential = r_geometry[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL);
-        double potential = r_geometry[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL);
-        double potential_jump = aux_potential - potential;
-
-        if (distances[i] > 0)
-        {
-            r_geometry[i].SetLock();
-            r_geometry[i].SetValue(POTENTIAL_JUMP, -2.0 / vinfinity_norm * (potential_jump));
-            r_geometry[i].UnSetLock();
-        }
-        else
-        {
-            r_geometry[i].SetLock();
-            r_geometry[i].SetValue(POTENTIAL_JUMP, 2.0 / vinfinity_norm * (potential_jump));
-            r_geometry[i].UnSetLock();
-        }
     }
 }
 

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.h
@@ -164,8 +164,6 @@ public:
 
     void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
-
     ///@}
     ///@name Access
     ///@{
@@ -291,8 +289,6 @@ private:
                                    const BoundedVector<double, NumNodes>& rWake_rhs,
                                    const ElementalData<NumNodes, Dim>& rData,
                                    unsigned int& rRow) const;
-
-    void ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo);
 
     ///@}
     ///@name Private Operations

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.cpp
@@ -144,17 +144,6 @@ void CompressiblePotentialFlowElement<Dim, NumNodes>::GetDofList(DofsVectorType&
 template <int Dim, int NumNodes>
 void CompressiblePotentialFlowElement<Dim, NumNodes>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
-    bool active = true;
-    if ((this)->IsDefined(ACTIVE))
-        active = (this)->Is(ACTIVE);
-
-    const CompressiblePotentialFlowElement& r_this = *this;
-    const int wake = r_this.GetValue(WAKE);
-
-    if (wake != 0 && active == true)
-    {
-        ComputePotentialJump(rCurrentProcessInfo);
-    }
     ComputeElementInternalEnergy();
 }
 
@@ -814,37 +803,6 @@ void CompressiblePotentialFlowElement<Dim, NumNodes>::AssignRightHandSideWakeNod
     else{
         rRightHandSideVector[rRow] = rWake_rhs(rRow);
         rRightHandSideVector[rRow + NumNodes] = rLower_rhs(rRow);
-    }
-}
-
-template <int Dim, int NumNodes>
-void CompressiblePotentialFlowElement<Dim, NumNodes>::ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo)
-{
-    const array_1d<double, 3>& vinfinity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
-    const double vinfinity_norm = sqrt(inner_prod(vinfinity, vinfinity));
-
-    array_1d<double, NumNodes> distances;
-    GetWakeDistances(distances);
-
-    auto& r_geometry = GetGeometry();
-    for (unsigned int i = 0; i < NumNodes; i++)
-    {
-        double aux_potential = r_geometry[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL);
-        double potential = r_geometry[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL);
-        double potential_jump = aux_potential - potential;
-
-        if (distances[i] > 0)
-        {
-            r_geometry[i].SetLock();
-            r_geometry[i].SetValue(POTENTIAL_JUMP, -2.0 / vinfinity_norm * (potential_jump));
-            r_geometry[i].UnSetLock();
-        }
-        else
-        {
-            r_geometry[i].SetLock();
-            r_geometry[i].SetValue(POTENTIAL_JUMP, 2.0 / vinfinity_norm * (potential_jump));
-            r_geometry[i].UnSetLock();
-        }
     }
 }
 

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.h
@@ -289,8 +289,6 @@ private:
                                    const ElementalData<NumNodes, Dim>& rData,
                                    unsigned int& rRow) const;
 
-    void ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo);
-
     void ComputeElementInternalEnergy();
 
     ///@}

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_perturbation_potential_flow_element.h
@@ -135,8 +135,6 @@ public:
 
     void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
-
     ///@}
     ///@name Access
     ///@{
@@ -247,8 +245,6 @@ private:
                                    const BoundedVector<double, NumNodes>& rWake_rhs,
                                    const ElementalData<NumNodes, Dim>& rData,
                                    unsigned int& rRow) const;
-
-    void ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo);
 
     ///@}
     ///@name Serialization

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.cpp
@@ -141,17 +141,6 @@ void IncompressiblePotentialFlowElement<Dim, NumNodes>::GetDofList(DofsVectorTyp
 template <int Dim, int NumNodes>
 void IncompressiblePotentialFlowElement<Dim, NumNodes>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
-    bool active = true;
-    if ((this)->IsDefined(ACTIVE))
-        active = (this)->Is(ACTIVE);
-
-    const IncompressiblePotentialFlowElement& r_this = *this;
-    const int wake = r_this.GetValue(WAKE);
-
-    if (wake != 0 && active == true)
-    {
-        ComputePotentialJump(rCurrentProcessInfo);
-    }
     ComputeElementInternalEnergy();
 }
 
@@ -610,35 +599,6 @@ void IncompressiblePotentialFlowElement<Dim, NumNodes>::AssignLocalSystemWakeNod
             // Applying wake condition in AUXILIARY_VELOCITY_POTENTIAL dofs
             rLeftHandSideMatrix(row + NumNodes, column + NumNodes) = rLhs_wake_condition(row, column);
             rLeftHandSideMatrix(row + NumNodes, column) = -rLhs_wake_condition(row, column); // Side 2
-        }
-    }
-}
-
-template <int Dim, int NumNodes>
-void IncompressiblePotentialFlowElement<Dim, NumNodes>::ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo)
-{
-    const array_1d<double, 3> free_stream_velocity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
-    const double free_stream_velocity_norm = sqrt(inner_prod(free_stream_velocity, free_stream_velocity));
-    const double reference_chord = rCurrentProcessInfo[REFERENCE_CHORD];
-
-    array_1d<double, NumNodes> distances;
-    GetWakeDistances(distances);
-
-    auto r_geometry = GetGeometry();
-    for (unsigned int i = 0; i < NumNodes; i++){
-        double aux_potential = r_geometry[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL);
-        double potential = r_geometry[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL);
-        double potential_jump = aux_potential - potential;
-
-        if (distances[i] > 0){
-            r_geometry[i].SetLock();
-            r_geometry[i].SetValue(POTENTIAL_JUMP, - (2.0 * potential_jump) / (free_stream_velocity_norm * reference_chord));
-            r_geometry[i].UnSetLock();
-        }
-        else{
-            r_geometry[i].SetLock();
-            r_geometry[i].SetValue(POTENTIAL_JUMP, (2.0 * potential_jump) / (free_stream_velocity_norm * reference_chord));
-            r_geometry[i].UnSetLock();
         }
     }
 }

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.h
@@ -231,8 +231,6 @@ private:
                                    const ElementalData<NumNodes, Dim>& data,
                                    unsigned int& row) const;
 
-    void ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo);
-
     void ComputeElementInternalEnergy();
 
     ///@}

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.cpp
@@ -192,20 +192,6 @@ void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::GetDofList(Dofs
     }
 }
 
-template <int TDim, int TNumNodes>
-void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
-{
-    const bool active = Is(ACTIVE);
-
-    const TransonicPerturbationPotentialFlowElement& r_const_this = *this;
-    const int wake = r_const_this.GetValue(WAKE);
-
-    if (wake != 0 && active == true)
-    {
-        ComputePotentialJump(rCurrentProcessInfo);
-    }
-}
-
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Inquiry
 
@@ -1219,33 +1205,6 @@ array_1d<size_t, TNumNodes> TransonicPerturbationPotentialFlowElement<TDim, TNum
     }
 
     return upwind_node_key;
-}
-
-template <int TDim, int TNumNodes>
-void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo)
-{
-    const array_1d<double, 3>& vinfinity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
-    const double v_infinity_norm = sqrt(inner_prod(vinfinity, vinfinity));
-
-    array_1d<double, TNumNodes> distances;
-    GetWakeDistances(distances);
-
-    for (unsigned int i = 0; i < TNumNodes; i++)
-    {
-        double aux_potential =
-            GetGeometry()[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL);
-        double potential = GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL);
-        double potential_jump = aux_potential - potential;
-        if (distances[i] > 0)
-        {
-            GetGeometry()[i].SetValue(POTENTIAL_JUMP,
-                                      -2.0 / v_infinity_norm * (potential_jump));
-        }
-        else
-        {
-            GetGeometry()[i].SetValue(POTENTIAL_JUMP, 2.0 / v_infinity_norm * (potential_jump));
-        }
-    }
 }
 
 template <int TDim, int TNumNodes>

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.h
@@ -169,8 +169,6 @@ public:
     void GetDofList(DofsVectorType& rElementalDofList,
                     const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
-
     ///@}
     ///@name Access
     ///@{
@@ -321,8 +319,6 @@ private:
     BoundedVector<double, TNumNodes + 1> AssembleDensityDerivativeAndShapeFunctions(const double densityDerivativeWRTVelocitySquared, const double densityDerivativeWRTUpwindVelocitySquared, const array_1d<double, TDim>& velocity, const array_1d<double, TDim>& upwindVelocity,const ProcessInfo& rCurrentProcessInfo);
 
     array_1d<size_t, TNumNodes> GetAssemblyKey(const GeometryType& rGeom, const GeometryType& rUpwindGeom, const ProcessInfo& rCurrentProcessInfo);
-
-    void ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo);
 
     void FindUpwindElement(const ProcessInfo& rCurrentProcessInfo);
 

--- a/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -33,6 +33,8 @@ void  AddCustomUtilitiesToPython(pybind11::module& m)
     mod_potential_flow_utilities.def("CheckIfWakeConditionsAreFulfilled3D",&PotentialFlowUtilities::CheckIfWakeConditionsAreFulfilled<3>);
     mod_potential_flow_utilities.def("CalculateArea",&PotentialFlowUtilities::CalculateArea<ModelPart::ElementsContainerType>);
     mod_potential_flow_utilities.def("CalculateArea",&PotentialFlowUtilities::CalculateArea<ModelPart::ConditionsContainerType>);
+    mod_potential_flow_utilities.def("ComputePotentialJump2D",&PotentialFlowUtilities::ComputePotentialJump<2,3>);
+    mod_potential_flow_utilities.def("ComputePotentialJump3D",&PotentialFlowUtilities::ComputePotentialJump<3,4>);
 }
 
 }  // namespace Python.

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
@@ -996,7 +996,7 @@ void ComputePotentialJump(ModelPart& rWakeModelPart)
 
         auto& r_geometry = r_elem.GetGeometry();
         array_1d<double, NumNodes> distances = PotentialFlowUtilities::GetWakeDistances<Dim, NumNodes>(r_elem);
-        for (unsigned int i = 0; i < NumNodes; i++)
+        for (IndexType i = 0; i < NumNodes; i++)
         {
             double aux_potential = r_geometry[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL);
             double potential = r_geometry[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL);

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
@@ -189,6 +189,9 @@ template <class TContainerType>
 double CalculateArea(TContainerType& rContainer);
 
 template <int Dim, int NumNodes>
+void ComputePotentialJump(ModelPart& rWakeModelPart);
+
+template <int Dim, int NumNodes>
 void AddKuttaConditionPenaltyTerm(const Element& rElement,
                               Matrix& rLeftHandSideMatrix,
                               Vector& rRightHandSideVector,

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_2d.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_2d.py
@@ -60,6 +60,7 @@ class DefineWakeProcess2D(KratosMultiphysics.Process):
 
         absolute_tolerance = 1e-9
         CPFApp.PotentialFlowUtilities.CheckIfWakeConditionsAreFulfilled2D(self.wake_sub_model_part, absolute_tolerance, self.echo_level)
+        CPFApp.PotentialFlowUtilities.ComputePotentialJump2D(self.wake_sub_model_part)
 
 
     def __FindWakeElements(self):

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_3d.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_3d.py
@@ -401,3 +401,4 @@ class DefineWakeProcess3D(KratosMultiphysics.Process):
 
     def ExecuteFinalizeSolutionStep(self):
         CPFApp.PotentialFlowUtilities.CheckIfWakeConditionsAreFulfilled3D(self.wake_sub_model_part, 1e-1, self.echo_level)
+        CPFApp.PotentialFlowUtilities.ComputePotentialJump3D(self.wake_sub_model_part)

--- a/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
@@ -211,6 +211,7 @@ class PotentialFlowTests(UnitTest.TestCase):
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_JUMP], 0.7241685913941622, 0.0, 1e-9)
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_FAR_FIELD], 0.7312296375421161, 0.0, 1e-9)
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.DRAG_COEFFICIENT_FAR_FIELD], 0.008607693464186337, 0.0, 1e-9)
+            self._check_results(self.main_model_part.GetNode(49).GetValue(CPFApp.POTENTIAL_JUMP), 0.3579390169527855, 0.0, 1e-9)
 
     @UnitTest.skipIfApplicationsNotAvailable("ShapeOptimizationApplication", "LinearSolversApplication", "MeshMovingApplication")
     def test_ShapeOptimizationLiftConstrainedBodyFitted2D(self):

--- a/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
@@ -60,6 +60,7 @@ class PotentialFlowTests(UnitTest.TestCase):
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_JUMP], 0.3230253050805644, 0.0, 1e-9)
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_FAR_FIELD], 0.32651526722535246, 0.0, 1e-9)
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.DRAG_COEFFICIENT_FAR_FIELD], 0.0036897206842046205, 0.0, 1e-9)
+            self._check_results(self.main_model_part.GetNode(13).GetValue(CPFApp.POTENTIAL_JUMP), 0.3230253050805686, 0.0, 1e-9)
             self._runTest(settings_file_name_adjoint)
             self._runTest(settings_file_name_adjoint_analytical)
 
@@ -79,6 +80,7 @@ class PotentialFlowTests(UnitTest.TestCase):
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.MOMENT_COEFFICIENT], -0.1631792300021498, 0.0, 1e-9)
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_JUMP], 0.4876931961465126, 0.0, 1e-9)
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_FAR_FIELD], 0.4953997676243705, 0.0, 1e-9)
+            self._check_results(self.main_model_part.GetNode(13).GetValue(CPFApp.POTENTIAL_JUMP), 0.48769319614651147, 0.0, 1e-9)
             self._check_perimeter_computation()
 
             for file_name in os.listdir():
@@ -97,6 +99,7 @@ class PotentialFlowTests(UnitTest.TestCase):
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.MOMENT_COEFFICIENT], -0.3804473187215503, 0.0, 1e-8)
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_JUMP], 0.8890010565994741, 0.0, 1e-8)
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_FAR_FIELD], 0.9085576033568474, 0.0, 1e-8)
+            # self._check_results(self.main_model_part.GetNode(13).GetValue(CPFApp.POTENTIAL_JUMP), 0.48769319614651147, 0.0, 1e-9)
 
         kratos_utilities.DeleteTimeFiles(work_folder)
 
@@ -112,6 +115,7 @@ class PotentialFlowTests(UnitTest.TestCase):
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.MOMENT_COEFFICIENT], -0.1631792300021498, 0.0, 1e-9)
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_JUMP], 0.4876931961465126, 0.0, 1e-9)
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_FAR_FIELD], 0.4953997676243705, 0.0, 1e-9)
+            self._check_results(self.main_model_part.GetNode(13).GetValue(CPFApp.POTENTIAL_JUMP), 0.48769319614651147, 0.0, 1e-9)
 
             for file_name in os.listdir():
                 if file_name.endswith(".time"):

--- a/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
@@ -19,11 +19,11 @@ except:
     numpy_stl_is_available = False
 
 try:
-    # import KratosMultiphysics.MultilevelMonteCarloApplication
-    # import xmc
-    # import exaqute
-    # import numpy as np
-    is_xmc_available = False
+    import KratosMultiphysics.MultilevelMonteCarloApplication
+    import xmc
+    import exaqute
+    import numpy as np
+    is_xmc_available = True
 except:
     is_xmc_available = False
 
@@ -219,15 +219,15 @@ class PotentialFlowTests(UnitTest.TestCase):
         with UnitTest.WorkFolderScope(work_folder, __file__):
             __import__(work_folder+".run_test")
 
-    # @UnitTest.skipIfApplicationsNotAvailable("ShapeOptimizationApplication", "LinearSolversApplication", "MeshMovingApplication", "MultilevelMonteCarloApplication")
-    # def test_StochasticShapeOptimizationLiftConstrainedBodyFitted2D(self):
-    #     if not is_xmc_available:
-    #         self.skipTest("XMC and its dependencies could not be imported. Please check applications/MultilevelMonteCarloApplication/README.md for installation details")
+    @UnitTest.skipIfApplicationsNotAvailable("ShapeOptimizationApplication", "LinearSolversApplication", "MeshMovingApplication", "MultilevelMonteCarloApplication")
+    def test_StochasticShapeOptimizationLiftConstrainedBodyFitted2D(self):
+        if not is_xmc_available:
+            self.skipTest("XMC and its dependencies could not be imported. Please check applications/MultilevelMonteCarloApplication/README.md for installation details")
 
-    #     work_folder = "stochastic_body_fitted_opt"
+        work_folder = "stochastic_body_fitted_opt"
 
-    #     with UnitTest.WorkFolderScope(work_folder, __file__):
-    #         __import__(work_folder+".run_test")
+        with UnitTest.WorkFolderScope(work_folder, __file__):
+            __import__(work_folder+".run_test")
 
     def _validateWakeProcess(self,reference_element_id_list, variable_name):
         variable = KratosMultiphysics.KratosGlobals.GetVariable(variable_name)

--- a/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
@@ -19,11 +19,11 @@ except:
     numpy_stl_is_available = False
 
 try:
-    import KratosMultiphysics.MultilevelMonteCarloApplication
-    import xmc
-    import exaqute
-    import numpy as np
-    is_xmc_available = True
+    # import KratosMultiphysics.MultilevelMonteCarloApplication
+    # import xmc
+    # import exaqute
+    # import numpy as np
+    is_xmc_available = False
 except:
     is_xmc_available = False
 
@@ -219,15 +219,15 @@ class PotentialFlowTests(UnitTest.TestCase):
         with UnitTest.WorkFolderScope(work_folder, __file__):
             __import__(work_folder+".run_test")
 
-    @UnitTest.skipIfApplicationsNotAvailable("ShapeOptimizationApplication", "LinearSolversApplication", "MeshMovingApplication", "MultilevelMonteCarloApplication")
-    def test_StochasticShapeOptimizationLiftConstrainedBodyFitted2D(self):
-        if not is_xmc_available:
-            self.skipTest("XMC and its dependencies could not be imported. Please check applications/MultilevelMonteCarloApplication/README.md for installation details")
+    # @UnitTest.skipIfApplicationsNotAvailable("ShapeOptimizationApplication", "LinearSolversApplication", "MeshMovingApplication", "MultilevelMonteCarloApplication")
+    # def test_StochasticShapeOptimizationLiftConstrainedBodyFitted2D(self):
+    #     if not is_xmc_available:
+    #         self.skipTest("XMC and its dependencies could not be imported. Please check applications/MultilevelMonteCarloApplication/README.md for installation details")
 
-        work_folder = "stochastic_body_fitted_opt"
+    #     work_folder = "stochastic_body_fitted_opt"
 
-        with UnitTest.WorkFolderScope(work_folder, __file__):
-            __import__(work_folder+".run_test")
+    #     with UnitTest.WorkFolderScope(work_folder, __file__):
+    #         __import__(work_folder+".run_test")
 
     def _validateWakeProcess(self,reference_element_id_list, variable_name):
         variable = KratosMultiphysics.KratosGlobals.GetVariable(variable_name)

--- a/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
@@ -99,7 +99,7 @@ class PotentialFlowTests(UnitTest.TestCase):
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.MOMENT_COEFFICIENT], -0.3804473187215503, 0.0, 1e-8)
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_JUMP], 0.8890010565994741, 0.0, 1e-8)
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_FAR_FIELD], 0.9085576033568474, 0.0, 1e-8)
-            # self._check_results(self.main_model_part.GetNode(13).GetValue(CPFApp.POTENTIAL_JUMP), 0.48769319614651147, 0.0, 1e-9)
+            self._check_results(self.main_model_part.GetNode(13).GetValue(CPFApp.POTENTIAL_JUMP), 0.88900105659947, 0.0, 1e-9)
 
         kratos_utilities.DeleteTimeFiles(work_folder)
 


### PR DESCRIPTION
**Description**
After debugging #8894 in the Docker container, I found the code was crashing randomly just after entering ComputePotentialJump, where some geometry.SetLock/UnsetLock() was happening. The crash happens just in the next access to the geometry data where it gives the segfault.

Im not sure if this is exactly the cause of the issue with #8894 but after removing this code from the element the test seems to work. 

I take the chance to move this from the element (which is repeated in many) to the utilities and compute this as a postprocess quantity in the wake process.


**Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Remove compute potential jump from the elements.
- Create utility and use it in define wake process.