### PR TITLE
[Core]LevelSet] only set Gradient var if it is defined

### DIFF
--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -439,7 +439,9 @@ protected:
             r_process_info.SetValue(CONVECTION_DIFFUSION_SETTINGS, p_conv_diff_settings);
             p_conv_diff_settings->SetUnknownVariable(*mpLevelSetVar);
             p_conv_diff_settings->SetConvectionVariable(*mpConvectVar);
-            p_conv_diff_settings->SetGradientVariable(*mpLevelSetGradientVar);
+            if (mpLevelSetGradientVar) {
+                p_conv_diff_settings->SetGradientVariable(*mpLevelSetGradientVar);
+            }
         }
 
         // This call returns a function pointer with the ProcessInfo filling directives


### PR DESCRIPTION
the Gradient var is optional and might not be needed:
https://github.com/KratosMultiphysics/Kratos/blob/7f594a0fc6667c39475c98375330143fcb7fd1ee/kratos/processes/levelset_convection_process.h#L823

unfortunately it is always set to the ConDiff settings, even if it is not specified! The weird thing is that the `nullptr` is dereferenced but does not crash ... not sure why.

Related:
- If the var is a nullpointer it will cause problems in the save/load of the ConDiffSettings
- The TwoFluidNavierStokesSolver specifies the Gradient var name explicitly here, not sure if it is actually used or not ...? @rubenzorrilla @ddiezrod @mrhashemi can you check please?
https://github.com/KratosMultiphysics/Kratos/blob/7f594a0fc6667c39475c98375330143fcb7fd1ee/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py#L132

for reference the parameters that get validated in here https://github.com/KratosMultiphysics/Kratos/blob/7f594a0fc6667c39475c98375330143fcb7fd1ee/kratos/processes/levelset_convection_process.h#L792:
~~~
{
    "convection_model_part_name": "",
    "echo_level": 0,
    "element_settings": {
        "cross_wind_stabilization_factor": 0.7,
        "dynamic_tau": 0.0,
        "requires_distance_gradient": false,
        "time_integration_theta": 0.5
    },
    "element_type": "levelset_convection_supg",
    "eulerian_error_compensation": false,
    "levelset_convection_variable_name": "VELOCITY",
    "levelset_gradient_variable_name": "DISTANCE_GRADIENT",
    "levelset_variable_name": "DISTANCE",
    "max_CFL": 1.0,
    "max_substeps": 0,
    "model_part_name": ""
}
~~~

one can clearly see that the distance gradient is not necessary

FYI @mpentek 