### PR TITLE
[MeshingApplication] Correct isosurface metric loading for MMG versions >=5.5

### DIFF
--- a/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
+++ b/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
@@ -204,10 +204,11 @@ void MmgProcess<TMMGLibrary>::ExecuteInitializeSolutionStep()
     // We retrieve the data form the Kratos model part to fill sol
     if (mDiscretization == DiscretizationOption::ISOSURFACE) {
         InitializeSolDataDistance();
-    } else {
-        if (!optimization_mode) {
-            InitializeSolDataMetric();
-        }
+    }
+
+    // We load the metric field, unless optimization mode is enabled.
+    if (!optimization_mode) {
+        InitializeSolDataMetric();
     }
 
     // We set the displacement vector
@@ -370,8 +371,14 @@ void MmgProcess<TMMGLibrary>::InitializeSolDataMetric()
 {
     KRATOS_TRY;
 
-    // We initialize the solution data with the given modelpart
-    mMmgUtilities.GenerateSolDataFromModelPart(mrThisModelPart);
+    if (mDiscretization == DiscretizationOption::ISOSURFACE) {
+        // This will only run for version >= 5.5
+        mMmgUtilities.GenerateIsosurfaceMetricDataFromModelPart(mrThisModelPart);
+    } else {
+        // We initialize the solution data with the given modelpart
+        mMmgUtilities.GenerateSolDataFromModelPart(mrThisModelPart);
+    }
+
 
     KRATOS_CATCH("");
 }

--- a/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
+++ b/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
@@ -1285,7 +1285,7 @@ const Parameters MmgProcess<TMMGLibrary>::GetDefaultParameters() const
         {
             "isosurface_variable"              : "DISTANCE",
             "nonhistorical_variable"           : false,
-            "use_metric_field"                 : true,
+            "use_metric_field"                 : false,
             "remove_internal_regions"          : false
         },
         "framework"                            : "Eulerian",

--- a/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
+++ b/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
@@ -373,7 +373,8 @@ void MmgProcess<TMMGLibrary>::InitializeSolDataMetric()
 
     if (mDiscretization == DiscretizationOption::ISOSURFACE) {
         // This will only run for version >= 5.5
-        mMmgUtilities.GenerateIsosurfaceMetricDataFromModelPart(mrThisModelPart);
+        if (mThisParameters["isosurface_parameters"]["use_metric_field"].GetBool())
+            mMmgUtilities.GenerateIsosurfaceMetricDataFromModelPart(mrThisModelPart);
     } else {
         // We initialize the solution data with the given modelpart
         mMmgUtilities.GenerateSolDataFromModelPart(mrThisModelPart);
@@ -1284,6 +1285,7 @@ const Parameters MmgProcess<TMMGLibrary>::GetDefaultParameters() const
         {
             "isosurface_variable"              : "DISTANCE",
             "nonhistorical_variable"           : false,
+            "use_metric_field"                 : true,
             "remove_internal_regions"          : false
         },
         "framework"                            : "Eulerian",

--- a/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.cpp
+++ b/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.cpp
@@ -1550,7 +1550,7 @@ void MmgUtilities<MMGLibrary::MMG2D>::InitMesh()
         MMG2D_Init_mesh( MMG5_ARG_start, MMG5_ARG_ppMesh, &mMmgMesh, MMG5_ARG_ppMet, &mMmgMet, MMG5_ARG_ppDisp, &mMmgDisp, MMG5_ARG_end);
     } else if (mDiscretization == DiscretizationOption::ISOSURFACE) {
     #if MMG_VERSION_GE(5,5)
-        MMG2D_Init_mesh( MMG5_ARG_start, MMG5_ARG_ppMesh, &mMmgMesh, MMG5_ARG_ppLs, &mMmgMet, MMG5_ARG_ppLs, &mMmgSol, MMG5_ARG_end);
+        MMG2D_Init_mesh( MMG5_ARG_start, MMG5_ARG_ppMesh, &mMmgMesh, MMG5_ARG_ppMet, &mMmgMet, MMG5_ARG_ppLs, &mMmgSol, MMG5_ARG_end);
     #else
         MMG2D_Init_mesh( MMG5_ARG_start, MMG5_ARG_ppMesh, &mMmgMesh, MMG5_ARG_ppLs, &mMmgMet, MMG5_ARG_end);
     #endif
@@ -1585,7 +1585,7 @@ void MmgUtilities<MMGLibrary::MMG3D>::InitMesh()
         MMG3D_Init_mesh( MMG5_ARG_start, MMG5_ARG_ppMesh, &mMmgMesh, MMG5_ARG_ppMet, &mMmgMet, MMG5_ARG_ppDisp, &mMmgDisp, MMG5_ARG_end);
     } else if (mDiscretization == DiscretizationOption::ISOSURFACE) {
     #if MMG_VERSION_GE(5,5)
-        MMG3D_Init_mesh( MMG5_ARG_start, MMG5_ARG_ppMesh, &mMmgMesh, MMG5_ARG_ppLs, &mMmgMet, MMG5_ARG_ppLs, &mMmgSol, MMG5_ARG_end);
+        MMG3D_Init_mesh( MMG5_ARG_start, MMG5_ARG_ppMesh, &mMmgMesh, MMG5_ARG_ppMet, &mMmgMet, MMG5_ARG_ppLs, &mMmgSol, MMG5_ARG_end);
     #else
         MMG3D_Init_mesh( MMG5_ARG_start, MMG5_ARG_ppMesh, &mMmgMesh, MMG5_ARG_ppLs, &mMmgMet, MMG5_ARG_end);
     #endif
@@ -1620,7 +1620,7 @@ void MmgUtilities<MMGLibrary::MMGS>::InitMesh()
         MMGS_Init_mesh( MMG5_ARG_start, MMG5_ARG_ppMesh, &mMmgMesh, MMG5_ARG_ppMet, &mMmgMet, MMG5_ARG_ppDisp, &mMmgDisp, MMG5_ARG_end);
     } else if (mDiscretization == DiscretizationOption::ISOSURFACE) {
     #if MMG_VERSION_GE(5,5)
-        MMGS_Init_mesh( MMG5_ARG_start, MMG5_ARG_ppMesh, &mMmgMesh, MMG5_ARG_ppLs, &mMmgMet, MMG5_ARG_ppLs, &mMmgSol, MMG5_ARG_end);
+        MMGS_Init_mesh( MMG5_ARG_start, MMG5_ARG_ppMesh, &mMmgMesh, MMG5_ARG_ppMet, &mMmgMet, MMG5_ARG_ppLs, &mMmgSol, MMG5_ARG_end);
     #else
         MMGS_Init_mesh( MMG5_ARG_start, MMG5_ARG_ppMesh, &mMmgMesh, MMG5_ARG_ppLs, &mMmgMet, MMG5_ARG_end);
     #endif
@@ -1983,6 +1983,7 @@ void MmgUtilities<MMGLibrary::MMG2D>::CheckMeshData()
     } else if (mDiscretization == DiscretizationOption::ISOSURFACE) {
     #if MMG_VERSION_GE(5,5)
         KRATOS_ERROR_IF( MMG2D_Chk_meshData(mMmgMesh, mMmgSol) != 1 ) << "Wrong solution data" << std::endl;
+        KRATOS_ERROR_IF( MMG2D_Chk_meshData(mMmgMesh, mMmgMet) != 1 ) << "Wrong metric data" << std::endl;
     #else
         KRATOS_ERROR_IF( MMG2D_Chk_meshData(mMmgMesh, mMmgMet) != 1 ) << "Wrong metric data" << std::endl;
     #endif
@@ -2007,6 +2008,7 @@ void MmgUtilities<MMGLibrary::MMG3D>::CheckMeshData()
     } else if (mDiscretization == DiscretizationOption::ISOSURFACE) {
     #if MMG_VERSION_GE(5,5)
         KRATOS_ERROR_IF( MMG3D_Chk_meshData(mMmgMesh, mMmgSol) != 1 ) << "Wrong solution data" << std::endl;
+        KRATOS_ERROR_IF( MMG3D_Chk_meshData(mMmgMesh, mMmgMet) != 1 ) << "Wrong metric data" << std::endl;
     #else
         KRATOS_ERROR_IF( MMG3D_Chk_meshData(mMmgMesh, mMmgMet) != 1 ) << "Wrong metric data" << std::endl;
     #endif
@@ -2031,6 +2033,7 @@ void MmgUtilities<MMGLibrary::MMGS>::CheckMeshData()
     } else if (mDiscretization == DiscretizationOption::ISOSURFACE) {
     #if MMG_VERSION_GE(5,5)
         KRATOS_ERROR_IF( MMGS_Chk_meshData(mMmgMesh, mMmgSol) != 1 ) << "Wrong solution data" << std::endl;
+        KRATOS_ERROR_IF( MMGS_Chk_meshData(mMmgMesh, mMmgMet) != 1 ) << "Wrong metric data" << std::endl;
     #else
         KRATOS_ERROR_IF( MMGS_Chk_meshData(mMmgMesh, mMmgMet) != 1 ) << "Wrong metric data" << std::endl;
     #endif
@@ -4289,6 +4292,21 @@ void MmgUtilities<TMMGLibrary>::GenerateSolDataFromModelPart(ModelPart& rModelPa
             }
         });
     }
+
+    KRATOS_CATCH("");
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<MMGLibrary TMMGLibrary>
+void MmgUtilities<TMMGLibrary>::GenerateIsosurfaceMetricDataFromModelPart(ModelPart& rModelPart)
+{
+    KRATOS_TRY;
+
+    #if MMG_VERSION_GE(5,5)
+        this->GenerateSolDataFromModelPart(rModelPart);
+    #endif
 
     KRATOS_CATCH("");
 }

--- a/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.h
+++ b/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.h
@@ -668,6 +668,13 @@ public:
     virtual void GenerateSolDataFromModelPart(ModelPart& rModelPart);
 
     /**
+     * @brief This method generates solution (metric) data from an existing model part
+     * for the isosurface algorithm
+     * @param[in,out] rModelPart The model part of interest to study
+     */
+    virtual void GenerateIsosurfaceMetricDataFromModelPart(ModelPart& rModelPart);
+
+    /**
      * @brief This method generates displacement data from an existing model part
      * @param[in,out] rModelPart The model part of interest to study
      */


### PR DESCRIPTION
**📝 Description**

After v5.5, MMG allows adaptation and isovalue discretiaziton in a single call. In our interface only the latter was working for versions >= 5.5.
Our interface was not loading correclty the metric field if provided. Instead mMmgMet was always NULL (it was never initialized), so it was behaving as v5.4.


**🆕 Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Added loading of metric field if v5.5 and isosurface is enabled. 
- Add option for users what use v5.5 and do not want to adapt to a metric field (only performing isovalue discretization).
