### PR TITLE
[Iga] Differentiate integration edge vs coupling edge

### DIFF
--- a/applications/IgaApplication/custom_modelers/iga_modeler.cpp
+++ b/applications/IgaApplication/custom_modelers/iga_modeler.cpp
@@ -83,9 +83,8 @@ namespace Kratos
         GetCadGeometryList(geometry_list, rCadModelPart, rParameters);
 
         if (!rParameters.Has("geometry_type")) {
-            std::string geometry_type = "";
             CreateQuadraturePointGeometries(
-                geometry_list, sub_model_part, rParameters["parameters"], geometry_type);
+                geometry_list, sub_model_part, rParameters["parameters"], std::string{});
         }
         else {
             std::string geometry_type = rParameters["geometry_type"].GetString();

--- a/applications/IgaApplication/custom_modelers/iga_modeler.cpp
+++ b/applications/IgaApplication/custom_modelers/iga_modeler.cpp
@@ -107,7 +107,7 @@ namespace Kratos
         GeometriesArrayType& rGeometryList,
         ModelPart& rModelPart,
         const Parameters rParameters,
-        std::string& rGeometryType) const
+        std::string GeometryType) const
     {
         KRATOS_ERROR_IF_NOT(rParameters.Has("type"))
             << "\"type\" need to be specified." << std::endl;
@@ -157,7 +157,7 @@ namespace Kratos
                 }
             }
 
-            if (rGeometryType == "SurfaceEdge"
+            if (GeometryType == "SurfaceEdge"
                 && rGeometryList[i].GetGeometryType() == GeometryData::KratosGeometryType::Kratos_Coupling_Geometry)
             {
                 rGeometryList[i].GetGeometryPart(0).CreateQuadraturePointGeometries(

--- a/applications/IgaApplication/custom_modelers/iga_modeler.cpp
+++ b/applications/IgaApplication/custom_modelers/iga_modeler.cpp
@@ -83,8 +83,9 @@ namespace Kratos
         GetCadGeometryList(geometry_list, rCadModelPart, rParameters);
 
         if (!rParameters.Has("geometry_type")) {
+            std::string geometry_type = "";
             CreateQuadraturePointGeometries(
-                geometry_list, sub_model_part, rParameters["parameters"]);
+                geometry_list, sub_model_part, rParameters["parameters"], geometry_type);
         }
         else {
             std::string geometry_type = rParameters["geometry_type"].GetString();
@@ -96,7 +97,7 @@ namespace Kratos
             }
             else {
                 CreateQuadraturePointGeometries(
-                    geometry_list, sub_model_part, rParameters["parameters"]);
+                    geometry_list, sub_model_part, rParameters["parameters"], geometry_type);
             }
         }
         KRATOS_INFO_IF("CreateIntegrationDomainElementCondition", mEchoLevel > 3)
@@ -106,7 +107,8 @@ namespace Kratos
     void IgaModeler::CreateQuadraturePointGeometries(
         GeometriesArrayType& rGeometryList,
         ModelPart& rModelPart,
-        const Parameters rParameters) const
+        const Parameters rParameters,
+        std::string& rGeometryType) const
     {
         KRATOS_ERROR_IF_NOT(rParameters.Has("type"))
             << "\"type\" need to be specified." << std::endl;
@@ -156,8 +158,17 @@ namespace Kratos
                 }
             }
 
-            rGeometryList[i].CreateQuadraturePointGeometries(
-                geometries, shape_function_derivatives_order, integration_info);
+            if (rGeometryType == "SurfaceEdge"
+                && rGeometryList[i].GetGeometryType() == GeometryData::KratosGeometryType::Kratos_Coupling_Geometry)
+            {
+                rGeometryList[i].GetGeometryPart(0).CreateQuadraturePointGeometries(
+                    geometries, shape_function_derivatives_order, integration_info);
+            }
+            else
+            {
+                rGeometryList[i].CreateQuadraturePointGeometries(
+                    geometries, shape_function_derivatives_order, integration_info);
+            }
 
             KRATOS_INFO_IF("CreateQuadraturePointGeometries", mEchoLevel > 1)
                 << geometries.size() << " quadrature point geometries have been created." << std::endl;

--- a/applications/IgaApplication/custom_modelers/iga_modeler.h
+++ b/applications/IgaApplication/custom_modelers/iga_modeler.h
@@ -138,7 +138,8 @@ private:
     void CreateQuadraturePointGeometries(
         GeometriesArrayType& rQuadraturePointGeometryList,
         ModelPart& rModelPart,
-        const Parameters rParameters) const;
+        const Parameters rParameters,
+        std::string& rGeometryType) const;
 
     ///@}
     ///@name CAD functionalities

--- a/applications/IgaApplication/custom_modelers/iga_modeler.h
+++ b/applications/IgaApplication/custom_modelers/iga_modeler.h
@@ -139,7 +139,7 @@ private:
         GeometriesArrayType& rQuadraturePointGeometryList,
         ModelPart& rModelPart,
         const Parameters rParameters,
-        std::string& rGeometryType) const;
+        std::string GeometryType) const;
 
     ///@}
     ///@name CAD functionalities

--- a/kratos/geometries/coupling_geometry.h
+++ b/kratos/geometries/coupling_geometry.h
@@ -544,6 +544,20 @@ public:
     }
 
     ///@}
+    ///@name Geometry Family
+    ///@{
+
+    GeometryData::KratosGeometryFamily GetGeometryFamily() const override
+    {
+        return GeometryData::KratosGeometryFamily::Kratos_Composite;
+    }
+
+    GeometryData::KratosGeometryType GetGeometryType() const override
+    {
+        return GeometryData::KratosGeometryType::Kratos_Coupling_Geometry;
+    }
+
+    ///@}
     ///@name Information
     ///@{
 

--- a/kratos/geometries/geometry_data.h
+++ b/kratos/geometries/geometry_data.h
@@ -101,7 +101,7 @@ public:
         Kratos_Nurbs,
         Kratos_Brep,
         Kratos_Quadrature_Geometry,
-        Kratos_Coupling,
+        Kratos_Composite,
         Kratos_generic_family,
         NumberOfGeometryFamilies // Note that this entry needs to be always the last to be used as geometry families counter
     };

--- a/kratos/geometries/geometry_data.h
+++ b/kratos/geometries/geometry_data.h
@@ -101,6 +101,7 @@ public:
         Kratos_Nurbs,
         Kratos_Brep,
         Kratos_Quadrature_Geometry,
+        Kratos_Coupling,
         Kratos_generic_family,
         NumberOfGeometryFamilies // Note that this entry needs to be always the last to be used as geometry families counter
     };
@@ -143,6 +144,7 @@ public:
         Kratos_Brep_Surface,
         Kratos_Brep_Curve_On_Surface,
         Kratos_Quadrature_Point_Geometry,
+        Kratos_Coupling_Geometry,
         Kratos_Quadrature_Point_Curve_On_Surface_Geometry,
         Kratos_Quadrature_Point_Surface_In_Volume_Geometry,
         NumberOfGeometryTypes // Note that this entry needs to be always the last to be used as geometry types counter

--- a/kratos/tests/cpp_tests/geometries/test_geometry.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_geometry.cpp
@@ -149,6 +149,8 @@ namespace Testing {
           return "Kratos_Brep_Curve_On_Surface";
         case GeometryData::KratosGeometryType::Kratos_Quadrature_Point_Geometry:
           return "Kratos_Quadrature_Point_Geometry";
+        case GeometryData::KratosGeometryType::Kratos_Coupling_Geometry:
+            return "Kratos_Coupling_Geometry";
         case GeometryData::KratosGeometryType::Kratos_Quadrature_Point_Curve_On_Surface_Geometry:
           return "Kratos_Quadrature_Point_Curve_On_Surface_Geometry";
         case GeometryData::KratosGeometryType::Kratos_Quadrature_Point_Surface_In_Volume_Geometry:

--- a/kratos/utilities/geometry_tester.h
+++ b/kratos/utilities/geometry_tester.h
@@ -1218,6 +1218,8 @@ private:
             return std::string("Kratos_Quadrature_Point_Curve_On_Surface_Geometry");
         case GeometryData::KratosGeometryType::Kratos_Quadrature_Point_Surface_In_Volume_Geometry:
             return std::string("Kratos_Quadrature_Point_Surface_In_Volume_Geometry");
+        case GeometryData::KratosGeometryType::Kratos_Coupling_Geometry:
+            return std::string("Kratos_Quadrature_Point_Surface_In_Volume_Geometry");
         case GeometryData::KratosGeometryType::NumberOfGeometryTypes:
             return std::string("UnknownGeometry");
         };


### PR DESCRIPTION
Allows a differentiation within the IgaModeler between coupling edges and standard edges in the integration.

Adds the composite and coupling geometry type and family.