### PR TITLE
[CLA] Add Damage CLs with Implex integration scheme

### DIFF
--- a/applications/ConstitutiveLawsApplication/constitutive_laws_application.cpp
+++ b/applications/ConstitutiveLawsApplication/constitutive_laws_application.cpp
@@ -46,7 +46,9 @@ void KratosConstitutiveLawsApplication::Register()
     KRATOS_REGISTER_CONSTITUTIVE_LAW("SmallStrainJ2Plasticity3DLaw", mSmallStrainJ2Plasticity3D);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("SmallStrainIsotropicDamagePlaneStrain2DLaw", mSmallStrainIsotropicDamagePlaneStrain2D);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("SmallStrainIsotropicDamage3DLaw", mSmallStrainIsotropicDamage3D);
+    KRATOS_REGISTER_CONSTITUTIVE_LAW("SmallStrainIsotropicDamageImplex3DLaw", mSmallStrainIsotropicDamageImplex3D);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("SmallStrainIsotropicDamageTractionOnly3DLaw", mSmallStrainIsotropicDamageTractionOnly3D);
+    KRATOS_REGISTER_CONSTITUTIVE_LAW("SmallStrainIsotropicDamageTractionOnlyImplex3DLaw", mSmallStrainIsotropicDamageTractionOnlyImplex3D);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("TrussPlasticityConstitutiveLaw", mTrussPlasticityConstitutiveLaw);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("HyperElasticIsotropicOgden1D", mHyperElasticIsotropicOgden1D);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("HyperElasticIsotropicHenky1D", mHyperElasticIsotropicHenky1D);

--- a/applications/ConstitutiveLawsApplication/constitutive_laws_application.h
+++ b/applications/ConstitutiveLawsApplication/constitutive_laws_application.h
@@ -40,8 +40,10 @@
 #include "custom_constitutive/small_strain_j2_plasticity_plane_strain_2d.h"
 #include "custom_constitutive/small_strain_j2_plasticity_3d.h"
 #include "custom_constitutive/small_strain_isotropic_damage_3d.h"
+#include "custom_constitutive/small_strain_isotropic_damage_implex_3d.h"
 #include "custom_constitutive/small_strain_isotropic_damage_plane_strain_2d.h"
 #include "custom_constitutive/small_strain_isotropic_damage_traction_only_3d.h"
+#include "custom_constitutive/small_strain_isotropic_damage_traction_only_implex_3d.h"
 #include "custom_constitutive/plane_stress_d_plus_d_minus_damage_masonry_2d.h"
 #include "custom_constitutive/d_plus_d_minus_damage_masonry_3d.h"
 #include "custom_constitutive/small_strain_isotropic_plasticity_factory.h"
@@ -262,8 +264,10 @@ private:
     const SmallStrainJ2Plasticity3D mSmallStrainJ2Plasticity3D;
     const SmallStrainJ2PlasticityPlaneStrain2D mSmallStrainJ2PlasticityPlaneStrain2D;
     const SmallStrainIsotropicDamage3D mSmallStrainIsotropicDamage3D;
+    const SmallStrainIsotropicDamageImplex3D mSmallStrainIsotropicDamageImplex3D;
     const SmallStrainIsotropicDamagePlaneStrain2D mSmallStrainIsotropicDamagePlaneStrain2D;
     const SmallStrainIsotropicDamageTractionOnly3D mSmallStrainIsotropicDamageTractionOnly3D;
+    const SmallStrainIsotropicDamageTractionOnlyImplex3D mSmallStrainIsotropicDamageTractionOnlyImplex3D;
     const TrussPlasticityConstitutiveLaw mTrussPlasticityConstitutiveLaw;
     const HyperElasticIsotropicOgden1D mHyperElasticIsotropicOgden1D;
     const HyperElasticIsotropicHenky1D mHyperElasticIsotropicHenky1D;

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/small_strain_isotropic_damage_implex_3d.cpp
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/small_strain_isotropic_damage_implex_3d.cpp
@@ -1,0 +1,537 @@
+// KRATOS ___                _   _ _         _   _             __                       _
+//       / __\___  _ __  ___| |_(_) |_ _   _| |_(_)_   _____  / /  __ ___      _____   /_\  _ __  _ __
+//      / /  / _ \| '_ \/ __| __| | __| | | | __| \ \ / / _ \/ /  / _` \ \ /\ / / __| //_\\| '_ \| '_  |
+//     / /__| (_) | | | \__ \ |_| | |_| |_| | |_| |\ V /  __/ /__| (_| |\ V  V /\__ \/  _  \ |_) | |_) |
+//     \____/\___/|_| |_|___/\__|_|\__|\__,_|\__|_| \_/ \___\____/\__,_| \_/\_/ |___/\_/ \_/ .__/| .__/
+//                                                                                         |_|   |_|
+//
+//  License:		 BSD License
+//					 license: structural_mechanics_application/license.txt
+//
+//  Main authors:    Marcelo Raschi
+//  Collaborators:
+//
+
+// Project includes
+#include "small_strain_isotropic_damage_implex_3d.h"
+#include "constitutive_laws_application_variables.h"
+#include "structural_mechanics_application_variables.h"
+#include "constitutive_laws_application_variables.h"
+#include "includes/checks.h"
+
+namespace Kratos
+{
+//******************************CONSTRUCTOR*******************************************
+//************************************************************************************
+
+SmallStrainIsotropicDamageImplex3D::SmallStrainIsotropicDamageImplex3D()
+    : ElasticIsotropic3D()
+{
+}
+
+//********************************COPY CONSTRUCTOR************************************
+//************************************************************************************
+
+SmallStrainIsotropicDamageImplex3D::SmallStrainIsotropicDamageImplex3D(
+    const SmallStrainIsotropicDamageImplex3D &rOther) = default;
+
+//********************************CLONE***********************************************
+//************************************************************************************
+
+ConstitutiveLaw::Pointer SmallStrainIsotropicDamageImplex3D::Clone() const
+{
+    return Kratos::make_shared<SmallStrainIsotropicDamageImplex3D>(
+        SmallStrainIsotropicDamageImplex3D(*this));
+}
+
+//********************************DESTRUCTOR******************************************
+//************************************************************************************
+
+SmallStrainIsotropicDamageImplex3D::~SmallStrainIsotropicDamageImplex3D() = default;
+
+//************************************************************************************
+//************************************************************************************
+
+bool SmallStrainIsotropicDamageImplex3D::Has(const Variable<double>& rThisVariable)
+{
+    if (rThisVariable == SCALE_FACTOR) {
+        // explicitly returning "false", so the element calls CalculateValue(...)
+        return false;
+    } else if (rThisVariable == STRAIN_ENERGY) {
+        // explicitly returning "false", so the element calls CalculateValue(...)
+        return false;
+    } else if (rThisVariable == DAMAGE_VARIABLE) {
+        // explicitly returning "false", so the element calls CalculateValue(...)
+        return false;
+    }
+
+    return false;
+}
+
+//************************************************************************************
+//************************************************************************************
+
+bool SmallStrainIsotropicDamageImplex3D::Has(const Variable<Vector>& rThisVariable)
+{
+    if(rThisVariable == INTERNAL_VARIABLES){
+        return true;
+    } else if(rThisVariable == STRAIN){
+        // explicitly returning "false", so the element calls CalculateValue(...)
+        return false;
+    }
+
+    return false;
+}
+
+//************************************************************************************
+//************************************************************************************
+
+Vector& SmallStrainIsotropicDamageImplex3D::GetValue(
+    const Variable<Vector>& rThisVariable,
+    Vector& rValue
+    )
+{
+    if (rThisVariable == INTERNAL_VARIABLES) {
+        rValue.resize(2);
+        rValue[0] = mStrainVariable;
+        rValue[1] = mStrainVariablePrevious;
+    }
+
+    return rValue;
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void SmallStrainIsotropicDamageImplex3D::SetValue(
+    const Variable<Vector>& rThisVariable,
+    const Vector& rValue,
+    const ProcessInfo& rProcessInfo
+    )
+{
+    if (rThisVariable == INTERNAL_VARIABLES) {
+        mStrainVariable = rValue[0];
+        mStrainVariablePrevious = rValue[1];
+    }
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void SmallStrainIsotropicDamageImplex3D::InitializeMaterial(
+    const Properties& rMaterialProperties,
+    const GeometryType& rElementGeometry,
+    const Vector& rShapeFunctionsValues
+    )
+{
+    const double yield_stress = rMaterialProperties[STRESS_LIMITS](0);
+    const double young_modulus = rMaterialProperties[YOUNG_MODULUS];
+    mStrainVariable = yield_stress / std::sqrt(young_modulus);
+    mStrainVariablePrevious = mStrainVariable;
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void SmallStrainIsotropicDamageImplex3D::FinalizeMaterialResponseCauchy(
+    ConstitutiveLaw::Parameters& rParametersValues)
+{
+    Vector internal_variables(2);
+    this->CalculateStressResponse(rParametersValues, internal_variables);
+    mStrainVariable = internal_variables[0];
+    mStrainVariablePrevious = internal_variables[1];
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void SmallStrainIsotropicDamageImplex3D::CalculateMaterialResponsePK2(
+    ConstitutiveLaw::Parameters& rParametersValues)
+{
+    Vector internal_variables(2);
+    CalculateStressResponse(rParametersValues, internal_variables);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void SmallStrainIsotropicDamageImplex3D::CalculateStressResponse(
+    ConstitutiveLaw::Parameters& rParametersValues,
+    Vector& rInternalVariables)
+{
+    const Properties& r_material_properties = rParametersValues.GetMaterialProperties();
+    Flags& r_constitutive_law_options = rParametersValues.GetOptions();
+    Vector& r_strain_vector = rParametersValues.GetStrainVector();
+    CalculateValue(rParametersValues, STRAIN, r_strain_vector);
+
+    // Implex
+    const double dt_n1 = rParametersValues.GetProcessInfo()[DELTA_TIME];
+    double dt_n0 = rParametersValues.GetProcessInfo().GetPreviousTimeStepInfo(1)[DELTA_TIME];
+    if (dt_n0 <= 0) {
+          dt_n0 = dt_n1; //To avoid division by zero in 1st increment
+    }
+    double r_implex = mStrainVariable + (dt_n1 / dt_n0) * (mStrainVariable - mStrainVariablePrevious);
+    const double q_implex = EvaluateHardeningLaw(r_implex, r_material_properties);
+    const double d_implex = 1. - q_implex / r_implex;
+
+    double r = mStrainVariable;
+
+    // If we compute the tangent moduli or the stress
+    if( r_constitutive_law_options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ||
+        r_constitutive_law_options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR )) {
+        Vector& r_stress_vector = rParametersValues.GetStressVector();
+        Matrix& r_constitutive_matrix = rParametersValues.GetConstitutiveMatrix();
+        CalculateElasticMatrix(r_constitutive_matrix, rParametersValues);
+        noalias(r_stress_vector) = prod(r_constitutive_matrix, r_strain_vector);
+
+        Vector r_stress_vector_pos = r_stress_vector;
+        ComputePositiveStressVector(r_stress_vector_pos, r_stress_vector);
+
+        double energy = inner_prod(r_stress_vector_pos, r_strain_vector);
+        // energy may be a small negative due to machine precision error, forcing zero
+        if (energy < 0) {
+            energy = 0;
+        }
+
+        const double strain_norm = std::sqrt(energy);
+
+        // inelastic case
+        if (strain_norm > mStrainVariable) {
+            r = strain_norm;
+        }
+
+        r_constitutive_matrix *= (1 - d_implex);
+        r_stress_vector *= (1 - d_implex);
+
+    }
+
+    rInternalVariables[0] = r;
+    rInternalVariables[1] = mStrainVariable;
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void SmallStrainIsotropicDamageImplex3D::ComputePositiveStressVector(
+            Vector& rStressVectorPos, Vector& rStressVector)
+{
+    // Auxiliary stress vector to allow derived models (e.g. traction-only damage)
+    // to set the value of r_stress_vector_pos with the ComputePositiveStressVector
+    // function.
+
+    // In this symmetric damage model, ComputePositiveStressVector function does
+    // nothing, as rStressVectorPos = rStressVector already.
+}
+
+//************************************************************************************
+//************************************************************************************
+
+double SmallStrainIsotropicDamageImplex3D::EvaluateHardeningModulus(
+        double r,
+        const Properties &rMaterialProperties)
+{
+    if (rMaterialProperties[HARDENING_CURVE] == 0) {
+
+        // 0: exponential hardening
+
+        const double young_modulus = rMaterialProperties[YOUNG_MODULUS];
+        const double yield_stress = rMaterialProperties[STRESS_LIMITS](0);
+        const double inf_yield_stress = rMaterialProperties[STRESS_LIMITS](1);
+        const double h0 = rMaterialProperties[HARDENING_PARAMETERS](0);
+        const double r0 = yield_stress / std::sqrt(young_modulus);
+        const double q1 = inf_yield_stress / std::sqrt(young_modulus);
+
+        if (r < r0)
+            return 0.;
+        else // >= r0:
+            return h0 * (q1/r0 - 1) * std::exp(h0 * (1 - r/r0));
+
+    } else {
+
+        // 1: multilinear hardening
+
+        const double young_modulus = rMaterialProperties[YOUNG_MODULUS];
+        const double yield_stress = rMaterialProperties[STRESS_LIMITS](0);
+        const double r0 = yield_stress / std::sqrt(young_modulus);
+        const double h0 = rMaterialProperties[HARDENING_PARAMETERS](0);
+
+        if (r < r0)
+            return  0.;
+
+        switch(rMaterialProperties[HARDENING_PARAMETERS].size())
+        {
+            case 1:  // linear
+                return h0;
+                break;
+
+            case 2:  // bilinear
+            {
+                const double q0 = r0;
+                const double s1 = rMaterialProperties[STRESS_LIMITS](1);
+                const double q1 = s1 / std::sqrt(young_modulus);
+                const double r1 = r0 + (q1 - q0) / h0;
+                const double h1 = rMaterialProperties[HARDENING_PARAMETERS](1);
+
+                if (r >= r0 && r < r1)
+                    return h0;
+                else  // r >= r1:
+                    return h1;
+                break;
+            }
+
+            case 3:   // trilinear
+            {
+                const double q0 = r0;
+                const double s1 = rMaterialProperties[STRESS_LIMITS](1);
+                const double q1 = s1 / std::sqrt(young_modulus);
+                const double r1 = r0 + (q1 - q0) / h0;
+                const double h1 = rMaterialProperties[HARDENING_PARAMETERS](1);
+                const double s2 = rMaterialProperties[STRESS_LIMITS](2);
+                const double q2 = s2 / std::sqrt(young_modulus);
+                const double r2 = r1 + (q2 - q1) / h1;
+                const double h2 = rMaterialProperties[HARDENING_PARAMETERS](2);
+
+                if (r >= r0 && r < r1)
+                    return h0;
+                else if (r >= r1 && r < r2)
+                    return h1;
+                else  // r >= r2
+                    return h2;
+                break;
+            }
+
+            default:  // for other cases, implement as needed
+                KRATOS_ERROR << "Multilinear hardening model of more than 3 " <<
+                "regions not yet implemented." << std::endl;
+                break;
+        }
+    }
+}
+
+//************************************************************************************
+//************************************************************************************
+
+double SmallStrainIsotropicDamageImplex3D::EvaluateHardeningLaw(
+    double r,
+    const Properties &rMaterialProperties)
+{
+    if (rMaterialProperties[HARDENING_CURVE] == 0) {
+
+        // 0: exponential hardening
+
+        const double young_modulus = rMaterialProperties[YOUNG_MODULUS];
+        const double yield_stress = rMaterialProperties[STRESS_LIMITS](0);
+        const double inf_yield_stress = rMaterialProperties[STRESS_LIMITS](1);
+        const double r0 = yield_stress / std::sqrt(young_modulus);
+        const double h0 = EvaluateHardeningModulus(r0, rMaterialProperties);
+        const double q0 = r0;  // strain_variable_init
+        const double q1 = inf_yield_stress / std::sqrt(young_modulus);  // stress_variable_inf
+
+        if (r < r0)
+            return q0;
+        else  // r >= r0:
+            return q1 - (q1 - r0) * std::exp(h0 * (1 - r/r0));  //  for H0 > 0
+
+    } else {
+
+        // 1: bilinear hardening
+
+        const double young_modulus = rMaterialProperties[YOUNG_MODULUS];
+        const double s0 = rMaterialProperties[STRESS_LIMITS](0);
+        const double r0 = s0 / std::sqrt(young_modulus);
+        const double h0 = EvaluateHardeningModulus(r0, rMaterialProperties);
+        const double q0 = r0;
+
+        if (r < r0)
+            return q0;
+
+        switch(rMaterialProperties[HARDENING_PARAMETERS].size())
+        {
+            case 1:  // linear
+                return q0 + h0 * (r - r0);
+                break;
+
+            case 2:  // bilinear
+            {
+                const double s1 = rMaterialProperties[STRESS_LIMITS](1);
+                const double q1 = s1 / std::sqrt(young_modulus);
+                const double r1 = r0 + (q1 - q0) / h0;
+                const double h1 = EvaluateHardeningModulus(r1, rMaterialProperties);
+
+                if (r >= r0 && r < r1)
+                    return q0 + h0 * (r - r0);
+                else  // r >= r1:
+                    return q1 + h1 * (r - r1);
+                break;
+            }
+
+            case 3:  // trilinear
+            {
+                const double s1 = rMaterialProperties[STRESS_LIMITS](1);
+                const double q1 = s1 / std::sqrt(young_modulus);
+                const double r1 = r0 + (q1 - q0) / h0;
+                const double h1 = EvaluateHardeningModulus(r1, rMaterialProperties);
+                const double s2 = rMaterialProperties[STRESS_LIMITS](2);
+                const double q2 = s2 / std::sqrt(young_modulus);
+                const double r2 = r1 + (q2 - q1) / h1;
+                const double h2 = EvaluateHardeningModulus(r2, rMaterialProperties);
+
+                if (r >= r0 && r < r1)
+                    return q0 + h0 * (r - r0);
+                else if (r >= r1 && r < r2)
+                    return q1 + h1 * (r - r1);
+                else  // r >= r2
+                    return q2 + h2 * (r - r2);
+                break;
+            }
+
+            default:  // for other cases, implement as needed
+                KRATOS_ERROR << "Multilinear hardening model of more than 3 " <<
+                "regions not yet implemented." << std::endl;
+                break;
+        }
+    }
+}
+
+//************************************************************************************
+//************************************************************************************
+
+double& SmallStrainIsotropicDamageImplex3D::CalculateValue(
+    ConstitutiveLaw::Parameters& rParametersValues,
+    const Variable<double>& rThisVariable,
+    double& rValue
+    )
+{
+    if (rThisVariable == SCALE_FACTOR) {
+        const Properties& r_material_properties = rParametersValues.GetMaterialProperties();
+        const double stress_like_variable = EvaluateHardeningLaw(
+                                                mStrainVariable,
+                                                r_material_properties);
+        const double hardening_modulus = EvaluateHardeningModulus(
+                                                mStrainVariable,
+                                                r_material_properties);
+
+        rValue = ((stress_like_variable - hardening_modulus * mStrainVariable) / (mStrainVariable*mStrainVariable))*(mStrainVariable - mStrainVariablePrevious);
+
+    } else if (rThisVariable == STRAIN_ENERGY) {
+        Vector& r_strain_vector = rParametersValues.GetStrainVector();
+        this->CalculateValue(rParametersValues, STRAIN, r_strain_vector);
+        const Properties& r_material_properties = rParametersValues.GetMaterialProperties();
+        Matrix constitutive_matrix;
+        CalculateElasticMatrix(constitutive_matrix, rParametersValues);
+        const double stress_like_variable = EvaluateHardeningLaw(
+                                                mStrainVariable,
+                                                r_material_properties);
+        const double damage_variable = 1. - stress_like_variable / mStrainVariable;
+
+        rValue = 0.5 * ((1. - damage_variable) * inner_prod(r_strain_vector,
+                                        prod(constitutive_matrix, r_strain_vector)));
+
+    } else if (rThisVariable == DAMAGE_VARIABLE){
+        const Properties& r_material_properties = rParametersValues.GetMaterialProperties();
+        const double stress_like_variable = EvaluateHardeningLaw(
+                                                mStrainVariable,
+                                                r_material_properties);
+
+        rValue = 1. - stress_like_variable / mStrainVariable;
+
+    } else {
+        ElasticIsotropic3D::CalculateValue(rParametersValues, rThisVariable, rValue);
+
+    }
+
+    return(rValue);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+Vector& SmallStrainIsotropicDamageImplex3D::CalculateValue(
+    ConstitutiveLaw::Parameters& rParametersValues,
+    const Variable<Vector>& rThisVariable,
+    Vector& rValue
+    )
+{
+    //Explicitly having STRAIN and INITAL_STRAIN_VECTOR calculated in base class
+    ElasticIsotropic3D::CalculateValue(rParametersValues, rThisVariable, rValue);
+    return(rValue);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void SmallStrainIsotropicDamageImplex3D::GetLawFeatures(Features& rFeatures)
+{
+    rFeatures.mOptions.Set(THREE_DIMENSIONAL_LAW);
+    rFeatures.mOptions.Set(INFINITESIMAL_STRAINS);
+    rFeatures.mOptions.Set(ISOTROPIC);
+    rFeatures.mStrainMeasures.push_back(StrainMeasure_Infinitesimal);
+    rFeatures.mStrainSize = this->GetStrainSize();
+    rFeatures.mSpaceDimension = this->WorkingSpaceDimension();
+}
+
+//************************************************************************************
+//************************************************************************************
+
+int SmallStrainIsotropicDamageImplex3D::Check(
+    const Properties& rMaterialProperties,
+    const GeometryType& rElementGeometry,
+    const ProcessInfo& rCurrentProcessInfo
+    )
+{
+    const double tolerance = std::numeric_limits<double>::epsilon();
+
+    KRATOS_CHECK(rMaterialProperties.Has(YOUNG_MODULUS));
+    KRATOS_CHECK(rMaterialProperties.Has(POISSON_RATIO));
+    KRATOS_CHECK(rMaterialProperties.Has(HARDENING_CURVE));
+    KRATOS_CHECK(rMaterialProperties.Has(STRESS_LIMITS));
+    KRATOS_CHECK(rMaterialProperties.Has(HARDENING_PARAMETERS));
+
+    // current supported hardening models:
+    KRATOS_CHECK(rMaterialProperties[HARDENING_CURVE] == 0 || rMaterialProperties[HARDENING_CURVE] == 1);
+
+    // checks specific for exponential hardening
+    if (rMaterialProperties[HARDENING_CURVE] == 0){
+        KRATOS_CHECK_GREATER_EQUAL(rMaterialProperties[STRESS_LIMITS].size(), 2);
+        KRATOS_CHECK_GREATER(rMaterialProperties[STRESS_LIMITS](0), tolerance);
+        KRATOS_CHECK_GREATER(rMaterialProperties[STRESS_LIMITS](1), rMaterialProperties[STRESS_LIMITS](0));
+        KRATOS_CHECK_GREATER_EQUAL(rMaterialProperties[HARDENING_PARAMETERS](0), 0.);
+    }
+
+    // checks specific for multilinear hardening
+    if (rMaterialProperties[HARDENING_CURVE] == 1){
+        KRATOS_CHECK_EQUAL(rMaterialProperties[HARDENING_PARAMETERS].size(),
+                           rMaterialProperties[STRESS_LIMITS].size());
+        for (const auto& h : rMaterialProperties[HARDENING_PARAMETERS]){
+            KRATOS_CHECK_GREATER_EQUAL(h, 0.);
+            KRATOS_CHECK_LESS_EQUAL(h, 1.);
+        }
+        for (const auto& h : rMaterialProperties[STRESS_LIMITS]){
+            KRATOS_CHECK_GREATER(h, tolerance);
+        }
+    }
+
+    return 0;
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void SmallStrainIsotropicDamageImplex3D::save(Serializer& rSerializer) const
+{
+    KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, ElasticIsotropic3D);
+    rSerializer.save("mStrainVariable", mStrainVariable);
+    rSerializer.save("mStrainVariablePrevious", mStrainVariablePrevious);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void SmallStrainIsotropicDamageImplex3D::load(Serializer& rSerializer)
+{
+    KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, ElasticIsotropic3D);
+    rSerializer.save("mStrainVariable", mStrainVariable);
+    rSerializer.save("mStrainVariablePrevious", mStrainVariablePrevious);
+}
+
+} /* namespace Kratos.*/

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/small_strain_isotropic_damage_implex_3d.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/small_strain_isotropic_damage_implex_3d.h
@@ -1,0 +1,334 @@
+// KRATOS ___                _   _ _         _   _             __                       _
+//       / __\___  _ __  ___| |_(_) |_ _   _| |_(_)_   _____  / /  __ ___      _____   /_\  _ __  _ __
+//      / /  / _ \| '_ \/ __| __| | __| | | | __| \ \ / / _ \/ /  / _` \ \ /\ / / __| //_\\| '_ \| '_  |
+//     / /__| (_) | | | \__ \ |_| | |_| |_| | |_| |\ V /  __/ /__| (_| |\ V  V /\__ \/  _  \ |_) | |_) |
+//     \____/\___/|_| |_|___/\__|_|\__|\__,_|\__|_| \_/ \___\____/\__,_| \_/\_/ |___/\_/ \_/ .__/| .__/
+//                                                                                         |_|   |_|
+//
+//  License:		 BSD License
+//					 license: structural_mechanics_application/license.txt
+//
+//  Main authors:    Marcelo Raschi
+
+#if !defined(KRATOS_SMALL_STRAIN_ISOTROPIC_DAMAGE_IMPLEX_3D_LAW_H_INCLUDED)
+#define KRATOS_SMALL_STRAIN_ISOTROPIC_DAMAGE_IMPLEX_3D_LAW_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "custom_constitutive/elastic_isotropic_3d.h"
+
+namespace Kratos
+{
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+/**
+ * @class SmallStrainIsotropicDamageImplex3D
+ * @ingroup ConstitutiveLawsApplication
+ * @brief Damage with hardening constitutive law in 3D, using Implex integration
+ * scheme (see J Oliver et al, 2008, An implicit/explicit integration scheme
+ * to increase computability of non-linear material and contact/friction problems)
+ * @details This material law is defined by the parameters:
+ * - YOUNG_MODULUS
+ * - POISSON_RATIO
+ * - HARDEDNING_CURVE: Type of hardening model: 0 exponential, 1 multilinear
+ * - STRESS_LIMITS: list of stress values in which the corresponding hardening
+ *   parameter is valid
+ * - HARDENING_PARAMETERS: List of hardening modules (max three branches considered)
+ * @warning Valid for small strains
+ * @note
+ * @author Marcelo Raschi
+ */
+class KRATOS_API(CONSTITUTIVE_LAWS_APPLICATION) SmallStrainIsotropicDamageImplex3D
+    : public ElasticIsotropic3D
+{
+public:
+
+    ///@name Type Definitions
+    ///@{
+    typedef ProcessInfo ProcessInfoType;
+    typedef std::size_t SizeType;
+
+    // Counted pointer
+    KRATOS_CLASS_POINTER_DEFINITION(SmallStrainIsotropicDamageImplex3D);
+
+    ///@}
+    ///@name Lyfe Cycle
+    ///@{
+
+    /**
+     * @brief Default constructor.
+     */
+    SmallStrainIsotropicDamageImplex3D();
+
+    /**
+     * @brief Copy constructor.
+     */
+    SmallStrainIsotropicDamageImplex3D(const SmallStrainIsotropicDamageImplex3D& rOther);
+
+    /**
+     * @brief Destructor.
+     */
+    ~SmallStrainIsotropicDamageImplex3D() override;
+
+    /**
+     * @brief Clone function
+     * @return A pointer to a new instance of this constitutive law
+     */
+    ConstitutiveLaw::Pointer Clone() const override;
+
+    ///@}
+    ///@name Operators
+    ///@{
+    ///@}
+
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief This function is designed to be called once to check compatibility with element
+     * @param rFeatures The Features of the law
+     */
+    void GetLawFeatures(Features& rFeatures) override;
+
+    /**
+     * @brief Returns whether this constitutive Law has specified variable (double)
+     * @param rThisVariable the variable to be checked for
+     * @return true if the variable is defined in the constitutive law
+     */
+    bool Has(const Variable<double>& rThisVariable) override;
+
+    /**
+     * @brief Returns whether this constitutive Law has specified variable (Vector)
+     * @param rThisVariable the variable to be checked for
+     * @return true if the variable is defined in the constitutive law
+     */
+    bool Has(const Variable<Vector>& rThisVariable) override;
+
+    /**
+     * @brief Returns the value of a specified variable (Vector)
+     * @param rThisVariable the variable to be returned
+     * @param rValue a reference to the returned value
+     * @return rValue output: the value of the specified variable
+     */
+    Vector& GetValue(
+        const Variable<Vector>& rThisVariable,
+        Vector& rValue
+        ) override;
+
+    /**
+     * @brief Sets the value of a specified variable (Vector)
+     * @param rThisVariable The variable to be returned
+     * @param rValue New value of the specified variable
+     * @param rCurrentProcessInfo the process info
+     */
+    void SetValue(
+        const Variable<Vector>& rThisVariable,
+        const Vector& rValue,
+        const ProcessInfo& rProcessInfo
+        ) override;
+
+    /**
+     * @brief This is to be called at the very beginning of the calculation
+     * @details (e.g. from InitializeElement) in order to initialize all relevant attributes of the constitutive law
+     * @param rMaterialProperties the Properties instance of the current element
+     * @param rElementGeometry the geometry of the current element
+     * @param rShapeFunctionsValues the shape functions values in the current integration point
+     */
+    void InitializeMaterial(const Properties& rMaterialProperties,
+                            const GeometryType& rElementGeometry,
+                            const Vector& rShapeFunctionsValues) override;
+
+    /**
+     * @brief This method computes the stress and constitutive tensor
+     * @param rValues The norm of the deviation stress
+     * @param rStrainVariable
+     */
+    void CalculateStressResponse(ConstitutiveLaw::Parameters& rValues,
+                                 Vector& rInternalVariables) override;
+
+    /**
+     * @brief Computes the material response in terms of 2nd Piola-Kirchhoff stress
+     * @param rValues The specific parameters of the current constitutive law
+     * @see Parameters
+     */
+    void CalculateMaterialResponsePK2(Parameters& rValues) override;
+
+    /**
+     * @brief Indicates if this CL requires initialization of the material response,
+     * called by the element in InitializeMaterialResponse.
+     */
+    bool RequiresInitializeMaterialResponse() override
+    {
+        return false;
+    }
+
+    /**
+     * @brief Indicates if this CL requires finalization of the material response,
+     * called by the element in FinalizeMaterialResponse.
+     */
+    bool RequiresFinalizeMaterialResponse() override
+    {
+        return true;
+    }
+
+    /**
+     * @brief Finalize the material response in terms of Cauchy stresses
+     * @param rValues The specific parameters of the current constitutive law
+     * @see Parameters
+     */
+    void FinalizeMaterialResponseCauchy(Parameters& rValues) override;
+
+    /**
+     * @brief calculates the value of a specified variable (double)
+     * @param rValues the needed parameters for the CL calculation
+     * @param rThisVariable the variable to be returned
+     * @param rValue a reference to the returned value
+     * @return rValue output: the value of the specified variable
+     */
+    double& CalculateValue(Parameters& rValues,
+                           const Variable<double>& rThisVariable,
+                           double& rValue) override;
+
+    /**
+     * @brief calculates the value of a specified variable (Vector)
+     * @param rValues the needed parameters for the CL calculation
+     * @param rThisVariable the variable to be returned
+     * @param rValue a reference to the returned value
+     * @return rValue output: the value of the specified variable
+     */
+     Vector& CalculateValue(Parameters& rValues,
+                            const Variable<Vector>& rThisVariable,
+                            Vector& rValue) override;
+
+    /**
+     * @brief This function provides the place to perform checks on the completeness of the input.
+     * @details It is designed to be called only once (or anyway, not often) typically at the beginning
+     * of the calculations, so to verify that nothing is missing from the input or that no common error is found.
+     * @param rMaterialProperties The properties of the material
+     * @param rElementGeometry The geometry of the element
+     * @param rCurrentProcessInfo The current process info instance
+     */
+    int Check(
+        const Properties& rMaterialProperties,
+        const GeometryType& rElementGeometry,
+        const ProcessInfo& rCurrentProcessInfo
+        ) override;
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const override {
+        rOStream << "Small Strain Isotropic Damage 3D constitutive law with Implex intergration scheme\n";
+    };
+
+protected:
+
+    ///@name Protected static Member Variables
+    ///@{
+    ///@}
+
+    ///@name Protected member Variables
+    ///@{
+    double mStrainVariable;
+    double mStrainVariablePrevious;
+    ///@}
+
+    ///@name Protected Operators
+    ///@{
+    ///@}
+
+    ///@name Protected Operations
+    ///@{
+
+    /**
+     * @brief This method computes the positive stress vector, which in the traction-only model, is different from the stress vector.
+     * @param rStressVectorPos
+     * @param rStressVector
+     */
+    virtual void ComputePositiveStressVector(
+            Vector& rStressVectorPos,
+            Vector& rStressVector);
+
+    /**
+     * @brief Computes H(r), the hardening module value as a function of the strain variable
+     * @param StrainVariable The properties of the material
+     * @param rMaterialProperties The elastic tensor/matrix to be computed
+     */
+    double EvaluateHardeningModulus(
+            double StrainVariable,
+            const Properties &rMaterialProperties);
+
+    /**
+     * @brief Computes q(r), the hardening law value as a function of the strain variable
+     * @param StrainVariable The properties of the material
+     * @param rMaterialProperties The elastic tensor/matrix to be computed
+     */
+    double EvaluateHardeningLaw(
+            double StrainVariable,
+            const Properties &rMaterialProperties);
+
+    ///@}
+
+private:
+
+    ///@name Static Member Variables
+    ///@{
+
+    ///@}
+
+    ///@name Member Variables
+    ///@{
+
+    ///@}
+
+    ///@name Private Operators
+    ///@{
+
+    ///@}
+
+    ///@name Private Operations
+    ///@{
+
+    ///@}
+
+    ///@name Private  Access
+    ///@{
+    ///@}
+
+    ///@name Serialization
+    ///@{
+
+    friend class Serializer;
+
+    void save(Serializer& rSerializer) const override;
+
+    void load(Serializer& rSerializer) override;
+
+}; // class SmallStrainIsotropicDamage3D
+} // namespace Kratos
+#endif

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/small_strain_isotropic_damage_traction_only_implex_3d.cpp
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/small_strain_isotropic_damage_traction_only_implex_3d.cpp
@@ -1,0 +1,87 @@
+// KRATOS ___                _   _ _         _   _             __                       _
+//       / __\___  _ __  ___| |_(_) |_ _   _| |_(_)_   _____  / /  __ ___      _____   /_\  _ __  _ __
+//      / /  / _ \| '_ \/ __| __| | __| | | | __| \ \ / / _ \/ /  / _` \ \ /\ / / __| //_\\| '_ \| '_  |
+//     / /__| (_) | | | \__ \ |_| | |_| |_| | |_| |\ V /  __/ /__| (_| |\ V  V /\__ \/  _  \ |_) | |_) |
+//     \____/\___/|_| |_|___/\__|_|\__|\__,_|\__|_| \_/ \___\____/\__,_| \_/\_/ |___/\_/ \_/ .__/| .__/
+//                                                                                         |_|   |_|
+//
+//  License:		 BSD License
+//					 license: structural_mechanics_application/license.txt
+//
+//  Main authors:    Marcelo Raschi
+//  Collaborators:
+//
+
+// Project includes
+#include "small_strain_isotropic_damage_traction_only_implex_3d.h"
+#include "constitutive_laws_application_variables.h"
+#include "structural_mechanics_application_variables.h"
+#include "utilities/math_utils.h"
+
+namespace Kratos
+{
+//******************************CONSTRUCTOR*******************************************
+//************************************************************************************
+
+SmallStrainIsotropicDamageTractionOnlyImplex3D::SmallStrainIsotropicDamageTractionOnlyImplex3D()
+        : SmallStrainIsotropicDamageImplex3D()
+{
+}
+
+//********************************COPY CONSTRUCTOR************************************
+//************************************************************************************
+
+SmallStrainIsotropicDamageTractionOnlyImplex3D::SmallStrainIsotropicDamageTractionOnlyImplex3D(
+        const SmallStrainIsotropicDamageTractionOnlyImplex3D &rOther) = default;
+
+//********************************CLONE***********************************************
+//************************************************************************************
+
+ConstitutiveLaw::Pointer SmallStrainIsotropicDamageTractionOnlyImplex3D::Clone() const
+{
+    return Kratos::make_shared<SmallStrainIsotropicDamageTractionOnlyImplex3D>(SmallStrainIsotropicDamageTractionOnlyImplex3D(*this));
+}
+
+//********************************DESTRUCTOR******************************************
+//************************************************************************************
+
+SmallStrainIsotropicDamageTractionOnlyImplex3D::~SmallStrainIsotropicDamageTractionOnlyImplex3D() = default;
+
+//************************************************************************************
+//************************************************************************************
+
+void SmallStrainIsotropicDamageTractionOnlyImplex3D::ComputePositiveStressVector(
+        Vector& rStressVectorPos, Vector& rStressVector)
+{
+    BoundedMatrix<double, 3, 3> stress_matrix;
+    BoundedMatrix<double, 3, 3> eigen_values, eigen_vectors;
+    stress_matrix = MathUtils<double>::StressVectorToTensor(rStressVector);
+    MathUtils<double>::GaussSeidelEigenSystem(stress_matrix, eigen_vectors, eigen_values);
+    for (unsigned int i = 0; i < 3; i++)
+    {
+        if(eigen_values(i, i) < 0.)
+        {
+            eigen_values(i, i) = 0.;
+        }
+    }
+    MathUtils<double>::BDBtProductOperation(stress_matrix, eigen_values, eigen_vectors);
+    rStressVectorPos = MathUtils<double>::StressTensorToVector(stress_matrix);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void SmallStrainIsotropicDamageTractionOnlyImplex3D::save(Serializer& rSerializer) const
+{
+    KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, SmallStrainIsotropicDamageImplex3D);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void SmallStrainIsotropicDamageTractionOnlyImplex3D::load(Serializer& rSerializer)
+{
+    KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, SmallStrainIsotropicDamageImplex3D);
+}
+
+} /* namespace Kratos.*/

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/small_strain_isotropic_damage_traction_only_implex_3d.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/small_strain_isotropic_damage_traction_only_implex_3d.h
@@ -1,0 +1,145 @@
+// KRATOS ___                _   _ _         _   _             __                       _
+//       / __\___  _ __  ___| |_(_) |_ _   _| |_(_)_   _____  / /  __ ___      _____   /_\  _ __  _ __
+//      / /  / _ \| '_ \/ __| __| | __| | | | __| \ \ / / _ \/ /  / _` \ \ /\ / / __| //_\\| '_ \| '_  |
+//     / /__| (_) | | | \__ \ |_| | |_| |_| | |_| |\ V /  __/ /__| (_| |\ V  V /\__ \/  _  \ |_) | |_) |
+//     \____/\___/|_| |_|___/\__|_|\__|\__,_|\__|_| \_/ \___\____/\__,_| \_/\_/ |___/\_/ \_/ .__/| .__/
+//                                                                                         |_|   |_|
+//
+//  License:		 BSD License
+//					 license: structural_mechanics_application/license.txt
+//
+//  Main authors:    Marcelo Raschi
+
+#if !defined(KRATOS_SMALL_STRAIN_ISOTROPIC_DAMAGE_TRACTION_ONLY_IMPLEX_3D_LAW_H_INCLUDED)
+#define KRATOS_SMALL_STRAIN_ISOTROPIC_DAMAGE_TRACTION_ONLY_IMPLEX_3D_LAW_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "small_strain_isotropic_damage_implex_3d.h"
+
+namespace Kratos
+{
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+/**
+ * @class SmallStrainIsotropicDamageTractionOnlyImplex3D
+ * @ingroup ConstitutiveLawsApplication
+ * @brief Traction-only damage with hardening constitutive law in 3D, using Implex
+ * integration scheme (see J Oliver et al, 2008, An implicit/explicit integration scheme
+ * to increase computability of non-linear material and contact/friction problems)
+ * @details This material law is defined by the parameters:
+ * - YOUNG_MODULUS
+ * - POISSON_RATIO
+ * - HARDEDNING_CURVE: Type of hardening model: 0 exponential, 1 multilinear
+ * - STRESS_LIMITS: list of stress values in which the corresponding hardening
+ *   parameter is valid
+ * - HARDENING_PARAMETERS: List of hardening modules (max three branches considered)
+ * @warning Valid for small strains
+ * @note
+ * @author Marcelo Raschi
+ */
+class KRATOS_API(CONSTITUTIVE_LAWS_APPLICATION) SmallStrainIsotropicDamageTractionOnlyImplex3D
+    : public SmallStrainIsotropicDamageImplex3D
+{
+public:
+
+    ///@name Type Definitions
+    ///@{
+    typedef ProcessInfo ProcessInfoType;
+    typedef std::size_t SizeType;
+
+    // Counted pointer
+    KRATOS_CLASS_POINTER_DEFINITION(SmallStrainIsotropicDamageTractionOnlyImplex3D);
+
+    ///@}
+    ///@name Lyfe Cycle
+    ///@{
+
+    /**
+     * @brief Default constructor.
+     */
+    SmallStrainIsotropicDamageTractionOnlyImplex3D();
+
+    /**
+     * @brief Copy constructor.
+     */
+    SmallStrainIsotropicDamageTractionOnlyImplex3D(const SmallStrainIsotropicDamageTractionOnlyImplex3D& rOther);
+
+    /**
+     * @brief Destructor.
+     */
+    ~SmallStrainIsotropicDamageTractionOnlyImplex3D() override;
+
+    /**
+     * @brief Clone function
+     * @return A pointer to a new instance of this constitutive law
+     */
+    ConstitutiveLaw::Pointer Clone() const override;
+
+    /**
+     * @brief This method computes the positive stress vector, which in the traction-only model, is different from the stress vector.
+     * @param rStressVectorPos
+     * @param rStressVector
+     */
+    void ComputePositiveStressVector(
+            Vector& rStressVectorPos,
+            Vector& rStressVector) override;
+
+private:
+
+    ///@name Static Member Variables
+    ///@{
+
+    ///@}
+
+    ///@name Member Variables
+    ///@{
+
+    ///@}
+
+    ///@name Private Operators
+    ///@{
+
+    ///@}
+
+    ///@name Private Operations
+    ///@{
+
+    ///@}
+
+    ///@name Private  Access
+    ///@{
+    ///@}
+
+    ///@name Serialization
+    ///@{
+
+    friend class Serializer;
+
+    void save(Serializer& rSerializer) const override;
+
+    void load(Serializer& rSerializer) override;
+
+}; // class SmallStrainIsotropicDamageTractionOnlyImplex3D
+} // namespace Kratos
+#endif

--- a/applications/ConstitutiveLawsApplication/custom_python/add_custom_constitutive_laws_to_python.cpp
+++ b/applications/ConstitutiveLawsApplication/custom_python/add_custom_constitutive_laws_to_python.cpp
@@ -33,7 +33,9 @@
 #include "custom_constitutive/small_strain_j2_plasticity_3d.h"
 #include "custom_constitutive/small_strain_j2_plasticity_plane_strain_2d.h"
 #include "custom_constitutive/small_strain_isotropic_damage_3d.h"
+#include "custom_constitutive/small_strain_isotropic_damage_implex_3d.h"
 #include "custom_constitutive/small_strain_isotropic_damage_traction_only_3d.h"
+#include "custom_constitutive/small_strain_isotropic_damage_traction_only_implex_3d.h"
 #include "custom_constitutive/wrinkling_linear_2d_law.h"
 #include "custom_constitutive/multi_linear_elastic_1d_law.h"
 #include "custom_constitutive/multi_linear_isotropic_plane_stress_2d.h"
@@ -168,8 +170,16 @@ void AddCustomConstitutiveLawsToPython(pybind11::module& m)
     (m,"SmallStrainIsotropicDamage3DLaw").def(py::init<>())
     ;
 
+    py::class_< SmallStrainIsotropicDamageImplex3D, typename SmallStrainIsotropicDamageImplex3D::Pointer,  ConstitutiveLaw  >
+    (m,"SmallStrainIsotropicDamageImplex3DLaw").def(py::init<>())
+    ;
+
     py::class_< SmallStrainIsotropicDamageTractionOnly3D, typename SmallStrainIsotropicDamageTractionOnly3D::Pointer,  ConstitutiveLaw  >
     (m,"SmallStrainIsotropicDamageTractionOnly3DLaw").def(py::init<>())
+    ;
+
+    py::class_< SmallStrainIsotropicDamageTractionOnlyImplex3D, typename SmallStrainIsotropicDamageTractionOnlyImplex3D::Pointer,  ConstitutiveLaw  >
+    (m,"SmallStrainIsotropicDamageTractionOnlyImplex3DLaw").def(py::init<>())
     ;
 
     py::class_< PlasticityIsotropicKinematicJ2, typename PlasticityIsotropicKinematicJ2::Pointer,  ConstitutiveLaw >

--- a/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_small_strain_isotropic_damage_implex_3d.cpp
+++ b/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_small_strain_isotropic_damage_implex_3d.cpp
@@ -49,6 +49,7 @@ KRATOS_TEST_CASE_IN_SUITE(_ConstitutiveLaw_SmallStrainIsotropicDamageImplex3D, K
     // Create gauss point
     Model current_model;
     ModelPart& test_model_part = current_model.CreateModelPart("Main");
+    test_model_part.SetBufferSize(2);
     NodeType::Pointer p_node_1 = test_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
     NodeType::Pointer p_node_2 = test_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
     NodeType::Pointer p_node_3 = test_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);

--- a/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_small_strain_isotropic_damage_implex_3d.cpp
+++ b/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_small_strain_isotropic_damage_implex_3d.cpp
@@ -1,0 +1,261 @@
+// KRATOS ___                _   _ _         _   _             __                       _
+//       / __\___  _ __  ___| |_(_) |_ _   _| |_(_)_   _____  / /  __ ___      _____   /_\  _ __  _ __
+//      / /  / _ \| '_ \/ __| __| | __| | | | __| \ \ / / _ \/ /  / _` \ \ /\ / / __| //_\\| '_ \| '_  |
+//     / /__| (_) | | | \__ \ |_| | |_| |_| | |_| |\ V /  __/ /__| (_| |\ V  V /\__ \/  _  \ |_) | |_) |
+//     \____/\___/|_| |_|___/\__|_|\__|\__,_|\__|_| \_/ \___\____/\__,_| \_/\_/ |___/\_/ \_/ .__/| .__/
+//                                                                                         |_|   |_|
+//
+//  License:         BSD License
+//                     license: structural_mechanics_application/license.txt
+//
+//  Main authors:    Marcelo Raschi
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/process_info.h"
+#include "testing/testing.h"
+#include "containers/model.h"
+
+// Application includes
+#include "structural_mechanics_application_variables.h"
+#include "constitutive_laws_application_variables.h"
+
+// Constitutive law
+#include "custom_constitutive/small_strain_isotropic_damage_implex_3d.h"
+#include "includes/model_part.h"
+#include "geometries/tetrahedra_3d_4.h"
+
+namespace Kratos
+{
+namespace Testing
+{
+typedef Node<3> NodeType;
+
+KRATOS_TEST_CASE_IN_SUITE(_ConstitutiveLaw_SmallStrainIsotropicDamageImplex3D, KratosConstitutiveLawsFastSuite)
+{
+
+    //
+    //  CREATE LAW
+    //
+
+    ConstitutiveLaw::Parameters cl_parameters;
+    Properties material_properties;
+    Vector stress_vector(6), strain_vector(6);
+    Matrix const_matrix;
+    // Create gauss point
+    Model current_model;
+    ModelPart& test_model_part = current_model.CreateModelPart("Main");
+    NodeType::Pointer p_node_1 = test_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    NodeType::Pointer p_node_2 = test_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    NodeType::Pointer p_node_3 = test_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    NodeType::Pointer p_node_4 = test_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
+    Tetrahedra3D4<NodeType> geometry = Tetrahedra3D4<NodeType>(p_node_1, p_node_2, p_node_3, p_node_4);
+    // Set material properties
+    material_properties.SetValue(YOUNG_MODULUS, 6);
+    material_properties.SetValue(POISSON_RATIO, 0.3);
+    material_properties.SetValue(HARDENING_CURVE, 0);
+    Vector stress_limits(2);
+    stress_limits(0) = 1.5;
+    stress_limits(1) = 3.0;
+    material_properties.SetValue(STRESS_LIMITS, stress_limits);
+    Vector hardening_params(1);
+    hardening_params(0) = 0.5;
+    material_properties.SetValue(HARDENING_PARAMETERS, hardening_params);
+    // Set constitutive law flags:
+    Flags& ConstitutiveLawOptions=cl_parameters.GetOptions();
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, true);
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
+    // Set required constitutive law parameters:
+    cl_parameters.SetElementGeometry(geometry);
+    cl_parameters.SetProcessInfo(test_model_part.GetProcessInfo());
+    cl_parameters.SetMaterialProperties(material_properties);
+    cl_parameters.SetStrainVector(strain_vector);
+    cl_parameters.SetStressVector(stress_vector);
+    cl_parameters.SetConstitutiveMatrix(const_matrix);
+    // Create the CL
+    SmallStrainIsotropicDamageImplex3D cl = SmallStrainIsotropicDamageImplex3D();
+
+    //
+    //  TESTS
+    //
+
+    //
+    // Test: check correct behavior of internal and calculated variables
+    //
+    KRATOS_CHECK_IS_FALSE(cl.Check(material_properties, geometry, test_model_part.GetProcessInfo()));
+
+    KRATOS_CHECK_IS_FALSE(cl.Has(STRAIN_ENERGY));  // false
+    KRATOS_CHECK_IS_FALSE(cl.Has(DAMAGE_VARIABLE));  // false
+    KRATOS_CHECK_IS_FALSE(cl.Has(SCALE_FACTOR));  // false
+    KRATOS_CHECK_IS_FALSE(cl.Has(STRAIN));  // false
+    KRATOS_CHECK(cl.Has(INTERNAL_VARIABLES));  // true
+    Vector internal_variables_w(2);
+    internal_variables_w[0] = 0.123;
+    internal_variables_w[1] = 0.456;
+    cl.SetValue(INTERNAL_VARIABLES, internal_variables_w, test_model_part.GetProcessInfo());
+    Vector internal_variables_r;
+    cl.GetValue(INTERNAL_VARIABLES, internal_variables_r);  // CL resizes it
+    KRATOS_CHECK_NEAR(internal_variables_r.size(), 2., 1.e-5);
+    KRATOS_CHECK_NEAR(internal_variables_r[0], 0.123, 1.e-5);
+    KRATOS_CHECK_NEAR(internal_variables_r[1], 0.456, 1.e-5);
+
+    //
+    // Test: exponential hardening model, load in traction
+    //
+
+    // Simulate the call sequence of the element
+    Vector dummy_vector;
+    cl.InitializeMaterial(material_properties, geometry, dummy_vector);
+    Vector imposed_strain = ZeroVector(6);
+    imposed_strain(0) = -0.0759;
+    imposed_strain(1) =  0.7483;
+    imposed_strain(2) =  0.1879;
+    imposed_strain(3) =  0.5391;
+    imposed_strain(4) =  0.0063;
+    imposed_strain(5) = -0.3292;
+    
+    for (std::size_t t = 0; t < 10; ++t){
+
+        test_model_part.CloneTimeStep(t / 9);
+
+        for (std::size_t comp = 0; comp < 6; ++comp)
+            strain_vector(comp) = t / 9 * imposed_strain(comp);
+
+        if (cl.RequiresInitializeMaterialResponse()){
+            cl.InitializeMaterialResponseCauchy(cl_parameters);
+        }
+
+        cl.CalculateMaterialResponseCauchy(cl_parameters);
+
+        if (cl.RequiresFinalizeMaterialResponse()){
+            cl.FinalizeMaterialResponseCauchy(cl_parameters);
+        }
+    }
+
+    // Checks
+    const double tolerance = 1e-4;
+    double value_double;
+    Vector value_vector;
+
+    cl.CalculateValue(cl_parameters, DAMAGE_VARIABLE, value_double);
+    KRATOS_CHECK_NEAR(0.56273, value_double, tolerance);
+    
+    cl.CalculateValue(cl_parameters, STRAIN_ENERGY, value_double);
+    KRATOS_CHECK_NEAR(1.36795, value_double, tolerance);
+
+    cl.CalculateValue(cl_parameters, SCALE_FACTOR, value_double);
+    KRATOS_CHECK_NEAR(0.24946, value_double, tolerance);
+
+    cl.CalculateValue(cl_parameters, STRAIN, value_vector);
+    KRATOS_CHECK_VECTOR_NEAR(value_vector, imposed_strain, tolerance);
+
+    cl.CalculateValue(cl_parameters, INITIAL_STRAIN_VECTOR, value_vector);
+    KRATOS_CHECK_VECTOR_NEAR(value_vector, ZeroVector(6), tolerance);
+
+    cl.GetValue(INTERNAL_VARIABLES, internal_variables_r);
+    KRATOS_CHECK_NEAR(internal_variables_r.size(), 2., tolerance);
+    KRATOS_CHECK_NEAR(internal_variables_r[0], 2.50135, tolerance);  // r_{t}
+    KRATOS_CHECK_NEAR(internal_variables_r[1], 0.61237, tolerance);  // r_{t-1}
+
+    Vector ref_stress = ZeroVector(6);
+    ref_stress(0) =  2.62765;
+    ref_stress(1) =  6.43165;
+    ref_stress(2) =  3.84519;
+    ref_stress(3) =  1.24408;
+    ref_stress(4) =  0.01454;
+    ref_stress(5) = -0.75969;
+    KRATOS_CHECK_VECTOR_NEAR(stress_vector, ref_stress, tolerance);
+
+    Matrix ref_C = ZeroMatrix(6, 6);
+    ref_C(0,0) =  8.07692; ref_C(0,1) =3.46154; ref_C(0,2) = 3.46154; ref_C(0,3) = 0      ; ref_C(0,4) = 0      ; ref_C(0,5) = 0      ;
+    ref_C(1,0) =  3.46154; ref_C(1,1) =8.07692; ref_C(1,2) = 3.46154; ref_C(1,3) = 0      ; ref_C(1,4) = 0      ; ref_C(1,5) = 0      ;
+    ref_C(2,0) =  3.46154; ref_C(2,1) =3.46154; ref_C(2,2) = 8.07692; ref_C(2,3) = 0      ; ref_C(2,4) = 0      ; ref_C(2,5) = 0      ;
+    ref_C(3,0) =  0      ; ref_C(3,1) =0      ; ref_C(3,2) = 0      ; ref_C(3,3) = 2.30769; ref_C(3,4) = 0      ; ref_C(3,5) = 0      ;
+    ref_C(4,0) =  0      ; ref_C(4,1) =0      ; ref_C(4,2) = 0      ; ref_C(4,3) = 0      ; ref_C(4,4) = 2.30769; ref_C(4,5) = 0      ;
+    ref_C(5,0) =  0      ; ref_C(5,1) =0      ; ref_C(5,2) = 0      ; ref_C(5,3) = 0      ; ref_C(5,4) = 0      ; ref_C(5,5) = 2.30769;
+    KRATOS_CHECK_MATRIX_NEAR(const_matrix, ref_C, tolerance);
+
+
+    //
+    // Test: trilinear hardening model, load in traction
+    //
+
+    // Update properties for this test
+    material_properties.SetValue(HARDENING_CURVE, 1);
+    stress_limits.resize(3);
+    stress_limits(0) = 1.5;
+    stress_limits(1) = 2.0;
+    stress_limits(2) = 3.0;
+    material_properties.SetValue(STRESS_LIMITS, stress_limits);
+    hardening_params.resize(3);
+    hardening_params(0) = 0.6;
+    hardening_params(1) = 0.4;
+    hardening_params(2) = 0.0;
+    material_properties.SetValue(HARDENING_PARAMETERS, hardening_params);
+
+    // Simulate the call sequence of the element
+    cl.Check(material_properties, geometry, test_model_part.GetProcessInfo());
+    cl.InitializeMaterial(material_properties, geometry, dummy_vector);
+    imposed_strain(0) = -0.0759;
+    imposed_strain(1) =  0.7483;
+    imposed_strain(2) =  0.1879;
+    imposed_strain(3) =  0.5391;
+    imposed_strain(4) =  0.0063;
+    imposed_strain(5) = -0.3292;
+
+    for (std::size_t t = 0; t < 10; ++t){
+
+        test_model_part.CloneTimeStep(t / 9);
+
+        for (std::size_t comp = 0; comp < 6; ++comp)
+            strain_vector(comp) = t / 9 * imposed_strain(comp);
+
+        if (cl.RequiresInitializeMaterialResponse()){
+            cl.InitializeMaterialResponseCauchy(cl_parameters);
+        }
+
+        cl.CalculateMaterialResponseCauchy(cl_parameters);
+
+        if (cl.RequiresFinalizeMaterialResponse()){
+            cl.FinalizeMaterialResponseCauchy(cl_parameters);
+        }
+    }
+
+    // Checks
+    cl.CalculateValue(cl_parameters, DAMAGE_VARIABLE, value_double);
+    KRATOS_CHECK_NEAR(0.51037, value_double, tolerance);
+
+    cl.CalculateValue(cl_parameters, STRAIN_ENERGY, value_double);
+    KRATOS_CHECK_NEAR(1.53176, value_double, tolerance);
+
+    cl.CalculateValue(cl_parameters, SCALE_FACTOR, value_double);
+    KRATOS_CHECK_NEAR(0.36976, value_double, tolerance);
+
+    cl.GetValue(INTERNAL_VARIABLES, internal_variables_r);
+    KRATOS_CHECK_NEAR(internal_variables_r.size(), 2., tolerance);
+    KRATOS_CHECK_NEAR(internal_variables_r[0], 2.50135, tolerance);  // r_{t}
+    KRATOS_CHECK_NEAR(internal_variables_r[1], 0.61237, tolerance);  // r_{t-1}
+
+    ref_stress(0) =  2.62765;
+    ref_stress(1) =  6.43165;
+    ref_stress(2) =  3.84519;
+    ref_stress(3) =  1.24408;
+    ref_stress(4) =  0.01454;
+    ref_stress(5) = -0.759692;
+    KRATOS_CHECK_VECTOR_NEAR(stress_vector, ref_stress, tolerance);
+
+    ref_C(0,0) =  8.07692; ref_C(0,1) =3.46154; ref_C(0,2) = 3.46154; ref_C(0,3) = 0      ; ref_C(0,4) = 0      ; ref_C(0,5) = 0      ;
+    ref_C(1,0) =  3.46154; ref_C(1,1) =8.07692; ref_C(1,2) = 3.46154; ref_C(1,3) = 0      ; ref_C(1,4) = 0      ; ref_C(1,5) = 0      ;
+    ref_C(2,0) =  3.46154; ref_C(2,1) =3.46154; ref_C(2,2) = 8.07692; ref_C(2,3) = 0      ; ref_C(2,4) = 0      ; ref_C(2,5) = 0      ;
+    ref_C(3,0) =  0      ; ref_C(3,1) =0      ; ref_C(3,2) = 0      ; ref_C(3,3) = 2.30769; ref_C(3,4) = 0      ; ref_C(3,5) = 0      ;
+    ref_C(4,0) =  0      ; ref_C(4,1) =0      ; ref_C(4,2) = 0      ; ref_C(4,3) = 0      ; ref_C(4,4) = 2.30769; ref_C(4,5) = 0      ;
+    ref_C(5,0) =  0      ; ref_C(5,1) =0      ; ref_C(5,2) = 0      ; ref_C(5,3) = 0      ; ref_C(5,4) = 0      ; ref_C(5,5) = 2.30769;
+    KRATOS_CHECK_MATRIX_NEAR(const_matrix, ref_C, tolerance);
+}
+} // namespace Testing
+} // namespace Kratos

--- a/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_small_strain_isotropic_damage_implex_3d.cpp
+++ b/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_small_strain_isotropic_damage_implex_3d.cpp
@@ -155,9 +155,6 @@ KRATOS_TEST_CASE_IN_SUITE(_ConstitutiveLaw_SmallStrainIsotropicDamageImplex3D, K
     cl.CalculateValue(cl_parameters, STRAIN, value_vector);
     KRATOS_CHECK_VECTOR_NEAR(value_vector, imposed_strain, tolerance);
 
-    cl.CalculateValue(cl_parameters, INITIAL_STRAIN_VECTOR, value_vector);
-    KRATOS_CHECK_VECTOR_NEAR(value_vector, ZeroVector(6), tolerance);
-
     cl.GetValue(INTERNAL_VARIABLES, internal_variables_r);
     KRATOS_CHECK_NEAR(internal_variables_r.size(), 2., tolerance);
     KRATOS_CHECK_NEAR(internal_variables_r[0], 2.50135, tolerance);  // r_{t}

--- a/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_small_strain_isotropic_damage_traction_only_implex_3d.cpp
+++ b/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_small_strain_isotropic_damage_traction_only_implex_3d.cpp
@@ -155,9 +155,6 @@ KRATOS_TEST_CASE_IN_SUITE(_ConstitutiveLaw_SmallStrainIsotropicDamageTractionOnl
     cl.CalculateValue(cl_parameters, STRAIN, value_vector);
     KRATOS_CHECK_VECTOR_NEAR(value_vector, imposed_strain, tolerance);
 
-    cl.CalculateValue(cl_parameters, INITIAL_STRAIN_VECTOR, value_vector);
-    KRATOS_CHECK_VECTOR_NEAR(value_vector, ZeroVector(6), tolerance);
-
     cl.GetValue(INTERNAL_VARIABLES, internal_variables_r);
     KRATOS_CHECK_NEAR(internal_variables_r.size(), 2., tolerance);
     KRATOS_CHECK_NEAR(internal_variables_r[0], 2.50135, tolerance);  // r_{t}

--- a/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_small_strain_isotropic_damage_traction_only_implex_3d.cpp
+++ b/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_small_strain_isotropic_damage_traction_only_implex_3d.cpp
@@ -49,6 +49,7 @@ KRATOS_TEST_CASE_IN_SUITE(_ConstitutiveLaw_SmallStrainIsotropicDamageTractionOnl
     // Create gauss point
     Model current_model;
     ModelPart& test_model_part = current_model.CreateModelPart("Main");
+    test_model_part.SetBufferSize(2);
     NodeType::Pointer p_node_1 = test_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
     NodeType::Pointer p_node_2 = test_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
     NodeType::Pointer p_node_3 = test_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);

--- a/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_small_strain_isotropic_damage_traction_only_implex_3d.cpp
+++ b/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_small_strain_isotropic_damage_traction_only_implex_3d.cpp
@@ -1,0 +1,261 @@
+// KRATOS ___                _   _ _         _   _             __                       _
+//       / __\___  _ __  ___| |_(_) |_ _   _| |_(_)_   _____  / /  __ ___      _____   /_\  _ __  _ __
+//      / /  / _ \| '_ \/ __| __| | __| | | | __| \ \ / / _ \/ /  / _` \ \ /\ / / __| //_\\| '_ \| '_  |
+//     / /__| (_) | | | \__ \ |_| | |_| |_| | |_| |\ V /  __/ /__| (_| |\ V  V /\__ \/  _  \ |_) | |_) |
+//     \____/\___/|_| |_|___/\__|_|\__|\__,_|\__|_| \_/ \___\____/\__,_| \_/\_/ |___/\_/ \_/ .__/| .__/
+//                                                                                         |_|   |_|
+//
+//  License:         BSD License
+//                     license: structural_mechanics_application/license.txt
+//
+//  Main authors:    Marcelo Raschi
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/process_info.h"
+#include "testing/testing.h"
+#include "containers/model.h"
+
+// Application includes
+#include "structural_mechanics_application_variables.h"
+#include "constitutive_laws_application_variables.h"
+
+// Constitutive law
+#include "custom_constitutive/small_strain_isotropic_damage_traction_only_implex_3d.h"
+#include "includes/model_part.h"
+#include "geometries/tetrahedra_3d_4.h"
+
+namespace Kratos
+{
+namespace Testing
+{
+typedef Node<3> NodeType;
+
+KRATOS_TEST_CASE_IN_SUITE(_ConstitutiveLaw_SmallStrainIsotropicDamageTractionOnlyImplex3D, KratosConstitutiveLawsFastSuite)
+{
+
+    //
+    //  CREATE LAW
+    //
+
+    ConstitutiveLaw::Parameters cl_parameters;
+    Properties material_properties;
+    Vector stress_vector(6), strain_vector(6);
+    Matrix const_matrix;
+    // Create gauss point
+    Model current_model;
+    ModelPart& test_model_part = current_model.CreateModelPart("Main");
+    NodeType::Pointer p_node_1 = test_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    NodeType::Pointer p_node_2 = test_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    NodeType::Pointer p_node_3 = test_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    NodeType::Pointer p_node_4 = test_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
+    Tetrahedra3D4<NodeType> geometry = Tetrahedra3D4<NodeType>(p_node_1, p_node_2, p_node_3, p_node_4);
+    // Set material properties
+    material_properties.SetValue(YOUNG_MODULUS, 6);
+    material_properties.SetValue(POISSON_RATIO, 0.3);
+    material_properties.SetValue(HARDENING_CURVE, 0);
+    Vector stress_limits(2);
+    stress_limits(0) = 1.5;
+    stress_limits(1) = 3.0;
+    material_properties.SetValue(STRESS_LIMITS, stress_limits);
+    Vector hardening_params(1);
+    hardening_params(0) = 0.5;
+    material_properties.SetValue(HARDENING_PARAMETERS, hardening_params);
+    // Set constitutive law flags:
+    Flags& ConstitutiveLawOptions=cl_parameters.GetOptions();
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, true);
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
+    // Set required constitutive law parameters:
+    cl_parameters.SetElementGeometry(geometry);
+    cl_parameters.SetProcessInfo(test_model_part.GetProcessInfo());
+    cl_parameters.SetMaterialProperties(material_properties);
+    cl_parameters.SetStrainVector(strain_vector);
+    cl_parameters.SetStressVector(stress_vector);
+    cl_parameters.SetConstitutiveMatrix(const_matrix);
+    // Create the CL
+    SmallStrainIsotropicDamageTractionOnlyImplex3D cl = SmallStrainIsotropicDamageTractionOnlyImplex3D();
+
+    //
+    //  TESTS
+    //
+
+    //
+    // Test: check correct behavior of internal and calculated variables
+    //
+    KRATOS_CHECK_IS_FALSE(cl.Check(material_properties, geometry, test_model_part.GetProcessInfo()));
+
+    KRATOS_CHECK_IS_FALSE(cl.Has(STRAIN_ENERGY));  // false
+    KRATOS_CHECK_IS_FALSE(cl.Has(DAMAGE_VARIABLE));  // false
+    KRATOS_CHECK_IS_FALSE(cl.Has(SCALE_FACTOR));  // false
+    KRATOS_CHECK_IS_FALSE(cl.Has(STRAIN));  // false
+    KRATOS_CHECK(cl.Has(INTERNAL_VARIABLES));  // true
+    Vector internal_variables_w(2);
+    internal_variables_w[0] = 0.123;
+    internal_variables_w[1] = 0.456;
+    cl.SetValue(INTERNAL_VARIABLES, internal_variables_w, test_model_part.GetProcessInfo());
+    Vector internal_variables_r;
+    cl.GetValue(INTERNAL_VARIABLES, internal_variables_r);  // CL resizes it
+    KRATOS_CHECK_NEAR(internal_variables_r.size(), 2., 1.e-5);
+    KRATOS_CHECK_NEAR(internal_variables_r[0], 0.123, 1.e-5);
+    KRATOS_CHECK_NEAR(internal_variables_r[1], 0.456, 1.e-5);
+
+    //
+    // Test: exponential hardening model, load in traction
+    //
+
+    // Simulate the call sequence of the element
+    Vector dummy_vector;
+    cl.InitializeMaterial(material_properties, geometry, dummy_vector);
+    Vector imposed_strain = ZeroVector(6);
+    imposed_strain(0) = -0.0759;
+    imposed_strain(1) =  0.7483;
+    imposed_strain(2) =  0.1879;
+    imposed_strain(3) =  0.5391;
+    imposed_strain(4) =  0.0063;
+    imposed_strain(5) = -0.3292;
+    
+    for (std::size_t t = 0; t < 10; ++t){
+
+        test_model_part.CloneTimeStep(t / 9);
+
+        for (std::size_t comp = 0; comp < 6; ++comp)
+            strain_vector(comp) = t / 9 * imposed_strain(comp);
+
+        if (cl.RequiresInitializeMaterialResponse()){
+            cl.InitializeMaterialResponseCauchy(cl_parameters);
+        }
+
+        cl.CalculateMaterialResponseCauchy(cl_parameters);
+
+        if (cl.RequiresFinalizeMaterialResponse()){
+            cl.FinalizeMaterialResponseCauchy(cl_parameters);
+        }
+    }
+
+    // Checks
+    const double tolerance = 1e-4;
+    double value_double;
+    Vector value_vector;
+
+    cl.CalculateValue(cl_parameters, DAMAGE_VARIABLE, value_double);
+    KRATOS_CHECK_NEAR(0.56273, value_double, tolerance);
+    
+    cl.CalculateValue(cl_parameters, STRAIN_ENERGY, value_double);
+    KRATOS_CHECK_NEAR(1.36795, value_double, tolerance);
+
+    cl.CalculateValue(cl_parameters, SCALE_FACTOR, value_double);
+    KRATOS_CHECK_NEAR(0.24946, value_double, tolerance);
+
+    cl.CalculateValue(cl_parameters, STRAIN, value_vector);
+    KRATOS_CHECK_VECTOR_NEAR(value_vector, imposed_strain, tolerance);
+
+    cl.CalculateValue(cl_parameters, INITIAL_STRAIN_VECTOR, value_vector);
+    KRATOS_CHECK_VECTOR_NEAR(value_vector, ZeroVector(6), tolerance);
+
+    cl.GetValue(INTERNAL_VARIABLES, internal_variables_r);
+    KRATOS_CHECK_NEAR(internal_variables_r.size(), 2., tolerance);
+    KRATOS_CHECK_NEAR(internal_variables_r[0], 2.50135, tolerance);  // r_{t}
+    KRATOS_CHECK_NEAR(internal_variables_r[1], 0.61237, tolerance);  // r_{t-1}
+
+    Vector ref_stress = ZeroVector(6);
+    ref_stress(0) =  2.62765;
+    ref_stress(1) =  6.43165;
+    ref_stress(2) =  3.84519;
+    ref_stress(3) =  1.24408;
+    ref_stress(4) =  0.01454;
+    ref_stress(5) = -0.75969;
+    KRATOS_CHECK_VECTOR_NEAR(stress_vector, ref_stress, tolerance);
+
+    Matrix ref_C = ZeroMatrix(6, 6);
+    ref_C(0,0) =  8.07692; ref_C(0,1) =3.46154; ref_C(0,2) = 3.46154; ref_C(0,3) = 0      ; ref_C(0,4) = 0      ; ref_C(0,5) = 0      ;
+    ref_C(1,0) =  3.46154; ref_C(1,1) =8.07692; ref_C(1,2) = 3.46154; ref_C(1,3) = 0      ; ref_C(1,4) = 0      ; ref_C(1,5) = 0      ;
+    ref_C(2,0) =  3.46154; ref_C(2,1) =3.46154; ref_C(2,2) = 8.07692; ref_C(2,3) = 0      ; ref_C(2,4) = 0      ; ref_C(2,5) = 0      ;
+    ref_C(3,0) =  0      ; ref_C(3,1) =0      ; ref_C(3,2) = 0      ; ref_C(3,3) = 2.30769; ref_C(3,4) = 0      ; ref_C(3,5) = 0      ;
+    ref_C(4,0) =  0      ; ref_C(4,1) =0      ; ref_C(4,2) = 0      ; ref_C(4,3) = 0      ; ref_C(4,4) = 2.30769; ref_C(4,5) = 0      ;
+    ref_C(5,0) =  0      ; ref_C(5,1) =0      ; ref_C(5,2) = 0      ; ref_C(5,3) = 0      ; ref_C(5,4) = 0      ; ref_C(5,5) = 2.30769;
+    KRATOS_CHECK_MATRIX_NEAR(const_matrix, ref_C, tolerance);
+
+
+    //
+    // Test: trilinear hardening model, load in traction
+    //
+
+    // Update properties for this test
+    material_properties.SetValue(HARDENING_CURVE, 1);
+    stress_limits.resize(3);
+    stress_limits(0) = 1.5;
+    stress_limits(1) = 2.0;
+    stress_limits(2) = 3.0;
+    material_properties.SetValue(STRESS_LIMITS, stress_limits);
+    hardening_params.resize(3);
+    hardening_params(0) = 0.6;
+    hardening_params(1) = 0.4;
+    hardening_params(2) = 0.0;
+    material_properties.SetValue(HARDENING_PARAMETERS, hardening_params);
+
+    // Simulate the call sequence of the element
+    cl.Check(material_properties, geometry, test_model_part.GetProcessInfo());
+    cl.InitializeMaterial(material_properties, geometry, dummy_vector);
+    imposed_strain(0) = -0.0759;
+    imposed_strain(1) =  0.7483;
+    imposed_strain(2) =  0.1879;
+    imposed_strain(3) =  0.5391;
+    imposed_strain(4) =  0.0063;
+    imposed_strain(5) = -0.3292;
+
+    for (std::size_t t = 0; t < 10; ++t){
+
+        test_model_part.CloneTimeStep(t / 9);
+
+        for (std::size_t comp = 0; comp < 6; ++comp)
+            strain_vector(comp) = t / 9 * imposed_strain(comp);
+
+        if (cl.RequiresInitializeMaterialResponse()){
+            cl.InitializeMaterialResponseCauchy(cl_parameters);
+        }
+
+        cl.CalculateMaterialResponseCauchy(cl_parameters);
+
+        if (cl.RequiresFinalizeMaterialResponse()){
+            cl.FinalizeMaterialResponseCauchy(cl_parameters);
+        }
+    }
+
+    // Checks
+    cl.CalculateValue(cl_parameters, DAMAGE_VARIABLE, value_double);
+    KRATOS_CHECK_NEAR(0.51037, value_double, tolerance);
+
+    cl.CalculateValue(cl_parameters, STRAIN_ENERGY, value_double);
+    KRATOS_CHECK_NEAR(1.53176, value_double, tolerance);
+
+    cl.CalculateValue(cl_parameters, SCALE_FACTOR, value_double);
+    KRATOS_CHECK_NEAR(0.36976, value_double, tolerance);
+
+    cl.GetValue(INTERNAL_VARIABLES, internal_variables_r);
+    KRATOS_CHECK_NEAR(internal_variables_r.size(), 2., tolerance);
+    KRATOS_CHECK_NEAR(internal_variables_r[0], 2.50135, tolerance);  // r_{t}
+    KRATOS_CHECK_NEAR(internal_variables_r[1], 0.61237, tolerance);  // r_{t-1}
+
+    ref_stress(0) =  2.62765;
+    ref_stress(1) =  6.43165;
+    ref_stress(2) =  3.84519;
+    ref_stress(3) =  1.24408;
+    ref_stress(4) =  0.01454;
+    ref_stress(5) = -0.759692;
+    KRATOS_CHECK_VECTOR_NEAR(stress_vector, ref_stress, tolerance);
+
+    ref_C(0,0) =  8.07692; ref_C(0,1) =3.46154; ref_C(0,2) = 3.46154; ref_C(0,3) = 0      ; ref_C(0,4) = 0      ; ref_C(0,5) = 0      ;
+    ref_C(1,0) =  3.46154; ref_C(1,1) =8.07692; ref_C(1,2) = 3.46154; ref_C(1,3) = 0      ; ref_C(1,4) = 0      ; ref_C(1,5) = 0      ;
+    ref_C(2,0) =  3.46154; ref_C(2,1) =3.46154; ref_C(2,2) = 8.07692; ref_C(2,3) = 0      ; ref_C(2,4) = 0      ; ref_C(2,5) = 0      ;
+    ref_C(3,0) =  0      ; ref_C(3,1) =0      ; ref_C(3,2) = 0      ; ref_C(3,3) = 2.30769; ref_C(3,4) = 0      ; ref_C(3,5) = 0      ;
+    ref_C(4,0) =  0      ; ref_C(4,1) =0      ; ref_C(4,2) = 0      ; ref_C(4,3) = 0      ; ref_C(4,4) = 2.30769; ref_C(4,5) = 0      ;
+    ref_C(5,0) =  0      ; ref_C(5,1) =0      ; ref_C(5,2) = 0      ; ref_C(5,3) = 0      ; ref_C(5,4) = 0      ; ref_C(5,5) = 2.30769;
+    KRATOS_CHECK_MATRIX_NEAR(const_matrix, ref_C, tolerance);
+}
+} // namespace Testing
+} // namespace Kratos


### PR DESCRIPTION
**Description**
Add Implex version of symmetric and traction-only damage constitutive laws.

**Changelog**
- Added Implex version of small strain isotropic damage 3d constitutive law to ConstitutiveLawsApplication
- Added Implex version of traction-only small strain isotropic damage 3d constitutive law to ConstitutiveLawsApplication
- Exported to python
- Tests 
