### PR TITLE
Remove zlib binary examples

### DIFF
--- a/external_libraries/zlib/CMakeLists.txt
+++ b/external_libraries/zlib/CMakeLists.txt
@@ -229,29 +229,3 @@ endif()
 if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL )
     install(FILES ${ZLIB_PC} DESTINATION "${INSTALL_PKGCONFIG_DIR}")
 endif()
-
-#============================================================================
-# Example binaries
-#============================================================================
-
-add_executable(example test/example.c)
-target_link_libraries(example zlib)
-set_target_properties(example PROPERTIES UNITY_BUILD "OFF")
-add_test(example example)
-
-add_executable(minigzip test/minigzip.c)
-target_link_libraries(minigzip zlib)
-set_target_properties(minigzip PROPERTIES UNITY_BUILD "OFF")
-
-if(HAVE_OFF64_T)
-    add_executable(example64 test/example.c)
-    target_link_libraries(example64 zlib)
-    set_target_properties(example64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
-    set_target_properties(example64 PROPERTIES UNITY_BUILD "OFF")
-    add_test(example64 example64)
-
-    add_executable(minigzip64 test/minigzip.c)
-    target_link_libraries(minigzip64 zlib)
-    set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
-    set_target_properties(minigzip64 PROPERTIES UNITY_BUILD "OFF")
-endif()


### PR DESCRIPTION
**📝 Description**
This PR removes the compilation of the binaries added by zlib. This is specially relevant in windows as VS may add a dependency with python debug library which is not in any dependency path since we don't populate it from our cmake. Also those were unwanted examples.

This fixes #9404

**🆕 Changelog**
- Remove examples from zlib compilation
