### PR TITLE
[Core] Append small test suite

### DIFF
--- a/kratos/tests/test_KratosCore.py
+++ b/kratos/tests/test_KratosCore.py
@@ -60,6 +60,7 @@ import test_file_name_data_collector
 import test_function_parser_utility
 import test_integration_points
 import test_mls_shape_functions_utility
+import test_force_and_torque_utils
 
 def AssembleTestSuites():
     ''' Populates the test suites to run.
@@ -143,6 +144,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_function_parser_utility.TestGenericFunctionUtility]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_integration_points.TestIntegrationPoints]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_mls_shape_functions_utility.TestMLSShapeFunctionsUtility]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_force_and_torque_utils.TestForceAndTorqueUtils]))
 
     # Create a test suite with the selected tests plus all small tests
     nightSuite = suites['nightly']


### PR DESCRIPTION
**Description**
Add ```TestForceAndTorqueUtils``` to the small test suite of Core. Up until now, I embarrassingly thought that python tests were globbed at runtime.