### PR TITLE
Solving a Bug when using Large displacement elements in combination to rotated LOCAL_AXIS

### DIFF
--- a/applications/ConstitutiveLawsApplication/custom_constitutive/hyper_elastic_isotropic_neo_hookean_3d.cpp
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/hyper_elastic_isotropic_neo_hookean_3d.cpp
@@ -108,6 +108,7 @@ void  HyperElasticIsotropicNeoHookean3D::CalculateMaterialResponsePK2(Constituti
 
     if(r_flags.IsNot( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
         this->CalculateGreenLagrangianStrain(rValues, strain_vector);
+        KRATOS_WATCH(strain_vector)
     }
 
     if( r_flags.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ){
@@ -148,7 +149,7 @@ void HyperElasticIsotropicNeoHookean3D::CalculateMaterialResponseKirchhoff (Cons
     const double lame_lambda = (young_modulus * poisson_coefficient)/((1.0 + poisson_coefficient)*(1.0 - 2.0 * poisson_coefficient));
     const double lame_mu = young_modulus/(2.0 * (1.0 + poisson_coefficient));
 
-    if(r_flags.Is( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
+    if(r_flags.IsNot( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
         CalculateAlmansiStrain(rValues, strain_vector);
     }
 

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/hyper_elastic_isotropic_neo_hookean_3d.cpp
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/hyper_elastic_isotropic_neo_hookean_3d.cpp
@@ -108,7 +108,6 @@ void  HyperElasticIsotropicNeoHookean3D::CalculateMaterialResponsePK2(Constituti
 
     if(r_flags.IsNot( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
         this->CalculateGreenLagrangianStrain(rValues, strain_vector);
-        KRATOS_WATCH(strain_vector)
     }
 
     if( r_flags.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ){

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -1592,11 +1592,9 @@ void BaseSolidElement::RotateToGlobalAxes(
             if (stress_option)
                 rValues.GetStressVector() = prod(trans(voigt_rotation_matrix), rValues.GetStressVector());
             if (constitutive_matrix_option) {
-                const auto& r_C = rValues.GetConstitutiveMatrix();
-                Matrix C_global = r_C;
-                noalias(C_global) = prod(trans(voigt_rotation_matrix), r_C);
-                C_global = prod(C_global, voigt_rotation_matrix);
-                rValues.SetConstitutiveMatrix(C_global);
+                BoundedMatrix<double, 6, 6> aux;
+                noalias(aux) = prod(trans(voigt_rotation_matrix), rValues.GetConstitutiveMatrix());
+                noalias(rValues.GetConstitutiveMatrix()) = prod(aux, voigt_rotation_matrix);
             }
         } else if (strain_size == 3) {
             BoundedMatrix<double, 3, 3> voigt_rotation_matrix;
@@ -1605,11 +1603,9 @@ void BaseSolidElement::RotateToGlobalAxes(
             if (stress_option)
                 rValues.GetStressVector() = prod(trans(voigt_rotation_matrix), rValues.GetStressVector());
             if (constitutive_matrix_option) {
-                const auto& r_C = rValues.GetConstitutiveMatrix();
-                Matrix C_global = r_C;
-                noalias(C_global) = prod(trans(voigt_rotation_matrix), r_C);
-                C_global = prod(C_global, voigt_rotation_matrix);
-                rValues.SetConstitutiveMatrix(C_global);
+                BoundedMatrix<double, 3, 3> aux;
+                noalias(aux) = prod(trans(voigt_rotation_matrix), rValues.GetConstitutiveMatrix());
+                noalias(rValues.GetConstitutiveMatrix()) = prod(aux, voigt_rotation_matrix);
             }
         }
         // Now undo the rotation in F if required

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -954,14 +954,14 @@ private:
      * global to local coordinates
      * @param rValues The constitutive laws parameters
      */
-    void RotateToLocalAxes(ConstitutiveLaw::Parameters &rValues);
+    void RotateToLocalAxes(ConstitutiveLaw::Parameters &rValues, KinematicVariables& rThisKinematicVariables);
 
     /**
      * @brief This method rotates the F or strain according to local axis from
      * local de global
      * @param rValues The constitutive laws parameters
      */
-    void RotateToGlobalAxes(ConstitutiveLaw::Parameters &rValues);
+    void RotateToGlobalAxes(ConstitutiveLaw::Parameters &rValues, KinematicVariables& rThisKinematicVariables);
 
     /**
      * @brief This method builds the rotation matrices and local axes

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -953,6 +953,7 @@ private:
      * @brief This method rotates the F or strain according to local axis from
      * global to local coordinates
      * @param rValues The constitutive laws parameters
+     * @param rThisKinematicVariables The Kinematic parameters
      */
     void RotateToLocalAxes(
         ConstitutiveLaw::Parameters &rValues,
@@ -962,6 +963,7 @@ private:
      * @brief This method rotates the F or strain according to local axis from
      * local de global
      * @param rValues The constitutive laws parameters
+     * @param rThisKinematicVariables The Kinematic parameters
      */
     void RotateToGlobalAxes(
         ConstitutiveLaw::Parameters &rValues,

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -954,14 +954,18 @@ private:
      * global to local coordinates
      * @param rValues The constitutive laws parameters
      */
-    void RotateToLocalAxes(ConstitutiveLaw::Parameters &rValues, KinematicVariables& rThisKinematicVariables);
+    void RotateToLocalAxes(
+        ConstitutiveLaw::Parameters &rValues,
+        KinematicVariables& rThisKinematicVariables);
 
     /**
      * @brief This method rotates the F or strain according to local axis from
      * local de global
      * @param rValues The constitutive laws parameters
      */
-    void RotateToGlobalAxes(ConstitutiveLaw::Parameters &rValues, KinematicVariables& rThisKinematicVariables);
+    void RotateToGlobalAxes(
+        ConstitutiveLaw::Parameters &rValues,
+        KinematicVariables& rThisKinematicVariables);
 
     /**
      * @brief This method builds the rotation matrices and local axes


### PR DESCRIPTION
**📝 Description**
In this PR I am correcting and improving an implementation within the `BaseSolidElement` regarding the rotation of strains, stresses and F according to a rotated `LOCAL_AXIS` system. This is required when using `Updated` or `Total` lagrangian elements in combination with orthotropic or anisotropic constitutive laws.

The bug involved the rotation of F. Now it workd properly without memory corruption.

Additionally I have improved the rotation efficiency for the constitutive tensor.
