### PR TITLE
[Core] adding vars needed from processes

### DIFF
--- a/applications/DEMApplication/python_scripts/sphere_strategy.py
+++ b/applications/DEMApplication/python_scripts/sphere_strategy.py
@@ -359,7 +359,7 @@ class ExplicitStrategy():
     def AddVariables(self):
         pass
 
-    def AddAdditionalHistoricalVariables(self):
+    def AddAdditionalHistoricalVariables(self,list_additional_variables):
         pass
 
     def BeforeInitialize(self):

--- a/applications/DEMApplication/python_scripts/sphere_strategy.py
+++ b/applications/DEMApplication/python_scripts/sphere_strategy.py
@@ -359,6 +359,9 @@ class ExplicitStrategy():
     def AddVariables(self):
         pass
 
+    def AddAdditionalHistoricalVariables(self):
+        pass
+
     def BeforeInitialize(self):
         self.CreateCPlusPlusStrategy()
         self.RebuildListOfDiscontinuumSphericParticles()

--- a/applications/DEMApplication/python_scripts/sphere_strategy.py
+++ b/applications/DEMApplication/python_scripts/sphere_strategy.py
@@ -359,7 +359,7 @@ class ExplicitStrategy():
     def AddVariables(self):
         pass
 
-    def AddAdditionalHistoricalVariables(self,list_additional_variables):
+    def AddAdditionalHistoricalVariables(self, map_additional_variables):
         pass
 
     def BeforeInitialize(self):

--- a/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
@@ -13,7 +13,7 @@ def GetHistoricalVariables(settings):
     copy_settings.AddMissingParameters(ApplyInletProcess.GetDefaultParameters())
     root_model_part_name = copy_settings["model_part_name"].GetString().split(".")[0]
 
-    applied_var = KratosMultiphysics.KratosGlobals.GetVariable(copy_settings["variable_name"].GetString())
+    applied_var =copy_settings["variable_name"].GetString()
     vars_dict = {root_model_part : {applied_var}}
     return vars_dict
 

--- a/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
@@ -12,7 +12,11 @@ def GetHistoricalVariables(settings):
     copy_settings = settings.__deepcopy__()
     copy_settings.AddMissingParameters(ApplyInletProcess.GetDefaultParameters())
     model_part_name = copy_settings["model_part_name"].GetString()
-    root_model_part = model_part_name[:model_part_name.index(".")]
+    if "." in model_part_name:
+        root_model_part = model_part_name[:model_part_name.index(".")]
+    else:
+        root_model_part = model_part_name
+
     applied_var = KratosMultiphysics.KratosGlobals.GetVariable(copy_settings["variable_name"].GetString())
     vars_dict = {root_model_part : [applied_var]}
     return vars_dict

--- a/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
@@ -18,7 +18,7 @@ def GetHistoricalVariables(settings):
         root_model_part = model_part_name
 
     applied_var = KratosMultiphysics.KratosGlobals.GetVariable(copy_settings["variable_name"].GetString())
-    vars_dict = {root_model_part : [applied_var]}
+    vars_dict = {root_model_part : {applied_var}}
     return vars_dict
 
 class ApplyInletProcess(KratosMultiphysics.Process):

--- a/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
@@ -9,12 +9,13 @@ def Factory(settings, Model):
     return ApplyInletProcess(Model, settings["Parameters"])
 
 def GetHistoricalVariables(settings):
-    copy_settings = settings.__copy__()
+    copy_settings = settings.__deepcopy__()
     copy_settings.AddMissingParameters(ApplyInletProcess.GetDefaultParameters())
-    required_vars = []
-    applied_var = copy_settings["variable_name"].GetString()
-    required_vars.append(KratosMultiphysics.KratosGlobals.GetVariable(applied_var))
-    return required_vars
+    model_part_name = copy_settings["model_part_name"].GetString()
+    root_model_part = model_part_name[:model_part_name.index(".")]
+    applied_var = KratosMultiphysics.KratosGlobals.GetVariable(copy_settings["variable_name"].GetString())
+    vars_dict = {root_model_part : [applied_var]}
+    return vars_dict
 
 class ApplyInletProcess(KratosMultiphysics.Process):
     def __init__(self, Model, settings):

--- a/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
@@ -14,7 +14,7 @@ def GetHistoricalVariables(settings):
     root_model_part_name = copy_settings["model_part_name"].GetString().split(".")[0]
 
     applied_var =copy_settings["variable_name"].GetString()
-    vars_dict = {root_model_part : {applied_var}}
+    vars_dict = {root_model_part_name : {applied_var}}
     return vars_dict
 
 class ApplyInletProcess(KratosMultiphysics.Process):

--- a/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
@@ -9,7 +9,7 @@ def Factory(settings, Model):
     return ApplyInletProcess(Model, settings["Parameters"])
 
 def GetHistoricalVariables(settings):
-    copy_settings = settings.__deepcopy__()
+    copy_settings = settings.Clone()
     copy_settings.AddMissingParameters(ApplyInletProcess.GetDefaultParameters())
     model_part_name = copy_settings["model_part_name"].GetString()
     root_model_part = model_part_name[:model_part_name.index(".")]

--- a/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
@@ -8,22 +8,19 @@ def Factory(settings, Model):
         raise Exception("expected input shall be a Parameters object, encapsulating a json string")
     return ApplyInletProcess(Model, settings["Parameters"])
 
+def GetHistoricalVariables(settings):
+    copy_settings = settings.__copy__()
+    copy_settings.ValidateAndAssignDefaults(ApplyInletProcess.GetDefaultParameters())
+    required_vars = []
+    applied_var = copy_settings["variable_name"].GetString()
+    required_vars.append(KratosMultiphysics.KratosGlobals.GetVariable(applied_var))
+    return required_vars
 
 class ApplyInletProcess(KratosMultiphysics.Process):
     def __init__(self, Model, settings):
         KratosMultiphysics.Process.__init__(self)
 
-        default_settings = KratosMultiphysics.Parameters("""
-        {
-            "mesh_id"         : 0,
-            "model_part_name" : "",
-            "variable_name"   : "VELOCITY",
-            "modulus"         : 0.0,
-            "constrained"     : true,
-            "direction"       : [1.0,0.0,0.0],
-            "interval"        : [0.0,"End"]
-        }
-        """)
+        default_settings = ApplyInletProcess.GetDefaultParameters()
 
         # Trick: allow "modulus" and "direction" to be a double or a string value (otherwise the ValidateAndAssignDefaults might fail)
         if (settings.Has("modulus")):
@@ -59,6 +56,19 @@ class ApplyInletProcess(KratosMultiphysics.Process):
         # Construct the base process AssignVectorByDirectionProcess
         self.aux_process = assign_vector_by_direction_process.AssignVectorByDirectionProcess(Model, settings)
 
+    @staticmethod
+    def GetDefaultParameters():
+        return KratosMultiphysics.Parameters("""
+        {
+            "mesh_id"         : 0,
+            "model_part_name" : "",
+            "variable_name"   : "VELOCITY",
+            "modulus"         : 0.0,
+            "constrained"     : true,
+            "direction"       : [1.0,0.0,0.0],
+            "interval"        : [0.0,"End"]
+        }
+        """)
 
     def ExecuteInitializeSolutionStep(self):
         # Call the base process ExecuteInitializeSolutionStep()

--- a/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
@@ -10,7 +10,7 @@ def Factory(settings, Model):
 
 def GetHistoricalVariables(settings):
     copy_settings = settings.__copy__()
-    copy_settings.ValidateAndAssignDefaults(ApplyInletProcess.GetDefaultParameters())
+    copy_settings.AddMissingParameters(ApplyInletProcess.GetDefaultParameters())
     required_vars = []
     applied_var = copy_settings["variable_name"].GetString()
     required_vars.append(KratosMultiphysics.KratosGlobals.GetVariable(applied_var))

--- a/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_inlet_process.py
@@ -11,11 +11,7 @@ def Factory(settings, Model):
 def GetHistoricalVariables(settings):
     copy_settings = settings.Clone()
     copy_settings.AddMissingParameters(ApplyInletProcess.GetDefaultParameters())
-    model_part_name = copy_settings["model_part_name"].GetString()
-    if "." in model_part_name:
-        root_model_part = model_part_name[:model_part_name.index(".")]
-    else:
-        root_model_part = model_part_name
+    root_model_part_name = copy_settings["model_part_name"].GetString().split(".")[0]
 
     applied_var = KratosMultiphysics.KratosGlobals.GetVariable(copy_settings["variable_name"].GetString())
     vars_dict = {root_model_part : {applied_var}}

--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -350,8 +350,9 @@ class AnalysisStage(object):
         self._list_of_processes.extend(self._list_of_output_processes) # Adding the output processes to the regular processes
 
     def _GetMapOfAdditionalHistoricalVariables(self):
-        """This function returns the list of (additional) historicsl variables
-        needed in the simulation
+        """This function returns a dictionary of (additional) historical variables
+        needed in the simulation. The keys are the model part names where variables
+        will be added and the values are sets with the names of the variables.
         It can be overridden in derived classes
         """
         map_additional_vars = defaultdict(set)
@@ -361,7 +362,10 @@ class AnalysisStage(object):
         return map_additional_vars
 
     def _GetLMapOfAdditionalVariablesFromProcesses(self, parameter_name, map_additional_vars):
-        """This function extracts the required historical variables needed by the processes
+        """This function extracts the required historical variables needed by the processes.
+        A dictionary is given as a parameter (map_additional_vars) that will be filled in this
+        function. The keys are the model part names where variables will be added and the
+        values are sets with the names of the variables.
         """
         factory = KratosProcessFactory(self.model)
 

--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -360,7 +360,6 @@ class AnalysisStage(object):
     def __GetListOfAdditionalVariablesFromProcesses(self, parameter_name, list_additional_vars):
         """This function extracts the required historical variables needed by the processes
         """
-        from process_factory import KratosProcessFactory
         factory = KratosProcessFactory(self.model)
 
         if self.project_parameters.Has(parameter_name):

--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -40,7 +40,7 @@ class AnalysisStage(object):
 
         self._GetSolver().AddVariables() # this creates the solver and adds the variables
         list_additional_vars = self._GetListOfAdditionalHistoricalVariables()
-        self._GetSolver().AddAdditionalVariables(list_additional_vars)
+        self._GetSolver().AddAdditionalHistoricalVariables(list_additional_vars)
 
     def Run(self):
         """This function executes the entire AnalysisStage

--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -355,12 +355,12 @@ class AnalysisStage(object):
         It can be overridden in derived classes
         """
         map_additional_vars = defaultdict(set)
-        self.__GetLMapOfAdditionalVariablesFromProcesses("processes", map_additional_vars)
-        self.__GetLMapOfAdditionalVariablesFromProcesses("output_processes", map_additional_vars)
+        self._GetLMapOfAdditionalVariablesFromProcesses("processes", map_additional_vars)
+        self._GetLMapOfAdditionalVariablesFromProcesses("output_processes", map_additional_vars)
 
         return map_additional_vars
 
-    def __GetLMapOfAdditionalVariablesFromProcesses(self, parameter_name, map_additional_vars):
+    def _GetLMapOfAdditionalVariablesFromProcesses(self, parameter_name, map_additional_vars):
         """This function extracts the required historical variables needed by the processes
         """
         factory = KratosProcessFactory(self.model)

--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -354,7 +354,7 @@ class AnalysisStage(object):
         needed in the simulation
         It can be overridden in derived classes
         """
-        map_additional_vars = defaultdict(list)
+        map_additional_vars = defaultdict(set)
         self.__GetLMapOfAdditionalVariablesFromProcesses("processes", map_additional_vars)
         self.__GetLMapOfAdditionalVariablesFromProcesses("output_processes", map_additional_vars)
 
@@ -371,7 +371,7 @@ class AnalysisStage(object):
             for value in processes_params.values():
                 process_variables_dict = factory.GetMapOfRequiredHistoricalVariables(value)
                 for mp in process_variables_dict:
-                    map_additional_vars[mp].extend(process_variables_dict[mp])
+                    map_additional_vars[mp].update(process_variables_dict[mp])
 
     def __CheckIfSolveSolutionStepReturnsAValue(self, is_converged):
         """In case the solver does not return the state of convergence

--- a/kratos/python_scripts/process_factory.py
+++ b/kratos/python_scripts/process_factory.py
@@ -28,7 +28,7 @@ class KratosProcessFactory(object):
         return constructed_processes
 
     def GetMapOfRequiredHistoricalVariables( self, process_list):
-        required_variables_map = defaultdict(list)
+        required_variables_map = defaultdict(set)
         for i in range(0,process_list.size()):
             item = process_list[i]
             if not item.Has("python_module"):
@@ -42,7 +42,7 @@ class KratosProcessFactory(object):
             if hasattr(python_module, "GetHistoricalVariables"):
                 new_dict = python_module.GetHistoricalVariables(item["Parameters"])
                 for mp in new_dict:
-                    required_variables_map[mp].extend(new_dict[mp])
+                    required_variables_map[mp].update(new_dict[mp])
 
         return required_variables_map
 

--- a/kratos/python_scripts/process_factory.py
+++ b/kratos/python_scripts/process_factory.py
@@ -29,8 +29,7 @@ class KratosProcessFactory(object):
 
     def GetMapOfRequiredHistoricalVariables( self, process_list):
         required_variables_map = defaultdict(list)
-        for i in range(0,process_list.size()):
-            item = process_list[i]
+        for item in process_list:
             if not item.Has("python_module"):
                 KM.Logger.PrintWarning("Your list of processes: ", process_list)
                 raise NameError('"python_module" must be defined in your parameters. Check all your processes')

--- a/kratos/python_scripts/process_factory.py
+++ b/kratos/python_scripts/process_factory.py
@@ -20,7 +20,7 @@ class KratosProcessFactory(object):
 
             # python-script that contains the process
             python_module_name = self._GetFullModuleNameName(item)
-            
+
             python_module = import_module(python_module_name)
             p = python_module.Factory(item, self.Model)
             constructed_processes.append( p )

--- a/kratos/python_scripts/process_factory.py
+++ b/kratos/python_scripts/process_factory.py
@@ -29,7 +29,8 @@ class KratosProcessFactory(object):
 
     def GetMapOfRequiredHistoricalVariables( self, process_list):
         required_variables_map = defaultdict(list)
-        for item in process_list:
+        for i in range(0,process_list.size()):
+            item = process_list[i]
             if not item.Has("python_module"):
                 KM.Logger.PrintWarning("Your list of processes: ", process_list)
                 raise NameError('"python_module" must be defined in your parameters. Check all your processes')

--- a/kratos/python_scripts/process_factory.py
+++ b/kratos/python_scripts/process_factory.py
@@ -32,7 +32,7 @@ class KratosProcessFactory(object):
         for i in range(0,process_list.size()):
             item = process_list[i]
             if not item.Has("python_module"):
-                KM.Logger.PrintWarning("Your list of processes: ", process_list)
+                KM.Logger.PrintWarning("Your process parameters: ", item)
                 raise NameError('"python_module" must be defined in your parameters. Check all your processes')
 
             # python-script that contains the process

--- a/kratos/python_scripts/process_factory.py
+++ b/kratos/python_scripts/process_factory.py
@@ -43,6 +43,23 @@ class KratosProcessFactory(object):
 
         return constructed_processes
 
+    def GetListOfRequiredHistoricalVariables( self, process_list):
+        required_variables = []
+        for i in range(0,process_list.size()):
+            item = process_list[i]
+            # The kratos_module is the application where the script must be loaded. ex. KratosMultiphysics.StructuralMechanicsApplication
+            if(item.Has("kratos_module")):
+                kratos_module = __import__(item["kratos_module"].GetString())
+            # The python_module is the actual scrpt that must be launch
+            if(item.Has("python_module")):
+                python_module = __import__(item["python_module"].GetString())
+                # not all processes define/need this method, therefore
+                # an explicit check is necessary
+                if hasattr(python_module, "GetHistoricalVariables"):
+                    required_variables.extend(python_module.GetHistoricalVariables(item["Parameters"]))
+
+        return required_variables
+
 
 ########## here we generate the common kratos processes --- IMPLEMENTED IN C++ ###################
 def Factory(settings, Model):

--- a/kratos/python_scripts/process_factory.py
+++ b/kratos/python_scripts/process_factory.py
@@ -3,6 +3,7 @@ import KratosMultiphysics as KM
 
 # Other imports
 from importlib import import_module
+from collections import defaultdict
 
 ################# Please do not change the following class:
 class KratosProcessFactory(object):
@@ -26,8 +27,8 @@ class KratosProcessFactory(object):
 
         return constructed_processes
 
-    def GetListOfRequiredHistoricalVariables( self, process_list):
-        required_variables = []
+    def GetMapOfRequiredHistoricalVariables( self, process_list):
+        required_variables_map = defaultdict(list)
         for i in range(0,process_list.size()):
             item = process_list[i]
             if not item.Has("python_module"):
@@ -39,9 +40,11 @@ class KratosProcessFactory(object):
             
             python_module = import_module(python_module_name)
             if hasattr(python_module, "GetHistoricalVariables"):
-                required_variables.extend(python_module.GetHistoricalVariables(item["Parameters"]))
+                new_dict = python_module.GetHistoricalVariables(item["Parameters"])
+                for mp in new_dict:
+                    required_variables_map[mp].extend(new_dict[mp])
 
-        return required_variables
+        return required_variables_map
 
 
     def _GetFullModuleNameName(self,item):

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -59,7 +59,7 @@ class PythonSolver:
         Those can e.g. be needed by processes or utilities.
         It has to be called BEFORE the ModelPart is read!
         """
-        for var in self.list_additional_variables:
+        for var in list_additional_variables:
             self.GetComputingModelPart.AddNodalSolutionStepVariable(var)
 
     def AddDofs(self):

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -54,6 +54,13 @@ class PythonSolver:
         """
         pass
 
+    def AddAdditionalVariables(self, list_additional_variables):
+        """This function adds additional historical variables to the ModelPart
+        Those can e.g. be needed by processes or utilities.
+        It has to be called BEFORE the ModelPart is read!
+        """
+        pass
+
     def AddDofs(self):
         """This function add the Dofs needed by this PythonSolver to the the ModelPart
         It has to be called AFTER the ModelPart is read!

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -56,7 +56,9 @@ class PythonSolver:
 
     def AddAdditionalHistoricalVariables(self, map_additional_variables):
         """This function adds additional historical variables to the ModelPart
-        Those can e.g. be needed by processes or utilities.
+        Those can e.g. be needed by processes or utilities. A dictionary is given
+        as a parameter where the keys are the model part names where variables
+        will be added and the values are sets with the names of the variables.
         It has to be called BEFORE the ModelPart is read!
         """
         pass

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -54,13 +54,13 @@ class PythonSolver:
         """
         pass
 
-    def AddAdditionalVariables(self, list_additional_variables):
+    def AddAdditionalHistoricalVariables(self, list_additional_variables):
         """This function adds additional historical variables to the ModelPart
         Those can e.g. be needed by processes or utilities.
         It has to be called BEFORE the ModelPart is read!
         """
         for var in list_additional_variables:
-            self.GetComputingModelPart.AddNodalSolutionStepVariable(var)
+            self.GetComputingModelPart().AddNodalSolutionStepVariable(var)
 
     def AddDofs(self):
         """This function add the Dofs needed by this PythonSolver to the the ModelPart

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -59,8 +59,7 @@ class PythonSolver:
         Those can e.g. be needed by processes or utilities.
         It has to be called BEFORE the ModelPart is read!
         """
-        for var in list_additional_variables:
-            self.GetComputingModelPart().AddNodalSolutionStepVariable(var)
+        pass
 
     def AddDofs(self):
         """This function add the Dofs needed by this PythonSolver to the the ModelPart

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -59,7 +59,8 @@ class PythonSolver:
         Those can e.g. be needed by processes or utilities.
         It has to be called BEFORE the ModelPart is read!
         """
-        pass
+        for var in self.list_additional_variables:
+            self.GetComputingModelPart.AddNodalSolutionStepVariable(var)
 
     def AddDofs(self):
         """This function add the Dofs needed by this PythonSolver to the the ModelPart

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -54,7 +54,7 @@ class PythonSolver:
         """
         pass
 
-    def AddAdditionalHistoricalVariables(self, list_additional_variables):
+    def AddAdditionalHistoricalVariables(self, map_additional_variables):
         """This function adds additional historical variables to the ModelPart
         Those can e.g. be needed by processes or utilities.
         It has to be called BEFORE the ModelPart is read!

--- a/kratos/tests/test_KratosCore.py
+++ b/kratos/tests/test_KratosCore.py
@@ -61,6 +61,7 @@ import test_function_parser_utility
 import test_integration_points
 import test_mls_shape_functions_utility
 import test_force_and_torque_utils
+import test_analysis_stage
 
 def AssembleTestSuites():
     ''' Populates the test suites to run.
@@ -141,6 +142,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_integration_points.TestIntegrationPoints]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_mls_shape_functions_utility.TestMLSShapeFunctionsUtility]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_force_and_torque_utils.TestForceAndTorqueUtils]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_analysis_stage.TestAnalysisStage]))
 
     # Create a test suite with the selected tests plus all small tests
     nightSuite = suites['nightly']

--- a/kratos/tests/test_analysis_stage.py
+++ b/kratos/tests/test_analysis_stage.py
@@ -48,9 +48,9 @@ class TestAnalysisStage(KratosUnittest.TestCase):
         }""")
         stage = DummyAnalysis(model, settings)
         obtained_map = stage._GetMapOfAdditionalHistoricalVariables()
-        expected_map = {"ModelPart": {KratosMultiphysics.VELOCITY}}
+        expected_map = {"ModelPart": {"VELOCITY"}}
         self.assertEqual(obtained_map, expected_map)
-        wrong_map = {"ModelPart": {KratosMultiphysics.VELOCITY, KratosMultiphysics.DISTANCE}}
+        wrong_map = {"ModelPart": {"VELOCITY", "DISTANCE"}}
         self.assertNotEqual(obtained_map, wrong_map)
 
 if __name__ == '__main__':

--- a/kratos/tests/test_analysis_stage.py
+++ b/kratos/tests/test_analysis_stage.py
@@ -1,7 +1,3 @@
-import os
-import sys
-from unittest.case import skipIf
-
 # Importing the Kratos Library
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/kratos/tests/test_analysis_stage.py
+++ b/kratos/tests/test_analysis_stage.py
@@ -35,15 +35,22 @@ class TestAnalysisStage(KratosUnittest.TestCase):
                         "Parameters" :{
                             "model_part_name" : "ModelPart.inlet"
                         }
+                    },
+                    {
+                        "kratos_module" : "KratosMultiphysics.FluidDynamicsApplication",
+                        "python_module" : "apply_inlet_process",
+                        "Parameters" :{
+                            "model_part_name" : "ModelPart"
+                        }
                     }
                 ]
             }
         }""")
         stage = DummyAnalysis(model, settings)
         obtained_map = stage._GetMapOfAdditionalHistoricalVariables()
-        expected_map = {"ModelPart": [KratosMultiphysics.VELOCITY]}
+        expected_map = {"ModelPart": {KratosMultiphysics.VELOCITY}}
         self.assertEqual(obtained_map, expected_map)
-        wrong_map = {"ModelPart": [KratosMultiphysics.VELOCITY, KratosMultiphysics.DISTANCE]}
+        wrong_map = {"ModelPart": {KratosMultiphysics.VELOCITY, KratosMultiphysics.DISTANCE}}
         self.assertNotEqual(obtained_map, wrong_map)
 
 if __name__ == '__main__':

--- a/kratos/tests/test_analysis_stage.py
+++ b/kratos/tests/test_analysis_stage.py
@@ -1,0 +1,51 @@
+import os
+import sys
+from unittest.case import skipIf
+
+# Importing the Kratos Library
+import KratosMultiphysics
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+import KratosMultiphysics.kratos_utilities as KratosUtils
+from KratosMultiphysics.analysis_stage import AnalysisStage
+from KratosMultiphysics.python_solver import PythonSolver
+
+dependencies_are_available = KratosUtils.CheckIfApplicationsAvailable("FluidDynamicsApplication")
+if dependencies_are_available:
+    import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
+
+class DummyAnalysis(AnalysisStage):
+    def _CreateSolver(self):
+        return PythonSolver(self.model, self.project_parameters["solver_settings"])
+
+@KratosUnittest.skipIfApplicationsNotAvailable("FluidDynamicsApplication")
+class TestAnalysisStage(KratosUnittest.TestCase):
+    def test_GetMapOfAdditionalHistoricalVariables(self):
+        model = KratosMultiphysics.Model()
+        settings = KratosMultiphysics.Parameters("""{
+            "problem_data":{
+                "echo_level": 0,
+                "parallel_type" : "OMP"
+            },
+            "solver_settings":{},
+            "processes":{
+                "initial_conditions":[
+                    {
+                        "kratos_module" : "KratosMultiphysics.FluidDynamicsApplication",
+                        "python_module" : "apply_inlet_process",
+                        "Parameters" :{
+                            "model_part_name" : "ModelPart.inlet"
+                        }
+                    }
+                ]
+            }
+        }""")
+        stage = DummyAnalysis(model, settings)
+        obtained_map = stage._GetMapOfAdditionalHistoricalVariables()
+        expected_map = {"ModelPart": [KratosMultiphysics.VELOCITY]}
+        self.assertEqual(obtained_map, expected_map)
+        wrong_map = {"ModelPart": [KratosMultiphysics.VELOCITY, KratosMultiphysics.DISTANCE]}
+        self.assertNotEqual(obtained_map, wrong_map)
+
+if __name__ == '__main__':
+    KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.WARNING)
+    KratosUnittest.main()


### PR DESCRIPTION
**Description**
New attempt to try to add variables in the solver that are required from the processes. For the moment it's basically the same that @philbucher implemented here: https://github.com/KratosMultiphysics/Kratos/pull/3561

I added an example of how we could use it in apply_inlet_process.py

I thought about the possibility of also specifying the model part as it was discussed in the mentioned PR. It worries me a little if the process will always know the correct model part where they should be added and also if this model part will be already created at that moment... At the end the solver will add these variables to its computing model part so I guess its not so bad...
