### PR TITLE
[Core][IndexedObject] missing include

### DIFF
--- a/kratos/includes/indexed_object.h
+++ b/kratos/includes/indexed_object.h
@@ -21,6 +21,7 @@
 
 // Project includes
 #include "includes/define.h"
+#include "includes/serializer.h"
 
 namespace Kratos
 {


### PR DESCRIPTION
The `IndexedObject` uses the `Serializer` but does not include it