### PR TITLE
Adding numpy to core non-unity and centos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,6 @@ jobs:
         set PATH=%PATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%/libs
         python kratos/python_scripts/run_tests.py -l small -c python
 
-
   centos:
     runs-on: ubuntu-latest
     env:
@@ -320,6 +319,11 @@ jobs:
         (New-Object System.Net.WebClient).DownloadFile($url, "$env:TEMP\boost.tar.gz")
         7z.exe x "$env:TEMP\boost.tar.gz" -o"$env:TEMP\boostArchive" -y | Out-Null
         7z.exe x "$env:TEMP\boostArchive" -o"$env:TEMP\boost" -y | Out-Null
+
+    - name: Installing dependencies
+      shell: cmd
+      run: |
+        pip install numpy
 
     - name: Build
       shell: cmd

--- a/scripts/docker_files/docker_file_ci_centos_7_python35/DockerFile
+++ b/scripts/docker_files/docker_file_ci_centos_7_python35/DockerFile
@@ -16,7 +16,7 @@ RUN ls /usr/src/Python-3.5.4
 RUN sh /usr/src/Python-3.5.4/configure --enable-optimizations --with-lto --enable-shared LDFLAGS="-Wl,-rpath /usr/local/lib"
 RUN make altinstall
 RUN rm Python-3.5.4.tgz
-RUN python3.5 -m pip install 'cx_Freeze==6.1'
+RUN python3.5 -m pip install 'cx_Freeze==6.1' numpy
 
 # Setting the needed environment variables for being able to run/compile
 ENV PYTHON_EXECUTABLE /usr/local/bin/python3.5


### PR DESCRIPTION
**📝 Description**
Since we now use numpy, we need to add it to the different CI images that were not using it (needed by #9542)

This **cannot** be cherry picked, it needs to be merged against the master in order for the Centos Fix to take place.

**🆕 Changelog**
- Added numpy to several workflows
