### PR TITLE
[DEM] Missing include

### DIFF
--- a/applications/DEMApplication/custom_utilities/discrete_random_variable.cpp
+++ b/applications/DEMApplication/custom_utilities/discrete_random_variable.cpp
@@ -3,6 +3,7 @@
 
 #include "discrete_random_variable.h"
 #include "includes/checks.h"
+#include <numeric>
 
 namespace Kratos {
     DiscreteRandomVariable::DiscreteRandomVariable():

--- a/applications/DEMApplication/custom_utilities/discrete_random_variable.h
+++ b/applications/DEMApplication/custom_utilities/discrete_random_variable.h
@@ -16,7 +16,6 @@
 #include "DEM_application_variables.h"
 #include "includes/model_part.h"
 #include "random_variable.h"
-#include <numeric>
 
 namespace Kratos {
 

--- a/applications/DEMApplication/custom_utilities/discrete_random_variable.h
+++ b/applications/DEMApplication/custom_utilities/discrete_random_variable.h
@@ -16,6 +16,7 @@
 #include "DEM_application_variables.h"
 #include "includes/model_part.h"
 #include "random_variable.h"
+#include <numeric>
 
 namespace Kratos {
 


### PR DESCRIPTION
**Description**
Missing include in DEM Application


**Changelog**
![image](https://user-images.githubusercontent.com/5918085/127820444-4b1ac2e0-7cfd-433a-bff0-30441313eb11.png)
added #include '< numeric>' in applications\DEMApplication\custom_utilities\discrete_random_variable.h

**Disclaimer**
I don't know if this is the proper fix. Maybe it could be fixed by including any other kratos  *.hpp header containing 'numeric'.
I just know that this works.
