### PR TITLE
[Core] Improve table performance

### DIFF
--- a/kratos/includes/table.h
+++ b/kratos/includes/table.h
@@ -48,8 +48,8 @@ namespace Kratos
 ///@}
 ///@name Kratos Classes
 ///@{
-    
-/** 
+
+/**
  * @class Table
  * @ingroup KratosCore
  * @brief This class represents the value of its variable depending to other variable.
@@ -79,6 +79,8 @@ public:
     typedef std::pair<argument_type, result_row_type> RecordType;
 
     typedef std::vector<RecordType> TableContainerType;
+
+
 
     ///@}
     ///@name Life Cycle
@@ -256,7 +258,7 @@ public:
     {
         mData.push_back(RecordType(X,Y));
     }
-    
+
     /**
      * @brief This method clears databse
      */
@@ -432,6 +434,8 @@ private:
 template<>
 class Table<double, double>
 {
+    static constexpr double epsilon = 1.0e-12;
+
 public:
     ///@name Type Definitions
     ///@{
@@ -617,22 +621,16 @@ public:
 
     result_type Interpolate(argument_type const& X, argument_type const& X1, result_type const& Y1, argument_type const& X2, result_type const& Y2) const
     {
-        constexpr double epsilon = 1.0e-12;
         return Y1 + (X2 - X1 > epsilon) * ( (Y2 - Y1)*(X - X1)/(X2 - X1) );
-
     }
     result_type ExtrapolateBelowLowest(argument_type const& X, argument_type const& X1, result_type const& Y1, argument_type const& X2, result_type const& Y2) const
     {
-        constexpr double epsilon = 1.0e-12;
         return Y1 - (X2 - X1 > epsilon) * ( (Y2 - Y1)*(X1 - X)/(X2 - X1 + std::numeric_limits<double>::min()) );
-
     }
 
     result_type ExtrapolateAboveHighest(argument_type const& X, argument_type const& X1, result_type const& Y1, argument_type const& X2, result_type const& Y2) const
     {
-        constexpr double epsilon = 1.0e-12;
         return Y2 + (X2 - X1 > epsilon) * ( (Y2 - Y1)*(X - X2)/(X2 - X1 + std::numeric_limits<double>::min()) );
-
     }
     // inserts a row in a sorted position where Xi-1 < X < Xi+1 and fills the first column with Y
     void insert(argument_type const& X, result_type const& Y)
@@ -701,7 +699,6 @@ public:
     }
      result_type InterpolateDerivative( argument_type const& X1, result_type const& Y1, argument_type const& X2, result_type const& Y2) const
     {
-        constexpr double epsilon = 1.0e-12;
         argument_type dx = X2 - X1;
         if (dx < epsilon)
         {
@@ -722,7 +719,7 @@ public:
     {
         mData.clear();
     }
-    
+
     ///@}
     ///@name Access
     ///@{
@@ -885,5 +882,3 @@ inline std::ostream& operator << (std::ostream& rOStream,
 }  // namespace Kratos.
 
 #endif // KRATOS_TABLE_H_INCLUDED  defined 
-
-

--- a/kratos/includes/table.h
+++ b/kratos/includes/table.h
@@ -617,21 +617,21 @@ public:
 
     result_type Interpolate(argument_type const& X, argument_type const& X1, result_type const& Y1, argument_type const& X2, result_type const& Y2) const
     {
-        // const double epsilon = 1e-12;
-        return Y1 + (X2 - X1 > 1.0e-12) * (Y2 - Y1)*(X - X1)/(X2 - X1);
+        constexpr double epsilon = 1.0e-12;
+        return Y1 + (X2 - X1 > epsilon) * ( (Y2 - Y1)*(X - X1)/(X2 - X1) );
 
     }
     result_type ExtrapolateBelowLowest(argument_type const& X, argument_type const& X1, result_type const& Y1, argument_type const& X2, result_type const& Y2) const
     {
-        // const double epsilon = 1e-12;
-        return Y1 - (X2 - X1 > 1.0e-12) * (Y2 - Y1)*(X1 - X)/(X2 - X1 + std::numeric_limits<double>::min());
+        constexpr double epsilon = 1.0e-12;
+        return Y1 - (X2 - X1 > epsilon) * ( (Y2 - Y1)*(X1 - X)/(X2 - X1 + std::numeric_limits<double>::min()) );
 
     }
 
     result_type ExtrapolateAboveHighest(argument_type const& X, argument_type const& X1, result_type const& Y1, argument_type const& X2, result_type const& Y2) const
     {
-        // const double epsilon = 1e-12;
-        return Y2 + (X2 - X1 > 1.0e-12) * (Y2 - Y1)*(X - X2)/(X2 - X1 + std::numeric_limits<double>::min());
+        constexpr double epsilon = 1.0e-12;
+        return Y2 + (X2 - X1 > epsilon) * ( (Y2 - Y1)*(X - X2)/(X2 - X1 + std::numeric_limits<double>::min()) );
 
     }
     // inserts a row in a sorted position where Xi-1 < X < Xi+1 and fills the first column with Y
@@ -680,7 +680,7 @@ public:
         }
 
         if(X >= mData[u].first){
-            // now the x is outside the table and we hae to extrapolate it using last two records of table.
+            // now the x is outside the table and we have to extrapolate it using the slope computed with last two records of table.
             return InterpolateDerivative(mData[u-1].first, mData[u-1].second[0], mData[u].first, mData[u].second[0]);
         }
 
@@ -701,7 +701,7 @@ public:
     }
      result_type InterpolateDerivative( argument_type const& X1, result_type const& Y1, argument_type const& X2, result_type const& Y2) const
     {
-        const double epsilon = 1e-12;
+        constexpr double epsilon = 1.0e-12;
         argument_type dx = X2 - X1;
         if (dx < epsilon)
         {

--- a/kratos/includes/table.h
+++ b/kratos/includes/table.h
@@ -528,12 +528,12 @@ public:
             return mData.begin()->second[0];
         }
         if(X <=  mData.begin()->first) {
-            return Interpolate(X,  mData.begin()->first, mData.begin()->second[0], mData[1].first, mData[1].second[0]);
+            return ExtrapolateBelowLowest(X,  mData.begin()->first, mData.begin()->second[0], mData[1].first, mData[1].second[0]);
         }
 
         if(X >= mData[u].first) {
             // now the x is outside the table and we hae to extrapolate it using last two records of table.
-            return Interpolate(X, mData[u-1].first, mData[u-1].second[0], mData[u].first, mData[u].second[0]);
+            return ExtrapolateAboveHighest(X, mData[u-1].first, mData[u-1].second[0], mData[u].first, mData[u].second[0]);
         }
 
 
@@ -621,7 +621,19 @@ public:
         return Y1 + (X2 - X1 > 1.0e-12) * (Y2 - Y1)*(X - X1)/(X2 - X1);
 
     }
+    result_type ExtrapolateBelowLowest(argument_type const& X, argument_type const& X1, result_type const& Y1, argument_type const& X2, result_type const& Y2) const
+    {
+        // const double epsilon = 1e-12;
+        return Y1 - (X2 - X1 > 1.0e-12) * (Y2 - Y1)*(X1 - X)/(X2 - X1 + std::numeric_limits<double>::min());
 
+    }
+
+    result_type ExtrapolateAboveHighest(argument_type const& X, argument_type const& X1, result_type const& Y1, argument_type const& X2, result_type const& Y2) const
+    {
+        // const double epsilon = 1e-12;
+        return Y2 + (X2 - X1 > 1.0e-12) * (Y2 - Y1)*(X - X2)/(X2 - X1 + std::numeric_limits<double>::min());
+
+    }
     // inserts a row in a sorted position where Xi-1 < X < Xi+1 and fills the first column with Y
     void insert(argument_type const& X, result_type const& Y)
     {

--- a/kratos/includes/table.h
+++ b/kratos/includes/table.h
@@ -523,14 +523,19 @@ public:
     {
         int u = mData.size()-1; //using directly u for optimizing one allocation
         KRATOS_ERROR_IF(u == -1) << "Get value from empty table" << std::endl;
-        if(u==0) // constant table. Returning the only value we have.
+        if(u==0) {
+            // constant table. Returning the only value we have.
             return mData.begin()->second[0];
-        if(X <=  mData.begin()->first)
+        }
+        if(X <=  mData.begin()->first) {
             return Interpolate(X,  mData.begin()->first, mData.begin()->second[0], mData[1].first, mData[1].second[0]);
+        }
 
-        if(X >= mData[u].first)
+        if(X >= mData[u].first) {
             // now the x is outside the table and we hae to extrapolate it using last two records of table.
             return Interpolate(X, mData[u-1].first, mData[u-1].second[0], mData[u].first, mData[u].second[0]);
+        }
+
 
         // Now the value lies inside the table domain, we apply a binary search
         int l = 0;
@@ -658,12 +663,14 @@ public:
     {
         int u = mData.size()-1; //using directly u for optimizing one allocation
         KRATOS_ERROR_IF(u == -1) << "Get value from empty table" << std::endl;
-        if(X <=  mData.begin()->first)
+        if(X <=  mData.begin()->first){
             return InterpolateDerivative(mData.begin()->first, mData.begin()->second[0], mData[1].first, mData[1].second[0]);
+        }
 
-        if(X >= mData[u].first)
+        if(X >= mData[u].first){
             // now the x is outside the table and we hae to extrapolate it using last two records of table.
             return InterpolateDerivative(mData[u-1].first, mData[u-1].second[0], mData[u].first, mData[u].second[0]);
+        }
 
         // Now the value lies inside the table domain, we apply a binary search
         int l = 0;

--- a/kratos/python_scripts/run_cpp_tests.py
+++ b/kratos/python_scripts/run_cpp_tests.py
@@ -1,3 +1,12 @@
-from KratosMultiphysics import *
-Tester.SetVerbosity(Tester.Verbosity.TESTS_OUTPUTS)
-Tester.RunAllTestCases()
+import KratosMultiphysics as Kratos
+import sys
+def run():
+    if len(sys.argv) < 2:
+        Kratos.Tester.SetVerbosity(Kratos.Tester.Verbosity.TESTS_OUTPUTS)
+        Kratos.Tester.RunAllTestCases()
+    else :
+        Kratos.Tester.SetVerbosity(Kratos.Tester.Verbosity.TESTS_OUTPUTS)
+        Kratos.Tester.RunTestCases(sys.argv[1])
+
+if __name__ == '__main__':
+    run()

--- a/kratos/tests/cpp_tests/sources/test_table.cpp
+++ b/kratos/tests/cpp_tests/sources/test_table.cpp
@@ -25,16 +25,45 @@ namespace Kratos {
             Table<double> table;
             for (std::size_t i = 0; i < 6; ++i)
                 table.PushBack(static_cast<double>(i), 2.0 * static_cast<double>(i));
-            
+
             double nearest = (table.GetNearestRow(2.1))[0];
             KRATOS_CHECK_DOUBLE_EQUAL(nearest, 4.0);
             KRATOS_CHECK_DOUBLE_EQUAL(table.GetValue(2.1), 4.2);
             KRATOS_CHECK_DOUBLE_EQUAL(table(2.1), 4.2);
+            KRATOS_CHECK_DOUBLE_EQUAL(table(2.0), 4.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(table(1.0), 2.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(table(7.5), 15.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(table(-1.5), -3.0);
             KRATOS_CHECK_DOUBLE_EQUAL(table.GetDerivative(2.1), 2.0);
-
+            KRATOS_CHECK_DOUBLE_EQUAL(table.GetDerivative(1.0), 2.0);
             auto& r_data = table.Data();
             KRATOS_CHECK_EQUAL(r_data.size(), 6);
-            
+            // Clear database
+            table.Clear();
+            KRATOS_CHECK_EQUAL(r_data.size(), 0);
+
+            for (std::size_t i = 0; i < 6; ++i){
+                table.PushBack(static_cast<double>(i), 2.0 * static_cast<double>(i));
+                table.PushBack(static_cast<double>(i), 2.0 * static_cast<double>(i));
+            }
+            KRATOS_CHECK_DOUBLE_EQUAL(table(2.1), 4.2);
+            KRATOS_CHECK_DOUBLE_EQUAL(table(2.0), 4.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(table(5.0), 10.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(table(7.5), 10.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(table(-1.5), 0.0);
+            // Clear database
+            table.Clear();
+            KRATOS_CHECK_EQUAL(r_data.size(), 0);
+
+            for (std::size_t i = 0; i < 6; ++i){
+                table.PushBack(static_cast<double>(i), 2.0 * static_cast<double>(i));
+                table.PushBack(static_cast<double>(i), 2.0 * static_cast<double>(i)+1.0);
+            }
+            KRATOS_CHECK_DOUBLE_EQUAL(table(2.1), 5.1);
+            KRATOS_CHECK_DOUBLE_EQUAL(table(2.0), 5.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(table(5.0), 11.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(table(7.5), 11.0);
+            KRATOS_CHECK_DOUBLE_EQUAL(table(-1.5), 0.0);
             // Clear database
             table.Clear();
             KRATOS_CHECK_EQUAL(r_data.size(), 0);
@@ -42,9 +71,7 @@ namespace Kratos {
             // Inverse filling with insert
             for (std::size_t i = 6; i > 0; --i)
                 table.insert(static_cast<double>(i), 2.0 * static_cast<double>(i));
-            
             KRATOS_CHECK_EQUAL(r_data.size(), 6);
-            
             nearest = (table.GetNearestRow(2.1))[0];
             KRATOS_CHECK_DOUBLE_EQUAL(nearest, 4.0);
             KRATOS_CHECK_DOUBLE_EQUAL(table.GetValue(2.1), 4.2);


### PR DESCRIPTION
We realized that on some of our calculations accessing the table values was one of the main bottlenecks. This PR tries to smoothen them by:

1. Firs checks if the value is out of bounds, so for the search it is inside the table range.
2.  Improving the lower and upper values search for the interpolation adding a binary search. Includes some tricks for trying to improve performance.
3. Improve the Interpolation calculation to improve performance, now it is formulated without if's.
4. Fix a bug I noticed when computing derivatives.
