### PR TITLE
[DelaunayMeshingApplication] Error compilation with CMake if USE_TRIANGLE_NONFREE_TPL not set

### DIFF
--- a/applications/DelaunayMeshingApplication/CMakeLists.txt
+++ b/applications/DelaunayMeshingApplication/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT DEFINED ${INCLUDE_TRIANGLE})
     set(INCLUDE_TRIANGLE ON)
     set(TRIANGLE_DIR "${KRATOS_SOURCE_DIR}/external_libraries/triangle")
   else(${USE_TRIANGLE_NONFREE_TPL} MATCHES ON )
-    message(STATUS "INCLUDE_TRIANGLE not defined, neither USE_TRIANGLE_NONFREE_TPL=ON is defined. The application DelaunayMeshingApplication will not compile")
+    message(FATAL_ERROR "INCLUDE_TRIANGLE not defined, neither USE_TRIANGLE_NONFREE_TPL=ON is defined. The application DelaunayMeshingApplication will not compile")
   endif(${USE_TRIANGLE_NONFREE_TPL} MATCHES ON )
 endif(NOT DEFINED ${INCLUDE_TRIANGLE})
 

--- a/applications/DelaunayMeshingApplication/CMakeLists.txt
+++ b/applications/DelaunayMeshingApplication/CMakeLists.txt
@@ -10,8 +10,13 @@ include(pybind11Tools)
 ## Set a default value for triangle and tetgen in case the user does not set it
 ## to avoid problems with the define linkage block. By default we will compile the lib
 if(NOT DEFINED ${INCLUDE_TRIANGLE})
-  set(INCLUDE_TRIANGLE ON)
-  set(TRIANGLE_DIR "${KRATOS_SOURCE_DIR}/external_libraries/triangle")
+  # Compiling the triangle library
+  if(${USE_TRIANGLE_NONFREE_TPL} MATCHES ON )
+    set(INCLUDE_TRIANGLE ON)
+    set(TRIANGLE_DIR "${KRATOS_SOURCE_DIR}/external_libraries/triangle")
+  else(${USE_TRIANGLE_NONFREE_TPL} MATCHES ON )
+    message(FATAL_ERROR "INCLUDE_TRIANGLE not defined, neither USE_TRIANGLE_NONFREE_TPL=ON")
+  endif(${USE_TRIANGLE_NONFREE_TPL} MATCHES ON )
 endif(NOT DEFINED ${INCLUDE_TRIANGLE})
 
 if(NOT DEFINED ${INCLUDE_TETGEN})
@@ -24,7 +29,6 @@ if(${INCLUDE_TRIANGLE} MATCHES ON)
   include_directories(${TRIANGLE_DIR})
   list(APPEND MESHER_LIBRARIES triangle)
 endif(${INCLUDE_TRIANGLE} MATCHES ON)
-
 
 if(${INCLUDE_TETGEN} MATCHES ON)
   set(EXTERNAL_LIBRARIES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external_libraries")

--- a/applications/DelaunayMeshingApplication/CMakeLists.txt
+++ b/applications/DelaunayMeshingApplication/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT DEFINED ${INCLUDE_TRIANGLE})
     set(INCLUDE_TRIANGLE ON)
     set(TRIANGLE_DIR "${KRATOS_SOURCE_DIR}/external_libraries/triangle")
   else(${USE_TRIANGLE_NONFREE_TPL} MATCHES ON )
-    message(FATAL_ERROR "INCLUDE_TRIANGLE not defined, neither USE_TRIANGLE_NONFREE_TPL=ON")
+    message(STATUS "INCLUDE_TRIANGLE not defined, neither USE_TRIANGLE_NONFREE_TPL=ON is defined. The application DelaunayMeshingApplication will not compile")
   endif(${USE_TRIANGLE_NONFREE_TPL} MATCHES ON )
 endif(NOT DEFINED ${INCLUDE_TRIANGLE})
 


### PR DESCRIPTION
**📝 Description**
Fix #9339

**🆕 Changelog**
- Error compilation with CMake if USE_TRIANGLE_NONFREE_TPL not set
