### PR TITLE
[Core] Fixed compiler warning in matrix_market_interface.h

### DIFF
--- a/kratos/includes/matrix_market_interface.h
+++ b/kratos/includes/matrix_market_interface.h
@@ -1,10 +1,10 @@
-//    |  /           | 
-//    ' /   __| _` | __|  _ \   __| 
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ \.
-//   _|\_\_|  \__,_|\__|\___/ ____/ 
-//                   Multi-Physics  
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
@@ -46,12 +46,17 @@ namespace Kratos
 {
 
 // Type checks
-inline bool IsCorrectType(MM_typecode& mm_code, const double& value)
+template<typename T>
+constexpr bool IsCorrectType(MM_typecode& mm_code);
+
+template<>
+constexpr inline bool IsCorrectType<double>(MM_typecode& mm_code)
 {
     return mm_is_real(mm_code);
 }
 
-inline bool IsCorrectType(MM_typecode& mm_code, const std::complex<double>& value)
+template<>
+constexpr inline bool IsCorrectType<std::complex<double>>(MM_typecode& mm_code)
 {
     return mm_is_complex(mm_code);
 }
@@ -126,7 +131,7 @@ template <typename CompressedMatrixType> inline bool ReadMatrixMarketMatrix(cons
     ValueType *V = new ValueType[nnz];
 
     // Check if matrix type matches MM file
-    if (!IsCorrectType(mm_code, V[0]))
+    if (!IsCorrectType<ValueType>(mm_code))
     {
         printf("ReadMatrixMarketMatrix(): MatrixMarket type, \"%s\" does not match provided matrix type.\n",  mm_typecode_to_str(mm_code));
         fclose(f);
@@ -446,7 +451,7 @@ inline bool ReadMatrixMarketVectorEntry(FILE *f, std::complex<double>& entry)
 template <typename VectorType> inline bool ReadMatrixMarketVector(const char *FileName, VectorType &V)
 {
     typedef typename VectorType::value_type ValueType;
-    
+
     // Open MM file for reading
     FILE *f = fopen(FileName, "r");
 
@@ -503,7 +508,7 @@ template <typename VectorType> inline bool ReadMatrixMarketVector(const char *Fi
     ValueType T;
 
     // Check if vector type matches MM file
-    if (!IsCorrectType(mm_code, T))
+    if (!IsCorrectType<ValueType>(mm_code))
     {
         printf("ReadMatrixMarketVector(): MatrixMarket type, \"%s\" does not match provided vector type.\n",  mm_typecode_to_str(mm_code));
         fclose(f);


### PR DESCRIPTION
**📝 Description**
Fixed warning arising from passing an unitialized value to a function as `const&`.

Per clang:
```
In file included from /home/egomez/Work/kratos_installs/kratos_ROM/kratos/python/add_matrix_market_interface_to_python.cpp:22:
/home/egomez/Work/kratos_installs/kratos_ROM/kratos/includes/matrix_market_interface.h:506:33: warning: variable 'T' is uninitialized when passed as a const reference argument here [-Wuninitialized-const-reference]
    if (!IsCorrectType(mm_code, T))
                                ^
/home/egomez/Work/kratos_installs/kratos_ROM/kratos/python/add_matrix_market_interface_to_python.cpp:42:37: note: in instantiation of function template specialization 'Kratos::ReadMatrixMarketVector<boost::numeric::ublas::vector<double>>' requested here
    m.def("ReadMatrixMarketVector", ReadMatrixMarketVector <Kratos::Vector>); 
```

This also prevents an admitedly unlikely segfault here:
```diff
ValueType *V = new ValueType[nnz];

// Check if matrix type matches MM file
- if (!IsCorrectType(mm_code, V[0]))
+ if (!IsCorrectType<ValueType>(mm_code))
```
in the rare case where `nnz` is 0.

**🆕 Changelog**
- Changed from implicit overload resolution to explicit template parameter.
- Removed trailing whitespace

**Potential improvement**
Since this check is performed at compile-time, the error could be changed to a static assert and disallow compilation of the ill-formed program.