### PR TITLE
[Core][Geometry] Projection and closest point: correct API and add new methods

### DIFF
--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -367,32 +367,36 @@ public:
     /* @brief Makes a check if the provided paramater rPointLocalCoordinates[0]
      *        is inside the curve, or on the boundary or if it lays outside.
      *        If it is outside, it is set to the boundary which is closer to it.
-     * @return if rPointLocalCoordinates[0] was before the projection: 
+     * @return if rPointLocalCoordinates[0] was before the projection:
      *         inside -> 1
      *         outside -> 0
      *         on boundary -> 2 - meaning that it is equal to start or end point.
      */
-    int ClosestPointLocalToLocalSpace(
-        CoordinatesArrayType& rPointLocalCoordinates,
+    virtual int ClosestPointLocalToLocalSpace(
+        const CoordinatesArrayType& rPointLocalCoordinates,
+        CoordinatesArrayType& rClosestPointLocalCoordinates,
         const double Tolerance = std::numeric_limits<double>::epsilon()
     ) const override
     {
         const double min_parameter = mCurveNurbsInterval.MinParameter();
         if (rPointLocalCoordinates[0] < min_parameter) {
-            rPointLocalCoordinates[0] = min_parameter;
+            rClosestPointLocalCoordinates[0] = min_parameter;
             return 0;
         } else if (std::abs(rPointLocalCoordinates[0] - min_parameter) < Tolerance) {
+            rClosestPointLocalCoordinates[0] = rPointLocalCoordinates[0];
             return 2;
         }
 
         const double max_parameter = mCurveNurbsInterval.MaxParameter();
         if (rPointLocalCoordinates[0] > max_parameter) {
-            rPointLocalCoordinates[0] = min_parameter;
+            rClosestPointLocalCoordinates[0] = min_parameter;
             return 0;
         } else if (std::abs(rPointLocalCoordinates[0] - max_parameter) < Tolerance) {
+            rClosestPointLocalCoordinates[0] = rPointLocalCoordinates[0];
             return 2;
         }
 
+        rClosestPointLocalCoordinates[0] = rPointLocalCoordinates[0];
         return 1;
     }
 
@@ -449,7 +453,7 @@ public:
      {
         return mpCurveOnSurface->GlobalCoordinates(rResult, rLocalCoordinates);
     }
-    
+
     /**
     * @brief This method maps from local space to global/working space and computes the
     *        number of derivatives at the underlying nurbs curve on surface

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -2603,7 +2603,7 @@ public:
      * @return int 0 -> failed
      *             1 -> converged
      */
-    virtual int ProjectionPoinGlobalToLocalSpace(
+    virtual int ProjectionPointGlobalToLocalSpace(
         const CoordinatesArrayType& rPointGlobalCoordinates,
         CoordinatesArrayType& rProjectionPointLocalCoordinates,
         const double Tolerance = std::numeric_limits<double>::epsilon()

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -2561,6 +2561,60 @@ public:
     }
 
     /**
+     * @brief Projects a point onto the geometry
+     * Projects a certain point on the geometry, or finds the closest point, depending on the provided initial guess.
+     * The external point does not necessary lay on the geometry.
+     * It shall deal as the interface to the mathematical projection function e.g. the Newton-Raphson.
+     * Thus, the breaking criteria does not necessarily mean that it found a point on the surface, if it is really
+     * the closest if or not.
+     * It shows only if the breaking criteria, defined by the tolerance is reached.
+     * This function requires an initial guess, provided by rProjectionPointLocalCoordinates.
+     * This function can be a very costly operation.
+     * @param rPointLocalCoordinates Local coordinates of the point to be projected
+     * @param rProjectionPointLocalCoordinates Projection point local coordinates. This should be initialized with the initial guess
+     * @param Tolerance Accepted orthogonal error
+     * @return int 0 -> failed
+     *             1 -> converged
+     */
+    virtual int ProjectionPointLocalToLocalSpace(
+        const CoordinatesArrayType& rPointLocalCoordinates,
+        CoordinatesArrayType& rProjectionPointLocalCoordinates,
+        const double Tolerance = std::numeric_limits<double>::epsilon()
+    ) const
+    {
+        KRATOS_ERROR << "Calling ProjectionPointLocalToLocalSpace within geometry base class."
+            << " Please check the definition within derived class. "
+            << *this << std::endl;
+    }
+
+    /**
+     * @brief Projects a point onto the geometry
+     * Projects a certain point on the geometry, or finds the closest point, depending on the provided initial guess.
+     * The external point does not necessary lay on the geometry.
+     * It shall deal as the interface to the mathematical projection function e.g. the Newton-Raphson.
+     * Thus, the breaking criteria does not necessarily mean that it found a point on the surface, if it is really
+     * the closest if or not.
+     * It shows only if the breaking criteria, defined by the tolerance is reached.
+     * This function requires an initial guess, provided by rProjectionPointLocalCoordinates.
+     * This function can be a very costly operation.
+     * @param rPointLocalCoordinates Global coordinates of the point to be projected
+     * @param rProjectionPointLocalCoordinates Projection point local coordinates. This should be initialized with the initial guess
+     * @param Tolerance Accepted orthogonal error
+     * @return int 0 -> failed
+     *             1 -> converged
+     */
+    virtual int ProjectionPoinGlobalToLocalSpace(
+        const CoordinatesArrayType& rPointGlobalCoordinates,
+        CoordinatesArrayType& rProjectionPointLocalCoordinates,
+        const double Tolerance = std::numeric_limits<double>::epsilon()
+    ) const
+    {
+        KRATOS_ERROR << "Calling ProjectionPoinGlobalToLocalSpace within geometry base class."
+            << " Please check the definition within derived class. "
+            << *this << std::endl;
+    }
+
+    /**
     * @brief Returns all coordinates of the closest point on
     *        the geometry given to an arbitrary point in global coordinates.
     *        The basic concept is to first do a projection towards
@@ -2678,23 +2732,46 @@ public:
     }
 
     /**
-    * @brief Checks if given local coordinates are within this geometry.
-    *        If not, the closest local coordinate within this geometry is found.
-    * @param rPointLocalCoordinates the point to which the
-    *        closest point has to be found.
-    *
-    * @param Tolerance accepted orthogonal error.
-    * @return -1 -> failed
-    *          0 -> outside
-    *          1 -> inside
-    *          2 -> on the boundary
-    */
+     * @brief Calculates the closes point projection
+     * This method calculates the closest point projection of a point in local space coordinates
+     * @param rPointLocalCoordinates Input local coordinates
+     * @param rClosestPointLocalCoordinates Closest point local coordinates. This should be initialized with the initial guess
+     * @param Tolerance Accepted orthogonal error
+     * @return int 1 -> failed
+     *             0 -> outside
+     *             1 -> inside
+     *             2 -> on the boundary
+     */
     virtual int ClosestPointLocalToLocalSpace(
-        CoordinatesArrayType& rPointLocalCoordinates,
+        const CoordinatesArrayType& rPointLocalCoordinates,
+        CoordinatesArrayType& rClosestPointLocalCoordinates,
         const double Tolerance = std::numeric_limits<double>::epsilon()
     ) const
     {
         KRATOS_ERROR << "Calling ClosestPointLocalToLocalSpace from base class."
+            << " Please check the definition of derived class. "
+            << *this << std::endl;
+        return 0;
+    }
+
+    /**
+     * @brief Calculates the closes point projection
+     * This method calculates the closest point projection of a point in global space coordinates
+     * @param rPointLocalCoordinates Input global coordinates
+     * @param rClosestPointLocalCoordinates Closest point local coordinates. This should be initialized with the initial guess
+     * @param Tolerance Accepted orthogonal error
+     * @return int 1 -> failed
+     *             0 -> outside
+     *             1 -> inside
+     *             2 -> on the boundary
+     */
+    virtual int ClosestPointGlobalToLocalSpace(
+        const CoordinatesArrayType& rPointGlobalCoordinates,
+        CoordinatesArrayType& rClosestPointLocalCoordinates,
+        const double Tolerance = std::numeric_limits<double>::epsilon()
+    ) const
+    {
+        KRATOS_ERROR << "Calling ClosestPointGlobalToLocalSpace from base class."
             << " Please check the definition of derived class. "
             << *this << std::endl;
         return 0;

--- a/kratos/geometries/nurbs_curve_geometry.h
+++ b/kratos/geometries/nurbs_curve_geometry.h
@@ -335,36 +335,36 @@ public:
     /* @brief Makes a check if the provided paramater rPointLocalCoordinates[0]
      *        is inside the curve, or on the boundary or if it lays outside.
      *        If it is outside, it is set to the boundary which is closer to it.
-     * @return if rPointLocalCoordinates[0] was before the projection: 
+     * @return if rPointLocalCoordinates[0] was before the projection:
      *         outside -> 0
      *         inside -> 1
      *         on boundary -> 2 - meaning that it is equal to start or end point.
      */
-    int ClosestPointLocalToLocalSpace(
-        CoordinatesArrayType& rPointLocalCoordinates,
+    virtual int ClosestPointLocalToLocalSpace(
+        const CoordinatesArrayType& rPointLocalCoordinates,
+        CoordinatesArrayType& rClosestPointLocalCoordinates,
         const double Tolerance = std::numeric_limits<double>::epsilon()
     ) const override
     {
-        const double min_parameter =
-            std::min(mKnots[mPolynomialDegree - 1],
-                mKnots[NumberOfKnots() - mPolynomialDegree]);
+        const double min_parameter = std::min(mKnots[mPolynomialDegree - 1], mKnots[NumberOfKnots() - mPolynomialDegree]);
         if (rPointLocalCoordinates[0] < min_parameter) {
-            rPointLocalCoordinates[0] = min_parameter;
+            rClosestPointLocalCoordinates[0] = min_parameter;
             return 0;
         } else if (rPointLocalCoordinates[0] == min_parameter) {
+            rClosestPointLocalCoordinates[0] = rPointLocalCoordinates[0];
             return 2;
         }
 
-        const double max_parameter =
-            std::max(mKnots[mPolynomialDegree - 1],
-                mKnots[NumberOfKnots() - mPolynomialDegree]);
+        const double max_parameter = std::max(mKnots[mPolynomialDegree - 1], mKnots[NumberOfKnots() - mPolynomialDegree]);
         if (rPointLocalCoordinates[0] > max_parameter) {
-            rPointLocalCoordinates[0] = max_parameter;
+            rClosestPointLocalCoordinates[0] = max_parameter;
             return 0;
         } else if (rPointLocalCoordinates[0] == max_parameter) {
+            rClosestPointLocalCoordinates[0] = rPointLocalCoordinates[0];
             return 2;
         }
 
+        rClosestPointLocalCoordinates[0] = rPointLocalCoordinates[0];
         return 1;
     }
 

--- a/kratos/geometries/nurbs_curve_on_surface_geometry.h
+++ b/kratos/geometries/nurbs_curve_on_surface_geometry.h
@@ -326,17 +326,18 @@ public:
     /* @brief Makes a check if the provided paramater rPointLocalCoordinates[0]
      *        is inside the curve, or on the boundary or if it lays outside.
      *        If it is outside, it is set to the boundary which is closer to it.
-     * @return if rPointLocalCoordinates[0] was before the projection: 
+     * @return if rPointLocalCoordinates[0] was before the projection:
      *         on boundary -> 2 - meaning that it is equal to start or end point.
      *         inside -> 1
      *         outside -> 0
      */
     int ClosestPointLocalToLocalSpace(
-        CoordinatesArrayType& rPointLocalCoordinates,
+        const CoordinatesArrayType& rPointLocalCoordinates,
+        CoordinatesArrayType& rClosestPointLocalCoordinates,
         const double Tolerance = std::numeric_limits<double>::epsilon()
     ) const override
     {
-        return mpNurbsCurve->ClosestPointLocalToLocalSpace(rPointLocalCoordinates, Tolerance);
+        return mpNurbsCurve->ClosestPointLocalToLocalSpace(rPointLocalCoordinates, rClosestPointLocalCoordinates, Tolerance);
     }
 
 

--- a/kratos/utilities/nurbs_utilities/projection_nurbs_geometry_utilities.h
+++ b/kratos/utilities/nurbs_utilities/projection_nurbs_geometry_utilities.h
@@ -74,7 +74,7 @@ public:
                 2);
             rResultLocal = derivatives[0];
 
-            // Compute the distance vector between the point and its 
+            // Compute the distance vector between the point and its
             // projection on the curve
             distance_vector = rResultLocal - rPointGlobal;
             if (norm_2(distance_vector) < Accuracy)
@@ -95,9 +95,9 @@ public:
             if (norm_2(delta_t * derivatives[1]) < Accuracy)
                 return true;
 
-            // Check if the parameter gets out of its interval of definition and if so clamp it 
+            // Check if the parameter gets out of its interval of definition and if so clamp it
             // back to the boundaries
-            int check = rGeometry.ClosestPointLocalToLocalSpace(rParameterLocalCoordinates);
+            int check = rGeometry.ClosestPointLocalToLocalSpace(rParameterLocalCoordinates, rParameterLocalCoordinates);
             if (check == 0) {
                 if (projection_reset_to_boundary) { return false; }
                 else { projection_reset_to_boundary = true; }
@@ -231,7 +231,7 @@ public:
             rParameterLocalCoordinates[0] += d_u;
             rParameterLocalCoordinates[1] += d_v;
 
-            // Check if the parametric coordinates get out of their interval of definition 
+            // Check if the parametric coordinates get out of their interval of definition
             // and if so clamp them back to their boundaries
             rNurbsSurface.DomainIntervalU().IsInside(rParameterLocalCoordinates[0]);
             rNurbsSurface.DomainIntervalV().IsInside(rParameterLocalCoordinates[1]);


### PR DESCRIPTION
**Description**
This correct the API of the new closest point method according to the discussion in #8491. I also took the chance to add the interface to the new ones, which throw an error as discussed.

In a further PR we can deprecate the old ones.

@tteschemacher can you please check that the changes I've done in your geometries are correct?

**Changelog**
New projection and closest point methods to the interface.
