### PR TITLE
[Core][ParUtils] fix when less MaxThreads is allocated

### DIFF
--- a/kratos/utilities/parallel_utilities.h
+++ b/kratos/utilities/parallel_utilities.h
@@ -129,7 +129,7 @@ class BlockPartition
 public:
     /** @param it_begin - iterator pointing at the beginning of the container
      *  @param it_end - iterator pointing to the end of the container
-     *  @param Nchunks - number of threads to be used in the loop (must be lower than TMaxThreads)
+     *  @param Nchunks - number of threads to be used in the loop
      */
     BlockPartition(TIteratorType it_begin,
                    TIteratorType it_end,
@@ -142,8 +142,7 @@ public:
         if (size_container == 0) {
             mNchunks = Nchunks;
         } else {
-            // in case the container is smaller than the number of chunks
-            mNchunks = std::min(static_cast<int>(size_container), Nchunks);
+            mNchunks = std::min(static_cast<int>(size_container), std::min(TMaxThreads, Nchunks));
         }
         const std::ptrdiff_t block_partition_size = size_container / mNchunks;
         mBlockPartition[0] = it_begin;
@@ -312,7 +311,7 @@ public:
 
 /** @brief constructor using the size of the partition to be used
  *  @param Size - the size of the partition
- *  @param Nchunks - number of threads to be used in the loop (must be lower than TMaxThreads)
+ *  @param Nchunks - number of threads to be used in the loop
  */
     IndexPartition(TIndexType Size,
                    int Nchunks = ParallelUtilities::GetNumThreads())
@@ -322,8 +321,7 @@ public:
         if (Size == 0) {
             mNchunks = Nchunks;
         } else {
-            // in case the container is smaller than the number of chunks
-            mNchunks = std::min(static_cast<int>(Size), Nchunks);
+            mNchunks = std::min(static_cast<int>(Size), std::min(TMaxThreads, Nchunks));
         }
 
         const int block_partition_size = Size / mNchunks;


### PR DESCRIPTION
Currently the loops in the `parallel_utilities` segfault when they are allocated with less Max Threads than threads they are then later used with:
~~~c++
constexpr int max_threads = 1;
IndexPartition<std::size_t, max_threads>(1000).for_each(...) // boom as this uses all threads by default
~~~

In my proposal I am considering this case, i.e. if I know at compiletime how many threads I want to use. 

ALTERNATIVELY we can throw an error at runtime (then the comment that  I removed can stay)
Not sure what is better, since I don't know if this was deliberately designed like this