### PR TITLE
[All][Core][Model] CreateModelPart new behavior

### DIFF
--- a/kratos/containers/model.cpp
+++ b/kratos/containers/model.cpp
@@ -64,7 +64,8 @@ ModelPart& Model::CreateModelPart( const std::string ModelPartName, ModelPart::I
             CreateRootModelPart(root_model_part_name, NewBufferSize);
             return *(mRootModelPartMap[root_model_part_name].get());
         } else {
-            KRATOS_ERROR << "Trying to create a root modelpart with name " << ModelPartName << " however a ModelPart with the same name already exists";
+            KRATOS_WARNING("Model") << "Trying to create a root modelpart with name " << ModelPartName << " however a ModelPart with the same name already exists. \nReturning the already existent ModelPart.\n";
+            return *(mRootModelPartMap[root_model_part_name].get());
         }
     } else {
         if (mRootModelPartMap.find(root_model_part_name) == mRootModelPartMap.end()) {


### PR DESCRIPTION
**📝 Description**
As it has been discussed in #9258, the creation of model parts must happen at the modelers stage in order to enable the multistage simulation (not at the solver instantiation as we're doing right now).

Changing the `CreateModelPart` method of the `Model` as suggested in here will ease the transition period. Long story short, right now we were throwing an error if the model part was already existing. With this change we will issue a warning and return the already existing model part.

Backwards compatibility is ensured as we were throwing an error so far.