### PR TITLE
Fixing LinearSolvers Test

### DIFF
--- a/applications/LinearSolversApplication/tests/test_feast_eigensystem_solver.py
+++ b/applications/LinearSolversApplication/tests/test_feast_eigensystem_solver.py
@@ -19,6 +19,8 @@ class TestFeastEigensystemSolver(KratosUnittest.TestCase):
             "symmetric": true,
             "number_of_eigenvalues": 3,
             "search_lowest_eigenvalues": true,
+            "sort_eigenvalues": true,
+            "sort_order": "sr",
             "e_min": 0.0,
             "e_max": 0.2,
             "echo_level": 0
@@ -77,6 +79,8 @@ class TestFeastEigensystemSolver(KratosUnittest.TestCase):
             "solver_type": "feast",
             "symmetric": false,
             "number_of_eigenvalues": 3,
+            "sort_eigenvalues": true,
+            "sort_order": "sr",
             "e_mid_re": 10.0,
             "e_mid_im": 0.0,
             "e_r": 3.0,


### PR DESCRIPTION
**📝 Description**
Fixes #9554

No idea why this was working before.
Also, while looking at the tests, seems that `test_real_symmetric_gev` could eventually have similar problems since the difference between pos 1 and 2 is smaller than the tolerance. But I am not sure.

**🆕 Changelog**
- Added missing sort to missing LinearSolverTests
