### PR TITLE
[Core] Extend MathUtils

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_math_utils.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_math_utils.cpp
@@ -868,6 +868,31 @@ namespace Kratos
             KRATOS_CHECK_EQUAL(a(1,0), 0.0);
             KRATOS_CHECK_EQUAL(a(0,1), 0.0);
             KRATOS_CHECK_EQUAL(a(1,1), 1.0);
+
+            BoundedMatrix<double,3,3> c = IdentityMatrix(3);
+            BoundedMatrix<double,2,2> d = IdentityMatrix(2);
+
+            MathUtils<double>::AddMatrix(c, d, 0 ,0);
+
+            KRATOS_CHECK_EQUAL(c(0,0), 2.0);
+            KRATOS_CHECK_EQUAL(c(1,0), 0.0);
+            KRATOS_CHECK_EQUAL(c(0,1), 0.0);
+            KRATOS_CHECK_EQUAL(c(1,1), 2.0);
+            KRATOS_CHECK_EQUAL(c(2,2), 1.0);
+        }
+
+        /** Checks if it calculates the vector operations
+         */
+        KRATOS_TEST_CASE_IN_SUITE(MathUtilsVectorOperations, KratosCoreFastSuite)
+        {
+            array_1d<double,3> a = ZeroVector(3);
+            array_1d<double,2> b (2, 1.0);
+        
+            MathUtils<double>::AddVector(a, b, 0);
+
+            KRATOS_CHECK_EQUAL(a[0], 1.0);
+            KRATOS_CHECK_EQUAL(a[1], 1.0);
+            KRATOS_CHECK_EQUAL(a[2], 0.0);
         }
 
         /** Checks if it calculates the Factorial

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -1125,7 +1125,7 @@ public:
      * @details "Destination" is assumed to be able to contain the "input vector" (no check is performed on the bounds)
      * @param rDestination The vector destination
      * @param rInputVector The input vector to be added
-     * @param InitialRow The initial index
+     * @param InitialIndex The initial index
      */
     template<class TVectorType1, class TVectorType2>
     static inline void AddVector(

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -1097,14 +1097,15 @@ public:
     /**
      * @brief "rInputMatrix" is ADDED to "Destination" matrix starting from InitialRow and InitialCol of the destination matrix
      * @details "Destination" is assumed to be able to contain the "input matrix" (no check is performed on the bounds)
-     * @param rDestination The matric destination
+     * @param rDestination The matrix destination
      * @param rInputMatrix The input matrix to be computed
      * @param InitialRow The initial row to compute
      * @param InitialCol The initial column to compute
      */
-    static inline void  AddMatrix(
-        MatrixType& rDestination,
-        const MatrixType& rInputMatrix,
+    template<class TMatrixType1, class TMatrixType2>
+    static inline void AddMatrix(
+        TMatrixType1& rDestination,
+        const TMatrixType2& rInputMatrix,
         const IndexType InitialRow,
         const IndexType InitialCol
         )

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -1121,6 +1121,28 @@ public:
     }
 
     /**
+     * @brief "rInputVector" is ADDED to "Destination" vector starting from InitialIndex of the destination matrix
+     * @details "Destination" is assumed to be able to contain the "input vector" (no check is performed on the bounds)
+     * @param rDestination The vector destination
+     * @param rInputVector The input vector to be computed
+     * @param InitialRow The initial row to compute
+     */
+    template<class TVectorType1, class TVectorType2>
+    static inline void AddVector(
+        TVectorType1& rDestination,
+        const TVectorType2& rInputVector,
+        const IndexType InitialIndex
+        )
+    {
+        KRATOS_TRY
+
+        for(IndexType i = 0; i < rInputVector.size(); ++i) {
+            rDestination[InitialIndex+i] += rInputVector[i];
+        }
+        KRATOS_CATCH("")
+    }
+
+    /**
      * @brief "rInputMatrix" is SUBTRACTED to "rDestination" matrix starting from InitialRow and InitialCol of the destination matrix
      * @details "rDestination" is assumed to be able to contain the "input matrix" (no check is performed on the bounds)
      * @param rDestination The matric destination

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -1098,9 +1098,9 @@ public:
      * @brief "rInputMatrix" is ADDED to "Destination" matrix starting from InitialRow and InitialCol of the destination matrix
      * @details "Destination" is assumed to be able to contain the "input matrix" (no check is performed on the bounds)
      * @param rDestination The matrix destination
-     * @param rInputMatrix The input matrix to be computed
-     * @param InitialRow The initial row to compute
-     * @param InitialCol The initial column to compute
+     * @param rInputMatrix The input matrix to be added
+     * @param InitialRow The initial row
+     * @param InitialCol The initial column
      */
     template<class TMatrixType1, class TMatrixType2>
     static inline void AddMatrix(
@@ -1124,8 +1124,8 @@ public:
      * @brief "rInputVector" is ADDED to "Destination" vector starting from InitialIndex of the destination matrix
      * @details "Destination" is assumed to be able to contain the "input vector" (no check is performed on the bounds)
      * @param rDestination The vector destination
-     * @param rInputVector The input vector to be computed
-     * @param InitialRow The initial row to compute
+     * @param rInputVector The input vector to be added
+     * @param InitialRow The initial index
      */
     template<class TVectorType1, class TVectorType2>
     static inline void AddVector(


### PR DESCRIPTION
**Description**
I would like to extend math utils to build an element by blocks. Since I'm using bonded matrices, I need to add a template. The same functionality is added for vectors.

**Changelog**
- Add template arguments
- Add AddVector
- Add tests
