### PR TITLE
[ROM] Unify ROM solver

### DIFF
--- a/applications/RomApplication/python_scripts/convection_diffusion_stationary_rom_solver.py
+++ b/applications/RomApplication/python_scripts/convection_diffusion_stationary_rom_solver.py
@@ -20,6 +20,8 @@ class ROMSolver(ConvectionDiffusionStationarySolver):
     """
 
     def __init__(self, model, custom_settings):
+        KratosMultiphysics.Logger.PrintWarning('\x1b[1;31m[DEPRECATED CLASS] \x1b[0m',"\'convection_diffusion_stationary_rom_solver\'", "class is deprecated. Use the generic\'RomSolver\' one instead.")
+
         super(ROMSolver, self).__init__(model, custom_settings)
         KratosMultiphysics.Logger.PrintInfo("::[ROMSolver]:: ", "Construction finished")
 

--- a/applications/RomApplication/python_scripts/convection_diffusion_transient_rom_solver.py
+++ b/applications/RomApplication/python_scripts/convection_diffusion_transient_rom_solver.py
@@ -20,6 +20,8 @@ class ROMSolver(ConvectionDiffusionTransientSolver):
     """
 
     def __init__(self, model, custom_settings):
+        KratosMultiphysics.Logger.PrintWarning('\x1b[1;31m[DEPRECATED CLASS] \x1b[0m',"\'convection_diffusion_transient_rom_solver\'", "class is deprecated. Use the generic\'RomSolver\' one instead.")
+
         super(ROMSolver, self).__init__(model, custom_settings)
         KratosMultiphysics.Logger.PrintInfo("::[ROMSolver]:: ", "Construction finished")
 

--- a/applications/RomApplication/python_scripts/navier_stokes_solver_vmsmonolithic_rom.py
+++ b/applications/RomApplication/python_scripts/navier_stokes_solver_vmsmonolithic_rom.py
@@ -14,6 +14,8 @@ def CreateSolver(model, custom_settings):
 class ROMSolver(NavierStokesSolverMonolithic):
 
     def __init__(self, model, custom_settings):
+        KratosMultiphysics.Logger.PrintWarning('\x1b[1;31m[DEPRECATED CLASS] \x1b[0m',"\'navier_stokes_solver_vmsmonolithic_rom\'", "class is deprecated. Use the generic\'RomSolver\' one instead.")
+
         super().__init__(model, custom_settings)
         KratosMultiphysics.Logger.PrintInfo("::[ROMSolver]:: ", "Construction finished")
 

--- a/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
+++ b/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
@@ -7,10 +7,10 @@ from KratosMultiphysics.RomApplication import rom_solver
 
 def CreateSolverByParameters(model, solver_settings, parallelism, analysis_stage_module_name):
 
-    if isinstance(model, KratosMultiphysics.Model):
+    if not isinstance(model, KratosMultiphysics.Model):
         raise Exception("input is expected to be provided as a Kratos Model object")
 
-    if isinstance(solver_settings, KratosMultiphysics.Parameters):
+    if not isinstance(solver_settings, KratosMultiphysics.Parameters):
         raise Exception("input is expected to be provided as a Kratos Parameters object")
 
     # Get the corresponding application from the analysis_stage path

--- a/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
+++ b/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
@@ -1,0 +1,64 @@
+import sys
+import importlib
+
+import KratosMultiphysics
+from KratosMultiphysics import kratos_utilities
+from KratosMultiphysics.RomApplication import rom_solver
+
+def CreateSolverByParameters(model, solver_settings, parallelism, analysis_stage_module_name):
+
+    if (type(model) != KratosMultiphysics.Model):
+        raise Exception("input is expected to be provided as a Kratos Model object")
+
+    if (type(solver_settings) != KratosMultiphysics.Parameters):
+        raise Exception("input is expected to be provided as a Kratos Parameters object")
+
+    # Get the corresponding application from the analysis_stage path
+    split_analysis_stage_module_name = analysis_stage_module_name.split('.')
+    application_module_name = split_analysis_stage_module_name[0] + "." + split_analysis_stage_module_name[1]
+    if not kratos_utilities.CheckIfApplicationsAvailable(split_analysis_stage_module_name[1]):
+        raise Exception("Module {} is not available.".format(application_module_name))
+
+    # Filter and retrieve the Python solvers wrapper from the corresponding application
+    #TODO: This filtering wouldn't be required with a unified solvers wrapper module name
+    if application_module_name == "KratosMultiphysics.FluidDynamicsApplication":
+        solvers_wrapper_module_module_name = "python_solvers_wrapper_fluid"
+    elif application_module_name == "KratosMultiphysics.StructuralMechanicsApplication":
+        solvers_wrapper_module_module_name = "python_solvers_wrapper_structural"
+    elif application_module_name == "KratosMultiphysics.ConvectionDiffusionApplication":
+        solvers_wrapper_module_module_name = "python_solvers_wrapper_convection_diffusion"
+    else:
+        err_msg = "Python module \'{0}\' is not available. Make sure \'{1}\' is compiled.".format(application_module_name, split_analysis_stage_module_name[1])
+        raise Exception(err_msg)
+    solvers_wrapper_module = importlib.import_module(application_module_name + "." + solvers_wrapper_module_module_name)
+
+    # Create a prototype class instance and get the module and name of the solver to be used as base
+    # Note that an auxiliary Kratos parameter settings without the rom_settings field is created to avoid the defaults error thrown
+    # Note that an auxiliary Kratos model is also created to avoid creating the main_model_part in the prototype class instance
+    #TODO: We could do the same exercise as we do in the stage (module_name to ClassName equal to ModuleName if we standarize the solver names)
+    aux_solver_settings = solver_settings.Clone()
+    aux_solver_settings.RemoveValue("rom_settings")
+    aux_base_solver_instance = solvers_wrapper_module.CreateSolverByParameters(KratosMultiphysics.Model(), aux_solver_settings, parallelism)
+    base_solver_class_name = aux_base_solver_instance.__class__.__name__
+    base_solver_module_name = aux_base_solver_instance.__class__.__module__
+    base_solver_class = getattr(sys.modules[base_solver_module_name], base_solver_class_name)
+
+    # Create the ROM solver from the base solver
+    rom_solver_instance = rom_solver.CreateSolver(base_solver_class, model, solver_settings)
+
+    return rom_solver_instance
+
+def CreateSolver(model, custom_settings):
+
+    if (type(model) != KratosMultiphysics.Model):
+        raise Exception("input is expected to be provided as a Kratos Model object")
+
+    if (type(custom_settings) != KratosMultiphysics.Parameters):
+        raise Exception("input is expected to be provided as a Kratos Parameters object")
+
+    parallelism = custom_settings["problem_data"]["parallel_type"].GetString()
+    analysis_stage = custom_settings["analysis_stage"].GetString()
+    solver_settings = custom_settings["solver_settings"]
+
+    return CreateSolverByParameters(model, solver_settings, parallelism, analysis_stage)
+

--- a/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
+++ b/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
@@ -7,10 +7,10 @@ from KratosMultiphysics.RomApplication import rom_solver
 
 def CreateSolverByParameters(model, solver_settings, parallelism, analysis_stage_module_name):
 
-    if (isinstance(model) != KratosMultiphysics.Model):
+    if isinstance(model, KratosMultiphysics.Model):
         raise Exception("input is expected to be provided as a Kratos Model object")
 
-    if (isinstance(solver_settings) != KratosMultiphysics.Parameters):
+    if isinstance(solver_settings, KratosMultiphysics.Parameters):
         raise Exception("input is expected to be provided as a Kratos Parameters object")
 
     # Get the corresponding application from the analysis_stage path

--- a/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
+++ b/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
@@ -20,7 +20,7 @@ def CreateSolverByParameters(model, solver_settings, parallelism, analysis_stage
         raise Exception("Module {} is not available.".format(application_module_name))
 
     # Filter and retrieve the Python solvers wrapper from the corresponding application
-    #TODO: This filtering wouldn't be required with a unified solvers wrapper module name
+    #TODO: This filtering wouldn't be required if we were using a unified solvers wrapper module name
     if application_module_name == "KratosMultiphysics.FluidDynamicsApplication":
         solvers_wrapper_module_module_name = "python_solvers_wrapper_fluid"
     elif application_module_name == "KratosMultiphysics.StructuralMechanicsApplication":
@@ -39,12 +39,9 @@ def CreateSolverByParameters(model, solver_settings, parallelism, analysis_stage
     aux_solver_settings = solver_settings.Clone()
     aux_solver_settings.RemoveValue("rom_settings")
     aux_base_solver_instance = solvers_wrapper_module.CreateSolverByParameters(KratosMultiphysics.Model(), aux_solver_settings, parallelism)
-    base_solver_class_name = aux_base_solver_instance.__class__.__name__
-    base_solver_module_name = aux_base_solver_instance.__class__.__module__
-    base_solver_class = getattr(sys.modules[base_solver_module_name], base_solver_class_name)
 
     # Create the ROM solver from the base solver
-    rom_solver_instance = rom_solver.CreateSolver(base_solver_class, model, solver_settings)
+    rom_solver_instance = rom_solver.CreateSolver(type(aux_base_solver_instance), model, solver_settings)
 
     return rom_solver_instance
 

--- a/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
+++ b/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
@@ -7,10 +7,10 @@ from KratosMultiphysics.RomApplication import rom_solver
 
 def CreateSolverByParameters(model, solver_settings, parallelism, analysis_stage_module_name):
 
-    if (type(model) != KratosMultiphysics.Model):
+    if (isinstance(model) != KratosMultiphysics.Model):
         raise Exception("input is expected to be provided as a Kratos Model object")
 
-    if (type(solver_settings) != KratosMultiphysics.Parameters):
+    if (isinstance(solver_settings) != KratosMultiphysics.Parameters):
         raise Exception("input is expected to be provided as a Kratos Parameters object")
 
     # Get the corresponding application from the analysis_stage path

--- a/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
+++ b/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
@@ -39,12 +39,9 @@ def CreateSolverByParameters(model, solver_settings, parallelism, analysis_stage
     aux_solver_settings = solver_settings.Clone()
     aux_solver_settings.RemoveValue("rom_settings")
     aux_base_solver_instance = solvers_wrapper_module.CreateSolverByParameters(KratosMultiphysics.Model(), aux_solver_settings, parallelism)
-    base_solver_class_name = aux_base_solver_instance.__class__.__name__
-    base_solver_module_name = aux_base_solver_instance.__class__.__module__
-    base_solver_class = getattr(sys.modules[base_solver_module_name], base_solver_class_name)
 
     # Create the ROM solver from the base solver
-    rom_solver_instance = rom_solver.CreateSolver(base_solver_class, model, solver_settings)
+    rom_solver_instance = rom_solver.CreateSolver(type(aux_base_solver_instance), model, solver_settings)
 
     return rom_solver_instance
 

--- a/applications/RomApplication/python_scripts/python_solvers_wrapper_rom.py
+++ b/applications/RomApplication/python_scripts/python_solvers_wrapper_rom.py
@@ -5,6 +5,8 @@ from importlib import import_module
 
 def CreateSolverByParameters(model, solver_settings, parallelism):
 
+    KratosMultiphysics.Logger.PrintWarning('\x1b[1;31m[DEPRECATED CLASS] \x1b[0m',"\'python_solvers_wrapper_rom\'", "module is deprecated. Use the generic\'new_python_solvers_wrapper_rom\' one instead.")
+
     if (type(model) != KratosMultiphysics.Model):
         raise Exception("input is expected to be provided as a Kratos Model object")
 

--- a/applications/RomApplication/python_scripts/rom_analysis.py
+++ b/applications/RomApplication/python_scripts/rom_analysis.py
@@ -5,6 +5,7 @@ import numpy as np
 import KratosMultiphysics
 import KratosMultiphysics.RomApplication as KratosROM
 from KratosMultiphysics.RomApplication import python_solvers_wrapper_rom
+from KratosMultiphysics.RomApplication import new_python_solvers_wrapper_rom
 from KratosMultiphysics.RomApplication.empirical_cubature_method import EmpiricalCubatureMethod
 
 def CreateRomAnalysisInstance(cls, global_model, parameters, hyper_reduction_element_selector = None):
@@ -33,10 +34,9 @@ def CreateRomAnalysisInstance(cls, global_model, parameters, hyper_reduction_ele
                 self.project_parameters["solver_settings"].AddValue("rom_settings", rom_settings["rom_settings"])
 
             # Create the ROM solver
-            return python_solvers_wrapper_rom.CreateSolverByParameters(
+            return new_python_solvers_wrapper_rom.CreateSolver(
                 self.model,
-                self.project_parameters["solver_settings"],
-                self.project_parameters["problem_data"]["parallel_type"].GetString())
+                self.project_parameters)
 
         def _GetSimulationName(self):
             return "::[ROM Simulation]:: "

--- a/applications/RomApplication/python_scripts/rom_analysis.py
+++ b/applications/RomApplication/python_scripts/rom_analysis.py
@@ -53,7 +53,7 @@ def CreateRomAnalysisInstance(cls, global_model, parameters, hyper_reduction_ele
                 # Get the ROM data from RomParameters.json
                 data = json.load(f)
                 nodal_modes = data["nodal_modes"]
-                nodal_dofs = len(data["rom_settings"]["nodal_unknowns"])
+                nodal_dofs = len(self.project_parameters["solver_settings"]["rom_settings"]["nodal_unknowns"].GetStringArray())
                 rom_dofs = self.project_parameters["solver_settings"]["rom_settings"]["number_of_rom_dofs"].GetInt()
 
                 # Set the nodal ROM basis

--- a/applications/RomApplication/python_scripts/rom_solver.py
+++ b/applications/RomApplication/python_scripts/rom_solver.py
@@ -1,0 +1,58 @@
+# Importing the Kratos Library
+import KratosMultiphysics
+
+# Import applications
+import KratosMultiphysics.RomApplication as KratosROM
+
+def CreateSolver(cls, model, custom_settings):
+    class ROMSolver(cls):
+        """ROM solver generic main class.
+        This class serves as a generic class to make a standard Kratos solver ROM-compatible.
+        It extends the default parameters to include the \'rom_settings\' and overrides the
+        creation of the builder and solver to use the ROM one.
+        """
+
+        def __init__(self, model, custom_settings):
+            super().__init__(model, custom_settings)
+            KratosMultiphysics.Logger.PrintInfo("::[ROMSolver]:: ", "Construction finished")
+
+        @classmethod
+        def GetDefaultParameters(cls):
+            default_settings = KratosMultiphysics.Parameters("""{
+                "rom_settings": {
+                    "nodal_unknowns": [],
+                    "number_of_rom_dofs": 0
+                }
+            }""")
+            default_settings.AddMissingParameters(super().GetDefaultParameters())
+            return default_settings
+
+        def _CreateBuilderAndSolver(self):
+            linear_solver = self._GetLinearSolver()
+            rom_parameters = self._ValidateAndReturnRomParameters()
+            builder_and_solver = KratosROM.ROMBuilderAndSolver(linear_solver, rom_parameters)
+            return builder_and_solver
+
+        def _ValidateAndReturnRomParameters(self):
+            # Check that the number of ROM DOFs has been provided
+            n_rom_dofs = self.settings["rom_settings"]["number_of_rom_dofs"].GetInt()
+            if not n_rom_dofs > 0:
+                err_msg = "\'number_of_rom_dofs\' in \'rom_settings\' is {}. Please set a larger than zero value.".format(n_rom_dofs)
+                raise Exception(err_msg)
+
+            # Check if the nodal unknowns have been provided by the user
+            # If not, take the DOFs list from the base solver
+            nodal_unknowns = self.settings["rom_settings"]["nodal_unknowns"].GetStringArray()
+            if len(nodal_unknowns) == 0:
+                solver_dofs_list = self.GetDofsList()
+                if not len(solver_dofs_list) == 0:
+                    self.settings["rom_settings"]["nodal_unknowns"].SetStringArray()
+                else:
+                    err_msg = "\'nodal_unknowns\' in \'rom_settings\' is not provided and there is a not-valid implementation in base solver."
+                    err_msg += " Please manually set \'nodal_unknowns\' in \'rom_settings\'."
+                    raise Exception(err_msg)
+
+            # Return the validated ROM parameters
+            return self.settings["rom_settings"]
+
+    return ROMSolver(model, custom_settings)

--- a/applications/RomApplication/python_scripts/rom_solver.py
+++ b/applications/RomApplication/python_scripts/rom_solver.py
@@ -46,7 +46,7 @@ def CreateSolver(cls, model, custom_settings):
             if len(nodal_unknowns) == 0:
                 solver_dofs_list = self.GetDofsList()
                 if not len(solver_dofs_list) == 0:
-                    self.settings["rom_settings"]["nodal_unknowns"].SetStringArray()
+                    self.settings["rom_settings"]["nodal_unknowns"].SetStringArray(solver_dofs_list)
                 else:
                     err_msg = "\'nodal_unknowns\' in \'rom_settings\' is not provided and there is a not-valid implementation in base solver."
                     err_msg += " Please manually set \'nodal_unknowns\' in \'rom_settings\'."

--- a/applications/RomApplication/python_scripts/structural_mechanics_implicit_dynamic_rom_solver.py
+++ b/applications/RomApplication/python_scripts/structural_mechanics_implicit_dynamic_rom_solver.py
@@ -23,6 +23,8 @@ class ROMSolver(ImplicitMechanicalSolver):
     """
 
     def __init__(self, main_model_part, custom_settings):
+        KratosMultiphysics.Logger.PrintWarning('\x1b[1;31m[DEPRECATED CLASS] \x1b[0m',"\'structural_mechanics_implicit_dynamic_rom_solver\'", "class is deprecated. Use the generic\'RomSolver\' one instead.")
+
         super(ROMSolver, self).__init__(main_model_part, custom_settings)
         KratosMultiphysics.Logger.PrintInfo("::[ROMSolver]:: ", "Construction finished")
 

--- a/applications/RomApplication/python_scripts/structural_mechanics_static_rom_solver.py
+++ b/applications/RomApplication/python_scripts/structural_mechanics_static_rom_solver.py
@@ -20,6 +20,8 @@ class ROMSolver(StaticMechanicalSolver):
     """
 
     def __init__(self, main_model_part, custom_settings):
+        KratosMultiphysics.Logger.PrintWarning('\x1b[1;31m[DEPRECATED CLASS] \x1b[0m',"\'stuctural_mechanics_static_rom_solver\'", "class is deprecated. Use the generic\'RomSolver\' one instead.")
+
         super(ROMSolver, self).__init__(main_model_part, custom_settings)
         KratosMultiphysics.Logger.PrintInfo("::[ROMSolver]:: ", "Construction finished")
 


### PR DESCRIPTION
**📝 Description**
Similar to what we did in #9439 with the `RomAnalysisStage`, in this PR I'm unifying the ROM solvers in a new `RomSolver`. The dynamic inheritance mechanism is equivalent to that of #9439. In order to keep backwards compatibility I kept the old solvers (adding a deprecation warning) and created a `new_python_solvers_wrapper_rom.py` module. This module filters the base solver from which the ROM solver has to inherit.

In this regard I'd like to note that, if we had a unified name for all the Python solvers wrapper (e.g. `python_solvers_wrapper` instead of `python_solvers_wrapper_fluid`), the new ROM wrapper would be simplified and easier to maintain. In my opinion, it makes not so much sense to have different names for the Python solvers wrappers among applications if we follow the rule that one application should have only one "standard" wrapper (I said standard because of the adjoints). In any case this is to be discussed in an independent issue.   

This requires #9467 to be merged first.
