### PR TITLE
[Poro] Fixed compilation error (undeclared variables in derived template element)

### DIFF
--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -42,6 +42,8 @@ public:
     typedef Matrix MatrixType;
     using UPwElement<TDim,TNumNodes>::mThisIntegrationMethod;
     using UPwElement<TDim,TNumNodes>::mConstitutiveLawVector;
+    using UPwElement<TDim,TNumNodes>::mIntrinsicPermeability;
+    using UPwElement<TDim,TNumNodes>::mImposedZStrainVector;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
**Description**
I added two member variables in a base template element and I forgot to tell the derived class where they are declared...

In windows I did not get the compilation error, and I just realized this after compiling with clang...

**Changelog**
- Added source of member variables mIntrinsicPermeability and mImposedZStrainVector in U_Pw_small_strain_element.hpp