### PR TITLE
[MLMC] Add processes per node variable

### DIFF
--- a/applications/MultilevelMonteCarloApplication/external_libraries/PyCOMPSs/exaqute/local/decorators.py
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/PyCOMPSs/exaqute/local/decorators.py
@@ -113,7 +113,7 @@ class Mpi(object):
         if "runner" not in kwargs:
             raise ExaquteException("Runner must be specified")
         for k, v in kwargs.items():
-            if k not in ("processes", "runner", "flags"):
+            if k not in ("processes", "runner", "flags", "processes_per_node"):
                 if not k.endswith("_layout"):
                     raise ExaquteException("Argument '{}' is not valid".format(k))
 

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/methodDefs_KratosSolverWrapper/mpi_solve.py
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/methodDefs_KratosSolverWrapper/mpi_solve.py
@@ -12,44 +12,17 @@ from KratosMultiphysics import IsDistributedRun, DataCommunicator
 from xmc.classDefs_solverWrapper.methodDefs_KratosSolverWrapper.solve import ExecuteInstanceDeterministicAdaptiveRefinementAux_Functionality,ExecuteInstanceReadingFromFileAux_Functionality,ExecuteInstanceStochasticAdaptiveRefinementAux_Functionality
 from exaqute import *
 
-try:
-    computing_units_mlmc_execute_0 = int(os.environ["computing_units_mlmc_execute_0"])
-except:
-    computing_units_mlmc_execute_0 = 1
-try:
-    computing_units_mlmc_execute_1 = int(os.environ["computing_units_mlmc_execute_1"])
-except:
-    computing_units_mlmc_execute_1 = 1
-try:
-    computing_units_mlmc_execute_2 = int(os.environ["computing_units_mlmc_execute_2"])
-except:
-    computing_units_mlmc_execute_2 = 1
+computing_units_mlmc_execute_0 = int(os.getenv("computing_units_mlmc_execute_0", 1))
+computing_units_mlmc_execute_1 = int(os.getenv("computing_units_mlmc_execute_1", 1))
+computing_units_mlmc_execute_2 = int(os.getenv("computing_units_mlmc_execute_2", 1))
 
-try:
-    computing_procs_mlmc_execute_0 = int(os.environ["computing_procs_mlmc_execute_0"])
-except:
-    computing_procs_mlmc_execute_0 = 1
-try:
-    computing_procs_mlmc_execute_1 = int(os.environ["computing_procs_mlmc_execute_1"])
-except:
-    computing_procs_mlmc_execute_1 = 1
-try:
-    computing_procs_mlmc_execute_2 = int(os.environ["computing_procs_mlmc_execute_2"])
-except:
-    computing_procs_mlmc_execute_2 = 1
+computing_procs_mlmc_execute_0 = int(os.getenv("computing_procs_mlmc_execute_0", 1))
+computing_procs_mlmc_execute_1 = int(os.getenv("computing_procs_mlmc_execute_1", 1))
+computing_procs_mlmc_execute_2 = int(os.getenv("computing_procs_mlmc_execute_2", 1))
 
-try:
-    ppn_mlmc_execute_0 = int(os.environ["ppn_mlmc_execute_0"])
-except:
-    ppn_mlmc_execute_0 = 1
-try:
-    ppn_mlmc_execute_1 = int(os.environ["ppn_mlmc_execute_1"])
-except:
-    ppn_mlmc_execute_1 = 1
-try:
-    ppn_mlmc_execute_2 = int(os.environ["ppn_mlmc_execute_2"])
-except:
-    ppn_mlmc_execute_2 = 1
+ppn_mlmc_execute_0 = int(os.getenv("ppn_mlmc_execute_0", 1))
+ppn_mlmc_execute_1 = int(os.getenv("ppn_mlmc_execute_1", 1))
+ppn_mlmc_execute_2 = int(os.getenv("ppn_mlmc_execute_2", 1))
 
 ####################################################################################################
 ############################################ WRAPPERS ##############################################

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/methodDefs_KratosSolverWrapper/mpi_solve.py
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/methodDefs_KratosSolverWrapper/mpi_solve.py
@@ -525,7 +525,7 @@ def executeInstanceDeterministicAdaptiveRefinementAuxLev2_Task(pickled_model,pic
 # @task(keep=True, filename=FILE_OUT, pickled_model=COLLECTION_IN, pickled_mapping_reference_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_0)
 @constraint(computing_units=computing_units_mlmc_execute_0)
 @mpi(runner="mpirun", processes=computing_procs_mlmc_execute_0, processes_per_node=ppn_mlmc_execute_0, pickled_model_layout={block_count: computing_procs_mlmc_execute_0, block_length: 1, stride: 1}, pickled_mapping_reference_model_layout={block_count: computing_procs_mlmc_execute_0, block_length: 1, stride: 1})
-@task(keep=True, filename=FILE_OUT, pickled_model=COLLECTION_IN, pickled_mapping_reference_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_0)
+@task(keep=True, pickled_model=COLLECTION_IN, pickled_mapping_reference_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_0)
 def executeInstanceReadingFromFileAuxLev0_Task(pickled_model,pickled_project_parameters,current_analysis,random_variable,time_for_qoi,mapping_flag,pickled_mapping_reference_model,print_to_file,filename):
     # Import Kratos
     import KratosMultiphysics

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/methodDefs_KratosSolverWrapper/mpi_solve.py
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/methodDefs_KratosSolverWrapper/mpi_solve.py
@@ -38,6 +38,18 @@ try:
 except:
     computing_procs_mlmc_execute_2 = 1
 
+try:
+    ppn_mlmc_execute_0 = int(os.environ["ppn_mlmc_execute_0"])
+except:
+    ppn_mlmc_execute_0 = 1
+try:
+    ppn_mlmc_execute_1 = int(os.environ["ppn_mlmc_execute_1"])
+except:
+    ppn_mlmc_execute_1 = 1
+try:
+    ppn_mlmc_execute_2 = int(os.environ["ppn_mlmc_execute_2"])
+except:
+    ppn_mlmc_execute_2 = 1
 
 ####################################################################################################
 ############################################ WRAPPERS ##############################################
@@ -172,7 +184,7 @@ def UnfoldFutureQMT(qoi_pickled_current_model_time_for_qoi_list):
 ########################################## Serialization ##########################################
 
 @constraint(computing_units=computing_units_mlmc_execute_0)
-@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_0)
+@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_0, processes_per_node=ppn_mlmc_execute_0)
 @task(keep=True, returns=computing_procs_mlmc_execute_0)
 def SerializeMPIModelAuxLev0_Task(pickled_parameters, main_model_part_name, fake_sample_to_serialize, analysis):
     import KratosMultiphysics
@@ -201,7 +213,7 @@ def SerializeMPIModelAuxLev0_Task(pickled_parameters, main_model_part_name, fake
     return pickled_model
 
 @constraint(computing_units=computing_units_mlmc_execute_1)
-@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_1)
+@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_1, processes_per_node=ppn_mlmc_execute_1)
 @task(keep=True, returns=computing_procs_mlmc_execute_1)
 def SerializeMPIModelAuxLev1_Task(pickled_parameters, main_model_part_name, fake_sample_to_serialize, analysis):
     import KratosMultiphysics
@@ -230,7 +242,7 @@ def SerializeMPIModelAuxLev1_Task(pickled_parameters, main_model_part_name, fake
     return pickled_model
 
 @constraint(computing_units=computing_units_mlmc_execute_2)
-@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_2)
+@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_2, processes_per_node=ppn_mlmc_execute_2)
 @task(keep=True, returns=computing_procs_mlmc_execute_2)
 def SerializeMPIModelAuxLev2_Task(pickled_parameters, main_model_part_name, fake_sample_to_serialize, analysis):
     import KratosMultiphysics
@@ -261,7 +273,7 @@ def SerializeMPIModelAuxLev2_Task(pickled_parameters, main_model_part_name, fake
 ########################################## Serialization DAR ##########################################
 
 @constraint(computing_units=computing_units_mlmc_execute_0)
-@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_0, pickled_coarse_model_layout={block_count: computing_procs_mlmc_execute_0, block_length: 1, stride: 1})
+@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_0, processes_per_node=ppn_mlmc_execute_0, pickled_coarse_model_layout={block_count: computing_procs_mlmc_execute_0, block_length: 1, stride: 1})
 @task(keep=True, pickled_coarse_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_0)
 def SerializeDeterministicAdaptiveRefinementMPIModelAuxLev0_Task(current_index,pickled_coarse_model,pickled_coarse_project_parameters,pickled_custom_metric_refinement_parameters,pickled_custom_remesh_refinement_parameters,random_variable,current_analysis,time_for_qoi,adaptive_refinement_jump_to_finest_level):
     # Import Kratos
@@ -289,7 +301,7 @@ def SerializeDeterministicAdaptiveRefinementMPIModelAuxLev0_Task(current_index,p
     return pickled_coarse_model
 
 @constraint(computing_units=computing_units_mlmc_execute_1)
-@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_1, pickled_coarse_model_layout={block_count: computing_procs_mlmc_execute_1, block_length: 1, stride: 1})
+@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_1, processes_per_node=ppn_mlmc_execute_1, pickled_coarse_model_layout={block_count: computing_procs_mlmc_execute_1, block_length: 1, stride: 1})
 @task(keep=True, pickled_coarse_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_1)
 def SerializeDeterministicAdaptiveRefinementMPIModelAuxLev1_Task(current_index,pickled_coarse_model,pickled_coarse_project_parameters,pickled_custom_metric_refinement_parameters,pickled_custom_remesh_refinement_parameters,random_variable,current_analysis,time_for_qoi,adaptive_refinement_jump_to_finest_level):
     # Import Kratos
@@ -317,7 +329,7 @@ def SerializeDeterministicAdaptiveRefinementMPIModelAuxLev1_Task(current_index,p
     return pickled_coarse_model
 
 @constraint(computing_units=computing_units_mlmc_execute_2)
-@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_2, pickled_coarse_model_layout={block_count: computing_procs_mlmc_execute_2, block_length: 1, stride: 1})
+@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_2, processes_per_node=ppn_mlmc_execute_2, pickled_coarse_model_layout={block_count: computing_procs_mlmc_execute_2, block_length: 1, stride: 1})
 @task(keep=True, pickled_coarse_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_2)
 def SerializeDeterministicAdaptiveRefinementMPIModelAuxLev2_Task(current_index,pickled_coarse_model,pickled_coarse_project_parameters,pickled_custom_metric_refinement_parameters,pickled_custom_remesh_refinement_parameters,random_variable,current_analysis,time_for_qoi,adaptive_refinement_jump_to_finest_level):
     # Import Kratos
@@ -348,7 +360,7 @@ def SerializeDeterministicAdaptiveRefinementMPIModelAuxLev2_Task(current_index,p
 
 # @task(keep=True, filename=FILE_OUT, pickled_coarse_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_0)
 @constraint(computing_units=computing_units_mlmc_execute_0)
-@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_0, pickled_coarse_model_layout={block_count: computing_procs_mlmc_execute_0, block_length: 1, stride: 1})
+@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_0, processes_per_node=ppn_mlmc_execute_0, pickled_coarse_model_layout={block_count: computing_procs_mlmc_execute_0, block_length: 1, stride: 1})
 @task(keep=True, pickled_coarse_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_0)
 def ExecuteInstanceStochasticAdaptiveRefinementAllAtOnceAuxLev0_Task(current_index,pickled_coarse_model,pickled_coarse_project_parameters,pickled_custom_metric_refinement_parameters,pickled_custom_remesh_refinement_parameters,random_variable,current_analysis,time_for_qoi,mapping_flag,adaptive_refinement_jump_to_finest_level,print_to_file,filename):
     # Import Kratos
@@ -374,7 +386,7 @@ def ExecuteInstanceStochasticAdaptiveRefinementAllAtOnceAuxLev0_Task(current_ind
 
 # @task(keep=True, filename=FILE_OUT, pickled_coarse_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_1)
 @constraint(computing_units=computing_units_mlmc_execute_1)
-@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_1, pickled_coarse_model_layout={block_count: computing_procs_mlmc_execute_1, block_length: 1, stride: 1})
+@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_1, processes_per_node=ppn_mlmc_execute_1, pickled_coarse_model_layout={block_count: computing_procs_mlmc_execute_1, block_length: 1, stride: 1})
 @task(keep=True, pickled_coarse_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_1)
 def ExecuteInstanceStochasticAdaptiveRefinementAllAtOnceAuxLev1_Task(current_index,pickled_coarse_model,pickled_coarse_project_parameters,pickled_custom_metric_refinement_parameters,pickled_custom_remesh_refinement_parameters,random_variable,current_analysis,time_for_qoi,mapping_flag,adaptive_refinement_jump_to_finest_level,print_to_file,filename):
     # Import Kratos
@@ -400,7 +412,7 @@ def ExecuteInstanceStochasticAdaptiveRefinementAllAtOnceAuxLev1_Task(current_ind
 
 # @task(keep=True, filename=FILE_OUT, pickled_coarse_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_2)
 @constraint(computing_units=computing_units_mlmc_execute_2)
-@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_2, pickled_coarse_model_layout={block_count: computing_procs_mlmc_execute_2, block_length: 1, stride: 1})
+@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_2, processes_per_node=ppn_mlmc_execute_2, pickled_coarse_model_layout={block_count: computing_procs_mlmc_execute_2, block_length: 1, stride: 1})
 @task(keep=True, pickled_coarse_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_2)
 def ExecuteInstanceStochasticAdaptiveRefinementAllAtOnceAuxLev2_Task(current_index,pickled_coarse_model,pickled_coarse_project_parameters,pickled_custom_metric_refinement_parameters,pickled_custom_remesh_refinement_parameters,random_variable,current_analysis,time_for_qoi,mapping_flag,adaptive_refinement_jump_to_finest_level,print_to_file,filename):
     # Import Kratos
@@ -428,7 +440,7 @@ def ExecuteInstanceStochasticAdaptiveRefinementAllAtOnceAuxLev2_Task(current_ind
 
 # @task(keep=True, filename=FILE_OUT,pickled_coarse_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_0)
 @constraint(computing_units=computing_units_mlmc_execute_0)
-@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_0, pickled_coarse_model_layout={block_count: computing_procs_mlmc_execute_0, block_length: 1, stride: 1})
+@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_0, processes_per_node=ppn_mlmc_execute_0, pickled_coarse_model_layout={block_count: computing_procs_mlmc_execute_0, block_length: 1, stride: 1})
 @task(keep=True, pickled_coarse_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_0)
 def ExecuteInstanceStochasticAdaptiveRefinementMultipleTasksAuxLev0_Task(current_index,pickled_coarse_model,pickled_coarse_project_parameters,pickled_custom_metric_refinement_parameters,pickled_custom_remesh_refinement_parameters,random_variable,current_local_index,current_analysis,time_for_qoi,mapping_flag,pickled_mapping_reference_model,print_to_file,filename):
     # Import Kratos
@@ -450,7 +462,7 @@ def ExecuteInstanceStochasticAdaptiveRefinementMultipleTasksAuxLev0_Task(current
 
 # @task(keep=True, filename=FILE_OUT,pickled_model=COLLECTION_IN, pickled_mapping_reference_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_0)
 @constraint(computing_units=computing_units_mlmc_execute_0)
-@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_0, pickled_model_layout={block_count: computing_procs_mlmc_execute_0, block_length: 1, stride: 1}, pickled_mapping_reference_model_layout={block_count: computing_procs_mlmc_execute_0, block_length: 1, stride: 1})
+@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_0, processes_per_node=ppn_mlmc_execute_0, pickled_model_layout={block_count: computing_procs_mlmc_execute_0, block_length: 1, stride: 1}, pickled_mapping_reference_model_layout={block_count: computing_procs_mlmc_execute_0, block_length: 1, stride: 1})
 @task(keep=True, pickled_model=COLLECTION_IN, pickled_mapping_reference_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_0)
 def executeInstanceDeterministicAdaptiveRefinementAuxLev0_Task(pickled_model,pickled_project_parameters,current_analysis,random_variable,time_for_qoi,mapping_flag,pickled_mapping_reference_model,print_to_file,filename):
     # Import Kratos
@@ -470,7 +482,7 @@ def executeInstanceDeterministicAdaptiveRefinementAuxLev0_Task(pickled_model,pic
 
 # @task(keep=True, filename=FILE_OUT,pickled_model=COLLECTION_IN, pickled_mapping_reference_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_1)
 @constraint(computing_units=computing_units_mlmc_execute_1)
-@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_1, pickled_model_layout={block_count: computing_procs_mlmc_execute_1, block_length: 1, stride: 1}, pickled_mapping_reference_model_layout={block_count: computing_procs_mlmc_execute_1, block_length: 1, stride: 1})
+@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_1, processes_per_node=ppn_mlmc_execute_1, pickled_model_layout={block_count: computing_procs_mlmc_execute_1, block_length: 1, stride: 1}, pickled_mapping_reference_model_layout={block_count: computing_procs_mlmc_execute_1, block_length: 1, stride: 1})
 @task(keep=True, pickled_model=COLLECTION_IN, pickled_mapping_reference_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_1)
 def executeInstanceDeterministicAdaptiveRefinementAuxLev1_Task(pickled_model,pickled_project_parameters,current_analysis,random_variable,time_for_qoi,mapping_flag,pickled_mapping_reference_model,print_to_file,filename):
     # Import Kratos
@@ -490,7 +502,7 @@ def executeInstanceDeterministicAdaptiveRefinementAuxLev1_Task(pickled_model,pic
 
 # @task(keep=True, filename=FILE_OUT,pickled_model=COLLECTION_IN, pickled_mapping_reference_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_2)
 @constraint(computing_units=computing_units_mlmc_execute_2)
-@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_2, pickled_model_layout={block_count: computing_procs_mlmc_execute_2, block_length: 1, stride: 1}, pickled_mapping_reference_model_layout={block_count: computing_procs_mlmc_execute_2, block_length: 1, stride: 1})
+@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_2, processes_per_node=ppn_mlmc_execute_2, pickled_model_layout={block_count: computing_procs_mlmc_execute_2, block_length: 1, stride: 1}, pickled_mapping_reference_model_layout={block_count: computing_procs_mlmc_execute_2, block_length: 1, stride: 1})
 @task(keep=True, pickled_model=COLLECTION_IN, pickled_mapping_reference_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_2)
 def executeInstanceDeterministicAdaptiveRefinementAuxLev2_Task(pickled_model,pickled_project_parameters,current_analysis,random_variable,time_for_qoi,mapping_flag,pickled_mapping_reference_model,print_to_file,filename):
     # Import Kratos
@@ -512,8 +524,8 @@ def executeInstanceDeterministicAdaptiveRefinementAuxLev2_Task(pickled_model,pic
 
 # @task(keep=True, filename=FILE_OUT, pickled_model=COLLECTION_IN, pickled_mapping_reference_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_0)
 @constraint(computing_units=computing_units_mlmc_execute_0)
-@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_0, pickled_model_layout={block_count: computing_procs_mlmc_execute_0, block_length: 1, stride: 1}, pickled_mapping_reference_model_layout={block_count: computing_procs_mlmc_execute_0, block_length: 1, stride: 1})
-@task(keep=True, pickled_model=COLLECTION_IN, pickled_mapping_reference_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_0)
+@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_0, processes_per_node=ppn_mlmc_execute_0, pickled_model_layout={block_count: computing_procs_mlmc_execute_0, block_length: 1, stride: 1}, pickled_mapping_reference_model_layout={block_count: computing_procs_mlmc_execute_0, block_length: 1, stride: 1})
+@task(keep=True, filename=FILE_OUT, pickled_model=COLLECTION_IN, pickled_mapping_reference_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_0)
 def executeInstanceReadingFromFileAuxLev0_Task(pickled_model,pickled_project_parameters,current_analysis,random_variable,time_for_qoi,mapping_flag,pickled_mapping_reference_model,print_to_file,filename):
     # Import Kratos
     import KratosMultiphysics
@@ -532,7 +544,7 @@ def executeInstanceReadingFromFileAuxLev0_Task(pickled_model,pickled_project_par
 
 # @task(keep=True, filename=FILE_OUT, pickled_model=COLLECTION_IN, pickled_mapping_reference_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_1)
 @constraint(computing_units=computing_units_mlmc_execute_1)
-@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_1, pickled_model_layout={block_count: computing_procs_mlmc_execute_1, block_length: 1, stride: 1}, pickled_mapping_reference_model_layout={block_count: computing_procs_mlmc_execute_1, block_length: 1, stride: 1})
+@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_1, processes_per_node=ppn_mlmc_execute_1, pickled_model_layout={block_count: computing_procs_mlmc_execute_1, block_length: 1, stride: 1}, pickled_mapping_reference_model_layout={block_count: computing_procs_mlmc_execute_1, block_length: 1, stride: 1})
 @task(keep=True, pickled_model=COLLECTION_IN, pickled_mapping_reference_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_1)
 def executeInstanceReadingFromFileAuxLev1_Task(pickled_model,pickled_project_parameters,current_analysis,random_variable,time_for_qoi,mapping_flag,pickled_mapping_reference_model,print_to_file,filename):
     # Import Kratos
@@ -552,7 +564,7 @@ def executeInstanceReadingFromFileAuxLev1_Task(pickled_model,pickled_project_par
 
 # @task(keep=True, filename=FILE_OUT, pickled_model=COLLECTION_IN, pickled_mapping_reference_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_2)
 @constraint(computing_units=computing_units_mlmc_execute_2)
-@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_2, pickled_model_layout={block_count: computing_procs_mlmc_execute_2, block_length: 1, stride: 1}, pickled_mapping_reference_model_layout={block_count: computing_procs_mlmc_execute_2, block_length: 1, stride: 1})
+@mpi(runner="mpirun", processes=computing_procs_mlmc_execute_2, processes_per_node=ppn_mlmc_execute_2, pickled_model_layout={block_count: computing_procs_mlmc_execute_2, block_length: 1, stride: 1}, pickled_mapping_reference_model_layout={block_count: computing_procs_mlmc_execute_2, block_length: 1, stride: 1})
 @task(keep=True, pickled_model=COLLECTION_IN, pickled_mapping_reference_model=COLLECTION_IN, returns=computing_procs_mlmc_execute_2)
 def executeInstanceReadingFromFileAuxLev2_Task(pickled_model,pickled_project_parameters,current_analysis,random_variable,time_for_qoi,mapping_flag,pickled_mapping_reference_model,print_to_file,filename):
     # Import Kratos

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/methodDefs_KratosSolverWrapper/solve.py
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/classDefs_solverWrapper/methodDefs_KratosSolverWrapper/solve.py
@@ -11,30 +11,12 @@ import KratosMultiphysics
 from KratosMultiphysics.MultilevelMonteCarloApplication.adaptive_refinement_utilities import AdaptiveRefinement
 from exaqute import *
 
-try:
-    computing_units_mlmc_execute_0 = int(os.environ["computing_units_mlmc_execute_0"])
-except:
-    computing_units_mlmc_execute_0 = 1
-try:
-    computing_units_mlmc_execute_1 = int(os.environ["computing_units_mlmc_execute_1"])
-except:
-    computing_units_mlmc_execute_1 = 1
-try:
-    computing_units_mlmc_execute_2 = int(os.environ["computing_units_mlmc_execute_2"])
-except:
-    computing_units_mlmc_execute_2 = 1
-try:
-    computing_units_mlmc_execute_3 = int(os.environ["computing_units_mlmc_execute_3"])
-except:
-    computing_units_mlmc_execute_3 = 1
-try:
-    computing_units_mlmc_execute_4 = int(os.environ["computing_units_mlmc_execute_4"])
-except:
-    computing_units_mlmc_execute_4 = 1
-try:
-    computing_units_mlmc_execute_5 = int(os.environ["computing_units_mlmc_execute_5"])
-except:
-    computing_units_mlmc_execute_5 = 1
+computing_units_mlmc_execute_0 = int(os.getenv("computing_units_mlmc_execute_0", 1))
+computing_units_mlmc_execute_1 = int(os.getenv("computing_units_mlmc_execute_1", 1))
+computing_units_mlmc_execute_2 = int(os.getenv("computing_units_mlmc_execute_2", 1))
+computing_units_mlmc_execute_3 = int(os.getenv("computing_units_mlmc_execute_3", 1))
+computing_units_mlmc_execute_4 = int(os.getenv("computing_units_mlmc_execute_4", 1))
+computing_units_mlmc_execute_5 = int(os.getenv("computing_units_mlmc_execute_5", 1))
 
 ####################################################################################################
 ############################################ WRAPPERS ##############################################


### PR DESCRIPTION
**📝 Description**
This MR adds the processes per node variable to MPI tasks, to ensure MPI parallel tasks are not split too much when running in distributed environment.

If
~~~bash
computing_units_mlmc_execute_0 = 1
computing_procs_mlmc_execute_0 = 96
ppn_mlmc_execute_0 = 48
~~~
this means that the MPI parallel tasks is at maximum split into two nodes.

If
~~~bash
computing_units_mlmc_execute_0 = 1
computing_procs_mlmc_execute_0 = 48
ppn_mlmc_execute_0 = 48
~~~
this means that the MPI parallel tasks is run within a single node.

This change has been extensively tested during ExaQUte deliverables 4.5 and 5.5.

Nightly checked here: https://github.com/KratosMultiphysics/Kratos/actions/runs/1439638116

Please mark the PR with appropriate tags: 
- Enhancement

**🆕 Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Added `processes per node` variable
