### PR TITLE
[Core] Skip also conditions incompatible in TetrahedralMeshOrientationCheck

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
+++ b/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
@@ -25,14 +25,6 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
 
         self.assign_neighbour_elements = Parameters["assign_neighbour_elements_to_conditions"].GetBool()
 
-
-        #self.volume_model_part_name = Parameters["volume_model_part_name"].GetString()
-        #self.list_of_inlets = Parameters["list_of_inlets"]
-        #self.list_of_slip = Parameters["list_of_inlets"]
-        #self.list_of_inlets = Parameters["list_of_inlets"]
-
-
-
     def Execute(self):
         if self.main_model_part.Name == self.volume_model_part_name:
             self.volume_model_part = self.main_model_part
@@ -43,8 +35,8 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
         for i in range(self.skin_name_list.size()):
             skin_parts.append(self.main_model_part.GetSubModelPart(self.skin_name_list[i].GetString()))
 
-        #construct a model part which contains both the skin and the volume
-        #temporarily we call it "fluid_computational_model_part"
+        # Construct a model part which contains both the skin and the volume
+        # Temporarily we call it "fluid_computational_model_part"
         self.main_model_part.CreateSubModelPart("fluid_computational_model_part")
         fluid_computational_model_part= self.main_model_part.GetSubModelPart("fluid_computational_model_part")
         fluid_computational_model_part.ProcessInfo = self.main_model_part.ProcessInfo
@@ -54,7 +46,7 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
         for elem in self.volume_model_part.Elements:
             fluid_computational_model_part.AddElement(elem,0)
 
-        #do some gymnastics to have this done fast. - create an ordered list to be added
+        # Do some gymnastics to have this done fast. - create an ordered list to be added
         list_of_ids = set()
         for part in skin_parts:
             for cond in part.Conditions:
@@ -62,7 +54,7 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
 
         fluid_computational_model_part.AddConditions(list(list_of_ids))
 
-        #verify the orientation of the skin
+        # Verify the orientation of the skin
         tmoc = KratosMultiphysics.TetrahedralMeshOrientationCheck
         throw_errors = False
         flags = (tmoc.COMPUTE_NODAL_NORMALS).AsFalse() | (tmoc.COMPUTE_CONDITION_NORMALS).AsFalse()

--- a/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
+++ b/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
@@ -25,6 +25,14 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
 
         self.assign_neighbour_elements = Parameters["assign_neighbour_elements_to_conditions"].GetBool()
 
+
+        #self.volume_model_part_name = Parameters["volume_model_part_name"].GetString()
+        #self.list_of_inlets = Parameters["list_of_inlets"]
+        #self.list_of_slip = Parameters["list_of_inlets"]
+        #self.list_of_inlets = Parameters["list_of_inlets"]
+
+
+
     def Execute(self):
         if self.main_model_part.Name == self.volume_model_part_name:
             self.volume_model_part = self.main_model_part
@@ -35,8 +43,8 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
         for i in range(self.skin_name_list.size()):
             skin_parts.append(self.main_model_part.GetSubModelPart(self.skin_name_list[i].GetString()))
 
-        # Construct a model part which contains both the skin and the volume
-        # Temporarily we call it "fluid_computational_model_part"
+        #construct a model part which contains both the skin and the volume
+        #temporarily we call it "fluid_computational_model_part"
         self.main_model_part.CreateSubModelPart("fluid_computational_model_part")
         fluid_computational_model_part= self.main_model_part.GetSubModelPart("fluid_computational_model_part")
         fluid_computational_model_part.ProcessInfo = self.main_model_part.ProcessInfo
@@ -46,7 +54,7 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
         for elem in self.volume_model_part.Elements:
             fluid_computational_model_part.AddElement(elem,0)
 
-        # Do some gymnastics to have this done fast. - create an ordered list to be added
+        #do some gymnastics to have this done fast. - create an ordered list to be added
         list_of_ids = set()
         for part in skin_parts:
             for cond in part.Conditions:
@@ -54,7 +62,7 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
 
         fluid_computational_model_part.AddConditions(list(list_of_ids))
 
-        # Verify the orientation of the skin
+        #verify the orientation of the skin
         tmoc = KratosMultiphysics.TetrahedralMeshOrientationCheck
         throw_errors = False
         flags = (tmoc.COMPUTE_NODAL_NORMALS).AsFalse() | (tmoc.COMPUTE_CONDITION_NORMALS).AsFalse()

--- a/kratos/processes/tetrahedral_mesh_orientation_check.cpp
+++ b/kratos/processes/tetrahedral_mesh_orientation_check.cpp
@@ -78,23 +78,28 @@ void TetrahedralMeshOrientationCheck::Execute()
         it_cond->Set(VISITED, false); // Mark
 
         GeometryType& r_geometry = it_cond->GetGeometry();
-        DenseVector<int> ids(r_geometry.size());
 
-        for(IndexType i=0; i<ids.size(); i++) {
-            r_geometry[i].Set(BOUNDARY,true);
-            ids[i] = r_geometry[i].Id();
-        }
+        const GeometryData::KratosGeometryType geometry_type = r_geometry.GetGeometryType();
 
-        //*** THE ARRAY OF IDS MUST BE ORDERED!!! ***
-        std::sort(ids.begin(), ids.end());
+        if (geometry_type == GeometryData::Kratos_Triangle3D3  || geometry_type == GeometryData::Kratos_Line2D2) {
+            DenseVector<int> ids(r_geometry.size());
 
-        // Insert a pointer to the condition identified by the hash value ids
-        hashmap::iterator it_face = faces_map.find(ids);
-        if(it_face != faces_map.end() ) { // Already defined geometry
-            KRATOS_ERROR_IF_NOT(mrOptions.Is(ALLOW_REPEATED_CONDITIONS)) << "The condition of ID:\t" << it_cond->Id() << " shares the same geometry as the condition ID:\t" << it_face->second[0]->Id() << " this is not allowed. Please, check your mesh" << std::endl;
-            it_face->second.push_back(*it_cond.base());
-        } else {
-            faces_map.insert( hashmap::value_type(ids, std::vector<Condition::Pointer>({*it_cond.base()})) );
+            for(IndexType i=0; i<ids.size(); i++) {
+                r_geometry[i].Set(BOUNDARY,true);
+                ids[i] = r_geometry[i].Id();
+            }
+
+            //*** THE ARRAY OF IDS MUST BE ORDERED!!! ***
+            std::sort(ids.begin(), ids.end());
+
+            // Insert a pointer to the condition identified by the hash value ids
+            hashmap::iterator it_face = faces_map.find(ids);
+            if(it_face != faces_map.end() ) { // Already defined geometry
+                KRATOS_ERROR_IF_NOT(mrOptions.Is(ALLOW_REPEATED_CONDITIONS)) << "The condition of ID:\t" << it_cond->Id() << " shares the same geometry as the condition ID:\t" << it_face->second[0]->Id() << " this is not allowed. Please, check your mesh" << std::endl;
+                it_face->second.push_back(*it_cond.base());
+            } else {
+                faces_map.insert( hashmap::value_type(ids, std::vector<Condition::Pointer>({*it_cond.base()})) );
+            }
         }
     }
 
@@ -243,8 +248,8 @@ bool TetrahedralMeshOrientationCheck::Orient(GeometryType& rGeometry)
     const GeometryData::IntegrationMethod integration_method = GeometryData::GI_GAUSS_1;
 
     // Re-orient the element if needed
-    const double DetJ = rGeometry.DeterminantOfJacobian(point_index,integration_method);
-    if (DetJ < 0.0) {
+    const double det_J = rGeometry.DeterminantOfJacobian(point_index,integration_method);
+    if (det_J < 0.0) {
         // Swap two nodes to change orientation
         rGeometry(0).swap(rGeometry(1));
         return true;

--- a/kratos/processes/tetrahedral_mesh_orientation_check.cpp
+++ b/kratos/processes/tetrahedral_mesh_orientation_check.cpp
@@ -75,14 +75,14 @@ void TetrahedralMeshOrientationCheck::Execute()
     hashmap faces_map;
 
     for (auto it_cond = mrModelPart.ConditionsBegin(); it_cond != mrModelPart.ConditionsEnd(); it_cond++) {
-        it_cond->Set(VISITED, false); //mark
+        it_cond->Set(VISITED, false); // Mark
 
-        GeometryType& geom = it_cond->GetGeometry();
-        DenseVector<int> ids(geom.size());
+        GeometryType& r_geometry = it_cond->GetGeometry();
+        DenseVector<int> ids(r_geometry.size());
 
         for(IndexType i=0; i<ids.size(); i++) {
-            geom[i].Set(BOUNDARY,true);
-            ids[i] = geom[i].Id();
+            r_geometry[i].Set(BOUNDARY,true);
+            ids[i] = r_geometry[i].Id();
         }
 
         //*** THE ARRAY OF IDS MUST BE ORDERED!!! ***
@@ -185,7 +185,7 @@ void TetrahedralMeshOrientationCheck::Execute()
         }
     }
 
-    //check that all of the conditions belong to at least an element. Throw an error otherwise (this is particularly useful in mpi)
+    // Check that all of the conditions belong to at least an element. Throw an error otherwise (this is particularly useful in mpi)
     for (auto& r_cond : mrModelPart.Conditions()) {
         KRATOS_ERROR_IF(r_cond.IsNot(VISITED)) << "Found a condition without any corresponding element. ID of condition = " << r_cond.Id() << std::endl;
     }

--- a/kratos/processes/tetrahedral_mesh_orientation_check.cpp
+++ b/kratos/processes/tetrahedral_mesh_orientation_check.cpp
@@ -75,7 +75,7 @@ void TetrahedralMeshOrientationCheck::Execute()
     hashmap faces_map;
 
     for (auto it_cond = mrModelPart.ConditionsBegin(); it_cond != mrModelPart.ConditionsEnd(); it_cond++) {
-        it_cond->Set(VISITED, false); // Mark
+        it_cond->Set(VISITED, false); //mark
 
         GeometryType& r_geometry = it_cond->GetGeometry();
 
@@ -190,7 +190,7 @@ void TetrahedralMeshOrientationCheck::Execute()
         }
     }
 
-    // Check that all of the conditions belong to at least an element. Throw an error otherwise (this is particularly useful in mpi)
+    //check that all of the conditions belong to at least an element. Throw an error otherwise (this is particularly useful in mpi)
     for (auto& r_cond : mrModelPart.Conditions()) {
         KRATOS_ERROR_IF(r_cond.IsNot(VISITED)) << "Found a condition without any corresponding element. ID of condition = " << r_cond.Id() << std::endl;
     }


### PR DESCRIPTION
Fixes #9056.

In this PR basically I added to skip also incompatible conditions in TetrahedralMeshOrientationCheck

Also minor clean up