### PR TITLE
[CLApp] Minor change in conv criteria in Serial Parallel RoM

### DIFF
--- a/applications/ConstitutiveLawsApplication/custom_constitutive/serial_parallel_rule_of_mixtures_law.cpp
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/serial_parallel_rule_of_mixtures_law.cpp
@@ -398,9 +398,7 @@ void SerialParallelRuleOfMixturesLaw::CheckStressEquilibrium(
             const double norm_product_fiber  = MathUtils<double>::Norm(prod(rConstitutiveTensorFiberSS, serial_total_strain));
             ref = std::min(norm_product_matrix, norm_product_fiber);
         }
-        tolerance = 1e-4 * ref;
-        if (tolerance < 1.0e-9)
-            tolerance = 1.0e-9;
+        tolerance = std::max(1e-4 * ref, 1.0e-9);
     }
 
     noalias(rStressSerialResidual) = serial_stress_matrix - serial_stress_fiber;

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/serial_parallel_rule_of_mixtures_law.cpp
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/serial_parallel_rule_of_mixtures_law.cpp
@@ -398,10 +398,9 @@ void SerialParallelRuleOfMixturesLaw::CheckStressEquilibrium(
             const double norm_product_fiber  = MathUtils<double>::Norm(prod(rConstitutiveTensorFiberSS, serial_total_strain));
             ref = std::min(norm_product_matrix, norm_product_fiber);
         }
-        if (ref < 1e-9)
-            tolerance = 1e-9;
-        else
-            tolerance = 1e-4 * ref;
+        tolerance = 1e-4 * ref;
+        if (tolerance < 1.0e-9)
+            tolerance = 1.0e-9;
     }
 
     noalias(rStressSerialResidual) = serial_stress_matrix - serial_stress_fiber;


### PR DESCRIPTION
Minor change, it was actually a minor bug wich induced the use of very low tolerances sometimes