### PR TITLE
[Core, Fluids] Two Fluids - setting process info values at every time step

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -298,6 +298,9 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
 
             self.main_model_part.ProcessInfo.SetValue(KratosCFD.VOLUME_ERROR, volume_error)
 
+            # We set this value at every time step as other processes/solvers also use them
+            dynamic_tau = self.settings["formulation"]["dynamic_tau"].GetDouble()
+            self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DYNAMIC_TAU, dynamic_tau)
 
 
     def FinalizeSolutionStep(self):

--- a/applications/FluidDynamicsApplication/tests/TwoFluidMassConservationSourceTest/ProjectParameter3D.json
+++ b/applications/FluidDynamicsApplication/tests/TwoFluidMassConservationSourceTest/ProjectParameter3D.json
@@ -37,6 +37,11 @@
             "dynamic_tau": 1.0,
             "mass_source": true
         },
+        "levelset_convection_settings": {
+            "element_settings" : {
+                "dynamic_tau" : 1.0
+            }
+        },
         "time_stepping"  : {
             "automatic_time_step" 	: false,
             "time_step"           	: 0.1

--- a/applications/FluidDynamicsApplication/tests/TwoFluidMassConservationSourceTest/ProjectParameters2D.json
+++ b/applications/FluidDynamicsApplication/tests/TwoFluidMassConservationSourceTest/ProjectParameters2D.json
@@ -35,6 +35,11 @@
             "dynamic_tau": 1.0,
             "mass_source": true
         },
+        "levelset_convection_settings": {
+            "element_settings" : {
+                "dynamic_tau" : 1.0
+            }
+        },
         "time_stepping"  : {
             "automatic_time_step" 	: false,
             "time_step"           	: 0.1

--- a/applications/FluidDynamicsApplication/tests/TwoFluidMassConservationSourceTest/ProjectParameters3DVariableInlet.json
+++ b/applications/FluidDynamicsApplication/tests/TwoFluidMassConservationSourceTest/ProjectParameters3DVariableInlet.json
@@ -37,6 +37,11 @@
             "dynamic_tau": 1.0,
             "mass_source": true
         },
+        "levelset_convection_settings": {
+            "element_settings" : {
+                "dynamic_tau" : 1.0
+            }
+        },
         "time_stepping"  : {
             "automatic_time_step" 	: false,
             "time_step"           	: 0.1

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -191,6 +191,10 @@ public:
         rCurrentProcessInfo.SetValue(DELTA_TIME, dt);
         rCurrentProcessInfo.GetValue(CONVECTION_DIFFUSION_SETTINGS)->SetUnknownVariable(*mpLevelSetVar);
 
+        // We set these values at every time step as other processes/solvers also use them
+        auto fill_process_info_function = GetFillProcessInfoFunction();
+        fill_process_info_function(mrBaseModelPart);
+
         for(unsigned int step = 1; step <= n_substep; ++step){
             KRATOS_INFO_IF("LevelSetConvectionProcess", mLevelSetConvectionSettings["echo_level"].GetInt() > 0) <<
                 "Doing step "<< step << " of " << n_substep << std::endl;
@@ -862,12 +866,14 @@ private:
             default_parameters = Parameters(R"({
                 "dynamic_tau" : 0.0,
                 "cross_wind_stabilization_factor" : 0.7,
-                "requires_distance_gradient" : false
+                "requires_distance_gradient" : false,
+                "time_integration_theta" : 0.5
             })");
         } else if (ElementType == "levelset_convection_algebraic_stabilization") {
             default_parameters = Parameters(R"({
                 "include_anti_diffusivity_terms" : false,
-                "requires_distance_gradient" : false
+                "requires_distance_gradient" : false,
+                "time_integration_theta" : 0.5
             })");
         } else {
             KRATOS_ERROR << "Default parameters are not implemented for the specified \'" << ElementType << "\' element. Available options are \n\t- \'levelset_convection_supg\'\n\t- \'levelset_convection_algebraic_stabilization\'" << std::endl;
@@ -889,14 +895,14 @@ private:
         if (mConvectionElementType == "LevelSetConvectionElementSimplex") {
             fill_process_info_function = [this](ModelPart &rModelPart) {
                 auto &r_process_info = rModelPart.GetProcessInfo();
-                // If not present, set the DYNAMIC_TAU
-                if (r_process_info.Has(DYNAMIC_TAU)) {
-                    KRATOS_WARNING("LevelSetConvectionProcess") << "ProcessInfo container already has DYNAMIC_TAU. Using the existent one" << r_process_info.GetValue(DYNAMIC_TAU) << " for the level set convection." << std::endl;
-                } else {
-                    r_process_info.SetValue(DYNAMIC_TAU, mLevelSetConvectionSettings["element_settings"]["dynamic_tau"].GetDouble());
-                }
-                // Set CROSS_WIND_STABILIZATION_FACTOR
+                r_process_info.SetValue(DYNAMIC_TAU, mLevelSetConvectionSettings["element_settings"]["dynamic_tau"].GetDouble());
                 r_process_info.SetValue(CROSS_WIND_STABILIZATION_FACTOR, mLevelSetConvectionSettings["element_settings"]["cross_wind_stabilization_factor"].GetDouble());
+                r_process_info.SetValue(TIME_INTEGRATION_THETA, mLevelSetConvectionSettings["element_settings"]["time_integration_theta"].GetDouble());
+            };
+        } else if (mConvectionElementType == "LevelSetConvectionElementSimplexAlgebraicStabilization") {
+            fill_process_info_function = [this](ModelPart &rModelPart) {
+                auto &r_process_info = rModelPart.GetProcessInfo();
+                r_process_info.SetValue(TIME_INTEGRATION_THETA, mLevelSetConvectionSettings["element_settings"]["time_integration_theta"].GetDouble());
             };
         } else {
             fill_process_info_function = [](ModelPart &rModelPart) {};


### PR DESCRIPTION
**📝 Description**
Closes https://github.com/KratosMultiphysics/Kratos/issues/9344, setting the values to the process info every time they are used.

**🆕 Changelog**
-Adding time integration theta as a parameter in levelset convection process.
-Set dynamic_tau, cross_wind_diffusion and time_integration_theta at every time step in levelset convection process.
-Set dynamic_tau ay every time step in the two fluids solver.
