### PR TITLE
[LinearSolversApp] Update Spectra to official release 1.0.0

### DIFF
--- a/applications/LinearSolversApplication/external_libraries/spectra1/COPYING.AUTHORS.md
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/COPYING.AUTHORS.md
@@ -2,15 +2,17 @@ The files
 
 - `include/Spectra/LinAlg/TridiagEigen.h`
 - `include/Spectra/LinAlg/UpperHessenbergEigen.h`
+- `include/Spectra/LinAlg/UpperHessenbergSchur.h`
 
 were adapted from
 
 - `Eigen/src/Eigenvaleus/SelfAdjointEigenSolver.h`
 - `Eigen/src/Eigenvaleus/EigenSolver.h`
+- `Eigen/src/Eigenvaleus/RealSchur.h`
 
 in the [Eigen](http://eigen.tuxfamily.org/) library.
 
-The authors for these two files were Gael Guennebaud <gael.guennebaud@inria.fr>
+The authors for these three files were Gael Guennebaud <gael.guennebaud@inria.fr>
 and Jitse Niesen <jitse@maths.leeds.ac.uk>.
 
 The file `include/contrib/LOBPCGSolver.h` was originally contributed by Anna Araslanova.

--- a/applications/LinearSolversApplication/external_libraries/spectra1/COPYING.CHANGELOG.md
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/COPYING.CHANGELOG.md
@@ -1,0 +1,274 @@
+## [1.0.0] - 2021-07-01
+### Added
+- Added version macros `SPECTRA_MAJOR_VERSION`, `SPECTRA_MINOR_VERSION`,
+  `SPECTRA_PATCH_VERSION`, and `SPECTRA_VERSION` that are included by all eigen solvers
+- Added the wrapper class `SparseGenComplexShiftSolve` for eigen solver with complex shifts
+- Added the `SymGEigsShiftSolver` class for symmetric generalized eigen solver with real shifts
+- Added the wrapper class `SymShiftInvert` that can be used with `SymGEigsShiftSolver`
+- Added test code for symmetric generalized eigen solver with real shifts
+- Added an internal class `UpperHessenbergSchur` to compute the Schur decomposition of
+  upper Hessenberg matrices more efficiently
+- Added a `Flags` template parameter to every matrix operation class
+  (e.g. `DenseCholesky` and `DenseSymMatProd`), whose possible values are `Eigen::ColMajor`
+  and `Eigen::RowMajor`. This parameter allows these wrapper classes to handle row-major matrices.
+  If the input matrix is inconsistent with the `Flags` parameter (e.g., if `Flags` is
+  `Eigen::ColMajor` but the input matrix is row-major), a compiler error will occur
+- Added the member function `info()` and convergence tests to `SparseRegularInverse`,
+  suggested by [@Spammed](https://github.com/Spammed) ([#111](https://github.com/yixuan/spectra/issues/111))
+- Added symmetric Davidson eigen solver `DavidsonSymEigsSolver`, written by Felipe Zapata,
+  Nicolas Renaud, Victor Azizi, Pablo Lopez-Tarifa, and Jens Wehner from the Netherlands eScience Center
+- Extended matrix operations in `DenseGenMatProd`, `DenseSymMatProd`, `SparseGenMatProd`, and
+  `SparseSymMatProd` to handle matrix-matrix products and coefficient-wise accessors
+
+### Changed
+- **API change**: Spectra now requires C++11
+- **API change**: All enumerations have been converted to enum classes
+  (e.g. `LARGEST_MAGN` is now `SortRule::LargestMagn`)
+- **API change**: Selection rules are no longer template parameters. They are now
+  specified in the `compute()` member function as arguments
+- **API change**: The `Scalar` template parameter has been removed from eigen solvers.
+  Instead, matrix operation classes now need to define a public type named `Scalar`
+- **API change**: Constructors of solvers now request references of matrix operators
+  instead of pointers
+- Clang-Format now uses the C++11 standard to format code
+- Updated documentation to reflect the new API
+- Many internal changes to make use of C++11 features
+- Added a `SPECTRA_` prefix to each header guard to prevent potential name clash
+- Changed the default value of the `Flags` template parameter that exists in various
+  class templates from `0` to the more readable constant `Eigen::ColMajor`
+- Renamed the function `mat_prod` to `perform_op` in the `SparseRegularInverse` wrapper class.
+  This makes the API more consistent when implementing new generalized eigen solvers
+- Improved the precision of `UpperHessenbergQR` and `TridiagQR` by computing the
+  Givens rotations in a more stable way
+- Added a deflation test to `TridiagQR` to accelerate the convergence of eigen solvers
+- Improved the precision of `TridiagQR::matrix_QtHQ()` by directly applying rotations
+  to the original input matrix
+- Improved the precision of `DoubleShiftQR` by computing the Householder reflectors
+  in a more stable way
+- Improved the deflation test in `DoubleShiftQR`
+- More careful computation of residual vectors in the `Lanczos` process
+- Initial vectors in the `Lanczos` and `Arnoldi` processes are now forced to be in the
+  range of the `A` matrix
+- More sensible test for orthogonality in generating new random vectors in the
+  `Lanczos` and `Arnoldi` processes
+- In symmetric eigen solvers large shifts are applied first to increase precision
+- Updated the included [Catch2](https://github.com/catchorg/Catch2) to v2.13.6
+
+
+## [0.9.0] - 2020-05-19
+### Added
+- Added support for CMake build, contributed by
+  [Guillaume Acke](https://github.com/guacke) and [Jens Wehner](https://github.com/JensWehner)
+  ([#70](https://github.com/yixuan/spectra/pull/70), [#88](https://github.com/yixuan/spectra/pull/88))
+- Spectra can now be installed via [conda-forge](https://github.com/conda-forge/spectralib-feedstock),
+  thanks to [Guillaume Acke](https://github.com/guacke) and [Julien Schueller](https://github.com/jschueller)
+  ([#81](https://github.com/yixuan/spectra/pull/81), [#85](https://github.com/yixuan/spectra/pull/85))
+- The source code of Spectra is now formatted using
+  [Clang-Format](https://clang.llvm.org/docs/ClangFormat.html), suggested by
+  [Jens Wehner](https://github.com/JensWehner)
+
+### Changed
+- Fixed a compiler warning caused by unused parameter, contributed by
+  [Julien Schueller](https://github.com/jschueller) ([#80](https://github.com/yixuan/spectra/pull/80))
+- Changed the implementation of `BKLDLT` solver to improve precision in some tests
+
+
+## [0.8.1] - 2019-06-05
+### Changed
+- Fixed a bug in `BKLDLT` in which a wrong type was used, thanks to
+  [@jdbancal](https://github.com/jdbancal) for the issue
+  [#64](https://github.com/yixuan/spectra/pull/64)
+- Fixed a bug in `BKLDLT` that caused segmentation fault in some edge
+  cases, also reported by [@jdbancal](https://github.com/jdbancal) in issue
+  [#66](https://github.com/yixuan/spectra/issues/66)
+- The type `Eigen::Index` is now globally used for indices and sizes, in order to
+  handle potentially large matrices. This was suggested by
+  [Yuan Yao](https://github.com/y-yao) in issue
+  [#19](https://github.com/yixuan/spectra/issues/19)
+
+
+## [0.8.0] - 2019-04-03
+### Added
+- Added a `BKLDLT` class that implements the Bunch-Kaufman LDLT decomposition
+  for symmetric indefinite matrices. According to the Eigen documentation,
+  currently `Eigen::LDLT` cannot handle some special indefinite matrices such
+  as `[0, 1; 1, 0]`, but `BKLDLT` is applicable to any symmetric matrices as
+  long as it is not singular. LDLT decomposition is used in shift-and-invert
+  solvers (see below)
+- Added a unit test for `BKLDLT`
+
+### Changed
+- `DenseSymShiftSolve` now uses the newly added `BKLDLT` class to do the
+  decomposition. This change broadens the class of matrices that
+  `DenseSymShiftSolve` can handle, reduces memory use, and should also improve
+  the numerical stability of the solver
+- Replaced `Eigen::SimplicialLDLT` with `Eigen::SparseLU` in the `SparseSymShiftSolve`
+  class, as some edge-case indefinite matrices may break `Eigen::SimplicialLDLT`
+- `SparseSymShiftSolve` and `SparseGenRealShiftSolve` will throw an error if
+  the factorization failed, for example, on singular matrices
+- Fixed a missing `#include` in `DenseCholesky.h`, thanks to
+  [Lennart Trunk](https://github.com/TheScarfix) for the issue
+  [#59](https://github.com/yixuan/spectra/issues/59)
+- Fixed errors in examples ([#60](https://github.com/yixuan/spectra/issues/60)),
+  thanks to [@linuxfreebird](https://github.com/linuxfreebird)
+- Updated the included [Catch2](https://github.com/catchorg/Catch2) to v2.7.0
+
+
+## [0.7.0] - 2019-01-10
+### Added
+- Added a directory `contrib` to include code contributed by users. It is not
+  formally a part of the Spectra library, but it may contain useful solvers
+  and applications based on Spectra. Code in `contrib` may not be fully tested,
+  so please use with caution. Feedback and report of issues are always welcome
+- Added an eigen solver `LOBPCGSolver` in the `contrib` directory using the
+  [LOBPCG](https://en.wikipedia.org/wiki/LOBPCG) algorithm,
+  contributed by [Anna Araslanova](https://github.com/AnnaAraslanova)
+- Added a partial SVD solver `PartialSVDSolver` in the `contrib` directory
+- Added two internal classes `Arnoldi` and `Lanczos` to compute the Arnoldi/Lanczos
+  factorization in eigen solvers
+- Added a few other internal classes to refactor the eigen solver classes (see below)
+
+### Changed
+- **API change**: Spectra now requires Eigen >= 3.3
+- **API change**: The library header files are moved into a directory
+  named `Spectra`. Hence the recommended include directive would look like
+  `#include <Spectra/SymEigsSolver.h>`
+- All eigen solvers have been refactored using a cleaner class hierarchy.
+  It may potentially make the implementation of new eigen solvers easier,
+  especially for generalized eigen problems
+- The matrix operation classes (e.g. `DenseSymMatProd` and `SparseSymMatProd`)
+  are now internally using an
+  [Eigen::Ref](https://eigen.tuxfamily.org/dox/classEigen_1_1Ref.html) object
+  to wrap the user matrices, thanks to
+  [Dario Mangoni](https://github.com/dariomangoni) who raised this issue in
+  [#16](https://github.com/yixuan/spectra/issues/16)
+- Fixed inappropriate range of random numbers in the tests
+- Updated the included [Catch2](https://github.com/catchorg/Catch2) to v2.4.2
+
+
+## [0.6.2] - 2018-05-22
+### Changed
+- Fixed regressions in v0.6.0 on some edge cases
+- Improved the accuracy of restarting processes in `SymEigsSolver` and `GenEigsSolver`
+- Updated the included [Catch2](https://github.com/catchorg/Catch2) to v2.2.2
+- Code and documentation cleanup
+
+
+## [0.6.1] - 2018-03-03
+### Changed
+- Fixed a bug of uninitialized memory
+- Updated the included [Catch2](https://github.com/catchorg/Catch2) to v2.1.2
+
+
+## [0.6.0] - 2018-03-03
+### Added
+- Added virtual destructors to the `SymEigsSolver` and `UpperHessenbergQR` classes
+  to fix compiler warnings, by [Julian Kent](https://github.com/jkflying)
+- Added a `NUMERICAL_ISSUE` entry to the `COMPUTATION_INFO` enumeration to indicate
+  the status of Cholesky decomposition
+- Added the `info()` member function to `DenseCholesky` and `SparseCholesky` to
+  report the status of the decomposition
+- Added a missing `#include` item in `SparseCholesky.h`, thanks to
+  [Maxim Torgonsky](https://github.com/kriolog)
+- Added a `TypeTraits` class to retrieve additional numeric limits of scalar value
+  types
+
+### Changed
+- Documentation updates
+- Updated the project URL to [https://spectralib.org](https://spectralib.org)
+- Some internal improvements, such as pre-allocating vectors in loops, and changing
+  return type to reference, thanks to
+  [Angelos Mantzaflaris](https://github.com/filiatra)
+- Improved the accuracy of symmetric and general eigen solvers
+- Reduced the memory use of `UpperHessenbergQR` and `TridiagQR` decompositions
+- Updated the included [Catch2](https://github.com/catchorg/Catch2) to v2.0.1
+- Updated the testing code using the new API of Catch2
+- Updated Travis CI script
+
+
+## [0.5.0] - 2017-02-05
+### Added
+- Added the generalized eigen solver `SymGEigsSolver` in the regular inverse mode
+- Added the wrapper class `SparseRegularInverse` that can be used with
+  `SymGEigsSolver` in the regular inverse mode
+- Added test code for generalized eigen solver in the regular inverse mode
+
+### Changed
+- Improved the numerical precision and stability of some internal linear
+  algebra classes, including `TridiagEigen`, `UpperHessenbergEigen`, and
+  `DoubleShiftQR`
+- **API change**: The `x_in` argument in matrix operation functions, e.g.
+  `perform_op()`, is now labelled to be constant
+- Fixed a [bug](https://github.com/yixuan/spectra/issues/15) that
+  `GenEigsComplexShiftSolver` gave wrong results when transforming back the
+  eigenvalues, discovered by [@jdbancal](https://github.com/jdbancal)
+- Updated included [Catch](https://github.com/philsquared/Catch) to v1.7.0
+- Documentation improvement
+
+
+## [0.4.0] - 2016-11-14
+### Added
+- Added an `Uplo` template parameter to the `DenseSymShiftSolve` class
+- Added the generalized eigen solver `SymGEigsSolver` in the Cholesky mode
+- Added the wrapper classes `DenseCholesky` and `SparseCholesky` that can be
+  used with `SymGEigsSolver` in the Cholesky mode
+- Added test code for generalized eigen solver in the Cholesky mode
+
+### Changed
+- Updated included [Catch](https://github.com/philsquared/Catch) to v1.5.7
+- Improved documentation
+- Updated Travis CI script
+- Allowing basic math functions such as `abs()` and `sqrt()` to be overloaded
+  (avoid using `std::abs` and `std::sqrt` directly), thanks to
+  [@jdbancal](https://github.com/jdbancal). This makes it possible to use
+  user-defined float number types with Spectra
+- Replaced other `std` functions by their Eigen counterparts, for example using
+  `Eigen::NumTraits<Scalar>::epsilon()` to substitute
+  `std::numeric_limits<Scalar>::epsilon()`
+- Improved the numerical stability of several operations, e.g. the function
+  `hypot(x, y)` is used to compute `sqrt(x^2 + y^2)`
+- More careful use of "approximate zero" constants
+- Fixed an out-of-bound [bug](https://github.com/yixuan/spectra/issues/14)
+  detected by [@jdbancal](https://github.com/jdbancal)
+
+
+## [0.3.0] - 2016-07-03
+### Added
+- Added the wrapper classes `SparseSymMatProd` and `SparseSymShiftSolve`
+  for sparse symmetric matrices
+- Added the wrapper class `SparseGenRealShiftSolve` for general sparse matrices
+- Added tests for sparse matrices
+- Using Travis CI for automatic unit test
+
+### Changed
+- Updated included [Catch](https://github.com/philsquared/Catch) to v1.5.6
+- **API change**: Each eigen solver was moved to its own header file.
+  For example to use `SymEigsShiftSolver` one needs to include
+  `<SymEigsShiftSolver.h>`
+- Header files for internal use were relocated
+
+
+## [0.2.0] - 2016-02-28
+### Added
+- Benchmark script now outputs number of matrix operations
+- Added this change log
+- Added a simple built-in random number generator, so that the algorithm
+  was made to be deterministic
+- Added the wrapper class `DenseSymMatProd` for symmetric matrices
+
+### Changed
+- Improved Arnoldi factorization
+  - Iteratively corrects orthogonality
+  - Creates new residual vector when invariant subspace is found
+  - Stability for matrices with repeated eigenvalues is greatly improved
+- Adjusted deflation tolerance in double shift QR
+- Updated result analyzer
+- Updated included [Catch](https://github.com/philsquared/Catch) to v1.3.4
+- Updated copyright information
+- **API change**: Default operator of `SymEigsSolver` was changed from
+  `DenseGenMatProd` to `DenseSymMatProd`
+
+
+## [0.1.0] - 2015-12-19
+### Added
+- Initial release of Spectra

--- a/applications/LinearSolversApplication/external_libraries/spectra1/COPYING.MIGRATION.md
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/COPYING.MIGRATION.md
@@ -1,0 +1,113 @@
+## [0.9.0] → [1.0.0]
+
+Spectra 1.0.0 introduces a lot of API-breaking changes, but the migration
+should be straightforward following the guide below.
+
+### Toolchain
+
+Spectra 1.0.0 requires a compiler supporting the C++11 standard.
+Any modern C++ compiler should already have this.
+
+### Matrix Operation Classes
+
+In most cases you do not need to change anything for the code involving
+built-in matrix operation classes such as `DenseSymMatProd` and
+`SparseGenMatProd`. However, if you have defined your own class, you
+need to add a public type definition named `Scalar`, as the example
+below shows. The type `Scalar` indicates the element type of the matrix.
+
+```cpp
+// A user-defined matrix operation class
+// representing the matrix A=diag(1, 2, ..., 10)
+class MyDiagonalTen
+{
+public:
+    // The line below is new
+    using Scalar = double;
+
+    int rows() { return 10; }
+    int cols() { return 10; }
+    // y_out = M * x_in
+    void perform_op(const double *x_in, double *y_out) const
+    {
+        for(int i = 0; i < rows(); i++)
+        {
+            y_out[i] = x_in[i] * (i + 1);
+        }
+    }
+};
+```
+
+### Eigen Solvers
+
+The biggest change happens in the eigen solvers:
+
+1. The first template parameter `Scalar` has been removed.
+2. The second template parameter, `SelectionRule`, has been changed to
+   a runtime parameter `selection` in the `compute()` member function.
+3. In the constructor, matrix operation objects are now passed as
+   references instead of pointers.
+4. All enumerations have been converted to enum classes (see the
+   conversion table below).
+
+Below shows the one-to-one conversion of the code reflecting the
+changes above:
+
+[0.9.0] code:
+```cpp
+// Construct matrix operation object using the wrapper class
+DenseSymMatProd<double> op(M);
+
+// Construct eigen solver object, requesting the largest three eigenvalues
+SymEigsSolver< double, LARGEST_ALGE, DenseSymMatProd<double> > eigs(&op, 3, 6);
+
+// Initialize, and compute with at most 1000 iterations
+eigs.init();
+int nconv = eigs.compute(1000);
+
+// Retrieve results
+Eigen::VectorXd evalues;
+if(eigs.info() == SUCCESSFUL)
+    evalues = eigs.eigenvalues();
+```
+
+[1.0.0] code:
+```cpp
+// Construct matrix operation object using the wrapper class
+DenseSymMatProd<double> op(M);
+
+// Construct eigen solver object, requesting the largest three eigenvalues
+SymEigsSolver<DenseSymMatProd<double>> eigs(op, 3, 6);
+
+// Initialize, and compute with at most 1000 iterations
+eigs.init();
+int nconv = eigs.compute(SortRule::LargestAlge, 1000);
+
+// Retrieve results
+Eigen::VectorXd evalues;
+if(eigs.info() == CompInfo::Successful)
+    evalues = eigs.eigenvalues();
+```
+
+### Enumerations
+
+| [0.9.0]                 | [1.0.0]                     |
+|-------------------------|-----------------------------|
+| `SUCCESSFUL`            | `CompInfo::Successful`      |
+| `NOT_COMPUTED`          | `CompInfo::NotComputed`     |
+| `NOT_CONVERGING`        | `CompInfo::NotConverging`   |
+| `NUMERICAL_ISSUE`       | `CompInfo::NumericalIssue`  |
+| `LARGEST_MAGN`          | `SortRule::LargestMagn`     |
+| `LARGEST_REAL`          | `SortRule::LargestReal`     |
+| `LARGEST_IMAG`          | `SortRule::LargestImag`     |
+| `LARGEST_ALGE`          | `SortRule::LargestAlge`     |
+| `SMALLEST_MAGN`         | `SortRule::SmallestMagn`    |
+| `SMALLEST_REAL`         | `SortRule::SmallestReal`    |
+| `SMALLEST_IMAG`         | `SortRule::SmallestImag`    |
+| `SMALLEST_ALGE`         | `SortRule::SmallestAlge`    |
+| `BOTH_ENDS`             | `SortRule::BothEnds`        |
+| `GEIGS_CHOLESKY`        | `GEigsMode::Cholesky`       |
+| `GEIGS_REGULAR_INVERSE` | `GEigsMode::RegularInverse` |
+| `GEIGS_SHIFT_INVERT`    | `GEigsMode::ShiftInvert`    |
+| `GEIGS_BUCKLING`        | `GEigsMode::Buckling`       |
+| `GEIGS_CAYLEY`          | `GEigsMode::Cayley`         |

--- a/applications/LinearSolversApplication/external_libraries/spectra1/COPYING.README.md
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/COPYING.README.md
@@ -4,12 +4,12 @@
 
 
 
-> **NOTE**: If you are interested in the future development of Spectra, please join
-> [this thread](https://github.com/yixuan/spectra/issues/92) to share your comments and suggestions.
-
-> **NOTE**: Spectra is moving to the 1.0.0 release, with a lot of
+> **NOTE**: Spectra 1.0.0 is released, with a lot of
 > API-breaking changes. Please see the [migration guide](MIGRATION.md)
 > for a smooth transition to the new version.
+
+> **NOTE**: If you are interested in the future development of Spectra, please join
+> [this thread](https://github.com/yixuan/spectra/issues/92) to share your comments and suggestions.
 
 [**Spectra**](https://spectralib.org) stands for **Sp**arse **E**igenvalue **C**omputation **T**oolkit
 as a **R**edesigned **A**RPACK. It is a C++ library for large scale eigenvalue
@@ -251,7 +251,7 @@ cmake .. -DCMAKE_INSTALL_PREFIX='intended installation directory' -DCMAKE_PREFIX
 make all && make tests && make install
 ```
 
-By installing Spectra in this way, you also create a CMake target 'Spectra::Spectra' that can be used in subsequent build procedures for other programs.
+By installing **Spectra** in this way, you also create a CMake target `Spectra::Spectra` that can be used in subsequent build procedures for other programs.
 
 ## License
 

--- a/applications/LinearSolversApplication/external_libraries/spectra1/README.md
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/README.md
@@ -1,7 +1,7 @@
-# Spectra 1.x
+# Spectra
 
 **Spectra stands for Sparse Eigenvalue Computation Toolkit as a Redesigned ARPACK. It is a C++ library for large scale eigenvalue problems, built on top of Eigen, an open source linear algebra library.**
 
-Version: [commit](https://github.com/yixuan/spectra/commit/5f8ea3a585504ce0eac341d33a48ce3b2f899306)
+Version: [Spectra v1.0.0](https://github.com/yixuan/spectra/releases/tag/v1.0.0)
 
 For more information go to https://github.com/yixuan/spectra.

--- a/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/LinAlg/TridiagEigen.h
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/LinAlg/TridiagEigen.h
@@ -38,6 +38,7 @@ private:
     bool m_computed;
 
     // Adapted from Eigen/src/Eigenvaleus/SelfAdjointEigenSolver.h
+    // Francis implicit QR step.
     static void tridiagonal_qr_step(RealScalar* diag,
                                     RealScalar* subdiag, Index start,
                                     Index end, Scalar* matrixQ,
@@ -45,6 +46,7 @@ private:
     {
         using std::abs;
 
+        // Wilkinson Shift.
         RealScalar td = (diag[end - 1] - diag[end]) * RealScalar(0.5);
         RealScalar e = subdiag[end - 1];
         // Note that thanks to scaling, e^2 or td^2 cannot overflow, however they can still
@@ -53,14 +55,14 @@ private:
         //   RealScalar mu = diag[end] - e2 / (td + (td>0 ? 1 : -1) * sqrt(td*td + e2));
         // This explain the following, somewhat more complicated, version:
         RealScalar mu = diag[end];
-        if (td == Scalar(0))
+        if (td == RealScalar(0))
             mu -= abs(e);
-        else
+        else if (e != RealScalar(0))
         {
-            RealScalar e2 = Eigen::numext::abs2(subdiag[end - 1]);
-            RealScalar h = Eigen::numext::hypot(td, e);
+            const RealScalar e2 = Eigen::numext::abs2(e);
+            const RealScalar h = Eigen::numext::hypot(td, e);
             if (e2 == RealScalar(0))
-                mu -= (e / (td + (td > RealScalar(0) ? RealScalar(1) : RealScalar(-1)))) * (e / h);
+                mu -= e / ((td + (td > RealScalar(0) ? h : -h)) / e);
             else
                 mu -= e2 / (td + (td > RealScalar(0) ? h : -h));
         }
@@ -68,7 +70,9 @@ private:
         RealScalar x = diag[start] - mu;
         RealScalar z = subdiag[start];
         Eigen::Map<Matrix> q(matrixQ, n, n);
-        for (Index k = start; k < end; ++k)
+        // If z ever becomes zero, the Givens rotation will be the identity and
+        // z will stay zero for all future iterations.
+        for (Index k = start; k < end && z != RealScalar(0); ++k)
         {
             Eigen::JacobiRotation<RealScalar> rot;
             rot.makeGivens(x, z);
@@ -87,8 +91,8 @@ private:
             if (k > start)
                 subdiag[k - 1] = c * subdiag[k - 1] - s * z;
 
+            // "Chasing the bulge" to return to triangular form.
             x = subdiag[k];
-
             if (k < end - 1)
             {
                 z = -s * subdiag[k + 1];
@@ -154,16 +158,25 @@ public:
         int info = 0;    // 0 for success, 1 for failure
 
         const Scalar considerAsZero = TypeTraits<Scalar>::min();
-        const Scalar precision = Scalar(2) * Eigen::NumTraits<Scalar>::epsilon();
+        const Scalar precision_inv = Scalar(1) / Eigen::NumTraits<Scalar>::epsilon();
 
         while (end > 0)
         {
             for (Index i = start; i < end; i++)
-                if (abs(subdiag[i]) <= considerAsZero ||
-                    abs(subdiag[i]) <= (abs(diag[i]) + abs(diag[i + 1])) * precision)
-                    subdiag[i] = 0;
+            {
+                if (abs(subdiag[i]) <= considerAsZero)
+                    subdiag[i] = Scalar(0);
+                else
+                {
+                    // abs(subdiag[i]) <= epsilon * sqrt(abs(diag[i]) + abs(diag[i+1]))
+                    // Scaled to prevent underflows.
+                    const Scalar scaled_subdiag = precision_inv * subdiag[i];
+                    if (scaled_subdiag * scaled_subdiag <= (abs(diag[i]) + abs(diag[i + 1])))
+                        subdiag[i] = Scalar(0);
+                }
+            }
 
-            // find the largest unreduced block
+            // find the largest unreduced block at the end of the matrix.
             while (end > 0 && subdiag[end - 1] == Scalar(0))
                 end--;
 

--- a/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/LinAlg/UpperHessenbergEigen.h
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/LinAlg/UpperHessenbergEigen.h
@@ -12,8 +12,9 @@
 #define SPECTRA_UPPER_HESSENBERG_EIGEN_H
 
 #include <Eigen/Core>
-#include <Eigen/Eigenvalues>
 #include <stdexcept>
+
+#include "UpperHessenbergSchur.h"
 
 namespace Spectra {
 
@@ -32,7 +33,7 @@ private:
     using ComplexVector = Eigen::Matrix<Complex, Eigen::Dynamic, 1>;
 
     Index m_n;                             // Size of the matrix
-    Eigen::RealSchur<Matrix> m_realSchur;  // Schur decomposition solver
+    UpperHessenbergSchur<Scalar> m_schur;  // Schur decomposition solver
     Matrix m_matT;                         // Schur T matrix
     Matrix m_eivec;                        // Storing eigenvectors
     ComplexVector m_eivalues;              // Eigenvalues
@@ -219,13 +220,9 @@ public:
         const Scalar scale = mat.cwiseAbs().maxCoeff();
 
         // Reduce to real Schur form
-        Matrix Q = Matrix::Identity(m_n, m_n);
-        m_realSchur.computeFromHessenberg(mat / scale, Q, true);
-        if (m_realSchur.info() != Eigen::Success)
-            throw std::runtime_error("UpperHessenbergEigen: eigen decomposition failed");
-
-        m_matT = m_realSchur.matrixT();
-        m_eivec = m_realSchur.matrixU();
+        m_schur.compute(mat / scale);
+        m_schur.swap_T(m_matT);
+        m_schur.swap_U(m_eivec);
 
         // Compute eigenvalues from matT
         m_eivalues.resize(m_n);

--- a/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/LinAlg/UpperHessenbergSchur.h
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/LinAlg/UpperHessenbergSchur.h
@@ -1,0 +1,364 @@
+// The code was adapted from Eigen/src/Eigenvaleus/RealSchur.h
+//
+// Copyright (C) 2008 Gael Guennebaud <gael.guennebaud@inria.fr>
+// Copyright (C) 2010,2012 Jitse Niesen <jitse@maths.leeds.ac.uk>
+// Copyright (C) 2021 Yixuan Qiu <yixuan.qiu@cos.name>
+//
+// This Source Code Form is subject to the terms of the Mozilla
+// Public License v. 2.0. If a copy of the MPL was not distributed
+// with this file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef SPECTRA_UPPER_HESSENBERG_SCHUR_H
+#define SPECTRA_UPPER_HESSENBERG_SCHUR_H
+
+#include <Eigen/Core>
+#include <Eigen/Jacobi>
+#include <Eigen/Householder>
+#include <stdexcept>
+
+#include "../Util/TypeTraits.h"
+
+namespace Spectra {
+
+template <typename Scalar = double>
+class UpperHessenbergSchur
+{
+private:
+    using Index = Eigen::Index;
+    using Matrix = Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>;
+    using Vector = Eigen::Matrix<Scalar, Eigen::Dynamic, 1>;
+    using Vector2s = Eigen::Matrix<Scalar, 2, 1>;
+    using Vector3s = Eigen::Matrix<Scalar, 3, 1>;
+    using GenericMatrix = Eigen::Ref<Matrix>;
+    using ConstGenericMatrix = const Eigen::Ref<const Matrix>;
+
+    Index m_n;   // Size of the matrix
+    Matrix m_T;  // T matrix, A = UTU'
+    Matrix m_U;  // U matrix, A = UTU'
+    bool m_computed;
+
+    // L1 norm of an upper Hessenberg matrix
+    static Scalar upper_hessenberg_l1_norm(ConstGenericMatrix& x)
+    {
+        const Index n = x.cols();
+        Scalar norm(0);
+        for (Index j = 0; j < n; j++)
+            norm += x.col(j).segment(0, (std::min)(n, j + 2)).cwiseAbs().sum();
+        return norm;
+    }
+
+    // Look for single small sub-diagonal element and returns its index
+    Index find_small_subdiag(Index iu, const Scalar& near_0) const
+    {
+        using std::abs;
+
+        const Scalar eps = Eigen::NumTraits<Scalar>::epsilon();
+        Index res = iu;
+        while (res > 0)
+        {
+            Scalar s = abs(m_T.coeff(res - 1, res - 1)) + abs(m_T.coeff(res, res));
+            s = Eigen::numext::maxi<Scalar>(s * eps, near_0);
+            if (abs(m_T.coeff(res, res - 1)) <= s)
+                break;
+            res--;
+        }
+
+        return res;
+    }
+
+    // Update T given that rows iu-1 and iu decouple from the rest
+    void split_off_two_rows(Index iu, const Scalar& ex_shift)
+    {
+        using std::sqrt;
+        using std::abs;
+
+        // The eigenvalues of the 2x2 matrix [a b; c d] are
+        // trace +/- sqrt(discr/4) where discr = tr^2 - 4*det, tr = a + d, det = ad - bc
+        Scalar p = Scalar(0.5) * (m_T.coeff(iu - 1, iu - 1) - m_T.coeff(iu, iu));
+        Scalar q = p * p + m_T.coeff(iu, iu - 1) * m_T.coeff(iu - 1, iu);  // q = tr^2 / 4 - det = discr/4
+        m_T.coeffRef(iu, iu) += ex_shift;
+        m_T.coeffRef(iu - 1, iu - 1) += ex_shift;
+
+        if (q >= Scalar(0))  // Two real eigenvalues
+        {
+            Scalar z = sqrt(abs(q));
+            Eigen::JacobiRotation<Scalar> rot;
+            rot.makeGivens((p >= Scalar(0)) ? (p + z) : (p - z), m_T.coeff(iu, iu - 1));
+            m_T.rightCols(m_n - iu + 1).applyOnTheLeft(iu - 1, iu, rot.adjoint());
+            m_T.topRows(iu + 1).applyOnTheRight(iu - 1, iu, rot);
+            m_T.coeffRef(iu, iu - 1) = Scalar(0);
+            m_U.applyOnTheRight(iu - 1, iu, rot);
+        }
+        if (iu > 1)
+            m_T.coeffRef(iu - 1, iu - 2) = Scalar(0);
+    }
+
+    // Form shift in shift_info, and update ex_shift if an exceptional shift is performed
+    void compute_shift(Index iu, Index iter, Scalar& ex_shift, Vector3s& shift_info)
+    {
+        using std::sqrt;
+        using std::abs;
+
+        shift_info.coeffRef(0) = m_T.coeff(iu, iu);
+        shift_info.coeffRef(1) = m_T.coeff(iu - 1, iu - 1);
+        shift_info.coeffRef(2) = m_T.coeff(iu, iu - 1) * m_T.coeff(iu - 1, iu);
+
+        // Wilkinson's original ad hoc shift
+        if (iter == 10)
+        {
+            ex_shift += shift_info.coeff(0);
+            for (Index i = 0; i <= iu; ++i)
+                m_T.coeffRef(i, i) -= shift_info.coeff(0);
+            Scalar s = abs(m_T.coeff(iu, iu - 1)) + abs(m_T.coeff(iu - 1, iu - 2));
+            shift_info.coeffRef(0) = Scalar(0.75) * s;
+            shift_info.coeffRef(1) = Scalar(0.75) * s;
+            shift_info.coeffRef(2) = Scalar(-0.4375) * s * s;
+        }
+
+        // MATLAB's new ad hoc shift
+        if (iter == 30)
+        {
+            Scalar s = (shift_info.coeff(1) - shift_info.coeff(0)) / Scalar(2);
+            s = s * s + shift_info.coeff(2);
+            if (s > Scalar(0))
+            {
+                s = sqrt(s);
+                if (shift_info.coeff(1) < shift_info.coeff(0))
+                    s = -s;
+                s = s + (shift_info.coeff(1) - shift_info.coeff(0)) / Scalar(2);
+                s = shift_info.coeff(0) - shift_info.coeff(2) / s;
+                ex_shift += s;
+                for (Index i = 0; i <= iu; ++i)
+                    m_T.coeffRef(i, i) -= s;
+                shift_info.setConstant(Scalar(0.964));
+            }
+        }
+    }
+
+    // Compute index im at which Francis QR step starts and the first Householder vector
+    void init_francis_qr_step(Index il, Index iu, const Vector3s& shift_info, Index& im, Vector3s& first_householder_vec) const
+    {
+        using std::abs;
+
+        const Scalar eps = Eigen::NumTraits<Scalar>::epsilon();
+        Vector3s& v = first_householder_vec;  // alias to save typing
+        for (im = iu - 2; im >= il; --im)
+        {
+            const Scalar Tmm = m_T.coeff(im, im);
+            const Scalar r = shift_info.coeff(0) - Tmm;
+            const Scalar s = shift_info.coeff(1) - Tmm;
+            v.coeffRef(0) = (r * s - shift_info.coeff(2)) / m_T.coeff(im + 1, im) + m_T.coeff(im, im + 1);
+            v.coeffRef(1) = m_T.coeff(im + 1, im + 1) - Tmm - r - s;
+            v.coeffRef(2) = m_T.coeff(im + 2, im + 1);
+            if (im == il)
+                break;
+            const Scalar lhs = m_T.coeff(im, im - 1) * (abs(v.coeff(1)) + abs(v.coeff(2)));
+            const Scalar rhs = v.coeff(0) * (abs(m_T.coeff(im - 1, im - 1)) + abs(Tmm) + abs(m_T.coeff(im + 1, im + 1)));
+            if (abs(lhs) < eps * rhs)
+                break;
+        }
+    }
+
+    // P = I - tau * v * v' = P'
+    // PX = X - tau * v * (v'X), X [3 x c]
+    static void apply_householder_left(const Vector2s& ess, const Scalar& tau, Scalar* x, Index ncol, Index stride)
+    {
+        const Scalar v1 = ess.coeff(0), v2 = ess.coeff(1);
+        const Scalar* const x_end = x + ncol * stride;
+        for (; x < x_end; x += stride)
+        {
+            const Scalar tvx = tau * (x[0] + v1 * x[1] + v2 * x[2]);
+            x[0] -= tvx;
+            x[1] -= tvx * v1;
+            x[2] -= tvx * v2;
+        }
+    }
+
+    // P = I - tau * v * v' = P'
+    // XP = X - tau * (X * v) * v', X [r x 3]
+    static void apply_householder_right(const Vector2s& ess, const Scalar& tau, Scalar* x, Index nrow, Index stride)
+    {
+        const Scalar v1 = ess.coeff(0), v2 = ess.coeff(1);
+        Scalar* x0 = x;
+        Scalar* x1 = x + stride;
+        Scalar* x2 = x1 + stride;
+        for (Index i = 0; i < nrow; i++)
+        {
+            const Scalar txv = tau * (x0[i] + v1 * x1[i] + v2 * x2[i]);
+            x0[i] -= txv;
+            x1[i] -= txv * v1;
+            x2[i] -= txv * v2;
+        }
+    }
+
+    // Perform a Francis QR step involving rows il:iu and columns im:iu
+    void perform_francis_qr_step(Index il, Index im, Index iu, const Vector3s& first_householder_vec, const Scalar& near_0)
+    {
+        using std::abs;
+
+        for (Index k = im; k <= iu - 2; ++k)
+        {
+            const bool first_iter = (k == im);
+            Vector3s v;
+            if (first_iter)
+                v = first_householder_vec;
+            else
+                v = m_T.template block<3, 1>(k, k - 1);
+
+            Scalar tau, beta;
+            Vector2s ess;
+            v.makeHouseholder(ess, tau, beta);
+
+            if (abs(beta) > near_0)  // if v is not zero
+            {
+                if (first_iter && k > il)
+                    m_T.coeffRef(k, k - 1) = -m_T.coeff(k, k - 1);
+                else if (!first_iter)
+                    m_T.coeffRef(k, k - 1) = beta;
+
+                // These Householder transformations form the O(n^3) part of the algorithm
+                // m_T.block(k, k, 3, m_n - k).applyHouseholderOnTheLeft(ess, tau, workspace);
+                // m_T.block(0, k, (std::min)(iu, k + 3) + 1, 3).applyHouseholderOnTheRight(ess, tau, workspace);
+                // m_U.block(0, k, m_n, 3).applyHouseholderOnTheRight(ess, tau, workspace);
+                apply_householder_left(ess, tau, &m_T.coeffRef(k, k), m_n - k, m_n);
+                apply_householder_right(ess, tau, &m_T.coeffRef(0, k), (std::min)(iu, k + 3) + 1, m_n);
+                apply_householder_right(ess, tau, &m_U.coeffRef(0, k), m_n, m_n);
+            }
+        }
+
+        // The last 2-row block
+        Eigen::JacobiRotation<Scalar> rot;
+        Scalar beta;
+        rot.makeGivens(m_T.coeff(iu - 1, iu - 2), m_T.coeff(iu, iu - 2), &beta);
+
+        if (abs(beta) > near_0)  // if v is not zero
+        {
+            m_T.coeffRef(iu - 1, iu - 2) = beta;
+            m_T.rightCols(m_n - iu + 1).applyOnTheLeft(iu - 1, iu, rot.adjoint());
+            m_T.topRows(iu + 1).applyOnTheRight(iu - 1, iu, rot);
+            m_U.applyOnTheRight(iu - 1, iu, rot);
+        }
+
+        // clean up pollution due to round-off errors
+        for (Index i = im + 2; i <= iu; ++i)
+        {
+            m_T.coeffRef(i, i - 2) = Scalar(0);
+            if (i > im + 2)
+                m_T.coeffRef(i, i - 3) = Scalar(0);
+        }
+    }
+
+public:
+    UpperHessenbergSchur() :
+        m_n(0), m_computed(false)
+    {}
+
+    UpperHessenbergSchur(ConstGenericMatrix& mat) :
+        m_n(mat.rows()), m_computed(false)
+    {
+        compute(mat);
+    }
+
+    void compute(ConstGenericMatrix& mat)
+    {
+        using std::abs;
+        using std::sqrt;
+
+        if (mat.rows() != mat.cols())
+            throw std::invalid_argument("UpperHessenbergSchur: matrix must be square");
+
+        m_n = mat.rows();
+        m_T.resize(m_n, m_n);
+        m_U.resize(m_n, m_n);
+        constexpr Index max_iter_per_row = 40;
+        const Index max_iter = m_n * max_iter_per_row;
+
+        m_T.noalias() = mat;
+        m_U.setIdentity();
+
+        // The matrix m_T is divided in three parts.
+        // Rows 0,...,il-1 are decoupled from the rest because m_T(il,il-1) is zero.
+        // Rows il,...,iu is the part we are working on (the active window).
+        // Rows iu+1,...,end are already brought in triangular form.
+        Index iu = m_n - 1;
+        Index iter = 0;        // iteration count for current eigenvalue
+        Index total_iter = 0;  // iteration count for whole matrix
+        Scalar ex_shift(0);    // sum of exceptional shifts
+        const Scalar norm = upper_hessenberg_l1_norm(m_T);
+        // sub-diagonal entries smaller than near_0 will be treated as zero.
+        // We use eps^2 to enable more precision in small eigenvalues.
+        const Scalar eps = Eigen::NumTraits<Scalar>::epsilon();
+        const Scalar near_0 = Eigen::numext::maxi<Scalar>(norm * eps * eps, TypeTraits<Scalar>::min());
+
+        if (norm != Scalar(0))
+        {
+            while (iu >= 0)
+            {
+                Index il = find_small_subdiag(iu, near_0);
+
+                // Check for convergence
+                if (il == iu)  // One root found
+                {
+                    m_T.coeffRef(iu, iu) += ex_shift;
+                    if (iu > 0)
+                        m_T.coeffRef(iu, iu - 1) = Scalar(0);
+                    iu--;
+                    iter = 0;
+                }
+                else if (il == iu - 1)  // Two roots found
+                {
+                    split_off_two_rows(iu, ex_shift);
+                    iu -= 2;
+                    iter = 0;
+                }
+                else  // No convergence yet
+                {
+                    Vector3s first_householder_vec = Vector3s::Zero(), shift_info;
+                    compute_shift(iu, iter, ex_shift, shift_info);
+                    iter++;
+                    total_iter++;
+                    if (total_iter > max_iter)
+                        break;
+                    Index im;
+                    init_francis_qr_step(il, iu, shift_info, im, first_householder_vec);
+                    perform_francis_qr_step(il, im, iu, first_householder_vec, near_0);
+                }
+            }
+        }
+
+        if (total_iter > max_iter)
+            throw std::runtime_error("UpperHessenbergSchur: Schur decomposition failed");
+
+        m_computed = true;
+    }
+
+    const Matrix& matrix_T() const
+    {
+        if (!m_computed)
+            throw std::logic_error("UpperHessenbergSchur: need to call compute() first");
+
+        return m_T;
+    }
+
+    const Matrix& matrix_U() const
+    {
+        if (!m_computed)
+            throw std::logic_error("UpperHessenbergSchur: need to call compute() first");
+
+        return m_U;
+    }
+
+    void swap_T(Matrix& other)
+    {
+        m_T.swap(other);
+    }
+
+    void swap_U(Matrix& other)
+    {
+        m_U.swap(other);
+    }
+};
+
+}  // namespace Spectra
+
+#endif  // SPECTRA_UPPER_HESSENBERG_SCHUR_H

--- a/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/DenseGenComplexShiftSolve.h
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/DenseGenComplexShiftSolve.h
@@ -21,6 +21,11 @@ namespace Spectra {
 /// \f$\sigma\f$ and real-valued vector \f$x\f$. It is mainly used in the
 /// GenEigsComplexShiftSolver eigen solver.
 ///
+/// \tparam Scalar_ The element type of the matrix, for example,
+///                 `float`, `double`, and `long double`.
+/// \tparam Flags   Either `Eigen::ColMajor` or `Eigen::RowMajor`, indicating
+///                 the storage format of the input matrix.
+///
 template <typename Scalar_, int Flags = Eigen::ColMajor>
 class DenseGenComplexShiftSolve
 {
@@ -58,9 +63,14 @@ public:
     /// `Eigen::MatrixXf`), or its mapped version
     /// (e.g. `Eigen::Map<Eigen::MatrixXd>`).
     ///
-    DenseGenComplexShiftSolve(ConstGenericMatrix& mat) :
+    template <typename Derived>
+    DenseGenComplexShiftSolve(const Eigen::MatrixBase<Derived>& mat) :
         m_mat(mat), m_n(mat.rows())
     {
+        static_assert(
+            static_cast<int>(Derived::PlainObject::IsRowMajor) == static_cast<int>(Matrix::IsRowMajor),
+            "DenseGenComplexShiftSolve: the \"Flags\" template parameter does not match the input matrix (Eigen::ColMajor/Eigen::RowMajor)");
+
         if (mat.rows() != mat.cols())
             throw std::invalid_argument("DenseGenComplexShiftSolve: matrix must be square");
     }

--- a/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/DenseGenMatProd.h
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/DenseGenMatProd.h
@@ -25,6 +25,11 @@ namespace Spectra {
 /// \f$x\f$. It is mainly used in the GenEigsSolver and
 /// SymEigsSolver eigen solvers.
 ///
+/// \tparam Scalar_ The element type of the matrix, for example,
+///                 `float`, `double`, and `long double`.
+/// \tparam Flags   Either `Eigen::ColMajor` or `Eigen::RowMajor`, indicating
+///                 the storage format of the input matrix.
+///
 template <typename Scalar_, int Flags = Eigen::ColMajor>
 class DenseGenMatProd
 {
@@ -53,9 +58,14 @@ public:
     /// `Eigen::MatrixXf`), or its mapped version
     /// (e.g. `Eigen::Map<Eigen::MatrixXd>`).
     ///
-    DenseGenMatProd(ConstGenericMatrix& mat) :
+    template <typename Derived>
+    DenseGenMatProd(const Eigen::MatrixBase<Derived>& mat) :
         m_mat(mat)
-    {}
+    {
+        static_assert(
+            static_cast<int>(Derived::PlainObject::IsRowMajor) == static_cast<int>(Matrix::IsRowMajor),
+            "DenseGenMatProd: the \"Flags\" template parameter does not match the input matrix (Eigen::ColMajor/Eigen::RowMajor)");
+    }
 
     ///
     /// Return the number of rows of the underlying matrix.

--- a/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/DenseGenRealShiftSolve.h
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/DenseGenRealShiftSolve.h
@@ -20,6 +20,11 @@ namespace Spectra {
 /// i.e., calculating \f$y=(A-\sigma I)^{-1}x\f$ for any real \f$\sigma\f$ and
 /// vector \f$x\f$. It is mainly used in the GenEigsRealShiftSolver eigen solver.
 ///
+/// \tparam Scalar_ The element type of the matrix, for example,
+///                 `float`, `double`, and `long double`.
+/// \tparam Flags   Either `Eigen::ColMajor` or `Eigen::RowMajor`, indicating
+///                 the storage format of the input matrix.
+///
 template <typename Scalar_, int Flags = Eigen::ColMajor>
 class DenseGenRealShiftSolve
 {
@@ -50,9 +55,14 @@ public:
     /// `Eigen::MatrixXf`), or its mapped version
     /// (e.g. `Eigen::Map<Eigen::MatrixXd>`).
     ///
-    DenseGenRealShiftSolve(ConstGenericMatrix& mat) :
+    template <typename Derived>
+    DenseGenRealShiftSolve(const Eigen::MatrixBase<Derived>& mat) :
         m_mat(mat), m_n(mat.rows())
     {
+        static_assert(
+            static_cast<int>(Derived::PlainObject::IsRowMajor) == static_cast<int>(Matrix::IsRowMajor),
+            "DenseGenRealShiftSolve: the \"Flags\" template parameter does not match the input matrix (Eigen::ColMajor/Eigen::RowMajor)");
+
         if (mat.rows() != mat.cols())
             throw std::invalid_argument("DenseGenRealShiftSolve: matrix must be square");
     }

--- a/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/DenseSymMatProd.h
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/DenseSymMatProd.h
@@ -18,6 +18,13 @@ namespace Spectra {
 /// symmetric real matrix \f$A\f$, i.e., calculating \f$y=Ax\f$ for any vector
 /// \f$x\f$. It is mainly used in the SymEigsSolver eigen solver.
 ///
+/// \tparam Scalar_ The element type of the matrix, for example,
+///                 `float`, `double`, and `long double`.
+/// \tparam Uplo    Either `Eigen::Lower` or `Eigen::Upper`, indicating which
+///                 triangular part of the matrix is used.
+/// \tparam Flags   Either `Eigen::ColMajor` or `Eigen::RowMajor`, indicating
+///                 the storage format of the input matrix.
+///
 template <typename Scalar_, int Uplo = Eigen::Lower, int Flags = Eigen::ColMajor>
 class DenseSymMatProd
 {
@@ -46,9 +53,14 @@ public:
     /// `Eigen::MatrixXf`), or its mapped version
     /// (e.g. `Eigen::Map<Eigen::MatrixXd>`).
     ///
-    DenseSymMatProd(ConstGenericMatrix& mat) :
+    template <typename Derived>
+    DenseSymMatProd(const Eigen::MatrixBase<Derived>& mat) :
         m_mat(mat)
-    {}
+    {
+        static_assert(
+            static_cast<int>(Derived::PlainObject::IsRowMajor) == static_cast<int>(Matrix::IsRowMajor),
+            "DenseSymMatProd: the \"Flags\" template parameter does not match the input matrix (Eigen::ColMajor/Eigen::RowMajor)");
+    }
 
     ///
     /// Return the number of rows of the underlying matrix.

--- a/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/DenseSymShiftSolve.h
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/DenseSymShiftSolve.h
@@ -22,6 +22,13 @@ namespace Spectra {
 /// i.e., calculating \f$y=(A-\sigma I)^{-1}x\f$ for any real \f$\sigma\f$ and
 /// vector \f$x\f$. It is mainly used in the SymEigsShiftSolver eigen solver.
 ///
+/// \tparam Scalar_ The element type of the matrix, for example,
+///                 `float`, `double`, and `long double`.
+/// \tparam Uplo    Either `Eigen::Lower` or `Eigen::Upper`, indicating which
+///                 triangular part of the matrix is used.
+/// \tparam Flags   Either `Eigen::ColMajor` or `Eigen::RowMajor`, indicating
+///                 the storage format of the input matrix.
+///
 template <typename Scalar_, int Uplo = Eigen::Lower, int Flags = Eigen::ColMajor>
 class DenseSymShiftSolve
 {
@@ -52,9 +59,14 @@ public:
     /// `Eigen::MatrixXf`), or its mapped version
     /// (e.g. `Eigen::Map<Eigen::MatrixXd>`).
     ///
-    DenseSymShiftSolve(ConstGenericMatrix& mat) :
+    template <typename Derived>
+    DenseSymShiftSolve(const Eigen::MatrixBase<Derived>& mat) :
         m_mat(mat), m_n(mat.rows())
     {
+        static_assert(
+            static_cast<int>(Derived::PlainObject::IsRowMajor) == static_cast<int>(Matrix::IsRowMajor),
+            "DenseSymShiftSolve: the \"Flags\" template parameter does not match the input matrix (Eigen::ColMajor/Eigen::RowMajor)");
+
         if (m_n != mat.cols())
             throw std::invalid_argument("DenseSymShiftSolve: matrix must be square");
     }

--- a/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/SparseGenComplexShiftSolve.h
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/SparseGenComplexShiftSolve.h
@@ -22,6 +22,12 @@ namespace Spectra {
 /// \f$\sigma\f$ and real-valued vector \f$x\f$. It is mainly used in the
 /// GenEigsComplexShiftSolver eigen solver.
 ///
+/// \tparam Scalar_      The element type of the matrix, for example,
+///                      `float`, `double`, and `long double`.
+/// \tparam Flags        Either `Eigen::ColMajor` or `Eigen::RowMajor`, indicating
+///                      the storage format of the input matrix.
+/// \tparam StorageIndex The type of the indices for the sparse matrix.
+///
 template <typename Scalar_, int Flags = Eigen::ColMajor, typename StorageIndex = int>
 class SparseGenComplexShiftSolve
 {
@@ -58,9 +64,14 @@ public:
     /// `Eigen::SparseMatrix<Scalar, ...>` or its mapped version
     /// `Eigen::Map<Eigen::SparseMatrix<Scalar, ...> >`.
     ///
-    SparseGenComplexShiftSolve(ConstGenericSparseMatrix& mat) :
+    template <typename Derived>
+    SparseGenComplexShiftSolve(const Eigen::SparseMatrixBase<Derived>& mat) :
         m_mat(mat), m_n(mat.rows())
     {
+        static_assert(
+            static_cast<int>(Derived::PlainObject::IsRowMajor) == static_cast<int>(SparseMatrix::IsRowMajor),
+            "SparseGenComplexShiftSolve: the \"Flags\" template parameter does not match the input matrix (Eigen::ColMajor/Eigen::RowMajor)");
+
         if (mat.rows() != mat.cols())
             throw std::invalid_argument("SparseGenComplexShiftSolve: matrix must be square");
     }

--- a/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/SparseGenMatProd.h
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/SparseGenMatProd.h
@@ -19,6 +19,12 @@ namespace Spectra {
 /// \f$x\f$. It is mainly used in the GenEigsSolver and SymEigsSolver
 /// eigen solvers.
 ///
+/// \tparam Scalar_      The element type of the matrix, for example,
+///                      `float`, `double`, and `long double`.
+/// \tparam Flags        Either `Eigen::ColMajor` or `Eigen::RowMajor`, indicating
+///                      the storage format of the input matrix.
+/// \tparam StorageIndex The type of the indices for the sparse matrix.
+///
 template <typename Scalar_, int Flags = Eigen::ColMajor, typename StorageIndex = int>
 class SparseGenMatProd
 {
@@ -47,9 +53,14 @@ public:
     /// `Eigen::SparseMatrix<Scalar, ...>` or its mapped version
     /// `Eigen::Map<Eigen::SparseMatrix<Scalar, ...> >`.
     ///
-    SparseGenMatProd(ConstGenericSparseMatrix& mat) :
+    template <typename Derived>
+    SparseGenMatProd(const Eigen::SparseMatrixBase<Derived>& mat) :
         m_mat(mat)
-    {}
+    {
+        static_assert(
+            static_cast<int>(Derived::PlainObject::IsRowMajor) == static_cast<int>(SparseMatrix::IsRowMajor),
+            "SparseGenMatProd: the \"Flags\" template parameter does not match the input matrix (Eigen::ColMajor/Eigen::RowMajor)");
+    }
 
     ///
     /// Return the number of rows of the underlying matrix.

--- a/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/SparseGenRealShiftSolve.h
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/SparseGenRealShiftSolve.h
@@ -21,6 +21,12 @@ namespace Spectra {
 /// i.e., calculating \f$y=(A-\sigma I)^{-1}x\f$ for any real \f$\sigma\f$ and
 /// vector \f$x\f$. It is mainly used in the GenEigsRealShiftSolver eigen solver.
 ///
+/// \tparam Scalar_      The element type of the matrix, for example,
+///                      `float`, `double`, and `long double`.
+/// \tparam Flags        Either `Eigen::ColMajor` or `Eigen::RowMajor`, indicating
+///                      the storage format of the input matrix.
+/// \tparam StorageIndex The type of the indices for the sparse matrix.
+///
 template <typename Scalar_, int Flags = Eigen::ColMajor, typename StorageIndex = int>
 class SparseGenRealShiftSolve
 {
@@ -50,9 +56,14 @@ public:
     /// `Eigen::SparseMatrix<Scalar, ...>` or its mapped version
     /// `Eigen::Map<Eigen::SparseMatrix<Scalar, ...> >`.
     ///
-    SparseGenRealShiftSolve(ConstGenericSparseMatrix& mat) :
+    template <typename Derived>
+    SparseGenRealShiftSolve(const Eigen::SparseMatrixBase<Derived>& mat) :
         m_mat(mat), m_n(mat.rows())
     {
+        static_assert(
+            static_cast<int>(Derived::PlainObject::IsRowMajor) == static_cast<int>(SparseMatrix::IsRowMajor),
+            "SparseGenRealShiftSolve: the \"Flags\" template parameter does not match the input matrix (Eigen::ColMajor/Eigen::RowMajor)");
+
         if (mat.rows() != mat.cols())
             throw std::invalid_argument("SparseGenRealShiftSolve: matrix must be square");
     }

--- a/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/SparseRegularInverse.h
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/SparseRegularInverse.h
@@ -25,6 +25,14 @@ namespace Spectra {
 /// This class is intended to be used with the SymGEigsSolver generalized eigen solver
 /// in the regular inverse mode.
 ///
+/// \tparam Scalar_      The element type of the matrix, for example,
+///                      `float`, `double`, and `long double`.
+/// \tparam Uplo         Either `Eigen::Lower` or `Eigen::Upper`, indicating which
+///                      triangular part of the matrix is used.
+/// \tparam Flags        Either `Eigen::ColMajor` or `Eigen::RowMajor`, indicating
+///                      the storage format of the input matrix.
+/// \tparam StorageIndex The type of the indices for the sparse matrix.
+///
 template <typename Scalar_, int Uplo = Eigen::Lower, int Flags = Eigen::ColMajor, typename StorageIndex = int>
 class SparseRegularInverse
 {
@@ -55,9 +63,14 @@ public:
     /// `Eigen::SparseMatrix<Scalar, ...>` or its mapped version
     /// `Eigen::Map<Eigen::SparseMatrix<Scalar, ...> >`.
     ///
-    SparseRegularInverse(ConstGenericSparseMatrix& mat) :
+    template <typename Derived>
+    SparseRegularInverse(const Eigen::SparseMatrixBase<Derived>& mat) :
         m_mat(mat), m_n(mat.rows())
     {
+        static_assert(
+            static_cast<int>(Derived::PlainObject::IsRowMajor) == static_cast<int>(SparseMatrix::IsRowMajor),
+            "SparseRegularInverse: the \"Flags\" template parameter does not match the input matrix (Eigen::ColMajor/Eigen::RowMajor)");
+
         if (mat.rows() != mat.cols())
             throw std::invalid_argument("SparseRegularInverse: matrix must be square");
 

--- a/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/SparseSymMatProd.h
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/SparseSymMatProd.h
@@ -19,6 +19,14 @@ namespace Spectra {
 /// sparse real symmetric matrix \f$A\f$, i.e., calculating \f$y=Ax\f$ for any vector
 /// \f$x\f$. It is mainly used in the SymEigsSolver eigen solver.
 ///
+/// \tparam Scalar_      The element type of the matrix, for example,
+///                      `float`, `double`, and `long double`.
+/// \tparam Uplo         Either `Eigen::Lower` or `Eigen::Upper`, indicating which
+///                      triangular part of the matrix is used.
+/// \tparam Flags        Either `Eigen::ColMajor` or `Eigen::RowMajor`, indicating
+///                      the storage format of the input matrix.
+/// \tparam StorageIndex The type of the indices for the sparse matrix.
+///
 template <typename Scalar_, int Uplo = Eigen::Lower, int Flags = Eigen::ColMajor, typename StorageIndex = int>
 class SparseSymMatProd
 {
@@ -47,9 +55,14 @@ public:
     /// `Eigen::SparseMatrix<Scalar, ...>` or its mapped version
     /// `Eigen::Map<Eigen::SparseMatrix<Scalar, ...> >`.
     ///
-    SparseSymMatProd(ConstGenericSparseMatrix& mat) :
+    template <typename Derived>
+    SparseSymMatProd(const Eigen::SparseMatrixBase<Derived>& mat) :
         m_mat(mat)
-    {}
+    {
+        static_assert(
+            static_cast<int>(Derived::PlainObject::IsRowMajor) == static_cast<int>(SparseMatrix::IsRowMajor),
+            "SparseSymMatProd: the \"Flags\" template parameter does not match the input matrix (Eigen::ColMajor/Eigen::RowMajor)");
+    }
 
     ///
     /// Return the number of rows of the underlying matrix.

--- a/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/SparseSymShiftSolve.h
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/SparseSymShiftSolve.h
@@ -21,6 +21,14 @@ namespace Spectra {
 /// i.e., calculating \f$y=(A-\sigma I)^{-1}x\f$ for any real \f$\sigma\f$ and
 /// vector \f$x\f$. It is mainly used in the SymEigsShiftSolver eigen solver.
 ///
+/// \tparam Scalar_      The element type of the matrix, for example,
+///                      `float`, `double`, and `long double`.
+/// \tparam Uplo         Either `Eigen::Lower` or `Eigen::Upper`, indicating which
+///                      triangular part of the matrix is used.
+/// \tparam Flags        Either `Eigen::ColMajor` or `Eigen::RowMajor`, indicating
+///                      the storage format of the input matrix.
+/// \tparam StorageIndex The type of the indices for the sparse matrix.
+///
 template <typename Scalar_, int Uplo = Eigen::Lower, int Flags = Eigen::ColMajor, typename StorageIndex = int>
 class SparseSymShiftSolve
 {
@@ -50,9 +58,14 @@ public:
     /// `Eigen::SparseMatrix<Scalar, ...>` or its mapped version
     /// `Eigen::Map<Eigen::SparseMatrix<Scalar, ...> >`.
     ///
-    SparseSymShiftSolve(ConstGenericSparseMatrix& mat) :
+    template <typename Derived>
+    SparseSymShiftSolve(const Eigen::SparseMatrixBase<Derived>& mat) :
         m_mat(mat), m_n(mat.rows())
     {
+        static_assert(
+            static_cast<int>(Derived::PlainObject::IsRowMajor) == static_cast<int>(SparseMatrix::IsRowMajor),
+            "SparseSymShiftSolve: the \"Flags\" template parameter does not match the input matrix (Eigen::ColMajor/Eigen::RowMajor)");
+
         if (mat.rows() != mat.cols())
             throw std::invalid_argument("SparseSymShiftSolve: matrix must be square");
     }

--- a/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/SymShiftInvert.h
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/SymShiftInvert.h
@@ -119,6 +119,7 @@ public:
 ///                        is a sparse matrix.
 /// \tparam StorageIndexB  The storage index type of the \f$B\f$ matrix, only used when \f$B\f$
 ///                        is a sparse matrix.
+///
 template <typename Scalar_, typename TypeA = Eigen::Sparse, typename TypeB = Eigen::Sparse,
           int UploA = Eigen::Lower, int UploB = Eigen::Lower,
           int FlagsA = Eigen::ColMajor, int FlagsB = Eigen::ColMajor,
@@ -186,9 +187,18 @@ public:
     ///          `Eigen::Ref<Eigen::SparseMatrix<...>>`, etc.
     /// \param B A dense or sparse matrix object.
     ///
-    SymShiftInvert(ConstGenericMatrixA& A, ConstGenericMatrixB& B) :
-        m_matA(A), m_matB(B), m_n(A.rows())
+    template <typename DerivedA, typename DerivedB>
+    SymShiftInvert(const Eigen::EigenBase<DerivedA>& A, const Eigen::EigenBase<DerivedB>& B) :
+        m_matA(A.derived()), m_matB(B.derived()), m_n(A.rows())
     {
+        static_assert(
+            static_cast<int>(DerivedA::PlainObject::IsRowMajor) == static_cast<int>(MatrixA::IsRowMajor),
+            "SymShiftInvert: the \"FlagsA\" template parameter does not match the input matrix (Eigen::ColMajor/Eigen::RowMajor)");
+
+        static_assert(
+            static_cast<int>(DerivedB::PlainObject::IsRowMajor) == static_cast<int>(MatrixB::IsRowMajor),
+            "SymShiftInvert: the \"FlagsB\" template parameter does not match the input matrix (Eigen::ColMajor/Eigen::RowMajor)");
+
         if (m_n != A.cols() || m_n != B.rows() || m_n != B.cols())
             throw std::invalid_argument("SymShiftInvert: A and B must be square matrices of the same size");
     }

--- a/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/internal/ArnoldiOp.h
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/include/Spectra/MatOp/internal/ArnoldiOp.h
@@ -113,7 +113,7 @@ private:
     const OpType& m_op;
 
 public:
-    ArnoldiOp<Scalar, OpType, IdentityBOp>(const OpType& op, const IdentityBOp& /*Bop*/) :
+    ArnoldiOp(const OpType& op, const IdentityBOp& /*Bop*/) :
         m_op(op)
     {}
 


### PR DESCRIPTION
**Description**
Update the Spectra headers to the official release [1.0.0](https://github.com/yixuan/spectra/releases/tag/v1.0.0) (previously we used the files from the master branch)
Just the Spectra files are updated, no further modification is necessary.

**Changelog**
- Update the Spectra headers to the official release 1.0.0

