### PR TITLE
[Fluid] Fixed bug in estimate dt utilities

### DIFF
--- a/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.h
@@ -266,7 +266,7 @@ private:
         KRATOS_TRY
 
         // Calculate the corresponding new time increments from the provided pairs
-        const double zero_tol = 1.0e-10;
+        const double zero_tol = std::min(0.1 * mDtMin, 1e-10);
         double new_dt_list[sizeof...(CharacteristicNumbersPairsType)] = {(
             (std::get<0>(rCharacteristicNumbersPairs) > zero_tol) ? CurrentDeltaTime * std::get<1>(rCharacteristicNumbersPairs) / std::get<0>(rCharacteristicNumbersPairs) : mDtMin
         )...};


### PR DESCRIPTION
**📝 Description**
There currently is a bug in the estimate dt utilities.

When the current `Δt` is less than a certain hardcoded `ϵ`, `Δt` is considered to be approximately zero.
When this happens, the value of `min_Δt` is used in the next step. Alternatively, when `Δt > ϵ`, a value is calculated as a function of Courant and Fourier numbers:
```
          { Δt_min         when Δt < ϵ
Δt_next = {
          { f(CFL, Fo)     otherwise
```
As of now, ϵ is hardcoded to be `ϵ := 1e-10`.

As such, when the folowing set  of conditions is fulfilled:
- `min_Δt < ϵ` (for instance in supersonic flows)
- `Δt < ϵ` (for instance, in the first time step when `Δt=0`).

the simulation is trapped in the `Δt < ϵ` branch above, and `Δt` remains `min_Δt` regardless of the CFL and Fo. To avoid such loops, I set `ϵ` to be strictly smaller than `min_Δt`.

**🆕 Changelog**
- Changed `ϵ := 1e-10` to `ϵ := min(0.1*min_Δt, 1e-10)`.
