### PR TITLE
Seepage head boundary conditions

### DIFF
--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_hydrostatic_pressure_process.hpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_hydrostatic_pressure_process.hpp
@@ -45,6 +45,7 @@ public:
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "is_fixed": false,
+                "is_seepage" : false,
                 "gravity_direction" : 2,
                 "reference_coordinate" : 0.0,
                 "specific_weight" : 10000.0,
@@ -62,7 +63,8 @@ public:
         rParameters.ValidateAndAssignDefaults(default_parameters);
 
         mVariableName = rParameters["variable_name"].GetString();
-        mIsFixed = rParameters["is_fixed"].GetBool();
+        mIsFixed  = rParameters["is_fixed"].GetBool();
+        mIsSeepage= rParameters["is_seepage"].GetBool();
         mGravityDirection = rParameters["gravity_direction"].GetInt();
         mReferenceCoordinate = rParameters["reference_coordinate"].GetDouble();
         mSpecificWeight = rParameters["specific_weight"].GetDouble();
@@ -96,18 +98,34 @@ public:
         if (mrModelPart.NumberOfNodes() > 0) {
             const Variable<double> &var = KratosComponents< Variable<double> >::Get(mVariableName);
 
-            block_for_each(mrModelPart.Nodes(), [&var, this](Node<3>& rNode) {
-                if (mIsFixed) rNode.Fix(var);
-                else          rNode.Free(var);
+            if (mIsSeepage) {
+                block_for_each(mrModelPart.Nodes(), [&var, this](Node<3>& rNode) {
 
-                const double pressure = - PORE_PRESSURE_SIGN_FACTOR * mSpecificWeight*( mReferenceCoordinate - rNode.Coordinates()[mGravityDirection] );
+                    const double pressure = - PORE_PRESSURE_SIGN_FACTOR * mSpecificWeight*( mReferenceCoordinate - rNode.Coordinates()[mGravityDirection] );
 
-                if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < mPressureTensionCutOff) {
-                    rNode.FastGetSolutionStepValue(var) = pressure;
-                } else {
-                    rNode.FastGetSolutionStepValue(var) = mPressureTensionCutOff;
-                }
-            });
+                    if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < 0.0) {
+                        rNode.FastGetSolutionStepValue(var) = pressure;
+                        if (mIsFixed) rNode.Fix(var);
+                    } else {
+                        rNode.FastGetSolutionStepValue(var) = mPressureTensionCutOff;
+                        rNode.Free(var);
+                    }
+                });
+            } else {
+                block_for_each(mrModelPart.Nodes(), [&var, this](Node<3>& rNode) {
+                    if (mIsFixed) rNode.Fix(var);
+                    else          rNode.Free(var);
+
+                    const double pressure = - PORE_PRESSURE_SIGN_FACTOR * mSpecificWeight*( mReferenceCoordinate - rNode.Coordinates()[mGravityDirection] );
+
+                    if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < mPressureTensionCutOff) {
+                        rNode.FastGetSolutionStepValue(var) = pressure;
+                    } else {
+                        rNode.FastGetSolutionStepValue(var) = mPressureTensionCutOff;
+                    }
+                });
+            }
+
         }
 
         KRATOS_CATCH("")
@@ -139,6 +157,7 @@ protected:
     ModelPart& mrModelPart;
     std::string mVariableName;
     bool mIsFixed;
+    bool mIsSeepage;
     unsigned int mGravityDirection;
     double mReferenceCoordinate;
     double mSpecificWeight;

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_line_pressure_process.hpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_line_pressure_process.hpp
@@ -45,6 +45,7 @@ public:
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "is_fixed": false,
+                "is_seepage": false,
                 "gravity_direction": 1,
                 "out_of_plane_direction": 2,
                 "first_reference_coordinate":           [0.0,1.0,0.0],
@@ -66,6 +67,7 @@ public:
 
         mVariableName = rParameters["variable_name"].GetString();
         mIsFixed = rParameters["is_fixed"].GetBool();
+        mIsSeepage = rParameters["is_seepage"].GetBool();
         mGravityDirection = rParameters["gravity_direction"].GetInt();
         mOutOfPlaneDirection = rParameters["out_of_plane_direction"].GetInt();
         if (mGravityDirection == mOutOfPlaneDirection)
@@ -123,31 +125,30 @@ public:
         if (mrModelPart.NumberOfNodes() > 0) {
             const Variable<double> &var = KratosComponents< Variable<double> >::Get(mVariableName);
 
-            block_for_each(mrModelPart.Nodes(), [&var, this](Node<3>& rNode) {
-                if (mIsFixed) rNode.Fix(var);
-                else          rNode.Free(var);
+            if (mIsSeepage) {
+                block_for_each(mrModelPart.Nodes(), [&var, this](Node<3>& rNode) {
+                    const double pressure = CalculatePressure(rNode);
 
-                const double HorizontalCoordiante = rNode.Coordinates()[mHorizontalDirection];
+                    if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < 0) {
+                        rNode.FastGetSolutionStepValue(var) = pressure;
+                        if (mIsFixed) rNode.Fix(var);
+                    } else {
+                        rNode.Free(var);
+                    }
+                });
+            } else {
+                block_for_each(mrModelPart.Nodes(), [&var, this](Node<3>& rNode) {
+                    if (mIsFixed) rNode.Fix(var);
+                    else          rNode.Free(var);
+                    const double pressure = CalculatePressure(rNode);
 
-                double height = 0.0;
-                if (HorizontalCoordiante >= mMinHorizontalCoordinate && HorizontalCoordiante <= mMaxHorizontalCoordinate) {
-                    height = mSlope * (HorizontalCoordiante - mFirstReferenceCoordinate[mHorizontalDirection]) + mFirstReferenceCoordinate[mGravityDirection];
-                } else if (HorizontalCoordiante < mMinHorizontalCoordinate) {
-                    height = mSlope * (mMinHorizontalCoordinate - mFirstReferenceCoordinate[mHorizontalDirection]) + mFirstReferenceCoordinate[mGravityDirection];
-                } else if (HorizontalCoordiante > mMaxHorizontalCoordinate) {
-                    height = mSlope * (mMaxHorizontalCoordinate - mFirstReferenceCoordinate[mHorizontalDirection]) + mFirstReferenceCoordinate[mGravityDirection];
-                }
-
-                const double distance = height - rNode.Coordinates()[mGravityDirection];
-                const double pressure = - PORE_PRESSURE_SIGN_FACTOR * mSpecificWeight * distance ;
-
-                if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < mPressureTensionCutOff) {
-                    rNode.FastGetSolutionStepValue(var) = pressure;
-                } else {
-                    rNode.FastGetSolutionStepValue(var) = mPressureTensionCutOff;
-                }
-            });
-
+                    if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < mPressureTensionCutOff) {
+                        rNode.FastGetSolutionStepValue(var) = pressure;
+                    } else {
+                        rNode.FastGetSolutionStepValue(var) = mPressureTensionCutOff;
+                    }
+                });
+            }
         }
 
         KRATOS_CATCH("")
@@ -179,6 +180,7 @@ protected:
     ModelPart& mrModelPart;
     std::string mVariableName;
     bool mIsFixed;
+    bool mIsSeepage;
     unsigned int mGravityDirection;
     double mSpecificWeight;
     unsigned int mOutOfPlaneDirection;
@@ -190,6 +192,21 @@ protected:
     double mMaxHorizontalCoordinate;
     double mPressureTensionCutOff;
 
+    double CalculatePressure(const Node<3> &rNode) const
+    {
+        double height = 0.0;
+        if (rNode.Coordinates()[mHorizontalDirection] >= mMinHorizontalCoordinate && rNode.Coordinates()[mHorizontalDirection] <= mMaxHorizontalCoordinate) {
+            height = mSlope * (rNode.Coordinates()[mHorizontalDirection] - mFirstReferenceCoordinate[mHorizontalDirection]) + mFirstReferenceCoordinate[mGravityDirection];
+        } else if (rNode.Coordinates()[mHorizontalDirection] < mMinHorizontalCoordinate) {
+            height = mSlope * (mMinHorizontalCoordinate - mFirstReferenceCoordinate[mHorizontalDirection]) + mFirstReferenceCoordinate[mGravityDirection];
+        } else if (rNode.Coordinates()[mHorizontalDirection] > mMaxHorizontalCoordinate) {
+            height = mSlope * (mMaxHorizontalCoordinate - mFirstReferenceCoordinate[mHorizontalDirection]) + mFirstReferenceCoordinate[mGravityDirection];
+        }
+
+        const double distance = height - rNode.Coordinates()[mGravityDirection];
+        const double pressure = - PORE_PRESSURE_SIGN_FACTOR * mSpecificWeight * distance;
+        return pressure;
+    }
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 private:

--- a/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_surface_pressure_process.hpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_constant_phreatic_surface_pressure_process.hpp
@@ -45,6 +45,7 @@ public:
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "is_fixed": false,
+                "is_seepage": false,
                 "gravity_direction": 1,
                 "first_reference_coordinate":          [0.0,1.0,0.0],
                 "second_reference_coordinate":         [1.0,0.5,0.0],
@@ -68,6 +69,7 @@ public:
 
         mVariableName = rParameters["variable_name"].GetString();
         mIsFixed = rParameters["is_fixed"].GetBool();
+        mIsSeepage = rParameters["is_seepage"].GetBool();
         mGravityDirection = rParameters["gravity_direction"].GetInt();
         mFirstReferenceCoordinate = rParameters["first_reference_coordinate"].GetVector();
         mSecondReferenceCoordinate= rParameters["second_reference_coordinate"].GetVector();
@@ -108,26 +110,47 @@ public:
             Vector3 direction=ZeroVector(3);
             direction[mGravityDirection] = 1.0;
 
-            block_for_each(mrModelPart.Nodes(), [&var, &direction, this](Node<3>& rNode) {
-                if (mIsFixed) rNode.Fix(var);
-                else          rNode.Free(var);
+            if (mIsSeepage) {
+                block_for_each(mrModelPart.Nodes(), [&var, &direction, this](Node<3>& rNode) {
+                    double distance = 0.0;
+                    double d = 0.0;
+                    for (unsigned int j=0; j < rNode.Coordinates().size(); ++j) {
+                        distance += mNormalVector[j] * rNode.Coordinates()[j];
+                        d += mNormalVector[j]*direction[j];
+                    }
+                    distance = -(distance - mEqRHS) / d;
 
-                double distance = 0.0;
-                double d = 0.0;
-                for (unsigned int j=0; j < rNode.Coordinates().size(); ++j) {
-                    distance += mNormalVector[j] * rNode.Coordinates()[j];
-                    d += mNormalVector[j]*direction[j];
-                }
-                distance = -(distance - mEqRHS) / d;
+                    const double pressure = - PORE_PRESSURE_SIGN_FACTOR * mSpecificWeight * distance;
 
-                const double pressure = - PORE_PRESSURE_SIGN_FACTOR * mSpecificWeight * distance;
+                    if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < 0) {
+                        rNode.FastGetSolutionStepValue(var) = pressure;
+                        if (mIsFixed) rNode.Fix(var);
+                    } else {
+                        rNode.Free(var);
+                    }
+                });
+            } else {
+                block_for_each(mrModelPart.Nodes(), [&var, &direction, this](Node<3>& rNode) {
+                    if (mIsFixed) rNode.Fix(var);
+                    else          rNode.Free(var);
 
-                if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < mPressureTensionCutOff) {
-                    rNode.FastGetSolutionStepValue(var) = pressure;
-                } else {
-                    rNode.FastGetSolutionStepValue(var) = mPressureTensionCutOff;
-                }
-            });
+                    double distance = 0.0;
+                    double d = 0.0;
+                    for (unsigned int j=0; j < rNode.Coordinates().size(); ++j) {
+                        distance += mNormalVector[j] * rNode.Coordinates()[j];
+                        d += mNormalVector[j]*direction[j];
+                    }
+                    distance = -(distance - mEqRHS) / d;
+
+                    const double pressure = - PORE_PRESSURE_SIGN_FACTOR * mSpecificWeight * distance;
+
+                    if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < mPressureTensionCutOff) {
+                        rNode.FastGetSolutionStepValue(var) = pressure;
+                    } else {
+                        rNode.FastGetSolutionStepValue(var) = mPressureTensionCutOff;
+                    }
+                });
+            }
 
         }
 
@@ -160,6 +183,7 @@ protected:
     ModelPart& mrModelPart;
     std::string mVariableName;
     bool mIsFixed;
+    bool mIsSeepage;
     unsigned int mGravityDirection;
     double mSpecificWeight;
     Vector3 mFirstReferenceCoordinate;

--- a/applications/GeoMechanicsApplication/custom_processes/apply_hydrostatic_pressure_table_process.hpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_hydrostatic_pressure_table_process.hpp
@@ -70,16 +70,30 @@ public:
             const double Time = mrModelPart.GetProcessInfo()[TIME]/mTimeUnitConverter;
             const double deltaH = mpTable->GetValue(Time);
 
-            block_for_each(mrModelPart.Nodes(), [&var, &deltaH, this](Node<3>& rNode) {
-                const double distance = mReferenceCoordinate - rNode.Coordinates()[mGravityDirection];
-                const double pressure = - PORE_PRESSURE_SIGN_FACTOR * mSpecificWeight * (distance + deltaH);
+            if (mIsSeepage) {
+                block_for_each(mrModelPart.Nodes(), [&var, &deltaH, this](Node<3>& rNode) {
+                    const double distance = mReferenceCoordinate - rNode.Coordinates()[mGravityDirection];
+                    const double pressure = - PORE_PRESSURE_SIGN_FACTOR * mSpecificWeight * (distance + deltaH);
 
-                if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < mPressureTensionCutOff) {
-                    rNode.FastGetSolutionStepValue(var) = pressure;
-                } else {
-                    rNode.FastGetSolutionStepValue(var) = mPressureTensionCutOff;
-                }
-            });
+                    if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < 0.0) {
+                        rNode.FastGetSolutionStepValue(var) = pressure;
+                        if (mIsFixed) rNode.Fix(var);
+                    } else {
+                        rNode.Free(var);
+                    }
+                });
+            } else {
+                block_for_each(mrModelPart.Nodes(), [&var, &deltaH, this](Node<3>& rNode) {
+                    const double distance = mReferenceCoordinate - rNode.Coordinates()[mGravityDirection];
+                    const double pressure = - PORE_PRESSURE_SIGN_FACTOR * mSpecificWeight * (distance + deltaH);
+
+                    if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < mPressureTensionCutOff) {
+                        rNode.FastGetSolutionStepValue(var) = pressure;
+                    } else {
+                        rNode.FastGetSolutionStepValue(var) = mPressureTensionCutOff;
+                    }
+                });
+            }
         }
 
         KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/custom_processes/apply_phreatic_line_pressure_table_process.hpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_phreatic_line_pressure_table_process.hpp
@@ -91,29 +91,28 @@ public:
             mSlope = (y[1] - y[0])
                     /(mSecondReferenceCoordinate[mHorizontalDirection] - mFirstReferenceCoordinate[mHorizontalDirection]);
 
+            if (mIsSeepage) {
+                block_for_each(mrModelPart.Nodes(), [&var, &y, this](Node<3>& rNode) {
+                    const double pressure = CalculatePressure(rNode, y);
 
-            block_for_each(mrModelPart.Nodes(), [&var, &y, this](Node<3>& rNode) {
-                double height = 0.0;
-                if (rNode.Coordinates()[mHorizontalDirection] >= mMinHorizontalCoordinate && rNode.Coordinates()[mHorizontalDirection] <= mMaxHorizontalCoordinate) {
-                    height = mSlope * (rNode.Coordinates()[mHorizontalDirection] - mFirstReferenceCoordinate[mHorizontalDirection]) + y[0];
+                    if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < 0) {
+                        rNode.FastGetSolutionStepValue(var) = pressure;
+                        if (mIsFixed) rNode.Fix(var);
+                    } else {
+                        rNode.Free(var);
+                    }
+                });
+            } else {
+                block_for_each(mrModelPart.Nodes(), [&var, &y, this](Node<3>& rNode) {
+                    const double pressure = CalculatePressure(rNode, y);
 
-                } else if (rNode.Coordinates()[mHorizontalDirection] < mMinHorizontalCoordinate) {
-                    height = mSlope * (mMinHorizontalCoordinate - mFirstReferenceCoordinate[mHorizontalDirection]) + y[0];
-
-                } else if (rNode.Coordinates()[mHorizontalDirection] > mMaxHorizontalCoordinate) {
-                    height = mSlope * (mMaxHorizontalCoordinate - mFirstReferenceCoordinate[mHorizontalDirection]) + y[0];
-                }
-
-                const double distance = height - rNode.Coordinates()[mGravityDirection];
-                const double pressure = - PORE_PRESSURE_SIGN_FACTOR * mSpecificWeight * distance;
-
-                if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < mPressureTensionCutOff) {
-                    rNode.FastGetSolutionStepValue(var) = pressure;
-                } else {
-                    rNode.FastGetSolutionStepValue(var) = mPressureTensionCutOff;
-                }
-            });
-
+                    if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < mPressureTensionCutOff) {
+                        rNode.FastGetSolutionStepValue(var) = pressure;
+                    } else {
+                        rNode.FastGetSolutionStepValue(var) = mPressureTensionCutOff;
+                    }
+                });
+            }
         }
 
         KRATOS_CATCH("");
@@ -144,6 +143,24 @@ protected:
 
     array_1d<TableType::Pointer,2> mpTable;
     double mTimeUnitConverter;
+
+    double CalculatePressure(const Node<3> &rNode, const array_1d<double, 2> &y) const
+    {
+        double height = 0.0;
+        if (rNode.Coordinates()[mHorizontalDirection] >= mMinHorizontalCoordinate && rNode.Coordinates()[mHorizontalDirection] <= mMaxHorizontalCoordinate) {
+            height = mSlope * (rNode.Coordinates()[mHorizontalDirection] - mFirstReferenceCoordinate[mHorizontalDirection]) + y[0];
+
+        } else if (rNode.Coordinates()[mHorizontalDirection] < mMinHorizontalCoordinate) {
+            height = mSlope * (mMinHorizontalCoordinate - mFirstReferenceCoordinate[mHorizontalDirection]) + y[0];
+
+        } else if (rNode.Coordinates()[mHorizontalDirection] > mMaxHorizontalCoordinate) {
+            height = mSlope * (mMaxHorizontalCoordinate - mFirstReferenceCoordinate[mHorizontalDirection]) + y[0];
+        }
+
+        const double distance = height - rNode.Coordinates()[mGravityDirection];
+        const double pressure = - PORE_PRESSURE_SIGN_FACTOR * mSpecificWeight * distance;
+        return pressure;
+    }
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_processes/apply_time_dependent_interpolate_line_pressure_process.hpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_time_dependent_interpolate_line_pressure_process.hpp
@@ -65,18 +65,31 @@ public:
         if (mrModelPart.NumberOfNodes() > 0) {
             const Variable<double> &var = KratosComponents< Variable<double> >::Get(mVariableName);
 
-            block_for_each(mrModelPart.Nodes(), [&var, this](Node<3>& rNode) {
-                if (mIsFixed) rNode.Fix(var);
-                else          rNode.Free(var);
+            if (mIsSeepage) {
+                block_for_each(mrModelPart.Nodes(), [&var, this](Node<3>& rNode) {
+                    const double pressure = CalculatePressure(rNode);
 
-                const double pressure = CalculatePressure(rNode);
+                    if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < 0.0) {
+                        rNode.FastGetSolutionStepValue(var) = pressure;
+                        if (mIsFixed) rNode.Fix(var);
+                    } else {
+                        rNode.Free(var);
+                    }
+                });
+            } else {
+                block_for_each(mrModelPart.Nodes(), [&var, this](Node<3>& rNode) {
+                    if (mIsFixed) rNode.Fix(var);
+                    else          rNode.Free(var);
 
-                if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < mPressureTensionCutOff) {
-                    rNode.FastGetSolutionStepValue(var) = pressure;
-                } else {
-                    rNode.FastGetSolutionStepValue(var) = mPressureTensionCutOff;
-                }
-            });
+                    const double pressure = CalculatePressure(rNode);
+
+                    if ((PORE_PRESSURE_SIGN_FACTOR * pressure) < mPressureTensionCutOff) {
+                        rNode.FastGetSolutionStepValue(var) = pressure;
+                    } else {
+                        rNode.FastGetSolutionStepValue(var) = mPressureTensionCutOff;
+                    }
+                });
+            }
         }
 
         KRATOS_CATCH("")

--- a/applications/GeoMechanicsApplication/python_scripts/apply_scalar_constraint_table_process.py
+++ b/applications/GeoMechanicsApplication/python_scripts/apply_scalar_constraint_table_process.py
@@ -37,6 +37,9 @@ class ApplyScalarConstraintTableProcess(KratosMultiphysics.Process):
                 if settings.Has("pressure_tension_cut_off"):
                     self.params.AddValue("pressure_tension_cut_off",settings["pressure_tension_cut_off"])
 
+                if settings.Has("is_seepage"):
+                    self.params.AddValue("is_seepage",settings["is_seepage"])
+
                 if settings["table"].GetInt() == 0:
                     self.process = KratosGeo.ApplyConstantHydrostaticPressureProcess(self.model_part, self.params)
                 else:
@@ -52,6 +55,9 @@ class ApplyScalarConstraintTableProcess(KratosMultiphysics.Process):
                 if settings.Has("pressure_tension_cut_off"):
                     self.params.AddValue("pressure_tension_cut_off",settings["pressure_tension_cut_off"])
 
+                if settings.Has("is_seepage"):
+                    self.params.AddValue("is_seepage",settings["is_seepage"])
+
                 if settings["table"][0].GetInt() == 0 and settings["table"][1].GetInt() == 0:
                     self.process = KratosGeo.ApplyConstantPhreaticLinePressureProcess(self.model_part, self.params)
                 else:
@@ -63,6 +69,9 @@ class ApplyScalarConstraintTableProcess(KratosMultiphysics.Process):
 
                 if settings.Has("pressure_tension_cut_off"):
                     self.params.AddValue("pressure_tension_cut_off",settings["pressure_tension_cut_off"])
+
+                if settings.Has("is_seepage"):
+                    self.params.AddValue("is_seepage",settings["is_seepage"])
 
                 if settings["table"].GetInt() == 0:
                     self.process = KratosGeo.ApplyConstantInterpolateLinePressureProcess(self.model_part, self.params)
@@ -77,6 +86,9 @@ class ApplyScalarConstraintTableProcess(KratosMultiphysics.Process):
 
                 if settings.Has("pressure_tension_cut_off"):
                     self.params.AddValue("pressure_tension_cut_off",settings["pressure_tension_cut_off"])
+
+                if settings.Has("is_seepage"):
+                    self.params.AddValue("is_seepage",settings["is_seepage"])
 
                 if settings["table"][0].GetInt() == 0 and settings["table"][1].GetInt() == 0 and settings["table"][2].GetInt() == 0:
                     self.process = KratosGeo.ApplyConstantPhreaticSurfacePressureProcess(self.model_part, self.params)


### PR DESCRIPTION
**📝 Description**
In this PR seepage boundary condition is considered in pore pressure type boundary conditions. According to the seepage boundary condition, below phreatic level (negative pore pressure), simply the pore pressure is applied and above it, nothing is applied and the degrees of freedom are set to free.
