### PR TITLE
[Poro] Making CLs Check methods const

### DIFF
--- a/applications/PoromechanicsApplication/custom_constitutive/bilinear_cohesive_3D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/bilinear_cohesive_3D_law.cpp
@@ -36,7 +36,7 @@ void BilinearCohesive3DLaw::GetLawFeatures(Features& rFeatures)
 
 //----------------------------------------------------------------------------------------
 
-int BilinearCohesive3DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo)
+int BilinearCohesive3DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo) const
 {
 
     // Verify Properties variables

--- a/applications/PoromechanicsApplication/custom_constitutive/bilinear_cohesive_3D_law.hpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/bilinear_cohesive_3D_law.hpp
@@ -60,7 +60,7 @@ public:
 
     void GetLawFeatures(Features& rFeatures) override;
 
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) const override;
 
     void InitializeMaterial( const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const Vector& rShapeFunctionsValues ) override;
 

--- a/applications/PoromechanicsApplication/custom_constitutive/exponential_cohesive_3D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/exponential_cohesive_3D_law.cpp
@@ -16,7 +16,7 @@
 namespace Kratos
 {
 
-int ExponentialCohesive3DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo)
+int ExponentialCohesive3DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo) const
 {
     // Verify ProcessInfo variables
 

--- a/applications/PoromechanicsApplication/custom_constitutive/exponential_cohesive_3D_law.hpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/exponential_cohesive_3D_law.hpp
@@ -59,7 +59,7 @@ public:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) const override;
 
     void InitializeMaterial( const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const Vector& rShapeFunctionsValues ) override;
 

--- a/applications/PoromechanicsApplication/custom_constitutive/hyperelastic_3D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/hyperelastic_3D_law.cpp
@@ -1006,7 +1006,7 @@ bool HyperElastic3DLaw::CheckParameters(Parameters& rValues)
 
 int HyperElastic3DLaw::Check(const Properties& rMaterialProperties,
                              const GeometryType& rElementGeometry,
-                             const ProcessInfo& rCurrentProcessInfo)
+                             const ProcessInfo& rCurrentProcessInfo) const
 {
 
     if(YOUNG_MODULUS.Key() == 0 || rMaterialProperties[YOUNG_MODULUS]<= 0.00)

--- a/applications/PoromechanicsApplication/custom_constitutive/hyperelastic_3D_law.hpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/hyperelastic_3D_law.hpp
@@ -246,7 +246,7 @@ public:
      * @param rCurrentProcessInfo
      * @return
      */
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Input and output

--- a/applications/PoromechanicsApplication/custom_constitutive/hyperelastic_plastic_3D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/hyperelastic_plastic_3D_law.cpp
@@ -613,7 +613,7 @@ bool HyperElasticPlastic3DLaw::CheckParameters(Parameters& rValues)
 
 int HyperElasticPlastic3DLaw::Check(const Properties& rMaterialProperties,
                              const GeometryType& rElementGeometry,
-                             const ProcessInfo& rCurrentProcessInfo)
+                             const ProcessInfo& rCurrentProcessInfo) const
 {
 
     if(YOUNG_MODULUS.Key() == 0 || rMaterialProperties[YOUNG_MODULUS]<= 0.00)

--- a/applications/PoromechanicsApplication/custom_constitutive/hyperelastic_plastic_3D_law.hpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/hyperelastic_plastic_3D_law.hpp
@@ -190,7 +190,7 @@ public:
      * @param rCurrentProcessInfo
      * @return
      */
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) const override;
 
 
 

--- a/applications/PoromechanicsApplication/custom_constitutive/linear_elastic_3D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/linear_elastic_3D_law.cpp
@@ -421,7 +421,7 @@ bool LinearElastic3DLaw::CheckParameters(Parameters& rValues)
 
 int LinearElastic3DLaw::Check(const Properties& rMaterialProperties,
                               const GeometryType& rElementGeometry,
-                              const ProcessInfo& rCurrentProcessInfo)
+                              const ProcessInfo& rCurrentProcessInfo) const
 {
 
     if(YOUNG_MODULUS.Key() == 0 || rMaterialProperties[YOUNG_MODULUS]<= 0.00)

--- a/applications/PoromechanicsApplication/custom_constitutive/linear_elastic_3D_law.hpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/linear_elastic_3D_law.hpp
@@ -118,7 +118,7 @@ public:
      * @param rCurrentProcessInfo
      * @return
      */
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) const override;
 
     /**
      * Input and output

--- a/applications/PoromechanicsApplication/custom_constitutive/local_damage_3D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/local_damage_3D_law.cpp
@@ -32,7 +32,7 @@ LocalDamage3DLaw::~LocalDamage3DLaw() {}
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-int LocalDamage3DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo)
+int LocalDamage3DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo) const
 {
     int ierr = HyperElasticPlastic3DLaw::Check(rMaterialProperties,rElementGeometry,rCurrentProcessInfo);
     if(ierr != 0) return ierr;

--- a/applications/PoromechanicsApplication/custom_constitutive/local_damage_3D_law.hpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/local_damage_3D_law.hpp
@@ -45,7 +45,7 @@ public:
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) const override;
     
     ConstitutiveLaw::Pointer Clone() const override;
     

--- a/applications/PoromechanicsApplication/custom_constitutive/modified_mises_nonlocal_damage_3D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/modified_mises_nonlocal_damage_3D_law.cpp
@@ -37,7 +37,7 @@ ModifiedMisesNonlocalDamage3DLaw::~ModifiedMisesNonlocalDamage3DLaw() {}
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-int ModifiedMisesNonlocalDamage3DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo)
+int ModifiedMisesNonlocalDamage3DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo) const
 {
     int ierr = NonlocalDamage3DLaw::Check(rMaterialProperties,rElementGeometry,rCurrentProcessInfo);
     if(ierr != 0) return ierr;

--- a/applications/PoromechanicsApplication/custom_constitutive/modified_mises_nonlocal_damage_3D_law.hpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/modified_mises_nonlocal_damage_3D_law.hpp
@@ -48,7 +48,7 @@ public:
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) const override;
     
     ConstitutiveLaw::Pointer Clone() const override;
 

--- a/applications/PoromechanicsApplication/custom_constitutive/modified_mises_nonlocal_damage_plane_strain_2D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/modified_mises_nonlocal_damage_plane_strain_2D_law.cpp
@@ -37,7 +37,7 @@ ModifiedMisesNonlocalDamagePlaneStrain2DLaw::~ModifiedMisesNonlocalDamagePlaneSt
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-int ModifiedMisesNonlocalDamagePlaneStrain2DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo)
+int ModifiedMisesNonlocalDamagePlaneStrain2DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo) const
 {
     int ierr = NonlocalDamage3DLaw::Check(rMaterialProperties,rElementGeometry,rCurrentProcessInfo);
     if(ierr != 0) return ierr;

--- a/applications/PoromechanicsApplication/custom_constitutive/modified_mises_nonlocal_damage_plane_strain_2D_law.hpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/modified_mises_nonlocal_damage_plane_strain_2D_law.hpp
@@ -48,7 +48,7 @@ public:
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) const override;
     
     ConstitutiveLaw::Pointer Clone() const override;
 

--- a/applications/PoromechanicsApplication/custom_constitutive/modified_mises_nonlocal_damage_plane_stress_2D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/modified_mises_nonlocal_damage_plane_stress_2D_law.cpp
@@ -37,7 +37,7 @@ ModifiedMisesNonlocalDamagePlaneStress2DLaw::~ModifiedMisesNonlocalDamagePlaneSt
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-int ModifiedMisesNonlocalDamagePlaneStress2DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo)
+int ModifiedMisesNonlocalDamagePlaneStress2DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo) const
 {
     int ierr = NonlocalDamage3DLaw::Check(rMaterialProperties,rElementGeometry,rCurrentProcessInfo);
     if(ierr != 0) return ierr;

--- a/applications/PoromechanicsApplication/custom_constitutive/modified_mises_nonlocal_damage_plane_stress_2D_law.hpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/modified_mises_nonlocal_damage_plane_stress_2D_law.hpp
@@ -48,7 +48,7 @@ public:
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) const override;
     
     ConstitutiveLaw::Pointer Clone() const override;
         

--- a/applications/PoromechanicsApplication/custom_constitutive/nonlocal_damage_3D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/nonlocal_damage_3D_law.cpp
@@ -32,7 +32,7 @@ NonlocalDamage3DLaw::~NonlocalDamage3DLaw() {}
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-int NonlocalDamage3DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo)
+int NonlocalDamage3DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo) const
 {
     int ierr = LocalDamage3DLaw::Check(rMaterialProperties,rElementGeometry,rCurrentProcessInfo);
     if(ierr != 0) return ierr;

--- a/applications/PoromechanicsApplication/custom_constitutive/nonlocal_damage_3D_law.hpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/nonlocal_damage_3D_law.hpp
@@ -45,7 +45,7 @@ public:
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) const override;
     
     ConstitutiveLaw::Pointer Clone() const override;
 

--- a/applications/PoromechanicsApplication/custom_constitutive/simo_ju_local_damage_3D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/simo_ju_local_damage_3D_law.cpp
@@ -37,7 +37,7 @@ SimoJuLocalDamage3DLaw::~SimoJuLocalDamage3DLaw() {}
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-int SimoJuLocalDamage3DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo)
+int SimoJuLocalDamage3DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo) const
 {
     int ierr = LocalDamage3DLaw::Check(rMaterialProperties,rElementGeometry,rCurrentProcessInfo);
     if(ierr != 0) return ierr;

--- a/applications/PoromechanicsApplication/custom_constitutive/simo_ju_local_damage_3D_law.hpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/simo_ju_local_damage_3D_law.hpp
@@ -51,7 +51,7 @@ public:
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) const override;
     
     ConstitutiveLaw::Pointer Clone() const override;
     

--- a/applications/PoromechanicsApplication/custom_constitutive/simo_ju_local_damage_plane_strain_2D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/simo_ju_local_damage_plane_strain_2D_law.cpp
@@ -37,7 +37,7 @@ SimoJuLocalDamagePlaneStrain2DLaw::~SimoJuLocalDamagePlaneStrain2DLaw() {}
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-int SimoJuLocalDamagePlaneStrain2DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo)
+int SimoJuLocalDamagePlaneStrain2DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo) const
 {
     int ierr = LocalDamage3DLaw::Check(rMaterialProperties,rElementGeometry,rCurrentProcessInfo);
     if(ierr != 0) return ierr;

--- a/applications/PoromechanicsApplication/custom_constitutive/simo_ju_local_damage_plane_strain_2D_law.hpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/simo_ju_local_damage_plane_strain_2D_law.hpp
@@ -51,7 +51,7 @@ public:
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) const override;
 
     ConstitutiveLaw::Pointer Clone() const override;
 

--- a/applications/PoromechanicsApplication/custom_constitutive/simo_ju_local_damage_plane_stress_2D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/simo_ju_local_damage_plane_stress_2D_law.cpp
@@ -37,7 +37,7 @@ SimoJuLocalDamagePlaneStress2DLaw::~SimoJuLocalDamagePlaneStress2DLaw() {}
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-int SimoJuLocalDamagePlaneStress2DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo)
+int SimoJuLocalDamagePlaneStress2DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo) const
 {
     int ierr = LocalDamage3DLaw::Check(rMaterialProperties,rElementGeometry,rCurrentProcessInfo);
     if(ierr != 0) return ierr;

--- a/applications/PoromechanicsApplication/custom_constitutive/simo_ju_local_damage_plane_stress_2D_law.hpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/simo_ju_local_damage_plane_stress_2D_law.hpp
@@ -51,7 +51,7 @@ public:
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) const override;
     
     ConstitutiveLaw::Pointer Clone() const override;
         

--- a/applications/PoromechanicsApplication/custom_constitutive/simo_ju_nonlocal_damage_3D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/simo_ju_nonlocal_damage_3D_law.cpp
@@ -37,7 +37,7 @@ SimoJuNonlocalDamage3DLaw::~SimoJuNonlocalDamage3DLaw() {}
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-int SimoJuNonlocalDamage3DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo)
+int SimoJuNonlocalDamage3DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo) const
 {
     int ierr = NonlocalDamage3DLaw::Check(rMaterialProperties,rElementGeometry,rCurrentProcessInfo);
     if(ierr != 0) return ierr;

--- a/applications/PoromechanicsApplication/custom_constitutive/simo_ju_nonlocal_damage_3D_law.hpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/simo_ju_nonlocal_damage_3D_law.hpp
@@ -51,7 +51,7 @@ public:
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) const override;
     
     ConstitutiveLaw::Pointer Clone() const override;
 

--- a/applications/PoromechanicsApplication/custom_constitutive/simo_ju_nonlocal_damage_plane_strain_2D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/simo_ju_nonlocal_damage_plane_strain_2D_law.cpp
@@ -37,7 +37,7 @@ SimoJuNonlocalDamagePlaneStrain2DLaw::~SimoJuNonlocalDamagePlaneStrain2DLaw() {}
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-int SimoJuNonlocalDamagePlaneStrain2DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo)
+int SimoJuNonlocalDamagePlaneStrain2DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo) const
 {
     int ierr = NonlocalDamage3DLaw::Check(rMaterialProperties,rElementGeometry,rCurrentProcessInfo);
     if(ierr != 0) return ierr;

--- a/applications/PoromechanicsApplication/custom_constitutive/simo_ju_nonlocal_damage_plane_strain_2D_law.hpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/simo_ju_nonlocal_damage_plane_strain_2D_law.hpp
@@ -51,7 +51,7 @@ public:
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) const override;
     
     ConstitutiveLaw::Pointer Clone() const override;
 

--- a/applications/PoromechanicsApplication/custom_constitutive/simo_ju_nonlocal_damage_plane_stress_2D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/simo_ju_nonlocal_damage_plane_stress_2D_law.cpp
@@ -37,7 +37,7 @@ SimoJuNonlocalDamagePlaneStress2DLaw::~SimoJuNonlocalDamagePlaneStress2DLaw() {}
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-int SimoJuNonlocalDamagePlaneStress2DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo)
+int SimoJuNonlocalDamagePlaneStress2DLaw::Check(const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const ProcessInfo& rCurrentProcessInfo) const
 {
     int ierr = NonlocalDamage3DLaw::Check(rMaterialProperties,rElementGeometry,rCurrentProcessInfo);
     if(ierr != 0) return ierr;

--- a/applications/PoromechanicsApplication/custom_constitutive/simo_ju_nonlocal_damage_plane_stress_2D_law.hpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/simo_ju_nonlocal_damage_plane_stress_2D_law.hpp
@@ -51,7 +51,7 @@ public:
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) const override;
     
     ConstitutiveLaw::Pointer Clone() const override;
         


### PR DESCRIPTION
**Description**
Following PR #7948, I made all the CLs Check methods const.

**Changelog**
- Check methods in CLs are now const
