### PR TITLE
Fixed assign_vector_variable_process defaults

### DIFF
--- a/kratos/python_scripts/assign_vector_by_direction_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_process.py
@@ -37,7 +37,7 @@ class AssignVectorByDirectionProcess(KratosMultiphysics.Process):
             "model_part_name"      : "please_specify_model_part_name",
             "variable_name"        : "SPECIFY_VARIABLE_NAME",
             "interval"             : [0.0, 1e30],
-            "modulus"              : 1.0,
+            "modulus"              : 0.0,
             "constrained"          : true,
             "direction"            : [1.0, 0.0, 0.0],
             "local_axes"           : {}

--- a/kratos/python_scripts/assign_vector_by_direction_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_process.py
@@ -48,10 +48,14 @@ class AssignVectorByDirectionProcess(KratosMultiphysics.Process):
         if settings.Has("modulus"):
             if settings["modulus"].IsString():
                 default_settings["modulus"].SetString("0.0")
+        else:
+            raise RuntimeError("Please specify the modulus of the vector")
 
         if settings.Has("direction"):
             if settings["direction"].IsString():
                 default_settings["direction"].SetString("Automatic")
+        else:
+            raise RuntimeError("Please specify the direction of the vector")
 
         # Detect "End" as a tag and replace it by a large number
         if settings.Has("interval"):

--- a/kratos/python_scripts/assign_vector_by_direction_to_condition_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_condition_process.py
@@ -38,7 +38,7 @@ class AssignVectorByDirectionToConditionProcess(assign_vector_by_direction_to_en
             "model_part_name"      : "please_specify_model_part_name",
             "variable_name"        : "SPECIFY_VARIABLE_NAME",
             "interval"             : [0.0, 1e30],
-            "modulus"              : 1.0,
+            "modulus"              : 0.0,
             "direction"            : [1.0, 0.0, 0.0],
             "local_axes"           : {},
             "entities"             : ["conditions"]

--- a/kratos/python_scripts/assign_vector_by_direction_to_condition_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_condition_process.py
@@ -49,10 +49,14 @@ class AssignVectorByDirectionToConditionProcess(assign_vector_by_direction_to_en
         if settings.Has("modulus"):
             if settings["modulus"].IsString():
                 default_settings["modulus"].SetString("0.0")
+        else:
+            raise RuntimeError("Please specify the modulus of the vector")
 
         if settings.Has("direction"):
             if settings["direction"].IsString():
                 default_settings["direction"].SetString("Automatic")
+        else:
+            raise RuntimeError("Please specify the direction of the vector")
 
         # Detect "End" as a tag and replace it by a large number
         if settings.Has("interval"):

--- a/kratos/python_scripts/assign_vector_by_direction_to_element_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_element_process.py
@@ -46,10 +46,14 @@ class AssignVectorByDirectionToElementProcess(assign_vector_by_direction_to_enti
         if settings.Has("modulus"):
             if settings["modulus"].IsString():
                 default_settings["modulus"].SetString("0.0")
+        else:
+            raise RuntimeError("Please specify the modulus of the vector")
 
         if settings.Has("direction"):
             if settings["direction"].IsString():
                 default_settings["direction"].SetString("Automatic")
+        else:
+            raise RuntimeError("Please specify the direction of the vector")
 
         # Detect "End" as a tag and replace it by a large number
         if settings.Has("interval"):

--- a/kratos/python_scripts/assign_vector_by_direction_to_element_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_element_process.py
@@ -35,7 +35,7 @@ class AssignVectorByDirectionToElementProcess(assign_vector_by_direction_to_enti
             "model_part_name"      : "please_specify_model_part_name",
             "variable_name"        : "SPECIFY_VARIABLE_NAME",
             "interval"             : [0.0, 1e30],
-            "modulus"              : 1.0,
+            "modulus"              : 0.0,
             "direction"            : [1.0, 0.0, 0.0],
             "local_axes"           : {},
             "entities"             : ["elements"]

--- a/kratos/python_scripts/assign_vector_by_direction_to_entity_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_entity_process.py
@@ -109,7 +109,7 @@ class AssignVectorByDirectionToEntityProcess(KratosMultiphysics.Process):
                 avg_normal = KratosMultiphysics.VariableUtils().SumConditionVectorVariable(KratosMultiphysics.NORMAL, self.model_part)
                 avg_normal_norm = math.sqrt(pow(avg_normal[0],2) + pow(avg_normal[1],2) + pow(avg_normal[2],2))
                 if avg_normal_norm < 1.0e-6:
-                    raise Exception("Direction norm is close to 0 in AssignVectorByDirectionToConditionProcess.")
+                    raise Exception("Direction norm is close to 0 in AssignVectorByDirectionToEntityProcess.")
 
                 unit_direction = KratosMultiphysics.Vector(3)
                 unit_direction = (1.0/avg_normal_norm) * avg_normal
@@ -134,7 +134,7 @@ class AssignVectorByDirectionToEntityProcess(KratosMultiphysics.Process):
             if all_numeric:
                 direction_norm = math.sqrt(direction_norm)
                 if direction_norm < 1.0e-6:
-                    raise Exception("Direction norm is close to 0 in AssignVectorByDirectionToConditionProcess.")
+                    raise Exception("Direction norm is close to 0 in AssignVectorByDirectionToEntityProcess.")
 
                 for i in range(0,3):
                     unit_direction[i] = unit_direction[i]/direction_norm

--- a/kratos/python_scripts/assign_vector_by_direction_to_entity_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_entity_process.py
@@ -37,7 +37,7 @@ class AssignVectorByDirectionToEntityProcess(KratosMultiphysics.Process):
             "model_part_name"      : "please_specify_model_part_name",
             "variable_name"        : "SPECIFY_VARIABLE_NAME",
             "interval"             : [0.0, 1e30],
-            "modulus"              : 1.0,
+            "modulus"              : 0.0,
             "direction"            : [1.0, 0.0, 0.0],
             "local_axes"           : {},
             "entities"             : []

--- a/kratos/python_scripts/assign_vector_by_direction_to_entity_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_entity_process.py
@@ -48,10 +48,15 @@ class AssignVectorByDirectionToEntityProcess(KratosMultiphysics.Process):
         if settings.Has("modulus"):
             if settings["modulus"].IsString():
                 default_settings["modulus"].SetString("0.0")
+        else:
+            raise RuntimeError("Please specify the modulus of the vector")
+
 
         if settings.Has("direction"):
             if settings["direction"].IsString():
                 default_settings["direction"].SetString("Automatic")
+        else:
+            raise RuntimeError("Please specify the direction of the vector")
 
         # Detect "End" as a tag and replace it by a large number
         if settings.Has("interval"):

--- a/kratos/python_scripts/assign_vector_by_direction_to_node_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_node_process.py
@@ -35,7 +35,7 @@ class AssignVectorByDirectionToNodeProcess(assign_vector_by_direction_to_entity_
             "model_part_name"      : "please_specify_model_part_name",
             "variable_name"        : "SPECIFY_VARIABLE_NAME",
             "interval"             : [0.0, 1e30],
-            "modulus"              : 1.0,
+            "modulus"              : 0.0,
             "direction"            : [1.0, 0.0, 0.0],
             "local_axes"           : {},
             "entities"             : ["nodes"]

--- a/kratos/python_scripts/assign_vector_by_direction_to_node_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_node_process.py
@@ -46,10 +46,14 @@ class AssignVectorByDirectionToNodeProcess(assign_vector_by_direction_to_entity_
         if settings.Has("modulus"):
             if settings["modulus"].IsString():
                 default_settings["modulus"].SetString("0.0")
+        else:
+            raise RuntimeError("Please specify the modulus of the vector")
 
         if settings.Has("direction"):
             if settings["direction"].IsString():
                 default_settings["direction"].SetString("Automatic")
+        else:
+            raise RuntimeError("Please specify the direction of the vector")
 
         # Detect "End" as a tag and replace it by a large number
         if settings.Has("interval"):

--- a/kratos/python_scripts/assign_vector_variable_process.py
+++ b/kratos/python_scripts/assign_vector_variable_process.py
@@ -2,14 +2,13 @@
 import KratosMultiphysics
 from KratosMultiphysics import assign_scalar_variable_process
 
-from math import *
 
 def Factory(settings, Model):
     if not isinstance(settings, KratosMultiphysics.Parameters):
         raise Exception("expected input shall be a Parameters object, encapsulating a json string")
     return AssignVectorVariableProcess(Model, settings["Parameters"])
 
-## All the processes python should be derived from "Process"
+
 class AssignVectorVariableProcess(KratosMultiphysics.Process):
     """This process assigns a given value (vector) to the nodes belonging a certain submodelpart
 
@@ -38,7 +37,7 @@ class AssignVectorVariableProcess(KratosMultiphysics.Process):
             "model_part_name"      : "please_specify_model_part_name",
             "variable_name"        : "SPECIFY_VARIABLE_NAME",
             "interval"             : [0.0, 1e30],
-            "value"                : [10.0, "3*t", "x+y"],
+            "value"                : [0.0, 0.0, 0.0],
             "constrained"          : [true,true,true],
             "local_axes"           : {}
         }
@@ -54,6 +53,9 @@ class AssignVectorVariableProcess(KratosMultiphysics.Process):
                 settings["constrained"] = default_settings["constrained"]
                 for i in range(3):
                     settings["constrained"][i].SetBool(is_fixed)
+
+        if not settings.Has("value"):
+            raise RuntimeError("Please specify the values to set the vector to.")
 
         settings.ValidateAndAssignDefaults(default_settings)
 

--- a/kratos/python_scripts/assign_vector_variable_process.py
+++ b/kratos/python_scripts/assign_vector_variable_process.py
@@ -37,7 +37,7 @@ class AssignVectorVariableProcess(KratosMultiphysics.Process):
             "model_part_name"      : "please_specify_model_part_name",
             "variable_name"        : "SPECIFY_VARIABLE_NAME",
             "interval"             : [0.0, 1e30],
-            "value"                : [1.0, 0.0, 0.0],
+            "value"                : [0.0, 0.0, 0.0],
             "constrained"          : [true,true,true],
             "local_axes"           : {}
         }

--- a/kratos/python_scripts/assign_vector_variable_process.py
+++ b/kratos/python_scripts/assign_vector_variable_process.py
@@ -37,7 +37,7 @@ class AssignVectorVariableProcess(KratosMultiphysics.Process):
             "model_part_name"      : "please_specify_model_part_name",
             "variable_name"        : "SPECIFY_VARIABLE_NAME",
             "interval"             : [0.0, 1e30],
-            "value"                : [0.0, 0.0, 0.0],
+            "value"                : [1.0, 0.0, 0.0],
             "constrained"          : [true,true,true],
             "local_axes"           : {}
         }
@@ -53,9 +53,6 @@ class AssignVectorVariableProcess(KratosMultiphysics.Process):
                 settings["constrained"] = default_settings["constrained"]
                 for i in range(3):
                     settings["constrained"][i].SetBool(is_fixed)
-
-        if not settings.Has("value"):
-            raise RuntimeError("Please specify the values to set the vector to.")
 
         settings.ValidateAndAssignDefaults(default_settings)
 

--- a/kratos/python_scripts/assign_vector_variable_process.py
+++ b/kratos/python_scripts/assign_vector_variable_process.py
@@ -54,6 +54,10 @@ class AssignVectorVariableProcess(KratosMultiphysics.Process):
                 for i in range(3):
                     settings["constrained"][i].SetBool(is_fixed)
 
+        if not settings.Has("value"):
+            raise RuntimeError("Please specify the value to set the vector to. Example:\n" \
+                               + '{\n\t"value" : [10.0, "3*t", "x+y"]\n}\n')
+
         settings.ValidateAndAssignDefaults(default_settings)
 
         self.variable = KratosMultiphysics.KratosGlobals.GetVariable(settings["variable_name"].GetString())

--- a/kratos/python_scripts/assign_vector_variable_to_conditions_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_conditions_process.py
@@ -43,6 +43,10 @@ class AssignVectorVariableToConditionProcess(assign_vector_variable_to_entities_
         """
         )
 
+        if not settings.Has("value"):
+            raise RuntimeError("Please specify the value to set the vector to. Example:\n" \
+                               + '{\n\t"value" : [10.0, "3*t", "x+y"]\n}\n')
+
         settings.ValidateAndAssignDefaults(default_settings)
 
         # Ensure proper entities

--- a/kratos/python_scripts/assign_vector_variable_to_conditions_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_conditions_process.py
@@ -36,7 +36,7 @@ class AssignVectorVariableToConditionProcess(assign_vector_variable_to_entities_
             "model_part_name"      : "please_specify_model_part_name",
             "variable_name"        : "SPECIFY_VARIABLE_NAME",
             "interval"             : [0.0, 1e30],
-            "value"                : [10.0, "3*t", "x+y"],
+            "value"                : [0.0, 0.0, 0.0],
             "local_axes"           : {},
             "entities"             : ["conditions"]
         }

--- a/kratos/python_scripts/assign_vector_variable_to_constraints_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_constraints_process.py
@@ -36,7 +36,7 @@ class AssignVectorVariableToConstraintProcess(assign_vector_variable_to_entities
             "model_part_name"      : "please_specify_model_part_name",
             "variable_name"        : "SPECIFY_VARIABLE_NAME",
             "interval"             : [0.0, 1e30],
-            "value"                : [10.0, 2.0, 0.0],
+            "value"                : [0.0, 0.0, 0.0],
             "local_axes"           : {},
             "entities"             : ["constraints"]
         }

--- a/kratos/python_scripts/assign_vector_variable_to_constraints_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_constraints_process.py
@@ -43,6 +43,10 @@ class AssignVectorVariableToConstraintProcess(assign_vector_variable_to_entities
         """
         )
 
+        if not settings.Has("value"):
+            raise RuntimeError("Please specify the value to set the vector to. Example:\n" \
+                               + '{\n\t"value" : [10.0, "3*t", "x+y"]\n}\n')
+
         settings.ValidateAndAssignDefaults(default_settings)
 
         # Here i do a trick, since i want to allow "value" to be a string or a double value

--- a/kratos/python_scripts/assign_vector_variable_to_elements_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_elements_process.py
@@ -36,7 +36,7 @@ class AssignVectorVariableToElementProcess(assign_vector_variable_to_entities_pr
             "model_part_name"      : "please_specify_model_part_name",
             "variable_name"        : "SPECIFY_VARIABLE_NAME",
             "interval"             : [0.0, 1e30],
-            "value"                : [10.0, "3*t", "x+y"],
+            "value"                : [0.0, 0.0, 0.0],
             "local_axes"           : {},
             "entities"             : ["elements"]
         }

--- a/kratos/python_scripts/assign_vector_variable_to_elements_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_elements_process.py
@@ -43,6 +43,10 @@ class AssignVectorVariableToElementProcess(assign_vector_variable_to_entities_pr
         """
         )
 
+        if not settings.Has("value"):
+            raise RuntimeError("Please specify the value to set the vector to. Example:\n" \
+                               + '{\n\t"value" : [10.0, "3*t", "x+y"]\n}\n')
+
         settings.ValidateAndAssignDefaults(default_settings)
 
         # Ensure proper entities

--- a/kratos/python_scripts/assign_vector_variable_to_entities_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_entities_process.py
@@ -52,6 +52,10 @@ class AssignVectorVariableToEntitiesProcess(KratosMultiphysics.Process):
                 else:
                     raise Exception("the second value of interval can be \"End\" or a number, interval currently:"+settings["interval"].PrettyPrintJsonString())
 
+        if not settings.Has("value"):
+            raise RuntimeError("Please specify the value to set the vector to. Example:\n" \
+                               + '{\n\t"value" : [10.0, "3*t", "x+y"]\n}\n')
+
         settings.ValidateAndAssignDefaults(default_settings)
 
         self.variable = KratosMultiphysics.KratosGlobals.GetVariable(settings["variable_name"].GetString())

--- a/kratos/python_scripts/assign_vector_variable_to_entities_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_entities_process.py
@@ -37,7 +37,7 @@ class AssignVectorVariableToEntitiesProcess(KratosMultiphysics.Process):
             "model_part_name"      : "please_specify_model_part_name",
             "variable_name"        : "SPECIFY_VARIABLE_NAME",
             "interval"             : [0.0, 1e30],
-            "value"                : [10.0, "3*t", "x+y"],
+            "value"                : [0.0, 0.0, 0.0],
             "local_axes"           : {},
             "entities"             : []
         }

--- a/kratos/python_scripts/assign_vector_variable_to_nodes_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_nodes_process.py
@@ -43,6 +43,10 @@ class AssignVectorVariableToNodeProcess(assign_vector_variable_to_entities_proce
         """
         )
 
+        if not settings.Has("value"):
+            raise RuntimeError("Please specify the value to set the vector to. Example:\n" \
+                               + '{\n\t"value" : [10.0, "3*t", "x+y"]\n}\n')
+
         settings.ValidateAndAssignDefaults(default_settings)
 
         # Ensure proper entities

--- a/kratos/python_scripts/assign_vector_variable_to_nodes_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_nodes_process.py
@@ -36,7 +36,7 @@ class AssignVectorVariableToNodeProcess(assign_vector_variable_to_entities_proce
             "model_part_name"      : "please_specify_model_part_name",
             "variable_name"        : "SPECIFY_VARIABLE_NAME",
             "interval"             : [0.0, 1e30],
-            "value"                : [10.0, "3*t", "x+y"],
+            "value"                : [0.0, 0.0, 0.0],
             "local_axes"           : {},
             "entities"             : ["nodes"]
         }


### PR DESCRIPTION
**📝 Description**
I saw an easy fix in issue #9065, and I propose a solution.

Previously the defaults in `assign_vector_*` processes were arbitrary and prone to unexpected behaviour. Now they all require the user to specify the value of the vector, else a `RuntimeError` with a clear message is raised.

**🆕 Changelog**
- `assign_vector_*` processes no longer have an arbitrary set of defaults
- `assign_vector_*` processes now require the user to specify the value (or the direction and modulus when necessary).
- Removed an unused import