### PR TITLE
[Core] Level set process - small improvements

### DIFF
--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -278,7 +278,7 @@ public:
     {
         Parameters default_parameters = Parameters(R"({
             "model_part_name" : "",
-            "new_model_part_name" : "",
+            "convection_model_part_name" : "",
             "levelset_variable_name" : "DISTANCE",
             "levelset_convection_variable_name" : "VELOCITY",
             "levelset_gradient_variable_name" : "DISTANCE_GRADIENT",

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -466,7 +466,7 @@ protected:
 
         mpDistanceModelPart->SetProcessInfo(rBaseModelPart.pGetProcessInfo());
         mpDistanceModelPart->SetBufferSize(base_buffer_size);
-        for(auto i_properties = rBaseModelPart.PropertiesBegin() ; i_properties != rBaseModelPart.PropertiesEnd() ; i_properties++){
+        for(auto i_properties = rBaseModelPart.PropertiesBegin() ; i_properties != rBaseModelPart.PropertiesEnd() ; ++i_properties){
             mpDistanceModelPart->AddProperties(*(i_properties).base(),0);
         }
         mpDistanceModelPart->Tables() = rBaseModelPart.Tables();

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -808,10 +808,10 @@ private:
         mMaxAllowedCFL = ThisParameters["max_CFL"].GetDouble();
         mpLevelSetVar = &KratosComponents<Variable<double>>::Get(ThisParameters["levelset_variable_name"].GetString());
         mpConvectVar = &KratosComponents<Variable<array_1d<double,3>>>::Get(ThisParameters["levelset_convection_variable_name"].GetString());
-        if (ThisParameters["new_model_part_name"].GetString() == "") {
+        if (ThisParameters["convection_model_part_name"].GetString() == "") {
             mAuxModelPartName = mrBaseModelPart.Name() + "_DistanceConvectionPart";
         } else {
-            mAuxModelPartName = ThisParameters["new_model_part_name"].GetString();
+            mAuxModelPartName = ThisParameters["convection_model_part_name"].GetString();
         }
 
         // Limiter related settings

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -278,6 +278,7 @@ public:
     {
         Parameters default_parameters = Parameters(R"({
             "model_part_name" : "",
+            "new_model_part_name" : "",
             "levelset_variable_name" : "DISTANCE",
             "levelset_convection_variable_name" : "VELOCITY",
             "levelset_gradient_variable_name" : "DISTANCE_GRADIENT",
@@ -465,7 +466,9 @@ protected:
 
         mpDistanceModelPart->SetProcessInfo(rBaseModelPart.pGetProcessInfo());
         mpDistanceModelPart->SetBufferSize(base_buffer_size);
-        mpDistanceModelPart->SetProperties(rBaseModelPart.pProperties());
+        for(auto i_properties = rBaseModelPart.PropertiesBegin() ; i_properties != rBaseModelPart.PropertiesEnd() ; i_properties++){
+            mpDistanceModelPart->AddProperties(*(i_properties).base(),0);
+        }
         mpDistanceModelPart->Tables() = rBaseModelPart.Tables();
 
         // Assigning the nodes to the new model part
@@ -805,7 +808,11 @@ private:
         mMaxAllowedCFL = ThisParameters["max_CFL"].GetDouble();
         mpLevelSetVar = &KratosComponents<Variable<double>>::Get(ThisParameters["levelset_variable_name"].GetString());
         mpConvectVar = &KratosComponents<Variable<array_1d<double,3>>>::Get(ThisParameters["levelset_convection_variable_name"].GetString());
-        mAuxModelPartName = mrBaseModelPart.Name() + "_DistanceConvectionPart";
+        if (ThisParameters["new_model_part_name"].GetString() == "") {
+            mAuxModelPartName = mrBaseModelPart.Name() + "_DistanceConvectionPart";
+        } else {
+            mAuxModelPartName = ThisParameters["new_model_part_name"].GetString();
+        }
 
         // Limiter related settings
         mpLevelSetGradientVar = (mIsBfecc || mElementRequiresLevelSetGradient) ? &(KratosComponents<Variable<array_1d<double, 3>>>::Get(ThisParameters["levelset_gradient_variable_name"].GetString())) : nullptr;

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -466,8 +466,8 @@ protected:
 
         mpDistanceModelPart->SetProcessInfo(rBaseModelPart.pGetProcessInfo());
         mpDistanceModelPart->SetBufferSize(base_buffer_size);
-        for(auto i_properties = rBaseModelPart.PropertiesBegin() ; i_properties != rBaseModelPart.PropertiesEnd() ; ++i_properties){
-            mpDistanceModelPart->AddProperties(*(i_properties).base(),0);
+        for(auto it_properties = rBaseModelPart.PropertiesBegin() ; it_properties != rBaseModelPart.PropertiesEnd() ; ++it_properties){
+            mpDistanceModelPart->AddProperties(*(it_properties).base());
         }
         mpDistanceModelPart->Tables() = rBaseModelPart.Tables();
 


### PR DESCRIPTION
I added two small fixes/improvementes in level set process.
First, I added the possibility of letting the user decide the name of the new model part. Currently, we cannot use the same base model part to solve more than one level set problem (for example convection of distance and convection of some kind of species) because they would use the same name. If nothing is provided, current behaviour is maintained.

Also, I added a fix detected some time ago by @pablobecker and @pooyan-dadvand when setting the properties. If I understand it correctly, the problem is that when you do

`mpDistanceModelPart->SetProperties(rBaseModelPart.pProperties());`

you are changing the pointer in the mpDistanceModelPart, but the original object still exists and can lead to memory problems. 

@RiccardoRossi  @rubenzorrilla @mrhashemi @philbucher 