### PR TITLE
[Mapping] adding more deprecation warnings

### DIFF
--- a/applications/MappingApplication/MappingApplication.py
+++ b/applications/MappingApplication/MappingApplication.py
@@ -1,33 +1,43 @@
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
-from KratosMultiphysics import Mapper, MapperFactory # for backward compatibility
+from KratosMultiphysics import Mapper as _CoreMapper
+from KratosMultiphysics import MapperFactory as _CoreMapperFactory
 from KratosMappingApplication import *
 application = KratosMappingApplication()
 application_name = "KratosMappingApplication"
 
 _ImportApplication(application, application_name)
 
-
-# hack for backward compatibility
+# hacks for backward compatibility
 from KratosMultiphysics.kratos_utilities import IssueDeprecationWarning
-def CreateMPIMapper(*args):
-    IssueDeprecationWarning("MappingApplication", 'CreateMPIMapper is deprecated, please use "MappingApplication.MPIExtension.MPIMapperFactory.CreateMapper" instead')
-    from KratosMultiphysics.MappingApplication.MPIExtension import MPIMapperFactory
-    return MPIMapperFactory.CreateMapper(*args)
 
-def HasMPIMapper(*args):
-    IssueDeprecationWarning("MappingApplication", 'HasMPIMapper is deprecated, please use "MappingApplication.MPIExtension.MPIMapperFactory.HasMapper" instead')
-    from KratosMultiphysics.MappingApplication.MPIExtension import MPIMapperFactory
-    return MPIMapperFactory.HasMapper(*args)
+class _DeprecatedMapper:
+    def __getattribute__(self, method_name):
+        IssueDeprecationWarning("MappingApplication", 'The "Mapper" was moved to the Core! (used for "{}")'.format(method_name))
+        return getattr(_CoreMapper, method_name)
 
-def GetRegisteredMPIMapperNames(*args):
-    IssueDeprecationWarning("MappingApplication", 'GetRegisteredMPIMapperNames is deprecated, please use "MappingApplication.MPIExtension.MPIMapperFactory.GetRegisteredMapperNames" instead')
-    from KratosMultiphysics.MappingApplication.MPIExtension import MPIMapperFactory
-    return MPIMapperFactory.GetRegisteredMapperNames(*args)
+class _DeprecatedMapperFactory:
+    def __getattr__(self, method_name):
+        IssueDeprecationWarning("MappingApplication", 'The "MapperFactory" was moved to the Core! (used for "{}")'.format(method_name))
+        return getattr(_CoreMapperFactory, method_name)
 
-setattr(MapperFactory, 'CreateMPIMapper', CreateMPIMapper)
-setattr(MapperFactory, 'HasMPIMapper', HasMPIMapper)
-setattr(MapperFactory, 'GetRegisteredMPIMapperNames', GetRegisteredMPIMapperNames)
+    def CreateMPIMapper(self, *args):
+        IssueDeprecationWarning("MappingApplication", 'CreateMPIMapper is deprecated, please use "MappingApplication.MPIExtension.MPIMapperFactory.CreateMapper" instead')
+        from KratosMultiphysics.MappingApplication.MPIExtension import MPIMapperFactory
+        return MPIMapperFactory.CreateMapper(*args)
+
+    def HasMPIMapper(self, *args):
+        IssueDeprecationWarning("MappingApplication", 'HasMPIMapper is deprecated, please use "MappingApplication.MPIExtension.MPIMapperFactory.HasMapper" instead')
+        from KratosMultiphysics.MappingApplication.MPIExtension import MPIMapperFactory
+        return MPIMapperFactory.HasMapper(*args)
+
+    def GetRegisteredMPIMapperNames(self, *args):
+        IssueDeprecationWarning("MappingApplication", 'GetRegisteredMPIMapperNames is deprecated, please use "MappingApplication.MPIExtension.MPIMapperFactory.GetRegisteredMapperNames" instead')
+        from KratosMultiphysics.MappingApplication.MPIExtension import MPIMapperFactory
+        return MPIMapperFactory.GetRegisteredMapperNames(*args)
+
+Mapper = _DeprecatedMapper()
+MapperFactory = _DeprecatedMapperFactory()
 
 '''
 TODO:
@@ -36,8 +46,6 @@ TODO:
     - Cleanup how the MapperParams are used
     - Further cleanup Trilinos and try some things (read up on opt-stuff)
     - use std::unordered_set for row & column indices-vectors in trilinos => does the map need sorted indices?
-    - For Trilinos: What happens if a rank does not have local nodes???
     - Function-Documentation
     - Delete copy and assignment-constructors?
-    - testing => do some logical tests with USE_TRANSPOSE
 '''


### PR DESCRIPTION
after moving the `Mapper` to the Core in #8979 I realized that I didn't add deprecation warnings for everything
=> using the `Mapper` and the `MapperFactory` don't emit deprecation warnings when used from the MappingApp
This is fixed by this PR