### PR TITLE
[Core] level set process - move functions from constructor to initialize

### DIFF
--- a/applications/TrilinosApplication/custom_processes/trilinos_levelset_convection_process.h
+++ b/applications/TrilinosApplication/custom_processes/trilinos_levelset_convection_process.h
@@ -107,7 +107,6 @@ public:
             mrEpetraCommunicator,
             row_size_guess,
             pLinearSolver);
-        InitializeConvectionStrategy(p_builder_and_solver);
 
         KRATOS_CATCH("")
     }

--- a/applications/TrilinosApplication/custom_processes/trilinos_levelset_convection_process.h
+++ b/applications/TrilinosApplication/custom_processes/trilinos_levelset_convection_process.h
@@ -103,7 +103,7 @@ public:
         KRATOS_TRY
 
         const int row_size_guess = (TDim == 2 ? 15 : 40);
-        auto p_builder_and_solver = Kratos::make_shared< TrilinosBlockBuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver>>(
+        BaseType::mpBuilderAndSolver = Kratos::make_shared< TrilinosBlockBuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver>>(
             mrEpetraCommunicator,
             row_size_guess,
             pLinearSolver);
@@ -286,7 +286,7 @@ private:
     ///@name Private Operations
     ///@{
 
-    void InitializeConvectionStrategy(BuilderSolverPointerType pBuilderAndSolver)
+    void InitializeConvectionStrategy(BuilderSolverPointerType pBuilderAndSolver) override
     {
         KRATOS_TRY
 

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -123,7 +123,7 @@ public:
     {
         KRATOS_TRY
 
-        mpBuilderAndSolver = Kratos::make_shared< ResidualBasedBlockBuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver>>(pLinearSolver);;
+        mpBuilderAndSolver = Kratos::make_shared< ResidualBasedBlockBuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver>>(pLinearSolver);
 
         KRATOS_CATCH("")
     }

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -149,37 +149,6 @@ public:
     ///@name Operations
     ///@{
 
-    void SetUpLevelSetConvection()
-    {
-        KRATOS_TRY;
-
-        // Validate the common settings as well as the element formulation specific ones
-        mLevelSetConvectionSettings.ValidateAndAssignDefaults(this->GetDefaultParameters());
-        mLevelSetConvectionSettings["element_settings"].ValidateAndAssignDefaults(this->GetConvectionElementDefaultParameters(mLevelSetConvectionSettings["element_type"].GetString()));
-
-        // Checks and assign all the required member variables
-        CheckAndAssignSettings(mLevelSetConvectionSettings);
-
-        // Sets the convection diffusion problem settings
-        SetConvectionProblemSettings();
-
-        if (mIsBfecc || mElementRequiresLevelSetGradient){
-            mpGradientCalculator = Kratos::make_unique<ComputeGradientProcessType>(
-            mrBaseModelPart,
-            *mpLevelSetVar,
-            *mpLevelSetGradientVar,
-            NODAL_AREA,
-            false);
-        }
-
-        InitializeConvectionStrategy(mpBuilderAndSolver);
-
-        mProcessIsSetUp = true;
-
-        KRATOS_CATCH("")
-
-    }
-
 
     /**
      * @brief Perform the level-set convection
@@ -436,6 +405,40 @@ protected:
         , mrModel(rModelPart.GetModel())
         , mLevelSetConvectionSettings(ThisParameters)
     {}
+
+    /**
+     * @brief This method validates and assigns the process settings and initializes
+     *  the convection strategy. Also, creates mpGradientCalculator if needed.
+     */
+    void SetUpLevelSetConvection()
+    {
+        KRATOS_TRY;
+
+        // Validate the common settings as well as the element formulation specific ones
+        mLevelSetConvectionSettings.ValidateAndAssignDefaults(this->GetDefaultParameters());
+        mLevelSetConvectionSettings["element_settings"].ValidateAndAssignDefaults(this->GetConvectionElementDefaultParameters(mLevelSetConvectionSettings["element_type"].GetString()));
+
+        // Checks and assign all the required member variables
+        CheckAndAssignSettings(mLevelSetConvectionSettings);
+
+        // Sets the convection diffusion problem settings
+        SetConvectionProblemSettings();
+
+        if (mIsBfecc || mElementRequiresLevelSetGradient){
+            mpGradientCalculator = Kratos::make_unique<ComputeGradientProcessType>(
+            mrBaseModelPart,
+            *mpLevelSetVar,
+            *mpLevelSetGradientVar,
+            NODAL_AREA,
+            false);
+        }
+
+        InitializeConvectionStrategy(mpBuilderAndSolver);
+
+        mProcessIsSetUp = true;
+
+        KRATOS_CATCH("")
+    }
 
     /**
      * @brief Set the level set convection formulation settings

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -104,8 +104,7 @@ public:
             rModel.GetModelPart(ThisParameters["model_part_name"].GetString()),
             pLinearSolver,
             ThisParameters)
-    {
-    }
+    {}
 
     /**
      * @brief Construct a new Level Set Convection Process object
@@ -118,9 +117,9 @@ public:
         ModelPart& rBaseModelPart,
         typename TLinearSolver::Pointer pLinearSolver,
         Parameters ThisParameters)
-        : mrBaseModelPart(rBaseModelPart),
-          mrModel(rBaseModelPart.GetModel()),
-          mLevelSetConvectionSettings(ThisParameters)
+        : LevelSetConvectionProcess(
+            rBaseModelPart,
+            ThisParameters)
     {
         KRATOS_TRY
 

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -193,13 +193,13 @@ public:
     {
         KRATOS_TRY;
 
+        if (!mProcessIsInitialized) {
+            ExecuteInitialize();
+        }
+
         // Fill the auxiliary convection model part if not done yet
         if(mDistancePartIsInitialized == false){
             ReGenerateConvectionModelPart(mrBaseModelPart);
-        }
-
-        if (!mProcessIsInitialized) {
-            ExecuteInitialize();
         }
 
         // Evaluate steps needed to achieve target max_cfl

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -149,7 +149,7 @@ public:
     ///@name Operations
     ///@{
 
-    void ExecuteInitialize() override
+    void SetUpLevelSetConvection()
     {
         KRATOS_TRY;
 
@@ -174,7 +174,7 @@ public:
 
         InitializeConvectionStrategy(mpBuilderAndSolver);
 
-        mProcessIsInitialized = true;
+        mProcessIsSetUp = true;
 
         KRATOS_CATCH("")
 
@@ -193,8 +193,8 @@ public:
     {
         KRATOS_TRY;
 
-        if (!mProcessIsInitialized) {
-            ExecuteInitialize();
+        if (!mProcessIsSetUp) {
+            SetUpLevelSetConvection();
         }
 
         // Fill the auxiliary convection model part if not done yet
@@ -419,7 +419,7 @@ protected:
 
     BuilderAndSolverPointerType mpBuilderAndSolver = nullptr;
 
-    bool mProcessIsInitialized = false;
+    bool mProcessIsSetUp = false;
 
     ///@}
     ///@name Protected Operators


### PR DESCRIPTION
As we discussed some time ago, I was trying to create a derived version of level_set_convection_process in altair side, overwritting some of the methods (especially those related to ElementFactory). The problem is that those functions are called in the constructor of the base class, when derived class is not constructed yet and therefore, the base class methods are always called.

The most obvious solution I found was to simplify the constructor to the very minimum that is needed and move the rest to ExecuteInitialize. I think this makes sense in general, I have the feeling that we tend to "overload" the constructors.

I added a mProcessIsInitialized flag to the process so nothing gets broken. It can be removed if you prefer so.

Is this ok to you?

Changelog:

- moved many functions from constructor to ExecuteInitialize()
- made InitializeConvectionStrategy virtual.
- added mpBuilderAndSolver as a member variable, is the only way I found to use it in ExecuteInitialize.