### PR TITLE
[CLApp] Minor corrections in Mohr Coulomb yield surfaces

### DIFF
--- a/applications/ConstitutiveLawsApplication/custom_constitutive/yield_surfaces/modified_mohr_coulomb_yield_surface.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/yield_surfaces/modified_mohr_coulomb_yield_surface.h
@@ -275,9 +275,7 @@ class ModifiedMohrCoulombYieldSurface
         const double tens_yield = has_symmetric_yield_stress ? r_material_properties[YIELD_STRESS] : r_material_properties[YIELD_STRESS_TENSION];
         const double n = compr_yield / tens_yield;
 
-        const double dilatancy = r_material_properties[DILATANCY_ANGLE] * Globals::Pi / 180.0;
-
-        const double angle_phi = (Globals::Pi * 0.25) + dilatancy * 0.5;
+        const double angle_phi = (Globals::Pi * 0.25) + friction_angle * 0.5;
         const double alpha = n / (std::tan(angle_phi) * std::tan(angle_phi));
 
         const double CFL = 2.0 * std::tan(angle_phi) / cons_phi;

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/yield_surfaces/mohr_coulomb_yield_surface.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/yield_surfaces/mohr_coulomb_yield_surface.h
@@ -232,7 +232,7 @@ public:
 		double checker = std::abs(lode_angle * 180.0 / Globals::Pi);
 
         if (std::abs(checker) < 29.0) { // If it is not the edge
-            c1 = std::sin(friction_angle);
+            c1 = std::sin(friction_angle) / 3.0;
             c3 = (std::sqrt(3.0) * std::sin(lode_angle) + std::sin(friction_angle) * std::cos(lode_angle)) /
                 (2.0 * J2 * std::cos(3.0 * lode_angle));
             c2 = 0.5 * std::cos(lode_angle)*(1.0 + std::tan(lode_angle) * std::sin(3.0 * lode_angle) +

--- a/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_plasticity_constitutive_laws_3d.cpp
+++ b/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_plasticity_constitutive_laws_3d.cpp
@@ -164,7 +164,7 @@ KRATOS_TEST_CASE_IN_SUITE(ConstitutiveLawIntegrateStressPlasticitySmallStrain, K
     T TrescaCL = T();
 
     std::vector<double> MCres, VMres, DPres, Tres;
-    MCres = {9.99683e+06, 9.99683e+06, 1.00063e+07, 0, 0, 1.00636e-13};
+    MCres = {1.00033e+07,1.00033e+07,9.99343e+06,0,0,-1.0439e-13};
     VMres = {1.00033e+07, 1.00033e+07, 9.99343e+06, 0, 0, -1.0439e-13};
     DPres = {11102.3, 11102.3, 11101.8, 0, 0, -5.46183e-18};
     Tres = {1.00033e+07, 1.00033e+07, 9.99343e+06, 0, 0, -1.0439e-13};

--- a/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_yield_surfaces_3d.cpp
+++ b/applications/ConstitutiveLawsApplication/tests/cpp_tests/test_yield_surfaces_3d.cpp
@@ -132,7 +132,7 @@ KRATOS_TEST_CASE_IN_SUITE(YieldSurfacesDerivatives, KratosConstitutiveLawsFastSu
 
     // Analytical solutions of the yield surfaces derivatives
     std::vector<double> MCres, VMres, DPres, Rres, Tres, SJres;
-    MCres = {0.109261, 2.07822, 10.6714, 2.6863, 11.8748, 2.62528};
+    MCres = {-0.102799,1.27795,7.82485,2.40467,8.84815,1.84099};
     VMres = {-0.316228, -0.316228, 0.632456, 0.948683, 0.948683, 0.0};
     DPres = {0.197647,0.197647,1.85929,1.66165,1.66165,0};
     Tres = {-0.369513, -0.364032, 0.733545, 1.08113, 1.10671, 0.0073077};


### PR DESCRIPTION
**📝 Description**
Quick Bugfix with very little impact

The Modified MOhr Coulomb yield surface derivative should not depend on dilatancy.
The Mohr-Coulomb yield derivative missed 1/3 by mistake.