### PR TITLE
[PotentialFlow] Adding CalculationOnIntegrationPoints for int type in adjoint elements

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_base_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_base_potential_flow_element.cpp
@@ -76,6 +76,14 @@ namespace Kratos
     }
 
     template <class TPrimalElement>
+    void AdjointBasePotentialFlowElement<TPrimalElement>::CalculateOnIntegrationPoints(const Variable<int>& rVariable,
+            std::vector<int>& rValues,
+            const ProcessInfo& rCurrentProcessInfo)
+    {
+        mpPrimalElement->CalculateOnIntegrationPoints(rVariable,rValues,rCurrentProcessInfo);
+    }
+
+    template <class TPrimalElement>
     void AdjointBasePotentialFlowElement<TPrimalElement>::CalculateOnIntegrationPoints(const Variable<double>& rVariable,
             std::vector<double>& rValues,
             const ProcessInfo& rCurrentProcessInfo)

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_base_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_base_potential_flow_element.h
@@ -108,6 +108,10 @@ public:
     void CalculateRightHandSide(VectorType& rRightHandSideVector,
                                         const ProcessInfo& rCurrentProcessInfo) override;
 
+    void CalculateOnIntegrationPoints(const Variable<int>& rVariable,
+            std::vector<int>& rValues,
+            const ProcessInfo& rCurrentProcessInfo) override;
+
     void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
             std::vector<double>& rValues,
             const ProcessInfo& rCurrentProcessInfo) override;


### PR DESCRIPTION
**Description**
Adding CalculationOnIntegrationPoints for int type in adjoint elements, which are computed in the primal element.

**Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Added calc. on integration points 
