### PR TITLE
[CI] switching to python 3.8 in Win CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v1
       with:
-        python-version: '3.6'
+        python-version: '3.8'
 
     - name: Download boost
       run: |
@@ -312,7 +312,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v1
       with:
-        python-version: '3.6'
+        python-version: '3.8'
 
     - name: Download boost
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v1
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Download boost
       run: |
@@ -312,7 +312,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v1
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Download boost
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
       with:
         python-version: '3.10'
 
@@ -310,7 +310,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
       with:
         python-version: '3.10'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
         python3 kratos/python_scripts/testing/run_python_mpi_tests.py -l small -n 4
 
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     env:
       KRATOS_BUILD_TYPE: Custom
 
@@ -127,7 +127,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.10'
+        python-version: '3.8'
 
     - name: Download boost
       run: |
@@ -304,7 +304,7 @@ jobs:
 
 
   windows-core-without-unity:
-    runs-on: windows-latest
+    runs-on: windows-2019
     env:
       KRATOS_BUILD_TYPE: Custom
 
@@ -312,7 +312,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.10'
+        python-version: '3.8'
 
     - name: Download boost
       run: |

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -108,7 +108,7 @@ jobs:
 
     - uses: actions/setup-python@v1
       with:
-        python-version: '3.6'
+        python-version: '3.8'
 
     - name: Download boost
       run: |

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -106,7 +106,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v2
       with:
         python-version: '3.10'
 

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -108,7 +108,7 @@ jobs:
 
     - uses: actions/setup-python@v1
       with:
-        python-version: '3.8'
+        python-version: '3.10'
 
     - name: Download boost
       run: |

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -99,7 +99,7 @@ jobs:
 
 
   windows-nightly:
-    runs-on: windows-latest
+    runs-on: windows-2019
     env:
       KRATOS_BUILD_TYPE: Custom
 
@@ -108,7 +108,7 @@ jobs:
 
     - uses: actions/setup-python@v2
       with:
-        python-version: '3.10'
+        python-version: '3.8'
 
     - name: Download boost
       run: |


### PR DESCRIPTION
seems that Github removed python 3.6