### PR TITLE
[Core] [GidOutputProcess] time label format

### DIFF
--- a/kratos/python_scripts/gid_output_process.py
+++ b/kratos/python_scripts/gid_output_process.py
@@ -29,7 +29,7 @@ class GiDOutputProcess(KM.Process):
                 "MultiFileFlag": "SingleFile"
             },
             "file_label": "time",
-            "time_label_format": "",
+            "time_label_format": "{:.12f}",
             "output_control_type": "step",
             "output_interval": 1.0,
             "flush_after_output": false,
@@ -198,7 +198,7 @@ class GiDOutputProcess(KM.Process):
         else:
             msg = "{0} Error: Unknown value \"{1}\" read for parameter \"{2}\"".format(self.__class__.__name__,output_file_label,"file_label")
             raise Exception(msg)
-        
+
         self.time_label_format = result_file_configuration["time_label_format"].GetString()
 
         output_control_type = result_file_configuration["output_control_type"].GetString()
@@ -282,7 +282,7 @@ class GiDOutputProcess(KM.Process):
         self.printed_step_count += 1
         self.model_part.ProcessInfo[PRINTED_STEP] = self.printed_step_count
         if self.output_label_is_time:
-            label = self._GetPrettyTime(time)
+            label = time
         else:
             label = self.printed_step_count
 
@@ -290,12 +290,11 @@ class GiDOutputProcess(KM.Process):
             self.__write_mesh(label)
             self.__initialize_results(label)
 
-        time_label = self._GetPrettyTime(time) # should this be label instead of time_label?
-        self.__write_nodal_results(time_label)
-        self.__write_gp_results(time_label)
-        self.__write_nonhistorical_nodal_results(time_label)
-        self.__write_nodal_flags(time_label)
-        self.__write_elemental_conditional_flags(time_label)
+        self.__write_nodal_results(time)
+        self.__write_gp_results(time)
+        self.__write_nonhistorical_nodal_results(time)
+        self.__write_nodal_flags(time)
+        self.__write_elemental_conditional_flags(time)
 
         if self.flush_after_output and self.multifile_flag != MultiFileFlag.MultipleFiles:
             if self.body_io is not None:
@@ -365,7 +364,7 @@ class GiDOutputProcess(KM.Process):
                                 WriteConditionsFlag.WriteConditionsOnly) # Cuts are conditions, so we always print conditions in the cut ModelPart
 
     def __get_pretty_time(self,time):
-        pretty_time = "{0:.12g}".format(time)
+        pretty_time = self.time_label_format.format(time)
         pretty_time = float(pretty_time)
         return pretty_time
 
@@ -741,9 +740,3 @@ class GiDOutputProcess(KM.Process):
 
         # Restart .post.lst files
         self.__restart_list_files(additional_list_files) # FIXME
-
-    def _GetPrettyTime(self, time):
-        if self.time_label_format:
-            return float(self.time_label_format.format(time))
-        else:
-            return time

--- a/kratos/python_scripts/gid_output_process.py
+++ b/kratos/python_scripts/gid_output_process.py
@@ -29,6 +29,7 @@ class GiDOutputProcess(KM.Process):
                 "MultiFileFlag": "SingleFile"
             },
             "file_label": "time",
+            "time_label_format": "",
             "output_control_type": "step",
             "output_interval": 1.0,
             "flush_after_output": false,
@@ -197,6 +198,8 @@ class GiDOutputProcess(KM.Process):
         else:
             msg = "{0} Error: Unknown value \"{1}\" read for parameter \"{2}\"".format(self.__class__.__name__,output_file_label,"file_label")
             raise Exception(msg)
+        
+        self.time_label_format = result_file_configuration["time_label_format"].GetString()
 
         output_control_type = result_file_configuration["output_control_type"].GetString()
         if output_control_type == "time":
@@ -279,7 +282,7 @@ class GiDOutputProcess(KM.Process):
         self.printed_step_count += 1
         self.model_part.ProcessInfo[PRINTED_STEP] = self.printed_step_count
         if self.output_label_is_time:
-            label = time
+            label = self._GetPrettyTime(time)
         else:
             label = self.printed_step_count
 
@@ -287,11 +290,12 @@ class GiDOutputProcess(KM.Process):
             self.__write_mesh(label)
             self.__initialize_results(label)
 
-        self.__write_nodal_results(time)
-        self.__write_gp_results(time)
-        self.__write_nonhistorical_nodal_results(time)
-        self.__write_nodal_flags(time)
-        self.__write_elemental_conditional_flags(time)
+        time_label = self._GetPrettyTime(time) # should this be label instead of time_label?
+        self.__write_nodal_results(time_label)
+        self.__write_gp_results(time_label)
+        self.__write_nonhistorical_nodal_results(time_label)
+        self.__write_nodal_flags(time_label)
+        self.__write_elemental_conditional_flags(time_label)
 
         if self.flush_after_output and self.multifile_flag != MultiFileFlag.MultipleFiles:
             if self.body_io is not None:
@@ -737,3 +741,9 @@ class GiDOutputProcess(KM.Process):
 
         # Restart .post.lst files
         self.__restart_list_files(additional_list_files) # FIXME
+
+    def _GetPrettyTime(self, time):
+        if self.time_label_format:
+            return float(self.time_label_format.format(time))
+        else:
+            return time


### PR DESCRIPTION
**📝 Description**

Currently, `GidOutputProcess` sets the time format as `"{:.12f}"`. In this PR the format can be modified by the user. The default value is the same.

I want to merge two independent simulations which share the time. Even if the output frequency is the same in both simulations, the time stamp is different for each simulation. Hence, its not possible to synchronize the results. E.g, if the output interval is 0.1, the time stamps for the two simulations can be:
> 0.103...
0.105...
0.206...
0.215...
0.309...
0.301...

In this PR I'm adding the time label format as an option in the project parameters. Following the same example, I can set a custom time format `"{:.1f}"` and the new time stamps will be:
> 0.1
0.2
0.3

**🆕 Changelog**
- Add `time_label_format` in the project parameters
