### PR TITLE
[Shallow] Refactor friction laws

### DIFF
--- a/applications/ShallowWaterApplication/custom_elements/shallow_water_2d_3.cpp
+++ b/applications/ShallowWaterApplication/custom_elements/shallow_water_2d_3.cpp
@@ -168,10 +168,10 @@ void ShallowWater2D3::CalculateLocalSystem(
     ComputeDampingCoefficient(data.damping, rCurrentProcessInfo[ABSORBING_DISTANCE], rCurrentProcessInfo[DISSIPATION]);
 
     data.pBottomFriction = Kratos::make_shared<ManningLaw>();
-    data.pBottomFriction->Initialize(GetGeometry(), rCurrentProcessInfo);
+    data.pBottomFriction->Initialize(GetGeometry(), GetProperties(), rCurrentProcessInfo);
 
     data.pSurfaceFriction = Kratos::make_shared<WindWaterFriction>();
-    data.pSurfaceFriction->Initialize(GetGeometry(), rCurrentProcessInfo);
+    data.pSurfaceFriction->Initialize(GetGeometry(), GetProperties(), rCurrentProcessInfo);
 
     AddGradientTerms(rLeftHandSideMatrix, rRightHandSideVector, data, N, DN_DX);
 

--- a/applications/ShallowWaterApplication/custom_elements/shallow_water_2d_3.cpp
+++ b/applications/ShallowWaterApplication/custom_elements/shallow_water_2d_3.cpp
@@ -21,9 +21,8 @@
 #include "utilities/geometry_utilities.h"
 #include "includes/mesh_moving_variables.h"
 #include "shallow_water_application_variables.h"
-#include "custom_friction_laws/manning_law.h"
-#include "custom_friction_laws/wind_water_friction.h"
 #include "custom_utilities/shallow_water_utilities.h"
+#include "custom_friction_laws/friction_laws_factory.h"
 #include "shallow_water_2d_3.h"
 
 namespace Kratos
@@ -45,7 +44,6 @@ int ShallowWater2D3::Check(const ProcessInfo& rCurrentProcessInfo) const
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(HEIGHT, node)
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TOPOGRAPHY, node)
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(RAIN, node)
-        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(WIND, node)
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(ATMOSPHERIC_PRESSURE, node)
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(ACCELERATION, node)
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VERTICAL_VELOCITY, node)
@@ -167,11 +165,8 @@ void ShallowWater2D3::CalculateLocalSystem(
     data.boundary_velocity = rCurrentProcessInfo[BOUNDARY_VELOCITY];
     ComputeDampingCoefficient(data.damping, rCurrentProcessInfo[ABSORBING_DISTANCE], rCurrentProcessInfo[DISSIPATION]);
 
-    data.pBottomFriction = Kratos::make_shared<ManningLaw>();
-    data.pBottomFriction->Initialize(GetGeometry(), GetProperties(), rCurrentProcessInfo);
-
-    data.pSurfaceFriction = Kratos::make_shared<WindWaterFriction>();
-    data.pSurfaceFriction->Initialize(GetGeometry(), GetProperties(), rCurrentProcessInfo);
+    data.pBottomFriction = FrictionLawsFactory().CreateBottomFrictionLaw(GetGeometry(), GetProperties(), rCurrentProcessInfo);
+    data.pSurfaceFriction = FrictionLawsFactory().CreateSurfaceFrictionLaw(GetGeometry(), GetProperties(), rCurrentProcessInfo);
 
     AddGradientTerms(rLeftHandSideMatrix, rRightHandSideVector, data, N, DN_DX);
 
@@ -284,7 +279,7 @@ void ShallowWater2D3::AddSourceTerms(
 
     // Friction term
     rLHS += rData.gravity * rData.pBottomFriction->CalculateLHS(rData.height, rData.velocity) * flow_mass_matrix;
-    rLHS -= rData.gravity * rData.pSurfaceFriction->CalculateLHS(ZeroVector(3), rData.wind) * flow_mass_matrix;
+    rLHS -= rData.gravity * rData.pSurfaceFriction->CalculateLHS(ZeroVector(3)) * flow_mass_matrix;
 
     // Newtonian damper for the absorbing boundaries
     rLHS += rData.damping * flow_mass_matrix;
@@ -367,7 +362,6 @@ void ShallowWater2D3::ElementData::GetNodalData(const GeometryType& rGeometry, c
     height = 0.0;
     flow_rate = ZeroVector(3);
     velocity = ZeroVector(3);
-    wind = ZeroVector(3);
 
     for (size_t i = 0; i < 3; i++)
     {
@@ -380,7 +374,6 @@ void ShallowWater2D3::ElementData::GetNodalData(const GeometryType& rGeometry, c
         height += h;
         flow_rate += f;
         velocity += rGeometry[i].FastGetSolutionStepValue(VELOCITY);
-        wind += rGeometry[i].FastGetSolutionStepValue(WIND);
 
         topography[i] = rGeometry[i].FastGetSolutionStepValue(TOPOGRAPHY);
         rain[i] = rGeometry[i].FastGetSolutionStepValue(RAIN);

--- a/applications/ShallowWaterApplication/custom_elements/shallow_water_2d_3.h
+++ b/applications/ShallowWaterApplication/custom_elements/shallow_water_2d_3.h
@@ -332,7 +332,6 @@ protected:
         array_1d<double,3> velocity;
 
         array_1d<double,3> topography;
-        array_1d<double,3> wind;
         array_1d<double,3> rain;
         array_1d<double,9> unknown;
         array_1d<double,9> mesh_acc;

--- a/applications/ShallowWaterApplication/custom_elements/wave_element.cpp
+++ b/applications/ShallowWaterApplication/custom_elements/wave_element.cpp
@@ -180,7 +180,7 @@ void WaveElement<TNumNodes>::InitializeData(ElementData& rData, const ProcessInf
     rData.relative_dry_height = rCurrentProcessInfo[RELATIVE_DRY_HEIGHT];
     rData.gravity = rCurrentProcessInfo[GRAVITY_Z];
     rData.p_bottom_friction = Kratos::make_shared<ManningLaw>();
-    rData.p_bottom_friction->Initialize(this->GetGeometry(), rCurrentProcessInfo);
+    rData.p_bottom_friction->Initialize(this->GetGeometry(), this->GetProperties(), rCurrentProcessInfo);
 }
 
 template<std::size_t TNumNodes>

--- a/applications/ShallowWaterApplication/custom_elements/wave_element.cpp
+++ b/applications/ShallowWaterApplication/custom_elements/wave_element.cpp
@@ -21,8 +21,8 @@
 #include "includes/checks.h"
 #include "utilities/math_utils.h"
 #include "utilities/geometry_utilities.h"
-#include "custom_friction_laws/manning_law.h"
 #include "custom_utilities/shallow_water_utilities.h"
+#include "custom_friction_laws/friction_laws_factory.h"
 #include "shallow_water_application_variables.h"
 
 namespace Kratos
@@ -43,7 +43,6 @@ int WaveElement<TNumNodes>::Check(const ProcessInfo& rCurrentProcessInfo) const
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(MOMENTUM, r_node)
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VELOCITY, r_node)
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(HEIGHT, r_node)
-        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(MANNING, r_node)
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TOPOGRAPHY, r_node)
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(ACCELERATION, r_node)
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VERTICAL_VELOCITY, r_node)
@@ -179,8 +178,8 @@ void WaveElement<TNumNodes>::InitializeData(ElementData& rData, const ProcessInf
     rData.shock_stab_factor = rCurrentProcessInfo[SHOCK_STABILIZATION_FACTOR];
     rData.relative_dry_height = rCurrentProcessInfo[RELATIVE_DRY_HEIGHT];
     rData.gravity = rCurrentProcessInfo[GRAVITY_Z];
-    rData.p_bottom_friction = Kratos::make_shared<ManningLaw>();
-    rData.p_bottom_friction->Initialize(this->GetGeometry(), this->GetProperties(), rCurrentProcessInfo);
+    rData.p_bottom_friction = FrictionLawsFactory().CreateBottomFrictionLaw(
+        this->GetGeometry(), this->GetProperties(), rCurrentProcessInfo);
 }
 
 template<std::size_t TNumNodes>

--- a/applications/ShallowWaterApplication/custom_friction_laws/chezy_law.cpp
+++ b/applications/ShallowWaterApplication/custom_friction_laws/chezy_law.cpp
@@ -25,14 +25,21 @@
 namespace Kratos
 {
 
-void ChezyLaw::Initialize(const GeometryType& rGeometry, const ProcessInfo& rProcessInfo)
+void ChezyLaw::Initialize(
+    const GeometryType& rGeometry,
+    const Properties& rProperty,
+    const ProcessInfo& rProcessInfo)
 {
     double chezy = 0.0;
-    for (auto& r_node : rGeometry)
-    {
-        chezy += r_node.FastGetSolutionStepValue(CHEZY);
+    if (rProperty.Has(CHEZY)) {
+        chezy = rProperty.GetValue(CHEZY);
+    } else {
+        for (auto& r_node : rGeometry)
+        {
+            chezy += r_node.FastGetSolutionStepValue(CHEZY);
+        }
+        chezy /= rGeometry.size();
     }
-    chezy /= rGeometry.size();
     mCoefficient = 1. / std::pow(chezy, 2);
 
     mEpsilon = rGeometry.Length() * rProcessInfo[RELATIVE_DRY_HEIGHT];

--- a/applications/ShallowWaterApplication/custom_friction_laws/chezy_law.cpp
+++ b/applications/ShallowWaterApplication/custom_friction_laws/chezy_law.cpp
@@ -30,18 +30,8 @@ void ChezyLaw::Initialize(
     const Properties& rProperty,
     const ProcessInfo& rProcessInfo)
 {
-    double chezy = 0.0;
-    if (rProperty.Has(CHEZY)) {
-        chezy = rProperty.GetValue(CHEZY);
-    } else {
-        for (auto& r_node : rGeometry)
-        {
-            chezy += r_node.FastGetSolutionStepValue(CHEZY);
-        }
-        chezy /= rGeometry.size();
-    }
+    const double chezy = rProperty.GetValue(CHEZY);
     mCoefficient = 1. / std::pow(chezy, 2);
-
     mEpsilon = rGeometry.Length() * rProcessInfo[RELATIVE_DRY_HEIGHT];
 }
 

--- a/applications/ShallowWaterApplication/custom_friction_laws/chezy_law.cpp
+++ b/applications/ShallowWaterApplication/custom_friction_laws/chezy_law.cpp
@@ -25,6 +25,14 @@
 namespace Kratos
 {
 
+ChezyLaw::ChezyLaw(
+    const GeometryType& rGeometry,
+    const Properties& rProperty,
+    const ProcessInfo& rProcessInfo)
+{
+    this->Initialize(rGeometry, rProperty, rProcessInfo);
+}
+
 void ChezyLaw::Initialize(
     const GeometryType& rGeometry,
     const Properties& rProperty,

--- a/applications/ShallowWaterApplication/custom_friction_laws/chezy_law.h
+++ b/applications/ShallowWaterApplication/custom_friction_laws/chezy_law.h
@@ -68,10 +68,22 @@ public:
     ///@name Life Cycle
     ///@{
 
-    /// Default constructor.
+    /**
+     * @brief Default Constructor
+     */
     ChezyLaw() {}
 
-    /// Destructor.
+    /**
+     * @brief Constructor with data
+     */
+    ChezyLaw(
+        const GeometryType& rGeometry,
+        const Properties& rProperty,
+        const ProcessInfo& rProcessInfo);
+
+    /**
+     * @brief Destructor
+     */
     virtual ~ChezyLaw() {}
 
     ///@}
@@ -130,19 +142,6 @@ public:
         buffer << "ChezyLaw";
         return buffer.str();
     }
-    
-    /**
-     * @brief Print information about this object.
-     */
-    void PrintInfo(std::ostream& rOStream) const override
-    {
-        rOStream << "ChezyLaw";
-    }
-
-    /**
-     * @brief Print object's data.
-     */
-    void PrintData(std::ostream& rOStream) const override {}
 
     ///@}
     ///@name Friends

--- a/applications/ShallowWaterApplication/custom_friction_laws/chezy_law.h
+++ b/applications/ShallowWaterApplication/custom_friction_laws/chezy_law.h
@@ -22,7 +22,6 @@
 
 // Project includes
 #include "friction_law.h"
-#include "shallow_water_application_variables.h"
 
 
 namespace Kratos

--- a/applications/ShallowWaterApplication/custom_friction_laws/chezy_law.h
+++ b/applications/ShallowWaterApplication/custom_friction_laws/chezy_law.h
@@ -87,7 +87,10 @@ public:
     /**
      * @brief Initialize the friction law variables
      */
-    void Initialize(const GeometryType& rGeometry, const ProcessInfo& rProcessInfo) override;
+    void Initialize(
+        const GeometryType& rGeometry,
+        const Properties& rProperty,
+        const ProcessInfo& rProcessInfo) override;
 
     /**
      * @brief Calculate the LHS coefficient for the given data

--- a/applications/ShallowWaterApplication/custom_friction_laws/friction_law.h
+++ b/applications/ShallowWaterApplication/custom_friction_laws/friction_law.h
@@ -24,6 +24,7 @@
 
 // Project includes
 #include "includes/node.h"
+#include "includes/properties.h"
 #include "includes/process_info.h"
 #include "geometries/geometry.h"
 
@@ -101,7 +102,10 @@ public:
     /**
      * @brief Initialize the friction law variables
      */
-    virtual void Initialize(const GeometryType& rGeometry, const ProcessInfo& rProcessInfo) {}
+    virtual void Initialize(
+        const GeometryType& rGeometry,
+        const Properties& rProperty,
+        const ProcessInfo& rProcessInfo) {}
 
     /**
      * @brief Calculate the LHS coefficient for the given data

--- a/applications/ShallowWaterApplication/custom_friction_laws/friction_law.h
+++ b/applications/ShallowWaterApplication/custom_friction_laws/friction_law.h
@@ -110,45 +110,43 @@ public:
     /**
      * @brief Calculate the LHS coefficient for the given data
      * @param rHeight The layer depth
-     * @param rVector The layer velocity or momentum
+     * @param rVector The layer velocity
      * @return The LHS coefficient
      */
     virtual double CalculateLHS(const double& rHeight, const array_1d<double,3>& rVelocity)
     {
-        KRATOS_ERROR << "Calling the base class of CalculateLHS of the friction law" << std::endl;
+        return 0.0;
     }
 
     /**
      * @brief Calculate the RHS coefficient for the given data
      * @param rHeight The layer depth
-     * @param rVector The layer velocity or momentum
+     * @param rVector The layer velocity
      * @return The components of the RHS coefficients
      */
     virtual array_1d<double,3> CalculateRHS(const double& rHeight, const array_1d<double,3>& rVelocity)
     {
-        KRATOS_ERROR << "Calling the base class of CalculateRHS of the friction law" << std::endl;
+        return ZeroVector(3);
     }
 
     /**
      * @brief Calculate the LHS coefficient for the given data
-     * @param rInnerLayer The current layer velocity or momentum
-     * @param rOuterLayer The outer layer velocity or momentum
+     * @param rInnerLayer The current layer velocity
      * @return The LHS coefficient
      */
-    virtual double CalculateLHS(const array_1d<double,3>& rInnerLayer, const array_1d<double,3>& rOuterLayer)
+    virtual double CalculateLHS(const array_1d<double,3>& rInnerLayer)
     {
-        KRATOS_ERROR << "Calling the base class of CalculateLHS of the friction law" << std::endl;
+        return 0.0;
     }
 
     /**
      * @brief Calculate the RHS coefficient for the given data
-     * @param rInnerLayer The current layer velocity or momentum
-     * @param rOuterLayer The outer layer velocity or momentum
+     * @param rInnerLayer The current layer velocity
      * @return The components of the RHS coefficients
      */
-    virtual array_1d<double,3> CalculateRHS(const array_1d<double,3>& rInnerLayer, const array_1d<double,3>& rOuterLayer)
+    virtual array_1d<double,3> CalculateRHS(const array_1d<double,3>& rInnerLayer)
     {
-        KRATOS_ERROR << "Calling the base class of CalculateRHS of the friction law" << std::endl;
+        return ZeroVector(3);
     }
 
     ///@}
@@ -179,7 +177,7 @@ public:
      */
     virtual void PrintInfo(std::ostream& rOStream) const
     {
-        rOStream << "FrictionLaw";
+        rOStream << Info();
     }
 
     /**

--- a/applications/ShallowWaterApplication/custom_friction_laws/friction_laws_factory.cpp
+++ b/applications/ShallowWaterApplication/custom_friction_laws/friction_laws_factory.cpp
@@ -1,0 +1,62 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Miguel Maso Sotomayor
+//
+
+// System includes
+
+
+// External includes
+
+
+// Project includes
+#include "friction_laws_factory.h"
+#include "nodal_manning_law.h"
+#include "manning_law.h"
+#include "chezy_law.h"
+#include "wind_water_friction.h"
+
+
+namespace Kratos
+{
+
+FrictionLaw::Pointer FrictionLawsFactory::CreateBottomFrictionLaw(
+    const GeometryType& rGeometry,
+    const Properties& rProperty,
+    const ProcessInfo& rProcessInfo)
+{
+    if (rProperty.Has(MANNING)) {
+        return Kratos::make_shared<ManningLaw>();
+    }
+    else if (rProperty.Has(CHEZY)) {
+        return Kratos::make_shared<ChezyLaw>();
+    }
+    else if (rGeometry[0].SolutionStepsDataHas(MANNING)) {
+        return Kratos::make_shared<NodalManningLaw>();
+    }
+    else {
+        return Kratos::make_shared<FrictionLaw>();
+    }
+}
+
+FrictionLaw::Pointer FrictionLawsFactory::CreateSurfaceFrictionLaw(
+    const GeometryType& rGeometry,
+    const Properties& rProperty,
+    const ProcessInfo& rProcessInfo)
+{
+    if (rProcessInfo.Has(DENSITY_AIR) & rGeometry[0].SolutionStepsDataHas(WIND)) {
+        return Kratos::make_shared<WindWaterFriction>();
+    }
+    else {
+        return Kratos::make_shared<FrictionLaw>();
+    }
+}
+
+}  // namespace Kratos

--- a/applications/ShallowWaterApplication/custom_friction_laws/friction_laws_factory.cpp
+++ b/applications/ShallowWaterApplication/custom_friction_laws/friction_laws_factory.cpp
@@ -33,13 +33,13 @@ FrictionLaw::Pointer FrictionLawsFactory::CreateBottomFrictionLaw(
     const ProcessInfo& rProcessInfo)
 {
     if (rProperty.Has(MANNING)) {
-        return Kratos::make_shared<ManningLaw>();
+        return Kratos::make_shared<ManningLaw>(rGeometry, rProperty, rProcessInfo);
     }
     else if (rProperty.Has(CHEZY)) {
-        return Kratos::make_shared<ChezyLaw>();
+        return Kratos::make_shared<ChezyLaw>(rGeometry, rProperty, rProcessInfo);
     }
     else if (rGeometry[0].SolutionStepsDataHas(MANNING)) {
-        return Kratos::make_shared<NodalManningLaw>();
+        return Kratos::make_shared<NodalManningLaw>(rGeometry, rProperty, rProcessInfo);
     }
     else {
         return Kratos::make_shared<FrictionLaw>();
@@ -52,7 +52,7 @@ FrictionLaw::Pointer FrictionLawsFactory::CreateSurfaceFrictionLaw(
     const ProcessInfo& rProcessInfo)
 {
     if (rProcessInfo.Has(DENSITY_AIR) & rGeometry[0].SolutionStepsDataHas(WIND)) {
-        return Kratos::make_shared<WindWaterFriction>();
+        return Kratos::make_shared<WindWaterFriction>(rGeometry, rProperty, rProcessInfo);
     }
     else {
         return Kratos::make_shared<FrictionLaw>();

--- a/applications/ShallowWaterApplication/custom_friction_laws/friction_laws_factory.h
+++ b/applications/ShallowWaterApplication/custom_friction_laws/friction_laws_factory.h
@@ -1,0 +1,147 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Miguel Maso Sotomayor
+//
+
+#ifndef KRATOS_FRICTION_LAWS_FACTORY_H_INCLUDED
+#define KRATOS_FRICTION_LAWS_FACTORY_H_INCLUDED
+
+
+// System includes
+#include <string>
+#include <iostream>
+
+
+// External includes
+
+
+// Project includes
+#include "friction_law.h"
+
+
+namespace Kratos
+{
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+/** 
+ * @class FrictionLawsFactory
+ * @ingroup ShallowWaterApplication
+ * @brief The base class for the bottom and surface friction laws
+ * @details This class does nothing, define derived friction laws in order to make use of it
+ * @author Miguel Maso Sotomayor
+ */
+class FrictionLawsFactory
+{
+public:
+    ///@name Type Definitions
+    ///@{
+    
+    typedef Node <3> NodeType;
+
+    typedef Geometry<NodeType> GeometryType;
+
+    ///@}
+    ///@name Pointer Definition
+    ///@{
+
+    KRATOS_CLASS_POINTER_DEFINITION(FrictionLawsFactory);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /**
+     * @brief Default constructor
+     */
+    FrictionLawsFactory() {}
+
+    /**
+     * @brief Destructor
+     */
+    ~FrictionLawsFactory() {}
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Create a bottom friction law
+     */
+    FrictionLaw::Pointer CreateBottomFrictionLaw(
+        const GeometryType& rGeometry,
+        const Properties& rProperty,
+        const ProcessInfo& rProcessInfo);
+
+    /**
+     * @brief Create a surface friction law
+     */
+    FrictionLaw::Pointer CreateSurfaceFrictionLaw(
+        const GeometryType& rGeometry,
+        const Properties& rProperty,
+        const ProcessInfo& rProcessInfo);
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /**
+     * @brief Turn back information as a string.
+     */
+    std::string Info() const
+    {
+        std::stringstream buffer;
+        buffer << "FrictionLawsFactory";
+        return buffer.str();
+    }
+
+    /**
+     * @brief Print information about this object.
+     */
+    void PrintInfo(std::ostream& rOStream) const
+    {
+        rOStream << Info();
+    }
+
+    /**
+     * @brief Print object's data.
+     */
+    void PrintData(std::ostream& rOStream) const {}
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+
+}; // Class FrictionLawsFactory
+
+///@}
+
+}  // namespace Kratos.
+
+#endif // KRATOS_FRICTION_LAWS_FACTORY_H_INCLUDED  defined

--- a/applications/ShallowWaterApplication/custom_friction_laws/manning_law.cpp
+++ b/applications/ShallowWaterApplication/custom_friction_laws/manning_law.cpp
@@ -25,6 +25,14 @@
 namespace Kratos
 {
 
+ManningLaw::ManningLaw(
+    const GeometryType& rGeometry,
+    const Properties& rProperty,
+    const ProcessInfo& rProcessInfo)
+{
+    this->Initialize(rGeometry, rProperty, rProcessInfo);
+}
+
 void ManningLaw::Initialize(
     const GeometryType& rGeometry,
     const Properties& rProperty,

--- a/applications/ShallowWaterApplication/custom_friction_laws/manning_law.cpp
+++ b/applications/ShallowWaterApplication/custom_friction_laws/manning_law.cpp
@@ -24,14 +24,21 @@
 namespace Kratos
 {
 
-void ManningLaw::Initialize(const GeometryType& rGeometry, const ProcessInfo& rProcessInfo)
+void ManningLaw::Initialize(
+    const GeometryType& rGeometry,
+    const Properties& rProperty,
+    const ProcessInfo& rProcessInfo)
 {
     double manning = 0.0;
-    for (auto& r_node : rGeometry)
-    {
-        manning += r_node.FastGetSolutionStepValue(MANNING);
+    if (rProperty.Has(MANNING)) {
+        manning = rProperty.GetValue(MANNING);
+    } else {
+        for (auto& r_node : rGeometry)
+        {
+            manning += r_node.FastGetSolutionStepValue(MANNING);
+        }
+        manning /= rGeometry.size();
     }
-    manning /= rGeometry.size();
     mManning2 = std::pow(manning, 2);
 
     mEpsilon = rGeometry.Length() * rProcessInfo[RELATIVE_DRY_HEIGHT];

--- a/applications/ShallowWaterApplication/custom_friction_laws/manning_law.h
+++ b/applications/ShallowWaterApplication/custom_friction_laws/manning_law.h
@@ -87,7 +87,10 @@ public:
     /**
      * @brief Initialize the friction law variables
      */
-    void Initialize(const GeometryType& rGeometry, const ProcessInfo& rProcessInfo) override;
+    void Initialize(
+        const GeometryType& rGeometry,
+        const Properties& rProperty,
+        const ProcessInfo& rProcessInfo) override;
 
     /**
      * @brief Calculate the LHS coefficient for the given data

--- a/applications/ShallowWaterApplication/custom_friction_laws/manning_law.h
+++ b/applications/ShallowWaterApplication/custom_friction_laws/manning_law.h
@@ -68,10 +68,22 @@ public:
     ///@name Life Cycle
     ///@{
 
-    /// Default constructor.
+    /**
+     * @brief Default Constructor
+     */
     ManningLaw() {}
 
-    /// Destructor.
+    /**
+     * @brief Constructor with data
+     */
+    ManningLaw(
+        const GeometryType& rGeometry,
+        const Properties& rProperty,
+        const ProcessInfo& rProcessInfo);
+
+    /**
+     * @brief Initialize the friction law variables
+     */
     virtual ~ManningLaw() {}
 
     ///@}

--- a/applications/ShallowWaterApplication/custom_friction_laws/nodal_manning_law.cpp
+++ b/applications/ShallowWaterApplication/custom_friction_laws/nodal_manning_law.cpp
@@ -17,7 +17,7 @@
 
 
 // Project includes
-#include "manning_law.h"
+#include "nodal_manning_law.h"
 #include "shallow_water_application_variables.h"
 #include "custom_utilities/shallow_water_utilities.h"
 
@@ -25,25 +25,19 @@
 namespace Kratos
 {
 
-void ManningLaw::Initialize(
+void NodalManningLaw::Initialize(
     const GeometryType& rGeometry,
     const Properties& rProperty,
     const ProcessInfo& rProcessInfo)
 {
-    const double manning = rProperty.GetValue(MANNING);
+    double manning = 0.0;
+    for (auto& r_node : rGeometry) {
+        manning += r_node.FastGetSolutionStepValue(MANNING);
+    }
+    manning /= rGeometry.size();
     mManning2 = std::pow(manning, 2);
+
     mEpsilon = rGeometry.Length() * rProcessInfo[RELATIVE_DRY_HEIGHT];
-}
-
-double ManningLaw::CalculateLHS(const double& rHeight, const array_1d<double,3>& rVelocity)
-{
-    const double inv_height = ShallowWaterUtilities().InverseHeight(rHeight, mEpsilon);
-    return mManning2 * norm_2(rVelocity) * std::pow(inv_height, 4.0 / 3.0);
-}
-
-array_1d<double,3> ManningLaw::CalculateRHS(const double& rHeight, const array_1d<double,3>& rVelocity)
-{
-    return rVelocity * CalculateLHS(rHeight, rVelocity);
 }
 
 }  // namespace Kratos

--- a/applications/ShallowWaterApplication/custom_friction_laws/nodal_manning_law.cpp
+++ b/applications/ShallowWaterApplication/custom_friction_laws/nodal_manning_law.cpp
@@ -25,6 +25,14 @@
 namespace Kratos
 {
 
+NodalManningLaw::NodalManningLaw(
+    const GeometryType& rGeometry,
+    const Properties& rProperty,
+    const ProcessInfo& rProcessInfo)
+{
+    this->Initialize(rGeometry, rProperty, rProcessInfo);
+}
+
 void NodalManningLaw::Initialize(
     const GeometryType& rGeometry,
     const Properties& rProperty,

--- a/applications/ShallowWaterApplication/custom_friction_laws/nodal_manning_law.h
+++ b/applications/ShallowWaterApplication/custom_friction_laws/nodal_manning_law.h
@@ -70,6 +70,14 @@ public:
     NodalManningLaw() {}
 
     /**
+     * @brief Constructor with data
+     */
+    NodalManningLaw(
+        const GeometryType& rGeometry,
+        const Properties& rProperty,
+        const ProcessInfo& rProcessInfo);
+
+    /**
      * @brief Destructor
      */
     virtual ~NodalManningLaw() {}

--- a/applications/ShallowWaterApplication/custom_friction_laws/nodal_manning_law.h
+++ b/applications/ShallowWaterApplication/custom_friction_laws/nodal_manning_law.h
@@ -10,8 +10,8 @@
 //  Main authors:    Miguel Maso Sotomayor
 //
 
-#ifndef KRATOS_MANNING_LAW_H_INCLUDED
-#define KRATOS_MANNING_LAW_H_INCLUDED
+#ifndef KRATOS_NODAL_MANNING_LAW_H_INCLUDED
+#define KRATOS_NODAL_MANNING_LAW_H_INCLUDED
 
 
 // System includes
@@ -21,14 +21,11 @@
 
 
 // Project includes
-#include "friction_law.h"
+#include "manning_law.h"
 
 
 namespace Kratos
 {
-///@addtogroup ShallowWaterApplication
-///@{
-
 ///@name Kratos Globals
 ///@{
 
@@ -49,30 +46,33 @@ namespace Kratos
 ///@{
 
 
-/** 
- * @class ManningLaw
+/**
+ * @class NodalManningLaw
  * @ingroup ShallowWaterApplication
- * @brief The base class for the bottom and surface friction laws
- * @details This class computes the bottom friction according to the Manning law
+ * @brief This class computes the bottom friction according to the Manning law
  * @author Miguel Maso Sotomayor
  */
-class ManningLaw : public FrictionLaw
+class NodalManningLaw : public ManningLaw
 {
 public:
     ///@name Type Definitions
     ///@{
 
-    KRATOS_CLASS_POINTER_DEFINITION(ManningLaw);
+    KRATOS_CLASS_POINTER_DEFINITION(NodalManningLaw);
 
     ///@}
     ///@name Life Cycle
     ///@{
 
-    /// Default constructor.
-    ManningLaw() {}
+    /**
+     * @brief Default constructor
+     */
+    NodalManningLaw() {}
 
-    /// Destructor.
-    virtual ~ManningLaw() {}
+    /**
+     * @brief Destructor
+     */
+    virtual ~NodalManningLaw() {}
 
     ///@}
     ///@name Operators
@@ -90,22 +90,6 @@ public:
         const GeometryType& rGeometry,
         const Properties& rProperty,
         const ProcessInfo& rProcessInfo) override;
-
-    /**
-     * @brief Calculate the LHS coefficient for the given data
-     * @param rHeight The layer depth
-     * @param rVector The layer velocity or momentum
-     * @return The LHS coefficient
-     */
-    double CalculateLHS(const double& rHeight, const array_1d<double,3>& rVelocity) override;
-
-    /**
-     * @brief Calculate the RHS coefficient for the given data
-     * @param rHeight The layer depth
-     * @param rVector The layer velocity or momentum
-     * @return The components of the RHS coefficients
-     */
-    array_1d<double,3> CalculateRHS(const double& rHeight, const array_1d<double,3>& rVelocity) override;
 
     ///@}
     ///@name Access
@@ -127,41 +111,36 @@ public:
     std::string Info() const override
     {
         std::stringstream buffer;
-        buffer << "ManningLaw";
+        buffer << "NodalManningLaw";
         return buffer.str();
     }
 
     ///@}
-
-protected:
-
-    ///@name Member variables
+    ///@name Friends
     ///@{
 
-    double mManning2;
-
-    double mEpsilon;
 
     ///@}
 
 private:
 
+    ///@}
     ///@name Un accessible methods
     ///@{
 
     /// Assignment operator.
-    ManningLaw& operator=(ManningLaw const& rOther)
+    NodalManningLaw& operator=(NodalManningLaw const& rOther)
     {
         return *this;
     }
 
     /// Copy constructor.
-    ManningLaw(ManningLaw const& rOther) {}
+    NodalManningLaw(NodalManningLaw const& rOther) {}
 
 
     ///@}
 
-}; // Class ManningLaw
+}; // Class NodalManningLaw
 
 ///@}
 
@@ -175,7 +154,7 @@ private:
 
 /// output stream function
 inline std::ostream& operator << (std::ostream& rOStream,
-                const ManningLaw& rThis)
+                const NodalManningLaw& rThis)
 {
     rThis.PrintInfo(rOStream);
     rOStream << std::endl;
@@ -186,8 +165,6 @@ inline std::ostream& operator << (std::ostream& rOStream,
 
 ///@}
 
-///@} addtogroup block
-
 }  // namespace Kratos.
 
-#endif // KRATOS_MANNING_LAW_H_INCLUDED  defined
+#endif // KRATOS_NODAL_MANNING_LAW_H_INCLUDED  defined

--- a/applications/ShallowWaterApplication/custom_friction_laws/wind_water_friction.cpp
+++ b/applications/ShallowWaterApplication/custom_friction_laws/wind_water_friction.cpp
@@ -24,6 +24,14 @@
 namespace Kratos
 {
 
+WindWaterFriction::WindWaterFriction(
+    const GeometryType& rGeometry,
+    const Properties& rProperty,
+    const ProcessInfo& rProcessInfo)
+{
+    this->Initialize(rGeometry, rProperty, rProcessInfo);
+}
+
 void WindWaterFriction::Initialize(
     const GeometryType& rGeometry,
     const Properties& rProperty,

--- a/applications/ShallowWaterApplication/custom_friction_laws/wind_water_friction.cpp
+++ b/applications/ShallowWaterApplication/custom_friction_laws/wind_water_friction.cpp
@@ -24,7 +24,10 @@
 namespace Kratos
 {
 
-void WindWaterFriction::Initialize(const GeometryType& rGeometry, const ProcessInfo& rProcessInfo)
+void WindWaterFriction::Initialize(
+    const GeometryType& rGeometry,
+    const Properties& rProperty,
+    const ProcessInfo& rProcessInfo)
 {
     mAirDensity = rProcessInfo[DENSITY_AIR];
     mWaterDensity = rProcessInfo[DENSITY];

--- a/applications/ShallowWaterApplication/custom_friction_laws/wind_water_friction.h
+++ b/applications/ShallowWaterApplication/custom_friction_laws/wind_water_friction.h
@@ -57,10 +57,22 @@ public:
     ///@name Life Cycle
     ///@{
 
-    /// Default constructor.
+    /**
+     * @brief Default Constructor
+     */
     WindWaterFriction() {}
 
-    /// Destructor.
+    /**
+     * @brief Constructor with data
+     */
+    WindWaterFriction(
+        const GeometryType& rGeometry,
+        const Properties& rProperty,
+        const ProcessInfo& rProcessInfo);
+
+    /**
+     * @brief Destructor
+     */
     virtual ~WindWaterFriction() {}
 
     ///@}

--- a/applications/ShallowWaterApplication/custom_friction_laws/wind_water_friction.h
+++ b/applications/ShallowWaterApplication/custom_friction_laws/wind_water_friction.h
@@ -27,9 +27,6 @@
 
 namespace Kratos
 {
-///@addtogroup ShallowWaterApplication
-///@{
-
 ///@name Kratos Globals
 ///@{
 
@@ -38,17 +35,8 @@ namespace Kratos
 ///@{
 
 ///@}
-///@name  Enum's
-///@{
-
-///@}
-///@name  Functions
-///@{
-
-///@}
 ///@name Kratos Classes
 ///@{
-
 
 /** 
  * @class WindWaterFriction
@@ -76,11 +64,6 @@ public:
     virtual ~WindWaterFriction() {}
 
     ///@}
-    ///@name Operators
-    ///@{
-
-
-    ///@}
     ///@name Operations
     ///@{
 
@@ -94,33 +77,17 @@ public:
 
     /**
      * @brief Calculate the LHS coefficient for the given data
-     * @param rHeight The layer depth
-     * @param rVector The layer velocity or momentum
+     * @param rVector The layer velocity
      * @return The LHS coefficient
      */
-    double CalculateLHS(
-        const array_1d<double,3>& rInnerVelocity,
-        const array_1d<double,3>& rOuterVelocity) override;
+    double CalculateLHS(const array_1d<double,3>& rVelocity) override;
 
     /**
      * @brief Calculate the RHS coefficient for the given data
-     * @param rHeight The layer depth
-     * @param rVector The layer velocity or momentum
+     * @param rVector The layer velocity
      * @return The components of the RHS coefficients
      */
-    array_1d<double,3> CalculateRHS(
-        const array_1d<double,3>& rInnerVelocity,
-        const array_1d<double,3>& rOuterVelocity) override;
-
-    ///@}
-    ///@name Access
-    ///@{
-
-
-    ///@}
-    ///@name Inquiry
-    ///@{
-
+    array_1d<double,3> CalculateRHS(const array_1d<double,3>& rVelocity) override;
 
     ///@}
     ///@name Input and output
@@ -135,24 +102,6 @@ public:
         buffer << "WindWaterFriction";
         return buffer.str();
     }
-    
-    /**
-     * @brief Print information about this object.
-     */
-    void PrintInfo(std::ostream& rOStream) const override
-    {
-        rOStream << "WindWaterFriction";
-    }
-
-    /**
-     * @brief Print object's data.
-     */
-    void PrintData(std::ostream& rOStream) const override {}
-
-    ///@}
-    ///@name Friends
-    ///@{
-
 
     ///@}
 
@@ -163,6 +112,7 @@ private:
 
     double mAirDensity;
     double mWaterDensity;
+    array_1d<double,3> mWind;
 
     ///@}
     ///@name Un accessible methods
@@ -176,7 +126,6 @@ private:
 
     /// Copy constructor.
     WindWaterFriction(WindWaterFriction const& rOther) {}
-
 
     ///@}
 
@@ -204,8 +153,6 @@ inline std::ostream& operator << (std::ostream& rOStream,
 }
 
 ///@}
-
-///@} addtogroup block
 
 }  // namespace Kratos.
 

--- a/applications/ShallowWaterApplication/custom_friction_laws/wind_water_friction.h
+++ b/applications/ShallowWaterApplication/custom_friction_laws/wind_water_friction.h
@@ -89,6 +89,7 @@ public:
      */
     void Initialize(
         const GeometryType& rGeometry,
+        const Properties& rProperty,
         const ProcessInfo& rProcessInfo) override;
 
     /**

--- a/applications/ShallowWaterApplication/tests/elements_tests/square_domain.mdpa
+++ b/applications/ShallowWaterApplication/tests/elements_tests/square_domain.mdpa
@@ -1,7 +1,7 @@
 Begin Properties 0
 End Properties
 Begin Properties 1
-  MANNING 0.004
+  MANNING 0.0
 End Properties
 
 Begin Nodes


### PR DESCRIPTION
**Description**
Refactor the friction laws. Now the friction laws selection is more modular and the python solver is more standard.
This is a partial work before deleting the custom_problemtype.

**Changelog**
- Refactor friction laws
- Add import materials method to the base solver
