### PR TITLE
[Core] MaxReduction is failing in empty container

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
@@ -540,6 +540,18 @@ KRATOS_TEST_CASE_IN_SUITE(OmpVsPureC11, KratosCoreFastSuite)
 
 }
 
+KRATOS_TEST_CASE_IN_SUITE(MaxReductionInEmptyVector, KratosCoreFastSuite)
+{
+    std::vector<double> data_vector;
+    double max_value = 0.0;
+
+    max_value = block_for_each<MaxReduction<double>>(data_vector,[&](double& value){
+        return value;
+    });
+
+    KRATOS_CHECK_NEAR(max_value, 0.0, 1e-10);
+}
+
 
 } // namespace Testing
 } // namespace Kratos


### PR DESCRIPTION
**📝 Description**
As you can see in the added failing test, if the container is empty the max reduction is not working properly. I think the expected output of the test should be zero. This MR is just to show the problem, my idea is to add the fix in this MR also.
