### PR TITLE
Revert "[Core] level set process - move functions from constructor to…

### DIFF
--- a/applications/TrilinosApplication/custom_processes/trilinos_levelset_convection_process.h
+++ b/applications/TrilinosApplication/custom_processes/trilinos_levelset_convection_process.h
@@ -103,10 +103,11 @@ public:
         KRATOS_TRY
 
         const int row_size_guess = (TDim == 2 ? 15 : 40);
-        BaseType::mpBuilderAndSolver = Kratos::make_shared< TrilinosBlockBuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver>>(
+        auto p_builder_and_solver = Kratos::make_shared< TrilinosBlockBuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver>>(
             mrEpetraCommunicator,
             row_size_guess,
             pLinearSolver);
+        InitializeConvectionStrategy(p_builder_and_solver);
 
         KRATOS_CATCH("")
     }
@@ -285,7 +286,7 @@ private:
     ///@name Private Operations
     ///@{
 
-    void InitializeConvectionStrategy(BuilderSolverPointerType pBuilderAndSolver) override
+    void InitializeConvectionStrategy(BuilderSolverPointerType pBuilderAndSolver)
     {
         KRATOS_TRY
 

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -104,7 +104,8 @@ public:
             rModel.GetModelPart(ThisParameters["model_part_name"].GetString()),
             pLinearSolver,
             ThisParameters)
-    {}
+    {
+    }
 
     /**
      * @brief Construct a new Level Set Convection Process object
@@ -123,7 +124,8 @@ public:
     {
         KRATOS_TRY
 
-        mpBuilderAndSolver = Kratos::make_shared< ResidualBasedBlockBuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver>>(pLinearSolver);
+        auto p_builder_solver = Kratos::make_shared< ResidualBasedBlockBuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver>>(pLinearSolver);
+        InitializeConvectionStrategy(p_builder_solver);
 
         KRATOS_CATCH("")
     }
@@ -149,7 +151,6 @@ public:
     ///@name Operations
     ///@{
 
-
     /**
      * @brief Perform the level-set convection
      * This solver provides a stabilized convection solver based on [Codina, R., 1993. Comput. Methods Appl. Mech. Engrg., 110(3-4), pp.325-342.]
@@ -161,10 +162,6 @@ public:
     void Execute() override
     {
         KRATOS_TRY;
-
-        if (!mProcessIsSetUp) {
-            SetUpLevelSetConvection();
-        }
 
         // Fill the auxiliary convection model part if not done yet
         if(mDistancePartIsInitialized == false){
@@ -386,10 +383,6 @@ protected:
 
     ComputeGradientProcessPointerType mpGradientCalculator = nullptr;
 
-    BuilderAndSolverPointerType mpBuilderAndSolver = nullptr;
-
-    bool mProcessIsSetUp = false;
-
     ///@}
     ///@name Protected Operators
     ///@{
@@ -403,23 +396,13 @@ protected:
         Parameters ThisParameters)
         : mrBaseModelPart(rModelPart)
         , mrModel(rModelPart.GetModel())
-        , mLevelSetConvectionSettings(ThisParameters)
-    {}
-
-    /**
-     * @brief This method validates and assigns the process settings and initializes
-     *  the convection strategy. Also, creates mpGradientCalculator if needed.
-     */
-    void SetUpLevelSetConvection()
     {
-        KRATOS_TRY;
-
         // Validate the common settings as well as the element formulation specific ones
-        mLevelSetConvectionSettings.ValidateAndAssignDefaults(this->GetDefaultParameters());
-        mLevelSetConvectionSettings["element_settings"].ValidateAndAssignDefaults(this->GetConvectionElementDefaultParameters(mLevelSetConvectionSettings["element_type"].GetString()));
+        ThisParameters.ValidateAndAssignDefaults(GetDefaultParameters());
+        ThisParameters["element_settings"].ValidateAndAssignDefaults(GetConvectionElementDefaultParameters(ThisParameters["element_type"].GetString()));
 
         // Checks and assign all the required member variables
-        CheckAndAssignSettings(mLevelSetConvectionSettings);
+        CheckAndAssignSettings(ThisParameters);
 
         // Sets the convection diffusion problem settings
         SetConvectionProblemSettings();
@@ -432,12 +415,6 @@ protected:
             NODAL_AREA,
             false);
         }
-
-        InitializeConvectionStrategy(mpBuilderAndSolver);
-
-        mProcessIsSetUp = true;
-
-        KRATOS_CATCH("")
     }
 
     /**
@@ -809,6 +786,8 @@ private:
      */
     void CheckAndAssignSettings(const Parameters ThisParameters)
     {
+        mLevelSetConvectionSettings = ThisParameters;
+
         // Convection element formulation settings
         std::string element_type = ThisParameters["element_type"].GetString();
         const auto element_list = GetConvectionElementsList();
@@ -925,7 +904,7 @@ private:
         return fill_process_info_function;
     }
 
-    virtual void InitializeConvectionStrategy(BuilderAndSolverPointerType pBuilderAndSolver)
+    void InitializeConvectionStrategy(BuilderAndSolverPointerType pBuilderAndSolver)
     {
         // Check that there is at least one element and node in the model
         KRATOS_ERROR_IF(mrBaseModelPart.NumberOfNodes() == 0) << "The model has no nodes." << std::endl;


### PR DESCRIPTION
This reverts commit 50d7ab514bfed192e65b63872e1d3740ac47199e.

we found that the solution we used in https://github.com/KratosMultiphysics/Kratos/pull/9027 is not really working well.

I found two issues:
- If we do not call Execute (e.g. in a test) we have an error in the destructor because mAuxModelPartName is not initialized.
- We cannot fix the dofs of the LevelSetVar because they are added in Execute.

We tried to find a solution for those two points, but it does not look good in general so we decided that we will revert these last changes and we will try to use this process directly in altair, without deriving it in our app.

@rubenzorrilla @mrhashemi 
