### PR TITLE
[core] Fix RK4 test

### DIFF
--- a/kratos/tests/cpp_tests/strategies/strategies/test_explicit_strategies.cpp
+++ b/kratos/tests/cpp_tests/strategies/strategies/test_explicit_strategies.cpp
@@ -79,12 +79,10 @@ namespace Testing
             EquationIdVectorType& rEquationIdVector,
             const ProcessInfo& rCurrentProcessInfo) const override
         {
-            unsigned int local_size = GetGeometry().PointsNumber();
-            rEquationIdVector.resize(local_size);
-            for (unsigned int i=0; i<local_size; i++)
-            {
-                rEquationIdVector[i] = GetGeometry()[i].GetDof(TEMPERATURE).EquationId();
+            if (rEquationIdVector.size() != 1) {
+                rEquationIdVector.resize(1)
             }
+            rEquationIdVector[0] = GetGeometry()[0].GetDof(TEMPERATURE).EquationId();
         }
 
     };

--- a/kratos/tests/cpp_tests/strategies/strategies/test_explicit_strategies.cpp
+++ b/kratos/tests/cpp_tests/strategies/strategies/test_explicit_strategies.cpp
@@ -75,6 +75,13 @@ namespace Testing
             r_node.FastGetSolutionStepValue(REACTION_FLUX) = 37.5 - 3.5 * aux;
         }
 
+        void EquationIdVector(
+            EquationIdVectorType& rEquationIdVector,
+            const ProcessInfo& rCurrentProcessInfo) const override
+        {
+            rEquationIdVector.resize(1);
+        }
+
     };
 
 

--- a/kratos/tests/cpp_tests/strategies/strategies/test_explicit_strategies.cpp
+++ b/kratos/tests/cpp_tests/strategies/strategies/test_explicit_strategies.cpp
@@ -79,7 +79,12 @@ namespace Testing
             EquationIdVectorType& rEquationIdVector,
             const ProcessInfo& rCurrentProcessInfo) const override
         {
-            rEquationIdVector.resize(1);
+            unsigned int local_size = GetGeometry().PointsNumber();
+            rEquationIdVector.resize(local_size);
+            for (unsigned int i=0; i<local_size; i++)
+            {
+                rEquationIdVector[i] = GetGeometry()[i].GetDof(TEMPERATURE).EquationId();
+            }
         }
 
     };


### PR DESCRIPTION
**Description**
As requested in #8049, this PR fixes the Runge-Kutta 4 test. The issue was that the [mass](https://github.com/KratosMultiphysics/Kratos/blob/core/kratos_checks/kratos/solving_strategies/strategies/explicit_solving_strategy_runge_kutta_4.h#L280) we use for updating the solution was 0. This was happening because no [equationId](https://github.com/KratosMultiphysics/Kratos/blob/core/kratos_checks/kratos/solving_strategies/builder_and_solvers/explicit_builder.h#L742) function was defined for the testing element and therefore the [size of the element equation Id](https://github.com/KratosMultiphysics/Kratos/blob/core/kratos_checks/kratos/solving_strategies/builder_and_solvers/explicit_builder.h#L745) was 0, causing the lumped mass matrix to be 0.

In my machine the test is now passing.

Please mark the PR with appropriate tags: 
- Bugfix, Testing

**Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Fixed Runge-Kutta 4 test.
