### PR TITLE
[Core] Add Step index for SetVariable in VariableUtils

### DIFF
--- a/kratos/python/add_variable_utils_to_python.cpp
+++ b/kratos/python/add_variable_utils_to_python.cpp
@@ -169,17 +169,6 @@ void VariableUtilsSetVariable(
     rVariableUtils.SetVariable(rVariable, rValue, rNodes);
 }
 
-template<class TDataType, class TVarType = Variable<TDataType>>
-void VariableUtilsSetVariableWithStep(
-    VariableUtils &rVariableUtils,
-    const TVarType &rVariable,
-    const TDataType &rValue,
-    ModelPart::NodesContainerType &rNodes,
-    const unsigned int Step)
-{
-    rVariableUtils.SetVariable(rVariable, rValue, rNodes, Step);
-}
-
 /**
  * @brief Auxiliary set variable export function
  * This function is required to export the SetVariable with flag overloaded method with a unique name
@@ -278,10 +267,10 @@ void AddVariableUtilsToPython(pybind11::module &m)
         .def("CopyModelPartElementalVar", &VariableUtils::CopyModelPartElementalVar<Variable<Vector>>)
         .def("CopyModelPartElementalVar", &VariableUtils::CopyModelPartElementalVar<Variable<Matrix>>)
         .def("SetVectorVar", VariableUtilsSetVariable<array_1d<double,3>>)
-        .def("SetVectorVar", VariableUtilsSetVariableWithStep<array_1d<double,3>>)
+        .def("SetVectorVar", [](VariableUtils& rVariableUtils, const Variable<array_1d<double, 3>>& rVariable, const array_1d<double, 3>& rValue, ModelPart::NodesContainerType& rNodes, const unsigned int Step){rVariableUtils.SetVariable(rVariable, rValue, rNodes, Step);})
         .def("SetVectorVar", VariableUtilsSetVariableForFlag<array_1d<double, 3>>)
         .def("SetScalarVar", VariableUtilsSetVariable<double>)
-        .def("SetScalarVar", VariableUtilsSetVariableWithStep<double>)
+        .def("SetScalarVar", [](VariableUtils& rVariableUtils, const Variable<double>& rVariable, const double& rValue, ModelPart::NodesContainerType& rNodes, const unsigned int Step){rVariableUtils.SetVariable(rVariable, rValue, rNodes, Step);})
         .def("SetScalarVar", VariableUtilsSetVariableForFlag<double>)
         .def("SetNonHistoricalScalarVar", VariableUtilsSetNonHistoricalVariable<int, ModelPart::NodesContainerType>)
         .def("SetNonHistoricalScalarVar", VariableUtilsSetNonHistoricalVariable<double, ModelPart::NodesContainerType>)
@@ -293,13 +282,13 @@ void AddVariableUtilsToPython(pybind11::module &m)
         .def("SetVariable", VariableUtilsSetVariable<Vector>)
         .def("SetVariable", VariableUtilsSetVariable<Matrix>)
         .def("SetVariable", VariableUtilsSetVariable<Quaternion<double>>)
-        .def("SetVariable", VariableUtilsSetVariableWithStep<int>)
-        .def("SetVariable", VariableUtilsSetVariableWithStep<bool>)
-        .def("SetVariable", VariableUtilsSetVariableWithStep<double>)
-        .def("SetVariable", VariableUtilsSetVariableWithStep<array_1d<double, 3>>)
-        .def("SetVariable", VariableUtilsSetVariableWithStep<Vector>)
-        .def("SetVariable", VariableUtilsSetVariableWithStep<Matrix>)
-        .def("SetVariable", VariableUtilsSetVariableWithStep<Quaternion<double>>)        
+        .def("SetVariable", [](VariableUtils& rVariableUtils, const Variable<int>& rVariable, const int& rValue, ModelPart::NodesContainerType& rNodes, const unsigned int Step){rVariableUtils.SetVariable(rVariable, rValue, rNodes, Step);})
+        .def("SetVariable", [](VariableUtils& rVariableUtils, const Variable<bool>& rVariable, const bool& rValue, ModelPart::NodesContainerType& rNodes, const unsigned int Step){rVariableUtils.SetVariable(rVariable, rValue, rNodes, Step);})
+        .def("SetVariable", [](VariableUtils& rVariableUtils, const Variable<double>& rVariable, const double& rValue, ModelPart::NodesContainerType& rNodes, const unsigned int Step){rVariableUtils.SetVariable(rVariable, rValue, rNodes, Step);})
+        .def("SetVariable", [](VariableUtils& rVariableUtils, const Variable<array_1d<double, 3>>& rVariable, const array_1d<double, 3>& rValue, ModelPart::NodesContainerType& rNodes, const unsigned int Step){rVariableUtils.SetVariable(rVariable, rValue, rNodes, Step);})
+        .def("SetVariable", [](VariableUtils& rVariableUtils, const Variable<Vector>& rVariable, const Vector& rValue, ModelPart::NodesContainerType& rNodes, const unsigned int Step){rVariableUtils.SetVariable(rVariable, rValue, rNodes, Step);})
+        .def("SetVariable", [](VariableUtils& rVariableUtils, const Variable<Matrix>& rVariable, const Matrix& rValue, ModelPart::NodesContainerType& rNodes, const unsigned int Step){rVariableUtils.SetVariable(rVariable, rValue, rNodes, Step);})
+        .def("SetVariable", [](VariableUtils& rVariableUtils, const Variable<Quaternion<double>>& rVariable, const Quaternion<double>& rValue, ModelPart::NodesContainerType& rNodes, const unsigned int Step){rVariableUtils.SetVariable(rVariable, rValue, rNodes, Step);})
         .def("SetVariable", VariableUtilsSetVariableForFlag<bool>)
         .def("SetVariable", VariableUtilsSetVariableForFlag<double>)
         .def("SetVariable", VariableUtilsSetVariableForFlag<array_1d<double, 3>>)

--- a/kratos/python/add_variable_utils_to_python.cpp
+++ b/kratos/python/add_variable_utils_to_python.cpp
@@ -169,6 +169,16 @@ void VariableUtilsSetVariable(
     rVariableUtils.SetVariable(rVariable, rValue, rNodes);
 }
 
+template<class TDataType, class TVarType = Variable<TDataType>>
+void VariableUtilsSetVariableWithStep(
+    VariableUtils &rVariableUtils,
+    const TVarType &rVariable,
+    const TDataType &rValue,
+    ModelPart::NodesContainerType &rNodes,
+    const unsigned int Step)
+{
+    rVariableUtils.SetVariable(rVariable, rValue, rNodes, Step);
+}
 
 /**
  * @brief Auxiliary set variable export function
@@ -268,8 +278,10 @@ void AddVariableUtilsToPython(pybind11::module &m)
         .def("CopyModelPartElementalVar", &VariableUtils::CopyModelPartElementalVar<Variable<Vector>>)
         .def("CopyModelPartElementalVar", &VariableUtils::CopyModelPartElementalVar<Variable<Matrix>>)
         .def("SetVectorVar", VariableUtilsSetVariable<array_1d<double,3>>)
+        .def("SetVectorVar", VariableUtilsSetVariableWithStep<array_1d<double,3>>)
         .def("SetVectorVar", VariableUtilsSetVariableForFlag<array_1d<double, 3>>)
         .def("SetScalarVar", VariableUtilsSetVariable<double>)
+        .def("SetScalarVar", VariableUtilsSetVariableWithStep<double>)
         .def("SetScalarVar", VariableUtilsSetVariableForFlag<double>)
         .def("SetNonHistoricalScalarVar", VariableUtilsSetNonHistoricalVariable<int, ModelPart::NodesContainerType>)
         .def("SetNonHistoricalScalarVar", VariableUtilsSetNonHistoricalVariable<double, ModelPart::NodesContainerType>)
@@ -281,6 +293,13 @@ void AddVariableUtilsToPython(pybind11::module &m)
         .def("SetVariable", VariableUtilsSetVariable<Vector>)
         .def("SetVariable", VariableUtilsSetVariable<Matrix>)
         .def("SetVariable", VariableUtilsSetVariable<Quaternion<double>>)
+        .def("SetVariable", VariableUtilsSetVariableWithStep<int>)
+        .def("SetVariable", VariableUtilsSetVariableWithStep<bool>)
+        .def("SetVariable", VariableUtilsSetVariableWithStep<double>)
+        .def("SetVariable", VariableUtilsSetVariableWithStep<array_1d<double, 3>>)
+        .def("SetVariable", VariableUtilsSetVariableWithStep<Vector>)
+        .def("SetVariable", VariableUtilsSetVariableWithStep<Matrix>)
+        .def("SetVariable", VariableUtilsSetVariableWithStep<Quaternion<double>>)        
         .def("SetVariable", VariableUtilsSetVariableForFlag<bool>)
         .def("SetVariable", VariableUtilsSetVariableForFlag<double>)
         .def("SetVariable", VariableUtilsSetVariableForFlag<array_1d<double, 3>>)

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -651,13 +651,13 @@ public:
     void SetVariable(
         const TVarType& rVariable,
         const TDataType& rValue,
-        NodesContainerType& rNodes
-        )
+        NodesContainerType& rNodes,
+        const unsigned int Step = 0)
     {
         KRATOS_TRY
 
         block_for_each(rNodes, [&](Node<3>& rNode) {
-            rNode.FastGetSolutionStepValue(rVariable) = rValue;
+            rNode.FastGetSolutionStepValue(rVariable, Step) = rValue;
         });
 
         KRATOS_CATCH("")


### PR DESCRIPTION
**📝 Description**
Adds the ability to set values based on `Step` index for `SetVariable` method in `VariableUtils`. Respective python interfaces are also added.

Only issue is, there is no way to check the buffersize of the nodal historical data base.

**🆕 Changelog**
- Adds `Step` argument to `SetVariable` method
- Adds respective python exposures.
