### PR TITLE
[Rom] Fixed test that was failing in MPI

### DIFF
--- a/applications/RomApplication/tests/test_calculate_rom_basis_output_process.py
+++ b/applications/RomApplication/tests/test_calculate_rom_basis_output_process.py
@@ -86,6 +86,8 @@ class TestCalculateRomBasisOutputProcess(KratosUnittest.TestCase):
 
             rom_basis_process.ExecuteFinalize()
 
+            model_part.GetCommunicator().GetDataCommunicator().Barrier()
+
     def __CheckResults(self, check_hrom_settings):
         with KratosUnittest.WorkFolderScope(self.work_folder, __file__):
             # Load ROM basis output file


### PR DESCRIPTION
**📝 Description**
Test `test_calculate_rom_basis_output_process.py` was failing in my machine due to a race condition. This is now fixed.

The test creates a file and then validates it. Some ranks were attempting to open the file before it was created.

**🆕 Changelog**
- Added a MPI barrier after output file is created.
