### PR TITLE
[IGA] Shell 3p damping and mass calculation

### DIFF
--- a/applications/IgaApplication/custom_elements/shell_3p_element.h
+++ b/applications/IgaApplication/custom_elements/shell_3p_element.h
@@ -250,6 +250,16 @@ public:
             rCurrentProcessInfo, true, true);
     }
 
+    /**
+    * @brief This is called during the assembling process in order to calculate the elemental mass matrix
+    * @param rMassMatrix The elemental mass matrix
+    * @param rCurrentProcessInfo The current process info instance
+    */
+    void CalculateMassMatrix(
+        MatrixType& rMassMatrix,
+        const ProcessInfo& rCurrentProcessInfo
+    ) override;
+
     void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**

--- a/applications/IgaApplication/custom_elements/shell_3p_element.h
+++ b/applications/IgaApplication/custom_elements/shell_3p_element.h
@@ -260,6 +260,16 @@ public:
         const ProcessInfo& rCurrentProcessInfo
     ) override;
 
+    /**
+    * @brief This is called during the assembling process in order to calculate the elemental damping matrix
+    * @param rDampingMatrix The elemental damping matrix
+    * @param rCurrentProcessInfo The current process info instance
+    */
+    void CalculateDampingMatrix(
+        MatrixType& rDampingMatrix,
+        const ProcessInfo& rCurrentProcessInfo
+    ) override;
+
     void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**


### PR DESCRIPTION
**Description**
In this PR, the new functions to calculate damping and mass matrix have been added. The calculation of the mass matrix is similar to the membrane element, and the calculation of the Rayleigh damping matrix refers to #8431.
