### PR TITLE
[PotentialFlow] Initialize condition in adjoint far field response

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_response_functions/adjoint_far_field_lift_response_function.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_response_functions/adjoint_far_field_lift_response_function.cpp
@@ -70,6 +70,7 @@ namespace Kratos
         const auto r_current_process_info = mrModelPart.GetProcessInfo();
         block_for_each(mrModelPart.GetRootModelPart().Conditions(), [&](Condition& rCondition)
         {
+            rCondition.Initialize(r_current_process_info);
             rCondition.FinalizeNonLinearIteration(r_current_process_info);
         });
 


### PR DESCRIPTION
**Description**
Adding conditiion initialize in the initializing of the far field response function. Sometimes at this point the condition did not have its correct corresponding element (when remeshing primal-adjoint).

**Changelog**
- Initialize conditions in far field response