### PR TITLE
[Fluid] Fixed most compilation warnings from FluidDynamicsApplication

### DIFF
--- a/applications/FluidDynamicsApplication/custom_conditions/navier_stokes_wall_condition.cpp
+++ b/applications/FluidDynamicsApplication/custom_conditions/navier_stokes_wall_condition.cpp
@@ -513,7 +513,7 @@ template<>
 void NavierStokesWallCondition<2,2>::ProjectViscousStress(
     const Vector& rViscousStress,
     const array_1d<double,3> rNormal,
-    array_1d<double,3> rProjectedViscousStress)
+    array_1d<double,3>& rProjectedViscousStress)
 {
     rProjectedViscousStress[0] = rViscousStress[0] * rNormal[0] + rViscousStress[2] * rNormal[1];
     rProjectedViscousStress[1] = rViscousStress[2] * rNormal[0] + rViscousStress[1] * rNormal[1];
@@ -524,7 +524,7 @@ template<>
 void NavierStokesWallCondition<3,3>::ProjectViscousStress(
     const Vector& rViscousStress,
     const array_1d<double,3> rNormal,
-    array_1d<double,3> rProjectedViscousStress)
+    array_1d<double,3>& rProjectedViscousStress)
 {
     rProjectedViscousStress[0] = rViscousStress[0] * rNormal[0] + rViscousStress[3] * rNormal[1] + rViscousStress[5] * rNormal[2];
     rProjectedViscousStress[1] = rViscousStress[3] * rNormal[0] + rViscousStress[1] * rNormal[1] + rViscousStress[4] * rNormal[2];

--- a/applications/FluidDynamicsApplication/custom_conditions/navier_stokes_wall_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/navier_stokes_wall_condition.h
@@ -451,7 +451,7 @@ private:
     void ProjectViscousStress(
         const Vector& rViscousStress,
         const array_1d<double,3> rNormal,
-        array_1d<double,3> rProjectedViscousStress);
+        array_1d<double,3>& rProjectedViscousStress);
 
     ///@}
     ///@name Private  Access

--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes.cpp
@@ -178,8 +178,8 @@ void TwoFluidNavierStokes<TElementData>::CalculateLocalSystem(
                 if (rCurrentProcessInfo[MOMENTUM_CORRECTION]){
                     BoundedMatrix<double, LocalSize, LocalSize> lhs_acc_correction = ZeroMatrix(LocalSize,LocalSize);
 
-                    double positive_density;
-                    double negative_density;
+                    double positive_density = 0.0;
+                    double negative_density = 0.0;
 
                     const auto& r_geom = this->GetGeometry();
 

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -19,6 +19,7 @@
 #include "containers/model.h"
 #include "includes/checks.h"
 #include "utilities/openmp_utils.h"
+#include "utilities/parallel_utils.h"
 #include "processes/find_nodal_h_process.h"
 
 // Application includes
@@ -215,8 +216,7 @@ void DistanceModificationProcess::ModifyDistance() {
     }
     // Case in where the original distance needs to be kept to track the interface (e.g. FSI)
     else {
-
-        const int num_chunks = 2 * OpenMPUtils::GetNumThreads();
+        const int num_chunks = 2 * ParallelUtils::GetNumThreads();
         OpenMPUtils::PartitionVector partition_vec;
         OpenMPUtils::DivideInPartitions(r_nodes.size(),num_chunks,partition_vec);
 
@@ -299,7 +299,7 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance(){
     } else {
         // Case in where the original distance needs to be kept to track the interface (e.g. FSI)
 
-        const int num_chunks = 2 * OpenMPUtils::GetNumThreads();
+        const int num_chunks = 2 * ParallelUtils::GetNumThreads();
         OpenMPUtils::PartitionVector partition_vec;
         OpenMPUtils::DivideInPartitions(n_elems,num_chunks,partition_vec);
 

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -216,7 +216,7 @@ void DistanceModificationProcess::ModifyDistance() {
     }
     // Case in where the original distance needs to be kept to track the interface (e.g. FSI)
     else {
-        const int num_chunks = 2 * ParallelUtils::GetNumThreads();
+        const int num_chunks = 2 * ParallelUtilities::GetNumThreads();
         OpenMPUtils::PartitionVector partition_vec;
         OpenMPUtils::DivideInPartitions(r_nodes.size(),num_chunks,partition_vec);
 
@@ -299,7 +299,7 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance(){
     } else {
         // Case in where the original distance needs to be kept to track the interface (e.g. FSI)
 
-        const int num_chunks = 2 * ParallelUtils::GetNumThreads();
+        const int num_chunks = 2 * ParallelUtilities::GetNumThreads();
         OpenMPUtils::PartitionVector partition_vec;
         OpenMPUtils::DivideInPartitions(n_elems,num_chunks,partition_vec);
 

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -19,7 +19,7 @@
 #include "containers/model.h"
 #include "includes/checks.h"
 #include "utilities/openmp_utils.h"
-#include "utilities/parallel_utils.h"
+#include "utilities/parallel_utilities.h"
 #include "processes/find_nodal_h_process.h"
 
 // Application includes

--- a/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
@@ -551,7 +551,9 @@ void EmbeddedSkinVisualizationProcess::CreateVisualizationMesh()
     // If MPI, this creates the communication plan among processes
     // If serial, it is only required to set the current mesh as local mesh in order to output the values
     if (mrVisualizationModelPart.IsDistributed()) {
-        ParallelEnvironment::CreateFillCommunicatorFromGlobalParallelism(mrVisualizationModelPart)->Execute();
+        ParallelEnvironment::CreateFillCommunicatorFromGlobalParallelism(
+            mrVisualizationModelPart, mrVisualizationModelPart.GetCommunicator().GetDataCommunicator()
+            )->Execute();
     } else {
         mrVisualizationModelPart.GetCommunicator().SetLocalMesh(mrVisualizationModelPart.pGetMesh(0));
     }

--- a/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
@@ -551,7 +551,7 @@ void EmbeddedSkinVisualizationProcess::CreateVisualizationMesh()
     // If MPI, this creates the communication plan among processes
     // If serial, it is only required to set the current mesh as local mesh in order to output the values
     if (mrVisualizationModelPart.IsDistributed()) {
-        ParallelEnvironment::CreateFillCommunicator(mrVisualizationModelPart)->Execute();
+        ParallelEnvironment::CreateFillCommunicatorFromGlobalParallelism(mrVisualizationModelPart)->Execute();
     } else {
         mrVisualizationModelPart.GetCommunicator().SetLocalMesh(mrVisualizationModelPart.pGetMesh(0));
     }

--- a/applications/FluidDynamicsApplication/custom_utilities/dynamic_smagorinsky_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/dynamic_smagorinsky_utilities.h
@@ -22,6 +22,7 @@
 #include "includes/node.h"
 #include "includes/element.h"
 #include "utilities/openmp_utils.h"
+#include "utilities/parallel_utilities.h"
 #include "utilities/geometry_utilities.h"
 
 #include "includes/cfd_variables.h"
@@ -103,7 +104,7 @@ public:
         }
 
         // Count the number of patches in the model (in parallel)
-        const int NumThreads = OpenMPUtils::GetNumThreads();
+        const int NumThreads = ParallelUtilities::GetNumThreads();
         OpenMPUtils::PartitionVector ElementPartition;
         OpenMPUtils::DivideInPartitions(mCoarseMesh.size(),NumThreads,ElementPartition);
 
@@ -146,7 +147,7 @@ public:
         this->SetCoarseVel();
 
         // Partitioning
-        const int NumThreads = OpenMPUtils::GetNumThreads();
+        const int NumThreads = ParallelUtilities::GetNumThreads();
         OpenMPUtils::PartitionVector CoarseElementPartition,FineElementPartition;
         OpenMPUtils::DivideInPartitions(mCoarseMesh.size(),NumThreads,CoarseElementPartition);
         OpenMPUtils::DivideInPartitions(mrModelPart.Elements().size(),NumThreads,FineElementPartition);
@@ -305,7 +306,7 @@ public:
     void CorrectFlagValues(Variable<double>& rThisVariable = FLAG_VARIABLE)
     {
         // Loop over coarse mesh to evaluate all terms that do not involve the fine mesh
-        const int NumThreads = OpenMPUtils::GetNumThreads();
+        const int NumThreads = ParallelUtilities::GetNumThreads();
         OpenMPUtils::PartitionVector NodePartition;
         OpenMPUtils::DivideInPartitions(mrModelPart.NumberOfNodes(),NumThreads,NodePartition);
 

--- a/applications/FluidDynamicsApplication/custom_utilities/statistics_record.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/statistics_record.cpp
@@ -19,6 +19,7 @@
 #include "containers/variable.h"
 #include "includes/model_part.h"
 #include "utilities/openmp_utils.h"
+#include "utilities/parallel_utilities.h"
 
 #include "statistics_record.h"
 #include "statistics_data.h"
@@ -59,7 +60,7 @@ void StatisticsRecord::AddHigherOrderStatistic(StatisticsSampler::Pointer pResul
 
 void StatisticsRecord::InitializeStorage(ModelPart::ElementsContainerType& rElements)
 {
-    mUpdateBuffer.resize(OpenMPUtils::GetNumThreads());
+    mUpdateBuffer.resize(ParallelUtilities::GetNumThreads());
     #pragma omp parallel
     {
         unsigned int k = OpenMPUtils::ThisThread();

--- a/applications/FluidDynamicsApplication/symbolic_generation/two_fluid_navier_stokes/two_fluid_navier_stokes_template.cpp
+++ b/applications/FluidDynamicsApplication/symbolic_generation/two_fluid_navier_stokes/two_fluid_navier_stokes_template.cpp
@@ -178,8 +178,8 @@ void TwoFluidNavierStokes<TElementData>::CalculateLocalSystem(
                 if (rCurrentProcessInfo[MOMENTUM_CORRECTION]){
                     BoundedMatrix<double, LocalSize, LocalSize> lhs_acc_correction = ZeroMatrix(LocalSize,LocalSize);
 
-                    double positive_density;
-                    double negative_density;
+                    double positive_density = 0.0;
+                    double negative_density = 0.0;
 
                     const auto& r_geom = this->GetGeometry();
 


### PR DESCRIPTION
**📝 Description**
Fixed the warnings when compiling FluidDynamicsApplication with Kratos' default compile flags.
The initial plan was to fix all warnings with `-Wall -Wextra -Wpedantic` but that quickly proved too ambitious a task.

The goal is of course to make it easier to implement new features, by not having to sift through old warnings to see our own.

Note that I used `g++-11` to compile. No idea if clang or MSVC will still show warnings.  I'll see what CI shows.

**🆕 Changelog**
- `-Wdeprecated`: Replaced `OpenMPUtils::GetNumThreads()` with `ParallelUtilities::GetNumThreads()`
    - `distance_modification_process.cpp`
    - `dynamic_smagorinsky_utilities.h`
- `-Wdeprecated`: Replaced `CreateFillCommunicator` with `CreateFillCommunicatorFromGlobalParallelism`
    - `embedded_skin_visualization_process.cpp`. I'm not familiar with this function so please @rubenzorrilla confirm I'm not breaking your code.
- `-Wmaybe-uninitialized`:
   -  `two_fluid_navier_stokes.cpp`: Initialized two variables to zero. This prevents undefined behaviour when the number of gauss points is zero (a.k.a. never, but at least we get rid of the warning). @mrhashemi you wrote this originally so tell me if I'm breaking anything.
   -  `navier_stokes_wall_condition.(h|cpp)` An uninitialized value was being passed by copy to `ProjectViscousStress` and then filled, I believe the real goal was to pass it by reference as an output parameter for the function to fill. This change changes the behaviour of the program but I strongly believe it was a bug. @rubenzorrilla please confirm I'm not breaking your code once again.

**⚠️ Existing warnings**
**Python API**
There is still this deprecation warning but it affects the Python API so it is may not be so easy to solve.
```
applications/FluidDynamicsApplication/custom_python/add_custom_utilities_to_python.cpp: In function ‘void Kratos::Python::AddCustomUtilitiesToPython(pybind11::module&)’:
applications/FluidDynamicsApplication/custom_python/add_custom_utilities_to_python.cpp:187:59: warning: ‘double Kratos::FluidPostProcessUtilities::CalculateFlow(const Kratos::ModelPart&)’ is deprecated [-Wdeprecated-declarations]
  187 |         .def("CalculateFlow", &FluidPostProcessUtilities::CalculateFlow)
      |                                                           ^~~~~~~~~~~~~
In file included from applications/FluidDynamicsApplication/custom_python/add_custom_utilities_to_python.cpp:31:
applications/FluidDynamicsApplication/custom_utilities/fluid_post_process_utilities.h:93:127: note: declared here
   93 | D_MESSAGE("This function is deprecated, please use the one from the \'FluidAuxiliaryUtilities\'.") double CalculateFlow(const ModelPart& rModelPart);
```
A search through repo says it is never used (all appearances correctly use `FluidAuxiliaryUtilities`) but changing it could easily break user's code outside this repository, so I'm more hesitant to do it.

**Communicator**
There is still a very verbose warning that I don't quite get yet, but it very much looks that trying to use `std::vector<bool>`. This template specialization is different from all other `std::vector<T>` and usually it doesn't play nice with anything and there may be a bug we're unaware of. I've delt with similar problems before (using `vector<bool>` in MPI) and the solution was to simply use `std::vector<short>`, and let implicit conversions do the work. This will have a memory impact though. Since you wrote the code @mrhashemi, do you have any recommendations?

```
In file included from /__w/Kratos/Kratos/kratos/includes/kratos_components.h:27:0,
                 from /__w/Kratos/Kratos/kratos/includes/kratos_flags.h:27,
                 from /__w/Kratos/Kratos/kratos/processes/process.h:25,
                 from /__w/Kratos/Kratos/applications/FluidDynamicsApplication/custom_python/add_custom_strategies_to_python.cpp:23,
                 from /__w/Kratos/Kratos/build/Custom/applications/FluidDynamicsApplication/CMakeFiles/KratosFluidDynamicsApplication.dir/Unity/unity_0_cxx.cxx:3:
/__w/Kratos/Kratos/kratos/includes/data_communicator.h: In instantiation of 'TObject Kratos::DataCommunicator::SendRecvImpl(const TObject&, int, int, int, int) const [with TObject = std::vector<bool>]':
/__w/Kratos/Kratos/kratos/includes/data_communicator.h:525:81:   required from 'TObject Kratos::DataCommunicator::SendRecv(const TObject&, int, int) const [with TObject = std::vector<bool>]'
/__w/Kratos/Kratos/kratos/utilities/pointer_communicator.h:238:100:   required from 'void Kratos::GlobalPointerCommunicator<TPointerDataType>::Update(TFunctorType&, Kratos::GlobalPointersUnorderedMap<TPointerDataType, typename Kratos::ResultsProxy<TPointerDataType, TFunctorType>::TSendType>&) [with TFunctorType = Kratos::DistanceSmoothingProcess<TDim, TSparseSpace, TDenseSpace, TLinearSolver>::Execute() [with unsigned int TDim = 3u; TSparseSpace = Kratos::UblasSpace<double, boost::numeric::ublas::compressed_matrix<double>, boost::numeric::ublas::vector<double> >; TDenseSpace = Kratos::UblasSpace<double, boost::numeric::ublas::matrix<double>, boost::numeric::ublas::vector<double> >; TLinearSolver = Kratos::LinearSolver<Kratos::UblasSpace<double, boost::numeric::ublas::compressed_matrix<double>, boost::numeric::ublas::vector<double> >, Kratos::UblasSpace<double, boost::numeric::ublas::matrix<double>, boost::numeric::ublas::vector<double> > >]::__lambda214; TPointerDataType = Kratos::Node<3ul>; typename Kratos::ResultsProxy<TPointerDataType, TFunctorType>::TSendType = bool]'
/__w/Kratos/Kratos/kratos/utilities/pointer_communicator.h:214:47:   required from 'Kratos::ResultsProxy<TPointerDataType, TFunctorType> Kratos::GlobalPointerCommunicator<TPointerDataType>::Apply(TFunctorType&&) [with TFunctorType = Kratos::DistanceSmoothingProcess<TDim, TSparseSpace, TDenseSpace, TLinearSolver>::Execute() [with unsigned int TDim = 3u; TSparseSpace = Kratos::UblasSpace<double, boost::numeric::ublas::compressed_matrix<double>, boost::numeric::ublas::vector<double> >; TDenseSpace = Kratos::UblasSpace<double, boost::numeric::ublas::matrix<double>, boost::numeric::ublas::vector<double> >; TLinearSolver = Kratos::LinearSolver<Kratos::UblasSpace<double, boost::numeric::ublas::compressed_matrix<double>, boost::numeric::ublas::vector<double> >, Kratos::UblasSpace<double, boost::numeric::ublas::matrix<double>, boost::numeric::ublas::vector<double> > >]::__lambda214; TPointerDataType = Kratos::Node<3ul>]'
/__w/Kratos/Kratos/applications/FluidDynamicsApplication/custom_processes/distance_smoothing_process.h:214:9:   required from 'void Kratos::DistanceSmoothingProcess<TDim, TSparseSpace, TDenseSpace, TLinearSolver>::Execute() [with unsigned int TDim = 3u; TSparseSpace = Kratos::UblasSpace<double, boost::numeric::ublas::compressed_matrix<double>, boost::numeric::ublas::vector<double> >; TDenseSpace = Kratos::UblasSpace<double, boost::numeric::ublas::matrix<double>, boost::numeric::ublas::vector<double> >; TLinearSolver = Kratos::LinearSolver<Kratos::UblasSpace<double, boost::numeric::ublas::compressed_matrix<double>, boost::numeric::ublas::vector<double> >, Kratos::UblasSpace<double, boost::numeric::ublas::matrix<double>, boost::numeric::ublas::vector<double> > >]'
/__w/Kratos/Kratos/applications/FluidDynamicsApplication/custom_python/fluid_dynamics_python_application.cpp:136:1:   required from here
/__w/Kratos/Kratos/kratos/includes/data_communicator.h:880:9: warning: 'void Kratos::DataCommunicator::CheckSerializationForSimpleType(const T&, Kratos::DataCommunicator::TypeFromBool<false>) const [with T = std::vector<bool>]' is deprecated (declared at /__w/Kratos/Kratos/kratos/includes/data_communicator.h:314) [-Wdeprecated-declarations]
         CheckSerializationForSimpleType(rSendObject, TypeFromBool<serialization_is_required<TObject>::value>());
         ^
```
