### PR TITLE
[Core] fix exposure of MemoryInfo

### DIFF
--- a/kratos/includes/memory_info.h
+++ b/kratos/includes/memory_info.h
@@ -75,6 +75,8 @@ public:
      **/
     static std::size_t GetCurrentMemoryUsage();
 
+    static std::string HumanReadableSize(std::size_t InBytes);
+
     ///@}
     ///@name Input and output
     ///@{
@@ -97,12 +99,6 @@ public:
   ///@}
 
 private:
-    ///@name Private Operations
-    ///@{
-
-    std::string HumanReadableSize(std::size_t InBytes) const;
-
-    ///@}
     ///@name Un accessible methods
     ///@{
 

--- a/kratos/python/add_memory_info_to_python.cpp
+++ b/kratos/python/add_memory_info_to_python.cpp
@@ -16,6 +16,7 @@
 
 // Project includes
 #include "includes/memory_info.h"
+#include "add_memory_info_to_python.h"
 
 namespace Kratos
 {
@@ -24,7 +25,7 @@ namespace Python
 {
 
 //
-void  AddMemoryInfoToPython(pybind11::module& m)
+void AddMemoryInfoToPython(pybind11::module& m)
 {
     namespace py = pybind11;
 
@@ -32,6 +33,8 @@ void  AddMemoryInfoToPython(pybind11::module& m)
     .def(py::init<>())
     .def_static("GetPeakMemoryUsage", &MemoryInfo::GetPeakMemoryUsage)
 	.def_static("GetCurrentMemoryUsage", &MemoryInfo::GetCurrentMemoryUsage)
+	.def_static("HumanReadableSize", &MemoryInfo::HumanReadableSize)
+    .def("__str__", PrintObject<MemoryInfo>)
     ;
 }
 

--- a/kratos/python/add_memory_info_to_python.h
+++ b/kratos/python/add_memory_info_to_python.h
@@ -16,6 +16,7 @@
 
 
 // Project includes
+#include "includes/define_python.h"
 
 
 namespace Kratos
@@ -24,7 +25,7 @@ namespace Kratos
 namespace Python
 {
 
-void  AddMemoryInfoToPython();
+void  AddMemoryInfoToPython(pybind11::module& m);
 
 }  // namespace Python.
 

--- a/kratos/python/kratos_python.cpp
+++ b/kratos/python/kratos_python.cpp
@@ -135,6 +135,7 @@ PYBIND11_MODULE(Kratos, m)
     AddSearchStrategiesToPython(m);
     AddTestingToPython(m);
     AddLoggerToPython(m);
+    AddMemoryInfoToPython(m);
     AddConstraintToPython(m);
     AddResponseFunctionsToPython(m);
     AddCommunicatorToPython(m);

--- a/kratos/sources/memory_info.cpp
+++ b/kratos/sources/memory_info.cpp
@@ -92,7 +92,7 @@ std::size_t MemoryInfo::GetCurrentMemoryUsage() {
 #endif
 }
 
-std::string MemoryInfo::HumanReadableSize(std::size_t InBytes) const {
+std::string MemoryInfo::HumanReadableSize(std::size_t InBytes) {
     constexpr char extension[] = {'\0', 'K', 'M', 'G', 'T', 'P', 'E', 'E'};
 
     std::stringstream output;


### PR DESCRIPTION
The exposure of `MemoryInfo` is broken since we moved to pybind many years ago :sweat_smile: 

this PR fixes this, also I exposed `HumanReadableSize`
