### PR TITLE
[Fluid] Compressible NS automatic_dt considers artificial diffusion

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
@@ -148,18 +148,21 @@ class NavierStokesCompressibleExplicitSolver(FluidSolver):
             err_msg = err_msg + " - {}\n".format(key)
         raise RuntimeError(err_msg)
 
+    def _OverrideBoolParameterWithWarning(self, parent, child, value):
+        if parent.Has(child) and parent[child].GetBool() != value:
+            KratosMultiphysics.Logger.PrintWarning("", "User-specifed {} will be overriden with {}".format(parameter, value))
+        else:
+            parent.AddEmptyValue(child)
+        parent[child].SetBool(True)
+
     def _CreateEstimateDtUtility(self):
         """This method overloads FluidSolver in order to enforce:
         ```
         self.settings["time_stepping"]["consider_compressibility_in_CFL"] == True
         ```
         """
-        if self.settings["time_stepping"].Has("consider_compressibility_in_CFL"):
-            KratosMultiphysics.Logger.PrintWarning("", "User-specifed consider_compressibility_in_CFL will be overriden with TRUE")
-        else:
-            self.settings["time_stepping"].AddEmptyValue("consider_compressibility_in_CFL")
-
-        self.settings["time_stepping"]["consider_compressibility_in_CFL"].SetBool(True)
+        self._OverrideBoolParameterWithWarning(self.settings["time_stepping"], "consider_compressibility_in_CFL", True)
+        self._OverrideBoolParameterWithWarning(self.settings["time_stepping"], "consider_artificial_diffusion", True)
 
         estimate_dt_utility = KratosFluid.EstimateDtUtility(
                 self.GetComputingModelPart(),

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
@@ -162,7 +162,9 @@ class NavierStokesCompressibleExplicitSolver(FluidSolver):
         ```
         """
         self._OverrideBoolParameterWithWarning(self.settings["time_stepping"], "consider_compressibility_in_CFL", True)
-        self._OverrideBoolParameterWithWarning(self.settings["time_stepping"], "consider_artificial_diffusion", True)
+
+        sc_enabled = self.GetComputingModelPart().ProcessInfo[KratosFluid.SHOCK_CAPTURING_SWITCH]
+        self._OverrideBoolParameterWithWarning(self.settings["time_stepping"], "consider_artificial_diffusion", sc_enabled)
 
         estimate_dt_utility = KratosFluid.EstimateDtUtility(
                 self.GetComputingModelPart(),

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
@@ -148,9 +148,10 @@ class NavierStokesCompressibleExplicitSolver(FluidSolver):
             err_msg = err_msg + " - {}\n".format(key)
         raise RuntimeError(err_msg)
 
-    def _OverrideBoolParameterWithWarning(self, parent, child, value):
+    @classmethod
+    def _OverrideBoolParameterWithWarning(cls, parent, child, value):
         if parent.Has(child) and parent[child].GetBool() != value:
-            KratosMultiphysics.Logger.PrintWarning("", "User-specifed {} will be overriden with {}".format(parameter, value))
+            KratosMultiphysics.Logger.PrintWarning("", "User-specifed {} will be overriden with {}".format(child, value))
         else:
             parent.AddEmptyValue(child)
         parent[child].SetBool(True)


### PR DESCRIPTION
**📝 Description**
Small change in compressible NS solver to enforce the use of artificial diffusivities in computation of Fourier numbers when shock capturing and automatic time step are enabled.

**🆕 Changelog**
- consider_artificial_diffusion is now overidden to the same value as `SHOCK_CAPTURING_SWITCH`.