### PR TITLE
[Core] Fixed compiler warning in reorder_and_optimize_modelpart_process.cpp

### DIFF
--- a/kratos/processes/reorder_and_optimize_modelpart_process.cpp
+++ b/kratos/processes/reorder_and_optimize_modelpart_process.cpp
@@ -190,15 +190,6 @@ namespace Kratos
                         graph[geom[k].Id()-1].insert(geom[l].Id()-1); //the -1 is because the ids of our nodes start in 1
             }
 
-
-            unsigned int nnz = 0; //number of nonzeros in the graph
-            for(unsigned int i=0; i<n; ++i)
-            {
-                //if(graph[i].size() == 0) KRATOS_ERROR << "node with Id " << i+1 << "has zero neighbours " << std::endl;
-                nnz += graph[i].size();
-            }
-
-
             CompressedMatrix graph_csr(n,n);
             for(unsigned int i=0; i<n; ++i)
                 for(const auto& k : graph[i])


### PR DESCRIPTION
**📝 Description**
Removes unused block of code that clang was warning about.

Per clang:
```
In file included from /home/egomez/Work/Kratos/build/Release/kratos/CMakeFiles/KratosCore.dir/Unity/unity_2_cxx.cxx:31:
/home/egomez/Work/Kratos/kratos/processes/reorder_and_optimize_modelpart_process.cpp:194:26: warning: variable 'nnz' set but not used [-Wunused-but-set-variable]
            unsigned int nnz = 0; //number of nonzeros in the graph
```


**🆕 Changelog**
- Removed a block of code that computed a variable that was never used.
