### PR TITLE
[MLMC] Use environment variable to set which XMC library to use

### DIFF
--- a/applications/MultilevelMonteCarloApplication/CMakeLists.txt
+++ b/applications/MultilevelMonteCarloApplication/CMakeLists.txt
@@ -74,35 +74,11 @@ endif(${INSTALL_TESTING_FILES} MATCHES ON)
 install(TARGETS KratosMultilevelMonteCarloCore DESTINATION libs )
 install(TARGETS KratosMultilevelMonteCarloApplication DESTINATION libs )
 
-############################################################################
-#####
-#####        PyCOMPSs (Distributed Computation library)
-#####
-############################################################################
 # Install PyCOMPSs mockup library
-if(NOT DEFINED USING_PYCOMPSS OR NOT USING_PYCOMPSS)
-    message ( STATUS "Automatic installation of PyCOMPSs mockup library" )
-    add_definitions(-DKRATOS_MLMC_USE_MOCKUP_PYCOMPSS=1)
-	kratos_python_install_directory(${INSTALL_PYTHON_USING_LINKS} ${CMAKE_CURRENT_SOURCE_DIR}/external_libraries/PyCOMPSs KratosMultiphysics/${CURRENT_DIR_NAME}/PyCOMPSs )
-else (USING_PYCOMPSS)
-    message ( STATUS "Manual installation of PyCOMPSs library" )
-    add_definitions(-DKRATOS_MLMC_USE_MOCKUP_PYCOMPSS=0)
-endif(NOT DEFINED USING_PYCOMPSS OR NOT USING_PYCOMPSS)
+kratos_python_install_directory(${INSTALL_PYTHON_USING_LINKS} ${CMAKE_CURRENT_SOURCE_DIR}/external_libraries/PyCOMPSs KratosMultiphysics/${CURRENT_DIR_NAME}/PyCOMPSs )
 
-############################################################################
-#####
-#####        XMC (Uncertainty Quantification library)
-#####
-############################################################################
 # Install XMC library
-if (NOT DEFINED USING_INTERNAL_XMC OR USING_INTERNAL_XMC)
-    message ( STATUS "Automatic installation of XMC library" )
-    add_definitions(-DKRATOS_MLMC_USE_INTERNAL_XMC=1)
-	kratos_python_install_directory(${INSTALL_PYTHON_USING_LINKS} ${CMAKE_CURRENT_SOURCE_DIR}/external_libraries/XMC KratosMultiphysics/${CURRENT_DIR_NAME}/XMC )
-else (NOT USING_INTERNAL_XMC)
-    message ( STATUS "Manual installation of XMC library" )
-    add_definitions(-DKRATOS_MLMC_USE_INTERNAL_XMC=0)
-endif(NOT DEFINED USING_INTERNAL_XMC OR USING_INTERNAL_XMC)
+kratos_python_install_directory(${INSTALL_PYTHON_USING_LINKS} ${CMAKE_CURRENT_SOURCE_DIR}/external_libraries/XMC KratosMultiphysics/${CURRENT_DIR_NAME}/XMC )
 
 # Define custom targets
 set(KRATOS_KERNEL "${KRATOS_KERNEL};KratosMultilevelMonteCarloCore" PARENT_SCOPE)

--- a/applications/MultilevelMonteCarloApplication/MultilevelMonteCarloApplication.py
+++ b/applications/MultilevelMonteCarloApplication/MultilevelMonteCarloApplication.py
@@ -11,7 +11,7 @@ application_name = "KratosMultilevelMonteCarloApplication"
 
 _ImportApplication(application, application_name)
 
-# PyCOMPSs/Quake
+# ExaQUte API
 exaqute_backend = os.environ.get("EXAQUTE_BACKEND")
 if exaqute_backend:
     print("EXAQUTE_BACKEND={}".format(exaqute_backend))
@@ -19,7 +19,7 @@ if exaqute_backend:
 else:
     exaqute_backend = "local"
     print("Default ExaQUte backend: {}".format(exaqute_backend))
-    
+
 if exaqute_backend == "local":
     print("*********************************************************")
     print("** Warning: Running a mockup version of PyCOMPSs       **")
@@ -29,7 +29,12 @@ if exaqute_backend == "local":
 elif exaqute_backend in ("quake", "pycompss"):
     pass
 else:
-    raise ValueError("Unknown ExaQUte backend: {}".format(exaqute_backend))
+    raise ValueError(
+        (
+            "Unknown ExaQUte backend: {}\n"
+            "Supported values are 'local', 'pycompss' and 'quake'"
+        ).format(exaqute_backend)
+    )
 
 # XMC
 XMC_backend = os.environ.get("XMC_BACKEND")
@@ -45,7 +50,7 @@ if XMC_backend == "external":
 elif XMC_backend == "local":
     sys.path.append(os.path.join(os.path.dirname(__file__),'XMC'))
 else:
-    raise ModuleNotFoundError(
+    raise ValueError(
         (
             "Unknown XMC backend: {}\n"
             "Supported values are 'local' and 'external'"

--- a/applications/MultilevelMonteCarloApplication/MultilevelMonteCarloApplication.py
+++ b/applications/MultilevelMonteCarloApplication/MultilevelMonteCarloApplication.py
@@ -11,17 +11,31 @@ application_name = "KratosMultilevelMonteCarloApplication"
 
 _ImportApplication(application, application_name)
 
-if UseMockupPyCOMPSs():
+# PyCOMPSs/Quake
+exaqute_backend = os.environ.get("EXAQUTE_BACKEND")
+if exaqute_backend:
+    print("EXAQUTE_BACKEND={}".format(exaqute_backend))
+    exaqute_backend = exaqute_backend.lower()
+else:
+    exaqute_backend = "local"
+    print("Default ExaQUte backend: {}".format(exaqute_backend))
+    
+if exaqute_backend == "local":
     print("*********************************************************")
     print("** Warning: Running a mockup version of PyCOMPSs       **")
     print("** Warning: The code will NOT RUN USING PARALLEL TASKS **")
     print("*********************************************************")
-
     sys.path.append(os.path.join(os.path.dirname(__file__),'PyCOMPSs'))
+elif exaqute_backend in ("quake", "pycompss"):
+    pass
+else:
+    raise ValueError("Unknown ExaQUte backend: {}".format(exaqute_backend))
 
+# XMC
 XMC_backend = os.environ.get("XMC_BACKEND")
 if XMC_backend:
     print("XMC_BACKEND={}".format(XMC_backend))
+    XMC_backend = XMC_backend.lower()
 else:
     XMC_backend = "local"
     print("Default XMC backend: {}".format(XMC_backend))

--- a/applications/MultilevelMonteCarloApplication/MultilevelMonteCarloApplication.py
+++ b/applications/MultilevelMonteCarloApplication/MultilevelMonteCarloApplication.py
@@ -19,5 +19,21 @@ if UseMockupPyCOMPSs():
 
     sys.path.append(os.path.join(os.path.dirname(__file__),'PyCOMPSs'))
 
-if UseInternalXMC():
+XMC_backend = os.environ.get("XMC_BACKEND")
+if XMC_backend:
+    print("XMC_BACKEND={}".format(XMC_backend))
+else:
+    XMC_backend = "local"
+    print("Default XMC backend: {}".format(XMC_backend))
+
+if XMC_backend == "external":
+    pass
+elif XMC_backend == "local":
     sys.path.append(os.path.join(os.path.dirname(__file__),'XMC'))
+else:
+    raise ModuleNotFoundError(
+        (
+            "Unknown XMC backend: {}\n"
+            "Supported values are 'local' and 'external'"
+        ).format(XMC_backend)
+    )

--- a/applications/MultilevelMonteCarloApplication/MultilevelMonteCarloApplication.py
+++ b/applications/MultilevelMonteCarloApplication/MultilevelMonteCarloApplication.py
@@ -14,11 +14,11 @@ _ImportApplication(application, application_name)
 # ExaQUte API
 exaqute_backend = os.environ.get("EXAQUTE_BACKEND")
 if exaqute_backend:
-    print("EXAQUTE_BACKEND={}".format(exaqute_backend))
+    print("EXAQUTE_BACKEND = {}".format(exaqute_backend))
     exaqute_backend = exaqute_backend.lower()
 else:
     exaqute_backend = "local"
-    print("Default ExaQUte backend: {}".format(exaqute_backend))
+    print("Default ExaQUte backend = {}".format(exaqute_backend))
 
 if exaqute_backend == "local":
     print("*********************************************************")
@@ -31,7 +31,7 @@ elif exaqute_backend in ("quake", "pycompss"):
 else:
     raise ValueError(
         (
-            "Unknown ExaQUte backend: {}\n"
+            "Unknown ExaQUte backend = {}\n"
             "Supported values are 'local', 'pycompss' and 'quake'"
         ).format(exaqute_backend)
     )
@@ -39,11 +39,11 @@ else:
 # XMC
 XMC_backend = os.environ.get("XMC_BACKEND")
 if XMC_backend:
-    print("XMC_BACKEND={}".format(XMC_backend))
+    print("XMC_BACKEND = {}".format(XMC_backend))
     XMC_backend = XMC_backend.lower()
 else:
     XMC_backend = "local"
-    print("Default XMC backend: {}".format(XMC_backend))
+    print("Default XMC backend = {}".format(XMC_backend))
 
 if XMC_backend == "external":
     pass
@@ -52,7 +52,7 @@ elif XMC_backend == "local":
 else:
     raise ValueError(
         (
-            "Unknown XMC backend: {}\n"
+            "Unknown XMC backend = {}\n"
             "Supported values are 'local' and 'external'"
         ).format(XMC_backend)
     )

--- a/applications/MultilevelMonteCarloApplication/README.md
+++ b/applications/MultilevelMonteCarloApplication/README.md
@@ -134,14 +134,14 @@ Information about these libraries can be found in their respective pages, which 
 
 ### XMC
 
-[XMC](https://gitlab.com/RiccardoRossi/exaqute-xmc) is a Python library, with BSD 4 license, designed for hierarchical Monte Carlo methods. The library develops the above-mentioned algorithms, statistical tools and convergence criteria. The library presents a natural integration with Kratos, which is XMC default solver. By default, an internal version of the library is used. If one wants to use an external version of the library, the flag `-DUSING_INTERNAL_XMC=OFF \ ` should be added when compiling Kratos.
+[XMC](https://gitlab.com/RiccardoRossi/exaqute-xmc) is a Python library, with BSD 4 license, designed for hierarchical Monte Carlo methods. The library develops the above-mentioned algorithms, statistical tools and convergence criteria. The library presents a natural integration with Kratos, which is XMC default solver. By default, an internal version of the library is used. If one wants to use an external version of the library, the environment variable `XMC_BACKEND=external` should be set.
 
 ### PyCOMPSs
 
 PyCOMPSs is the Python library required in order to use task-based programming software [COMPSs](https://www.bsc.es/research-and-development/software-and-apps/software-list/comp-superscalar) in a Python environment.
 By default PyCOMPSs is not required in order to run the application.
-In case one wants to run using this library, Kratos needs to be compiled adding the flag `-DUSING_PYCOMPSS=ON \ `.
-The current version is able to run several thousands of samples at once exploiting PyCOMPSs in distributed systems, maximizing parallelism and computational efficiency. Optimal strong scalability up to 128 working nodes (6144 CPUs) has been demonstrated.
+In case one wants to run using this library, the environment variable `EXAQUTE_BACKEND=pycompss` must be set.
+The current version is able to run several thousands of samples at once exploiting PyCOMPSs in distributed systems, maximizing parallelism and computational efficiency. Optimal scalability up to 128 working nodes (6144 CPUs) has been demonstrated with both OpenMP and MPI parallelisms.
 
 Instructions for the installation can be found in the [Kratos wiki](https://github.com/KratosMultiphysics/Kratos/wiki/How-to-run-multiple-cases-using-PyCOMPSs).
 To run with `runcompss`, the environment variable `EXAQUTE_BACKEND=pycompss` must be set to use the distributed computing capabilities.

--- a/applications/MultilevelMonteCarloApplication/custom_python/multilevel_monte_carlo_python_application.cpp
+++ b/applications/MultilevelMonteCarloApplication/custom_python/multilevel_monte_carlo_python_application.cpp
@@ -44,9 +44,6 @@ PYBIND11_MODULE(KratosMultilevelMonteCarloApplication,m)
     // AddCustomUtilitiesToPython(m);
     AddCustomStatisticsToPython(m);
 
-    m.def("UseMockupPyCOMPSs", [](){return KRATOS_MLMC_USE_MOCKUP_PYCOMPSS;});
-    m.def("UseInternalXMC", [](){return KRATOS_MLMC_USE_INTERNAL_XMC;});
-
     //registering variables in python
 
     KRATOS_REGISTER_IN_PYTHON_VARIABLE(m, POWER_SUM_1 )


### PR DESCRIPTION
**📝 Description**
We use an environment variable to decide which XMC library to use. Checking nightly here https://github.com/KratosMultiphysics/Kratos/actions/runs/1472220505

Please mark the PR with appropriate tags: 
- 

**🆕 Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Added support to use an environment variable to decide which XMC library to use
