### PR TITLE
[CI] remove non-working Docker entrypoint

### DIFF
--- a/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
@@ -90,7 +90,3 @@ RUN apt-get update -y && apt-get upgrade -y && \
 CMD [ "/bin/bash" ]
 
 WORKDIR $HOME
-
-COPY scripts/docker_files/docker_file_ci_ubuntu_20_04/entrypoint_ci.sh /entrypoint_ci.sh
-
-ENTRYPOINT ["/entrypoint_ci.sh"]

--- a/scripts/docker_files/docker_file_ci_ubuntu_20_04/entrypoint_ci.sh
+++ b/scripts/docker_files/docker_file_ci_ubuntu_20_04/entrypoint_ci.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# initialize the Intel environment (compiler env, MKL, ...)
-source /opt/intel/oneapi/setvars.sh


### PR DESCRIPTION
This is a leftover, Github Actions don't support `ENTRYPOINT` (cannot find the reference now but I did test it extensively)

(Another motivation of this PR is to rebuild the docker image with a newer version of the Intel compiler to hopefully fix the issues in #8599)