### PR TITLE
[Core] Added const to condition's GetIntegrationMethod

### DIFF
--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -283,7 +283,7 @@ public:
      * @return default integration method of the used Geometry
      * this method is: OPTIONAL ( is recommended to reimplement it in the derived class )
      */
-    virtual IntegrationMethod GetIntegrationMethod()
+    virtual IntegrationMethod GetIntegrationMethod() const
     {
         return pGetGeometry()->GetDefaultIntegrationMethod();
     }

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -290,7 +290,7 @@ public:
 
     KRATOS_DEPRECATED virtual IntegrationMethod GetIntegrationMethod()
     {
-        return static_cast<const Condition * const>(this)->GetIntegrationMethod();
+        return const_cast<const Condition&>(*this).GetIntegrationMethod();
     }
 
     /**

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -290,7 +290,7 @@ public:
 
     KRATOS_DEPRECATED virtual IntegrationMethod GetIntegrationMethod()
     {
-        return pGetGeometry()->GetDefaultIntegrationMethod();
+        return static_cast<const Condition * const>(this)->GetIntegrationMethod();
     }
 
     /**

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -288,6 +288,11 @@ public:
         return pGetGeometry()->GetDefaultIntegrationMethod();
     }
 
+    KRATOS_DEPRECATED virtual IntegrationMethod GetIntegrationMethod()
+    {
+        return pGetGeometry()->GetDefaultIntegrationMethod();
+    }
+
     /**
      * CONDITIONS inherited from this class must implement this methods
      * if they need the values of the time derivatives of any of the dof

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -285,12 +285,6 @@ public:
         return pGetGeometry()->GetDefaultIntegrationMethod();
     }
 
-
-    KRATOS_DEPRECATED virtual IntegrationMethod GetIntegrationMethod()
-    {
-        return pGetGeometry()->GetDefaultIntegrationMethod();
-    }
-
     /**
      * ELEMENTS inherited from this class must implement this methods
      * if they need the values of the time derivatives of any of the dof

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -285,6 +285,12 @@ public:
         return pGetGeometry()->GetDefaultIntegrationMethod();
     }
 
+
+    KRATOS_DEPRECATED virtual IntegrationMethod GetIntegrationMethod()
+    {
+        return pGetGeometry()->GetDefaultIntegrationMethod();
+    }
+
     /**
      * ELEMENTS inherited from this class must implement this methods
      * if they need the values of the time derivatives of any of the dof


### PR DESCRIPTION
**📝 Description**
The base element has method `virtual IntegrationMethod GetIntegrationMethod() const`.
Base condition has method `virtual IntegrationMethod GetIntegrationMethod()`.

This discrepancy is fixed in favour of the const version. Note that this would break any derived condition with `IntegrationMethod GetIntegrationMethod() override`, so the non-const version is kept with a deprecation warning.

**🆕 Changelog**
- Made base condition's GetIntegrationMethod `const`.