### PR TITLE
[Fluid] Added compressible form of CFL stability condition

### DIFF
--- a/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.cpp
@@ -89,7 +89,7 @@ namespace Kratos
         // Obtain the maximum CFL
         const double current_dt = mrModelPart.GetProcessInfo().GetValue(DELTA_TIME);
         const double current_cfl = block_for_each<MaxReduction<double>>(mrModelPart.Elements(), [&](Element& rElement) -> double {
-            return FluidCharacteristicNumbersUtilities::CalculateElementCFL(rElement, minimum_h_func, current_dt);
+            return FluidCharacteristicNumbersUtilities::CalculateElementCFL(rElement, minimum_h_func, current_dt, mConsiderCompressibility);
         });
 
         // Calculate the new time increment from the maximum local CFL in the mesh

--- a/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.cpp
@@ -89,7 +89,7 @@ namespace Kratos
         // Obtain the maximum CFL
         const double current_dt = mrModelPart.GetProcessInfo().GetValue(DELTA_TIME);
         const double current_cfl = block_for_each<MaxReduction<double>>(mrModelPart.Elements(), [&](Element& rElement) -> double {
-            return FluidCharacteristicNumbersUtilities::CalculateElementCFL(rElement, minimum_h_func, current_dt, mConsiderCompressibility);
+            return FluidCharacteristicNumbersUtilities::CalculateElementCFL(rElement, minimum_h_func, current_dt, mConsiderCompressibilityInCFL);
         });
 
         // Calculate the new time increment from the maximum local CFL in the mesh

--- a/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.cpp
@@ -76,6 +76,19 @@ namespace Kratos
         }
     }
 
+    const EstimateDtUtility::CFLCalculatorType EstimateDtUtility::GetCFLCalculatorUtility() const
+    {
+        if(mConsiderCompressibilityInCFL){
+            return [](const Element & e, const ElementSizeFunctionType & f, const double dt) -> double {
+                return FluidCharacteristicNumbersUtilities::CalculateElementCFLWithSoundVelocity(e,f,dt);
+            };
+        }
+        return [](const Element & e, const ElementSizeFunctionType & f, const double dt) -> double {
+            return FluidCharacteristicNumbersUtilities::CalculateElementCFL(e,f,dt);
+        };
+    }
+
+
     template<>
     double EstimateDtUtility::InternalEstimateDt<true,false,false>() const
     {
@@ -88,15 +101,13 @@ namespace Kratos
 
         
         // Deciding what CFL calculator to use
-        auto compute_cfl = mConsiderCompressibilityInCFL ? 
-                & FluidCharacteristicNumbersUtilities::CalculateElementCFLWithSoundVelocity
-                : & FluidCharacteristicNumbersUtilities::CalculateElementCFL;
+        auto cfl_calculator = GetCFLCalculatorUtility();
         
         // Obtain the maximum CFL
         const double current_dt = mrModelPart.GetProcessInfo().GetValue(DELTA_TIME);
 
         const double current_cfl = block_for_each<MaxReduction<double>>(mrModelPart.Elements(), [&](Element& rElement) -> double {
-            return compute_cfl(rElement, minimum_h_func, current_dt);
+            return cfl_calculator(rElement, minimum_h_func, current_dt);
         });
 
         // Calculate the new time increment from the maximum local CFL in the mesh
@@ -138,9 +149,10 @@ namespace Kratos
         // Obtain the maximum CFL and Peclet numbers
         double max_CFL, max_Fo_k;
         const double current_dt = mrModelPart.GetProcessInfo().GetValue(DELTA_TIME);
+        auto cfl_calculator = GetCFLCalculatorUtility();
         typedef CombinedReduction<MaxReduction<double>, MaxReduction<double>> CombinedMaxReduction;
         std::tie(max_CFL, max_Fo_k) = block_for_each<CombinedMaxReduction>(mrModelPart.Elements(), [&](Element& rElement){
-            const double CFL = FluidCharacteristicNumbersUtilities::CalculateElementCFL(rElement, minimum_h_func, current_dt);
+            const double CFL = cfl_calculator(rElement, minimum_h_func, current_dt);
             const double thermal_Fo_number = thermal_fourier_number_function(rElement, minimum_h_func, current_dt);
             return std::make_tuple(CFL, thermal_Fo_number);
         });
@@ -185,9 +197,10 @@ namespace Kratos
         // Obtain the maximum CFL and Peclet numbers
         double max_CFL, max_Fo_mu, max_Fo_k;
         const double current_dt = mrModelPart.GetProcessInfo().GetValue(DELTA_TIME);
+        auto cfl_calculator = GetCFLCalculatorUtility();
         typedef CombinedReduction<MaxReduction<double>, MaxReduction<double>, MaxReduction<double>> CombinedMaxReduction;
         std::tie(max_CFL, max_Fo_mu, max_Fo_k) = block_for_each<CombinedMaxReduction>(mrModelPart.Elements(), [&](Element& rElement){
-            const double CFL = FluidCharacteristicNumbersUtilities::CalculateElementCFL(rElement, minimum_h_func, current_dt);
+            const double CFL = cfl_calculator(rElement, minimum_h_func, current_dt);
             const auto Fo_numbers = fourier_numbers_function(rElement, minimum_h_func, current_dt);
             return std::make_tuple(CFL, std::get<0>(Fo_numbers), std::get<1>(Fo_numbers));
         });

--- a/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.cpp
@@ -89,8 +89,8 @@ namespace Kratos
         
         // Deciding what CFL calculator to use
         auto compute_cfl = mConsiderCompressibilityInCFL ? 
-                & FluidCharacteristicNumbersUtilities::CalculateElementCFL
-                : & FluidCharacteristicNumbersUtilities::CalculateElementCFLWithSoundVelocity;
+                & FluidCharacteristicNumbersUtilities::CalculateElementCFLWithSoundVelocity
+                : & FluidCharacteristicNumbersUtilities::CalculateElementCFL;
         
         // Obtain the maximum CFL
         const double current_dt = mrModelPart.GetProcessInfo().GetValue(DELTA_TIME);

--- a/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.h
@@ -226,7 +226,7 @@ private:
     bool      mNodalDensityFormulation;     // Specifies if the density is nodally stored (only required for the Peclet number)
     double    mDtMax;                       // User-defined maximum time increment allowed
     double    mDtMin;                       // User-defined minimum time increment allowed
-    bool      mConsiderCompressibilityInCFL;                // User-defined formulation. CFL number depends on this parameter.
+    bool      mConsiderCompressibilityInCFL;// User-defined formulation. CFL number depends on this parameter.
     Flags     mDtEstimationMagnitudesFlags; // Flags indicating the reference magnitudes used in the Dt estimation
     ModelPart &mrModelPart;                 // The problem's model part
 

--- a/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.h
@@ -53,6 +53,9 @@ public:
     /// Function type for the element size calculator function
     typedef std::function<double(const Geometry<Node<3>>&)> ElementSizeFunctionType;
 
+    // Funciton type for the CFL calculator function
+    typedef std::function<double(const Element &, const ElementSizeFunctionType &, const double)> CFLCalculatorType;
+
 	///@}
 	///@name Life Cycle
 	///@{
@@ -287,6 +290,15 @@ private:
      * @param rNewDeltaTime Time increment to be checked
      */
     void LimitNewDeltaTime(double& rNewDeltaTime) const;
+
+    
+    /**
+     * @brief Gets utility to compute the CFL with
+     * This method returns a utility according to the compressibility, as expressed by 
+     * mConsiderCompressibilityInCFL
+     * @return CFLCalculatorType The utlity to compute the CFL with
+     */
+    const CFLCalculatorType GetCFLCalculatorUtility() const;
 
     ///@} // Private Operations
 };

--- a/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.h
@@ -77,7 +77,7 @@ public:
         mViscousFourier = 0.0;
         mThermalFourier = 0.0;
         mConsiderArtificialDiffusion = false;
-        mConsiderCompressibility = false;
+        mConsiderCompressibilityInCFL = false;
 
         SetDtEstimationMagnitudesFlag();
     }
@@ -90,7 +90,7 @@ public:
      * @param ThermalFourier The user-defined thermal conductivity Peclet number
      * @param DtMin user-defined minimum time increment allowed
      * @param DtMax user-defined maximum time increment allowed
-     * @param ConsiderCompressibility user-defined switch to select between compressible or incompressible N-S stability conditions
+     * @param ConsiderCompressibilityInCFL user-defined switch to select between compressible or incompressible CFL stability conditions
      */
     EstimateDtUtility(
         ModelPart &ModelPart,
@@ -101,7 +101,7 @@ public:
         const bool NodalDensityFormulation,
         const double DtMin,
         const double DtMax,
-        const bool ConsiderCompressibility = false)
+        const bool ConsiderCompressibilityInCFL = false)
         : mrModelPart(ModelPart)
     {
         mCFL = CFL;
@@ -111,7 +111,7 @@ public:
         mThermalFourier = ThermalFourier;
         mConsiderArtificialDiffusion = ConsiderArtificialDiffusion;
         mNodalDensityFormulation = NodalDensityFormulation;
-        mConsiderCompressibility = ConsiderCompressibility;
+        mConsiderCompressibilityInCFL = ConsiderCompressibilityInCFL;
 
         SetDtEstimationMagnitudesFlag();
     }
@@ -127,15 +127,15 @@ public:
         : mrModelPart(ModelPart)
     {
         Parameters defaultParameters(R"({
-            "automatic_time_step"           : true,
-            "CFL_number"                    : 1.0,
-            "Viscous_Fourier_number"        : 0.0,
-            "Thermal_Fourier_number"        : 0.0,
-            "consider_artificial_diffusion" : false,
-            "nodal_density_formulation"     : false,
-            "minimum_delta_time"            : 1e-4,
-            "maximum_delta_time"            : 0.1,
-            "consider_compressibility"      : false
+            "automatic_time_step"             : true,
+            "CFL_number"                      : 1.0,
+            "Viscous_Fourier_number"          : 0.0,
+            "Thermal_Fourier_number"          : 0.0,
+            "consider_artificial_diffusion"   : false,
+            "nodal_density_formulation"       : false,
+            "minimum_delta_time"              : 1e-4,
+            "maximum_delta_time"              : 0.1,
+            "consider_compressibility_in_CFL" : false
         })");
 
         rParameters.ValidateAndAssignDefaults(defaultParameters);
@@ -147,7 +147,7 @@ public:
         mNodalDensityFormulation = rParameters["nodal_density_formulation"].GetBool();
         mDtMin = rParameters["minimum_delta_time"].GetDouble();
         mDtMax = rParameters["maximum_delta_time"].GetDouble();
-        mConsiderCompressibility = rParameters["consider_compressibility"].GetBool();
+        mConsiderCompressibilityInCFL = rParameters["consider_compressibility_in_CFL"].GetBool();
 
         SetDtEstimationMagnitudesFlag();
     }
@@ -226,7 +226,7 @@ private:
     bool      mNodalDensityFormulation;     // Specifies if the density is nodally stored (only required for the Peclet number)
     double    mDtMax;                       // User-defined maximum time increment allowed
     double    mDtMin;                       // User-defined minimum time increment allowed
-    bool      mConsiderCompressibility;                // User-defined formulation. CFL number depends on this parameter.
+    bool      mConsiderCompressibilityInCFL;                // User-defined formulation. CFL number depends on this parameter.
     Flags     mDtEstimationMagnitudesFlags; // Flags indicating the reference magnitudes used in the Dt estimation
     ModelPart &mrModelPart;                 // The problem's model part
 

--- a/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.h
@@ -53,7 +53,7 @@ public:
     /// Function type for the element size calculator function
     typedef std::function<double(const Geometry<Node<3>>&)> ElementSizeFunctionType;
 
-    // Funciton type for the CFL calculator function
+    // Function type for the CFL calculator function
     typedef std::function<double(const Element &, const ElementSizeFunctionType &, const double)> CFLCalculatorType;
 
 	///@}

--- a/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.h
@@ -77,6 +77,7 @@ public:
         mViscousFourier = 0.0;
         mThermalFourier = 0.0;
         mConsiderArtificialDiffusion = false;
+        mConsiderCompressibility = false;
 
         SetDtEstimationMagnitudesFlag();
     }
@@ -89,6 +90,7 @@ public:
      * @param ThermalFourier The user-defined thermal conductivity Peclet number
      * @param DtMin user-defined minimum time increment allowed
      * @param DtMax user-defined maximum time increment allowed
+     * @param ConsiderCompressibility user-defined switch to select between compressible or incompressible N-S stability conditions
      */
     EstimateDtUtility(
         ModelPart &ModelPart,
@@ -98,7 +100,8 @@ public:
         const bool ConsiderArtificialDiffusion,
         const bool NodalDensityFormulation,
         const double DtMin,
-        const double DtMax)
+        const double DtMax,
+        const bool ConsiderCompressibility = false)
         : mrModelPart(ModelPart)
     {
         mCFL = CFL;
@@ -108,6 +111,7 @@ public:
         mThermalFourier = ThermalFourier;
         mConsiderArtificialDiffusion = ConsiderArtificialDiffusion;
         mNodalDensityFormulation = NodalDensityFormulation;
+        mConsiderCompressibility = ConsiderCompressibility;
 
         SetDtEstimationMagnitudesFlag();
     }
@@ -130,7 +134,8 @@ public:
             "consider_artificial_diffusion" : false,
             "nodal_density_formulation"     : false,
             "minimum_delta_time"            : 1e-4,
-            "maximum_delta_time"            : 0.1
+            "maximum_delta_time"            : 0.1,
+            "consider_compressibility"      : false
         })");
 
         rParameters.ValidateAndAssignDefaults(defaultParameters);
@@ -142,6 +147,7 @@ public:
         mNodalDensityFormulation = rParameters["nodal_density_formulation"].GetBool();
         mDtMin = rParameters["minimum_delta_time"].GetDouble();
         mDtMax = rParameters["maximum_delta_time"].GetDouble();
+        mConsiderCompressibility = rParameters["consider_compressibility"].GetBool();
 
         SetDtEstimationMagnitudesFlag();
     }
@@ -220,6 +226,7 @@ private:
     bool      mNodalDensityFormulation;     // Specifies if the density is nodally stored (only required for the Peclet number)
     double    mDtMax;                       // User-defined maximum time increment allowed
     double    mDtMin;                       // User-defined minimum time increment allowed
+    bool      mConsiderCompressibility;                // User-defined formulation. CFL number depends on this parameter.
     Flags     mDtEstimationMagnitudesFlags; // Flags indicating the reference magnitudes used in the Dt estimation
     ModelPart &mrModelPart;                 // The problem's model part
 

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.cpp
@@ -73,7 +73,7 @@ namespace Kratos
             return norm_2(element_vel) * Dt / h_min;
         }
 
-        // Computing CFl for compressible flows
+        // Computing CFL for compressible flows
         double sound_velocity = 0;
         for (unsigned int i = 0; i < n_nodes; ++i) {
             sound_velocity += r_geometry[i].GetValue(SOUND_VELOCITY);

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.cpp
@@ -55,7 +55,7 @@ namespace Kratos
         const Element &rElement,
         const ElementSizeFunctionType& rElementSizeCalculator,
         const double Dt,
-        const bool ConsiderCompressibility)
+        const bool ConsiderCompressibilityInCFL)
     {
         // Calculate the midpoint velocity
         const auto& r_geometry = rElement.GetGeometry();
@@ -69,7 +69,7 @@ namespace Kratos
         // Calculate element CFL for incompressible flows
         const double h_min = rElementSizeCalculator(r_geometry);
 
-        if(ConsiderCompressibility == false) {
+        if(ConsiderCompressibilityInCFL == false) {
             return norm_2(element_vel) * Dt / h_min;
         }
 

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.cpp
@@ -75,7 +75,7 @@ namespace Kratos
 
         // Computing CFl for compressible flows
         double sound_velocity = 0;
-        for (unsigned int i = 1; i < n_nodes; ++i) {
+        for (unsigned int i = 0; i < n_nodes; ++i) {
             sound_velocity += r_geometry[i].GetValue(SOUND_VELOCITY);
         }
         sound_velocity /= static_cast<double>(n_nodes);

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.cpp
@@ -67,7 +67,6 @@ namespace Kratos
 
         // Calculate element CFL
         const double h_min = rElementSizeCalculator(r_geometry);
-
         const double elem_cfl = norm_2(element_vel) * Dt / h_min;
 
         return elem_cfl;

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.cpp
@@ -86,7 +86,7 @@ namespace Kratos
         
         for (unsigned int i = 1; i < n_nodes; ++i) {
             sound_velocity += r_geometry[i].GetValue(SOUND_VELOCITY);
-            element_vel += r_geometry[i].FastGetSolutionStepValue(VELOCITY);
+            noalias(element_vel) += r_geometry[i].FastGetSolutionStepValue(VELOCITY);
         }
 
         element_vel /= static_cast<double>(n_nodes);

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.h
@@ -79,14 +79,27 @@ public:
      * @param rElement Element to calculate the CFL number
      * @param rGeometryInfo Auxiliary geometry data container
      * @param Dt Current time increment
-     * @param ConsiderCompressibilityInCFL Selects which CFL formula to use
      * @return double The element CFL number
      */
     static double CalculateElementCFL(
         const Element &rElement,
         const ElementSizeFunctionType& rElementSizeCalculator,
-        const double Dt,
-        const bool ConsiderCompressibilityInCFL = false);
+        const double Dt);
+
+
+    /**
+     * @brief Calulate element CFL number for compressible flows (considering sound velocity)
+     * For the given element, this method calculates the CFL number
+     * @param rElement Element to calculate the CFL number
+     * @param rGeometryInfo Auxiliary geometry data container
+     * @param Dt Current time increment
+     * @return double The element CFL number
+     */
+    static double CalculateElementCFLWithSoundVelocity(
+        const Element &rElement,
+        const ElementSizeFunctionType& rElementSizeCalculator,
+        const double Dt);
+
 
     /**
      * @brief Calculate the element Prandtl number

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.h
@@ -79,14 +79,14 @@ public:
      * @param rElement Element to calculate the CFL number
      * @param rGeometryInfo Auxiliary geometry data container
      * @param Dt Current time increment
-     * @param ConsiderCompressibility Selects which CFL formula to use
+     * @param ConsiderCompressibilityInCFL Selects which CFL formula to use
      * @return double The element CFL number
      */
     static double CalculateElementCFL(
         const Element &rElement,
         const ElementSizeFunctionType& rElementSizeCalculator,
         const double Dt,
-        const bool ConsiderCompressibility = false);
+        const bool ConsiderCompressibilityInCFL = false);
 
     /**
      * @brief Calculate the element Prandtl number

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_characteristic_numbers_utilities.h
@@ -79,12 +79,14 @@ public:
      * @param rElement Element to calculate the CFL number
      * @param rGeometryInfo Auxiliary geometry data container
      * @param Dt Current time increment
+     * @param ConsiderCompressibility Selects which CFL formula to use
      * @return double The element CFL number
      */
     static double CalculateElementCFL(
         const Element &rElement,
         const ElementSizeFunctionType& rElementSizeCalculator,
-        const double Dt);
+        const double Dt,
+        const bool ConsiderCompressibility = false);
 
     /**
      * @brief Calculate the element Prandtl number

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
@@ -136,14 +136,13 @@ class NavierStokesCompressibleExplicitSolver(FluidSolver):
         self.settings["time_stepping"]["consider_compressibility_in_CFL"] == True
         ```
         """
-
         if self.settings["time_stepping"].Has("consider_compressibility_in_CFL"):
             KratosMultiphysics.Logger.PrintWarning("", "User-specifed consider_compressibility_in_CFL will be overriden with TRUE")
         else:
             self.settings["time_stepping"].AddEmptyValue("consider_compressibility_in_CFL")
 
         self.settings["time_stepping"]["consider_compressibility_in_CFL"].SetBool(True)
-        
+
         estimate_dt_utility = KratosFluid.EstimateDtUtility(
                 self.GetComputingModelPart(),
                 self.settings["time_stepping"])

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
@@ -131,8 +131,7 @@ class NavierStokesCompressibleExplicitSolver(FluidSolver):
         return strategy
 
     def _CreateEstimateDtUtility(self):
-        """
-        This method overloads FluidSolver in order to enforce:
+        """This method overloads FluidSolver in order to enforce:
         ```
         self.settings["time_stepping"]["consider_compressibility_in_CFL"] == True
         ```
@@ -142,7 +141,7 @@ class NavierStokesCompressibleExplicitSolver(FluidSolver):
             KratosMultiphysics.Logger.PrintWarning("", "User-specifed consider_compressibility_in_CFL will be overriden with TRUE")
         else:
             self.settings["time_stepping"].AddEmptyValue("consider_compressibility_in_CFL")
-        
+
         self.settings["time_stepping"]["consider_compressibility_in_CFL"].SetBool(True)
         
         estimate_dt_utility = KratosFluid.EstimateDtUtility(

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
@@ -150,4 +150,3 @@ class NavierStokesCompressibleExplicitSolver(FluidSolver):
                 self.settings["time_stepping"])
 
         return estimate_dt_utility
-

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
@@ -141,7 +141,7 @@ class NavierStokesCompressibleExplicitSolver(FluidSolver):
         if self.settings["time_stepping"].Has("consider_compressibility_in_CFL"):
             KratosMultiphysics.Logger.PrintWarning("", "User-specifed consider_compressibility_in_CFL will be overriden with TRUE")
         else:
-            self.settings["time_stepping"].AddEmptyfield("consider_compressibility_in_CFL")
+            self.settings["time_stepping"].AddEmptyValue("consider_compressibility_in_CFL")
         
         self.settings["time_stepping"]["consider_compressibility_in_CFL"].SetBool(True)
         

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
@@ -62,8 +62,7 @@ class NavierStokesCompressibleExplicitSolver(FluidSolver):
                 "automatic_time_step" : true,
                 "CFL_number"          : 1.0,
                 "minimum_delta_time"  : 1.0e-8,
-                "maximum_delta_time"  : 1.0e-2,
-                "consider_compressibility_in_CFL" : true
+                "maximum_delta_time"  : 1.0e-2
             },
             "use_oss" : true
         }""")
@@ -130,3 +129,25 @@ class NavierStokesCompressibleExplicitSolver(FluidSolver):
             strategy_settings)
 
         return strategy
+
+    def _CreateEstimateDtUtility(self):
+        """
+        This method overloads FluidSolver in order to enforce:
+        ```
+        self.settings["time_stepping"]["consider_compressibility_in_CFL"] == True
+        ```
+        """
+
+        if self.settings["time_stepping"].Has("consider_compressibility_in_CFL"):
+            KratosMultiphysics.Logger.PrintWarning("", "User-specifed consider_compressibility_in_CFL will be overriden with TRUE")
+        else:
+            self.settings["time_stepping"].AddEmptyfield("consider_compressibility_in_CFL")
+        
+        self.settings["time_stepping"]["consider_compressibility_in_CFL"].SetBool(True)
+        
+        estimate_dt_utility = KratosFluid.EstimateDtUtility(
+                self.GetComputingModelPart(),
+                self.settings["time_stepping"])
+
+        return estimate_dt_utility
+

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
@@ -63,7 +63,7 @@ class NavierStokesCompressibleExplicitSolver(FluidSolver):
                 "CFL_number"          : 1.0,
                 "minimum_delta_time"  : 1.0e-8,
                 "maximum_delta_time"  : 1.0e-2,
-                "consider_compressibility" : true
+                "consider_compressibility_in_CFL" : true
             },
             "use_oss" : true
         }""")

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
@@ -62,7 +62,8 @@ class NavierStokesCompressibleExplicitSolver(FluidSolver):
                 "automatic_time_step" : true,
                 "CFL_number"          : 1.0,
                 "minimum_delta_time"  : 1.0e-8,
-                "maximum_delta_time"  : 1.0e-2
+                "maximum_delta_time"  : 1.0e-2,
+                "consider_compressibility" : true
             },
             "use_oss" : true
         }""")

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_estimate_dt_utilities.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_estimate_dt_utilities.cpp
@@ -59,6 +59,7 @@ void TestEstimateDtUtilitiesInitializeModelPart(
     for (auto& rNode : rModelPart.Nodes()) {
         rNode.SetValue(ARTIFICIAL_DYNAMIC_VISCOSITY, rNode.Id());
         rNode.SetValue(ARTIFICIAL_CONDUCTIVITY, 2.0 * rNode.Id());
+        rNode.SetValue(SOUND_VELOCITY, 340.0);
         rNode.FastGetSolutionStepValue(DENSITY) = rNode.Id() / 10.0;
         rNode.FastGetSolutionStepValue(VELOCITY_X) = rNode.Id() * rNode.X();
         rNode.FastGetSolutionStepValue(VELOCITY_Y) = rNode.Id() * rNode.Y();
@@ -105,21 +106,22 @@ KRATOS_TEST_CASE_IN_SUITE(EstimateDtUtilitiesEstimateDtCompressibleFlow, FluidDy
 
     // Estimate the delta time
     Parameters estimate_dt_settings = Parameters(R"({
-        "automatic_time_step"           : true,
-        "CFL_number"                    : 1.0,
-        "Viscous_Fourier_number"        : 1.0,
-        "Thermal_Fourier_number"        : 1.0,
-        "minimum_delta_time"            : 1e-4,
-        "maximum_delta_time"            : 1e+1,
-        "consider_artificial_diffusion" : true,
-        "nodal_density_formulation"     : true
+        "automatic_time_step"             : true,
+        "CFL_number"                      : 1.0,
+        "Viscous_Fourier_number"          : 1.0,
+        "Thermal_Fourier_number"          : 1.0,
+        "minimum_delta_time"              : 1e-4,
+        "maximum_delta_time"              : 1e+1,
+        "consider_artificial_diffusion"   : true,
+        "nodal_density_formulation"       : true,
+        "consider_compressibility_in_CFL" : true
     })");
     const auto estimate_dt_utility = EstimateDtUtility(r_model_part, estimate_dt_settings);
     const double obtained_dt = estimate_dt_utility.EstimateDt();
 
     // Check results
     const double tolerance = 1.0e-6;
-    const double expected_dt = 0.0075;
+    const double expected_dt = 0.0013017675;
     KRATOS_CHECK_NEAR(expected_dt, obtained_dt, tolerance);
 }
 

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_characteristic_numbers_utilities.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_characteristic_numbers_utilities.cpp
@@ -105,6 +105,33 @@ KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateLocalCFL, FluidDyna
     KRATOS_CHECK_NEAR(r_model_part.GetElement(2).GetValue(CFL_NUMBER), 0.792324, tolerance);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateLocalCFLVelocityCompressible, FluidDynamicsApplicationFastSuite)
+{
+    // Set the current delta time to calculate the CFL number
+    const double current_dt = 1.0e-1;
+
+    // Create the test model part
+    Model model;
+    ModelPart& r_model_part = model.CreateModelPart("TestModelPart");
+    TestFluidCharacteristicNumberInitializeModelPart(r_model_part, current_dt);
+
+    auto & r_element = r_model_part.Elements().front();
+    auto & geom = r_element.GetGeometry();
+    
+    // Set nodal data
+    for (std::size_t i=0; i<geom.size(); i++) {
+        geom[i].GetValue(SOUND_VELOCITY) = 340.0;
+    }
+
+    // Calculate the CFL number for an element
+    auto minimum_h_func = FluidCharacteristicNumbersUtilities::GetMinimumElementSizeFunction(r_element.GetGeometry());
+    const double element_cfl = FluidCharacteristicNumbersUtilities::CalculateElementCFLWithSoundVelocity(r_element, minimum_h_func, current_dt);
+
+    // Check result
+    const double tolerance = 1.0e-6;
+    KRATOS_CHECK_NEAR(element_cfl, 0.186339, tolerance);
+}
+
 KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateElementPrandtlNumber, FluidDynamicsApplicationFastSuite)
 {
     // Create the test element

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_characteristic_numbers_utilities.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_characteristic_numbers_utilities.cpp
@@ -105,7 +105,7 @@ KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateLocalCFL, FluidDyna
     KRATOS_CHECK_NEAR(r_model_part.GetElement(2).GetValue(CFL_NUMBER), 0.792324, tolerance);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateLocalCFLVelocityCompressible, FluidDynamicsApplicationFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateElementCFLWithSoundVelocity, FluidDynamicsApplicationFastSuite)
 {
     // Set the current delta time to calculate the CFL number
     const double current_dt = 1.0e-1;
@@ -119,8 +119,13 @@ KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateLocalCFLVelocityCom
     auto & geom = r_element.GetGeometry();
     
     // Set nodal data
+    constexpr double c = 340.0;
+    constexpr double V = 150.0;
+
     for (std::size_t i=0; i<geom.size(); i++) {
-        geom[i].GetValue(SOUND_VELOCITY) = 340.0;
+        geom[i].GetValue(SOUND_VELOCITY) = c;
+        geom[i].GetSolutionStepValue(VELOCITY_X) = V;
+        geom[i].GetSolutionStepValue(VELOCITY_Y) = 0.0;
     }
 
     // Calculate the CFL number for an element
@@ -128,8 +133,12 @@ KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateLocalCFLVelocityCom
     const double element_cfl = FluidCharacteristicNumbersUtilities::CalculateElementCFLWithSoundVelocity(r_element, minimum_h_func, current_dt);
 
     // Check result
-    const double tolerance = 1.0e-6;
-    KRATOS_CHECK_NEAR(element_cfl, 0.186339, tolerance);
+    constexpr double min_h = 0.8944271910;
+    constexpr double dt = 0.1;
+    constexpr double expected_cfl = (V + c) * dt / min_h;
+    
+    const double tolerance = 1.0e-8;
+    KRATOS_CHECK_NEAR(element_cfl, expected_cfl, tolerance);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(FluidCharacteristicNumbersCalculateElementPrandtlNumber, FluidDynamicsApplicationFastSuite)

--- a/applications/FluidDynamicsApplication/tests/test_navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/tests/test_navier_stokes_compressible_explicit_solver.py
@@ -24,78 +24,8 @@ class NavierStokesCompressibleExplicitSolverTest(KratosUnittest.TestCase):
         
         self.assertIn("Wrong domain size", str(context.exception))
 
-    def test_CFL_number(self):
-        solver_cfl_incompressible = self.CreateSolverAndModelPart(False)
-        solver_cfl_compressible = self.CreateSolverAndModelPart(True)
-
-        vel = 300
-        dt  = 0.1
-        c   = 0.0
-
-        # Case 1: ensuring both results are the same with c=0.0
-        v = KratosMultiphysics.Array3()
-        v[0] = vel
-        v[1] = 0.0
-        v[2] = 0.0
-
-        for node in solver_cfl_incompressible.GetComputingModelPart().Nodes:
-            node.SetSolutionStepValue(KratosMultiphysics.VELOCITY, v)
-            node.SetValue(KratosMultiphysics.SOUND_VELOCITY, c)
-        
-        for node in solver_cfl_compressible.GetComputingModelPart().Nodes:
-            node.SetSolutionStepValue(KratosMultiphysics.VELOCITY, v)
-            node.SetValue(KratosMultiphysics.SOUND_VELOCITY, c)
-
-        solver_cfl_compressible.GetComputingModelPart().ProcessInfo.SetValue(KratosMultiphysics.DELTA_TIME, dt)
-        solver_cfl_incompressible.GetComputingModelPart().ProcessInfo.SetValue(KratosMultiphysics.DELTA_TIME, dt)
-
-        dt_comp = solver_cfl_compressible._ComputeDeltaTime()
-        dt_inc = solver_cfl_incompressible._ComputeDeltaTime()
-
-        self.assertEqual(dt_comp, dt_inc, "Compressible and incompressible DELTA_TIME do not match with c=0")
-
-        solver_cfl_compressible.GetComputingModelPart().ProcessInfo.SetValue(KratosMultiphysics.DELTA_TIME, dt)
-        solver_cfl_incompressible.GetComputingModelPart().ProcessInfo.SetValue(KratosMultiphysics.DELTA_TIME, dt)
-
-        # Case 2: Ensuring compressible dt is more restricted that incompressible with c > 0
-        c = 340.0
-
-        for node in solver_cfl_incompressible.GetComputingModelPart().Nodes:
-            node.SetValue(KratosMultiphysics.SOUND_VELOCITY, c)
-        
-        for node in solver_cfl_compressible.GetComputingModelPart().Nodes:
-            node.SetValue(KratosMultiphysics.SOUND_VELOCITY, c)
-
-        dt_comp = solver_cfl_compressible._ComputeDeltaTime()
-        dt_inc = solver_cfl_incompressible._ComputeDeltaTime()
-
-        self.assertLess(dt_comp, dt_inc, "Compressible DELTA_TIME is not smaller than incompressible's despite having c=%f" % c)
-
-
     @classmethod
-    def CreateSolverAndModelPart(cls, consider_compressibility_in_CFL):
-        model = KratosMultiphysics.Model()
-        mpart = model.CreateModelPart("FluidModelPart")
-        mpart = mpart.CreateSubModelPart("volume_model_part")
-
-        solver = navier_stokes_compressible_explicit_solver.CreateSolver(model, cls.GetSettings(2, consider_compressibility_in_CFL))
-        solver.AddVariables()
-
-        mpart.CreateNewNode(1, 0.0, 0.0, 0.0)
-        mpart.CreateNewNode(2, 1e-3, 0.0, 0.0)
-        mpart.CreateNewNode(3, 0.0, 1e-3, 0.0)
-        mpart.CreateNewElement("Element2D3N", 1, [1,2,3], mpart.Properties[0])
-
-        solver.ImportModelPart()
-        solver.PrepareModelPart()
-        solver.AddDofs()
-        solver.Initialize()
-
-        return solver
-
-
-    @classmethod
-    def GetSettings(cls, n_dimensions = 2, consider_compressibility_in_CFL = True):
+    def GetSettings(cls, n_dimensions = 2):
         return KratosMultiphysics.Parameters("""
             {
                 "solver_type": "compressible_solver_from_defaults",
@@ -121,11 +51,11 @@ class NavierStokesCompressibleExplicitSolverTest(KratosUnittest.TestCase):
                     "automatic_time_step" : true,
                     "CFL_number"          : 1.0,
                     "minimum_delta_time"  : 1.0e-8,
-                    "maximum_delta_time"  : 1.0e-2,
-                    "consider_compressibility_in_CFL" : %s
+                    "maximum_delta_time"  : 1.0e-2
                 },
                 "use_oss" : true
-            }""" % (n_dimensions, str(consider_compressibility_in_CFL).lower()))
+            }""" % n_dimensions)
+
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/applications/FluidDynamicsApplication/tests/test_navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/tests/test_navier_stokes_compressible_explicit_solver.py
@@ -73,12 +73,12 @@ class NavierStokesCompressibleExplicitSolverTest(KratosUnittest.TestCase):
 
 
     @classmethod
-    def CreateSolverAndModelPart(cls, consider_compressibility):
+    def CreateSolverAndModelPart(cls, consider_compressibility_in_CFL):
         model = KratosMultiphysics.Model()
         mpart = model.CreateModelPart("FluidModelPart")
         mpart = mpart.CreateSubModelPart("volume_model_part")
 
-        solver = navier_stokes_compressible_explicit_solver.CreateSolver(model, cls.GetSettings(2, consider_compressibility))
+        solver = navier_stokes_compressible_explicit_solver.CreateSolver(model, cls.GetSettings(2, consider_compressibility_in_CFL))
         solver.AddVariables()
 
         mpart.CreateNewNode(1, 0.0, 0.0, 0.0)
@@ -95,7 +95,7 @@ class NavierStokesCompressibleExplicitSolverTest(KratosUnittest.TestCase):
 
 
     @classmethod
-    def GetSettings(cls, n_dimensions = 2, consider_compressibility = True):
+    def GetSettings(cls, n_dimensions = 2, consider_compressibility_in_CFL = True):
         return KratosMultiphysics.Parameters("""
             {
                 "solver_type": "compressible_solver_from_defaults",
@@ -122,10 +122,10 @@ class NavierStokesCompressibleExplicitSolverTest(KratosUnittest.TestCase):
                     "CFL_number"          : 1.0,
                     "minimum_delta_time"  : 1.0e-8,
                     "maximum_delta_time"  : 1.0e-2,
-                    "consider_compressibility" : %s
+                    "consider_compressibility_in_CFL" : %s
                 },
                 "use_oss" : true
-            }""" % (n_dimensions, str(consider_compressibility).lower()))
+            }""" % (n_dimensions, str(consider_compressibility_in_CFL).lower()))
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/applications/FluidDynamicsApplication/tests/test_navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/tests/test_navier_stokes_compressible_explicit_solver.py
@@ -24,20 +24,88 @@ class NavierStokesCompressibleExplicitSolverTest(KratosUnittest.TestCase):
         
         self.assertIn("Wrong domain size", str(context.exception))
 
+    def test_CFL_number(self):
+        solver_cfl_incompressible = self.CreateSolverAndModelPart(False)
+        solver_cfl_compressible = self.CreateSolverAndModelPart(True)
+
+        vel = 300
+        dt  = 0.1
+        c   = 0.0
+
+        # Case 1: ensuring both results are the same with c=0.0
+        v = KratosMultiphysics.Array3()
+        v[0] = vel
+        v[1] = 0.0
+        v[2] = 0.0
+
+        for node in solver_cfl_incompressible.GetComputingModelPart().Nodes:
+            node.SetSolutionStepValue(KratosMultiphysics.VELOCITY, v)
+            node.SetValue(KratosMultiphysics.SOUND_VELOCITY, c)
+        
+        for node in solver_cfl_compressible.GetComputingModelPart().Nodes:
+            node.SetSolutionStepValue(KratosMultiphysics.VELOCITY, v)
+            node.SetValue(KratosMultiphysics.SOUND_VELOCITY, c)
+
+        solver_cfl_compressible.GetComputingModelPart().ProcessInfo.SetValue(KratosMultiphysics.DELTA_TIME, dt)
+        solver_cfl_incompressible.GetComputingModelPart().ProcessInfo.SetValue(KratosMultiphysics.DELTA_TIME, dt)
+
+        dt_comp = solver_cfl_compressible._ComputeDeltaTime()
+        dt_inc = solver_cfl_incompressible._ComputeDeltaTime()
+
+        self.assertEqual(dt_comp, dt_inc, "Compressible and incompressible DELTA_TIME do not match with c=0")
+
+        solver_cfl_compressible.GetComputingModelPart().ProcessInfo.SetValue(KratosMultiphysics.DELTA_TIME, dt)
+        solver_cfl_incompressible.GetComputingModelPart().ProcessInfo.SetValue(KratosMultiphysics.DELTA_TIME, dt)
+
+        # Case 2: Ensuring compressible dt is more restricted that incompressible with c > 0
+        c = 340.0
+
+        for node in solver_cfl_incompressible.GetComputingModelPart().Nodes:
+            node.SetValue(KratosMultiphysics.SOUND_VELOCITY, c)
+        
+        for node in solver_cfl_compressible.GetComputingModelPart().Nodes:
+            node.SetValue(KratosMultiphysics.SOUND_VELOCITY, c)
+
+        dt_comp = solver_cfl_compressible._ComputeDeltaTime()
+        dt_inc = solver_cfl_incompressible._ComputeDeltaTime()
+
+        self.assertLess(dt_comp, dt_inc, "Compressible DELTA_TIME is not smaller than incompressible's despite having c=%f" % c)
+
+
     @classmethod
-    def GetSettings(cls, n_dimensions):
+    def CreateSolverAndModelPart(cls, consider_compressibility):
+        model = KratosMultiphysics.Model()
+        mpart = model.CreateModelPart("FluidModelPart")
+        mpart = mpart.CreateSubModelPart("volume_model_part")
+
+        solver = navier_stokes_compressible_explicit_solver.CreateSolver(model, cls.GetSettings(2, consider_compressibility))
+        solver.AddVariables()
+
+        mpart.CreateNewNode(1, 0.0, 0.0, 0.0)
+        mpart.CreateNewNode(2, 1e-3, 0.0, 0.0)
+        mpart.CreateNewNode(3, 0.0, 1e-3, 0.0)
+        mpart.CreateNewElement("Element2D3N", 1, [1,2,3], mpart.Properties[0])
+
+        solver.ImportModelPart()
+        solver.PrepareModelPart()
+        solver.AddDofs()
+        solver.Initialize()
+
+        return solver
+
+
+    @classmethod
+    def GetSettings(cls, n_dimensions = 2, consider_compressibility = True):
         return KratosMultiphysics.Parameters("""
             {
                 "solver_type": "compressible_solver_from_defaults",
                 "model_part_name": "FluidModelPart",
                 "domain_size": %d,
                 "model_import_settings": {
-                    "input_type": "mdpa",
-                    "input_filename": "",
-                    "reorder": false
+                    "input_type": "use_input_model_part"
                 },
                 "material_import_settings": {
-                    "materials_filename": "FluidMaterials.json"
+                    "materials_filename": ""
                 },
                 "echo_level": 1,
                 "time_order": 2,
@@ -47,16 +115,17 @@ class NavierStokesCompressibleExplicitSolverTest(KratosUnittest.TestCase):
                 "reform_dofs_at_each_step" : false,
                 "assign_neighbour_elements_to_conditions": true,
                 "volume_model_part_name" : "volume_model_part",
-                "skin_parts": [""],
-                "no_skin_parts":[""],
+                "skin_parts": [],
+                "no_skin_parts":[],
                 "time_stepping"                : {
                     "automatic_time_step" : true,
                     "CFL_number"          : 1.0,
                     "minimum_delta_time"  : 1.0e-8,
-                    "maximum_delta_time"  : 1.0e-2
+                    "maximum_delta_time"  : 1.0e-2,
+                    "consider_compressibility" : %s
                 },
                 "use_oss" : true
-            }""" % n_dimensions)
+            }""" % (n_dimensions, str(consider_compressibility).lower()))
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/applications/FluidDynamicsApplication/tests/test_navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/tests/test_navier_stokes_compressible_explicit_solver.py
@@ -25,17 +25,19 @@ class NavierStokesCompressibleExplicitSolverTest(KratosUnittest.TestCase):
         self.assertIn("Wrong domain size", str(context.exception))
 
     @classmethod
-    def GetSettings(cls, n_dimensions = 2):
+    def GetSettings(cls, n_dimensions):
         return KratosMultiphysics.Parameters("""
             {
                 "solver_type": "compressible_solver_from_defaults",
                 "model_part_name": "FluidModelPart",
                 "domain_size": %d,
                 "model_import_settings": {
-                    "input_type": "use_input_model_part"
+                    "input_type": "mdpa",
+                    "input_filename": "",
+                    "reorder": false
                 },
                 "material_import_settings": {
-                    "materials_filename": ""
+                    "materials_filename": "FluidMaterials.json"
                 },
                 "echo_level": 1,
                 "time_order": 2,
@@ -45,8 +47,8 @@ class NavierStokesCompressibleExplicitSolverTest(KratosUnittest.TestCase):
                 "reform_dofs_at_each_step" : false,
                 "assign_neighbour_elements_to_conditions": true,
                 "volume_model_part_name" : "volume_model_part",
-                "skin_parts": [],
-                "no_skin_parts":[],
+                "skin_parts": [""],
+                "no_skin_parts":[""],
                 "time_stepping"                : {
                     "automatic_time_step" : true,
                     "CFL_number"          : 1.0,
@@ -55,7 +57,6 @@ class NavierStokesCompressibleExplicitSolverTest(KratosUnittest.TestCase):
                 },
                 "use_oss" : true
             }""" % n_dimensions)
-
 
 if __name__ == '__main__':
     KratosUnittest.main()


### PR DESCRIPTION
**Motivation**
Up until now, only the incompressible form was considered.
This issue was raised in https://github.com/KratosMultiphysics/Kratos/issues/8624.

**Description**
Explicit compressible Navier Stokes now considers the compressible form of the Courant–Friedrichs–Lewy stability condition:

![Screenshot from 2021-09-16 11-58-56](https://user-images.githubusercontent.com/47142856/133592561-8a45f073-a499-40db-a364-b18db2c7ed00.png)

This has been done with backwards compatibility in mind, so all other usages of `FluidCharacteristicNumbersUtilities` and `EstimateDtUtility` do not change their behaviour. 

**Changelog**
- New method `FluidCharacteristicNumbersUtilities::CalculateElementCFLWithSoundVelocity`.
- `EstimateDtUtility` constructors now have a parameter `consider_compressibility`, both in full-constructor and JSON-style. They are false by default.
-  ` NavierStokesCompressibleExplicitSolver` is hardcoded to pass `consider_compressibility` parameterto the Dt `EstimateDtUtility`.
- Added a unit test to validate the results

**References**
```
ROA, Camilo Andrés Bayona; CODINA, Ramon; BAIGES, Joan. Adaptive mesh simulations of compressible flows using
stabilized formulations. 2018. PhD Thesis. Universitat Politècnica de Catalunya. Page 49, equation 3.84.
```