### PR TITLE
[CoSim] optionally change computation of residual for ConvAcc

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/convergence_accelerators/convergence_accelerator_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/convergence_accelerators/convergence_accelerator_wrapper.py
@@ -3,6 +3,7 @@ from KratosMultiphysics.CoSimulationApplication.factories.convergence_accelerato
 
 # Other imports
 import numpy as np
+from abc import ABCMeta, abstractmethod
 
 class ConvergenceAcceleratorWrapper:
     """This class wraps the convergence accelerators such that they can be used "automized"
@@ -13,8 +14,11 @@ class ConvergenceAcceleratorWrapper:
     """
     def __init__(self, settings, solver_wrapper):
         self.interface_data = solver_wrapper.GetInterfaceData(settings["data_name"].GetString())
+        self.residual_computation = CreateResidualComputation(settings, solver_wrapper)
+
         settings.RemoveValue("data_name")
         settings.RemoveValue("solver")
+        settings.RemoveValue("residual_computation")
 
         self.conv_acc = CreateConvergenceAccelerator(settings)
 
@@ -52,8 +56,7 @@ class ConvergenceAcceleratorWrapper:
     def ComputeAndApplyUpdate(self):
         if not self.interface_data.IsDefinedOnThisRank(): return
 
-        current_data = self.interface_data.GetData()
-        residual = current_data - self.input_data
+        residual = self.residual_computation.ComputeResidual(self.input_data)
         input_data_for_acc = self.input_data
 
         if self.gather_scatter_required:
@@ -78,3 +81,36 @@ class ConvergenceAcceleratorWrapper:
 
     def Check(self):
         self.conv_acc.Check()
+
+class ConvergenceAcceleratorResidual(metaclass=ABCMeta):
+    @abstractmethod
+    def ComputeResidual(self, input_data): pass
+
+class DataDifferenceResidual(ConvergenceAcceleratorResidual):
+    def __init__(self, settings, solver_wrapper):
+        self.interface_data = solver_wrapper.GetInterfaceData(settings["data_name"].GetString())
+
+    def ComputeResidual(self, input_data):
+        return self.interface_data.GetData() - input_data
+
+class DifferentDataDifferenceResidual(ConvergenceAcceleratorResidual):
+    def __init__(self, settings, solver_wrapper):
+        self.interface_data = solver_wrapper.GetInterfaceData(settings["data_name"].GetString())
+        self.interface_data1 = solver_wrapper.GetInterfaceData(settings["data_name1"].GetString())
+        self.interface_data2 = solver_wrapper.GetInterfaceData(settings["data_name2"].GetString())
+
+    def ComputeResidual(self, input_data):
+        return self.interface_data1.GetData() - self.interface_data2.GetData()
+
+
+def CreateResidualComputation(settings, solver_wrapper):
+    if "residual_computation" not in settings:
+        # default
+        return DataDifferenceResidual(settings, solver_wrapper)
+
+    res_computation_settings = settings["residual_computation"]
+    residual_computation_type = res_computation_settings["type"]
+    if residual_computation_type == "data_difference":
+        return DifferentDataDifferenceResidual(res_computation_settings, solver_wrapper)
+    else:
+        raise Exception("The specified residual computation is not available!")

--- a/applications/CoSimulationApplication/python_scripts/convergence_accelerators/convergence_accelerator_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/convergence_accelerators/convergence_accelerator_wrapper.py
@@ -96,21 +96,20 @@ class DataDifferenceResidual(ConvergenceAcceleratorResidual):
 class DifferentDataDifferenceResidual(ConvergenceAcceleratorResidual):
     def __init__(self, settings, solver_wrapper):
         self.interface_data = solver_wrapper.GetInterfaceData(settings["data_name"].GetString())
-        self.interface_data1 = solver_wrapper.GetInterfaceData(settings["data_name1"].GetString())
-        self.interface_data2 = solver_wrapper.GetInterfaceData(settings["data_name2"].GetString())
+        self.interface_data1 = solver_wrapper.GetInterfaceData(settings["residual_computation"]["data_name1"].GetString())
+        self.interface_data2 = solver_wrapper.GetInterfaceData(settings["residual_computation"]["data_name2"].GetString())
 
     def ComputeResidual(self, input_data):
         return self.interface_data1.GetData() - self.interface_data2.GetData()
 
-
 def CreateResidualComputation(settings, solver_wrapper):
-    if "residual_computation" not in settings:
-        # default
-        return DataDifferenceResidual(settings, solver_wrapper)
+    residual_computation_type = "data_difference"
+    if settings.Has("residual_computation"):
+        residual_computation_type = settings["residual_computation"]["type"].GetString()
 
-    res_computation_settings = settings["residual_computation"]
-    residual_computation_type = res_computation_settings["type"]
     if residual_computation_type == "data_difference":
-        return DifferentDataDifferenceResidual(res_computation_settings, solver_wrapper)
+        return DataDifferenceResidual(settings, solver_wrapper)
+    elif residual_computation_type == "different_data_difference":
+        return DifferentDataDifferenceResidual(settings, solver_wrapper)
     else:
-        raise Exception("The specified residual computation is not available!")
+        raise Exception('The specified residual computation "{}" is not available!'.format(residual_computation_type))


### PR DESCRIPTION
As discussed, now it is possible to optionally change the computation of the residual

@VeronikaSinger for your input you would give the following settings to the accelerator (I adapted the settings you sent me):
~~~js
{
  "type": "mvqn",
  "solver": "structure1",
  "data_name": "load",
  "residual_computation" : {
    "type": "different_data_difference",
    "data_name1": "disp_intermediate",
    "data_name2": "disp"
  }
}
~~~

the names of the residual computation types are up for discussion, I couldn't come up with better ones :sweat_smile: 