### PR TITLE
[AnalysisStage] [OutputProcesses] Unify processes

### DIFF
--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -353,8 +353,8 @@ class AnalysisStage(object):
         deprecated_output_processes    = self._CheckDeprecatedOutputProcesses(self._list_of_processes)
         order_processes_initialization = self._GetOrderOfOutputProcessesInitialization()
         self._list_of_output_processes = self._CreateProcesses("output_processes", order_processes_initialization)
-        self._list_of_output_processes.extend(deprecated_output_processes)
         self._list_of_processes.extend(self._list_of_output_processes) # Adding the output processes to the regular processes
+        self._list_of_output_processes.extend(deprecated_output_processes)
 
     def __CheckIfSolveSolutionStepReturnsAValue(self, is_converged):
         """In case the solver does not return the state of convergence

--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -330,6 +330,16 @@ class AnalysisStage(object):
         """
         return []
 
+    def _CheckDeprecatedOutputProcesses(self, list_of_processes):
+        deprecated_output_processes = []
+        for process in list_of_processes:
+            if issubclass(type(process), KratosMultiphysics.OutputProcess):
+                deprecated_output_processes.append(process)
+                msg  = "{} is an OutputProcess. However, it has been constructed as a regular process.\n"
+                msg += "Please, define it as an 'output_processes' in the ProjectParameters."
+                IssueDeprecationWarning("AnalysisStage", msg.format(process.__class__.__name__))
+        return deprecated_output_processes
+
     def _GetSimulationName(self):
         """Returns the name of the Simulation
         """
@@ -340,8 +350,10 @@ class AnalysisStage(object):
         """
         order_processes_initialization = self._GetOrderOfProcessesInitialization()
         self._list_of_processes        = self._CreateProcesses("processes", order_processes_initialization)
+        deprecated_output_processes    = self._CheckDeprecatedOutputProcesses(self._list_of_processes)
         order_processes_initialization = self._GetOrderOfOutputProcessesInitialization()
         self._list_of_output_processes = self._CreateProcesses("output_processes", order_processes_initialization)
+        self._list_of_output_processes.extend(deprecated_output_processes)
         self._list_of_processes.extend(self._list_of_output_processes) # Adding the output processes to the regular processes
 
     def __CheckIfSolveSolutionStepReturnsAValue(self, is_converged):

--- a/kratos/tests/test_KratosCore.py
+++ b/kratos/tests/test_KratosCore.py
@@ -28,6 +28,7 @@ import test_variable_utils
 import test_reorder
 import test_exact_integration
 import test_gid_io
+import test_output_process
 import test_vtk_output_process
 import test_vector_interface
 import test_matrix_interface
@@ -107,6 +108,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_reorder.TestReorder]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_exact_integration.TestExactIntegration]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_gid_io.TestGidIO]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_output_process.TestOutputProcess]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_vtk_output_process.TestVtkOutputProcess]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_vector_interface.TestVectorInterface]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_matrix_interface.TestMatrixInterface]))

--- a/kratos/tests/test_output_process.py
+++ b/kratos/tests/test_output_process.py
@@ -1,0 +1,28 @@
+import KratosMultiphysics as KM
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+
+class TestOutputProcess(KratosUnittest.TestCase):
+
+    def testOutputProcessSubclass(self):
+        output_process = KM.OutputProcess()
+        self.assertTrue(issubclass(type(output_process), KM.OutputProcess))
+        self.assertTrue(issubclass(type(output_process), KM.Process))
+
+    def testPythonOutputProcessSubclass(self):
+        class PythonOutputProcess(KM.OutputProcess):
+            pass
+        output_process = PythonOutputProcess()
+        self.assertTrue(issubclass(type(output_process), KM.OutputProcess))
+        self.assertTrue(issubclass(type(output_process), KM.Process))
+    
+    def testDerivedPythonOutputProcessSubclass(self):
+        class PythonOutputProcess(KM.OutputProcess):
+            pass
+        class DerivedPythonOutputProcess(PythonOutputProcess):
+            pass
+        output_process = DerivedPythonOutputProcess()
+        self.assertTrue(issubclass(type(output_process), KM.OutputProcess))
+        self.assertTrue(issubclass(type(output_process), KM.Process))
+
+if __name__ == "__main__":
+    KratosUnittest.main()


### PR DESCRIPTION
**📝 Description**
Several output processes does not derive from `OutputProcess` and does not implement `IsOutputStep` nor `PrintOutput`. This situation can lead to some confusions (e.g. #7877) and and makes difficult using them when operations are done at `ExecuteBeforeOutputStep`.

However, modifying the interface of that "output processes" may break the current simulations, since they are constructed as regular processes.

In this draft I'm proposing a possible solution to ensure a smooth transition. The key is to detect if an `OutputProcess` is constructed as a regular process. When implementing these lines I've seen three possible choices:

1. Throw a warning and append the output process to the output processes list. (this is the implementation in this draft)
2. Throw a warning and do nothing. This will be more disruptive, since the modified process will stop printing output until the user construct it as an OutputProcess.
3. Don't throw a warning and append the output process to the list of output processes. In the future we could remove the `output_processes` block in the project parameters and unify the `processes`.

I'm liking option 3 more. Any opinions @KratosMultiphysics/technical-committee @KratosMultiphysics/implementation-committee ?

**🆕 Changelog**
- Detect if an `OutputProcess` is constructed as a regular process
