### PR TITLE
[PfemFluid] Add wave output process

### DIFF
--- a/applications/PfemFluidDynamicsApplication/CMakeLists.txt
+++ b/applications/PfemFluidDynamicsApplication/CMakeLists.txt
@@ -45,6 +45,7 @@ set( KRATOS_PFEM_FLUID_DYNAMICS_APPLICATION_CORE
 	${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/two_step_updated_lagrangian_V_P_implicit_fluid_PSPG_element.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/two_step_updated_lagrangian_V_P_implicit_fluid_DEM_coupling_element.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/assign_scalar_variable_to_pfem_entities_process.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/calculate_wave_height_utility.cpp
 
     # Fluid constitutive laws
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/fluid_laws/fluid_constitutive_law.cpp

--- a/applications/PfemFluidDynamicsApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -45,7 +45,7 @@ void AddCustomUtilitiesToPython(pybind11::module &m)
                       WriteConditionsFlag>());
 
     py::class_<CalculateWaveHeightUtility, CalculateWaveHeightUtility::Pointer>(m, "CalculateWaveHeightUtility")
-        .def(py::init<>(ModelPart&, Parameters))
+        .def(py::init<ModelPart&, Parameters>())
         .def("Calculate", &CalculateWaveHeightUtility::Calculate)
         ;
 

--- a/applications/PfemFluidDynamicsApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -22,6 +22,7 @@
 #include "custom_utilities/two_step_v_p_settings.h"
 #include "custom_utilities/postprocess_utilities.h"
 #include "custom_utilities/pfem_fluid_gid_io.h"
+#include "custom_utilities/calculate_wave_height_utility.h"
 
 namespace Kratos
 {
@@ -42,6 +43,12 @@ void AddCustomUtilitiesToPython(pybind11::module &m)
                       MultiFileFlag,
                       WriteDeformedMeshFlag,
                       WriteConditionsFlag>());
+
+    py::class_<CalculateWaveHeightUtility, CalculateWaveHeightUtility::Pointer>(m, "CalculateWaveHeightUtility")
+        .def(py::init<>(ModelPart&, Parameters))
+        .def("Calculate", &CalculateWaveHeightUtility::Calculate)
+        ;
+
 }
 
 } // namespace Python.

--- a/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.cpp
@@ -33,9 +33,10 @@ CalculateWaveHeightUtility::CalculateWaveHeightUtility(
 ) : mrModelPart(rThisModelPart)
 {
     Parameters default_parameters(R"({
-        "model_part_name"  : "",
-        "mean_water_level" : 0.0,
-        "search_tolerance" : 1e-6
+        "model_part_name"        : "",
+        "mean_water_level"       : 0.0,
+        "relative_search_radius" : 0.7,
+        "search_tolerance"       : 1e-6
     })");
 
     ThisParameters.ValidateAndAssignDefaults(default_parameters);
@@ -44,12 +45,13 @@ CalculateWaveHeightUtility::CalculateWaveHeightUtility(
     mDirection = -gravity / norm_2(gravity);
     mMeanWaterLevel = ThisParameters["mean_water_level"].GetDouble();
     double search_tolerance = ThisParameters["search_tolerance"].GetDouble();
+    double relative_search_radius = ThisParameters["relative_search_radius"].GetDouble();
     double mean_elem_size = block_for_each<SumReduction<double>>(
         mrModelPart.Elements(), [](Element& rElement) {
         return rElement.GetGeometry().Length();
     });
     mean_elem_size /= mrModelPart.NumberOfElements();
-    mSearchRadius = 0.5 * mean_elem_size + search_tolerance;
+    mSearchRadius = relative_search_radius * mean_elem_size + search_tolerance;
 }
 
 double CalculateWaveHeightUtility::Calculate(const array_1d<double,3>& rCoordinates) const

--- a/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.cpp
@@ -35,7 +35,7 @@ CalculateWaveHeightUtility::CalculateWaveHeightUtility(
     Parameters default_parameters(R"({
         "model_part_name"        : "",
         "mean_water_level"       : 0.0,
-        "relative_search_radius" : 0.7,
+        "relative_search_radius" : 1.0,
         "search_tolerance"       : 1e-6
     })");
 

--- a/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.cpp
@@ -55,25 +55,24 @@ double CalculateWaveHeightUtility::Calculate(const array_1d<double,3>& rCoordina
     double counter = 0.0;
     double wave_height = 0.0;
 
-    std::tie(counter, height) = block_for_each<MultipleReduction>(
+    std::tie(counter, wave_height) = block_for_each<MultipleReduction>(
         mrModelPart.Nodes(), [&](NodeType& rNode)
     {
         double local_count = 0.0;
         double local_wave_height = 0.0;
 
-        if (rNode->IsNot(ISOLATED) && rNode->IsNot(RIGID) && rNode->Is(FREE_SURFACE))
+        if (rNode.IsNot(ISOLATED) && rNode.IsNot(RIGID) && rNode.Is(FREE_SURFACE))
         {
-            const auto vector_distance = MathUtils<double>::CrossProduct(mDirection - rCoordinates, rNode);
-            const double distance = norm_2(vector_distance);
+            const array_1d<double,3> relative_position = rNode.Coordinates() - rCoordinates;
+            const array_1d<double,3> horizontal_position = MathUtils<double>::CrossProduct(mDirection, relative_position);
+            const double distance = norm_2(horizontal_position);
 
             if (distance < mSearchTolerance)
             {
-                local_wave_height = inner_prod(mDirection, rNode) - mHeightReference;
                 local_count = 1.0;
+                local_wave_height = inner_prod(mDirection, rNode) - mMeanWaterLevel;
             }
         }
-        double to_sum = data_vector[i];
-        double to_max = data_vector[i];
         return std::make_tuple(local_count, local_wave_height);
     });
 

--- a/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.cpp
@@ -1,0 +1,108 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Miguel Maso Sotomayor
+//
+
+
+// System includes
+
+
+// External includes
+
+
+// Project includes
+#include "calculate_wave_height_utility.h"
+
+
+namespace Kratos
+{
+
+CalculateWaveHeightUtility::CalculateWaveHeightUtility(
+    ModelPart& rThisModelPart,
+    Parameters ThisParameters
+) : mrModelPart(rThisModelPart)
+{
+    Parameters default_parameters(R"({
+        "automatic_time_step"   : true,
+        "adaptive_time_step"    : true,
+        "time_step"             : 1.0,
+        "courant_number"        : 1.0,
+        "minimum_delta_time"    : 1e-4,
+        "maximum_delta_time"    : 1e+6
+    })");
+
+    ThisParameters.ValidateAndAssignDefaults(default_parameters);
+
+    mEstimateDt = ThisParameters["automatic_time_step"].GetBool();
+    mAdaptiveDt = ThisParameters["adaptive_time_step"].GetBool();
+    mConstantDt = ThisParameters["time_step"].GetDouble();
+    mCourant = ThisParameters["courant_number"].GetDouble();
+    mMinDt = ThisParameters["minimum_delta_time"].GetDouble();
+    mMaxDt = ThisParameters["maximum_delta_time"].GetDouble();
+
+    if (mEstimateDt && !mAdaptiveDt) {
+        mConstantDt = EstimateTimeStep();
+    }
+}
+
+double CalculateWaveHeightUtility::Execute() const
+{
+      KRATOS_TRY
+      const double time = mrModelPart.GetProcessInfo()[TIME];
+      const int step = mrModelPart.GetProcessInfo()[STEP];
+
+      if (time - mPreviousPlotTime > mTimeInterval || step == 1)
+      {
+        // We loop over the nodes...
+        const auto it_node_begin = mrModelPart.NodesBegin();
+        const int num_threads = ParallelUtilities::GetNumThreads();
+        // std::vector<double> max_vector(num_threads, -1.0);
+
+        double counter = 0;
+        double heightSum = 0;
+
+#pragma omp parallel for
+        for (int i = 0; i < static_cast<int>(mrModelPart.Nodes().size()); i++)
+        {
+          auto it_node = it_node_begin + i;
+
+          const int thread_id = OpenMPUtils::ThisThread();
+          const auto &r_node_coordinates = it_node->Coordinates();
+          if (it_node->IsNot(ISOLATED) && it_node->IsNot(RIGID) &&
+              it_node->Is(FREE_SURFACE) &&
+              r_node_coordinates(mPlaneDirection) < (mPlaneCoordinates + mTolerance) &&
+              r_node_coordinates(mPlaneDirection) > (mPlaneCoordinates - mTolerance))
+          {
+            const double height = r_node_coordinates(mHeightDirection);
+            // const double wave_height = std::abs(height - mHeightReference);
+            const double wave_height = height - mHeightReference;
+            counter += 1.0;
+            heightSum += wave_height;
+
+            // if (wave_height > max_vector[thread_id])
+            //   max_vector[thread_id] = wave_height;
+          }
+        }
+        // const double max_height = *std::max_element(max_vector.begin(), max_vector.end());
+        const double max_height = heightSum / counter;
+        // We open the file where we print the wave height values
+        if (max_height > -1.0)
+        {
+          std::ofstream my_file;
+          const std::string file_name = mOutputFileName + ".txt";
+          my_file.open(file_name, std::ios_base::app);
+          my_file << "  " + std::to_string(time) + "    " + std::to_string(max_height - mHeightReference) << std::endl;
+          mPreviousPlotTime = time;
+        }
+      }
+      KRATOS_CATCH("");
+}
+
+}  // namespace Kratos.

--- a/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.cpp
@@ -18,6 +18,8 @@
 
 
 // Project includes
+#include "utilities/math_utils.h"
+#include "utilities/parallel_utilities.h"
 #include "calculate_wave_height_utility.h"
 
 
@@ -41,60 +43,35 @@ CalculateWaveHeightUtility::CalculateWaveHeightUtility(
     mDirection = gravity / norm_2(gravity);
     mCoordinates = ThisParameters["coordinates"].GetBool();
     mMeanWaterLevel = ThisParameters["mean_water_level"].GetBool();
-    mTolerance = ThisParameters["search_tolerance"].GetDouble();
+    mSearchTolerance = ThisParameters["search_tolerance"].GetDouble();
 }
 
 double CalculateWaveHeightUtility::Execute() const
 {
-      KRATOS_TRY
-      const double time = mrModelPart.GetProcessInfo()[TIME];
-      const int step = mrModelPart.GetProcessInfo()[STEP];
+    KRATOS_TRY
 
-      if (time - mPreviousPlotTime > mTimeInterval || step == 1)
-      {
-        // We loop over the nodes...
-        const auto it_node_begin = mrModelPart.NodesBegin();
-        const int num_threads = ParallelUtilities::GetNumThreads();
-        // std::vector<double> max_vector(num_threads, -1.0);
+    double counter = 0.0;
+    double heightSum = 0.0;
 
-        double counter = 0;
-        double heightSum = 0;
-
-#pragma omp parallel for
-        for (int i = 0; i < static_cast<int>(mrModelPart.Nodes().size()); i++)
+    for (NodeType& rNode : mrModelPart.Nodes())
+    {
+        if (rNode->IsNot(ISOLATED) && rNode->IsNot(RIGID) && rNode->Is(FREE_SURFACE))
         {
-          auto it_node = it_node_begin + i;
-
-          const int thread_id = OpenMPUtils::ThisThread();
-          const auto &r_node_coordinates = it_node->Coordinates();
-          if (it_node->IsNot(ISOLATED) && it_node->IsNot(RIGID) &&
-              it_node->Is(FREE_SURFACE) &&
-              r_node_coordinates(mPlaneDirection) < (mPlaneCoordinates + mTolerance) &&
-              r_node_coordinates(mPlaneDirection) > (mPlaneCoordinates - mTolerance))
-          {
-            const double height = r_node_coordinates(mHeightDirection);
-            // const double wave_height = std::abs(height - mHeightReference);
-            const double wave_height = height - mHeightReference;
-            counter += 1.0;
-            heightSum += wave_height;
-
-            // if (wave_height > max_vector[thread_id])
-            //   max_vector[thread_id] = wave_height;
-          }
+            const auto vector_distance = MathUtils<double>::CrossProduct(mDirection, rNode);
+            const double distance = norm_2(vector_distance);
+            if (distance < mSearchTolerance)
+            {
+                const double wave_height = inner_prod(mDirection, rNode) - mHeightReference;
+                counter += 1.0;
+                heightSum += wave_height;
+            }
         }
-        // const double max_height = *std::max_element(max_vector.begin(), max_vector.end());
-        const double max_height = heightSum / counter;
-        // We open the file where we print the wave height values
-        if (max_height > -1.0)
-        {
-          std::ofstream my_file;
-          const std::string file_name = mOutputFileName + ".txt";
-          my_file.open(file_name, std::ios_base::app);
-          my_file << "  " + std::to_string(time) + "    " + std::to_string(max_height - mHeightReference) << std::endl;
-          mPreviousPlotTime = time;
-        }
-      }
-      KRATOS_CATCH("");
+    }
+
+    const double height = heightSum / counter;
+    return height;
+
+    KRATOS_CATCH("");
 }
 
 }  // namespace Kratos.

--- a/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.cpp
@@ -33,7 +33,7 @@ CalculateWaveHeightUtility::CalculateWaveHeightUtility(
 ) : mrModelPart(rThisModelPart)
 {
     Parameters default_parameters(R"({
-        "model_part_name"  : ""
+        "model_part_name"  : "",
         "mean_water_level" : 0.0,
         "search_tolerance" : 1.0
     })");
@@ -42,7 +42,7 @@ CalculateWaveHeightUtility::CalculateWaveHeightUtility(
 
     const array_1d<double,3> gravity = mrModelPart.GetProcessInfo()[GRAVITY];
     mDirection = -gravity / norm_2(gravity);
-    mMeanWaterLevel = ThisParameters["mean_water_level"].GetBool();
+    mMeanWaterLevel = ThisParameters["mean_water_level"].GetDouble();
     mSearchTolerance = ThisParameters["search_tolerance"].GetDouble();
 }
 

--- a/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.cpp
@@ -30,26 +30,18 @@ CalculateWaveHeightUtility::CalculateWaveHeightUtility(
 ) : mrModelPart(rThisModelPart)
 {
     Parameters default_parameters(R"({
-        "automatic_time_step"   : true,
-        "adaptive_time_step"    : true,
-        "time_step"             : 1.0,
-        "courant_number"        : 1.0,
-        "minimum_delta_time"    : 1e-4,
-        "maximum_delta_time"    : 1e+6
+        "coordinates"      : [0.0, 0.0, 0.0],
+        "mean_water_level" : 0.0,
+        "search_tolerance" : 1.0
     })");
 
     ThisParameters.ValidateAndAssignDefaults(default_parameters);
 
-    mEstimateDt = ThisParameters["automatic_time_step"].GetBool();
-    mAdaptiveDt = ThisParameters["adaptive_time_step"].GetBool();
-    mConstantDt = ThisParameters["time_step"].GetDouble();
-    mCourant = ThisParameters["courant_number"].GetDouble();
-    mMinDt = ThisParameters["minimum_delta_time"].GetDouble();
-    mMaxDt = ThisParameters["maximum_delta_time"].GetDouble();
-
-    if (mEstimateDt && !mAdaptiveDt) {
-        mConstantDt = EstimateTimeStep();
-    }
+    const array_1d<double,3> gravity = mrModelPart.GetProcessInfo()[GRAVITY];
+    mDirection = gravity / norm_2(gravity);
+    mCoordinates = ThisParameters["coordinates"].GetBool();
+    mMeanWaterLevel = ThisParameters["mean_water_level"].GetBool();
+    mTolerance = ThisParameters["search_tolerance"].GetDouble();
 }
 
 double CalculateWaveHeightUtility::Execute() const

--- a/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.cpp
@@ -33,7 +33,7 @@ CalculateWaveHeightUtility::CalculateWaveHeightUtility(
 ) : mrModelPart(rThisModelPart)
 {
     Parameters default_parameters(R"({
-        "coordinates"      : [0.0, 0.0, 0.0],
+        "model_part_name"  : ""
         "mean_water_level" : 0.0,
         "search_tolerance" : 1.0
     })");
@@ -41,13 +41,12 @@ CalculateWaveHeightUtility::CalculateWaveHeightUtility(
     ThisParameters.ValidateAndAssignDefaults(default_parameters);
 
     const array_1d<double,3> gravity = mrModelPart.GetProcessInfo()[GRAVITY];
-    mDirection = gravity / norm_2(gravity);
-    mCoordinates = ThisParameters["coordinates"].GetBool();
+    mDirection = -gravity / norm_2(gravity);
     mMeanWaterLevel = ThisParameters["mean_water_level"].GetBool();
     mSearchTolerance = ThisParameters["search_tolerance"].GetDouble();
 }
 
-double CalculateWaveHeightUtility::Execute() const
+double CalculateWaveHeightUtility::Calculate(const array_1d<double,3>& rCoordinates) const
 {
     KRATOS_TRY
 
@@ -64,7 +63,7 @@ double CalculateWaveHeightUtility::Execute() const
 
         if (rNode->IsNot(ISOLATED) && rNode->IsNot(RIGID) && rNode->Is(FREE_SURFACE))
         {
-            const auto vector_distance = MathUtils<double>::CrossProduct(mDirection, rNode);
+            const auto vector_distance = MathUtils<double>::CrossProduct(mDirection - rCoordinates, rNode);
             const double distance = norm_2(vector_distance);
 
             if (distance < mSearchTolerance)

--- a/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.h
+++ b/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.h
@@ -70,7 +70,7 @@ public:
     /**
      * @brief Calculate the wave height.
      */
-    double Execute();
+    double Calculate(const array_1d<double,3>& rCoordinates) const;
 
     ///@}
     ///@name Input and output

--- a/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.h
+++ b/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.h
@@ -94,8 +94,8 @@ protected:
     ///@name Protected LifeCycle
     ///@{
 
-    /// Copy constructor.
-    CalculateWaveHeightUtility(CalculateWaveHeightUtility const &rOther);
+    // /// Copy constructor.
+    // CalculateWaveHeightUtility(CalculateWaveHeightUtility const &rOther);
 
     ///@}
     ///@name Protected member Variables
@@ -117,7 +117,7 @@ private:
     ModelPart &mrModelPart;
     array_1d<double,3> mDirection;
     array_1d<double,3> mCoordinates;
-    double mHeightReference;
+    double mMeanWaterLevel;
     double mTolerance;
 
     ///@}
@@ -129,8 +129,8 @@ private:
     ///@name Private  Access
     ///@{
 
-    /// Assignment operator.
-    CalculateWaveHeightUtility &operator=(CalculateWaveHeightUtility const &rOther);
+    // /// Assignment operator.
+    // CalculateWaveHeightUtility &operator=(CalculateWaveHeightUtility const &rOther);
 
     ///@}
     ///@name Serialization

--- a/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.h
+++ b/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.h
@@ -47,6 +47,7 @@ public:
     ///@name Type Definitions
     ///@{
 
+    typedef Node<3> NodeType;
 
     ///@}
     ///@name Life Cycle
@@ -118,7 +119,7 @@ private:
     array_1d<double,3> mDirection;
     array_1d<double,3> mCoordinates;
     double mMeanWaterLevel;
-    double mTolerance;
+    double mSearchTolerance;
 
     ///@}
     ///@name Private Operations

--- a/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.h
+++ b/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.h
@@ -21,7 +21,7 @@
 
 // Project includes
 #include "includes/model_part.h"
-#include "include/kratos_parameters.h"
+#include "includes/kratos_parameters.h"
 
 namespace Kratos
 {
@@ -86,6 +86,11 @@ public:
     void PrintInfo(std::ostream &rOStream) const
     {
       rOStream << "CalculateWaveHeightUtility";
+    }
+
+    ///@brief Print information about this object.
+    void PrintData(std::ostream &rOStream) const
+    {
     }
 
     ///@}

--- a/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.h
+++ b/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.h
@@ -1,0 +1,163 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ \.
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics PfemFluidDynamics Application
+//
+//  License:         BSD License
+//    Kratos default license:
+//  kratos/license.txt
+//
+//  Main authors:    Alejandro Cornejo Velazquez
+//                   Miguel Maso Sotomayor
+//
+
+#ifndef KRATOS_CALCULATE_WAVE_HEIGHT_UTILITY_H_INCLUDED
+#define KRATOS_CALCULATE_WAVE_HEIGHT_UTILITY_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/model_part.h"
+#include "include/kratos_parameters.h"
+
+namespace Kratos
+{
+
+///@name Kratos Classes
+///@{
+
+/** 
+* @ingroup PfemFluidDynamicsApplication
+* @author Miguel Maso Sotomayor
+* @brief This function computes the wave height at a given point
+* @details The direction is taken from the gravity variable in the ProcessInfo
+*/
+class CalculateWaveHeightUtility
+{
+public:
+    ///@name Pointer Definition
+    ///@{
+
+    KRATOS_CLASS_POINTER_DEFINITION(CalculateWaveHeightUtility);
+
+    ///@}
+    ///@name Type Definitions
+    ///@{
+
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /**
+     * @brief Constructor with ModelPart and Parameters.
+     */
+    CalculateWaveHeightUtility(ModelPart &rThisModelPart, Parameters ThisParameters);
+
+    /**
+     * @brief Destructor.
+     */
+    ~CalculateWaveHeightUtility() {}
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Calculate the wave height.
+     */
+    double Execute();
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    ///@brief Turn back information as a string.
+    std::string Info() const
+    {
+      return "CalculateWaveHeightUtility";
+    }
+
+    ///@brief Print information about this object.
+    void PrintInfo(std::ostream &rOStream) const
+    {
+      rOStream << "CalculateWaveHeightUtility";
+    }
+
+    ///@}
+
+protected:
+
+    ///@name Protected LifeCycle
+    ///@{
+
+    /// Copy constructor.
+    CalculateWaveHeightUtility(CalculateWaveHeightUtility const &rOther);
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+
+    ///@}
+
+private:
+
+    ///@name Member Variables
+    ///@{
+
+    ModelPart &mrModelPart;
+    array_1d<double,3> mDirection;
+    array_1d<double,3> mCoordinates;
+    double mHeightReference;
+    double mTolerance;
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+    /// Assignment operator.
+    CalculateWaveHeightUtility &operator=(CalculateWaveHeightUtility const &rOther);
+
+    ///@}
+    ///@name Serialization
+    ///@{
+
+
+    ///@}
+
+}; // Class CalculateWaveHeightUtility
+
+///@}
+///@name Input and output
+///@{
+
+///@brief output stream function
+inline std::ostream &operator<<(std::ostream &rOStream,
+                                const CalculateWaveHeightUtility &rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+
+///@}
+
+} // namespace Kratos.
+
+#endif // KRATOS_CALCULATE_WAVE_HEIGHT_UTILITY_H_INCLUDED  defined

--- a/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.h
+++ b/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.h
@@ -124,7 +124,7 @@ private:
     array_1d<double,3> mDirection;
     array_1d<double,3> mCoordinates;
     double mMeanWaterLevel;
-    double mSearchTolerance;
+    double mSearchRadius;
 
     ///@}
     ///@name Private Operations

--- a/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.h
+++ b/applications/PfemFluidDynamicsApplication/custom_utilities/calculate_wave_height_utility.h
@@ -35,7 +35,7 @@ namespace Kratos
 * @brief This function computes the wave height at a given point
 * @details The direction is taken from the gravity variable in the ProcessInfo
 */
-class CalculateWaveHeightUtility
+class KRATOS_API(PFEM_FLUID_DYNAMICS_APPLICATION) CalculateWaveHeightUtility
 {
 public:
     ///@name Pointer Definition

--- a/applications/PfemFluidDynamicsApplication/python_scripts/wave_height_output_process.py
+++ b/applications/PfemFluidDynamicsApplication/python_scripts/wave_height_output_process.py
@@ -26,7 +26,7 @@ class WaveHeightOutputProcess(KM.OutputProcess):
             "model_part_name"        : "",
             "coordinates"            : [[0.0, 0.0, 0.0]],
             "mean_water_level"       : 0.0,
-            "relative_search_radius" : 0.7,
+            "relative_search_radius" : 1.0,
             "search_tolerance"       : 1e-6,
             "file_names"             : [""],
             "output_path"            : [""],

--- a/applications/PfemFluidDynamicsApplication/python_scripts/wave_height_output_process.py
+++ b/applications/PfemFluidDynamicsApplication/python_scripts/wave_height_output_process.py
@@ -12,10 +12,12 @@ class WaveHeightOutputProcess(KM.OutputProcess):
 
     This process records the wave height at several points.
     The direction used to calculate the water weight is defined as the opposite of the gravity direction.
+    The search radius is set as the average element half size plus the search tolerance. If no node is
+    found, Nan will be printed.
     Possible specifications of the Parameters:
      - coordinates: it can be a single coordinate or a list of coordinates for each gauge.
      - file_names:  it can be a single string or a list of string. If there is a single string and
-                    multiple coordinates, the string wil be repeated for all the coordinates.
+                    multiple coordinates, the string will be repeated for all the coordinates.
                     Some replacements can be added, such as 'gauge_<X>'.
      - output_path: same as file_names.
     """
@@ -25,7 +27,7 @@ class WaveHeightOutputProcess(KM.OutputProcess):
             "model_part_name"      : "",
             "coordinates"          : [[0.0, 0.0, 0.0]],
             "mean_water_level"     : 0.0,
-            "search_tolerance"     : 1.0,
+            "search_tolerance"     : 1e-6,
             "file_names"           : [""],
             "output_path"          : [""],
             "time_between_outputs" : 0.01

--- a/applications/PfemFluidDynamicsApplication/python_scripts/wave_height_output_process.py
+++ b/applications/PfemFluidDynamicsApplication/python_scripts/wave_height_output_process.py
@@ -11,6 +11,7 @@ class WaveHeightOutputProcess(KM.OutputProcess):
     """WaveHeightOutputProcess
 
     This process records the wave height at several points.
+    The direction used to calculate the water weight is the opposite of the gravity.
     """
 
     @staticmethod
@@ -40,6 +41,7 @@ class WaveHeightOutputProcess(KM.OutputProcess):
         self.file_names_list = self.settings["file_names_list"]
 
     def Check(self):
+        """Check all the variables have the right size"""
         for coordinate in self.coordinates_list:
             if not coordinate.size() == 3:
                 raise Exception("WaveHeightOutputProcess. The coordinates must be given with a 3-dimensional array")
@@ -48,6 +50,7 @@ class WaveHeightOutputProcess(KM.OutputProcess):
             raise Exception("WaveHeightOutputProcess. The number of coordinates must coincide with the number of filenames")
 
     def ExecuteBeforeSolutionLoop(self):
+        """Initialize the files and the utility to calculate the water height"""
         self.files = []
         for file_name in self.file_names_list:
             file_settings = KM.Parameters()
@@ -61,10 +64,12 @@ class WaveHeightOutputProcess(KM.OutputProcess):
         self.wave_height_utility = PFEM.CalculateWaveHeightUtility(self.model_part, utility_settings)
 
     def IsOutputStep(self):
+        """The output control is time based"""
         time = self.model_part.ProcessInfo[KM.TIME]
         return time >= self.next_output
     
     def PrintOutput(self):
+        """Print the wave height corresponding to each gauge and schedule the next output"""
         time = self.model_part.ProcessInfo.GetValue(KM.TIME)
         for file, coordinates in zip(self.files, self.coordinates_list):
             height = self.wave_height_utility.Calculate(coordinates)
@@ -75,5 +80,6 @@ class WaveHeightOutputProcess(KM.OutputProcess):
         self.next_output += self.settings["time_between_outputs"].GetDouble()
     
     def ExecuteFinalize(self):
+        """Close all the files"""
         for file in self.files:
             file.close()

--- a/applications/PfemFluidDynamicsApplication/python_scripts/wave_height_output_process.py
+++ b/applications/PfemFluidDynamicsApplication/python_scripts/wave_height_output_process.py
@@ -51,6 +51,8 @@ class WaveHeightOutputProcess(KM.OutputProcess):
         self.file_names_list = self._GetNamesList(self.settings["file_names"])
         self.output_path_list = self._GetNamesList(self.settings["output_path"])
 
+        self.next_output = self.model_part.ProcessInfo[KM.TIME]
+
     def Check(self):
         """Check all the variables have the right size"""
         for coordinate in self.coordinates_list:
@@ -84,7 +86,7 @@ class WaveHeightOutputProcess(KM.OutputProcess):
 
     def PrintOutput(self):
         """Print the wave height corresponding to each gauge and schedule the next output"""
-        time = self.model_part.ProcessInfo.GetValue(KM.TIME)
+        time = self.model_part.ProcessInfo[KM.TIME]
         for file, coordinates in zip(self.files, self.coordinates_list):
             height = self.wave_height_utility.Calculate(coordinates)
             value = "{}\t{}\n".format(time, height)
@@ -112,12 +114,12 @@ class WaveHeightOutputProcess(KM.OutputProcess):
             names_list = []
             for coordinate in self.coordinates_list:
                 name = settings.GetString()
-                name.replace("<x>", str(coordinate[0]))
-                name.replace("<X>", str(coordinate[0]))
-                name.replace("<y>", str(coordinate[1]))
-                name.replace("<Y>", str(coordinate[1]))
-                name.replace("<z>", str(coordinate[2]))
-                name.replace("<Z>", str(coordinate[2]))
+                name = name.replace("<x>", str(coordinate[0]))
+                name = name.replace("<X>", str(coordinate[0]))
+                name = name.replace("<y>", str(coordinate[1]))
+                name = name.replace("<Y>", str(coordinate[1]))
+                name = name.replace("<z>", str(coordinate[2]))
+                name = name.replace("<Z>", str(coordinate[2]))
                 names_list.append(name)
             return names_list
         else:

--- a/applications/PfemFluidDynamicsApplication/python_scripts/wave_height_output_process.py
+++ b/applications/PfemFluidDynamicsApplication/python_scripts/wave_height_output_process.py
@@ -70,6 +70,7 @@ class WaveHeightOutputProcess(KM.OutputProcess):
             height = self.wave_height_utility.Calculate(coordinates)
             value = "{}\t{}\n".format(time, height)
             file.write(value)
+            file.flush()
         
         self.next_output += self.settings["time_between_outputs"].GetDouble()
     

--- a/applications/PfemFluidDynamicsApplication/python_scripts/wave_height_output_process.py
+++ b/applications/PfemFluidDynamicsApplication/python_scripts/wave_height_output_process.py
@@ -12,8 +12,7 @@ class WaveHeightOutputProcess(KM.OutputProcess):
 
     This process records the wave height at several points.
     The direction used to calculate the water weight is defined as the opposite of the gravity direction.
-    The search radius is set as the average element half size plus the search tolerance. If no node is
-    found, Nan will be printed.
+    If no node is found, Nan will be printed.
     Possible specifications of the Parameters:
      - coordinates: it can be a single coordinate or a list of coordinates for each gauge.
      - file_names:  it can be a single string or a list of string. If there is a single string and
@@ -24,13 +23,14 @@ class WaveHeightOutputProcess(KM.OutputProcess):
 
     def GetDefaultParameters(self):
         default_parameters = KM.Parameters("""{
-            "model_part_name"      : "",
-            "coordinates"          : [[0.0, 0.0, 0.0]],
-            "mean_water_level"     : 0.0,
-            "search_tolerance"     : 1e-6,
-            "file_names"           : [""],
-            "output_path"          : [""],
-            "time_between_outputs" : 0.01
+            "model_part_name"        : "",
+            "coordinates"            : [[0.0, 0.0, 0.0]],
+            "mean_water_level"       : 0.0,
+            "relative_search_radius" : 0.7,
+            "search_tolerance"       : 1e-6,
+            "file_names"             : [""],
+            "output_path"            : [""],
+            "time_between_outputs"   : 0.01
         }""")
         if self.settings.Has("file_names"):
             if self.settings["file_names"].IsString():
@@ -79,6 +79,7 @@ class WaveHeightOutputProcess(KM.OutputProcess):
         utility_settings = KM.Parameters()
         utility_settings.AddValue("mean_water_level", self.settings["mean_water_level"])
         utility_settings.AddValue("search_tolerance", self.settings["search_tolerance"])
+        utility_settings.AddValue("relative_search_radius", self.settings["relative_search_radius"])
         self.wave_height_utility = PFEM.CalculateWaveHeightUtility(self.model_part, utility_settings)
 
     def IsOutputStep(self):

--- a/applications/PfemFluidDynamicsApplication/python_scripts/wave_height_output_process.py
+++ b/applications/PfemFluidDynamicsApplication/python_scripts/wave_height_output_process.py
@@ -58,13 +58,13 @@ class WaveHeightOutputProcess(KM.OutputProcess):
     def Check(self):
         """Check all the variables have the right size"""
         for coordinate in self.coordinates_list:
-            if not coordinate.size() == 3:
+            if not len(coordinate) == 3:
                 raise Exception("WaveHeightOutputProcess. The coordinates must be given with a 3-dimensional array")
 
-        if not self.file_names_list.size() == self.coordinates_list.size():
+        if not len(self.file_names_list) == len(self.coordinates_list):
             raise Exception("WaveHeightOutputProcess. The number of coordinates must coincide with the number of filenames")
 
-        if not self.output_path_list.size() == self.coordinates_list.size():
+        if not len(self.output_path_list) == len(self.coordinates_list):
             raise Exception("WaveHeightOutputProcess. The number of coordinates must coincide with the number of output paths")
 
     def ExecuteBeforeSolutionLoop(self):

--- a/applications/PfemFluidDynamicsApplication/python_scripts/wave_height_output_process.py
+++ b/applications/PfemFluidDynamicsApplication/python_scripts/wave_height_output_process.py
@@ -1,0 +1,69 @@
+from typing import Coroutine
+import KratosMultiphysics as KM
+import KratosMultiphysics.PfemFluidDynamicsApplication as PFEM
+from KratosMultiphysics.time_based_ascii_file_writer_utility import TimeBasedAsciiFileWriterUtility
+
+def Factory(settings, model):
+    if not isinstance(settings, KM.Parameters):
+        raise Exception("expected input shall be a Parameters object, encapsulating a json string")
+    return WaveHeightOutputProcess(model, settings["Parameters"])
+
+class WaveHeightOutputProcess(KM.Process):
+    """WaveHeightOutputProcess
+
+    This process records the wave height at several points.
+    """
+
+    @staticmethod
+    def GetDefaultParameters():
+        return KM.Parameters("""{
+            "model_part_name"      : ""
+            "coordinates_list"     : [[0.0, 0.0, 0.0]],
+            "mean_water_level"     : 0.0,
+            "search_tolerance"     : 1.0,
+            "file_names_list"      : [""],
+            "output_path"          : "",
+            "time_between_outputs" : 0.1
+        }""")
+
+    def __init__(self, model, settings):
+        """The constructor of the WaveHeightOutputProcess"""
+
+        KM.Process.__init__(self)
+        self.settings = settings
+        self.settings.ValidateAndAssignDefaults(self.GetDefaultParameters())
+
+        self.model_part = model.GetModelPart(self.settings["model_part_name"].GetString())
+
+        self.coordinates_list = []
+        for coordinate in self.settings["coordinates_list"]:
+            self.coordinates_list.append(coordinate.GetVector())
+        self.file_names_list = self.settings["file_names_list"]
+
+    def ExecuteBeforeSolutionLoop(self):
+        self.files = []
+        for file_name in self.file_names_list:
+            file_settings = KM.Parameters()
+            file_settings.AddString("file_name", file_name)
+            file_settings.AddValue("output_path", self.settings["output_path"])
+            header = "Time \tHeight"
+            self.files.append(TimeBasedAsciiFileWriterUtility(self.model_part, file_settings, header).file)
+
+    def Check(self):
+        for coordinate in self.coordinates_list:
+            if not coordinate.size() == 3:
+                raise Exception("WaveHeightOutputProcess. The coordinates must be given with a 3-dimensional array")
+
+        if not self.file_names_list.size() == self.coordinates_list.size():
+            raise Exception("WaveHeightOutputProcess. The number of coordinates must coincide with the number of filenames")
+
+    def IsOutputStep(self):
+        return True
+    
+    def PrintOutput(self):
+        time = self.model_part.ProcessInfo.GetValue(KM.TIME)
+        for file, coordinates in zip(self.files, self.coordinates_list):
+            height = self.utility.Calculate(coordinates)
+            value = "{}\t{}".format(time, height)
+            file.write(value)
+            file.close()


### PR DESCRIPTION
**📝 Description**
This PR adds an output process which is constructed with the project parameters. The implementation is based on `CalculateWaveHeightProcess`.

E.g, this piece of project parameters will generate the files `gauge_6.0.dat`, `gauge_8.8.dat` and `gauge_11.3.dat` under the folder `gauges`:
```jsonc
    "output_processes"     : {
        "custom_outputs_list"       : [{
            "python_module" : "wave_height_output_process",
            "kratos_module" : "KratosMultiphysics.PfemFluidDynamicsApplication",
            "Parameters"    : {
                "model_part_name"      : "PfemFluidModelPart",
                "coordinates"          : [
                    [ 6.0, 0.0, 0.0],
                    [ 8.8, 0.0, 0.0],
                    [11.3, 0.0, 0.0]
                ],
                "mean_water_level"     : 0.6,
                "file_names"           : "gauge_<X>.dat",
                "output_path"          : "gauges",
                "time_between_outputs" : 0.01
            }
        }],
    // another output process list...
```

The documentation is on the python docstrings.

NOTE: this PR duplicates the `CalculateWaveHeightProcess` but I haven't deprecated it.

FYI @ipouplana  

**🆕 Changelog**
- Add `c++` utility to calculate the wave height
- Add a python output process to print the wave height
