### PR TITLE
[MPI] enable AMGCL to use MPI_Comm other than MPI_COMM_WORLD

### DIFF
--- a/applications/TrilinosApplication/CMakeLists.txt
+++ b/applications/TrilinosApplication/CMakeLists.txt
@@ -45,9 +45,9 @@ include_directories("../../external_libraries")
 # Sources for the Trilinos application core
 set( KRATOS_TRILINOS_APPLICATION_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/trilinos_application.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/external_includes/amgcl_mpi_solver_impl.cpp;
+    ${CMAKE_CURRENT_SOURCE_DIR}/external_includes/amgcl_mpi_solver_impl.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_factories/trilinos_linear_solver_factory.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/trilinos_solver_utilities.cpp;
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/trilinos_solver_utilities.cpp
 )
 
 # Sources for the Python module

--- a/applications/TrilinosApplication/CMakeLists.txt
+++ b/applications/TrilinosApplication/CMakeLists.txt
@@ -47,6 +47,7 @@ set( KRATOS_TRILINOS_APPLICATION_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/trilinos_application.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/external_includes/amgcl_mpi_solver_impl.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_factories/trilinos_linear_solver_factory.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/trilinos_solver_utilities.cpp;
 )
 
 # Sources for the Python module

--- a/applications/TrilinosApplication/custom_utilities/trilinos_solver_utilities.cpp
+++ b/applications/TrilinosApplication/custom_utilities/trilinos_solver_utilities.cpp
@@ -11,7 +11,7 @@
 //
 
 // External includes
-#include "Epetra_MPIComm.h"
+#include "Epetra_MpiComm.h"
 
 // Project includes
 #include "trilinos_solver_utilities.h"
@@ -29,11 +29,10 @@ void SetTeuchosParameters(const Parameters rSettings, Teuchos::ParameterList& rP
     }
 }
 
-MPI_Comm GetMPICommFromEpetraComm()
+MPI_Comm GetMPICommFromEpetraComm(const Epetra_Comm& rEpetraComm)
 {
     // see https://github.com/trilinos/Trilinos/issues/10122#issuecomment-1021614956
-    const Epetra_Comm& r_epetra_comm = rA.Comm();
-    const Epetra_MpiComm& r_epetra_mpi_comm = dynamic_cast<const Epetra_MpiComm&>(r_epetra_comm); // cannot use static_cast due to virtual inheritance
+    const Epetra_MpiComm& r_epetra_mpi_comm = dynamic_cast<const Epetra_MpiComm&>(rEpetraComm); // cannot use static_cast due to virtual inheritance
     return r_epetra_mpi_comm.Comm();
 }
 

--- a/applications/TrilinosApplication/custom_utilities/trilinos_solver_utilities.cpp
+++ b/applications/TrilinosApplication/custom_utilities/trilinos_solver_utilities.cpp
@@ -1,0 +1,41 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
+//
+
+// External includes
+#include "Epetra_MPIComm.h"
+
+// Project includes
+#include "trilinos_solver_utilities.h"
+
+namespace Kratos {
+namespace TrilinosSolverUtilities {
+
+void SetTeuchosParameters(const Parameters rSettings, Teuchos::ParameterList& rParameterlist)
+{
+    for (auto it = rSettings.begin(); it != rSettings.end(); ++it) {
+        if      (it->IsString()) rParameterlist.set(it.name(), it->GetString());
+        else if (it->IsInt())    rParameterlist.set(it.name(), it->GetInt());
+        else if (it->IsBool())   rParameterlist.set(it.name(), it->GetBool());
+        else if (it->IsDouble()) rParameterlist.set(it.name(), it->GetDouble());
+    }
+}
+
+MPI_Comm GetMPICommFromEpetraComm()
+{
+    // see https://github.com/trilinos/Trilinos/issues/10122#issuecomment-1021614956
+    const Epetra_Comm& r_epetra_comm = rA.Comm();
+    const Epetra_MpiComm& r_epetra_mpi_comm = dynamic_cast<const Epetra_MpiComm&>(r_epetra_comm); // cannot use static_cast due to virtual inheritance
+    return r_epetra_mpi_comm.Comm();
+}
+
+}  // namespace TrilinosSolverUtilities.
+}  // namespace Kratos.

--- a/applications/TrilinosApplication/custom_utilities/trilinos_solver_utilities.h
+++ b/applications/TrilinosApplication/custom_utilities/trilinos_solver_utilities.h
@@ -7,7 +7,7 @@
 //  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
-//  Main authors:    Philipp Bucher
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
 //
 
 #if !defined (KRATOS_TRILINOS_SOLVER_UTILITIES_H_INCLUDED)
@@ -15,6 +15,8 @@
 
 // External includes
 #include "Teuchos_ParameterList.hpp"
+#include <mpi.h>
+#include "Epetra_Comm.h"
 
 // Project includes
 #include "includes/define.h"
@@ -23,15 +25,9 @@
 namespace Kratos {
 namespace TrilinosSolverUtilities {
 
-void SetTeuchosParameters(const Parameters rSettings, Teuchos::ParameterList& rParameterlist)
-{
-    for (auto it = rSettings.begin(); it != rSettings.end(); ++it) {
-        if      (it->IsString()) rParameterlist.set(it.name(), it->GetString());
-        else if (it->IsInt())    rParameterlist.set(it.name(), it->GetInt());
-        else if (it->IsBool())   rParameterlist.set(it.name(), it->GetBool());
-        else if (it->IsDouble()) rParameterlist.set(it.name(), it->GetDouble());
-    }
-}
+void SetTeuchosParameters(const Parameters rSettings, Teuchos::ParameterList& rParameterlist);
+
+MPI_Comm GetMPICommFromEpetraComm(const Epetra_Comm&);
 
 }  // namespace TrilinosSolverUtilities.
 }  // namespace Kratos.

--- a/applications/TrilinosApplication/custom_utilities/trilinos_solver_utilities.h
+++ b/applications/TrilinosApplication/custom_utilities/trilinos_solver_utilities.h
@@ -27,7 +27,7 @@ namespace TrilinosSolverUtilities {
 
 void SetTeuchosParameters(const Parameters rSettings, Teuchos::ParameterList& rParameterlist);
 
-MPI_Comm GetMPICommFromEpetraComm(const Epetra_Comm&);
+MPI_Comm GetMPICommFromEpetraComm(const Epetra_Comm& rEpetraComm);
 
 }  // namespace TrilinosSolverUtilities.
 }  // namespace Kratos.

--- a/applications/TrilinosApplication/external_includes/amgcl_mpi_schur_complement_solver.h
+++ b/applications/TrilinosApplication/external_includes/amgcl_mpi_schur_complement_solver.h
@@ -28,6 +28,7 @@
 #include "includes/kratos_parameters.h"
 #include "linear_solvers/linear_solver.h"
 #include "external_includes/amgcl_mpi_solver.h"
+#include "custom_utilities/trilinos_solver_utilities.h"
 
 #include <boost/range/iterator_range.hpp>
 #include <boost/property_tree/json_parser.hpp>
@@ -193,7 +194,9 @@ public:
         //using amgcl::prof;
         //prof.reset();
 
-        amgcl::mpi::communicator world ( MPI_COMM_WORLD );
+        MPI_Comm the_comm = TrilinosSolverUtilities::GetMPICommFromEpetraComm(rA.Comm());
+
+        amgcl::mpi::communicator world ( the_comm );
         if ( mVerbosity >=0 && world.rank == 0 ) {
             std::cout << "World size: " << world.size << std::endl;
         }

--- a/applications/TrilinosApplication/external_includes/amgcl_mpi_solver_impl.cpp
+++ b/applications/TrilinosApplication/external_includes/amgcl_mpi_solver_impl.cpp
@@ -22,6 +22,7 @@
 #include "Epetra_FECrsMatrix.h"
 #include "Epetra_FEVector.h"
 #include "trilinos_space.h"
+#include "custom_utilities/trilinos_solver_utilities.h"
 
 namespace Kratos
 {
@@ -45,10 +46,7 @@ void AMGCLScalarSolve(
     bool use_gpgpu
     )
 {
-    const Epetra_Comm& r_epetra_comm = rA.Comm();
-    const Epetra_MpiComm& r_epetra_mpi_comm = dynamic_cast<const Epetra_MpiComm&>(r_epetra_comm); // cannot use static_cast due to virtual inheritance
-
-    MPI_Comm the_comm = r_epetra_mpi_comm.Comm();
+    MPI_Comm the_comm = TrilinosSolverUtilities::GetMPICommFromEpetraComm(rA.Comm());
 
 #ifdef AMGCL_GPGPU
     if (use_gpgpu && vexcl_context()) {
@@ -112,10 +110,7 @@ void AMGCLBlockSolve(
     bool use_gpgpu
     )
 {
-    const Epetra_Comm& r_epetra_comm = rA.Comm();
-    const Epetra_MpiComm& r_epetra_mpi_comm = dynamic_cast<const Epetra_MpiComm&>(r_epetra_comm); // cannot use static_cast due to virtual inheritance
-
-    MPI_Comm the_comm = r_epetra_mpi_comm.Comm();
+    MPI_Comm the_comm = TrilinosSolverUtilities::GetMPICommFromEpetraComm(rA.Comm());
 
     if(amgclParams.get<std::string>("precond.class") != "amg")
         amgclParams.erase("precond.coarsening");

--- a/applications/TrilinosApplication/external_includes/amgcl_mpi_solver_impl.cpp
+++ b/applications/TrilinosApplication/external_includes/amgcl_mpi_solver_impl.cpp
@@ -46,8 +46,7 @@ void AMGCLScalarSolve(
     )
 {
     const Epetra_Comm& r_epetra_comm = rA.Comm();
-    // const Epetra_MpiComm epetra_mpi_comm(r_epetra_comm);
-    const Epetra_MpiComm& r_epetra_mpi_comm = dynamic_cast<const Epetra_MpiComm&>(r_epetra_comm);
+    const Epetra_MpiComm& r_epetra_mpi_comm = dynamic_cast<const Epetra_MpiComm&>(r_epetra_comm); // cannot use static_cast due to virtual inheritance
 
     MPI_Comm the_comm = r_epetra_mpi_comm.Comm();
 
@@ -114,8 +113,7 @@ void AMGCLBlockSolve(
     )
 {
     const Epetra_Comm& r_epetra_comm = rA.Comm();
-    // const Epetra_MpiComm epetra_mpi_comm(r_epetra_comm);
-    const Epetra_MpiComm& r_epetra_mpi_comm = dynamic_cast<const Epetra_MpiComm&>(r_epetra_comm);
+    const Epetra_MpiComm& r_epetra_mpi_comm = dynamic_cast<const Epetra_MpiComm&>(r_epetra_comm); // cannot use static_cast due to virtual inheritance
 
     MPI_Comm the_comm = r_epetra_mpi_comm.Comm();
 

--- a/applications/TrilinosApplication/external_includes/amgcl_mpi_solver_impl.cpp
+++ b/applications/TrilinosApplication/external_includes/amgcl_mpi_solver_impl.cpp
@@ -45,6 +45,12 @@ void AMGCLScalarSolve(
     bool use_gpgpu
     )
 {
+    const Epetra_Comm& r_epetra_comm = rA.Comm();
+    // const Epetra_MpiComm epetra_mpi_comm(r_epetra_comm);
+    const Epetra_MpiComm& r_epetra_mpi_comm = dynamic_cast<const Epetra_MpiComm&>(r_epetra_comm);
+
+    MPI_Comm the_comm = r_epetra_mpi_comm.Comm();
+
 #ifdef AMGCL_GPGPU
     if (use_gpgpu && vexcl_context()) {
         auto &ctx = vexcl_context();
@@ -61,7 +67,7 @@ void AMGCLScalarSolve(
         Backend::params bprm;
         bprm.q = ctx;
 
-        Solver solve(MPI_COMM_WORLD, amgcl::adapter::map(rA), amgclParams, bprm);
+        Solver solve(the_comm, amgcl::adapter::map(rA), amgclParams, bprm);
 
         std::size_t n = rA.NumMyRows();
 
@@ -83,7 +89,7 @@ void AMGCLScalarSolve(
                 >
             Solver;
 
-        Solver solve(MPI_COMM_WORLD, amgcl::adapter::map(rA), amgclParams);
+        Solver solve(the_comm, amgcl::adapter::map(rA), amgclParams);
 
         std::size_t n = rA.NumMyRows();
 
@@ -107,6 +113,12 @@ void AMGCLBlockSolve(
     bool use_gpgpu
     )
 {
+    const Epetra_Comm& r_epetra_comm = rA.Comm();
+    // const Epetra_MpiComm epetra_mpi_comm(r_epetra_comm);
+    const Epetra_MpiComm& r_epetra_mpi_comm = dynamic_cast<const Epetra_MpiComm&>(r_epetra_comm);
+
+    MPI_Comm the_comm = r_epetra_mpi_comm.Comm();
+
     if(amgclParams.get<std::string>("precond.class") != "amg")
         amgclParams.erase("precond.coarsening");
     else
@@ -136,7 +148,7 @@ void AMGCLBlockSolve(
         bprm.q = ctx;
 
         Solver solve(
-                MPI_COMM_WORLD,
+                the_comm,
                 amgcl::adapter::block_matrix<val_type>(amgcl::adapter::map(rA)),
                 amgclParams, bprm
                 );
@@ -163,7 +175,7 @@ void AMGCLBlockSolve(
             Solver;
 
         Solver solve(
-                MPI_COMM_WORLD,
+                the_comm,
                 amgcl::adapter::block_matrix<val_type>(amgcl::adapter::map(rA)),
                 amgclParams
                 );

--- a/applications/TrilinosApplication/tests/test_trilinos_linear_solvers.py
+++ b/applications/TrilinosApplication/tests/test_trilinos_linear_solvers.py
@@ -629,7 +629,6 @@ class TestAMGCLMPILinearSolvers(TestLinearSolvers):
             self._RunParametrized(params_string)
 
         with self.subTest('SubComm'):
-            self.skipTest("AMGCL does not yet support SubCommunicators")
             self._RunParametrizedWithSubComm(params_string)
 
     def test_amgcl_mpi_solver_bicgstab(self):
@@ -651,7 +650,6 @@ class TestAMGCLMPILinearSolvers(TestLinearSolvers):
             self._RunParametrized(params_string)
 
         with self.subTest('SubComm'):
-            self.skipTest("AMGCL does not yet support SubCommunicators")
             self._RunParametrizedWithSubComm(params_string)
 
     def test_amgcl_mpi_solver_bicgstabl(self):
@@ -673,7 +671,6 @@ class TestAMGCLMPILinearSolvers(TestLinearSolvers):
             self._RunParametrized(params_string)
 
         with self.subTest('SubComm'):
-            self.skipTest("AMGCL does not yet support SubCommunicators")
             self._RunParametrizedWithSubComm(params_string)
 
     def test_amgcl_mpi_solver_gmres(self):
@@ -695,7 +692,6 @@ class TestAMGCLMPILinearSolvers(TestLinearSolvers):
             self._RunParametrized(params_string)
 
         with self.subTest('SubComm'):
-            self.skipTest("AMGCL does not yet support SubCommunicators")
             self._RunParametrizedWithSubComm(params_string)
 
 

--- a/external_libraries/amgcl/solver/idrs.hpp
+++ b/external_libraries/amgcl/solver/idrs.hpp
@@ -196,7 +196,7 @@ class idrs {
                 std::vector<rhs_type> p(n);
 
 #ifdef MPI_VERSION
-                int pid = amgcl::mpi::communicator(MPI_COMM_WORLD).rank;
+                int pid = 0;
 #else
                 int pid = 0;
 #endif

--- a/external_libraries/amgcl/solver/idrs.hpp
+++ b/external_libraries/amgcl/solver/idrs.hpp
@@ -196,7 +196,7 @@ class idrs {
                 std::vector<rhs_type> p(n);
 
 #ifdef MPI_VERSION
-                amgcl::mpi::communicator(MPI_COMM_WORLD).rank;
+                int pid = amgcl::mpi::communicator(MPI_COMM_WORLD).rank;
 #else
                 int pid = 0;
 #endif

--- a/external_libraries/amgcl/solver/idrs.hpp
+++ b/external_libraries/amgcl/solver/idrs.hpp
@@ -196,7 +196,7 @@ class idrs {
                 std::vector<rhs_type> p(n);
 
 #ifdef MPI_VERSION
-                int pid = 0;
+                amgcl::mpi::communicator(MPI_COMM_WORLD).rank;
 #else
                 int pid = 0;
 #endif


### PR DESCRIPTION
This PR enables the use of AMGCL with sub-MPI communicators
The other trilinos solvers already support this

Two open questions:
- I didn't find a better way of retrieving the `MPI_Comm` from the Trilinos Matrix. Does anyone know a better way? I read all the documentation, tutorials and their github issues but didn't find anything. I have not yet asked in their github as maybe @RiccardoRossi or @roigcarlo know the answer
- @ddemidov the `idrs` hardcodes the use of `MPI_COMM_WORLD`. Is this necessary? It also works without for my case. To me it seems like the rank is only used as seed for some random distribution. I checked your master branch, it is also hardcoded there.

Thx for your help :)