### PR TITLE
Minor additions to Serial Parallel RoM to be used together with Finite displacements elements

### DIFF
--- a/applications/ConstitutiveLawsApplication/custom_constitutive/serial_parallel_rule_of_mixtures_law.cpp
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/serial_parallel_rule_of_mixtures_law.cpp
@@ -1000,13 +1000,6 @@ Matrix& SerialParallelRuleOfMixturesLaw::CalculateValue(
 /***********************************************************************************/
 /***********************************************************************************/
 
-void SerialParallelRuleOfMixturesLaw::InitializeMaterialResponsePK2(Parameters& rValues)
-{
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
 void SerialParallelRuleOfMixturesLaw::CalculateTangentTensor(ConstitutiveLaw::Parameters& rValues)
 {
     const Properties& r_material_properties = rValues.GetMaterialProperties();

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/serial_parallel_rule_of_mixtures_law.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/serial_parallel_rule_of_mixtures_law.h
@@ -336,7 +336,27 @@ class KRATOS_API(CONSTITUTIVE_LAWS_APPLICATION) SerialParallelRuleOfMixturesLaw
      * Initialize the material response in terms of 2nd Piola-Kirchhoff stresses
      * @see Parameters
      */
-    void InitializeMaterialResponsePK2(Parameters& rValues) override;
+    void InitializeMaterialResponsePK2(Parameters& rValues) override {};
+
+    /**
+     * Initialize the material response in terms of Cauchy stresses
+     * @see Parameters
+     */
+    void InitializeMaterialResponseCauchy(Parameters& rValues) override {};
+
+    /**
+     * Initialize the material response in terms of 1st Piola-Kirchhoff stresses
+     * @see Parameters
+     */
+
+    void InitializeMaterialResponsePK1 (Parameters& rValues) override {};
+
+    /**
+     * Initialize the material response in terms of Kirchhoff stresses
+     * @see Parameters
+     */
+
+    void InitializeMaterialResponseKirchhoff (Parameters& rValues) override {};
 
     /**
      * This method computes the strain vector in the fiber and matrix according to the total

--- a/applications/StructuralMechanicsApplication/custom_processes/set_cartesian_local_axes_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_cartesian_local_axes_process.cpp
@@ -69,11 +69,22 @@ void SetCartesianLocalAxesProcess::ExecuteInitialize()
 /***********************************************************************************/
 /***********************************************************************************/
 
+void SetCartesianLocalAxesProcess::ExecuteInitializeSolutionStep()
+{
+    if (mThisParameters["update_at_each_step"].GetBool()) {
+        ExecuteInitialize();
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
 const Parameters SetCartesianLocalAxesProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {
-        "cartesian_local_axis"          : [[1.0,0.0,0.0],[0.0,1.0,0.0]]
+        "cartesian_local_axis"          : [[1.0,0.0,0.0],[0.0,1.0,0.0]],
+        "update_at_each_step"           : false
     })" );
 
     return default_parameters;

--- a/applications/StructuralMechanicsApplication/custom_processes/set_cartesian_local_axes_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_cartesian_local_axes_process.h
@@ -50,6 +50,11 @@ public:
     void ExecuteInitialize() override;
 
     /**
+     * @brief This function is designed for being called at the beginning each time step
+     */
+    void ExecuteInitializeSolutionStep() override;
+
+    /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
     const Parameters GetDefaultParameters() const override;

--- a/applications/StructuralMechanicsApplication/custom_processes/set_cylindrical_local_axes_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_cylindrical_local_axes_process.cpp
@@ -64,12 +64,23 @@ void SetCylindricalLocalAxesProcess::ExecuteInitialize()
 /***********************************************************************************/
 /***********************************************************************************/
 
+void SetCylindricalLocalAxesProcess::ExecuteInitializeSolutionStep()
+{
+    if (mThisParameters["update_at_each_step"].GetBool()) {
+        ExecuteInitialize();
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
 const Parameters SetCylindricalLocalAxesProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {
         "cylindrical_generatrix_axis"   : [0.0,0.0,1.0],
-        "cylindrical_generatrix_point"  : [0.0,0.0,0.0]
+        "cylindrical_generatrix_point"  : [0.0,0.0,0.0],
+        "update_at_each_step"           : false
     })");
 
     return default_parameters;

--- a/applications/StructuralMechanicsApplication/custom_processes/set_cylindrical_local_axes_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_cylindrical_local_axes_process.h
@@ -51,6 +51,11 @@ public:
     void ExecuteInitialize() override;
 
     /**
+     * @brief This function is designed for being called at the beginning each time step
+     */
+    void ExecuteInitializeSolutionStep() override;
+
+    /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
     const Parameters GetDefaultParameters() const override;

--- a/applications/StructuralMechanicsApplication/custom_processes/set_spherical_local_axes_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_spherical_local_axes_process.cpp
@@ -71,12 +71,23 @@ void SetSphericalLocalAxesProcess::ExecuteInitialize()
 /***********************************************************************************/
 /***********************************************************************************/
 
+void SetSphericalLocalAxesProcess::ExecuteInitializeSolutionStep()
+{
+    if (mThisParameters["update_at_each_step"].GetBool()) {
+        ExecuteInitialize();
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
 const Parameters SetSphericalLocalAxesProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {
         "spherical_reference_axis"   : [0.0,0.0,1.0],
-        "spherical_central_point"    : [0.0,0.0,0.0]
+        "spherical_central_point"    : [0.0,0.0,0.0],
+        "update_at_each_step"        : false
     })" );
 
     return default_parameters;

--- a/applications/StructuralMechanicsApplication/custom_processes/set_spherical_local_axes_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_spherical_local_axes_process.h
@@ -51,6 +51,11 @@ public:
     void ExecuteInitialize() override;
 
     /**
+     * @brief This function is designed for being called at the beginning each time step
+     */
+    void ExecuteInitializeSolutionStep() override;
+
+    /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
     const Parameters GetDefaultParameters() const override;

--- a/applications/StructuralMechanicsApplication/python_scripts/set_cartesian_local_axes_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/set_cartesian_local_axes_process.py
@@ -10,7 +10,8 @@ def Factory(settings, Model):
     default_settings = KM.Parameters(
         """{
             "model_part_name"      : "set_model_part_name",
-            "cartesian_local_axis" : [[1.0,0.0,0.0],[0.0,1.0,0.0]]
+            "cartesian_local_axis" : [[1.0,0.0,0.0],[0.0,1.0,0.0]],
+            "update_at_each_step"  : false
         }""");
     process_settings = settings["Parameters"]
     process_settings.ValidateAndAssignDefaults(default_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/set_cylindrical_local_axes_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/set_cylindrical_local_axes_process.py
@@ -12,7 +12,8 @@ def Factory(settings, Model):
         """{
             "model_part_name"               : "set_model_part_name",
             "cylindrical_generatrix_axis"   : [0.0,0.0,1.0],
-            "cylindrical_generatrix_point"  : [0.0,0.0,0.0]
+            "cylindrical_generatrix_point"  : [0.0,0.0,0.0],
+            "update_at_each_step"           : false
         }""")
     process_settings = settings["Parameters"]
     process_settings.ValidateAndAssignDefaults(default_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/set_spherical_local_axes_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/set_spherical_local_axes_process.py
@@ -11,7 +11,8 @@ def Factory(settings, Model):
         """{
             "model_part_name"            : "set_model_part_name",
             "spherical_reference_axis"   : [0.0,0.0,1.0],
-            "spherical_central_point"    : [0.0,0.0,0.0]
+            "spherical_central_point"    : [0.0,0.0,0.0],
+            "update_at_each_step"        : false
         }""");
     process_settings = settings["Parameters"]
     process_settings.ValidateAndAssignDefaults(default_settings)


### PR DESCRIPTION
Now the `seial_parallel_rule_of_mixtures `can be used together with large displacements elements. Onlu the `InitializeMaterialResponse `was missing.

Additionally, the processes that compute and set the local axes have been enhanced to be able to update the local axes at each time step if required. By default they are only computed at the begining for efficiency.

