### PR TITLE
[MeshMoving] missing argument

### DIFF
--- a/applications/MeshMovingApplication/trilinos_extension/custom_strategies/trilinos_laplacian_meshmoving_strategy.h
+++ b/applications/MeshMovingApplication/trilinos_extension/custom_strategies/trilinos_laplacian_meshmoving_strategy.h
@@ -313,7 +313,7 @@ private:
                 it->Id(), it->pGetGeometry(), it->pGetProperties()));
 
         // Optimize communicaton plan
-        ParallelFillCommunicator CommunicatorGeneration(*mpmesh_model_part);
+        ParallelFillCommunicator CommunicatorGeneration(*mpmesh_model_part, mrReferenceModelPart.GetCommunicator().GetDataCommunicator());
         CommunicatorGeneration.Execute();
     }
 

--- a/applications/MeshMovingApplication/trilinos_extension/custom_strategies/trilinos_structural_meshmoving_strategy.h
+++ b/applications/MeshMovingApplication/trilinos_extension/custom_strategies/trilinos_structural_meshmoving_strategy.h
@@ -278,7 +278,7 @@ private:
                 it->Id(), it->pGetGeometry(), it->pGetProperties()));
 
         // Optimize communicaton plan
-        ParallelFillCommunicator CommunicatorGeneration(*mpmesh_model_part);
+        ParallelFillCommunicator CommunicatorGeneration(*mpmesh_model_part, mrReferenceModelPart.GetCommunicator().GetDataCommunicator());
         CommunicatorGeneration.Execute();
     }
 


### PR DESCRIPTION
Now it can be use with Communicators other than `MPI_COMM_WORLD`

Note that this should eventually be replaced with the `ConnectivityPreserveModeller`