### PR TITLE
[Core] cleanup ConDiff settings

### DIFF
--- a/kratos/includes/convection_diffusion_settings.h
+++ b/kratos/includes/convection_diffusion_settings.h
@@ -112,11 +112,11 @@ public:
         mpDensityVar = &rvar;
         mis_defined_DensityVar=true;
     }
-    const Variable<double>& GetDensityVariable()
+    const Variable<double>& GetDensityVariable() const
     {
         return *mpDensityVar;
     }
-    bool IsDefinedDensityVariable()
+    bool IsDefinedDensityVariable() const
     {
 		return mis_defined_DensityVar;
 	}
@@ -126,11 +126,11 @@ public:
         mpDiffusionVar = &rvar;
 		mis_defined_DiffusionVar=true;
     }
-    const Variable<double>& GetDiffusionVariable()
+    const Variable<double>& GetDiffusionVariable() const
     {
         return *mpDiffusionVar;
     }
-    bool IsDefinedDiffusionVariable()
+    bool IsDefinedDiffusionVariable() const
     {
 		return mis_defined_DiffusionVar;
 	}
@@ -140,11 +140,11 @@ public:
         mpUnknownVar = &rvar;
 		mis_defined_UnknownVar=true;
     }
-    const Variable<double>& GetUnknownVariable()
+    const Variable<double>& GetUnknownVariable() const
     {
         return *mpUnknownVar;
     }
-    bool IsDefinedUnknownVariable()
+    bool IsDefinedUnknownVariable() const
     {
 		return mis_defined_UnknownVar;
 	}
@@ -154,11 +154,11 @@ public:
         mpVolumeSourceVar = &rvar;
 		mis_defined_VolumeSourceVar=true;
     }
-    const Variable<double>& GetVolumeSourceVariable()
+    const Variable<double>& GetVolumeSourceVariable() const
     {
         return *mpVolumeSourceVar;
     }
-    bool IsDefinedVolumeSourceVariable()
+    bool IsDefinedVolumeSourceVariable() const
     {
 		return mis_defined_VolumeSourceVar;
 	}
@@ -168,11 +168,11 @@ public:
         mpSurfaceSourceVar = &rvar;
 		mis_defined_SurfaceSourceVar=true;
     }
-    const Variable<double>& GetSurfaceSourceVariable()
+    const Variable<double>& GetSurfaceSourceVariable() const
     {
         return *mpSurfaceSourceVar;
     }
-    bool IsDefinedSurfaceSourceVariable()
+    bool IsDefinedSurfaceSourceVariable() const
     {
 		return mis_defined_SurfaceSourceVar;
 	}
@@ -182,11 +182,11 @@ public:
         mpProjectionVar = &rvar;
 		mis_defined_ProjectionVar=true;
     }
-    const Variable<double>& GetProjectionVariable()
+    const Variable<double>& GetProjectionVariable() const
     {
         return *mpProjectionVar;
     }
-    bool IsDefinedProjectionVariable()
+    bool IsDefinedProjectionVariable() const
     {
 		return mis_defined_ProjectionVar;
 	}
@@ -196,11 +196,11 @@ public:
         mpConvectionVar = &rvar;
 		mis_defined_ConvectionVar=true;
     }
-    const Variable<array_1d<double,3> >& GetConvectionVariable()
+    const Variable<array_1d<double,3> >& GetConvectionVariable() const
     {
         return *mpConvectionVar;
     }
-    bool IsDefinedConvectionVariable()
+    bool IsDefinedConvectionVariable() const
     {
 		return mis_defined_ConvectionVar;
 	}
@@ -224,11 +224,11 @@ public:
         mpMeshVelocityVar = &rvar;
 		mis_defined_MeshVelocityVar=true;
     }
-    const Variable<array_1d<double,3> >& GetMeshVelocityVariable()
+    const Variable<array_1d<double,3> >& GetMeshVelocityVariable() const
     {
         return *mpMeshVelocityVar;
     }
-    bool IsDefinedMeshVelocityVariable()
+    bool IsDefinedMeshVelocityVariable() const
     {
 		return mis_defined_MeshVelocityVar;
 	}
@@ -238,11 +238,11 @@ public:
         mpTransferCoefficientVar = &rvar;
 		mis_defined_TransferCoefficientVar=true;
     }
-    const Variable<double>& GetTransferCoefficientVariable()
+    const Variable<double>& GetTransferCoefficientVariable() const
     {
         return *mpTransferCoefficientVar;
     }
-    bool IsDefinedTransferCoefficientVariable()
+    bool IsDefinedTransferCoefficientVariable() const
     {
 		return mis_defined_TransferCoefficientVar;
 	}
@@ -252,11 +252,11 @@ public:
         mpVelocityVar = &rvar;
 		mis_defined_VelocityVar=true;
     }
-    const Variable<array_1d<double,3> >& GetVelocityVariable()
+    const Variable<array_1d<double,3> >& GetVelocityVariable() const
     {
         return *mpVelocityVar;
     }
-    bool IsDefinedVelocityVariable()
+    bool IsDefinedVelocityVariable() const
     {
 		return mis_defined_VelocityVar;
 	}
@@ -266,11 +266,11 @@ public:
         mpSpecificHeatVar = &rvar;
 		mis_defined_SpecificHeatVar=true;
     }
-    const Variable<double>& GetSpecificHeatVariable()
+    const Variable<double>& GetSpecificHeatVariable() const
     {
         return *mpSpecificHeatVar;
     }
-    bool IsDefinedSpecificHeatVariable()
+    bool IsDefinedSpecificHeatVariable() const
     {
 		return mis_defined_SpecificHeatVar;
 	}
@@ -280,11 +280,11 @@ public:
         mpReactionVar = &rvar;
 		mis_defined_ReactionVar=true;
     }
-    const Variable<double>& GetReactionVariable()
+    const Variable<double>& GetReactionVariable() const
     {
         return *mpReactionVar;
     }
-    bool IsDefinedReactionVariable()
+    bool IsDefinedReactionVariable() const
     {
 		return mis_defined_ReactionVar;
 	}
@@ -294,13 +294,11 @@ public:
         mpReactionGradientVar = &rVar;
 		mIsDefinedReactionGradientVar=true;
     }
-
-    const Variable<array_1d<double,3>>& GetReactionGradientVariable()
+    const Variable<array_1d<double,3>>& GetReactionGradientVariable() const
     {
         return *mpReactionGradientVar;
     }
-
-    bool IsDefinedReactionGradientVariable()
+    bool IsDefinedReactionGradientVariable() const
     {
 		return mIsDefinedReactionGradientVar;
 	}

--- a/kratos/includes/convection_diffusion_settings.h
+++ b/kratos/includes/convection_diffusion_settings.h
@@ -11,28 +11,20 @@
 //                   Pablo Becker
 //
 
-
 #if !defined(KRATOS_CONVECTION_DIFFUSION_SETTINGS_INCLUDED )
 #define  KRATOS_CONVECTION_DIFFUSION_SETTINGS_INCLUDED
-
-
 
 // System includes
 #include <string>
 #include <iostream>
 
-
 // External includes
-
 
 // Project includes
 #include "containers/variable.h"
 #include "includes/define.h"
-#include "includes/kratos_components.h"
 
-
-namespace Kratos
-{
+namespace Kratos {
 
 ///@name Kratos Globals
 ///@{

--- a/kratos/includes/convection_diffusion_settings.h
+++ b/kratos/includes/convection_diffusion_settings.h
@@ -67,23 +67,8 @@ public:
     ///@{
 
     /// Default constructor.
-    ConvectionDiffusionSettings()
-    {
-        mis_defined_DensityVar=false;
-        mis_defined_DiffusionVar=false;
-		mis_defined_UnknownVar=false;
-		mis_defined_VolumeSourceVar=false;
-		mis_defined_SurfaceSourceVar=false;
-		mis_defined_ProjectionVar=false;
-		mis_defined_ConvectionVar=false;
-		mis_defined_GradientVar = false;
-		mis_defined_MeshVelocityVar=false;
-		mis_defined_TransferCoefficientVar=false;
-		mis_defined_VelocityVar=false;
-		mis_defined_SpecificHeatVar=false;
-        mis_defined_ReactionVar=false;
-        mIsDefinedReactionGradientVar=false;
-    };
+    ConvectionDiffusionSettings() = default;
+
     ConvectionDiffusionSettings(const ConvectionDiffusionSettings& rOther):
         mpDensityVar(rOther.mpDensityVar),
         mpDiffusionVar(rOther.mpDiffusionVar),

--- a/kratos/sources/convection_diffusion_settings.cpp
+++ b/kratos/sources/convection_diffusion_settings.cpp
@@ -17,6 +17,7 @@
 
 // Project includes
 #include "includes/convection_diffusion_settings.h"
+#include "includes/kratos_components.h"
 
 namespace Kratos {
 


### PR DESCRIPTION
- `default`ing the CTor (vars are properly initialized when defining them)
- adding missing `const`
- moving include to cpp
