### PR TITLE
[ROM] Allowed for arbitrary Dof arrangement in elements

### DIFF
--- a/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.cpp
+++ b/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.cpp
@@ -461,7 +461,7 @@ void RomAuxiliaryUtilities::GetPhiElemental(
 
                 const Matrix& nodal_rom_basis = it_node->GetValue(ROM_BASIS);
 
-                auto variable_key = r_dof.GetVariable().Key();
+                const auto variable_key = r_dof.GetVariable().Key();
                 const Matrix::size_type row_id = rVarToRowMapping.at(variable_key);
 
                 noalias(row(rPhiElemental, i)) = row(nodal_rom_basis, row_id);

--- a/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.cpp
+++ b/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.cpp
@@ -437,4 +437,36 @@ void RomAuxiliaryUtilities::ProjectRomSolutionIncrementToNodes(
     });
 }
 
+void RomAuxiliaryUtilities::GetPhiElemental(
+        Matrix &rPhiElemental,
+        const Element::DofsVectorType& rDofs,
+        const Element::GeometryType& rGeom,
+        const std::unordered_map<Kratos::VariableData::KeyType, Matrix::size_type>& rVarToRowMapping)
+    {
+        for(std::size_t i = 0; i < rDofs.size(); ++i)
+        {
+            const Dof<double>& r_dof = *rDofs[i];
+            if (r_dof.IsFixed())
+            {
+                noalias(row(rPhiElemental, i)) = ZeroVector(rPhiElemental.size2());
+            }
+            else
+            {
+                const auto it_node = std::find_if(rGeom.begin(), rGeom.end(),
+                    [&](const Node<3>& rNode)
+                    {
+                        return rNode.Id() == r_dof.Id();
+                    });
+                KRATOS_DEBUG_ERROR_IF(it_node == rGeom.end());
+
+                const Matrix& nodal_rom_basis = it_node->GetValue(ROM_BASIS);
+
+                auto variable_key = r_dof.GetVariable().Key();
+                const Matrix::size_type row_id = rVarToRowMapping.at(variable_key);
+
+                noalias(row(rPhiElemental, i)) = row(nodal_rom_basis, row_id);
+            }
+        }
+    }
+
 } // namespace Kratos

--- a/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.h
+++ b/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.h
@@ -28,6 +28,7 @@
 #include "modified_shape_functions/modified_shape_functions.h"
 
 // Application includes
+#include "rom_application_variables.h"
 
 
 namespace Kratos
@@ -129,6 +130,15 @@ public:
     static void ProjectRomSolutionIncrementToNodes(
         const std::vector<std::string> &rRomVariableNames,
         ModelPart &rModelPart);
+
+    /**
+     * @brief Obtain the elemental basis matrix for a particular element.
+     */
+    static void GetPhiElemental(
+        Matrix &rPhiElemental,
+        const Element::DofsVectorType& rDofs,
+        const Element::GeometryType& rGeom,
+        const std::unordered_map<Kratos::VariableData::KeyType, Matrix::size_type>& rVarToRowMapping);
 
     ///@}
 

--- a/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.h
+++ b/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.h
@@ -133,6 +133,10 @@ public:
 
     /**
      * @brief Obtain the elemental basis matrix for a particular element.
+     * @param rPhiElemental The matrix to store the result in. Must have the appropiate size already.
+     * @param rDofs The set of dofs of the element.
+     * @param rGeom The geometry of the element.
+     * @rVarToRowMapping A map from each variables's key to its row in the basis matrix.
      */
     static void GetPhiElemental(
         Matrix &rPhiElemental,


### PR DESCRIPTION
**📝 Description**
@SADPR and I found the source of a segmentation fault in the rom builder and solver testing ROM with the CompressiblePotentialFlowApplication.

As of now, it is assumed that the dofset from an element is oredered as such:
(exemplified with 1D fluid with velocity and pressure)
```
GetDofSet() -> [u1, v1, p1, u2, v2, p2]
                ^~~~~~~~~~~ ^~~~~~~~~~
                 Node 1      Node 2
```
If the ordering was different, a segmentation fault occurred in `GetPhiElemental`. Now any arrangement works. For example:
```
GetDofSet() -> [u1, u2, v1, v2, p1, p2]
```
This is necessary to support all elements, for instance those in the potential flow application.


**🆕 Changelog**
- Fixed `GetPhiElemental` to allow for arbitrary ordering of dofs.
- Made `GetPhiElemental` static and moved it to `custom_utilities/rom_auxiliary_utilities.cpp`

Regrading unit tests, I'm in a bit of a deadlock. To do a potential flow unit test, I need https://github.com/KratosMultiphysics/Kratos/pull/9678, but in order for it to work, I also need the current PR to be merged, so both PR depend on one another. The  unit test is created on the other PR, so go check there to see if you want to see it.