### PR TITLE
[Fluid] Minimum and maximum edge size calculators

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_element_size_calculator.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_element_size_calculator.cpp
@@ -231,9 +231,9 @@ namespace Kratos
         KRATOS_TEST_CASE_IN_SUITE(Triangle2D3MinimumEdgeSize, KratosCoreFastSuite)
         {
             Geometry<NodeType>::PointsArrayType nodes;
-            nodes.push_back(NodeType::Pointer(new NodeType(1,  0.0, 0.0, 0.0)));
-            nodes.push_back(NodeType::Pointer(new NodeType(2,  2.0, 0.0, 0.0)));
-            nodes.push_back(NodeType::Pointer(new NodeType(3, -2.0, 3.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(1, -2.0, 3.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(2,  0.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(3,  2.0, 0.0, 0.0)));
             const auto geometry = Triangle2D3<NodeType>(nodes);
             
             const double computed = ElementSizeCalculator<2,3>::MinimumEdgeSize(geometry);
@@ -245,9 +245,9 @@ namespace Kratos
         KRATOS_TEST_CASE_IN_SUITE(Triangle2D3MaximumEdgeSize, KratosCoreFastSuite)
         {
             Geometry<NodeType>::PointsArrayType nodes;
-            nodes.push_back(NodeType::Pointer(new NodeType(1,  0.0, 0.0, 0.0)));
-            nodes.push_back(NodeType::Pointer(new NodeType(2,  2.0, 0.0, 0.0)));
-            nodes.push_back(NodeType::Pointer(new NodeType(3, -2.0, 3.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(1, -2.0, 3.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(2,  0.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(3,  2.0, 0.0, 0.0)));
             const auto geometry = Triangle2D3<NodeType>(nodes);
             
             const double computed = ElementSizeCalculator<2,3>::MaximumEdgeSize(geometry);

--- a/kratos/tests/cpp_tests/utilities/test_element_size_calculator.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_element_size_calculator.cpp
@@ -228,6 +228,34 @@ namespace Kratos
                 ElementSizeCalculator<3, 8>::AverageElementSizeDerivative, 1e-8, 1e-7);
         }
 
+        KRATOS_TEST_CASE_IN_SUITE(Triangle2D3MinimumEdgeSize, KratosCoreFastSuite)
+        {
+            Geometry<NodeType>::PointsArrayType nodes;
+            nodes.push_back(NodeType::Pointer(new NodeType(1,  0.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(2,  2.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(3, -2.0, 3.0, 0.0)));
+            const auto geometry = Triangle2D3<NodeType>(nodes);
+            
+            const double computed = ElementSizeCalculator<2,3>::MinimumEdgeSize(geometry);
+            constexpr double analytical = 2.0;
+
+            KRATOS_CHECK_NEAR(computed, analytical, 1e-8);
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(Triangle2D3MaximumEdgeSize, KratosCoreFastSuite)
+        {
+            Geometry<NodeType>::PointsArrayType nodes;
+            nodes.push_back(NodeType::Pointer(new NodeType(1,  0.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(2,  2.0, 0.0, 0.0)));
+            nodes.push_back(NodeType::Pointer(new NodeType(3, -2.0, 3.0, 0.0)));
+            const auto geometry = Triangle2D3<NodeType>(nodes);
+            
+            const double computed = ElementSizeCalculator<2,3>::MaximumEdgeSize(geometry);
+            constexpr double analytical = 5.0;
+
+            KRATOS_CHECK_NEAR(computed, analytical, 1e-8);
+        }
+
     } // namespace Testing
 
 } // namespace Kratos

--- a/kratos/utilities/element_size_calculator.h
+++ b/kratos/utilities/element_size_calculator.h
@@ -139,7 +139,7 @@ public:
 
     /// Element size based on the shortest edge.
     /**
-     * @param rGeometry: The geometry to mesure the minimum size of
+     * @param rGeometry: The geometry to measure the minimum size of
      */
     static double MinimumEdgeSize(const Geometry<Node<3>>& rGeometry)
     {        
@@ -148,7 +148,7 @@ public:
 
     /// Element size based on the longest edge.
     /**
-     * @param rGeometry: The geometry to mesure the maximum size of
+     * @param rGeometry: The geometry to measure the maximum size of
      */
     static double MaximumEdgeSize(const Geometry<Node<3>>& rGeometry)
     {

--- a/kratos/utilities/element_size_calculator.h
+++ b/kratos/utilities/element_size_calculator.h
@@ -146,7 +146,7 @@ public:
         return ReduceEdgeLengths(rGeometry, [](const double x, const double y){ return std::min(x,y); });
     }
 
-    /// Element size based on the shortest edge.
+    /// Element size based on the longest edge.
     /**
      * @param rGeometry: The geometry to mesure the maximum size of
      */

--- a/kratos/utilities/element_size_calculator.h
+++ b/kratos/utilities/element_size_calculator.h
@@ -226,8 +226,6 @@ private:
         const Geometry<Node<3>>& rGeometry,
         double(*Reduction)(const double, const double))
     {
-        KRATOS_DEBUG_ERROR_IF(rGeometry.size() != TNumNodes);
-
         static const auto distance_2 = 
             [&](const std::size_t j, const std::size_t k)
         {


### PR DESCRIPTION
**📝 Description**
This PR introduces two new methods to `ElementSizeCalculator` that compute the shortest and longest side of an element.

The need for the minimum edge size arose in #9310. Since it's very little extra work, I also implemented the max version.

**🆕 Changelog**
Two new methods:
- `MinimumEdgeSize`
- `MaximumEdgeSize`