### PR TITLE
[Fluid] Fixed error when modelpart is empty

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
+++ b/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
@@ -67,7 +67,7 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
             # Empty modelpart
             return
 
-        geometry = self.main_model_part.GetElement(1).GetGeometry()
+        geometry = self.main_model_part.Elements().__iter__().__next__().GetGeometry()
         is_simplex = geometry.LocalSpaceDimension() + 1 == geometry.PointsNumber()
         if not is_simplex:
             msg = "Geoemetry is not simplex. Orientation check is only available"

--- a/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
+++ b/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
@@ -35,7 +35,7 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
     def _ElementsAreNotSimplex(self):
         "Checks whether the first element is non-simplex"
         if self.main_model_part.NumberOfElements() == 0:
-            return False
+            return True
         
         geometry = self.main_model_part.Elements.__iter__().__next__().GetGeometry()
         is_simplex = geometry.LocalSpaceDimension() + 1 == geometry.PointsNumber()

--- a/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
+++ b/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
@@ -67,7 +67,7 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
             # Empty modelpart
             return
 
-        geometry = self.main_model_part.Elements().__iter__().__next__().GetGeometry()
+        geometry = self.main_model_part.Elements.__iter__().__next__().GetGeometry()
         is_simplex = geometry.LocalSpaceDimension() + 1 == geometry.PointsNumber()
         if not is_simplex:
             msg = "Geoemetry is not simplex. Orientation check is only available"

--- a/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
+++ b/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
@@ -32,6 +32,15 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
         #self.list_of_inlets = Parameters["list_of_inlets"]
 
 
+    def _ElementsAreNotSimplex(self):
+        "Checks whether the first element is non-simplex"
+        if self.main_model_part.NumberOfElements() == 0:
+            return False
+        
+        geometry = self.main_model_part.Elements.__iter__().__next__().GetGeometry()
+        is_simplex = geometry.LocalSpaceDimension() + 1 == geometry.PointsNumber()
+        return not is_simplex
+
 
     def Execute(self):
         if self.main_model_part.Name == self.volume_model_part_name:
@@ -63,17 +72,10 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
         fluid_computational_model_part.AddConditions(list(list_of_ids))
 
         #verify the orientation of the skin (only implemented for tris and tets)
-        if self.main_model_part.NumberOfElements() == 0:
-            # Empty modelpart
-            return
-
-        geometry = self.main_model_part.Elements.__iter__().__next__().GetGeometry()
-        is_simplex = geometry.LocalSpaceDimension() + 1 == geometry.PointsNumber()
-        if not is_simplex:
+        if self._ElementsAreNotSimplex():
             msg = "Geoemetry is not simplex. Orientation check is only available"
-            msg += "for simplex geometries and hence it will be skipped"
+            msg += " for simplex geometries and hence it will be skipped."
             KratosMultiphysics.Logger.PrintWarning(type(self).__name__, msg)
-
             return
 
         tmoc = KratosMultiphysics.TetrahedralMeshOrientationCheck

--- a/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
+++ b/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
@@ -63,6 +63,10 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
         fluid_computational_model_part.AddConditions(list(list_of_ids))
 
         #verify the orientation of the skin (only implemented for tris and tets)
+        if self.main_model_part.NumberOfElements() == 0:
+            # Empty modelpart
+            return
+
         geometry = self.main_model_part.GetElement(1).GetGeometry()
         is_simplex = geometry.LocalSpaceDimension() + 1 == geometry.PointsNumber()
         if not is_simplex:


### PR DESCRIPTION
**📝 Description**
PR #9426 introduces a bug that makes the program crash in `check_and_prepare_model_process_fluid.py` when a modelpart is empty (most typical case is in an unbalanced MPI). This slipped through the standard CI but got caught in nightly.

**🆕 Changelog**
- Added check to avoid getting element by Id when modelpart is empty