### PR TITLE
[FastPR] Generate language server hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ bin/*
 
 # Most used editor files
 *.vscode
+/compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,13 @@ endif(NOT DEFINED CMAKE_INSTALL_MESSAGE)
 # Set kratos specific module path
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${KRATOS_SOURCE_DIR}/cmake_modules")
 
+# Generate and copy configuration for language servers
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+EXECUTE_PROCESS(
+    COMMAND ${CMAKE_COMMAND} -E create_symlink
+    "${CMAKE_BINARY_DIR}/compile_commands.json"
+    "${CMAKE_SOURCE_DIR}/compile_commands.json")
+
 # Include cmake modules
 include(DownloadLib)
 


### PR DESCRIPTION
**Description**
Generate a ```compile_commands.json``` with CMake and symlink it to the source directory. This helps language servers find included files and deduce compiler settings (such as the C++ version) to improve code analysis.

This can be done without any modifications to Kratos too, but that would involve some fiddling with the IDE/text editor (to find the ```compile_commands.json``` that is **not** in the source directory). I think it's preferable to let Kratos take care of this instead of doing it manually, but let me know if you think otherwise.

Intellisense can usually (but not always) deduce where to look for included files by default, but clangd won't work without a ```compile_commands.json```.

Closes #9229