### PR TITLE
[Core][Tests] replacing some deprecated calls

### DIFF
--- a/kratos/mpi/tests/sources/test_data_communicator.cpp
+++ b/kratos/mpi/tests/sources/test_data_communicator.cpp
@@ -51,7 +51,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorFromKratosComponents, KratosMPICoreFas
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorSumInt, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -67,7 +67,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorSumInt, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorSumDouble, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -83,7 +83,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorSumDouble, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorSumArray1d, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -105,7 +105,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorSumArray1d, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumIntVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -146,7 +146,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumIntVector, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumDoubleVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -189,7 +189,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumDoubleVector, KratosMPICoreFastSuit
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMinInt, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -205,7 +205,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMinInt, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMinDouble, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -221,7 +221,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMinDouble, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMinArray1d, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -243,7 +243,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMinArray1d, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinIntVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -284,7 +284,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinIntVector, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinDoubleVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -327,7 +327,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinDoubleVector, KratosMPICoreFastSuit
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMaxInt, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -343,7 +343,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMaxInt, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMaxDouble, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -359,7 +359,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMaxDouble, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMaxArray1d, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -381,7 +381,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMaxArray1d, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMaxIntVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -422,7 +422,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMaxIntVector, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMaxDoubleVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -822,7 +822,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScanSumDoubleVector, KratosMPICoreFast
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSendRecvInt, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
 
     const int world_size = r_world.Size();
     const int world_rank = r_world.Rank();
@@ -876,7 +876,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSendRecvInt, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSendRecvDouble, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
 
     const int world_size = r_world.Size();
     const int world_rank = r_world.Rank();
@@ -930,7 +930,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSendRecvDouble, KratosMPICoreFastSuite
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSendRecvString, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
 
     const int world_size = r_world.Size();
     const int world_rank = r_world.Rank();
@@ -981,7 +981,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSendRecvString, KratosMPICoreFastSuite
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorBroadcastInt, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     const int world_rank = r_world.Rank();
     const int send_rank = 0;
 
@@ -993,7 +993,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorBroadcastInt, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorBroadcastDouble, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     const int world_rank = r_world.Rank();
     const int send_rank = 0;
 
@@ -1005,7 +1005,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorBroadcastDouble, KratosMPICoreFastSuit
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorBroadcastIntVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     const int world_rank = r_world.Rank();
     const int send_rank = 0;
 
@@ -1018,7 +1018,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorBroadcastIntVector, KratosMPICoreFastS
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorBroadcastDoubleVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     const int world_rank = r_world.Rank();
     const int send_rank = 0;
 
@@ -1055,7 +1055,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScatterIntVector, KratosMPICoreFastSui
     }
 
     // remote calls are not supported
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     const int world_size = r_world.Size();
 
     if (world_size > 1) {
@@ -1106,7 +1106,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScatterDoubleVector, KratosMPICoreFast
     }
 
     // remote calls are not supported
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     const int world_size = r_world.Size();
 
     if (world_size > 1) {
@@ -1164,7 +1164,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScattervInt, KratosMPICoreFastSuite)
     }
 
     // remote calls are not supported
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     const int world_size = r_world.Size();
 
     if (world_size > 1) {
@@ -1230,7 +1230,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScattervDouble, KratosMPICoreFastSuite
     }
 
     // remote calls are not supported
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     const int world_size = r_world.Size();
 
     if (world_size > 1) {
@@ -1293,7 +1293,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorGatherInt, KratosMPICoreFastSuite)
     }
 
     // remote calls are not supported
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     const int world_size = r_world.Size();
 
     if (world_size > 1) {
@@ -1344,7 +1344,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorGatherDouble, KratosMPICoreFastSuite)
     }
 
     // remote calls are not supported
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     const int world_size = r_world.Size();
 
     if (world_size > 1) {
@@ -1402,7 +1402,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorGathervInt, KratosMPICoreFastSuite)
     }
 
     // remote calls are not supported
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     const int world_size = r_world.Size();
 
     if (world_size > 1) {
@@ -1468,7 +1468,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorGathervDouble, KratosMPICoreFastSuite)
     }
 
     // remote calls are not supported
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const DataCommunicator& r_world = Testing::GetDefaultDataCommunicator();
     const int world_size = r_world.Size();
 
     if (world_size > 1) {

--- a/kratos/mpi/tests/sources/test_data_communicator_manipulation.cpp
+++ b/kratos/mpi/tests/sources/test_data_communicator_manipulation.cpp
@@ -27,7 +27,7 @@ namespace Testing {
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(CreateMPIDataCommunicatorDuplicate, KratosMPICoreFastSuite)
 {
-    const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+    const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
     const DataCommunicator& r_duplicate = DataCommunicatorFactory::DuplicateAndRegister(r_comm, "Duplicate");
 
     KRATOS_CHECK_EQUAL(r_comm.Rank(), r_duplicate.Rank());
@@ -39,7 +39,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(CreateMPIDataCommunicatorDuplicate, Kratos
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(CreateMPIDataCommunicatorSplit, KratosMPICoreFastSuite)
 {
-    const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+    const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
     const int global_rank = r_comm.Rank();
     const int global_size = r_comm.Size();
 
@@ -65,7 +65,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(CreateMPIDataCommunicatorSplit, KratosMPIC
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(CreateMPIDataCommunicatorFromRanks, KratosMPICoreFastSuite)
 {
-    const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+    const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
     const int global_size = r_comm.Size();
 
     if (global_size > 1) // This test assumes at least two processes
@@ -102,7 +102,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(CreateMPIDataCommunicatorFromRanks, Kratos
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(CreateMPIDataCommunicatorUnion, KratosMPICoreFastSuite)
 {
-    const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+    const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
     const int global_size = r_comm.Size();
 
     if (global_size > 2) // This test assumes at least three processes
@@ -140,7 +140,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(CreateMPIDataCommunicatorUnion, KratosMPIC
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(CreateMPIDataCommunicatorIntersection, KratosMPICoreFastSuite)
 {
-    const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+    const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
     const int global_size = r_comm.Size();
 
     if (global_size > 2) // This test assumes at least three processes

--- a/kratos/mpi/tests/sources/test_debug_utilities.cpp
+++ b/kratos/mpi/tests/sources/test_debug_utilities.cpp
@@ -29,7 +29,7 @@ namespace Testing {
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableValue, KratosMPICoreFastSuite)
 {
-    const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+    const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
     const int world_size = r_comm.Size();
 
     Model model;
@@ -49,7 +49,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableVal
     }
 
     // Build the communicator
-    ParallelFillCommunicator(model_part).Execute();
+    ParallelFillCommunicator(model_part, r_comm).Execute();
 
     MpiDebugUtilities::CheckHistoricalVariable(model_part, PRESSURE);
     MpiDebugUtilities::CheckHistoricalVariable(model_part, TEMPERATURE);
@@ -57,7 +57,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableVal
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableFixity, KratosMPICoreFastSuite)
 {
-    const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+    const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
     const int world_size = r_comm.Size();
 
     Model model;
@@ -80,14 +80,14 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableFix
     }
 
     // Build the communicator
-    ParallelFillCommunicator(model_part).Execute();
+    ParallelFillCommunicator(model_part, r_comm).Execute();
 
     MpiDebugUtilities::CheckHistoricalVariable(model_part, PRESSURE);
 }
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableValueError, KratosMPICoreFastSuite)
 {
-    const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+    const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
     const int world_rank = r_comm.Rank();
     const int world_size = r_comm.Size();
 
@@ -106,7 +106,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableVal
     }
 
     // Build the communicator
-    ParallelFillCommunicator(model_part).Execute();
+    ParallelFillCommunicator(model_part, r_comm).Execute();
 
     std::stringstream error_message;
 
@@ -120,7 +120,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableVal
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableFixityError, KratosMPICoreFastSuite)
 {
-    const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+    const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
     const int world_rank = r_comm.Rank();
     const int world_size = r_comm.Size();
 
@@ -142,7 +142,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableFix
     }
 
     // Build the communicator
-    ParallelFillCommunicator(model_part).Execute();
+    ParallelFillCommunicator(model_part, r_comm).Execute();
 
     std::stringstream error_message;
 
@@ -156,7 +156,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableFix
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableCombinedError, KratosMPICoreFastSuite)
 {
-    const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+    const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
     const int world_rank = r_comm.Rank();
     const int world_size = r_comm.Size();
 
@@ -178,7 +178,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableCom
     }
 
     // Build the communicator
-    ParallelFillCommunicator(model_part).Execute();
+    ParallelFillCommunicator(model_part, r_comm).Execute();
 
     std::stringstream error_message;
 
@@ -193,7 +193,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableCom
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleNonHistoricalVariableValue, KratosMPICoreFastSuite)
 {
-    const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+    const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
     const int world_size = r_comm.Size();
 
     Model model;
@@ -211,7 +211,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleNonHistoricalVariable
     }
 
     // Build the communicator
-    ParallelFillCommunicator(model_part).Execute();
+    ParallelFillCommunicator(model_part, r_comm).Execute();
 
     MpiDebugUtilities::CheckNonHistoricalVariable(model_part, model_part.Nodes(), PRESSURE);
     MpiDebugUtilities::CheckNonHistoricalVariable(model_part, model_part.Nodes(), TEMPERATURE);
@@ -219,7 +219,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleNonHistoricalVariable
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleNonHistoricalVariableValueError, KratosMPICoreFastSuite)
 {
-    const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+    const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
     const int world_rank = r_comm.Rank();
     const int world_size = r_comm.Size();
 
@@ -237,7 +237,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleNonHistoricalVariable
     }
 
     // Build the communicator
-    ParallelFillCommunicator(model_part).Execute();
+    ParallelFillCommunicator(model_part, r_comm).Execute();
 
     std::stringstream error_message;
 
@@ -252,7 +252,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleNonHistoricalVariable
 // This will work with #5091 or when we move to C++17
 // KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckMultipleHistoricalVariablesValue, KratosMPICoreFastSuite)
 // {
-//     const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+//     const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
 //     const int world_rank = r_comm.Rank();
 //     const int world_size = r_comm.Size();
 
@@ -273,7 +273,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleNonHistoricalVariable
 //     }
 
 //     // Build the communicator
-//     ParallelFillCommunicator(model_part).Execute();
+//     ParallelFillCommunicator(model_part, r_comm).Execute();
 
 //     MpiDebugUtilities::CheckNodalHistoricalDatabase(model_part);
 // }

--- a/kratos/mpi/tests/sources/test_mpi_communicator.cpp
+++ b/kratos/mpi/tests/sources/test_mpi_communicator.cpp
@@ -62,7 +62,7 @@ void ModelPartForMPICommunicatorTests(ModelPart& rModelPart, const DataCommunica
     std::vector<ModelPart::IndexType> element_nodes{1, local_index, ghost_index};
     rModelPart.CreateNewElement("Element2D3N", rank+1, element_nodes, p_properties);
 
-    ParallelFillCommunicator(rModelPart).Execute();
+    ParallelFillCommunicator(rModelPart, Testing::GetDefaultDataCommunicator()).Execute();
 }
 
 }

--- a/kratos/tests/cpp_tests/input_output/test_logger.cpp
+++ b/kratos/tests/cpp_tests/input_output/test_logger.cpp
@@ -28,7 +28,7 @@ namespace Kratos {
             message << "Test message with number " << 12 << 'e' << "00";
 
             KRATOS_CHECK_C_STRING_EQUAL(message.GetLabel().c_str(), "label");
-            if (DataCommunicator::GetDefault().Rank() == 0) KRATOS_CHECK_C_STRING_EQUAL(message.GetMessage().c_str(), "Test message with number 12e00");
+            if (Testing::GetDefaultDataCommunicator().Rank() == 0) KRATOS_CHECK_C_STRING_EQUAL(message.GetMessage().c_str(), "Test message with number 12e00");
             KRATOS_CHECK_EQUAL(message.GetSeverity(), LoggerMessage::Severity::INFO);
             KRATOS_CHECK_EQUAL(message.GetCategory(), LoggerMessage::Category::STATUS);
             KRATOS_CHECK_EQUAL(message.GetLocation().GetFileName(), "Unknown");
@@ -55,7 +55,7 @@ namespace Kratos {
             LoggerMessage message("label");
             message << "Test message with number " << 12 << 'e' << "00";
 
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "label: Test message with number 12e00" : "";
+            std::string expected_output = Testing::GetDefaultDataCommunicator().Rank() == 0 ? "label: Test message with number 12e00" : "";
 
             output.WriteMessage(message);
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
@@ -69,7 +69,7 @@ namespace Kratos {
 
             Logger("TestLabel") << "Test message with number " << 12 << 'e' << "00";
 
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestLabel: Test message with number 12e00" : "";
+            std::string expected_output = Testing::GetDefaultDataCommunicator().Rank() == 0 ? "TestLabel: Test message with number 12e00" : "";
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
 
             Logger("TestDetail") << Logger::Severity::DETAIL << "This log has detailed severity and will not be printed in output "
@@ -87,7 +87,7 @@ namespace Kratos {
             KRATOS_CHECK_POINT("TestCheckPoint") << "The value in check point is " << 3.14;
 
 #if defined(KRATOS_ENABLE_CHECK_POINT)
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestCheckPoint: The value in check point is 3.14" : "";
+            std::string expected_output = Testing::GetDefaultDataCommunicator().Rank() == 0 ? "TestCheckPoint: The value in check point is 3.14" : "";
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
 #else
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), ""); // should print noting
@@ -102,7 +102,7 @@ namespace Kratos {
 
             KRATOS_INFO("TestInfo") << "Test info message";
 
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestInfo: Test info message" : "";
+            std::string expected_output = Testing::GetDefaultDataCommunicator().Rank() == 0 ? "TestInfo: Test info message" : "";
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 
@@ -115,7 +115,7 @@ namespace Kratos {
             KRATOS_INFO_IF("TestInfo", true) << "Test info message";
             KRATOS_INFO_IF("TestInfo", false) << "This should not appear";
 
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestInfo: Test info message" : "";
+            std::string expected_output = Testing::GetDefaultDataCommunicator().Rank() == 0 ? "TestInfo: Test info message" : "";
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 
@@ -130,7 +130,7 @@ namespace Kratos {
             }
 
 #ifdef KRATOS_DEBUG
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestInfo: Test info message - 0" : "";
+            std::string expected_output = Testing::GetDefaultDataCommunicator().Rank() == 0 ? "TestInfo: Test info message - 0" : "";
 #else
             std::string expected_output = "";
 #endif
@@ -149,7 +149,7 @@ namespace Kratos {
             }
 
 #ifdef KRATOS_DEBUG
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestInfo: .TestInfo: .TestInfo: .TestInfo: ." : "";
+            std::string expected_output = Testing::GetDefaultDataCommunicator().Rank() == 0 ? "TestInfo: .TestInfo: .TestInfo: .TestInfo: ." : "";
 #else
             std::string expected_output = "";
 #endif
@@ -164,7 +164,7 @@ namespace Kratos {
 
             KRATOS_WARNING("TestWarning") << "Test warning message";
 
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "[WARNING] TestWarning: Test warning message" : "";
+            std::string expected_output = Testing::GetDefaultDataCommunicator().Rank() == 0 ? "[WARNING] TestWarning: Test warning message" : "";
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 
@@ -177,7 +177,7 @@ namespace Kratos {
             KRATOS_WARNING_IF("TestWarning", true) << "Test warning message";
             KRATOS_WARNING_IF("TestWarning", false) << "This should not appear";
 
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "[WARNING] TestWarning: Test warning message" : "";
+            std::string expected_output = Testing::GetDefaultDataCommunicator().Rank() == 0 ? "[WARNING] TestWarning: Test warning message" : "";
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 
@@ -192,7 +192,7 @@ namespace Kratos {
             }
 
 #ifdef KRATOS_DEBUG
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "[WARNING] TestWarning: Test warning message - 0" : "";
+            std::string expected_output = Testing::GetDefaultDataCommunicator().Rank() == 0 ? "[WARNING] TestWarning: Test warning message - 0" : "";
 #else
             std::string expected_output = "";
 #endif
@@ -211,7 +211,7 @@ namespace Kratos {
             }
 
 #ifdef KRATOS_DEBUG
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "[WARNING] TestWarning: .[WARNING] TestWarning: .[WARNING] TestWarning: .[WARNING] TestWarning: ." : "";
+            std::string expected_output = Testing::GetDefaultDataCommunicator().Rank() == 0 ? "[WARNING] TestWarning: .[WARNING] TestWarning: .[WARNING] TestWarning: .[WARNING] TestWarning: ." : "";
 #else
             std::string expected_output = "";
 #endif
@@ -228,7 +228,7 @@ namespace Kratos {
 
             KRATOS_DETAIL("TestDetail") << "Test detail message";
 
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestDetail: Test detail message" : "";
+            std::string expected_output = Testing::GetDefaultDataCommunicator().Rank() == 0 ? "TestDetail: Test detail message" : "";
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 
@@ -242,7 +242,7 @@ namespace Kratos {
             KRATOS_DETAIL_IF("TestDetail", true) << "Test detail message";
             KRATOS_DETAIL_IF("TestDetail", false) << "This should not appear";
 
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestDetail: Test detail message" : "";
+            std::string expected_output = Testing::GetDefaultDataCommunicator().Rank() == 0 ? "TestDetail: Test detail message" : "";
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 
@@ -258,7 +258,7 @@ namespace Kratos {
             }
 
 #ifdef KRATOS_DEBUG
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestDetail: Test detail message - 0" : "";
+            std::string expected_output = Testing::GetDefaultDataCommunicator().Rank() == 0 ? "TestDetail: Test detail message - 0" : "";
 #else
             std::string expected_output = "";
 #endif
@@ -277,7 +277,7 @@ namespace Kratos {
             }
 
 #ifdef KRATOS_DEBUG
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestDetail: .TestDetail: .TestDetail: .TestDetail: ." : "";
+            std::string expected_output = Testing::GetDefaultDataCommunicator().Rank() == 0 ? "TestDetail: .TestDetail: .TestDetail: .TestDetail: ." : "";
 #else
             std::string expected_output = "";
 #endif
@@ -286,7 +286,7 @@ namespace Kratos {
 
         KRATOS_TEST_CASE_IN_SUITE(LoggerTableOutput, KratosCoreFastSuite)
         {
-            int rank = DataCommunicator::GetDefault().Rank();
+            int rank = Testing::GetDefaultDataCommunicator().Rank();
 
             static std::stringstream buffer;
             LoggerOutput::Pointer p_output(new LoggerTableOutput(buffer, {"Time Step    ", "Iteration Number        ", "Convergence        ", "Is converged"}));
@@ -342,7 +342,7 @@ namespace Kratos {
         KRATOS_TEST_CASE_IN_SUITE(LoggerTableDistributedOutput, KratosCoreFastSuite)
         {
             static std::stringstream buffer;
-            const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+            const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
             int rank = r_comm.Rank();
 
             // table can be is defined on all ranks
@@ -406,7 +406,7 @@ namespace Kratos {
             LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
             Logger::AddOutput(p_output);
 
-            const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+            const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
             int rank = r_comm.Rank();
 
             KRATOS_INFO_ALL_RANKS("TestInfo") << "Test info message";
@@ -422,7 +422,7 @@ namespace Kratos {
             LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
             Logger::AddOutput(p_output);
 
-            const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+            const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
             int rank = r_comm.Rank();
             std::stringstream out;
 
@@ -446,7 +446,7 @@ namespace Kratos {
 
             std::stringstream out;
 #ifdef KRATOS_DEBUG
-            out << "Rank " << DataCommunicator::GetDefault().Rank() << ": TestInfo: Test info message - 0";
+            out << "Rank " << Testing::GetDefaultDataCommunicator().Rank() << ": TestInfo: Test info message - 0";
 #else
             out << "";
 #endif
@@ -466,7 +466,7 @@ namespace Kratos {
 
             std::stringstream out;
 #ifdef KRATOS_DEBUG
-            int rank = DataCommunicator::GetDefault().Rank();
+            int rank = Testing::GetDefaultDataCommunicator().Rank();
             for(std::size_t i = 0; i < 4; i++) {
                 out << "Rank " << rank << ": TestInfo: .";
             }
@@ -493,7 +493,7 @@ namespace Kratos {
             KRATOS_INFO("TestInfo") << "Test message\n";
             KRATOS_DETAIL("TestDetail") << "Test message\n";
 
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestWarning: Test message\nTestInfo: Test message\nTestDetail: Test message\n" : "";
+            std::string expected_output = Testing::GetDefaultDataCommunicator().Rank() == 0 ? "TestWarning: Test message\nTestInfo: Test message\nTestDetail: Test message\n" : "";
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 
@@ -514,7 +514,7 @@ namespace Kratos {
             KRATOS_INFO("TestInfo") << "Test message\n";
             KRATOS_DETAIL("TestDetail") << "Test message\n";
 
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "[WARNING] TestWarning: Test message\n[INFO] TestInfo: Test message\n[DETAIL] TestDetail: Test message\n" : "";
+            std::string expected_output = Testing::GetDefaultDataCommunicator().Rank() == 0 ? "[WARNING] TestWarning: Test message\n[INFO] TestInfo: Test message\n[DETAIL] TestDetail: Test message\n" : "";
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 


### PR DESCRIPTION
`DataCommunicator::Default` => `Testing::GetDefaultDataCommunicator()`
