### PR TITLE
[Core] Adding KRATOS_WATCH_CERR

### DIFF
--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -806,7 +806,8 @@ namespace Kratos
 /* template<class TFunction> ApplyToLinearSolver(String Name){ */
 
 //Print Trace if defined
-#define KRATOS_WATCH(variable) std::cerr << #variable << " : " << variable << std::endl;
+#define KRATOS_WATCH(variable) std::cout << #variable << " : " << variable << std::endl;
+#define KRATOS_WATCH_CERR(variable) std::cerr << #variable << " : " << variable << std::endl;
 
 }  /* namespace Kratos.*/
 

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -806,7 +806,7 @@ namespace Kratos
 /* template<class TFunction> ApplyToLinearSolver(String Name){ */
 
 //Print Trace if defined
-#define KRATOS_WATCH(variable) std::cout << #variable << " : " << variable << std::endl;
+#define KRATOS_WATCH(variable) std::cerr << #variable << " : " << variable << std::endl;
 
 }  /* namespace Kratos.*/
 


### PR DESCRIPTION
~~The `KRATOS_WATCH` macro is used for debugging and uses `std::cout`. 
However especially in our testings we oftentimes filter the output of `cout` an suppress or hide it, which makes KRATOS_WATCH useless. Ofc I could turn up the verbosity of the tests but then I also get all the other output which I don't want~~

~~Hence my proposal is to use `std::cerr` for `KRATOS_WATCH`~~

EDIT Now I added the `KRATOS_WATCH_CERR` macro which leaves the original `KRATOS_WATCH` untouched