### PR TITLE
[FluidDynamics][Nightly] Move symbolic tetrahedra test to validation suite

### DIFF
--- a/applications/FluidDynamicsApplication/tests/test_FluidDynamicsApplication.py
+++ b/applications/FluidDynamicsApplication/tests/test_FluidDynamicsApplication.py
@@ -147,7 +147,7 @@ def AssembleTestSuites():
     validationSuite.addTest(SodShockTubeTest('testSodShockTubeExplicitOSS'))
     validationSuite.addTest(SodShockTubeTest('testSodShockTubeExplicitOSSShockCapturing'))
     if sympy_available:
-        nightSuite.addTest(CompressibleNavierStokesSymbolicGeneratorFormulationTest('testSymbolicTetrahedron'))
+        validationSuite.addTest(CompressibleNavierStokesSymbolicGeneratorFormulationTest('testSymbolicTetrahedron'))
 
     # Create a test suite that contains all the tests:
     allSuite = suites['all']


### PR DESCRIPTION
**📝 Description**

As reported in #9628, the windows build is failing,  after running out of time. 

This puts the tetrahedra symbolic test back to the validation suite,  which was (I assume) unintentionally put into the nightly suite here #9629. 

The nightly build runs fine without this. 
https://github.com/KratosMultiphysics/Kratos/actions/runs/1864046652


**🆕 Changelog**
- Move tetrahedra test to validation
