### PR TITLE
[MeshingApplication] Isosurface - Clean conditions that do not belong to an element face

### DIFF
--- a/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
+++ b/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
@@ -288,6 +288,7 @@ void MmgProcess<TMMGLibrary>::ExecuteFinalize()
     // Nodes not belonging to an element are removed
     if(mRemoveRegions) {
         CleanSuperfluousNodes();
+        CleanSuperfluousConditions();
     }
 
     // Save the mesh in an .mdpa format
@@ -1168,7 +1169,6 @@ void MmgProcess<TMMGLibrary>::CleanSuperfluousNodes()
     // Iterate over nodes
     auto& r_nodes_array = mrThisModelPart.Nodes();
     const SizeType initial_num = r_nodes_array.size();
-    const SizeType initial_num_cond = mrThisModelPart.Conditions().size();
 
     // Marking all nodes as "superfluous"
     VariableUtils().SetFlag(TO_ERASE, true, r_nodes_array);
@@ -1185,6 +1185,18 @@ void MmgProcess<TMMGLibrary>::CleanSuperfluousNodes()
     });
 
     mrThisModelPart.RemoveNodesFromAllLevels(TO_ERASE);
+    const SizeType final_num = mrThisModelPart.Nodes().size();
+    KRATOS_INFO("MmgProcess") << "In total " << (initial_num - final_num) <<" superfluous nodes were cleared" << std::endl;
+
+    KRATOS_CATCH("");
+}
+
+template<MMGLibrary TMMGLibrary>
+void MmgProcess<TMMGLibrary>::CleanSuperfluousConditions()
+{
+    KRATOS_TRY;
+
+    const SizeType initial_num_cond = mrThisModelPart.Conditions().size();
 
     // Check which conditions do not have a parent element
     typedef std::unordered_map<DenseVector<int>, std::vector<Condition::Pointer>, KeyHasherRange<DenseVector<int>>, KeyComparorRange<DenseVector<int>> > IndexCondMapType;
@@ -1247,9 +1259,7 @@ void MmgProcess<TMMGLibrary>::CleanSuperfluousNodes()
 
     mrThisModelPart.RemoveConditionsFromAllLevels(TO_ERASE);
 
-    const SizeType final_num = mrThisModelPart.Nodes().size();
     const SizeType final_num_cond = mrThisModelPart.Conditions().size();
-    KRATOS_INFO("MmgProcess") << "In total " << (initial_num - final_num) <<" superfluous nodes were cleared" << std::endl;
     KRATOS_INFO("MmgProcess") << "In total " << (initial_num_cond - final_num_cond) <<" wrong conditions were cleared" << std::endl;
 
     KRATOS_CATCH("");

--- a/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
+++ b/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
@@ -1014,8 +1014,8 @@ void MmgProcess<TMMGLibrary>::ClearConditionsDuplicatedGeometries()
     KRATOS_TRY;
 
     // Next check that the conditions are oriented accordingly to do so begin by putting all of the conditions in a set
-    typedef std::unordered_map<DenseVector<IndexType>, std::vector<IndexType>, KeyHasherRange<DenseVector<IndexType>>, KeyComparorRange<DenseVector<IndexType>> > IndexCondMapTypeType;
-    IndexCondMapTypeType faces_map;
+    typedef std::unordered_map<DenseVector<IndexType>, std::vector<IndexType>, KeyHasherRange<DenseVector<IndexType>>, KeyComparorRange<DenseVector<IndexType>> > HashMapType;
+    HashMapType faces_map;
 
     // Iterate over conditions
     auto& r_conditions_array = mrThisModelPart.Conditions();
@@ -1037,13 +1037,13 @@ void MmgProcess<TMMGLibrary>::ClearConditionsDuplicatedGeometries()
         std::sort(ids.begin(), ids.end());
 
         // Insert a pointer to the condition identified by the hash value ids
-        IndexCondMapTypeType::iterator it_face = faces_map.find(ids);
+        HashMapType::iterator it_face = faces_map.find(ids);
         if(it_face != faces_map.end() ) { // Already defined vector
             (it_face->second).push_back(r_cond.Id());
         } else {
             std::vector<IndexType> aux_cond_id(1);
             aux_cond_id[0] = r_cond.Id();
-            faces_map.insert( IndexCondMapTypeType::value_type(std::pair<DenseVector<IndexType>, std::vector<IndexType>>({ids, aux_cond_id})) );
+            faces_map.insert( HashMapType::value_type(std::pair<DenseVector<IndexType>, std::vector<IndexType>>({ids, aux_cond_id})) );
         }
     }
 

--- a/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
+++ b/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
@@ -1235,8 +1235,8 @@ void MmgProcess<TMMGLibrary>::CleanSuperfluousNodes()
 
                 // Order ids to use them in the map
                 std::sort(aux.begin(), aux.end());
-                if(faces_map.find(aux) != faces_map.end()) { // It was actually found!!
-                    // Mark the condition as visited. This will be useful for a check at the endif
+                if(faces_map.find(aux) != faces_map.end()) {
+                    // Found condition in element face, do not erase
                     for (auto p_cond : faces_map[aux]) {
                         p_cond->Set(TO_ERASE,false);
                     }

--- a/applications/MeshingApplication/custom_processes/mmg/mmg_process.h
+++ b/applications/MeshingApplication/custom_processes/mmg/mmg_process.h
@@ -220,6 +220,11 @@ public:
     void CleanSuperfluousNodes();
 
     /**
+     * @brief Ths function removes superfluous (defined by "not belonging to an element") conditions from the model part
+     */
+    void CleanSuperfluousConditions();
+
+    /**
      * @brief This method retrieves the current Mmg version
      * @return The current version of Mmg (as a string)
      */


### PR DESCRIPTION
**📝 Description**
When running a case to solve a fluid dynamic problem using the isosurface option with remove_regions=true, there were some conditions that did not have a corresponding element. 

For instance, this situation could happen after removing the internal regions:

![image](https://user-images.githubusercontent.com/32136457/140524582-e36f46e9-a3fe-4817-858f-eecfe7585ce8.png)

Those 3 nodes were part of a condition which no longer had an element.

Now these conditions are cleaned up


**🆕 Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Added function to remove conditions that do not match with an element face
