### PR TITLE
[Compressible Potential] Updated GetNumThreads->ParallelUtilities

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_processes/apply_far_field_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/apply_far_field_process.cpp
@@ -44,7 +44,7 @@ void ApplyFarFieldProcess::Execute()
 void ApplyFarFieldProcess::FindFarthestUpstreamBoundaryNode()
 {
     // Declaring omp variables, generating vectors of size = num_threads
-    std::size_t num_threads = OpenMPUtils::GetNumThreads();
+    std::size_t num_threads = ParallelUtilities::GetNumThreads();
     std::vector<double> min_projections(num_threads, std::numeric_limits<double>::max());
     std::vector<std::size_t> nodes_id_list(num_threads, 0);
 


### PR DESCRIPTION
**📝 Description**
Small maintenance change to remove deprecation warning during compilation.

**🆕 Changelog**
- Call to `OpenMPUtils::GetNumThreads()` is now `ParallelUtils::GetNumThreads()`
