### PR TITLE
[Core] [ConnectivityPreserveModeler] copy of the properties container

### DIFF
--- a/applications/ConvectionDiffusionApplication/python_scripts/coupled_structural_thermal_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/coupled_structural_thermal_solver.py
@@ -78,6 +78,9 @@ class CoupledThermoMechanicalSolver(PythonSolver):
         # Call the structural solver to import the model part from the mdpa
         self.structural_solver.ImportModelPart()
 
+    def PrepareModelPart(self):
+        self.structural_solver.PrepareModelPart()
+
         # Save the convection diffusion settings
         convection_diffusion_settings = self.thermal_solver.main_model_part.ProcessInfo.GetValue(KratosMultiphysics.CONVECTION_DIFFUSION_SETTINGS)
 
@@ -97,8 +100,6 @@ class CoupledThermoMechanicalSolver(PythonSolver):
         # Set the saved convection diffusion settings to the new thermal model part
         self.thermal_solver.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.CONVECTION_DIFFUSION_SETTINGS, convection_diffusion_settings)
 
-    def PrepareModelPart(self):
-        self.structural_solver.PrepareModelPart()
         self.thermal_solver.PrepareModelPart()
 
     def AddDofs(self):

--- a/kratos/modeler/connectivity_preserve_modeler.cpp
+++ b/kratos/modeler/connectivity_preserve_modeler.cpp
@@ -144,7 +144,7 @@ void ConnectivityPreserveModeler::CopyCommonData(
 
     // These should be safe for SubModelParts
     rDestinationModelPart.SetProcessInfo( rOriginModelPart.pGetProcessInfo() );
-    rDestinationModelPart.SetProperties( rOriginModelPart.pProperties() );
+    rDestinationModelPart.PropertiesArray() = rOriginModelPart.PropertiesArray();
     rDestinationModelPart.Tables() = rOriginModelPart.Tables();
 
     // Assign the nodes to the new model part

--- a/kratos/tests/test_connectivity_preserve_modeler.py
+++ b/kratos/tests/test_connectivity_preserve_modeler.py
@@ -199,5 +199,35 @@ class TestConnectivityPreserveModeler(KratosUnittest.TestCase):
         self.assertEqual(len(condition_sub1_copy.Conditions) , len(sub1.Conditions))
 
 
+    def test_properties_shared(self):
+        current_model = KratosMultiphysics.Model()
+        model_part_1 = current_model.CreateModelPart("Main")
+        model_part_2 = current_model.CreateModelPart("Destination")
+
+        model_part_1.CreateNewNode(1, 0.0, 0.1, 0.0)
+        model_part_1.CreateNewNode(2, 2.0, 0.1, 0.0)
+        model_part_1.CreateNewNode(3, 1.0, 1.1, 0.0)
+
+        properties_0 = model_part_1.CreateNewProperties(0)
+        properties_1 = model_part_1.CreateNewProperties(1)
+        properties_0.SetValue(KratosMultiphysics.DENSITY, 0.1)
+        properties_1.SetValue(KratosMultiphysics.DENSITY, 1.0)
+
+        model_part_1.CreateNewElement("Element2D3N", 1, [1,2,3], model_part_1.GetProperties()[1])
+
+        KratosMultiphysics.ConnectivityPreserveModeler().GenerateModelPart(model_part_1, model_part_2, "Element2D3N")
+
+        self.assertEqual(model_part_2.NumberOfProperties(), 2)
+        self.assertEqual(model_part_2.GetProperties()[0].GetValue(KratosMultiphysics.DENSITY), 0.1)
+        self.assertEqual(model_part_2.GetProperties()[1].GetValue(KratosMultiphysics.DENSITY), 1.0)
+
+        model_part_2.RemoveProperties(0)
+        model_part_2.GetProperties()[1].SetValue(KratosMultiphysics.DENSITY, 2.0)
+
+        self.assertEqual(model_part_1.NumberOfProperties(), 2)
+        self.assertEqual(model_part_1.GetProperties()[0].GetValue(KratosMultiphysics.DENSITY), 0.1)
+        self.assertEqual(model_part_1.GetProperties()[1].GetValue(KratosMultiphysics.DENSITY), 2.0)
+
+
 if __name__ == '__main__':
     KratosUnittest.main()


### PR DESCRIPTION
**📝 Description**
Possible solution to #9495 
Related to #9756 

**🆕 Changelog**
- Copy of the properties container instead of sharing it
- `coupled_structural_thermal_solver`: calling the modeler after reading the properties (see the comment below)
