### PR TITLE
[Core][IntrusivePointer] improve initialization of ref-counter

### DIFF
--- a/kratos/containers/variables_list.h
+++ b/kratos/containers/variables_list.h
@@ -89,12 +89,10 @@ namespace Kratos
 
 		/// Default constructor. mPosition should have at least on entry.
         VariablesList()
-		: mReferenceCounter(0)
 		{}
 
         template <class TInputIteratorType>
 		VariablesList(TInputIteratorType First, TInputIteratorType Last)
-		: mReferenceCounter(0)
 		{
 			for (; First != Last; First++)
 				Add(*First);
@@ -108,7 +106,6 @@ namespace Kratos
 			, mVariables(rOther.mVariables)
 			, mDofVariables(rOther.mDofVariables)
 			, mDofReactions(rOther.mDofReactions)
-			, mReferenceCounter(0) 
 			{}
 
 		/// Destructor.
@@ -238,7 +235,7 @@ namespace Kratos
 
 			mDofVariables.swap(rOther.mDofVariables);
 			mDofReactions.swap(rOther.mDofReactions);
-			
+
 			mKeys.swap(rOther.mKeys);
 			mPositions.swap(rOther.mPositions);
 		}
@@ -266,7 +263,7 @@ namespace Kratos
 			if (ThisVariable.SourceKey() == 0)
 				KRATOS_THROW_ERROR(std::logic_error,
 					"Adding uninitialize variable to this variable list. Check if all variables are registered before kernel initialization", "");
-					
+
 
 			if (Has(ThisVariable))
 				return;
@@ -283,7 +280,7 @@ namespace Kratos
 		}
 
 		int AddDof(VariableData const* pThisDofVariable){
-			
+
 			for(std::size_t dof_index = 0 ; dof_index < mDofVariables.size() ; dof_index++){
 				if(*mDofVariables[dof_index] == *pThisDofVariable){
 					return static_cast<int>(dof_index);
@@ -293,7 +290,7 @@ namespace Kratos
 #ifdef KRATOS_DEBUG
         if(OpenMPUtils::IsInParallel() != 0)
             KRATOS_ERROR << "attempting to call AddDof for: " << pThisDofVariable << ". Unfortunately the Dof was not added before and the operations is not threadsafe (this function is being called within a parallel region)" << std::endl;
-#endif 
+#endif
 			mDofVariables.push_back(pThisDofVariable);
 			mDofReactions.push_back(nullptr);
 
@@ -303,7 +300,7 @@ namespace Kratos
 		}
 
 		int AddDof(VariableData const* pThisDofVariable, VariableData const* pThisDofReaction){
-			
+
 			for(std::size_t dof_index = 0 ; dof_index < mDofVariables.size() ; dof_index++){
 				if(*mDofVariables[dof_index] == *pThisDofVariable){
 					mDofReactions[dof_index] = pThisDofReaction;
@@ -314,7 +311,7 @@ namespace Kratos
 #ifdef KRATOS_DEBUG
         if(OpenMPUtils::IsInParallel() != 0)
             KRATOS_ERROR << "attempting to call AddDof for: " << pThisDofVariable << ". Unfortunately the Dof was not added before and the operations is not threadsafe (this function is being called within a parallel region)" << std::endl;
-#endif 
+#endif
 			mDofVariables.push_back(pThisDofVariable);
 			mDofReactions.push_back(pThisDofReaction);
 
@@ -416,7 +413,7 @@ namespace Kratos
 			for (IndexType i = 0; i < mVariables.size(); ++i)
 				rOStream << "    " << mVariables[i]->Name() << " \t-> " << GetPosition(mVariables[i]->Key()) << std::endl;
 
-			rOStream << " with " << mDofVariables.size() << " Dofs:";	
+			rOStream << " with " << mDofVariables.size() << " Dofs:";
 			for (IndexType i = 0; i < mDofVariables.size(); ++i)
 				rOStream << "    [" << mDofVariables[i]->Name() << " ,  " << ((mDofReactions[i] == nullptr) ? "NONE" : mDofReactions[i]->Name()) << "]" << std::endl;
 		}
@@ -444,7 +441,7 @@ namespace Kratos
 		///@name Private Operators
 		///@{
 		//this block is needed for refcounting
-		mutable std::atomic<int> mReferenceCounter;
+		mutable std::atomic<int> mReferenceCounter{0};
 
 		friend void intrusive_ptr_add_ref(const VariablesList* x)
 		{

--- a/kratos/includes/geometrical_object.h
+++ b/kratos/includes/geometrical_object.h
@@ -84,16 +84,14 @@ public:
     explicit GeometricalObject(IndexType NewId = 0)
         : IndexedObject(NewId),
           Flags(),
-          mpGeometry(),
-          mReferenceCounter(0)
+          mpGeometry()
     {}
 
     /// Default constructor.
     GeometricalObject(IndexType NewId, GeometryType::Pointer pGeometry)
         : IndexedObject(NewId),
           Flags(),
-          mpGeometry(pGeometry),
-          mReferenceCounter(0)
+          mpGeometry(pGeometry)
     {}
 
     /// Destructor.
@@ -103,8 +101,7 @@ public:
     GeometricalObject(GeometricalObject const& rOther)
         : IndexedObject(rOther.Id()),
           Flags(rOther),
-          mpGeometry(rOther.mpGeometry),
-          mReferenceCounter(0)
+          mpGeometry(rOther.mpGeometry)
     {}
 
 
@@ -400,7 +397,7 @@ private:
 
     //*********************************************
     //this block is needed for refcounting
-    mutable std::atomic<int> mReferenceCounter;
+    mutable std::atomic<int> mReferenceCounter{0};
 
     friend void intrusive_ptr_add_ref(const GeometricalObject* x)
     {

--- a/kratos/includes/initial_state.h
+++ b/kratos/includes/initial_state.h
@@ -63,7 +63,7 @@ class KRATOS_API(KRATOS_CORE) InitialState
         ///@{
 
         /// Default constructor.
-        InitialState() : mReferenceCounter(0)
+        InitialState()
         {}
 
         /// Only defining Dimension constructor.
@@ -167,7 +167,7 @@ class KRATOS_API(KRATOS_CORE) InitialState
 
     //*********************************************
         //this block is needed for refcounting
-        mutable std::atomic<int> mReferenceCounter;
+        mutable std::atomic<int> mReferenceCounter{0};
         friend void intrusive_ptr_add_ref(const InitialState* x)
         {
             x->mReferenceCounter.fetch_add(1, std::memory_order_relaxed);

--- a/kratos/includes/node.h
+++ b/kratos/includes/node.h
@@ -118,7 +118,6 @@ public:
         , mData()
         , mInitialPosition()
         , mNodeLock()
-        , mReferenceCounter(0)
     {
         CreateSolutionStepData();
     }
@@ -131,7 +130,6 @@ public:
         , mData()
         , mInitialPosition()
         , mNodeLock()
-        , mReferenceCounter(0)
     {
         KRATOS_ERROR <<  "Calling the default constructor for the node ... illegal operation!!" << std::endl;
         CreateSolutionStepData();
@@ -146,7 +144,6 @@ public:
         , mData()
         , mInitialPosition(NewX)
         , mNodeLock()
-        , mReferenceCounter(0)
     {
         CreateSolutionStepData();
     }
@@ -160,7 +157,6 @@ public:
         , mData()
         , mInitialPosition(NewX, NewY)
         , mNodeLock()
-        , mReferenceCounter(0)
     {
         CreateSolutionStepData();
     }
@@ -174,7 +170,6 @@ public:
         , mData()
         , mInitialPosition(NewX, NewY, NewZ)
         , mNodeLock()
-        , mReferenceCounter(0)
     {
         CreateSolutionStepData();
     }
@@ -188,7 +183,6 @@ public:
         , mData()
         , mInitialPosition(rThisPoint)
         , mNodeLock()
-        , mReferenceCounter(0)
     {
         CreateSolutionStepData();
     }
@@ -242,7 +236,6 @@ public:
         , mData()
         , mInitialPosition(NewX, NewY, NewZ)
         , mNodeLock()
-        , mReferenceCounter(0)
     {
     }
 
@@ -1035,7 +1028,7 @@ private:
     ///@{
     //*********************************************
     //this block is needed for refcounting
-    mutable std::atomic<int> mReferenceCounter;
+    mutable std::atomic<int> mReferenceCounter{0};
 
     friend void intrusive_ptr_add_ref(const NodeType* x)
     {


### PR DESCRIPTION
This PR improves the initialization of the refcounter for the intrusive pointer.
This way we are safe when for some reason we need to add another Constructor

@maceligueta I think you tried this before no?

I tested and use this in the [CoSimIO](https://github.com/KratosMultiphysics/CoSimIO/pull/218), works fine