### PR TITLE
Missing include in ContactMechanics

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_processes/alm_variables_calculation_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/alm_variables_calculation_process.cpp
@@ -16,6 +16,7 @@
 
 // Project includes
 #include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 #include "contact_structural_mechanics_application_variables.h"
 #include "custom_processes/alm_variables_calculation_process.h"
 


### PR DESCRIPTION
**📝 Description**
Missing include

Btw, those are happening because the unity build hides them...

**🆕 Changelog**
- Added missing reduction utils include
