### PR TITLE
[IGA] Add refinement modeler

### DIFF
--- a/applications/IgaApplication/custom_modelers/refinement_modeler.cpp
+++ b/applications/IgaApplication/custom_modelers/refinement_modeler.cpp
@@ -57,7 +57,6 @@ namespace Kratos
             ? mpModel->GetModelPart(model_part_name)
             : mpModel->CreateModelPart(model_part_name);
 
-
         // Generate the list of geometries, which are needed, here.
         GeometriesArrayType geometry_list;
         GetGeometryList(geometry_list, r_model_part, rParameters);
@@ -70,10 +69,9 @@ namespace Kratos
             << rParameters << std::endl;
         if (rParameters["geometry_type"].GetString() == "NurbsSurface") {
             for (IndexType n = 0; n < geometry_list.size(); ++n) {
-                //auto nurbs_surface = (geometry_list[n].size() > 0)
-                //    ? static_cast<NurbsSurfaceGeometry<3, PointerVector<Node<3>>>>(geometry_list[n])
-                //    : static_cast<NurbsSurfaceGeometry<3, PointerVector<Node<3>>>>(geometry_list[n].GetGeometryPart(GeometryType::BACKGROUND_GEOMETRY_INDEX));
-                auto p_nurbs_surface = dynamic_pointer_cast<NurbsSurfaceGeometry<3, PointerVector<Node<3>>>>(geometry_list[n].pGetGeometryPart(GeometryType::BACKGROUND_GEOMETRY_INDEX));
+                auto p_nurbs_surface = (geometry_list[n].size() > 0)
+                    ? dynamic_pointer_cast<NurbsSurfaceGeometry<3, PointerVector<Node<3>>>>(geometry_list(n))
+                    : dynamic_pointer_cast<NurbsSurfaceGeometry<3, PointerVector<Node<3>>>>(geometry_list(n)->pGetGeometryPart(GeometryType::BACKGROUND_GEOMETRY_INDEX));
                 if (rParameters["parameters"].Has("insert_nb_per_span_u")) {
                     const IndexType nb_per_span_u = rParameters["parameters"]["insert_nb_per_span_u"].GetInt();
 

--- a/applications/IgaApplication/custom_modelers/refinement_modeler.cpp
+++ b/applications/IgaApplication/custom_modelers/refinement_modeler.cpp
@@ -1,0 +1,199 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License 
+//                   Kratos default license: kratos/license.txt
+//
+
+
+// Project includes
+#include "refinement_modeler.h"
+
+namespace Kratos
+{
+    ///@name Stages
+    ///@{
+
+    void RefinementModeler::PrepareGeometryModel()
+    {
+        const std::string DataFileName = mParameters.Has("refinements_file_name")
+            ? mParameters["refinements_file_name"].GetString()
+            : "refinements.iga.json";
+
+        KRATOS_INFO_IF("::[RefinementModeler]::", mEchoLevel > 0) << "Refining model by: " << DataFileName << std::endl;
+
+        const Parameters refinements_parameters = ReadParamatersFile(DataFileName);
+
+        ApplyRefinements(refinements_parameters);
+    }
+
+    void RefinementModeler::ApplyRefinements(
+        const Parameters rParameters) const
+    {
+        KRATOS_ERROR_IF_NOT(rParameters.Has("refinements"))
+            << "Parameters do not have refinements section.\n"
+            << rParameters << std::endl;
+
+        KRATOS_ERROR_IF_NOT(rParameters["refinements"].IsArray())
+            << "refinements section need to be of type array.\n"
+            << rParameters << std::endl;
+
+        for (IndexType i = 0; i < rParameters["refinements"].size(); ++i) {
+            ApplyRefinement(rParameters["refinements"][i]);
+        }
+    }
+
+    void RefinementModeler::ApplyRefinement(
+        const Parameters rParameters) const
+    {
+        KRATOS_ERROR_IF_NOT(rParameters.Has("model_part_name"))
+            << "Missing \"model_part_name\" in refinements block.\n"
+            << rParameters << std::endl;
+        const std::string model_part_name = rParameters["model_part_name"].GetString();
+        ModelPart& r_model_part = mpModel->HasModelPart(model_part_name)
+            ? mpModel->GetModelPart(model_part_name)
+            : mpModel->CreateModelPart(model_part_name);
+
+
+        // Generate the list of geometries, which are needed, here.
+        GeometriesArrayType geometry_list;
+        GetGeometryList(geometry_list, r_model_part, rParameters);
+
+        KRATOS_ERROR_IF_NOT(rParameters.Has("parameters"))
+            << "Missing \"parameters\" in refinements block.\n"
+            << rParameters << std::endl;
+        KRATOS_ERROR_IF_NOT(rParameters.Has("geometry_type"))
+            << "Missing \"geometry_type\".\n"
+            << rParameters << std::endl;
+        if (rParameters["geometry_type"].GetString() == "NurbsSurface") {
+            for (IndexType n = 0; n < geometry_list.size(); ++n) {
+                //auto nurbs_surface = (geometry_list[n].size() > 0)
+                //    ? static_cast<NurbsSurfaceGeometry<3, PointerVector<Node<3>>>>(geometry_list[n])
+                //    : static_cast<NurbsSurfaceGeometry<3, PointerVector<Node<3>>>>(geometry_list[n].GetGeometryPart(GeometryType::BACKGROUND_GEOMETRY_INDEX));
+                auto p_nurbs_surface = dynamic_pointer_cast<NurbsSurfaceGeometry<3, PointerVector<Node<3>>>>(geometry_list[n].pGetGeometryPart(GeometryType::BACKGROUND_GEOMETRY_INDEX));
+                if (rParameters["parameters"].Has("insert_nb_per_span_u")) {
+                    const IndexType nb_per_span_u = rParameters["parameters"]["insert_nb_per_span_u"].GetInt();
+
+                    std::vector<double> spans_local_space;
+                    p_nurbs_surface->Spans(spans_local_space, 0);
+
+                    std::vector<double> knots_to_insert_u;
+                    for (IndexType i = 0; i < spans_local_space.size() - 1; ++i) {
+                        const double delta_u = (spans_local_space[i] - spans_local_space[i + 1]) / (nb_per_span_u + 1);
+                        for (IndexType j = 0; j < nb_per_span_u; ++j) {
+                            knots_to_insert_u.push_back(spans_local_space[i] + delta_u * j);
+                        }
+                    }
+
+                    PointerVector<NodeType> PointsRefined;
+                    Vector KnotsURefined;
+                    Vector WeightsRefined;
+
+                    NurbsSurfaceRefinementUtilities::KnotRefinementU(*(p_nurbs_surface.get()), knots_to_insert_u,
+                        PointsRefined, KnotsURefined, WeightsRefined);
+
+                    // Recreate nodes in model part to ensure correct assignment of dofs
+                    IndexType node_id = (r_model_part.NodesEnd() - 1)->Id() + 1;
+                    for (IndexType i = 0; i < PointsRefined.size(); ++i) {
+                        if (PointsRefined(i)->Id() == 0) {
+                            PointsRefined(i) = r_model_part.CreateNewNode(node_id, PointsRefined[i][0], PointsRefined[i][1], PointsRefined[i][2]);
+                            node_id++;
+                        }
+                    }
+
+                    p_nurbs_surface->SetInternals(PointsRefined,
+                        p_nurbs_surface->PolynomialDegreeU(), p_nurbs_surface->PolynomialDegreeV(),
+                        KnotsURefined, p_nurbs_surface->KnotsV(),
+                        WeightsRefined);
+                }
+                if (rParameters["parameters"].Has("insert_nb_per_span_v")) {
+                    const IndexType nb_per_span_v = rParameters["parameters"]["insert_nb_per_span_v"].GetInt();
+
+                    std::vector<double> spans_local_space;
+                    p_nurbs_surface->Spans(spans_local_space, 1);
+
+                    std::vector<double> knots_to_insert_v;
+                    for (IndexType i = 0; i < spans_local_space.size() - 1; ++i) {
+                        const double delta_v = (spans_local_space[i] - spans_local_space[i + 1]) / (nb_per_span_v + 1);
+                        for (IndexType j = 0; j < spans_local_space.size() - 1; ++j) {
+                            knots_to_insert_v.push_back(spans_local_space[j] + delta_v);
+                        }
+                    }
+
+                    PointerVector<NodeType> PointsRefined;
+                    Vector KnotsURefined;
+                    Vector WeightsRefined;
+
+                    NurbsSurfaceRefinementUtilities::KnotRefinementU(*(p_nurbs_surface.get()), knots_to_insert_v,
+                        PointsRefined, KnotsURefined, WeightsRefined);
+
+                    // Recreate nodes in model part to ensure correct assignment of dofs
+                    IndexType node_id = (r_model_part.NodesEnd() - 1)->Id() + 1;
+                    for (IndexType i = 0; i < PointsRefined.size(); ++i) {
+                        if (PointsRefined(i)->Id() == 0) {
+                            PointsRefined(i) = r_model_part.CreateNewNode(node_id, PointsRefined[i][0], PointsRefined[i][1], PointsRefined[i][2]);
+                            node_id++;
+                        }
+                    }
+
+                    p_nurbs_surface->SetInternals(PointsRefined,
+                        p_nurbs_surface->PolynomialDegreeU(), p_nurbs_surface->PolynomialDegreeV(),
+                        KnotsURefined, p_nurbs_surface->KnotsV(),
+                        WeightsRefined);
+                }
+            }
+        }
+    }
+
+    void RefinementModeler::GetGeometryList(
+        GeometriesArrayType& rGeometryList,
+        ModelPart& rModelPart,
+        const Parameters rParameters) const
+    {
+        if (rParameters.Has("brep_id")) {
+            rGeometryList.push_back(rModelPart.pGetGeometry(rParameters["brep_id"].GetInt()));
+        }
+        if (rParameters.Has("brep_ids")) {
+            for (SizeType i = 0; i < rParameters["brep_ids"].size(); ++i) {
+                rGeometryList.push_back(rModelPart.pGetGeometry(rParameters["brep_ids"][i].GetInt()));
+            }
+        }
+        if (rParameters.Has("brep_name")) {
+            rGeometryList.push_back(rModelPart.pGetGeometry(rParameters["brep_name"].GetString()));
+        }
+        if (rParameters.Has("brep_names")) {
+            for (SizeType i = 0; i < rParameters["brep_names"].size(); ++i) {
+                rGeometryList.push_back(rModelPart.pGetGeometry(rParameters["brep_names"][i].GetString()));
+            }
+        }
+
+        KRATOS_ERROR_IF(rGeometryList.size() == 0)
+            << "Empty geometry list. Either \"brep_id\", \"brep_ids\", \"brep_name\" or \"brep_names\" are the possible options." << std::endl;
+    }
+
+    /// Reads in a json formatted file and returns its KratosParameters instance.
+    Parameters RefinementModeler::ReadParamatersFile(
+        const std::string& rDataFileName) const
+    {
+        // Check if rDataFileName ends with ".cad.json" and add it if needed.
+        const std::string data_file_name = (rDataFileName.compare(rDataFileName.size() - 9, 9, ".iga.json") != 0)
+            ? rDataFileName + ".iga.json"
+            : rDataFileName;
+
+        std::ifstream infile(data_file_name);
+        KRATOS_ERROR_IF_NOT(infile.good()) << "Physics fil: "
+            << data_file_name << " cannot be found." << std::endl;
+        KRATOS_INFO_IF("ReadParamatersFile", mEchoLevel > 3)
+            << "Reading file: \"" << data_file_name << "\"" << std::endl;
+
+        std::stringstream buffer;
+        buffer << infile.rdbuf();
+
+        return Parameters(buffer.str());
+    }
+
+    ///@}
+}

--- a/applications/IgaApplication/custom_modelers/refinement_modeler.h
+++ b/applications/IgaApplication/custom_modelers/refinement_modeler.h
@@ -1,0 +1,169 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//
+
+
+#if !defined(KRATOS_REFINEMENT_MODELER_H_INCLUDED )
+#define  KRATOS_REFINEMENT_MODELER_H_INCLUDED
+
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "modeler/modeler.h"
+
+#include "geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.h"
+#include "geometries/nurbs_surface_geometry.h"
+
+namespace Kratos
+{
+
+///@name Kratos Classes
+///@{
+
+/// Short class definition.
+/** Detail class definition.
+*/
+class KRATOS_API(IGA_APPLICATION) RefinementModeler
+    : public Modeler
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of Modeler
+    KRATOS_CLASS_POINTER_DEFINITION(RefinementModeler);
+
+    typedef std::size_t SizeType;
+    typedef std::size_t IndexType;
+
+    typedef Node<3> NodeType;
+    typedef Geometry<NodeType> GeometryType;
+    typedef typename GeometryType::GeometriesArrayType GeometriesArrayType;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+    RefinementModeler()
+        : Modeler()
+    {
+    }
+
+    /// Constructor.
+    RefinementModeler(
+        Model& rModel,
+        Parameters ModelerParameters = Parameters())
+        : Modeler(rModel, ModelerParameters)
+        , mpModel(&rModel)
+    {
+    }
+
+    /// Destructor.
+    virtual ~RefinementModeler() = default;
+
+    /// Creates the Modeler Pointer
+    Modeler::Pointer Create(
+        Model& rModel, const Parameters ModelParameters) const override
+    {
+        return Kratos::make_shared<RefinementModeler>(rModel, ModelParameters);
+    }
+
+    ///@}
+    ///@name Stages
+    ///@{
+
+    void PrepareGeometryModel() override;
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        return "RefinementModeler";
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream & rOStream) const override
+    {
+        rOStream << Info();
+    }
+
+    /// Print object's data.
+    void PrintData(std::ostream & rOStream) const override
+    {
+    }
+
+    ///@}
+
+private:
+    ///@name Memory
+    ///@{
+
+    Model* mpModel = nullptr;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    void ApplyRefinements(
+        const Parameters rParameters) const;
+
+    void ApplyRefinement(
+        const Parameters rParameters) const;
+
+    void GetGeometryList(
+        GeometriesArrayType& rGeometryList,
+        ModelPart& rModelPart,
+        const Parameters rParameters) const;
+
+    Parameters ReadParamatersFile(
+        const std::string& rDataFileName) const;
+
+    ///@}
+    ///@name Serializer
+    ///@{
+
+    friend class Serializer;
+
+    ///@}
+}; // Class RefinementModeler
+
+///@}
+///@name Input and output
+///@{
+
+/// input stream function
+inline std::istream& operator >> (
+    std::istream& rIStream,
+    RefinementModeler& rThis);
+
+/// output stream function
+inline std::ostream& operator << (
+    std::ostream& rOStream,
+    const RefinementModeler& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+
+///@}
+
+}  // namespace Kratos.
+
+#endif // KRATOS_IGA_IO_MODELER_H_INCLUDED  defined

--- a/applications/IgaApplication/iga_application.cpp
+++ b/applications/IgaApplication/iga_application.cpp
@@ -76,6 +76,7 @@ KRATOS_INFO("") << "    KRATOS  _____ _____\n"
     KRATOS_REGISTER_CONDITION("SupportNitscheCondition", mSupportNitscheCondition)
 
     KRATOS_REGISTER_MODELER("IgaModeler", mIgaModeler);
+    KRATOS_REGISTER_MODELER("RefinementModeler", mRefinementModeler);
     KRATOS_REGISTER_MODELER("NurbsGeometryModeler", mNurbsGeometryModeler);
 
     // VARIABLES

--- a/applications/IgaApplication/iga_application.h
+++ b/applications/IgaApplication/iga_application.h
@@ -37,6 +37,7 @@
 
 //modelers
 #include "custom_modelers/iga_modeler.h"
+#include "custom_modelers/refinement_modeler.h"
 #include "custom_modelers/nurbs_geometry_modeler.h"
 
 namespace Kratos {
@@ -130,6 +131,7 @@ private:
 
     // Modelers
     const IgaModeler mIgaModeler;
+    const RefinementModeler mRefinementModeler;
     const NurbsGeometryModeler mNurbsGeometryModeler;
 
     ///@}

--- a/applications/IgaApplication/tests/modeler_tests/refinements.iga.json
+++ b/applications/IgaApplication/tests/modeler_tests/refinements.iga.json
@@ -1,0 +1,12 @@
+{
+  "refinements": [
+    {
+      "brep_ids": [ 1 ],
+      "geometry_type": "NurbsSurface",
+      "model_part_name": "IgaModelPart",
+      "parameters": {
+        "insert_nb_per_span_u": 2
+      }
+    }
+  ]
+}

--- a/applications/IgaApplication/tests/test_modelers.py
+++ b/applications/IgaApplication/tests/test_modelers.py
@@ -17,8 +17,8 @@ def run_modelers(current_model, modelers_list):
         modeler.SetupModelPart()
 
 class TestModelers(KratosUnittest.TestCase):
-    def _strong_support_surface_test(self, current_model):
-
+    def test_StrongSupportSurface(self):
+        current_model = KratosMultiphysics.Model()
         modelers_list = KratosMultiphysics.Parameters(
         """ [{
             "modeler_name": "CadIoModeler",
@@ -66,10 +66,6 @@ class TestModelers(KratosUnittest.TestCase):
         self.assertEqual(support_2_Variation_model_part.GetNodes()[4].Id, 4)
         self.assertEqual(support_2_Variation_model_part.GetNodes()[5].Id, 5)
         self.assertEqual(support_2_Variation_model_part.GetNodes()[6].Id, 6)
-
-    def test_StrongSupportSurface(self):
-        current_model = KratosMultiphysics.Model()
-        self._strong_support_surface_test(current_model)
 
     def test_nurbs_geometry_3d_modeler_control_points(self):
         current_model = KratosMultiphysics.Model()

--- a/applications/IgaApplication/tests/test_modelers.py
+++ b/applications/IgaApplication/tests/test_modelers.py
@@ -67,6 +67,30 @@ class TestModelers(KratosUnittest.TestCase):
         self.assertEqual(support_2_Variation_model_part.GetNodes()[5].Id, 5)
         self.assertEqual(support_2_Variation_model_part.GetNodes()[6].Id, 6)
 
+    def test_RefinementModeler(self):
+        current_model = KratosMultiphysics.Model()
+        modelers_list = KratosMultiphysics.Parameters(
+        """ [{
+            "modeler_name": "CadIoModeler",
+            "Parameters": {
+                "echo_level": 0,
+                "cad_model_part_name": "IgaModelPart",
+                "geometry_file_name": "modeler_tests/surface_geometry.cad.json"
+            } }, {
+            "modeler_name": "RefinementModeler",
+            "Parameters": {
+                "echo_level":  0,
+                "refinements_file_name": "modeler_tests/refinements.iga.json"
+            } }] """ )
+
+        run_modelers(current_model, modelers_list)
+
+        model_part = current_model.GetModelPart("IgaModelPart")
+
+        # Check if all needed node are within the model parts
+        self.assertEqual(model_part.NumberOfNodes(), 40)
+        self.assertEqual(model_part.GetGeometry(1).GetGeometryPart(KratosMultiphysics.Geometry.BACKGROUND_GEOMETRY_INDEX).PointsNumber(), 28)
+
     def test_nurbs_geometry_3d_modeler_control_points(self):
         current_model = KratosMultiphysics.Model()
         modeler_settings = KratosMultiphysics.Parameters("""

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
@@ -156,7 +156,7 @@ namespace Kratos {
                         IndexType cp_index_refined_after = NurbsUtilities::GetVectorIndexFromMatrixIndices(
                             nb_cp_u_refined, nb_cp_v, index - 1, m);
 
-                        array_1d<double, 3> cp_coordinates = rPointsRefined[cp_index_refined_after] + (1.0 - alpha) * rPointsRefined[cp_index_refined_before];
+                        const array_1d<double, 3> cp_coordinates = rPointsRefined[cp_index_refined_after] + (1.0 - alpha) * rPointsRefined[cp_index_refined_before];
 
                         rPointsRefined(cp_index_refined_after) = Kratos::make_intrusive<NodeType>(0, cp_coordinates);
                         rWeightsRefined[cp_index_refined_after] = rWeightsRefined[cp_index_refined_after] * alpha + rWeightsRefined[cp_index_refined_before] * (1 - alpha);

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
@@ -223,7 +223,7 @@ namespace Kratos {
 
                 const array_1d<double, 3> cp_coordinates = rGeometry[cp_index_old] * weights_old[cp_index_old];
 
-                rPointsRefined(cp_index_refined) = Kratos::make_intrusive<NodeType>(cp_index_refined + 1, cp_coordinates);
+                rPointsRefined(cp_index_refined) = Kratos::make_intrusive<NodeType>(0, cp_coordinates);
                 rWeightsRefined[cp_index_refined] = weights_old[cp_index_old];
             }
         }
@@ -237,7 +237,7 @@ namespace Kratos {
 
                 const array_1d<double, 3> cp_coordinates = rGeometry[cp_index_old] * weights_old[cp_index_old];
 
-                rPointsRefined(cp_index_refined) = Kratos::make_intrusive<NodeType>(cp_index_refined + 1, cp_coordinates);
+                rPointsRefined(cp_index_refined) = Kratos::make_intrusive<NodeType>(0, cp_coordinates);
                 rWeightsRefined[cp_index_refined] = weights_old[cp_index_old];
             }
         }
@@ -268,7 +268,7 @@ namespace Kratos {
                     rPointsRefined(cp_index_refined) = Kratos::make_intrusive<NodeType>(0, cp_coordinates);
                     rWeightsRefined[cp_index_refined] = weights_old[cp_index_old];
                 }
-                rKnotsVRefined[k - 1] = knots_v_old[-1 + i];
+                rKnotsVRefined[k - 1] = knots_v_old[i - 1];
 
                 k -= 1;
                 i -= 1;

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
@@ -315,7 +315,7 @@ namespace Kratos {
                         IndexType cp_index_refined_after = NurbsUtilities::GetVectorIndexFromMatrixIndices(
                             nb_cp_u, nb_cp_v_refined, m, index - 1);
 
-                        array_1d<double, 3> cp_coordinates = alpha * rPointsRefined[cp_index_refined_after] + (1.0 - alpha) * rPointsRefined[cp_index_refined_before];
+                        const array_1d<double, 3> cp_coordinates = alpha * rPointsRefined[cp_index_refined_after] + (1.0 - alpha) * rPointsRefined[cp_index_refined_before];
 
                         rPointsRefined(cp_index_refined_after) = Kratos::make_intrusive<NodeType>(0, cp_coordinates);
                         rWeightsRefined[cp_index_refined_after] = rWeightsRefined[cp_index_refined_after] * alpha + rWeightsRefined[cp_index_refined_before] * (1 - alpha);

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
@@ -37,7 +37,6 @@ namespace Kratos {
         const SizeType nb_cp_v = rGeometry.PointsNumberInDirection(1);
 
         const Vector& knots_u_old = rGeometry.KnotsU();
-        const Vector& knots_v = rGeometry.KnotsV();
 
         const Vector& weights_old = rGeometry.Weights();
 
@@ -99,7 +98,6 @@ namespace Kratos {
             rKnotsURefined[i + nb_knots_u_to_insert] = knots_u_old[i];
         }
 
-        const IndexType n = nb_cp_u_old - 1;
         const IndexType r = nb_knots_u_to_insert - 1;
 
         IndexType i = b + 2 + degree_u - 1;
@@ -191,7 +189,6 @@ namespace Kratos {
         const SizeType nb_cp_u = rGeometry.PointsNumberInDirection(0);
         const SizeType nb_cp_v_old = rGeometry.PointsNumberInDirection(1);
 
-        const Vector& knots_u = rGeometry.KnotsU();
         const Vector& knots_v_old = rGeometry.KnotsV();
 
         const Vector& weights_old = rGeometry.Weights();
@@ -253,7 +250,6 @@ namespace Kratos {
             rKnotsVRefined[i + nb_knots_v_to_insert] = knots_v_old[i];
         }
 
-        const IndexType n = nb_cp_v_old - 1;
         const IndexType r = nb_knots_v_to_insert - 1;
 
         IndexType i = b + 2 + degree_v - 1;

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
@@ -38,7 +38,11 @@ namespace Kratos {
 
         const Vector& knots_u_old = rGeometry.KnotsU();
 
-        const Vector& weights_old = rGeometry.Weights();
+        Vector weights_old = rGeometry.Weights();
+        if (weights_old.size() != rGeometry.size()) {
+            weights_old.resize(rGeometry.size());
+            std::fill(weights_old.begin(), weights_old.end(), 1.0);
+        }
 
         const SizeType nb_knots_u_old = knots_u_old.size();
 
@@ -71,7 +75,7 @@ namespace Kratos {
 
                 const array_1d<double, 3> cp_coordinates = rGeometry[cp_index_old] * weights_old[cp_index_old];
 
-                rPointsRefined(cp_index_refined) = Kratos::make_intrusive<NodeType>(cp_index_refined + 1, cp_coordinates);
+                rPointsRefined(cp_index_refined) = Kratos::make_intrusive<NodeType>(0, cp_coordinates);
                 rWeightsRefined[cp_index_refined] = weights_old[cp_index_old];
             }
         }
@@ -85,7 +89,7 @@ namespace Kratos {
 
                 const array_1d<double, 3> cp_coordinates = rGeometry[cp_index_old] * weights_old[cp_index_old];
 
-                rPointsRefined(cp_index_refined) = Kratos::make_intrusive<NodeType>(cp_index_refined + 1, cp_coordinates);
+                rPointsRefined(cp_index_refined) = Kratos::make_intrusive<NodeType>(0, cp_coordinates);
                 rWeightsRefined[cp_index_refined] = weights_old[cp_index_old];
             }
         }
@@ -191,7 +195,11 @@ namespace Kratos {
 
         const Vector& knots_v_old = rGeometry.KnotsV();
 
-        const Vector& weights_old = rGeometry.Weights();
+        Vector weights_old = rGeometry.Weights();
+        if (weights_old.size() != rGeometry.size()) {
+            weights_old.resize(rGeometry.size());
+            std::fill(weights_old.begin(), weights_old.end(), 1.0);
+        }
 
         const SizeType nb_knots_v_old = knots_v_old.size();
 

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
@@ -160,7 +160,7 @@ namespace Kratos {
                         IndexType cp_index_refined_after = NurbsUtilities::GetVectorIndexFromMatrixIndices(
                             nb_cp_u_refined, nb_cp_v, index - 1, m);
 
-                        const array_1d<double, 3> cp_coordinates = rPointsRefined[cp_index_refined_after] + (1.0 - alpha) * rPointsRefined[cp_index_refined_before];
+                        const array_1d<double, 3> cp_coordinates = alpha * rPointsRefined[cp_index_refined_after] + (1.0 - alpha) * rPointsRefined[cp_index_refined_before];
 
                         rPointsRefined(cp_index_refined_after) = Kratos::make_intrusive<NodeType>(0, cp_coordinates);
                         rWeightsRefined[cp_index_refined_after] = rWeightsRefined[cp_index_refined_after] * alpha + rWeightsRefined[cp_index_refined_before] * (1 - alpha);
@@ -315,7 +315,7 @@ namespace Kratos {
                         IndexType cp_index_refined_after = NurbsUtilities::GetVectorIndexFromMatrixIndices(
                             nb_cp_u, nb_cp_v_refined, m, index - 1);
 
-                        array_1d<double, 3> cp_coordinates = rPointsRefined[cp_index_refined_after] + (1.0 - alpha) * rPointsRefined[cp_index_refined_before];
+                        array_1d<double, 3> cp_coordinates = alpha * rPointsRefined[cp_index_refined_after] + (1.0 - alpha) * rPointsRefined[cp_index_refined_before];
 
                         rPointsRefined(cp_index_refined_after) = Kratos::make_intrusive<NodeType>(0, cp_coordinates);
                         rWeightsRefined[cp_index_refined_after] = rWeightsRefined[cp_index_refined_after] * alpha + rWeightsRefined[cp_index_refined_before] * (1 - alpha);

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
@@ -42,8 +42,8 @@ namespace Kratos {
 
         const SizeType nb_knots_u_old = knots_u_old.size();
 
-        const SizeType a = NurbsUtilities::GetUpperSpan(degree_u, knots_u_old, *knots_u_old.begin());
-        const SizeType b = NurbsUtilities::GetUpperSpan(degree_u, knots_u_old, *knots_u_old.end());
+        const SizeType a = NurbsUtilities::GetUpperSpan(degree_u, knots_u_old, knots_u_old[0]);
+        const SizeType b = NurbsUtilities::GetUpperSpan(degree_u, knots_u_old, knots_u_old[knots_u_old.size() - 1]);
 
         const SizeType nb_cp_u_refined = nb_cp_u_old + nb_knots_u_to_insert;
         const SizeType nb_knots_u_refined = nb_knots_u_old + nb_knots_u_to_insert;
@@ -195,8 +195,8 @@ namespace Kratos {
 
         const SizeType nb_knots_v_old = knots_v_old.size();
 
-        const SizeType a = NurbsUtilities::GetUpperSpan(degree_v, knots_v_old, *knots_v_old.begin());
-        const SizeType b = NurbsUtilities::GetUpperSpan(degree_v, knots_v_old, *knots_v_old.end());
+        const SizeType a = NurbsUtilities::GetUpperSpan(degree_v, knots_v_old, knots_v_old[0]);
+        const SizeType b = NurbsUtilities::GetUpperSpan(degree_v, knots_v_old, knots_v_old[knots_v_old.size() - 1]);
 
         const SizeType nb_cp_v_refined = nb_cp_v_old + nb_knots_v_to_insert;
         const SizeType nb_knots_v_refined = nb_knots_v_old + nb_knots_v_to_insert;

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
@@ -1,0 +1,339 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "nurbs_surface_refinement_utilities.h"
+
+namespace Kratos {
+
+    ///@name Operations
+    ///@{
+
+    void NurbsSurfaceRefinementUtilities::KnotRefinementU(
+        NurbsSurfaceGeometryType& rGeometry,
+        std::vector<double>& rKnotsUToInsert,
+        PointerVector<NodeType>& rPointsRefined,
+        Vector& rKnotsURefined,
+        Vector& rWeightsRefined)
+    {
+        std::sort(rKnotsUToInsert.begin(), rKnotsUToInsert.end());
+
+        const SizeType nb_knots_u_to_insert = rKnotsUToInsert.size();
+
+        const SizeType degree_u = rGeometry.PolynomialDegree(0);
+        const SizeType degree_v = rGeometry.PolynomialDegree(1);
+
+        const SizeType nb_cp_u_old = rGeometry.PointsNumberInDirection(0);
+        const SizeType nb_cp_v = rGeometry.PointsNumberInDirection(1);
+
+        const Vector& knots_u_old = rGeometry.KnotsU();
+        const Vector& knots_v = rGeometry.KnotsV();
+
+        const Vector& weights_old = rGeometry.Weights();
+
+        const SizeType nb_knots_u_old = knots_u_old.size();
+        const SizeType nb_knots_v = knots_v.size();
+
+        const SizeType a = NurbsUtilities::GetUpperSpan(degree_u, knots_u_old, *knots_u_old.begin());
+        const SizeType b = NurbsUtilities::GetUpperSpan(degree_u, knots_u_old, *knots_u_old.end());
+
+        const SizeType nb_cp_u_refined = nb_cp_u_old + nb_knots_u_to_insert;
+        const SizeType nb_knots_u_refined = nb_knots_u_old + nb_knots_u_to_insert;
+
+        // Resize reference variables
+        if (rKnotsURefined.size() != nb_knots_u_refined) {
+            rKnotsURefined.resize(nb_knots_u_refined);
+        }
+        rKnotsURefined = ZeroVector(nb_knots_u_refined);
+        if (rWeightsRefined.size() != nb_cp_u_refined * nb_cp_v) {
+            rWeightsRefined.resize(nb_cp_u_refined * nb_cp_v);
+        }
+        rWeightsRefined = ZeroVector(nb_cp_u_refined * nb_cp_v);
+        if (rPointsRefined.size() != nb_cp_u_refined * nb_cp_v) {
+            rPointsRefined.resize(nb_cp_u_refined * nb_cp_v);
+        }
+
+        // Create new node vector
+        for (IndexType i = 0; i < a - degree_u + 2; ++i) {
+            for (IndexType m = 0; m < nb_cp_v; ++m) {
+                IndexType cp_index_refined = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                    nb_cp_u_refined, nb_cp_v, i, m);
+                IndexType cp_index_old = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                    nb_cp_u_old, nb_cp_v, i, m);
+
+                const array_1d<double, 3> cp_coordinates = rGeometry[cp_index_old] * weights_old[cp_index_old];
+
+                rPointsRefined(cp_index_refined) = Kratos::make_intrusive<NodeType>(cp_index_refined + 1, cp_coordinates);
+                rWeightsRefined[cp_index_refined] = weights_old[cp_index_old];
+            }
+        }
+
+        for (IndexType i = b; i < nb_cp_u_old; ++i) {
+            for (IndexType m = 0; m < nb_cp_v; ++m) {
+                IndexType cp_index_refined = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                    nb_cp_u_refined, nb_cp_v, i + nb_knots_u_to_insert, m);
+                IndexType cp_index_old = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                    nb_cp_u_old, nb_cp_v, i, m);
+
+                const array_1d<double, 3> cp_coordinates = rGeometry[cp_index_old] * weights_old[cp_index_old];
+
+                rPointsRefined(cp_index_refined) = Kratos::make_intrusive<NodeType>(cp_index_refined + 1, cp_coordinates);
+                rWeightsRefined[cp_index_refined] = weights_old[cp_index_old];
+            }
+        }
+
+        // Create new knot span vector
+        for (IndexType i = 0; i < a + 1; ++i) {
+            rKnotsURefined[i] = knots_u_old[i];
+        }
+        for (IndexType i = b + degree_u - 1; i < nb_knots_u_old; ++i) {
+            rKnotsURefined[i + nb_knots_u_to_insert] = knots_u_old[i];
+        }
+
+        const IndexType n = nb_cp_u_old - 1;
+        const IndexType m = n + degree_u + 1;
+        const IndexType r = nb_knots_u_to_insert - 1;
+
+        IndexType i = b + 2 + degree_u - 1;
+        IndexType k = b + 2 + degree_u + r;
+
+        for (int j = r; j >= 0; --j) {
+            while (rKnotsUToInsert[j] <= knots_u_old[-1 + i] && i > a + 1) {
+                for (IndexType m = 0; m < nb_cp_v; ++m) {
+                    IndexType cp_index_refined = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                        nb_cp_u_refined, nb_cp_v, k - degree_u - 1, m);
+                    IndexType cp_index_old = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                        nb_cp_u_old, nb_cp_v, i - degree_u - 1, m);
+
+                    const array_1d<double, 3> cp_coordinates = rGeometry[cp_index_old] * weights_old[cp_index_old];
+
+                    rPointsRefined(cp_index_refined) = Kratos::make_intrusive<NodeType>(0, cp_coordinates);
+                    rWeightsRefined[cp_index_refined] = weights_old[cp_index_old];
+                }
+
+                rKnotsURefined[-1 + k] = knots_u_old[-1 + i];
+
+                k -= 1;
+                i -= 1;
+            }
+
+            for (IndexType m = 0; m < nb_cp_v; m++) {
+                IndexType cp_index_refined_before = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                    nb_cp_u_refined, nb_cp_v, k - degree_u, m);
+                IndexType cp_index_refined_after = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                    nb_cp_u_refined, nb_cp_v, k - degree_u - 1, m);
+
+                rPointsRefined(cp_index_refined_after) = rPointsRefined(cp_index_refined_before);
+                rWeightsRefined[cp_index_refined_after] = rWeightsRefined[cp_index_refined_before];
+            }
+
+            for (IndexType l = 1; l < degree_u + 1; ++l) {
+                const IndexType index = k - degree_u + l;
+                auto alpha = rKnotsURefined[-1 + k + l] - rKnotsUToInsert[j];
+
+                if (std::abs(alpha) < 1e-7) {
+                    for (IndexType m = 0; m < nb_cp_v; ++m) {
+                        IndexType cp_index_refined_before = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                            nb_cp_u_refined, nb_cp_v, index, m);
+                        IndexType cp_index_refined_after = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                            nb_cp_u_refined, nb_cp_v, index - 1, m);
+
+                        rPointsRefined(cp_index_refined_after) = rPointsRefined(cp_index_refined_before);
+                        rWeightsRefined[cp_index_refined_after] = rWeightsRefined[cp_index_refined_before];
+                    }
+                }
+                else {
+                    alpha = alpha / (rKnotsURefined[k + l - 1] - knots_u_old[i + l - degree_u - 1]);
+                    for (IndexType m = 0; m < nb_cp_v; ++m) {
+                        IndexType cp_index_refined_before = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                            nb_cp_u_refined, nb_cp_v, index, m);
+                        IndexType cp_index_refined_after = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                            nb_cp_u_refined, nb_cp_v, index - 1, m);
+
+                        array_1d<double, 3> cp_coordinates = rPointsRefined[cp_index_refined_after] + (1.0 - alpha) * rPointsRefined[cp_index_refined_before];
+
+                        rPointsRefined(cp_index_refined_after) = Kratos::make_intrusive<NodeType>(0, cp_coordinates);
+                        rWeightsRefined[cp_index_refined_after] = rWeightsRefined[cp_index_refined_after] * alpha + rWeightsRefined[cp_index_refined_before] * (1 - alpha);
+                    }
+                }
+            }
+            rKnotsURefined[-1 + k] = rKnotsUToInsert[j];
+
+            k -= 1;
+        }
+
+        for (IndexType i = 0; i < nb_cp_u_refined * nb_cp_v; ++i) {
+            rPointsRefined(i)->Coordinates() = rPointsRefined(i)->Coordinates() / rWeightsRefined[i];
+        }
+    }
+
+    void NurbsSurfaceRefinementUtilities::KnotRefinementV(
+        NurbsSurfaceGeometryType& rGeometry,
+        std::vector<double>& rKnotsVToInsert,
+        PointerVector<NodeType>& rPointsRefined,
+        Vector& rKnotsVRefined,
+        Vector& rWeightsRefined)
+    {
+        std::sort(rKnotsVToInsert.begin(), rKnotsVToInsert.end());
+
+        const SizeType nb_knots_v_to_insert = rKnotsVToInsert.size();
+
+        const SizeType degree_u = rGeometry.PolynomialDegree(0);
+        const SizeType degree_v = rGeometry.PolynomialDegree(1);
+
+        const SizeType nb_cp_u = rGeometry.PointsNumberInDirection(0);
+        const SizeType nb_cp_v_old = rGeometry.PointsNumberInDirection(1);
+
+        const Vector& knots_u = rGeometry.KnotsU();
+        const Vector& knots_v_old = rGeometry.KnotsV();
+
+        const Vector& weights_old = rGeometry.Weights();
+
+        const SizeType nb_knots_u = knots_u.size();
+        const SizeType nb_knots_v_old = knots_v_old.size();
+
+        const SizeType a = NurbsUtilities::GetUpperSpan(degree_v, knots_v_old, *knots_v_old.begin());
+        const SizeType b = NurbsUtilities::GetUpperSpan(degree_v, knots_v_old, *knots_v_old.end());
+
+        const SizeType nb_cp_v_refined = nb_cp_v_old + nb_knots_v_to_insert;
+        const SizeType nb_knots_v_refined = nb_knots_v_old + nb_knots_v_to_insert;
+
+        // Resize reference variables
+        if (rKnotsVRefined.size() != nb_knots_v_refined) {
+            rKnotsVRefined.resize(nb_knots_v_refined);
+        }
+        rKnotsVRefined = ZeroVector(nb_knots_v_refined);
+        if (rWeightsRefined.size() != nb_cp_v_refined * nb_cp_u) {
+            rWeightsRefined.resize(nb_cp_v_refined * nb_cp_u);
+        }
+        rWeightsRefined = ZeroVector(nb_cp_v_refined * nb_cp_u);
+        if (rPointsRefined.size() != nb_cp_v_refined * nb_cp_u) {
+            rPointsRefined.resize(nb_cp_v_refined * nb_cp_u);
+        }
+
+        for (IndexType i = 0; i < a - degree_v + 2; ++i) {
+            for (IndexType m = 0; m < nb_cp_u; ++m) {
+                IndexType cp_index_refined = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                    nb_cp_u, nb_cp_v_refined, m, i);
+                IndexType cp_index_old = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                    nb_cp_u, nb_cp_v_old, m, i);
+
+                const array_1d<double, 3> cp_coordinates = rGeometry[cp_index_old] * weights_old[cp_index_old];
+
+                rPointsRefined(cp_index_refined) = Kratos::make_intrusive<NodeType>(cp_index_refined + 1, cp_coordinates);
+                rWeightsRefined[cp_index_refined] = weights_old[cp_index_old];
+            }
+        }
+
+        for (IndexType i = b; i < nb_cp_v_old; ++i) {
+            for (IndexType m = 0; m < nb_cp_u; ++m) {
+                IndexType cp_index_refined = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                    nb_cp_u, nb_cp_v_refined, m, i + nb_knots_v_to_insert);
+                IndexType cp_index_old = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                    nb_cp_u, nb_cp_v_old, m, i);
+
+                const array_1d<double, 3> cp_coordinates = rGeometry[cp_index_old] * weights_old[cp_index_old];
+
+                rPointsRefined(cp_index_refined) = Kratos::make_intrusive<NodeType>(cp_index_refined + 1, cp_coordinates);
+                rWeightsRefined[cp_index_refined] = weights_old[cp_index_old];
+            }
+        }
+
+        // Create new knot span vector
+        for (IndexType i = 0; i < a + 1; i++) {
+            rKnotsVRefined[i] = knots_v_old[i];
+        }
+        for (IndexType i = b + degree_v - 1; i < nb_knots_v_old; i++) {
+            rKnotsVRefined[i + nb_knots_v_to_insert] = knots_v_old[i];
+        }
+
+        const IndexType n = nb_cp_v_old - 1;
+        const IndexType m = n + degree_v + 1;
+        const IndexType r = nb_knots_v_to_insert - 1;
+
+        IndexType i = b + 2 + degree_v - 1;
+        IndexType k = b + 2 + degree_v + r;
+
+        for (int j = r; j >= 0; --j) {
+            while ((rKnotsVToInsert[j] <= knots_v_old[-1 + i]) && (i > a + 1)) {
+                for (IndexType m = 0; m < nb_cp_u; ++m) {
+                    IndexType cp_index_refined = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                        nb_cp_u, nb_cp_v_refined, m, k - degree_v - 1);
+                    IndexType cp_index_old = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                        nb_cp_u, nb_cp_v_old, m, i - degree_v - 1);
+
+                    const array_1d<double, 3> cp_coordinates = rGeometry[cp_index_old] * weights_old[cp_index_old];
+
+                    rPointsRefined(cp_index_refined) = Kratos::make_intrusive<NodeType>(0, cp_coordinates);
+                    rWeightsRefined[cp_index_refined] = weights_old[cp_index_old];
+                }
+                rKnotsVRefined[-1 + k] = knots_v_old[-1 + i];
+
+                k -= 1;
+                i -= 1;
+            }
+
+            for (IndexType m = 0; m < nb_cp_u; m++) {
+                IndexType cp_index_refined_before = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                    nb_cp_u, nb_cp_v_refined, m, k - degree_v);
+                IndexType cp_index_refined_after = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                    nb_cp_u, nb_cp_v_refined, m, k - degree_v - 1);
+
+                rPointsRefined(cp_index_refined_after) = rPointsRefined(cp_index_refined_before);
+                rWeightsRefined[cp_index_refined_after] = rWeightsRefined[cp_index_refined_before];
+            }
+
+            for (IndexType l = 1; l < degree_v + 1; l++) {
+                const IndexType index = k - degree_v + l;
+                auto alpha = rKnotsVRefined[k + l - 1] - rKnotsVToInsert[j];
+
+                if (std::abs(alpha) < 1e-7) {
+                    for (IndexType m = 0; m < nb_cp_u; ++m) {
+                        IndexType cp_index_refined_before = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                            nb_cp_u, nb_cp_v_refined, m, index);
+                        IndexType cp_index_refined_after = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                            nb_cp_u, nb_cp_v_refined, m, index - 1);
+
+                        rPointsRefined(cp_index_refined_after) = rPointsRefined(cp_index_refined_before);
+                        rWeightsRefined[cp_index_refined_after] = rWeightsRefined[cp_index_refined_before];
+                    }
+                }
+                else {
+                    alpha = alpha / (rKnotsVRefined[k + l - 1] - knots_v_old[i + l - degree_u - 1]);
+                    for (IndexType m = 0; m < nb_cp_u; ++m) {
+                        IndexType cp_index_refined_before = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                            nb_cp_u, nb_cp_v_refined, m, index);
+                        IndexType cp_index_refined_after = NurbsUtilities::GetVectorIndexFromMatrixIndices(
+                            nb_cp_u, nb_cp_v_refined, m, index - 1);
+
+                        array_1d<double, 3> cp_coordinates = rPointsRefined[cp_index_refined_after] + (1.0 - alpha) * rPointsRefined[cp_index_refined_before];
+
+                        rPointsRefined(cp_index_refined_after) = Kratos::make_intrusive<NodeType>(0, cp_coordinates);
+                        rWeightsRefined[cp_index_refined_after] = rWeightsRefined[cp_index_refined_after] * alpha + rWeightsRefined[cp_index_refined_before] * (1 - alpha);
+                    }
+                }
+            }
+            rKnotsVRefined[-1 + k] = rKnotsVToInsert[j];
+
+            k -= 1;
+        }
+
+        for (IndexType i = 0; i < nb_cp_v_refined * nb_cp_u; ++i) {
+            rPointsRefined(i)->Coordinates() = rPointsRefined(i)->Coordinates() / rWeightsRefined[i];
+        }
+    }
+
+    ///@}
+
+} // End namespace kratos

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
@@ -32,7 +32,6 @@ namespace Kratos {
         const SizeType nb_knots_u_to_insert = rKnotsUToInsert.size();
 
         const SizeType degree_u = rGeometry.PolynomialDegree(0);
-        const SizeType degree_v = rGeometry.PolynomialDegree(1);
 
         const SizeType nb_cp_u_old = rGeometry.PointsNumberInDirection(0);
         const SizeType nb_cp_v = rGeometry.PointsNumberInDirection(1);
@@ -43,7 +42,6 @@ namespace Kratos {
         const Vector& weights_old = rGeometry.Weights();
 
         const SizeType nb_knots_u_old = knots_u_old.size();
-        const SizeType nb_knots_v = knots_v.size();
 
         const SizeType a = NurbsUtilities::GetUpperSpan(degree_u, knots_u_old, *knots_u_old.begin());
         const SizeType b = NurbsUtilities::GetUpperSpan(degree_u, knots_u_old, *knots_u_old.end());
@@ -102,7 +100,6 @@ namespace Kratos {
         }
 
         const IndexType n = nb_cp_u_old - 1;
-        const IndexType m = n + degree_u + 1;
         const IndexType r = nb_knots_u_to_insert - 1;
 
         IndexType i = b + 2 + degree_u - 1;
@@ -189,7 +186,6 @@ namespace Kratos {
 
         const SizeType nb_knots_v_to_insert = rKnotsVToInsert.size();
 
-        const SizeType degree_u = rGeometry.PolynomialDegree(0);
         const SizeType degree_v = rGeometry.PolynomialDegree(1);
 
         const SizeType nb_cp_u = rGeometry.PointsNumberInDirection(0);
@@ -200,7 +196,6 @@ namespace Kratos {
 
         const Vector& weights_old = rGeometry.Weights();
 
-        const SizeType nb_knots_u = knots_u.size();
         const SizeType nb_knots_v_old = knots_v_old.size();
 
         const SizeType a = NurbsUtilities::GetUpperSpan(degree_v, knots_v_old, *knots_v_old.begin());
@@ -259,7 +254,6 @@ namespace Kratos {
         }
 
         const IndexType n = nb_cp_v_old - 1;
-        const IndexType m = n + degree_v + 1;
         const IndexType r = nb_knots_v_to_insert - 1;
 
         IndexType i = b + 2 + degree_v - 1;
@@ -310,7 +304,7 @@ namespace Kratos {
                     }
                 }
                 else {
-                    alpha = alpha / (rKnotsVRefined[k + l - 1] - knots_v_old[i + l - degree_u - 1]);
+                    alpha = alpha / (rKnotsVRefined[k + l - 1] - knots_v_old[i + l - degree_v - 1]);
                     for (IndexType m = 0; m < nb_cp_u; ++m) {
                         IndexType cp_index_refined_before = NurbsUtilities::GetVectorIndexFromMatrixIndices(
                             nb_cp_u, nb_cp_v_refined, m, index);

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.cpp
@@ -104,7 +104,7 @@ namespace Kratos {
         IndexType k = b + 2 + degree_u + r;
 
         for (int j = r; j >= 0; --j) {
-            while (rKnotsUToInsert[j] <= knots_u_old[-1 + i] && i > a + 1) {
+            while (rKnotsUToInsert[j] <= knots_u_old[i - 1] && i > a + 1) {
                 for (IndexType m = 0; m < nb_cp_v; ++m) {
                     IndexType cp_index_refined = NurbsUtilities::GetVectorIndexFromMatrixIndices(
                         nb_cp_u_refined, nb_cp_v, k - degree_u - 1, m);
@@ -117,7 +117,7 @@ namespace Kratos {
                     rWeightsRefined[cp_index_refined] = weights_old[cp_index_old];
                 }
 
-                rKnotsURefined[-1 + k] = knots_u_old[-1 + i];
+                rKnotsURefined[k - 1] = knots_u_old[i - 1];
 
                 k -= 1;
                 i -= 1;
@@ -135,7 +135,7 @@ namespace Kratos {
 
             for (IndexType l = 1; l < degree_u + 1; ++l) {
                 const IndexType index = k - degree_u + l;
-                auto alpha = rKnotsURefined[-1 + k + l] - rKnotsUToInsert[j];
+                auto alpha = rKnotsURefined[k + l - 1] - rKnotsUToInsert[j];
 
                 if (std::abs(alpha) < 1e-7) {
                     for (IndexType m = 0; m < nb_cp_v; ++m) {
@@ -163,7 +163,7 @@ namespace Kratos {
                     }
                 }
             }
-            rKnotsURefined[-1 + k] = rKnotsUToInsert[j];
+            rKnotsURefined[k - 1] = rKnotsUToInsert[j];
 
             k -= 1;
         }
@@ -256,7 +256,7 @@ namespace Kratos {
         IndexType k = b + 2 + degree_v + r;
 
         for (int j = r; j >= 0; --j) {
-            while ((rKnotsVToInsert[j] <= knots_v_old[-1 + i]) && (i > a + 1)) {
+            while ((rKnotsVToInsert[j] <= knots_v_old[i - 1]) && (i > a + 1)) {
                 for (IndexType m = 0; m < nb_cp_u; ++m) {
                     IndexType cp_index_refined = NurbsUtilities::GetVectorIndexFromMatrixIndices(
                         nb_cp_u, nb_cp_v_refined, m, k - degree_v - 1);
@@ -268,7 +268,7 @@ namespace Kratos {
                     rPointsRefined(cp_index_refined) = Kratos::make_intrusive<NodeType>(0, cp_coordinates);
                     rWeightsRefined[cp_index_refined] = weights_old[cp_index_old];
                 }
-                rKnotsVRefined[-1 + k] = knots_v_old[-1 + i];
+                rKnotsVRefined[k - 1] = knots_v_old[-1 + i];
 
                 k -= 1;
                 i -= 1;
@@ -314,7 +314,7 @@ namespace Kratos {
                     }
                 }
             }
-            rKnotsVRefined[-1 + k] = rKnotsVToInsert[j];
+            rKnotsVRefined[k - 1] = rKnotsVToInsert[j];
 
             k -= 1;
         }

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.h
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.h
@@ -22,7 +22,7 @@
 
 namespace Kratos {
 
-class NurbsSurfaceRefinementUtilities
+class KRATOS_API(KRATOS_CORE) NurbsSurfaceRefinementUtilities
 {
 public:
     ///@name Type Definitions

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.h
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.h
@@ -45,7 +45,7 @@ public:
      *          Piegl 1995, Algorithm A5.5.
      *
      * Portet from carat++ (https://www.bgu.tum.de/st/software/forschung/carat/)
-     * and ANurbs (https://www.bgu.tum.de/st/software/forschung/anurbs/)
+     * and ANurbs (https://github.com/oberbichler/ANurbs)
      *
      * @param rGeometry surface to be refined.
      * @param rKnotsUToInsert Knots to be inserted.
@@ -66,7 +66,7 @@ public:
      *          Piegl 1995, Algorithm A5.5.
      *
      * Portet from carat++ (https://www.bgu.tum.de/st/software/forschung/carat/)
-     * and ANurbs (https://www.bgu.tum.de/st/software/forschung/anurbs/)
+     * and ANurbs (https://github.com/oberbichler/ANurbs)
      *
      * @param rGeometry surface to be refined.
      * @param rKnotsVToInsert Knots to be inserted.

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.h
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.h
@@ -1,0 +1,81 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+
+#if !defined(KRATOS_NURBS_SURFACE_REFINEMENT_UTILITIES_H_INCLUDED )
+#define  KRATOS_NURBS_SURFACE_REFINEMENT_UTILITIES_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "geometries/nurbs_surface_geometry.h"
+#include "nurbs_utilities.h"
+#include "includes/node.h"
+
+namespace Kratos {
+
+class NurbsSurfaceRefinementUtilities
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    typedef std::size_t IndexType;
+    typedef std::size_t SizeType;
+    typedef Node<3> NodeType;
+
+    typedef NurbsSurfaceGeometry<3, PointerVector<NodeType>> NurbsSurfaceGeometryType;
+    typedef typename NurbsSurfaceGeometryType::Pointer NurbsSurfaceGeometryPointerType;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /*
+     * @brief Refines the u-knot vector of a NurbsSurfaceGeometry.
+     * @details This function adopts the surface knot-refinement algorithm from Piegl 1995.
+     *
+     * @param rGeometry surface to be refined.
+     * @param rKnotsUToInsert Knots to be inserted.
+     * @param rPointsRefined the nodes for the refined geometry.
+     * @param rKnotsURefined the new knot vector.
+     * @param rWeightsRefined the new weight vector.
+     */
+    static void KnotRefinementU(
+        NurbsSurfaceGeometryType& rGeometry,
+        std::vector<double>& rKnotsUToInsert,
+        PointerVector<NodeType>& rPointsRefined,
+        Vector& rKnotsURefined,
+        Vector& rWeightsRefined);
+
+    /*
+     * @brief Refines the v-knot vector of a NurbsSurfaceGeometry.
+     * @details This function adopts the surface knot-refinement algorithm from Piegl 1995.
+     *
+     * @param rGeometry surface to be refined.
+     * @param rKnotsVToInsert Knots to be inserted.
+     * @param rPointsRefined the nodes for the refined geometry.
+     * @param rKnotsVRefined the new knot vector.
+     * @param rWeightsRefined the new weight vector.
+     */
+    static void KnotRefinementV(
+        NurbsSurfaceGeometryType& rGeometry,
+        std::vector<double>& rKnotsVToInsert,
+        PointerVector<NodeType>& rPointsRefined,
+        Vector& rKnotsVRefined,
+        Vector& rWeightsRefined);
+
+    ///@}
+};
+
+} // End namespace kratos
+
+#endif // KRATOS_NURBS_SURFACE_REFINEMENT_UTILITIES_H_INCLUDED

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.h
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.h
@@ -41,7 +41,11 @@ public:
 
     /*
      * @brief Refines the u-knot vector of a NurbsSurfaceGeometry.
-     * @details This function adopts the surface knot-refinement algorithm from Piegl 1995.
+     * @details This function adopts the surface knot-refinement algorithm from
+     *          Piegl 1995, Algorithm A5.5.
+     *
+     * Portet from carat++ (https://www.bgu.tum.de/st/software/forschung/carat/)
+     * and ANurbs (https://www.bgu.tum.de/st/software/forschung/anurbs/)
      *
      * @param rGeometry surface to be refined.
      * @param rKnotsUToInsert Knots to be inserted.
@@ -58,7 +62,11 @@ public:
 
     /*
      * @brief Refines the v-knot vector of a NurbsSurfaceGeometry.
-     * @details This function adopts the surface knot-refinement algorithm from Piegl 1995.
+     * @details This function adopts the surface knot-refinement algorithm from
+     *          Piegl 1995, Algorithm A5.5.
+     *
+     * Portet from carat++ (https://www.bgu.tum.de/st/software/forschung/carat/)
+     * and ANurbs (https://www.bgu.tum.de/st/software/forschung/anurbs/)
      *
      * @param rGeometry surface to be refined.
      * @param rKnotsVToInsert Knots to be inserted.

--- a/kratos/geometries/nurbs_surface_geometry.h
+++ b/kratos/geometries/nurbs_surface_geometry.h
@@ -229,6 +229,27 @@ public:
     ///@name Get and Set functions
     ///@{
 
+    void SetInternals(
+        const PointsArrayType& rThisPoints,
+        const SizeType PolynomialDegreeU,
+        const SizeType PolynomialDegreeV,
+        const Vector& rKnotsU,
+        const Vector& rKnotsV,
+        const Vector& rWeights)
+    {
+        this->Points() = rThisPoints;
+        mPolynomialDegreeU = PolynomialDegreeU;
+        mPolynomialDegreeV = PolynomialDegreeV;
+        mKnotsU = rKnotsU;
+        mKnotsV = rKnotsV;
+        mWeights = rWeights;
+
+        CheckAndFitKnotVectors();
+
+        KRATOS_ERROR_IF(rWeights.size() != rThisPoints.size())
+            << "Number of control points and weights do not match!" << std::endl;
+    }
+
     /// @return returns the polynomial degree 'p' in u direction.
     SizeType PolynomialDegreeU() const
     {
@@ -273,7 +294,16 @@ public:
      * @return true if NURBS, false if B-Splines only (all weights are considered as 1) */
     bool IsRational() const
     {
-        return mWeights.size() != 0;
+        if (mWeights.size() == 0)
+            return false;
+        else {
+            for (IndexType i = 0; i < mWeights.size(); ++i) {
+                if (std::abs(mWeights[i] - 1.0) > 1e-8) {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 
     /* Get Weights vector. All values are 1.0 for B-Splines, for NURBS those can be unequal 1.0.

--- a/kratos/tests/cpp_tests/geometries/test_nurbs_surface.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_nurbs_surface.cpp
@@ -152,37 +152,6 @@ namespace Testing {
             points, p, q, knot_u, knot_v);
     }
 
-    NurbsSurfaceGeometry<3, PointerVector<NodeType>> GenerateReferenceNodeSurfaceWithWeightVector() {
-        PointerVector<NodeType> points;
-
-        points.push_back(NodeType::Pointer(new NodeType(1, 0, 5, 0)));
-        points.push_back(NodeType::Pointer(new NodeType(2, 5, 5, 0)));
-        points.push_back(NodeType::Pointer(new NodeType(3, 10, 5, -4)));
-        points.push_back(NodeType::Pointer(new NodeType(4, 0, 0, 0)));
-        points.push_back(NodeType::Pointer(new NodeType(5, 5, 0, 0)));
-        points.push_back(NodeType::Pointer(new NodeType(6, 10, 0, -4)));
-
-        Vector knot_u = ZeroVector(4);
-        knot_u[0] = 0.0;
-        knot_u[1] = 0.0;
-        knot_u[2] = 10.0;
-        knot_u[3] = 10.0;
-        Vector knot_v = ZeroVector(2);
-        knot_v[0] = 0.0;
-        knot_v[1] = 5.0;
-
-        int p = 2;
-        int q = 1;
-
-        Vector weights(6);
-        for (IndexType i = 0; i < 6; i++) {
-            weights[i] = 1.0;
-        }
-
-        return NurbsSurfaceGeometry<3, PointerVector<NodeType>>(
-            points, p, q, knot_u, knot_v, weights);
-    }
-
     NurbsSurfaceGeometry<3, PointerVector<Point>> GenerateReferenceQuarterSphereGeometry()
     {
         NurbsSurfaceGeometry<3, PointerVector<Point>>::PointsArrayType points;
@@ -523,7 +492,7 @@ namespace Testing {
 
     /// Check refinement of nurbs surface in direction u.
     KRATOS_TEST_CASE_IN_SUITE(NurbsSurfaceRefinementU, KratosCoreNurbsGeometriesFastSuite) {
-        auto surface = GenerateReferenceNodeSurfaceWithWeightVector();
+        auto surface = GenerateReferenceNodeSurface();
 
         // Check general information, input to ouput
         std::vector<double> knots_to_insert_u;
@@ -572,7 +541,7 @@ namespace Testing {
 
     /// Check refinement of nurbs surface in direction u.
     KRATOS_TEST_CASE_IN_SUITE(NurbsSurfaceRefinementV, KratosCoreNurbsGeometriesFastSuite) {
-        auto surface = GenerateReferenceNodeSurfaceWithWeightVector();
+        auto surface = GenerateReferenceNodeSurface();
 
         // Check general information, input to ouput
         std::vector<double> knots_to_insert_v;

--- a/kratos/tests/cpp_tests/geometries/test_nurbs_surface.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_nurbs_surface.cpp
@@ -20,6 +20,7 @@
 #include "testing/testing.h"
 #include "containers/pointer_vector.h"
 #include "geometries/nurbs_surface_geometry.h"
+#include "geometries/nurbs_shape_function_utilities/nurbs_surface_refinement_utilities.h"
 
 #include "tests/cpp_tests/geometries/test_geometry.h"
 
@@ -149,6 +150,37 @@ namespace Testing {
 
         return NurbsSurfaceGeometry<3, PointerVector<NodeType>>(
             points, p, q, knot_u, knot_v);
+    }
+
+    NurbsSurfaceGeometry<3, PointerVector<NodeType>> GenerateReferenceNodeSurfaceWithWeightVector() {
+        PointerVector<NodeType> points;
+
+        points.push_back(NodeType::Pointer(new NodeType(1, 0, 5, 0)));
+        points.push_back(NodeType::Pointer(new NodeType(2, 5, 5, 0)));
+        points.push_back(NodeType::Pointer(new NodeType(3, 10, 5, -4)));
+        points.push_back(NodeType::Pointer(new NodeType(4, 0, 0, 0)));
+        points.push_back(NodeType::Pointer(new NodeType(5, 5, 0, 0)));
+        points.push_back(NodeType::Pointer(new NodeType(6, 10, 0, -4)));
+
+        Vector knot_u = ZeroVector(4);
+        knot_u[0] = 0.0;
+        knot_u[1] = 0.0;
+        knot_u[2] = 10.0;
+        knot_u[3] = 10.0;
+        Vector knot_v = ZeroVector(2);
+        knot_v[0] = 0.0;
+        knot_v[1] = 5.0;
+
+        int p = 2;
+        int q = 1;
+
+        Vector weights(6);
+        for (IndexType i = 0; i < 6; i++) {
+            weights[i] = 1.0;
+        }
+
+        return NurbsSurfaceGeometry<3, PointerVector<NodeType>>(
+            points, p, q, knot_u, knot_v, weights);
     }
 
     NurbsSurfaceGeometry<3, PointerVector<Point>> GenerateReferenceQuarterSphereGeometry()
@@ -487,6 +519,93 @@ namespace Testing {
         local_coords[1] = integration_points[5][1];
         surface.GlobalCoordinates(global_coords, local_coords);
         KRATOS_CHECK_VECTOR_NEAR(quadrature_points[5].Center(), global_coords, TOLERANCE);
+    }
+
+    /// Check refinement of nurbs surface in direction u.
+    KRATOS_TEST_CASE_IN_SUITE(NurbsSurfaceRefinementU, KratosCoreNurbsGeometriesFastSuite) {
+        auto surface = GenerateReferenceNodeSurfaceWithWeightVector();
+
+        // Check general information, input to ouput
+        std::vector<double> knots_to_insert_u;
+        knots_to_insert_u.push_back(2.0);
+        knots_to_insert_u.push_back(4.0);
+
+        PointerVector<NodeType> PointsRefined;
+        Vector KnotsURefined;
+        Vector WeightsRefined;
+
+        NurbsSurfaceRefinementUtilities::KnotRefinementU(surface, knots_to_insert_u,
+            PointsRefined, KnotsURefined, WeightsRefined);
+        surface.SetInternals(PointsRefined,
+            surface.PolynomialDegreeU(), surface.PolynomialDegreeV(),
+            KnotsURefined, surface.KnotsV(),
+            WeightsRefined);
+
+        std::vector<double> knots_to_insert_u_2;
+        knots_to_insert_u_2.push_back(8.0);
+        knots_to_insert_u_2.push_back(3.0);
+
+
+        NurbsSurfaceRefinementUtilities::KnotRefinementU(surface, knots_to_insert_u_2,
+            PointsRefined, KnotsURefined, WeightsRefined);
+        surface.SetInternals(PointsRefined,
+            surface.PolynomialDegreeU(), surface.PolynomialDegreeV(),
+            KnotsURefined, surface.KnotsV(),
+            WeightsRefined);
+
+        // Check knot span
+        KRATOS_CHECK_NEAR(surface.KnotsU()[3], 3.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(surface.KnotsU()[4], 4.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(surface.KnotsU()[5], 8.0, TOLERANCE);
+
+        // Check general information, input to ouput
+        typename Geometry<Node<3>>::IntegrationPointsArrayType integration_points;
+        surface.CreateIntegrationPoints(integration_points);
+
+        KRATOS_CHECK_EQUAL(integration_points.size(), 30);
+        double area = 0;
+        for (IndexType i = 0; i < integration_points.size(); ++i) {
+            area += integration_points[i].Weight();
+        }
+        KRATOS_CHECK_NEAR(area, 50.0, TOLERANCE);
+    }
+
+    /// Check refinement of nurbs surface in direction u.
+    KRATOS_TEST_CASE_IN_SUITE(NurbsSurfaceRefinementV, KratosCoreNurbsGeometriesFastSuite) {
+        auto surface = GenerateReferenceNodeSurfaceWithWeightVector();
+
+        // Check general information, input to ouput
+        std::vector<double> knots_to_insert_v;
+        knots_to_insert_v.push_back(4.8);
+        knots_to_insert_v.push_back(2.0);
+        knots_to_insert_v.push_back(4.0);
+
+        PointerVector<NodeType> PointsRefined;
+        Vector KnotsVRefined;
+        Vector WeightsRefined;
+
+        NurbsSurfaceRefinementUtilities::KnotRefinementV(surface, knots_to_insert_v,
+            PointsRefined, KnotsVRefined, WeightsRefined);
+        surface.SetInternals(PointsRefined,
+            surface.PolynomialDegreeU(), surface.PolynomialDegreeV(),
+            surface.KnotsU(), KnotsVRefined,
+            WeightsRefined);
+
+        // Check knot span
+        KRATOS_CHECK_NEAR(surface.KnotsV()[1], 2.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(surface.KnotsV()[2], 4.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(surface.KnotsV()[3], 4.8, TOLERANCE);
+
+        // Check general information, input to ouput
+        typename Geometry<Node<3>>::IntegrationPointsArrayType integration_points;
+        surface.CreateIntegrationPoints(integration_points);
+
+        KRATOS_CHECK_EQUAL(integration_points.size(), 24);
+        double area = 0;
+        for (IndexType i = 0; i < integration_points.size(); ++i) {
+            area += integration_points[i].Weight();
+        }
+        KRATOS_CHECK_NEAR(area, 50.0, TOLERANCE);
     }
 
     KRATOS_TEST_CASE_IN_SUITE(NurbsSurfaceQuarterSphere, KratosCoreNurbsGeometriesFastSuite) {


### PR DESCRIPTION
**Description**
This PR adds the refinement modeler which makes use of #8360 . Yet, only one avenue of refinements is supported, however, more can be attached easily.