### PR TITLE
Adding missing link-time imports

### DIFF
--- a/applications/CSharpWrapperApplication/CSharpWrapperApplication.py
+++ b/applications/CSharpWrapperApplication/CSharpWrapperApplication.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 from KratosMultiphysics import _ImportApplication
-import KratosMultiphysics.KratosStructuralMechanicsApplication
+import KratosMultiphysics.StructuralMechanicsApplication
 from KratosCSharpWrapperApplication import *
 application = KratosCSharpWrapperApplication()
 application_name = "KratosCSharpWrapperApplication"

--- a/applications/CSharpWrapperApplication/CSharpWrapperApplication.py
+++ b/applications/CSharpWrapperApplication/CSharpWrapperApplication.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 from KratosMultiphysics import _ImportApplication
+import KratosMultiphysics.KratosStructuralMechanicsApplication
 from KratosCSharpWrapperApplication import *
 application = KratosCSharpWrapperApplication()
 application_name = "KratosCSharpWrapperApplication"

--- a/applications/CableNetApplication/CableNetApplication.py
+++ b/applications/CableNetApplication/CableNetApplication.py
@@ -3,6 +3,7 @@ from __future__ import print_function, absolute_import, division
 
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
+import KratosMultiphysics.KratosStructuralMechanicsApplication
 from KratosCableNetApplication import *
 application = KratosCableNetApplication()
 application_name = "KratosCableNetApplication"

--- a/applications/CableNetApplication/CableNetApplication.py
+++ b/applications/CableNetApplication/CableNetApplication.py
@@ -3,7 +3,7 @@ from __future__ import print_function, absolute_import, division
 
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
-import KratosMultiphysics.KratosStructuralMechanicsApplication
+import KratosMultiphysics.StructuralMechanicsApplication
 from KratosCableNetApplication import *
 application = KratosCableNetApplication()
 application_name = "KratosCableNetApplication"

--- a/applications/ContactMechanicsApplication/ContactMechanicsApplication.py
+++ b/applications/ContactMechanicsApplication/ContactMechanicsApplication.py
@@ -3,7 +3,7 @@ from KratosMultiphysics.DelaunayMeshingApplication import *
 
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
-import KratosMultiphysics.KratosDelaunayMeshingApplication
+import KratosMultiphysics.DelaunayMeshingApplication
 from KratosContactMechanicsApplication import *
 application = KratosContactMechanicsApplication()
 application_name = "KratosContactMechanicsApplication"

--- a/applications/ContactMechanicsApplication/ContactMechanicsApplication.py
+++ b/applications/ContactMechanicsApplication/ContactMechanicsApplication.py
@@ -3,6 +3,7 @@ from KratosMultiphysics.DelaunayMeshingApplication import *
 
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
+import KratosMultiphysics.KratosDelaunayMeshingApplication
 from KratosContactMechanicsApplication import *
 application = KratosContactMechanicsApplication()
 application_name = "KratosContactMechanicsApplication"

--- a/applications/ContactStructuralMechanicsApplication/ContactStructuralMechanicsApplication.py
+++ b/applications/ContactStructuralMechanicsApplication/ContactStructuralMechanicsApplication.py
@@ -1,5 +1,6 @@
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
+import KratosMultiphysics.KratosStructuralMechanicsApplication
 from KratosContactStructuralMechanicsApplication import *
 application = KratosContactStructuralMechanicsApplication()
 application_name = "KratosContactStructuralMechanicsApplication"

--- a/applications/ContactStructuralMechanicsApplication/ContactStructuralMechanicsApplication.py
+++ b/applications/ContactStructuralMechanicsApplication/ContactStructuralMechanicsApplication.py
@@ -1,6 +1,6 @@
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
-import KratosMultiphysics.KratosStructuralMechanicsApplication
+import KratosMultiphysics.StructuralMechanicsApplication
 from KratosContactStructuralMechanicsApplication import *
 application = KratosContactStructuralMechanicsApplication()
 application_name = "KratosContactStructuralMechanicsApplication"

--- a/applications/DamApplication/DamApplication.py
+++ b/applications/DamApplication/DamApplication.py
@@ -3,6 +3,8 @@ from __future__ import print_function, absolute_import, division
 
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
+import KratosMultiphysics.KratosStructuralMechanicsApplication
+import KratosMultiphysics.KratosPoromechanicsApplication
 from KratosDamApplication import *
 application = KratosDamApplication()
 application_name = "KratosDamApplication"

--- a/applications/DamApplication/DamApplication.py
+++ b/applications/DamApplication/DamApplication.py
@@ -3,8 +3,8 @@ from __future__ import print_function, absolute_import, division
 
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
-import KratosMultiphysics.KratosStructuralMechanicsApplication
-import KratosMultiphysics.KratosPoromechanicsApplication
+import KratosMultiphysics.StructuralMechanicsApplication
+import KratosMultiphysics.PoromechanicsApplication
 from KratosDamApplication import *
 application = KratosDamApplication()
 application_name = "KratosDamApplication"

--- a/applications/DemStructuresCouplingApplication/DemStructuresCouplingApplication.py
+++ b/applications/DemStructuresCouplingApplication/DemStructuresCouplingApplication.py
@@ -1,5 +1,7 @@
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
+import KratosMultiphysics.KratosStructuralMechanicsApplication
+import KratosMultiphysics.KratosDEMApplication
 from KratosDemStructuresCouplingApplication import *
 application = KratosDemStructuresCouplingApplication()
 application_name = "KratosDemStructuresCouplingApplication"

--- a/applications/DemStructuresCouplingApplication/DemStructuresCouplingApplication.py
+++ b/applications/DemStructuresCouplingApplication/DemStructuresCouplingApplication.py
@@ -1,7 +1,7 @@
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
-import KratosMultiphysics.KratosStructuralMechanicsApplication
-import KratosMultiphysics.KratosDEMApplication
+import KratosMultiphysics.StructuralMechanicsApplication
+import KratosMultiphysics.DEMApplication
 from KratosDemStructuresCouplingApplication import *
 application = KratosDemStructuresCouplingApplication()
 application_name = "KratosDemStructuresCouplingApplication"

--- a/applications/ExaquteSandboxApplication/ExaquteSandboxApplication.py
+++ b/applications/ExaquteSandboxApplication/ExaquteSandboxApplication.py
@@ -2,6 +2,7 @@
 from __future__ import print_function, absolute_import, division
 
 from KratosMultiphysics import _ImportApplication
+import KratosMultiphysics.KratosMeshingApplication
 from KratosExaquteSandboxApplication import *
 application = KratosExaquteSandboxApplication()
 application_name = "KratosExaquteSandboxApplication"

--- a/applications/ExaquteSandboxApplication/ExaquteSandboxApplication.py
+++ b/applications/ExaquteSandboxApplication/ExaquteSandboxApplication.py
@@ -2,7 +2,7 @@
 from __future__ import print_function, absolute_import, division
 
 from KratosMultiphysics import _ImportApplication
-import KratosMultiphysics.KratosMeshingApplication
+import KratosMultiphysics.MeshingApplication
 from KratosExaquteSandboxApplication import *
 application = KratosExaquteSandboxApplication()
 application_name = "KratosExaquteSandboxApplication"

--- a/applications/FluidTransportApplication/FluidTransportApplication.py
+++ b/applications/FluidTransportApplication/FluidTransportApplication.py
@@ -3,6 +3,7 @@ from __future__ import print_function, absolute_import, division
 
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
+import KratosMultiphysics.FluidDynamicsApplication
 from KratosFluidTransportApplication import *
 application = KratosFluidTransportApplication()
 application_name = "KratosFluidTransportApplication"

--- a/applications/UmatApplication/UmatApplication.py
+++ b/applications/UmatApplication/UmatApplication.py
@@ -3,6 +3,7 @@ from __future__ import print_function, absolute_import, division
 
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
+import KratosMultiphysics.ConstitutiveModelsApplication
 from KratosUmatApplication import *
 application = KratosUmatApplication()
 application_name = "KratosUmatApplication"


### PR DESCRIPTION
**📝 Description**
This PR addresses some missing imports that happen at the import of the applications.
While some of the apps already did this for convenience, now it is required as wheel distribution will not see non imported shared libraries even if in the path.

I've created some follow up issues tacking some problems I found in some apps while creating them. Those unless specified are not needed for 9.0

**🆕 Changelog**
- Added missing link-time dependencies imports for missing apps.
