### PR TITLE
Fixing:Two Fluid Navier Stokes Solver -Outlet process

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -210,6 +210,9 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
         solution_strategy.SetEchoLevel(self.settings["echo_level"].GetInt())
         solution_strategy.Initialize()
 
+        # Set nodal properties after setting distance(level-set).
+        self._SetNodalProperties()
+
         # Initialize the distance correction process
         self._GetDistanceModificationProcess().ExecuteInitialize()
         self._GetDistanceModificationProcess().ExecuteInitializeSolutionStep()


### PR DESCRIPTION
**Description**

_Change:_ In this PR I suggest to assign two fluid material properties once the distance level set is set and **_before_** the outlet process gets the material properties( such as DENSITY) in order to calculate properly hydrostatic pressure. 

_Why_: Now, the two fluid material properties are assigned **_after_** the outlet process computes nodal hydrostatic pressure. Therefore, during my simulations using an outlet process, the external pressure does not correspond to the initial hydrostatic pressure of the simulation since the material properties are not well assigned in that moment.   


**Changelog**
- A function in order to assign material properties is added (see figure) 
![two_fluid_change](https://user-images.githubusercontent.com/73470625/133643861-f8f8ce72-c102-4ab8-97c4-6ebc3ddd010f.png)

