### PR TITLE
Fixing race condition in unordered elem/cond pvs

### DIFF
--- a/kratos/processes/replace_elements_and_condition_process.cpp
+++ b/kratos/processes/replace_elements_and_condition_process.cpp
@@ -58,7 +58,7 @@ void UpdateElementsInSubModelPart(
     ModelPart& rRootModelPart,
     std::unordered_set<std::size_t>& rSetOfElementsIds)
 {
-    if(!rRootModelPart.Elements().IsSorted) {
+    if(!rRootModelPart.Elements().IsSorted()) {
         rRootModelPart.Elements().Sort();
     }
     IndexPartition<std::size_t>(rModelPart.Elements().size()).for_each([&](std::size_t Index){
@@ -86,7 +86,7 @@ void UpdateConditionsInSubModelPart(
     ModelPart& rRootModelPart,
     std::unordered_set<std::size_t>& rSetOfConditions)
 {
-    if(!rRootModelPart.Conditions().IsSorted) {
+    if(!rRootModelPart.Conditions().IsSorted()) {
         rRootModelPart.Conditions().Sort();
     }
     IndexPartition<std::size_t>(rModelPart.Conditions().size()).for_each([&](std::size_t Index){

--- a/kratos/processes/replace_elements_and_condition_process.cpp
+++ b/kratos/processes/replace_elements_and_condition_process.cpp
@@ -58,7 +58,9 @@ void UpdateElementsInSubModelPart(
     ModelPart& rRootModelPart,
     std::unordered_set<std::size_t>& rSetOfElementsIds)
 {
-    rRootModelPart.Elements().Sort();
+    if(!rRootModelPart.Elements().IsSorted) {
+        rRootModelPart.Elements().Sort();
+    }
     IndexPartition<std::size_t>(rModelPart.Elements().size()).for_each([&](std::size_t Index){
         auto it_elem = rModelPart.ElementsBegin() + Index;
         if (rSetOfElementsIds.find(it_elem->Id()) != rSetOfElementsIds.end()) {
@@ -84,7 +86,9 @@ void UpdateConditionsInSubModelPart(
     ModelPart& rRootModelPart,
     std::unordered_set<std::size_t>& rSetOfConditions)
 {
-    rRootModelPart.Conditions().Sort();
+    if(!rRootModelPart.Conditions().IsSorted) {
+        rRootModelPart.Conditions().Sort();
+    }
     IndexPartition<std::size_t>(rModelPart.Conditions().size()).for_each([&](std::size_t Index){
         auto it_cond = rModelPart.ConditionsBegin() + Index;
         if (rSetOfConditions.find(it_cond->Id()) != rSetOfConditions.end()) {

--- a/kratos/processes/replace_elements_and_condition_process.cpp
+++ b/kratos/processes/replace_elements_and_condition_process.cpp
@@ -58,6 +58,7 @@ void UpdateElementsInSubModelPart(
     ModelPart& rRootModelPart,
     std::unordered_set<std::size_t>& rSetOfElementsIds)
 {
+    rRootModelPart.Elements().Sort();
     IndexPartition<std::size_t>(rModelPart.Elements().size()).for_each([&](std::size_t Index){
         auto it_elem = rModelPart.ElementsBegin() + Index;
         if (rSetOfElementsIds.find(it_elem->Id()) != rSetOfElementsIds.end()) {
@@ -83,6 +84,7 @@ void UpdateConditionsInSubModelPart(
     ModelPart& rRootModelPart,
     std::unordered_set<std::size_t>& rSetOfConditions)
 {
+    rRootModelPart.Conditions().Sort();
     IndexPartition<std::size_t>(rModelPart.Conditions().size()).for_each([&](std::size_t Index){
         auto it_cond = rModelPart.ConditionsBegin() + Index;
         if (rSetOfConditions.find(it_cond->Id()) != rSetOfConditions.end()) {


### PR DESCRIPTION
**Description**
This solves a quite elusive bug that causes access to unordered pointer vector set to sometimes corrupt the mData vector while trying to sort it, as the first sort can happen in a parallel region in multiple threads simultaneously.

@marcnunezc Check if this solves your error the cps/stochastic-ouu-mlmc-testing branch

**Changelog**
E.g.
- Fixed race condition in replac element and conditions process.

