### PR TITLE
[Core][MPI] improve DataComm handling in Communicator

### DIFF
--- a/kratos/includes/communicator.h
+++ b/kratos/includes/communicator.h
@@ -187,7 +187,7 @@ public:
 
     virtual Communicator::Pointer Create(const DataCommunicator& rDataCommunicator) const;
 
-    virtual Communicator::Pointer Create() const;
+    Communicator::Pointer Create() const;
 
     ///@}
     ///@name Operators

--- a/kratos/mpi/includes/mpi_communicator.h
+++ b/kratos/mpi/includes/mpi_communicator.h
@@ -722,12 +722,7 @@ public:
     , mpVariables_list(rOther.mpVariables_list)
     {}
 
-
-
-    Communicator::Pointer Create() const override
-    {
-        return Create(DataCommunicator::GetDefault());
-    }
+    using BaseType::Create;
 
     Communicator::Pointer Create(const DataCommunicator& rDataCommunicator) const override
     {

--- a/kratos/sources/communicator.cpp
+++ b/kratos/sources/communicator.cpp
@@ -73,7 +73,7 @@ Communicator::Pointer Communicator::Create(const DataCommunicator& rDataCommunic
 
 Communicator::Pointer Communicator::Create() const
 {
-    return Kratos::make_shared<Communicator>();
+    return Create(mrDataCommunicator);
 }
 
 // Public Access //////////////////////////////////////////////////////////////


### PR DESCRIPTION
Using the previously passed `DataCommunicator` in `Create`