### PR TITLE
[Structral][EigenSolver] using sprecta by default

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
@@ -35,9 +35,8 @@ class EigenSolver(MechanicalSolver):
             "scheme_type"         : "dynamic",
             "compute_modal_decomposition": false,
             "eigensolver_settings" : {
-                "solver_type"           : "eigen_eigensystem",
+                "solver_type"           : "spectra_sym_g_eigs_shift",
                 "max_iteration"         : 1000,
-                "tolerance"             : 1e-6,
                 "number_of_eigenvalues" : 5,
                 "echo_level"            : 1
             },

--- a/applications/StructuralMechanicsApplication/tests/test_eigen_solver_with_constraints.py
+++ b/applications/StructuralMechanicsApplication/tests/test_eigen_solver_with_constraints.py
@@ -99,8 +99,7 @@ class TestEigenSolverWithConstraints(KratosUnittest.TestCase):
 
         self.assertEqual(eigen_val_vec.Size(), eigen_val_vec_with_constraints.Size())
 
-        for eig_val, eig_val_constr in zip(eigen_val_vec, eigen_val_vec_with_constraints):
-            self.assertAlmostEqual(eig_val, eig_val_constr, 8)
+        assertVectorAlmostEqual(eigen_val_vec, eigen_val_vec_with_constraints, 6)
 
         for node in model_part.Nodes:
             node_const = model_part_with_constraints.Nodes[node.Id] # to make sure to get the corresponding node

--- a/applications/StructuralMechanicsApplication/tests/test_eigen_solver_with_constraints.py
+++ b/applications/StructuralMechanicsApplication/tests/test_eigen_solver_with_constraints.py
@@ -99,7 +99,7 @@ class TestEigenSolverWithConstraints(KratosUnittest.TestCase):
 
         self.assertEqual(eigen_val_vec.Size(), eigen_val_vec_with_constraints.Size())
 
-        assertVectorAlmostEqual(eigen_val_vec, eigen_val_vec_with_constraints, 6)
+        self.assertVectorAlmostEqual(eigen_val_vec, eigen_val_vec_with_constraints, 6)
 
         for node in model_part.Nodes:
             node_const = model_part_with_constraints.Nodes[node.Id] # to make sure to get the corresponding node


### PR DESCRIPTION
The spectra eigensolver (added in #8440) is much faster (in my quite large models ~10 times!) than the currently used default solver.

Hence I recommend switching the default to the new spectra solver