### PR TITLE
[MLMC] Add central moment order 2 dimension 1

### DIFF
--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/methodDefs_momentEstimator/computeCentralMoments.py
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/methodDefs_momentEstimator/computeCentralMoments.py
@@ -15,10 +15,12 @@ def centralMomentWrapper(dimension,order,*args):
     elif dimension==1:
         if order==1:
             return computeCentralMomentsOrderOneDimensionOne(*args)
+        elif order==2:
+            return computeCentralMomentsOrderTwoDimensionOne(*args)
         else:
-            raise ValueError('Moments of order > 0 are not supported yet for dimension 1.')
+            raise ValueError('Moments of order > 2 are not supported yet for dimension 1.')
     else:
-        raise ValueError('Index sets of dimension > 0 are not supported yet.')
+        raise ValueError('Index sets of dimension > 1 are not supported yet.')
 
 @task(keep=True, returns=1)
 def centralMomentWrapper_Task(*args):


### PR DESCRIPTION
**Description**
Update XMC. 

Please mark the PR with appropriate tags: 
- External library

**Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Added central moment of dimension 1 (MLMC) and order 2 (variance).
