### PR TITLE
A method name mangling modification an error correction in the mass term

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -259,7 +259,7 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
             (self.time_discretization).ComputeAndSaveBDFCoefficients(self.GetComputingModelPart().ProcessInfo)
 
             # Perform the level-set convection according to the previous step velocity
-            self.__PerformLevelSetConvection()
+            self._PerformLevelSetConvection()
 
             KratosMultiphysics.Logger.PrintInfo(self.__class__.__name__, "Level-set convection is performed.")
 
@@ -293,7 +293,7 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
             if self.mass_source:
                 water_volume_after_transport = KratosCFD.FluidAuxiliaryUtilities.CalculateFluidNegativeVolume(self.GetComputingModelPart())
                 volume_error = (water_volume_after_transport - system_volume) / system_volume
-                self.initial_system_volume=water_volume_after_transport
+                self.initial_system_volume=system_volume
             else:
                 volume_error=0
 
@@ -337,7 +337,7 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
             if self._apply_acceleration_limitation and self.main_model_part.ProcessInfo[KratosMultiphysics.STEP] >= self.min_buffer_size:
                 self._GetAccelerationLimitationUtility().Execute()
 
-    def __PerformLevelSetConvection(self):
+    def _PerformLevelSetConvection(self):
         # Solve the levelset convection problem
         self._GetLevelSetConvectionProcess().Execute()
 


### PR DESCRIPTION
**Description**
This PR corrects a previous error in the mass source in order to conserve the mass and also a name mangling modification has been done in order to be able to use **TwoFluidNavierStokesSolver** as a parent class of  a future class that is being implementing currently. This future class will be available in a new two fluid solver which is going to be pulled soon. 
**Changelog**

- Name mangling: **_PerformLevelSetConvection** This methods needs to be used in a child class therefore the double underscore is avoided. 
- Mass correction: The initial volume in each time step should be the calculated theoretical volume before the convection problem.
