### PR TITLE
Local dimension of interface2D4N must be 2

### DIFF
--- a/kratos/geometries/hexahedra_interface_3d_8.h
+++ b/kratos/geometries/hexahedra_interface_3d_8.h
@@ -1838,7 +1838,7 @@ GeometryData HexahedraInterface3D8<TPointType>::msGeometryData(
 
 template<class TPointType>
 const GeometryDimension HexahedraInterface3D8<TPointType>::msGeometryDimension(
-    3, 3, 2);
+    3, 3, 3);
 
 }// namespace Kratos.
 

--- a/kratos/geometries/prism_interface_3d_6.h
+++ b/kratos/geometries/prism_interface_3d_6.h
@@ -1556,7 +1556,7 @@ GeometryData PrismInterface3D6<TPointType>::msGeometryData(
 
 template<class TPointType> const
 GeometryDimension PrismInterface3D6<TPointType>::msGeometryDimension(
-    3, 3, 2);
+    3, 3, 3);
 
 }// namespace Kratos.
 

--- a/kratos/geometries/quadrilateral_interface_2d_4.h
+++ b/kratos/geometries/quadrilateral_interface_2d_4.h
@@ -1388,7 +1388,7 @@ GeometryData QuadrilateralInterface2D4<TPointType>::msGeometryData(
 
 template<class TPointType>
 const GeometryDimension QuadrilateralInterface2D4<TPointType>::msGeometryDimension(
-    2, 2, 1);
+    2, 2, 2);
 
 }// namespace Kratos.
 


### PR DESCRIPTION
**📝 Description**
Local dimension of interface2D4N should be 2 in order to get correct edge numbers. If this is one, `GenerateBoundariesEntities()` returns point numbers which is not correct. Please check https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/geometries/geometry.h#L1998


