### PR TITLE
[CoSim] ward OpenMP functions

### DIFF
--- a/applications/CoSimulationApplication/custom_utilities/feti_dynamic_coupling_utilities.cpp
+++ b/applications/CoSimulationApplication/custom_utilities/feti_dynamic_coupling_utilities.cpp
@@ -696,8 +696,8 @@ namespace Kratos
         if (!solver_parameters.Has("solver_type")) solver_parameters.AddString("solver_type", "skyline_lu_factorization");
 
         #ifdef KRATOS_SMP_OPENMP
-        const int omp_nest = omp_get_max_active_levels();
-        omp_set_max_active_levels(0); // disable omp nesting, forces solvers to be serial
+        const int omp_nest = omp_get_nested();
+        omp_set_nested(0); // disable omp nesting, forces solvers to be serial
         #endif
 
         IndexPartition<>(interface_dofs).for_each([&](SizeType i)
@@ -713,7 +713,7 @@ namespace Kratos
         );
 
         #ifdef KRATOS_SMP_OPENMP
-        omp_set_max_active_levels(omp_nest);
+        omp_set_nested(omp_nest);
         #endif
         rUnitResponse = SparseMatrixType(result);
 

--- a/applications/CoSimulationApplication/custom_utilities/feti_dynamic_coupling_utilities.cpp
+++ b/applications/CoSimulationApplication/custom_utilities/feti_dynamic_coupling_utilities.cpp
@@ -13,6 +13,9 @@
 // System includes
 
 // External includes
+#ifdef KRATOS_SMP_OPENMP
+#include <omp.h>
+#endif
 
 // Project includes
 #include "feti_dynamic_coupling_utilities.h"
@@ -692,8 +695,10 @@ namespace Kratos
         Parameters solver_parameters(mParameters["linear_solver_settings"]);
         if (!solver_parameters.Has("solver_type")) solver_parameters.AddString("solver_type", "skyline_lu_factorization");
 
-        const int omp_nest = omp_get_nested();
-        omp_set_nested(0); // disable omp nesting, forces solvers to be serial
+        #ifdef KRATOS_SMP_OPENMP
+        const int omp_nest = omp_get_max_active_levels();
+        omp_set_max_active_levels(0); // disable omp nesting, forces solvers to be serial
+        #endif
 
         IndexPartition<>(interface_dofs).for_each([&](SizeType i)
             {
@@ -707,7 +712,9 @@ namespace Kratos
             }
         );
 
-        omp_set_nested(omp_nest);
+        #ifdef KRATOS_SMP_OPENMP
+        omp_set_max_active_levels(omp_nest);
+        #endif
         rUnitResponse = SparseMatrixType(result);
 
         //auto end = std::chrono::system_clock::now();


### PR DESCRIPTION
- Ward Omp fcts, otherwise it doesn't compile when omp is disabled
- ~replace the deprecated routines (@peterjwilson can you please have a look it this is ok?)~ edit we cannot do this, as msvc has a too old omp, hence I left it as is