### PR TITLE
[Structural] Add GetSpecifications to some elements

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_conditions/displacement_control_condition.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/displacement_control_condition.cpp
@@ -343,13 +343,47 @@ int DisplacementControlCondition::Check( const ProcessInfo& rCurrentProcessInfo 
 {
     // Base check
     Condition::Check(rCurrentProcessInfo);
-    
+
     // Check that the condition's nodes contain all required SolutionStepData and Degrees of freedom
     for (const auto& r_node : GetGeometry().Points()) {
         KRATOS_CHECK_DOF_IN_NODE(LOAD_FACTOR, r_node)
     }
 
     return 0;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+const Parameters DisplacementControlCondition::GetSpecifications() const
+{
+    const Parameters specifications = Parameters(R"({
+        "time_integration"           : ["static","implicit"],
+        "framework"                  : "lagrangian",
+        "symmetric_lhs"              : true,
+        "positive_definite_lhs"      : true,
+        "output"                     : {
+            "gauss_point"            : [],
+            "nodal_historical"       : ["DISPLACEMENT","LOAD_FACTOR"],
+            "nodal_non_historical"   : [],
+            "entity"                 : []
+        },
+        "required_variables"         : ["DISPLACEMENT","LOAD_FACTOR"],
+        "required_dofs"              : ["DISPLACEMENT_X","DISPLACEMENT_Y","DISPLACEMENT_Z","LOAD_FACTOR"],
+        "flags_used"                 : [],
+        "compatible_geometries"      : ["Point3D"],
+        "element_integrates_in_time" : false,
+        "compatible_constitutive_laws": {
+            "type"        : [],
+            "dimension"   : [],
+            "strain_size" : []
+        },
+        "required_polynomial_degree_of_geometry" : -1,
+        "documentation"   : "Displacement control load condition."
+
+    })");
+
+    return specifications;
 }
 
 /***********************************************************************************/

--- a/applications/StructuralMechanicsApplication/custom_conditions/displacement_control_condition.h
+++ b/applications/StructuralMechanicsApplication/custom_conditions/displacement_control_condition.h
@@ -240,6 +240,8 @@ public:
     ///@name Input and output
     ///@{
 
+    const Parameters GetSpecifications() const override;
+
     /// Turn back information as a string.
     std::string Info() const override
     {

--- a/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.cpp
@@ -555,6 +555,37 @@ void BaseShellElement<TCoordinateTransformation>::SetCrossSectionsOnIntegrationP
 }
 
 template <class TCoordinateTransformation>
+const Parameters BaseShellElement<TCoordinateTransformation>::GetSpecifications() const
+{
+    const Parameters specifications = Parameters(R"({
+        "time_integration"           : ["static","implicit","explicit"],
+        "framework"                  : "lagrangian",
+        "symmetric_lhs"              : true,
+        "positive_definite_lhs"      : true,
+        "output"                     : {
+            "gauss_point"            : [],
+            "nodal_historical"       : ["DISPLACEMENT","ROTATION","VELOCITY","ACCELERATION"],
+            "nodal_non_historical"   : [],
+            "entity"                 : []
+        },
+        "required_variables"         : ["DISPLACEMENT","ROTATION"],
+        "required_dofs"              : ["DISPLACEMENT_X","DISPLACEMENT_Y","DISPLACEMENT_Z","ROTATION_X","ROTATION_Y","ROTATION_Z"],
+        "flags_used"                 : [],
+        "compatible_geometries"      : ["Triangle3D3", "Quadrilateral3D4"],
+        "element_integrates_in_time" : false,
+        "compatible_constitutive_laws": {
+            "type"        : ["PlaneStress"],
+            "dimension"   : ["2D"],
+            "strain_size" : [3]
+        },
+        "required_polynomial_degree_of_geometry" : 1,
+        "documentation"   : "Base element for thin/thick shell formulations."
+    })");
+
+    return specifications;
+}
+
+template <class TCoordinateTransformation>
 std::string BaseShellElement<TCoordinateTransformation>::Info() const
 {
     std::stringstream buffer;

--- a/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.cpp
@@ -575,7 +575,7 @@ const Parameters BaseShellElement<TCoordinateTransformation>::GetSpecifications(
         "element_integrates_in_time" : false,
         "compatible_constitutive_laws": {
             "type"        : ["PlaneStress"],
-            "dimension"   : ["2D"],
+            "dimension"   : ["3D"],
             "strain_size" : [3]
         },
         "required_polynomial_degree_of_geometry" : 1,

--- a/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.h
@@ -201,6 +201,8 @@ public:
     ///@name Input and output
     ///@{
 
+    const Parameters GetSpecifications() const override;
+
     /// Turn back information as a string.
     virtual std::string Info() const override;
 

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -1927,7 +1927,7 @@ const Parameters BaseSolidElement::GetSpecifications() const
             "entity"                 : []
         },
         "required_variables"         : ["DISPLACEMENT"],
-        "required_dofs"              : ["DISPLACEMENT_X","DISPLACEMENT_Y","DISPLACEMENT_Z"],
+        "required_dofs"              : [],
         "flags_used"                 : [],
         "compatible_geometries"      : ["Triangle2D3", "Triangle2D6", "Quadrilateral2D4", "Quadrilateral2D8", "Quadrilateral2D9","Tetrahedra3D4", "Prism3D6", "Prism3D15", "Hexahedra3D8", "Hexahedra3D20", "Hexahedra3D27", "Tetrahedra3D10"],
         "element_integrates_in_time" : true,
@@ -1939,6 +1939,16 @@ const Parameters BaseSolidElement::GetSpecifications() const
         "required_polynomial_degree_of_geometry" : -1,
         "documentation"   : "This is a pure displacement element"
     })");
+
+    const SizeType dimension = GetGeometry().WorkingSpaceDimension();
+    if (dimension == 2) {
+        std::vector<std::string> dofs_2d({"DISPLACEMENT_X","DISPLACEMENT_Y"});
+        specifications["required_dofs"].SetStringArray(dofs_2d);
+    } else {
+        std::vector<std::string> dofs_3d({"DISPLACEMENT_X","DISPLACEMENT_Y","DISPLACEMENT_Z"});
+        specifications["required_dofs"].SetStringArray(dofs_3d);
+    }
+
     return specifications;
 }
 

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
@@ -992,7 +992,8 @@ const Parameters CrBeamElement2D2N::GetSpecifications() const
         "compatible_constitutive_laws": {
             "type"        : ["BeamConstitutiveLaw"],
             "dimension"   : ["1D"],
-            "strain_size" : [1]
+            "strain_size" : [2]
+
         },
         "required_polynomial_degree_of_geometry" : 1,
         "documentation"   : "This elements implements a 2D non-linear beam formulation."

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
@@ -991,7 +991,7 @@ const Parameters CrBeamElement2D2N::GetSpecifications() const
         "element_integrates_in_time" : false,
         "compatible_constitutive_laws": {
             "type"        : ["BeamConstitutiveLaw"],
-            "dimension"   : ["2D"],
+            "dimension"   : ["1D"],
             "strain_size" : [1]
         },
         "required_polynomial_degree_of_geometry" : 1,

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
@@ -992,10 +992,7 @@ const Parameters CrBeamElement2D2N::GetSpecifications() const
         "compatible_constitutive_laws": {
             "type"        : ["BeamConstitutiveLaw"],
             "dimension"   : ["2D"],
-
             "strain_size" : [3]
-
-
         },
         "required_polynomial_degree_of_geometry" : 1,
         "documentation"   : "This elements implements a 2D non-linear beam formulation."

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
@@ -991,8 +991,10 @@ const Parameters CrBeamElement2D2N::GetSpecifications() const
         "element_integrates_in_time" : false,
         "compatible_constitutive_laws": {
             "type"        : ["BeamConstitutiveLaw"],
-            "dimension"   : ["1D"],
-            "strain_size" : [2]
+            "dimension"   : ["2D"],
+
+            "strain_size" : [3]
+
 
         },
         "required_polynomial_degree_of_geometry" : 1,

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
@@ -971,6 +971,36 @@ int CrBeamElement2D2N::Check(const ProcessInfo& rCurrentProcessInfo) const
     KRATOS_CATCH("")
 }
 
+const Parameters CrBeamElement2D2N::GetSpecifications() const
+{
+    const Parameters specifications = Parameters(R"({
+        "time_integration"           : ["static","implicit","explicit"],
+        "framework"                  : "lagrangian",
+        "symmetric_lhs"              : true,
+        "positive_definite_lhs"      : true,
+        "output"                     : {
+            "gauss_point"            : ["MOMENT","FORCE","INTEGRATION_COORDINATES"],
+            "nodal_historical"       : ["DISPLACEMENT","ROTATION","VELOCITY","ACCELERATION"],
+            "nodal_non_historical"   : [],
+            "entity"                 : []
+        },
+        "required_variables"         : ["DISPLACEMENT","ROTATION"],
+        "required_dofs"              : ["DISPLACEMENT_X","DISPLACEMENT_Y","ROTATION_Z"],
+        "flags_used"                 : [],
+        "compatible_geometries"      : ["Line2D2"],
+        "element_integrates_in_time" : false,
+        "compatible_constitutive_laws": {
+            "type"        : ["BeamConstitutiveLaw"],
+            "dimension"   : ["2D"],
+            "strain_size" : [1]
+        },
+        "required_polynomial_degree_of_geometry" : 1,
+        "documentation"   : "This elements implements a 2D non-linear beam formulation."
+    })");
+
+    return specifications;
+}
+
 void CrBeamElement2D2N::save(Serializer& rSerializer) const
 {
     KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.hpp
@@ -273,6 +273,8 @@ public:
         std::vector< array_1d<double, 3 > >& rOutput,
         const ProcessInfo& rCurrentProcessInfo) override;
 
+    const Parameters GetSpecifications() const override;
+
 private:
 
     friend class Serializer;

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
@@ -1746,8 +1746,10 @@ const Parameters CrBeamElement3D2N::GetSpecifications() const
         "element_integrates_in_time" : false,
         "compatible_constitutive_laws": {
             "type"        : ["BeamConstitutiveLaw"],
-            "dimension"   : ["1D"],
-            "strain_size" : [3]
+            "dimension"   : ["3D"],
+
+            "strain_size" : [6]
+
 
         },
         "required_polynomial_degree_of_geometry" : 1,

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
@@ -1746,7 +1746,7 @@ const Parameters CrBeamElement3D2N::GetSpecifications() const
         "element_integrates_in_time" : false,
         "compatible_constitutive_laws": {
             "type"        : ["BeamConstitutiveLaw"],
-            "dimension"   : ["3D"],
+            "dimension"   : ["1D"],
             "strain_size" : [1]
         },
         "required_polynomial_degree_of_geometry" : 1,

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
@@ -1747,7 +1747,8 @@ const Parameters CrBeamElement3D2N::GetSpecifications() const
         "compatible_constitutive_laws": {
             "type"        : ["BeamConstitutiveLaw"],
             "dimension"   : ["1D"],
-            "strain_size" : [1]
+            "strain_size" : [3]
+
         },
         "required_polynomial_degree_of_geometry" : 1,
         "documentation"   : "This elements implements a 3D non-linear beam formulation."

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
@@ -1747,10 +1747,7 @@ const Parameters CrBeamElement3D2N::GetSpecifications() const
         "compatible_constitutive_laws": {
             "type"        : ["BeamConstitutiveLaw"],
             "dimension"   : ["3D"],
-
             "strain_size" : [6]
-
-
         },
         "required_polynomial_degree_of_geometry" : 1,
         "documentation"   : "This elements implements a 3D non-linear beam formulation."

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
@@ -1726,6 +1726,36 @@ void CrBeamElement3D2N::FinalizeNonLinearIteration(const ProcessInfo& rCurrentPr
     SaveQuaternionParameters();
 }
 
+const Parameters CrBeamElement3D2N::GetSpecifications() const
+{
+    const Parameters specifications = Parameters(R"({
+        "time_integration"           : ["static","implicit","explicit"],
+        "framework"                  : "lagrangian",
+        "symmetric_lhs"              : true,
+        "positive_definite_lhs"      : true,
+        "output"                     : {
+            "gauss_point"            : ["MOMENT","FORCE","LOCAL_AXIS_1","LOCAL_AXIS_2","LOCAL_AXIS_3","INTEGRATION_COORDINATES"],
+            "nodal_historical"       : ["DISPLACEMENT","ROTATION","VELOCITY","ACCELERATION"],
+            "nodal_non_historical"   : [],
+            "entity"                 : []
+        },
+        "required_variables"         : ["DISPLACEMENT","ROTATION"],
+        "required_dofs"              : ["DISPLACEMENT_X","DISPLACEMENT_Y","DISPLACEMENT_Z","ROTATION_X","ROTATION_Y","ROTATION_Z"],
+        "flags_used"                 : [],
+        "compatible_geometries"      : ["Line3D2"],
+        "element_integrates_in_time" : false,
+        "compatible_constitutive_laws": {
+            "type"        : ["BeamConstitutiveLaw"],
+            "dimension"   : ["3D"],
+            "strain_size" : [1]
+        },
+        "required_polynomial_degree_of_geometry" : 1,
+        "documentation"   : "This elements implements a 3D non-linear beam formulation."
+    })");
+
+    return specifications;
+}
+
 void CrBeamElement3D2N::save(Serializer& rSerializer) const
 {
     KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.hpp
@@ -234,7 +234,7 @@ public:
      * @param rBigMatrix The total global rotation matrix
      */
     void AssembleSmallInBigMatrix(
-        const Matrix& rSmallMatrix, 
+        const Matrix& rSmallMatrix,
         BoundedMatrix<double,msElementSize,msElementSize>& rBigMatrix
         ) const;
 
@@ -311,6 +311,8 @@ public:
 
     void UpdateQuaternionParameters(double& rScalNodeA,double& rScalNodeB,
          Vector& rVecNodeA,Vector& rVecNodeB) const;
+
+    const Parameters GetSpecifications() const override;
 
 private:
 

--- a/applications/StructuralMechanicsApplication/custom_elements/membrane_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/membrane_element.cpp
@@ -1315,6 +1315,36 @@ void MembraneElement::CalculateDampingMatrix(
         GetGeometry().WorkingSpaceDimension()*GetGeometry().size());
 }
 
+const Parameters MembraneElement::GetSpecifications() const
+{
+    const Parameters specifications = Parameters(R"({
+        "time_integration"           : ["static","implicit","explicit"],
+        "framework"                  : "lagrangian",
+        "symmetric_lhs"              : true,
+        "positive_definite_lhs"      : true,
+        "output"                     : {
+            "gauss_point"            : [],
+            "nodal_historical"       : ["DISPLACEMENT","ROTATION","VELOCITY","ACCELERATION"],
+            "nodal_non_historical"   : [],
+            "entity"                 : []
+        },
+        "required_variables"         : ["DISPLACEMENT","ROTATION"],
+        "required_dofs"              : ["DISPLACEMENT_X","DISPLACEMENT_Y","DISPLACEMENT_Z","ROTATION_X","ROTATION_Y","ROTATION_Z"],
+        "flags_used"                 : [],
+        "compatible_geometries"      : ["Triangle3D3", "Quadrilateral3D4"],
+        "element_integrates_in_time" : false,
+        "compatible_constitutive_laws": {
+            "type"        : ["PlaneStress"],
+            "dimension"   : ["2D"],
+            "strain_size" : [3]
+        },
+        "required_polynomial_degree_of_geometry" : 1,
+        "documentation"   : "This element implements a pre-stressed membrane formulation."
+    })");
+
+    return specifications;
+}
+
 void MembraneElement::AddExplicitContribution(
     const VectorType& rRHSVector, const Variable<VectorType>& rRHSVariable,
     const Variable<array_1d<double, 3>>& rDestinationVariable,

--- a/applications/StructuralMechanicsApplication/custom_elements/membrane_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/membrane_element.cpp
@@ -1335,7 +1335,7 @@ const Parameters MembraneElement::GetSpecifications() const
         "element_integrates_in_time" : false,
         "compatible_constitutive_laws": {
             "type"        : ["PlaneStress"],
-            "dimension"   : ["2D"],
+            "dimension"   : ["3D"],
             "strain_size" : [3]
         },
         "required_polynomial_degree_of_geometry" : 1,

--- a/applications/StructuralMechanicsApplication/custom_elements/membrane_element.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/membrane_element.hpp
@@ -154,6 +154,8 @@ namespace Kratos
     void CalculateDampingMatrix(MatrixType& rDampingMatrix,
       const ProcessInfo& rCurrentProcessInfo) override;
 
+    const Parameters GetSpecifications() const override;
+
   private:
      /**
      * @brief Calculates the covariant base vectors

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_mixed_volumetric_strain_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_mixed_volumetric_strain_element.cpp
@@ -1140,6 +1140,49 @@ void SmallDisplacementMixedVolumetricStrainElement::CalculateOnIntegrationPoints
     }
 }
 
+/***********************************************************************************/
+/***********************************************************************************/
+
+const Parameters SmallDisplacementMixedVolumetricStrainElement::GetSpecifications() const
+{
+    const Parameters specifications = Parameters(R"({
+        "time_integration"           : ["static"],
+        "framework"                  : "lagrangian",
+        "symmetric_lhs"              : true,
+        "positive_definite_lhs"      : true,
+        "output"                     : {
+            "gauss_point"            : ["CAUCHY_STRESS_VECTOR"],
+            "nodal_historical"       : ["DISPLACEMENT","VOLUMETRIC_STRAIN"],
+            "nodal_non_historical"   : [],
+            "entity"                 : []
+        },
+        "required_variables"         : ["DISPLACEMENT","VOLUMETRIC_STRAIN"],
+        "required_dofs"              : [],
+        "flags_used"                 : [],
+        "compatible_geometries"      : ["Triangle2D3", "Quadrilateral2D4", "Tetrahedra3D4","Hexahedra3D8"],
+        "element_integrates_in_time" : true,
+        "compatible_constitutive_laws": {
+            "type"        : ["PlaneStrain","PlaneStress","ThreeDimensional"],
+            "dimension"   : ["2D","3D"],
+            "strain_size" : [3,6]
+        },
+        "required_polynomial_degree_of_geometry" : 1,
+        "documentation"   :
+            "This element implements a mixed displacement - volumetric strain formulation with Variational MultiScales (VMS) stabilization.
+            This formulation is capable to deal with materials in the incompressible limit as well as with anisotropy."
+    })");
+
+    const SizeType dimension = GetGeometry().WorkingSpaceDimension();
+    if (dimension == 2) {
+        std::vector<std::string> dofs_2d({"DISPLACEMENT_X","DISPLACEMENT_Y","VOLUMETRIC_STRAIN"});
+        specifications["required_dofs"].SetStringArray(dofs_2d);
+    } else {
+        std::vector<std::string> dofs_3d({"DISPLACEMENT_X","DISPLACEMENT_Y","DISPLACEMENT_Z","VOLUMETRIC_STRAIN"});
+        specifications["required_dofs"].SetStringArray(dofs_3d);
+    }
+
+    return specifications;
+}
 
 /***********************************************************************************/
 /***********************************************************************************/

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_mixed_volumetric_strain_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_mixed_volumetric_strain_element.h
@@ -360,6 +360,8 @@ public:
     ///@name Input and output
     ///@{
 
+    const Parameters GetSpecifications() const override;
+
     /// Turn back information as a string.
     std::string Info() const override
     {

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
@@ -983,6 +983,36 @@ bool TrussElement3D2N::HasSelfWeight() const
     }
 }
 
+const Parameters TrussElement3D2N::GetSpecifications() const
+{
+    const Parameters specifications = Parameters(R"({
+        "time_integration"           : ["static","implicit","explicit"],
+        "framework"                  : "lagrangian",
+        "symmetric_lhs"              : true,
+        "positive_definite_lhs"      : true,
+        "output"                     : {
+            "gauss_point"            : [],
+            "nodal_historical"       : ["DISPLACEMENT","VELOCITY","ACCELERATION"],
+            "nodal_non_historical"   : [],
+            "entity"                 : []
+        },
+        "required_variables"         : ["DISPLACEMENT"],
+        "required_dofs"              : ["DISPLACEMENT_X","DISPLACEMENT_Y","DISPLACEMENT_Z"],
+        "flags_used"                 : [],
+        "compatible_geometries"      : ["Line3D2"],
+        "element_integrates_in_time" : false,
+        "compatible_constitutive_laws": {
+            "type"        : ["TrussConstitutiveLaw"],
+            "dimension"   : ["3D"],
+            "strain_size" : [1]
+        },
+        "required_polynomial_degree_of_geometry" : 1,
+        "documentation"   : "This elements implements a non-linear truss formulation."
+    })");
+
+    return specifications;
+}
+
 void TrussElement3D2N::CalculateLumpedMassVector(
     VectorType& rLumpedMassVector,
     const ProcessInfo& rCurrentProcessInfo) const

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
@@ -1003,7 +1003,7 @@ const Parameters TrussElement3D2N::GetSpecifications() const
         "element_integrates_in_time" : false,
         "compatible_constitutive_laws": {
             "type"        : ["TrussConstitutiveLaw"],
-            "dimension"   : ["3D"],
+            "dimension"   : ["1D"],
             "strain_size" : [1]
         },
         "required_polynomial_degree_of_geometry" : 1,

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
@@ -1003,7 +1003,7 @@ const Parameters TrussElement3D2N::GetSpecifications() const
         "element_integrates_in_time" : false,
         "compatible_constitutive_laws": {
             "type"        : ["TrussConstitutiveLaw"],
-            "dimension"   : ["1D"],
+            "dimension"   : ["3D"],
             "strain_size" : [1]
         },
         "required_polynomial_degree_of_geometry" : 1,

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.hpp
@@ -258,6 +258,8 @@ namespace Kratos
          */
         bool HasSelfWeight() const;
 
+        const Parameters GetSpecifications() const override;
+
 private:
     /**
      * @brief This method computes directly the lumped mass vector

--- a/kratos/tests/test_specifications_utilities.py
+++ b/kratos/tests/test_specifications_utilities.py
@@ -107,7 +107,7 @@ class TestSpecificationsUtilities(KratosUnittest.TestCase):
         KratosMultiphysics.SpecificationsUtilities.AddMissingDofs(model_part)
         self.assertEqual(node1.HasDofFor(KratosMultiphysics.DISPLACEMENT_X), True)
         self.assertEqual(node1.HasDofFor(KratosMultiphysics.DISPLACEMENT_Y), True)
-        self.assertEqual(node1.HasDofFor(KratosMultiphysics.DISPLACEMENT_Z), True)
+        self.assertEqual(node1.HasDofFor(KratosMultiphysics.DISPLACEMENT_Z), False)
 
         self.assertEqual(KratosMultiphysics.SpecificationsUtilities.DetermineTimeIntegration(model_part).sort(), ['explicit', 'static', 'implicit'].sort())
         self.assertEqual(KratosMultiphysics.SpecificationsUtilities.DetermineFramework(model_part), "lagrangian")


### PR DESCRIPTION
**📝 Description**
In this PR I'm adding the `GetSpecifications` method to some of the elements in the `StructuralMechanicsApplication`. I did it in such a way that we can retrieve the DOFs from the `required_dofs` field. That is to say, not to all the elements but to "all" the base elements. Besides this, I may have missed some of the fields so I'd appreciate any comment from you @loumalouomega @philbucher guys. 
