### PR TITLE
[Meshing][MMGProcess] minor syntax simplification

### DIFF
--- a/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
+++ b/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
@@ -1052,7 +1052,7 @@ void MmgProcess<TMMGLibrary>::ClearConditionsDuplicatedGeometries()
         } else {
             std::vector<IndexType> aux_cond_id(1);
             aux_cond_id[0] = r_cond.Id();
-            faces_map.insert( HashMapType::value_type(std::pair<DenseVector<IndexType>, std::vector<IndexType>>({ids, aux_cond_id})) );
+            faces_map.insert({ids, aux_cond_id});
         }
     }
 


### PR DESCRIPTION
This gives a linker error with Clang 10 when compiling with C++17:
~~~
/usr/bin/ld: CMakeFiles/KratosMeshingCore.dir/custom_processes/mmg/mmg_process.cpp.o: in function `Kratos::MmgProcess<(Kratos::MMGLibrary)0>::ClearConditionsDuplicatedGeometries()':
mmg_process.cpp:(.text._ZN6Kratos10MmgProcessILNS_10MMGLibraryE0EE35ClearConditionsDuplicatedGeometriesEv[_ZN6Kratos10MmgProcessILNS_10MMGLibraryE0EE35ClearConditionsDuplicatedGeometriesEv]+0x553): undefined reference to `std::pair<boost::numeric::ublas::vector<unsigned long, boost::numeric::ublas::unbounded_array<unsigned long, std::allocator<unsigned long> > > const, std::vector<unsigned long, std::allocator<unsigned long> > >::~pair()'
/usr/bin/ld: mmg_process.cpp:(.text._ZN6Kratos10MmgProcessILNS_10MMGLibraryE0EE35ClearConditionsDuplicatedGeometriesEv[_ZN6Kratos10MmgProcessILNS_10MMGLibraryE0EE35ClearConditionsDuplicatedGeometriesEv]+0xa48): undefined reference to `std::pair<boost::numeric::ublas::vector<unsigned long, boost::numeric::ublas::unbounded_array<unsigned long, std::allocator<unsigned long> > > const, std::vector<unsigned long, std::allocator<unsigned long> > >::~pair()'
/usr/bin/ld: mmg_process.cpp:(.text._ZN6Kratos10MmgProcessILNS_10MMGLibraryE0EE35ClearConditionsDuplicatedGeometriesEv[_ZN6Kratos10MmgProcessILNS_10MMGLibraryE0EE35ClearConditionsDuplicatedGeometriesEv]+0xb0d): undefined reference to `std::pair<boost::numeric::ublas::vector<unsigned long, boost::numeric::ublas::unbounded_array<unsigned long, std::allocator<unsigned long> > > const, std::vector<unsigned long, std::allocator<unsigned long> > >::~pair()'
/usr/bin/ld: mmg_process.cpp:(.text._ZN6Kratos10MmgProcessILNS_10MMGLibraryE0EE35ClearConditionsDuplicatedGeometriesEv[_ZN6Kratos10MmgProcessILNS_10MMGLibraryE0EE35ClearConditionsDuplicatedGeometriesEv]+0xc98): undefined reference to `std::pair<boost::numeric::ublas::vector<unsigned long, boost::numeric::ublas::unbounded_array<unsigned long, std::allocator<unsigned long> > > const, std::vector<unsigned long, std::allocator<unsigned long> > >::~pair()'
/usr/bin/ld: CMakeFiles/KratosMeshingCore.dir/custom_processes/mmg/mmg_process.cpp.o: in function `Kratos::MmgProcess<(Kratos::MMGLibrary)1>::ClearConditionsDuplicatedGeometries()':
mmg_process.cpp:(.text._ZN6Kratos10MmgProcessILNS_10MMGLibraryE1EE35ClearConditionsDuplicatedGeometriesEv[_ZN6Kratos10MmgProcessILNS_10MMGLibraryE1EE35ClearConditionsDuplicatedGeometriesEv]+0x553): undefined reference to `std::pair<boost::numeric::ublas::vector<unsigned long, boost::numeric::ublas::unbounded_array<unsigned long, std::allocator<unsigned long> > > const, std::vector<unsigned long, std::allocator<unsigned long> > >::~pair()'
/usr/bin/ld: CMakeFiles/KratosMeshingCore.dir/custom_processes/mmg/mmg_process.cpp.o:mmg_process.cpp:(.text._ZN6Kratos10MmgProcessILNS_10MMGLibraryE1EE35ClearConditionsDuplicatedGeometriesEv[_ZN6Kratos10MmgProcessILNS_10MMGLibraryE1EE35ClearConditionsDuplicatedGeometriesEv]+0xa48): more undefined references to `std::pair<boost::numeric::ublas::vector<unsigned long, boost::numeric::ublas::unbounded_array<unsigned long, std::allocator<unsigned long> > > const, std::vector<unsigned long, std::allocator<unsigned long> > >::~pair()' follow
~~~

=> hence my recommendation / simplification is to let the compiler take care of what he wants :)