### PR TITLE
[Core] improve restart utility

### DIFF
--- a/applications/DEMApplication/python_scripts/DEM_restart_utility.py
+++ b/applications/DEMApplication/python_scripts/DEM_restart_utility.py
@@ -23,8 +23,7 @@ class DEMRestartUtility(RestartUtility):
             "load_restart_files_from_folder" : true,
             "restart_save_frequency"         : 0.0,
             "restart_control_type"           : "time",
-            "save_restart_files_in_folder"   : true,
-            "set_mpi_communicator"           : true
+            "save_restart_files_in_folder"   : true
         }
         """)
 

--- a/kratos/mpi/python_scripts/distributed_restart_utility.py
+++ b/kratos/mpi/python_scripts/distributed_restart_utility.py
@@ -17,8 +17,14 @@ class DistributedRestartUtility(RestartUtility):
         super().__init__(model_part, settings)
 
         self.set_mpi_communicator = settings["set_mpi_communicator"].GetBool()
-        # the mpi-comm is not set yet, maybe change this once the communicator can be splitted
-        self.rank = KratosMultiphysics.DataCommunicator.GetDefault().Rank()
+
+        data_comm_name = settings["data_communicator_name"].GetString()
+        if data_comm_name != "":
+            self.comm = KratosMultiphysics.ParallelEnvironment.GetDataCommunicator(data_comm_name)
+        else:
+            self.comm = KratosMultiphysics.ParallelEnvironment.GetDefaultDataCommunicator()
+
+        self.rank = self.comm.Rank()
 
     #### Protected functions ####
 
@@ -30,7 +36,7 @@ class DistributedRestartUtility(RestartUtility):
 
     def _ExecuteAfterLoad(self):
         if self.set_mpi_communicator:
-            KratosMPI.ParallelFillCommunicator(self.main_model_part.GetRootModelPart()).Execute()
+            KratosMPI.ParallelFillCommunicator(self.main_model_part.GetRootModelPart(), self.comm).Execute()
 
     def _GetFileNamePattern( self ):
         """Return the pattern of flags in the file name for FileNameDataCollector."""
@@ -48,3 +54,12 @@ class DistributedRestartUtility(RestartUtility):
 
     def _GetSerializerFlags(self):
         return KratosMultiphysics.Serializer.MPI | KratosMultiphysics.Serializer.SHALLOW_GLOBAL_POINTERS_SERIALIZATION
+
+    @classmethod
+    def _GetDefaultParameters(cls):
+        this_defaults = KratosMultiphysics.Parameters("""{
+            "set_mpi_communicator"   : true,
+            "data_communicator_name" : ""
+        }""")
+        this_defaults.AddMissingParameters(super()._GetDefaultParameters())
+        return this_defaults

--- a/kratos/python_scripts/restart_utility.py
+++ b/kratos/python_scripts/restart_utility.py
@@ -14,24 +14,6 @@ class RestartUtility:
     in the main-script
     """
     def __init__(self, model_part, settings):
-        # max_files_to_keep    : max number of restart files to keep
-        #                       - negative value keeps all restart files (default)
-        default_settings = KratosMultiphysics.Parameters("""
-        {
-            "input_filename"                 : "",
-            "input_output_path"              : "",
-            "echo_level"                     : 0,
-            "serializer_trace"               : "no_trace",
-            "restart_load_file_label"        : "",
-            "load_restart_files_from_folder" : true,
-            "restart_save_frequency"         : 0.0,
-            "restart_control_type"           : "time",
-            "save_restart_files_in_folder"   : true,
-            "set_mpi_communicator"           : true,
-            "max_files_to_keep"              : -1
-        }
-        """)
-
         __serializer_flags = {
             "no_trace":           KratosMultiphysics.SerializerTraceType.SERIALIZER_NO_TRACE,     # binary
             "trace_error":        KratosMultiphysics.SerializerTraceType.SERIALIZER_TRACE_ERROR,  # ascii
@@ -43,7 +25,7 @@ class RestartUtility:
             settings.RemoveValue("io_foldername")
             KratosMultiphysics.Logger.PrintWarning('RestartUtility', '"io_foldername" key is deprecated. Use "input_output_path" instead.')
 
-        settings.ValidateAndAssignDefaults(default_settings)
+        settings.ValidateAndAssignDefaults(self._GetDefaultParameters())
 
         self.model_part = model_part
         self.model_part_name = model_part.Name
@@ -246,6 +228,23 @@ class RestartUtility:
 
     def _GetSerializerFlags(self):
         return KratosMultiphysics.Serializer.SHALLOW_GLOBAL_POINTERS_SERIALIZATION
+
+    @classmethod
+    def _GetDefaultParameters(cls):
+        # max_files_to_keep    : max number of restart files to keep
+        #                       - negative value keeps all restart files (default)
+        return KratosMultiphysics.Parameters("""{
+            "input_filename"                 : "",
+            "input_output_path"              : "",
+            "echo_level"                     : 0,
+            "serializer_trace"               : "no_trace",
+            "restart_load_file_label"        : "",
+            "load_restart_files_from_folder" : true,
+            "restart_save_frequency"         : 0.0,
+            "restart_control_type"           : "time",
+            "save_restart_files_in_folder"   : true,
+            "max_files_to_keep"              : -1
+        }""")
 
     #### Private functions ####
 


### PR DESCRIPTION
1. Improve the handling of the parameters in the restart utility (same as we do for many other classes)
2. Allow the usage of custom `DataCommunicator`s, same as what is done in the `DistributedImportModelPartUtility`