### PR TITLE
Adding VariableUtils method: SetHistoricalVariableToPreviousInfo

### DIFF
--- a/kratos/python/add_variable_utils_to_python.cpp
+++ b/kratos/python/add_variable_utils_to_python.cpp
@@ -51,6 +51,7 @@ void AddCopyModelPartFlaggedInterface(pybind11::class_<VariableUtils>& rPythonVa
     rPythonVariableUtils.def("CopyModelPartFlaggedNodalNonHistoricalVarToNonHistoricalVar", (void(VariableUtils::*)(const Variable<TDataType>&, const ModelPart&, ModelPart&, const Flags&, const bool))(&VariableUtils::CopyModelPartFlaggedNodalNonHistoricalVarToNonHistoricalVar));
     rPythonVariableUtils.def("CopyModelPartFlaggedElementVar", (void(VariableUtils::*)(const Variable<TDataType>&, const ModelPart&, ModelPart&, const Flags&, const bool))(&VariableUtils::CopyModelPartFlaggedElementVar));
     rPythonVariableUtils.def("CopyModelPartFlaggedConditionVar", (void(VariableUtils::*)(const Variable<TDataType>&, const ModelPart&, ModelPart&, const Flags&, const bool))(&VariableUtils::CopyModelPartFlaggedConditionVar));
+    rPythonVariableUtils.def("SetHistoricalVariableToPreviousInfo", (void(VariableUtils::*)(const Variable< TDataType >& , ModelPart::NodesContainerType& , const int ))(&VariableUtils::SetHistoricalVariableToPreviousInfo));
 }
 
 void VariableUtilsUpdateCurrentPosition(

--- a/kratos/python/add_variable_utils_to_python.cpp
+++ b/kratos/python/add_variable_utils_to_python.cpp
@@ -51,7 +51,6 @@ void AddCopyModelPartFlaggedInterface(pybind11::class_<VariableUtils>& rPythonVa
     rPythonVariableUtils.def("CopyModelPartFlaggedNodalNonHistoricalVarToNonHistoricalVar", (void(VariableUtils::*)(const Variable<TDataType>&, const ModelPart&, ModelPart&, const Flags&, const bool))(&VariableUtils::CopyModelPartFlaggedNodalNonHistoricalVarToNonHistoricalVar));
     rPythonVariableUtils.def("CopyModelPartFlaggedElementVar", (void(VariableUtils::*)(const Variable<TDataType>&, const ModelPart&, ModelPart&, const Flags&, const bool))(&VariableUtils::CopyModelPartFlaggedElementVar));
     rPythonVariableUtils.def("CopyModelPartFlaggedConditionVar", (void(VariableUtils::*)(const Variable<TDataType>&, const ModelPart&, ModelPart&, const Flags&, const bool))(&VariableUtils::CopyModelPartFlaggedConditionVar));
-    rPythonVariableUtils.def("SetHistoricalVariableToPreviousInfo", (void(VariableUtils::*)(const Variable< TDataType >& , ModelPart::NodesContainerType& , const int ))(&VariableUtils::SetHistoricalVariableToPreviousInfo));
 }
 
 void VariableUtilsUpdateCurrentPosition(
@@ -468,7 +467,17 @@ void AddVariableUtilsToPython(pybind11::module &m)
         .def("UpdateInitialToCurrentConfiguration", &VariableUtils::UpdateInitialToCurrentConfiguration)
         .def("UpdateCurrentPosition", VariableUtilsUpdateCurrentPosition)
         .def("UpdateCurrentPosition", VariableUtilsUpdateCurrentPositionWithVariable)
-        .def("UpdateCurrentPosition", VariableUtilsUpdateCurrentPositionWithVariableAndPosition);
+        .def("UpdateCurrentPosition", VariableUtilsUpdateCurrentPositionWithVariableAndPosition)
+        .def("SetHistoricalVariableToPreviousInfo", &VariableUtils::SetHistoricalVariableToPreviousInfo<bool>)
+        .def("SetHistoricalVariableToPreviousInfo", &VariableUtils::SetHistoricalVariableToPreviousInfo<int>)
+        .def("SetHistoricalVariableToPreviousInfo", &VariableUtils::SetHistoricalVariableToPreviousInfo<double>)
+        .def("SetHistoricalVariableToPreviousInfo", &VariableUtils::SetHistoricalVariableToPreviousInfo<Vector>)
+        .def("SetHistoricalVariableToPreviousInfo", &VariableUtils::SetHistoricalVariableToPreviousInfo<Matrix>)
+        .def("SetHistoricalVariableToPreviousInfo", &VariableUtils::SetHistoricalVariableToPreviousInfo<array_1d<double, 3>>)
+        .def("SetHistoricalVariableToPreviousInfo", &VariableUtils::SetHistoricalVariableToPreviousInfo<array_1d<double, 3>>)
+        .def("SetHistoricalVariableToPreviousInfo", &VariableUtils::SetHistoricalVariableToPreviousInfo<array_1d<double, 4>>)
+        .def("SetHistoricalVariableToPreviousInfo", &VariableUtils::SetHistoricalVariableToPreviousInfo<array_1d<double, 6>>)
+        .def("SetHistoricalVariableToPreviousInfo", &VariableUtils::SetHistoricalVariableToPreviousInfo<array_1d<double, 9>>);
 
     AddCopyModelPartFlaggedInterface<bool>(python_variable_utils);
     AddCopyModelPartFlaggedInterface<double>(python_variable_utils);

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -722,7 +722,7 @@ public:
     }
 
     /**
-     * @brief Sets the nodal value of any variable to zero
+     * @brief Sets the nodal value of any variable to the previous stored data
      * @param rVariable reference to the scalar variable to be set
      * @param rNodes reference to the objective node set
      */

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -722,6 +722,24 @@ public:
     }
 
     /**
+     * @brief Sets the nodal value of any variable to zero
+     * @param rVariable reference to the scalar variable to be set
+     * @param rNodes reference to the objective node set
+     */
+    template< class TType >
+    void SetHistoricalVariableToPreviousInfo(
+        const Variable< TType >& rVariable,
+        NodesContainerType& rNodes,
+        const int PreviousStep = 1)
+    {
+        KRATOS_TRY
+        block_for_each(rNodes, [&](Node<3> &rNode) {
+            rNode.FastGetSolutionStepValue(rVariable) = rNode.FastGetSolutionStepValue(rVariable, PreviousStep);
+        });
+        KRATOS_CATCH("")
+    }
+
+    /**
      * @brief Sets the container value of any type of non historical variable
      * @param rVariable reference to the scalar variable to be set
      * @param Value Value to be set


### PR DESCRIPTION
**📝 Description**
Adding a new `VariableUtils `method: 
~~~c++
    template< class TType >
    void SetHistoricalVariableToPreviousInfo(
        const Variable< TType >& rVariable,
        NodesContainerType& rNodes,
        const int PreviousStep = 1)
    {
        KRATOS_TRY
        block_for_each(rNodes, [&](Node<3> &rNode) {
            rNode.FastGetSolutionStepValue(rVariable) = rNode.FastGetSolutionStepValue(rVariable, PreviousStep);
        });
        KRATOS_CATCH("")
    }
~~~


This is closely related to https://github.com/KratosMultiphysics/Kratos/issues/4594