### PR TITLE
[Poro] Adding missing includes

### DIFF
--- a/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_2D_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_2D_utilities.hpp
@@ -25,6 +25,7 @@
 #include "includes/define.h"
 #include "includes/model_part.h"
 #include "includes/kratos_parameters.h"
+#include "utilities/openmp_utils.h"
 #include "utilities/parallel_utilities.h"
 
 // Application includes

--- a/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_3D_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_3D_utilities.hpp
@@ -25,6 +25,7 @@
 #include "includes/define.h"
 #include "includes/model_part.h"
 #include "includes/kratos_parameters.h"
+#include "utilities/openmp_utils.h"
 #include "utilities/parallel_utilities.h"
 
 // Application includes

--- a/applications/PoromechanicsApplication/custom_utilities/initial_stress_2D_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/initial_stress_2D_utilities.hpp
@@ -23,6 +23,7 @@
 #include "includes/define.h"
 #include "includes/model_part.h"
 #include "includes/kratos_parameters.h"
+#include "utilities/openmp_utils.h"
 #include "utilities/parallel_utilities.h"
 #include "utilities/math_utils.h"
 

--- a/applications/PoromechanicsApplication/custom_utilities/initial_stress_3D_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/initial_stress_3D_utilities.hpp
@@ -23,6 +23,7 @@
 #include "includes/define.h"
 #include "includes/model_part.h"
 #include "includes/kratos_parameters.h"
+#include "utilities/openmp_utils.h"
 #include "utilities/parallel_utilities.h"
 #include "utilities/math_utils.h"
 

--- a/applications/PoromechanicsApplication/custom_utilities/nonlocal_damage_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/nonlocal_damage_utilities.hpp
@@ -23,6 +23,7 @@
 #include "includes/define.h"
 #include "includes/model_part.h"
 #include "includes/kratos_parameters.h"
+#include "utilities/openmp_utils.h"
 #include "utilities/parallel_utilities.h"
 
 // Application includes


### PR DESCRIPTION
**Description**
In the previous PR I deleted some openmp_utils includes that were necessary. In this PR I restore them. 
In FullDebug I did not get the compilation error, and I just realized they were missing once I compiled the code in Release mode... 

**Changelog**
- Added missing #include "utilities/openmp_utils.h" in some utilities