### PR TITLE
[Core] moving check to model part and removing processinfo from arguments

### DIFF
--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -1864,7 +1864,7 @@ public:
     }
 
     /// run input validation
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo) const;
+    virtual int Check() const;
 
     ///@}
     ///@name Access

--- a/kratos/solving_strategies/schemes/scheme.h
+++ b/kratos/solving_strategies/schemes/scheme.h
@@ -538,31 +538,6 @@ public:
     virtual int Check(const ModelPart& rModelPart) const
     {
         KRATOS_TRY
-
-        //TODO: This is required for the exception handling. It can be removed once we move to the C++ parallelism
-#ifdef KRATOS_SMP_CXX11
-        int num_threads = ParallelUtilities::GetNumThreads();
-#else
-        int num_threads = 1;
-#endif
-
-        const ProcessInfo& r_current_process_info = rModelPart.GetProcessInfo();
-
-        // Checks for all of the elements
-        BlockPartition<const ModelPart::ElementsContainerType>(rModelPart.Elements(), num_threads).for_each([&r_current_process_info](const Element& rElement){
-            rElement.Check(r_current_process_info);
-        });
-
-        // Checks for all of the conditions
-        BlockPartition<const ModelPart::ConditionsContainerType>(rModelPart.Conditions(), num_threads).for_each([&r_current_process_info](const Condition& rCondition){
-            rCondition.Check(r_current_process_info);
-        });
-
-        // Checks for all of the constraints
-        BlockPartition<const ModelPart::MasterSlaveConstraintContainerType>(rModelPart.MasterSlaveConstraints(), num_threads).for_each([&r_current_process_info](const MasterSlaveConstraint& rConstraint){
-            rConstraint.Check(r_current_process_info);
-        });
-
         return 0;
         KRATOS_CATCH("");
     }

--- a/kratos/solving_strategies/strategies/solving_strategy.h
+++ b/kratos/solving_strategies/strategies/solving_strategy.h
@@ -387,17 +387,7 @@ public:
             VariableUtils().CheckVariableExists<>(DISPLACEMENT, GetModelPart().Nodes());
         }
 
-        // Check elements, conditions and constraints
-        const auto& r_process_info = GetModelPart().GetProcessInfo();
-        for (const auto& r_elem : GetModelPart().Elements()) {
-            r_elem.Check(r_process_info);
-        }
-        for (const auto& r_cond : GetModelPart().Conditions()) {
-            r_cond.Check(r_process_info);
-        }
-        for (const auto& r_cons : GetModelPart().MasterSlaveConstraints()) {
-            r_cons.Check(r_process_info);
-        }
+        GetModelPart.Check();
 
         return 0;
 

--- a/kratos/solving_strategies/strategies/solving_strategy.h
+++ b/kratos/solving_strategies/strategies/solving_strategy.h
@@ -387,7 +387,7 @@ public:
             VariableUtils().CheckVariableExists<>(DISPLACEMENT, GetModelPart().Nodes());
         }
 
-        GetModelPart.Check();
+        GetModelPart().Check();
 
         return 0;
 

--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -2207,7 +2207,6 @@ int ModelPart::Check() const
 {
     KRATOS_TRY
 
-    const int num_threads = ParallelUtilities::GetNumThreads();
     const ProcessInfo& r_current_process_info = this->GetProcessInfo();
 
     // Checks for all of the elements

--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -2211,17 +2211,17 @@ int ModelPart::Check() const
     const ProcessInfo& r_current_process_info = this->GetProcessInfo();
 
     // Checks for all of the elements
-    BlockPartition<const ModelPart::ElementsContainerType>(this->Elements(), num_threads).for_each([&r_current_process_info](const Element& rElement){
+    block_for_each(this->Elements(), [&r_current_process_info](const Element& rElement){
         rElement.Check(r_current_process_info);
     });
 
     // Checks for all of the conditions
-    BlockPartition<const ModelPart::ConditionsContainerType>(this->Conditions(), num_threads).for_each([&r_current_process_info](const Condition& rCondition){
+    block_for_each(this->Conditions(), [&r_current_process_info](const Condition& rCondition){
         rCondition.Check(r_current_process_info);
     });
 
     // Checks for all of the constraints
-    BlockPartition<const ModelPart::MasterSlaveConstraintContainerType>(this->MasterSlaveConstraints(), num_threads).for_each([&r_current_process_info](const MasterSlaveConstraint& rConstraint){
+    block_for_each(this->MasterSlaveConstraints(), [&r_current_process_info](const MasterSlaveConstraint& rConstraint){
         rConstraint.Check(r_current_process_info);
     });
 

--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -2206,13 +2206,8 @@ void ModelPart::SetBufferSizeSubModelParts(ModelPart::IndexType NewBufferSize)
 int ModelPart::Check() const
 {
     KRATOS_TRY
-    //TODO: This is required for the exception handling. It can be removed once we move to the C++ parallelism
-    #ifdef KRATOS_SMP_CXX11
-        int num_threads = ParallelUtilities::GetNumThreads();
-    #else
-        int num_threads = 1;
-    #endif
 
+    const int num_threads = ParallelUtilities::GetNumThreads();
     const ProcessInfo& r_current_process_info = this->GetProcessInfo();
 
     // Checks for all of the elements


### PR DESCRIPTION
**📝 Description**
As shown in https://github.com/KratosMultiphysics/Kratos/issues/7713 , right now there is a bit of confusion about who should Check the elements/conditions etc. Right this check is actually being called twice, once in the solving strategy and once again in the scheme. The solution proposed here is to call the model part check only from the strategy and add there the checks for the entities. I think this should not break anything unless there is a strategy somewhere that is not calling the base class (I did not find any)


**🆕 Changelog**
- Removed elements/conditions/constraints checks from solving_strategy and scheme base classes.
- Update model part Check so it does exactly what the scheme used to do.
- Call model part check from scheme.
