### PR TITLE
[Fluid] Fixed issue with ApplyCompressibleNavierStokesBoundaryConditionsProcess input validation

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/apply_compressible_navier_stokes_boundary_conditions_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/apply_compressible_navier_stokes_boundary_conditions_process.cpp
@@ -187,7 +187,7 @@ void ApplyCompressibleNavierStokesBoundaryConditionsProcess::ReadBoundaryConditi
     IntervalUtility interval_utility{Parameters};
     
     // Reading value and acting depending on if it's vector or double
-    if(Parameters["value"].IsDouble())
+    if(Parameters["value"].IsNumber())
     {
         rBCList.emplace_back(
             Parameters["variable_name"].GetString(),

--- a/applications/FluidDynamicsApplication/tests/apply_compressible_navier_stokes_boundary_conditions_process_test.py
+++ b/applications/FluidDynamicsApplication/tests/apply_compressible_navier_stokes_boundary_conditions_process_test.py
@@ -183,7 +183,7 @@ class ApplyMachDependentBoundaryConditionsTest(UnitTest.TestCase):
                 "supersonic_boundary_conditions" : [
                     {
                         "variable_name" : "TEMPERATURE",
-                        "value" : 273.15,
+                        "value" : 273,
                         "interval" : [0, "End"]
                     }
                 ]
@@ -253,7 +253,7 @@ class ApplyMachDependentBoundaryConditionsTest(UnitTest.TestCase):
 
             self.assertTrue(node.IsFixed(KratosMultiphysics.TEMPERATURE),
                 msg="Failed to fix supersonic boundary condition (Node #%d)." % node.Id)
-            self.assertAlmostEqual(node.GetSolutionStepValue(KratosMultiphysics.TEMPERATURE), 273.15,
+            self.assertAlmostEqual(node.GetSolutionStepValue(KratosMultiphysics.TEMPERATURE), 273,
                 msg="Failed to set value for supersonic boundary condition (Node #%d)." % node.Id)
 
         for node in self.model["main_model_part.closed_boundaries"].Nodes:


### PR DESCRIPTION
**📝 Description**
This PR is a minor quality of life improvement.

The `value` field in the JSON of this process can either be a vector or a scalar. `Parameters::GetDouble` can read an int and cast it to a double without any issues, however the input validation of the process was rejecting ints as input. This is now fixed and ints are also allowed in the `value` field (although still interpreted as doubles).

**🆕 Changelog**
- Changed C++ side of `ApplyCompressibleNavierStokesBoundaryConditionsProcess` to validate via `IsNumber` instead of `IsDouble`
- Modified pre-existing unit test so that the value of temperature to fix is `273` instead of `273.15`, hence validating the previous point.