### PR TITLE
[Core][Geometry] ShapeFunctionsIntegrationPointsGradients improvements

### DIFF
--- a/applications/CableNetApplication/custom_geometries/line_3d_n.h
+++ b/applications/CableNetApplication/custom_geometries/line_3d_n.h
@@ -570,10 +570,9 @@ public:
 
 
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
+    void ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
 

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -3643,13 +3643,13 @@ public:
     }
 
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult ) const
+    void ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult ) const
     {
         ShapeFunctionsIntegrationPointsGradients( rResult, mpGeometryData->DefaultIntegrationMethod() );
-        return rResult;
+        // return rResult;
     }
 
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    virtual void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod ) const
     {
@@ -3681,10 +3681,10 @@ public:
             noalias(rResult[pnt]) =  prod( DN_De[pnt], Jinv );
         }
 
-        return rResult;
+        // return rResult;
     }
 
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    virtual void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         Vector& rDeterminantsOfJacobian,
         IntegrationMethod ThisMethod ) const
@@ -3719,12 +3719,10 @@ public:
             noalias(rResult[pnt]) =  prod( DN_De[pnt], Jinv );
             rDeterminantsOfJacobian[pnt] = DetJ;
         }
-
-        return rResult;
     }
 
     KRATOS_DEPRECATED_MESSAGE("This is signature of \'ShapeFunctionsIntegrationPointsGradients\' is legacy (use any of the alternatives without shape functions calculation).")
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    virtual void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         Vector& rDeterminantsOfJacobian,
         IntegrationMethod ThisMethod,
@@ -3733,7 +3731,6 @@ public:
 
         ShapeFunctionsIntegrationPointsGradients(rResult, rDeterminantsOfJacobian, ThisMethod);
         ShapeFunctionsIntegrationPointsValues = ShapeFunctionsValues(ThisMethod);
-        return rResult;
     }
 
     virtual int Check() const

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -3653,6 +3653,10 @@ public:
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod ) const
     {
+        //check that current geometry can perform this operation
+        KRATOS_ERROR_IF_NOT(this->WorkingSpaceDimension() == this->LocalSpaceDimension())
+            << "\'ShapeFunctionsIntegrationPointsGradients\' is not defined for current geometry type as gradients are only defined in the local space." << std::endl;
+
         const unsigned int integration_points_number = this->IntegrationPointsNumber( ThisMethod );
 
         if ( integration_points_number == 0 )
@@ -3665,22 +3669,30 @@ public:
         const ShapeFunctionsGradientsType& DN_De = ShapeFunctionsLocalGradients( ThisMethod );
 
         //loop over all integration points
-        Matrix J(this->WorkingSpaceDimension(),this->LocalSpaceDimension()),Jinv(this->WorkingSpaceDimension(),this->LocalSpaceDimension());
+        Matrix J(this->WorkingSpaceDimension(), this->LocalSpaceDimension());
+        Matrix Jinv(this->LocalSpaceDimension(), this->WorkingSpaceDimension());
         double DetJ;
         for ( unsigned int pnt = 0; pnt < integration_points_number; pnt++ )
         {
-            if(rResult[pnt].size1() != this->WorkingSpaceDimension() ||  rResult[pnt].size2() != this->LocalSpaceDimension())
+            if (rResult[pnt].size1() != (*this).size() || rResult[pnt].size2() != this->LocalSpaceDimension())
                 rResult[pnt].resize( (*this).size(), this->LocalSpaceDimension(), false );
             this->Jacobian(J,pnt, ThisMethod);
-            MathUtils<double>::GeneralizedInvertMatrix( J, Jinv, DetJ );
+            MathUtils<double>::InvertMatrix(J, Jinv, DetJ);
             noalias(rResult[pnt]) =  prod( DN_De[pnt], Jinv );
         }
 
         return rResult;
     }
 
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, Vector& determinants_of_jacobian, IntegrationMethod ThisMethod ) const
+    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType& rResult,
+        Vector& rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod ) const
     {
+        //check that current geometry can perform this operation
+        KRATOS_ERROR_IF_NOT(this->WorkingSpaceDimension() == this->LocalSpaceDimension())
+            << "\'ShapeFunctionsIntegrationPointsGradients\' is not defined for current geometry type as gradients are only defined in the local space." << std::endl;
+
         const unsigned int integration_points_number = this->IntegrationPointsNumber( ThisMethod );
 
         if ( integration_points_number == 0 )
@@ -3688,33 +3700,37 @@ public:
 
         if ( rResult.size() != integration_points_number )
             rResult.resize(  this->IntegrationPointsNumber( ThisMethod ), false  );
-        if ( determinants_of_jacobian.size() != integration_points_number )
-            determinants_of_jacobian.resize(  this->IntegrationPointsNumber( ThisMethod ), false  );
+        if (rDeterminantsOfJacobian.size() != integration_points_number)
+            rDeterminantsOfJacobian.resize(this->IntegrationPointsNumber(ThisMethod), false);
 
         //calculating the local gradients
         const ShapeFunctionsGradientsType& DN_De = ShapeFunctionsLocalGradients( ThisMethod );
 
         //loop over all integration points
         Matrix J(this->WorkingSpaceDimension(),this->LocalSpaceDimension());
-        Matrix Jinv(this->WorkingSpaceDimension(),this->LocalSpaceDimension());
+        Matrix Jinv(this->LocalSpaceDimension(), this->WorkingSpaceDimension());
         double DetJ;
         for ( unsigned int pnt = 0; pnt < integration_points_number; pnt++ )
         {
-            if(rResult[pnt].size1() != this->WorkingSpaceDimension() ||  rResult[pnt].size2() != this->LocalSpaceDimension())
+            if (rResult[pnt].size1() != (*this).size() || rResult[pnt].size2() != this->LocalSpaceDimension())
                 rResult[pnt].resize( (*this).size(), this->LocalSpaceDimension(), false );
             this->Jacobian(J,pnt, ThisMethod);
-            MathUtils<double>::GeneralizedInvertMatrix( J, Jinv, DetJ );
+            MathUtils<double>::InvertMatrix( J, Jinv, DetJ );
             noalias(rResult[pnt]) =  prod( DN_De[pnt], Jinv );
-            determinants_of_jacobian[pnt] = DetJ;
+            rDeterminantsOfJacobian[pnt] = DetJ;
         }
 
         return rResult;
     }
 
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, Vector& determinants_of_jacobian, IntegrationMethod ThisMethod, Matrix& ShapeFunctionsIntegrationPointsValues ) const
+    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType& rResult,
+        Vector& rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod,
+        Matrix& ShapeFunctionsIntegrationPointsValues) const
     {
 
-        ShapeFunctionsIntegrationPointsGradients(rResult,determinants_of_jacobian,ThisMethod);
+        ShapeFunctionsIntegrationPointsGradients(rResult, rDeterminantsOfJacobian, ThisMethod);
         ShapeFunctionsIntegrationPointsValues = ShapeFunctionsValues(ThisMethod);
         return rResult;
     }

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -3723,6 +3723,7 @@ public:
         return rResult;
     }
 
+    KRATOS_DEPRECATED_MESSAGE("This is signature of \'ShapeFunctionsIntegrationPointsGradients\' is legacy (use any of the alternatives without shape functions calculation).")
     virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         Vector& rDeterminantsOfJacobian,

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -3646,7 +3646,6 @@ public:
     void ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult ) const
     {
         ShapeFunctionsIntegrationPointsGradients( rResult, mpGeometryData->DefaultIntegrationMethod() );
-        // return rResult;
     }
 
     virtual void ShapeFunctionsIntegrationPointsGradients(
@@ -3680,8 +3679,6 @@ public:
             MathUtils<double>::InvertMatrix(J, Jinv, DetJ);
             noalias(rResult[pnt]) =  prod( DN_De[pnt], Jinv );
         }
-
-        // return rResult;
     }
 
     virtual void ShapeFunctionsIntegrationPointsGradients(

--- a/kratos/geometries/hexahedra_interface_3d_8.h
+++ b/kratos/geometries/hexahedra_interface_3d_8.h
@@ -1337,7 +1337,7 @@ public:
      *
      * :TODO: TESTING!!!
      */
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod ) const override
     {
@@ -1381,12 +1381,10 @@ public:
                 }
             }
         }//end of loop over integration points
-
-        return rResult;
     }
 
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         Vector& determinants_of_jacobian,
         IntegrationMethod ThisMethod) const override
@@ -1448,8 +1446,6 @@ public:
                 }
             }
         }
-
-        return rResult;
     }
 
 

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -784,16 +784,6 @@ public:
         return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
-        ShapeFunctionsGradientsType &rResult,
-        Vector &rDeterminantsOfJacobian,
-        IntegrationMethod ThisMethod,
-        Matrix &ShapeFunctionsIntegrationPointsValues) const override
-    {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
-    }
-
     ///@}
     ///@name Input and output
     ///@{

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -767,21 +767,19 @@ public:
     ///@name Shape Function Integration Points Gradient
     ///@{
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType &rResult,
         Vector &rDeterminantsOfJacobian,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
     ///@}

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -767,12 +767,32 @@ public:
     ///@name Shape Function Integration Points Gradient
     ///@{
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType& rResult,
+        IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
         return rResult;
     }
 
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
+
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod,
+        Matrix &ShapeFunctionsIntegrationPointsValues) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
 
     ///@}
     ///@name Input and output

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -797,16 +797,6 @@ public:
         return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
-        ShapeFunctionsGradientsType &rResult,
-        Vector &rDeterminantsOfJacobian,
-        IntegrationMethod ThisMethod,
-        Matrix &ShapeFunctionsIntegrationPointsValues) const override
-    {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
-    }
-
     ///@}
     ///@name Input and output
     ///@{

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -777,6 +777,37 @@ public:
     }
 
     ///@}
+    ///@name Shape Function Integration Points Gradient
+    ///@{
+
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
+
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
+
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod,
+        Matrix &ShapeFunctionsIntegrationPointsValues) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
+
+    ///@}
     ///@name Input and output
     ///@{
 

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -780,21 +780,19 @@ public:
     ///@name Shape Function Integration Points Gradient
     ///@{
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType &rResult,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType &rResult,
         Vector &rDeterminantsOfJacobian,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
     ///@}

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -827,21 +827,19 @@ public:
     ///@name Shape Function Integration Points Gradient
     ///@{
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType &rResult,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType &rResult,
         Vector &rDeterminantsOfJacobian,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
     ///@}

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -760,11 +760,6 @@ public:
         return ZeroVector(3);
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
-    {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-    }
-
     /**
      * @brief Returns whether given arbitrary point is inside the Geometry and the respective
      * local point for the given global point
@@ -827,6 +822,41 @@ public:
 
         return rResult ;
     }
+
+    ///@}
+    ///@name Shape Function Integration Points Gradient
+    ///@{
+
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
+
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
+
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod,
+        Matrix &ShapeFunctionsIntegrationPointsValues) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
+
+    ///@}
+    ///@name Input and output
+    ///@{
 
     /** Turn back information as a string.
 

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -844,16 +844,6 @@ public:
         return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
-        ShapeFunctionsGradientsType &rResult,
-        Vector &rDeterminantsOfJacobian,
-        IntegrationMethod ThisMethod,
-        Matrix &ShapeFunctionsIntegrationPointsValues) const override
-    {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
-    }
-
     ///@}
     ///@name Input and output
     ///@{

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -723,14 +723,36 @@ public:
         return 0;
     }
 
+    ///@}
+    ///@name Shape Function Integration Points Gradient
+    ///@{
 
-
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
         return rResult;
     }
 
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
+
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod,
+        Matrix &ShapeFunctionsIntegrationPointsValues) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
 
     ///@}
     ///@name Input and output

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -727,21 +727,19 @@ public:
     ///@name Shape Function Integration Points Gradient
     ///@{
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType &rResult,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType &rResult,
         Vector &rDeterminantsOfJacobian,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
     ///@}

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -744,16 +744,6 @@ public:
         return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
-        ShapeFunctionsGradientsType &rResult,
-        Vector &rDeterminantsOfJacobian,
-        IntegrationMethod ThisMethod,
-        Matrix &ShapeFunctionsIntegrationPointsValues) const override
-    {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
-    }
-
     ///@}
     ///@name Input and output
     ///@{

--- a/kratos/geometries/line_gauss_lobatto_3d_2.h
+++ b/kratos/geometries/line_gauss_lobatto_3d_2.h
@@ -645,13 +645,32 @@ public:
         return( rResult );
     }
 
-
-
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
+    ShapeFunctionsGradientsType &ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
     }
 
+    ShapeFunctionsGradientsType &ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
+
+    ShapeFunctionsGradientsType &ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod,
+        Matrix &ShapeFunctionsIntegrationPointsValues) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
 
     /** Turn back information as a string.
 

--- a/kratos/geometries/point_2d.h
+++ b/kratos/geometries/point_2d.h
@@ -555,14 +555,6 @@ public:
 //       return 0;
 //          }
 
-
-
-    //      virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod) const
-    //	{
-    //		  KRATOS_ERROR << "Jacobian is not square" << std::endl;
-    //	}
-
-
     ///@}
     ///@name Input and output
     ///@{

--- a/kratos/geometries/point_3d.h
+++ b/kratos/geometries/point_3d.h
@@ -555,13 +555,6 @@ public:
 //       return 0;
 //          }
 //
-//
-//
-//          virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod) const
-//     	{
-//     		  KRATOS_ERROR << "Jacobian is not square" << std::endl;
-//     	}
-
     /*
 
 

--- a/kratos/geometries/prism_3d_15.h
+++ b/kratos/geometries/prism_3d_15.h
@@ -1228,7 +1228,7 @@ public:
      *
      * :TODO: TESTING!!!
      */
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod ) const override
     {
@@ -1272,8 +1272,6 @@ public:
                 }
             }
         }//end of loop over integration points
-
-        return rResult;
     }
 
     /** This method gives gradient of all shape functions evaluated

--- a/kratos/geometries/prism_interface_3d_6.h
+++ b/kratos/geometries/prism_interface_3d_6.h
@@ -1060,7 +1060,7 @@ public:
      * KLUDGE: method call only works with explicit JacobiansType rather than creating
      * JacobiansType within argument list
     */
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod ) const override
     {
@@ -1104,8 +1104,6 @@ public:
                 }
             }
         }//end of loop over integration points
-
-        return rResult;
     }
 
     ///@}

--- a/kratos/geometries/quadrilateral_2d_8.h
+++ b/kratos/geometries/quadrilateral_2d_8.h
@@ -1068,7 +1068,7 @@ public:
      * KLUDGE: method call only works with explicit JacobiansType
      * rather than creating JacobiansType within argument list
      */
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod ) const override
     {
@@ -1113,8 +1113,6 @@ public:
                 }
             }
         }//end of loop over integration points
-
-        return rResult;
     }
 
     /**

--- a/kratos/geometries/quadrilateral_3d_4.h
+++ b/kratos/geometries/quadrilateral_3d_4.h
@@ -1258,21 +1258,19 @@ public:
     ///@name Shape Function Integration Points Gradient
     ///@{
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType &rResult,
         Vector &rDeterminantsOfJacobian,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
     ///@}

--- a/kratos/geometries/quadrilateral_3d_4.h
+++ b/kratos/geometries/quadrilateral_3d_4.h
@@ -1275,16 +1275,6 @@ public:
         return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
-        ShapeFunctionsGradientsType &rResult,
-        Vector &rDeterminantsOfJacobian,
-        IntegrationMethod ThisMethod,
-        Matrix &ShapeFunctionsIntegrationPointsValues) const override
-    {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
-    }
-
     ///@}
     ///@name Input and output
     ///@{

--- a/kratos/geometries/quadrilateral_3d_4.h
+++ b/kratos/geometries/quadrilateral_3d_4.h
@@ -1254,62 +1254,34 @@ public:
         return rResult;
     }
 
-    /**
-     * Calculates the Gradients of the shape functions.
-     * Calculates the gradients of the shape functions with regard to
-     * the global coordinates in all
-     * integration points (\f$ \frac{\partial N^i}{\partial X_j} \f$)
-     *
-     * @param rResult a container which takes the calculated gradients
-     * @param ThisMethod the given IntegrationMethod
-     *
-     * @return the gradients of all shape functions with regard to the global coordinates
-     * KLUDGE: method call only works with explicit JacobiansType rather than creating
-     * JacobiansType within argument list
-    */
+    ///@}
+    ///@name Shape Function Integration Points Gradient
+    ///@{
+
     ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
-        IntegrationMethod ThisMethod ) const override
+        IntegrationMethod ThisMethod) const override
     {
-        const unsigned int integration_points_number = msGeometryData.IntegrationPointsNumber( ThisMethod );
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
 
-        if ( integration_points_number == 0 )
-        {
-            KRATOS_ERROR << "This integration method is not supported" << *this << std::endl;
-        }
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
 
-        if ( rResult.size() != integration_points_number )
-        {
-            // KLUDGE: While there is a bug in ublas
-            // vector resize, I have to put this beside resizing!!
-            ShapeFunctionsGradientsType temp( integration_points_number );
-            rResult.swap( temp );
-        }
-
-        // Calculating the local gradients
-        const ShapeFunctionsGradientsType& shape_functions_local_gradient = msGeometryData.ShapeFunctionsLocalGradients( ThisMethod );
-
-        //getting the inverse jacobian matrices
-        JacobiansType temp( integration_points_number );
-
-        JacobiansType invJ = InverseOfJacobian( temp, ThisMethod );
-
-        //loop over all integration points
-        for ( unsigned int pnt = 0; pnt < integration_points_number; pnt++ )
-        {
-            rResult[pnt].resize( 4, 2, false );
-
-            for ( int i = 0; i < 4; i++ )
-            {
-                for ( int j = 0; j < 2; j++ )
-                {
-                    rResult[pnt]( i, j ) =
-                        ( shape_functions_local_gradient[pnt]( i, 0 ) * invJ[pnt]( j, 0 ) )
-                        + ( shape_functions_local_gradient[pnt]( i, 1 ) * invJ[pnt]( j, 1 ) );
-                }
-            }
-        }//end of loop over integration points
-
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod,
+        Matrix &ShapeFunctionsIntegrationPointsValues) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
         return rResult;
     }
 

--- a/kratos/geometries/quadrilateral_3d_8.h
+++ b/kratos/geometries/quadrilateral_3d_8.h
@@ -995,16 +995,6 @@ public:
         return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
-        ShapeFunctionsGradientsType &rResult,
-        Vector &rDeterminantsOfJacobian,
-        IntegrationMethod ThisMethod,
-        Matrix &ShapeFunctionsIntegrationPointsValues) const override
-    {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
-    }
-
     ///@}
 
     /**

--- a/kratos/geometries/quadrilateral_3d_8.h
+++ b/kratos/geometries/quadrilateral_3d_8.h
@@ -978,21 +978,19 @@ public:
     ///@name Shape Function Integration Points Gradient
     ///@{
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType &rResult,
         Vector &rDeterminantsOfJacobian,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
     ///@}

--- a/kratos/geometries/quadrilateral_3d_8.h
+++ b/kratos/geometries/quadrilateral_3d_8.h
@@ -974,70 +974,38 @@ public:
         return rResult;
     }
 
-    /**
-     * :TODO: implemented but not yet tested
-     */
-    /**
-     * Calculates the Gradients of the shape functions.
-     * Calculates the gradients of the shape functions with regard to the global
-     * coordinates in all
-     * integration points (\f$ \frac{\partial N^i}{\partial X_j} \f$)
-     *
-     * @param rResult a container which takes the calculated gradients
-     * @param ThisMethod the given IntegrationMethod
-     *
-     * @return the gradients of all shape functions with regard to the
-     * global coordinates
-     *
-     * KLUDGE: method call only works with explicit JacobiansType
-     * rather than creating JacobiansType within argument list
-     */
+    ///@}
+    ///@name Shape Function Integration Points Gradient
+    ///@{
+
     ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
-        IntegrationMethod ThisMethod ) const override
+        IntegrationMethod ThisMethod) const override
     {
-        const unsigned int integration_points_number =
-            msGeometryData.IntegrationPointsNumber( ThisMethod );
-
-        if ( integration_points_number == 0 )
-            KRATOS_ERROR << "This integration method is not supported" << *this << std::endl;
-
-        //workaround by riccardo
-        if ( rResult.size() != integration_points_number )
-        {
-            // KLUDGE: While there is a bug in ublas
-            // vector resize, I have to put this beside resizing!!
-            ShapeFunctionsGradientsType temp( integration_points_number );
-            rResult.swap( temp );
-        }
-
-        //calculating the local gradients
-        ShapeFunctionsGradientsType locG =
-            CalculateShapeFunctionsIntegrationPointsLocalGradients( ThisMethod );
-
-        //getting the inverse jacobian matrices
-        JacobiansType temp( integration_points_number );
-
-        JacobiansType invJ = this->InverseOfJacobian( temp, ThisMethod );
-
-        //loop over all integration points
-        for ( unsigned int pnt = 0; pnt < integration_points_number; pnt++ )
-        {
-            rResult[pnt].resize( 4, 2, false );
-
-            for ( int i = 0; i < 4; i++ )
-            {
-                for ( int j = 0; j < 2; j++ )
-                {
-                    rResult[pnt]( i, j ) =
-                        ( locG[pnt]( i, 0 ) * invJ[pnt]( j, 0 ) )
-                        + ( locG[pnt]( i, 1 ) * invJ[pnt]( j, 1 ) );
-                }
-            }
-        }//end of loop over integration points
-
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
         return rResult;
     }
+
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
+
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod,
+        Matrix &ShapeFunctionsIntegrationPointsValues) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
+
+    ///@}
 
     /**
      * Input and Output

--- a/kratos/geometries/quadrilateral_3d_9.h
+++ b/kratos/geometries/quadrilateral_3d_9.h
@@ -991,16 +991,6 @@ public:
         return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
-        ShapeFunctionsGradientsType &rResult,
-        Vector &rDeterminantsOfJacobian,
-        IntegrationMethod ThisMethod,
-        Matrix &ShapeFunctionsIntegrationPointsValues) const override
-    {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
-    }
-
     ///@}
 
     /**

--- a/kratos/geometries/quadrilateral_3d_9.h
+++ b/kratos/geometries/quadrilateral_3d_9.h
@@ -970,69 +970,38 @@ public:
         return rResult;
     }
 
-    /**
-     * :TODO: implemented but not yet tested
-     */
-    /**
-     * Calculates the Gradients of the shape functions.
-     * Calculates the gradients of the shape functions with
-     * regard to the global coordinates in all
-     * integration points (\f$ \frac{\partial N^i}{\partial X_j} \f$)
-     *
-     * @param rResult a container which takes the calculated gradients
-     * @param ThisMethod the given IntegrationMethod
-     * @return the gradients of all shape functions with regard to the
-     * global coordinates
-     *
-     * KLUDGE: method call only works with explicit JacobiansType rather than creating
-     * JacobiansType within argument list
-     */
-    ShapeFunctionsGradientsType&
-    ShapeFunctionsIntegrationPointsGradients(
+    ///@}
+    ///@name Shape Function Integration Points Gradient
+    ///@{
+
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
-        IntegrationMethod ThisMethod ) const override
+        IntegrationMethod ThisMethod) const override
     {
-        const unsigned int integration_points_number = msGeometryData.IntegrationPointsNumber( ThisMethod );
-
-        if ( integration_points_number == 0 )
-            KRATOS_ERROR << "This integration method is not supported" << *this << std::endl;
-
-        //workaround by riccardo
-        if ( rResult.size() != integration_points_number )
-        {
-            // KLUDGE: While there is a bug in ublas
-            // vector resize, I have to put this beside resizing!!
-            ShapeFunctionsGradientsType temp( integration_points_number );
-            rResult.swap( temp );
-        }
-
-        //calculating the local gradients
-        ShapeFunctionsGradientsType locG =
-            CalculateShapeFunctionsIntegrationPointsLocalGradients( ThisMethod );
-
-        //getting the inverse jacobian matrices
-        JacobiansType temp( integration_points_number );
-
-        JacobiansType invJ = this->InverseOfJacobian( temp, ThisMethod );
-
-        //loop over all integration points
-        for ( unsigned int pnt = 0; pnt < integration_points_number; pnt++ )
-        {
-            rResult[pnt].resize( 4, 2, false );
-
-            for ( int i = 0; i < 4; i++ )
-            {
-                for ( int j = 0; j < 2; j++ )
-                {
-                    rResult[pnt]( i, j ) = ( locG[pnt]( i, 0 ) * invJ[pnt]( j, 0 ) )
-                                           + ( locG[pnt]( i, 1 ) * invJ[pnt]( j, 1 ) );
-                }
-            }
-        }//end of loop over integration points
-
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
         return rResult;
     }
 
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
+
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod,
+        Matrix &ShapeFunctionsIntegrationPointsValues) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
+
+    ///@}
 
     /**
      * Input and Output

--- a/kratos/geometries/quadrilateral_3d_9.h
+++ b/kratos/geometries/quadrilateral_3d_9.h
@@ -974,21 +974,19 @@ public:
     ///@name Shape Function Integration Points Gradient
     ///@{
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType &rResult,
         Vector &rDeterminantsOfJacobian,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
     ///@}

--- a/kratos/geometries/quadrilateral_interface_2d_4.h
+++ b/kratos/geometries/quadrilateral_interface_2d_4.h
@@ -916,7 +916,7 @@ public:
      * KLUDGE: method call only works with explicit JacobiansType rather than creating
      * JacobiansType within argument list
     */
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod ) const override
     {
@@ -959,8 +959,6 @@ public:
                 }
             }
         }//end of loop over integration points
-
-        return rResult;
     }
 
     ///@}

--- a/kratos/geometries/quadrilateral_interface_3d_4.h
+++ b/kratos/geometries/quadrilateral_interface_3d_4.h
@@ -958,7 +958,7 @@ public:
      * KLUDGE: method call only works with explicit JacobiansType rather than creating
      * JacobiansType within argument list
     */
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod ) const override
     {
@@ -1001,8 +1001,6 @@ public:
                 }
             }
         }//end of loop over integration points
-
-        return rResult;
     }
 
     ///@}

--- a/kratos/geometries/sphere_3d_1.h
+++ b/kratos/geometries/sphere_3d_1.h
@@ -640,14 +640,10 @@ public:
         return( rResult );
     }
 
-
-
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
+    void ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
     {
         std::cout<<"This method (ShapeFunctionsLocalGradients) has no meaning for this type of geometry (Sphere)."<<std::endl;
-        return( rResult );
     }
-
 
     /** Turn back information as a string.
 

--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -1335,7 +1335,7 @@ public:
      *
      * :TODO: TESTING!!!
      */
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod) const override
     {
@@ -1380,13 +1380,10 @@ public:
 
         for(unsigned int i=0; i<integration_points_number; i++)
                 rResult[i] = DN_DX;
-
-
-        return rResult;
     }
 
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult
         , Vector& determinants_of_jacobian
         , IntegrationMethod ThisMethod) const override
@@ -1441,9 +1438,6 @@ public:
         }
         for(unsigned int i=0; i<integration_points_number; i++)
                 rResult[i] = DN_DX;
-
-
-        return rResult;
     }
 
 

--- a/kratos/geometries/triangle_2d_3.h
+++ b/kratos/geometries/triangle_2d_3.h
@@ -974,7 +974,7 @@ public:
      * @return the gradients of all shape functions with regard to the global coordinates
 
     */
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod ) const override
     {
@@ -1012,11 +1012,9 @@ public:
         }
         for(unsigned int i=0; i<integration_points_number; i++)
             rResult[i] = DN_DX;
-
-        return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         Vector& determinants_of_jacobian,
         IntegrationMethod ThisMethod ) const override
@@ -1061,8 +1059,6 @@ public:
 
         for(unsigned int i=0; i<integration_points_number; i++)
             determinants_of_jacobian[i] = detJ;
-
-        return rResult;
     }
 
     /**

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -1466,16 +1466,6 @@ public:
         return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
-        ShapeFunctionsGradientsType &rResult,
-        Vector &rDeterminantsOfJacobian,
-        IntegrationMethod ThisMethod,
-        Matrix &ShapeFunctionsIntegrationPointsValues) const override
-    {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
-    }
-
     ///@}
     ///@name Input and output
     ///@{

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -1445,63 +1445,34 @@ public:
         return rResult;
     }
 
-    /**
-     * Calculates the Gradients of the shape functions.
-     * Calculates the gradients of the shape functions with regard to
-     * the global coordinates in all
-     * integration points (\f$ \frac{\partial N^i}{\partial X_j} \f$)
-     *
-     * @param rResult a container which takes the calculated gradients
-     * @param ThisMethod the given IntegrationMethod
-     *
-     * @return the gradients of all shape functions with regard to the global coordinates
-     * KLUDGE: method call only works with explicit JacobiansType rather than creating
-     * JacobiansType within argument list
-    */
+    ///@}
+    ///@name Shape Function Integration Points Gradient
+    ///@{
+
     ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
-        IntegrationMethod ThisMethod ) const override
+        IntegrationMethod ThisMethod) const override
     {
-        const unsigned int integration_points_number =
-            msGeometryData.IntegrationPointsNumber( ThisMethod );
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
 
-        if ( integration_points_number == 0 )
-            KRATOS_ERROR << "This integration method is not supported" << *this << std::endl;
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
 
-        //workaround by riccardo
-        if ( rResult.size() != integration_points_number )
-        {
-            // KLUDGE: While there is a bug in ublas
-            // vector resize, I have to put this beside resizing!!
-            ShapeFunctionsGradientsType temp( integration_points_number );
-            rResult.swap( temp );
-        }
-
-        //calculating the local gradients
-        ShapeFunctionsGradientsType locG =
-            CalculateShapeFunctionsIntegrationPointsLocalGradients( ThisMethod );
-
-        //getting the inverse jacobian matrices
-        JacobiansType temp( integration_points_number );
-
-        JacobiansType invJ = InverseOfJacobian( temp, ThisMethod );
-
-        //loop over all integration points
-        for ( unsigned int pnt = 0; pnt < integration_points_number; pnt++ )
-        {
-            rResult[pnt].resize( 3, 2,false );
-
-            for ( int i = 0; i < 3; i++ )
-            {
-                for ( int j = 0; j < 2; j++ )
-                {
-                    rResult[pnt]( i, j ) =
-                        ( locG[pnt]( i, 0 ) * invJ[pnt]( j, 0 ) )
-                        + ( locG[pnt]( i, 1 ) * invJ[pnt]( j, 1 ) );
-                }
-            }
-        }//end of loop over integration points
-
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod,
+        Matrix &ShapeFunctionsIntegrationPointsValues) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
         return rResult;
     }
 
@@ -2365,7 +2336,7 @@ private:
         b = -(U0[i0] - U2[i0]);
         c = -a * U2[i0] - b * U2[i1];
         d2 = a * V0[i0] + b * V0[i1] + c;
-        
+
         if (d0 * d1 > 0.0){
             if (d0 * d2 > 0.0) return true;
         }

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -1449,21 +1449,19 @@ public:
     ///@name Shape Function Integration Points Gradient
     ///@{
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType &rResult,
         Vector &rDeterminantsOfJacobian,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
     ///@}

--- a/kratos/geometries/triangle_3d_6.h
+++ b/kratos/geometries/triangle_3d_6.h
@@ -894,16 +894,6 @@ public:
         return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
-        ShapeFunctionsGradientsType &rResult,
-        Vector &rDeterminantsOfJacobian,
-        IntegrationMethod ThisMethod,
-        Matrix &ShapeFunctionsIntegrationPointsValues) const override
-    {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
-    }
-
     ///@}
     ///@name Input and output
     ///@{

--- a/kratos/geometries/triangle_3d_6.h
+++ b/kratos/geometries/triangle_3d_6.h
@@ -873,66 +873,34 @@ public:
         return 0;
     }
 
-    /**
-     * TODO: implemented but not yet tested
-     */
-    /**
-     * Calculates the Gradients of the shape functions.
-     * Calculates the gradients of the shape functions with regard to
-     * the global coordinates in all
-     * integration points (\f$ \frac{\partial N^i}{\partial X_j} \f$)
-     *
-     * @param rResult a container which takes the calculated gradients
-     * @param ThisMethod the given IntegrationMethod
-     *
-     * @return the gradients of all shape functions with regard to the global coordinates
-     * KLUDGE: method call only works with explicit JacobiansType rather than creating
-     * JacobiansType within argument list
-    */
+    ///@}
+    ///@name Shape Function Integration Points Gradient
+    ///@{
+
     ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
-        IntegrationMethod ThisMethod ) const override
+        IntegrationMethod ThisMethod) const override
     {
-        const unsigned int integration_points_number =
-            msGeometryData.IntegrationPointsNumber( ThisMethod );
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
 
-        if ( integration_points_number == 0 )
-            KRATOS_ERROR << "This integration method is not supported" << *this << std::endl;
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return rResult;
+    }
 
-        //workaround by riccardo
-        if ( rResult.size() != integration_points_number )
-        {
-            // KLUDGE: While there is a bug in ublas
-            // vector resize, I have to put this beside resizing!!
-            ShapeFunctionsGradientsType temp( integration_points_number );
-            rResult.swap( temp );
-        }
-
-        //calculating the local gradients
-        ShapeFunctionsGradientsType locG =
-            CalculateShapeFunctionsIntegrationPointsLocalGradients( ThisMethod );
-
-        //getting the inverse jacobian matrices
-        JacobiansType temp( integration_points_number );
-
-        JacobiansType invJ = this->InverseOfJacobian( temp, ThisMethod );
-
-        //loop over all integration points
-        for ( unsigned int pnt = 0; pnt < integration_points_number; pnt++ )
-        {
-            rResult[pnt].resize( 6, 2 ,false);
-
-            for ( int i = 0; i < 6; i++ )
-            {
-                for ( int j = 0; j < 2; j++ )
-                {
-                    rResult[pnt]( i, j ) =
-                        ( locG[pnt]( i, 0 ) * invJ[pnt]( j, 0 ) )
-                        + ( locG[pnt]( i, 1 ) * invJ[pnt]( j, 1 ) );
-                }
-            }
-        }//end of loop over integration points
-
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+        ShapeFunctionsGradientsType &rResult,
+        Vector &rDeterminantsOfJacobian,
+        IntegrationMethod ThisMethod,
+        Matrix &ShapeFunctionsIntegrationPointsValues) const override
+    {
+        KRATOS_ERROR << "Jacobian is not square" << std::endl;
         return rResult;
     }
 
@@ -1499,4 +1467,3 @@ GeometryDimension Triangle3D6<TPointType>::msGeometryDimension(
 }// namespace Kratos.
 
 #endif // KRATOS_TRIANGLE_3D_6_H_INCLUDED defined
-

--- a/kratos/geometries/triangle_3d_6.h
+++ b/kratos/geometries/triangle_3d_6.h
@@ -877,21 +877,19 @@ public:
     ///@name Shape Function Integration Points Gradient
     ///@{
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
-    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    void ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType &rResult,
         Vector &rDeterminantsOfJacobian,
         IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
     }
 
     ///@}

--- a/kratos/modified_shape_functions/modified_shape_functions.cpp
+++ b/kratos/modified_shape_functions/modified_shape_functions.cpp
@@ -530,7 +530,7 @@ namespace Kratos
             // Get the subdivision shape function values
             const Matrix subdivision_sh_func_values = r_subdivision_geom.ShapeFunctionsValues(IntegrationMethod);
             ShapeFunctionsGradientsType subdivision_sh_func_gradients_values;
-            subdivision_sh_func_gradients_values = r_subdivision_geom.ShapeFunctionsIntegrationPointsGradients(subdivision_sh_func_gradients_values, IntegrationMethod);
+            r_subdivision_geom.ShapeFunctionsIntegrationPointsGradients(subdivision_sh_func_gradients_values, IntegrationMethod);
 
             // Get the subdivision Jacobian values on all Gauss pts.
             Vector subdivision_jacobians_values;


### PR DESCRIPTION
**📝 Description**
This aims to completely fix the issue raised in #9144 according to the @KratosMultiphysics/technical-committee conclusions reported in #9242.

**Done**
- [x] Error thrown in base `Geometry` class.
- [x] Line geometries error thrown
- [x] 3D triangles error thrown
- [x] 3D quads error thrown

**To discuss**

- I think we should remove the next `ShapeFunctionsIntegrationPointsGradients` signature
```c++
    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
        ShapeFunctionsGradientsType& rResult,
        Vector& rDeterminantsOfJacobian,
        IntegrationMethod ThisMethod,
        Matrix& ShapeFunctionsIntegrationPointsValues) const
```
- I think we should remove the return the legacy `ShapeFunctionsGradientsType&` return type from the signature. I don't think it would be hard to do it at once as we will incur in a compilation error.

closes #9144