### PR TITLE
[ConvDiff] Extract system matrix and vector to scipy/numpy

### DIFF
--- a/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_stationary_matrix_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_stationary_matrix_solver.py
@@ -1,0 +1,88 @@
+# Importing the Kratos Library
+import KratosMultiphysics
+
+# Import applications
+import KratosMultiphysics.ConvectionDiffusionApplication as ConvectionDiffusionApplication
+
+# Import base class file
+from KratosMultiphysics.ConvectionDiffusionApplication import convection_diffusion_stationary_solver
+import KratosMultiphysics.scipy_conversion_tools
+import numpy as np
+
+
+def CreateSolver(main_model_part, custom_settings):
+    return ConvectionDiffusionStationaryMatrixSolver(main_model_part, custom_settings)
+
+
+class ConvectionDiffusionStationaryMatrixSolver(convection_diffusion_stationary_solver.ConvectionDiffusionStationarySolver):
+    """Variant of the stationary convection diffusion solver that extracts:
+    - the system matrix as scipy.sparse.csr_matrix
+    - the system vector as np.ndarray
+    """
+
+    def __init__(self, main_model_part, custom_settings):
+
+        # Construct the base solver and validate the remaining settings in the base class
+        super(ConvectionDiffusionStationaryMatrixSolver, self).__init__(main_model_part, custom_settings)
+
+        KratosMultiphysics.Logger.PrintInfo(self.__class__.__name__, "Construction finished")
+
+
+    def SolveSolutionStep(self):
+        """Assembles the system and stores the system matrix and vector as member variables"""
+        self.K, self.p = self._SystemComputation()
+
+        # example of a solution with the extracted matrix and vector
+        # ----
+        # import scipy.sparse.linalg
+        # x = scipy.sparse.linalg.spsolve(self.K, self.p)
+
+        # self._AssignSystemVector(x)
+        # ----
+
+        KratosMultiphysics.Logger.PrintInfo("::[ConvectionDiffusionStationaryMatrixSolver]:: ", "Extracted system matrix and vector.")
+        KratosMultiphysics.Logger.PrintInfo("::[ConvectionDiffusionStationaryMatrixSolver]:: ", "No solution triggered!")
+
+        return True
+
+    def _SystemComputation(self):
+        """Assembles the system matrix and vector and returns them as scipy.sparse.csr_matrix and np.ndarray respectively"""
+        space = KratosMultiphysics.UblasSparseSpace()
+        strategy = self.get_convection_diffusion_solution_strategy()
+        scheme = strategy.GetScheme()
+
+        A = strategy.GetSystemMatrix()
+        space.SetToZeroMatrix(A)
+
+        b = strategy.GetSystemVector()
+        space.SetToZeroVector(b)
+
+        # Create dummy vector
+        xD = space.CreateEmptyVectorPointer()
+        space.ResizeVector( xD, space.Size1(A) )
+        space.SetToZeroVector(xD)
+
+        # Build matrix
+        builder_and_solver = self.get_builder_and_solver()
+        builder_and_solver.Build(scheme, self.GetComputingModelPart(), A, b)
+        # Apply constraints
+        builder_and_solver.ApplyConstraints(scheme, self.GetComputingModelPart(), A, b)
+        # Apply boundary conditions
+        builder_and_solver.ApplyDirichletConditions(scheme, self.GetComputingModelPart(), A, xD, b)
+        # Convert system matrix to scipy
+        A_csr = KratosMultiphysics.scipy_conversion_tools.to_csr(A)
+        # Convert system vector to np
+        b_np = np.array(b)
+
+        return A_csr, b_np
+
+
+    def _AssignSystemVector(self, vector):
+        """Assigns the values of the vector to the TEMPERATURE dofs """
+        print(len(vector))
+        for node in self.GetComputingModelPart().Nodes:
+            dof = node.GetDof(KratosMultiphysics.TEMPERATURE)
+
+            if not dof.IsFixed():
+                value = vector[dof.EquationId]
+                node.SetSolutionStepValue(KratosMultiphysics.TEMPERATURE, value)

--- a/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_stationary_matrix_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_stationary_matrix_solver.py
@@ -40,8 +40,8 @@ class ConvectionDiffusionStationaryMatrixSolver(convection_diffusion_stationary_
         # self._AssignSystemVector(x)
         # ----
 
-        KratosMultiphysics.Logger.PrintInfo("::[ConvectionDiffusionStationaryMatrixSolver]:: ", "Extracted system matrix and vector.")
-        KratosMultiphysics.Logger.PrintInfo("::[ConvectionDiffusionStationaryMatrixSolver]:: ", "No solution triggered!")
+        KratosMultiphysics.Logger.PrintInfo("::[{}]:: ".format(self.__class__.__name__), "Extracted system matrix and vector.")
+        KratosMultiphysics.Logger.PrintInfo("::[{}]:: ".format(self.__class__.__name__), "No solution triggered!")
 
         return True
 
@@ -79,7 +79,6 @@ class ConvectionDiffusionStationaryMatrixSolver(convection_diffusion_stationary_
 
     def _AssignSystemVector(self, vector):
         """Assigns the values of the vector to the TEMPERATURE dofs """
-        print(len(vector))
         for node in self.GetComputingModelPart().Nodes:
             dof = node.GetDof(KratosMultiphysics.TEMPERATURE)
 

--- a/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_stationary_matrix_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_stationary_matrix_solver.py
@@ -1,9 +1,6 @@
 # Importing the Kratos Library
 import KratosMultiphysics
 
-# Import applications
-import KratosMultiphysics.ConvectionDiffusionApplication as ConvectionDiffusionApplication
-
 # Import base class file
 from KratosMultiphysics.ConvectionDiffusionApplication import convection_diffusion_stationary_solver
 import KratosMultiphysics.scipy_conversion_tools
@@ -15,6 +12,7 @@ def CreateSolver(main_model_part, custom_settings):
 
 
 class ConvectionDiffusionStationaryMatrixSolver(convection_diffusion_stationary_solver.ConvectionDiffusionStationarySolver):
+
     """Variant of the stationary convection diffusion solver that extracts:
     - the system matrix as scipy.sparse.csr_matrix
     - the system vector as np.ndarray
@@ -29,7 +27,7 @@ class ConvectionDiffusionStationaryMatrixSolver(convection_diffusion_stationary_
 
 
     def SolveSolutionStep(self):
-        """Assembles the system and stores the system matrix and vector as member variables"""
+        """Assembles the system and stores the system matrix and vector as member variables."""
         self.K, self.p = self._SystemComputation()
 
         # example of a solution with the extracted matrix and vector
@@ -46,7 +44,7 @@ class ConvectionDiffusionStationaryMatrixSolver(convection_diffusion_stationary_
         return True
 
     def _SystemComputation(self):
-        """Assembles the system matrix and vector and returns them as scipy.sparse.csr_matrix and np.ndarray respectively"""
+        """Assembles the system matrix and vector and returns them as scipy.sparse.csr_matrix and np.ndarray respectively."""
         space = KratosMultiphysics.UblasSparseSpace()
         strategy = self.get_convection_diffusion_solution_strategy()
         scheme = strategy.GetScheme()
@@ -78,7 +76,7 @@ class ConvectionDiffusionStationaryMatrixSolver(convection_diffusion_stationary_
 
 
     def _AssignSystemVector(self, vector):
-        """Assigns the values of the vector to the TEMPERATURE dofs """
+        """Assigns the values of the vector to the TEMPERATURE dofs."""
         for node in self.GetComputingModelPart().Nodes:
             dof = node.GetDof(KratosMultiphysics.TEMPERATURE)
 

--- a/applications/ConvectionDiffusionApplication/python_scripts/python_solvers_wrapper_convection_diffusion.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/python_solvers_wrapper_convection_diffusion.py
@@ -36,6 +36,8 @@ def CreateSolverByParameters(model, solver_settings, parallelism):
         # Steady solver
         elif (solver_type == "stationary" or solver_type == "Stationary"):
             solver_module_name = "convection_diffusion_stationary_solver"
+        elif (solver_type == "stationary_matrix"):
+            solver_module_name = "convection_diffusion_stationary_matrix_solver"
         # Coupled CFD-thermal solvers (volume coupling by Boussinesq approximation)
         elif (solver_type == "thermally_coupled" or solver_type == "ThermallyCoupled"):
             solver_module_name = "coupled_fluid_thermal_solver"


### PR DESCRIPTION
**Description**
A solver that extracts system matrix and vector as scipy/numpy without actually solving. Based on the `applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_custom_scipy_base_solver.py`

**Changelog**
- Add stationary convection diffusion solver for system matrix and vector extraction to scipy and numpy

**Example usage**
```python
import KratosMultiphysics
from KratosMultiphysics.ConvectionDiffusionApplication.convection_diffusion_analysis import ConvectionDiffusionAnalysis

import scipy.sparse

def main():
    with open("ProjectParameters.json",'r') as parameter_file:
        parameters = KratosMultiphysics.Parameters(parameter_file.read())

    model = KratosMultiphysics.Model()
    simulation = ConvectionDiffusionAnalysis(model,parameters)
    simulation.Run()

    K = simulation._GetSolver().K  # system matrix
    p = simulation._GetSolver().p  # system vector

    matrix_file_name = "K.npz"
    print("Storing system matrix as {}. Hint: Use scipy.sparse.load_npz to read it.".format(matrix_file_name))
    scipy.sparse.save_npz(matrix_file_name, K)

    print("--Finished!--")

if __name__ == "__main__":
    main()
```