### PR TITLE
[Structural] allow usage of SubModelPart for ComputingModelPart

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -96,6 +96,7 @@ class MechanicalSolver(PythonSolver):
         this_defaults = KratosMultiphysics.Parameters("""{
             "solver_type" : "mechanical_solver",
             "model_part_name" : "",
+            "computing_sub_model_part_name" : "",
             "domain_size" : -1,
             "echo_level": 0,
             "buffer_size": 2,
@@ -262,7 +263,13 @@ class MechanicalSolver(PythonSolver):
             raise Exception("::[MechanicalSolver]:: Time stepping not defined!")
 
     def GetComputingModelPart(self):
-        return self.main_model_part
+        computing_sub_model_part_name = self.settings["computing_sub_model_part_name"].GetString()
+        if computing_sub_model_part_name == "":
+            # if the user didn't specify a SubModelPart, then use the MainModelPart
+            return self.main_model_part
+        else:
+            computing_model_part_name = self.main_model_part.Name + "." + computing_sub_model_part_name
+            return self.model[computing_model_part_name]
 
     def ExportModelPart(self):
         name_out_file = self.settings["model_import_settings"]["input_filename"].GetString()+".out"


### PR DESCRIPTION
This PR allows to use a SubModelPart as the ComputingModelPart in the Structural Solvers.

I thought some days about this and agree with the reasoning in #9130 about this being a valid usecase.

This solution is minimally intrusive, as suggested by @pablobecker. Ofc this is not mutually exclusive with the other solutions proposed in #9130

@pablobecker if this solution looks good to you, can you please test it with your usecase and if possible also add a small test?

closes #9130 

**Note**: This has nothing to do with the nasty ComputingModelPart that we had in the past (which was awkwardly constructed by creating a separate SubModelPart based on a list of SubModelPart-Names)
This PR allows to pass an EXISTING (aka defined in e.g. the mdpa) SubModelPart to the Strategy & B&S instead of the RootModelPart