### PR TITLE
[CoSim] adding MPIExtension

### DIFF
--- a/applications/CoSimulationApplication/CMakeLists.txt
+++ b/applications/CoSimulationApplication/CMakeLists.txt
@@ -81,6 +81,12 @@ endif(${INSTALL_TESTING_FILES} MATCHES ON)
 install(TARGETS KratosCoSimulationCore DESTINATION libs )
 install(TARGETS KratosCoSimulationApplication DESTINATION libs )
 
+## If MPI is used, then enable the MPIExtension
+if(${USE_MPI})
+  message("Enabling mpi extension for CoSimulationApplication")
+  add_subdirectory(mpi_extension)
+endif(${USE_MPI})
+
 # Define custom targets
 set(KRATOS_KERNEL "${KRATOS_KERNEL};KratosCoSimulationCore" PARENT_SCOPE)
 set(KRATOS_PYTHON_INTERFACE "${KRATOS_PYTHON_INTERFACE};KratosCoSimulationApplication" PARENT_SCOPE)

--- a/applications/CoSimulationApplication/mpi_extension/CMakeLists.txt
+++ b/applications/CoSimulationApplication/mpi_extension/CMakeLists.txt
@@ -1,0 +1,42 @@
+include_directories(
+  ${KRATOS_SOURCE_DIR}/kratos
+  ${KRATOS_SOURCE_DIR}/applications/CoSimulationApplication
+)
+
+file(
+  GLOB_RECURSE
+  KRATOS_CO_SIMULATION_MPI_EXTENSION_PYTHON_INTERFACE_SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
+)
+
+## Python module
+pybind11_add_module( KratosCoSimulationMPIExtension MODULE THIN_LTO ${KRATOS_CO_SIMULATION_MPI_EXTENSION_PYTHON_INTERFACE_SOURCES} )
+
+target_link_libraries( KratosCoSimulationMPIExtension PRIVATE KratosCoSimulationCore KratosMPICore )
+set_target_properties( KratosCoSimulationMPIExtension PROPERTIES PREFIX "")
+
+# Set batch size in the unity build
+IF(CMAKE_UNITY_BUILD MATCHES ON)
+    set_target_properties(KratosCoSimulationMPIExtension PROPERTIES UNITY_BUILD_BATCH_SIZE ${KRATOS_UNITY_BUILD_BATCH_SIZE})
+ENDIF(CMAKE_UNITY_BUILD MATCHES ON)
+
+###############################################################################
+# changing the .dll suffix to .pyd
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  set_target_properties(KratosCoSimulationMPIExtension PROPERTIES SUFFIX .pyd)
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+
+# changing the .dylib suffix to .so
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+	set_target_properties(KratosCoSimulationMPIExtension PROPERTIES SUFFIX .so)
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+
+###############################################################################
+## installing the resulting libraries
+install(TARGETS KratosCoSimulationMPIExtension DESTINATION libs )
+
+###############################################################################
+## install python module
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/MPIExtension.py" DESTINATION "KratosMultiphysics/CoSimulationApplication")
+
+set(KRATOS_PYTHON_INTERFACE "${KRATOS_PYTHON_INTERFACE};KratosCoSimulationMPIExtension" PARENT_SCOPE)

--- a/applications/CoSimulationApplication/mpi_extension/MPIExtension.py
+++ b/applications/CoSimulationApplication/mpi_extension/MPIExtension.py
@@ -1,0 +1,2 @@
+import KratosMultiphysics.mpi # importing the MPI-Core, since the MPIExtension directly links to it
+from KratosCoSimulationMPIExtension import *

--- a/applications/CoSimulationApplication/mpi_extension/custom_python/co_simulation_mpi_extension.cpp
+++ b/applications/CoSimulationApplication/mpi_extension/custom_python/co_simulation_mpi_extension.cpp
@@ -1,0 +1,29 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define_python.h"
+
+namespace Kratos {
+namespace Python {
+
+PYBIND11_MODULE(KratosCoSimulationMPIExtension,m)
+{
+
+}
+
+}
+}


### PR DESCRIPTION
**Description**
This PR adds the `MPIExtension` for the CoSimApp. It is in preparation for the CoSimIO V3 which will have MPI support, i.e. then we can do coupling to external solvers fully MPI parallel :D

I did the implementation in the same way as for the MappingApp