### PR TITLE
[Fluid] Removed last compiler warning in FluidDynamicsApplication

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/distance_smoothing_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_smoothing_process.h
@@ -205,11 +205,12 @@ public:
                     global_pointer->GetValue(DISTANCE),
                     global_pointer->Coordinates());
             });
-
+        
         auto contact_proxy = pointer_comm.Apply(
-            [&](GlobalPointer<Node<3> >& global_pointer) -> bool
+            [&](const GlobalPointer<Node<3> >& global_pointer) -> int
             {
-                return global_pointer->Is(CONTACT);
+                // Casting to int to avoid using std::vector<bool> inside the communicator
+                return static_cast<int>(global_pointer->Is(CONTACT));
             }
         );
 
@@ -229,7 +230,7 @@ public:
             {
                 auto& global_pointer = global_pointer_list(j);
 
-                if (contact_proxy.Get(global_pointer) == rNode.Is(CONTACT)){
+                if (static_cast<bool>(contact_proxy.Get(global_pointer)) == rNode.Is(CONTACT)){
 
                     auto result = combined_proxy.Get(global_pointer);
                     const array_1d<double,3>& x_j = std::get<1>(result);

--- a/applications/FluidDynamicsApplication/custom_processes/distance_smoothing_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_smoothing_process.h
@@ -205,7 +205,7 @@ public:
                     global_pointer->GetValue(DISTANCE),
                     global_pointer->Coordinates());
             });
-        
+
         auto contact_proxy = pointer_comm.Apply(
             [&](const GlobalPointer<Node<3> >& global_pointer) -> int
             {

--- a/applications/FluidDynamicsApplication/custom_processes/distance_smoothing_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_smoothing_process.h
@@ -200,7 +200,7 @@ public:
         GlobalPointerCommunicator< Node<3 > > pointer_comm(r_data_comm, gp_list);
 
         auto combined_proxy = pointer_comm.Apply(
-            [&](GlobalPointer<Node<3>> &global_pointer) -> std::pair<double, array_1d<double,3>> {
+            [&](const GlobalPointer<Node<3>> &global_pointer) -> std::pair<double, array_1d<double,3>> {
                 return std::make_pair(
                     global_pointer->GetValue(DISTANCE),
                     global_pointer->Coordinates());


### PR DESCRIPTION
**📝 Description**
This gets rid of the last compilation warning of the fluid dynamics app.

**🆕 Changelog**
- Communicating ints instead of bools in `distance_smoothing_process.h`.
- Added a couple `const`s nearby.

**💡 Related material**
- Issue #9381 explains the warning
- PR #9551 is an attempt to fix it from the communicator side, and if succesful then the current PR will be discarded.