### PR TITLE
[HDF5] Meaning full error for Invalid Path

### DIFF
--- a/applications/HDF5Application/custom_io/hdf5_file.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file.cpp
@@ -8,6 +8,7 @@
 #include "includes/kratos_parameters.h"
 #include "utilities/builtin_timer.h"
 #include "input_output/logger.h"
+#include "utilities/string_utilities.h"
 
 namespace Kratos
 {
@@ -23,18 +24,6 @@ bool IsPath(const std::string& rPath)
 #else
     return regex_match(rPath, std::regex("(/[\\w\\(\\)]+)+"));
 #endif
-}
-
-std::vector<std::string> Split(const std::string& rPath, char Delimiter)
-{
-    std::vector<std::string> splitted;
-    splitted.reserve(10);
-    std::stringstream ss(rPath);
-    std::string sub_string;
-    while (std::getline(ss, sub_string, Delimiter))
-        if (sub_string.size() > 0)
-            splitted.push_back(sub_string);
-    return splitted;
 }
 
 hid_t GetScalarDataType(const Vector<int>&)
@@ -211,7 +200,7 @@ bool File::HasPath(const std::string& rPath) const
     // Expects a valid path.
     KRATOS_ERROR_IF_NOT(Internals::IsPath(rPath)) << "Invalid path: \"" << rPath << "\". Path should start with \"/\" and should only have characters A-Z, a-z, 0-9, \"/\", and \"_\"." << std::endl;
 
-    std::vector<std::string> splitted_path = Internals::Split(rPath, '/');
+    std::vector<std::string> splitted_path = StringUtilities::SplitStringByDelimiter(rPath, '/');
     std::string sub_path;
     for (const auto& r_link: splitted_path)
     {
@@ -381,7 +370,7 @@ void File::AddPath(const std::string& rPath)
 {
     KRATOS_ERROR_IF_NOT(Internals::IsPath(rPath)) << "Invalid path: \"" << rPath << "\". Path should start with \"/\" and should only have characters A-Z, a-z, 0-9, \"/\", and \"_\"." << std::endl;
 
-    std::vector<std::string> splitted_path = Internals::Split(rPath, '/');
+    std::vector<std::string> splitted_path = StringUtilities::SplitStringByDelimiter(rPath, '/');
     std::string sub_path;
     for (const auto& r_link: splitted_path)
     {

--- a/applications/HDF5Application/custom_io/hdf5_file.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file.cpp
@@ -201,6 +201,7 @@ bool File::HasPath(const std::string& rPath) const
     KRATOS_ERROR_IF_NOT(Internals::IsPath(rPath)) << "Invalid path: \"" << rPath << "\". Path should start with \"/\" and should only have characters A-Z, a-z, 0-9, \"/\", and \"_\"." << std::endl;
 
     std::vector<std::string> splitted_path = StringUtilities::SplitStringByDelimiter(rPath, '/');
+    splitted_path.erase(std::remove_if(splitted_path.begin(), splitted_path.end(), [](const std::string& s) {return (s.size() == 0);}));
     std::string sub_path;
     for (const auto& r_link: splitted_path)
     {
@@ -371,6 +372,7 @@ void File::AddPath(const std::string& rPath)
     KRATOS_ERROR_IF_NOT(Internals::IsPath(rPath)) << "Invalid path: \"" << rPath << "\". Path should start with \"/\" and should only have characters A-Z, a-z, 0-9, \"/\", and \"_\"." << std::endl;
 
     std::vector<std::string> splitted_path = StringUtilities::SplitStringByDelimiter(rPath, '/');
+    splitted_path.erase(std::remove_if(splitted_path.begin(), splitted_path.end(), [](const std::string& s) {return (s.size() == 0);}));
     std::string sub_path;
     for (const auto& r_link: splitted_path)
     {

--- a/applications/HDF5Application/custom_io/hdf5_file.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file.cpp
@@ -209,7 +209,7 @@ bool File::HasPath(const std::string& rPath) const
 {
     KRATOS_TRY;
     // Expects a valid path.
-    KRATOS_ERROR_IF_NOT(Internals::IsPath(rPath)) << "Invalid path: \"" << rPath << '"' << std::endl;
+    KRATOS_ERROR_IF_NOT(Internals::IsPath(rPath)) << "Invalid path: \"" << rPath << "\". Path should only have characters A-Z, a-z, 0-9, \"/\", and \"_\"." << std::endl;
 
     std::vector<std::string> splitted_path = Internals::Split(rPath, '/');
     std::string sub_path;
@@ -379,7 +379,7 @@ std::vector<std::string> File::GetDataSetNames(const std::string& rGroupPath) co
 
 void File::AddPath(const std::string& rPath)
 {
-    KRATOS_ERROR_IF_NOT(Internals::IsPath(rPath)) << "Invalid path: " << rPath << std::endl;
+    KRATOS_ERROR_IF_NOT(Internals::IsPath(rPath)) << "Invalid path: \"" << rPath << "\". Path should only have characters A-Z, a-z, 0-9, \"/\", and \"_\"." << std::endl;
 
     std::vector<std::string> splitted_path = Internals::Split(rPath, '/');
     std::string sub_path;

--- a/applications/HDF5Application/custom_io/hdf5_file.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file.cpp
@@ -209,7 +209,7 @@ bool File::HasPath(const std::string& rPath) const
 {
     KRATOS_TRY;
     // Expects a valid path.
-    KRATOS_ERROR_IF_NOT(Internals::IsPath(rPath)) << "Invalid path: \"" << rPath << "\". Path should only have characters A-Z, a-z, 0-9, \"/\", and \"_\"." << std::endl;
+    KRATOS_ERROR_IF_NOT(Internals::IsPath(rPath)) << "Invalid path: \"" << rPath << "\". Path should start with \"/\" and should only have characters A-Z, a-z, 0-9, \"/\", and \"_\"." << std::endl;
 
     std::vector<std::string> splitted_path = Internals::Split(rPath, '/');
     std::string sub_path;
@@ -379,7 +379,7 @@ std::vector<std::string> File::GetDataSetNames(const std::string& rGroupPath) co
 
 void File::AddPath(const std::string& rPath)
 {
-    KRATOS_ERROR_IF_NOT(Internals::IsPath(rPath)) << "Invalid path: \"" << rPath << "\". Path should only have characters A-Z, a-z, 0-9, \"/\", and \"_\"." << std::endl;
+    KRATOS_ERROR_IF_NOT(Internals::IsPath(rPath)) << "Invalid path: \"" << rPath << "\". Path should start with \"/\" and should only have characters A-Z, a-z, 0-9, \"/\", and \"_\"." << std::endl;
 
     std::vector<std::string> splitted_path = Internals::Split(rPath, '/');
     std::string sub_path;

--- a/applications/HDF5Application/tests/test_hdf5_file.cpp
+++ b/applications/HDF5Application/tests/test_hdf5_file.cpp
@@ -165,7 +165,7 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5_File_IsGroup1, KratosHDF5TestSuite)
 {
     KRATOS_TRY;
     KRATOS_CHECK_EXCEPTION_IS_THROWN(GetTestFile().IsGroup("invalid_path");
-                                     , "Invalid path: \"invalid_path\"");
+                                     , "Invalid path: \"invalid_path\". Path should start with \"/\" and should only have characters A-Z, a-z, 0-9, \"/\", and \"_\".");
     H5close(); // Clean HDF5 for next unit test.
     KRATOS_CATCH_WITH_BLOCK("", H5close(););
 }
@@ -443,7 +443,7 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5_File_AddPath1, KratosHDF5TestSuite)
 {
     KRATOS_TRY;
     KRATOS_CHECK_EXCEPTION_IS_THROWN(GetTestFile().AddPath("invalid_path");
-                                     , "Invalid path: invalid_path");
+                                     , "Invalid path: \"invalid_path\". Path should start with \"/\" and should only have characters A-Z, a-z, 0-9, \"/\", and \"_\".");
     H5close(); // Clean HDF5 for next unit test.
     KRATOS_CATCH_WITH_BLOCK("", H5close(););
 }

--- a/applications/HDF5Application/tests/test_hdf5_file.cpp
+++ b/applications/HDF5Application/tests/test_hdf5_file.cpp
@@ -58,26 +58,6 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5_Internals_IsPath6, KratosHDF5TestSuite)
     KRATOS_CHECK(HDF5::Internals::IsPath("/foo//bar") == false);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(HDF5_Internals_Split1, KratosHDF5TestSuite)
-{
-    KRATOS_CHECK(HDF5::Internals::Split("", '/').size() == 0);
-}
-
-KRATOS_TEST_CASE_IN_SUITE(HDF5_Internals_Split2, KratosHDF5TestSuite)
-{
-    auto result = HDF5::Internals::Split("foo", '/');
-    KRATOS_CHECK(result.size() == 1);
-    KRATOS_CHECK(result[0] == "foo");
-}
-
-KRATOS_TEST_CASE_IN_SUITE(HDF5_Internals_Split3, KratosHDF5TestSuite)
-{
-    auto result = HDF5::Internals::Split("/foo//bar", '/');
-    KRATOS_CHECK(result.size() == 2);
-    KRATOS_CHECK(result[0] == "foo");
-    KRATOS_CHECK(result[1] == "bar");
-}
-
 KRATOS_TEST_CASE_IN_SUITE(HDF5_File_File1, KratosHDF5TestSuite)
 {
     KRATOS_TRY;


### PR DESCRIPTION
**📝 Description**
`IsPath` in hdf5 uses `regex` to check whether the given path is a compatible path. In there, `\w` (alphanumeric + `_`) is used which checks whether characters other than `A-Z`, `a-z`, `0-9`, and `_` is in the given path and if so, it gives `Invalid Path` error which is not descriptive enough. This adds the actual cause for the error since I don't know which punctuation marks to allow or disallow at this point.

Using `regex`; I am not sure how to pinpoint the exact character atm in the path.

https://github.com/KratosMultiphysics/Kratos/blob/9a003679c1a12a159466e6e61a371e1286f379ca/applications/HDF5Application/custom_io/hdf5_file.cpp#L19-L26

**🆕 Changelog**
- Changing error message in HDF5
