### PR TITLE
[FSI] use edge distances for embedded FSI (treat incised elements)

### DIFF
--- a/applications/FSIApplication/python_scripts/partitioned_embedded_fsi_base_solver.py
+++ b/applications/FSIApplication/python_scripts/partitioned_embedded_fsi_base_solver.py
@@ -217,11 +217,15 @@ class PartitionedEmbeddedFSIBaseSolver(PartitionedFSIBaseSolver):
             if self._GetDomainSize() == 2:
                 return KratosMultiphysics.CalculateDiscontinuousDistanceToSkinProcess2D(
                     self.GetFluidComputingModelPart(),
-                    self._GetFSICouplingInterfaceFluid().GetInterfaceModelPart())
+                    self._GetFSICouplingInterfaceFluid().GetInterfaceModelPart(),
+                    KratosMultiphysics.CalculateDiscontinuousDistanceToSkinProcess2D.CALCULATE_ELEMENTAL_EDGE_DISTANCES,
+                    KratosMultiphysics.CalculateDiscontinuousDistanceToSkinProcess2D.CALCULATE_ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED)
             elif self._GetDomainSize() == 3:
                 return KratosMultiphysics.CalculateDiscontinuousDistanceToSkinProcess3D(
                     self.GetFluidComputingModelPart(),
-                    self._GetFSICouplingInterfaceFluid().GetInterfaceModelPart())
+                    self._GetFSICouplingInterfaceFluid().GetInterfaceModelPart(),
+                    KratosMultiphysics.CalculateDiscontinuousDistanceToSkinProcess3D.CALCULATE_ELEMENTAL_EDGE_DISTANCES,
+                    KratosMultiphysics.CalculateDiscontinuousDistanceToSkinProcess3D.CALCULATE_ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED)
             else:
                 raise Exception("Domain size expected to be 2 or 3. Got " + str(self._GetDomainSize()))
         else:


### PR DESCRIPTION
**📝 Description**
Remnant of treating incised (not completely cut) elements in embedded FluidDynamics simulations.
The flags `CALCULATE_ELEMENTAL_EDGE_DISTANCES` and `CALCULATE_ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED` were added to in the `PartitionedEmbeddedFSIBaseSolver` of the `FSIApplication` in order to calculate the edge distances and extrapolated edge distances necessary for treating incised elements in the fluid partition.

**🆕 Changelog**
- Added both flags `CALCULATE_ELEMENTAL_EDGE_DISTANCES` and `CALCULATE_ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED` to initialization of `CalculateDiscontinuousDistanceToSkinProcess` to `PartitionedEmbeddedFSIBaseSolver` (2D and 3D)
