### PR TITLE
[Fluid] Modify edge distances consistently (for incised elements)

### DIFF
--- a/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.cpp
@@ -305,13 +305,6 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::InitializeGeometryData(Emb
         }
     }
 
-    // Number of intersected edges
-    for (std::size_t i = 0; i < EmbeddedDiscontinuousElementData::NumEdges; ++i) {
-        if (rData.ElementalEdgeDistances[i] > 0.0) {
-            rData.NumIntersectedEdges++;
-        }
-    }
-
     // Number of edges cut by extrapolated geometry, if not empty
     for (std::size_t i = 0; i < rData.ElementalEdgeDistancesExtrapolated.size(); ++i) {
         if (rData.ElementalEdgeDistancesExtrapolated[i] > 0.0) {
@@ -319,7 +312,7 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::InitializeGeometryData(Emb
         }
     }
 
-    // Check whether element is intersected or incised and whether user gave flag CALCULATE_EXTRAPOLATED_EDGE_DISTANCES,
+    // Check whether element is intersected or incised and whether user gave flag CALCULATE_ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED,
     // then use Ausas incised shape functions
     if ( rData.IsCut() ) {
         this->DefineCutGeometryData(rData);

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -19,6 +19,7 @@
 #include "containers/model.h"
 #include "includes/checks.h"
 #include "utilities/openmp_utils.h"
+#include "utilities/parallel_utilities.h"
 #include "processes/find_nodal_h_process.h"
 
 // Application includes
@@ -77,7 +78,7 @@ DistanceModificationProcess::DistanceModificationProcess(
 
 void DistanceModificationProcess::InitializeEmbeddedIsActive()
 {
-    for (int i_node = 0; i_node < static_cast<int>(mrModelPart.NumberOfNodes()); ++i_node) {
+    for (size_t i_node = 0; i_node < static_cast<size_t>(mrModelPart.NumberOfNodes()); ++i_node) {
         auto it_node = mrModelPart.NodesBegin() + i_node;
         it_node->SetValue(EMBEDDED_IS_ACTIVE, 0);
     }
@@ -133,13 +134,14 @@ void DistanceModificationProcess::ExecuteInitialize()
     KRATOS_CATCH("");
 }
 
-void DistanceModificationProcess::ExecuteBeforeSolutionLoop() {
+void DistanceModificationProcess::ExecuteBeforeSolutionLoop()
+{
     this->ExecuteInitializeSolutionStep();
     this->ExecuteFinalizeSolutionStep();
 }
 
-void DistanceModificationProcess::ExecuteInitializeSolutionStep() {
-
+void DistanceModificationProcess::ExecuteInitializeSolutionStep()
+{
     if(!mIsModified){
         // Modify the nodal distance values to avoid bad intersections
         if (mContinuousDistance) {
@@ -159,8 +161,8 @@ void DistanceModificationProcess::ExecuteInitializeSolutionStep() {
     }
 }
 
-void DistanceModificationProcess::ExecuteFinalizeSolutionStep() {
-
+void DistanceModificationProcess::ExecuteFinalizeSolutionStep()
+{
     // Restore the initial state if the distance is checked at each time step
     if (mCheckAtEachStep){
         // Restore the is modified flag to false
@@ -183,15 +185,15 @@ void DistanceModificationProcess::ExecuteFinalizeSolutionStep() {
 
 /* Protected functions ****************************************************/
 
-void DistanceModificationProcess::ModifyDistance() {
-
+void DistanceModificationProcess::ModifyDistance()
+{
     ModelPart::NodesContainerType& r_nodes = mrModelPart.Nodes();
 
     // Distance modification
     // Case in where the original distance does not need to be preserved (e.g. CFD)
     if (mRecoverOriginalDistance == false) {
         #pragma omp parallel for
-        for (int k = 0; k < static_cast<int>(r_nodes.size()); ++k) {
+        for (size_t k = 0; k < static_cast<size_t>(r_nodes.size()); ++k) {
             auto it_node = r_nodes.begin() + k;
             const double h = it_node->GetValue(NODAL_H);
             const double tol_d = mDistanceThreshold*h;
@@ -216,18 +218,18 @@ void DistanceModificationProcess::ModifyDistance() {
     // Case in where the original distance needs to be kept to track the interface (e.g. FSI)
     else {
 
-        const int num_chunks = 2 * OpenMPUtils::GetNumThreads();
+        const size_t num_chunks = 2 * ParallelUtilities::GetNumThreads();
         OpenMPUtils::PartitionVector partition_vec;
         OpenMPUtils::DivideInPartitions(r_nodes.size(),num_chunks,partition_vec);
 
         #pragma omp parallel for
-        for (int i_chunk = 0; i_chunk < num_chunks; ++i_chunk)
+        for (size_t i_chunk = 0; i_chunk < num_chunks; ++i_chunk)
         {
             auto nodes_begin = r_nodes.begin() + partition_vec[i_chunk];
             auto nodes_end = r_nodes.begin() + partition_vec[i_chunk + 1];
 
             // Auxiliar chunk arrays
-            std::vector<unsigned int> aux_modified_distances_ids;
+            std::vector<size_t> aux_modified_distances_ids;
             std::vector<double> aux_modified_distance_values;
 
             for (auto it_node = nodes_begin; it_node < nodes_end; ++it_node) {
@@ -272,69 +274,176 @@ void DistanceModificationProcess::ModifyDistance() {
     this->SetContinuousDistanceToSplitFlag();
 }
 
-void DistanceModificationProcess::ModifyDiscontinuousDistance(){
-
+void DistanceModificationProcess::ModifyDiscontinuousDistance()
+{
     auto r_elems = mrModelPart.Elements();
     auto elems_begin = mrModelPart.ElementsBegin();
     const auto n_elems = mrModelPart.NumberOfElements();
+    const size_t n_edges_extrapolated = elems_begin->GetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED).size();
 
     // Distance modification
     if (mRecoverOriginalDistance == false) {
-        // Case in where the original distance does not need to be preserved (e.g. CFD)
-        #pragma omp parallel for
-        for (int i_elem = 0; i_elem < static_cast<int>(n_elems); ++i_elem){
-            auto it_elem = elems_begin + i_elem;
+        // Case in which the original distance does not need to be preserved (e.g. CFD)
 
-            // Compute the distance tolerance
-            const double tol_d = mDistanceThreshold*(it_elem->GetGeometry()).Length();
+        // If user has provided flag to calculate elemental edge distances of extrapolated geometry,
+        // modify them according to elemental distances in order to stay consistent with element splitting
+        if (n_edges_extrapolated > 0) {
+            #pragma omp parallel for
+            for (size_t i_elem = 0; i_elem < static_cast<size_t>(n_elems); ++i_elem) {
+                auto it_elem = elems_begin + i_elem;
 
-            // Check if the distance values are close to zero
-            Vector &r_elem_dist = it_elem->GetValue(ELEMENTAL_DISTANCES);
-            for (unsigned int i_node = 0; i_node < r_elem_dist.size(); ++i_node){
-                if (std::abs(r_elem_dist(i_node)) < tol_d){
-                    r_elem_dist(i_node) = r_elem_dist(i_node) > 0.0 ? tol_d : -tol_d;
+                // Compute the distance tolerance
+                const double tol_d = mDistanceThreshold*(it_elem->GetGeometry()).Length();
+
+                // Check if the elemental distance values are close to zero
+                bool is_modified = false;
+                Vector &r_elem_dist = it_elem->GetValue(ELEMENTAL_DISTANCES);
+                for (size_t i_node = 0; i_node < r_elem_dist.size(); ++i_node){
+                    if (std::abs(r_elem_dist(i_node)) < tol_d){
+                        is_modified = true;
+                        r_elem_dist(i_node) = r_elem_dist(i_node) > 0.0 ? tol_d : -tol_d;
+                    }
+                }
+
+                // Modify ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED consistently
+                if (is_modified) {
+                    Vector &r_elem_edge_dist_extra = it_elem->GetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED);
+                    for (size_t i_edge = 0; i_edge < n_edges_extrapolated; ++i_edge) {
+
+                        // Get corresponding node IDs and elemental distances
+                        const std::array<size_t, 2> node_ids = GetNodeIDs(n_edges_extrapolated, i_edge);
+                        const double node_i_distance = r_elem_dist(node_ids[0]);
+                        const double node_j_distance = r_elem_dist(node_ids[1]);
+
+                        // Check if the edge is split by extrapolated geometry
+                        if (r_elem_edge_dist_extra(i_edge)) {
+                            // Compute edge ratio of intersection point using modified elemental distances
+                            r_elem_edge_dist_extra(i_edge) = std::abs( node_i_distance / (node_j_distance - node_i_distance) );
+                        }
+                    }
                 }
             }
-        }
-    } else {
-        // Case in where the original distance needs to be kept to track the interface (e.g. FSI)
+        } else {
+            #pragma omp parallel for
+            for (size_t i_elem = 0; i_elem < static_cast<size_t>(n_elems); ++i_elem) {
+                auto it_elem = elems_begin + i_elem;
 
-        const int num_chunks = 2 * OpenMPUtils::GetNumThreads();
-        OpenMPUtils::PartitionVector partition_vec;
-        OpenMPUtils::DivideInPartitions(n_elems,num_chunks,partition_vec);
-
-        #pragma omp parallel for
-        for (int i_chunk = 0; i_chunk < num_chunks; ++i_chunk)
-        {
-            auto elems_begin = r_elems.begin() + partition_vec[i_chunk];
-            auto elems_end = r_elems.begin() + partition_vec[i_chunk + 1];
-
-            // Auxiliar chunk arrays
-            std::vector<unsigned int> aux_modified_distances_ids;
-            std::vector<Vector> aux_modified_elemental_distances;
-
-            for (auto it_elem = elems_begin; it_elem < elems_end; ++it_elem){
                 // Compute the distance tolerance
-                const double tol_d = mDistanceThreshold * (it_elem->GetGeometry()).Length();
+                const double tol_d = mDistanceThreshold*(it_elem->GetGeometry()).Length();
 
-                bool is_saved = false;
+                // Check if the elemental distance values are close to zero
                 Vector &r_elem_dist = it_elem->GetValue(ELEMENTAL_DISTANCES);
-                for (unsigned int i_node = 0; i_node < r_elem_dist.size(); ++i_node){
+                for (size_t i_node = 0; i_node < r_elem_dist.size(); ++i_node){
                     if (std::abs(r_elem_dist(i_node)) < tol_d){
-                        if (!is_saved){
-                            aux_modified_distances_ids.push_back(it_elem->Id());
-                            aux_modified_elemental_distances.push_back(r_elem_dist);
-                        }
                         r_elem_dist(i_node) = r_elem_dist(i_node) > 0.0 ? tol_d : -tol_d;
                     }
                 }
             }
+        }
+    } else {
+        // Case in which the original distance needs to be kept to track the interface (e.g. FSI)
 
-            // Save the auxiliar chunk arrays
-            #pragma omp critical
+        const size_t num_chunks = 2 * ParallelUtilities::GetNumThreads();
+        OpenMPUtils::PartitionVector partition_vec;
+        OpenMPUtils::DivideInPartitions(n_elems,num_chunks,partition_vec);
+
+        // If user has provided flag to calculate elemental edge distances of extrapolated geometry,
+        // modify them according to elemental distances in order to stay consistent with element splitting
+        if (n_edges_extrapolated > 0) {
+            #pragma omp parallel for
+            for (size_t i_chunk = 0; i_chunk < num_chunks; ++i_chunk)
             {
-                mModifiedDistancesIDs.insert(mModifiedDistancesIDs.end(),aux_modified_distances_ids.begin(),aux_modified_distances_ids.end());
-                mModifiedElementalDistancesValues.insert(mModifiedElementalDistancesValues.end(),aux_modified_elemental_distances.begin(),aux_modified_elemental_distances.end());
+                auto elems_begin = r_elems.begin() + partition_vec[i_chunk];
+                auto elems_end = r_elems.begin() + partition_vec[i_chunk + 1];
+
+                // Auxiliar chunk arrays
+                std::vector<size_t> aux_modified_distances_ids;
+                std::vector<Vector> aux_modified_elemental_distances;
+                std::vector<size_t> aux_modified_edge_dist_extra_ids;
+                std::vector<Vector> aux_modified_edge_dist_extra;
+
+                for (auto it_elem = elems_begin; it_elem < elems_end; ++it_elem) {
+                    // Compute the distance tolerance
+                    const double tol_d = mDistanceThreshold * (it_elem->GetGeometry()).Length();
+
+                    bool is_saved = false;
+                    Vector &r_elem_dist = it_elem->GetValue(ELEMENTAL_DISTANCES);
+                    for (size_t i_node = 0; i_node < r_elem_dist.size(); ++i_node){
+                        if (std::abs(r_elem_dist(i_node)) < tol_d){
+                            if (!is_saved){
+                                aux_modified_distances_ids.push_back(it_elem->Id());
+                                aux_modified_elemental_distances.push_back(r_elem_dist);
+                                is_saved = true;
+                            }
+                            r_elem_dist(i_node) = r_elem_dist(i_node) > 0.0 ? tol_d : -tol_d;
+                        }
+                    }
+
+                    // Modify ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED consistently
+                    if (is_saved) {
+                        Vector &r_elem_edge_dist_extra = it_elem->GetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED);
+                        for (size_t i_edge = 0; i_edge < n_edges_extrapolated; ++i_edge) {
+
+                            // Get corresponding node IDs and elemental distances
+                            const std::array<size_t, 2> node_ids = GetNodeIDs(n_edges_extrapolated,i_edge);
+                            const double node_i_distance = r_elem_dist(node_ids[0]);
+                            const double node_j_distance = r_elem_dist(node_ids[1]);
+
+                            // Check if the edge is split by extrapolated geometry
+                            if (r_elem_edge_dist_extra(i_edge) > 0) {
+                                aux_modified_edge_dist_extra_ids.push_back(it_elem->Id());
+                                aux_modified_edge_dist_extra.push_back(r_elem_edge_dist_extra);
+                                // Compute edge ratio of intersection point using modified elemental distances
+                                r_elem_edge_dist_extra(i_edge) = std::abs( node_i_distance / (node_j_distance - node_i_distance) );
+                            }
+                        }
+                    }
+                }
+
+                // Save the auxiliar chunk arrays
+                #pragma omp critical
+                {
+                    mModifiedDistancesIDs.insert(mModifiedDistancesIDs.end(),aux_modified_distances_ids.begin(),aux_modified_distances_ids.end());
+                    mModifiedElementalDistancesValues.insert(mModifiedElementalDistancesValues.end(),aux_modified_elemental_distances.begin(),aux_modified_elemental_distances.end());
+                    mModifiedExtrapolatedIDs.insert(mModifiedExtrapolatedIDs.end(),aux_modified_edge_dist_extra_ids.begin(),aux_modified_edge_dist_extra_ids.end());
+                    mModifiedExtrapolatedValues.insert(mModifiedExtrapolatedValues.end(),aux_modified_edge_dist_extra.begin(),aux_modified_edge_dist_extra.end());
+                }
+            }
+        } else {
+            #pragma omp parallel for
+            for (size_t i_chunk = 0; i_chunk < num_chunks; ++i_chunk)
+            {
+                auto elems_begin = r_elems.begin() + partition_vec[i_chunk];
+                auto elems_end = r_elems.begin() + partition_vec[i_chunk + 1];
+
+                // Auxiliar chunk arrays
+                std::vector<size_t> aux_modified_distances_ids;
+                std::vector<Vector> aux_modified_elemental_distances;
+
+                for (auto it_elem = elems_begin; it_elem < elems_end; ++it_elem) {
+                    // Compute the distance tolerance
+                    const double tol_d = mDistanceThreshold * (it_elem->GetGeometry()).Length();
+
+                    bool is_saved = false;
+                    Vector &r_elem_dist = it_elem->GetValue(ELEMENTAL_DISTANCES);
+                    for (size_t i_node = 0; i_node < r_elem_dist.size(); ++i_node){
+                        if (std::abs(r_elem_dist(i_node)) < tol_d){
+                            if (!is_saved){
+                                aux_modified_distances_ids.push_back(it_elem->Id());
+                                aux_modified_elemental_distances.push_back(r_elem_dist);
+                                is_saved = true;
+                            }
+                            r_elem_dist(i_node) = r_elem_dist(i_node) > 0.0 ? tol_d : -tol_d;
+                        }
+                    }
+                }
+
+                // Save the auxiliar chunk arrays
+                #pragma omp critical
+                {
+                    mModifiedDistancesIDs.insert(mModifiedDistancesIDs.end(),aux_modified_distances_ids.begin(),aux_modified_distances_ids.end());
+                    mModifiedElementalDistancesValues.insert(mModifiedElementalDistancesValues.end(),aux_modified_elemental_distances.begin(),aux_modified_elemental_distances.end());
+                }
             }
         }
     }
@@ -343,17 +452,18 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance(){
     this->SetDiscontinuousDistanceToSplitFlag();
 }
 
-void DistanceModificationProcess::RecoverDeactivationPreviousState(){
+void DistanceModificationProcess::RecoverDeactivationPreviousState()
+{
     // Activate again all the elements
     #pragma omp parallel for
-    for (int i_elem = 0; i_elem < static_cast<int>(mrModelPart.NumberOfElements()); ++i_elem){
+    for (size_t i_elem = 0; i_elem < static_cast<size_t>(mrModelPart.NumberOfElements()); ++i_elem){
         auto it_elem = mrModelPart.ElementsBegin() + i_elem;
         it_elem->Set(ACTIVE,true);
     }
     if ((mDoubleVariablesList.size() > 0.0) || (mComponentVariablesList.size() > 0.0)){
         // Free the negative DOFs that were fixed
         #pragma omp parallel for
-        for (int i_node = 0; i_node < static_cast<int>(mrModelPart.NumberOfNodes()); ++i_node){
+        for (size_t i_node = 0; i_node < static_cast<size_t>(mrModelPart.NumberOfNodes()); ++i_node){
             auto it_node = mrModelPart.NodesBegin() + i_node;
             if (it_node->GetValue(EMBEDDED_IS_ACTIVE) == 0){
                 for (std::size_t i_var = 0; i_var < mDoubleVariablesList.size(); i_var++){
@@ -371,9 +481,10 @@ void DistanceModificationProcess::RecoverDeactivationPreviousState(){
     }
 }
 
-void DistanceModificationProcess::RecoverOriginalDistance() {
+void DistanceModificationProcess::RecoverOriginalDistance()
+{
     #pragma omp parallel for
-    for (int i = 0; i < static_cast<int>(mModifiedDistancesIDs.size()); ++i) {
+    for (size_t i = 0; i < static_cast<size_t>(mModifiedDistancesIDs.size()); ++i) {
         const auto node_id = mModifiedDistancesIDs[i];
         mrModelPart.GetNode(node_id).FastGetSolutionStepValue(DISTANCE) = mModifiedDistancesValues[i];
     }
@@ -391,12 +502,22 @@ void DistanceModificationProcess::RecoverOriginalDistance() {
     this->SetContinuousDistanceToSplitFlag();
 }
 
-void DistanceModificationProcess::RecoverOriginalDiscontinuousDistance() {
+void DistanceModificationProcess::RecoverOriginalDiscontinuousDistance()
+{    
+    // Recover original elemental distances
     #pragma omp parallel for
-    for (int i_elem = 0; i_elem < static_cast<int>(mModifiedDistancesIDs.size()); ++i_elem) {
-        const unsigned int elem_id = mModifiedDistancesIDs[i_elem];
-        const auto elem_dist = mModifiedElementalDistancesValues[i_elem];
-        mrModelPart.GetElement(elem_id).SetValue(ELEMENTAL_DISTANCES,elem_dist);
+    for (size_t i_elem = 0; i_elem < static_cast<size_t>(mModifiedDistancesIDs.size()); ++i_elem) {
+        const size_t elem_id = mModifiedDistancesIDs[i_elem];
+        const auto r_elem_dist = mModifiedElementalDistancesValues[i_elem];
+        mrModelPart.GetElement(elem_id).SetValue(ELEMENTAL_DISTANCES,r_elem_dist);
+    }
+
+    // Recover original extrapolated elemental edge distances
+    #pragma omp parallel for
+    for (size_t i_elem = 0; i_elem < static_cast<size_t>(mModifiedExtrapolatedIDs.size()); ++i_elem) {
+        const size_t elem_id = mModifiedExtrapolatedIDs[i_elem];
+        const auto elem_edge_dist_extra = mModifiedExtrapolatedValues[i_elem];
+        mrModelPart.GetElement(elem_id).SetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED,elem_edge_dist_extra);
     }
 
     // Empty the modified distance vectors
@@ -405,31 +526,37 @@ void DistanceModificationProcess::RecoverOriginalDiscontinuousDistance() {
     mModifiedDistancesIDs.shrink_to_fit();
     mModifiedElementalDistancesValues.shrink_to_fit();
 
+    // Empty the modified vectors for ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED
+    mModifiedExtrapolatedIDs.resize(0);
+    mModifiedExtrapolatedValues.resize(0);
+    mModifiedExtrapolatedIDs.shrink_to_fit();
+    mModifiedExtrapolatedValues.shrink_to_fit();
+
     // Restore the TO_SPLIT flag original status
     this->SetDiscontinuousDistanceToSplitFlag();
 }
 
-void DistanceModificationProcess::DeactivateFullNegativeElements() {
-
+void DistanceModificationProcess::DeactivateFullNegativeElements()
+{
     ModelPart::NodesContainerType& rNodes = mrModelPart.Nodes();
     ModelPart::ElementsContainerType& rElements = mrModelPart.Elements();
 
     // Initialize the EMBEDDED_IS_ACTIVE variable flag to 0
     #pragma omp parallel for
-    for (int i_node = 0; i_node < static_cast<int>(rNodes.size()); ++i_node){
+    for (size_t i_node = 0; i_node < static_cast<size_t>(rNodes.size()); ++i_node){
         ModelPart::NodesContainerType::iterator it_node = rNodes.begin() + i_node;
         it_node->SetValue(EMBEDDED_IS_ACTIVE, 0);
     }
 
     // Deactivate those elements whose negative distance nodes summation is equal to their number of nodes
     #pragma omp parallel for
-    for (int k = 0; k < static_cast<int>(rElements.size()); ++k){
-        unsigned int n_neg = 0;
+    for (size_t k = 0; k < static_cast<size_t>(rElements.size()); ++k){
+        size_t n_neg = 0;
         ModelPart::ElementsContainerType::iterator itElement = rElements.begin() + k;
         auto& rGeometry = itElement->GetGeometry();
 
         // Check the distance function sign at the element nodes
-        for (unsigned int i_node=0; i_node<rGeometry.size(); i_node++){
+        for (size_t i_node=0; i_node<rGeometry.size(); i_node++){
             if (rGeometry[i_node].FastGetSolutionStepValue(DISTANCE) < 0.0){
                 n_neg++;
             }
@@ -439,7 +566,7 @@ void DistanceModificationProcess::DeactivateFullNegativeElements() {
 
         // If the element is ACTIVE, all its nodes are active as well
         if (itElement->Is(ACTIVE)){
-            for (unsigned int i_node = 0; i_node < rGeometry.size(); ++i_node){
+            for (size_t i_node = 0; i_node < rGeometry.size(); ++i_node){
                 int& activation_index = rGeometry[i_node].GetValue(EMBEDDED_IS_ACTIVE);
                 #pragma omp atomic
                 activation_index += 1;
@@ -453,7 +580,7 @@ void DistanceModificationProcess::DeactivateFullNegativeElements() {
     // Set to zero and fix the DOFs in the remaining inactive nodes
     if ((mDoubleVariablesList.size() > 0.0) || (mComponentVariablesList.size() > 0.0)){
         #pragma omp parallel for
-        for (int i_node = 0; i_node < static_cast<int>(rNodes.size()); ++i_node){
+        for (size_t i_node = 0; i_node < static_cast<size_t>(rNodes.size()); ++i_node){
             auto it_node = rNodes.begin() + i_node;
             if (it_node->GetValue(EMBEDDED_IS_ACTIVE) == 0){
                 for (std::size_t i_var = 0; i_var < mDoubleVariablesList.size(); i_var++){
@@ -478,11 +605,11 @@ void DistanceModificationProcess::DeactivateFullNegativeElements() {
 void DistanceModificationProcess::SetContinuousDistanceToSplitFlag()
 {
     #pragma omp parallel for
-    for (int i_elem = 0; i_elem < static_cast<int>(mrModelPart.NumberOfElements()); ++i_elem) {
+    for (size_t i_elem = 0; i_elem < static_cast<size_t>(mrModelPart.NumberOfElements()); ++i_elem) {
         auto it_elem = mrModelPart.ElementsBegin() + i_elem;
         auto &r_geom = it_elem->GetGeometry();
         std::vector<double> elem_dist;
-        for (unsigned int i_node = 0; i_node < r_geom.PointsNumber(); ++i_node) {
+        for (size_t i_node = 0; i_node < r_geom.PointsNumber(); ++i_node) {
             elem_dist.push_back(r_geom[i_node].FastGetSolutionStepValue(DISTANCE));
         }
         this->SetElementToSplitFlag(*it_elem, elem_dist);
@@ -492,7 +619,7 @@ void DistanceModificationProcess::SetContinuousDistanceToSplitFlag()
 void DistanceModificationProcess::SetDiscontinuousDistanceToSplitFlag()
 {
     #pragma omp parallel for
-    for (int i_elem = 0; i_elem < static_cast<int>(mrModelPart.NumberOfElements()); ++i_elem) {
+    for (size_t i_elem = 0; i_elem < static_cast<size_t>(mrModelPart.NumberOfElements()); ++i_elem) {
         auto it_elem = mrModelPart.ElementsBegin() + i_elem;
         const auto &r_elem_dist = it_elem->GetValue(ELEMENTAL_DISTANCES);
         this->SetElementToSplitFlag(*it_elem, r_elem_dist);
@@ -542,6 +669,23 @@ void DistanceModificationProcess::CheckAndStoreVariablesList(const std::vector<s
                 KRATOS_ERROR << "The variable defined in the list is not a double variable nor a component variable. Given variable: " << rVariableStringArray[i_variable] << std::endl;
             }
         }
+    }
+}
+
+const std::array<size_t,2> DistanceModificationProcess::GetNodeIDs(
+    const size_t numEdges, 
+    const size_t edgeID) 
+{
+    std::array<std::array<size_t,2>, 3> node_ids_2d {{ {{1,2}}, {{2,0}}, {{0,1}} }};
+    std::array<std::array<size_t,2>, 6> node_ids_3d {{ {{0,1}}, {{1,2}}, {{2,0}}, {{0,3}}, {{1,3}}, {{2,3}} }};
+    switch (numEdges)
+    {
+    case 3:
+        return node_ids_2d[edgeID];
+    case 6:
+        return node_ids_3d[edgeID];
+    default:
+        KRATOS_ERROR << "The number of edges does not correspond to any support element type (Triangle2D3 and Tetrahedra3D4). The number of edges is: " << numEdges << std::endl;
     }
 }
 

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -28,6 +28,10 @@
 
 namespace Kratos
 {
+/* Type definitions *******************************************************/
+
+constexpr std::array<std::array<std::size_t,2>, 3> DistanceModificationProcess::NodeIDs2D;
+constexpr std::array<std::array<std::size_t,2>, 6> DistanceModificationProcess::NodeIDs3D; 
 
 /* Public functions *******************************************************/
 DistanceModificationProcess::DistanceModificationProcess(
@@ -78,7 +82,7 @@ DistanceModificationProcess::DistanceModificationProcess(
 
 void DistanceModificationProcess::InitializeEmbeddedIsActive()
 {
-    for (size_t i_node = 0; i_node < static_cast<size_t>(mrModelPart.NumberOfNodes()); ++i_node) {
+    for (std::size_t i_node = 0; i_node < static_cast<std::size_t>(mrModelPart.NumberOfNodes()); ++i_node) {
         auto it_node = mrModelPart.NodesBegin() + i_node;
         it_node->SetValue(EMBEDDED_IS_ACTIVE, 0);
     }
@@ -229,7 +233,7 @@ void DistanceModificationProcess::ModifyDistance()
             auto nodes_end = r_nodes.begin() + partition_vec[i_chunk + 1];
 
             // Auxiliar chunk arrays
-            std::vector<size_t> aux_modified_distances_ids;
+            std::vector<std::size_t> aux_modified_distances_ids;
             std::vector<double> aux_modified_distance_values;
 
             for (auto it_node = nodes_begin; it_node < nodes_end; ++it_node) {
@@ -279,7 +283,7 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance()
     auto r_elems = mrModelPart.Elements();
     auto elems_begin = mrModelPart.ElementsBegin();
     const auto n_elems = mrModelPart.NumberOfElements();
-    const size_t n_edges_extrapolated = elems_begin->GetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED).size();
+    const std::size_t n_edges_extrapolated = elems_begin->GetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED).size();
 
     // Distance modification
     if (mRecoverOriginalDistance == false) {
@@ -298,7 +302,7 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance()
                 // Check if the elemental distance values are close to zero
                 bool is_modified = false;
                 Vector &r_elem_dist = it_elem->GetValue(ELEMENTAL_DISTANCES);
-                for (size_t i_node = 0; i_node < r_elem_dist.size(); ++i_node){
+                for (std::size_t i_node = 0; i_node < r_elem_dist.size(); ++i_node){
                     if (std::abs(r_elem_dist(i_node)) < tol_d){
                         is_modified = true;
                         r_elem_dist(i_node) = r_elem_dist(i_node) > 0.0 ? tol_d : -tol_d;
@@ -308,10 +312,10 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance()
                 // Modify ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED consistently
                 if (is_modified) {
                     Vector &r_elem_edge_dist_extra = it_elem->GetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED);
-                    for (size_t i_edge = 0; i_edge < n_edges_extrapolated; ++i_edge) {
+                    for (std::size_t i_edge = 0; i_edge < n_edges_extrapolated; ++i_edge) {
 
                         // Get corresponding node IDs and elemental distances
-                        const std::array<size_t, 2> node_ids = GetNodeIDs(n_edges_extrapolated, i_edge);
+                        const std::array<std::size_t, 2> node_ids = GetNodeIDs(n_edges_extrapolated, i_edge);
                         const double node_i_distance = r_elem_dist(node_ids[0]);
                         const double node_j_distance = r_elem_dist(node_ids[1]);
 
@@ -333,7 +337,7 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance()
 
                 // Check if the elemental distance values are close to zero
                 Vector &r_elem_dist = it_elem->GetValue(ELEMENTAL_DISTANCES);
-                for (size_t i_node = 0; i_node < r_elem_dist.size(); ++i_node){
+                for (std::size_t i_node = 0; i_node < r_elem_dist.size(); ++i_node){
                     if (std::abs(r_elem_dist(i_node)) < tol_d){
                         r_elem_dist(i_node) = r_elem_dist(i_node) > 0.0 ? tol_d : -tol_d;
                     }
@@ -357,9 +361,9 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance()
                 auto elems_end = r_elems.begin() + partition_vec[i_chunk + 1];
 
                 // Auxiliar chunk arrays
-                std::vector<size_t> aux_modified_distances_ids;
+                std::vector<std::size_t> aux_modified_distances_ids;
                 std::vector<Vector> aux_modified_elemental_distances;
-                std::vector<size_t> aux_modified_edge_dist_extra_ids;
+                std::vector<std::size_t> aux_modified_edge_dist_extra_ids;
                 std::vector<Vector> aux_modified_edge_dist_extra;
 
                 for (auto it_elem = elems_begin; it_elem < elems_end; ++it_elem) {
@@ -368,7 +372,7 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance()
 
                     bool is_saved = false;
                     Vector &r_elem_dist = it_elem->GetValue(ELEMENTAL_DISTANCES);
-                    for (size_t i_node = 0; i_node < r_elem_dist.size(); ++i_node){
+                    for (std::size_t i_node = 0; i_node < r_elem_dist.size(); ++i_node){
                         if (std::abs(r_elem_dist(i_node)) < tol_d){
                             if (!is_saved){
                                 aux_modified_distances_ids.push_back(it_elem->Id());
@@ -382,10 +386,10 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance()
                     // Modify ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED consistently
                     if (is_saved) {
                         Vector &r_elem_edge_dist_extra = it_elem->GetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED);
-                        for (size_t i_edge = 0; i_edge < n_edges_extrapolated; ++i_edge) {
+                        for (std::size_t i_edge = 0; i_edge < n_edges_extrapolated; ++i_edge) {
 
                             // Get corresponding node IDs and elemental distances
-                            const std::array<size_t, 2> node_ids = GetNodeIDs(n_edges_extrapolated,i_edge);
+                            const std::array<std::size_t, 2> node_ids = GetNodeIDs(n_edges_extrapolated,i_edge);
                             const double node_i_distance = r_elem_dist(node_ids[0]);
                             const double node_j_distance = r_elem_dist(node_ids[1]);
 
@@ -417,7 +421,7 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance()
                 auto elems_end = r_elems.begin() + partition_vec[i_chunk + 1];
 
                 // Auxiliar chunk arrays
-                std::vector<size_t> aux_modified_distances_ids;
+                std::vector<std::size_t> aux_modified_distances_ids;
                 std::vector<Vector> aux_modified_elemental_distances;
 
                 for (auto it_elem = elems_begin; it_elem < elems_end; ++it_elem) {
@@ -426,7 +430,7 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance()
 
                     bool is_saved = false;
                     Vector &r_elem_dist = it_elem->GetValue(ELEMENTAL_DISTANCES);
-                    for (size_t i_node = 0; i_node < r_elem_dist.size(); ++i_node){
+                    for (std::size_t i_node = 0; i_node < r_elem_dist.size(); ++i_node){
                         if (std::abs(r_elem_dist(i_node)) < tol_d){
                             if (!is_saved){
                                 aux_modified_distances_ids.push_back(it_elem->Id());
@@ -507,17 +511,17 @@ void DistanceModificationProcess::RecoverOriginalDiscontinuousDistance()
     // Recover original elemental distances
     #pragma omp parallel for
     for (int i_elem = 0; i_elem < static_cast<int>(mModifiedDistancesIDs.size()); ++i_elem) {
-        const size_t elem_id = mModifiedDistancesIDs[i_elem];
-        const auto r_elem_dist = mModifiedElementalDistancesValues[i_elem];
-        mrModelPart.GetElement(elem_id).SetValue(ELEMENTAL_DISTANCES,r_elem_dist);
+        const std::size_t elem_id = mModifiedDistancesIDs[i_elem];
+        const auto& r_elem_dist = mModifiedElementalDistancesValues[i_elem];
+        mrModelPart.GetElement(elem_id).GetValue(ELEMENTAL_DISTANCES) = r_elem_dist;
     }
 
     // Recover original extrapolated elemental edge distances
     #pragma omp parallel for
     for (int i_elem = 0; i_elem < static_cast<int>(mModifiedExtrapolatedIDs.size()); ++i_elem) {
-        const size_t elem_id = mModifiedExtrapolatedIDs[i_elem];
-        const auto elem_edge_dist_extra = mModifiedExtrapolatedValues[i_elem];
-        mrModelPart.GetElement(elem_id).SetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED,elem_edge_dist_extra);
+        const std::size_t elem_id = mModifiedExtrapolatedIDs[i_elem];
+        const auto& r_elem_edge_dist_extra = mModifiedExtrapolatedValues[i_elem];
+        mrModelPart.GetElement(elem_id).GetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED) = r_elem_edge_dist_extra;
     }
 
     // Empty the modified distance vectors
@@ -551,12 +555,12 @@ void DistanceModificationProcess::DeactivateFullNegativeElements()
     // Deactivate those elements whose negative distance nodes summation is equal to their number of nodes
     #pragma omp parallel for
     for (int k = 0; k < static_cast<int>(rElements.size()); ++k){
-        size_t n_neg = 0;
+        std::size_t n_neg = 0;
         ModelPart::ElementsContainerType::iterator itElement = rElements.begin() + k;
         auto& rGeometry = itElement->GetGeometry();
 
         // Check the distance function sign at the element nodes
-        for (size_t i_node=0; i_node<rGeometry.size(); i_node++){
+        for (std::size_t i_node=0; i_node<rGeometry.size(); i_node++){
             if (rGeometry[i_node].FastGetSolutionStepValue(DISTANCE) < 0.0){
                 n_neg++;
             }
@@ -566,7 +570,7 @@ void DistanceModificationProcess::DeactivateFullNegativeElements()
 
         // If the element is ACTIVE, all its nodes are active as well
         if (itElement->Is(ACTIVE)){
-            for (size_t i_node = 0; i_node < rGeometry.size(); ++i_node){
+            for (std::size_t i_node = 0; i_node < rGeometry.size(); ++i_node){
                 int& activation_index = rGeometry[i_node].GetValue(EMBEDDED_IS_ACTIVE);
                 #pragma omp atomic
                 activation_index += 1;
@@ -609,7 +613,7 @@ void DistanceModificationProcess::SetContinuousDistanceToSplitFlag()
         auto it_elem = mrModelPart.ElementsBegin() + i_elem;
         auto &r_geom = it_elem->GetGeometry();
         std::vector<double> elem_dist;
-        for (size_t i_node = 0; i_node < r_geom.PointsNumber(); ++i_node) {
+        for (std::size_t i_node = 0; i_node < r_geom.PointsNumber(); ++i_node) {
             elem_dist.push_back(r_geom[i_node].FastGetSolutionStepValue(DISTANCE));
         }
         this->SetElementToSplitFlag(*it_elem, elem_dist);
@@ -672,20 +676,18 @@ void DistanceModificationProcess::CheckAndStoreVariablesList(const std::vector<s
     }
 }
 
-const std::array<size_t,2> DistanceModificationProcess::GetNodeIDs(
-    const size_t numEdges, 
-    const size_t edgeID) 
+const std::array<std::size_t,2> DistanceModificationProcess::GetNodeIDs(
+    const std::size_t NumEdges, 
+    const std::size_t EdgeID) 
 {
-    std::array<std::array<size_t,2>, 3> node_ids_2d {{ {{1,2}}, {{2,0}}, {{0,1}} }};
-    std::array<std::array<size_t,2>, 6> node_ids_3d {{ {{0,1}}, {{1,2}}, {{2,0}}, {{0,3}}, {{1,3}}, {{2,3}} }};
-    switch (numEdges)
+    switch (NumEdges)
     {
     case 3:
-        return node_ids_2d[edgeID];
+        return NodeIDs2D[EdgeID];
     case 6:
-        return node_ids_3d[edgeID];
+        return NodeIDs3D[EdgeID];
     default:
-        KRATOS_ERROR << "The number of edges does not correspond to any support element type (Triangle2D3 and Tetrahedra3D4). The number of edges is: " << numEdges << std::endl;
+        KRATOS_ERROR << "The number of edges does not correspond to any supported element type (Triangle2D3 and Tetrahedra3D4). The number of edges is: " << NumEdges << std::endl;
     }
 }
 

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -291,10 +291,6 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance()
         // If user has provided flag to calculate elemental edge distances of extrapolated geometry,
         // modify them according to elemental distances in order to stay consistent with element splitting
         if (n_edges_extrapolated > 0) {
-            /*IndexPartition<std::size_t>(n_elems).for_each([&](std::size_t i_elem){
-
-                
-            });*/
             block_for_each(r_elems, [&](Element& rElement){
                 // Compute the distance tolerance
                 const double tol_d = mDistanceThreshold*(rElement.GetGeometry()).Length();

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -395,8 +395,6 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance()
 
                             // Check if the edge is split by extrapolated geometry
                             if (r_elem_edge_dist_extra(i_edge) > 0) {
-                                aux_modified_edge_dist_extra_ids.push_back(it_elem->Id());
-                                aux_modified_edge_dist_extra.push_back(r_elem_edge_dist_extra);
                                 // Compute edge ratio of intersection point using modified elemental distances
                                 r_elem_edge_dist_extra(i_edge) = std::abs( node_i_distance / (node_j_distance - node_i_distance) );
                             }
@@ -409,8 +407,6 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance()
                 {
                     mModifiedDistancesIDs.insert(mModifiedDistancesIDs.end(),aux_modified_distances_ids.begin(),aux_modified_distances_ids.end());
                     mModifiedElementalDistancesValues.insert(mModifiedElementalDistancesValues.end(),aux_modified_elemental_distances.begin(),aux_modified_elemental_distances.end());
-                    mModifiedExtrapolatedIDs.insert(mModifiedExtrapolatedIDs.end(),aux_modified_edge_dist_extra_ids.begin(),aux_modified_edge_dist_extra_ids.end());
-                    mModifiedExtrapolatedValues.insert(mModifiedExtrapolatedValues.end(),aux_modified_edge_dist_extra.begin(),aux_modified_edge_dist_extra.end());
                 }
             }
         } else {
@@ -516,25 +512,11 @@ void DistanceModificationProcess::RecoverOriginalDiscontinuousDistance()
         mrModelPart.GetElement(elem_id).GetValue(ELEMENTAL_DISTANCES) = r_elem_dist;
     }
 
-    // Recover original extrapolated elemental edge distances
-    #pragma omp parallel for
-    for (int i_elem = 0; i_elem < static_cast<int>(mModifiedExtrapolatedIDs.size()); ++i_elem) {
-        const std::size_t elem_id = mModifiedExtrapolatedIDs[i_elem];
-        const auto& r_elem_edge_dist_extra = mModifiedExtrapolatedValues[i_elem];
-        mrModelPart.GetElement(elem_id).GetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED) = r_elem_edge_dist_extra;
-    }
-
     // Empty the modified distance vectors
     mModifiedDistancesIDs.resize(0);
     mModifiedElementalDistancesValues.resize(0);
     mModifiedDistancesIDs.shrink_to_fit();
     mModifiedElementalDistancesValues.shrink_to_fit();
-
-    // Empty the modified vectors for ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED
-    mModifiedExtrapolatedIDs.resize(0);
-    mModifiedExtrapolatedValues.resize(0);
-    mModifiedExtrapolatedIDs.shrink_to_fit();
-    mModifiedExtrapolatedValues.shrink_to_fit();
 
     // Restore the TO_SPLIT flag original status
     this->SetDiscontinuousDistanceToSplitFlag();

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -193,7 +193,7 @@ void DistanceModificationProcess::ModifyDistance()
     // Case in where the original distance does not need to be preserved (e.g. CFD)
     if (mRecoverOriginalDistance == false) {
         #pragma omp parallel for
-        for (size_t k = 0; k < static_cast<size_t>(r_nodes.size()); ++k) {
+        for (int k = 0; k < static_cast<size_t>(r_nodes.size()); ++k) {
             auto it_node = r_nodes.begin() + k;
             const double h = it_node->GetValue(NODAL_H);
             const double tol_d = mDistanceThreshold*h;
@@ -223,7 +223,7 @@ void DistanceModificationProcess::ModifyDistance()
         OpenMPUtils::DivideInPartitions(r_nodes.size(),num_chunks,partition_vec);
 
         #pragma omp parallel for
-        for (size_t i_chunk = 0; i_chunk < num_chunks; ++i_chunk)
+        for (int i_chunk = 0; i_chunk < num_chunks; ++i_chunk)
         {
             auto nodes_begin = r_nodes.begin() + partition_vec[i_chunk];
             auto nodes_end = r_nodes.begin() + partition_vec[i_chunk + 1];
@@ -289,7 +289,7 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance()
         // modify them according to elemental distances in order to stay consistent with element splitting
         if (n_edges_extrapolated > 0) {
             #pragma omp parallel for
-            for (size_t i_elem = 0; i_elem < static_cast<size_t>(n_elems); ++i_elem) {
+            for (int i_elem = 0; i_elem < static_cast<size_t>(n_elems); ++i_elem) {
                 auto it_elem = elems_begin + i_elem;
 
                 // Compute the distance tolerance
@@ -325,7 +325,7 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance()
             }
         } else {
             #pragma omp parallel for
-            for (size_t i_elem = 0; i_elem < static_cast<size_t>(n_elems); ++i_elem) {
+            for (int i_elem = 0; i_elem < static_cast<size_t>(n_elems); ++i_elem) {
                 auto it_elem = elems_begin + i_elem;
 
                 // Compute the distance tolerance
@@ -351,7 +351,7 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance()
         // modify them according to elemental distances in order to stay consistent with element splitting
         if (n_edges_extrapolated > 0) {
             #pragma omp parallel for
-            for (size_t i_chunk = 0; i_chunk < num_chunks; ++i_chunk)
+            for (int i_chunk = 0; i_chunk < num_chunks; ++i_chunk)
             {
                 auto elems_begin = r_elems.begin() + partition_vec[i_chunk];
                 auto elems_end = r_elems.begin() + partition_vec[i_chunk + 1];
@@ -411,7 +411,7 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance()
             }
         } else {
             #pragma omp parallel for
-            for (size_t i_chunk = 0; i_chunk < num_chunks; ++i_chunk)
+            for (int i_chunk = 0; i_chunk < num_chunks; ++i_chunk)
             {
                 auto elems_begin = r_elems.begin() + partition_vec[i_chunk];
                 auto elems_end = r_elems.begin() + partition_vec[i_chunk + 1];
@@ -456,14 +456,14 @@ void DistanceModificationProcess::RecoverDeactivationPreviousState()
 {
     // Activate again all the elements
     #pragma omp parallel for
-    for (size_t i_elem = 0; i_elem < static_cast<size_t>(mrModelPart.NumberOfElements()); ++i_elem){
+    for (int i_elem = 0; i_elem < static_cast<size_t>(mrModelPart.NumberOfElements()); ++i_elem){
         auto it_elem = mrModelPart.ElementsBegin() + i_elem;
         it_elem->Set(ACTIVE,true);
     }
     if ((mDoubleVariablesList.size() > 0.0) || (mComponentVariablesList.size() > 0.0)){
         // Free the negative DOFs that were fixed
         #pragma omp parallel for
-        for (size_t i_node = 0; i_node < static_cast<size_t>(mrModelPart.NumberOfNodes()); ++i_node){
+        for (int i_node = 0; i_node < static_cast<size_t>(mrModelPart.NumberOfNodes()); ++i_node){
             auto it_node = mrModelPart.NodesBegin() + i_node;
             if (it_node->GetValue(EMBEDDED_IS_ACTIVE) == 0){
                 for (std::size_t i_var = 0; i_var < mDoubleVariablesList.size(); i_var++){
@@ -484,7 +484,7 @@ void DistanceModificationProcess::RecoverDeactivationPreviousState()
 void DistanceModificationProcess::RecoverOriginalDistance()
 {
     #pragma omp parallel for
-    for (size_t i = 0; i < static_cast<size_t>(mModifiedDistancesIDs.size()); ++i) {
+    for (int i = 0; i < static_cast<size_t>(mModifiedDistancesIDs.size()); ++i) {
         const auto node_id = mModifiedDistancesIDs[i];
         mrModelPart.GetNode(node_id).FastGetSolutionStepValue(DISTANCE) = mModifiedDistancesValues[i];
     }
@@ -506,7 +506,7 @@ void DistanceModificationProcess::RecoverOriginalDiscontinuousDistance()
 {    
     // Recover original elemental distances
     #pragma omp parallel for
-    for (size_t i_elem = 0; i_elem < static_cast<size_t>(mModifiedDistancesIDs.size()); ++i_elem) {
+    for (int i_elem = 0; i_elem < static_cast<size_t>(mModifiedDistancesIDs.size()); ++i_elem) {
         const size_t elem_id = mModifiedDistancesIDs[i_elem];
         const auto r_elem_dist = mModifiedElementalDistancesValues[i_elem];
         mrModelPart.GetElement(elem_id).SetValue(ELEMENTAL_DISTANCES,r_elem_dist);
@@ -514,7 +514,7 @@ void DistanceModificationProcess::RecoverOriginalDiscontinuousDistance()
 
     // Recover original extrapolated elemental edge distances
     #pragma omp parallel for
-    for (size_t i_elem = 0; i_elem < static_cast<size_t>(mModifiedExtrapolatedIDs.size()); ++i_elem) {
+    for (int i_elem = 0; i_elem < static_cast<size_t>(mModifiedExtrapolatedIDs.size()); ++i_elem) {
         const size_t elem_id = mModifiedExtrapolatedIDs[i_elem];
         const auto elem_edge_dist_extra = mModifiedExtrapolatedValues[i_elem];
         mrModelPart.GetElement(elem_id).SetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED,elem_edge_dist_extra);
@@ -543,14 +543,14 @@ void DistanceModificationProcess::DeactivateFullNegativeElements()
 
     // Initialize the EMBEDDED_IS_ACTIVE variable flag to 0
     #pragma omp parallel for
-    for (size_t i_node = 0; i_node < static_cast<size_t>(rNodes.size()); ++i_node){
+    for (int i_node = 0; i_node < static_cast<size_t>(rNodes.size()); ++i_node){
         ModelPart::NodesContainerType::iterator it_node = rNodes.begin() + i_node;
         it_node->SetValue(EMBEDDED_IS_ACTIVE, 0);
     }
 
     // Deactivate those elements whose negative distance nodes summation is equal to their number of nodes
     #pragma omp parallel for
-    for (size_t k = 0; k < static_cast<size_t>(rElements.size()); ++k){
+    for (int k = 0; k < static_cast<size_t>(rElements.size()); ++k){
         size_t n_neg = 0;
         ModelPart::ElementsContainerType::iterator itElement = rElements.begin() + k;
         auto& rGeometry = itElement->GetGeometry();
@@ -580,7 +580,7 @@ void DistanceModificationProcess::DeactivateFullNegativeElements()
     // Set to zero and fix the DOFs in the remaining inactive nodes
     if ((mDoubleVariablesList.size() > 0.0) || (mComponentVariablesList.size() > 0.0)){
         #pragma omp parallel for
-        for (size_t i_node = 0; i_node < static_cast<size_t>(rNodes.size()); ++i_node){
+        for (int i_node = 0; i_node < static_cast<size_t>(rNodes.size()); ++i_node){
             auto it_node = rNodes.begin() + i_node;
             if (it_node->GetValue(EMBEDDED_IS_ACTIVE) == 0){
                 for (std::size_t i_var = 0; i_var < mDoubleVariablesList.size(); i_var++){
@@ -605,7 +605,7 @@ void DistanceModificationProcess::DeactivateFullNegativeElements()
 void DistanceModificationProcess::SetContinuousDistanceToSplitFlag()
 {
     #pragma omp parallel for
-    for (size_t i_elem = 0; i_elem < static_cast<size_t>(mrModelPart.NumberOfElements()); ++i_elem) {
+    for (int i_elem = 0; i_elem < static_cast<size_t>(mrModelPart.NumberOfElements()); ++i_elem) {
         auto it_elem = mrModelPart.ElementsBegin() + i_elem;
         auto &r_geom = it_elem->GetGeometry();
         std::vector<double> elem_dist;
@@ -619,7 +619,7 @@ void DistanceModificationProcess::SetContinuousDistanceToSplitFlag()
 void DistanceModificationProcess::SetDiscontinuousDistanceToSplitFlag()
 {
     #pragma omp parallel for
-    for (size_t i_elem = 0; i_elem < static_cast<size_t>(mrModelPart.NumberOfElements()); ++i_elem) {
+    for (int i_elem = 0; i_elem < static_cast<size_t>(mrModelPart.NumberOfElements()); ++i_elem) {
         auto it_elem = mrModelPart.ElementsBegin() + i_elem;
         const auto &r_elem_dist = it_elem->GetValue(ELEMENTAL_DISTANCES);
         this->SetElementToSplitFlag(*it_elem, r_elem_dist);

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
@@ -164,8 +164,6 @@ private:
     std::vector<std::size_t>               mModifiedDistancesIDs;
     std::vector<double>                 mModifiedDistancesValues;
     std::vector<Vector>        mModifiedElementalDistancesValues;
-    std::vector<std::size_t>            mModifiedExtrapolatedIDs;
-    std::vector<Vector>              mModifiedExtrapolatedValues;
     std::vector<const Variable<double>*>    mDoubleVariablesList;
     std::vector<const ComponentType*>    mComponentVariablesList;
 

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
@@ -59,7 +59,11 @@ class KRATOS_API(FLUID_DYNAMICS_APPLICATION) DistanceModificationProcess : publi
 public:
     ///@name Type Definitions
     ///@{
+
     typedef Variable<double> ComponentType;
+    
+    static constexpr std::array<std::array<std::size_t,2>, 3> NodeIDs2D {{ {{1,2}}, {{2,0}}, {{0,1}} }};
+    static constexpr std::array<std::array<std::size_t,2>, 6> NodeIDs3D {{ {{0,1}}, {{1,2}}, {{2,0}}, {{0,3}}, {{1,3}}, {{2,3}} }};    
 
     /// Pointer definition of DistanceModificationProcess
     KRATOS_CLASS_POINTER_DEFINITION(DistanceModificationProcess);
@@ -157,13 +161,13 @@ private:
     bool                                    mNegElemDeactivation;
     bool                               mAvoidAlmostEmptyElements;
     bool                                mRecoverOriginalDistance;
-    std::vector<size_t>                    mModifiedDistancesIDs;
+    std::vector<std::size_t>               mModifiedDistancesIDs;
     std::vector<double>                 mModifiedDistancesValues;
     std::vector<Vector>        mModifiedElementalDistancesValues;
-    std::vector<size_t>                 mModifiedExtrapolatedIDs;
+    std::vector<std::size_t>            mModifiedExtrapolatedIDs;
     std::vector<Vector>              mModifiedExtrapolatedValues;
     std::vector<const Variable<double>*>    mDoubleVariablesList;
-    std::vector<const ComponentType*>    mComponentVariablesList;                
+    std::vector<const ComponentType*>    mComponentVariablesList;
 
     ///@}
     ///@name Protected Operators
@@ -200,8 +204,8 @@ private:
         Element &rElem,
         const TDistancesVectorType& rDistancesVector)
     {
-        size_t n_pos = 0;
-        size_t n_neg = 0;
+        std::size_t n_pos = 0;
+        std::size_t n_neg = 0;
         for (double i_dist : rDistancesVector) {
             if (i_dist < 0.0) {
                 n_neg++;
@@ -233,12 +237,12 @@ private:
      * This mapping is a consequence of the node and edge order used in the CalculateDiscontinuousDistanceToSkinProcess
      * for ELEMENTAL_DISTANCES and ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED, 
      * which is based on triangle_2d_3.h and tetrahedra_3d_4.h (geometry)
-     * @param numEdges Number of edges of one element to distinguish between Triangle2D3N and Tetrahedra2D4N 
-     * @param edgeID ID of the element's edge
+     * @param NumEdges Number of edges of one element to distinguish between Triangle2D3N and Tetrahedra2D4N 
+     * @param EdgeID ID of the element's edge
     */
-    const std::array<size_t,2> GetNodeIDs(
-        const size_t numEdges, 
-        const size_t edgeID);
+    const std::array<std::size_t,2> GetNodeIDs(
+        const std::size_t NumEdges, 
+        const std::size_t EdgeID);
 
     ///@}
     ///@name Private  Access

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
@@ -157,11 +157,13 @@ private:
     bool                                    mNegElemDeactivation;
     bool                               mAvoidAlmostEmptyElements;
     bool                                mRecoverOriginalDistance;
-    std::vector<unsigned int>              mModifiedDistancesIDs;
+    std::vector<size_t>                    mModifiedDistancesIDs;
     std::vector<double>                 mModifiedDistancesValues;
     std::vector<Vector>        mModifiedElementalDistancesValues;
+    std::vector<size_t>                 mModifiedExtrapolatedIDs;
+    std::vector<Vector>              mModifiedExtrapolatedValues;
     std::vector<const Variable<double>*>    mDoubleVariablesList;
-    std::vector<const ComponentType*>    mComponentVariablesList;
+    std::vector<const ComponentType*>    mComponentVariablesList;                
 
     ///@}
     ///@name Protected Operators
@@ -198,8 +200,8 @@ private:
         Element &rElem,
         const TDistancesVectorType& rDistancesVector)
     {
-        unsigned int n_pos = 0;
-        unsigned int n_neg = 0;
+        size_t n_pos = 0;
+        size_t n_neg = 0;
         for (double i_dist : rDistancesVector) {
             if (i_dist < 0.0) {
                 n_neg++;
@@ -225,6 +227,18 @@ private:
      * @param rVariableStringArray Array containing the variables to be fixed in the full negative elements
     */
     void CheckAndStoreVariablesList(const std::vector<std::string>& rVariableStringArray);
+
+    /**
+     * @brief Returns the node IDs corresponding to the given edge ID. 
+     * This mapping is a consequence of the node and edge order used in the CalculateDiscontinuousDistanceToSkinProcess
+     * for ELEMENTAL_DISTANCES and ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED, 
+     * which is based on triangle_2d_3.h and tetrahedra_3d_4.h (geometry)
+     * @param numEdges Number of edges of one element to distinguish between Triangle2D3N and Tetrahedra2D4N 
+     * @param edgeID ID of the element's edge
+    */
+    const std::array<size_t,2> GetNodeIDs(
+        const size_t numEdges, 
+        const size_t edgeID);
 
     ///@}
     ///@name Private  Access

--- a/applications/FluidDynamicsApplication/custom_utilities/embedded_discontinuous_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/embedded_discontinuous_data.h
@@ -49,7 +49,6 @@ double SlipLength;
 double PenaltyCoefficient;
 
 NodalScalarData ElementalDistances;
-Vector ElementalEdgeDistances;
 Vector ElementalEdgeDistancesExtrapolated;
 
 Matrix PositiveSideN;
@@ -73,7 +72,6 @@ std::vector< size_t > NegativeIndices;
 
 std::size_t NumPositiveNodes;
 std::size_t NumNegativeNodes;
-std::size_t NumIntersectedEdges;
 std::size_t NumIntersectedEdgesExtrapolated;
 
 ///@}
@@ -95,12 +93,10 @@ void Initialize(
 {
     TFluidData::Initialize(rElement, rProcessInfo);
     this->FillFromElementData(ElementalDistances, ELEMENTAL_DISTANCES, rElement);
-    this->FillFromElementData(ElementalEdgeDistances, ELEMENTAL_EDGE_DISTANCES, rElement);
     this->FillFromElementData(ElementalEdgeDistancesExtrapolated, ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED, rElement);
 
     NumPositiveNodes = 0;
     NumNegativeNodes = 0;
-    NumIntersectedEdges = 0;
     NumIntersectedEdgesExtrapolated = 0;
 }
 

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_distance_modification_process.cpp
@@ -56,7 +56,6 @@ void TriangleModelPartForDistanceModification(
         Vector elem_edge_dist(3,-1.0);
         elem_edge_dist(1) = 0.8;
         rModelPart.ElementsBegin()->SetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED, elem_edge_dist);
-   
     }
 }
 

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_distance_modification_process.cpp
@@ -134,9 +134,8 @@ KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceModificationTriangle, FluidDynami
     r_elem_dist = (model_part.ElementsBegin())->GetValue(ELEMENTAL_DISTANCES);
     r_elem_edge_dist_extra = (model_part.ElementsBegin())->GetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED);
     const std::vector<double> expected_orig_values = {-1.0e-5, 1.0, 1.0};
-    const std::vector<double> expected_orig_extra_values = {-1.0, 0.8, -1.0};
     KRATOS_CHECK_VECTOR_NEAR(r_elem_edge_dist_extra, expected_orig_values, tolerance);
-    KRATOS_CHECK_VECTOR_NEAR(r_elem_edge_dist_extra, expected_orig_extra_values, tolerance);
+    KRATOS_CHECK_VECTOR_NEAR(r_elem_edge_dist_extra, expected_extra_values, tolerance);
 }
 
 }

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_distance_modification_process.cpp
@@ -134,7 +134,7 @@ KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceModificationTriangle, FluidDynami
     r_elem_dist = (model_part.ElementsBegin())->GetValue(ELEMENTAL_DISTANCES);
     r_elem_edge_dist_extra = (model_part.ElementsBegin())->GetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED);
     const std::vector<double> expected_orig_values = {-1.0e-5, 1.0, 1.0};
-    KRATOS_CHECK_VECTOR_NEAR(r_elem_edge_dist_extra, expected_orig_values, tolerance);
+    KRATOS_CHECK_VECTOR_NEAR(r_elem_dist, expected_orig_values, tolerance);
     KRATOS_CHECK_VECTOR_NEAR(r_elem_edge_dist_extra, expected_extra_values, tolerance);
 }
 

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_distance_modification_process.cpp
@@ -53,6 +53,10 @@ void TriangleModelPartForDistanceModification(
         Vector elem_dist(3,1.0);
         elem_dist(0) = -1e-5;
         rModelPart.ElementsBegin()->SetValue(ELEMENTAL_DISTANCES, elem_dist);
+        Vector elem_edge_dist(3,-1.0);
+        elem_edge_dist(1) = 0.8;
+        rModelPart.ElementsBegin()->SetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED, elem_edge_dist);
+   
     }
 }
 
@@ -79,7 +83,7 @@ KRATOS_TEST_CASE_IN_SUITE(DistanceModificationTriangle, FluidDynamicsApplication
     dist_mod_process.ExecuteInitializeSolutionStep();
     const double tolerance = 1e-9;
     std::array<double, 3> expected_values = {-1.0e-3, 1.0, 1.0};
-    for (unsigned int i_node = 1; i_node < 4; ++i_node) {
+    for (size_t i_node = 1; i_node < 4; ++i_node) {
         KRATOS_CHECK_NEAR((model_part.GetNode(i_node)).FastGetSolutionStepValue(DISTANCE), expected_values[i_node - 1], tolerance);
     }
 
@@ -89,7 +93,7 @@ KRATOS_TEST_CASE_IN_SUITE(DistanceModificationTriangle, FluidDynamicsApplication
     // Check the original distance recovering
     dist_mod_process.ExecuteFinalizeSolutionStep();
     std::array<double, 3> expected_orig_values = {-1.0e-5, 1.0, 1.0};
-    for (unsigned int i_node = 1; i_node < 4; ++i_node) {
+    for (size_t i_node = 1; i_node < 4; ++i_node) {
         KRATOS_CHECK_NEAR((model_part.GetNode(i_node)).FastGetSolutionStepValue(DISTANCE), expected_orig_values[i_node - 1], tolerance);
     }
 }
@@ -115,10 +119,13 @@ KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceModificationTriangle, FluidDynami
     dist_mod_process.ExecuteBeforeSolutionLoop();
     dist_mod_process.ExecuteInitializeSolutionStep();
     auto elem_dist = (model_part.ElementsBegin())->GetValue(ELEMENTAL_DISTANCES);
+    auto elem_edge_dist_extra = (model_part.ElementsBegin())->GetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED);
     const double tolerance = 1e-9;
     std::array<double, 3> expected_values = {-0.000797885, 1.0, 1.0};
-    for (unsigned int i = 0; i < elem_dist.size(); ++i) {
+    std::array<double, 3> expected_extra_values = {-1.0, 0.9992027516, -1.0};
+    for (size_t i = 0; i < elem_dist.size(); ++i) {
         KRATOS_CHECK_NEAR(elem_dist[i], expected_values[i], tolerance);
+        KRATOS_CHECK_NEAR(elem_edge_dist_extra[i], expected_extra_values[i], tolerance);
     }
 
     // Check that the flag TO_SPLIT is correctly set
@@ -127,9 +134,12 @@ KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceModificationTriangle, FluidDynami
     // Check the original distance recovering
     dist_mod_process.ExecuteFinalizeSolutionStep();
     elem_dist = (model_part.ElementsBegin())->GetValue(ELEMENTAL_DISTANCES);
+    elem_edge_dist_extra = (model_part.ElementsBegin())->GetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED);
     std::array<double, 3> expected_orig_values = {-1.0e-5, 1.0, 1.0};
-    for (unsigned int i = 0; i < elem_dist.size(); ++i) {
+    std::array<double, 3> expected_orig_extra_values = {-1.0, 0.8, -1.0};
+    for (size_t i = 0; i < elem_dist.size(); ++i) {
         KRATOS_CHECK_NEAR(elem_dist[i], expected_orig_values[i], tolerance);
+        KRATOS_CHECK_NEAR(elem_edge_dist_extra[i], expected_orig_extra_values[i], tolerance);
     }
 }
 

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_distance_modification_process.cpp
@@ -82,7 +82,7 @@ KRATOS_TEST_CASE_IN_SUITE(DistanceModificationTriangle, FluidDynamicsApplication
     dist_mod_process.ExecuteBeforeSolutionLoop();
     dist_mod_process.ExecuteInitializeSolutionStep();
     const double tolerance = 1e-9;
-    std::array<double, 3> expected_values = {-1.0e-3, 1.0, 1.0};
+    const std::array<double, 3> expected_values = {-1.0e-3, 1.0, 1.0};
     for (size_t i_node = 1; i_node < 4; ++i_node) {
         KRATOS_CHECK_NEAR((model_part.GetNode(i_node)).FastGetSolutionStepValue(DISTANCE), expected_values[i_node - 1], tolerance);
     }
@@ -92,7 +92,7 @@ KRATOS_TEST_CASE_IN_SUITE(DistanceModificationTriangle, FluidDynamicsApplication
 
     // Check the original distance recovering
     dist_mod_process.ExecuteFinalizeSolutionStep();
-    std::array<double, 3> expected_orig_values = {-1.0e-5, 1.0, 1.0};
+    const std::array<double, 3> expected_orig_values = {-1.0e-5, 1.0, 1.0};
     for (size_t i_node = 1; i_node < 4; ++i_node) {
         KRATOS_CHECK_NEAR((model_part.GetNode(i_node)).FastGetSolutionStepValue(DISTANCE), expected_orig_values[i_node - 1], tolerance);
     }
@@ -118,29 +118,25 @@ KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceModificationTriangle, FluidDynami
     dist_mod_process.ExecuteInitialize();
     dist_mod_process.ExecuteBeforeSolutionLoop();
     dist_mod_process.ExecuteInitializeSolutionStep();
-    auto elem_dist = (model_part.ElementsBegin())->GetValue(ELEMENTAL_DISTANCES);
-    auto elem_edge_dist_extra = (model_part.ElementsBegin())->GetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED);
+    auto& r_elem_dist = (model_part.ElementsBegin())->GetValue(ELEMENTAL_DISTANCES);
+    auto& r_elem_edge_dist_extra = (model_part.ElementsBegin())->GetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED);
     const double tolerance = 1e-9;
-    std::array<double, 3> expected_values = {-0.000797885, 1.0, 1.0};
-    std::array<double, 3> expected_extra_values = {-1.0, 0.9992027516, -1.0};
-    for (size_t i = 0; i < elem_dist.size(); ++i) {
-        KRATOS_CHECK_NEAR(elem_dist[i], expected_values[i], tolerance);
-        KRATOS_CHECK_NEAR(elem_edge_dist_extra[i], expected_extra_values[i], tolerance);
-    }
+    const std::vector<double> expected_values = {-0.000797885, 1.0, 1.0};
+    const std::vector<double> expected_extra_values = {-1.0, 0.9992027516, -1.0};
+    KRATOS_CHECK_VECTOR_NEAR(r_elem_dist, expected_values, tolerance);
+    KRATOS_CHECK_VECTOR_NEAR(r_elem_edge_dist_extra, expected_extra_values, tolerance);
 
     // Check that the flag TO_SPLIT is correctly set
     KRATOS_CHECK((model_part.ElementsBegin())->Is(TO_SPLIT));
 
     // Check the original distance recovering
     dist_mod_process.ExecuteFinalizeSolutionStep();
-    elem_dist = (model_part.ElementsBegin())->GetValue(ELEMENTAL_DISTANCES);
-    elem_edge_dist_extra = (model_part.ElementsBegin())->GetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED);
-    std::array<double, 3> expected_orig_values = {-1.0e-5, 1.0, 1.0};
-    std::array<double, 3> expected_orig_extra_values = {-1.0, 0.8, -1.0};
-    for (size_t i = 0; i < elem_dist.size(); ++i) {
-        KRATOS_CHECK_NEAR(elem_dist[i], expected_orig_values[i], tolerance);
-        KRATOS_CHECK_NEAR(elem_edge_dist_extra[i], expected_orig_extra_values[i], tolerance);
-    }
+    r_elem_dist = (model_part.ElementsBegin())->GetValue(ELEMENTAL_DISTANCES);
+    r_elem_edge_dist_extra = (model_part.ElementsBegin())->GetValue(ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED);
+    const std::vector<double> expected_orig_values = {-1.0e-5, 1.0, 1.0};
+    const std::vector<double> expected_orig_extra_values = {-1.0, 0.8, -1.0};
+    KRATOS_CHECK_VECTOR_NEAR(r_elem_edge_dist_extra, expected_orig_values, tolerance);
+    KRATOS_CHECK_VECTOR_NEAR(r_elem_edge_dist_extra, expected_orig_extra_values, tolerance);
 }
 
 }


### PR DESCRIPTION
**📝 Description**
Remnant of treating incised (not completely cut) elements in embedded `FluidDynamics` simulations.

The modification of the `ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED` was added to the discontinuous part of the `DistanceModificationProcess`. As the extrapolated edge distances are already a part of `ELEMENTAL_DISTANCES`, if they get calculated in the `CalculateDiscontinuousDistanceToSkinProcess`, they will be modified in the `DistanceModificationProcess` and used for the element splitting operation. In order to stay consistent with the element splitting, now the extrapolated edge distances get modified in a consistent way, which will be used for the Ausas incised shape functions of the element.

Additionally unused variables and assignments were removed from the `EmbeddedFluidElementDiscontinuous`.

**🆕 Changelog**
- Added modification of `ELEMENTAL_EDGE_DISTANCES_EXTRAPOLATED` to discontinuous part of `DistanceModificationProcess`. Therefore, adapted the methods `ModifyDiscontinuousDistance` and `RecoverOriginalDiscontinuousDistance` and added method `GetNodeIDs` to translate an edge ID of the element edge distances vector to the node IDs of that edge needed for the elemental distances vector.
- Extended test of `DistanceModificationProcess`.
- Removed fetching `ELEMENTAL_EDGE_DISTANCES` (actually not needed at all) and NumIntersectedEdges from the `EmbeddedFluidElementDiscontinuous` and its data.
