### PR TITLE
[HDF5] Allow conditional model part write for multiple_mesh_temporal_output process

### DIFF
--- a/applications/HDF5Application/custom_io/hdf5_model_part_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_model_part_io.cpp
@@ -52,7 +52,18 @@ int GlobalNumberOfConditions(ModelPart const& rModelPart)
 }
 
 ModelPartIO::ModelPartIO(File::Pointer pFile, std::string const& rPrefix)
-: mpFile(pFile), mPrefix(rPrefix)
+    : mpFile(pFile),
+      mPrefix(rPrefix),
+      mIsUpdateMeshIndicationFlagUsed(false),
+      mUpdateMeshIndicationFlag(MODIFIED)
+{
+}
+
+ModelPartIO::ModelPartIO(File::Pointer pFile, std::string const& rPrefix, const bool IsUpdateMeshIndicationFlagUsed, const Flags& rUpdatedMeshIndicationFlag)
+    : mpFile(pFile),
+      mPrefix(rPrefix),
+      mIsUpdateMeshIndicationFlagUsed(IsUpdateMeshIndicationFlagUsed),
+      mUpdateMeshIndicationFlag(rUpdatedMeshIndicationFlag)
 {
 }
 
@@ -191,6 +202,12 @@ void ModelPartIO::WriteConditions(ConditionsContainerType const& rConditions)
 void ModelPartIO::WriteModelPart(ModelPart& rModelPart)
 {
     KRATOS_TRY;
+
+    if (mIsUpdateMeshIndicationFlagUsed) {
+        if (!rModelPart.Is(mUpdateMeshIndicationFlag)) {
+            return;
+        }
+    }
 
     BuiltinTimer timer;
     Internals::WriteVariablesList(*mpFile, mPrefix, rModelPart);

--- a/applications/HDF5Application/custom_io/hdf5_model_part_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_model_part_io.cpp
@@ -54,16 +54,16 @@ int GlobalNumberOfConditions(ModelPart const& rModelPart)
 ModelPartIO::ModelPartIO(File::Pointer pFile, std::string const& rPrefix)
     : mpFile(pFile),
       mPrefix(rPrefix),
-      mIsUpdateMeshIndicationFlagUsed(false),
-      mUpdateMeshIndicationFlag(MODIFIED)
+      mIsUpdatedMeshIndicationFlagUsed(false),
+      mUpdatedMeshIndicationFlag(MODIFIED)
 {
 }
 
-ModelPartIO::ModelPartIO(File::Pointer pFile, std::string const& rPrefix, const bool IsUpdateMeshIndicationFlagUsed, const Flags& rUpdatedMeshIndicationFlag)
+ModelPartIO::ModelPartIO(File::Pointer pFile, std::string const& rPrefix, const bool IsUpdatedMeshIndicationFlagUsed, const Flags& rUpdatedMeshIndicationFlag)
     : mpFile(pFile),
       mPrefix(rPrefix),
-      mIsUpdateMeshIndicationFlagUsed(IsUpdateMeshIndicationFlagUsed),
-      mUpdateMeshIndicationFlag(rUpdatedMeshIndicationFlag)
+      mIsUpdatedMeshIndicationFlagUsed(IsUpdatedMeshIndicationFlagUsed),
+      mUpdatedMeshIndicationFlag(rUpdatedMeshIndicationFlag)
 {
 }
 
@@ -203,8 +203,8 @@ void ModelPartIO::WriteModelPart(ModelPart& rModelPart)
 {
     KRATOS_TRY;
 
-    if (mIsUpdateMeshIndicationFlagUsed) {
-        if (!rModelPart.Is(mUpdateMeshIndicationFlag)) {
+    if (mIsUpdatedMeshIndicationFlagUsed) {
+        if (!rModelPart.Is(mUpdatedMeshIndicationFlag)) {
             return;
         }
     }

--- a/applications/HDF5Application/custom_io/hdf5_model_part_io.h
+++ b/applications/HDF5Application/custom_io/hdf5_model_part_io.h
@@ -53,7 +53,7 @@ public:
     /// Constructor.
     ModelPartIO(File::Pointer pFile, std::string const& rPrefix);
 
-    ModelPartIO(File::Pointer pFile, std::string const& rPrefix, const bool IsUpdateMeshIndicationFlagUsed, const Flags& rUpdatedMeshIndicationFlag);
+    ModelPartIO(File::Pointer pFile, std::string const& rPrefix, const bool IsUpdatedMeshIndicationFlagUsed, const Flags& rUpdatedMeshIndicationFlag);
 
     ///@}
     ///@name Operations
@@ -103,8 +103,8 @@ protected:
     File::Pointer mpFile;
     const std::string mPrefix;
 
-    const bool mIsUpdateMeshIndicationFlagUsed;
-    const Flags& mUpdateMeshIndicationFlag;
+    const bool mIsUpdatedMeshIndicationFlagUsed;
+    const Flags& mUpdatedMeshIndicationFlag;
 
     ///@}
 

--- a/applications/HDF5Application/custom_io/hdf5_model_part_io.h
+++ b/applications/HDF5Application/custom_io/hdf5_model_part_io.h
@@ -53,6 +53,8 @@ public:
     /// Constructor.
     ModelPartIO(File::Pointer pFile, std::string const& rPrefix);
 
+    ModelPartIO(File::Pointer pFile, std::string const& rPrefix, const bool IsUpdateMeshIndicationFlagUsed, const Flags& rUpdatedMeshIndicationFlag);
+
     ///@}
     ///@name Operations
     ///@{
@@ -100,6 +102,9 @@ protected:
 
     File::Pointer mpFile;
     const std::string mPrefix;
+
+    const bool mIsUpdateMeshIndicationFlagUsed;
+    const Flags& mUpdateMeshIndicationFlag;
 
     ///@}
 

--- a/applications/HDF5Application/custom_io/hdf5_partitioned_model_part_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_partitioned_model_part_io.cpp
@@ -20,6 +20,16 @@ PartitionedModelPartIO::PartitionedModelPartIO(File::Pointer pFile, std::string 
     KRATOS_CATCH("");
 }
 
+PartitionedModelPartIO::PartitionedModelPartIO(File::Pointer pFile, std::string const& rPrefix, const bool IsUpdatedMeshIndicationFlagUsed, const Flags& rUpdatedMeshIndicationFlag)
+: ModelPartIO(pFile, rPrefix, IsUpdatedMeshIndicationFlagUsed, rUpdatedMeshIndicationFlag)
+{
+    KRATOS_TRY;
+
+    Check();
+
+    KRATOS_CATCH("");
+}
+
 bool PartitionedModelPartIO::ReadNodes(NodesContainerType& rNodes)
 {
     KRATOS_TRY;

--- a/applications/HDF5Application/custom_io/hdf5_partitioned_model_part_io.h
+++ b/applications/HDF5Application/custom_io/hdf5_partitioned_model_part_io.h
@@ -52,6 +52,8 @@ public:
     /// Constructor.
     PartitionedModelPartIO(File::Pointer pFile, std::string const& rPrefix);
 
+    PartitionedModelPartIO(File::Pointer pFile, std::string const& rPrefix, const bool IsUpdatedMeshIndicationFlagUsed, const Flags& rUpdatedMeshIndicationFlag);
+
     ///@}
     ///@name Operations
     ///@{
@@ -70,7 +72,7 @@ protected:
     void Check();
 
     std::tuple<unsigned, unsigned> StartIndexAndBlockSize(std::string const& rPath) const override;
-    
+
     void StoreWriteInfo(std::string const& rPath, WriteInfo const& rInfo) override;
 
     ///@}

--- a/applications/HDF5Application/custom_python/add_custom_io_to_python.cpp
+++ b/applications/HDF5Application/custom_python/add_custom_io_to_python.cpp
@@ -75,6 +75,7 @@ void AddCustomIOToPython(pybind11::module& m)
 
     py::class_<HDF5::ModelPartIO, HDF5::ModelPartIO::Pointer, IO>(m,"HDF5ModelPartIO")
         .def(py::init<HDF5::File::Pointer, std::string const&>())
+        .def(py::init<HDF5::File::Pointer, std::string const&, const bool, const Flags&>())
         ;
 
     py::class_<HDF5::NodalSolutionStepDataIO, HDF5::NodalSolutionStepDataIO::Pointer>(

--- a/applications/HDF5Application/custom_python/add_custom_io_to_python.cpp
+++ b/applications/HDF5Application/custom_python/add_custom_io_to_python.cpp
@@ -155,6 +155,7 @@ void AddCustomIOToPython(pybind11::module& m)
     py::class_<HDF5::PartitionedModelPartIO, HDF5::PartitionedModelPartIO::Pointer, HDF5::ModelPartIO>
         (m,"HDF5PartitionedModelPartIO")
         .def(py::init<HDF5::File::Pointer, std::string const&>())
+        .def(py::init<HDF5::File::Pointer, std::string const&, const bool, const Flags&>())
         ;
 #endif
 

--- a/applications/HDF5Application/python_scripts/core/operations/model_part.py
+++ b/applications/HDF5Application/python_scripts/core/operations/model_part.py
@@ -52,7 +52,13 @@ class ModelPartOutput:
 
     def __init__(self, settings):
         settings.SetDefault('prefix', '/ModelData')
+        settings.SetDefault('is_updated_mesh_indication_flag_used', False)
+        settings.SetDefault('updated_mesh_indication_flag_name', 'MODIFIED')
+
         self.prefix = settings['prefix']
+        self.is_updated_mesh_indication_flag_used = settings['is_updated_mesh_indication_flag_used']
+        updated_mesh_indication_flag_name = settings['updated_mesh_indication_flag_name']
+        self.updated_mesh_indication_flag = KratosMultiphysics.KratosGlobals.GetFlag(updated_mesh_indication_flag_name)
         if '<time>' in self.prefix:
             settings.SetDefault('time_format', '0.4f')
             self.time_format = settings['time_format']
@@ -63,7 +69,7 @@ class ModelPartOutput:
         else:
             prefix = Prefix(self.prefix, model_part)
         KratosHDF5.HDF5ModelPartIO(
-            hdf5_file, prefix).WriteModelPart(model_part)
+            hdf5_file, prefix, self.is_updated_mesh_indication_flag_used, self.updated_mesh_indication_flag).WriteModelPart(model_part)
 
 
 class PartitionedModelPartOutput:
@@ -71,7 +77,13 @@ class PartitionedModelPartOutput:
 
     def __init__(self, settings):
         settings.SetDefault('prefix', '/ModelData')
+        settings.SetDefault('is_updated_mesh_indication_flag_used', False)
+        settings.SetDefault('updated_mesh_indication_flag_name', 'MODIFIED')
+
         self.prefix = settings['prefix']
+        self.is_updated_mesh_indication_flag_used = settings['is_updated_mesh_indication_flag_used']
+        updated_mesh_indication_flag_name = settings['updated_mesh_indication_flag_name']
+        self.updated_mesh_indication_flag = KratosMultiphysics.KratosGlobals.GetFlag(updated_mesh_indication_flag_name)
         if '<time>' in self.prefix:
             settings.SetDefault('time_format', '0.4f')
             self.time_format = settings['time_format']
@@ -82,7 +94,7 @@ class PartitionedModelPartOutput:
         else:
             prefix = Prefix(self.prefix, model_part)
         KratosHDF5.HDF5PartitionedModelPartIO(
-            hdf5_file, prefix).WriteModelPart(model_part)
+            hdf5_file, prefix, self.is_updated_mesh_indication_flag_used, self.updated_mesh_indication_flag).WriteModelPart(model_part)
 
 
 class VariableIO:

--- a/applications/HDF5Application/python_scripts/multiple_mesh_temporal_output_process.py
+++ b/applications/HDF5Application/python_scripts/multiple_mesh_temporal_output_process.py
@@ -24,49 +24,51 @@ def Factory(settings, Model):
     """Return a process for multiple mesh temporal output with HDF5.
 
     The input settings are given in the following table:
-    +---------------------------------------------+------------+---------------------------------+
-    | Setting                                     | Type       | Default Value                   |
-    +---------------------------------------------+------------+---------------------------------+
-    | "model_part_name"                           | String     | ""                              |
-    +---------------------------------------------+------------+---------------------------------+
-    | "file_settings"                             | Parameters | "file_name": "<model_part_name>"|
-    |                                             |            | "time_format": "0.4f"           |
-    |                                             |            | "file_access_mode": "exclusive" |
-    |                                             |            | "max_files_to_keep": "unlimited"|
-    |                                             |            | "echo_level":  0                |
-    +---------------------------------------------+------------+---------------------------------+
-    | "output_time_settings"                      | Parameters | "time_frequency": 1.0           |
-    |                                             |            | "step_frequency": 1             |
-    +---------------------------------------------+------------+---------------------------------+
-    | "model_part_output_settings"                | Parameters | "prefix": "/ModelData"          |
-    +---------------------------------------------+------------+---------------------------------+
-    | "nodal_solution_step_data_settings"         | Parameters | "prefix": "/ResultsData"        |
-    |                                             |            | "list_of_variables": []         |
-    +---------------------------------------------+------------+---------------------------------+
-    | "nodal_data_value_settings"                 | Parameters | "prefix": "/ResultsData"        |
-    |                                             |            | "list_of_variables": []         |
-    +---------------------------------------------+------------+---------------------------------+
-    | "element_data_value_settings"               | Parameters | "prefix": "/ResultsData"        |
-    |                                             |            | "list_of_variables": []         |
-    +---------------------------------------------+------------+---------------------------------+
-    | "nodal_flag_value_settings"                 | Parameters | "prefix": "/ResultsData"        |
-    |                                             |            | "list_of_variables": []         |
-    +---------------------------------------------+------------+---------------------------------+
-    | "element_flag_value_settings"               | Parameters | "prefix": "/ResultsData"        |
-    |                                             |            | "list_of_variables": []         |
-    +---------------------------------------------+------------+---------------------------------+
-    | "element_gauss_point_value_settings"        | Parameters | "prefix": "/ResultsData"        |
-    |                                             |            | "list_of_variables": []         |
-    +---------------------------------------------+------------+---------------------------------+
-    | "condition_flag_value_settings"             | Parameters | "prefix": "/ResultsData"        |
-    |                                             |            | "list_of_variables": []         |
-    +---------------------------------------------+------------+---------------------------------+
-    | "condition_data_value_settings"             | Parameters | "prefix": "/ResultsData"        |
-    |                                             |            | "list_of_variables": []         |
-    +---------------------------------------------+------------+---------------------------------+
-    | "condition_gauss_point_value_settings"      | Parameters | "prefix": "/ResultsData"        |
-    |                                             |            | "list_of_variables": []         |
-    +---------------------------------------------+------------+---------------------------------+
+    +---------------------------------------------+------------+---------------------------------------------------+
+    | Setting                                     | Type       | Default Value                                     |
+    +---------------------------------------------+------------+---------------------------------------------------+
+    | "model_part_name"                           | String     | ""                                                |
+    +---------------------------------------------+------------+---------------------------------------------------+
+    | "file_settings"                             | Parameters | "file_name": "<model_part_name>"                  |
+    |                                             |            | "time_format": "0.4f"                             |
+    |                                             |            | "file_access_mode": "exclusive"                   |
+    |                                             |            | "max_files_to_keep": "unlimited"                  |
+    |                                             |            | "echo_level":  0                                  |
+    +---------------------------------------------+------------+---------------------------------------------------+
+    | "output_time_settings"                      | Parameters | "time_frequency": 1.0                             |
+    |                                             |            | "step_frequency": 1                               |
+    +---------------------------------------------+------------+---------------------------------------------------+
+    | "model_part_output_settings"                | Parameters | "prefix": "/ModelData"                            |
+    |                                             |            | "is_updated_mesh_indication_flag_used": false     |
+    |                                             |            | "updated_mesh_indication_flag_name"   : "MODIFIED"|
+    +---------------------------------------------+------------+---------------------------------------------------+
+    | "nodal_solution_step_data_settings"         | Parameters | "prefix": "/ResultsData"                          |
+    |                                             |            | "list_of_variables": []                           |
+    +---------------------------------------------+------------+---------------------------------------------------+
+    | "nodal_data_value_settings"                 | Parameters | "prefix": "/ResultsData"                          |
+    |                                             |            | "list_of_variables": []                           |
+    +---------------------------------------------+------------+---------------------------------------------------+
+    | "element_data_value_settings"               | Parameters | "prefix": "/ResultsData"                          |
+    |                                             |            | "list_of_variables": []                           |
+    +---------------------------------------------+------------+---------------------------------------------------+
+    | "nodal_flag_value_settings"                 | Parameters | "prefix": "/ResultsData"                          |
+    |                                             |            | "list_of_variables": []                           |
+    +---------------------------------------------+------------+---------------------------------------------------+
+    | "element_flag_value_settings"               | Parameters | "prefix": "/ResultsData"                          |
+    |                                             |            | "list_of_variables": []                           |
+    +---------------------------------------------+------------+---------------------------------------------------+
+    | "element_gauss_point_value_settings"        | Parameters | "prefix": "/ResultsData"                          |
+    |                                             |            | "list_of_variables": []                           |
+    +---------------------------------------------+------------+---------------------------------------------------+
+    | "condition_flag_value_settings"             | Parameters | "prefix": "/ResultsData"                          |
+    |                                             |            | "list_of_variables": []                           |
+    +---------------------------------------------+------------+---------------------------------------------------+
+    | "condition_data_value_settings"             | Parameters | "prefix": "/ResultsData"                          |
+    |                                             |            | "list_of_variables": []                           |
+    +---------------------------------------------+------------+---------------------------------------------------+
+    | "condition_gauss_point_value_settings"      | Parameters | "prefix": "/ResultsData"                          |
+    |                                             |            | "list_of_variables": []                           |
+    +---------------------------------------------+------------+---------------------------------------------------+
     """
     core_settings = CreateCoreSettings(settings["Parameters"], Model)
     return MultipleMeshTemporalOutputProcessFactory(core_settings, Model)

--- a/applications/HDF5Application/tests/test_hdf5_core.py
+++ b/applications/HDF5Application/tests/test_hdf5_core.py
@@ -304,7 +304,9 @@ class TestOperations(KratosUnittest.TestCase):
         settings = variable_io.GetSettings(_SurrogateModelPart())
         self.assertEqual(settings['prefix'], '/ModelData/model_part/1.23')
 
-    def test_ModelPartOutput(self):
+    @patch("KratosMultiphysics.kratos_globals.KratosGlobalsImpl.GetFlag", autospec=True)
+    def test_ModelPartOutput(self, mock_get_flag):
+        mock_get_flag.return_value = "MODIFIED"
         settings = ParametersWrapper()
         model_part_output = operations.Create(settings)
         self.assertTrue(settings.Has('operation_type'))
@@ -315,7 +317,7 @@ class TestOperations(KratosUnittest.TestCase):
             model_part = _SurrogateModelPart()
             hdf5_file = MagicMock(spec=KratosHDF5.HDF5FileSerial)
             model_part_output(model_part, hdf5_file)
-            p.assert_called_once_with(hdf5_file, '/ModelData')
+            p.assert_called_once_with(hdf5_file, '/ModelData', False, "MODIFIED")
             model_part_io.WriteModelPart.assert_called_once_with(model_part)
 
     def test_ModelPartOutput_NonTerminalPrefix(self):

--- a/applications/HDF5Application/tests/test_hdf5_model_part_io.cpp
+++ b/applications/HDF5Application/tests/test_hdf5_model_part_io.cpp
@@ -129,6 +129,27 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5_ModelPartIO_ReadConditions3, KratosHDF5TestSuite)
     model_part_io.ReadConditions(r_read_model_part.Nodes(), r_read_model_part.rProperties(), r_read_model_part.Conditions());
 }
 
+KRATOS_TEST_CASE_IN_SUITE(HDF5_ModelPartIO_ConditionalWriteModelPart, KratosHDF5TestSuite)
+{
+    Model this_model;
+    ModelPart& r_write_model_part = this_model.CreateModelPart("test_write");
+    ModelPart& r_read_model_part = this_model.CreateModelPart("test_read");
+
+    TestModelPartFactory::CreateModelPart(r_write_model_part, {}, {});
+    HDF5::ModelPartIO model_part_io(pGetTestSerialFile(), "/Step", true, MODIFIED);
+
+    model_part_io.WriteModelPart(r_write_model_part);
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(model_part_io.ReadModelPart(r_read_model_part), "H5Aexists_by_name failed.");
+
+    r_write_model_part.Set(MODIFIED, true);
+    model_part_io.WriteModelPart(r_write_model_part);
+    model_part_io.ReadModelPart(r_read_model_part);
+
+    KRATOS_CHECK_EQUAL(r_write_model_part.NumberOfNodes(), r_read_model_part.NumberOfNodes());
+    KRATOS_CHECK_EQUAL(r_write_model_part.NumberOfElements(), r_read_model_part.NumberOfElements());
+    KRATOS_CHECK_EQUAL(r_write_model_part.NumberOfConditions(), r_read_model_part.NumberOfConditions());
+}
+
 KRATOS_TEST_CASE_IN_SUITE(HDF5_ModelPartIO_Properties1, KratosHDF5TestSuite)
 {
     Model this_model;

--- a/applications/HDF5Application/tests/test_hdf5_processes.py
+++ b/applications/HDF5Application/tests/test_hdf5_processes.py
@@ -41,6 +41,8 @@ class TestHDF5Processes(KratosUnittest.TestCase):
             'KratosMultiphysics.HDF5Application.core.operations.KratosHDF5.HDF5ElementGaussPointOutput', autospec=True)
         self.patcher12 = patch(
             'KratosMultiphysics.HDF5Application.core.operations.KratosHDF5.HDF5ConditionGaussPointOutput', autospec=True)
+        self.patcher13 = patch(
+            "KratosMultiphysics.kratos_globals.KratosGlobalsImpl.GetFlag", autospec=True)
         self.HDF5FileSerial = self.patcher1.start()
         self.HDF5ModelPartIO = self.patcher2.start()
         self.HDF5NodalSolutionStepDataIO = self.patcher3.start()
@@ -55,6 +57,8 @@ class TestHDF5Processes(KratosUnittest.TestCase):
         self.HDF5ConditionDataValueIO = self.patcher10.start()
         self.HDF5ElementGaussPointOutput = self.patcher11.start()
         self.HDF5ConditionGaussPointOutput = self.patcher12.start()
+        self.GetFlag = self.patcher13.start()
+        self.GetFlag.return_value = "MODIFIED"
 
     def tearDown(self):
         self.patcher1.stop()
@@ -69,6 +73,7 @@ class TestHDF5Processes(KratosUnittest.TestCase):
         self.patcher10.stop()
         self.patcher11.stop()
         self.patcher12.stop()
+        self.patcher13.stop()
 
     def test_SingleMeshTemporalOutputProcess(self):
         settings = KratosMultiphysics.Parameters('''
@@ -132,7 +137,7 @@ class TestHDF5Processes(KratosUnittest.TestCase):
         self.assertEqual(
             self.HDF5FileSerial.call_args[0][0]['echo_level'].GetInt(), 1)
         self.HDF5ModelPartIO.assert_called_once_with(
-            self.HDF5FileSerial.return_value, '/ModelData/test_model_part')
+            self.HDF5FileSerial.return_value, '/ModelData/test_model_part', False, "MODIFIED")
         self.HDF5ModelPartIO.return_value.WriteModelPart.assert_called_once_with(
             self.model_part)
         self.assertEqual(self.HDF5NodalSolutionStepDataIO.call_count, 2)
@@ -257,7 +262,7 @@ class TestHDF5Processes(KratosUnittest.TestCase):
             self.HDF5FileSerial.call_args[0][0]['echo_level'].GetInt(), 0)
         self.assertEqual(self.HDF5ModelPartIO.call_count, 3)
         self.HDF5ModelPartIO.assert_called_with(
-            self.HDF5FileSerial.return_value, '/ModelData')
+            self.HDF5FileSerial.return_value, '/ModelData', False, "MODIFIED")
         self.assertEqual(
             self.HDF5ModelPartIO.return_value.WriteModelPart.call_count, 3)
         self.HDF5ModelPartIO.return_value.WriteModelPart.assert_called_with(

--- a/applications/HDF5Application/tests/test_hdf5_xdmf.py
+++ b/applications/HDF5Application/tests/test_hdf5_xdmf.py
@@ -260,14 +260,14 @@ class TestFindMatchingFiles(KratosUnittest.TestCase):
 class TestCreateXdmfTemporalGridFromMultifile(KratosUnittest.TestCase):
 
     def setUp(self):
-        with h5py.File("kratos.h5") as f0:
+        with h5py.File("kratos.h5", "w") as f0:
             f0.create_dataset(
             "/ModelPart/Nodes/Local/Coordinates", (15, 3), "float64")
             elem2d4n = f0.create_group("/ModelPart/Xdmf/Elements/Element2D4N")
             elem2d4n.attrs["Dimension"] = 2
             elem2d4n.attrs["NumberOfNodes"] = 4
             elem2d4n.create_dataset("Connectivities", (10, 4), "int32")
-        with h5py.File("kratos-1.0.h5") as f1:
+        with h5py.File("kratos-1.0.h5", "w") as f1:
             f1.create_dataset(
             "/Results/NodalSolutionStepData/VELOCITY", (15, 3), "float64")
 


### PR DESCRIPTION
**📝 Description**
This PR allows to have conditional model part output when `HDF5::ModelPartIO::WriteModelPart` is called. A single `Flag` is passed at the constructor which is checked whenever `HDF5::ModelPartIO::WriteModelPart`. A new constructor is made to provide information about flag to the hdf5 model part writer. This is very usefull in the cases where adaptive mesh refinement is used in transient simulations. So `MODIFIED` flag from `mmg` can be used to identify when to write model part information when adaptive mesh refinement is carried out, then HDF5 writes the model info.

**This does not change existing behaviour**

**🆕 Changelog**
- Added conditional support to write model parts in hdf5
- Added proper tests
- Changes existing ones to support the new interface
