### PR TITLE
Fixing problems related to residuals collection

### DIFF
--- a/applications/RomApplication/python_scripts/structural_mechanics_analysis_rom.py
+++ b/applications/RomApplication/python_scripts/structural_mechanics_analysis_rom.py
@@ -58,14 +58,13 @@ class StructuralMechanicsAnalysisROM(StructuralMechanicsAnalysis):
                 self.ResidualUtilityObject = romapp.RomResidualsUtility(self._GetSolver().GetComputingModelPart(), self.project_parameters["solver_settings"]["rom_settings"], self._GetSolver().get_solution_scheme())
 
     def FinalizeSolutionStep(self):
-        super().FinalizeSolutionStep()
-
         if self.hyper_reduction_element_selector != None:
             if self.hyper_reduction_element_selector.Name == "EmpiricalCubature":
                 print('\n\n\n\nGenerating matrix of residuals')
                 ResMat = self.ResidualUtilityObject.GetResiduals()
                 NP_ResMat = np.array(ResMat, copy=False)
                 self.time_step_residual_matrix_container.append(NP_ResMat)
+        super().FinalizeSolutionStep()
 
     def Finalize(self):
         super().FinalizeSolutionStep()

--- a/applications/RomApplication/python_scripts/structural_mechanics_analysis_rom.py
+++ b/applications/RomApplication/python_scripts/structural_mechanics_analysis_rom.py
@@ -67,7 +67,7 @@ class StructuralMechanicsAnalysisROM(StructuralMechanicsAnalysis):
         super().FinalizeSolutionStep()
 
     def Finalize(self):
-        super().FinalizeSolutionStep()
+        super().Finalize()
         if self.hyper_reduction_element_selector != None:
             if self.hyper_reduction_element_selector.Name == "EmpiricalCubature":
                 OriginalNumberOfElements = self._GetSolver().GetComputingModelPart().NumberOfElements()

--- a/applications/RomApplication/python_scripts/structural_mechanics_analysis_rom.py
+++ b/applications/RomApplication/python_scripts/structural_mechanics_analysis_rom.py
@@ -55,7 +55,7 @@ class StructuralMechanicsAnalysisROM(StructuralMechanicsAnalysis):
                 counter+=1
         if self.hyper_reduction_element_selector != None:
             if self.hyper_reduction_element_selector.Name == "EmpiricalCubature":
-                self.ResidualUtilityObject = romapp.RomResidualsUtility(self._GetSolver().GetComputingModelPart(), self.project_parameters["solver_settings"]["rom_settings"], KratosMultiphysics.ResidualBasedIncrementalUpdateStaticScheme())
+                self.ResidualUtilityObject = romapp.RomResidualsUtility(self._GetSolver().GetComputingModelPart(), self.project_parameters["solver_settings"]["rom_settings"], self._GetSolver().get_solution_scheme())
 
     def FinalizeSolutionStep(self):
         super().FinalizeSolutionStep()


### PR DESCRIPTION
This PR fixes the following errors regarding the residuals in the structural strategy of the RomApplication:

1. The method for collecting the residuals is now called before calling the super() (in order to have the fixed dofs still fixed)
2. The scheme used for collecting the residuals was hard-coded, now it is general 