### PR TITLE
bug in finding neighbour elements when more than one condition is applied to an element

### DIFF
--- a/applications/GeoMechanicsApplication/custom_processes/find_neighbour_elements_of_conditions_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/find_neighbour_elements_of_conditions_process.cpp
@@ -118,17 +118,20 @@ void FindNeighbourElementsOfConditionsProcess::Execute()
 
             if (itFace != FacesMap.end()) {
                 // condition is found!
-                // Mark the condition as visited. This will be useful for a check at the endif
-                std::vector<Condition::Pointer>& ListConditions = itFace->second;
-                for (Condition::Pointer pCondition : ListConditions) {
-                    pCondition->Set(VISITED,true);
-                }
+                // but check if there are more than one condition on the element
+                std::pair <hashmap::iterator, hashmap::iterator> ret;
+                ret = FacesMap.equal_range(FaceIds);
+                for (hashmap::iterator it=ret.first; it!=ret.second; ++it) {
+                    std::vector<Condition::Pointer>& ListConditions = it->second;
 
-                GlobalPointersVector< Element > VectorOfNeighbours;
-                VectorOfNeighbours.resize(1);
-                VectorOfNeighbours(0) = Element::WeakPointer( *itElem.base() );
-                for (Condition::Pointer pCondition : ListConditions) {
-                    pCondition->SetValue(NEIGHBOUR_ELEMENTS, VectorOfNeighbours);
+                    GlobalPointersVector< Element > VectorOfNeighbours;
+                    VectorOfNeighbours.resize(1);
+                    VectorOfNeighbours(0) = Element::WeakPointer( *itElem.base() );
+
+                    for (Condition::Pointer pCondition : ListConditions) {
+                        pCondition->Set(VISITED,true);
+                        pCondition->SetValue(NEIGHBOUR_ELEMENTS, VectorOfNeighbours);
+                    }
                 }
             }
         }
@@ -159,18 +162,21 @@ void FindNeighbourElementsOfConditionsProcess::Execute()
 
                 hashmap::iterator itFace = FacesMap.find(PointIds);
                 if (itFace != FacesMap.end()) {
-                    // Condition is found!
-                    // Mark the condition as visited. This will be useful for a check at the endif
-                    std::vector<Condition::Pointer>& ListConditions = itFace->second;
-                    for (Condition::Pointer pCondition : ListConditions) {
-                        pCondition->Set(VISITED,true);
-                    }
+                    // condition is found!
+                    // but check if there are more than one condition on the element
+                    std::pair <hashmap::iterator, hashmap::iterator> ret;
+                    ret = FacesMap.equal_range(PointIds);
+                    for (hashmap::iterator it=ret.first; it!=ret.second; ++it) {
+                        std::vector<Condition::Pointer>& ListConditions = it->second;
 
-                    GlobalPointersVector< Element > VectorOfNeighbours;
-                    VectorOfNeighbours.resize(1);
-                    VectorOfNeighbours(0) = Element::WeakPointer( *itElem.base() );
-                    for (Condition::Pointer pCondition : ListConditions) {
-                        pCondition->SetValue(NEIGHBOUR_ELEMENTS, VectorOfNeighbours);
+                        GlobalPointersVector< Element > VectorOfNeighbours;
+                        VectorOfNeighbours.resize(1);
+                        VectorOfNeighbours(0) = Element::WeakPointer( *itElem.base() );
+
+                        for (Condition::Pointer pCondition : ListConditions) {
+                            pCondition->Set(VISITED,true);
+                            pCondition->SetValue(NEIGHBOUR_ELEMENTS, VectorOfNeighbours);
+                        }
                     }
                 }
             }

--- a/applications/GeoMechanicsApplication/custom_processes/find_neighbour_elements_of_conditions_process.hpp
+++ b/applications/GeoMechanicsApplication/custom_processes/find_neighbour_elements_of_conditions_process.hpp
@@ -28,7 +28,7 @@ namespace Kratos
 {
 ///@name Type Definitions
 ///@{
-    typedef std::unordered_map<DenseVector<int>, std::vector<Condition::Pointer>, KeyHasherRange<DenseVector<int>>, KeyComparorRange<DenseVector<int>> > hashmap;
+    typedef std::unordered_multimap<DenseVector<int>, std::vector<Condition::Pointer>, KeyHasherRange<DenseVector<int>>, KeyComparorRange<DenseVector<int>> > hashmap;
 
 ///@}
 ///@name Kratos Classes


### PR DESCRIPTION
**📝 Description**
When more than one condition is applied to an element, find_neighbour_elements_of_conditions_process couldn't find all conditions.

