### PR TITLE
[.gitignore] ignore a.out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 ~scripts/standard_configure.sh
 ~scripts/standard_configure_MINGW.bat
 ~scripts/standard_configure.bat
+scripts/a.out
 scripts/*.sh
 scripts/*.bat
 build/*

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@
 ~scripts/standard_configure.sh
 ~scripts/standard_configure_MINGW.bat
 ~scripts/standard_configure.bat
-scripts/a.out
+scripts/*.out
 scripts/*.sh
 scripts/*.bat
 build/*


### PR DESCRIPTION
**📝 Description**
For some reason beyond my knowledge, the compilation file `a.out` has appeared in my scripts folder. Its annoying to have this file in the control versions.

**🆕 Changelog**
- Add `scripts/a.out` to `.gitignore`
