### PR TITLE
[MLMC] Fix bug of seed of ensemble averaging

### DIFF
--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/KratosSolverWrapper.py
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/KratosSolverWrapper.py
@@ -119,7 +119,7 @@ class KratosSolverWrapper(sw.SolverWrapper):
                 msg += "Default \"refinementStrategy\" is \"reading_from_file\". "
                 msg += "Running with {} instead. ".format(self.refinement_strategy)
                 msg += "This implies that \"refinementParametersPath\" is required for running, and it will not be used."
-                print(msg)
+                warnings.warn(msg, RuntimeWarning)
             self.solverWrapperIndex.append(0)
 
         if (self.solverWrapperIndex[0] >= 0): # for index < 0 not needed
@@ -175,6 +175,7 @@ class KratosSolverWrapper(sw.SolverWrapper):
             aux_qoi_array = []
             # loop over contributions (by default only one)
             for contribution_counter in range (0,self.number_contributions_per_instance):
+                # store current contribution
                 self.current_local_contribution = contribution_counter
                 # if multiple ensembles, append a seed to the random variable list
                 # for example, this seed is used to generate different initial conditions
@@ -189,8 +190,8 @@ class KratosSolverWrapper(sw.SolverWrapper):
                     qoi,time_for_qoi = self.executeInstanceReadingFromFile(random_variable)
                 # append components to aux array
                 aux_qoi_array.append(qoi)
-            # delete COMPSs future objects no longer needed
-            delete_object(random_variable)
+                # delete COMPSs future objects no longer needed
+                delete_object(random_variable)
 
             # postprocess components
             if self.number_contributions_per_instance > 1:


### PR DESCRIPTION
**Description**
This PR fixes a bug that was appearing when running in distributed environemnts. Ths issue was caused by the fact the random variable file (a future) was removed outside the ensemble averaging loop, thus all ensemble averaging tasks were spawned with the same random variable file (and of course the same seed). We solve the issue by deleting the random variable object just after its usage. Now different random variable files are correctly passed to different tasks, thus ensuring independent realizations.

Please mark the PR with appropriate tags: 
- Bugfix
- External library

**Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Fixed a bug
