### PR TITLE
[CoSim] pass DataCommunicator of CoupledSolver to helper classes

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
@@ -124,11 +124,13 @@ class CoSimulationCoupledSolver(CoSimulationSolverWrapper):
             self.settings["coupling_operations"],
             self.solver_wrappers,
             self.process_info,
+            self.data_communicator,
             self.echo_level)
 
         ### Creating the data transfer operators
         self.data_transfer_operators_dict = factories_helper.CreateDataTransferOperators(
             self.settings["data_transfer_operators"],
+            self.data_communicator,
             self.echo_level)
 
         for predictor in self.predictors_list:

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupling_operation.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupling_operation.py
@@ -9,11 +9,12 @@ class CoSimulationCouplingOperation:
     This class can be used to customize the behavior of the CoSimulation,
     by providing a large interface and access to the solvers/models
     """
-    def __init__(self, settings, parent_coupled_solver_process_info):
+    def __init__(self, settings, parent_coupled_solver_process_info, parent_coupled_solver_data_communicator):
         SettingsTypeCheck(settings)
         self.settings = settings
         self.settings.ValidateAndAssignDefaults(self._GetDefaultParameters())
         self.process_info = parent_coupled_solver_process_info
+        self.data_communicator = parent_coupled_solver_data_communicator
         self.echo_level = self.settings["echo_level"].GetInt()
 
     def Initialize(self):

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_data_transfer_operator.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_data_transfer_operator.py
@@ -8,10 +8,11 @@ class CoSimulationDataTransferOperator(metaclass=ABCMeta):
     """Baseclass for the data transfer operators used for CoSimulation
     It transfers data from one interface to another. This can e.g. be mapping or a copy of values.
     """
-    def __init__(self, settings):
+    def __init__(self, settings, parent_coupled_solver_data_communicator):
         self.settings = settings
         self.settings.ValidateAndAssignDefaults(self._GetDefaultParameters())
         self.echo_level = self.settings["echo_level"].GetInt()
+        self.data_communicator = parent_coupled_solver_data_communicator
         self.__checked_combinations = []
 
     def TransferData(self, from_solver_data, to_solver_data, transfer_options):

--- a/applications/CoSimulationApplication/python_scripts/convergence_accelerators/convergence_accelerator_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/convergence_accelerators/convergence_accelerator_wrapper.py
@@ -12,7 +12,7 @@ class ConvergenceAcceleratorWrapper:
     In case of distributed data, it is checked whether the convergence accelerator supports it.
     If not, the data is gathered / scattered and the accelerator is executed on only one rank
     """
-    def __init__(self, settings, solver_wrapper):
+    def __init__(self, settings, solver_wrapper, parent_coupled_solver_data_communicator):
         self.interface_data = solver_wrapper.GetInterfaceData(settings["data_name"].GetString())
         self.residual_computation = CreateResidualComputation(settings, solver_wrapper)
 
@@ -21,6 +21,7 @@ class ConvergenceAcceleratorWrapper:
         settings.RemoveValue("residual_computation")
 
         self.conv_acc = CreateConvergenceAccelerator(settings)
+        self.data_communicator = parent_coupled_solver_data_communicator
 
         if self.interface_data.IsDefinedOnThisRank():
             conv_acc_supports_dist_data = self.conv_acc.SupportsDistributedData()

--- a/applications/CoSimulationApplication/python_scripts/convergence_criteria/convergence_criteria_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/convergence_criteria/convergence_criteria_wrapper.py
@@ -20,7 +20,7 @@ class ConvergenceCriteriaWrapper:
             settings.AddEmptyValue("label").SetString(colors.bold('{}.{}'.format(self.interface_data.solver_name, self.interface_data.name)))
 
         self.conv_crit = CreateConvergenceCriterion(settings)
-        self.parent_coupled_solver_data_communicator = parent_coupled_solver_data_communicator
+        self.data_communicator = parent_coupled_solver_data_communicator
 
         self.executing_rank = False
         if self.interface_data.IsDefinedOnThisRank():
@@ -64,7 +64,7 @@ class ConvergenceCriteriaWrapper:
             is_converged = self.conv_crit.IsConverged(residual, current_data)
 
         # all ranks of the coupled solver need to know the convergence information
-        is_converged = bool(self.parent_coupled_solver_data_communicator.Broadcast(bool(is_converged), 0))
+        is_converged = bool(self.data_communicator.Broadcast(bool(is_converged), 0))
 
         return is_converged
 

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_strong.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_strong.py
@@ -24,6 +24,7 @@ class GaussSeidelStrongCoupledSolver(CoSimulationCoupledSolver):
 
         self.convergence_accelerators_list = factories_helper.CreateConvergenceAccelerators(
             self.settings["convergence_accelerators"],
+            self.data_communicator,
             self.solver_wrappers,
             self.echo_level)
 

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_strong.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_strong.py
@@ -24,8 +24,8 @@ class GaussSeidelStrongCoupledSolver(CoSimulationCoupledSolver):
 
         self.convergence_accelerators_list = factories_helper.CreateConvergenceAccelerators(
             self.settings["convergence_accelerators"],
-            self.data_communicator,
             self.solver_wrappers,
+            self.data_communicator,
             self.echo_level)
 
         self.convergence_criteria_list = factories_helper.CreateConvergenceCriteria(

--- a/applications/CoSimulationApplication/python_scripts/coupling_operations/compute_normals.py
+++ b/applications/CoSimulationApplication/python_scripts/coupling_operations/compute_normals.py
@@ -10,8 +10,8 @@ def Create(*args):
 class ComputeNormalsOperation(CoSimulationCouplingOperation):
     """This operation computes the Normals (NORMAL) on a given ModelPart
     """
-    def __init__(self, settings, solver_wrappers, process_info):
-        super().__init__(settings, process_info)
+    def __init__(self, settings, solver_wrappers, process_info, data_communicator):
+        super().__init__(settings, process_info, data_communicator)
         solver_name = self.settings["solver"].GetString()
         data_name = self.settings["data_name"].GetString()
         self.interface_data = solver_wrappers[solver_name].GetInterfaceData(data_name)

--- a/applications/CoSimulationApplication/python_scripts/coupling_operations/coupling_output.py
+++ b/applications/CoSimulationApplication/python_scripts/coupling_operations/coupling_output.py
@@ -14,8 +14,8 @@ class CouplingOutput(CoSimulationCouplingOperation):
     - add tests
     - more cleanup
     """
-    def __init__(self, settings, solver_wrappers, process_info):
-        super().__init__(settings, process_info)
+    def __init__(self, settings, solver_wrappers, process_info, data_communicator):
+        super().__init__(settings, process_info, data_communicator)
         self.model = solver_wrappers[self.settings["solver"].GetString()].model
         self.execution_point = self.settings["execution_point"].GetString()
         model_part_name = self.settings["output_parameters"]["model_part_name"].GetString()

--- a/applications/CoSimulationApplication/python_scripts/coupling_operations/create_point_load_model_part.py
+++ b/applications/CoSimulationApplication/python_scripts/coupling_operations/create_point_load_model_part.py
@@ -14,9 +14,9 @@ def Create(*args):
 class CreatePointLoadModelPart(CoSimulationCouplingOperation):
     """This operation creates a submodelpart containing PointLoad Conidtions for transferring loads
     """
-    def __init__(self, settings, solver_wrappers, process_info):
+    def __init__(self, settings, solver_wrappers, process_info, data_communicator):
         IssueDeprecationWarning('CreatePointLoadModelPart', 'please use CreatePointBasedEntitiesProcess" instead')
-        super().__init__(settings, process_info)
+        super().__init__(settings, process_info, data_communicator)
         self.model = solver_wrappers[self.settings["solver"].GetString()].model
 
     def Initialize(self):

--- a/applications/CoSimulationApplication/python_scripts/coupling_operations/elemental_data_to_nodal_data.py
+++ b/applications/CoSimulationApplication/python_scripts/coupling_operations/elemental_data_to_nodal_data.py
@@ -14,8 +14,8 @@ def Create(*args):
 class ElementalToNodalData(CoSimulationCouplingOperation):
     """This operation maps the Elemental Data to Nodal Data for a given ModelPart
     """
-    def __init__(self, settings, solver_wrappers, process_info):
-        super().__init__(settings, process_info)
+    def __init__(self, settings, solver_wrappers, process_info, data_communicator):
+        super().__init__(settings, process_info, data_communicator)
         solver_name = self.settings["solver"].GetString()
         data_name = self.settings["data_name"].GetString()
         self.interface_data = solver_wrappers[solver_name].GetInterfaceData(data_name)

--- a/applications/CoSimulationApplication/python_scripts/coupling_operations/print_iteration_number.py
+++ b/applications/CoSimulationApplication/python_scripts/coupling_operations/print_iteration_number.py
@@ -17,8 +17,8 @@ class PrintIterationNumberOperation(CoSimulationCouplingOperation):
     - add tests
     - more cleanup
     """
-    def __init__(self, settings, solver_wrappers, process_info):
-        super().__init__(settings, process_info)
+    def __init__(self, settings, solver_wrappers, process_info, data_communicator):
+        super().__init__(settings, process_info, data_communicator)
         self.model = solver_wrappers[self.settings["solver"].GetString()].model
         self.model_part_name = self.settings["model_part_name"].GetString()
         self.model_part = self.model[self.model_part_name]

--- a/applications/CoSimulationApplication/python_scripts/coupling_operations/reset_pfem_kinematics.py
+++ b/applications/CoSimulationApplication/python_scripts/coupling_operations/reset_pfem_kinematics.py
@@ -18,8 +18,8 @@ class ResetPfemKinematics(CoSimulationCouplingOperation):
     - add tests
     - more cleanup
     """
-    def __init__(self, settings, solver_wrappers, process_info):
-        super().__init__(settings, process_info)
+    def __init__(self, settings, solver_wrappers, process_info, data_communicator):
+        super().__init__(settings, process_info, data_communicator)
         model = solver_wrappers[self.settings["solver"].GetString()].model
         self.model_part_name = self.settings["model_part_name"].GetString()
         self.model_part = model[self.model_part_name]

--- a/applications/CoSimulationApplication/python_scripts/coupling_operations/scaling.py
+++ b/applications/CoSimulationApplication/python_scripts/coupling_operations/scaling.py
@@ -15,7 +15,7 @@ class ScalingOperation(CoSimulationCouplingOperation):
     """This operation performs scaling of values on an InterfaceData
     The value can be given directly as a value or as a string containing an evaluable function
     """
-    def __init__(self, settings, solver_wrappers, parent_coupled_solver_process_info, parent_coupled_solver_data_communicator):
+    def __init__(self, settings, solver_wrappers, process_info, data_communicator):
         if not settings.Has("scaling_factor"):
             raise Exception('Please provide a "scaling_factor"!')
 
@@ -29,7 +29,7 @@ class ScalingOperation(CoSimulationCouplingOperation):
         # removing since the type of "scaling_factor" can be double or string and hence would fail in the validation
         settings.RemoveValue("scaling_factor")
 
-        super().__init__(settings, parent_coupled_solver_process_info, parent_coupled_solver_data_communicator)
+        super().__init__(settings, process_info, data_communicator)
 
         solver_name = self.settings["solver"].GetString()
         data_name = self.settings["data_name"].GetString()

--- a/applications/CoSimulationApplication/python_scripts/coupling_operations/scaling.py
+++ b/applications/CoSimulationApplication/python_scripts/coupling_operations/scaling.py
@@ -15,7 +15,7 @@ class ScalingOperation(CoSimulationCouplingOperation):
     """This operation performs scaling of values on an InterfaceData
     The value can be given directly as a value or as a string containing an evaluable function
     """
-    def __init__(self, settings, solver_wrappers, process_info):
+    def __init__(self, settings, solver_wrappers, parent_coupled_solver_process_info, parent_coupled_solver_data_communicator):
         if not settings.Has("scaling_factor"):
             raise Exception('Please provide a "scaling_factor"!')
 
@@ -29,7 +29,7 @@ class ScalingOperation(CoSimulationCouplingOperation):
         # removing since the type of "scaling_factor" can be double or string and hence would fail in the validation
         settings.RemoveValue("scaling_factor")
 
-        super().__init__(settings, process_info)
+        super().__init__(settings, parent_coupled_solver_process_info, parent_coupled_solver_data_communicator)
 
         solver_name = self.settings["solver"].GetString()
         data_name = self.settings["data_name"].GetString()

--- a/applications/CoSimulationApplication/python_scripts/data_transfer_operators/copy.py
+++ b/applications/CoSimulationApplication/python_scripts/data_transfer_operators/copy.py
@@ -1,8 +1,8 @@
 # Importing the base class
 from KratosMultiphysics.CoSimulationApplication.base_classes.co_simulation_data_transfer_operator import CoSimulationDataTransferOperator
 
-def Create(settings):
-    return CopyDataTransferOperator(settings)
+def Create(*args):
+    return CopyDataTransferOperator(*args)
 
 class CopyDataTransferOperator(CoSimulationDataTransferOperator):
     """DataTransferOperator that copies values from one interface to another, without any checks

--- a/applications/CoSimulationApplication/python_scripts/data_transfer_operators/copy_single_to_distributed.py
+++ b/applications/CoSimulationApplication/python_scripts/data_transfer_operators/copy_single_to_distributed.py
@@ -1,8 +1,8 @@
 # Importing the base class
 from KratosMultiphysics.CoSimulationApplication.base_classes.co_simulation_data_transfer_operator import CoSimulationDataTransferOperator
 
-def Create(settings):
-    return CopySingleToDistributed(settings)
+def Create(*args):
+    return CopySingleToDistributed(*args)
 
 class CopySingleToDistributed(CoSimulationDataTransferOperator):
     """DataTransferOperator to take one single value and set it to all values on another interface.

--- a/applications/CoSimulationApplication/python_scripts/data_transfer_operators/kratos_mapping.py
+++ b/applications/CoSimulationApplication/python_scripts/data_transfer_operators/kratos_mapping.py
@@ -13,8 +13,8 @@ import KratosMultiphysics.CoSimulationApplication.colors as colors
 from KratosMultiphysics.CoSimulationApplication.utilities import data_communicator_utilities
 from time import time
 
-def Create(settings):
-    return KratosMappingDataTransferOperator(settings)
+def Create(*args):
+    return KratosMappingDataTransferOperator(*args)
 
 class KratosMappingDataTransferOperator(CoSimulationDataTransferOperator):
     """DataTransferOperator that maps values from one interface (ModelPart) to another.
@@ -33,10 +33,10 @@ class KratosMappingDataTransferOperator(CoSimulationDataTransferOperator):
     __dummy_model = None
     __rank_zero_model_part = None
 
-    def __init__(self, settings):
+    def __init__(self, settings, parent_coupled_solver_data_communicator):
         if not settings.Has("mapper_settings"):
             raise Exception('No "mapper_settings" provided!')
-        super().__init__(settings)
+        super().__init__(settings, parent_coupled_solver_data_communicator)
         self.__mappers = {}
 
     def _ExecuteTransferData(self, from_solver_data, to_solver_data, transfer_options):

--- a/applications/CoSimulationApplication/python_scripts/data_transfer_operators/sum_distributed_to_single.py
+++ b/applications/CoSimulationApplication/python_scripts/data_transfer_operators/sum_distributed_to_single.py
@@ -4,8 +4,8 @@ from KratosMultiphysics.CoSimulationApplication.base_classes.co_simulation_data_
 # Other imports
 import numpy as np
 
-def Create(settings):
-    return SumDistributedToSingle(settings)
+def Create(*args):
+    return SumDistributedToSingle(*args)
 
 class SumDistributedToSingle(CoSimulationDataTransferOperator):
     """DataTransferOperator to sum values on one interface and put it to another interface.

--- a/applications/CoSimulationApplication/python_scripts/factories/convergence_accelerator_factory.py
+++ b/applications/CoSimulationApplication/python_scripts/factories/convergence_accelerator_factory.py
@@ -1,5 +1,5 @@
 from KratosMultiphysics.CoSimulationApplication.factories import base_factory
 
-def CreateConvergenceAccelerator(convergence_accelerator_settings):
+def CreateConvergenceAccelerator(convergence_accelerator_settings, *args):
     """This function creates and returns the Convergence Accelerator used for CoSimulation"""
-    return base_factory.Create(convergence_accelerator_settings, [], "KratosMultiphysics.CoSimulationApplication.convergence_accelerators")
+    return base_factory.Create(convergence_accelerator_settings, [*args], "KratosMultiphysics.CoSimulationApplication.convergence_accelerators")

--- a/applications/CoSimulationApplication/python_scripts/factories/coupling_operation_factory.py
+++ b/applications/CoSimulationApplication/python_scripts/factories/coupling_operation_factory.py
@@ -1,5 +1,5 @@
 from KratosMultiphysics.CoSimulationApplication.factories import base_factory
 
-def CreateCouplingOperation(coupling_operation_settings, solvers, parent_coupled_solver_process_info):
+def CreateCouplingOperation(coupling_operation_settings, *args):
     """This function creates and returns the Coupling Operation used for CoSimulation"""
-    return base_factory.Create(coupling_operation_settings, [solvers, parent_coupled_solver_process_info], "KratosMultiphysics.CoSimulationApplication.coupling_operations")
+    return base_factory.Create(coupling_operation_settings, [*args], "KratosMultiphysics.CoSimulationApplication.coupling_operations")

--- a/applications/CoSimulationApplication/python_scripts/factories/data_transfer_operator_factory.py
+++ b/applications/CoSimulationApplication/python_scripts/factories/data_transfer_operator_factory.py
@@ -1,5 +1,5 @@
 from KratosMultiphysics.CoSimulationApplication.factories import base_factory
 
-def CreateDataTransferOperator(coupling_operation_settings):
+def CreateDataTransferOperator(coupling_operation_settings, *args):
     """This function creates and returns the Data Transfer Operator used for CoSimulation"""
-    return base_factory.Create(coupling_operation_settings, [], "KratosMultiphysics.CoSimulationApplication.data_transfer_operators")
+    return base_factory.Create(coupling_operation_settings, [*args], "KratosMultiphysics.CoSimulationApplication.data_transfer_operators")

--- a/applications/CoSimulationApplication/python_scripts/factories/helpers.py
+++ b/applications/CoSimulationApplication/python_scripts/factories/helpers.py
@@ -25,12 +25,12 @@ def CreatePredictors(predictor_settings_list, solvers, parent_echo_level):
         predictors.append(CreatePredictor(predictor_settings, solver))
     return predictors
 
-def CreateConvergenceAccelerators(convergence_accelerator_settings_list, solvers, parent_echo_level):
+def CreateConvergenceAccelerators(convergence_accelerator_settings_list, solvers, parent_data_communicator, parent_echo_level):
     convergence_accelerators = []
     for conv_acc_settings in convergence_accelerator_settings_list:
         solver = solvers[conv_acc_settings["solver"].GetString()]
         AddEchoLevelToSettings(conv_acc_settings, parent_echo_level)
-        convergence_accelerators.append(ConvergenceAcceleratorWrapper(conv_acc_settings, solver))
+        convergence_accelerators.append(ConvergenceAcceleratorWrapper(conv_acc_settings, solver, parent_data_communicator))
 
     return convergence_accelerators
 
@@ -46,18 +46,18 @@ def CreateConvergenceCriteria(convergence_criterion_settings_list, solvers, pare
 
     return convergence_criteria
 
-def CreateCouplingOperations(coupling_operations_settings_dict, solvers, parent_coupled_solver_process_info, parent_echo_level):
+def CreateCouplingOperations(coupling_operations_settings_dict, solvers, parent_coupled_solver_process_info, parent_data_communicator, parent_echo_level):
     coupling_operations = {}
     for coupling_operation_name, coupling_operation_settings in coupling_operations_settings_dict.items():
         AddEchoLevelToSettings(coupling_operation_settings, parent_echo_level)
-        coupling_operations[coupling_operation_name] = CreateCouplingOperation(coupling_operation_settings, solvers, parent_coupled_solver_process_info)
+        coupling_operations[coupling_operation_name] = CreateCouplingOperation(coupling_operation_settings, solvers, parent_coupled_solver_process_info, parent_data_communicator)
 
     return coupling_operations
 
-def CreateDataTransferOperators(data_transfer_operators_settings_dict, parent_echo_level):
+def CreateDataTransferOperators(data_transfer_operators_settings_dict, parent_data_communicator, parent_echo_level):
     data_transfer_operators = {}
     for data_transfer_operators_name, data_transfer_operators_settings in data_transfer_operators_settings_dict.items():
         AddEchoLevelToSettings(data_transfer_operators_settings, parent_echo_level)
-        data_transfer_operators[data_transfer_operators_name] = CreateDataTransferOperator(data_transfer_operators_settings)
+        data_transfer_operators[data_transfer_operators_name] = CreateDataTransferOperator(data_transfer_operators_settings, parent_data_communicator)
 
     return data_transfer_operators

--- a/applications/CoSimulationApplication/tests/test_convergence_accelerators.py
+++ b/applications/CoSimulationApplication/tests/test_convergence_accelerators.py
@@ -65,7 +65,7 @@ class TestConvergenceAcceleratorWrapper(KratosUnittest.TestCase):
 
         with patch('KratosMultiphysics.CoSimulationApplication.convergence_accelerators.convergence_accelerator_wrapper.CreateConvergenceAccelerator') as p:
             p.return_value = conv_acc_mock
-            conv_acc_wrapper = ConvergenceAcceleratorWrapper(conv_acc_settings, self.dummy_solver_wrapper)
+            conv_acc_wrapper = ConvergenceAcceleratorWrapper(conv_acc_settings, self.dummy_solver_wrapper, KM.Testing.GetDefaultDataCommunicator())
 
         conv_acc_wrapper.InitializeSolutionStep()
 
@@ -111,7 +111,7 @@ class TestConvergenceAcceleratorWrapper(KratosUnittest.TestCase):
 
         with patch('KratosMultiphysics.CoSimulationApplication.convergence_accelerators.convergence_accelerator_wrapper.CreateConvergenceAccelerator') as p:
             p.return_value = conv_acc_mock
-            conv_acc_wrapper = ConvergenceAcceleratorWrapper(conv_acc_settings, self.dummy_solver_wrapper)
+            conv_acc_wrapper = ConvergenceAcceleratorWrapper(conv_acc_settings, self.dummy_solver_wrapper, KM.Testing.GetDefaultDataCommunicator())
 
         exp_inp = self.interface_data.GetData()
 

--- a/applications/CoSimulationApplication/tests/test_coupling_operations.py
+++ b/applications/CoSimulationApplication/tests/test_coupling_operations.py
@@ -39,7 +39,7 @@ class TestScalingOperation(KratosUnittest.TestCase):
             "echo_level"     : 0
         }""")
 
-        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info)
+        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info, KM.Testing.GetDefaultDataCommunicator())
 
         factors = [1.5] * 3
 
@@ -54,7 +54,7 @@ class TestScalingOperation(KratosUnittest.TestCase):
             "echo_level"     : 0
         }""")
 
-        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info)
+        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info, KM.Testing.GetDefaultDataCommunicator())
 
         factors = [1.5] * 3
 
@@ -69,7 +69,7 @@ class TestScalingOperation(KratosUnittest.TestCase):
             "echo_level"     : 0
         }""")
 
-        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info)
+        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info, KM.Testing.GetDefaultDataCommunicator())
 
         factors = [1.5*0.25, 1.5*0.5, 1.5*0.75]
 
@@ -84,7 +84,7 @@ class TestScalingOperation(KratosUnittest.TestCase):
             "echo_level"     : 0
         }""")
 
-        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info)
+        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info, KM.Testing.GetDefaultDataCommunicator())
 
         factors = [1.5*pi*sqrt(1), 1.5*pi*sqrt(2), 1.5*pi*sqrt(3), 1.5*pi*sqrt(4), 1.5*pi*sqrt(5)]
 
@@ -99,7 +99,7 @@ class TestScalingOperation(KratosUnittest.TestCase):
             "interval"       : [0.0, 0.3]
         }""")
 
-        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info)
+        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info, KM.Testing.GetDefaultDataCommunicator())
 
         factors = [1.0] * 5
         factors[0] = 1.22
@@ -115,7 +115,7 @@ class TestScalingOperation(KratosUnittest.TestCase):
             "interval"       : [0.8, "End"]
         }""")
 
-        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info)
+        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info, KM.Testing.GetDefaultDataCommunicator())
 
         factors = [1.0] * 3
         factors.extend([1.22] * 3)
@@ -183,7 +183,7 @@ class TestConversionOperation(KratosUnittest.TestCase):
             "echo_level"     : 0
         }""")
 
-        conversion_operation = coupling_operation_factory.CreateCouplingOperation(conversion_op_settings, self.solver_wrappers, self.solver_process_info)
+        conversion_operation = coupling_operation_factory.CreateCouplingOperation(conversion_op_settings, self.solver_wrappers, self.solver_process_info, KM.Testing.GetDefaultDataCommunicator())
 
         conversion_operation.Check()
 

--- a/applications/CoSimulationApplication/tests/test_data_transfer_operators.py
+++ b/applications/CoSimulationApplication/tests/test_data_transfer_operators.py
@@ -120,7 +120,7 @@ class TestDataTransferOperators(KratosUnittest.TestCase):
             "type" : "copy"
         }""")
 
-        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings)
+        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings, KM.Testing.GetDefaultDataCommunicator())
 
         self.__TestTransferMatching(data_transfer_op)
         self.__TestTransferMatchingSwapSign(data_transfer_op)
@@ -142,7 +142,7 @@ class TestDataTransferOperators(KratosUnittest.TestCase):
 
         exp_error = 'No "mapper_settings" provided!'
         with self.assertRaisesRegex(Exception, exp_error):
-            data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings_missing)
+            data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings_missing, KM.Testing.GetDefaultDataCommunicator())
 
         data_transfer_op_settings = KM.Parameters("""{
             "type" : "kratos_mapping",
@@ -151,7 +151,7 @@ class TestDataTransferOperators(KratosUnittest.TestCase):
             }
         }""")
 
-        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings)
+        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings, KM.Testing.GetDefaultDataCommunicator())
 
         self.__TestTransferMatching(data_transfer_op)
         self.__TestTransferMatchingSwapSign(data_transfer_op)
@@ -193,7 +193,7 @@ class TestDataTransferOperators(KratosUnittest.TestCase):
             }
         }""")
 
-        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings)
+        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings, KM.Testing.GetDefaultDataCommunicator())
 
         transfer_options_empty = KM.Parameters(""" [] """)
         # origin is non-hist
@@ -238,7 +238,7 @@ class TestDataTransferOperators(KratosUnittest.TestCase):
             "type" : "copy_single_to_distributed"
         }""")
 
-        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings)
+        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings, KM.Testing.GetDefaultDataCommunicator())
         transfer_options = KM.Parameters(""" [] """)
 
         for node in self.origin_data_single_node.GetModelPart().Nodes:
@@ -263,7 +263,7 @@ class TestDataTransferOperators(KratosUnittest.TestCase):
             "type" : "copy_single_to_distributed"
         }""")
 
-        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings)
+        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings, KM.Testing.GetDefaultDataCommunicator())
         transfer_options = KM.Parameters(""" ["swap_sign"] """)
 
         for node in self.origin_data_single_node.GetModelPart().Nodes:
@@ -282,7 +282,7 @@ class TestDataTransferOperators(KratosUnittest.TestCase):
             "type" : "copy_single_to_distributed"
         }""")
 
-        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings)
+        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings, KM.Testing.GetDefaultDataCommunicator())
         transfer_options = KM.Parameters(""" ["distribute_values"] """)
 
         for node in self.origin_data_single_node.GetModelPart().Nodes:
@@ -301,7 +301,7 @@ class TestDataTransferOperators(KratosUnittest.TestCase):
             "type" : "copy_single_to_distributed"
         }""")
 
-        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings)
+        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings, KM.Testing.GetDefaultDataCommunicator())
         transfer_options_empty = KM.Parameters(""" [] """)
         transfer_options_add = KM.Parameters(""" ["add_values"] """)
 
@@ -329,7 +329,7 @@ class TestDataTransferOperators(KratosUnittest.TestCase):
             "type" : "copy_single_to_distributed"
         }""")
 
-        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings)
+        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings, KM.Testing.GetDefaultDataCommunicator())
         transfer_options = KM.Parameters(""" ["distribute_values", "swap_sign"] """)
 
         for node in self.origin_data_single_node.GetModelPart().Nodes:
@@ -348,7 +348,7 @@ class TestDataTransferOperators(KratosUnittest.TestCase):
             "type" : "copy_single_to_distributed"
         }""")
 
-        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings)
+        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings, KM.Testing.GetDefaultDataCommunicator())
         transfer_options = KM.Parameters(""" ["distribute_values", "swap_sign"] """)
         transfer_options_with_add_vals = KM.Parameters(""" ["distribute_values", "swap_sign", "add_values"] """)
 
@@ -376,7 +376,7 @@ class TestDataTransferOperators(KratosUnittest.TestCase):
             "type" : "sum_distributed_to_single"
         }""")
 
-        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings)
+        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings, KM.Testing.GetDefaultDataCommunicator())
         transfer_options = KM.Parameters(""" [] """)
 
         for node in self.origin_data_scalar.GetModelPart().Nodes:
@@ -401,7 +401,7 @@ class TestDataTransferOperators(KratosUnittest.TestCase):
             "type" : "sum_distributed_to_single"
         }""")
 
-        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings)
+        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings, KM.Testing.GetDefaultDataCommunicator())
         transfer_options = KM.Parameters(""" ["swap_sign"] """)
 
         for node in self.origin_data_scalar.GetModelPart().Nodes:
@@ -421,7 +421,7 @@ class TestDataTransferOperators(KratosUnittest.TestCase):
             "type" : "sum_distributed_to_single"
         }""")
 
-        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings)
+        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings, KM.Testing.GetDefaultDataCommunicator())
         transfer_options = KM.Parameters(""" ["add_values"] """)
 
         for node in self.origin_data_scalar.GetModelPart().Nodes:
@@ -443,7 +443,7 @@ class TestDataTransferOperators(KratosUnittest.TestCase):
             "type" : "sum_distributed_to_single"
         }""")
 
-        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings)
+        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings, KM.Testing.GetDefaultDataCommunicator())
         transfer_options = KM.Parameters(""" ["add_values", "swap_sign"] """)
 
         for node in self.origin_data_scalar.GetModelPart().Nodes:
@@ -465,7 +465,7 @@ class TestDataTransferOperators(KratosUnittest.TestCase):
             "type" : "sum_distributed_to_single"
         }""")
 
-        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings)
+        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings, KM.Testing.GetDefaultDataCommunicator())
         transfer_options = KM.Parameters(""" [] """)
 
         with self.assertRaisesRegex(Exception, 'Variable of interface data "default" of solver "default_solver" has to be a scalar!'):
@@ -478,7 +478,7 @@ class TestDataTransferOperators(KratosUnittest.TestCase):
             "type" : "copy_single_to_distributed"
         }""")
 
-        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings)
+        data_transfer_op = data_transfer_operator_factory.CreateDataTransferOperator(data_transfer_op_settings, KM.Testing.GetDefaultDataCommunicator())
         transfer_options = KM.Parameters(""" [] """)
 
         with self.assertRaisesRegex(Exception, 'Variable of interface data "default" of solver "default_solver" has to be a scalar!'):


### PR DESCRIPTION
The parent coupled solver has a `DataCommunicator` that contains all the ranks on which its subsolvers run

hence the helper classes need access to this `DataCommunicator` in some cases, see e.g. #9472 

FYI @RiedlAndreas @mpentek this is a preparation for proper communication in #9472 