### PR TITLE
[CoSim][Predictors] improve buffer handling

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
@@ -85,7 +85,7 @@ class HistoricalDataAccessor:
 
     def GetData(self, buffer_index):
         if buffer_index >= self.buffer_size:
-            raise Exception("the buffer-size is not large enough current buffer size: {} | requested solution_step_index: {}!".format(self.buffer_size, buffer_index+1))
+            raise Exception("Buffer-size is not large enough. Current buffer size: {} | requested solution_step_index: {}!".format(self.buffer_size, buffer_index+1))
 
         if self.interface_data.GetBufferSize() > buffer_index:
             # the interface data buffer size is large enough

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
@@ -81,7 +81,7 @@ class HistoricalDataAccessor:
     def CloneTimeStep(self):
         self.step += 1
         if self.additional_buffer_size > 0:
-            self.aux_data.appendleft(self.interface_data())
+            self.aux_data.appendleft(self.interface_data.GetData())
 
     def GetData(self, buffer_index):
         if self.interface_data.GetBufferSize() > buffer_index:

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
@@ -84,6 +84,9 @@ class HistoricalDataAccessor:
             self.aux_data.appendleft(self.interface_data.GetData())
 
     def GetData(self, buffer_index):
+        if buffer_index >= self.buffer_size:
+            raise Exception("the buffer-size is not large enough current buffer size: {} | requested solution_step_index: {}!".format(self.buffer_size, buffer_index+1))
+
         if self.interface_data.GetBufferSize() > buffer_index:
             # the interface data buffer size is large enough
             return self.interface_data.GetData(buffer_index)

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
@@ -5,6 +5,9 @@ import KratosMultiphysics as KM
 import KratosMultiphysics.CoSimulationApplication.co_simulation_tools as cs_tools
 import KratosMultiphysics.CoSimulationApplication.colors as colors
 
+# other imports
+from collections import deque
+
 class CoSimulationPredictor:
     """Baseclass for the predictors used for CoSimulation
     It predicts the solution of the next step at the beginning of a step
@@ -14,11 +17,9 @@ class CoSimulationPredictor:
         self.settings.RecursivelyValidateAndAssignDefaults(self._GetDefaultParameters())
 
         self.interface_data = solver_wrapper.GetInterfaceData(self.settings["data_name"].GetString())
+        self.historical_data_accessor = HistoricalDataAccessor(self.interface_data, self._GetMinimumBufferSize())
 
         self.echo_level = self.settings["echo_level"].GetInt()
-
-        # TODO check buffer size
-        self._GetMinimumBufferSize()
 
     def Initialize(self):
         pass
@@ -27,7 +28,7 @@ class CoSimulationPredictor:
         pass
 
     def InitializeSolutionStep(self):
-        pass
+        self.historical_data_accessor.CloneTimeStep()
 
     def Predict(self):
         raise Exception('"Predict" has to be implemented in the derived class!')
@@ -66,3 +67,29 @@ class CoSimulationPredictor:
             "data_name"  : "UNSPECIFIED",
             "echo_level" : 0
         }""")
+
+
+class HistoricalDataAccessor:
+    def __init__(self, interface_data, buffer_size):
+        self.interface_data = interface_data
+        self.buffer_size = buffer_size
+        self.step = 0
+
+        self.additional_buffer_size = max(0, buffer_size - interface_data.GetBufferSize())
+        self.aux_data = deque(maxlen=self.additional_buffer_size)
+
+    def CloneTimeStep(self):
+        self.step += 1
+        if self.additional_buffer_size > 0:
+            self.aux_data.appendleft(self.interface_data())
+
+    def GetData(self, buffer_index):
+        if self.interface_data.GetBufferSize() > buffer_index:
+            # the interface data buffer size is large enough
+            return self.interface_data.GetData(buffer_index)
+        else:
+            # TODO check if time buffer is initialized
+            return self.aux_data[buffer_index-self.additional_buffer_size]
+
+    def TimeBufferIsInitialized(self):
+        return self.step >= self.additional_buffer_size

--- a/applications/CoSimulationApplication/python_scripts/predictors/average_value_based.py
+++ b/applications/CoSimulationApplication/python_scripts/predictors/average_value_based.py
@@ -24,15 +24,25 @@ class AverageValuePredictor(CoSimulationPredictor):
             raise Exception("Wrong value for beta. Admissible interval [0.0, 1.0]")
 
     def Predict(self):
-        current_data  = self.interface_data.GetData(0)
-        previous_data = self.interface_data.GetData(1)
+        if not self.historical_data_accessor.TimeBufferIsInitialized():
+            if self.echo_level > 0:
+                cs_tools.cs_print_info(self._ClassName(), "Skipped prediction because time buffer is not yet filled")
+            return
+
+        current_data  = self.historical_data_accessor.GetData(0)
+        previous_data = self.historical_data_accessor.GetData(1)
 
         self.predicted_data = 2*current_data - previous_data
 
         self._UpdateData(self.predicted_data)
 
     def FinalizeSolutionStep(self):
-        current_data  = self.interface_data.GetData(0)
+        if not self.historical_data_accessor.TimeBufferIsInitialized():
+            if self.echo_level > 0:
+                cs_tools.cs_print_info(self._ClassName(), "Skipped prediction because time buffer is not yet filled")
+            return
+
+        current_data  = self.historical_data_accessor.GetData(0)
 
         self.predicted_data = self.beta * current_data + (1-self.beta) * self.predicted_data
 

--- a/applications/CoSimulationApplication/python_scripts/predictors/linear.py
+++ b/applications/CoSimulationApplication/python_scripts/predictors/linear.py
@@ -10,8 +10,13 @@ def Create(settings, solver_wrapper):
 
 class LinearPredictor(CoSimulationPredictor):
     def Predict(self):
-        current_data  = self.interface_data.GetData(0)
-        previous_data  = self.interface_data.GetData(1)
+        if not self.historical_data_accessor.TimeBufferIsInitialized():
+            if self.echo_level > 0:
+                cs_tools.cs_print_info(self._ClassName(), "Skipped prediction because time buffer is not yet filled")
+            return
+
+        current_data  = self.historical_data_accessor.GetData(0)
+        previous_data  = self.historical_data_accessor.GetData(1)
 
         predicted_data = 2*current_data - previous_data
 

--- a/applications/CoSimulationApplication/python_scripts/predictors/linear_derivative_based.py
+++ b/applications/CoSimulationApplication/python_scripts/predictors/linear_derivative_based.py
@@ -16,7 +16,16 @@ class LinearDerivativeBasedPredictor(CoSimulationPredictor):
         super().__init__(settings, solver_wrapper)
         self.historical_derivative_data_accessor = HistoricalDataAccessor(solver_wrapper.GetInterfaceData(self.settings["derivative_data_name"].GetString()), self._GetMinimumBufferSize())
 
+    def InitializeSolutionStep(self):
+        super().InitializeSolutionStep()
+        self.historical_derivative_data_accessor.CloneTimeStep()
+
     def Predict(self):
+        if not self.historical_data_accessor.TimeBufferIsInitialized() or not self.historical_derivative_data_accessor.TimeBufferIsInitialized():
+            if self.echo_level > 0:
+                cs_tools.cs_print_info(self._ClassName(), "Skipped prediction because time buffer is not yet filled", self.historical_data_accessor.TimeBufferIsInitialized(), self.historical_derivative_data_accessor.TimeBufferIsInitialized())
+            return
+
         data  = self.historical_data_accessor.GetData(1)
         derivative_data = self.historical_derivative_data_accessor.GetData(1)
 

--- a/applications/CoSimulationApplication/python_scripts/predictors/linear_derivative_based.py
+++ b/applications/CoSimulationApplication/python_scripts/predictors/linear_derivative_based.py
@@ -2,7 +2,7 @@
 import KratosMultiphysics as KM
 
 # Importing the base class
-from KratosMultiphysics.CoSimulationApplication.base_classes.co_simulation_predictor import CoSimulationPredictor
+from KratosMultiphysics.CoSimulationApplication.base_classes.co_simulation_predictor import CoSimulationPredictor, HistoricalDataAccessor
 
 # Other imports
 import KratosMultiphysics.CoSimulationApplication.co_simulation_tools as cs_tools
@@ -14,13 +14,13 @@ def Create(settings, solver_wrapper):
 class LinearDerivativeBasedPredictor(CoSimulationPredictor):
     def __init__(self, settings, solver_wrapper):
         super().__init__(settings, solver_wrapper)
-        self.interface_derivative_data = solver_wrapper.GetInterfaceData(self.settings["derivative_data_name"].GetString())
-        self.solver_wrapper = solver_wrapper
+        self.historical_derivative_data_accessor = HistoricalDataAccessor(solver_wrapper.GetInterfaceData(self.settings["derivative_data_name"].GetString()), self._GetMinimumBufferSize())
 
     def Predict(self):
-        data  = self.interface_data.GetData(1)
-        derivative_data  = self.interface_derivative_data.GetData(1)
+        data  = self.historical_data_accessor.GetData(1)
+        derivative_data = self.historical_derivative_data_accessor.GetData(1)
 
+        # TODO this is a hack and currently is only supported by Kratos solvers!
         delta_time = self.interface_data.GetModelPart().ProcessInfo[KM.DELTA_TIME]
         if abs(delta_time) < 1E-15:
             raise Exception("delta-time is almost zero!")

--- a/applications/CoSimulationApplication/python_scripts/predictors/linear_derivative_based.py
+++ b/applications/CoSimulationApplication/python_scripts/predictors/linear_derivative_based.py
@@ -23,7 +23,7 @@ class LinearDerivativeBasedPredictor(CoSimulationPredictor):
     def Predict(self):
         if not self.historical_data_accessor.TimeBufferIsInitialized() or not self.historical_derivative_data_accessor.TimeBufferIsInitialized():
             if self.echo_level > 0:
-                cs_tools.cs_print_info(self._ClassName(), "Skipped prediction because time buffer is not yet filled", self.historical_data_accessor.TimeBufferIsInitialized(), self.historical_derivative_data_accessor.TimeBufferIsInitialized())
+                cs_tools.cs_print_info(self._ClassName(), "Skipped prediction because time buffer is not yet filled")
             return
 
         data  = self.historical_data_accessor.GetData(1)


### PR DESCRIPTION
Until now the predictors use the buffer of the `ModelPart` for which they do the prediction. This means that the buffer size of that modelpart has to be large enough for the corresponding predictor. This has two major disadvantages:
- Predictors can only be used for nodal historical data
- The buffer size of the entire ModelPart has to be increased if the Predictor requires it, which is neither memory efficient nor black box

In order to improve this I added an additional buffer to the Predictors (implemented within the `HistoricalDataAccessor`). 
It is only used if necessary, i.e. if the buffer of the ModelPart is not large enough. In that case only the ADDITIONAL data is stored, everything that is accessible through the ModelPart is still accessed in that way to avoid memory overhead

@ashishdarekar can you please try this as discussed?

@shahrokh-shayegan this basically implements what you told me long time ago :)