### PR TITLE
[DEM] reducing tests computation time

### DIFF
--- a/applications/DEMApplication/tests/DEM2D_contact_tests_files/ProjectParametersDEM.json
+++ b/applications/DEMApplication/tests/DEM2D_contact_tests_files/ProjectParametersDEM.json
@@ -34,7 +34,7 @@
     "ElementType"                    : "SphericPartDEMElement3D",
     "TranslationalIntegrationScheme" : "Symplectic_Euler",
     "RotationalIntegrationScheme"    : "Direct_Integration",
-    "MaxTimeStep"                    : 1e-4,
+    "MaxTimeStep"                    : 5e-4,
     "FinalTime"                      : 0.3,
     "NeighbourSearchFrequency"       : 50,
     "GraphExportFreq"                : 0.001,

--- a/applications/DEMApplication/tests/DEM3D_continuum_vs_discontinuum_tests_files/ProjectParametersDEM.json
+++ b/applications/DEMApplication/tests/DEM3D_continuum_vs_discontinuum_tests_files/ProjectParametersDEM.json
@@ -31,7 +31,7 @@
     "ElementType"                         : "SphericContPartDEMElement3D",
     "TranslationalIntegrationScheme"      : "Symplectic_Euler",
     "RotationalIntegrationScheme"         : "Direct_Integration",
-    "MaxTimeStep"                         : 15e-5,
+    "MaxTimeStep"                         : 3e-4,
     "FinalTime"                           : 0.6,
     "NeighbourSearchFrequency"            : 100,
     "GraphExportFreq"                     : 1e-2,

--- a/applications/DEMApplication/tests/kinematic_constraints_tests_files/ProjectParametersDEM.json
+++ b/applications/DEMApplication/tests/kinematic_constraints_tests_files/ProjectParametersDEM.json
@@ -158,7 +158,7 @@
     "ElementType"                    : "SphericPartDEMElement3D",
     "TranslationalIntegrationScheme" : "Symplectic_Euler",
     "RotationalIntegrationScheme"    : "Direct_Integration",
-    "MaxTimeStep"                    : 0.0001,
+    "MaxTimeStep"                    : 0.0005,
     "FinalTime"                      : 0.31,
     "NeighbourSearchFrequency"       : 50,
     "GraphExportFreq"                : 0.001,

--- a/applications/DEMApplication/tests/kinematic_constraints_tests_files/ProjectParametersDEM.json
+++ b/applications/DEMApplication/tests/kinematic_constraints_tests_files/ProjectParametersDEM.json
@@ -158,7 +158,7 @@
     "ElementType"                    : "SphericPartDEMElement3D",
     "TranslationalIntegrationScheme" : "Symplectic_Euler",
     "RotationalIntegrationScheme"    : "Direct_Integration",
-    "MaxTimeStep"                    : 0.0002,
+    "MaxTimeStep"                    : 0.0001,
     "FinalTime"                      : 0.31,
     "NeighbourSearchFrequency"       : 50,
     "GraphExportFreq"                : 0.001,

--- a/applications/DEMApplication/tests/test_DEMApplication.py
+++ b/applications/DEMApplication/tests/test_DEMApplication.py
@@ -77,6 +77,9 @@ def AssembleTestSuites():
     smallSuite.addTest(test_DEM_schemes.TestDEMSchemes("test_Symplectic"))
     smallSuite.addTest(test_DEM_schemes.TestDEMSchemes("test_Verlet"))
     smallSuite.addTest(test_random_variable.TestRandomVariable("test_random_variable"))
+    smallSuite.addTest(test_DEM_3D_continuum_vs_discontinuum.TestDEM3DContinuumVsDiscontinuum("test_DEM3D_continuum_vs_discontinuum"))
+    smallSuite.addTest(test_DEM_2D_contact.TestDEM2DContact("test_DEM2D_contact"))
+    smallSuite.addTest(test_kinematic_constraints.TestKinematicConstraints("test_KinematicConstraints_1"))
 
     # Create a test suit with the selected tests plus all small tests
     nightSuite = suites['nightly']
@@ -87,9 +90,7 @@ def AssembleTestSuites():
     nightSuite.addTest(test_DEM_search_tolerance.TestSearchTolerance("test_SearchB"))
     nightSuite.addTest(test_DEM_search_tolerance.TestSearchTolerance("test_SearchC"))
     nightSuite.addTest(test_DEM_search_tolerance.TestSearchTolerance("test_SearchD"))
-    nightSuite.addTest(test_DEM_3D_continuum_vs_discontinuum.TestDEM3DContinuumVsDiscontinuum("test_DEM3D_continuum_vs_discontinuum"))
-    nightSuite.addTest(test_DEM_2D_contact.TestDEM2DContact("test_DEM2D_contact"))
-    nightSuite.addTest(test_kinematic_constraints.TestKinematicConstraints("test_KinematicConstraints_1"))
+
 
     # For very long tests that should not be in nightly and you can use to validate
     validationSuite = suites['validation']

--- a/applications/DEMApplication/tests/test_DEM_2D_contact.py
+++ b/applications/DEMApplication/tests/test_DEM_2D_contact.py
@@ -24,21 +24,21 @@ class DEM2D_ContactTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_s
 
     def FinalizeSolutionStep(self):
         super().FinalizeSolutionStep()
-        tolerance = 1.001
+        tolerance = 1e-3
         for node in self.rigid_face_model_part.Nodes:
             dem_pressure = node.GetSolutionStepValue(DEM.DEM_PRESSURE)
             contact_force = node.GetSolutionStepValue(DEM.CONTACT_FORCES_Y)
             if node.Id == 13:
                 if self.time > 0.3:
-                    expected_value = 45126
+                    expected_value = 45072.56712114167
                     self.assertAlmostEqual(dem_pressure, expected_value, delta=tolerance)
-                    expected_value = -23141
+                    expected_value = -23114.136984276265
                     self.assertAlmostEqual(contact_force, expected_value, delta=tolerance)
             if node.Id == 22:
                 if self.time > 0.3:
-                    expected_value = 26712
+                    expected_value = 26774.109523872536
                     self.assertAlmostEqual(dem_pressure, expected_value, delta=tolerance)
-                    expected_value = -13698
+                    expected_value = -13730.31257668813
                     self.assertAlmostEqual(contact_force, expected_value, delta=tolerance)
 
     def Finalize(self):

--- a/applications/DEMApplication/tests/test_DEM_3D_continuum_vs_discontinuum.py
+++ b/applications/DEMApplication/tests/test_DEM_3D_continuum_vs_discontinuum.py
@@ -19,7 +19,7 @@ class DEM3D_ContinuumTestVsDiscontinuumSolution(KratosMultiphysics.DEMApplicatio
     def InitializeSolutionStep(self):
         super().InitializeSolutionStep()
 
-        self.tolerance = 2e-5
+        self.tolerance = 5e-5
 
     def FinalizeSolutionStep(self):
         super().FinalizeSolutionStep()
@@ -76,6 +76,11 @@ class DEM3D_ContinuumTestVsDiscontinuumSolution(KratosMultiphysics.DEMApplicatio
 
     def GetProblemNameWithPath(self):
         return os.path.join(self.main_path, self.DEM_parameters["problem_name"].GetString())
+
+    def Finalize(self):
+        self.procedures.RemoveFoldersWithResults(str(self.main_path), str(self.problem_name), '')
+        super().Finalize()
+
 
 class TestDEM3DContinuumVsDiscontinuum(KratosUnittest.TestCase):
 

--- a/applications/DEMApplication/tests/test_kinematic_constraints.py
+++ b/applications/DEMApplication/tests/test_kinematic_constraints.py
@@ -42,15 +42,15 @@ class KinematicConstraintsTestSolution(KratosMultiphysics.DEMApplication.DEM_ana
                     expected_value = 0.0
                     self.CheckKinematicValues(angular_velocity, 2, expected_value, tolerance)
                 elif self.time > 0.3099 and self.time < 0.31:
-                    expected_value = -1.0791000000000002
+                    expected_value = -1.0791000000000033
                     self.CheckKinematicValues(velocity, 1, expected_value, tolerance)
 
             if node.Id == 2:
                 if self.time > 0.25 and self.time < 0.3:
                     expected_value = -10.0 * self.time
                     self.CheckKinematicValues(velocity, 0, expected_value, tolerance)
-                if self.time > 0.3099 and self.time < 0.31:
-                    expected_value = -0.0981
+                if self.time > 0.3095 and self.time < 0.31:
+                    expected_value = -0.09319499999999994
                     self.CheckKinematicValues(velocity, 1, expected_value, tolerance)
 
             if node.Id == 3:
@@ -69,23 +69,23 @@ class KinematicConstraintsTestSolution(KratosMultiphysics.DEMApplication.DEM_ana
                     self.CheckKinematicValues(angular_velocity, 2, expected_value, tolerance)
 
             if node.Id == 4:
-                if self.time > 0.2499 and self.time < 0.25:
-                    expected_value = 0.2209203058453185
+                if self.time > 0.2495 and self.time < 0.25:
+                    expected_value = 0.21215864699077178
                     self.CheckKinematicValues(angular_velocity, 2, expected_value, tolerance)
 
             if node.Id == 5:
-                if self.time > 0.2999 and self.time < 0.30:
-                    expected_value = 3
+                if self.time > 0.2994 and self.time < 0.30:
+                    expected_value = 2.995000000000002
                     self.CheckKinematicValues(velocity, 0, expected_value, tolerance)
-                    expected_value = 2.99804
+                    expected_value = 2.990095000000002
                     self.CheckKinematicValues(velocity, 1, expected_value, tolerance)
-                    expected_value = 3
+                    expected_value = 2.995000000000002
                     self.CheckKinematicValues(velocity, 2, expected_value, tolerance)
-                    expected_value = 3
+                    expected_value = 2.995000000000002
                     self.CheckKinematicValues(angular_velocity, 0, expected_value, tolerance)
-                    expected_value = 3
+                    expected_value = 2.995000000000002
                     self.CheckKinematicValues(angular_velocity, 1, expected_value, tolerance)
-                    expected_value = 3
+                    expected_value = 2.995000000000002
                     self.CheckKinematicValues(angular_velocity, 2, expected_value, tolerance)
 
         for node in self.rigid_face_model_part.Nodes:
@@ -93,14 +93,14 @@ class KinematicConstraintsTestSolution(KratosMultiphysics.DEMApplication.DEM_ana
             angular_velocity = node.GetSolutionStepValue(Kratos.ANGULAR_VELOCITY)
 
             if node.Id == 10:
-                if self.time > 0.2999 and self.time < 0.30:
+                if self.time > 0.2995 and self.time < 0.30:
                     expected_value = -0.464725
                     self.CheckKinematicValues(velocity, 0, expected_value, tolerance)
-                    expected_value = 1.04281
+                    expected_value = 1.0408537823387725
                     self.CheckKinematicValues(velocity, 1, expected_value, tolerance)
-                    expected_value = 9.19637
+                    expected_value = 9.191646120463801
                     self.CheckKinematicValues(velocity, 2, expected_value, tolerance)
-                    expected_value = 2.45516
+                    expected_value = 2.447989288623642
                     self.CheckKinematicValues(angular_velocity, 0, expected_value, tolerance)
                     expected_value = -0.6
                     self.CheckKinematicValues(angular_velocity, 1, expected_value, tolerance)
@@ -108,19 +108,20 @@ class KinematicConstraintsTestSolution(KratosMultiphysics.DEMApplication.DEM_ana
                     self.CheckKinematicValues(angular_velocity, 2, expected_value, tolerance)
 
             if node.Id == 20:
-                if self.time > 0.2999 and self.time < 0.30:
-                    expected_value = 2.42451
+                if self.time > 0.2995 and self.time < 0.30:
+                    expected_value = 2.4193720111091825
                     self.CheckKinematicValues(velocity, 0, expected_value, tolerance)
-                    expected_value = -0.05332439955825208
+                    expected_value = -0.056663533294800894
                     self.CheckKinematicValues(velocity, 1, expected_value, tolerance)
-                    expected_value = 0.651258
+                    expected_value = 0.6500061249830357
                     self.CheckKinematicValues(velocity, 2, expected_value, tolerance)
                     expected_value = 0.225
                     self.CheckKinematicValues(angular_velocity, 0, expected_value, tolerance)
-                    expected_value = 1.2
+                    expected_value = 1.1980000000000008
                     self.CheckKinematicValues(angular_velocity, 1, expected_value, tolerance)
-                    expected_value = 2.7
+                    expected_value = 2.695500000000002
                     self.CheckKinematicValues(angular_velocity, 2, expected_value, tolerance)
+
 
     def CheckKinematicValues(self, kinematic_variable, component, expected_value, tolerance):
         self.assertAlmostEqual(kinematic_variable[component], expected_value, delta=tolerance)

--- a/applications/DEMApplication/tests/test_kinematic_constraints.py
+++ b/applications/DEMApplication/tests/test_kinematic_constraints.py
@@ -41,16 +41,15 @@ class KinematicConstraintsTestSolution(KratosMultiphysics.DEMApplication.DEM_ana
                     self.CheckKinematicValues(angular_velocity, 1, expected_value, tolerance)
                     expected_value = 0.0
                     self.CheckKinematicValues(angular_velocity, 2, expected_value, tolerance)
-                elif self.time > 0.30990 and self.time < 0.31:
-                    expected_value = -1.08106
+                elif self.time > 0.3099 and self.time < 0.31:
+                    expected_value = -1.0791000000000002
                     self.CheckKinematicValues(velocity, 1, expected_value, tolerance)
 
             if node.Id == 2:
                 if self.time > 0.25 and self.time < 0.3:
                     expected_value = -10.0 * self.time
                     self.CheckKinematicValues(velocity, 0, expected_value, tolerance)
-                if self.time > 0.30990 and self.time < 0.31:
-
+                if self.time > 0.3099 and self.time < 0.31:
                     expected_value = -0.0981
                     self.CheckKinematicValues(velocity, 1, expected_value, tolerance)
 
@@ -70,12 +69,12 @@ class KinematicConstraintsTestSolution(KratosMultiphysics.DEMApplication.DEM_ana
                     self.CheckKinematicValues(angular_velocity, 2, expected_value, tolerance)
 
             if node.Id == 4:
-                if self.time > 0.2495 and self.time < 0.25:
-                    expected_value = 0.2192
+                if self.time > 0.2499 and self.time < 0.25:
+                    expected_value = 0.2209203058453185
                     self.CheckKinematicValues(angular_velocity, 2, expected_value, tolerance)
 
             if node.Id == 5:
-                if self.time > 0.2998 and self.time < 0.30:
+                if self.time > 0.2999 and self.time < 0.30:
                     expected_value = 3
                     self.CheckKinematicValues(velocity, 0, expected_value, tolerance)
                     expected_value = 2.99804
@@ -94,7 +93,7 @@ class KinematicConstraintsTestSolution(KratosMultiphysics.DEMApplication.DEM_ana
             angular_velocity = node.GetSolutionStepValue(Kratos.ANGULAR_VELOCITY)
 
             if node.Id == 10:
-                if self.time > 0.2998 and self.time < 0.30:
+                if self.time > 0.2999 and self.time < 0.30:
                     expected_value = -0.464725
                     self.CheckKinematicValues(velocity, 0, expected_value, tolerance)
                     expected_value = 1.04281
@@ -109,10 +108,10 @@ class KinematicConstraintsTestSolution(KratosMultiphysics.DEMApplication.DEM_ana
                     self.CheckKinematicValues(angular_velocity, 2, expected_value, tolerance)
 
             if node.Id == 20:
-                if self.time > 0.2998 and self.time < 0.30:
+                if self.time > 0.2999 and self.time < 0.30:
                     expected_value = 2.42451
                     self.CheckKinematicValues(velocity, 0, expected_value, tolerance)
-                    expected_value = -0.0543884
+                    expected_value = -0.05332439955825208
                     self.CheckKinematicValues(velocity, 1, expected_value, tolerance)
                     expected_value = 0.651258
                     self.CheckKinematicValues(velocity, 2, expected_value, tolerance)

--- a/applications/DEMApplication/tests/test_search_tolerance/ProjectParametersDEM.json
+++ b/applications/DEMApplication/tests/test_search_tolerance/ProjectParametersDEM.json
@@ -34,7 +34,7 @@
     "ElementType"                    : "SphericPartDEMElement3D",
     "TranslationalIntegrationScheme" : "Symplectic_Euler",
     "RotationalIntegrationScheme"    : "Direct_Integration",
-    "MaxTimeStep"                    : 0.5e-5,
+    "MaxTimeStep"                    : 3.5e-5,
     "FinalTime"                      : 0.23,
     "NeighbourSearchFrequency"       : 20,
     "SearchTolerance"                : 1e-3,


### PR DESCRIPTION
**Description**
from  #8908 Decreased computation time of the slower tests.

~~~
______________
python3 test_DEM_3D_continuum_vs_discontinuum.py 
 |  /           |
 ' /   __| _` | __|  _ \   __|
 . \  |   (   | |   (   |\__ \
_|\_\_|  \__,_|\__|\___/ ____/
           Multi-Physics 9.0."Dev"-3fff561d625-Release
Compiled with threading support.
Maximum number of threads: 1.
.
----------------------------------------------------------------------
Ran 1 test in 0.455s

Ok

python3 test_DEM_2D_contact.py
 |  /           |
 ' /   __| _` | __|  _ \   __|
 . \  |   (   | |   (   |\__ \
_|\_\_|  \__,_|\__|\___/ ____/
           Multi-Physics 9.0."Dev"-91ebcc0c1d5-Release
Compiled with threading support.
Maximum number of threads: 1.
.
----------------------------------------------------------------------
Ran 1 test in 0.134s

OK


python3 test_kinematic_constraints.py
 |  /           |
 ' /   __| _` | __|  _ \   __|
 . \  |   (   | |   (   |\__ \
_|\_\_|  \__,_|\__|\___/ ____/
           Multi-Physics 9.0."Dev"-91ebcc0c1d5-Release
Compiled with threading support.
Maximum number of threads: 1.
.
----------------------------------------------------------------------
Ran 1 test in 0.233s

OK




NIGHTLY:
python3 test_DEM_search_tolerance.py  |  /           |
 ' /   __| _` | __|  _ \   __|
 . \  |   (   | |   (   |\__ \
_|\_\_|  \__,_|\__|\___/ ____/
           Multi-Physics 9.0."Dev"-3fff561d625-Release
Compiled with threading support.
Maximum number of threads: 1.
....
----------------------------------------------------------------------
Ran 4 tests in 5.300s

OK
~~~

