### PR TITLE
[Core] improve error messages in function parser

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_function_parser_utility.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_function_parser_utility.cpp
@@ -67,7 +67,7 @@ KRATOS_TEST_CASE_IN_SUITE(GenericFunctionUtility1, KratosCoreFastSuite)
     KRATOS_CHECK_STRING_EQUAL(function6.FunctionBody(), "(1.0)*(50*(exp(t)-2))");
     KRATOS_CHECK_DOUBLE_EQUAL(function6.CallFunction(0.0,0.0,0.0,0.0), -50);
 
-    KRATOS_CHECK_EXCEPTION_IS_THROWN(GenericFunctionUtility("A quien"), "Error: \nParsing error in function: A quien\nError occurred near here : ^ (char [0])\nCheck your locale (e.g. if \".\" or \",\" is used as decimal point)");
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(GenericFunctionUtility("NotAValidExpression"), "Error: \nParsing error in function: NotAValidExpression\nError occurred near here : ^ (char [0])\nCheck your locale (e.g. if \".\" or \",\" is used as decimal point)");
 }
 
 KRATOS_TEST_CASE_IN_SUITE(GenericFunctionUtility2, KratosCoreFastSuite)

--- a/kratos/tests/cpp_tests/utilities/test_function_parser_utility.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_function_parser_utility.cpp
@@ -67,7 +67,7 @@ KRATOS_TEST_CASE_IN_SUITE(GenericFunctionUtility1, KratosCoreFastSuite)
     KRATOS_CHECK_STRING_EQUAL(function6.FunctionBody(), "(1.0)*(50*(exp(t)-2))");
     KRATOS_CHECK_DOUBLE_EQUAL(function6.CallFunction(0.0,0.0,0.0,0.0), -50);
 
-    KRATOS_CHECK_EXCEPTION_IS_THROWN(GenericFunctionUtility("NotAValidExpression"), "Error: \nParsing error in function: NotAValidExpression\nError occurred near here : ^ (char [0])\nCheck your locale (e.g. if \".\" or \",\" is used as decimal point)");
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(GenericFunctionUtility("NotAValidExpression"), "Error: \nParsing error in function: NotAValidExpression\nError occurred near here :                   ^ (char [18])\nCheck your locale (e.g. if \".\" or \",\" is used as decimal point)");
 }
 
 KRATOS_TEST_CASE_IN_SUITE(GenericFunctionUtility2, KratosCoreFastSuite)

--- a/kratos/tests/cpp_tests/utilities/test_function_parser_utility.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_function_parser_utility.cpp
@@ -67,7 +67,7 @@ KRATOS_TEST_CASE_IN_SUITE(GenericFunctionUtility1, KratosCoreFastSuite)
     KRATOS_CHECK_STRING_EQUAL(function6.FunctionBody(), "(1.0)*(50*(exp(t)-2))");
     KRATOS_CHECK_DOUBLE_EQUAL(function6.CallFunction(0.0,0.0,0.0,0.0), -50);
 
-    KRATOS_CHECK_EXCEPTION_IS_THROWN(GenericFunctionUtility("A quien le importa lo que yo haga A quien le importa lo que yo diga  Yo soy asi, y asi seguire, nunca cambiare"), "Error: Parsing error in function: A quien le importa lo que yo haga A quien le importa lo que yo diga  Yo soy asi, y asi seguire, nunca cambiare");
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(GenericFunctionUtility("A quien"), "Error: \nParsing error in function: A quien\nError occurred near here : ^ (char [0])\nCheck your locale (e.g. if \".\" or \",\" is used as decimal point)");
 }
 
 KRATOS_TEST_CASE_IN_SUITE(GenericFunctionUtility2, KratosCoreFastSuite)

--- a/kratos/tests/test_function_parser_utility.py
+++ b/kratos/tests/test_function_parser_utility.py
@@ -169,6 +169,11 @@ class TestGenericFunctionUtility(KratosUnittest.TestCase):
         with self.assertRaisesRegex(Exception, 'Parsing error in function: 1.5 if t<2.0 3.0 if defined, but not else'):
             KM.GenericFunctionUtility("1.5 if t<2.0 3.0", parameters)
 
+    def test_GenericFunctionUtilityError(self):
+        with self.assertRaisesRegex(Exception, 'Parsing error in function: \(0\)\*\(50\*\(expp\(t\)-1\)\)\nError occurred near here :             \^ \(char \[12\]\)\nCheck your locale \(e.g. if "." or "," is used as decimal point'):
+            KM.GenericFunctionUtility("(0)*(50*(expp(t)-1))")
+
+
 if __name__ == '__main__':
     KM.Logger.GetDefaultOutput().SetSeverity(KM.Logger.Severity.WARNING)
     KratosUnittest.main()

--- a/kratos/utilities/function_parser_utility.cpp
+++ b/kratos/utilities/function_parser_utility.cpp
@@ -182,11 +182,24 @@ void BasicGenericFunctionUtility::InitializeParser()
         /* Store variable names and pointers. */
         const te_variable vars[] = {{"x", &x}, {"y", &y}, {"z", &z}, {"t", &t}, {"X", &X}, {"Y", &Y}, {"Z", &Z}};
 
+        auto fct_checker = [](const bool IsValid, const std::string& rFunction, const int ErrPos){
+            if (IsValid) return;
+
+            std::stringstream ss;
+            ss << "\nParsing error in function: " << rFunction << '\n';
+            ss <<   "Error occurred near here : ";
+            for(int i=0; i<ErrPos-1; ++i) ss << ' ';
+            ss << "^ (char ["<< ErrPos-1 << "])\n";
+            ss << "Check your locale (e.g. if \".\" or \",\" is used as decimal point)";
+
+            KRATOS_ERROR << ss.str() << std::endl;
+        };
+
         /* Compile the expression with variables. */
         const bool python_like_ternary = StringUtilities::ContainsPartialString(mFunctionBody, "if") ? true : false;
         if (!python_like_ternary) {
             mpTinyExpr[0] = te_compile(mFunctionBody.c_str(), vars, 7, &err);
-            KRATOS_ERROR_IF_NOT(mpTinyExpr[0]) << "Parsing error in function: " << mFunctionBody << std::endl;
+            fct_checker(mpTinyExpr[0], mFunctionBody, err);
         } else { // Ternary operator
             mpTinyExpr.resize(3, nullptr);
             std::string condition, first_function, second_function;
@@ -205,10 +218,10 @@ void BasicGenericFunctionUtility::InitializeParser()
 
             // Parsing the functions
             mpTinyExpr[1] = te_compile(first_function.c_str(), vars, 7, &err);
-            KRATOS_ERROR_IF_NOT(mpTinyExpr[1]) << "Parsing error in function: " << first_function << std::endl;
+            fct_checker(mpTinyExpr[1], first_function, err);
 
             mpTinyExpr[2] = te_compile(second_function.c_str(), vars, 7, &err);
-            KRATOS_ERROR_IF_NOT(mpTinyExpr[2]) << "Parsing error in function: " << second_function << std::endl;
+            fct_checker(mpTinyExpr[2], second_function, err);
 
             // Parsing the condition
             if (StringUtilities::ContainsPartialString(condition, "==")) {
@@ -242,7 +255,7 @@ void BasicGenericFunctionUtility::InitializeParser()
             } else {
                 KRATOS_ERROR << "Cannot identify condition: " << condition << std::endl;
             }
-            KRATOS_ERROR_IF_NOT(mpTinyExpr[0]) << "Parsing error in function: " << condition << std::endl;
+            fct_checker(mpTinyExpr[0], condition, err);
         }
     }
 }


### PR DESCRIPTION
Inspired by #9688 I added improved error messages which should help the user understand what is wrong in their code

Example:
Old error message:
~~~
Parsing error in function: (0)*(50*(expp(t)-1))
~~~

new error message:
~~~
Parsing error in function: (0)*(50*(expp(t)-1))
Error occurred near here :             ^ (char [12])
Check your locale (e.g. if "." or "," is used as decimal point)
~~~

related: #9689, #9684

FYI I also played around with the locale of C++, but without success, i.e. I could not add more useful information