### PR TITLE
[Fluid] two fluid mpi hotfix

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -339,7 +339,7 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
         # Check if the fluid properties are provided using a .json file
         materials_filename = self.settings["material_import_settings"]["materials_filename"].GetString()
         if (materials_filename != ""):
-            data_comm = self.main_model_part.GetCommunicator().GetDataCommunicator()
+            data_comm = KratosMultiphysics.ParallelEnvironment.GetDataCommunicator() # only using the global comm as the Communicators are not yet created when running in MPI. Hotfix since this method will disappear completely when using subproperties!
 
             def GetAuxMaterialsFileName(mat_file_name, prop_id):
                 p_mat_file_name = Path(mat_file_name)

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_two_fluids_solver.py
@@ -37,10 +37,9 @@ class NavierStokesMPITwoFluidsSolver(NavierStokesTwoFluidsSolver):
         KratosMultiphysics.Logger.PrintInfo(self.__class__.__name__,"MPI model reading finished.")
 
     def PrepareModelPart(self):
+        super(NavierStokesMPITwoFluidsSolver,self).PrepareModelPart()
         ## Construct the MPI communicators
         self.distributed_model_part_importer.CreateCommunicators()
-
-        super(NavierStokesMPITwoFluidsSolver,self).PrepareModelPart()
 
     def _GetEpetraCommunicator(self):
         if not hasattr(self, '_epetra_communicator'):


### PR DESCRIPTION
turns out that I broke the TwoFluid in #9615 when running in MPI (specifically [this](7ad50a1b2eeb65434c3627c19171d250ddab53e5) commit)
In a nutshell, the problem is that when the `ParallelFillComm` is called before the `TetrahedralMeshOrientationCheck`, then it hangs later when creating the level set. No clue why but unfortunately I didn't notice this
Sorry for the inconvenience

Hence this PR reverts the problematic commit and uses the global data comm for now (until the subproperties are implemented in the two fluid)