### PR TITLE
[Poro] Initializing elements in serial to avoid OMP error for certain non-linear CLs (temporary fix)

### DIFF
--- a/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_quasistatic_U_Pw_scheme.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_quasistatic_U_Pw_scheme.hpp
@@ -150,6 +150,29 @@ public:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
+    void InitializeElements( ModelPart& rModelPart) override
+    {
+        KRATOS_TRY
+
+        const ProcessInfo& CurrentProcessInfo = rModelPart.GetProcessInfo();
+
+        int NElems = static_cast<int>(rModelPart.Elements().size());
+        ModelPart::ElementsContainerType::iterator el_begin = rModelPart.ElementsBegin();
+
+        // #pragma omp parallel for
+        for(int i = 0; i < NElems; i++)
+        {
+            ModelPart::ElementsContainerType::iterator itElem = el_begin + i;
+            itElem -> Initialize(CurrentProcessInfo);
+        }
+
+        this->SetElementsAreInitialized();
+
+        KRATOS_CATCH("")
+    }
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
     void InitializeSolutionStep(
         ModelPart& r_model_part,
         TSystemMatrixType& A,

--- a/applications/PoromechanicsApplication/custom_strategies/schemes/poro_explicit_cd_scheme.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/schemes/poro_explicit_cd_scheme.hpp
@@ -165,6 +165,32 @@ public:
         KRATOS_CATCH("")
     }
 
+    // /**
+    //  * @brief This is the place to initialize the elements.
+    //  * @details This is intended to be called just once when the strategy is initialized
+    //  * @param rModelPart The model part of the problem to solve
+    //  */
+    void InitializeElements( ModelPart& rModelPart) override
+    {
+        KRATOS_TRY
+
+        const ProcessInfo& CurrentProcessInfo = rModelPart.GetProcessInfo();
+
+        int NElems = static_cast<int>(rModelPart.Elements().size());
+        ModelPart::ElementsContainerType::iterator el_begin = rModelPart.ElementsBegin();
+
+        // #pragma omp parallel for
+        for(int i = 0; i < NElems; i++)
+        {
+            ModelPart::ElementsContainerType::iterator itElem = el_begin + i;
+            itElem -> Initialize(CurrentProcessInfo);
+        }
+
+        this->SetElementsAreInitialized();
+
+        KRATOS_CATCH("")
+    }
+
     /**
      * @brief This method initializes some rutines related with the explicit scheme
      * @param rModelPart The model of the problem to solve


### PR DESCRIPTION
**Description**
This PR is a temporary fix to run non-linear problems with more than 1 OMP thread while I find the source of a race condition (I was getting an incorrect initialization of some variables of a damage CL when using more than 1 OMP thread).

**Changelog**
- Overridden InitializeElements method in poro schemes.
