### PR TITLE
defining -DBOOST_UBLAS_MOVE_SEMANTICS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -517,6 +517,7 @@ include_directories( ${KRATOS_SOURCE_DIR}/external_libraries )
 
 # defines needed
 add_definitions( -DKRATOS_PYTHON )
+add_definitions( -DBOOST_UBLAS_MOVE_SEMANTICS )
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   add_definitions( -fPIC )


### PR DESCRIPTION
this option should activate move semantics for ublas types

**📝 Description**
tentatively activating ublas semantics for ublas types

Please mark the PR with appropriate tags: 
- improvement
-
**🆕 Changelog**
this option should activate move semantics for ublas types

