### PR TITLE
[Mapping] clean searching

### DIFF
--- a/applications/MappingApplication/custom_mappers/interpolative_mapper_base.h
+++ b/applications/MappingApplication/custom_mappers/interpolative_mapper_base.h
@@ -105,7 +105,6 @@ public:
 
         KRATOS_WARNING_IF("Mapper", mMapperSettings["use_initial_configuration"].GetBool()) << "Updating the interface while using the initial configuration for mapping!" << std::endl;
 
-        // Set the Flags according to the type of remeshing
         if (MappingOptions.Is(MapperFlags::REMESHED)) {
             InitializeInterface(MappingOptions);
         }
@@ -295,19 +294,19 @@ private:
         KRATOS_CATCH("");
     }
 
-    void InitializeInterface(Kratos::Flags MappingOptions = Kratos::Flags())
+    void InitializeInterface()
     {
         KRATOS_TRY;
 
         CreateMapperLocalSystems(mrModelPartDestination.GetCommunicator(),
-                                mMapperLocalSystems);
+                                 mMapperLocalSystems);
 
-        BuildMappingMatrix(MappingOptions);
+        BuildMappingMatrix();
 
         KRATOS_CATCH("");
     }
 
-    void BuildMappingMatrix(Kratos::Flags MappingOptions = Kratos::Flags())
+    void BuildMappingMatrix()
     {
         KRATOS_TRY;
 
@@ -328,8 +327,7 @@ private:
         const MapperInterfaceInfoUniquePointerType p_ref_interface_info = GetMapperInterfaceInfo();
 
         mpIntefaceCommunicator->ExchangeInterfaceData(mrModelPartDestination.GetCommunicator(),
-                                                    MappingOptions,
-                                                    p_ref_interface_info);
+                                                      p_ref_interface_info);
 
         const int echo_level = mMapperSettings["echo_level"].GetInt();
 

--- a/applications/MappingApplication/custom_mappers/interpolative_mapper_base.h
+++ b/applications/MappingApplication/custom_mappers/interpolative_mapper_base.h
@@ -271,7 +271,7 @@ private:
     InterfaceVectorContainerPointerType mpInterfaceVectorContainerOrigin;
     InterfaceVectorContainerPointerType mpInterfaceVectorContainerDestination;
 
-    bool mMeshesAreConforming = false;
+    int mMeshesAreConforming = false;
 
     ///@}
     ///@name Private Operations

--- a/applications/MappingApplication/custom_mappers/interpolative_mapper_base.h
+++ b/applications/MappingApplication/custom_mappers/interpolative_mapper_base.h
@@ -105,12 +105,7 @@ public:
 
         KRATOS_WARNING_IF("Mapper", mMapperSettings["use_initial_configuration"].GetBool()) << "Updating the interface while using the initial configuration for mapping!" << std::endl;
 
-        if (MappingOptions.Is(MapperFlags::REMESHED)) {
-            InitializeInterface(MappingOptions);
-        }
-        else {
-            BuildMappingMatrix(MappingOptions);
-        }
+        Initialize();
 
         if (mpInverseMapper) {
             mpInverseMapper->UpdateInterface(MappingOptions,
@@ -200,7 +195,7 @@ public:
     int AreMeshesConforming() const override
     {
         KRATOS_WARNING_ONCE("Mapper") << "Developer-warning: \"AreMeshesConforming\" is deprecated and will be removed in the future" << std::endl;
-        return mpIntefaceCommunicator->AreMeshesConforming();
+        return mMeshesAreConforming;
     }
 
     ///@}
@@ -237,8 +232,7 @@ protected:
     {
         KRATOS_TRY;
 
-        InitializeInterfaceCommunicator();
-        InitializeInterface();
+        BuildMappingMatrix();
 
         KRATOS_CATCH("");
     }
@@ -274,41 +268,21 @@ private:
 
     MapperLocalSystemPointerVector mMapperLocalSystems;
 
-    InterfaceCommunicatorPointerType mpIntefaceCommunicator;
     InterfaceVectorContainerPointerType mpInterfaceVectorContainerOrigin;
     InterfaceVectorContainerPointerType mpInterfaceVectorContainerDestination;
+
+    bool mMeshesAreConforming = false;
 
     ///@}
     ///@name Private Operations
     ///@{
 
-    void InitializeInterfaceCommunicator()
-    {
-        KRATOS_TRY;
-
-        mpIntefaceCommunicator = Kratos::make_unique<InterfaceCommunicatorType>(
-            mrModelPartOrigin,
-            mMapperLocalSystems,
-            mMapperSettings);
-
-        KRATOS_CATCH("");
-    }
-
-    void InitializeInterface()
+    void BuildMappingMatrix()
     {
         KRATOS_TRY;
 
         CreateMapperLocalSystems(mrModelPartDestination.GetCommunicator(),
                                  mMapperLocalSystems);
-
-        BuildMappingMatrix();
-
-        KRATOS_CATCH("");
-    }
-
-    void BuildMappingMatrix()
-    {
-        KRATOS_TRY;
 
         const bool use_initial_configuration = mMapperSettings["use_initial_configuration"].GetBool();
 
@@ -322,12 +296,18 @@ private:
 
         AssignInterfaceEquationIds(); // Has to be done ever time in case of overlapping interfaces!
 
-        KRATOS_ERROR_IF_NOT(mpIntefaceCommunicator) << "mpIntefaceCommunicator is a nullptr!" << std::endl;
+        auto p_interface_comm = Kratos::make_unique<InterfaceCommunicatorType>(
+            mrModelPartOrigin,
+            mMapperLocalSystems,
+            mMapperSettings);
 
         const MapperInterfaceInfoUniquePointerType p_ref_interface_info = GetMapperInterfaceInfo();
 
-        mpIntefaceCommunicator->ExchangeInterfaceData(mrModelPartDestination.GetCommunicator(),
+        p_interface_comm->ExchangeInterfaceData(mrModelPartDestination.GetCommunicator(),
                                                       p_ref_interface_info);
+
+        // ugly hack until this function can be removed
+        mMeshesAreConforming = p_interface_comm->AreMeshesConforming();
 
         const int echo_level = mMapperSettings["echo_level"].GetInt();
 

--- a/applications/MappingApplication/custom_searching/interface_communicator.cpp
+++ b/applications/MappingApplication/custom_searching/interface_communicator.cpp
@@ -90,16 +90,8 @@ void InterfaceCommunicator::InitializeSearch(const Kratos::Flags& rOptions,
 {
     KRATOS_TRY;
 
-    if (mpInterfaceObjectsOrigin == nullptr || rOptions.Is(MapperFlags::REMESHED)) {
-        CreateInterfaceObjectsOrigin(rpRefInterfaceInfo);
-    }
-    else {
-        UpdateInterfaceObjectsOrigin();
-    }
-
-    if (mpLocalBinStructure == nullptr || !rOptions.Is(MapperFlags::DESTINATION_ONLY)) {
-        InitializeBinsSearchStructure(); // This cannot be updated, has to be recreated
-    }
+    CreateInterfaceObjectsOrigin(rpRefInterfaceInfo);
+    InitializeBinsSearchStructure(); // This cannot be updated, has to be recreated
 
     KRATOS_CATCH("");
 }
@@ -254,20 +246,6 @@ void InterfaceCommunicator::CreateInterfaceObjectsOrigin(const MapperInterfaceIn
     KRATOS_ERROR_IF_NOT(num_interface_objects > 0)
         << "No interface objects were created in Origin-ModelPart \""
         << mrModelPartOrigin.Name() << "\"!" << std::endl;
-
-    KRATOS_CATCH("");
-}
-
-void InterfaceCommunicator::UpdateInterfaceObjectsOrigin()
-{
-    KRATOS_TRY;
-
-    const auto begin = mpInterfaceObjectsOrigin->begin();
-
-    #pragma omp parallel for
-    for (int i = 0; i< static_cast<int>(mpInterfaceObjectsOrigin->size()); ++i) {
-        (*(begin + i))->UpdateCoordinates();
-    }
 
     KRATOS_CATCH("");
 }

--- a/applications/MappingApplication/custom_searching/interface_communicator.cpp
+++ b/applications/MappingApplication/custom_searching/interface_communicator.cpp
@@ -23,15 +23,6 @@
 
 namespace Kratos {
 
-namespace {
-
-bool SearchNotSuccessful(const InterfaceCommunicator::MapperInterfaceInfoPointerType& rpInterfaceInfo)
-{
-    return !(rpInterfaceInfo->GetLocalSearchWasSuccessful());
-}
-
-}
-
 typedef std::size_t IndexType;
 typedef std::size_t SizeType;
 
@@ -152,7 +143,8 @@ void InterfaceCommunicator::FilterInterfaceInfosSuccessfulSearch()
         auto new_end = std::remove_if(
             r_interface_infos_rank.begin(),
             r_interface_infos_rank.end(),
-            SearchNotSuccessful); // cannot use lambda here bcs it is not supported by some older compilers
+            [](const MapperInterfaceInfoPointerType& rpInterfaceInfo)
+            { return !(rpInterfaceInfo->GetLocalSearchWasSuccessful()); });
 
         r_interface_infos_rank.erase(new_end, r_interface_infos_rank.end());
     }

--- a/applications/MappingApplication/custom_searching/interface_communicator.cpp
+++ b/applications/MappingApplication/custom_searching/interface_communicator.cpp
@@ -30,8 +30,7 @@ typedef std::size_t SizeType;
 /* PUBLIC Methods */
 /***********************************************************************************/
 void InterfaceCommunicator::ExchangeInterfaceData(const Communicator& rComm,
-                            const Kratos::Flags& rOptions,
-                            const MapperInterfaceInfoUniquePointerType& rpInterfaceInfo)
+                                                  const MapperInterfaceInfoUniquePointerType& rpInterfaceInfo)
 {
     KRATOS_TRY;
 
@@ -40,7 +39,7 @@ void InterfaceCommunicator::ExchangeInterfaceData(const Communicator& rComm,
 
     const double increase_factor = 4.0;
     int num_iteration = 1;
-    InitializeSearch(rOptions, rpInterfaceInfo);
+    InitializeSearch(rpInterfaceInfo);
 
     // First Iteration is done outside the search loop bcs it has
     // to be done in any case
@@ -49,7 +48,7 @@ void InterfaceCommunicator::ExchangeInterfaceData(const Communicator& rComm,
     // only if some points did not find a neighbor or dont have a valid
     // projection, more search iterations are necessary
     mMeshesAreConforming = 1;
-    ConductSearchIteration(rOptions, rpInterfaceInfo, rComm);
+    ConductSearchIteration(rpInterfaceInfo, rComm);
 
     while (++num_iteration <= max_search_iterations && !AllNeighborsFound(rComm)) {
         mSearchRadius *= increase_factor;
@@ -63,7 +62,7 @@ void InterfaceCommunicator::ExchangeInterfaceData(const Communicator& rComm,
             << "search iteration " << num_iteration << " / "<< max_search_iterations << " | "
             << "search radius " << mSearchRadius << std::endl;
 
-        ConductSearchIteration(rOptions, rpInterfaceInfo, rComm);
+        ConductSearchIteration(rpInterfaceInfo, rComm);
     }
 
     FinalizeSearch();
@@ -76,8 +75,7 @@ void InterfaceCommunicator::ExchangeInterfaceData(const Communicator& rComm,
 /***********************************************************************************/
 /* PROTECTED Methods */
 /***********************************************************************************/
-void InterfaceCommunicator::InitializeSearch(const Kratos::Flags& rOptions,
-                                             const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo)
+void InterfaceCommunicator::InitializeSearch(const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo)
 {
     KRATOS_TRY;
 
@@ -98,8 +96,7 @@ void InterfaceCommunicator::FinalizeSearch()
     KRATOS_CATCH("");
 }
 
-void InterfaceCommunicator::InitializeSearchIteration(const Kratos::Flags& rOptions,
-                                                      const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo)
+void InterfaceCommunicator::InitializeSearchIteration(const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo)
 {
     KRATOS_TRY;
 
@@ -322,13 +319,12 @@ void InterfaceCommunicator::ConductLocalSearch(const Communicator& rComm)
     KRATOS_CATCH("");
 }
 
-void InterfaceCommunicator::ConductSearchIteration(const Kratos::Flags& rOptions,
-                            const MapperInterfaceInfoUniquePointerType& rpInterfaceInfo,
-                            const Communicator& rComm)
+void InterfaceCommunicator::ConductSearchIteration(const MapperInterfaceInfoUniquePointerType& rpInterfaceInfo,
+                                                   const Communicator& rComm)
 {
     KRATOS_TRY;
 
-    InitializeSearchIteration(rOptions, rpInterfaceInfo);
+    InitializeSearchIteration(rpInterfaceInfo);
 
     ConductLocalSearch(rComm);
 

--- a/applications/MappingApplication/custom_searching/interface_communicator.h
+++ b/applications/MappingApplication/custom_searching/interface_communicator.h
@@ -87,7 +87,6 @@ public:
     ///@{
 
     void ExchangeInterfaceData(const Communicator& rComm,
-                               const Kratos::Flags& rOptions,
                                const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo);
 
     ///@}
@@ -143,13 +142,11 @@ protected:
     ///@name Protected Operations
     ///@{
 
-    virtual void InitializeSearch(const Kratos::Flags& rOptions,
-                                        const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo);
+    virtual void InitializeSearch(const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo);
 
     virtual void FinalizeSearch();
 
-    virtual void InitializeSearchIteration(const Kratos::Flags& rOptions,
-                                           const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo);
+    virtual void InitializeSearchIteration(const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo);
 
     virtual void FinalizeSearchIteration(const MapperInterfaceInfoUniquePointerType& rpInterfaceInfo);
 
@@ -172,8 +169,7 @@ private:
     void InitializeBinsSearchStructure();
 
     // this function performs the search and the exchange of the data on the interface
-    void ConductSearchIteration(const Kratos::Flags& rOptions,
-                                const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo,
+    void ConductSearchIteration(const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo,
                                 const Communicator& rComm);
 
     bool AllNeighborsFound(const Communicator& rComm) const;

--- a/applications/MappingApplication/custom_searching/interface_object.h
+++ b/applications/MappingApplication/custom_searching/interface_object.h
@@ -87,11 +87,6 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void UpdateCoordinates()
-    {
-        KRATOS_ERROR << "Base class function called!" << std::endl;
-    }
-
     ///@}
     ///@name Access
     ///@{
@@ -173,11 +168,6 @@ public:
     explicit InterfaceNode(NodePointerType pNode)
         : mpNode(pNode)
     {
-        UpdateCoordinates();
-    }
-
-    void UpdateCoordinates() override
-    {
         noalias(Coordinates()) = mpNode->Coordinates();
     }
 
@@ -210,11 +200,6 @@ public:
 
     explicit InterfaceGeometryObject(GeometryPointerType pGeometry)
         : mpGeometry(pGeometry)
-    {
-        UpdateCoordinates();
-    }
-
-    void UpdateCoordinates() override
     {
         noalias(Coordinates()) = mpGeometry->Center();
     }

--- a/applications/MappingApplication/mpi_extension/custom_searching/interface_communicator_mpi.cpp
+++ b/applications/MappingApplication/mpi_extension/custom_searching/interface_communicator_mpi.cpp
@@ -57,17 +57,15 @@ InterfaceCommunicatorMPI::InterfaceCommunicatorMPI(ModelPart& rModelPartOrigin,
 /***********************************************************************************/
 /* PROTECTED Methods */
 /***********************************************************************************/
-void InterfaceCommunicatorMPI::InitializeSearch(const Kratos::Flags& rOptions,
-                                                const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo)
+void InterfaceCommunicatorMPI::InitializeSearch(const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo)
 {
-    InterfaceCommunicator::InitializeSearch(rOptions, rpRefInterfaceInfo);
+    InterfaceCommunicator::InitializeSearch(rpRefInterfaceInfo);
 
     // Exchange Bounding Boxes => has to be done every time
     ComputeGlobalBoundingBoxes();
 }
 
-void InterfaceCommunicatorMPI::InitializeSearchIteration(const Kratos::Flags& rOptions,
-                                                         const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo)
+void InterfaceCommunicatorMPI::InitializeSearchIteration(const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo)
 {
     // Reset to zero
     std::fill(mSendSizes.begin(), mSendSizes.end(), 0);

--- a/applications/MappingApplication/mpi_extension/custom_searching/interface_communicator_mpi.h
+++ b/applications/MappingApplication/mpi_extension/custom_searching/interface_communicator_mpi.h
@@ -88,14 +88,12 @@ protected:
     ///@name Protected Operations
     ///@{
 
-    void InitializeSearch(const Kratos::Flags& rOptions,
-                          const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo) override;
+    void InitializeSearch(const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo) override;
 
     // This function constructs the InterfaceObjects on the Destination
     // In serial it only does it once, whereas in MPI this involves Data-Exchange!
     // Imagine a sliding interface, there the partitions might change!
-    void InitializeSearchIteration(const Kratos::Flags& rOptions,
-                                   const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo) override;
+    void InitializeSearchIteration(const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo) override;
 
     void FinalizeSearchIteration(const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo) override;
 

--- a/applications/MappingApplication/tests/cpp_tests/test_interface_object.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_interface_object.cpp
@@ -28,9 +28,6 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceGeometryObject, KratosMappingApplicationSeria
 
     InterfaceObject interface_obj(init_coords);
 
-    KRATOS_CHECK_EXCEPTION_IS_THROWN(interface_obj.UpdateCoordinates(),
-        "Error: Base class function called!");
-
     KRATOS_CHECK_EXCEPTION_IS_THROWN(interface_obj.pGetBaseNode(),
         "Error: Base class function called!");
 
@@ -65,15 +62,6 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceNode, KratosMappingApplicationSerialTestSuite
     for (std::size_t i=0; i<3; ++i)
         KRATOS_CHECK_DOUBLE_EQUAL(p_interface_obj->Coordinates()[i], coords[i]);
 
-    Point new_coords(18.3, -89.123, 125.7);
-
-    noalias(node_1->Coordinates()) = new_coords;
-
-    p_interface_obj->UpdateCoordinates();
-
-    for (std::size_t i=0; i<3; ++i)
-        KRATOS_CHECK_DOUBLE_EQUAL(p_interface_obj->Coordinates()[i], new_coords[i]);
-
     KRATOS_CHECK_EQUAL(*(p_interface_obj->pGetBaseNode()), *node_1);
 }
 
@@ -97,26 +85,6 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceObject, KratosMappingApplicationSerialTestSui
 
     for (std::size_t i=0; i<3; ++i)
         KRATOS_CHECK_DOUBLE_EQUAL(p_interface_obj->Coordinates()[i], center_coords[i]);
-
-    p_point1->X() -= 2.5;
-    p_point2->X() -= 2.5;
-    p_point3->X() -= 2.5;
-    p_point4->X() -= 2.5;
-
-    p_point1->Y() += 2.0;
-    p_point4->Y() += 2.0;
-
-    p_point1->Z() = 2.0;
-    p_point2->Z() = 2.0;
-    p_point3->Z() = 2.0;
-    p_point4->Z() = 2.0;
-
-    Point new_center_coords(2.5, 6.0, 2.0);
-
-    p_interface_obj->UpdateCoordinates();
-
-    for (std::size_t i=0; i<3; ++i)
-        KRATOS_CHECK_DOUBLE_EQUAL(p_interface_obj->Coordinates()[i], new_center_coords[i]);
 
     // KRATOS_CHECK_EQUAL(*(p_interface_obj->pGetBaseGeometry()), *p_quad); // does not compile ...
 }


### PR DESCRIPTION
Some minor refactoring and cleaning

Important change is that now I no longer save the search structure but recompute it every time I need it (i.e. when `UpdateInterface` is called, which usually doesn't happen)
This way I can simplify the code a lot and save memory!