### PR TITLE
[CI] Adding sympy to centos and windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,7 @@ jobs:
       shell: cmd
       run: |
         pip install numpy
+        pip install sympy
         pip install h5py
 
     - name: Build
@@ -324,6 +325,7 @@ jobs:
       shell: cmd
       run: |
         pip install numpy
+        pip install sympy
 
     - name: Build
       shell: cmd

--- a/scripts/docker_files/docker_file_ci_centos_7_python35/DockerFile
+++ b/scripts/docker_files/docker_file_ci_centos_7_python35/DockerFile
@@ -16,7 +16,7 @@ RUN ls /usr/src/Python-3.5.4
 RUN sh /usr/src/Python-3.5.4/configure --enable-optimizations --with-lto --enable-shared LDFLAGS="-Wl,-rpath /usr/local/lib"
 RUN make altinstall
 RUN rm Python-3.5.4.tgz
-RUN python3.5 -m pip install 'cx_Freeze==6.1' numpy
+RUN python3.5 -m pip install 'cx_Freeze==6.1' numpy sympy
 
 # Setting the needed environment variables for being able to run/compile
 ENV PYTHON_EXECUTABLE /usr/local/bin/python3.5


### PR DESCRIPTION
**📝 Description**
Changes missed in #9544.

> There are some scripts within Kratos where sympy is imported (for instance here).
>
> So far this hadn't been an issue because no file that used them was unit-tested. Now, however, the FluidDynamicsApplication will start testing its symbolic file generation in #9426.

**🆕 Changelog**
- Added `sympy`to centos CI docker 
- Added `sympy` to windows CI run
