### PR TITLE
[CI] using github native solution to cancel redundant runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,11 @@ on:
 
   workflow_dispatch:
 
+# for cancelling redundant runs
+concurrency:
+  group: ci-${{ github.head_ref }}
+  cancel-in-progress: true
+
 
 jobs:
   ubuntu:
@@ -26,10 +31,6 @@ jobs:
       options: --user 1001
 
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
     - uses: actions/checkout@v2
 
     - name: Build
@@ -165,10 +166,6 @@ jobs:
       options: --user 1001
 
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
     - uses: actions/checkout@v2
 
     - name: Build
@@ -200,10 +197,6 @@ jobs:
         CCACHE_MAXSIZE: 500M
 
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
     - uses: actions/checkout@v2
 
     - name: Cache Build
@@ -384,10 +377,6 @@ jobs:
       options: --user 1001
 
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
     - uses: actions/checkout@v2
 
     - name: Build

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -20,6 +20,11 @@ on:
 
   workflow_dispatch:
 
+# for cancelling redundant runs
+concurrency:
+  group: nightly-build-${{ github.head_ref }}
+  cancel-in-progress: true
+
 
 jobs:
   ubuntu-nightly:
@@ -38,10 +43,6 @@ jobs:
       options: --user 1001
 
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
     - uses: actions/checkout@v2
 
     - name: Build


### PR DESCRIPTION
Finally this is possible!

see https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency

The advantage is that this also cancels runs without having to start.
I.e. on busy days until now when there were many jobs running, even when pushing a newer commit it did not cancel the old run, as the new run couldn't start.
With this (I tested it) it instantly cancels old/redundant builds :)