### PR TITLE
[PotentialFlow] Prevent adding non existing elements

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_processes/define_3d_wake_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/define_3d_wake_process.cpp
@@ -498,17 +498,14 @@ void Define3DWakeProcess::MarkWakeElements() const
     std::vector<std::size_t> wake_elements_ordered_ids;
     std::vector<std::size_t> trailing_edge_elements_ordered_ids;
 
-    bool found_value = true;
-    while (found_value) {
-        std::size_t id;
-        found_value = wake_elements_ordered_ids_concurrent_queue.try_dequeue(id);
+    bool found_value;
+    std::size_t id;
+
+    while ( (found_value = wake_elements_ordered_ids_concurrent_queue.try_dequeue(id)) ) {
         wake_elements_ordered_ids.push_back(id);
     }
 
-    found_value = true;
-    while (found_value) {
-        std::size_t id;
-        found_value = trailing_edge_elements_ordered_ids_concurrent_queue.try_dequeue(id);
+    while ( (found_value = trailing_edge_elements_ordered_ids_concurrent_queue.try_dequeue(id)) ) {
         trailing_edge_elements_ordered_ids.push_back(id);
     }
 


### PR DESCRIPTION
**Description**
Small PR addressing the problem of adding non existing elements in concurrent queue, as found by @roigcarlo in https://github.com/KratosMultiphysics/Kratos/issues/8924#issuecomment-876994659, and addressed in https://github.com/KratosMultiphysics/Kratos/commit/4d1f8b1b26f81e350191f73cb4d109474cafcdbd

**Changelog**
- Changing push back loop after parallel section in function MarkWakeElements of Define3DWakeProcess
