### PR TITLE
[Poro] Fixed compilation error in explicit strategies

### DIFF
--- a/applications/PoromechanicsApplication/custom_strategies/strategies/poromechanics_explicit_nonlocal_strategy.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/strategies/poromechanics_explicit_nonlocal_strategy.hpp
@@ -36,7 +36,7 @@ public:
 
     KRATOS_CLASS_POINTER_DEFINITION(PoromechanicsExplicitNonlocalStrategy);
 
-    typedef SolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver> BaseType;
+    typedef ImplicitSolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver> BaseType;
     typedef MechanicalExplicitStrategy<TSparseSpace, TDenseSpace, TLinearSolver> GrandMotherType;
     typedef PoromechanicsExplicitStrategy<TSparseSpace, TDenseSpace, TLinearSolver> MotherType;
     typedef typename BaseType::TSchemeType TSchemeType;

--- a/applications/PoromechanicsApplication/custom_strategies/strategies/poromechanics_explicit_strategy.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/strategies/poromechanics_explicit_strategy.hpp
@@ -36,7 +36,7 @@ public:
 
     KRATOS_CLASS_POINTER_DEFINITION(PoromechanicsExplicitStrategy);
 
-    typedef SolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver> BaseType;
+    typedef ImplicitSolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver> BaseType;
     typedef MechanicalExplicitStrategy<TSparseSpace, TDenseSpace, TLinearSolver> MotherType;
     typedef typename BaseType::TSchemeType TSchemeType;
     typedef typename BaseType::DofsArrayType DofsArrayType;


### PR DESCRIPTION
**Description**
Base class definition has been corrected in explicit strategies to avoid compilation error after merge of PR #7898. Citing issue [9190](https://github.com/KratosMultiphysics/Kratos/issues/9109)

**Changelog**
- Replaced "SolvingStrategy" by "ImplicitSolvingStrategy" as BaseType of poro explicit strategies.
