### PR TITLE
Adapting space to communicator for apps

### DIFF
--- a/applications/FSIApplication/custom_utilities/partitioned_fsi_utilities.hpp
+++ b/applications/FSIApplication/custom_utilities/partitioned_fsi_utilities.hpp
@@ -193,7 +193,8 @@ public:
      */
     virtual VectorPointerType SetUpInterfaceVector(ModelPart& rInterfaceModelPart)
     {
-        VectorPointerType p_int_vector = TSpace::CreateEmptyVectorPointer();
+        const DataCommunicator &r_comm = rInterfaceModelPart.GetCommunicator().GetDataCommunicator();
+        VectorPointerType p_int_vector = TSpace::CreateEmptyVectorPointer(r_comm);
         const unsigned int residual_size = this->GetInterfaceResidualSize(rInterfaceModelPart);
         if (TSpace::Size(*p_int_vector) != residual_size){
             TSpace::Resize(p_int_vector, residual_size);

--- a/applications/FemToDemApplication/custom_strategies/hexahedra_newton_raphson_strategy.h
+++ b/applications/FemToDemApplication/custom_strategies/hexahedra_newton_raphson_strategy.h
@@ -155,9 +155,10 @@ class HexahedraNewtonRaphsonStrategy
         // By default the matrices are rebuilt at each iteration
         this->SetRebuildLevel(2);
 
-        BaseType::mpA = TSparseSpace::CreateEmptyMatrixPointer();
-        BaseType::mpDx = TSparseSpace::CreateEmptyVectorPointer();
-        BaseType::mpb = TSparseSpace::CreateEmptyVectorPointer();
+        const DataCommunicator &r_comm = rModelPart.GetCommunicator().GetDataCommunicator();
+        BaseType::mpA = TSparseSpace::CreateEmptyMatrixPointer(r_comm);
+        BaseType::mpDx = TSparseSpace::CreateEmptyVectorPointer(r_comm);
+        BaseType::mpb = TSparseSpace::CreateEmptyVectorPointer(r_comm);
 
         KRATOS_CATCH("");
     }
@@ -225,9 +226,10 @@ class HexahedraNewtonRaphsonStrategy
         // By default the matrices are rebuilt at each iteration
         this->SetRebuildLevel(2);
 
-        BaseType::mpA = TSparseSpace::CreateEmptyMatrixPointer();
-        BaseType::mpDx = TSparseSpace::CreateEmptyVectorPointer();
-        BaseType::mpb = TSparseSpace::CreateEmptyVectorPointer();
+        const DataCommunicator &r_comm = rModelPart.GetCommunicator().GetDataCommunicator();
+        BaseType::mpA = TSparseSpace::CreateEmptyMatrixPointer(r_comm);
+        BaseType::mpDx = TSparseSpace::CreateEmptyVectorPointer(r_comm);
+        BaseType::mpb = TSparseSpace::CreateEmptyVectorPointer(r_comm);
 
         KRATOS_CATCH("")
     }

--- a/applications/IgaApplication/custom_strategies/custom_strategies/eigensolver_nitsche_stabilization_strategy.hpp
+++ b/applications/IgaApplication/custom_strategies/custom_strategies/eigensolver_nitsche_stabilization_strategy.hpp
@@ -288,8 +288,9 @@ public:
         SparseMatrixType& rStabilizationMatrix = this->GetStabilizationMatrix();
 
         // Initialize dummy vectors
-        SparseVectorPointerType pDx = SparseSpaceType::CreateEmptyVectorPointer();
-        SparseVectorPointerType pb = SparseSpaceType::CreateEmptyVectorPointer();
+        const DataCommunicator &r_comm = rModelPart.GetCommunicator().GetDataCommunicator();
+        SparseVectorPointerType pDx = SparseSpaceType::CreateEmptyVectorPointer(r_comm);
+        SparseVectorPointerType pb = SparseSpaceType::CreateEmptyVectorPointer(r_comm);
         auto& rDx = *pDx;
         auto& rb = *pb;
 
@@ -574,8 +575,10 @@ public:
             <<  "Entering FinalizeSolutionStep" << std::endl;
 
         SparseMatrixType& rStabilizationMatrix = this->GetStabilizationMatrix();
-        SparseVectorPointerType pDx = SparseSpaceType::CreateEmptyVectorPointer();
-        SparseVectorPointerType pb = SparseSpaceType::CreateEmptyVectorPointer();
+
+        const DataCommunicator &r_comm = BaseType::GetModelPart().GetCommunicator().GetDataCommunicator();
+        SparseVectorPointerType pDx = SparseSpaceType::CreateEmptyVectorPointer(r_comm);
+        SparseVectorPointerType pb = SparseSpaceType::CreateEmptyVectorPointer(r_comm);
         pGetBuilderAndSolver()->FinalizeSolutionStep(
             BaseType::GetModelPart(), rStabilizationMatrix, *pDx, *pb);
         pGetScheme()->FinalizeSolutionStep(BaseType::GetModelPart(),

--- a/applications/PfemFluidDynamicsApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -50,7 +50,8 @@ namespace Kratos
 
             //base types
             typedef LinearSolver<SparseSpaceType, LocalSpaceType> LinearSolverType;
-            typedef ImplicitSolvingStrategy<SparseSpaceType, LocalSpaceType, LinearSolverType> BaseSolvingStrategyType;
+            typedef SolvingStrategy<SparseSpaceType, LocalSpaceType> BaseSolvingStrategyType;
+            typedef ImplicitSolvingStrategy<SparseSpaceType, LocalSpaceType, LinearSolverType> ImplicitBaseSolvingStrategyType;
             typedef BuilderAndSolver<SparseSpaceType, LocalSpaceType, LinearSolverType> BuilderAndSolverType;
             typedef Scheme<SparseSpaceType, LocalSpaceType> BaseSchemeType;
             //typedef ConvergenceCriteria< SparseSpaceType, LocalSpaceType > ConvergenceCriteriaBaseType;
@@ -63,35 +64,38 @@ namespace Kratos
             typedef NodalTwoStepVPStrategy<SparseSpaceType, LocalSpaceType, LinearSolverType> NodalTwoStepVPStrategyType;
             typedef NodalTwoStepVPStrategyForFSI<SparseSpaceType, LocalSpaceType, LinearSolverType> NodalTwoStepVPStrategyForFSIType;
             typedef GaussSeidelLinearStrategy<SparseSpaceType, LocalSpaceType, LinearSolverType> GaussSeidelLinearStrategyType;
+
+            // Clustom Settings Types
+            typedef TwoStepVPSolverSettings<SparseSpaceType, LocalSpaceType, LinearSolverType> TwoStepVPSolverSettingsType;
             //********************************************************************
             //*************************SHCHEME CLASSES****************************
             //********************************************************************
 
             py::class_<VPStrategyType, VPStrategyType::Pointer, BaseSolvingStrategyType>(m, "VPStrategy")
-                .def(py::init<ModelPart &, LinearSolverType::Pointer, LinearSolverType::Pointer, bool, unsigned int>())
+                .def(py::init<ModelPart &, TwoStepVPSolverSettingsType &>())
                 .def("CalculateAccelerations", &VPStrategyType::CalculateAccelerations)
                 .def("CalculateDisplacements", &VPStrategyType::CalculateDisplacementsAndPorosity)
                 // .def("InitializeStressStrain",&VPStrategy<SparseSpaceType,LocalSpaceType,LinearSolverType>::InitializeStressStrain)
                 ;
 
-            py::class_<TwoStepVPStrategyType, TwoStepVPStrategyType::Pointer, BaseSolvingStrategyType>(m, "TwoStepVPStrategy")
+            py::class_<TwoStepVPStrategyType, TwoStepVPStrategyType::Pointer, VPStrategyType>(m, "TwoStepVPStrategy")
                 .def(py::init<ModelPart &, LinearSolverType::Pointer, LinearSolverType::Pointer, bool, double, double, int, unsigned int, unsigned int>());
             ;
 
-            py::class_<ThreeStepVPStrategyType, ThreeStepVPStrategyType::Pointer, BaseSolvingStrategyType>(m, "ThreeStepVPStrategy")
+            py::class_<ThreeStepVPStrategyType, ThreeStepVPStrategyType::Pointer, VPStrategyType>(m, "ThreeStepVPStrategy")
                 .def(py::init<ModelPart &, LinearSolverType::Pointer, LinearSolverType::Pointer, bool, double, double, int, unsigned int, unsigned int>());
             ;
 
             py::class_<TwoStepVPDEMcouplingStrategyType, TwoStepVPDEMcouplingStrategyType::Pointer, TwoStepVPStrategyType>(m, "TwoStepVPDEMcouplingStrategy")
                 .def(py::init<ModelPart &, LinearSolverType::Pointer, LinearSolverType::Pointer, bool, double, double, int, unsigned int, unsigned int>());
 
-            py::class_<NodalTwoStepVPStrategyType, NodalTwoStepVPStrategyType::Pointer, BaseSolvingStrategyType>(m, "NodalTwoStepVPStrategy")
+            py::class_<NodalTwoStepVPStrategyType, NodalTwoStepVPStrategyType::Pointer, ImplicitBaseSolvingStrategyType>(m, "NodalTwoStepVPStrategy")
                 .def(py::init<ModelPart &, LinearSolverType::Pointer, LinearSolverType::Pointer, bool, double, double, int, unsigned int, unsigned int>());
 
-            py::class_<NodalTwoStepVPStrategyForFSIType, NodalTwoStepVPStrategyForFSIType::Pointer, BaseSolvingStrategyType>(m, "NodalTwoStepVPStrategyForFSI")
+            py::class_<NodalTwoStepVPStrategyForFSIType, NodalTwoStepVPStrategyForFSIType::Pointer, NodalTwoStepVPStrategyType>(m, "NodalTwoStepVPStrategyForFSI")
                 .def(py::init<ModelPart &, LinearSolverType::Pointer, LinearSolverType::Pointer, bool, double, double, int, unsigned int, unsigned int>());
 
-            py::class_<GaussSeidelLinearStrategyType, GaussSeidelLinearStrategyType::Pointer, BaseSolvingStrategyType>(m, "GaussSeidelLinearStrategy")
+            py::class_<GaussSeidelLinearStrategyType, GaussSeidelLinearStrategyType::Pointer, ImplicitBaseSolvingStrategyType>(m, "GaussSeidelLinearStrategy")
                 .def(py::init<ModelPart &, BaseSchemeType::Pointer, LinearSolverType::Pointer, BuilderAndSolverType::Pointer, bool, bool>())
                 .def("GetResidualNorm", &GaussSeidelLinearStrategyType::GetResidualNorm)
                 .def("SetBuilderAndSolver", &GaussSeidelLinearStrategyType::SetBuilderAndSolver);

--- a/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/three_step_v_p_strategy.h
+++ b/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/three_step_v_p_strategy.h
@@ -86,7 +86,7 @@ namespace Kratos
 
     typedef typename BaseType::LocalSystemMatrixType LocalSystemMatrixType;
 
-    typedef typename SolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver>::Pointer StrategyPointerType;
+    typedef typename SolvingStrategy<TSparseSpace, TDenseSpace>::Pointer StrategyPointerType;
 
     typedef TwoStepVPSolverSettings<TSparseSpace, TDenseSpace, TLinearSolver> SolverSettingsType;
 
@@ -123,7 +123,7 @@ namespace Kratos
 
       // Additional Typedefs
       typedef typename BuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>::Pointer BuilderSolverTypePointer;
-      typedef SolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver> BaseType;
+      typedef SolvingStrategy<TSparseSpace, TDenseSpace> BaseType;
 
       //initializing fractional velocity solution step
       typedef Scheme<TSparseSpace, TDenseSpace> SchemeType;

--- a/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/two_step_v_p_strategy.h
+++ b/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/two_step_v_p_strategy.h
@@ -138,7 +138,7 @@ namespace Kratos
 
       this->mpMomentumStrategy = typename BaseType::Pointer(new GaussSeidelLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(rModelPart, pScheme, pVelocityLinearSolver, vel_build, ReformDofAtEachIteration, CalculateNormDxFlag));
 
-      this->mpMomentumStrategy->SetEchoLevel(BaseType::GetEchoLevel());
+      this->mpMomentumStrategy->SetEchoLevel(1);
 
       vel_build->SetCalculateReactionsFlag(false);
 
@@ -147,7 +147,7 @@ namespace Kratos
 
       this->mpPressureStrategy = typename BaseType::Pointer(new GaussSeidelLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(rModelPart, pScheme, pPressureLinearSolver, pressure_build, ReformDofAtEachIteration, CalculateNormDxFlag));
 
-      this->mpPressureStrategy->SetEchoLevel(BaseType::GetEchoLevel());
+      this->mpPressureStrategy->SetEchoLevel(1);
 
       pressure_build->SetCalculateReactionsFlag(false);
 

--- a/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/two_step_v_p_strategy.h
+++ b/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/two_step_v_p_strategy.h
@@ -138,16 +138,12 @@ namespace Kratos
 
       this->mpMomentumStrategy = typename BaseType::Pointer(new GaussSeidelLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(rModelPart, pScheme, pVelocityLinearSolver, vel_build, ReformDofAtEachIteration, CalculateNormDxFlag));
 
-      this->mpMomentumStrategy->SetEchoLevel(1);
-
       vel_build->SetCalculateReactionsFlag(false);
 
       /* BuilderSolverTypePointer pressure_build = BuilderSolverTypePointer(new ResidualBasedEliminationBuilderAndSolverComponentwise<TSparseSpace, TDenseSpace, TLinearSolver, Variable<double> >(pPressureLinearSolver, PRESSURE)); */
       BuilderSolverTypePointer pressure_build = BuilderSolverTypePointer(new ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>(pPressureLinearSolver));
 
       this->mpPressureStrategy = typename BaseType::Pointer(new GaussSeidelLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(rModelPart, pScheme, pPressureLinearSolver, pressure_build, ReformDofAtEachIteration, CalculateNormDxFlag));
-
-      this->mpPressureStrategy->SetEchoLevel(1);
 
       pressure_build->SetCalculateReactionsFlag(false);
 

--- a/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/v_p_strategy.h
+++ b/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/v_p_strategy.h
@@ -55,14 +55,14 @@ namespace Kratos
   template <class TSparseSpace,
             class TDenseSpace,
             class TLinearSolver>
-  class VPStrategy : public SolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver>
+  class VPStrategy : public SolvingStrategy<TSparseSpace, TDenseSpace>
   {
   public:
     ///@name Type Definitions
     ///@{
     KRATOS_CLASS_POINTER_DEFINITION(VPStrategy);
 
-    typedef SolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver> BaseType;
+    typedef SolvingStrategy<TSparseSpace, TDenseSpace> BaseType;
 
     typedef TwoStepVPSolverSettings<TSparseSpace, TDenseSpace, TLinearSolver> SolverSettingsType;
 

--- a/applications/PfemFluidDynamicsApplication/custom_utilities/solver_settings.h
+++ b/applications/PfemFluidDynamicsApplication/custom_utilities/solver_settings.h
@@ -62,7 +62,7 @@ namespace Kratos
         /// Pointer definition of TwoStepVPSolverSettings
         KRATOS_CLASS_POINTER_DEFINITION(TwoStepVPSolverSettings);
 
-        typedef SolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver> StrategyType;
+        typedef SolvingStrategy<TSparseSpace, TDenseSpace> StrategyType;
         typedef typename StrategyType::Pointer StrategyPointerType;
         typedef typename Process::Pointer ProcessPointerType;
 

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/eigensolver_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/eigensolver_strategy.hpp
@@ -315,8 +315,10 @@ public:
         SparseMatrixType& rStiffnessMatrix = this->GetStiffnessMatrix();
 
         // Initialize dummy vectors
-        SparseVectorPointerType pDx = SparseSpaceType::CreateEmptyVectorPointer();
-        SparseVectorPointerType pb = SparseSpaceType::CreateEmptyVectorPointer();
+        const DataCommunicator &r_comm = rModelPart.GetCommunicator().GetDataCommunicator();
+        SparseVectorPointerType pDx = SparseSpaceType::CreateEmptyVectorPointer(r_comm);
+        SparseVectorPointerType pb = SparseSpaceType::CreateEmptyVectorPointer(r_comm);
+
         auto& rDx = *pDx;
         auto& rb = *pb;
 
@@ -356,9 +358,9 @@ public:
         }
         else
         {
-            SparseSpaceType::Resize(rb, SparseSpaceType::Size1(rStiffnessMatrix));
+            // SparseSpaceType::Resize(rb, SparseSpaceType::Size1(rStiffnessMatrix));
             SparseSpaceType::Set(rb, 0.0);
-            SparseSpaceType::Resize(rDx, SparseSpaceType::Size1(rStiffnessMatrix));
+            // SparseSpaceType::Resize(rDx, SparseSpaceType::Size1(rStiffnessMatrix));
             SparseSpaceType::Set(rDx, 0.0);
         }
 
@@ -392,7 +394,7 @@ public:
 
         // Initialize dummy rhs vector
         SparseVectorType b;
-        SparseSpaceType::Resize(b,SparseSpaceType::Size1(rMassMatrix));
+        // SparseSpaceType::Resize(b,SparseSpaceType::Size1(rMassMatrix));
         SparseSpaceType::Set(b,0.0);
 
         // if the size of the Matrix is the same as the size of the dofset, then also the dirichlet-dofs are in the matrix
@@ -474,8 +476,9 @@ public:
             <<  "Entering FinalizeSolutionStep" << std::endl;
 
         SparseMatrixType& rStiffnessMatrix = this->GetStiffnessMatrix();
-        SparseVectorPointerType pDx = SparseSpaceType::CreateEmptyVectorPointer();
-        SparseVectorPointerType pb = SparseSpaceType::CreateEmptyVectorPointer();
+        const DataCommunicator &r_comm = BaseType::GetModelPart().GetCommunicator().GetDataCommunicator();
+        SparseVectorPointerType pDx = SparseSpaceType::CreateEmptyVectorPointer(r_comm);
+        SparseVectorPointerType pb = SparseSpaceType::CreateEmptyVectorPointer(r_comm);
         pGetBuilderAndSolver()->FinalizeSolutionStep(
             BaseType::GetModelPart(), rStiffnessMatrix, *pDx, *pb);
         pGetScheme()->FinalizeSolutionStep(BaseType::GetModelPart(),

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
@@ -95,6 +95,7 @@ public:
         : ImplicitSolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(rModelPart)
     {
         KRATOS_TRY
+        const DataCommunicator &r_comm = rModelPart.GetCommunicator().GetDataCommunicator();
 
         mpScheme = pScheme;
 
@@ -103,8 +104,8 @@ public:
         // ensure initialization of system matrices in InitializeSolutionStep()
         mpBuilderAndSolver->SetDofSetIsInitializedFlag(false);
 
-        mpForceVector = SparseSpaceType::CreateEmptyVectorPointer();
-        mpModalMatrix = DenseSpaceType::CreateEmptyMatrixPointer();
+        mpForceVector = SparseSpaceType::CreateEmptyVectorPointer(r_comm);
+        mpModalMatrix = DenseSpaceType::CreateEmptyMatrixPointer(r_comm);
 
         this->SetUseMaterialDampingFlag(UseMaterialDampingFlag);
 
@@ -310,13 +311,14 @@ public:
                 mMaterialDampingRatios = ZeroVector( n_modes );
 
                 //initialize dummy vectors
-                auto pDx = SparseSpaceType::CreateEmptyVectorPointer();
-                auto pb = SparseSpaceType::CreateEmptyVectorPointer();
+                const DataCommunicator &r_comm = r_model_part.GetCommunicator().GetDataCommunicator();
+                auto pDx = SparseSpaceType::CreateEmptyVectorPointer(r_comm);
+                auto pb = SparseSpaceType::CreateEmptyVectorPointer(r_comm);
                 auto& rDx = *pDx;
                 auto& rb = *pb;
-                SparseSpaceType::Resize(rDx,system_size);
+                // SparseSpaceType::Resize(rDx,system_size);
                 SparseSpaceType::Set(rDx,0.0);
-                SparseSpaceType::Resize(rb,system_size);
+                // SparseSpaceType::Resize(rb,system_size);
                 SparseSpaceType::Set(rb,0.0);
 
                 //loop over all modes and initialize the material damping ratio per mode
@@ -339,7 +341,7 @@ public:
                         }
 
                         //initialize the submodelpart stiffness matrix
-                        auto temp_stiffness_matrix = SparseSpaceType::CreateEmptyMatrixPointer();
+                        auto temp_stiffness_matrix = SparseSpaceType::CreateEmptyMatrixPointer(r_comm);
                         p_builder_and_solver->ResizeAndInitializeVectors(p_scheme,
                             temp_stiffness_matrix,
                             pDx,

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/prebuckling_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/prebuckling_strategy.hpp
@@ -151,10 +151,12 @@ public:
         this->SetRebuildLevel(1);
 
         // Set Matrices and Vectors to empty pointers
-        mpStiffnessMatrix = TSparseSpace::CreateEmptyMatrixPointer();
-        mpStiffnessMatrixPrevious = TSparseSpace::CreateEmptyMatrixPointer();
-        mpDx = TSparseSpace::CreateEmptyVectorPointer();
-        mpRHS = TSparseSpace::CreateEmptyVectorPointer();
+        const DataCommunicator &r_comm = rModelPart.GetCommunicator().GetDataCommunicator();
+        mpStiffnessMatrix = TSparseSpace::CreateEmptyMatrixPointer(r_comm);
+        mpStiffnessMatrixPrevious = TSparseSpace::CreateEmptyMatrixPointer(r_comm);
+
+        mpDx = TSparseSpace::CreateEmptyVectorPointer(r_comm);
+        mpRHS = TSparseSpace::CreateEmptyVectorPointer(r_comm);
 
         rModelPart.GetProcessInfo()[TIME] = 1.0;
 
@@ -344,8 +346,9 @@ public:
             SparseVectorType& rDx  = *mpDx;
 
             // Initialize dummy vectors
-            SparseVectorPointerType _pDx = SparseSpaceType::CreateEmptyVectorPointer();
-            SparseVectorPointerType _pb = SparseSpaceType::CreateEmptyVectorPointer();
+            const DataCommunicator &r_comm = rModelPart.GetCommunicator().GetDataCommunicator();
+            SparseVectorPointerType _pDx = SparseSpaceType::CreateEmptyVectorPointer(r_comm);
+            SparseVectorPointerType _pb = SparseSpaceType::CreateEmptyVectorPointer(r_comm);
 
             // Reset solution dofs
             BuiltinTimer system_construction_time;

--- a/applications/StructuralMechanicsApplication/custom_utilities/perturb_geometry_base_utility.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/perturb_geometry_base_utility.cpp
@@ -31,8 +31,10 @@ PerturbGeometryBaseUtility::PerturbGeometryBaseUtility( ModelPart& rInitialModel
         mMaximalDisplacement(Settings["max_displacement"].GetDouble())
     {
         KRATOS_TRY
+        const DataCommunicator &r_comm = rInitialModelPart.GetCommunicator().GetDataCommunicator();
+
         NormalCalculationUtils().CalculateUnitNormals<Element>(mrInitialModelPart, true);
-        mpPerturbationMatrix = TDenseSpaceType::CreateEmptyMatrixPointer();
+        mpPerturbationMatrix = TDenseSpaceType::CreateEmptyMatrixPointer(r_comm);
         KRATOS_CATCH("")
     }
 

--- a/kratos/solving_strategies/schemes/residualbased_incremental_aitken_static_scheme.h
+++ b/kratos/solving_strategies/schemes/residualbased_incremental_aitken_static_scheme.h
@@ -139,7 +139,7 @@ public:
     {
         BaseType::InitializeSolutionStep(r_model_part,A,Dx,b);
         if (TSparseSpace::Size(mPreviousDx) != TSparseSpace::Size(Dx)) {
-            TSparseSpace::Resize(mPreviousDx, TSparseSpace::Size(Dx));
+            // TSparseSpace::Resize(mPreviousDx, TSparseSpace::Size(Dx));
         }
         TSparseSpace::SetToZero(mPreviousDx);
         mIterationCounter = 0;


### PR DESCRIPTION
**Description**
Missing changes in apps for #8784
@AFranci PfemFluidDynamics was not compiling at all, all the interface was broken. Since I needed to test the changes I tried to fix it, but I don't know if the solution is ok.

**TODO**:
- [ ] Deleted resize interface for vector/matrix references is causing problems in Core/StructuralApp

**Changelog**
- Added r_comm to missing spaces.
- Fixed PfemFluid
