### PR TITLE
[Core] SpecificationUtils addition of GetDofsListFromSpecifications

### DIFF
--- a/kratos/elements/distance_calculation_element_simplex.h
+++ b/kratos/elements/distance_calculation_element_simplex.h
@@ -397,6 +397,36 @@ public:
     ///@name Input and output
     ///@{
 
+    const Parameters GetSpecifications() const override
+    {
+        const Parameters specifications = Parameters(R"({
+            "time_integration"           : ["static"],
+            "framework"                  : "eulerian",
+            "symmetric_lhs"              : true,
+            "positive_definite_lhs"      : true,
+            "output"                     : {
+                "gauss_point"            : [],
+                "nodal_historical"       : ["DISTANCE"],
+                "nodal_non_historical"   : [],
+                "entity"                 : []
+            },
+            "required_variables"         : ["DISTANCE"],
+            "required_dofs"              : ["DISTANCE"],
+            "flags_used"                 : ["BOUNDARY"],
+            "compatible_geometries"      : ["Triangle2D3","Tetrahedra3D4"],
+            "element_integrates_in_time" : false,
+            "compatible_constitutive_laws": {
+                "type"        : [],
+                "dimension"   : [],
+                "strain_size" : []
+            },
+            "required_polynomial_degree_of_geometry" : 1,
+            "documentation"   :
+                "This element is intended to be used in combination with the VariationalDistanceCalculationProcess. It implements a two-step resolution of an Eikonal equation in order to obtain a distance field with unit gradient norm."
+        })");
+        return specifications;
+    }
+
     /// Turn back information as a string.
     std::string Info() const override
     {

--- a/kratos/python/add_other_utilities_to_python.cpp
+++ b/kratos/python/add_other_utilities_to_python.cpp
@@ -600,6 +600,9 @@ void AddOtherUtilitiesToPython(pybind11::module &m)
     mod_spec_utils.def("CheckCompatibleConstitutiveLaws", &SpecificationsUtilities::CheckCompatibleConstitutiveLaws );
     mod_spec_utils.def("CheckGeometricalPolynomialDegree", &SpecificationsUtilities::CheckGeometricalPolynomialDegree );
     mod_spec_utils.def("GetDocumention", &SpecificationsUtilities::GetDocumention );
+    mod_spec_utils.def("GetDofsListFromSpecifications", &SpecificationsUtilities::GetDofsListFromSpecifications);
+    mod_spec_utils.def("GetDofsListFromElementsSpecifications", &SpecificationsUtilities::GetDofsListFromElementsSpecifications);
+    mod_spec_utils.def("GetDofsListFromConditionsSpecifications", &SpecificationsUtilities::GetDofsListFromConditionsSpecifications);
 
     // PropertiesUtilities
     auto mod_prop_utils = m.def_submodule("PropertiesUtilities");
@@ -700,7 +703,7 @@ void AddOtherUtilitiesToPython(pybind11::module &m)
 
     auto single_model_part_import = m.def_submodule("SingleImportModelPart");
     single_model_part_import.def("Import", &SingleImportModelPart::Import );
-  
+
     // RVE periodicity utility
     py::class_<RVEPeriodicityUtility>(m,"RVEPeriodicityUtility")
         .def(py::init<ModelPart&>())

--- a/kratos/tests/test_specifications_utilities.py
+++ b/kratos/tests/test_specifications_utilities.py
@@ -162,5 +162,25 @@ class TestSpecificationsUtilities(KratosUnittest.TestCase):
         docu = KratosMultiphysics.Parameters("""{"SurfaceLoadCondition3D3N"   : "This is a pure displacement condition"}""")
         self.assertEqual(KratosMultiphysics.SpecificationsUtilities.GetDocumention(model_part).IsEquivalentTo(docu), True)
 
+    def testGetDofsListFromSpecifications(self):
+        # Set the test model part
+        current_model = KratosMultiphysics.Model()
+        model_part = current_model.CreateModelPart("Main")
+        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
+        model_part.CreateNewNode(1,0.0,0.0,0.0)
+        model_part.CreateNewNode(2,1.0,0.0,0.0)
+        model_part.CreateNewNode(3,0.0,1.0,0.0)
+        model_part.CreateNewNode(4,1.0,1.0,0.0)
+        prop_1 = model_part.CreateNewProperties(1)
+        model_part.CreateNewElement("DistanceCalculationElementSimplex2D3N",1,[1,2,3],prop_1)
+        model_part.CreateNewElement("DistanceCalculationElementSimplex2D3N",2,[2,4,3],prop_1)
+
+        # Get the DOFs list from the elements specifications
+        dofs_list = KratosMultiphysics.SpecificationsUtilities.GetDofsListFromSpecifications(model_part)
+
+        # Check the obtained DOFs list
+        expected_dofs_list = ["DISTANCE"]
+        self.assertEqual(dofs_list, expected_dofs_list)
+
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/kratos/utilities/specifications_utilities.cpp
+++ b/kratos/utilities/specifications_utilities.cpp
@@ -61,10 +61,6 @@ std::vector<std::string> GetDofsListFromGenericEntitiesSpecifications(const TCon
     return dofs_var_names_list;
 }
 
-template KRATOS_API(KRATOS_CORE) std::vector<std::string> GetDofsListFromGenericEntitiesSpecifications<const ModelPart::ElementsContainerType>(const ModelPart::ElementsContainerType&);
-
-template KRATOS_API(KRATOS_CORE) std::vector<std::string> GetDofsListFromGenericEntitiesSpecifications<const ModelPart::ConditionsContainerType>(const ModelPart::ConditionsContainerType&);
-
 }
 
 void AddMissingVariables(ModelPart& rModelPart)

--- a/kratos/utilities/specifications_utilities.cpp
+++ b/kratos/utilities/specifications_utilities.cpp
@@ -4,13 +4,15 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Vicente Mataix Ferrandiz
+//                   Ruben Zorrilla
 //
 
 // System includes
+#include <unordered_set>
 
 // External includes
 
@@ -23,6 +25,48 @@ namespace Kratos
 {
 namespace SpecificationsUtilities
 {
+
+namespace
+{
+
+template< class TContainerType>
+std::vector<std::string> GetDofsListFromGenericEntitiesSpecifications(const TContainerType& rContainer)
+{
+    // Create a set with the DOFs variables in the container entities specifications
+    std::unordered_set<std::string> dofs_var_names_set;
+    const std::size_t n_entities = rContainer.size();
+    for (std::size_t i = 0; i < n_entities; ++i) {
+        const auto it_entity = rContainer.begin() + i;
+        const auto specifications = it_entity->GetSpecifications();
+        if (specifications.Has("required_dofs")) {
+            const auto required_dofs = specifications["required_dofs"].GetStringArray();
+            for (std::size_t i_dof = 0; i_dof < required_dofs.size(); ++i_dof) {
+                dofs_var_names_set.insert(required_dofs[i_dof]);
+            }
+        }
+    }
+    KRATOS_WARNING_IF("GetDofsListFromGenericEntitiesSpecifications", n_entities > 0 && dofs_var_names_set.empty())
+        << "DOFs variables set is empty. Check and complete your element/condition GetSpecifications() implementation." << std::endl;
+
+    // Check that all the DOFs variables exist
+    for (auto& r_var_name : dofs_var_names_set) {
+        KRATOS_ERROR_IF_NOT(KratosComponents<Variable<double>>::Has(r_var_name))
+            << "DOF \'" << r_var_name << "\' is not in KratosComponents. Check your element/condition GetSpecifications() implementation." << std::endl;
+    }
+
+    // Return a list with the DOFs variables
+    std::vector<std::string> dofs_var_names_list;
+    dofs_var_names_list.insert(dofs_var_names_list.end(), dofs_var_names_set.begin(), dofs_var_names_set.end());
+
+    return dofs_var_names_list;
+}
+
+template KRATOS_API(KRATOS_CORE) std::vector<std::string> GetDofsListFromGenericEntitiesSpecifications<ModelPart::ElementsContainerType>(const ModelPart::ElementsContainerType&);
+
+template KRATOS_API(KRATOS_CORE) std::vector<std::string> GetDofsListFromGenericEntitiesSpecifications<ModelPart::ConditionsContainerType>(const ModelPart::ConditionsContainerType&);
+
+}
+
 void AddMissingVariables(ModelPart& rModelPart)
 {
     KRATOS_TRY
@@ -264,6 +308,42 @@ void AddMissingDofsFromSpecifications(
     }
 
     KRATOS_CATCH("")
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::vector<std::string> GetDofsListFromSpecifications(const ModelPart& rModelPart)
+{
+    // Get DOFs variable names list from elements and conditions
+    const auto elem_dofs_list = GetDofsListFromElementsSpecifications(rModelPart);
+    const auto cond_dofs_list = GetDofsListFromConditionsSpecifications(rModelPart);
+
+    // Remove duplicates
+    std::vector<std::string> all_dofs;
+    std::merge(elem_dofs_list.begin(), elem_dofs_list.end(), cond_dofs_list.begin(), cond_dofs_list.end(), std::back_inserter(all_dofs));
+    std::sort(all_dofs.begin(),all_dofs.end());
+    all_dofs.erase(std::unique(all_dofs.begin(),all_dofs.end()), all_dofs.end());
+
+    return all_dofs;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::vector<std::string> GetDofsListFromElementsSpecifications(const ModelPart& rModelPart)
+{
+    KRATOS_ERROR_IF(rModelPart.IsDistributed()) << "This method is not MPI-compatible yet." << std::endl;
+    return GetDofsListFromGenericEntitiesSpecifications(rModelPart.Elements());
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::vector<std::string> GetDofsListFromConditionsSpecifications(const ModelPart& rModelPart)
+{
+    KRATOS_ERROR_IF(rModelPart.IsDistributed()) << "This method is not MPI-compatible yet." << std::endl;
+    return GetDofsListFromGenericEntitiesSpecifications(rModelPart.Conditions());
 }
 
 /***********************************************************************************/
@@ -1067,9 +1147,9 @@ bool CheckCompatibleConstitutiveLaws(ModelPart& rModelPart)
             const Vector compatible_constitutive_laws_strain_size = specifications["compatible_constitutive_laws"]["strain_size"].GetVector();
             const std::size_t number_of_cl_compatible = compatible_constitutive_laws_strain_size.size();
             // If the vector is full of nullptr we just return true
-            if (cl_vector.size() > 0) 
-                if (cl_vector[0] == nullptr) 
-                    return true; 
+            if (cl_vector.size() > 0)
+                if (cl_vector[0] == nullptr)
+                    return true;
             for (auto& p_cl : cl_vector) {
                 bool check = false;
                 for (std::size_t i = 0; i < number_of_cl_compatible; ++i) {
@@ -1112,9 +1192,9 @@ bool CheckCompatibleConstitutiveLaws(ModelPart& rModelPart)
                     const Vector compatible_constitutive_laws_strain_size = specifications["compatible_constitutive_laws"]["strain_size"].GetVector();
                     const std::size_t number_of_cl_compatible = compatible_constitutive_laws_strain_size.size();
                     // If the vector is full of nullptr we just return true
-                    if (cl_vector.size() > 0) 
-                        if (cl_vector[0] == nullptr) 
-                            return true; 
+                    if (cl_vector.size() > 0)
+                        if (cl_vector[0] == nullptr)
+                            return true;
                     for (auto& p_cl : cl_vector) {
                         bool check = false;
                         for (std::size_t i = 0; i < number_of_cl_compatible; ++i) {
@@ -1237,7 +1317,7 @@ int CheckGeometricalPolynomialDegree(ModelPart& rModelPart)
         }
     }
 
-    // Final message 
+    // Final message
     KRATOS_WARNING_IF("SpecificationsUtilities", polynomial_degree_of_geometry > 0) << "Finally, the polynomial degree of geometry considered is: " << polynomial_degree_of_geometry << std::endl;
 
     return polynomial_degree_of_geometry;

--- a/kratos/utilities/specifications_utilities.cpp
+++ b/kratos/utilities/specifications_utilities.cpp
@@ -61,9 +61,9 @@ std::vector<std::string> GetDofsListFromGenericEntitiesSpecifications(const TCon
     return dofs_var_names_list;
 }
 
-template KRATOS_API(KRATOS_CORE) std::vector<std::string> GetDofsListFromGenericEntitiesSpecifications<ModelPart::ElementsContainerType>(const ModelPart::ElementsContainerType&);
+template KRATOS_API(KRATOS_CORE) std::vector<std::string> GetDofsListFromGenericEntitiesSpecifications<const ModelPart::ElementsContainerType>(const ModelPart::ElementsContainerType&);
 
-template KRATOS_API(KRATOS_CORE) std::vector<std::string> GetDofsListFromGenericEntitiesSpecifications<ModelPart::ConditionsContainerType>(const ModelPart::ConditionsContainerType&);
+template KRATOS_API(KRATOS_CORE) std::vector<std::string> GetDofsListFromGenericEntitiesSpecifications<const ModelPart::ConditionsContainerType>(const ModelPart::ConditionsContainerType&);
 
 }
 

--- a/kratos/utilities/specifications_utilities.h
+++ b/kratos/utilities/specifications_utilities.h
@@ -52,6 +52,13 @@ namespace Kratos
  */
 namespace SpecificationsUtilities
 {
+
+namespace
+{
+    template< class TContainerType>
+    std::vector<std::string> GetDofsListFromGenericEntitiesSpecifications(const TContainerType& rContainer);
+}
+
     /**
      * @brief This enum defines a "hash" used to identify if implicit/explicit or static time integration is considered
      */
@@ -153,6 +160,12 @@ namespace SpecificationsUtilities
         const Parameters SpecificationsParameters,
         const std::string EntityName = "NOT_DEFINED"
         );
+
+    std::vector<std::string> KRATOS_API(KRATOS_CORE) GetDofsListFromSpecifications(const ModelPart& rModelPart);
+
+    std::vector<std::string> KRATOS_API(KRATOS_CORE) GetDofsListFromElementsSpecifications(const ModelPart& rModelPart);
+
+    std::vector<std::string> KRATOS_API(KRATOS_CORE) GetDofsListFromConditionsSpecifications(const ModelPart& rModelPart);
 
     /**
      * @brief This method determine the flags used on the simulation


### PR DESCRIPTION
**📝 Description**
This PR adds a new method to the `SpecificationUtils` namespace (:fearful:). The idea is to get a list with the DOFs that are specified in the `required_dofs`  field of the elements and/or conditions `GetSpecifications` method.

Note that these methods are not MPI-compatible compatible yet as we don't have the capability to synchronize the list/set (yet).
