### PR TITLE
[Docker] Upgrading Linix Wheelbuilder

### DIFF
--- a/kratos/KratosMultiphysics.json
+++ b/kratos/KratosMultiphysics.json
@@ -2,7 +2,7 @@
 	"wheel_name": "KratosMultiphysics",
     "included_modules":  ["response_functions", "mpi"],
 	"included_binaries": ["Kratos.*", "KratosCore.*", "KratosCore.*", "KratosMPICore.*", "KratosMPI.*", "zlib.*", "libz.*"],
-	"dependencies": [],
+	"dependencies": ["numpy"],
 	"author": "Kratos Team",
 	"author_email": "kratos@listas.cimne.upc.edu",
 	"description": "KRATOS Multiphysics (\"Kratos\") is a framework for building parallel, multi-disciplinary simulation software, aiming at modularity, extensibility, and high performance. Kratos is written in C++, and counts with an extensive Python interface.",

--- a/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux2010_x86_64
+FROM quay.io/pypa/manylinux2014_x86_64
 
 ENV MMG_ROOT=/external_libraries/mmg/mmg_5_4_1
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:{MMG_ROOT}/lib

--- a/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
@@ -14,8 +14,13 @@ RUN mkdir -p /workspace/scripts; \
 	mkdir -p /workspace/kratos; \
     mkdir -p /workspace/boost
 
-# Install Boost
-RUN git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git /workspace/boost/boost_1_71_0
+# Install Boost (from source)
+# RUN git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git /workspace/boost/boost_1_71_0
+
+# Install Boost (form zip)
+RUN wget -P /workspace/boost https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.gz; \
+	tar -C /workspace/boost -xzf /workspace/boost/boost_1_71_0.tar.gz; \
+	rm /workspace/boost/boost_1_71_0.tar.gz
 
 # Install MMG 5.5.1
 # Note ( upgraded from 5.4.1 because of https://github.com/MmgTools/mmg/issues/85)
@@ -25,7 +30,7 @@ RUN git clone -b 'v5.5.1' --depth 1 https://github.com/MmgTools/mmg /workspace/m
     mkdir -p /workspace/external_libraries/mmg/mmg_5_5_1 && \
     cd /workspace/mmg_5_5_1/build && \
     cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/workspace/external_libraries/mmg/mmg_5_5_1" -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
-    make -j24 install && \
+    make -j2 install && \
     rm -r /workspace/mmg_5_5_1 && \
     cd /
 

--- a/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
@@ -12,10 +12,8 @@ RUN mkdir -p /workspace/scripts; \
 	mkdir -p /workspace/kratos
 
 # Install Boost
-RUN mkdir /workspace/boost; \
-	wget -P /workspace/boost https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.gz; \
-	tar -C /workspace/boost -xzf /workspace/boost/boost_1_71_0.tar.gz; \
-	rm /workspace/boost/boost_1_71_0.tar.gz
+RUN /workspace/boost; \
+    git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules https://github.com/boostorg/boost.git boost_1_71_0
 
 # Install CMake
 RUN mkdir /workspace/cmake; \

--- a/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/pypa/manylinux2014_x86_64
 
-ENV MMG_ROOT=/external_libraries/mmg/mmg_5_4_1
+ENV MMG_ROOT=/external_libraries/mmg/mmg_5_5_3
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:{MMG_ROOT}/lib
 
 RUN yum install -y git wget zip
@@ -23,15 +23,16 @@ RUN mkdir /workspace/cmake; \
 	tar -C /workspace/cmake -xzf /workspace/cmake/cmake-3.15.3-Linux-x86_64.tar.gz; \
 	rm /workspace/cmake/cmake-3.15.3-Linux-x86_64.tar.gz
 
-# Install MMG 5.4
-RUN mkdir -p /workspace/mmg_5_4_1
-RUN git clone -b 'v5.4.1' --depth 1 https://github.com/MmgTools/mmg /workspace/mmg_5_4_1 && \
-    mkdir /workspace/mmg_5_4_1/build && \
-    mkdir -p /workspace/external_libraries/mmg/mmg_5_4_1 && \
-    cd /workspace/mmg_5_4_1/build && \
-    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/workspace/external_libraries/mmg/mmg_5_4_1" -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
+# Install MMG 5.5.3
+# Note ( upgraded from 5.4.1 because of https://github.com/MmgTools/mmg/issues/85)
+RUN mkdir -p /workspace/mmg_5_5_3
+RUN git clone -b 'v5.5.3' --depth 1 https://github.com/MmgTools/mmg /workspace/mmg_5_5_3 && \
+    mkdir /workspace/mmg_5_5_3/build && \
+    mkdir -p /workspace/external_libraries/mmg/mmg_5_5_3 && \
+    cd /workspace/mmg_5_5_3/build && \
+    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/workspace/external_libraries/mmg/mmg_5_5_3" -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
     make -j2 install && \
-    rm -r /workspace/mmg_5_4_1 && \
+    rm -r /workspace/mmg_5_5_3 && \
     cd /
 
 ENV CMAKE /workspace/cmake/cmake-3.15.3-Linux-x86_64/bin/cmake

--- a/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
@@ -3,23 +3,19 @@ FROM quay.io/pypa/manylinux2014_x86_64
 ENV MMG_ROOT=/external_libraries/mmg/mmg_5_5_1
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:{MMG_ROOT}/lib
 
+# Prepare package dependencies
 RUN yum install -y git wget zip
 
-# Prepare File system
+# Prepare Shared Volumes
 RUN mkdir -p /data_swap_guest
 
+# Prepare File System
 RUN mkdir -p /workspace/scripts; \
-	mkdir -p /workspace/kratos
+	mkdir -p /workspace/kratos; \
+    mkdir -p /workspace/boost
 
 # Install Boost
-RUN /workspace/boost; \
-    git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git boost_1_71_0
-
-# Install CMake
-RUN mkdir /workspace/cmake; \
-	wget -P /workspace/cmake https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3-Linux-x86_64.tar.gz; \
-	tar -C /workspace/cmake -xzf /workspace/cmake/cmake-3.15.3-Linux-x86_64.tar.gz; \
-	rm /workspace/cmake/cmake-3.15.3-Linux-x86_64.tar.gz
+RUN git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git boost_1_71_0
 
 # Install MMG 5.5.1
 # Note ( upgraded from 5.4.1 because of https://github.com/MmgTools/mmg/issues/85)
@@ -32,8 +28,6 @@ RUN git clone -b 'v5.5.1' --depth 1 https://github.com/MmgTools/mmg /workspace/m
     make -j2 install && \
     rm -r /workspace/mmg_5_5_1 && \
     cd /
-
-ENV CMAKE /workspace/cmake/cmake-3.15.3-Linux-x86_64/bin/cmake
 
 COPY start.sh /workspace/scripts/start.sh
 

--- a/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/pypa/manylinux2014_x86_64
 
-ENV MMG_ROOT=/external_libraries/mmg/mmg_5_5_3
+ENV MMG_ROOT=/external_libraries/mmg/mmg_5_5_1
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:{MMG_ROOT}/lib
 
 RUN yum install -y git wget zip
@@ -23,16 +23,16 @@ RUN mkdir /workspace/cmake; \
 	tar -C /workspace/cmake -xzf /workspace/cmake/cmake-3.15.3-Linux-x86_64.tar.gz; \
 	rm /workspace/cmake/cmake-3.15.3-Linux-x86_64.tar.gz
 
-# Install MMG 5.5.3
+# Install MMG 5.5.1
 # Note ( upgraded from 5.4.1 because of https://github.com/MmgTools/mmg/issues/85)
-RUN mkdir -p /workspace/mmg_5_5_3
-RUN git clone -b 'v5.5.3' --depth 1 https://github.com/MmgTools/mmg /workspace/mmg_5_5_3 && \
-    mkdir /workspace/mmg_5_5_3/build && \
-    mkdir -p /workspace/external_libraries/mmg/mmg_5_5_3 && \
-    cd /workspace/mmg_5_5_3/build && \
-    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/workspace/external_libraries/mmg/mmg_5_5_3" -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
+RUN mkdir -p /workspace/mmg_5_5_1
+RUN git clone -b 'v5.5.1' --depth 1 https://github.com/MmgTools/mmg /workspace/mmg_5_5_1 && \
+    mkdir /workspace/mmg_5_5_1/build && \
+    mkdir -p /workspace/external_libraries/mmg/mmg_5_5_1 && \
+    cd /workspace/mmg_5_5_1/build && \
+    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/workspace/external_libraries/mmg/mmg_5_5_1" -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
     make -j2 install && \
-    rm -r /workspace/mmg_5_5_3 && \
+    rm -r /workspace/mmg_5_5_1 && \
     cd /
 
 ENV CMAKE /workspace/cmake/cmake-3.15.3-Linux-x86_64/bin/cmake

--- a/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
@@ -5,8 +5,6 @@ ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:{MMG_ROOT}/lib
 
 RUN yum install -y git wget zip
 
-RUN yum install -y libgfortran.x86_64 blas-devel lapack-devel
-
 # Prepare File system
 RUN mkdir -p /data_swap_guest
 

--- a/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p /workspace/scripts; \
     mkdir -p /workspace/boost
 
 # Install Boost
-RUN git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git boost_1_71_0
+RUN git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git /workspace/boost/boost_1_71_0
 
 # Install MMG 5.5.1
 # Note ( upgraded from 5.4.1 because of https://github.com/MmgTools/mmg/issues/85)
@@ -25,7 +25,7 @@ RUN git clone -b 'v5.5.1' --depth 1 https://github.com/MmgTools/mmg /workspace/m
     mkdir -p /workspace/external_libraries/mmg/mmg_5_5_1 && \
     cd /workspace/mmg_5_5_1/build && \
     cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/workspace/external_libraries/mmg/mmg_5_5_1" -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
-    make -j2 install && \
+    make -j24 install && \
     rm -r /workspace/mmg_5_5_1 && \
     cd /
 

--- a/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /workspace/scripts; \
 
 # Install Boost
 RUN /workspace/boost; \
-    git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules https://github.com/boostorg/boost.git boost_1_71_0
+    git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git boost_1_71_0
 
 # Install CMake
 RUN mkdir /workspace/cmake; \

--- a/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/pypa/manylinux2010_x86_64
+FROM quay.io/pypa/manylinux2014_x86_64
 
 ENV MMG_ROOT=/external_libraries/mmg/mmg_5_4_1
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:{MMG_ROOT}/lib

--- a/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
@@ -14,8 +14,13 @@ RUN mkdir -p /workspace/scripts; \
 	mkdir -p /workspace/kratos; \
     mkdir -p /workspace/boost
 
-# Install Boost
+# Install Boost (from source)
 RUN git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git /workspace/boost/boost_1_71_0
+
+# Install Boost (form zip)
+RUN wget -P /workspace/boost https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.gz; \
+	tar -C /workspace/boost -xzf /workspace/boost/boost_1_71_0.tar.gz; \
+	rm /workspace/boost/boost_1_71_0.tar.gz
 
 # Install MMG 5.5.1
 # Note ( upgraded from 5.4.1 because of https://github.com/MmgTools/mmg/issues/85)

--- a/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
@@ -12,10 +12,8 @@ RUN mkdir -p /workspace/scripts; \
 	mkdir -p /workspace/kratos
 
 # Install Boost
-RUN mkdir /workspace/boost; \
-	wget -P /workspace/boost https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.gz; \
-	tar -C /workspace/boost -xzf /workspace/boost/boost_1_71_0.tar.gz; \
-	rm /workspace/boost/boost_1_71_0.tar.gz
+RUN /workspace/boost; \
+    git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules https://github.com/boostorg/boost.git boost_1_71_0
 
 # Install CMake
 RUN mkdir /workspace/cmake; \

--- a/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/pypa/manylinux2014_x86_64
 
-ENV MMG_ROOT=/external_libraries/mmg/mmg_5_5_3
+ENV MMG_ROOT=/external_libraries/mmg/mmg_5_5_1
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:{MMG_ROOT}/lib
 
 RUN yum install -y git wget zip
@@ -28,14 +28,14 @@ RUN yum install -y mpich mpich-devel mpich-autoload metis metis-devel
 
 # Install MMG 5.5.3
 # Note ( upgraded from 5.4.1 because of https://github.com/MmgTools/mmg/issues/85)
-RUN mkdir -p /workspace/mmg_5_5_3
-RUN git clone -b 'v5.5.3' --depth 1 https://github.com/MmgTools/mmg /workspace/mmg_5_5_3 && \
-    mkdir /workspace/mmg_5_5_3/build && \
-    mkdir -p /workspace/external_libraries/mmg/mmg_5_5_3 && \
-    cd /workspace/mmg_5_5_3/build && \
-    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/workspace/external_libraries/mmg/mmg_5_5_3" -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
+RUN mkdir -p /workspace/mmg_5_5_1
+RUN git clone -b 'v5.5.1' --depth 1 https://github.com/MmgTools/mmg /workspace/mmg_5_5_1 && \
+    mkdir /workspace/mmg_5_5_1/build && \
+    mkdir -p /workspace/external_libraries/mmg/mmg_5_5_1 && \
+    cd /workspace/mmg_5_5_1/build && \
+    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/workspace/external_libraries/mmg/mmg_5_5_1" -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
     make -j2 install && \
-    rm -r /workspace/mmg_5_5_3 && \
+    rm -r /workspace/mmg_5_5_1 && \
     cd /
 
 ENV CMAKE /workspace/cmake/cmake-3.15.3-Linux-x86_64/bin/cmake

--- a/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/pypa/manylinux2014_x86_64
 
-ENV MMG_ROOT=/external_libraries/mmg/mmg_5_4_1
+ENV MMG_ROOT=/external_libraries/mmg/mmg_5_5_3
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:{MMG_ROOT}/lib
 
 RUN yum install -y git wget zip
@@ -26,15 +26,16 @@ RUN mkdir /workspace/cmake; \
 # Mpi libraries
 RUN yum install -y mpich mpich-devel mpich-autoload metis metis-devel
 
-# Install MMG 5.4
-RUN mkdir -p /workspace/mmg_5_4_1
-RUN git clone -b 'v5.4.1' --depth 1 https://github.com/MmgTools/mmg /workspace/mmg_5_4_1 && \
-    mkdir /workspace/mmg_5_4_1/build && \
-    mkdir -p /workspace/external_libraries/mmg/mmg_5_4_1 && \
-    cd /workspace/mmg_5_4_1/build && \
-    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/workspace/external_libraries/mmg/mmg_5_4_1" -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
+# Install MMG 5.5.3
+# Note ( upgraded from 5.4.1 because of https://github.com/MmgTools/mmg/issues/85)
+RUN mkdir -p /workspace/mmg_5_5_3
+RUN git clone -b 'v5.5.3' --depth 1 https://github.com/MmgTools/mmg /workspace/mmg_5_5_3 && \
+    mkdir /workspace/mmg_5_5_3/build && \
+    mkdir -p /workspace/external_libraries/mmg/mmg_5_5_3 && \
+    cd /workspace/mmg_5_5_3/build && \
+    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/workspace/external_libraries/mmg/mmg_5_5_3" -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
     make -j2 install && \
-    rm -r /workspace/mmg_5_4_1 && \
+    rm -r /workspace/mmg_5_5_3 && \
     cd /
 
 ENV CMAKE /workspace/cmake/cmake-3.15.3-Linux-x86_64/bin/cmake

--- a/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
@@ -3,28 +3,21 @@ FROM quay.io/pypa/manylinux2014_x86_64
 ENV MMG_ROOT=/external_libraries/mmg/mmg_5_5_1
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:{MMG_ROOT}/lib
 
-RUN yum install -y git wget zip
+# Prepare package dependencies
+RUN yum install -y git wget zip mpich mpich-devel mpich-autoload metis metis-devel
 
-# Prepare File system
+# Prepare Shared Volumes
 RUN mkdir -p /data_swap_guest
 
+# Prepare File System
 RUN mkdir -p /workspace/scripts; \
-	mkdir -p /workspace/kratos
+	mkdir -p /workspace/kratos; \
+    mkdir -p /workspace/boost
 
 # Install Boost
-RUN /workspace/boost; \
-    git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git boost_1_71_0
+RUN git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git boost_1_71_0
 
-# Install CMake
-RUN mkdir /workspace/cmake; \
-	wget -P /workspace/cmake https://github.com/Kitware/CMake/releases/download/v3.15.3/cmake-3.15.3-Linux-x86_64.tar.gz; \
-	tar -C /workspace/cmake -xzf /workspace/cmake/cmake-3.15.3-Linux-x86_64.tar.gz; \
-	rm /workspace/cmake/cmake-3.15.3-Linux-x86_64.tar.gz
-
-# Mpi libraries
-RUN yum install -y mpich mpich-devel mpich-autoload metis metis-devel
-
-# Install MMG 5.5.3
+# Install MMG 5.5.1
 # Note ( upgraded from 5.4.1 because of https://github.com/MmgTools/mmg/issues/85)
 RUN mkdir -p /workspace/mmg_5_5_1
 RUN git clone -b 'v5.5.1' --depth 1 https://github.com/MmgTools/mmg /workspace/mmg_5_5_1 && \
@@ -35,8 +28,6 @@ RUN git clone -b 'v5.5.1' --depth 1 https://github.com/MmgTools/mmg /workspace/m
     make -j2 install && \
     rm -r /workspace/mmg_5_5_1 && \
     cd /
-
-ENV CMAKE /workspace/cmake/cmake-3.15.3-Linux-x86_64/bin/cmake
 
 COPY start.sh /workspace/scripts/start.sh
 

--- a/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p /workspace/scripts; \
     mkdir -p /workspace/boost
 
 # Install Boost (from source)
-RUN git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git /workspace/boost/boost_1_71_0
+# RUN git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git /workspace/boost/boost_1_71_0
 
 # Install Boost (form zip)
 RUN wget -P /workspace/boost https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.gz; \

--- a/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
@@ -15,7 +15,7 @@ RUN mkdir -p /workspace/scripts; \
     mkdir -p /workspace/boost
 
 # Install Boost
-RUN git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git boost_1_71_0
+RUN git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git /workspace/boost/boost_1_71_0
 
 # Install MMG 5.5.1
 # Note ( upgraded from 5.4.1 because of https://github.com/MmgTools/mmg/issues/85)
@@ -25,7 +25,7 @@ RUN git clone -b 'v5.5.1' --depth 1 https://github.com/MmgTools/mmg /workspace/m
     mkdir -p /workspace/external_libraries/mmg/mmg_5_5_1 && \
     cd /workspace/mmg_5_5_1/build && \
     cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/workspace/external_libraries/mmg/mmg_5_5_1" -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
-    make -j2 install && \
+    make -j24 install && \
     rm -r /workspace/mmg_5_5_1 && \
     cd /
 

--- a/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /workspace/scripts; \
 
 # Install Boost
 RUN /workspace/boost; \
-    git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules https://github.com/boostorg/boost.git boost_1_71_0
+    git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git boost_1_71_0
 
 # Install CMake
 RUN mkdir /workspace/cmake; \

--- a/scripts/wheels/linux/configure.sh
+++ b/scripts/wheels/linux/configure.sh
@@ -71,6 +71,6 @@ ${CMAKE} -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
 -DLAPACK_LIBRARIES="/usr/lib64/liblapack.so.3"                         \
 -DBLAS_LIBRARIES="/usr/lib64/libblas.so.3"                             \
 -DINCLUDE_MMG=ON                                                       \
--DMMG_ROOT="/workspace/external_libraries/mmg/mmg_5_5_3"               \
+-DMMG_ROOT="/workspace/external_libraries/mmg/mmg_5_5_1"               \
 -DKRATOS_BUILD_TESTING=OFF                                             \
 -DINSTALL_RUNKRATOS=OFF

--- a/scripts/wheels/linux/configure.sh
+++ b/scripts/wheels/linux/configure.sh
@@ -59,7 +59,7 @@ rm -rf "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}/cmake_install.cmake"
 rm -rf "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}/CMakeCache.txt"
 rm -rf "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}/CMakeFiles"
 
-${CMAKE} -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
+cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
 -DCMAKE_INSTALL_PREFIX=$2                                              \
 -DUSE_TRIANGLE_NONFREE_TPL=ON                                          \
 -DUSE_MPI=OFF                                                          \

--- a/scripts/wheels/linux/configure.sh
+++ b/scripts/wheels/linux/configure.sh
@@ -71,6 +71,6 @@ ${CMAKE} -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
 -DLAPACK_LIBRARIES="/usr/lib64/liblapack.so.3"                         \
 -DBLAS_LIBRARIES="/usr/lib64/libblas.so.3"                             \
 -DINCLUDE_MMG=ON                                                       \
--DMMG_ROOT="/workspace/external_libraries/mmg/mmg_5_4_1"               \
+-DMMG_ROOT="/workspace/external_libraries/mmg/mmg_5_5_3"               \
 -DKRATOS_BUILD_TESTING=OFF                                             \
 -DINSTALL_RUNKRATOS=OFF

--- a/scripts/wheels/linux/configure_mpi.sh
+++ b/scripts/wheels/linux/configure_mpi.sh
@@ -62,7 +62,7 @@ rm -rf "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}/CMakeFiles"
 
 # -DKRATOS_ENABLE_LTO=ON                                                 \
 
-${CMAKE} -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
+cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
 -DCMAKE_INSTALL_PREFIX=$2                                              \
 -DUSE_TRIANGLE_NONFREE_TPL=ON                                          \
 -DUSE_MPI=ON                                                           \

--- a/scripts/wheels/linux/configure_mpi.sh
+++ b/scripts/wheels/linux/configure_mpi.sh
@@ -43,7 +43,7 @@ add_app ${KRATOS_APP_DIR}/DemStructuresCouplingApplication;
 add_app ${KRATOS_APP_DIR}/MeshMovingApplication;
 add_app ${KRATOS_APP_DIR}/CSharpWrapperApplication;
 add_app ${KRATOS_APP_DIR}/ShapeOptimizationApplication;
-# add_app ${KRATOS_APP_DIR}/CoSimulationApplication;
+add_app ${KRATOS_APP_DIR}/CoSimulationApplication;
 # add_app ${KRATOS_APP_DIR}/CableNetApplication;
 add_app ${KRATOS_APP_DIR}/RANSApplication;
 add_app ${KRATOS_APP_DIR}/MappingApplication;

--- a/scripts/wheels/linux/configure_mpi.sh
+++ b/scripts/wheels/linux/configure_mpi.sh
@@ -72,6 +72,6 @@ ${CMAKE} -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
 -DCMAKE_C_FLAGS="-msse3"                                               \
 -DBOOST_ROOT="/workspace/boost/boost_1_71_0"                           \
 -DINCLUDE_MMG=ON                                                       \
--DMMG_ROOT="/workspace/external_libraries/mmg/mmg_5_5_3"               \
+-DMMG_ROOT="/workspace/external_libraries/mmg/mmg_5_5_1"               \
 -DKRATOS_BUILD_TESTING=OFF                                             \
 -DINSTALL_RUNKRATOS=OFF

--- a/scripts/wheels/linux/configure_mpi.sh
+++ b/scripts/wheels/linux/configure_mpi.sh
@@ -72,6 +72,6 @@ ${CMAKE} -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
 -DCMAKE_C_FLAGS="-msse3"                                               \
 -DBOOST_ROOT="/workspace/boost/boost_1_71_0"                           \
 -DINCLUDE_MMG=ON                                                       \
--DMMG_ROOT="/workspace/external_libraries/mmg/mmg_5_4_1"               \
+-DMMG_ROOT="/workspace/external_libraries/mmg/mmg_5_5_3"               \
 -DKRATOS_BUILD_TESTING=OFF                                             \
 -DINSTALL_RUNKRATOS=OFF


### PR DESCRIPTION
**📝 Description**
Updating the base wheelbuilder image to Centos7

This allows us to reactivate CoSimApplication (we had to disable it because it depended on glib 2.16, ml2010 was glib 2.12)

Also I took the opportunity to 
- Upgrade mmg to 5.5.1 due to a bug in 5.4.3 with recent versions of gcc
- Changes to the tree structure are now done in the same layer 
- Using native cmake from the ml2014 image, which has the minimum version req for Kratos
- Numpy is now a core dependency

@philbucher this should solve the problems with the CoSimIO that I was having, just FYI.

**🆕 Changelog**
- Upgrading base image for linux wheelbuilder
- Upgrading mmg version for linux wheelbuilders
- Using native cmake in linux wheelbuilders 