### PR TITLE
[core] Update AMGCL, enable block arithmetics for elasticity problems

### DIFF
--- a/external_libraries/amgcl/adapter/block_matrix.hpp
+++ b/external_libraries/amgcl/adapter/block_matrix.hpp
@@ -172,7 +172,7 @@ block_matrix_adapter<Matrix, BlockType> block_matrix(const Matrix &A) {
 template <class Matrix>
 std::shared_ptr<
     backend::crs<
-        typename math::scalar_of<
+        typename math::element_of<
             typename backend::value_type<Matrix>::type
             >::type,
         typename backend::col_type<Matrix>::type,
@@ -181,19 +181,21 @@ std::shared_ptr<
     >
 unblock_matrix(const Matrix &B) {
     typedef typename backend::value_type<Matrix>::type Block;
-    typedef typename math::scalar_of<Block>::type Scalar;
+    typedef typename math::element_of<Block>::type Scalar;
     typedef typename backend::col_type<Matrix>::type Col;
     typedef typename backend::ptr_type<Matrix>::type Ptr;
 
     const int brows = math::static_rows<Block>::value;
     const int bcols = math::static_cols<Block>::value;
 
+    static_assert(brows > 1 || bcols > 1, "Can not unblock scalar matrix!");
+
     auto A = std::make_shared<backend::crs<Scalar, Col, Ptr>>();
 
     A->set_size(backend::rows(B) * brows, backend::cols(B) * bcols);
     A->ptr[0] = 0;
 
-    const auto nb = backend::rows(B);
+    const ptrdiff_t nb = backend::rows(B);
 
 #pragma omp for
     for (ptrdiff_t ib = 0; ib < nb; ++ib) {

--- a/external_libraries/amgcl/adapter/eigen.hpp
+++ b/external_libraries/amgcl/adapter/eigen.hpp
@@ -51,7 +51,7 @@ struct is_eigen_type : std::false_type {};
 
 template <typename Scalar, int Flags, typename Storage>
 struct is_eigen_sparse_matrix<
-    Eigen::MappedSparseMatrix<Scalar, Flags, Storage>
+    Eigen::Map<Eigen::SparseMatrix<Scalar, Flags, Storage>>
     > : std::true_type
 {};
 

--- a/external_libraries/amgcl/adapter/scaled_problem.hpp
+++ b/external_libraries/amgcl/adapter/scaled_problem.hpp
@@ -107,11 +107,6 @@ struct scaled_problem {
 
     template <class Vector>
     std::shared_ptr<typename Backend::vector> rhs(const Vector &v) const {
-        typedef typename backend::value_type<Vector>::type value_type;
-        typedef typename math::scalar_of<value_type>::type scalar_type;
-        const auto one  = math::identity<scalar_type>();
-        const auto zero = math::zero<scalar_type>();
-
         auto t = Backend::copy_vector(v, bprm);
         (*this)(*t);
         return t;

--- a/external_libraries/amgcl/backend/block_crs.hpp
+++ b/external_libraries/amgcl/backend/block_crs.hpp
@@ -300,8 +300,10 @@ struct residual_impl< bcrs<V, C, P>, Vec1, Vec2, Vec3 >
 
     static void apply(const Vec1 &rhs, const matrix &A, const Vec2 &x, Vec3 &r)
     {
+        typedef typename math::scalar_of<V>::type S;
+        const auto one = math::identity<S>();
         backend::copy(rhs, r);
-        backend::spmv(-1, A, x, 1, r);
+        backend::spmv(-one, A, x, one, r);
     }
 };
 

--- a/external_libraries/amgcl/backend/builtin_hybrid.hpp
+++ b/external_libraries/amgcl/backend/builtin_hybrid.hpp
@@ -32,6 +32,7 @@ THE SOFTWARE.
  */
 
 #include <amgcl/backend/builtin.hpp>
+#include <amgcl/value_type/interface.hpp>
 #include <amgcl/adapter/block_matrix.hpp>
 
 namespace amgcl {
@@ -39,8 +40,10 @@ namespace backend {
 
 // Hybrid backend uses scalar matrices to build the hierarchy,
 // but stores the computed matrices in the block format.
-template <typename ScalarType, typename BlockType, typename ColumnType = ptrdiff_t, typename PointerType = ColumnType>
-struct builtin_hybrid : public builtin<ScalarType> {
+template <typename BlockType, typename ColumnType = ptrdiff_t, typename PointerType = ColumnType>
+struct builtin_hybrid : public builtin<typename math::scalar_of<BlockType>::type, ColumnType, PointerType>
+{
+    typedef typename math::scalar_of<BlockType>::type ScalarType;
     typedef builtin<ScalarType, ColumnType, PointerType> Base;
     typedef crs<BlockType, ColumnType, PointerType> matrix;
     struct provides_row_iterator : std::false_type {};
@@ -52,14 +55,14 @@ struct builtin_hybrid : public builtin<ScalarType> {
     }
 };
 
-template <typename T1, typename B1, typename T2, typename B2>
-struct backends_compatible< builtin_hybrid<T1, B1>, builtin_hybrid<T2, B2> > : std::true_type {};
+template <typename B1, typename B2, typename C, typename P>
+struct backends_compatible< builtin_hybrid<B1, C, P>, builtin_hybrid<B2, C, P> > : std::true_type {};
 
-template <typename T1, typename T2, typename B2>
-struct backends_compatible< builtin<T1>, builtin_hybrid<T2, B2> > : std::true_type {};
+template <typename T1, typename B2, typename C, typename P>
+struct backends_compatible< builtin<T1, C, P>, builtin_hybrid<B2, C, P> > : std::true_type {};
 
-template <typename T1, typename B1, typename T2>
-struct backends_compatible< builtin_hybrid<T1, B1>, builtin<T2> > : std::true_type {};
+template <typename B1, typename T2, typename C, typename P>
+struct backends_compatible< builtin_hybrid<B1, C, P>, builtin<T2, C, P> > : std::true_type {};
 
 } // namespace backend
 } // namespace amgcl

--- a/external_libraries/amgcl/backend/detail/default_direct_solver.hpp
+++ b/external_libraries/amgcl/backend/detail/default_direct_solver.hpp
@@ -41,6 +41,7 @@ namespace detail {
 template <class Backend>
 struct default_direct_solver {
     typedef typename Backend::value_type   real;
+    typedef typename math::scalar_of<real>::type scalar;
     typedef typename Backend::matrix       matrix;
     typedef typename builtin<real>::matrix host_matrix;
 
@@ -58,7 +59,7 @@ struct default_direct_solver {
 
     template <class Vec1, class Vec2>
     void operator()(const Vec1 &rhs, Vec2 &x) const {
-        backend::spmv(1, *Ainv, rhs, 0, x);
+        backend::spmv(math::identity<scalar>(), *Ainv, rhs, math::zero<scalar>(), x);
     }
 
     static size_t coarse_enough() { return 500; }

--- a/external_libraries/amgcl/backend/eigen.hpp
+++ b/external_libraries/amgcl/backend/eigen.hpp
@@ -54,7 +54,7 @@ struct eigen {
     typedef ptrdiff_t ptr_type;
 
     typedef
-        Eigen::MappedSparseMatrix<value_type, Eigen::RowMajor, index_type>
+        Eigen::Map<Eigen::SparseMatrix<value_type, Eigen::RowMajor, index_type>>
         matrix;
 
     typedef Eigen::Matrix<value_type, Eigen::Dynamic, 1> vector;

--- a/external_libraries/amgcl/backend/vexcl.hpp
+++ b/external_libraries/amgcl/backend/vexcl.hpp
@@ -258,8 +258,15 @@ struct vexcl {
 
 // Hybrid backend uses scalar matrices to build the hierarchy,
 // but stores the computed matrices in the block format.
-template <typename ScalarType, typename BlockType, typename ColumnType = ptrdiff_t, typename PointerType = ColumnType, class DirectSolver = solver::vexcl_skyline_lu<ScalarType> >
-struct vexcl_hybrid : public vexcl<ScalarType, ColumnType, PointerType, DirectSolver> {
+template <
+    typename BlockType,
+    typename ColumnType = ptrdiff_t,
+    typename PointerType = ColumnType,
+    class DirectSolver = solver::vexcl_skyline_lu<typename math::scalar_of<BlockType>::type>
+    >
+struct vexcl_hybrid : public vexcl<typename math::scalar_of<BlockType>::type, ColumnType, PointerType, DirectSolver>
+{
+    typedef typename math::scalar_of<BlockType>::type ScalarType;
     typedef vexcl<ScalarType, DirectSolver> Base;
     typedef vex::sparse::distributed<
                 vex::sparse::matrix<
@@ -295,14 +302,14 @@ struct vexcl_hybrid : public vexcl<ScalarType, ColumnType, PointerType, DirectSo
 template <typename T1, typename T2, typename C, typename P>
 struct backends_compatible< vexcl<T1, C, P>, vexcl<T2, C, P> > : std::true_type {};
 
-template <typename T1, typename B1, typename T2, typename B2, typename C, typename P>
-struct backends_compatible< vexcl_hybrid<T1, B1, C, P>, vexcl_hybrid<T2, B2, C, P> > : std::true_type {};
+template <typename B1, typename B2, typename C, typename P>
+struct backends_compatible< vexcl_hybrid<B1, C, P>, vexcl_hybrid<B2, C, P> > : std::true_type {};
 
-template <typename T1, typename T2, typename B2, typename C, typename P>
-struct backends_compatible< vexcl<T1, C, P>, vexcl_hybrid<T2, B2, C, P> > : std::true_type {};
+template <typename T1, typename B2, typename C, typename P>
+struct backends_compatible< vexcl<T1, C, P>, vexcl_hybrid<B2, C, P> > : std::true_type {};
 
-template <typename T1, typename B1, typename T2, typename C, typename P>
-struct backends_compatible< vexcl_hybrid<T1, B1, C, P>, vexcl<T2, C, P> > : std::true_type {};
+template <typename B1, typename T2, typename C, typename P>
+struct backends_compatible< vexcl_hybrid<B1, C, P>, vexcl<T2, C, P> > : std::true_type {};
 
 template < typename V, typename C, typename P >
 struct bytes_impl< vex::sparse::distributed<vex::sparse::matrix<V,C,P> > > {

--- a/external_libraries/amgcl/coarsening/runtime.hpp
+++ b/external_libraries/amgcl/coarsening/runtime.hpp
@@ -47,6 +47,7 @@ THE SOFTWARE.
 #include <amgcl/coarsening/aggregation.hpp>
 #include <amgcl/coarsening/smoothed_aggregation.hpp>
 #include <amgcl/coarsening/smoothed_aggr_emin.hpp>
+#include <amgcl/coarsening/as_scalar.hpp>
 
 namespace amgcl {
 namespace runtime {
@@ -100,6 +101,7 @@ template <class Backend>
 struct wrapper {
     typedef boost::property_tree::ptree params;
     type c;
+    bool as_scalar;
     void *handle;
 
     wrapper(params prm = params())
@@ -108,11 +110,24 @@ struct wrapper {
     {
         if (!prm.erase("type")) AMGCL_PARAM_MISSING("type");
 
+        typedef typename backend::value_type<Backend>::type value_type;
+        const bool block_value_type = math::static_rows<value_type>::value > 1;
+
+        as_scalar = (
+                block_value_type &&
+                c != ruge_stuben &&
+                prm.get("nullspace.cols", 0) > 0
+                );
+
         switch(c) {
 
-#define AMGCL_RUNTIME_COARSENING(type) \
-            case type: \
-                handle = call_constructor<amgcl::coarsening::type>(prm); \
+#define AMGCL_RUNTIME_COARSENING(t) \
+            case t: \
+                if (as_scalar) { \
+                    handle = call_constructor<amgcl::coarsening::as_scalar<amgcl::coarsening::t>::type>(prm); \
+                } else { \
+                    handle = call_constructor<amgcl::coarsening::t>(prm); \
+                } \
                 break
 
             AMGCL_RUNTIME_COARSENING(ruge_stuben);
@@ -130,9 +145,13 @@ struct wrapper {
     ~wrapper() {
         switch(c) {
 
-#define AMGCL_RUNTIME_COARSENING(type) \
-            case type: \
-                call_destructor<amgcl::coarsening::type>(); \
+#define AMGCL_RUNTIME_COARSENING(t) \
+            case t: \
+                if (as_scalar) { \
+                    call_destructor<amgcl::coarsening::as_scalar<amgcl::coarsening::t>::type>(); \
+                } else { \
+                    call_destructor<amgcl::coarsening::t>(); \
+                } \
                 break
 
             AMGCL_RUNTIME_COARSENING(ruge_stuben);
@@ -152,9 +171,12 @@ struct wrapper {
     transfer_operators(const Matrix &A) {
         switch(c) {
 
-#define AMGCL_RUNTIME_COARSENING(type) \
-            case type: \
-                return make_operators<amgcl::coarsening::type>(A)
+#define AMGCL_RUNTIME_COARSENING(t) \
+            case t: \
+                if (as_scalar) { \
+                    return make_operators<amgcl::coarsening::as_scalar<amgcl::coarsening::t>::type>(A); \
+                } \
+                return make_operators<amgcl::coarsening::t>(A)
 
             AMGCL_RUNTIME_COARSENING(ruge_stuben);
             AMGCL_RUNTIME_COARSENING(aggregation);
@@ -173,9 +195,12 @@ struct wrapper {
     coarse_operator(const Matrix &A, const Matrix &P, const Matrix &R) const {
         switch(c) {
 
-#define AMGCL_RUNTIME_COARSENING(type) \
-            case type: \
-                return make_coarse<amgcl::coarsening::type>(A, P, R)
+#define AMGCL_RUNTIME_COARSENING(t) \
+            case t: \
+                if (as_scalar) { \
+                    return make_coarse<amgcl::coarsening::as_scalar<amgcl::coarsening::t>::type>(A, P, R); \
+                } \
+                return make_coarse<amgcl::coarsening::t>(A, P, R)
 
             AMGCL_RUNTIME_COARSENING(ruge_stuben);
             AMGCL_RUNTIME_COARSENING(aggregation);

--- a/external_libraries/amgcl/mpi/cpr.hpp
+++ b/external_libraries/amgcl/mpi/cpr.hpp
@@ -54,6 +54,7 @@ class cpr {
         typedef typename PPrecond::backend_type backend_type;
 
         typedef typename backend_type::value_type value_type;
+        typedef typename math::scalar_of<value_type>::type scalar_type;
         typedef typename backend_type::matrix     bmatrix;
         typedef typename backend_type::vector     vector;
         typedef typename backend_type::params     backend_params;
@@ -113,13 +114,16 @@ class cpr {
 
         template <class Vec1, class Vec2>
         void apply(const Vec1 &rhs, Vec2 &&x) const {
+            const auto one = math::identity<scalar_type>();
+            const auto zero = math::zero<scalar_type>();
+
             S->apply(rhs, x);
             backend::residual(rhs, S->system_matrix(), x, *rs);
 
-            backend::spmv(1, *Fpp, *rs, 0, *rp);
+            backend::spmv(one, *Fpp, *rs, zero, *rp);
             P->apply(*rp, *xp);
 
-            backend::spmv(1, *Scatter, *xp, 1, x);
+            backend::spmv(one, *Scatter, *xp, one, x);
         }
 
         std::shared_ptr<matrix> system_matrix_ptr() const {

--- a/external_libraries/amgcl/mpi/distributed_matrix.hpp
+++ b/external_libraries/amgcl/mpi/distributed_matrix.hpp
@@ -522,6 +522,8 @@ class distributed_matrix {
 
         template <class A, class VecX, class B, class VecY>
         void mul(A alpha, const VecX &x, B beta, VecY &y) const {
+            const auto one = math::identity<scalar_type>();
+
             C->start_exchange(x);
 
             // Compute local part of the product.
@@ -531,18 +533,20 @@ class distributed_matrix {
             C->finish_exchange();
 
             if (C->needs_remote())
-                backend::spmv(alpha, *A_rem, *C->x_rem, 1, y);
+                backend::spmv(alpha, *A_rem, *C->x_rem, one, y);
         }
 
         template <class Vec1, class Vec2, class Vec3>
         void residual(const Vec1 &f, const Vec2 &x, Vec3 &r) const {
+            const auto one = math::identity<scalar_type>();
+
             C->start_exchange(x);
             backend::residual(f, *A_loc, x, r);
 
             C->finish_exchange();
 
             if (C->needs_remote())
-                backend::spmv(-1, *A_rem, *C->x_rem, 1, r);
+                backend::spmv(-one, *A_rem, *C->x_rem, one, r);
         }
 
     private:

--- a/external_libraries/amgcl/mpi/schur_pressure_correction.hpp
+++ b/external_libraries/amgcl/mpi/schur_pressure_correction.hpp
@@ -57,6 +57,7 @@ class schur_pressure_correction {
         typedef typename USolver::backend_type backend_type;
 
         typedef typename backend_type::value_type value_type;
+        typedef typename math::scalar_of<value_type>::type scalar_type;
         typedef typename backend_type::matrix     bmatrix;
         typedef typename backend_type::vector     vector;
         typedef typename backend_type::params     backend_params;
@@ -509,9 +510,12 @@ class schur_pressure_correction {
 
         template <class Vec1, class Vec2>
         void apply(const Vec1 &rhs, Vec2 &&x) const {
+            const auto one = math::identity<scalar_type>();
+            const auto zero = math::zero<scalar_type>();
+
             AMGCL_TIC("split variables");
-            backend::spmv(1, *x2u, rhs, 0, *rhs_u);
-            backend::spmv(1, *x2p, rhs, 0, *rhs_p);
+            backend::spmv(one, *x2u, rhs, zero, *rhs_u);
+            backend::spmv(one, *x2p, rhs, zero, *rhs_p);
             AMGCL_TOC("split variables");
 
             // Ai u = rhs_u
@@ -522,7 +526,7 @@ class schur_pressure_correction {
 
             // rhs_p -= Kpu u
             AMGCL_TIC("solve P");
-            backend::spmv(-1, *Kpu, *u, 1, *rhs_p);
+            backend::spmv(-one, *Kpu, *u, one, *rhs_p);
 
             // S p = rhs_p
             backend::clear(*p);
@@ -531,7 +535,7 @@ class schur_pressure_correction {
 
             // rhs_u -= Kup p
             AMGCL_TIC("Update U");
-            backend::spmv(-1, *Kup, *p, 1, *rhs_u);
+            backend::spmv(-one, *Kup, *p, one, *rhs_u);
 
             // Ai u = rhs_u
             backend::clear(*u);
@@ -539,25 +543,28 @@ class schur_pressure_correction {
             AMGCL_TOC("Update U");
 
             AMGCL_TIC("merge variables");
-            backend::spmv(1, *u2x, *u, 0, x);
-            backend::spmv(1, *p2x, *p, 1, x);
+            backend::spmv(one, *u2x, *u, zero, x);
+            backend::spmv(one, *p2x, *p, one, x);
             AMGCL_TOC("merge variables");
         }
 
         template <class Alpha, class Vec1, class Beta, class Vec2>
         void spmv(Alpha alpha, const Vec1 &x, Beta beta, Vec2 &y) const {
+            const auto one = math::identity<scalar_type>();
+            const auto zero = math::zero<scalar_type>();
+
             // y = beta y + alpha S x, where S = Kpp - Kpu Kuu^-1 Kup
             AMGCL_TIC("matrix-free spmv");
             backend::spmv(alpha, P->system_matrix(), x, beta, y);
 
-            backend::spmv(1, *Kup, x, 0, *tmp);
+            backend::spmv(one, *Kup, x, zero, *tmp);
             if (prm.approx_schur) {
-                backend::vmul(1, *M, *tmp, 0, *u);
+                backend::vmul(one, *M, *tmp, zero, *u);
             } else {
                 backend::clear(*u);
                 (*U)(*tmp, *u);
             }
-            backend::spmv(-alpha, *Kpu, *u, 1, y);
+            backend::spmv(-alpha, *Kpu, *u, one, y);
             AMGCL_TOC("matrix-free spmv");
         }
     private:

--- a/external_libraries/amgcl/mpi/subdomain_deflation.hpp
+++ b/external_libraries/amgcl/mpi/subdomain_deflation.hpp
@@ -157,6 +157,7 @@ class subdomain_deflation {
         };
 
         typedef typename backend_type::value_type value_type;
+        typedef typename math::scalar_of<value_type>::type scalar_type;
         typedef typename backend_type::matrix     bmatrix;
         typedef typename backend_type::vector     vector;
         typedef distributed_matrix<backend_type>  matrix;
@@ -494,6 +495,8 @@ class subdomain_deflation {
 
         template <class Vector>
         void project(Vector &x) const {
+            const auto one = math::identity<scalar_type>();
+
             AMGCL_TIC("project");
 
             AMGCL_TIC("local inner product");
@@ -505,7 +508,7 @@ class subdomain_deflation {
 
             AMGCL_TIC("spmv");
             backend::copy(dx, *dd);
-            backend::spmv(-1, *AZ, *dd, 1, x);
+            backend::spmv(-one, *AZ, *dd, one, x);
             AMGCL_TOC("spmv");
 
             AMGCL_TOC("project");
@@ -545,11 +548,13 @@ class subdomain_deflation {
 
         template <class Vec1, class Vec2>
         void postprocess(const Vec1 &rhs, Vec2 &x) const {
+            const auto one = math::identity<scalar_type>();
+
             AMGCL_TIC("postprocess");
 
             // q = rhs - Ax
             backend::copy(rhs, *q);
-            backend::spmv(-1, *A, x, 1, *q);
+            backend::spmv(-one, *A, x, one, *q);
 
             // df = transp(Z) * (rhs - Ax)
             AMGCL_TIC("local inner product");
@@ -561,7 +566,7 @@ class subdomain_deflation {
             coarse_solve(df, dx);
 
             // x += Z * dx
-            backend::lin_comb(ndv, dx, Z, 1, x);
+            backend::lin_comb(ndv, dx, Z, one, x);
 
             AMGCL_TOC("postprocess");
         }

--- a/external_libraries/amgcl/mpi/util.hpp
+++ b/external_libraries/amgcl/mpi/util.hpp
@@ -34,6 +34,7 @@ THE SOFTWARE.
 
 #include <vector>
 #include <numeric>
+#include <complex>
 
 #include <type_traits>
 #include <amgcl/value_type/interface.hpp>
@@ -94,6 +95,16 @@ struct datatype_impl<long long> {
 template <>
 struct datatype_impl<unsigned long long> {
     static MPI_Datatype get() { return MPI_UNSIGNED_LONG_LONG; }
+};
+
+template <>
+struct datatype_impl< std::complex<double> > {
+    static MPI_Datatype get() { return MPI_CXX_DOUBLE_COMPLEX; }
+};
+
+template <>
+struct datatype_impl< std::complex<float> > {
+    static MPI_Datatype get() { return MPI_CXX_FLOAT_COMPLEX; }
 };
 
 template <typename T>
@@ -182,9 +193,7 @@ struct communicator {
 
     template <typename T>
     T reduce(MPI_Op op, const T &lval) const {
-        typedef typename math::scalar_of<T>::type S;
-
-        const int elems = sizeof(T) / sizeof(S);
+        const int elems = math::static_rows<T>::value * math::static_cols<T>::value;
         T gval;
 
         MPI_Allreduce((void*)&lval, &gval, elems, datatype<T>(), op, comm);

--- a/external_libraries/amgcl/preconditioner/cpr.hpp
+++ b/external_libraries/amgcl/preconditioner/cpr.hpp
@@ -131,17 +131,20 @@ class cpr {
 
         template <class Vec1, class Vec2>
         void apply(const Vec1 &rhs, Vec2 &&x) const {
+            const auto one = math::identity<scalar_type>();
+            const auto zero = math::zero<scalar_type>();
+
             AMGCL_TIC("sprecond");
             S->apply(rhs, x);
             AMGCL_TOC("sprecond");
             backend::residual(rhs, S->system_matrix(), x, *rs);
 
-            backend::spmv(1, *Fpp, *rs, 0, *rp);
+            backend::spmv(one, *Fpp, *rs, zero, *rp);
             AMGCL_TIC("pprecond");
             P->apply(*rp, *xp);
             AMGCL_TOC("pprecond");
 
-            backend::spmv(1, *Scatter, *xp, 1, x);
+            backend::spmv(one, *Scatter, *xp, one, x);
         }
 
         std::shared_ptr<matrix> system_matrix_ptr() const {

--- a/external_libraries/amgcl/relaxation/detail/ilu_solve.hpp
+++ b/external_libraries/amgcl/relaxation/detail/ilu_solve.hpp
@@ -454,11 +454,11 @@ class ilu_solve< backend::builtin<value_type, col_type, ptr_type> > {
         }
 };
 
-template <class ScalarType, class BlockType>
-class ilu_solve< backend::builtin_hybrid<ScalarType, BlockType> >
-    : public ilu_solve< backend::builtin<ScalarType> >
+template <class Block, class Col, class Ptr>
+class ilu_solve< backend::builtin_hybrid<Block, Col, Ptr> >
+    : public ilu_solve< backend::builtin<typename math::scalar_of<Block>::type, Col, Ptr> >
 {
-    typedef ilu_solve< backend::builtin<ScalarType> > Base;
+    typedef ilu_solve< backend::builtin<typename math::scalar_of<Block>::type> > Base;
 
     public:
         using Base::Base;

--- a/external_libraries/amgcl/solver/eigen.hpp
+++ b/external_libraries/amgcl/solver/eigen.hpp
@@ -76,7 +76,7 @@ class EigenSolver {
 
             S.compute(
                     MatrixType(
-                        Eigen::MappedSparseMatrix<value_type, Eigen::RowMajor, ptrdiff_t>(
+                        Eigen::Map<Eigen::SparseMatrix<value_type, Eigen::RowMajor, ptrdiff_t>>(
                             backend::rows(A), backend::cols(A), backend::nonzeros(A),
                             const_cast<ptr_type*>(backend::ptr_data(A)),
                             const_cast<col_type*>(backend::col_data(A)),

--- a/external_libraries/amgcl/value_type/eigen.hpp
+++ b/external_libraries/amgcl/value_type/eigen.hpp
@@ -65,6 +65,12 @@ struct rhs_of< Eigen::Matrix<T, N, N> > {
     typedef Eigen::Matrix<T, N, 1> type;
 };
 
+/// Element type of a non-scalar type
+template <class T, int N, int M>
+struct element_of< Eigen::Matrix<T, N, M> > {
+    typedef T type;
+};
+
 /// Whether the value type is a statically sized matrix.
 template <class T, int N, int M>
 struct is_static_matrix< Eigen::Matrix<T, N, M> > : std::true_type {};

--- a/external_libraries/amgcl/value_type/interface.hpp
+++ b/external_libraries/amgcl/value_type/interface.hpp
@@ -48,6 +48,12 @@ struct rhs_of {
     typedef T type;
 };
 
+/// Element type of a non-scalar type
+template <class T, class Enable = void>
+struct element_of {
+    typedef T type;
+};
+
 /// Replace scalar type in the static matrix
 template<class T, class S, class Enable = void>
 struct replace_scalar {

--- a/external_libraries/amgcl/value_type/static_matrix.hpp
+++ b/external_libraries/amgcl/value_type/static_matrix.hpp
@@ -197,6 +197,12 @@ struct rhs_of< static_matrix<T, N, N> > {
     typedef static_matrix<T, N, 1> type;
 };
 
+/// Element type of a non-scalar type
+template <class T, int N, int M>
+struct element_of< static_matrix<T, N, M> > {
+    typedef T type;
+};
+
 /// Whether the value type is a statically sized matrix.
 template <class T, int N, int M>
 struct is_static_matrix< static_matrix<T, N, M> > : std::true_type {};

--- a/kratos/linear_solvers/amgcl_solver.h
+++ b/kratos/linear_solvers/amgcl_solver.h
@@ -230,12 +230,6 @@ public:
 
         mUseBlockMatricesIfPossible = ThisParameters["use_block_matrices_if_possible"].GetBool();
 
-        if(mProvideCoordinates && mUseBlockMatricesIfPossible) {
-            KRATOS_WARNING("AMGCL Linear Solver") << "Sorry coordinates can not be provided when using block matrices, hence setting muse_block_matrices_if_possible to false" << std::endl;
-            mUseBlockMatricesIfPossible = false;
-            ThisParameters["use_block_matrices_if_possible"].SetBool(false);
-        }
-
         mUseGPGPU = ThisParameters["use_gpgpu"].GetBool();
     }
 
@@ -358,14 +352,17 @@ public:
         int static_block_size = mUseBlockMatricesIfPossible ? mBlockSize : 1;
         std::vector<double> B;
         if(mUseAMGPreconditioning && mProvideCoordinates && (mBlockSize == 2 || mBlockSize == 3)) {
- 
             int nmodes = amgcl::coarsening::rigid_body_modes(mBlockSize,
                     boost::make_iterator_range(
                         &mCoordinates[0][0],
                         &mCoordinates[0][0] + TSparseSpaceType::Size1(rA)),
                     B);
 
-            static_block_size = 1;
+            if (static_block_size != 1 && static_block_size != 3) {
+                KRATOS_WARNING("AMGCL Linear Solver") << "Can only combine block matrices with coordinates in 3D. Falling back to scalar matrices" << std::endl;
+                static_block_size = 1;
+            }
+
             mAMGCLParameters.put("precond.coarsening.aggr.eps_strong", 0.0);
             mAMGCLParameters.put("precond.coarsening.aggr.block_size", 1);
             mAMGCLParameters.put("precond.coarsening.nullspace.cols",  nmodes);


### PR DESCRIPTION
**📝 Description**

This updates AMGCL to the latest version and enables the use of block matrices with elasticity problems in case the coordinates are provided. This makes the solution of 3D elasticity problems about twice faster (see the tests below).

This currently is only implemented for the serial (non-MPI) solver.

After the PR, it is possible to enable both the `provide_coordinates` and `use_block_matrices_if_possible` to the amgcl solver. Before the PR, the best option would be to either use block matrices without the coordinates (may not converge in some cases) or provide the coordinates (helps the convergence, but requires more memory).

The model problem is a 3D thin wall model (provided by @RiccardoRossi), `1 320 660` DOFs, `94 618 944` non-zeros in the system matrix.

**Possible configurations before the PR**

[scalar.log](https://github.com/KratosMultiphysics/Kratos/files/8109897/scalar.log): `provide_coordinates=false`, `use_block_matrices_if_possible=false`
```
AMGCL Memory Occupation : 2.12 G
AMGCL Linear Solver: Iterations: 289
Error: 9.70573e-07
ResidualBasedBlockBuilderAndSolver: System solve time: 152.28
```

[block.log](https://github.com/KratosMultiphysics/Kratos/files/8109894/block.log): `provide_coordinates=false`, `use_block_matrices_if_possible=true`
```
AMGCL Memory Occupation : 1.99 G
AMGCL Linear Solver: Iterations: 289
Error: 9.73858e-07
ResidualBasedBlockBuilderAndSolver: System solve time: 86.661
```

[ns_scalar.log](https://github.com/KratosMultiphysics/Kratos/files/8109896/ns_scalar.log): `provide_coordinates=true`, `use_block_matrices_if_possible=false`
```
AMGCL Memory Occupation : 3.00 G
AMGCL Linear Solver: Iterations: 44
Error: 1.94871e-07
ResidualBasedBlockBuilderAndSolver: System solve time: 36.4775
```

**After the PR, with both the coordinates and the block matrices enabled**

[ns_block.log](https://github.com/KratosMultiphysics/Kratos/files/8109895/ns_block.log): `provide_coordinates=true`, `use_block_matrices_if_possible=true`
```
AMGCL Memory Occupation : 2.48 G
AMGCL Linear Solver: Iterations: 39
Error: 6.66416e-07
ResidualBasedBlockBuilderAndSolver: System solve time: 19.1043
```

More details on the change are available in [Demidov, Denis. Efficient solution of 3D elasticity problems with smoothed aggregation algebraic multigrid and block arithmetics. arXiv preprint arXiv:2202:09056 (2022)](https://arxiv.org/abs/2202.09056).

**🆕 Changelog**

* AMGCL is updated to the latest version
* `kratos/linear_solvers/amgcl_solver.h` is updated so that the options `provide_coordinates` and `use_block_matrices_if_possible` are no longer mutually exclusive.