### PR TITLE
[Core]ModelPartIO] missing decrement of counter

### DIFF
--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -981,7 +981,9 @@ void ModelPartIO::SkipBlock(std::string const& BlockName)
             if(number_of_nested_blocks == 0){
                     if(CheckStatement(word , BlockName))
                         break;
-                }
+            } else {
+                number_of_nested_blocks--;
+            }
         }
         else if(word == "Begin")
         {

--- a/kratos/tests/auxiliar_files_for_python_unittest/mdpa_files/coarse_sphere_with_conditions.mdpa
+++ b/kratos/tests/auxiliar_files_for_python_unittest/mdpa_files/coarse_sphere_with_conditions.mdpa
@@ -349,6 +349,28 @@ Begin Elements Element3D4N// GUI group identifier: Parts Auto1
        249          1          3         16         23         17
 End Elements
 
+Begin SubModelPart Partial_Skin_Part
+    Begin SubModelPartNodes
+            34
+            37
+            48
+            51
+            52
+            60
+            64
+            68
+            70
+            73
+            74
+            79
+            80
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+    End SubModelPartConditions
+End SubModelPart
+
 Begin Conditions	SurfaceCondition3D3N
 	1	1	77	85	82
 	2	1	79	73	78
@@ -862,28 +884,6 @@ Begin SubModelPart Skin_Part
             83
             84
             85
-    End SubModelPartNodes
-    Begin SubModelPartElements
-    End SubModelPartElements
-    Begin SubModelPartConditions
-    End SubModelPartConditions
-End SubModelPart
-
-Begin SubModelPart Partial_Skin_Part
-    Begin SubModelPartNodes
-            34
-            37
-            48
-            51
-            52
-            60
-            64
-            68
-            70
-            73
-            74
-            79
-            80
     End SubModelPartNodes
     Begin SubModelPartElements
     End SubModelPartElements


### PR DESCRIPTION
While debugging a case in MPI I noticed that the `ModelPartIO` throws if e.g. Conditions are defined after the SubModelParts block in the mdpa file, they seemed to e ignores

I checked and found that that the function `SkipBlock` reads the entire stream if there is a nested structure like
~~~
Begin SubModelPart
    Begin SubModelPartNodes // this increases the counter "number_of_nested_blocks"
    End SubModelPartNodes // until now this did not decrease the counter!
End
~~~
Hence everything after the nested blocks was ignored!

This PR fixes this by decrementing the counter correctly