### PR TITLE
[Meshing] ParMmg - Pass MPI COMM world from modelpart data communicator

### DIFF
--- a/applications/MeshingApplication/custom_processes/parmmg/pmmg_process.cpp
+++ b/applications/MeshingApplication/custom_processes/parmmg/pmmg_process.cpp
@@ -109,7 +109,7 @@ void ParMmgProcess<TPMMGLibrary>::ExecuteInitialize()
 
     /* We restart the PMMG mesh and solution */
     mPMmgUtilities.SetEchoLevel(mEchoLevel);
-    mPMmgUtilities.InitMesh();
+    mPMmgUtilities.InitMesh(mrThisModelPart.GetCommunicator().GetDataCommunicator());
 
     KRATOS_CATCH("");
 }

--- a/applications/MeshingApplication/custom_processes/parmmg/pmmg_process.cpp
+++ b/applications/MeshingApplication/custom_processes/parmmg/pmmg_process.cpp
@@ -225,7 +225,7 @@ void ParMmgProcess<TPMMGLibrary>::ExecuteFinalize()
     FreeMemory();
 
     // Call parallel fill communicator
-    ParallelFillCommunicator(mrThisModelPart).Execute();
+    ParallelFillCommunicator(mrThisModelPart, mrThisModelPart.GetCommunicator().GetDataCommunicator()).Execute();
 
     // Save the mesh in an .mdpa format
     const bool save_mdpa_file = mThisParameters["save_mdpa_file"].GetBool();

--- a/applications/MeshingApplication/custom_utilities/parmmg/pmmg_utilities.cpp
+++ b/applications/MeshingApplication/custom_utilities/parmmg/pmmg_utilities.cpp
@@ -24,6 +24,8 @@
 
 // Project includes
 #include "custom_utilities/parmmg/pmmg_utilities.h"
+#include "mpi/includes/mpi_data_communicator.h"
+
 
 // NOTE: The following contains the license of the PMMG library
 /* =============================================================================
@@ -370,13 +372,13 @@ Element::Pointer ParMmgUtilities<PMMGLibrary::PMMG3D>::CreateFirstTypeElement(
 /***********************************************************************************/
 
 template<>
-void ParMmgUtilities<PMMGLibrary::PMMG3D>::InitMesh()
+void ParMmgUtilities<PMMGLibrary::PMMG3D>::InitMesh(const DataCommunicator& rDataCommunicator)
 {
     mParMmgMesh = nullptr;
 
     // We init the PMMG mesh and sol
     if (GetDiscretization() == DiscretizationOption::STANDARD) {
-        PMMG_Init_parMesh( PMMG_ARG_start, PMMG_ARG_ppParMesh, &mParMmgMesh, PMMG_ARG_pMesh, PMMG_ARG_pMet, PMMG_ARG_dim, 3, PMMG_ARG_MPIComm, MPI_COMM_WORLD, PMMG_ARG_end);
+        PMMG_Init_parMesh( PMMG_ARG_start, PMMG_ARG_ppParMesh, &mParMmgMesh, PMMG_ARG_pMesh, PMMG_ARG_pMet, PMMG_ARG_dim, 3, PMMG_ARG_MPIComm, MPIDataCommunicator::GetMPICommunicator(rDataCommunicator), PMMG_ARG_end);
     } else {
         KRATOS_ERROR << "Discretization type: " << static_cast<int>(GetDiscretization()) << " not fully implemented" << std::endl;
     }

--- a/applications/MeshingApplication/custom_utilities/parmmg/pmmg_utilities.cpp
+++ b/applications/MeshingApplication/custom_utilities/parmmg/pmmg_utilities.cpp
@@ -378,7 +378,10 @@ void ParMmgUtilities<PMMGLibrary::PMMG3D>::InitMesh(const DataCommunicator& rDat
 
     // We init the PMMG mesh and sol
     if (GetDiscretization() == DiscretizationOption::STANDARD) {
-        PMMG_Init_parMesh( PMMG_ARG_start, PMMG_ARG_ppParMesh, &mParMmgMesh, PMMG_ARG_pMesh, PMMG_ARG_pMet, PMMG_ARG_dim, 3, PMMG_ARG_MPIComm, MPIDataCommunicator::GetMPICommunicator(rDataCommunicator), PMMG_ARG_end);
+        KRATOS_ERROR_IF_NOT(rDataCommunicator.IsDistributed()) << "ConnectMPI requires a distributed DataCommunicator!" << std::endl;
+        KRATOS_ERROR_IF_NOT(rDataCommunicator.IsDefinedOnThisRank()) << "This rank is not part of this MPI_Comm!" << std::endl;
+        MPI_Comm the_mpi_comm = MPIDataCommunicator::GetMPICommunicator(rDataCommunicator);
+        PMMG_Init_parMesh( PMMG_ARG_start, PMMG_ARG_ppParMesh, &mParMmgMesh, PMMG_ARG_pMesh, PMMG_ARG_pMet, PMMG_ARG_dim, 3, PMMG_ARG_MPIComm, the_mpi_comm, PMMG_ARG_end);
     } else {
         KRATOS_ERROR << "Discretization type: " << static_cast<int>(GetDiscretization()) << " not fully implemented" << std::endl;
     }

--- a/applications/MeshingApplication/custom_utilities/parmmg/pmmg_utilities.cpp
+++ b/applications/MeshingApplication/custom_utilities/parmmg/pmmg_utilities.cpp
@@ -378,7 +378,7 @@ void ParMmgUtilities<PMMGLibrary::PMMG3D>::InitMesh(const DataCommunicator& rDat
 
     // We init the PMMG mesh and sol
     if (GetDiscretization() == DiscretizationOption::STANDARD) {
-        KRATOS_ERROR_IF_NOT(rDataCommunicator.IsDistributed()) << "ConnectMPI requires a distributed DataCommunicator!" << std::endl;
+        KRATOS_ERROR_IF_NOT(rDataCommunicator.IsDistributed()) << "ParMMG requires a distributed DataCommunicator!" << std::endl;
         KRATOS_ERROR_IF_NOT(rDataCommunicator.IsDefinedOnThisRank()) << "This rank is not part of this MPI_Comm!" << std::endl;
         MPI_Comm the_mpi_comm = MPIDataCommunicator::GetMPICommunicator(rDataCommunicator);
         PMMG_Init_parMesh( PMMG_ARG_start, PMMG_ARG_ppParMesh, &mParMmgMesh, PMMG_ARG_pMesh, PMMG_ARG_pMet, PMMG_ARG_dim, 3, PMMG_ARG_MPIComm, the_mpi_comm, PMMG_ARG_end);

--- a/applications/MeshingApplication/custom_utilities/parmmg/pmmg_utilities.h
+++ b/applications/MeshingApplication/custom_utilities/parmmg/pmmg_utilities.h
@@ -275,8 +275,10 @@ public:
      * -# &mmgMesh pointer toward your MMG5_pMesh (that store your mesh)
      * -# MMG5_ARG_ppMet next arg will be a pointer over a MMG5_pSol storing a metric
      * -# &mmgSol pointer toward your MMG5_pSol (that store your metric)
+     * @param[in] rDataCommunicator Data communicator to be used to initialize ParMmg
+     *
      */
-    void InitMesh() override;
+    void InitMesh(const DataCommunicator& rDataCommunicator);
 
     /**
      * @brief Here the verbosity is set


### PR DESCRIPTION
**📝 Description**
As requested in https://github.com/KratosMultiphysics/Kratos/pull/7808#discussion_r544188556, this passes the MPI_COM_WORLD to ParMmg from the data communicator. 

**🆕 Changelog**
- Pass MPI_COMM_WORLD from data comm. 
