### PR TITLE
[Fluid] Fixed errors in entropy-viscosity shock capturing

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/shock_capturing_entropy_viscosity_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/shock_capturing_entropy_viscosity_process.cpp
@@ -304,7 +304,7 @@ void ShockCapturingEntropyViscosityProcess::ComputeArtificialMagnitudes()
 
 void ShockCapturingEntropyViscosityProcess::DistributeVariablesToNodes(
     Element& rElement,
-    const double ArtificialBulkViscosity,
+    const double ArtificialDynamicViscosity,
     const double ArtificialMassDiffusivity,
     const double ArtificialConductivity,
     const std::function<double(Geometry<Node<3>>*)>& rGeometrySize) const
@@ -317,7 +317,7 @@ void ShockCapturingEntropyViscosityProcess::DistributeVariablesToNodes(
         auto& r_node = r_geometry[i];
         const double weight = element_volume / r_node.GetValue(NODAL_AREA);
         r_node.SetLock();
-        r_node.GetValue(ARTIFICIAL_BULK_VISCOSITY) += weight * ArtificialBulkViscosity;
+        r_node.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY) += weight * ArtificialDynamicViscosity;
         r_node.GetValue(ARTIFICIAL_MASS_DIFFUSIVITY) += weight * ArtificialMassDiffusivity;
         r_node.GetValue(ARTIFICIAL_CONDUCTIVITY) += weight * ArtificialConductivity;
         r_node.UnSetLock();

--- a/applications/FluidDynamicsApplication/custom_processes/shock_capturing_entropy_viscosity_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/shock_capturing_entropy_viscosity_process.cpp
@@ -103,8 +103,8 @@ const Parameters ShockCapturingEntropyViscosityProcess::GetDefaultParameters() c
     {
         "model_part_name" : "",
         "calculate_nodal_area_at_each_step" : false,
-        "entropy_constant"  : 0.0,
-        "energy_constant"   : 0.0,
+        "entropy_constant"  : 1.0,
+        "energy_constant"   : 0.25,
         "artificial_mass_viscosity_Prandtl"   : 0.1,
         "artificial_conductivity_Prandtl"     : 0.1
     }

--- a/applications/FluidDynamicsApplication/custom_processes/shock_capturing_entropy_viscosity_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/shock_capturing_entropy_viscosity_process.h
@@ -250,7 +250,7 @@ private:
     void DistributeVariablesToNodes(
         Element& rElement,
         const double ArtificialDynamicViscosity,
-        const double ArtificialBulkViscosity,
+        const double ArtificialMassDiffusivity,
         const double ArtificialConductivity,
         const std::function<double(Geometry<Node<3>>*)>& rGeometrySize) const;
 

--- a/applications/FluidDynamicsApplication/custom_processes/shock_capturing_entropy_viscosity_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/shock_capturing_entropy_viscosity_process.h
@@ -48,6 +48,13 @@ namespace Kratos
 ///@name Kratos Classes
 ///@{
 
+/**
+ * Shock Capturing Process for compressible navier stokes. Source:
+ * 
+ * 2011. Guermond, Pasquetti, Popov. Entropy viscosity method for nonlinear conservation laws
+ * Journal of Computational Physics. Volume 230, Issue 11, 20 May 2011, Pages 4248-4267
+ * 
+ */
 class KRATOS_API(FLUID_DYNAMICS_APPLICATION) ShockCapturingEntropyViscosityProcess : public Process
 {
 public:

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
@@ -141,7 +141,9 @@ class NavierStokesCompressibleExplicitSolver(FluidSolver):
         }
 
         if rk_parameter in rk_startegies:
-            return rk_startegies[rk_parameter](self.computing_model_part, strategy_settings)
+            strat = rk_startegies[rk_parameter](self.computing_model_part, strategy_settings)
+            self.settings["shock_capturing_settings"] = strategy_settings["shock_capturing_settings"]
+            return strat
 
         err_msg = "Runge-Kutta method of type '{}' not available. Try any of\n".format(rk_parameter)
         for key in rk_startegies:

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_shock_capturing_entropy_viscosity_process.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_shock_capturing_entropy_viscosity_process.cpp
@@ -151,8 +151,8 @@ namespace ShockCapturingEntropyViscosityTesting{
 
         KRATOS_CHECK_NEAR(r_test_node.GetValue(ARTIFICIAL_MASS_DIFFUSIVITY), 0.0000467293, tolerance);
         KRATOS_CHECK_NEAR(r_test_node.GetValue(ARTIFICIAL_CONDUCTIVITY),     0.0005555568, tolerance);
-        KRATOS_CHECK_NEAR(r_test_node.GetValue(ARTIFICIAL_BULK_VISCOSITY),   0.0022222273, tolerance);
-        KRATOS_CHECK_NEAR(r_test_node.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY),0.0, tolerance);
+        KRATOS_CHECK_NEAR(r_test_node.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY),   0.0022222273, tolerance);
+        KRATOS_CHECK_NEAR(r_test_node.GetValue(ARTIFICIAL_BULK_VISCOSITY), 0.0, tolerance);
     }
 
     /**
@@ -193,12 +193,12 @@ namespace ShockCapturingEntropyViscosityTesting{
         KRATOS_CHECK_NEAR(r_shock_node.GetValue(ARTIFICIAL_CONDUCTIVITY), 0.4417240025, tolerance);
         KRATOS_CHECK_NEAR(r_still_node.GetValue(ARTIFICIAL_CONDUCTIVITY), 0.0, tolerance);
 
-        KRATOS_CHECK_NEAR(r_shock_node.GetValue(ARTIFICIAL_BULK_VISCOSITY), 1.7668960100, tolerance);
-        KRATOS_CHECK_NEAR(r_still_node.GetValue(ARTIFICIAL_BULK_VISCOSITY), 0.0, tolerance);
+        KRATOS_CHECK_NEAR(r_shock_node.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY), 1.7668960100, tolerance);
+        KRATOS_CHECK_NEAR(r_still_node.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY), 0.0, tolerance);
 
         // This process does not add dynamic viscosity
-        KRATOS_CHECK_NEAR(r_shock_node.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY), 0.0, tolerance);
-        KRATOS_CHECK_NEAR(r_still_node.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY), 0.0, tolerance);
+        KRATOS_CHECK_NEAR(r_shock_node.GetValue(ARTIFICIAL_BULK_VISCOSITY), 0.0, tolerance);
+        KRATOS_CHECK_NEAR(r_still_node.GetValue(ARTIFICIAL_BULK_VISCOSITY), 0.0, tolerance);
     }
 
 } // namespace Testing


### PR DESCRIPTION
**📝 Description**
Fixed errors in entropy-viscosity shock capturing

**🆕 Changelog**
- Default values disabled the shock capturing. Changed those to the ones recommended in the source article.
- Viscosity was being stored in `ARTIFICIAL_BULK_VISCOSITY` instead of `ARTIFICIAL_DYNAMIC_VISCOSITY`. Fixed.
- Added comment with the reference paper.
- Changes in the shock capturing project parameters were not printed when ran with high echo-level because they are deep copied from solver settings to strategy settings. Fixed.