### PR TITLE
[Mapping] fix registration of MPI-C++ tests

### DIFF
--- a/applications/MappingApplication/mpi_extension/cpp_tests/test_mapper_utilities_mpi.cpp
+++ b/applications/MappingApplication/mpi_extension/cpp_tests/test_mapper_utilities_mpi.cpp
@@ -7,7 +7,7 @@
 //  License:		 BSD License
 //                   Kratos default license: kratos/license.txt
 //
-//  Main authors:    Philipp Bucher
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
 //
 
 // Project includes
@@ -19,7 +19,7 @@
 namespace Kratos {
 namespace Testing {
 
-KRATOS_TEST_CASE_IN_SUITE(MapperUtilities_ComputeGlobalBoundingBox_distributed, KratosMappingApplicationMPITestSuite)
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MapperUtilities_ComputeGlobalBoundingBox_distributed, KratosMappingApplicationMPITestSuite)
 {
     Model current_model;
     ModelPart& model_part = current_model.CreateModelPart("Generated");

--- a/applications/MappingApplication/tests/run_cpp_mpi_unit_tests.py
+++ b/applications/MappingApplication/tests/run_cpp_mpi_unit_tests.py
@@ -1,6 +1,5 @@
 from KratosMultiphysics import *
-from KratosMultiphysics import mpi
-from KratosMultiphysics.MappingApplication import *
+from KratosMultiphysics.MappingApplication import MPIExtension # registering the tests
 
 def run():
     Tester.SetVerbosity(Tester.Verbosity.TESTS_OUTPUTS)

--- a/applications/MappingApplication/tests/test_MappingApplication_mpi.py
+++ b/applications/MappingApplication/tests/test_MappingApplication_mpi.py
@@ -7,6 +7,7 @@ if not KratosMultiphysics.IsDistributedRun():
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 
 # Import the tests or test_classes to create the suits
+import run_cpp_mpi_unit_tests
 import test_nearest_neighbor_mapper
 import test_nearest_element_mapper
 
@@ -63,4 +64,5 @@ def AssembleTestSuites():
 
 if __name__ == '__main__':
     KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.WARNING)
+    run_cpp_mpi_unit_tests.run() # Application-MPI tests are currently not run automatically, hence this hack is temporarily required
     KratosUnittest.runTests(AssembleTestSuites())


### PR DESCRIPTION
see title, it was broken and the tests were not executed!