### PR TITLE
Copy properties modeler

### DIFF
--- a/kratos/modeler/copy_properties_modeler.cpp
+++ b/kratos/modeler/copy_properties_modeler.cpp
@@ -55,13 +55,7 @@ void CopyPropertiesModeler::SetupModelPart()
     auto& r_destination_model_part = mpModel->GetModelPart(destination_model_part_name);
 
     // clear the properties of the destination model part
-    std::vector<std::size_t> properties_ids;
-    for (const auto& r_prop : r_origin_model_part.rProperties()) {
-        properties_ids.push_back(r_prop.Id());
-    }
-    for (auto prop_id : properties_ids) {
-        r_destination_model_part.RemovePropertiesFromAllLevels(prop_id);
-    }
+    r_destination_model_part.SetProperties(Kratos::make_shared<ModelPart::PropertiesContainerType>());
 
     // make copies of the properties
     RecursivelyCopyProperties(r_origin_model_part, r_destination_model_part);

--- a/kratos/modeler/copy_properties_modeler.cpp
+++ b/kratos/modeler/copy_properties_modeler.cpp
@@ -31,10 +31,10 @@ CopyPropertiesModeler::CopyPropertiesModeler(
     mParameters.ValidateAndAssignDefaults(this->GetDefaultParameters());
 }
 
-
 CopyPropertiesModeler::CopyPropertiesModeler(
     ModelPart& rOriginModelPart,
     ModelPart& rDestinationModelPart)
+        : Modeler()
 {
     mpModel = &rOriginModelPart.GetModel();
     KRATOS_ERROR_IF_NOT(mpModel == &rDestinationModelPart.GetModel()) << "CopyPropertiesModeler. The model parts belong to different models." << std::endl;

--- a/kratos/modeler/copy_properties_modeler.cpp
+++ b/kratos/modeler/copy_properties_modeler.cpp
@@ -31,6 +31,17 @@ CopyPropertiesModeler::CopyPropertiesModeler(
     mParameters.ValidateAndAssignDefaults(this->GetDefaultParameters());
 }
 
+
+CopyPropertiesModeler::CopyPropertiesModeler(
+    ModelPart& rOriginModelPart,
+    ModelPart& rDestinationModelPart)
+{
+    mpModel = &rOriginModelPart.GetModel();
+    KRATOS_ERROR_IF_NOT(mpModel == &rDestinationModelPart.GetModel()) << "CopyPropertiesModeler. The model parts belong to different models." << std::endl;
+    mParameters.AddString("origin_model_part_name", rOriginModelPart.Name());
+    mParameters.AddString("destination_model_part_name", rDestinationModelPart.Name());
+}
+
 Modeler::Pointer CopyPropertiesModeler::Create(Model& rModel,
     const Parameters ModelParameters) const
 {

--- a/kratos/modeler/copy_properties_modeler.cpp
+++ b/kratos/modeler/copy_properties_modeler.cpp
@@ -64,13 +64,26 @@ void CopyPropertiesModeler::SetupModelPart()
     }
 
     // make copies of the properties
-    for (auto& r_prop : r_origin_model_part.rProperties()) {
-        r_destination_model_part.AddProperties(Kratos::make_shared<Properties>(r_prop));
-    }
+    RecursivelyCopyProperties(r_origin_model_part, r_destination_model_part);
 
     // replace the properties of the elements and conditions
     ReplaceProperties(r_destination_model_part.Elements(), r_destination_model_part);
     ReplaceProperties(r_destination_model_part.Conditions(), r_destination_model_part);
+}
+
+void CopyPropertiesModeler::RecursivelyCopyProperties(
+    ModelPart& rOriginModelPart,
+    ModelPart& rDestinationModelPart)
+{
+    for (auto& r_prop : rOriginModelPart.rProperties()) {
+        rDestinationModelPart.AddProperties(Kratos::make_shared<Properties>(r_prop));
+    }
+    for (auto& r_orig_sub_mp : rOriginModelPart.SubModelParts()) {
+        if (rDestinationModelPart.HasSubModelPart(r_orig_sub_mp.Name())) {
+            auto& r_dest_sub_mp = rDestinationModelPart.GetSubModelPart(r_orig_sub_mp.Name());
+            RecursivelyCopyProperties(r_orig_sub_mp, r_dest_sub_mp);
+        }
+    }
 }
 
 template<class TContainerType>

--- a/kratos/modeler/copy_properties_modeler.cpp
+++ b/kratos/modeler/copy_properties_modeler.cpp
@@ -51,7 +51,7 @@ void CopyPropertiesModeler::SetupModelPart()
 {
     const std::string origin_model_part_name = mParameters["origin_model_part_name"].GetString();
     const std::string destination_model_part_name = mParameters["destination_model_part_name"].GetString();
-    const auto& r_origin_model_part = mpModel->GetModelPart(origin_model_part_name);
+    auto& r_origin_model_part = mpModel->GetModelPart(origin_model_part_name);
     auto& r_destination_model_part = mpModel->GetModelPart(destination_model_part_name);
 
     // clear the properties of the destination model part

--- a/kratos/modeler/copy_properties_modeler.cpp
+++ b/kratos/modeler/copy_properties_modeler.cpp
@@ -76,7 +76,7 @@ void CopyPropertiesModeler::SetupModelPart()
 template<class TContainerType>
 void CopyPropertiesModeler::ReplaceProperties(
     TContainerType& rContainer,
-    ModelPart& rModelPart)
+    const ModelPart& rModelPart)
 {
     block_for_each(rContainer, [&](typename TContainerType::value_type& rEntity){
         auto properties_id = rEntity.GetProperties().Id();

--- a/kratos/modeler/copy_properties_modeler.cpp
+++ b/kratos/modeler/copy_properties_modeler.cpp
@@ -61,7 +61,6 @@ void CopyPropertiesModeler::SetupModelPart()
     }
     for (auto prop_id : properties_ids) {
         r_destination_model_part.RemovePropertiesFromAllLevels(prop_id);
-
     }
 
     // make copies of the properties

--- a/kratos/modeler/copy_properties_modeler.cpp
+++ b/kratos/modeler/copy_properties_modeler.cpp
@@ -1,0 +1,89 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Miguel Maso Sotomayor
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "modeler/copy_properties_modeler.h"
+#include "utilities/parallel_utilities.h"
+
+namespace Kratos
+{
+
+CopyPropertiesModeler::CopyPropertiesModeler(
+    Model& rModel,
+    Parameters ModelerParameters)
+        : Modeler(rModel, ModelerParameters)
+        , mpModel(&rModel)
+{
+    mParameters.ValidateAndAssignDefaults(this->GetDefaultParameters());
+}
+
+Modeler::Pointer CopyPropertiesModeler::Create(Model& rModel,
+    const Parameters ModelParameters) const
+{
+    return Kratos::make_shared<CopyPropertiesModeler>(rModel, ModelParameters);
+}
+
+const Parameters CopyPropertiesModeler::GetDefaultParameters() const
+{
+    const Parameters default_parameters = Parameters(R"({
+        "echo_level"                  : 0,
+        "origin_model_part_name"      : "",
+        "destination_model_part_name" : ""
+    })");
+    return default_parameters;
+}
+
+void CopyPropertiesModeler::SetupModelPart()
+{
+    const auto origin_model_part_name = mParameters["origin_model_part_name"].GetString();
+    const auto destination_model_part_name = mParameters["destination_model_part_name"].GetString();
+    ModelPart& r_origin_model_part = mpModel->GetModelPart(origin_model_part_name);
+    ModelPart& r_destination_model_part = mpModel->GetModelPart(destination_model_part_name);
+
+    // clear the properties of the destination model part
+    std::vector<std::size_t> properties_ids;
+    for (const auto& r_prop : r_origin_model_part.rProperties()) {
+        properties_ids.push_back(r_prop.Id());
+    }
+    for (auto prop_id : properties_ids) {
+        r_destination_model_part.RemovePropertiesFromAllLevels(prop_id);
+
+    }
+
+    // make copies of the properties
+    for (auto& r_prop : r_origin_model_part.rProperties()) {
+        r_destination_model_part.AddProperties(Kratos::make_shared<Properties>(r_prop));
+    }
+
+    // replace the properties of the elements and conditions
+    ReplaceProperties(r_destination_model_part.Elements(), r_destination_model_part);
+    ReplaceProperties(r_destination_model_part.Conditions(), r_destination_model_part);
+}
+
+template<class TContainerType>
+void CopyPropertiesModeler::ReplaceProperties(
+    TContainerType& rContainer,
+    ModelPart& rModelPart)
+{
+    block_for_each(rContainer, [&](typename TContainerType::value_type& rEntity){
+        auto properties_id = rEntity.GetProperties().Id();
+        auto p_properties = rModelPart.pGetProperties(properties_id);
+        rEntity.SetProperties(p_properties);
+    });
+}
+
+}

--- a/kratos/modeler/copy_properties_modeler.cpp
+++ b/kratos/modeler/copy_properties_modeler.cpp
@@ -49,10 +49,10 @@ const Parameters CopyPropertiesModeler::GetDefaultParameters() const
 
 void CopyPropertiesModeler::SetupModelPart()
 {
-    const auto origin_model_part_name = mParameters["origin_model_part_name"].GetString();
-    const auto destination_model_part_name = mParameters["destination_model_part_name"].GetString();
-    ModelPart& r_origin_model_part = mpModel->GetModelPart(origin_model_part_name);
-    ModelPart& r_destination_model_part = mpModel->GetModelPart(destination_model_part_name);
+    const std::string origin_model_part_name = mParameters["origin_model_part_name"].GetString();
+    const std::string destination_model_part_name = mParameters["destination_model_part_name"].GetString();
+    const auto& r_origin_model_part = mpModel->GetModelPart(origin_model_part_name);
+    auto& r_destination_model_part = mpModel->GetModelPart(destination_model_part_name);
 
     // clear the properties of the destination model part
     std::vector<std::size_t> properties_ids;

--- a/kratos/modeler/copy_properties_modeler.h
+++ b/kratos/modeler/copy_properties_modeler.h
@@ -65,6 +65,15 @@ public:
         Model& rModel,
         Parameters ModelerParameters);
 
+    /**
+     * @brief Constructor with origin and destination model parts
+     * @param rOriginModelPart Reference of the origin ModelPart
+     * @param rDestinationModelPart Reference of the destination ModelPart
+     */
+    CopyPropertiesModeler(
+        ModelPart& rOriginModelPart,
+        ModelPart& rDestinationModelPart);
+
     ///@brief Copy constructor.
     CopyPropertiesModeler(CopyPropertiesModeler const& rOther) = delete;
 

--- a/kratos/modeler/copy_properties_modeler.h
+++ b/kratos/modeler/copy_properties_modeler.h
@@ -1,0 +1,166 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Miguel Maso Sotomayor
+//
+//
+
+#ifndef KRATOS_COPY_PROPERTIES_MODELER_H_INCLUDED
+#define KRATOS_COPY_PROPERTIES_MODELER_H_INCLUDED
+
+
+// System includes
+
+
+// External includes
+
+
+// Project includes
+#include "modeler/modeler.h"
+
+
+namespace Kratos
+{
+
+///@name Kratos Classes
+///@{
+
+/**
+ * @author Miguel Maso Sotomayor
+ * @class CopyPropertiesModeler
+ * @brief Copy the properties from one model part to another.
+ * @details The properties of the elements and conditions of the destination model part are replaced by the copies.
+ */
+class KRATOS_API(KRATOS_CORE) CopyPropertiesModeler : public Modeler
+{
+public:
+    ///@name Pointer Definition
+    ///@{
+
+    KRATOS_CLASS_POINTER_DEFINITION(CopyPropertiesModeler);
+
+    ///@}
+    ///@name Type Definitions
+    ///@{
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    ///@brief Default constructor.
+    CopyPropertiesModeler() : Modeler() {}
+
+    /**
+     * @brief Constructor with Model and Parameters
+     * @param rModel Reference of the Model
+     * @param ModelerParameters Parameters of the Modeler
+     */
+    CopyPropertiesModeler(
+        Model& rModel,
+        Parameters ModelerParameters);
+
+    ///@brief Copy constructor.
+    CopyPropertiesModeler(CopyPropertiesModeler const& rOther) = delete;
+
+    ///@brief Destructor.
+    ~CopyPropertiesModeler() override = default;
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    ///@brief Assignment operator.
+    CopyPropertiesModeler & operator=(CopyPropertiesModeler const& rOther) = delete;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Creates the Modeler Pointer and returns a pointer to a new CopyPropertiesModeler
+     * @param rModel Reference of the Model
+     * @param ModelerParameters Parameters of the discretization
+     * @return a Pointer to the new Modeler
+     */
+    Modeler::Pointer Create(
+        Model& rModel,
+        const Parameters ModelParameters) const override;
+
+    /**
+     * @brief Get the Default Parameters object
+     * @return * This const 
+     */
+    const Parameters GetDefaultParameters() const override;
+
+    ///@}
+    ///@name Stages
+    ///@{
+
+    /**
+     * @brief Create a copy of the properties from the origin ModelPart to the destination ModelPart
+     */
+    void SetupModelPart() override;
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        return "CopyPropertiesModeler";
+    }
+
+    ///@}
+
+private:
+
+    ///@name Member Variables
+    ///@{
+
+    Model* mpModel = nullptr;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    template<class TContainerType>
+    void ReplaceProperties(
+        TContainerType& rContainer,
+        ModelPart& rModelPart);
+
+    ///@}
+};
+
+///@}
+///@name Input and output
+///@{
+
+///@brief input stream function
+inline std::istream& operator>>(std::istream& rIStream,
+    CopyPropertiesModeler& rThis)
+{
+    return rIStream;
+}
+
+///@brief output stream function
+inline std::ostream& operator<<(std::ostream& rOStream, const CopyPropertiesModeler& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+
+///@}
+
+} // namespace Kratos.
+
+#endif //KRATOS_COPY_PROPERTIES_MODELER_H_INCLUDED defined

--- a/kratos/modeler/copy_properties_modeler.h
+++ b/kratos/modeler/copy_properties_modeler.h
@@ -133,7 +133,7 @@ private:
     template<class TContainerType>
     void ReplaceProperties(
         TContainerType& rContainer,
-        ModelPart& rModelPart);
+        const ModelPart& rModelPart);
 
     ///@}
 };

--- a/kratos/modeler/copy_properties_modeler.h
+++ b/kratos/modeler/copy_properties_modeler.h
@@ -130,6 +130,10 @@ private:
     ///@name Operations
     ///@{
 
+    void RecursivelyCopyProperties(
+        ModelPart& rOriginModelPart,
+        ModelPart& rDestinationModelPart);
+
     template<class TContainerType>
     void ReplaceProperties(
         TContainerType& rContainer,

--- a/kratos/python/add_modeler_to_python.cpp
+++ b/kratos/python/add_modeler_to_python.cpp
@@ -101,6 +101,7 @@ void  AddModelerToPython(pybind11::module& m)
 
     py::class_< CopyPropertiesModeler, CopyPropertiesModeler::Pointer, Modeler >(m,"CopyPropertiesModeler")
         .def(py::init<Model&, Parameters>())
+        .def(py::init<ModelPart&, ModelPart&>())
     ;
 
 }

--- a/kratos/python/add_modeler_to_python.cpp
+++ b/kratos/python/add_modeler_to_python.cpp
@@ -23,6 +23,7 @@
 #include "modeler/connectivity_preserve_modeler.h"
 #include "modeler/serial_model_part_combinator_modeler.h"
 #include "modeler/duplicate_mesh_modeler.h"
+#include "modeler/copy_properties_modeler.h"
 
 namespace Kratos
 {
@@ -97,6 +98,12 @@ void  AddModelerToPython(pybind11::module& m)
     py::class_< DuplicateMeshModeler, DuplicateMeshModeler::Pointer, Modeler >(m,"DuplicateMeshModeler")
         .def(py::init<ModelPart&>())
     ;
+
+    py::class_< CopyPropertiesModeler, CopyPropertiesModeler::Pointer, Modeler >(m,"CopyPropertiesModeler")
+        .def(py::init< >())
+        .def(py::init<Model&, Parameters>())
+    ;
+
 }
 
 }  // namespace Python.

--- a/kratos/python/add_modeler_to_python.cpp
+++ b/kratos/python/add_modeler_to_python.cpp
@@ -100,7 +100,6 @@ void  AddModelerToPython(pybind11::module& m)
     ;
 
     py::class_< CopyPropertiesModeler, CopyPropertiesModeler::Pointer, Modeler >(m,"CopyPropertiesModeler")
-        .def(py::init< >())
         .def(py::init<Model&, Parameters>())
     ;
 

--- a/kratos/tests/cpp_tests/modeler/test_copy_properties_modeler.cpp
+++ b/kratos/tests/cpp_tests/modeler/test_copy_properties_modeler.cpp
@@ -31,6 +31,7 @@ namespace Testing
 
         model_part_1.CreateNewProperties(0);
         model_part_1.CreateNewProperties(1);
+        model_part_1.GetProperties(1).SetValue(DISTANCE, 1.1);
 
         model_part_2.CreateNewProperties(0);
         model_part_2.CreateNewProperties(5);
@@ -53,6 +54,10 @@ namespace Testing
         KRATOS_CHECK_EQUAL(model_part_1.NumberOfProperties(), 2);
         KRATOS_CHECK_EQUAL(model_part_2.NumberOfProperties(), 2);
         KRATOS_CHECK_EQUAL(model_part_2.GetElement(1).GetProperties().Id(), 1);
+
+        model_part_2.GetProperties(1).SetValue(DISTANCE, 2.2);
+        KRATOS_CHECK_EQUAL(model_part_1.GetProperties(1).GetValue(DISTANCE), 1.1);
+        KRATOS_CHECK_EQUAL(model_part_2.GetProperties(1).GetValue(DISTANCE), 2.2);
     }
 
     KRATOS_TEST_CASE_IN_SUITE(CopyPropertiesModelerDuplicateMesh, KratosCoreFastSuite)
@@ -63,6 +68,7 @@ namespace Testing
 
         model_part_1.CreateNewProperties(0);
         model_part_1.CreateNewProperties(1);
+        model_part_1.GetProperties(1).SetValue(DISTANCE, 1.1);
 
         model_part_2.CreateNewProperties(0);
         model_part_2.CreateNewProperties(5);
@@ -85,6 +91,10 @@ namespace Testing
         KRATOS_CHECK_EQUAL(model_part_1.NumberOfProperties(), 2);
         KRATOS_CHECK_EQUAL(model_part_2.NumberOfProperties(), 2);
         KRATOS_CHECK_EQUAL(model_part_2.GetElement(1).GetProperties().Id(), 1);
+
+        model_part_2.GetProperties(1).SetValue(DISTANCE, 2.2);
+        KRATOS_CHECK_EQUAL(model_part_1.GetProperties(1).GetValue(DISTANCE), 1.1);
+        KRATOS_CHECK_EQUAL(model_part_2.GetProperties(1).GetValue(DISTANCE), 2.2);
     }
 
 }

--- a/kratos/tests/cpp_tests/modeler/test_copy_properties_modeler.cpp
+++ b/kratos/tests/cpp_tests/modeler/test_copy_properties_modeler.cpp
@@ -82,11 +82,7 @@ namespace Testing
         DuplicateMeshModeler(model_part_1).GenerateMesh(model_part_2,
             KratosComponents<Element>::Get("Element2D3N"), KratosComponents<Condition>::Get("LineCondition2D2N"));
 
-        Parameters parameters(R"({
-            "origin_model_part_name"      : "origin",
-            "destination_model_part_name" : "destination"
-        })");
-        CopyPropertiesModeler(model, parameters).SetupModelPart();
+        CopyPropertiesModeler(model_part_1, model_part_2).SetupModelPart();
 
         KRATOS_CHECK_EQUAL(model_part_1.NumberOfProperties(), 2);
         KRATOS_CHECK_EQUAL(model_part_2.NumberOfProperties(), 2);

--- a/kratos/tests/cpp_tests/modeler/test_copy_properties_modeler.cpp
+++ b/kratos/tests/cpp_tests/modeler/test_copy_properties_modeler.cpp
@@ -1,0 +1,92 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Miguel Maso Sotomayor
+//
+//
+
+// Project includes
+#include "testing/testing.h"
+#include "modeler/connectivity_preserve_modeler.h"
+#include "modeler/duplicate_mesh_modeler.h"
+#include "modeler/copy_properties_modeler.h"
+
+namespace Kratos
+{
+
+namespace Testing
+{
+
+    KRATOS_TEST_CASE_IN_SUITE(CopyPropertiesModelerConnectivityPreserve, KratosCoreFastSuite)
+    {
+        Model model;
+        auto& model_part_1 = model.CreateModelPart("origin");
+        auto& model_part_2 = model.CreateModelPart("destination");
+
+        model_part_1.CreateNewProperties(0);
+        model_part_1.CreateNewProperties(1);
+
+        model_part_2.CreateNewProperties(0);
+        model_part_2.CreateNewProperties(5);
+        model_part_2.CreateNewProperties(6);
+
+        model_part_1.CreateNewNode(1, 0.0, 0.0, 0.0);
+        model_part_1.CreateNewNode(2, 1.0, 0.0, 0.0);
+        model_part_1.CreateNewNode(3, 0.0, 1.0, 0.0);
+        model_part_1.CreateNewElement("Element2D3N", 1, {1, 2, 3}, model_part_1.pGetProperties(1));
+
+        ConnectivityPreserveModeler().GenerateModelPart(model_part_1, model_part_2,
+            KratosComponents<Element>::Get("Element2D3N"), KratosComponents<Condition>::Get("LineCondition2D2N"));
+
+        Parameters parameters(R"({
+            "origin_model_part_name"      : "origin",
+            "destination_model_part_name" : "destination"
+        })");
+        CopyPropertiesModeler(model, parameters).SetupModelPart();
+
+        KRATOS_CHECK_EQUAL(model_part_1.NumberOfProperties(), 2);
+        KRATOS_CHECK_EQUAL(model_part_2.NumberOfProperties(), 2);
+        KRATOS_CHECK_EQUAL(model_part_2.GetElement(1).GetProperties().Id(), 1);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(CopyPropertiesModelerDuplicateMesh, KratosCoreFastSuite)
+    {
+        Model model;
+        auto& model_part_1 = model.CreateModelPart("origin");
+        auto& model_part_2 = model.CreateModelPart("destination");
+
+        model_part_1.CreateNewProperties(0);
+        model_part_1.CreateNewProperties(1);
+
+        model_part_2.CreateNewProperties(0);
+        model_part_2.CreateNewProperties(5);
+        model_part_2.CreateNewProperties(6);
+
+        model_part_1.CreateNewNode(1, 0.0, 0.0, 0.0);
+        model_part_1.CreateNewNode(2, 1.0, 0.0, 0.0);
+        model_part_1.CreateNewNode(3, 0.0, 1.0, 0.0);
+        model_part_1.CreateNewElement("Element2D3N", 1, {1, 2, 3}, model_part_1.pGetProperties(1));
+
+        DuplicateMeshModeler(model_part_1).GenerateMesh(model_part_2,
+            KratosComponents<Element>::Get("Element2D3N"), KratosComponents<Condition>::Get("LineCondition2D2N"));
+
+        Parameters parameters(R"({
+            "origin_model_part_name"      : "origin",
+            "destination_model_part_name" : "destination"
+        })");
+        CopyPropertiesModeler(model, parameters).SetupModelPart();
+
+        KRATOS_CHECK_EQUAL(model_part_1.NumberOfProperties(), 2);
+        KRATOS_CHECK_EQUAL(model_part_2.NumberOfProperties(), 2);
+        KRATOS_CHECK_EQUAL(model_part_2.GetElement(1).GetProperties().Id(), 1);
+    }
+
+}
+
+}  // namespace Kratos.


### PR DESCRIPTION
**📝 Description**
In ConnectivityPreserveModeler and DuplicatePropertiesModeler the properties are shared. In some cases it's interesting to work with a copy of the properties. In my case, I want it for postprocessing.

**🆕 Changelog**
- Add CopyPropertiesModeler
