### PR TITLE
[Core] Fixing uninitialized Dx in block builder and solver

### DIFF
--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -476,7 +476,9 @@ public:
         else
             norm_b = 0.00;
 
+        // Initialize the solution vector
         TSparseSpace::SetToZero(Dx);
+
 
         if (norm_b != 0.00) {
             //provide physical data as needed

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -476,6 +476,8 @@ public:
         else
             norm_b = 0.00;
 
+        TSparseSpace::SetToZero(Dx);
+
         if (norm_b != 0.00) {
             //provide physical data as needed
             if(BaseType::mpLinearSystemSolver->AdditionalPhysicalDataIsNeeded() )
@@ -484,7 +486,6 @@ public:
             //do solve
             BaseType::mpLinearSystemSolver->Solve(A, Dx, b);
         } else {
-            TSparseSpace::SetToZero(Dx);
             KRATOS_WARNING_IF("ResidualBasedBlockBuilderAndSolver", mOptions.IsNot(SILENT_WARNINGS)) << "ATTENTION! setting the RHS to zero!" << std::endl;
         }
 

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -445,6 +445,9 @@ public:
         if(rModelPart.MasterSlaveConstraints().size() != 0) {
             TSystemVectorType Dxmodified(rb.size());
 
+            // Initialize the solution vector
+            TSparseSpace::SetToZero(Dxmodified);
+
             InternalSystemSolveWithPhysics(rA, Dxmodified, rb, rModelPart);
 
             //recover solution of the original problem
@@ -475,10 +478,6 @@ public:
             norm_b = TSparseSpace::TwoNorm(b);
         else
             norm_b = 0.00;
-
-        // Initialize the solution vector
-        TSparseSpace::SetToZero(Dx);
-
 
         if (norm_b != 0.00) {
             //provide physical data as needed

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -445,7 +445,7 @@ public:
         if(rModelPart.MasterSlaveConstraints().size() != 0) {
             TSystemVectorType Dxmodified(rb.size());
 
-            // Initialize the solution vector
+            // Initialize the vector
             TSparseSpace::SetToZero(Dxmodified);
 
             InternalSystemSolveWithPhysics(rA, Dxmodified, rb, rModelPart);


### PR DESCRIPTION
**📝 Description**
The Dx was uninitialized in `SystemSolveWithPhysics` and valgrind correctly detected it.


**🆕 Changelog**
Move the SetToZero call outside of the if to include all branches

Thanks to @pablobecker and @qiukailu for pin pointing the error!