### PR TITLE
[ROM] Corrected misleading error message

### DIFF
--- a/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
+++ b/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
@@ -21,14 +21,17 @@ def CreateSolverByParameters(model, solver_settings, parallelism, analysis_stage
 
     # Filter and retrieve the Python solvers wrapper from the corresponding application
     #TODO: This filtering wouldn't be required if we were using a unified solvers wrapper module name
-    if application_module_name == "KratosMultiphysics.FluidDynamicsApplication":
-        solvers_wrapper_module_module_name = "python_solvers_wrapper_fluid"
-    elif application_module_name == "KratosMultiphysics.StructuralMechanicsApplication":
-        solvers_wrapper_module_module_name = "python_solvers_wrapper_structural"
-    elif application_module_name == "KratosMultiphysics.ConvectionDiffusionApplication":
-        solvers_wrapper_module_module_name = "python_solvers_wrapper_convection_diffusion"
-    else:
-        err_msg = "Python module \'{0}\' is not available. Make sure \'{1}\' is compiled.".format(application_module_name, split_analysis_stage_module_name[1])
+    available_modules = {
+        "KratosMultiphysics.FluidDynamicsApplication"       : "python_solvers_wrapper_fluid",
+        "KratosMultiphysics.StructuralMechanicsApplication" : "python_solvers_wrapper_structural",
+        "KratosMultiphysics.ConvectionDiffusionApplication" : "python_solvers_wrapper_convection_diffusion"
+    }
+
+    if application_module_name in available_modules:
+        solvers_wrapper_module_module_name = available_modules[application_module_name]
+    else:    
+        err_msg = "Python module \'{0}\' is not available. Make sure \'{1}\' is compiled and in the following list:\n".format(application_module_name, split_analysis_stage_module_name[1])
+        err_msg += "\n".join(" - {}".format(key) for key in available_modules)
         raise Exception(err_msg)
     solvers_wrapper_module = importlib.import_module(application_module_name + "." + solvers_wrapper_module_module_name)
 

--- a/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
+++ b/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
@@ -5,6 +5,15 @@ import KratosMultiphysics
 from KratosMultiphysics import kratos_utilities
 from KratosMultiphysics.RomApplication import rom_solver
 
+
+def _GetAvailableSolverWrapperModules():
+    return {
+        "KratosMultiphysics.FluidDynamicsApplication"       : "python_solvers_wrapper_fluid",
+        "KratosMultiphysics.StructuralMechanicsApplication" : "python_solvers_wrapper_structural",
+        "KratosMultiphysics.ConvectionDiffusionApplication" : "python_solvers_wrapper_convection_diffusion"
+    }
+
+
 def CreateSolverByParameters(model, solver_settings, parallelism, analysis_stage_module_name):
 
     if not isinstance(model, KratosMultiphysics.Model):
@@ -21,17 +30,17 @@ def CreateSolverByParameters(model, solver_settings, parallelism, analysis_stage
 
     # Filter and retrieve the Python solvers wrapper from the corresponding application
     #TODO: This filtering wouldn't be required if we were using a unified solvers wrapper module name
-    available_modules = {
-        "KratosMultiphysics.FluidDynamicsApplication"       : "python_solvers_wrapper_fluid",
-        "KratosMultiphysics.StructuralMechanicsApplication" : "python_solvers_wrapper_structural",
-        "KratosMultiphysics.ConvectionDiffusionApplication" : "python_solvers_wrapper_convection_diffusion"
-    }
+    available_modules = _GetAvailableSolverWrapperModules()
 
     if application_module_name in available_modules:
         solvers_wrapper_module_module_name = available_modules[application_module_name]
     else:    
-        err_msg = "Python module \'{0}\' is not available. Make sure \'{1}\' is compiled and in the following list:\n".format(application_module_name, split_analysis_stage_module_name[1])
-        err_msg += "\n".join(" - {}".format(key) for key in available_modules)
+        err_msg = "Python module \'{0}\' is not available. Make sure \'{1}\' is compiled and implemented.\n".format(
+            application_module_name, split_analysis_stage_module_name[1])
+        err_msg += "Currently implemented applications are:\n"
+        err_msg += "".join(" - {}\n".format(key) for key in available_modules)
+        err_msg += "To add a new implementation, do so in '{}' in {}".format(
+            _GetAvailableSolverWrapperModules.__name__, __file__)
         raise Exception(err_msg)
     solvers_wrapper_module = importlib.import_module(application_module_name + "." + solvers_wrapper_module_module_name)
 

--- a/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
+++ b/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
@@ -34,7 +34,7 @@ def CreateSolverByParameters(model, solver_settings, parallelism, analysis_stage
 
     if application_module_name in available_modules:
         solvers_wrapper_module_module_name = available_modules[application_module_name]
-    else:    
+    else:
         err_msg = "Python module \'{0}\' is not available. Make sure \'{1}\' is compiled and implemented.\n".format(
             application_module_name, split_analysis_stage_module_name[1])
         err_msg += "Currently implemented applications are:\n"


### PR DESCRIPTION
**📝 Description**
If yout try to use ROM on an application that is not suported, the error message was:
```
Python module 'KratosMultiphysics.CompressiblePotentialFlowApplication' is not available. Make sure 'CompressiblePotentialFlowApplication' is compiled.
```
when the issue is not compilation.

This has been changed to:
```
Exception: Python module 'KratosMultiphysics.CompressiblePotentialFlowApplication' is not available. Make sure 'CompressiblePotentialFlowApplication' is compiled and implemented.
Currently implemented applications are:
 - KratosMultiphysics.FluidDynamicsApplication
 - KratosMultiphysics.StructuralMechanicsApplication
 - KratosMultiphysics.ConvectionDiffusionApplication
To add a new implementation, do so in '_GetAvailableSolverWrapperModules' in /home/egomez/Work/Kratos/bin/Release/KratosMultiphysics/RomApplication/new_python_solvers_wrapper_rom.py
```

I'm new to this application so please go ahead and tell me if this doesn't make sense.

**🆕 Changelog**
- Changed error message so that it is more accurate.
