### PR TITLE
[Core] Reduce tolerance when checking if two points are the same in calculate discontinuous distance process

### DIFF
--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
@@ -310,7 +310,7 @@ namespace Kratos
             aux_pts.clear();
 
             // Check against all candidates to count the number of current edge intersections
-            const double edge_tolerance = 1e-2*norm_2(rEdgesContainer[i_edge][0] - rEdgesContainer[i_edge][1]);
+            const double edge_tolerance = 1e-6*norm_2(rEdgesContainer[i_edge][0] - rEdgesContainer[i_edge][1]);
             for (const auto &r_int_obj : rIntersectedObjects){
                 // Call the compute intersection method
                 Point int_pt;

--- a/kratos/tests/cpp_tests/processes/test_calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_calculate_discontinuous_distance_to_skin_process.cpp
@@ -860,7 +860,7 @@ namespace Testing {
 
         // Check edge distances
         const auto &r_elem_dist_edge = (volume_part.ElementsBegin())->GetValue(ELEMENTAL_EDGE_DISTANCES);
-        const std::vector<double> expected_values_edge = {-1,-1,-1,0.961531,-1,-1};
+        const std::vector<double> expected_values_edge = {-1,-1,-1,0.959824,-1,-1};
         KRATOS_CHECK_VECTOR_NEAR(r_elem_dist_edge, expected_values_edge, 1.0e-6);
     }
 

--- a/kratos/tests/cpp_tests/processes/test_calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_calculate_discontinuous_distance_to_skin_process.cpp
@@ -1806,5 +1806,37 @@ namespace Testing {
         KRATOS_CHECK_EQUAL(n_cut_edges, 1);
     }
 
+    KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceProcessCloseToVertexIntersection3D, KratosCoreFastSuite)
+    {
+        Model current_model;
+
+        // Generate the element
+        ModelPart &fluid_part = current_model.CreateModelPart("Surface");
+        fluid_part.CreateNewNode(1, 0.498262,	0.296646,	-0.0435666);
+        fluid_part.CreateNewNode(2, 0.494408,	0.298003,	-0.0436762);
+        fluid_part.CreateNewNode(3, 0.497984,	0.301717,	-0.046839);
+        fluid_part.CreateNewNode(4, 0.496292,	0.295241,	-0.0478173);
+
+        Properties::Pointer p_properties_0(new Properties(0));
+        fluid_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties_0);
+
+		// Generate the skin
+		ModelPart &skin_part = current_model.CreateModelPart("Skin");
+		skin_part.CreateNewNode(901, 0.2490485, -0.01, -0.02178895);
+		skin_part.CreateNewNode(903, 0.498097, 2.0, -0.0435779);
+		skin_part.CreateNewNode(904, 0.498097, -0.01, -0.0435779);
+		skin_part.CreateNewNode(905, 2.0, 2.0, 0.0);
+
+		Properties::Pointer p_properties = skin_part.CreateNewProperties(0);
+		skin_part.CreateNewElement("Element3D3N", 901, { 901,904,903}, p_properties);
+		skin_part.CreateNewElement("Element3D3N", 902, { 904,905,903}, p_properties);
+
+        // Compute the discontinuous distance function
+        CalculateDiscontinuousDistanceToSkinProcess<3> disc_dist_proc(fluid_part, skin_part);
+        disc_dist_proc.Execute();
+        auto p_elem = fluid_part.ElementsBegin();
+        KRATOS_CHECK(p_elem->Is(TO_SPLIT));
+    }
+
 }  // namespace Testing.
 }  // namespace Kratos.


### PR DESCRIPTION
**📝 Description**
Running some cases I have experienced that the discontinuous process does not capture some cuts when it should. Specifically it was due to the tolerance:

https://github.com/KratosMultiphysics/Kratos/blob/feaff80c19cbb9cb04edd4aa73a556ce667eb9a4/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp#L313

Which uses a factor of 1e-2 (1% change). This tolerance is used to decide if two points are the same point.

The test case Im adding features a cut very close to the vertex. This means that the three intersection points are very close to each other, and the check above was considering two of the intersection points as the same point. This means that it was disregarding one of the intersection points as the process thinks the intersection point is already in the list of int_pts_vector and the element is considered not cut (and I think it should). 

**Element snapshot**
![dist_tol1](https://user-images.githubusercontent.com/32136457/143054150-2263ae39-ad6e-4e58-814d-d6092529b3e7.png)

**Zoom in**
![dist_tol2](https://user-images.githubusercontent.com/32136457/143054681-d761fc5b-5c3b-470a-9e90-1054d4f5c1ec.png)


This problem is partially a consequence on the changes in #5595. Before #5595, `edge_tolerance` was used only for the intersection points within one edge. After #5595, the check on two points being the same is performed among all edges (this was important for the case where only one node is intersected, to avoid the 3 edges cut to return the exact same point). 


**🆕 Changelog**
- Decrease edge_tolerance when checking if two points are the same.
- Adding test case currently failing at master. 
