### PR TITLE
[Shallow] Mass conservation

### DIFF
--- a/applications/ShallowWaterApplication/custom_friction_laws/wind_water_friction.cpp
+++ b/applications/ShallowWaterApplication/custom_friction_laws/wind_water_friction.cpp
@@ -27,7 +27,7 @@ namespace Kratos
 void WindWaterFriction::Initialize(const GeometryType& rGeometry, const ProcessInfo& rProcessInfo)
 {
     mAirDensity = rProcessInfo[DENSITY_AIR];
-    mWaterDensity = rProcessInfo[DENSITY_WATER];
+    mWaterDensity = rProcessInfo[DENSITY];
 }
 
 double WindWaterFriction::CalculateLHS(

--- a/applications/ShallowWaterApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/ShallowWaterApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -32,14 +32,34 @@ namespace Kratos
 
 namespace Python
 {
-  typedef ModelPart::NodesContainerType NodesContainerType;
 
-  typedef ModelPart::ElementsContainerType ElementsContainerType;
+typedef ModelPart::NodesContainerType NodesContainerType;
 
-  typedef ModelPart::ConditionsContainerType ConditionsContainerType;
+typedef ModelPart::ElementsContainerType ElementsContainerType;
 
-  void  AddCustomUtilitiesToPython(pybind11::module& m)
-  {
+typedef ModelPart::ConditionsContainerType ConditionsContainerType;
+
+template<class TContainerType>
+array_1d<double,3> ComputeHydrostaticForces1(
+    ShallowWaterUtilities& rUtility,
+    TContainerType& rContainer,
+    const ProcessInfo& rProcessInfo)
+{
+    return rUtility.ComputeHydrostaticForces(rContainer, rProcessInfo);
+}
+
+template<class TContainerType>
+array_1d<double,3> ComputeHydrostaticForces2(
+    ShallowWaterUtilities& rUtility,
+    TContainerType& rContainer,
+    const ProcessInfo& rProcessInfo,
+    const double RelativeDryHeight)
+{
+    return rUtility.ComputeHydrostaticForces(rContainer, rProcessInfo, RelativeDryHeight);
+}
+
+void  AddCustomUtilitiesToPython(pybind11::module& m)
+{
     namespace py = pybind11;
 
     py::class_< MoveShallowWaterParticleUtility<2> > (m, "MoveShallowWaterParticleUtility")
@@ -82,8 +102,10 @@ namespace Python
         .def("ComputeL2Norm", &ShallowWaterUtilities::ComputeL2NormAABB<true>)
         .def("ComputeL2NormNonHistorical", &ShallowWaterUtilities::ComputeL2Norm<false>)
         .def("ComputeL2NormNonHistorical", &ShallowWaterUtilities::ComputeL2NormAABB<false>)
-        .def("ComputeHydrostaticForces", &ShallowWaterUtilities::ComputeHydrostaticForces<ElementsContainerType>)
-        .def("ComputeHydrostaticForces", &ShallowWaterUtilities::ComputeHydrostaticForces<ConditionsContainerType>)
+        .def("ComputeHydrostaticForces", ComputeHydrostaticForces1<ElementsContainerType>)
+        .def("ComputeHydrostaticForces", ComputeHydrostaticForces2<ElementsContainerType>)
+        .def("ComputeHydrostaticForces", ComputeHydrostaticForces1<ConditionsContainerType>)
+        .def("ComputeHydrostaticForces", ComputeHydrostaticForces2<ConditionsContainerType>)
         ;
 
     py::class_< EstimateTimeStepUtility > (m, "EstimateTimeStepUtility")
@@ -127,7 +149,7 @@ namespace Python
         .def("MapResults", &MoveMeshUtility::MapResults)
         ;
 
-  }
+}
 
 }  // namespace Python.
 

--- a/applications/ShallowWaterApplication/custom_utilities/shallow_water_utilities.cpp
+++ b/applications/ShallowWaterApplication/custom_utilities/shallow_water_utilities.cpp
@@ -271,6 +271,28 @@ double ShallowWaterUtilities::GetValue<false>(NodeType& rNode, const Variable<do
     return rNode.GetValue(rVariable);
 }
 
+
+bool ShallowWaterUtilities::IsWet(const GeometryType& rGeometry, const double RelativeDryHeight)
+{
+    double height = 0.0;
+    for (const auto& r_node : rGeometry)
+    {
+        height += r_node.FastGetSolutionStepValue(HEIGHT);
+    }
+    height /= rGeometry.size();
+    return IsWet(rGeometry, height, RelativeDryHeight);
+}
+
+bool ShallowWaterUtilities::IsWet(const GeometryType& rGeometry, const double Height, const double RelativeDryHeight)
+{
+    const double epsilon = RelativeDryHeight * rGeometry.Length();
+    const double wet_fraction = WetFraction(Height, epsilon);
+    const double threshold = 1.0 - 1e-16;
+    const bool is_wet = (wet_fraction >= threshold);
+    return is_wet;
+
+}
+
 template<>
 array_1d<double,3> ShallowWaterUtilities::EvaluateHydrostaticForce<ModelPart::ConditionsContainerType>(
     const double Density,

--- a/applications/ShallowWaterApplication/python_scripts/stabilized_shallow_water_solver.py
+++ b/applications/ShallowWaterApplication/python_scripts/stabilized_shallow_water_solver.py
@@ -38,7 +38,7 @@ class StabilizedShallowWaterSolver(ShallowWaterBaseSolver):
         self.main_model_part.ProcessInfo.SetValue(KM.STABILIZATION_FACTOR, self.settings["stabilization_factor"].GetDouble())
         self.main_model_part.ProcessInfo.SetValue(SW.SHOCK_STABILIZATION_FACTOR, self.settings["shock_stabilization_factor"].GetDouble())
         self.main_model_part.ProcessInfo.SetValue(KM.DENSITY_AIR, 1e0)
-        self.main_model_part.ProcessInfo.SetValue(KM.DENSITY_WATER, 1e3)
+        self.main_model_part.ProcessInfo.SetValue(KM.DENSITY, 1e3)
 
     def FinalizeSolutionStep(self):
         super().FinalizeSolutionStep()

--- a/applications/ShallowWaterApplication/tests/cpp_tests/test_shallow_element.cpp
+++ b/applications/ShallowWaterApplication/tests/cpp_tests/test_shallow_element.cpp
@@ -149,7 +149,7 @@ void PerformSteadyStateTest(
     model_part.GetProcessInfo().SetValue(STABILIZATION_FACTOR, stab_factor);
     model_part.GetProcessInfo().SetValue(SHOCK_STABILIZATION_FACTOR, shock_stab_factor);
     model_part.GetProcessInfo().SetValue(RELATIVE_DRY_HEIGHT, relative_dry_height);
-    model_part.GetProcessInfo().SetValue(DENSITY_WATER, density_water);
+    model_part.GetProcessInfo().SetValue(DENSITY, density_water);
     model_part.GetProcessInfo().SetValue(DENSITY_AIR, density_air);
 
     // Geometry creation


### PR DESCRIPTION
**Description**
The utility to compute the hydrostatic forces has been extended to integrate only over the wet domain. This is need to check the accuracy of the wetting model.

**Changelog**
- Extend `ComputeHydrostaticForces` from `ShallowWaterUtilities`
