### PR TITLE
[CI] Adding CXX environment variable to nighly run

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -72,6 +72,14 @@ jobs:
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${KRATOS_BUILD_TYPE}
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${KRATOS_BUILD_TYPE}/libs
         python3 kratos/python_scripts/run_tests.py -l nightly -c python3
+        if [ ${{ matrix.compiler }} = gcc ]; then
+          export CXX=/usr/bin/g++
+        elif [ ${{ matrix.compiler }} = clang ]; then
+          export CXX=/usr/bin/clang++
+        else
+          echo 'Unsupported compiler: ${{ matrix.compiler }}'
+          exit 1
+        fi
 
     - name: Running Python MPI tests (2 Cores)
       shell: bash


### PR DESCRIPTION
**📝 Description**
Adds the compiler as an environment variable to the nighly run.

This change is necessary for #9569.

Will stay Draft until discussion of said PR ends and is agreed to be merged.

**🆕 Changelog**
- Added CXX environment variable to nighly run 