### PR TITLE
[Structural] Postprocess: Fix sign error in M-Z calculation for 3D linear beam

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_linear_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_linear_3D2N.cpp
@@ -252,9 +252,9 @@ void CrBeamElementLinear3D2N::CalculateOnIntegrationPoints(
         rOutput[1][1] = -1.0 * stress[4] * 0.50 + stress[10] * 0.50;
         rOutput[2][1] = -1.0 * stress[4] * 0.25 + stress[10] * 0.75;
 
-        rOutput[0][2] = 1.0 * stress[5] * 0.75 - stress[11] * 0.25;
-        rOutput[1][2] = 1.0 * stress[5] * 0.50 - stress[11] * 0.50;
-        rOutput[2][2] = 1.0 * stress[5] * 0.25 - stress[11] * 0.75;
+        rOutput[0][2] = -1.0 * stress[5] * 0.75 + stress[11] * 0.25;
+        rOutput[1][2] = -1.0 * stress[5] * 0.50 + stress[11] * 0.50;
+        rOutput[2][2] = -1.0 * stress[5] * 0.25 + stress[11] * 0.75;
     }
     if (rVariable == FORCE) {
         rOutput[0][0] = -1.0 * stress[0] * 0.75 + stress[6] * 0.25;

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_cr_beam.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_cr_beam.py
@@ -612,12 +612,12 @@ class StaticPatchTestBeam3D2N(BasePatchTestCrBeam3D2N):
 
         out1 = mp.Elements[1].CalculateOnIntegrationPoints(KratosMultiphysics.MOMENT,mp.ProcessInfo)
         out2 = mp.Elements[2].CalculateOnIntegrationPoints(KratosMultiphysics.MOMENT,mp.ProcessInfo)
-        self.assertAlmostEqual(out1[0][2], 165000.0)
-        self.assertAlmostEqual(out1[1][2], 110000.0)
-        self.assertAlmostEqual(out1[2][2], 55000.0)
-        self.assertAlmostEqual(out2[2][2], 165000.0)
-        self.assertAlmostEqual(out2[1][2], 110000.0)
-        self.assertAlmostEqual(out2[0][2], 55000.0)
+        self.assertAlmostEqual(out1[0][2], -165000.0)
+        self.assertAlmostEqual(out1[1][2], -110000.0)
+        self.assertAlmostEqual(out1[2][2], -55000.0)
+        self.assertAlmostEqual(out2[2][2], -165000.0)
+        self.assertAlmostEqual(out2[1][2], -110000.0)
+        self.assertAlmostEqual(out2[0][2], -55000.0)
 
 
 class BasePatchTestCrBeam2D2N(KratosUnittest.TestCase):


### PR DESCRIPTION
Similar to #9183 this PR fixes the postprocessing of the moment around the local z-axis for the **linear** 3D beam element.