### PR TITLE
[Core] using GlobalLock in ReductionUtils

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_response_functions/adjoint_far_field_lift_response_function.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_response_functions/adjoint_far_field_lift_response_function.cpp
@@ -20,6 +20,7 @@
 #include "adjoint_far_field_lift_response_function.h"
 #include "compressible_potential_flow_application_variables.h"
 #include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 
 namespace Kratos
 {

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
@@ -14,6 +14,7 @@
 #include "fluid_dynamics_application_variables.h"
 #include "includes/model_part.h"
 #include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 
 namespace Kratos {
 namespace PotentialFlowUtilities {

--- a/applications/DEMApplication/custom_utilities/post_utilities.h
+++ b/applications/DEMApplication/custom_utilities/post_utilities.h
@@ -4,6 +4,8 @@
 #include "utilities/timer.h"
 #include "includes/define.h"
 #include "includes/variables.h"
+#include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 #include "custom_utilities/create_and_destroy.h"
 #include "custom_utilities/GeometryFunctions.h"
 #include "custom_elements/Particle_Contact_Element.h"

--- a/applications/FluidDynamicsApplication/custom_utilities/acceleration_limitation_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/acceleration_limitation_utilities.cpp
@@ -17,6 +17,7 @@
 
 // Project includes
 #include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 
 // Application includes
 #include "acceleration_limitation_utilities.h"

--- a/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.cpp
@@ -24,6 +24,7 @@
 #include "utilities/element_size_calculator.h"
 #include "utilities/geometry_utilities.h"
 #include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 
 // Application includes
 #include "estimate_dt_utilities.h"
@@ -99,10 +100,10 @@ namespace Kratos
         const auto& r_geom = mrModelPart.ElementsBegin()->GetGeometry();
         ElementSizeFunctionType minimum_h_func = FluidCharacteristicNumbersUtilities::GetMinimumElementSizeFunction(r_geom);
 
-        
+
         // Deciding what CFL calculator to use
         auto cfl_calculator = GetCFLCalculatorUtility();
-        
+
         // Obtain the maximum CFL
         const double current_dt = mrModelPart.GetProcessInfo().GetValue(DELTA_TIME);
 

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_auxiliary_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_auxiliary_utilities.cpp
@@ -21,6 +21,7 @@
 #include "modified_shape_functions/triangle_2d_3_modified_shape_functions.h"
 #include "modified_shape_functions/tetrahedra_3d_4_modified_shape_functions.h"
 #include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 
 // Application includes
 #include "fluid_auxiliary_utilities.h"

--- a/applications/MappingApplication/custom_mappers/interpolative_mapper_base.h
+++ b/applications/MappingApplication/custom_mappers/interpolative_mapper_base.h
@@ -30,6 +30,8 @@
 #include "custom_searching/interface_communicator.h"
 #include "custom_utilities/interface_vector_container.h"
 #include "mappers/mapper_flags.h"
+#include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 #include "custom_utilities/mapper_local_system.h"
 #include "custom_utilities/mapping_matrix_utilities.h"
 #include "custom_utilities/mapper_utilities.h"

--- a/applications/MappingApplication/custom_searching/interface_communicator.cpp
+++ b/applications/MappingApplication/custom_searching/interface_communicator.cpp
@@ -21,6 +21,7 @@
 
 // Project includes
 #include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 #include "custom_utilities/mapper_utilities.h"
 #include "interface_communicator.h"
 

--- a/applications/MappingApplication/custom_utilities/mapper_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/mapper_utilities.cpp
@@ -20,6 +20,7 @@
 // Project includes
 #include "includes/stream_serializer.h"
 #include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 #include "mapper_utilities.h"
 #include "mapping_application_variables.h"
 

--- a/applications/ShallowWaterApplication/custom_processes/calculate_distance_to_boundary_process.cpp
+++ b/applications/ShallowWaterApplication/custom_processes/calculate_distance_to_boundary_process.cpp
@@ -22,6 +22,7 @@
 #include "geometries/line_2d_2.h"
 #include "utilities/variable_utils.h"
 #include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 #include "calculate_distance_to_boundary_process.h"
 
 

--- a/applications/ShallowWaterApplication/custom_utilities/estimate_dt_utility.cpp
+++ b/applications/ShallowWaterApplication/custom_utilities/estimate_dt_utility.cpp
@@ -21,6 +21,7 @@
 #include "estimate_dt_utility.h"
 #include "includes/model_part.h"
 #include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 #include "shallow_water_application_variables.h"
 
 

--- a/applications/ShallowWaterApplication/custom_utilities/shallow_water_utilities.cpp
+++ b/applications/ShallowWaterApplication/custom_utilities/shallow_water_utilities.cpp
@@ -17,6 +17,8 @@
 
 
 // Project includes
+#include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 #include "shallow_water_utilities.h"
 #include "phase_function.h"
 

--- a/applications/ShallowWaterApplication/custom_utilities/shallow_water_utilities.h
+++ b/applications/ShallowWaterApplication/custom_utilities/shallow_water_utilities.h
@@ -23,6 +23,7 @@
 // Project includes
 #include "includes/model_part.h"
 #include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 #include "shallow_water_application_variables.h"
 
 

--- a/applications/ShapeOptimizationApplication/custom_utilities/geometry_utilities.h
+++ b/applications/ShapeOptimizationApplication/custom_utilities/geometry_utilities.h
@@ -30,6 +30,7 @@
 #include "shape_optimization_application.h"
 #include "utilities/variable_utils.h"
 #include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 
 #include "spatial_containers/spatial_containers.h"
 

--- a/applications/ShapeOptimizationApplication/custom_utilities/response_functions/face_angle_response_function_utility.cpp
+++ b/applications/ShapeOptimizationApplication/custom_utilities/response_functions/face_angle_response_function_utility.cpp
@@ -15,8 +15,8 @@
 // Project includes
 #include "custom_utilities/response_functions/face_angle_response_function_utility.h"
 #include "utilities/variable_utils.h"
-#include "utilities/parallel_utils.h"
-#include "utilities/reduction_utils.h"
+#include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 
 // ==============================================================================
 

--- a/applications/ShapeOptimizationApplication/custom_utilities/response_functions/face_angle_response_function_utility.cpp
+++ b/applications/ShapeOptimizationApplication/custom_utilities/response_functions/face_angle_response_function_utility.cpp
@@ -15,6 +15,8 @@
 // Project includes
 #include "custom_utilities/response_functions/face_angle_response_function_utility.h"
 #include "utilities/variable_utils.h"
+#include "utilities/parallel_utils.h"
+#include "utilities/reduction_utils.h"
 
 // ==============================================================================
 

--- a/kratos/containers/csr_matrix.h
+++ b/kratos/containers/csr_matrix.h
@@ -23,6 +23,7 @@
 #include "containers/system_vector.h"
 #include "utilities/parallel_utilities.h"
 #include "utilities/atomic_utilities.h"
+#include "utilities/reduction_utilities.h"
 #include "includes/key_hash.h"
 #include "includes/parallel_environment.h"
 
@@ -85,7 +86,7 @@ public:
 
         mpComm = &rComm;
     }
-    
+
 
     /// constructor.
     template<class TGraphType>
@@ -145,7 +146,7 @@ public:
         mRowIndices = rOtherMatrix.mRowIndices;
         mColIndices = rOtherMatrix.mColIndices;
         mValuesVector = rOtherMatrix.mValuesVector;
-        
+
         mNrows = rOtherMatrix.mNrows;
         mNcols = rOtherMatrix.mNcols;
 
@@ -155,12 +156,12 @@ public:
     ~CsrMatrix(){
         AssignIndex1Data(nullptr,0);
         AssignIndex2Data(nullptr,0);
-        AssignValueData(nullptr,0);        
+        AssignValueData(nullptr,0);
     }
 
-    /// Assignment operator. 
+    /// Assignment operator.
     CsrMatrix& operator=(CsrMatrix const& rOtherMatrix) = delete; //i really think this should not be allowed, too risky
- 
+
     //move assignement operator
     CsrMatrix& operator=(CsrMatrix&& rOtherMatrix)
     {
@@ -177,7 +178,7 @@ public:
         mRowIndices = rOtherMatrix.mRowIndices;
         mColIndices = rOtherMatrix.mColIndices;
         mValuesVector = rOtherMatrix.mValuesVector;
-        
+
         mNrows = rOtherMatrix.mNrows;
         mNcols = rOtherMatrix.mNcols;
         return *this;
@@ -263,7 +264,7 @@ public:
 
     void ComputeColSize()
     {
-        //compute the max id 
+        //compute the max id
         IndexType max_col = IndexPartition<IndexType>(mColIndices.size()).template for_each< MaxReduction<double> >([&](IndexType i){
                 return mColIndices[i];
             });
@@ -373,7 +374,7 @@ public:
                 for(IndexType k = row_begin; k < row_end; ++k){
                     IndexType col = index2_data()[k];
                     y(i) += value_data()[k] * x(col);
-                }  
+                }
             });
         }
     }
@@ -381,7 +382,7 @@ public:
     //y = alpha*y + beta*A*x
     template<class TInputVectorType, class TOutputVectorType>
     void SpMV(const TDataType alpha,
-              const TInputVectorType& x, 
+              const TInputVectorType& x,
               const TDataType beta,
               TOutputVectorType& y) const
     {
@@ -394,12 +395,12 @@ public:
             for(IndexType k = row_begin; k < row_end; ++k){
                 IndexType col = index2_data()[k];
                 aux += value_data()[k] * x(col);
-            }  
+            }
             y(i) = beta*y(i) + alpha*aux;
         });
     }
 
-    // y += A^t*x  -- where A is *this    
+    // y += A^t*x  -- where A is *this
     template<class TInputVectorType, class TOutputVectorType>
     void TransposeSpMV(const TInputVectorType& x, TOutputVectorType& y) const
     {
@@ -411,14 +412,14 @@ public:
             for(IndexType k = row_begin; k < row_end; ++k){
                 IndexType j = index2_data()[k];
                 AtomicAdd(y(j), value_data()[k] * x(i) );
-            }  
+            }
         });
     }
 
     //y = alpha*y + beta*A^t*x
     template<class TInputVectorType, class TOutputVectorType>
     void TransposeSpMV(const TDataType alpha,
-              const TInputVectorType& x, 
+              const TInputVectorType& x,
               const TDataType beta,
               TOutputVectorType& y) const
     {
@@ -433,7 +434,7 @@ public:
             for(IndexType k = row_begin; k < row_end; ++k){
                 IndexType j = index2_data()[k];
                 AtomicAdd(y(j), value_data()[k] * x(i) );
-            }  
+            }
         });
     }
 
@@ -477,7 +478,7 @@ public:
                 IndexType j = index2_data()[k];
                 TDataType v = value_data()[k];
                 value_map[{i,j}] = v;
-            }  
+            }
         }
         return value_map;
     }
@@ -627,7 +628,7 @@ public:
     void PrintData(std::ostream& rOStream) const {
         rOStream << "size1 : " << size1() <<std::endl;
         rOStream << "size2 : " << size2() <<std::endl;
-        rOStream << "nnz : " << nnz() <<std::endl; 
+        rOStream << "nnz : " << nnz() <<std::endl;
         rOStream << "index1_data : " << std::endl;
         for(auto item : index1_data())
             rOStream << item << ",";
@@ -635,7 +636,7 @@ public:
         rOStream << "index2_data : " << std::endl;
         for(auto item : index2_data())
             rOStream << item << ",";
-        rOStream << std::endl;        
+        rOStream << std::endl;
         rOStream << "value_data  : " << std::endl;
         for(auto item : value_data())
             rOStream << item << ",";
@@ -662,32 +663,32 @@ protected:
     ///@}
     ///@name Protected Operators
     ///@{
-    // A non-recursive binary search function. It returns 
-    // location of x in given array arr[l..r] is present, 
+    // A non-recursive binary search function. It returns
+    // location of x in given array arr[l..r] is present,
     // otherwise std::dec << std::numeric_limits<IndexType>::max()
-    template< class TVectorType > 
-    inline IndexType BinarySearch(const TVectorType& arr, 
+    template< class TVectorType >
+    inline IndexType BinarySearch(const TVectorType& arr,
                         IndexType l, IndexType r, IndexType x) const
-    { 
-        while (l <= r) { 
-            int m = l + (r - l) / 2; 
-    
-            // Check if x is present at mid 
-            if (arr[m] == x) 
-                return m; 
-    
-            // If x greater, ignore left half 
-            if (arr[m] < x) 
-                l = m + 1; 
-    
-            // If x is smaller, ignore right half 
+    {
+        while (l <= r) {
+            int m = l + (r - l) / 2;
+
+            // Check if x is present at mid
+            if (arr[m] == x)
+                return m;
+
+            // If x greater, ignore left half
+            if (arr[m] < x)
+                l = m + 1;
+
+            // If x is smaller, ignore right half
             else
-                r = m - 1; 
-        } 
-    
-        // if we reach here, then element was not present 
-        return std::numeric_limits<IndexType>::max(); 
-    } 
+                r = m - 1;
+        }
+
+        // if we reach here, then element was not present
+        return std::numeric_limits<IndexType>::max();
+    }
 
     ///@}
     ///@name Protected Operations
@@ -750,7 +751,7 @@ private:
         rSerializer.save("val_size",mValuesVector.size());
         for(IndexType i=0; i<mValuesVector.size(); ++i)
             rSerializer.save("d",mValuesVector[i]);
-        
+
         rSerializer.save("Nrow",mNrows);
         rSerializer.save("Ncol",mNcols);
     }
@@ -784,7 +785,7 @@ private:
         mValuesVector = Kratos::span<TDataType>(mpValuesVectorData, vals_size);
         for(IndexType i=0; i<mValuesVector.size(); ++i)
             rSerializer.load("d",mValuesVector[i]);
-        
+
         rSerializer.load("Nrow",mNrows);
         rSerializer.load("Ncol",mNcols);
     }

--- a/kratos/input_output/vtk_output.cpp
+++ b/kratos/input_output/vtk_output.cpp
@@ -23,6 +23,7 @@
 #include "includes/kratos_filesystem.h"
 #include "processes/fast_transfer_between_model_parts_process.h"
 #include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 
 namespace Kratos
 {

--- a/kratos/processes/apply_periodic_boundary_condition_process.cpp
+++ b/kratos/processes/apply_periodic_boundary_condition_process.cpp
@@ -20,6 +20,8 @@
 #include "utilities/binbased_fast_point_locator_conditions.h"
 #include "utilities/geometrical_transformation_utilities.h"
 #include "utilities/builtin_timer.h"
+#include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 
 namespace Kratos
 {

--- a/kratos/processes/from_json_check_result_process.cpp
+++ b/kratos/processes/from_json_check_result_process.cpp
@@ -17,6 +17,8 @@
 // Project includes
 #include "containers/model.h"
 #include "processes/from_json_check_result_process.h"
+#include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 
 namespace Kratos
 {
@@ -374,7 +376,7 @@ void FromJSONCheckResultProcess::CheckNodeValues(IndexType& rCheckCounter)
 
 /***********************************************************************************/
 /***********************************************************************************/
-    
+
 void FromJSONCheckResultProcess::CheckNodeHistoricalValues(IndexType& rCheckCounter)
 {
     // Get time

--- a/kratos/processes/from_json_check_result_process.h
+++ b/kratos/processes/from_json_check_result_process.h
@@ -22,7 +22,6 @@
 #include "includes/model_part.h"
 #include "includes/kratos_parameters.h"
 #include "utilities/result_dabatase.h"
-#include "utilities/parallel_utilities.h"
 
 namespace Kratos
 {
@@ -258,7 +257,7 @@ protected:
      * @param rCheckCounter The check counter
      */
     void CheckNodeValues(IndexType& rCheckCounter);
-    
+
     /**
      * @brief This method check the nodal historical values
      * @param rCheckCounter The check counter

--- a/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
@@ -20,6 +20,7 @@
 // Project includes
 #include "testing/testing.h"
 #include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 #include "utilities/builtin_timer.h"
 
 namespace Kratos {

--- a/kratos/utilities/parallel_utilities.h
+++ b/kratos/utilities/parallel_utilities.h
@@ -34,7 +34,6 @@
 #include "includes/define.h"
 #include "includes/global_variables.h"
 #include "includes/lock_object.h"
-#include "utilities/reduction_utilities.h"
 
 
 namespace Kratos

--- a/kratos/utilities/reduction_utilities.h
+++ b/kratos/utilities/reduction_utilities.h
@@ -19,12 +19,14 @@
 #include <tuple>
 #include <limits>
 #include <algorithm>
+#include <mutex>
 
 // External includes
 
 // Project includes
 #include "includes/define.h"
 #include "utilities/atomic_utilities.h"
+#include "utilities/parallel_utilities.h"
 
 namespace Kratos
 {
@@ -145,7 +147,7 @@ public:
     /// THREADSAFE (needs some sort of lock guard) reduction, to be used to sync threads
     void ThreadSafeReduce(const MaxReduction<TDataType, TReturnType>& rOther)
     {
-        #pragma omp critical
+        const std::lock_guard<LockObject> scope_lock(ParallelUtilities::GetGlobalLock());
         mValue = std::max(mValue,rOther.mValue);
     }
 };
@@ -176,7 +178,7 @@ public:
     /// THREADSAFE (needs some sort of lock guard) reduction, to be used to sync threads
     void ThreadSafeReduce(const MinReduction<TDataType, TReturnType>& rOther)
     {
-        #pragma omp critical
+        const std::lock_guard<LockObject> scope_lock(ParallelUtilities::GetGlobalLock());
         mValue = std::min(mValue,rOther.mValue);
     }
 };
@@ -208,7 +210,7 @@ public:
     /// THREADSAFE (needs some sort of lock guard) reduction, to be used to sync threads
     void ThreadSafeReduce(const AccumReduction<TDataType, TReturnType>& rOther)
     {
-        #pragma omp critical
+        const std::lock_guard<LockObject> scope_lock(ParallelUtilities::GetGlobalLock());
         mValue.insert(mValue.end(), rOther.mValue.begin(), rOther.mValue.end());
     }
 };

--- a/kratos/utilities/variable_redistribution_utility.cpp
+++ b/kratos/utilities/variable_redistribution_utility.cpp
@@ -14,6 +14,7 @@
 #include "includes/fsi_variables.h"
 #include "utilities/atomic_utilities.h"
 #include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 #include "variable_redistribution_utility.h"
 
 namespace Kratos

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -26,6 +26,7 @@
 #include "includes/checks.h"
 #include "utilities/parallel_utilities.h"
 #include "utilities/atomic_utilities.h"
+#include "utilities/reduction_utilities.h"
 
 namespace Kratos
 {


### PR DESCRIPTION
as title says, another step towards C++11 based parallelism :tada:
=> replacing some `omp critical` with `GlobalLock`

I had to include the `ParallelUtils` in the `ReductionUtils` (and not the other way round) hence it might be that the reduction utils have to be included to fix the compilation. I did this already for the Core and the Apps in this PR

NOTE: This should NOT be generally used to replace `omp critical`! Most loops in Kratos using `omp critical` can be replaced by one of the reductions (e.g. `AccumReduction` or `MaxReduction`)