### PR TITLE
[Core][Fluid] Using bounded array for normals

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_embedded_lift_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_embedded_lift_process.cpp
@@ -57,7 +57,7 @@ void ComputeEmbeddedLiftProcess<Dim, NumNodes>::Execute()
             ModifiedShapeFunctions::Pointer pModifiedShFunc = this->pGetModifiedShapeFunctions(it_elem->pGetGeometry(), Vector(geometry_distances));
 
             // Computing Normal
-            std::vector<Vector> cut_normal;
+            std::vector<array_1d<double,3>> cut_normal;
             pModifiedShFunc -> ComputePositiveSideInterfaceAreaNormals(cut_normal,GeometryData::GI_GAUSS_1);
 
             std::vector<double> pressure_coefficient;

--- a/applications/FluidDynamicsApplication/custom_conditions/embedded_ausas_navier_stokes_wall_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/embedded_ausas_navier_stokes_wall_condition.h
@@ -123,13 +123,13 @@ public:
         MatrixType N_pos_face;                          // Positive interface Gauss pts. shape functions values
         ShapeFunctionsGradientsType DN_DX_pos_face;     // Positive interface Gauss pts. shape functions gradients values
         VectorType w_gauss_pos_face;                    // Positive interface Gauss pts. weights
-        std::vector<VectorType> pos_face_area_normals;  // Positive interface unit normal vector in each Gauss pt.
+        std::vector<array_1d<double,3>> pos_face_area_normals;  // Positive interface unit normal vector in each Gauss pt.
 
         // Negative face geometry data
         MatrixType N_neg_face;                          // Positive interface Gauss pts. shape functions values
         ShapeFunctionsGradientsType DN_DX_neg_face;     // Positive interface Gauss pts. shape functions gradients values
         VectorType w_gauss_neg_face;                    // Positive interface Gauss pts. weights
-        std::vector<VectorType> neg_face_area_normals;  // Positive interface unit normal vector in each Gauss pt.
+        std::vector<array_1d<double,3>> neg_face_area_normals;  // Positive interface unit normal vector in each Gauss pt.
 
         unsigned int n_pos = 0;     // Number of positive distance nodes
         unsigned int n_neg = 0;     // Number of negative distance nodes

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
@@ -116,13 +116,13 @@ public:
         MatrixType                  N_pos_int;              // Positive interface Gauss pts. shape functions values
         ShapeFunctionsGradientsType DN_DX_pos_int;          // Positive interface Gauss pts. shape functions gradients values
         VectorType                  w_gauss_pos_int;        // Positive interface Gauss pts. weights
-        std::vector<VectorType>     pos_int_unit_normals;   // Positive interface unit normal vector in each Gauss pt.
+        std::vector<array_1d<double,3>> pos_int_unit_normals;   // Positive interface unit normal vector in each Gauss pt.
 
         // Negative interface geometry data
         MatrixType                  N_neg_int;              // Positive interface Gauss pts. shape functions values
         ShapeFunctionsGradientsType DN_DX_neg_int;          // Positive interface Gauss pts. shape functions gradients values
         VectorType                  w_gauss_neg_int;        // Positive interface Gauss pts. weights
-        std::vector<VectorType>     neg_int_unit_normals;   // Positive interface unit normal vector in each Gauss pt.
+        std::vector<array_1d<double,3>> neg_int_unit_normals;   // Positive interface unit normal vector in each Gauss pt.
 
         std::vector<unsigned int>   int_vec_identifiers;    // Interior (fluid) nodes identifiers
         std::vector<unsigned int>   out_vec_identifiers;    // Outside (stucture) nodes identifiers
@@ -568,13 +568,13 @@ protected:
             const unsigned int n_gauss_neg = (rData.neg_int_unit_normals).size();
 
             for (unsigned int i_gauss = 0;  i_gauss < n_gauss_pos; ++i_gauss) {
-                Vector& normal = rData.pos_int_unit_normals[i_gauss];
+                array_1d<double,3>& normal = rData.pos_int_unit_normals[i_gauss];
                 const double n_norm = norm_2(normal);
                 normal /= std::max(n_norm, tol);
             }
 
             for (unsigned int i_gauss = 0;  i_gauss < n_gauss_neg; ++i_gauss) {
-                Vector& normal = rData.neg_int_unit_normals[i_gauss];
+                array_1d<double,3>& normal = rData.neg_int_unit_normals[i_gauss];
                 const double n_norm = norm_2(normal);
                 normal /= std::max(n_norm, tol);
             }

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_navier_stokes.h
@@ -88,7 +88,7 @@ public:
         MatrixType                  N_pos_int;              // Positive interface Gauss pts. shape functions values
         ShapeFunctionsGradientsType DN_DX_pos_int;          // Positive interface Gauss pts. shape functions gradients values
         VectorType                  w_gauss_pos_int;        // Positive interface Gauss pts. weights
-        std::vector<VectorType>     pos_int_unit_normals;   // Positive interface unit normal vector in each Gauss pt.
+        std::vector<array_1d<double,3>> pos_int_unit_normals;   // Positive interface unit normal vector in each Gauss pt.
 
         std::vector<unsigned int>   int_vec_identifiers;    // Interior (fluid) nodes identifiers
         std::vector<unsigned int>   out_vec_identifiers;    // Outside (stucture) nodes identifiers
@@ -220,7 +220,7 @@ public:
             const unsigned int n_gauss = (rData.pos_int_unit_normals).size();
 
             for (unsigned int i_gauss = 0;  i_gauss < n_gauss; ++i_gauss) {
-                Vector& normal = rData.pos_int_unit_normals[i_gauss];
+                array_1d<double,3>& normal = rData.pos_int_unit_normals[i_gauss];
                 const double n_norm = norm_2(normal);
                 normal /= std::max(n_norm, tol);
             }

--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes.cpp
@@ -1914,7 +1914,7 @@ void TwoFluidNavierStokes<TElementData>::ComputeSplitInterface(
     MatrixType& rEnrInterfaceShapeFunctionNeg,
     GeometryType::ShapeFunctionsGradientsType& rInterfaceShapeDerivativesNeg,
     Vector& rInterfaceWeightsNeg,
-    std::vector<Vector>& rInterfaceNormalsNeg,
+    std::vector<array_1d<double,3>>& rInterfaceNormalsNeg,
     ModifiedShapeFunctions::Pointer pModifiedShapeFunctions)
 {
     Matrix enr_neg_interp = ZeroMatrix(NumNodes, NumNodes);
@@ -1991,7 +1991,7 @@ void TwoFluidNavierStokes<TElementData>::SurfaceTension(
     const Vector& rCurvature,
     const Vector& rInterfaceWeights,
     const Matrix& rInterfaceShapeFunctions,
-    const std::vector<Vector>& rInterfaceNormalsNeg,
+    const std::vector<array_1d<double,3>>& rInterfaceNormalsNeg,
     VectorType& rRHS)
 {
     for (unsigned int intgp = 0; intgp < rInterfaceWeights.size(); ++intgp){
@@ -2237,7 +2237,7 @@ void TwoFluidNavierStokes<TElementData>::AddSurfaceTensionContribution(
     Matrix int_shape_function, int_shape_function_enr_neg, int_shape_function_enr_pos;
     GeometryType::ShapeFunctionsGradientsType int_shape_derivatives;
     Vector int_gauss_pts_weights;
-    std::vector<Vector> int_normals_neg;
+    std::vector<array_1d<double,3>> int_normals_neg;
     Vector gauss_pts_curvature;
 
     ComputeSplitInterface(

--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes.h
@@ -431,7 +431,7 @@ private:
         MatrixType& rEnrInterfaceShapeFunctionNeg,
         GeometryType::ShapeFunctionsGradientsType& rInterfaceShapeDerivativesNeg,
         Vector& rInterfaceWeightsNeg,
-        std::vector<Vector>& rInterfaceNormalsNeg,
+        std::vector<array_1d<double,3>>& rInterfaceNormalsNeg,
         ModifiedShapeFunctions::Pointer pModifiedShapeFunctions);
 
     /**
@@ -466,7 +466,7 @@ private:
         const Vector& rCurvature,
         const Vector& rInterfaceWeights,
         const Matrix& rInterfaceShapeFunctions,
-        const std::vector<Vector>& rInterfaceNormalsNeg,
+        const std::vector<array_1d<double,3>>& rInterfaceNormalsNeg,
         VectorType& rRHS);
 
     /**

--- a/applications/FluidDynamicsApplication/custom_utilities/embedded_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/embedded_data.h
@@ -36,7 +36,7 @@ using NodalScalarData = typename TFluidData::NodalScalarData;
 using NodalVectorData = typename TFluidData::NodalVectorData;
 
 typedef GeometryData::ShapeFunctionsGradientsType ShapeFunctionsGradientsType;
-typedef std::vector< Vector > InterfaceNormalsType;
+typedef std::vector<array_1d<double,3>> InterfaceNormalsType;
 
 ///@}
 ///@name Public Members

--- a/applications/FluidDynamicsApplication/custom_utilities/embedded_discontinuous_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/embedded_discontinuous_data.h
@@ -36,7 +36,7 @@ using NodalScalarData = typename TFluidData::NodalScalarData;
 using NodalVectorData = typename TFluidData::NodalVectorData;
 
 typedef GeometryData::ShapeFunctionsGradientsType ShapeFunctionsGradientsType;
-typedef std::vector< Vector > InterfaceNormalsType;
+typedef std::vector<array_1d<double,3>> InterfaceNormalsType;
 
 /// Number of edges of the element (simplex elements are assumed)
 constexpr static std::size_t NumEdges = (TFluidData::NumNodes == 3) ? 3 : 6;

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_auxiliary_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_auxiliary_utilities.cpp
@@ -294,7 +294,7 @@ double FluidAuxiliaryUtilities::CalculateFlowRateAuxiliary(
 
                     Vector w_vect;
                     Matrix N_container;
-                    std::vector<Vector> normals_vect;
+                    std::vector<array_1d<double,3>> normals_vect;
                     CalculateSplitConditionGeometryData<IsPositiveSubdomain>(p_mod_sh_func, face_id, N_container, normals_vect, w_vect);
 
                     // Interpolate the flow rate in the positive subdomain
@@ -393,7 +393,7 @@ void FluidAuxiliaryUtilities::CalculateSplitConditionGeometryData<true>(
     const ModifiedShapeFunctions::UniquePointer& rpModShapeFunc,
     const std::size_t FaceId,
     Matrix& rShapeFunctions,
-    std::vector<Vector>& rNormals,
+    std::vector<array_1d<double,3>>& rNormals,
     Vector& rWeights)
 {
     //TODO: Use a method without gradients when we implement it
@@ -407,7 +407,7 @@ void FluidAuxiliaryUtilities::CalculateSplitConditionGeometryData<false>(
     const ModifiedShapeFunctions::UniquePointer& rpModShapeFunc,
     const std::size_t FaceId,
     Matrix& rShapeFunctions,
-    std::vector<Vector>& rNormals,
+    std::vector<array_1d<double,3>>& rNormals,
     Vector& rWeights)
 {
     //TODO: Use a method without gradients when we implement it

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_auxiliary_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_auxiliary_utilities.h
@@ -241,7 +241,7 @@ private:
         const ModifiedShapeFunctions::UniquePointer& rpModShapeFunc,
         const std::size_t FaceId,
         Matrix& rShapeFunctions,
-        std::vector<Vector>& rNormals,
+        std::vector<array_1d<double,3>>& rNormals,
         Vector& rWeights);
 
 };

--- a/applications/FluidDynamicsApplication/symbolic_generation/two_fluid_navier_stokes/two_fluid_navier_stokes_template.cpp
+++ b/applications/FluidDynamicsApplication/symbolic_generation/two_fluid_navier_stokes/two_fluid_navier_stokes_template.cpp
@@ -672,7 +672,7 @@ void TwoFluidNavierStokes<TElementData>::ComputeSplitInterface(
     MatrixType& rEnrInterfaceShapeFunctionNeg,
     GeometryType::ShapeFunctionsGradientsType& rInterfaceShapeDerivativesNeg,
     Vector& rInterfaceWeightsNeg,
-    std::vector<Vector>& rInterfaceNormalsNeg,
+    std::vector<array_1d<double,3>>& rInterfaceNormalsNeg,
     ModifiedShapeFunctions::Pointer pModifiedShapeFunctions)
 {
     Matrix enr_neg_interp = ZeroMatrix(NumNodes, NumNodes);
@@ -751,7 +751,7 @@ void TwoFluidNavierStokes<TElementData>::SurfaceTension(
     const Vector& rCurvature,
     const Vector& rInterfaceWeights,
     const Matrix& rInterfaceShapeFunctions,
-    const std::vector<Vector>& rInterfaceNormalsNeg,
+    const std::vector<array_1d<double,3>>& rInterfaceNormalsNeg,
     VectorType& rRHS)
 {
     for (unsigned int intgp = 0; intgp < rInterfaceWeights.size(); ++intgp){
@@ -997,7 +997,7 @@ void TwoFluidNavierStokes<TElementData>::AddSurfaceTensionContribution(
     Matrix int_shape_function, int_shape_function_enr_neg, int_shape_function_enr_pos;
     GeometryType::ShapeFunctionsGradientsType int_shape_derivatives;
     Vector int_gauss_pts_weights;
-    std::vector<Vector> int_normals_neg;
+    std::vector<array_1d<double,3>> int_normals_neg;
     Vector gauss_pts_curvature;
 
     ComputeSplitInterface(

--- a/kratos/modified_shape_functions/modified_shape_functions.cpp
+++ b/kratos/modified_shape_functions/modified_shape_functions.cpp
@@ -319,7 +319,7 @@ namespace Kratos
 
     // Compute the positive side interface outwards area normal vector values.
     void ModifiedShapeFunctions::ComputePositiveSideInterfaceAreaNormals(
-        std::vector<Vector> &rPositiveSideInterfaceAreaNormal,
+        AreaNormalsContainerType& rPositiveSideInterfaceAreaNormal,
         const IntegrationMethodType IntegrationMethod)
     {
         if (this->IsSplit()) {
@@ -336,7 +336,7 @@ namespace Kratos
 
     // Compute the positive side interface outwards area normal vector values.
     void ModifiedShapeFunctions::ComputeNegativeSideInterfaceAreaNormals(
-        std::vector<Vector> &rNegativeSideInterfaceAreaNormal,
+        AreaNormalsContainerType& rNegativeSideInterfaceAreaNormal,
         const IntegrationMethodType IntegrationMethod)
     {
         if (this->IsSplit()) {
@@ -353,7 +353,7 @@ namespace Kratos
 
     // For a given face, computes the positive side face outwards area normal vector values.
     void ModifiedShapeFunctions::ComputePositiveExteriorFaceAreaNormals(
-        std::vector<Vector> &rPositiveExteriorFaceAreaNormal,
+        AreaNormalsContainerType& rPositiveExteriorFaceAreaNormal,
         const unsigned int FaceId,
         const IntegrationMethodType IntegrationMethod)
     {
@@ -380,7 +380,7 @@ namespace Kratos
 
     // For a given face, computes the positive side face outwards area normal vector values.
     void ModifiedShapeFunctions::ComputeNegativeExteriorFaceAreaNormals(
-        std::vector<Vector> &rNegativeExteriorFaceAreaNormal,
+        AreaNormalsContainerType& rNegativeExteriorFaceAreaNormal,
         const unsigned int FaceId,
         const IntegrationMethodType IntegrationMethod)
     {
@@ -686,7 +686,7 @@ namespace Kratos
 
     // Given the interfaces pattern of either the positive or negative interface side, computes the outwards area normal vector
     void ModifiedShapeFunctions::ComputeFaceNormalOnOneSide(
-        std::vector<Vector> &rInterfaceAreaNormalValues,
+        AreaNormalsContainerType& rInterfaceAreaNormalValues,
         const std::vector<IndexedPointGeometryPointerType> &rInterfacesVector,
         const IntegrationMethodType IntegrationMethod) {
 

--- a/kratos/modified_shape_functions/modified_shape_functions.h
+++ b/kratos/modified_shape_functions/modified_shape_functions.h
@@ -57,6 +57,7 @@ public:
     typedef GeometryType::CoordinatesArrayType                                                      CoordinatesArrayType;
     typedef GeometryData::IntegrationMethod                                                         IntegrationMethodType;
     typedef GeometryData::ShapeFunctionsGradientsType                                               ShapeFunctionsGradientsType;
+    typedef std::vector<array_1d<double,3>> AreaNormalsContainerType;
 
     typedef DivideGeometry::IndexedPointGeometryType                                                IndexedPointGeometryType;
     typedef DivideGeometry::IndexedPointGeometryPointerType                                         IndexedPointGeometryPointerType;
@@ -231,7 +232,7 @@ public:
     * @param IntegrationMethod Desired integration quadrature.
     */
     void ComputePositiveSideInterfaceAreaNormals(
-        std::vector<Vector> &rPositiveSideInterfaceAreaNormal,
+        AreaNormalsContainerType& rPositiveSideInterfaceAreaNormal,
         const IntegrationMethodType IntegrationMethod);
 
     /**
@@ -240,7 +241,7 @@ public:
     * @param IntegrationMethod Desired integration quadrature.
     */
     void ComputeNegativeSideInterfaceAreaNormals(
-        std::vector<Vector> &rNegativeSideInterfaceAreaNormal,
+        AreaNormalsContainerType& rNegativeSideInterfaceAreaNormal,
         const IntegrationMethodType IntegrationMethod);
 
     /**
@@ -250,7 +251,7 @@ public:
     * @param IntegrationMethod Desired integration quadrature.
     */
     void ComputePositiveExteriorFaceAreaNormals(
-        std::vector<Vector> &rPositiveExteriorFaceAreaNormal,
+        AreaNormalsContainerType& rPositiveExteriorFaceAreaNormal,
         const unsigned int FaceId,
         const IntegrationMethodType IntegrationMethod);
 
@@ -261,7 +262,7 @@ public:
     * @param IntegrationMethod Desired integration quadrature.
     */
     void ComputeNegativeExteriorFaceAreaNormals(
-        std::vector<Vector> &rNegativeExteriorFaceAreaNormal,
+        AreaNormalsContainerType& rNegativeExteriorFaceAreaNormal,
         const unsigned int FaceId,
         const IntegrationMethodType IntegrationMethod);
 
@@ -395,7 +396,7 @@ protected:
     * @param IntegrationMethod Desired integration quadrature.
     */
     void ComputeFaceNormalOnOneSide(
-        std::vector<Vector> &rInterfaceAreaNormalValues,
+        AreaNormalsContainerType& rInterfaceAreaNormalValues,
         const std::vector<IndexedPointGeometryPointerType> &rInterfacesVector,
         const IntegrationMethodType IntegrationMethod);
 

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_ausas_incised_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_ausas_incised_shape_functions.cpp
@@ -90,7 +90,7 @@ namespace Kratos
                 GeometryData::GI_GAUSS_1);
 
             // Call the interface outwards normal unit vector calculator
-            std::vector<Vector> positive_side_area_normals, negative_side_area_normals;
+            std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
 
             tetrahedra_ausas_shape_functions.ComputePositiveSideInterfaceAreaNormals(
                 positive_side_area_normals,
@@ -244,7 +244,7 @@ namespace Kratos
                 GeometryData::GI_GAUSS_1);
 
             // Call the interface outwards normal unit vector calculator
-            std::vector<Vector> positive_side_area_normals, negative_side_area_normals;
+            std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
 
             tetrahedra_ausas_shape_functions.ComputePositiveSideInterfaceAreaNormals(
                 positive_side_area_normals,

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_ausas_modified_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_ausas_modified_shape_functions.cpp
@@ -91,21 +91,21 @@ namespace Kratos
                 negative_interface_side_sh_func_gradients,
                 negative_interface_side_weights,
                 GeometryData::GI_GAUSS_1);
-            
+
             // Call the external face modified shape functions calculator
             Matrix pos_ext_face_sh_func_0, neg_ext_face_sh_func_0,
                    pos_ext_face_sh_func_1, neg_ext_face_sh_func_1,
                    pos_ext_face_sh_func_2, neg_ext_face_sh_func_2,
                    pos_ext_face_sh_func_3, neg_ext_face_sh_func_3;
 
-            ModifiedShapeFunctions::ShapeFunctionsGradientsType 
+            ModifiedShapeFunctions::ShapeFunctionsGradientsType
                 pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
                 pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
                 pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2,
                 pos_ext_face_sh_func_gradients_3, neg_ext_face_sh_func_gradients_3;
 
-            Vector pos_ext_face_weights_0, neg_ext_face_weights_0, 
-                   pos_ext_face_weights_1, neg_ext_face_weights_1, 
+            Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
+                   pos_ext_face_weights_1, neg_ext_face_weights_1,
                    pos_ext_face_weights_2, neg_ext_face_weights_2,
                    pos_ext_face_weights_3, neg_ext_face_weights_3;
 
@@ -166,7 +166,7 @@ namespace Kratos
                 GeometryData::GI_GAUSS_1);
 
             // Call the interface outwards normal unit vector calculator
-            std::vector<Vector> positive_side_area_normals, negative_side_area_normals;
+            std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
 
             tetrahedra_ausas_shape_functions.ComputePositiveSideInterfaceAreaNormals(
                 positive_side_area_normals,
@@ -177,7 +177,7 @@ namespace Kratos
                 GeometryData::GI_GAUSS_1);
 
             // Call the exterior faces outwards normal area vector calculator
-            std::vector<Vector>
+            std::vector<array_1d<double,3>>
                 area_normals_pos_face_0, area_normals_neg_face_0,
                 area_normals_pos_face_1, area_normals_neg_face_1,
                 area_normals_pos_face_2, area_normals_neg_face_2,
@@ -351,7 +351,7 @@ namespace Kratos
             KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,2), 0.0, tolerance);
 
             KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), 0.216506, 10e-5);
-            
+
             KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0),     0.0, tolerance);
             KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1), 2.0/3.0, tolerance);
             KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 1.0/3.0, tolerance);
@@ -485,14 +485,14 @@ namespace Kratos
                    pos_ext_face_sh_func_2, neg_ext_face_sh_func_2,
                    pos_ext_face_sh_func_3, neg_ext_face_sh_func_3;
 
-            ModifiedShapeFunctions::ShapeFunctionsGradientsType 
+            ModifiedShapeFunctions::ShapeFunctionsGradientsType
                 pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
                 pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
                 pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2,
                 pos_ext_face_sh_func_gradients_3, neg_ext_face_sh_func_gradients_3;
 
-            Vector pos_ext_face_weights_0, neg_ext_face_weights_0, 
-                   pos_ext_face_weights_1, neg_ext_face_weights_1, 
+            Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
+                   pos_ext_face_weights_1, neg_ext_face_weights_1,
                    pos_ext_face_weights_2, neg_ext_face_weights_2,
                    pos_ext_face_weights_3, neg_ext_face_weights_3;
 
@@ -553,7 +553,7 @@ namespace Kratos
                 GeometryData::GI_GAUSS_1);
 
             // Call the interface outwards normal unit vector calculator
-            std::vector<Vector> positive_side_area_normals, negative_side_area_normals;
+            std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
 
             tetrahedra_ausas_shape_functions.ComputePositiveSideInterfaceAreaNormals(
                 positive_side_area_normals,
@@ -564,7 +564,7 @@ namespace Kratos
                 GeometryData::GI_GAUSS_1);
 
             // Call the exterior faces outwards normal area vector calculator
-            std::vector<Vector>
+            std::vector<array_1d<double,3>>
                 area_normals_pos_face_0, area_normals_neg_face_0,
                 area_normals_pos_face_1, area_normals_neg_face_1,
                 area_normals_pos_face_2, area_normals_neg_face_2,

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_modified_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_modified_shape_functions.cpp
@@ -98,14 +98,14 @@ namespace Kratos
                    pos_ext_face_sh_func_2, neg_ext_face_sh_func_2,
                    pos_ext_face_sh_func_3, neg_ext_face_sh_func_3;
 
-            ModifiedShapeFunctions::ShapeFunctionsGradientsType 
+            ModifiedShapeFunctions::ShapeFunctionsGradientsType
                 pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
                 pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
                 pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2,
                 pos_ext_face_sh_func_gradients_3, neg_ext_face_sh_func_gradients_3;
 
-            Vector pos_ext_face_weights_0, neg_ext_face_weights_0, 
-                   pos_ext_face_weights_1, neg_ext_face_weights_1, 
+            Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
+                   pos_ext_face_weights_1, neg_ext_face_weights_1,
                    pos_ext_face_weights_2, neg_ext_face_weights_2,
                    pos_ext_face_weights_3, neg_ext_face_weights_3;
 
@@ -166,7 +166,7 @@ namespace Kratos
                 GeometryData::GI_GAUSS_1);
 
             // Call the interface outwards normal unit vector calculator
-            std::vector<Vector> positive_side_area_normals, negative_side_area_normals;
+            std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
 
             tetrahedra_shape_functions.ComputePositiveSideInterfaceAreaNormals(
                 positive_side_area_normals,
@@ -177,7 +177,7 @@ namespace Kratos
                 GeometryData::GI_GAUSS_1);
 
             // Call the exterior faces outwards normal area vector calculator
-            std::vector<Vector>
+            std::vector<array_1d<double,3>>
                 area_normals_pos_face_0, area_normals_neg_face_0,
                 area_normals_pos_face_1, area_normals_neg_face_1,
                 area_normals_pos_face_2, area_normals_neg_face_2,
@@ -323,7 +323,7 @@ namespace Kratos
             KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,2),  1.0, tolerance);
 
             KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), 0.216506, 10e-5);
-            
+
             KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0),     0.0, tolerance);
             KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1),     0.5, tolerance);
             KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 1.0/3.0, tolerance);
@@ -360,7 +360,7 @@ namespace Kratos
 
             KRATOS_CHECK_NEAR(neg_ext_face_weights_0(0), 0.433013, 10e-5);
             KRATOS_CHECK_NEAR(neg_ext_face_weights_0(1), 0.216506, 10e-5);
-            
+
             KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](0), 0.125, tolerance);
             KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](1), 0.125, tolerance);
             KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](2), 0.125, tolerance);
@@ -385,7 +385,7 @@ namespace Kratos
         KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTetrahedra3D4Oblique, KratosCoreFastSuite)
         {
             Model current_model;
-            
+
             // Generate a model part with the previous
             ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
             base_model_part.AddNodalSolutionStepVariable(DISTANCE);
@@ -457,14 +457,14 @@ namespace Kratos
                    pos_ext_face_sh_func_2, neg_ext_face_sh_func_2,
                    pos_ext_face_sh_func_3, neg_ext_face_sh_func_3;
 
-            ModifiedShapeFunctions::ShapeFunctionsGradientsType 
+            ModifiedShapeFunctions::ShapeFunctionsGradientsType
                 pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
                 pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
                 pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2,
                 pos_ext_face_sh_func_gradients_3, neg_ext_face_sh_func_gradients_3;
 
-            Vector pos_ext_face_weights_0, neg_ext_face_weights_0, 
-                   pos_ext_face_weights_1, neg_ext_face_weights_1, 
+            Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
+                   pos_ext_face_weights_1, neg_ext_face_weights_1,
                    pos_ext_face_weights_2, neg_ext_face_weights_2,
                    pos_ext_face_weights_3, neg_ext_face_weights_3;
 
@@ -525,7 +525,7 @@ namespace Kratos
                 GeometryData::GI_GAUSS_1);
 
             // Call the interface outwards normal unit vector calculator
-            std::vector<Vector> positive_side_area_normals, negative_side_area_normals;
+            std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
 
             tetrahedra_shape_functions.ComputePositiveSideInterfaceAreaNormals(
                 positive_side_area_normals,
@@ -536,7 +536,7 @@ namespace Kratos
                 GeometryData::GI_GAUSS_1);
 
             // Call the exterior faces outwards normal area vector calculator
-            std::vector<Vector>
+            std::vector<array_1d<double,3>>
                 area_normals_pos_face_0, area_normals_neg_face_0,
                 area_normals_pos_face_1, area_normals_neg_face_1,
                 area_normals_pos_face_2, area_normals_neg_face_2,

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_ausas_incised_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_ausas_incised_shape_functions.cpp
@@ -85,7 +85,7 @@ namespace Kratos
                 GeometryData::GI_GAUSS_1);
 
             // Call the interface outwards normal unit vector calculator
-            std::vector<Vector> positive_side_area_normals, negative_side_area_normals;
+            std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
 
             triangle_ausas_shape_functions.ComputePositiveSideInterfaceAreaNormals(
                 positive_side_area_normals,
@@ -229,7 +229,7 @@ namespace Kratos
                 GeometryData::GI_GAUSS_1);
 
             // Call the interface outwards normal unit vector calculator
-            std::vector<Vector> positive_side_area_normals, negative_side_area_normals;
+            std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
 
             triangle_ausas_shape_functions.ComputePositiveSideInterfaceAreaNormals(
                 positive_side_area_normals,

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_ausas_modified_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_ausas_modified_shape_functions.cpp
@@ -26,7 +26,7 @@ namespace Kratos
 		KRATOS_TEST_CASE_IN_SUITE(AusasModifiedShapeFunctionsTriangle2D3Horizontal, KratosCoreFastSuite)
 		{
 			Model current_model;
-			
+
 			// Generate a model part with the previous
 			ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
 			base_model_part.AddNodalSolutionStepVariable(DISTANCE);
@@ -95,13 +95,13 @@ namespace Kratos
 		         pos_ext_face_sh_func_1, neg_ext_face_sh_func_1,
 				     pos_ext_face_sh_func_2, neg_ext_face_sh_func_2;
 
-			ModifiedShapeFunctions::ShapeFunctionsGradientsType 
+			ModifiedShapeFunctions::ShapeFunctionsGradientsType
 				pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
 				pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
 				pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2;
 
-			Vector pos_ext_face_weights_0, neg_ext_face_weights_0, 
-				     pos_ext_face_weights_1, neg_ext_face_weights_1, 
+			Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
+				     pos_ext_face_weights_1, neg_ext_face_weights_1,
 				     pos_ext_face_weights_2, neg_ext_face_weights_2;
 
 			triangle_ausas_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
@@ -147,7 +147,7 @@ namespace Kratos
 				GeometryData::GI_GAUSS_1);
 
 			// Call the interface outwards normal unit vector calculator
-			std::vector<Vector> positive_side_area_normals, negative_side_area_normals;
+			std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
 
 			triangle_ausas_shape_functions.ComputePositiveSideInterfaceAreaNormals(
 				positive_side_area_normals,
@@ -158,7 +158,7 @@ namespace Kratos
 				GeometryData::GI_GAUSS_1);
 
 			// Call the exterior faces outwards normal area vector calculator
-			std::vector<Vector>
+			std::vector<array_1d<double,3>>
 				area_normals_pos_face_0, area_normals_neg_face_0,
 				area_normals_pos_face_1, area_normals_neg_face_1,
 				area_normals_pos_face_2, area_normals_neg_face_2;
@@ -271,7 +271,7 @@ namespace Kratos
 			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,0), 0.0, tolerance);
 			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,1), 0.0, tolerance);
 			KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), 0.5*std::sqrt(2.0), tolerance);
-			
+
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0), 0.0, tolerance);
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1), 1.0, tolerance);
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 0.0, tolerance);
@@ -301,7 +301,7 @@ namespace Kratos
 			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](2,0), 0.0, tolerance);
 			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](2,1), 0.0, tolerance);
 			KRATOS_CHECK_NEAR(pos_ext_face_weights_1(0), 0.5, tolerance);
-			
+
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,0), 1.0, tolerance);
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,1), 0.0, tolerance);
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,2), 0.0, tolerance);
@@ -325,7 +325,7 @@ namespace Kratos
 			KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_2.size2(), 3);
 			KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_gradients_2.size(), 0);
 			KRATOS_CHECK_EQUAL(pos_ext_face_weights_2.size(), 0);
-			
+
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,0), 0.5, tolerance);
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,1), 0.5, tolerance);
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,2), 0.0, tolerance);
@@ -347,7 +347,7 @@ namespace Kratos
 		KRATOS_TEST_CASE_IN_SUITE(AusasModifiedShapeFunctionsTriangle2D3Vertical, KratosCoreFastSuite)
 		{
 			Model current_model;
-			
+
 			// Generate a model part with the previous
 			ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
 			base_model_part.AddNodalSolutionStepVariable(DISTANCE);
@@ -410,19 +410,19 @@ namespace Kratos
 				negative_interface_side_sh_func_gradients,
 				negative_interface_side_weights,
 				GeometryData::GI_GAUSS_1);
-			
+
 			// Call the external face modified shape functions calculator
 			Matrix pos_ext_face_sh_func_0, neg_ext_face_sh_func_0,
 				     pos_ext_face_sh_func_1, neg_ext_face_sh_func_1,
 				     pos_ext_face_sh_func_2, neg_ext_face_sh_func_2;
 
-			ModifiedShapeFunctions::ShapeFunctionsGradientsType 
+			ModifiedShapeFunctions::ShapeFunctionsGradientsType
 				pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
 				pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
 				pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2;
 
-			Vector pos_ext_face_weights_0, neg_ext_face_weights_0, 
-				     pos_ext_face_weights_1, neg_ext_face_weights_1, 
+			Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
+				     pos_ext_face_weights_1, neg_ext_face_weights_1,
 				     pos_ext_face_weights_2, neg_ext_face_weights_2;
 
 			triangle_ausas_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
@@ -468,7 +468,7 @@ namespace Kratos
 				GeometryData::GI_GAUSS_1);
 
 			// Call the interface outwards normal unit vector calculator
-			std::vector<Vector> positive_side_area_normals, negative_side_area_normals;
+			std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
 
 			triangle_ausas_shape_functions.ComputePositiveSideInterfaceAreaNormals(
 				positive_side_area_normals,
@@ -479,7 +479,7 @@ namespace Kratos
 				GeometryData::GI_GAUSS_1);
 
 			// Call the exterior faces outwards normal area vector calculator
-			std::vector<Vector>
+			std::vector<array_1d<double,3>>
 				area_normals_pos_face_0, area_normals_neg_face_0,
 				area_normals_pos_face_1, area_normals_neg_face_1,
 				area_normals_pos_face_2, area_normals_neg_face_2;
@@ -592,7 +592,7 @@ namespace Kratos
 			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,0), 0.0, tolerance);
 			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,1), 0.0, tolerance);
 			KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), 0.5 * std::sqrt(2.0), tolerance);
-			
+
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0), 0.0, tolerance);
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1), 0.0, tolerance);
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 1.0, tolerance);
@@ -616,7 +616,7 @@ namespace Kratos
 			KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_1.size2(), 3);
 			KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_gradients_1.size(), 0);
 			KRATOS_CHECK_EQUAL(pos_ext_face_weights_1.size(), 0);
-			
+
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,0), 0.5, tolerance);
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,1), 0.0, tolerance);
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,2), 0.5, tolerance);
@@ -644,7 +644,7 @@ namespace Kratos
 			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_2[0](2,0), 0.0, tolerance);
 			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_2[0](2,1), 0.0, tolerance);
 			KRATOS_CHECK_NEAR(pos_ext_face_weights_2(0), 0.5, tolerance);
-			
+
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,0), 1.0, tolerance);
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,1), 0.0, tolerance);
 			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,2), 0.0, tolerance);

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_modified_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_modified_shape_functions.cpp
@@ -180,7 +180,7 @@ namespace Kratos
 				GeometryData::GI_GAUSS_1);
 
 			// Call the interface outwards normal area vector calculator
-			std::vector<Vector> positive_side_area_normals, negative_side_area_normals;
+			std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
 
 			triangle_shape_functions.ComputePositiveSideInterfaceAreaNormals(
 				positive_side_area_normals,
@@ -191,7 +191,7 @@ namespace Kratos
 				GeometryData::GI_GAUSS_1);
 
 			// Call the exterior faces outwards normal area vector calculator
-			std::vector<Vector>
+			std::vector<array_1d<double,3>>
 				area_normals_pos_face_0, area_normals_neg_face_0,
 				area_normals_pos_face_1, area_normals_neg_face_1,
 				area_normals_pos_face_2, area_normals_neg_face_2;
@@ -438,7 +438,7 @@ namespace Kratos
 				GeometryData::GI_GAUSS_1);
 
 			// Call the interface outwards normal unit vector calculator
-			std::vector<Vector> positive_side_area_normals, negative_side_area_normals;
+			std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
 
 			triangle_shape_functions.ComputePositiveSideInterfaceAreaNormals(
 				positive_side_area_normals,
@@ -505,7 +505,7 @@ namespace Kratos
 				GeometryData::GI_GAUSS_1);
 
 			// Call the exterior faces outwards normal area vector calculator
-			std::vector<Vector>
+			std::vector<array_1d<double,3>>
 				area_normals_pos_face_0, area_normals_neg_face_0,
 				area_normals_pos_face_1, area_normals_neg_face_1,
 				area_normals_pos_face_2, area_normals_neg_face_2;


### PR DESCRIPTION
**Description**
As reported in #9030, the `ModifiedShapeFunctions` use heap arrays for the normals. As the geometries always return a bounded vector type this implies a meaningless overhead. This PR modifies the type in the base `ModifiedShapeFunctions` class and propagates the changes through all the elements using it.

Closes #9030 
