### PR TITLE
[FluidDyn] Two Fluids - paralllel redistance - decrease the number of layers in parallel

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -83,6 +83,7 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
                 }
             },
             "distance_reinitialization": "variational",
+            "parallel_redistance_max_layers" : 50,
             "distance_smoothing": false,
             "distance_smoothing_coefficient": 1.0,
             "distance_modification_settings": {
@@ -311,8 +312,7 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
             if (self._reinitialization_type == "variational"):
                 self._GetDistanceReinitializationProcess().Execute()
             elif (self._reinitialization_type == "parallel"):
-                adjusting_parameter = 0.05
-                layers = int(adjusting_parameter*self.main_model_part.GetCommunicator().GlobalNumberOfElements()) # this parameter is essential
+                layers = self.settings["parallel_redistance_max_layers"].GetInt()
                 max_distance = 1.0 # use this parameter to define the redistancing range
                 # if using CalculateInterfacePreservingDistances(), the initial interface is preserved
                 self._GetDistanceReinitializationProcess().CalculateDistances(

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -83,7 +83,7 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
                 }
             },
             "distance_reinitialization": "variational",
-            "parallel_redistance_max_layers" : 50,
+            "parallel_redistance_max_layers" : 25,
             "distance_smoothing": false,
             "distance_smoothing_coefficient": 1.0,
             "distance_modification_settings": {


### PR DESCRIPTION
**📝 Description**
I've been testing lately the two fluids solver from the core. In some occasions, using the variational level set is giving me problems. That's why in casting simulation in altair we always use the parallel one. The problem is that the default number of layers is very very high so it is taking way too much time. 

The whole point of this redistance is that it gives you a quick solution that is correct near the interface (that is at the end what really matters). I set it here as a modifiable value but from our experience, the default value (25 layers) should work fine in all cases.

Also, I think this solver is already quite overloaded, so in my opinion it would be better to have everything related to the redistance in a wrapper class in a different file (maybe even creating a two_fluids folder in python scripts) so we remove some responsibilities from this solver.
