### PR TITLE
[MLMC] Move serial serialization within a task

### DIFF
--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/KratosSolverWrapper.py
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/KratosSolverWrapper.py
@@ -479,7 +479,7 @@ class KratosSolverWrapper(sw.SolverWrapper):
         else:
             if parameters["problem_data"]["parallel_type"].GetString()=="MPI":
                 raise(Exception("Kratos is set in MPI but XMC is not!"))
-            serialized_model, pickled_model = mds.SerializeSerialModel(pickled_project_parameters_tmp, self.wrapper.GetModelPartName(), self.fake_sample_to_serialize, self.analysis)
+            serialized_model, pickled_model = mds.SerializeSerialModel_Task(pickled_project_parameters_tmp, self.wrapper.GetModelPartName(), self.fake_sample_to_serialize, self.analysis)
         # append to attribute
         self.serialized_model.append(serialized_model)
         self.pickled_model.append(pickled_model)
@@ -579,7 +579,7 @@ class KratosSolverWrapper(sw.SolverWrapper):
             else:
                 if parameters["problem_data"]["parallel_type"].GetString()=="MPI":
                     raise(Exception("Kratos is set in MPI but XMC is not!"))
-                serialized_model, pickled_model = mds.SerializeSerialModel(pickled_project_parameters, self.wrapper.GetModelPartName(), self.fake_sample_to_serialize, self.analysis)
+                serialized_model, pickled_model = mds.SerializeSerialModel_Task(pickled_project_parameters, self.wrapper.GetModelPartName(), self.fake_sample_to_serialize, self.analysis)
                 self.serialized_model.append(serialized_model)
             # append to attribute
             self.pickled_model.append(pickled_model)

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/KratosSolverWrapper.py
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/KratosSolverWrapper.py
@@ -425,33 +425,6 @@ class KratosSolverWrapper(sw.SolverWrapper):
         self.is_model_pickled = True
 
 
-    def SerializeSerialModel(self, parameters):
-        """
-        Method serializing and pickling the Kratos Model and the Kratos Parameters of the problem. It builds self.pickled_model and self.pickled_project_parameters. It is called if we are not runnnig in MPI.
-
-        Inputs:
-
-
-        parameters: KratosMultiphysics.ProjectParameters object.
-            It contains the settings of the simulation.
-        """
-        # prepare the model to serialize
-        model = KratosMultiphysics.Model()
-        fake_sample = self.fake_sample_to_serialize
-        simulation = self.analysis(model,parameters,fake_sample)
-        simulation.Initialize()
-        # reset general flags
-        main_model_part_name = self.wrapper.GetModelPartName()
-        simulation.model.GetModelPart(main_model_part_name).ProcessInfo.SetValue(KratosMultiphysics.IS_RESTARTED,True)
-        # serialize model
-        serialized_model = KratosMultiphysics.MpiSerializer()
-        serialized_model.Save("ModelSerialization",simulation.model)
-        self.serialized_model.append(serialized_model)
-        # pickle dataserialized_data
-        pickled_model = pickle.dumps(serialized_model, 2) # second argument is the protocol and is NECESSARY (according to pybind11 docs)
-        return pickled_model
-
-
     def SerializeModelParametersStochasticAdaptiveRefinement(self):
         """
         Method serializing and pickling the Kratos Model and the Kratos Parameters of the problem. It builds self.pickled_model and self.pickled_project_parameters. To be called if the selected refinement strategy is stochastic_adaptive_refinement.
@@ -506,8 +479,9 @@ class KratosSolverWrapper(sw.SolverWrapper):
         else:
             if parameters["problem_data"]["parallel_type"].GetString()=="MPI":
                 raise(Exception("Kratos is set in MPI but XMC is not!"))
-            pickled_model = self.SerializeSerialModel(parameters)
+            serialized_model, pickled_model = mds.SerializeSerialModel(pickled_project_parameters_tmp, self.wrapper.GetModelPartName(), self.fake_sample_to_serialize, self.analysis)
         # append to attribute
+        self.serialized_model.append(serialized_model)
         self.pickled_model.append(pickled_model)
 
         # remove temporary objects created for MPI serialization
@@ -605,7 +579,8 @@ class KratosSolverWrapper(sw.SolverWrapper):
             else:
                 if parameters["problem_data"]["parallel_type"].GetString()=="MPI":
                     raise(Exception("Kratos is set in MPI but XMC is not!"))
-                pickled_model = self.SerializeSerialModel(parameters)
+                serialized_model, pickled_model = mds.SerializeSerialModel(pickled_project_parameters, self.wrapper.GetModelPartName(), self.fake_sample_to_serialize, self.analysis)
+                self.serialized_model.append(serialized_model)
             # append to attribute
             self.pickled_model.append(pickled_model)
             if self.is_mpi:
@@ -725,3 +700,4 @@ class KratosSolverWrapper(sw.SolverWrapper):
 
         """
         return len(self.qoi_estimator)
+

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/KratosSolverWrapper.py
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/KratosSolverWrapper.py
@@ -480,8 +480,8 @@ class KratosSolverWrapper(sw.SolverWrapper):
             if parameters["problem_data"]["parallel_type"].GetString()=="MPI":
                 raise(Exception("Kratos is set in MPI but XMC is not!"))
             serialized_model, pickled_model = mds.SerializeSerialModel_Task(pickled_project_parameters_tmp, self.wrapper.GetModelPartName(), self.fake_sample_to_serialize, self.analysis)
-        # append to attribute
-        self.serialized_model.append(serialized_model)
+            # append to attribute
+            self.serialized_model.append(serialized_model) # this only for non-MPI parallelism, since a serialized_model cannot be retrieved in MPI
         self.pickled_model.append(pickled_model)
 
         # remove temporary objects created for MPI serialization
@@ -580,7 +580,7 @@ class KratosSolverWrapper(sw.SolverWrapper):
                 if parameters["problem_data"]["parallel_type"].GetString()=="MPI":
                     raise(Exception("Kratos is set in MPI but XMC is not!"))
                 serialized_model, pickled_model = mds.SerializeSerialModel_Task(pickled_project_parameters, self.wrapper.GetModelPartName(), self.fake_sample_to_serialize, self.analysis)
-                self.serialized_model.append(serialized_model)
+                self.serialized_model.append(serialized_model) # this only for non-MPI parallelism, since a serialized_model cannot be retrieved in MPI
             # append to attribute
             self.pickled_model.append(pickled_model)
             if self.is_mpi:

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/methodDefs_KratosSolverWrapper/solve.py
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/methodDefs_KratosSolverWrapper/solve.py
@@ -119,7 +119,7 @@ def executeInstanceReadingFromFile_Wrapper(current_index,pickled_model,pickled_p
 
 @constraint(computing_units=computing_units_mlmc_execute_0)
 @task(keep=True,returns=2)
-def SerializeSerialModel(pickled_parameters, main_model_part_name, fake_sample_to_serialize, analysis):
+def SerializeSerialModel_Task(pickled_parameters, main_model_part_name, fake_sample_to_serialize, analysis):
     """
     Function serializing and pickling the Kratos Model of the problem. It builds pickled_model and serialized_model. It is called if we are not runnnig in MPI.
 


### PR DESCRIPTION
**Description**
As commented in [this issue](https://gitlab.com/RiccardoRossi/exaqute-xmc/-/issues/64), we move the serial serialization within a task. This should solve the issue @marcnunezc is facing.

Please mark the PR with appropriate tags: 
- Bugfix

**Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Moved serial serialization within a task.
