### PR TITLE
[Poro] Adding 2.5D element and variable permeability (at each element)

### DIFF
--- a/applications/PoromechanicsApplication/custom_constitutive/history_linear_elastic_3D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/history_linear_elastic_3D_law.cpp
@@ -71,7 +71,12 @@ void HistoryLinearElastic3DLaw::AddInitialStresses( Parameters& rValues, Vector&
     noalias(gp_initial_stress_vector) = ZeroVector(voigt_size);
 
     for (unsigned int i = 0; i < number_of_nodes; i++) {
-        noalias(nodal_initial_stress_tensor) = geometry[i].GetSolutionStepValue(INITIAL_STRESS_TENSOR);
+        const Matrix& r_initial_stress_tensor = geometry[i].GetSolutionStepValue(INITIAL_STRESS_TENSOR);
+        for(unsigned int j=0; j < dimension; j++) {
+            for(unsigned int k=0; k < dimension; k++) {
+                nodal_initial_stress_tensor(j,k) = r_initial_stress_tensor(j,k);
+            }
+        }
         noalias(nodal_initial_stress_vector) = MathUtils<double>::StressTensorToVector(nodal_initial_stress_tensor);
 
         for(unsigned int j=0; j < voigt_size; j++) {

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_element.hpp
@@ -96,6 +96,9 @@ public:
 
     void SetValuesOnIntegrationPoints(const Variable<double>& rVariable, const std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
+    void SetValuesOnIntegrationPoints(const Variable<Matrix>& rVariable, const std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
+
+
     void CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateOnIntegrationPoints(const Variable<array_1d<double,3>>& rVariable, std::vector<array_1d<double,3>>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
@@ -129,6 +132,10 @@ protected:
     GeometryData::IntegrationMethod mThisIntegrationMethod;
 
     std::vector<ConstitutiveLaw::Pointer> mConstitutiveLawVector;
+
+    Matrix mIntrinsicPermeability;
+
+    std::vector<double> mImposedZStrainVector; /// The vector containing the imposed z strains (for 2.5D element: 2D geom with 3D CL)
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
@@ -40,14 +40,13 @@ void UPwSmallStrainFICElement<TDim,TNumNodes>::Initialize(const ProcessInfo& rCu
 
     UPwElement<TDim,TNumNodes>::Initialize(rCurrentProcessInfo);
 
-    unsigned int VoigtSize = 6;
-    if(TDim == 2) VoigtSize = 3;
+    const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
 
     for(unsigned int i = 0; i < TDim; i++)
     {
-        mNodalConstitutiveTensor[i].resize(VoigtSize);
+        mNodalConstitutiveTensor[i].resize(strain_size);
 
-        for(unsigned int j = 0; j < VoigtSize; j++)
+        for(unsigned int j = 0; j < strain_size; j++)
         {
             for(unsigned int k = 0; k < TNumNodes; k++)
                 mNodalConstitutiveTensor[i][j][k] = 0.0;
@@ -74,20 +73,19 @@ void UPwSmallStrainFICElement<TDim,TNumNodes>::InitializeNonLinearIteration(cons
     const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
     GeometryType::ShapeFunctionsGradientsType DN_DXContainer(NumGPoints);
     Geom.ShapeFunctionsIntegrationPointsGradients(DN_DXContainer,mThisIntegrationMethod);
+    const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
 
-    unsigned int VoigtSize = 6;
-    if(TDim == 2) VoigtSize = 3;
-    Matrix B(VoigtSize,TNumNodes*TDim);
-    noalias(B) = ZeroMatrix(VoigtSize,TNumNodes*TDim);
+    Matrix B(strain_size,TNumNodes*TDim);
+    noalias(B) = ZeroMatrix(strain_size,TNumNodes*TDim);
     array_1d<double,TNumNodes*TDim> DisplacementVector;
     PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
     array_1d<double,TNumNodes*TDim> VelocityVector;
     PoroElementUtilities::GetNodalVariableVector(VelocityVector,Geom,VELOCITY);
 
     //Create constitutive law parameters:
-    Vector StrainVector(VoigtSize);
-    Vector StressVector(VoigtSize);
-    Matrix ConstitutiveMatrix(VoigtSize,VoigtSize);
+    Vector StrainVector(strain_size);
+    Vector StressVector(strain_size);
+    Matrix ConstitutiveMatrix(strain_size,strain_size);
     Vector Np(TNumNodes);
     Matrix GradNpT(TNumNodes,TDim);
     Matrix F = identity_matrix<double>(TDim);
@@ -107,7 +105,7 @@ void UPwSmallStrainFICElement<TDim,TNumNodes>::InitializeNonLinearIteration(cons
     array_1d<Matrix,TDim> ConstitutiveTensorContainer;
     for(unsigned int i = 0; i < TDim; i++)
     {
-        ConstitutiveTensorContainer[i].resize(NumGPoints,VoigtSize,false);
+        ConstitutiveTensorContainer[i].resize(NumGPoints,strain_size,false);
     }
     Matrix DtStressContainer(NumGPoints,TDim);
 
@@ -115,11 +113,10 @@ void UPwSmallStrainFICElement<TDim,TNumNodes>::InitializeNonLinearIteration(cons
     for( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++)
     {
         noalias(Np) = row(NContainer,GPoint);
-        noalias(GradNpT) = DN_DXContainer[GPoint];
-        this->CalculateBMatrix(B, GradNpT);
+
+        this->CalculateKinematics(GradNpT,B,StrainVector,DN_DXContainer,DisplacementVector,GPoint);
 
         // Compute ConstitutiveTensor
-        noalias(StrainVector) = prod(B,DisplacementVector);
         mConstitutiveLawVector[GPoint]->CalculateMaterialResponseCauchy(ConstitutiveParameters);
         this->SaveGPConstitutiveTensor(ConstitutiveTensorContainer,ConstitutiveMatrix,GPoint);
 
@@ -144,20 +141,19 @@ void UPwSmallStrainFICElement<TDim,TNumNodes>::FinalizeNonLinearIteration(const 
     const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
     GeometryType::ShapeFunctionsGradientsType DN_DXContainer(NumGPoints);
     Geom.ShapeFunctionsIntegrationPointsGradients(DN_DXContainer,mThisIntegrationMethod);
+    const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
 
-    unsigned int VoigtSize = 6;
-    if(TDim == 2) VoigtSize = 3;
-    Matrix B(VoigtSize,TNumNodes*TDim);
-    noalias(B) = ZeroMatrix(VoigtSize,TNumNodes*TDim);
+    Matrix B(strain_size,TNumNodes*TDim);
+    noalias(B) = ZeroMatrix(strain_size,TNumNodes*TDim);
     array_1d<double,TNumNodes*TDim> DisplacementVector;
     PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
     array_1d<double,TNumNodes*TDim> VelocityVector;
     PoroElementUtilities::GetNodalVariableVector(VelocityVector,Geom,VELOCITY);
 
     //Create constitutive law parameters:
-    Vector StrainVector(VoigtSize);
-    Vector StressVector(VoigtSize);
-    Matrix ConstitutiveMatrix(VoigtSize,VoigtSize);
+    Vector StrainVector(strain_size);
+    Vector StressVector(strain_size);
+    Matrix ConstitutiveMatrix(strain_size,strain_size);
     Vector Np(TNumNodes);
     Matrix GradNpT(TNumNodes,TDim);
     Matrix F = identity_matrix<double>(TDim);
@@ -180,11 +176,10 @@ void UPwSmallStrainFICElement<TDim,TNumNodes>::FinalizeNonLinearIteration(const 
     for( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++)
     {
         noalias(Np) = row(NContainer,GPoint);
-        noalias(GradNpT) = DN_DXContainer[GPoint];
-        this->CalculateBMatrix(B, GradNpT);
+
+        this->CalculateKinematics(GradNpT,B,StrainVector,DN_DXContainer,DisplacementVector,GPoint);
 
         // Compute ConstitutiveTensor
-        noalias(StrainVector) = prod(B,DisplacementVector);
         mConstitutiveLawVector[GPoint]->CalculateMaterialResponseCauchy(ConstitutiveParameters);
 
         // Compute DtStress
@@ -203,7 +198,7 @@ void UPwSmallStrainFICElement<TDim,TNumNodes>::SaveGPConstitutiveTensor(array_1d
 {
     for(unsigned int i = 0; i < TDim; i++)
     {
-        for(unsigned int j = 0; j < ConstitutiveMatrix.size1(); j++) //VoigtSize
+        for(unsigned int j = 0; j < ConstitutiveMatrix.size1(); j++)
         {
             rConstitutiveTensorContainer[i](GPoint,j) = ConstitutiveMatrix(i,j);
         }
@@ -248,16 +243,18 @@ void UPwSmallStrainFICElement<2,3>::ExtrapolateGPConstitutiveTensor(const array_
 {
     // Triangle_2d_3 with GI_GAUSS_2
 
+    const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
+
     BoundedMatrix<double,3,3> ExtrapolationMatrix;
     PoroElementUtilities::Calculate2DExtrapolationMatrix(ExtrapolationMatrix);
 
-    BoundedMatrix<double,3,3> AuxNodalConstitutiveTensor;
+    BoundedMatrix<double,3,strain_size> AuxNodalConstitutiveTensor;
 
     for(unsigned int i = 0; i < 2; i++) //TDim
     {
         noalias(AuxNodalConstitutiveTensor) = prod(ExtrapolationMatrix,ConstitutiveTensorContainer[i]);
 
-        for(unsigned int j = 0; j < 3; j++) // VoigtSize
+        for(unsigned int j = 0; j < strain_size; j++)
             noalias(mNodalConstitutiveTensor[i][j]) = column(AuxNodalConstitutiveTensor,j);
     }
 
@@ -278,16 +275,18 @@ void UPwSmallStrainFICElement<2,4>::ExtrapolateGPConstitutiveTensor(const array_
 {
     // Quadrilateral_2d_4 with GI_GAUSS_2
 
+    const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
+
     BoundedMatrix<double,4,4> ExtrapolationMatrix;
     PoroElementUtilities::Calculate2DExtrapolationMatrix(ExtrapolationMatrix);
 
-    BoundedMatrix<double,4,3> AuxNodalConstitutiveTensor;
+    BoundedMatrix<double,4,strain_size> AuxNodalConstitutiveTensor;
 
     for(unsigned int i = 0; i < 2; i++) //TDim
     {
         noalias(AuxNodalConstitutiveTensor) = prod(ExtrapolationMatrix,ConstitutiveTensorContainer[i]);
 
-        for(unsigned int j = 0; j < 3; j++) // VoigtSize
+        for(unsigned int j = 0; j < strain_size; j++)
             noalias(mNodalConstitutiveTensor[i][j]) = column(AuxNodalConstitutiveTensor,j);
     }
 }
@@ -447,9 +446,7 @@ void UPwSmallStrainFICElement<TDim,TNumNodes>::CalculateAll( MatrixType& rLeftHa
     for( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++)
     {
         //Compute GradNpT, B and StrainVector
-        noalias(Variables.GradNpT) = DN_DXContainer[GPoint];
-        this->CalculateBMatrix(Variables.B, Variables.GradNpT);
-        noalias(Variables.StrainVector) = prod(Variables.B,Variables.DisplacementVector);
+        this->CalculateKinematics(Variables.GradNpT,Variables.B,Variables.StrainVector,DN_DXContainer,Variables.DisplacementVector,GPoint);
 
         //Compute Np, Nu and BodyAcceleration
         noalias(Variables.Np) = row(NContainer,GPoint);
@@ -514,9 +511,7 @@ void UPwSmallStrainFICElement<TDim,TNumNodes>::CalculateRHS( VectorType& rRightH
     for( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++)
     {
         //Compute GradNpT, B and StrainVector
-        noalias(Variables.GradNpT) = DN_DXContainer[GPoint];
-        this->CalculateBMatrix(Variables.B, Variables.GradNpT);
-        noalias(Variables.StrainVector) = prod(Variables.B,Variables.DisplacementVector);
+        this->CalculateKinematics(Variables.GradNpT,Variables.B,Variables.StrainVector,DN_DXContainer,Variables.DisplacementVector,GPoint);
 
         //Compute Np, Nu and BodyAcceleration
         noalias(Variables.Np) = row(NContainer,GPoint);
@@ -738,10 +733,12 @@ void UPwSmallStrainFICElement<3,8>::CalculateElementLength(double& rElementLengt
 template<>
 void UPwSmallStrainFICElement<2,3>::InitializeSecondOrderTerms(FICElementVariables& rFICVariables)
 {
-    for(unsigned int i = 0; i < 2; i++) //TDim
-        rFICVariables.ConstitutiveTensorGradients[i].resize(3); //VoigtSize
+    const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
 
-    rFICVariables.DimVoigtMatrix.resize(2,3,false); //TDim X VoigtSize
+    for(unsigned int i = 0; i < 2; i++) //TDim
+        rFICVariables.ConstitutiveTensorGradients[i].resize(strain_size); //VoigtSize
+
+    rFICVariables.DimVoigtMatrix.resize(2,strain_size,false); //TDim X VoigtSize
 }
 
 //----------------------------------------------------------------------------------------
@@ -749,20 +746,28 @@ void UPwSmallStrainFICElement<2,3>::InitializeSecondOrderTerms(FICElementVariabl
 template<>
 void UPwSmallStrainFICElement<2,4>::InitializeSecondOrderTerms(FICElementVariables& rFICVariables)
 {
+    const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
+
     //Voigt identity matrix
-    rFICVariables.VoigtMatrix.resize(3,3,false); //VoigtSize X VoigtSize
-    noalias(rFICVariables.VoigtMatrix) = ZeroMatrix(3,3);
+    rFICVariables.VoigtMatrix.resize(strain_size,strain_size,false); //VoigtSize X VoigtSize
+    noalias(rFICVariables.VoigtMatrix) = ZeroMatrix(strain_size,strain_size);
     rFICVariables.VoigtMatrix(0,0) = 1.0;
     rFICVariables.VoigtMatrix(1,1) = 1.0;
     rFICVariables.VoigtMatrix(2,2) = 0.5;
+    if (strain_size == 6) {
+        rFICVariables.VoigtMatrix(2,2) = 0.0;
+        rFICVariables.VoigtMatrix(3,3) = 0.5;
+        rFICVariables.VoigtMatrix(4,4) = 0.0;
+        rFICVariables.VoigtMatrix(5,5) = 0.0;
+    }
 
     for(unsigned int i = 0; i < 4; i++) //TNumNodes
-        rFICVariables.ShapeFunctionsSecondOrderGradients[i].resize(3,false); //VoigtSize
+        rFICVariables.ShapeFunctionsSecondOrderGradients[i].resize(strain_size,false); //VoigtSize
 
     for(unsigned int i = 0; i < 2; i++) //TDim
-        rFICVariables.ConstitutiveTensorGradients[i].resize(3); //VoigtSize
+        rFICVariables.ConstitutiveTensorGradients[i].resize(strain_size); //VoigtSize
 
-    rFICVariables.DimVoigtMatrix.resize(2,3,false); //TDim X VoigtSize
+    rFICVariables.DimVoigtMatrix.resize(2,strain_size,false); //TDim X VoigtSize
 }
 
 //----------------------------------------------------------------------------------------
@@ -943,9 +948,11 @@ void UPwSmallStrainFICElement<TDim,TNumNodes>::CalculateAndAddDtStressGradientMa
 template< >
 void UPwSmallStrainFICElement<2,3>::CalculateConstitutiveTensorGradients(FICElementVariables& rFICVariables, const ElementVariables& Variables)
 {
+    const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
+
     for(unsigned int i = 0; i < 2; i++) //TDim
     {
-        for(unsigned int j = 0; j < 3; j++) //VoigtSize
+        for(unsigned int j = 0; j < strain_size; j++)
         {
             for(unsigned int k = 0; k < 2; k++) //TDim
             {
@@ -959,7 +966,7 @@ void UPwSmallStrainFICElement<2,3>::CalculateConstitutiveTensorGradients(FICElem
 
     for(unsigned int i = 0; i < 2; i++) //TDim
     {
-        for(unsigned int j = 0; j < 3; j++) //VoigtSize
+        for(unsigned int j = 0; j < strain_size; j++)
         {
             rFICVariables.DimVoigtMatrix(i,j) = 0.0;
 
@@ -987,9 +994,11 @@ void UPwSmallStrainFICElement<2,3>::CalculateConstitutiveTensorGradients(FICElem
 template< >
 void UPwSmallStrainFICElement<2,4>::CalculateConstitutiveTensorGradients(FICElementVariables& rFICVariables, const ElementVariables& Variables)
 {
+    const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
+
     for(unsigned int i = 0; i < 2; i++) //TDim
     {
-        for(unsigned int j = 0; j < 3; j++) //VoigtSize
+        for(unsigned int j = 0; j < strain_size; j++)
         {
             for(unsigned int k = 0; k < 2; k++) //TDim
             {
@@ -1003,7 +1012,7 @@ void UPwSmallStrainFICElement<2,4>::CalculateConstitutiveTensorGradients(FICElem
 
     for(unsigned int i = 0; i < 2; i++) //TDim
     {
-        for(unsigned int j = 0; j < 3; j++) //VoigtSize
+        for(unsigned int j = 0; j < strain_size; j++)
         {
             rFICVariables.DimVoigtMatrix(i,j) = 0.0;
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
@@ -248,7 +248,7 @@ void UPwSmallStrainFICElement<2,3>::ExtrapolateGPConstitutiveTensor(const array_
     BoundedMatrix<double,3,3> ExtrapolationMatrix;
     PoroElementUtilities::Calculate2DExtrapolationMatrix(ExtrapolationMatrix);
 
-    BoundedMatrix<double,3,strain_size> AuxNodalConstitutiveTensor;
+    Matrix AuxNodalConstitutiveTensor(3,strain_size);
 
     for(unsigned int i = 0; i < 2; i++) //TDim
     {
@@ -280,7 +280,7 @@ void UPwSmallStrainFICElement<2,4>::ExtrapolateGPConstitutiveTensor(const array_
     BoundedMatrix<double,4,4> ExtrapolationMatrix;
     PoroElementUtilities::Calculate2DExtrapolationMatrix(ExtrapolationMatrix);
 
-    BoundedMatrix<double,4,strain_size> AuxNodalConstitutiveTensor;
+    Matrix AuxNodalConstitutiveTensor(4,strain_size);
 
     for(unsigned int i = 0; i < 2; i++) //TDim
     {

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -109,17 +109,16 @@ void UPwSmallStrainElement<TDim,TNumNodes>::InitializeNonLinearIteration(const P
     GeometryType::ShapeFunctionsGradientsType DN_DXContainer(NumGPoints);
     Geom.ShapeFunctionsIntegrationPointsGradients(DN_DXContainer,mThisIntegrationMethod);
 
-    unsigned int VoigtSize = 6;
-    if(TDim == 2) VoigtSize = 3;
-    Matrix B(VoigtSize,TNumNodes*TDim);
-    noalias(B) = ZeroMatrix(VoigtSize,TNumNodes*TDim);
+    const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
+    Matrix B(strain_size,TNumNodes*TDim);
+    noalias(B) = ZeroMatrix(strain_size,TNumNodes*TDim);
     array_1d<double,TNumNodes*TDim> DisplacementVector;
     PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
 
     //Create constitutive law parameters:
-    Vector StrainVector(VoigtSize);
-    Vector StressVector(VoigtSize);
-    Matrix ConstitutiveMatrix(VoigtSize,VoigtSize);
+    Vector StrainVector(strain_size);
+    Vector StressVector(strain_size);
+    Matrix ConstitutiveMatrix(strain_size,strain_size);
     Vector Np(TNumNodes);
     Matrix GradNpT(TNumNodes,TDim);
     Matrix F = identity_matrix<double>(TDim);
@@ -140,11 +139,10 @@ void UPwSmallStrainElement<TDim,TNumNodes>::InitializeNonLinearIteration(const P
     for( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++)
     {
         noalias(Np) = row(NContainer,GPoint);
-        noalias(GradNpT) = DN_DXContainer[GPoint];
-        this->CalculateBMatrix(B, GradNpT);
+
+        this->CalculateKinematics(GradNpT,B,StrainVector,DN_DXContainer,DisplacementVector,GPoint);
 
         // Compute Stress
-        noalias(StrainVector) = prod(B,DisplacementVector);
         mConstitutiveLawVector[GPoint]->CalculateMaterialResponseCauchy(ConstitutiveParameters);
     }
 }
@@ -171,17 +169,16 @@ void UPwSmallStrainElement<TDim,TNumNodes>::FinalizeSolutionStep( const ProcessI
     GeometryType::ShapeFunctionsGradientsType DN_DXContainer(NumGPoints);
     Geom.ShapeFunctionsIntegrationPointsGradients(DN_DXContainer,mThisIntegrationMethod);
 
-    unsigned int VoigtSize = 6;
-    if(TDim == 2) VoigtSize = 3;
-    Matrix B(VoigtSize,TNumNodes*TDim);
-    noalias(B) = ZeroMatrix(VoigtSize,TNumNodes*TDim);
+    const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
+    Matrix B(strain_size,TNumNodes*TDim);
+    noalias(B) = ZeroMatrix(strain_size,TNumNodes*TDim);
     array_1d<double,TNumNodes*TDim> DisplacementVector;
     PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
 
     //Create constitutive law parameters:
-    Vector StrainVector(VoigtSize);
-    Vector StressVector(VoigtSize);
-    Matrix ConstitutiveMatrix(VoigtSize,VoigtSize);
+    Vector StrainVector(strain_size);
+    Vector StressVector(strain_size);
+    Matrix ConstitutiveMatrix(strain_size,strain_size);
     Vector Np(TNumNodes);
     Matrix GradNpT(TNumNodes,TDim);
     Matrix F = identity_matrix<double>(TDim);
@@ -199,7 +196,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::FinalizeSolutionStep( const ProcessI
 
     if(rCurrentProcessInfo[NODAL_SMOOTHING] == true)
     {
-        Matrix StressContainer(NumGPoints,VoigtSize);
+        Matrix StressContainer(NumGPoints,strain_size);
 
         Matrix GradPressureContainer(NumGPoints,TDim);
         array_1d<double,TNumNodes> PressureVector;
@@ -211,11 +208,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::FinalizeSolutionStep( const ProcessI
         //Loop over integration points
         for ( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++ )
         {
-            noalias(GradNpT) = DN_DXContainer[GPoint];
-
-            this->CalculateBMatrix(B, GradNpT);
-
-            noalias(StrainVector) = prod(B,DisplacementVector);
+            this->CalculateKinematics(GradNpT,B,StrainVector,DN_DXContainer,DisplacementVector,GPoint);
 
             noalias(Np) = row(NContainer,GPoint);
 
@@ -224,20 +217,16 @@ void UPwSmallStrainElement<TDim,TNumNodes>::FinalizeSolutionStep( const ProcessI
 
             //compute constitutive tensor and/or stresses
             mConstitutiveLawVector[GPoint]->FinalizeMaterialResponseCauchy(ConstitutiveParameters);
-            this->SaveGPStress(StressContainer,StressVector,VoigtSize,GPoint);
+            this->SaveGPStress(StressContainer,StressVector,strain_size,GPoint);
         }
-        this->ExtrapolateGPValues(GradPressureContainer,StressContainer,VoigtSize);
+        this->ExtrapolateGPValues(GradPressureContainer,StressContainer,strain_size);
     }
     else
     {
         //Loop over integration points
         for ( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++ )
         {
-            noalias(GradNpT) = DN_DXContainer[GPoint];
-
-            this->CalculateBMatrix(B, GradNpT);
-
-            noalias(StrainVector) = prod(B,DisplacementVector);
+            this->CalculateKinematics(GradNpT,B,StrainVector,DN_DXContainer,DisplacementVector,GPoint);
 
             noalias(Np) = row(NContainer,GPoint);
 
@@ -313,11 +302,12 @@ void UPwSmallStrainElement<2,3>::ExtrapolateGPValues(const Matrix& GradPressureC
     array_1d<array_1d<double,2>,3> NodalGradPressure; //List with 2D GradP at each node
     array_1d<Vector,3> NodalStressVector; //List with stresses at each node
     array_1d<Matrix,3> NodalStressTensor;
+    const unsigned int cl_dimension = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->WorkingSpaceDimension();
 
     for(unsigned int Node = 0; Node < 3; Node++)
     {
         NodalStressVector[Node].resize(VoigtSize);
-        NodalStressTensor[Node].resize(2,2);
+        NodalStressTensor[Node].resize(cl_dimension,cl_dimension);
     }
 
     BoundedMatrix<double,3,3> ExtrapolationMatrix;
@@ -362,7 +352,12 @@ void UPwSmallStrainElement<2,3>::ExtrapolateGPValues(const Matrix& GradPressureC
         {
             r_nodal_grad_pressure[j] += NodalGradPressure[i][j];
         }
-        noalias(rGeom[i].FastGetSolutionStepValue(NODAL_EFFECTIVE_STRESS_TENSOR)) += NodalStressTensor[i];
+        Matrix& rNodalStress = itNode->FastGetSolutionStepValue(NODAL_EFFECTIVE_STRESS_TENSOR);
+        for(unsigned int j = 0; j < cl_dimension; j++){
+            for(unsigned int k = 0; k < cl_dimension; k++){
+                rNodalStress(j,k) += NodalStressTensor[i](j,k);
+            }
+        }
         rGeom[i].FastGetSolutionStepValue(NODAL_DAMAGE_VARIABLE) += NodalDamage[i]*Area;
         rGeom[i].FastGetSolutionStepValue(NODAL_AREA) += Area;
         rGeom[i].UnSetLock();
@@ -393,11 +388,12 @@ void UPwSmallStrainElement<2,4>::ExtrapolateGPValues(const Matrix& GradPressureC
     array_1d<array_1d<double,2>,4> NodalGradPressure; //List with 2D GradP at each node
     array_1d<Vector,4> NodalStressVector; //List with stresses at each node
     array_1d<Matrix,4> NodalStressTensor;
+    const unsigned int cl_dimension = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->WorkingSpaceDimension();
 
     for(unsigned int Node = 0; Node < 4; Node ++)
     {
         NodalStressVector[Node].resize(VoigtSize);
-        NodalStressTensor[Node].resize(2,2);
+        NodalStressTensor[Node].resize(cl_dimension,cl_dimension);
     }
 
     BoundedMatrix<double,4,4> ExtrapolationMatrix;
@@ -434,7 +430,12 @@ void UPwSmallStrainElement<2,4>::ExtrapolateGPValues(const Matrix& GradPressureC
         {
             r_nodal_grad_pressure[j] += NodalGradPressure[i][j];
         }
-        noalias(rGeom[i].FastGetSolutionStepValue(NODAL_EFFECTIVE_STRESS_TENSOR)) += NodalStressTensor[i];
+        Matrix& rNodalStress = itNode->FastGetSolutionStepValue(NODAL_EFFECTIVE_STRESS_TENSOR);
+        for(unsigned int j = 0; j < cl_dimension; j++){
+            for(unsigned int k = 0; k < cl_dimension; k++){
+                rNodalStress(j,k) += NodalStressTensor[i](j,k);
+            }
+        }
         rGeom[i].FastGetSolutionStepValue(NODAL_DAMAGE_VARIABLE) += NodalDamage[i]*Area;
         rGeom[i].FastGetSolutionStepValue(NODAL_AREA) += Area;
         rGeom[i].UnSetLock();
@@ -575,18 +576,17 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const 
         const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
         GeometryType::ShapeFunctionsGradientsType DN_DXContainer(NumGPoints);
         Geom.ShapeFunctionsIntegrationPointsGradients(DN_DXContainer,mThisIntegrationMethod);
+        const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
 
-        unsigned int VoigtSize = 6;
-        if(TDim == 2) VoigtSize = 3;
-        Matrix B(VoigtSize,TNumNodes*TDim);
-        noalias(B) = ZeroMatrix(VoigtSize,TNumNodes*TDim);
+        Matrix B(strain_size,TNumNodes*TDim);
+        noalias(B) = ZeroMatrix(strain_size,TNumNodes*TDim);
         array_1d<double,TNumNodes*TDim> DisplacementVector;
         PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
 
         //Create constitutive law parameters:
-        Vector StrainVector(VoigtSize);
-        Vector StressVector(VoigtSize);
-        Matrix ConstitutiveMatrix(VoigtSize,VoigtSize);
+        Vector StrainVector(strain_size);
+        Vector StressVector(strain_size);
+        Matrix ConstitutiveMatrix(strain_size,strain_size);
         Vector Np(TNumNodes);
         Matrix GradNpT(TNumNodes,TDim);
         Matrix F = identity_matrix<double>(TDim);
@@ -605,11 +605,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const 
         //Loop over integration points
         for ( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++ )
         {
-            noalias(GradNpT) = DN_DXContainer[GPoint];
-
-            this->CalculateBMatrix(B, GradNpT);
-
-            noalias(StrainVector) = prod(B,DisplacementVector);
+            this->CalculateKinematics(GradNpT,B,StrainVector,DN_DXContainer,DisplacementVector,GPoint);
 
             noalias(Np) = row(NContainer,GPoint);
 
@@ -651,8 +647,6 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const 
         PoroElementUtilities::GetNodalVariableVector(VolumeAcceleration,Geom,VOLUME_ACCELERATION);
         array_1d<double,TDim> BodyAcceleration;
         BoundedMatrix<double,TNumNodes, TDim> GradNpT;
-        BoundedMatrix<double,TDim, TDim> PermeabilityMatrix;
-        PoroElementUtilities::CalculatePermeabilityMatrix(PermeabilityMatrix,Prop);
         const double& DynamicViscosityInverse = 1.0/Prop[DYNAMIC_VISCOSITY];
         const double& FluidDensity = Prop[DENSITY_WATER];
         array_1d<double,TDim> GradPressureTerm;
@@ -668,7 +662,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const 
             noalias(GradPressureTerm) = prod(trans(GradNpT),PressureVector);
             noalias(GradPressureTerm) += -FluidDensity*BodyAcceleration;
 
-            noalias(FluidFlux) = -DynamicViscosityInverse*prod(PermeabilityMatrix,GradPressureTerm);
+            noalias(FluidFlux) = -DynamicViscosityInverse*prod(mIntrinsicPermeability,GradPressureTerm);
 
             PoroElementUtilities::FillArray1dOutput(rOutput[GPoint],FluidFlux);
         }
@@ -717,18 +711,18 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const 
         const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
         GeometryType::ShapeFunctionsGradientsType DN_DXContainer(NumGPoints);
         Geom.ShapeFunctionsIntegrationPointsGradients(DN_DXContainer,mThisIntegrationMethod);
+        const unsigned int cl_dimension = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->WorkingSpaceDimension();
+        const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
 
-        unsigned int VoigtSize = 6;
-        if(TDim == 2) VoigtSize = 3;
-        Matrix B(VoigtSize,TNumNodes*TDim);
-        noalias(B) = ZeroMatrix(VoigtSize,TNumNodes*TDim);
+        Matrix B(strain_size,TNumNodes*TDim);
+        noalias(B) = ZeroMatrix(strain_size,TNumNodes*TDim);
         array_1d<double,TNumNodes*TDim> DisplacementVector;
         PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
 
         //Create constitutive law parameters:
-        Vector StrainVector(VoigtSize);
-        Vector StressVector(VoigtSize);
-        Matrix ConstitutiveMatrix(VoigtSize,VoigtSize);
+        Vector StrainVector(strain_size);
+        Vector StressVector(strain_size);
+        Matrix ConstitutiveMatrix(strain_size,strain_size);
         Vector Np(TNumNodes);
         Matrix GradNpT(TNumNodes,TDim);
         Matrix F = identity_matrix<double>(TDim);
@@ -747,18 +741,14 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const 
         //Loop over integration points
         for ( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++ )
         {
-            noalias(GradNpT) = DN_DXContainer[GPoint];
-
-            this->CalculateBMatrix(B, GradNpT);
-
-            noalias(StrainVector) = prod(B,DisplacementVector);
+            this->CalculateKinematics(GradNpT,B,StrainVector,DN_DXContainer,DisplacementVector,GPoint);
 
             noalias(Np) = row(NContainer,GPoint);
 
             //compute constitutive tensor and/or stresses
             mConstitutiveLawVector[GPoint]->CalculateMaterialResponseCauchy(ConstitutiveParameters);
 
-            rOutput[GPoint].resize(TDim,TDim,false );
+            rOutput[GPoint].resize(cl_dimension,cl_dimension,false );
             rOutput[GPoint] = MathUtils<double>::StressVectorToTensor(StressVector);
         }
     }
@@ -771,30 +761,21 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const 
         const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
         GeometryType::ShapeFunctionsGradientsType DN_DXContainer(NumGPoints);
         Geom.ShapeFunctionsIntegrationPointsGradients(DN_DXContainer,mThisIntegrationMethod);
+        const unsigned int cl_dimension = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->WorkingSpaceDimension();
+        const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
 
-        unsigned int VoigtSize;
-        Vector VoigtVector;
-        if(TDim == 3)
-        {
-            VoigtSize = 6;
-            VoigtVector.resize(VoigtSize);
+        Vector VoigtVector(strain_size);
+        noalias(VoigtVector) = ZeroVector(strain_size);
+        if(cl_dimension == 3) {
             VoigtVector[0] = 1.0;
             VoigtVector[1] = 1.0;
             VoigtVector[2] = 1.0;
-            VoigtVector[3] = 0.0;
-            VoigtVector[4] = 0.0;
-            VoigtVector[5] = 0.0;
-        }
-        else
-        {
-            VoigtSize = 3;
-            VoigtVector.resize(VoigtSize);
+        } else {
             VoigtVector[0] = 1.0;
             VoigtVector[1] = 1.0;
-            VoigtVector[2] = 0.0;
         }
-        Matrix B(VoigtSize,TNumNodes*TDim);
-        noalias(B) = ZeroMatrix(VoigtSize,TNumNodes*TDim);
+        Matrix B(strain_size,TNumNodes*TDim);
+        noalias(B) = ZeroMatrix(strain_size,TNumNodes*TDim);
         array_1d<double,TNumNodes*TDim> DisplacementVector;
         PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
         double Pressure;
@@ -806,9 +787,9 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const 
         const double BiotCoefficient = Prop[BIOT_COEFFICIENT];
 
         //Create constitutive law parameters:
-        Vector StrainVector(VoigtSize);
-        Vector StressVector(VoigtSize);
-        Matrix ConstitutiveMatrix(VoigtSize,VoigtSize);
+        Vector StrainVector(strain_size);
+        Vector StressVector(strain_size);
+        Matrix ConstitutiveMatrix(strain_size,strain_size);
         Vector Np(TNumNodes);
         Matrix GradNpT(TNumNodes,TDim);
         Matrix F = identity_matrix<double>(TDim);
@@ -827,11 +808,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const 
         //Loop over integration points
         for ( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++ )
         {
-            noalias(GradNpT) = DN_DXContainer[GPoint];
-
-            this->CalculateBMatrix(B, GradNpT);
-
-            noalias(StrainVector) = prod(B,DisplacementVector);
+            this->CalculateKinematics(GradNpT,B,StrainVector,DN_DXContainer,DisplacementVector,GPoint);
 
             noalias(Np) = row(NContainer,GPoint);
 
@@ -846,7 +823,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const 
 
             noalias(StressVector) += -BiotCoefficient*Pressure*VoigtVector;
 
-            rOutput[GPoint].resize(TDim,TDim,false );
+            rOutput[GPoint].resize(cl_dimension,cl_dimension,false );
             rOutput[GPoint] = MathUtils<double>::StressVectorToTensor(StressVector);
         }
     }
@@ -857,23 +834,22 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const 
         const unsigned int NumGPoints = Geom.IntegrationPointsNumber( mThisIntegrationMethod );
         GeometryType::ShapeFunctionsGradientsType DN_DXContainer(NumGPoints);
         Geom.ShapeFunctionsIntegrationPointsGradients(DN_DXContainer,mThisIntegrationMethod);
+        const unsigned int cl_dimension = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->WorkingSpaceDimension();
+        const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
 
-        unsigned int VoigtSize = 6;
-        if(TDim == 2) VoigtSize = 3;
-        Matrix B(VoigtSize,TNumNodes*TDim);
-        noalias(B) = ZeroMatrix(VoigtSize,TNumNodes*TDim);
+        Matrix B(strain_size,TNumNodes*TDim);
+        noalias(B) = ZeroMatrix(strain_size,TNumNodes*TDim);
+        Matrix GradNpT(TNumNodes,TDim);
         array_1d<double,TNumNodes*TDim> DisplacementVector;
         PoroElementUtilities::GetNodalVariableVector(DisplacementVector,Geom,DISPLACEMENT);
-        Vector StrainVector(VoigtSize);
+        Vector StrainVector(strain_size);
 
         //Loop over integration points
         for ( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++ )
         {
-            this->CalculateBMatrix(B, DN_DXContainer[GPoint]);
+            this->CalculateKinematics(GradNpT,B,StrainVector,DN_DXContainer,DisplacementVector,GPoint);
 
-            noalias(StrainVector) = prod(B,DisplacementVector);
-
-            rOutput[GPoint].resize(TDim,TDim,false );
+            rOutput[GPoint].resize(cl_dimension,cl_dimension,false );
             rOutput[GPoint] = MathUtils<double>::StrainVectorToTensor(StrainVector);
         }
     }
@@ -881,15 +857,11 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const 
     {
         const unsigned int NumGPoints = this->GetGeometry().IntegrationPointsNumber( mThisIntegrationMethod );
 
-        //If the permeability of the element is a given property
-        BoundedMatrix<double,TDim,TDim> PermeabilityMatrix;
-        PoroElementUtilities::CalculatePermeabilityMatrix(PermeabilityMatrix,this->GetProperties());
-
         //Loop over integration points
         for ( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++ )
         {
             rOutput[GPoint].resize(TDim,TDim,false);
-            noalias(rOutput[GPoint]) = PermeabilityMatrix;
+            noalias(rOutput[GPoint]) = mIntrinsicPermeability;
         }
     } else {
         UPwElement<TDim,TNumNodes>::CalculateOnIntegrationPoints(rVariable,rOutput,rCurrentProcessInfo);
@@ -937,9 +909,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateStiffnessMatrix( MatrixType
     {
         //Compute Np, GradNpT, B and StrainVector
         noalias(Variables.Np) = row(NContainer,GPoint);
-        noalias(Variables.GradNpT) = DN_DXContainer[GPoint];
-        this->CalculateBMatrix(Variables.B, Variables.GradNpT);
-        noalias(Variables.StrainVector) = prod(Variables.B,Variables.DisplacementVector);
+        this->CalculateKinematics(Variables.GradNpT,Variables.B,Variables.StrainVector,DN_DXContainer,Variables.DisplacementVector,GPoint);
 
         //Compute constitutive tensor
         mConstitutiveLawVector[GPoint]->CalculateMaterialResponseCauchy(ConstitutiveParameters);
@@ -987,9 +957,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAll( MatrixType& rLeftHandS
     for( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++)
     {
         //Compute GradNpT, B and StrainVector
-        noalias(Variables.GradNpT) = DN_DXContainer[GPoint];
-        this->CalculateBMatrix(Variables.B, Variables.GradNpT);
-        noalias(Variables.StrainVector) = prod(Variables.B,Variables.DisplacementVector);
+        this->CalculateKinematics(Variables.GradNpT,Variables.B,Variables.StrainVector,DN_DXContainer,Variables.DisplacementVector,GPoint);
 
         //Compute Np, Nu and BodyAcceleration
         noalias(Variables.Np) = row(NContainer,GPoint);
@@ -1044,9 +1012,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateRHS( VectorType& rRightHand
     for( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++)
     {
         //Compute GradNpT, B and StrainVector
-        noalias(Variables.GradNpT) = DN_DXContainer[GPoint];
-        this->CalculateBMatrix(Variables.B, Variables.GradNpT);
-        noalias(Variables.StrainVector) = prod(Variables.B,Variables.DisplacementVector);
+        this->CalculateKinematics(Variables.GradNpT,Variables.B,Variables.StrainVector,DN_DXContainer,Variables.DisplacementVector,GPoint);
 
         //Compute Np, Nu and BodyAcceleration
         noalias(Variables.Np) = row(NContainer,GPoint);
@@ -1082,7 +1048,6 @@ void UPwSmallStrainElement<TDim,TNumNodes>::InitializeElementVariables(ElementVa
     rVariables.Density = Porosity*rVariables.FluidDensity + (1.0-Porosity)*Prop[DENSITY_SOLID];
     rVariables.BiotCoefficient = Prop[BIOT_COEFFICIENT];
     rVariables.BiotModulusInverse = (rVariables.BiotCoefficient-Porosity)/BulkModulusSolid + Porosity/Prop[BULK_MODULUS_FLUID];
-    PoroElementUtilities::CalculatePermeabilityMatrix(rVariables.PermeabilityMatrix,Prop);
 
     //ProcessInfo variables
     rVariables.VelocityCoefficient = CurrentProcessInfo[VELOCITY_COEFFICIENT];
@@ -1099,35 +1064,28 @@ void UPwSmallStrainElement<TDim,TNumNodes>::InitializeElementVariables(ElementVa
     PoroElementUtilities::GetNodalVariableVector(rVariables.VolumeAcceleration,Geom,VOLUME_ACCELERATION);
 
     //General Variables
-    unsigned int VoigtSize;
-    if(TDim == 3)
-    {
-        VoigtSize = 6;
-        rVariables.VoigtVector.resize(VoigtSize);
+    const unsigned int strain_size = Prop.GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
+    const unsigned int cl_dimension = Prop.GetValue( CONSTITUTIVE_LAW )->WorkingSpaceDimension();
+
+    rVariables.VoigtVector.resize(strain_size);
+    noalias(rVariables.VoigtVector) = ZeroVector(strain_size);
+    if(cl_dimension == 3) {
         rVariables.VoigtVector[0] = 1.0;
         rVariables.VoigtVector[1] = 1.0;
         rVariables.VoigtVector[2] = 1.0;
-        rVariables.VoigtVector[3] = 0.0;
-        rVariables.VoigtVector[4] = 0.0;
-        rVariables.VoigtVector[5] = 0.0;
-    }
-    else
-    {
-        VoigtSize = 3;
-        rVariables.VoigtVector.resize(VoigtSize);
+    } else {
         rVariables.VoigtVector[0] = 1.0;
         rVariables.VoigtVector[1] = 1.0;
-        rVariables.VoigtVector[2] = 0.0;
     }
 
     //Variables computed at each GP
-    rVariables.B.resize(VoigtSize,TNumNodes*TDim,false);
-    noalias(rVariables.B) = ZeroMatrix(VoigtSize,TNumNodes*TDim);
+    rVariables.B.resize(strain_size,TNumNodes*TDim,false);
+    noalias(rVariables.B) = ZeroMatrix(strain_size,TNumNodes*TDim);
     noalias(rVariables.Nu) = ZeroMatrix(TDim, TNumNodes*TDim);
     //Constitutive Law parameters
-    rVariables.StrainVector.resize(VoigtSize,false);
-    rVariables.StressVector.resize(VoigtSize,false);
-    rVariables.ConstitutiveMatrix.resize(VoigtSize,VoigtSize,false);
+    rVariables.StrainVector.resize(strain_size,false);
+    rVariables.StressVector.resize(strain_size,false);
+    rVariables.ConstitutiveMatrix.resize(strain_size,strain_size,false);
     rVariables.Np.resize(TNumNodes,false);
     rVariables.GradNpT.resize(TNumNodes,TDim,false);
     rVariables.F.resize(TDim,TDim,false);
@@ -1140,11 +1098,51 @@ void UPwSmallStrainElement<TDim,TNumNodes>::InitializeElementVariables(ElementVa
     rConstitutiveParameters.SetDeformationGradientF(rVariables.F);
     rConstitutiveParameters.SetDeterminantF(rVariables.detF);
     //Auxiliary variables
-    rVariables.UVoigtMatrix.resize(TNumNodes*TDim,VoigtSize,false);
+    rVariables.UVoigtMatrix.resize(TNumNodes*TDim,strain_size,false);
 
     KRATOS_CATCH( "" )
 }
 
+//----------------------------------------------------------------------------------------
+
+template< unsigned int TDim, unsigned int TNumNodes >
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateKinematics(Matrix& rGradNpT,
+                                        Matrix& rB,
+                                        Vector& rStrainVector,
+                                        const GeometryType::ShapeFunctionsGradientsType& DN_DXContainer,
+                                        const array_1d<double,TNumNodes*TDim>& DisplacementVector,
+                                        const unsigned int& GPoint)
+{
+    KRATOS_TRY
+
+    noalias(rGradNpT) = DN_DXContainer[GPoint];
+    this->CalculateBMatrix(rB, rGradNpT);
+    noalias(rStrainVector) = prod(rB,DisplacementVector);
+
+    // 2.5D element (2D Geometry with 3D ConstitutiveLaw)
+    const unsigned int cl_dimension = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->WorkingSpaceDimension();
+    if (cl_dimension > TDim) {
+
+        // StrainVector must have the shape of a 3D element
+        rStrainVector[3] = rStrainVector[2];
+        rStrainVector[2] = mImposedZStrainVector[GPoint];
+
+        unsigned int index;
+        // B matrix must have the shape of a 3D element
+        for ( unsigned int i = 0; i < TNumNodes; i++ )
+        {
+            index = 2 * i;
+
+            rB( 3, index + 0 ) = rB( 2, index + 0 );
+            rB( 3, index + 1 ) = rB( 2, index + 1 );
+            rB( 2, index + 0 ) = 0.0;
+            rB( 2, index + 1 ) = 0.0;
+        }
+    }
+    
+    KRATOS_CATCH( "" )
+
+}
 //----------------------------------------------------------------------------------------
 
 template< >
@@ -1283,9 +1281,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateFluxResidual( VectorType& r
     for( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++)
     {
         //Compute GradNpT, B and StrainVector
-        noalias(Variables.GradNpT) = DN_DXContainer[GPoint];
-        this->CalculateBMatrix(Variables.B, Variables.GradNpT);
-        noalias(Variables.StrainVector) = prod(Variables.B,Variables.DisplacementVector);
+        this->CalculateKinematics(Variables.GradNpT,Variables.B,Variables.StrainVector,DN_DXContainer,Variables.DisplacementVector,GPoint);
 
         //Compute Np, Nu and BodyAcceleration
         noalias(Variables.Np) = row(NContainer,GPoint);
@@ -1346,9 +1342,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateMixBodyForce( VectorType& r
     for( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++)
     {
         //Compute GradNpT, B and StrainVector
-        noalias(Variables.GradNpT) = DN_DXContainer[GPoint];
-        this->CalculateBMatrix(Variables.B, Variables.GradNpT);
-        noalias(Variables.StrainVector) = prod(Variables.B,Variables.DisplacementVector);
+        this->CalculateKinematics(Variables.GradNpT,Variables.B,Variables.StrainVector,DN_DXContainer,Variables.DisplacementVector,GPoint);
 
         //Compute Np, Nu and BodyAcceleration
         noalias(Variables.Np) = row(NContainer,GPoint);
@@ -1407,9 +1401,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateNegInternalForce( VectorTyp
     for( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++)
     {
         //Compute GradNpT, B and StrainVector
-        noalias(Variables.GradNpT) = DN_DXContainer[GPoint];
-        this->CalculateBMatrix(Variables.B, Variables.GradNpT);
-        noalias(Variables.StrainVector) = prod(Variables.B,Variables.DisplacementVector);
+        this->CalculateKinematics(Variables.GradNpT,Variables.B,Variables.StrainVector,DN_DXContainer,Variables.DisplacementVector,GPoint);
 
         //Compute Np, Nu and BodyAcceleration
         noalias(Variables.Np) = row(NContainer,GPoint);
@@ -1474,9 +1466,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateExplicitContributions (Vect
     for( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++)
     {
         //Compute GradNpT, B and StrainVector
-        noalias(Variables.GradNpT) = DN_DXContainer[GPoint];
-        this->CalculateBMatrix(Variables.B, Variables.GradNpT);
-        noalias(Variables.StrainVector) = prod(Variables.B,Variables.DisplacementVector);
+        this->CalculateKinematics(Variables.GradNpT,Variables.B,Variables.StrainVector,DN_DXContainer,Variables.DisplacementVector,GPoint);
 
         //Compute Np, Nu and BodyAcceleration
         noalias(Variables.Np) = row(NContainer,GPoint);
@@ -1563,7 +1553,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddCompressibilityMatrix
 template< unsigned int TDim, unsigned int TNumNodes >
 void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddPermeabilityMatrix(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables)
 {
-    noalias(rVariables.PDimMatrix) = prod(rVariables.GradNpT,rVariables.PermeabilityMatrix);
+    noalias(rVariables.PDimMatrix) = prod(rVariables.GradNpT,mIntrinsicPermeability);
 
     noalias(rVariables.PMatrix) = rVariables.DynamicViscosityInverse*prod(rVariables.PDimMatrix,trans(rVariables.GradNpT))*rVariables.IntegrationCoefficient;
 
@@ -1650,7 +1640,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddCompressibilityFlow(V
 template< unsigned int TDim, unsigned int TNumNodes >
 void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddPermeabilityFlow(VectorType& rRightHandSideVector, ElementVariables& rVariables)
 {
-    noalias(rVariables.PDimMatrix) = prod(rVariables.GradNpT,rVariables.PermeabilityMatrix);
+    noalias(rVariables.PDimMatrix) = prod(rVariables.GradNpT,mIntrinsicPermeability);
 
     noalias(rVariables.PMatrix) = rVariables.DynamicViscosityInverse*prod(rVariables.PDimMatrix,trans(rVariables.GradNpT))*rVariables.IntegrationCoefficient;
 
@@ -1665,7 +1655,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddPermeabilityFlow(Vect
 template< unsigned int TDim, unsigned int TNumNodes >
 void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddFluidBodyFlow(VectorType& rRightHandSideVector, ElementVariables& rVariables)
 {
-    noalias(rVariables.PDimMatrix) = prod(rVariables.GradNpT,rVariables.PermeabilityMatrix)*rVariables.IntegrationCoefficient;
+    noalias(rVariables.PDimMatrix) = prod(rVariables.GradNpT,mIntrinsicPermeability)*rVariables.IntegrationCoefficient;
 
     noalias(rVariables.PVector) = rVariables.DynamicViscosityInverse*rVariables.FluidDensity*
                                     prod(rVariables.PDimMatrix,rVariables.BodyAcceleration);

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -325,7 +325,7 @@ void UPwSmallStrainElement<2,3>::ExtrapolateGPValues(const Matrix& GradPressureC
         * GradPY-2 = GradPY at node 2
     */
 
-    BoundedMatrix<double,3,3> AuxNodalStress;
+    Matrix AuxNodalStress(3,VoigtSize);
     noalias(AuxNodalStress) = prod(ExtrapolationMatrix,StressContainer);
 
     /* INFO:
@@ -352,7 +352,7 @@ void UPwSmallStrainElement<2,3>::ExtrapolateGPValues(const Matrix& GradPressureC
         {
             r_nodal_grad_pressure[j] += NodalGradPressure[i][j];
         }
-        Matrix& rNodalStress = itNode->FastGetSolutionStepValue(NODAL_EFFECTIVE_STRESS_TENSOR);
+        Matrix& rNodalStress = rGeom[i].FastGetSolutionStepValue(NODAL_EFFECTIVE_STRESS_TENSOR);
         for(unsigned int j = 0; j < cl_dimension; j++){
             for(unsigned int k = 0; k < cl_dimension; k++){
                 rNodalStress(j,k) += NodalStressTensor[i](j,k);
@@ -402,7 +402,7 @@ void UPwSmallStrainElement<2,4>::ExtrapolateGPValues(const Matrix& GradPressureC
     BoundedMatrix<double,4,2> AuxNodalGradPressure;
     noalias(AuxNodalGradPressure) = prod(ExtrapolationMatrix,GradPressureContainer);
 
-    BoundedMatrix<double,4,3> AuxNodalStress;
+    Matrix AuxNodalStress(4,VoigtSize);
     noalias(AuxNodalStress) = prod(ExtrapolationMatrix,StressContainer);
 
     /* INFO:
@@ -430,7 +430,7 @@ void UPwSmallStrainElement<2,4>::ExtrapolateGPValues(const Matrix& GradPressureC
         {
             r_nodal_grad_pressure[j] += NodalGradPressure[i][j];
         }
-        Matrix& rNodalStress = itNode->FastGetSolutionStepValue(NODAL_EFFECTIVE_STRESS_TENSOR);
+        Matrix& rNodalStress = rGeom[i].FastGetSolutionStepValue(NODAL_EFFECTIVE_STRESS_TENSOR);
         for(unsigned int j = 0; j < cl_dimension; j++){
             for(unsigned int k = 0; k < cl_dimension; k++){
                 rNodalStress(j,k) += NodalStressTensor[i](j,k);

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -96,7 +96,6 @@ protected:
         double Density;
         double BiotCoefficient;
         double BiotModulusInverse;
-        BoundedMatrix<double,TDim, TDim> PermeabilityMatrix;
 
         ///ProcessInfo variables
         double VelocityCoefficient;
@@ -159,6 +158,12 @@ protected:
 
     void CalculateBMatrix(Matrix& rB, const Matrix& GradNpT);
 
+    void CalculateKinematics(Matrix& rGradNpT,
+                                Matrix& rB,
+                                Vector& rStrainVector,
+                                const GeometryType::ShapeFunctionsGradientsType& DN_DXContainer,
+                                const array_1d<double,TNumNodes*TDim>& DisplacementVector,
+                                const unsigned int& GPoint);
 
     void CalculateAndAddLHS(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables);
 

--- a/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -878,7 +878,7 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints( const Variabl
 
         double Pressure;
         const SizeType NumPNodes = mpPressureGeometry->PointsNumber();
-        array_1d<double,NumPNodes> PressureVector;
+        Vector PressureVector(NumPNodes);
         for(SizeType i=0; i<NumPNodes; i++)
         {
             PressureVector[i] = rGeom[i].FastGetSolutionStepValue(WATER_PRESSURE);
@@ -908,7 +908,7 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints( const Variabl
                 Pressure += NpContainer(PointNumber,i)*PressureVector[i];
             }
 
-            noalias(StressVector) += -BiotCoefficient*Pressure*VoigtVector;
+            noalias(StressVector[PointNumber]) += -BiotCoefficient*Pressure*VoigtVector;
 
             if ( rOutput[PointNumber].size2() != cl_dimension )
                 rOutput[PointNumber].resize( cl_dimension, cl_dimension, false );

--- a/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -143,18 +143,25 @@ void SmallStrainUPwDiffOrderElement::Initialize(const ProcessInfo& rCurrentProce
 {
     KRATOS_TRY
 
+    const PropertiesType& Prop = this->GetProperties();
     const GeometryType& rGeom = GetGeometry();
-	const GeometryType::IntegrationPointsArrayType& integration_points = rGeom.IntegrationPoints( mThisIntegrationMethod );
+    const unsigned int NumGPoints = rGeom.IntegrationPointsNumber( mThisIntegrationMethod );
 
-    if ( mConstitutiveLawVector.size() != integration_points.size() )
-        mConstitutiveLawVector.resize( integration_points.size() );
+    if ( mConstitutiveLawVector.size() != NumGPoints )
+        mConstitutiveLawVector.resize( NumGPoints );
+    
+    //Imposed Z strain vector initialisation
+    if ( mImposedZStrainVector.size() != NumGPoints )
+        mImposedZStrainVector.resize( NumGPoints );
 
-    if ( GetProperties()[CONSTITUTIVE_LAW] != NULL )
+    if (Prop[CONSTITUTIVE_LAW] != NULL )
     {
         for ( unsigned int i = 0; i < mConstitutiveLawVector.size(); i++ )
         {
-            mConstitutiveLawVector[i] = GetProperties()[CONSTITUTIVE_LAW]->Clone();
-            mConstitutiveLawVector[i]->InitializeMaterial( GetProperties(), rGeom,row( rGeom.ShapeFunctionsValues( mThisIntegrationMethod ), i ) );
+            mConstitutiveLawVector[i] =Prop[CONSTITUTIVE_LAW]->Clone();
+            mConstitutiveLawVector[i]->InitializeMaterial( Prop, rGeom,row( rGeom.ShapeFunctionsValues( mThisIntegrationMethod ), i ) );
+            
+            mImposedZStrainVector[i] = 0.0;
         }
     }
     else
@@ -187,6 +194,11 @@ void SmallStrainUPwDiffOrderElement::Initialize(const ProcessInfo& rCurrentProce
             KRATOS_THROW_ERROR(std::logic_error,"Unexpected geometry type for different order interpolation element","");
             break;
     }
+
+    // Initializing the intrinsic permeability matrix from the properties
+    const SizeType Dim = rGeom.WorkingSpaceDimension();
+    
+    PoroElementUtilities::CalculatePermeabilityMatrix(mIntrinsicPermeability,Prop,Dim);
 
     KRATOS_CATCH( "" )
 }
@@ -599,8 +611,15 @@ void SmallStrainUPwDiffOrderElement::FinalizeSolutionStep( const ProcessInfo& rC
 
 void SmallStrainUPwDiffOrderElement::SetValuesOnIntegrationPoints( const Variable<double>& rVariable,const std::vector<double>& rValues,const ProcessInfo& rCurrentProcessInfo )
 {
-    for ( unsigned int PointNumber = 0; PointNumber < mConstitutiveLawVector.size(); PointNumber++ )
-        mConstitutiveLawVector[PointNumber]->SetValue( rVariable, rValues[PointNumber], rCurrentProcessInfo );
+    if (rVariable == IMPOSED_Z_STRAIN_VALUE) {
+        for ( IndexType PointNumber = 0; PointNumber < mImposedZStrainVector.size(); ++PointNumber ) {
+            mImposedZStrainVector[PointNumber] = rValues[PointNumber];
+        }
+
+    } else {
+        for ( unsigned int PointNumber = 0; PointNumber < mConstitutiveLawVector.size(); ++PointNumber )
+            mConstitutiveLawVector[PointNumber]->SetValue( rVariable, rValues[PointNumber], rCurrentProcessInfo );
+    }
 }
 
 //----------------------------------------------------------------------------------------
@@ -615,8 +634,14 @@ void SmallStrainUPwDiffOrderElement::SetValuesOnIntegrationPoints( const Variabl
 
 void SmallStrainUPwDiffOrderElement::SetValuesOnIntegrationPoints( const Variable<Matrix>& rVariable,const std::vector<Matrix>& rValues,const ProcessInfo& rCurrentProcessInfo )
 {
-    for ( unsigned int PointNumber = 0; PointNumber < mConstitutiveLawVector.size(); PointNumber++ )
-        mConstitutiveLawVector[PointNumber]->SetValue( rVariable, rValues[PointNumber], rCurrentProcessInfo );
+    if (rVariable == PERMEABILITY_MATRIX) {
+        // Permeability is set only on the element, not on every GP
+        noalias(mIntrinsicPermeability) = rValues[0];
+
+    } else {
+        for ( unsigned int PointNumber = 0; PointNumber < mConstitutiveLawVector.size(); PointNumber++ )
+            mConstitutiveLawVector[PointNumber]->SetValue( rVariable, rValues[PointNumber], rCurrentProcessInfo );
+    }
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -631,8 +656,7 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints( const Variabl
     if ( rOutput.size() != integration_points_number )
         rOutput.resize( integration_points_number, false );
 
-    if ( rVariable == VON_MISES_STRESS )
-    {
+    if ( rVariable == VON_MISES_STRESS ) {
         //Definition of variables
         ElementalVariables Variables;
         this->InitializeElementalVariables(Variables, rCurrentProcessInfo);
@@ -656,11 +680,11 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints( const Variabl
 
             rOutput[PointNumber] =  ElementUtilities::CalculateVonMises(Variables.StressVector);
         }
-    }
-    else
-    {
-        for ( unsigned int i = 0; i < integration_points_number; i++ )
+    } else {
+        for ( unsigned int i = 0; i < integration_points_number; i++ ) {
+            rOutput[i] = 0.0;
             rOutput[i] = mConstitutiveLawVector[i]->GetValue( rVariable, rOutput[i] );
+        }
     }
 
     KRATOS_CATCH( "" )
@@ -722,8 +746,13 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints( const Variabl
             rOutput[PointNumber] = Variables.StrainVector;
         }
     } else {
-        for ( unsigned int i = 0; i < mConstitutiveLawVector.size(); i++ )
+        const unsigned int dimension = rGeom.WorkingSpaceDimension();
+        for ( unsigned int i = 0; i < mConstitutiveLawVector.size(); i++ ) {
+            if ( rOutput[i].size() != dimension )
+                rOutput[i].resize( dimension, false );
+            noalias(rOutput[i]) = ZeroVector(dimension);
             rOutput[i] = mConstitutiveLawVector[i]->GetValue( rVariable , rOutput[i] );
+        }
     }
 
     KRATOS_CATCH( "" )
@@ -770,7 +799,7 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints(const Variable
             noalias(GradPressureTerm) -= GetProperties()[DENSITY_WATER]*BodyAcceleration;
 
             Vector AuxFluidFlux = ZeroVector(Dim);
-            AuxFluidFlux = - 1.0/Variables.DynamicViscosity * prod(Variables.IntrinsicPermeability, GradPressureTerm );
+            AuxFluidFlux = - 1.0/Variables.DynamicViscosity * prod(mIntrinsicPermeability, GradPressureTerm );
 
             array_1d<double,3> FluidFlux = ZeroVector(3);
             FluidFlux[0] = AuxFluidFlux[0];
@@ -805,6 +834,12 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints(const Variable
 
             rOutput[PointNumber] = GradPressureVector;
         }
+    } else {
+        for ( unsigned int i = 0;  i < mConstitutiveLawVector.size(); i++ )
+        {
+            noalias(rOutput[i]) = ZeroVector(3);
+            rOutput[i] = mConstitutiveLawVector[i]->GetValue( rVariable, rOutput[i] );
+        }
     }
 
     KRATOS_CATCH( "" )
@@ -819,12 +854,12 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints( const Variabl
     const GeometryType& rGeom = GetGeometry();
     const unsigned int& integration_points_number = rGeom.IntegrationPointsNumber( mThisIntegrationMethod );
     const unsigned int dimension       = rGeom.WorkingSpaceDimension();
+    const unsigned int cl_dimension = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->WorkingSpaceDimension();
 
     if ( rOutput.size() != integration_points_number )
         rOutput.resize( integration_points_number );
 
-    if ( rVariable == EFFECTIVE_STRESS_TENSOR )
-    {
+    if ( rVariable == EFFECTIVE_STRESS_TENSOR ) {
         std::vector<Vector> StressVector;
 
         this->CalculateOnIntegrationPoints( CAUCHY_STRESS_VECTOR, StressVector, rCurrentProcessInfo );
@@ -832,14 +867,55 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints( const Variabl
         //loop integration points
         for ( unsigned int PointNumber = 0; PointNumber < mConstitutiveLawVector.size(); PointNumber++ )
         {
-            if ( rOutput[PointNumber].size2() != dimension )
-                rOutput[PointNumber].resize( dimension, dimension, false );
+            if ( rOutput[PointNumber].size2() != cl_dimension )
+                rOutput[PointNumber].resize( cl_dimension, cl_dimension, false );
 
-            rOutput[PointNumber] = MathUtils<double>::StressVectorToTensor(StressVector[PointNumber]);
+            noalias(rOutput[PointNumber]) = MathUtils<double>::StressVectorToTensor(StressVector[PointNumber]);
         }
-    }
-    else if ( rVariable == GREEN_LAGRANGE_STRAIN_TENSOR )
-    {
+    } else if ( rVariable == TOTAL_STRESS_TENSOR ) {
+        std::vector<Vector> StressVector;
+        this->CalculateOnIntegrationPoints( CAUCHY_STRESS_VECTOR, StressVector, rCurrentProcessInfo );
+
+        double Pressure;
+        const SizeType NumPNodes = mpPressureGeometry->PointsNumber();
+        array_1d<double,NumPNodes> PressureVector;
+        for(SizeType i=0; i<NumPNodes; i++)
+        {
+            PressureVector[i] = rGeom[i].FastGetSolutionStepValue(WATER_PRESSURE);
+        }
+        const double BiotCoefficient = this->GetProperties()[BIOT_COEFFICIENT];
+        Matrix NpContainer(integration_points_number,NumPNodes);
+        noalias(NpContainer) = mpPressureGeometry->ShapeFunctionsValues( mThisIntegrationMethod );
+
+        const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
+        Vector VoigtVector(strain_size);
+        noalias(VoigtVector) = ZeroVector(strain_size);
+        if(cl_dimension == 3) {
+            VoigtVector[0] = 1.0;
+            VoigtVector[1] = 1.0;
+            VoigtVector[2] = 1.0;
+        } else {
+            VoigtVector[0] = 1.0;
+            VoigtVector[1] = 1.0;
+        }
+
+        //loop integration points
+        for ( unsigned int PointNumber = 0; PointNumber < mConstitutiveLawVector.size(); PointNumber++ )
+        {
+            Pressure = 0.0;
+            for(unsigned int i = 0; i < NumPNodes; i++)
+            {
+                Pressure += NpContainer(PointNumber,i)*PressureVector[i];
+            }
+
+            noalias(StressVector) += -BiotCoefficient*Pressure*VoigtVector;
+
+            if ( rOutput[PointNumber].size2() != cl_dimension )
+                rOutput[PointNumber].resize( cl_dimension, cl_dimension, false );
+
+            noalias(rOutput[PointNumber]) = MathUtils<double>::StressVectorToTensor(StressVector[PointNumber]);
+        }
+    } else if ( rVariable == GREEN_LAGRANGE_STRAIN_TENSOR ) {
         std::vector<Vector> StrainVector;
 
         CalculateOnIntegrationPoints( GREEN_LAGRANGE_STRAIN_VECTOR, StrainVector, rCurrentProcessInfo );
@@ -847,16 +923,27 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints( const Variabl
         //loop integration points
         for ( unsigned int PointNumber = 0; PointNumber < mConstitutiveLawVector.size(); PointNumber++ )
         {
+            if ( rOutput[PointNumber].size2() != cl_dimension )
+                rOutput[PointNumber].resize( cl_dimension, cl_dimension, false );
+
+            noalias(rOutput[PointNumber]) = MathUtils<double>::StrainVectorToTensor(StrainVector[PointNumber]);
+        }
+    } else if(rVariable == PERMEABILITY_MATRIX) {
+        //loop integration points
+        for ( unsigned int PointNumber = 0; PointNumber < mConstitutiveLawVector.size(); PointNumber++ )
+        {
             if ( rOutput[PointNumber].size2() != dimension )
                 rOutput[PointNumber].resize( dimension, dimension, false );
 
-            rOutput[PointNumber] = MathUtils<double>::StrainVectorToTensor(StrainVector[PointNumber]);
+            noalias(rOutput[PointNumber]) = mIntrinsicPermeability;
         }
-    }
-    else
-    {
-        for ( unsigned int i = 0; i < mConstitutiveLawVector.size(); i++ )
+    } else {
+        for ( unsigned int i = 0; i < mConstitutiveLawVector.size(); i++ ){
+            if ( rOutput[i].size2() != dimension )
+                rOutput[i].resize( dimension, dimension, false );
+            noalias(rOutput[i]) = ZeroMatrix(dimension, dimension);
             rOutput[i] = mConstitutiveLawVector[i]->GetValue( rVariable , rOutput[i] );
+        }
     }
 
     KRATOS_CATCH( "" )
@@ -935,6 +1022,7 @@ void SmallStrainUPwDiffOrderElement::InitializeElementalVariables (ElementalVari
     const SizeType NumPNodes = mpPressureGeometry->PointsNumber();
     const SizeType NumGPoints = rGeom.IntegrationPointsNumber( mThisIntegrationMethod );
     const SizeType Dim = rGeom.WorkingSpaceDimension();
+    const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
 
     //Variables at all integration points
     (rVariables.NuContainer).resize(NumGPoints,NumUNodes,false);
@@ -961,13 +1049,11 @@ void SmallStrainUPwDiffOrderElement::InitializeElementalVariables (ElementalVari
     mpPressureGeometry->ShapeFunctionsIntegrationPointsGradients(rVariables.DNp_DXContainer,detJpContainer,mThisIntegrationMethod);
 
     //Variables computed at each integration point
-    unsigned int voigtsize  = 3;
-    if( Dim == 3 ) voigtsize  = 6;
-    (rVariables.B).resize(voigtsize, NumUNodes * Dim, false);
-    noalias(rVariables.B) = ZeroMatrix( voigtsize, NumUNodes * Dim );
-    (rVariables.StrainVector).resize(voigtsize,false);
-    (rVariables.ConstitutiveMatrix).resize(voigtsize, voigtsize, false);
-    (rVariables.StressVector).resize(voigtsize,false);
+    (rVariables.B).resize(strain_size, NumUNodes * Dim, false);
+    noalias(rVariables.B) = ZeroMatrix( strain_size, NumUNodes * Dim );
+    (rVariables.StrainVector).resize(strain_size,false);
+    (rVariables.ConstitutiveMatrix).resize(strain_size, strain_size, false);
+    (rVariables.StressVector).resize(strain_size,false);
 
     //Needed parameters for consistency with the general constitutive law
     rVariables.detF  = 1.0;
@@ -1040,20 +1126,6 @@ void SmallStrainUPwDiffOrderElement::InitializeProperties (ElementalVariables& r
     double Porosity = GetProperties()[POROSITY];
     rVariables.BiotModulusInverse = (rVariables.BiotCoefficient-Porosity)/BulkModulusSolid + Porosity/GetProperties()[BULK_MODULUS_FLUID];
     rVariables.DynamicViscosity = GetProperties()[DYNAMIC_VISCOSITY];
-    //Setting the intrinsic permeability matrix
-    (rVariables.IntrinsicPermeability).resize(dimension,dimension,false);
-    rVariables.IntrinsicPermeability(0,0) = GetProperties()[PERMEABILITY_XX];
-    rVariables.IntrinsicPermeability(1,1) = GetProperties()[PERMEABILITY_YY];
-    rVariables.IntrinsicPermeability(0,1) = GetProperties()[PERMEABILITY_XY];
-    rVariables.IntrinsicPermeability(1,0) = rVariables.IntrinsicPermeability(0,1);
-    if(dimension==3)
-    {
-        rVariables.IntrinsicPermeability(2,2) = GetProperties()[PERMEABILITY_ZZ];
-        rVariables.IntrinsicPermeability(2,0) = GetProperties()[PERMEABILITY_ZX];
-        rVariables.IntrinsicPermeability(1,2) = GetProperties()[PERMEABILITY_YZ];
-        rVariables.IntrinsicPermeability(0,2) = rVariables.IntrinsicPermeability(2,0);
-        rVariables.IntrinsicPermeability(2,1) = rVariables.IntrinsicPermeability(1,2);
-    }
 }
 
 //----------------------------------------------------------------------------------------
@@ -1109,6 +1181,26 @@ void SmallStrainUPwDiffOrderElement::CalculateKinematics(ElementalVariables& rVa
 
     //Compute infinitessimal strain
     rVariables.StrainVector = prod(rVariables.B,rVariables.DisplacementVector);
+
+    const unsigned int cl_dimension = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->WorkingSpaceDimension();
+    // 2.5D element (2D Geometry with 3D ConstitutiveLaw)
+    if (cl_dimension > Dim) {
+
+        // StrainVector must have the shape of a 3D element
+        rVariables.StrainVector[3] = rVariables.StrainVector[2];
+        rVariables.StrainVector[2] = mImposedZStrainVector[PointNumber];
+
+        // B matrix must have the shape of a 3D element
+        for ( SizeType i = 0; i < NumUNodes; i++ )
+        {
+            node = 2 * i;
+
+            rVariables.B( 3, node + 0 ) = rVariables.B( 2, node + 0 );
+            rVariables.B( 3, node + 1 ) = rVariables.B( 2, node + 1 );
+            rVariables.B( 2, node + 0 ) = 0.0;
+            rVariables.B( 2, node + 1 ) = 0.0;
+        }
+    }
 
     KRATOS_CATCH( "" )
 }
@@ -1198,13 +1290,13 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddCouplingMatrix(MatrixType& r
 {
     const GeometryType& rGeom = GetGeometry();
     const SizeType Dim = rGeom.WorkingSpaceDimension();
-    unsigned int voigtsize  = 3;
-    if( Dim == 3 ) voigtsize  = 6;
+    const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
+    const unsigned int cl_dimension = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->WorkingSpaceDimension();
 
-    Vector VoigtVector = ZeroVector(voigtsize);
+    Vector VoigtVector = ZeroVector(strain_size);
     VoigtVector[0] = 1.0;
     VoigtVector[1] = 1.0;
-    if(Dim == 3) VoigtVector[2] = 1.0;
+    if(cl_dimension == 3) VoigtVector[2] = 1.0;
 
     Matrix CouplingMatrix = rVariables.BiotCoefficient*prod(trans(rVariables.B),Matrix(outer_prod(VoigtVector,rVariables.Np)))*rVariables.IntegrationCoefficient;
 
@@ -1270,7 +1362,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddCompressibilityMatrix(Matrix
 void SmallStrainUPwDiffOrderElement::CalculateAndAddPermeabilityMatrix(MatrixType& rLeftHandSideMatrix, ElementalVariables& rVariables)
 {
     Matrix PermeabilityMatrix = 1.0/rVariables.DynamicViscosity*
-                                prod(rVariables.GradNpT,Matrix(prod(rVariables.IntrinsicPermeability,trans(rVariables.GradNpT))))*
+                                prod(rVariables.GradNpT,Matrix(prod(mIntrinsicPermeability,trans(rVariables.GradNpT))))*
                                 rVariables.IntegrationCoefficient;
 
     //Distribute permeability block matrix into the elemental matrix
@@ -1368,13 +1460,13 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddCouplingTerms(VectorType& rR
 {
     const GeometryType& rGeom = GetGeometry();
     const SizeType Dim = rGeom.WorkingSpaceDimension();
-    unsigned int voigtsize  = 3;
-    if( Dim == 3 ) voigtsize  = 6;
+    const unsigned int strain_size = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
+    const unsigned int cl_dimension = this->GetProperties().GetValue( CONSTITUTIVE_LAW )->WorkingSpaceDimension();
 
-    Vector VoigtVector = ZeroVector(voigtsize);
+    Vector VoigtVector = ZeroVector(strain_size);
     VoigtVector[0] = 1.0;
     VoigtVector[1] = 1.0;
-    if(Dim == 3) VoigtVector[2] = 1.0;
+    if(cl_dimension == 3) VoigtVector[2] = 1.0;
 
     Matrix CouplingMatrix = rVariables.BiotCoefficient*prod(trans(rVariables.B),Matrix(outer_prod(VoigtVector,rVariables.Np)))*rVariables.IntegrationCoefficient;
 
@@ -1430,7 +1522,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddCompressibilityFlow(VectorTy
 
 void SmallStrainUPwDiffOrderElement::CalculateAndAddPermeabilityFlow(VectorType& rRightHandSideVector, ElementalVariables& rVariables)
 {
-    Matrix PermeabilityMatrix = 1.0/rVariables.DynamicViscosity*prod(rVariables.GradNpT,Matrix(prod(rVariables.IntrinsicPermeability,trans(rVariables.GradNpT))))*rVariables.IntegrationCoefficient;
+    Matrix PermeabilityMatrix = 1.0/rVariables.DynamicViscosity*prod(rVariables.GradNpT,Matrix(prod(mIntrinsicPermeability,trans(rVariables.GradNpT))))*rVariables.IntegrationCoefficient;
 
     Vector PermeabilityFlow = prod(PermeabilityMatrix,rVariables.PressureVector);
 
@@ -1451,7 +1543,7 @@ void SmallStrainUPwDiffOrderElement::CalculateAndAddPermeabilityFlow(VectorType&
 void SmallStrainUPwDiffOrderElement::CalculateAndAddFluidBodyFlow(VectorType& rRightHandSideVector, ElementalVariables& rVariables)
 {
     Matrix GradNpTPerm = 1.0/rVariables.DynamicViscosity*GetProperties()[DENSITY_WATER]*
-                         prod(rVariables.GradNpT,rVariables.IntrinsicPermeability)*rVariables.IntegrationCoefficient;
+                         prod(rVariables.GradNpT,mIntrinsicPermeability)*rVariables.IntegrationCoefficient;
 
     const GeometryType& rGeom = GetGeometry();
     const SizeType Dim = rGeom.WorkingSpaceDimension();

--- a/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -25,6 +25,7 @@
 
 // Application includes
 #include "custom_utilities/element_utilities.hpp"
+#include "custom_utilities/poro_element_utilities.hpp"
 #include "poromechanics_application_variables.h"
 
 namespace Kratos
@@ -136,7 +137,6 @@ protected:
         double BiotCoefficient;
         double BiotModulusInverse;
         double DynamicViscosity;
-        Matrix IntrinsicPermeability;
         double NewmarkCoefficient1;
         double NewmarkCoefficient2;
     };
@@ -148,6 +148,10 @@ protected:
     std::vector<ConstitutiveLaw::Pointer> mConstitutiveLawVector;
 
     Geometry< Node<3> >::Pointer mpPressureGeometry;
+
+    Matrix mIntrinsicPermeability;
+    
+    std::vector<double> mImposedZStrainVector; /// The vector containing the imposed z strains (for 2.5D element: 2D geom with 3D CL)
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/PoromechanicsApplication/custom_processes/periodic_interface_process.hpp
+++ b/applications/PoromechanicsApplication/custom_processes/periodic_interface_process.hpp
@@ -116,7 +116,7 @@ public:
             ModelPart::ConditionsContainerType::iterator itCond = con_begin + i;
             Condition::GeometryType& rGeom = itCond->GetGeometry();
 
-            Matrix NodalStressMatrix(mDimension,mDimension);
+            Matrix NodalStressMatrix(3,3);
             noalias(NodalStressMatrix) = 0.5 * ( rGeom[0].FastGetSolutionStepValue(NODAL_EFFECTIVE_STRESS_TENSOR)
                                                 + rGeom[1].FastGetSolutionStepValue(NODAL_EFFECTIVE_STRESS_TENSOR) );
             Vector PrincipalStresses(mDimension);

--- a/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_quasistatic_U_Pw_scheme.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_quasistatic_U_Pw_scheme.hpp
@@ -128,6 +128,21 @@ public:
         r_model_part.GetProcessInfo().SetValue(VELOCITY_COEFFICIENT,mGamma/(mBeta*mDeltaTime));
         r_model_part.GetProcessInfo().SetValue(DT_PRESSURE_COEFFICIENT,1.0/(mTheta*mDeltaTime));
 
+        const int NNodes = static_cast<int>(r_model_part.Nodes().size());
+        ModelPart::NodesContainerType::iterator node_begin = r_model_part.NodesBegin();
+
+        // Initialize INITIAL_STRESS_TENSOR
+        #pragma omp parallel for
+        for(int i = 0; i < NNodes; i++)
+        {
+            ModelPart::NodesContainerType::iterator itNode = node_begin + i;
+
+            Matrix& rInitialStress = itNode->FastGetSolutionStepValue(INITIAL_STRESS_TENSOR);
+            if(rInitialStress.size1() != 3)
+                rInitialStress.resize(3,3,false);
+            noalias(rInitialStress) = ZeroMatrix(3,3);
+        }
+
         BaseType::mSchemeIsInitialized = true;
 
         KRATOS_CATCH("")

--- a/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_quasistatic_U_Pw_scheme.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_quasistatic_U_Pw_scheme.hpp
@@ -266,8 +266,6 @@ public:
 
         if(rModelPart.GetProcessInfo()[NODAL_SMOOTHING] == true)
         {
-            unsigned int Dim = rModelPart.GetProcessInfo()[DOMAIN_SIZE];
-
             const int NNodes = static_cast<int>(rModelPart.Nodes().size());
             ModelPart::NodesContainerType::iterator node_begin = rModelPart.NodesBegin();
 
@@ -279,9 +277,9 @@ public:
 
                 itNode->FastGetSolutionStepValue(NODAL_AREA) = 0.0;
                 Matrix& rNodalStress = itNode->FastGetSolutionStepValue(NODAL_EFFECTIVE_STRESS_TENSOR);
-                if(rNodalStress.size1() != Dim)
-                    rNodalStress.resize(Dim,Dim,false);
-                noalias(rNodalStress) = ZeroMatrix(Dim,Dim);
+                if(rNodalStress.size1() != 3)
+                    rNodalStress.resize(3,3,false);
+                noalias(rNodalStress) = ZeroMatrix(3,3);
                 array_1d<double,3>& r_nodal_grad_pressure = itNode->FastGetSolutionStepValue(NODAL_WATER_PRESSURE_GRADIENT);
                 noalias(r_nodal_grad_pressure) = ZeroVector(3);
                 itNode->FastGetSolutionStepValue(NODAL_DAMAGE_VARIABLE) = 0.0;
@@ -304,10 +302,10 @@ public:
                     const double InvNodalArea = 1.0/NodalArea;
                     Matrix& rNodalStress = itNode->FastGetSolutionStepValue(NODAL_EFFECTIVE_STRESS_TENSOR);
                     array_1d<double,3>& r_nodal_grad_pressure = itNode->FastGetSolutionStepValue(NODAL_WATER_PRESSURE_GRADIENT);
-                    for(unsigned int i = 0; i<Dim; i++)
+                    for(unsigned int i = 0; i<3; i++)
                     {
                         r_nodal_grad_pressure[i] *= InvNodalArea;
-                        for(unsigned int j = 0; j<Dim; j++)
+                        for(unsigned int j = 0; j<3; j++)
                         {
                             rNodalStress(i,j) *= InvNodalArea;
                         }

--- a/applications/PoromechanicsApplication/custom_strategies/schemes/poro_explicit_cd_scheme.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/schemes/poro_explicit_cd_scheme.hpp
@@ -197,6 +197,10 @@ public:
             r_flux_residual = 0.0;
             noalias(r_external_force) = ZeroVector(3);
             noalias(r_internal_force) = ZeroVector(3);
+            Matrix& rInitialStress = it_node->FastGetSolutionStepValue(INITIAL_STRESS_TENSOR);
+            if(rInitialStress.size1() != 3)
+                rInitialStress.resize(3,3,false);
+            noalias(rInitialStress) = ZeroMatrix(3,3);
         }
 
         KRATOS_CATCH("")

--- a/applications/PoromechanicsApplication/custom_strategies/schemes/poro_explicit_cd_scheme.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/schemes/poro_explicit_cd_scheme.hpp
@@ -603,8 +603,6 @@ public:
 
         if(rModelPart.GetProcessInfo()[NODAL_SMOOTHING] == true)
         {
-            unsigned int Dim = rModelPart.GetProcessInfo()[DOMAIN_SIZE];
-
             const int NNodes = static_cast<int>(rModelPart.Nodes().size());
             ModelPart::NodesContainerType::iterator node_begin = rModelPart.NodesBegin();
 
@@ -616,9 +614,9 @@ public:
 
                 itNode->FastGetSolutionStepValue(NODAL_AREA) = 0.0;
                 Matrix& rNodalStress = itNode->FastGetSolutionStepValue(NODAL_EFFECTIVE_STRESS_TENSOR);
-                if(rNodalStress.size1() != Dim)
-                    rNodalStress.resize(Dim,Dim,false);
-                noalias(rNodalStress) = ZeroMatrix(Dim,Dim);
+                if(rNodalStress.size1() != 3)
+                    rNodalStress.resize(3,3,false);
+                noalias(rNodalStress) = ZeroMatrix(3,3);
                 array_1d<double,3>& r_nodal_grad_pressure = itNode->FastGetSolutionStepValue(NODAL_WATER_PRESSURE_GRADIENT);
                 noalias(r_nodal_grad_pressure) = ZeroVector(3);
                 itNode->FastGetSolutionStepValue(NODAL_DAMAGE_VARIABLE) = 0.0;
@@ -641,10 +639,10 @@ public:
                     const double InvNodalArea = 1.0/NodalArea;
                     Matrix& rNodalStress = itNode->FastGetSolutionStepValue(NODAL_EFFECTIVE_STRESS_TENSOR);
                     array_1d<double,3>& r_nodal_grad_pressure = itNode->FastGetSolutionStepValue(NODAL_WATER_PRESSURE_GRADIENT);
-                    for(unsigned int i = 0; i<Dim; i++)
+                    for(unsigned int i = 0; i<3; i++)
                     {
                         r_nodal_grad_pressure[i] *= InvNodalArea;
-                        for(unsigned int j = 0; j<Dim; j++)
+                        for(unsigned int j = 0; j<3; j++)
                         {
                             rNodalStress(i,j) *= InvNodalArea;
                         }

--- a/applications/PoromechanicsApplication/custom_strategies/schemes/poro_explicit_vv_scheme.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/schemes/poro_explicit_vv_scheme.hpp
@@ -154,6 +154,10 @@ public:
             noalias(r_external_force) = ZeroVector(3);
             noalias(r_internal_force) = ZeroVector(3);
             noalias(r_damping_force) = ZeroVector(3);
+            Matrix& rInitialStress = it_node->FastGetSolutionStepValue(INITIAL_STRESS_TENSOR);
+            if(rInitialStress.size1() != 3)
+                rInitialStress.resize(3,3,false);
+            noalias(rInitialStress) = ZeroMatrix(3,3);
         }
 
         KRATOS_CATCH("")

--- a/applications/PoromechanicsApplication/custom_utilities/initial_stress_2D_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/initial_stress_2D_utilities.hpp
@@ -100,7 +100,7 @@ public:
         this->WriteLinearElements(initial_stresses_mdpa,rCurrentModelPart);
 
         this->CalculateNodalStresses(rCurrentModelPart);
-        Matrix InitialStressTensor(2,2);
+        Matrix InitialStressTensor(3,3);
         initial_stresses_mdpa << "Begin NodalData INITIAL_STRESS_TENSOR" << std::endl;
         // #pragma omp parallel for
         for(int i = 0; i < NNodes; i++) {
@@ -362,9 +362,9 @@ private:
             ModelPart::NodesContainerType::iterator it_node = node_begin + i;
             it_node->FastGetSolutionStepValue(NODAL_AREA) = 0.0;
             Matrix& rNodalStress = it_node->FastGetSolutionStepValue(NODAL_EFFECTIVE_STRESS_TENSOR);
-            if(rNodalStress.size1() != 2) // Dimension
-                rNodalStress.resize(2,2,false);
-            noalias(rNodalStress) = ZeroMatrix(2,2);
+            if(rNodalStress.size1() != 3)
+                rNodalStress.resize(3,3,false);
+            noalias(rNodalStress) = ZeroMatrix(3,3);
         }
 
         // Calculate and Extrapolate Stresses
@@ -386,9 +386,9 @@ private:
             {
                 const double InvNodalArea = 1.0/NodalArea;
                 Matrix& rNodalStress = it_node->FastGetSolutionStepValue(NODAL_EFFECTIVE_STRESS_TENSOR);
-                for(unsigned int i = 0; i<2; i++) // Dimension
+                for(unsigned int i = 0; i<3; i++) // Dimension
                 {
-                    for(unsigned int j = 0; j<2; j++)
+                    for(unsigned int j = 0; j<3; j++)
                     {
                         rNodalStress(i,j) *= InvNodalArea;
                     }

--- a/applications/PoromechanicsApplication/custom_utilities/poro_element_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/poro_element_utilities.hpp
@@ -363,6 +363,29 @@ public:
         rPermeabilityMatrix(0,2) = rPermeabilityMatrix(2,0);
     }
 
+    //----------------------------------------------------------------------------------------
+
+    static inline void CalculatePermeabilityMatrix(Matrix& rPermeabilityMatrix,
+                                                    const Element::PropertiesType& Prop,
+                                                    const unsigned int& Dim)
+    {
+        if ( rPermeabilityMatrix.size1() != Dim )
+            rPermeabilityMatrix.resize( Dim, Dim, false );
+
+        rPermeabilityMatrix(0,0) = Prop[PERMEABILITY_XX];
+        rPermeabilityMatrix(1,1) = Prop[PERMEABILITY_YY];
+        rPermeabilityMatrix(0,1) = Prop[PERMEABILITY_XY];
+        rPermeabilityMatrix(1,0) = rPermeabilityMatrix(0,1);
+        if(Dim==3)
+        {
+            rPermeabilityMatrix(2,2) = Prop[PERMEABILITY_ZZ];
+            rPermeabilityMatrix(2,0) = Prop[PERMEABILITY_ZX];
+            rPermeabilityMatrix(1,2) = Prop[PERMEABILITY_YZ];
+            rPermeabilityMatrix(0,2) = rPermeabilityMatrix(2,0);
+            rPermeabilityMatrix(2,1) = rPermeabilityMatrix(1,2);
+        }
+    }
+
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/PoromechanicsApplication/python_scripts/poromechanics_analysis.py
+++ b/applications/PoromechanicsApplication/python_scripts/poromechanics_analysis.py
@@ -41,14 +41,17 @@ class PoromechanicsAnalysis(AnalysisStage):
         # Creating solver and model part and adding variables
         super(PoromechanicsAnalysis,self).__init__(model,parameters)
 
+        self.initial_stress_mode = 'external' # Not from a Poromechanics solution
         if parameters["problem_data"].Has("initial_stress_utility_settings"):
+            self.initial_stress_mode = self.parameters["problem_data"]["initial_stress_utility_settings"]["mode"].GetString()
+        if (self.initial_stress_mode == 'load' or self.initial_stress_mode == 'save'):
             from KratosMultiphysics.PoromechanicsApplication.poromechanics_initial_stress_utility import InitialStressUtility
             self.initial_stress_utility = InitialStressUtility(model,parameters)
 
     def Initialize(self):
         super(PoromechanicsAnalysis,self).Initialize()
 
-        if self.project_parameters["problem_data"].Has("initial_stress_utility_settings"):
+        if (self.initial_stress_mode == 'load'):
             self.initial_stress_utility.Load()
 
     def OutputSolutionStep(self):
@@ -68,7 +71,7 @@ class PoromechanicsAnalysis(AnalysisStage):
         if self.project_parameters["problem_data"]["fracture_utility"].GetBool():
             self.fracture_utility.Finalize()
 
-        if self.project_parameters["problem_data"].Has("initial_stress_utility_settings"):
+        if (self.initial_stress_mode == 'save'):
             self.initial_stress_utility.Save()
 
         # Finalizing strategy

--- a/applications/PoromechanicsApplication/python_scripts/poromechanics_analysis.py
+++ b/applications/PoromechanicsApplication/python_scripts/poromechanics_analysis.py
@@ -43,7 +43,7 @@ class PoromechanicsAnalysis(AnalysisStage):
 
         self.initial_stress_mode = 'external' # Not from a Poromechanics solution
         if parameters["problem_data"].Has("initial_stress_utility_settings"):
-            self.initial_stress_mode = self.parameters["problem_data"]["initial_stress_utility_settings"]["mode"].GetString()
+            self.initial_stress_mode = parameters["problem_data"]["initial_stress_utility_settings"]["mode"].GetString()
         if (self.initial_stress_mode == 'load' or self.initial_stress_mode == 'save'):
             from KratosMultiphysics.PoromechanicsApplication.poromechanics_initial_stress_utility import InitialStressUtility
             self.initial_stress_utility = InitialStressUtility(model,parameters)

--- a/applications/PoromechanicsApplication/python_scripts/poromechanics_initial_stress_utility.py
+++ b/applications/PoromechanicsApplication/python_scripts/poromechanics_initial_stress_utility.py
@@ -16,8 +16,6 @@ class InitialStressUtility(object):
         self.model = model
         self.parameters = parameters
 
-        self.mode = self.parameters["problem_data"]["initial_stress_utility_settings"]["mode"].GetString()
-
         domain_size = self.parameters["solver_settings"]["domain_size"].GetInt()
         if domain_size == 2:
             self.initial_stress_utility = KratosPoro.InitialStress2DUtilities()
@@ -27,42 +25,38 @@ class InitialStressUtility(object):
         self.current_model_part = self.model.GetModelPart(self.parameters["solver_settings"]["model_part_name"].GetString())
 
     def Load(self):
-
         # Read the initial model part with initial stresses and perform a mapping to transfer them to the current model part
-        if self.mode == 'load':
 
-            initial_model_part_name = 'InitialPorousModelPart'
+        initial_model_part_name = 'InitialPorousModelPart'
 
-            # Create initial solver (and initial_model_part)
-            initial_solver_settings = self.parameters["solver_settings"]
-            initial_solver_settings["model_part_name"].SetString(initial_model_part_name)
-            initial_solver_settings["model_import_settings"]["input_filename"].SetString(self.parameters["problem_data"]["initial_stress_utility_settings"]["initial_input_filename"].GetString())
-            python_module_name = "KratosMultiphysics.PoromechanicsApplication"
-            full_module_name = python_module_name + "." + initial_solver_settings["solver_type"].GetString()
-            solver_module = import_module(full_module_name)
-            initial_solver = solver_module.CreateSolver(self.model, initial_solver_settings)
+        # Create initial solver (and initial_model_part)
+        initial_solver_settings = self.parameters["solver_settings"]
+        initial_solver_settings["model_part_name"].SetString(initial_model_part_name)
+        initial_solver_settings["model_import_settings"]["input_filename"].SetString(self.parameters["problem_data"]["initial_stress_utility_settings"]["initial_input_filename"].GetString())
+        python_module_name = "KratosMultiphysics.PoromechanicsApplication"
+        full_module_name = python_module_name + "." + initial_solver_settings["solver_type"].GetString()
+        solver_module = import_module(full_module_name)
+        initial_solver = solver_module.CreateSolver(self.model, initial_solver_settings)
 
-            initial_solver.AddVariables()
-            initial_solver.ImportModelPart()
-            # initial_solver.PrepareModelPart()
-            initial_solver.AddDofs()
+        initial_solver.AddVariables()
+        initial_solver.ImportModelPart()
+        # initial_solver.PrepareModelPart()
+        initial_solver.AddDofs()
 
-            # Mapping between initial and current model parts
-            initial_model_part = self.model.GetModelPart(initial_model_part_name)
+        # Mapping between initial and current model parts
+        initial_model_part = self.model.GetModelPart(initial_model_part_name)
 
-            self.initial_stress_utility.TransferInitialStresses(initial_model_part,self.current_model_part)
+        self.initial_stress_utility.TransferInitialStresses(initial_model_part,self.current_model_part)
 
-            # Delete initial_model_part
-            self.model.DeleteModelPart(initial_model_part_name)
+        # Delete initial_model_part
+        self.model.DeleteModelPart(initial_model_part_name)
 
     def Save(self):
-
         # Write an mdpa file containing the initial stress tensor as NodalData
-        if self.mode == 'save':
 
-            initial_stress_parameters = KratosMultiphysics.Parameters("{}")
-            initial_stress_parameters.AddValue("initial_input_filename",self.parameters["problem_data"]["initial_stress_utility_settings"]["initial_input_filename"])
+        initial_stress_parameters = KratosMultiphysics.Parameters("{}")
+        initial_stress_parameters.AddValue("initial_input_filename",self.parameters["problem_data"]["initial_stress_utility_settings"]["initial_input_filename"])
 
-            self.current_model_part.ProcessInfo.SetValue(KratosPoro.NODAL_SMOOTHING, True)
+        self.current_model_part.ProcessInfo.SetValue(KratosPoro.NODAL_SMOOTHING, True)
 
-            self.initial_stress_utility.SaveInitialStresses(initial_stress_parameters,self.current_model_part)
+        self.initial_stress_utility.SaveInitialStresses(initial_stress_parameters,self.current_model_part)


### PR DESCRIPTION
**Description**
Poromechanics 2D elements have been adapted to work with 3D constitutive laws (i.e. to work as 2.5D elements). In order to do so, one just needs to define a 2D geometry and assign a 3D constitutive law in the properties of the material.
The permeability of each element is now initialized from the properties, but it can be modified for each element using the SetValueOnIntegrationPoints method with the PERMEABILITY_MATRIX variable name. 
The INITIAL_STRESS_TENSOR, which previously could only be obtained from an auxiliar poromechanics calculation, can now be defined externally (at each node) and used as before.

All poromechanics tests are running ok, both in Release and FullDebug.

**Changelog**
- Generalized 2D u_pw_element, u_pw_fic_element and u_pw_diff_order_element to work with 3D CL
- Elements now have mIntrinsicPermeability as a member variable
- Schemes have been adapted to the above changes
- Added TOTAL_STRESS_TENSOR variable in quadratic elements
