### PR TITLE
[Fluid] Parallelized gauss point loops in symbolic generator

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/symbolic_generation/compressible_navier_stokes/compressible_navier_stokes_symbolic_generator.py
+++ b/applications/FluidDynamicsApplication/python_scripts/symbolic_generation/compressible_navier_stokes/compressible_navier_stokes_symbolic_generator.py
@@ -174,7 +174,7 @@ class CompressibleNavierStokesSymbolicGenerator:
         residuals = [None for _ in self.geometry.SymbolicIntegrationPoints()]
         ngauss = len(residuals)
 
-        with Futures.ThreadPoolExecutor(max_workers=ngauss) as executor:
+        with Futures.ProcessPoolExecutor() as executor:
             
             for i_gauss in self.geometry.SymbolicIntegrationPoints():
                 residuals[i_gauss] = executor.submit(
@@ -249,7 +249,7 @@ class CompressibleNavierStokesSymbolicGenerator:
         rv_gauss = [None for _ in self.geometry.SymbolicIntegrationPoints()]
         ngauss = len(rv_gauss)
 
-        with Futures.ThreadPoolExecutor(max_workers=ngauss) as executor:
+        with Futures.ProcessPoolExecutor() as executor:
             for i_gauss in self.geometry.SymbolicIntegrationPoints():
                 rv_gauss[i_gauss] = executor.submit(self._ComputeResidualAtGaussPoint, acc, bdf, dUdt, f, forcing_terms, H, i_gauss, mg, params, Q, res_proj, ResProj, res, rg, rv, sc_nodes, sc_params, subscales, subscales_type, Tau, U, Ug, Un, Unn, V, w)
         


### PR DESCRIPTION
**📝 Description**
I was motivated by Riccardo Rossi's class in the CIMNE Winter School to attempt to parallelize parts of the code in the symbolic generator. Particularly, the loops over the gauss points.

*Theoretical expectations*
The serial execution of `generate_triangle.py` takes 328 seconds*. The parallelizable parts take 174 seconds. If they were perfectly parallelized into three threads (one for each gauss point), the total execution time would come down to 212s, therefore an improvement ceiling of 35%.

\*These benchmarks are with profiling enabled, without profiling it takes 148 seconds.

*Results*
They're bad. It runs 20% slower on my old laptop. I will run a benchmark on my PC and see if it is also bad or if it improves. If it improves, the CI run will be the tiebreaker. If it doesn't improve, this branch will be removed.

I ran the benchmark with `htop` on and when run in serial, one of the cores is at 100% and the others idle.
When running in parallel, all four cores went to about 20-30%. If anyone can offer their expertise as to why this may happen I'll be glad to listen.

**🆕 Changelog**
- Loops over gauss points in symbolic generation are now parallel.