### PR TITLE
[Core][GiDIO] fix GP initialization

### DIFF
--- a/kratos/includes/gid_io.h
+++ b/kratos/includes/gid_io.h
@@ -147,7 +147,8 @@ public:
         const GiD_PostMode Mode,
         const MultiFileFlag UseMultipleFilesFlag,
         const WriteDeformedMeshFlag WriteDeformedFlag,
-        const WriteConditionsFlag WriteConditions
+        const WriteConditionsFlag WriteConditions,
+        const bool InitializeGaussPointContainers=true
          ) : mResultFileName(rDatafilename),
         mMeshFileName(rDatafilename),
         mWriteDeformed(WriteDeformedFlag),
@@ -160,7 +161,9 @@ public:
 
         InitializeResultFile(mResultFileName);
         SetUpMeshContainers();
-        SetUpGaussPointContainers();
+        if (InitializeGaussPointContainers) {
+            SetUpGaussPointContainers();
+        }
 
         GidIOBase& r_gid_io_base = GidIOBase::GetInstance();
 
@@ -300,7 +303,7 @@ public:
     {
         //elements with 1 gauss point
         std::vector<int> gp_indices(1, 0);
-        
+
         //case Triangle with 1 gauss point
         mGidGaussPointContainers.push_back( TGaussPointContainer( "tri1_element_gp",
                                             GeometryData::KratosGeometryFamily::Kratos_Triangle, GiD_Triangle, 1, gp_indices ) );

--- a/kratos/python/add_io_to_python.cpp
+++ b/kratos/python/add_io_to_python.cpp
@@ -100,6 +100,7 @@ void  AddIOToPython(pybind11::module& m)
 
     py::class_<GidIO<>, GidIO<>::Pointer, IO>(m, "GidIO")
     .def(py::init<std::string const&, const GiD_PostMode, const MultiFileFlag, const WriteDeformedMeshFlag, const WriteConditionsFlag>())
+    .def(py::init<std::string const&, const GiD_PostMode, const MultiFileFlag, const WriteDeformedMeshFlag, const WriteConditionsFlag, const bool>())
     //.def(py::init<std::string const&>())
     .def("WriteMesh",[](GidIO<>& dummy, GidIO<>::MeshType& rThisMesh){dummy.WriteMesh( rThisMesh );})
     .def("WriteNodeMesh",[](GidIO<>& dummy, GidIO<>::MeshType& rThisMesh){dummy.WriteNodeMesh( rThisMesh );})

--- a/kratos/python_scripts/gid_output_process.py
+++ b/kratos/python_scripts/gid_output_process.py
@@ -355,14 +355,16 @@ class GiDOutputProcess(KM.Process):
                                     self.post_mode,
                                     self.multifile_flag,
                                     self.write_deformed_mesh,
-                                    self.write_conditions)
+                                    self.write_conditions,
+                                    self.param["result_file_configuration"]["gauss_point_results"].size()>0)
 
         if self.skin_output or self.num_planes > 0:
             self.cut_io = GidIO(self.cut_file_name,
                                 self.post_mode,
                                 self.multifile_flag,
                                 self.write_deformed_mesh,
-                                WriteConditionsFlag.WriteConditionsOnly) # Cuts are conditions, so we always print conditions in the cut ModelPart
+                                WriteConditionsFlag.WriteConditionsOnly,
+                                self.param["result_file_configuration"]["gauss_point_results"].size()>0) # Cuts are conditions, so we always print conditions in the cut ModelPart
 
     def __get_pretty_time(self,time):
         pretty_time = self.time_label_format.format(time)

--- a/kratos/tests/auxiliar_files_for_python_unittest/reference_files/results_out_ref.ref
+++ b/kratos/tests/auxiliar_files_for_python_unittest/reference_files/results_out_ref.ref
@@ -1,13 +1,4 @@
 GiD Post Results File 1.0
-GaussPoints "tri1_element_gp" ElemType Triangle
-Number Of Gauss Points: 1
-Natural Coordinates: Internal
-End GaussPoints
-GaussPoints "lin1_element_gp" ElemType Linear
-Number Of Gauss Points: 1
-  Nodes not included
-Natural Coordinates: Internal
-End GaussPoints
 Result "DISPLACEMENT" "Kratos" 0 Vector OnNodes
 Values
 1 0.1 0 0

--- a/kratos/tests/test_KratosCore.py
+++ b/kratos/tests/test_KratosCore.py
@@ -4,6 +4,12 @@ import KratosMultiphysics
 # Import Kratos "wrapper" for unittests
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 
+try:
+    import sympy
+    sympy_available = True
+except:
+    sympy_available = False
+
 # Import the tests or test_classes to create the suites
 import test_bounding_box
 import test_calculate_distance_to_skin
@@ -66,7 +72,8 @@ import test_model_part_combination_utilities
 import test_force_and_torque_utils
 import test_print_info_in_file
 import test_sparse_matrices
-import test_sympy_fe_utilities
+if sympy_available:
+    import test_sympy_fe_utilities
 
 def AssembleTestSuites():
     ''' Populates the test suites to run.
@@ -153,7 +160,8 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_model_part_combination_utilities.TestModelPartCombinationUtilities]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_force_and_torque_utils.TestForceAndTorqueUtils]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_sparse_matrices.TestSparseMatrixInterface]))
-    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_sympy_fe_utilities.TestSympyFEUtilities]))
+    if sympy_available:
+        smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_sympy_fe_utilities.TestSympyFEUtilities]))
 
     # Create a test suite with the selected tests plus all small tests
     nightSuite = suites['nightly']

--- a/kratos/tests/test_gid_io_gauss_points.py
+++ b/kratos/tests/test_gid_io_gauss_points.py
@@ -150,10 +150,4 @@ class TestGiDIOGaussPoints(UnitTest.TestCase):
 
 
 if __name__ == '__main__':
-    test = TestGiDIOGaussPoints()
-    test.setUp()
-    test.test_write_active_only()
-    test.tearDown()
-    test.setUp()
-    test.test_write_dynamic_deactivation()
-    test.tearDown()
+    UnitTest.main()


### PR DESCRIPTION
The GiDIO always initializes the GaussPoint containers, unconditionally if the user requested any GP-results.
In structural elements this causes problems with uninitialized elements as then the preparation of the GP-results can fail
Hence I am making the writing of GP-results optional, but keeping the default behavior

closes #3234
closes #9671