### PR TITLE
[Core] Extend triangle intersections

### DIFF
--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -2131,7 +2131,8 @@ private:
 
         // compute interval for triangle 2 //
         double d, e, f, y0, y1;
-        if (ComputeIntervals(up0, up1, up2, distances_1[0], distances_1[1], distances_1[2], d, e, f, y0, y1) == true)
+        if (ComputeIntervals(up0, up1, up2, distances_1[0], distances_1[1], distances_1[2], d, e, f, y0, y1))
+
         {
             return CoplanarIntersectionCheck(plane_1.GetNormal(), rPoint1, rPoint2, rPoint3);
         }

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -2262,9 +2262,10 @@ private:
 		}
 
 		// test all edges of triangle 1 against the edges of triangle 2 //
-		if (EdgeToTriangleEdgesCheck(i0, i1, this->GetPoint(0), this->GetPoint(1), rPoint1, rPoint2, rPoint3) == true) return true;
-		if (EdgeToTriangleEdgesCheck(i0, i1, this->GetPoint(1), this->GetPoint(2), rPoint1, rPoint2, rPoint3) == true) return true;
-		if (EdgeToTriangleEdgesCheck(i0, i1, this->GetPoint(2), this->GetPoint(0), rPoint1, rPoint2, rPoint3) == true) return true;
+		if (EdgeToTriangleEdgesCheck(i0, i1, this->GetPoint(0), this->GetPoint(1), rPoint1, rPoint2, rPoint3)) return true;
+		if (EdgeToTriangleEdgesCheck(i0, i1, this->GetPoint(1), this->GetPoint(2), rPoint1, rPoint2, rPoint3)) return true;
+		if (EdgeToTriangleEdgesCheck(i0, i1, this->GetPoint(2), this->GetPoint(0), rPoint1, rPoint2, rPoint3)) return true;
+
 
 		// finally, test if tri1 is totally contained in tri2 or vice versa //
         if (PointInTriangle(i0, i1, this->GetPoint(0), rPoint1, rPoint2, rPoint3)) return true;

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -2368,9 +2368,8 @@ private:
         
         if (d0 * d1 > 0.0){
             if (d0 * d2 > 0.0) return true;
-        } else {
-            return false;
         }
+        return false;
     }
 
     /**

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -2080,8 +2080,7 @@ private:
     {
         array_1d<double,3> intersection_point;
         const int result = IntersectionUtilities::ComputeTriangleLineIntersection(*this, rPoint1, rPoint2, intersection_point);
-        if (result == 1) return true;
-        else return false;
+        return result == 1 ? true : false;
     }
 
     bool TriangleTriangleOverlap(

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -2344,10 +2344,10 @@ private:
     bool PointInTriangle(
         int i0,
         int i1,
-        double V0,
-        double U0,
-        double U1,
-        double U2)
+        const array_1d<double,3>& V0,
+        const array_1d<double,3>& U0,
+        const array_1d<double,3>& U1,
+        const array_1d<double,3>& U2)
     {
         double a,b,c,d0,d1,d2;
         /* is T1 completely inside T2? */

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -673,9 +673,9 @@ public:
         double a, f, u, v;
         array_1d<double,3> h, s, q;
         const array_1d<double,3> ray_vector = rLine[1] - rLine[0];
-        const array_1d<double,3> vert0 = this->GetPoint(0);
-        const array_1d<double,3> vert1 = this->GetPoint(1);
-        const array_1d<double,3> vert2 = this->GetPoint(2);
+        const array_1d<double,3>& r_vert0 = this->GetPoint(0);
+        const array_1d<double,3>& r_vert1 = this->GetPoint(1);
+        const array_1d<double,3>& r_vert2 = this->GetPoint(2);
         const array_1d<double,3> edge1 = vert1 - vert0;
         const array_1d<double,3> edge2 = vert2 - vert0;
         h = MathUtils<double>::CrossProduct(ray_vector, edge2);

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -2331,10 +2331,10 @@ private:
 		if ((f>0.00 && d >= 0.00 && d <= f) || (f<0.00 && d <= 0.00 && d >= f)) {
 			e = Ax*Cy - Ay*Cx;
 
-			if (f > 0.0) {
-				if (e >= 0.0 && e <= f) return true;
-			} else {
-				if (e <= 0.0 && e >= f) return true;
+                        if (f > 0.0) {
+                            if (e >= 0.0 && e <= f) return true;
+                        } else {
+                            if (e <= 0.0 && e >= f) return true;
 			}
 		}
 		return false;

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -2167,7 +2167,8 @@ private:
         return true;
     }
 
-	bool ComputeIntervals(double& VV0,
+	bool ComputeIntervals(
+        double& VV0,
 		double& VV1,
 		double& VV2,
 		double& D0,
@@ -2241,7 +2242,7 @@ private:
 		const GeometryType& OtherTriangle)
 	{
 		array_1d<double, 3 > A;
-		short i0, i1;
+		int i0, i1;
 
 		// first project onto an axis-aligned plane, that maximizes the area //
 		// of the triangles, compute indices: i0,i1. //
@@ -2293,8 +2294,9 @@ private:
 		return false;
 	}
 
-	bool EdgeToTriangleEdgesCheck(const short& i0,
-		const short& i1,
+	bool EdgeToTriangleEdgesCheck(
+        const int& i0,
+		const int& i1,
 		const Point& V0,
 		const Point& V1,
 		const Point&U0,
@@ -2321,7 +2323,8 @@ private:
 	//   this edge to edge test is based on Franlin Antonio's gem:
 	//   "Faster Line Segment Intersection", in Graphics Gems III,
 	//   pp. 199-202
-	bool EdgeToEdgeIntersectionCheck(double& Ax,
+	bool EdgeToEdgeIntersectionCheck(
+        double& Ax,
 		double& Ay,
 		double& Bx,
 		double& By,
@@ -2330,8 +2333,8 @@ private:
 		double& e,
 		double& d,
 		double& f,
-		const short& i0,
-		const short& i1,
+		const int& i0,
+		const int& i1,
 		const Point& V0,
 		const Point& U0,
 		const Point& U1)

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -2283,10 +2283,12 @@ private:
 		if (EdgeToTriangleEdgesCheck(i0, i1, this->GetPoint(2), this->GetPoint(0), OtherTriangle[0], OtherTriangle[1], OtherTriangle[2]) == true) return true;
 
 		// finally, test if tri1 is totally contained in tri2 or vice versa //
-		array_1d<double, 3> local_coordinates;
-		// TODO: I should add the const to the is inside method in all geometries. Pooyan.
-		if (const_cast<GeometryType&>(OtherTriangle).IsInside(this->GetPoint(0), local_coordinates) == true) return true;
-		if (IsInside(OtherTriangle[0], local_coordinates) == true) return true;
+        if (PointInTriangle(i0, i1, this->GetPoint(0), OtherTriangle[0], OtherTriangle[1], OtherTriangle[2])) {
+            return true;
+        }
+        else if (PointInTriangle(i0, i1, OtherTriangle[0], this->GetPoint(0), this->GetPoint(1), this->GetPoint(2))) {
+            return true;
+        }
 
 		return false;
 	}
@@ -2361,6 +2363,38 @@ private:
 		return false;
 	}
 
+    bool PointInTriangle(
+        int i0,
+        int i1,
+        double V0,
+        double U0,
+        double U1,
+        double U2)
+    {
+        double a,b,c,d0,d1,d2;
+        /* is T1 completely inside T2? */
+        /* check if V0 is inside tri(U0,U1,U2) */
+        a =   U1[i1] - U0[i1];
+        b = -(U1[i0] - U0[i0]);
+        c = -a * U0[i0] -b * U0[i1];
+        d0=  a * V0[i0] +b * V0[i1] + c;
+
+        a =   U2[i1] - U1[i1];
+        b = -(U2[i0] - U1[i0]);
+        c = -a * U1[i0] -b * U1[i1];
+        d1=  a * V0[i0] +b * V0[i1] + c;
+
+        a =   U0[i1] - U2[i1];
+        b = -(U0[i0] - U2[i0]);
+        c = -a * U2[i0] - b * U2[i1];
+        d2 = a * V0[i0] + b * V0[i1] + c;
+        
+        if (d0 * d1 > 0.0){
+            if (d0 * d2 > 0.0) return true;
+        } else {
+            return false;
+        }
+    }
 
     /**
      * @see HasIntersection

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -2102,7 +2102,7 @@ private:
 
         Plane3D plane_2(rPoint1, rPoint2, rPoint3);
         array_1d<double, 3> distances_2;
-        for (int i = 0; i < 3; i++)
+        for (int i = 0; i < 3; ++i)
             distances_2[i] = plane_2.CalculateSignedDistance(this->GetPoint(i));
         if (AllSameSide(distances_2))
             return false;

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -648,16 +648,13 @@ public:
     {
         const auto geometry_type = rThisGeometry.GetGeometryType();
 
-        if (geometry_type == GeometryData::KratosGeometryType::Kratos_Line2D2 ||
-            geometry_type == GeometryData::KratosGeometryType::Kratos_Line3D2) {
+        if (geometry_type == GeometryData::KratosGeometryType::Kratos_Line3D2) {
             return LineTriangleOverlap(rThisGeometry);
         }
-        else if(geometry_type == GeometryData::KratosGeometryType::Kratos_Triangle2D3 ||
-                geometry_type == GeometryData::KratosGeometryType::Kratos_Triangle3D3) {
+        else if(geometry_type == GeometryData::KratosGeometryType::Kratos_Triangle3D3) {
             return TriTriOverlap(rThisGeometry);
         }
-        else if(geometry_type == GeometryData::KratosGeometryType::Kratos_Quadrilateral2D4 ||
-                geometry_type == GeometryData::KratosGeometryType::Kratos_Quadrilateral3D4) {
+        else if(geometry_type == GeometryData::KratosGeometryType::Kratos_Quadrilateral3D4) {
             Triangle3D3 triangle_0 (rThisGeometry.pGetPoint(0), rThisGeometry.pGetPoint(1), rThisGeometry.pGetPoint(2));
             Triangle3D3 triangle_1 (rThisGeometry.pGetPoint(2), rThisGeometry.pGetPoint(3), rThisGeometry.pGetPoint(0));
             if      ( TriTriOverlap(triangle_0) ) return true;

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -2075,8 +2075,8 @@ private:
     }
 
     bool LineTriangleOverlap(
-        const array_1d<double,3>& rPoint1,
-        const array_1d<double,3>& rPoint2)
+        const Point& rPoint1,
+        const Point& rPoint2)
     {
         array_1d<double,3> intersection_point;
         const int result = IntersectionUtilities::ComputeTriangleLineIntersection(*this, rPoint1, rPoint2, intersection_point);
@@ -2085,9 +2085,9 @@ private:
     }
 
     bool TriangleTriangleOverlap(
-        const array_1d<double,3>& rPoint1,
-        const array_1d<double,3>& rPoint2,
-        const array_1d<double,3>& rPoint3)
+        const Point& rPoint1,
+        const Point& rPoint2,
+        const Point& rPoint3)
     {
         // Based on code develop by Moller: http://fileadmin.cs.lth.se/cs/Personal/Tomas_Akenine-Moller/code/opttritri.txt
         // and the article "A Fast Triangle-Triangle Intersection Test", Journal of Graphics Tools, 2(2), 1997:
@@ -2232,9 +2232,9 @@ private:
 
 	bool CoplanarIntersectionCheck(
         const array_1d<double,3>& N,
-		const array_1d<double,3>& rPoint1,
-		const array_1d<double,3>& rPoint2,
-		const array_1d<double,3>& rPoint3)
+		const Point& rPoint1,
+		const Point& rPoint2,
+		const Point& rPoint3)
 	{
 		array_1d<double, 3 > A;
 		int i0, i1;
@@ -2279,11 +2279,10 @@ private:
 		const int& i1,
 		const Point& V0,
 		const Point& V1,
-		const Point&U0,
-		const Point&U1,
-		const Point&U2)
+		const Point& U0,
+		const Point& U1,
+		const Point& U2)
 	{
-
 		double Ax, Ay, Bx, By, Cx, Cy, e, d, f;
 		Ax = V1[i0] - V0[i0];
 		Ay = V1[i1] - V0[i1];
@@ -2344,10 +2343,10 @@ private:
     bool PointInTriangle(
         int i0,
         int i1,
-        const array_1d<double,3>& V0,
-        const array_1d<double,3>& U0,
-        const array_1d<double,3>& U1,
-        const array_1d<double,3>& U2)
+        const Point& V0,
+        const Point& U0,
+        const Point& U1,
+        const Point& U2)
     {
         double a,b,c,d0,d1,d2;
         /* is T1 completely inside T2? */

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -2303,13 +2303,13 @@ private:
 		double Ax, Ay, Bx, By, Cx, Cy, e, d, f;
 		Ax = V1[i0] - V0[i0];
 		Ay = V1[i1] - V0[i1];
-		// test edge U0,U1 against V0,V1 //
 
-		//std::cout<< "Proof One B " << std::endl;
+		// test edge U0,U1 against V0,V1 //
 		if (EdgeToEdgeIntersectionCheck(Ax, Ay, Bx, By, Cx, Cy, e, d, f, i0, i1, V0, U0, U1) == true) return true;
+
 		// test edge U1,U2 against V0,V1 //
-		//std::cout<< "Proof Two B " << std::endl;
 		if (EdgeToEdgeIntersectionCheck(Ax, Ay, Bx, By, Cx, Cy, e, d, f, i0, i1, V0, U1, U2) == true) return true;
+
 		// test edge U2,U1 against V0,V1 //
 		if (EdgeToEdgeIntersectionCheck(Ax, Ay, Bx, By, Cx, Cy, e, d, f, i0, i1, V0, U2, U0) == true) return true;
 

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -650,21 +650,16 @@ public:
         const auto geometry_type = rThisGeometry.GetGeometryType();
 
         if (geometry_type == GeometryData::KratosGeometryType::Kratos_Line3D2) {
-            array_1d<double,3> intersection_point;
-            const auto& point1 = rThisGeometry.GetPoint(0);
-            const auto& point2 = rThisGeometry.GetPoint(1);
-            const int result = IntersectionUtilities::ComputeTriangleLineIntersection(*this, point1, point2, intersection_point);
-            if (result == 1) return true;
-            else return false;
+            return LineTriangleOverlap(rThisGeometry[0], rThisGeometry[1]);
         }
         else if(geometry_type == GeometryData::KratosGeometryType::Kratos_Triangle3D3) {
-            return TriTriOverlap(rThisGeometry);
+            return TriangleTriangleOverlap(rThisGeometry);
         }
         else if(geometry_type == GeometryData::KratosGeometryType::Kratos_Quadrilateral3D4) {
             Triangle3D3 triangle_0 (rThisGeometry.pGetPoint(0), rThisGeometry.pGetPoint(1), rThisGeometry.pGetPoint(2));
             Triangle3D3 triangle_1 (rThisGeometry.pGetPoint(2), rThisGeometry.pGetPoint(3), rThisGeometry.pGetPoint(0));
-            if      ( TriTriOverlap(triangle_0) ) return true;
-            else if ( TriTriOverlap(triangle_1) ) return true;
+            if      ( TriangleTriangleOverlap(triangle_0) ) return true;
+            else if ( TriangleTriangleOverlap(triangle_1) ) return true;
             else return false;
         }
         else {
@@ -2081,7 +2076,17 @@ private:
       return 0.5 * std::sqrt((b+c-a) * (c+a-b) * (a+b-c) / (a+b+c));
     }
 
-    bool TriTriOverlap(const GeometryType& rThisGeometry)
+    bool LineTriangleOverlap(
+        const array_1d<double,3>& rPoint1,
+        const array_1d<double,3>& rPoint2)
+    {
+        array_1d<double,3> intersection_point;
+        const int result = IntersectionUtilities::ComputeTriangleLineIntersection(*this, rPoint1, rPoint2, intersection_point);
+        if (result == 1) return true;
+        else return false;
+    }
+
+    bool TriangleTriangleOverlap(const GeometryType& rThisGeometry)
     {
         // Based on code develop by Moller: http://fileadmin.cs.lth.se/cs/Personal/Tomas_Akenine-Moller/code/opttritri.txt
         // and the article "A Fast Triangle-Triangle Intersection Test", Journal of Graphics Tools, 2(2), 1997:

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -2121,7 +2121,6 @@ private:
         double up1 = rThisGeometry[1][index];
         double up2 = rThisGeometry[2][index];
 
-
         // compute interval for triangle 1 //
         double a, b, c, x0, x1;
         if (ComputeIntervals(vp0, vp1, vp2, distances_2[0], distances_2[1], distances_2[2], a, b, c, x0, x1) == true)
@@ -2181,11 +2180,10 @@ private:
 		double& X1
 		)
 	{
-		double D0D1 = D0*D1;
-		double D0D2 = D0*D2;
+		double D0D1 = D0 * D1;
+		double D0D2 = D0 * D2;
 
-		if (D0D1>0.00)
-		{
+		if (D0D1 > 0.0) {
 			// here we know that D0D2<=0.0 //
 			// that is D0, D1 are on the same side, D2 on the other or on the plane //
 			A = VV2;
@@ -2194,8 +2192,7 @@ private:
 			X0 = D2 - D0;
 			X1 = D2 - D1;
 		}
-		else if (D0D2>0.00)
-		{
+		else if (D0D2 > 0.0) {
 			// here we know that d0d1<=0.0 //
 			A = VV1;
 			B = (VV0 - VV1)*D1;
@@ -2203,8 +2200,7 @@ private:
 			X0 = D1 - D0;
 			X1 = D1 - D2;
 		}
-		else if (D1*D2>0.00 || D0 != 0.00)
-		{
+		else if (D1 * D2 > 0.00 || D0 != 0.00) {
 			// here we know that d0d1<=0.0 or that D0!=0.0 //
 			A = VV0;
 			B = (VV1 - VV0)*D0;
@@ -2212,30 +2208,24 @@ private:
 			X0 = D0 - D1;
 			X1 = D0 - D2;
 		}
-		else if (D1 != 0.00)
-		{
+		else if (D1 != 0.00) {
 			A = VV1;
 			B = (VV0 - VV1)*D1;
 			C = (VV2 - VV1)*D1;
 			X0 = D1 - D0;
 			X1 = D1 - D2;
 		}
-		else if (D2 != 0.00)
-		{
+		else if (D2 != 0.00) {
 			A = VV2;
 			B = (VV0 - VV2)*D2;
 			C = (VV1 - VV2)*D2;
 			X0 = D2 - D0;
 			X1 = D2 - D1;
 		}
-		else
-		{
-			///Triangles are coplanar
+		else { // Triangles are coplanar
 			return true;
 		}
-
 		return false;
-
 	}
 
 	bool CoplanarIntersectionCheck(const array_1d<double, 3>& N,
@@ -2249,28 +2239,19 @@ private:
 		A[0] = std::abs(N[0]);
 		A[1] = std::abs(N[1]);
 		A[2] = std::abs(N[2]);
-		if (A[0]>A[1])
-		{
-			if (A[0]>A[2])
-			{
+		if (A[0] > A[1]) {
+			if (A[0] > A[2]) {
 				i0 = 1;      // A[0] is greatest //
 				i1 = 2;
-			}
-			else
-			{
+			} else {
 				i0 = 0;      // A[2] is greatest //
 				i1 = 1;
 			}
-		}
-		else   // A[0]<=A[1] //
-		{
-			if (A[2]>A[1])
-			{
+		} else {             // A[0] <= A[1] //
+			if (A[2] > A[1]) {
 				i0 = 0;      // A[2] is greatest //
 				i1 = 1;
-			}
-			else
-			{
+			} else {
 				i0 = 0;      // A[1] is greatest //
 				i1 = 2;
 			}

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -2124,7 +2124,7 @@ private:
 
         // compute interval for triangle 1 //
         double a, b, c, x0, x1;
-        if (ComputeIntervals(vp0, vp1, vp2, distances_2[0], distances_2[1], distances_2[2], a, b, c, x0, x1) == true)
+        if (ComputeIntervals(vp0, vp1, vp2, distances_2[0], distances_2[1], distances_2[2], a, b, c, x0, x1))
         {
             return CoplanarIntersectionCheck(plane_1.GetNormal(), rPoint1, rPoint2, rPoint3);
         }

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -672,87 +672,6 @@ public:
         }
     }
 
-    bool TriTriOverlap(const GeometryType& rThisGeometry)
-    {
-        // Based on code develop by Moller: http://fileadmin.cs.lth.se/cs/Personal/Tomas_Akenine-Moller/code/opttritri.txt
-        // and the article "A Fast Triangle-Triangle Intersection Test", Journal of Graphics Tools, 2(2), 1997:
-        // http://web.stanford.edu/class/cs277/resources/papers/Moller1997b.pdf
-
-        Plane3D plane_1(this->GetPoint(0), this->GetPoint(1), this->GetPoint(2));
-        array_1d<double, 3> distances_1;
-        for (int i = 0; i < 3; i++)
-            distances_1[i] = plane_1.CalculateSignedDistance(rThisGeometry[i]);
-        if (AllSameSide(distances_1))
-            return false;
-
-        Plane3D plane_2(rThisGeometry[0], rThisGeometry[1], rThisGeometry[2]);
-        array_1d<double, 3> distances_2;
-        for (int i = 0; i < 3; i++)
-            distances_2[i] = plane_2.CalculateSignedDistance(this->GetPoint(i));
-        if (AllSameSide(distances_2))
-            return false;
-
-        // compute direction of intersection line //
-        array_1d<double, 3> intersection_direction;
-        MathUtils<double>::CrossProduct(intersection_direction, plane_1.GetNormal(), plane_2.GetNormal());
-
-        int index = GetMajorAxis(intersection_direction);
-
-        // this is the simplified projection onto L//
-        double vp0 = this->GetPoint(0)[index];
-        double vp1 = this->GetPoint(1)[index];
-        double vp2 = this->GetPoint(2)[index];
-
-        double up0 = rThisGeometry[0][index];
-        double up1 = rThisGeometry[1][index];
-        double up2 = rThisGeometry[2][index];
-
-
-        // compute interval for triangle 1 //
-        double a, b, c, x0, x1;
-        if (ComputeIntervals(vp0, vp1, vp2, distances_2[0], distances_2[1], distances_2[2], a, b, c, x0, x1) == true)
-        {
-            return CoplanarIntersectionCheck(plane_1.GetNormal(), rThisGeometry);
-        }
-
-        // compute interval for triangle 2 //
-        double d, e, f, y0, y1;
-        if (ComputeIntervals(up0, up1, up2, distances_1[0], distances_1[1], distances_1[2], d, e, f, y0, y1) == true)
-        {
-            return CoplanarIntersectionCheck(plane_1.GetNormal(), rThisGeometry);
-        }
-
-        double xx, yy, xxyy, tmp;
-        xx = x0*x1;
-        yy = y0*y1;
-        xxyy = xx*yy;
-
-        array_1d<double, 2> isect1, isect2;
-
-        tmp = a*xxyy;
-        isect1[0] = tmp + b*x1*yy;
-        isect1[1] = tmp + c*x0*yy;
-
-        tmp = d*xxyy;
-        isect2[0] = tmp + e*xx*y1;
-        isect2[1] = tmp + f*xx*y0;
-
-        if (isect1[0] > isect1[1]) {
-            isect1[1] = isect1[0] + isect1[1];
-            isect1[0] = isect1[1] - isect1[0];
-            isect1[1] = isect1[1] - isect1[0];
-        }
-
-        if (isect2[0] > isect2[1]) {
-            isect2[1] = isect2[0] + isect2[1];
-            isect2[0] = isect2[1] - isect2[0];
-            isect2[1] = isect2[1] - isect2[0];
-        }
-
-        if (isect1[1]<isect2[0] || isect2[1]<isect1[0]) return false;
-        return true;
-    }
-
     /**
      * Check if an axis-aliged bounding box (AABB) intersects a triangle
      *
@@ -2160,6 +2079,87 @@ private:
      */
     inline double CalculateInradius(const double a, const double b, const double c) const {
       return 0.5 * std::sqrt((b+c-a) * (c+a-b) * (a+b-c) / (a+b+c));
+    }
+
+    bool TriTriOverlap(const GeometryType& rThisGeometry)
+    {
+        // Based on code develop by Moller: http://fileadmin.cs.lth.se/cs/Personal/Tomas_Akenine-Moller/code/opttritri.txt
+        // and the article "A Fast Triangle-Triangle Intersection Test", Journal of Graphics Tools, 2(2), 1997:
+        // http://web.stanford.edu/class/cs277/resources/papers/Moller1997b.pdf
+
+        Plane3D plane_1(this->GetPoint(0), this->GetPoint(1), this->GetPoint(2));
+        array_1d<double, 3> distances_1;
+        for (int i = 0; i < 3; i++)
+            distances_1[i] = plane_1.CalculateSignedDistance(rThisGeometry[i]);
+        if (AllSameSide(distances_1))
+            return false;
+
+        Plane3D plane_2(rThisGeometry[0], rThisGeometry[1], rThisGeometry[2]);
+        array_1d<double, 3> distances_2;
+        for (int i = 0; i < 3; i++)
+            distances_2[i] = plane_2.CalculateSignedDistance(this->GetPoint(i));
+        if (AllSameSide(distances_2))
+            return false;
+
+        // compute direction of intersection line //
+        array_1d<double, 3> intersection_direction;
+        MathUtils<double>::CrossProduct(intersection_direction, plane_1.GetNormal(), plane_2.GetNormal());
+
+        int index = GetMajorAxis(intersection_direction);
+
+        // this is the simplified projection onto L//
+        double vp0 = this->GetPoint(0)[index];
+        double vp1 = this->GetPoint(1)[index];
+        double vp2 = this->GetPoint(2)[index];
+
+        double up0 = rThisGeometry[0][index];
+        double up1 = rThisGeometry[1][index];
+        double up2 = rThisGeometry[2][index];
+
+
+        // compute interval for triangle 1 //
+        double a, b, c, x0, x1;
+        if (ComputeIntervals(vp0, vp1, vp2, distances_2[0], distances_2[1], distances_2[2], a, b, c, x0, x1) == true)
+        {
+            return CoplanarIntersectionCheck(plane_1.GetNormal(), rThisGeometry);
+        }
+
+        // compute interval for triangle 2 //
+        double d, e, f, y0, y1;
+        if (ComputeIntervals(up0, up1, up2, distances_1[0], distances_1[1], distances_1[2], d, e, f, y0, y1) == true)
+        {
+            return CoplanarIntersectionCheck(plane_1.GetNormal(), rThisGeometry);
+        }
+
+        double xx, yy, xxyy, tmp;
+        xx = x0*x1;
+        yy = y0*y1;
+        xxyy = xx*yy;
+
+        array_1d<double, 2> isect1, isect2;
+
+        tmp = a*xxyy;
+        isect1[0] = tmp + b*x1*yy;
+        isect1[1] = tmp + c*x0*yy;
+
+        tmp = d*xxyy;
+        isect2[0] = tmp + e*xx*y1;
+        isect2[1] = tmp + f*xx*y0;
+
+        if (isect1[0] > isect1[1]) {
+            isect1[1] = isect1[0] + isect1[1];
+            isect1[0] = isect1[1] - isect1[0];
+            isect1[1] = isect1[1] - isect1[0];
+        }
+
+        if (isect2[0] > isect2[1]) {
+            isect2[1] = isect2[0] + isect2[1];
+            isect2[0] = isect2[1] - isect2[0];
+            isect2[1] = isect2[1] - isect2[0];
+        }
+
+        if (isect1[1]<isect2[0] || isect2[1]<isect1[0]) return false;
+        return true;
     }
 
 	bool ComputeIntervals(double& VV0,

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -676,14 +676,14 @@ public:
         const array_1d<double,3>& r_vert0 = this->GetPoint(0);
         const array_1d<double,3>& r_vert1 = this->GetPoint(1);
         const array_1d<double,3>& r_vert2 = this->GetPoint(2);
-        const array_1d<double,3> edge1 = vert1 - vert0;
-        const array_1d<double,3> edge2 = vert2 - vert0;
+        const array_1d<double,3> edge1 = r_vert1 - r_vert0;
+        const array_1d<double,3> edge2 = r_vert2 - r_vert0;
         h = MathUtils<double>::CrossProduct(ray_vector, edge2);
         a = inner_prod(edge1, h);
         if (a > -tolerance && a < tolerance)
             return false; // this ray is parallel to the triangle.
         f = 1.0 / a;
-        s = rLine[0] - vert0;
+        s = rLine[0] - r_vert0;
         u = f * inner_prod(s, h);
         if (u < 0.0 || u > 1.0)
             return false;

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -2164,8 +2164,7 @@ private:
             isect2[1] = isect2[1] - isect2[0];
         }
 
-        if (isect1[1]<isect2[0] || isect2[1]<isect1[0]) return false;
-        return true;
+        return (isect1[1]<isect2[0] || isect2[1]<isect1[0]) ? false : true;
     }
 
 	bool ComputeIntervals(

--- a/kratos/spatial_containers/octree_binary.h
+++ b/kratos/spatial_containers/octree_binary.h
@@ -1261,7 +1261,7 @@ namespace Kratos {
             triverts[i] = rGeometry1.GetPoint( i );
         }
 
-        if (geometry_type == GeometryData::KratosGeometryType::Kratos_Line2D2) { // Object is a line
+        if (geometry_type == GeometryData::KratosGeometryType::Kratos_Line2D2 || geometry_type == GeometryData::KratosGeometryType::Kratos_Line3D2) { // Object is a line
             return LinBoxOverlap( boxcenter, boxhalfsize, triverts);
         } else if(geometry_type == GeometryData::KratosGeometryType::Kratos_Triangle3D3 || geometry_type == GeometryData::KratosGeometryType::Kratos_Triangle2D3) { // Object is just a triangle
             return TriBoxOverlap( boxcenter, boxhalfsize, triverts );

--- a/kratos/tests/cpp_tests/geometries/test_triangle_3d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_triangle_3d_3.cpp
@@ -554,6 +554,48 @@ namespace Testing
         KRATOS_CHECK(triangle_1.HasIntersection(triangle_2));
     }
 
+    KRATOS_TEST_CASE_IN_SUITE(Triangle3D3LineIntersection, KratosCoreGeometriesFastSuite) {
+        Triangle3D3<Point> triangle(
+            std::make_shared<Point>(0.0, 0.0, 0.0),
+            std::make_shared<Point>(0.0, 0.0, 4.0),
+            std::make_shared<Point>(0.0, 4.0, 0.0)
+            );
+        Line3D2<Point> line(
+            std::make_shared<Point>(1.0, 0.0, 0.0),
+            std::make_shared<Point>(-1.0, 3.0, 1.0)
+            );
+
+        KRATOS_CHECK(triangle.HasIntersection(line));
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(Triangle3D3CoplanarLineNoIntersection, KratosCoreGeometriesFastSuite) {
+        Triangle3D3<Point> triangle(
+            std::make_shared<Point>(0.0, 0.0, 0.0),
+            std::make_shared<Point>(0.0, 0.0, 4.0),
+            std::make_shared<Point>(0.0, 4.0, 0.0)
+            );
+        Line3D2<Point> line(
+            std::make_shared<Point>(0.0, 2.0, 1.0),
+            std::make_shared<Point>(0.0, 6.0, 1.0)
+            );
+
+        KRATOS_CHECK_IS_FALSE(triangle.HasIntersection(line));
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(Triangle3D3ParallelLineNoIntersection, KratosCoreGeometriesFastSuite) {
+        Triangle3D3<Point> triangle(
+            std::make_shared<Point>(0.0, 0.0, 0.0),
+            std::make_shared<Point>(0.0, 0.0, 4.0),
+            std::make_shared<Point>(0.0, 4.0, 0.0)
+            );
+        Line3D2<Point> line(
+            std::make_shared<Point>(1.0, 0.0, 0.0),
+            std::make_shared<Point>(1.0, 3.0, 1.0)
+            );
+
+        KRATOS_CHECK_IS_FALSE(triangle.HasIntersection(line));
+    }
+
     /**
     * Test an overlaping box and triangle (intersects a triangle edge) HasIntersection
     */

--- a/kratos/tests/cpp_tests/utilities/test_intersection_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_intersection_utilities.cpp
@@ -328,6 +328,52 @@ namespace Testing {
         KRATOS_CHECK_EQUAL(int_id, 2);
     }
 
+    KRATOS_TEST_CASE_IN_SUITE(IntersectionUtilitiesTriangleLineCoplanarIntersection, KratosCoreFastSuite)
+    {
+        // Set the triangle to be intersected
+        auto triang_geom = GenerateStraightTriangle3D3();
+
+        // Set the points that define the intersection line
+        const Point line_pt_1(0.0,0.0,0.0);
+        const Point line_pt_2(0.0,1.0,1.0);
+
+        // Initialize the intersection point
+        Point int_pt(0.0,0.0,0.0);
+
+        // Call the intersection utility
+        const int int_id = IntersectionUtilities::ComputeTriangleLineIntersection<Triangle3D3<Point>>(
+            triang_geom,
+            line_pt_1.Coordinates(),
+            line_pt_2.Coordinates(),
+            int_pt.Coordinates());
+
+        // Check that are co-planar
+        KRATOS_CHECK_EQUAL(int_id, 2);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(IntersectionUtilitiesTriangleLineCoplanarNoIntersection, KratosCoreFastSuite)
+    {
+        // Set the triangle to be intersected
+        auto triang_geom = GenerateStraightTriangle3D3();
+
+        // Set the points that define the intersection line
+        const Point line_pt_1(0.0,2.0,0.0);
+        const Point line_pt_2(0.0,2.0,1.0);
+
+        // Initialize the intersection point
+        Point int_pt(0.0,0.0,0.0);
+
+        // Call the intersection utility
+        const int int_id = IntersectionUtilities::ComputeTriangleLineIntersection<Triangle3D3<Point>>(
+            triang_geom,
+            line_pt_1.Coordinates(),
+            line_pt_2.Coordinates(),
+            int_pt.Coordinates());
+
+        // Check that are co-planar
+        KRATOS_CHECK_EQUAL(int_id, 2);
+    }
+
     KRATOS_TEST_CASE_IN_SUITE(IntersectionUtilitiesTriangleLineBoundaryIntersection, KratosCoreFastSuite)
     {
         // Set the triangle to be intersected

--- a/kratos/utilities/intersection_utilities.h
+++ b/kratos/utilities/intersection_utilities.h
@@ -106,7 +106,7 @@ public:
 
         // This is the adaption of the implemnetation provided in:
         // http://www.softsurfer.com/Archive/algorithm_0105/algorithm_0105.htm#intersect_RayTriangle()
-
+        // Based on Tomas Möller & Ben Trumbore (1997) Fast, Minimum Storage Ray-Triangle Intersection, Journal of Graphics Tools, 2:1, 21-28, DOI: 10.1080/10867651.1997.10487468 
 
         // Get triangle edge vectors and plane normal
         const array_1d<double,3> u = rTriangleGeometry[1] - rTriangleGeometry[0];


### PR DESCRIPTION
**📝 Description**
My purpose is to extend the FindIntersectedGeometricalObjectsProcess to work with tretrahedras and lines. Those changes are enough. In addition, I have also extended it to quadrilaterals.

Some considerations:
- This PR could be shorter if  `intersection_utilities` is included in `Triangle3D3`, but ~~I've found a bug in `IntersectionUtilities::ComputeTriangleLineIntersection`. I should debug it deeper, but the link to the documentation is broken. That's why I've added the implementation in `Triangle3D3`. Moreover,~~ `HasIntersection` and `ComputeTriangleLineIntersection` are slightly different.
- The `OctreeBinary` has a lot of code duplication and dead code. I can make a fast PR with a clenaup proposal.

EDIT: there isn't any bug in `IntersectionUtilities::ComputeTriangleLineIntersection`, the point is that this function returns 2 for a co-planar line, which is evaluated to `true`. The algorithms are different. I can add some tests showing that behavior.

**🆕 Changelog**
- Extend the `Triangle3D3::HasIntersection` to lines and quadrilaterals.
- Add a new geometry type to the `OctreeBinary`