### PR TITLE
[ConvectionDiffusion] Analysis main has a typo

### DIFF
--- a/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_analysis.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_analysis.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     else: # using default name
         project_parameters_file_name = "ProjectParameters.json"
 
-    with open(parameter_file_name,'r') as parameter_file:
+    with open(project_parameters_file_name,'r') as parameter_file:
         parameters = KratosMultiphysics.Parameters(parameter_file.read())
 
     model = KratosMultiphysics.Model()


### PR DESCRIPTION
**📝 Description**
When the convection-diffusion analysis is called directly as a main, it's throwing an error as there is a typo in project parameters file.


**🆕 Changelog**
- Correct call to project parameters in main function of the convection-diffusion analysis.