### PR TITLE
Ported fix for vs2022 problem with crtdefs

### DIFF
--- a/external_libraries/pybind11/detail/common.h
+++ b/external_libraries/pybind11/detail/common.h
@@ -120,6 +120,14 @@
 #  pragma warning(push)
 #  pragma warning(disable: 4510 4610 4512 4005)
 #  if defined(_DEBUG) && !defined(Py_DEBUG)
+// Workaround for a VS 2022 issue.
+// NOTE: This workaround knowingly violates the Python.h include order requirement:
+// https://docs.python.org/3/c-api/intro.html#include-files
+// See https://github.com/pybind/pybind11/pull/3497 for full context.
+#    include <yvals.h>
+#    if _MSVC_STL_VERSION >= 143
+#      include <crtdefs.h>
+#    endif
 #    define PYBIND11_DEBUG_MARKER
 #    undef _DEBUG
 #  endif


### PR DESCRIPTION
**📝 Description**
See https://github.com/pybind/pybind11/pull/3497

**🆕 Changelog**
- Hotfix for vs2022 compat.
