### PR TITLE
[Core] Transfer distributed matrix to a serial one

### DIFF
--- a/kratos/containers/csr_matrix.h
+++ b/kratos/containers/csr_matrix.h
@@ -108,6 +108,26 @@ public:
         SetValue(0.0);
     }
 
+    CsrMatrix(const MatrixMapType& matrix_map)
+    {
+        SparseGraph<TIndexType> Agraph;
+        for(const auto item : matrix_map){
+            IndexType I = item.first.first;
+            IndexType J = item.first.second;
+            Agraph.AddEntry(I,J);
+        }
+        Agraph.Finalize();
+
+        this->BeginAssemble();
+        for(const auto item : matrix_map){
+            IndexType I = item.first.first;
+            IndexType J = item.first.second;
+            TDataType value = item.second;
+            this->AssembleEntry(value,I,J);
+        }        
+        this->FinalizeAssemble();
+    }
+
     explicit CsrMatrix(const CsrMatrix<TDataType,TIndexType>& rOtherMatrix)
     {
         mpComm = rOtherMatrix.mpComm;

--- a/kratos/containers/csr_matrix.h
+++ b/kratos/containers/csr_matrix.h
@@ -111,7 +111,7 @@ public:
     CsrMatrix(const MatrixMapType& matrix_map)
     {
         SparseGraph<TIndexType> Agraph;
-        for(const auto item : matrix_map){
+        for(const auto& item : matrix_map){
             IndexType I = item.first.first;
             IndexType J = item.first.second;
             Agraph.AddEntry(I,J);

--- a/kratos/containers/distributed_csr_matrix.h
+++ b/kratos/containers/distributed_csr_matrix.h
@@ -694,7 +694,7 @@ public:
 
     typename CsrMatrix<TDataType,TIndexType>::Pointer ToSerialCSR(MpiIndexType target_rank=0) const
     {
-        //flatten all data (both indices and values) into a single vector of doubles
+        // Flatten all data (both indices and values) into a single vector of doubles
         std::vector<double> tmp_data;
         tmp_data.reserve(GetDiagonalBlock().nnz()*3 + GetOffDiagonalBlock().nnz()*3);
         for(unsigned int i=0; i<GetDiagonalBlock().size1(); ++i){

--- a/kratos/containers/distributed_csr_matrix.h
+++ b/kratos/containers/distributed_csr_matrix.h
@@ -750,7 +750,7 @@ public:
             for(int i_proc=0; i_proc<num_processors; ++i_proc){
                 const auto& data = collected_data[i_proc];
                 for(IndexType i=0; i<data.size(); i+=3){
-                    IndexType I = static_cast<IndexType>(data[i]);
+                    const IndexType I = static_cast<IndexType>(data[i]);
                     IndexType J = static_cast<IndexType>(data[i+1]);
                     const double    v = data[i+2];
                     p_csr_output->AssembleEntry(v,I,J);

--- a/kratos/containers/distributed_csr_matrix.h
+++ b/kratos/containers/distributed_csr_matrix.h
@@ -724,7 +724,7 @@ public:
 
         auto collected_data = GetComm().Gatherv(tmp_data,target_rank);
 
-        MpiIndexType num_processors = GetComm().Size();
+        const MpiIndexType num_processors = GetComm().Size();
         MpiIndexType my_rank = GetComm().Rank();
 
         typename SparseContiguousRowGraph<TIndexType>::UniquePointer p_csr_graph;

--- a/kratos/containers/distributed_csr_matrix.h
+++ b/kratos/containers/distributed_csr_matrix.h
@@ -725,7 +725,7 @@ public:
         auto collected_data = GetComm().Gatherv(tmp_data,target_rank);
 
         const MpiIndexType num_processors = GetComm().Size();
-        MpiIndexType my_rank = GetComm().Rank();
+        const MpiIndexType my_rank = GetComm().Rank();
 
         typename SparseContiguousRowGraph<TIndexType>::UniquePointer p_csr_graph;
         typename CsrMatrix<TDataType,TIndexType>::Pointer p_csr_output;

--- a/kratos/containers/distributed_csr_matrix.h
+++ b/kratos/containers/distributed_csr_matrix.h
@@ -692,6 +692,76 @@ public:
         return value_map;
     }
 
+    typename CsrMatrix<TDataType,TIndexType>::Pointer ToSerialCSR(MpiIndexType target_rank=0) const
+    {
+        //flatten all data (both indices and values) into a single vector of doubles
+        std::vector<double> tmp_data;
+        tmp_data.reserve(GetDiagonalBlock().nnz()*3 + GetOffDiagonalBlock().nnz()*3);
+        for(unsigned int i=0; i<GetDiagonalBlock().size1(); ++i){
+            IndexType row_begin = GetDiagonalBlock().index1_data()[i];
+            IndexType row_end   = GetDiagonalBlock().index1_data()[i+1];
+            for(IndexType k = row_begin; k < row_end; ++k)
+            {
+                IndexType j = GetDiagonalBlock().index2_data()[k];
+                TDataType v = GetDiagonalBlock().value_data()[k];
+                tmp_data.push_back(GetRowNumbering().GlobalId(i));
+                tmp_data.push_back(GetColNumbering().GlobalId(j));
+                tmp_data.push_back(v);
+            }
+        }
+        for(unsigned int i=0; i<GetOffDiagonalBlock().size1(); ++i){
+            IndexType row_begin = GetOffDiagonalBlock().index1_data()[i];
+            IndexType row_end   = GetOffDiagonalBlock().index1_data()[i+1];
+            for(IndexType k = row_begin; k < row_end; ++k)
+            {
+                IndexType j = GetOffDiagonalBlock().index2_data()[k]; 
+                TDataType v = GetOffDiagonalBlock().value_data()[k];
+                tmp_data.push_back(GetRowNumbering().GlobalId(i));
+                tmp_data.push_back(mOffDiagonalGlobalIds[j]);
+                tmp_data.push_back(v);
+            }
+        }
+
+        auto collected_data = GetComm().Gatherv(tmp_data,target_rank);
+
+        MpiIndexType num_processors = GetComm().Size();
+        MpiIndexType my_rank = GetComm().Rank();
+
+        typename SparseContiguousRowGraph<TIndexType>::UniquePointer p_csr_graph;
+        typename CsrMatrix<TDataType,TIndexType>::Pointer p_csr_output;
+
+        if(my_rank==target_rank){
+            p_csr_graph = std::move( Kratos::make_unique<SparseContiguousRowGraph<TIndexType>>(GetRowNumbering().Size()) );
+
+            for(int i_proc=0; i_proc<num_processors; ++i_proc){
+                const auto& data = collected_data[i_proc];
+                for(IndexType i=0; i<data.size(); i+=3){
+                    IndexType I = static_cast<IndexType>(data[i]);
+                    IndexType J = static_cast<IndexType>(data[i+1]);
+                    p_csr_graph->AddEntry(I,J);
+                }
+            }
+            p_csr_graph->Finalize();
+        }
+
+        if(my_rank==target_rank){
+            p_csr_output = Kratos::make_shared<CsrMatrix<TDataType,TIndexType>>(*p_csr_graph);
+            p_csr_output->BeginAssemble();
+            for(int i_proc=0; i_proc<num_processors; ++i_proc){
+                const auto& data = collected_data[i_proc];
+                for(IndexType i=0; i<data.size(); i+=3){
+                    IndexType I = static_cast<IndexType>(data[i]);
+                    IndexType J = static_cast<IndexType>(data[i+1]);
+                    double    v = data[i+2];
+                    p_csr_output->AssembleEntry(v,I,J);
+                }
+            }
+            p_csr_output->FinalizeAssemble();
+        }        
+        
+        return p_csr_output;
+    }
+
     //TODO
     // LeftScaling
     // RightScaling

--- a/kratos/containers/distributed_csr_matrix.h
+++ b/kratos/containers/distributed_csr_matrix.h
@@ -751,7 +751,7 @@ public:
                 const auto& data = collected_data[i_proc];
                 for(IndexType i=0; i<data.size(); i+=3){
                     const IndexType I = static_cast<IndexType>(data[i]);
-                    IndexType J = static_cast<IndexType>(data[i+1]);
+                    const IndexType J = static_cast<IndexType>(data[i+1]);
                     const double    v = data[i+2];
                     p_csr_output->AssembleEntry(v,I,J);
                 }

--- a/kratos/containers/distributed_csr_matrix.h
+++ b/kratos/containers/distributed_csr_matrix.h
@@ -752,7 +752,7 @@ public:
                 for(IndexType i=0; i<data.size(); i+=3){
                     IndexType I = static_cast<IndexType>(data[i]);
                     IndexType J = static_cast<IndexType>(data[i+1]);
-                    double    v = data[i+2];
+                    const double    v = data[i+2];
                     p_csr_output->AssembleEntry(v,I,J);
                 }
             }

--- a/kratos/mpi/python/add_distributed_sparse_matrices_to_python.cpp
+++ b/kratos/mpi/python/add_distributed_sparse_matrices_to_python.cpp
@@ -190,7 +190,7 @@ void AddDistributedSparseMatricesToPython(pybind11::module& m)
             rA.AssembleEntry(value,I,J);
             })
         .def("ApplyHomogeneousDirichlet", &DistributedCsrMatrix<double,IndexType>::ApplyHomogeneousDirichlet )
-
+        .def("ToSerialCSR", &DistributedCsrMatrix<double,IndexType>::ToSerialCSR )
         .def("__str__", PrintObject<DistributedCsrMatrix<double,IndexType>>);
 }
 

--- a/kratos/mpi/tests/test_distributed_sparse_matrices.py
+++ b/kratos/mpi/tests/test_distributed_sparse_matrices.py
@@ -167,7 +167,19 @@ class TestDistributedSparseMatrices(KratosUnittest.TestCase):
         At.SpMV(b,y2)
         for i in range(y.LocalSize()):
             self.assertEqual(y[i], y2[i], 1e-14)
-  
+
+        #test moving material to serial
+        target_rank = 0
+        Aserial = A.ToSerialCSR(target_rank)
+        if(my_rank == 0):
+            y_serial = KratosMultiphysics.Vector(Aserial.Size1())
+            y_serial.fill(1.0)
+            b_serial = KratosMultiphysics.Vector(Aserial.Size1())
+            b_serial.fill(0.0)
+            Aserial.SpMV(y_serial, b_serial)
+            
+            for i in range(y_serial.Size()):
+                self.assertEqual(b_serial[i], reference_spmv_res[i], 1e-14)
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/kratos/mpi/tests/test_distributed_sparse_matrices.py
+++ b/kratos/mpi/tests/test_distributed_sparse_matrices.py
@@ -178,8 +178,8 @@ class TestDistributedSparseMatrices(KratosUnittest.TestCase):
             b_serial.fill(0.0)
             Aserial.SpMV(y_serial, b_serial)
             
-            for i in range(y_serial.Size()):
-                self.assertEqual(b_serial[i], reference_spmv_res[i], 1e-14)
+            self.assertVectorAlmostEqual(b_serial, reference_spmv_res)
+
 
 if __name__ == '__main__':
     KratosUnittest.main()


### PR DESCRIPTION
**📝 Description**
A constructor for serial CSR by dictionaries in the form 
({I,J}:value)

and a function to transfer a distributed matrix to its serial counterpart (useful for the coarse solver of DD preconditioners)

Please mark the PR with appropriate tags: 
Feature

**🆕 Changelog**
