### PR TITLE
Dem adding max and min to rv

### DIFF
--- a/applications/DEMApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/DEMApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -192,6 +192,7 @@ void AddCustomUtilitiesToPython(pybind11::module& m) {
             )
         .def("GetTotalNumberOfParticlesInjectedSoFar", &DEM_Inlet::GetTotalNumberOfParticlesInjectedSoFar)
         .def("GetTotalMassInjectedSoFar", &DEM_Inlet::GetTotalMassInjectedSoFar)
+        .def("GetMaxRadius", &DEM_Inlet::GetMaxRadius)
         ;
 
     py::class_<DEM_Force_Based_Inlet, DEM_Force_Based_Inlet::Pointer, DEM_Inlet>(m, "DEM_Force_Based_Inlet")
@@ -379,6 +380,7 @@ void AddCustomUtilitiesToPython(pybind11::module& m) {
 
     py::class_<RandomVariable, RandomVariable::Pointer>(m, "RandomVariable")
         .def(py::init<const Parameters>())
+        .def("GetSupport", &RandomVariable::GetSupport)
         ;
 
     py::class_<PiecewiseLinearRandomVariable, PiecewiseLinearRandomVariable::Pointer, RandomVariable>(m, "PiecewiseLinearRandomVariable")

--- a/applications/DEMApplication/custom_utilities/discrete_random_variable.cpp
+++ b/applications/DEMApplication/custom_utilities/discrete_random_variable.cpp
@@ -52,7 +52,7 @@ namespace Kratos {
 
         size_t low_index;
         size_t high_index;
-        CalculateFirstAndLastIndicesWithNonzeroValue<double>(mPossibleValues, low_index, high_index);
+        CalculateFirstAndLastIndicesWithNonzeroValue<double>(mRelativeFrequencies, low_index, high_index);
         SetSupport(mPossibleValues[low_index], mPossibleValues[high_index]);
 
         Check();

--- a/applications/DEMApplication/custom_utilities/discrete_random_variable.cpp
+++ b/applications/DEMApplication/custom_utilities/discrete_random_variable.cpp
@@ -50,6 +50,11 @@ namespace Kratos {
 
         mTrapezoidsDiscreteDistribution = std::discrete_distribution<int>(mRelativeFrequencies.begin(), mRelativeFrequencies.end());
 
+        size_t low_index;
+        size_t high_index;
+        CalculateFirstAndLastIndicesWithNonzeroValue<double>(mPossibleValues, low_index, high_index);
+        SetSupport(mPossibleValues[low_index], mPossibleValues[high_index]);
+
         Check();
 
         Normalize();

--- a/applications/DEMApplication/custom_utilities/discrete_random_variable.h
+++ b/applications/DEMApplication/custom_utilities/discrete_random_variable.h
@@ -68,8 +68,6 @@ private:
     DiscreteRandomVariable & operator=(DiscreteRandomVariable const& rOther);
 
     double mRelativeClosenessTolerance = 0.0;
-    double mMean = 0.0;
-    bool mMeanHasAlreadyBeenCalculated=false;
     std::vector<double> mRelativeFrequencies;
     std::vector<double> mPossibleValues;
     std::mt19937 mRandomNumberGenerator;

--- a/applications/DEMApplication/custom_utilities/inlet.h
+++ b/applications/DEMApplication/custom_utilities/inlet.h
@@ -74,6 +74,7 @@ namespace Kratos {
         double GetTotalMassInjectedSoFar();
         virtual double SetMaxDistributionRadius(ModelPart& mp);
         virtual double SetDistributionMeanRadius(ModelPart& mp);
+        virtual double GetMaxRadius(ModelPart& mp);
 
     protected:
         virtual void AddRandomPerpendicularComponentToGivenVector(array_1d<double, 3 >& vector, const double angle_in_degrees);

--- a/applications/DEMApplication/custom_utilities/piecewise_linear_random_variable.cpp
+++ b/applications/DEMApplication/custom_utilities/piecewise_linear_random_variable.cpp
@@ -50,7 +50,7 @@ namespace Kratos {
 
         size_t low_index;
         size_t high_index;
-        CalculateFirstAndLastIndicesWithNonzeroValue<double>(mPDFBreakpoints, low_index, high_index);
+        CalculateFirstAndLastIndicesWithNonzeroValue<double>(mPDFValues, low_index, high_index);
 
         SetSupport(mPDFBreakpoints[low_index], mPDFBreakpoints[high_index]);
 

--- a/applications/DEMApplication/custom_utilities/piecewise_linear_random_variable.cpp
+++ b/applications/DEMApplication/custom_utilities/piecewise_linear_random_variable.cpp
@@ -1,6 +1,6 @@
 // Authors:
 // Guillermo Casas gcasas@cimne-upc.edu
-
+#include <algorithm>
 #include "piecewise_linear_random_variable.h"
 #include "includes/checks.h"
 
@@ -47,6 +47,12 @@ namespace Kratos {
             mPDFBreakpoints[i] = breakpoints[i];
             mPDFValues[i] = values[i];
         }
+
+        size_t low_index;
+        size_t high_index;
+        CalculateFirstAndLastIndicesWithNonzeroValue<double>(mPDFBreakpoints, low_index, high_index);
+
+        SetSupport(mPDFBreakpoints[low_index], mPDFBreakpoints[high_index]);
 
         Check();
 

--- a/applications/DEMApplication/custom_utilities/piecewise_linear_random_variable.h
+++ b/applications/DEMApplication/custom_utilities/piecewise_linear_random_variable.h
@@ -73,8 +73,6 @@ private:
     PiecewiseLinearRandomVariable & operator=(PiecewiseLinearRandomVariable const& rOther);
 
     double mRelativeClosenessTolerance = 0.0;
-    double mMean = 0.0 ;
-    bool mMeanHasAlreadyBeenCalculated=false;
     std::vector<double> mPDFValues;
     std::vector<double> mPDFBreakpoints;
     std::mt19937 mRandomNumberGenerator;

--- a/applications/DEMApplication/custom_utilities/random_variable.cpp
+++ b/applications/DEMApplication/custom_utilities/random_variable.cpp
@@ -9,6 +9,15 @@ namespace Kratos {
     RandomVariable::RandomVariable(const Parameters rParameters){
     }
 
+    void RandomVariable::SetSupport(const double Min, const double Max){
+        mSupport[0] = Min;
+        mSupport[1] = Max;
+    }
+
+    const array_1d<double, 2>& RandomVariable::GetSupport(){
+        return mSupport;
+    }
+
     std::string RandomVariable::Info() const
     {
         std::stringstream buffer;

--- a/applications/DEMApplication/custom_utilities/random_variable.h
+++ b/applications/DEMApplication/custom_utilities/random_variable.h
@@ -36,6 +36,8 @@ public:
 
     virtual double GetMean(){KRATOS_ERROR << "You are calling 'GetMean' function of the abstract class 'RandomVariable'. Please instantiate a specific derived class instead."; return 0.0;};
 
+    const array_1d<double, 2>& GetSupport();
+
     /// Turn back information as a stemplate<class T, std::size_t dim> tring.
     virtual std::string Info() const;
 
@@ -48,8 +50,23 @@ public:
 
 protected:
     virtual void Check(){};
+    double mMean = 0.0;
+    bool mMeanHasAlreadyBeenCalculated=false;
+
+    template<typename T>
+    void CalculateFirstAndLastIndicesWithNonzeroValue(std::vector<T> values, size_t& low_index, size_t& high_index){
+                // finding first and last indices that correspond to nonzero probabilites
+
+        auto it = std::find_if(values.begin(), values.end(), [](const double x) { return x != 0; });
+        auto reverse_it = std::find_if(values.rbegin(), values.rend(), [](const double x) { return x != 0; });
+        low_index = std::distance(values.begin(), it);
+        high_index = std::distance(begin(values), reverse_it.base()) - 1;
+    }
+
+    void SetSupport(const double Min, const double Max);
 
 private:
+    array_1d<double, 2> mSupport;
 
     /// Assignment operator.
     RandomVariable & operator=(RandomVariable const& rOther);

--- a/applications/DEMApplication/tests/random_variable_based_inlet_tests_files/DiscreteProjectParametersDEM.json
+++ b/applications/DEMApplication/tests/random_variable_based_inlet_tests_files/DiscreteProjectParametersDEM.json
@@ -17,8 +17,8 @@
         "Inlet_inlet": {
             "inlet_name" : "Inlet_inlet",
             "random_variable_settings" : {
-                "possible_values" : [0.001, 0.002, 0.003, 0.004, 0.005],
-                "relative_frequencies" : [1, 3, 4, 2, 1],
+                "possible_values" : [0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007, 0.008],
+                "relative_frequencies" : [0, 0, 1, 3, 4, 2, 1, 0],
                 "do_use_seed" : false,
                 "seed" : 1,
                 "relative_closeness_tolerance" : 1e-6

--- a/applications/DEMApplication/tests/random_variable_based_inlet_tests_files/PiecewiseLinearProjectParametersDEM.json
+++ b/applications/DEMApplication/tests/random_variable_based_inlet_tests_files/PiecewiseLinearProjectParametersDEM.json
@@ -17,8 +17,8 @@
         "Inlet_inlet": {
             "inlet_name" : "Inlet_inlet",
             "random_variable_settings" : {
-                "pdf_breakpoints" : [0.001, 0.002, 0.003, 0.004, 0.005],
-                "pdf_values" : [1, 3, 4, 2, 1],
+                "pdf_breakpoints" : [0.001, 0.002, 0.003, 0.004, 0.005, 0.006, 0.007],
+                "pdf_values" : [1, 3, 4, 2, 1, 0, 0],
                 "do_use_seed" : false,
                 "seed" : 1,
                 "relative_closeness_tolerance" : 1e-6

--- a/applications/DEMApplication/tests/test_inlet.py
+++ b/applications/DEMApplication/tests/test_inlet.py
@@ -3,7 +3,6 @@ import numpy as np
 import KratosMultiphysics as Kratos
 from Kratos import Logger
 import KratosMultiphysics.KratosUnittest as KratosUnittest
-from KratosMultiphysics.KratosUnittest import TestCase
 
 import KratosMultiphysics.DEMApplication.DEM_analysis_stage as dem_analysis
 

--- a/applications/DEMApplication/tests/test_inlet.py
+++ b/applications/DEMApplication/tests/test_inlet.py
@@ -3,6 +3,8 @@ import numpy as np
 import KratosMultiphysics as Kratos
 from Kratos import Logger
 import KratosMultiphysics.KratosUnittest as KratosUnittest
+from KratosMultiphysics.KratosUnittest import TestCase
+
 import KratosMultiphysics.DEMApplication.DEM_analysis_stage as dem_analysis
 
 import random_variable_tests_files.random_variable as rv
@@ -69,6 +71,11 @@ class TestDEMPiecewiseInletAnalysis(dem_analysis.DEMAnalysisStage):
             self.error_norm = TestDEMPiecewiseInletAnalysis.Error(self.empirical_pdf, self.pdf_expected, interval_widths)
             TestDEMPiecewiseInletAnalysis.Say('Error = ' + '{:.4f}'.format(self.error_norm), '( self.tolerance = ' + '{:.4f}'.format(self.tolerance), ')')
 
+
+            inlet_sub_model_part = self.dem_inlet_model_part.GetSubModelPart('Inlet_inlet')
+            self.max_radius = self.DEM_inlet.GetMaxRadius(inlet_sub_model_part)
+            self.max_radius_expected = breakpoints[np.where(pdf_values)[0].max()]
+
         super().FinalizeSolutionStep()
 
     def Finalize(self):
@@ -128,6 +135,11 @@ class TestDEMDiscreteInletAnalysis(TestDEMPiecewiseInletAnalysis):
             error = self.histogram_expected - self.histogram / sum(self.histogram)
             self.error_norm = sum(abs(p) for p in error)
 
+            inlet_sub_model_part = self.dem_inlet_model_part.GetSubModelPart('Inlet_inlet')
+            self.max_radius = self.DEM_inlet.GetMaxRadius(inlet_sub_model_part)
+            self.max_radius_expected = self.possible_values[np.where(self.probabilities)[0].max()]
+
+
         TestDEMPiecewiseInletAnalysis.Say('Error = ' + '{:.2e}'.format(self.error_norm) + ' (Error tolerance = ' + '{:.2e}'.format(self.tolerance) + ')')
 
         dem_analysis.DEMAnalysisStage.FinalizeSolutionStep(self)
@@ -167,7 +179,10 @@ class TestPieceWiseLinearDEMInlet(KratosUnittest.TestCase):
         with open(parameters_file_name, 'r') as parameter_file:
             project_parameters = Kratos.Parameters(parameter_file.read())
 
-        self.analysis(model, project_parameters).Run()
+        analysis = self.analysis(model, project_parameters)
+        analysis.Run()
+        self.assertAlmostEqual(analysis.max_radius_expected, analysis.max_radius)
+
 
 class TestDiscreteDEMInlet(TestPieceWiseLinearDEMInlet):
     def setUp(self):


### PR DESCRIPTION
**Description**
Adding the support calculation to the RV and also using it in the inlet, so that the eggs' radii take it into account for random variables as it already does for the traditional approach.

**Changelog**
- I added the necessary functions in random_variable
- I also took some common member variables from derived classes to the abstract random variable
- I also added the check for the correct calculation of the pdf support (actually, it is the minimal interval that contains it) in the existing tests.

**Additional comments**
The inlet class is in need of modernization/tydiing up, as I have confirmed more deeply duting this development.
