### PR TITLE
[Core] Non-historical database DISTANCE calculation

### DIFF
--- a/kratos/processes/apply_ray_casting_process.h
+++ b/kratos/processes/apply_ray_casting_process.h
@@ -41,6 +41,12 @@ public:
     ///@name Type Definitions
     ///@{
 
+    /// Nodal databases auxiliary enum
+    enum class DistanceDatabase {
+        NodeHistorical,
+        NodeNonHistorical
+    };
+
     /// Pointer definition of ApplyRayCastingProcess
     KRATOS_CLASS_POINTER_DEFINITION(ApplyRayCastingProcess);
 
@@ -52,6 +58,9 @@ public:
 
     typedef Element::GeometryType IntersectionGeometryType;
     typedef std::vector<std::pair<double, IntersectionGeometryType*> > IntersectionsContainerType;
+
+    using NodeType = ModelPart::NodeType;
+    using NodeScalarGetFunctionType = std::function<double&(NodeType& rNode, const Variable<double>& rDistanceVariable)>;
 
     ///@}
     ///@name Life Cycle
@@ -98,11 +107,13 @@ public:
      * @param TheFindIntersectedObjectsProcess reference to the already created search structure
      * @param RelativeTolerance user-defined relative tolerance to be multiplied by the domain bounding box size
      * @param pDistanceVariable user-defined variabe to be used to read and store the distance to the skin
+     * @param rDistanceDatabase enum value specifying the database from which the distance variable is retrieved (see DistanceDatabase)
      */
     ApplyRayCastingProcess(
         FindIntersectedGeometricalObjectsProcess& TheFindIntersectedObjectsProcess,
         const double RelativeTolerance,
-        const Variable<double>* pDistanceVariable);
+        const Variable<double>* pDistanceVariable,
+        const DistanceDatabase& rDistanceDatabase);
 
     /// Destructor.
     ~ApplyRayCastingProcess() override;
@@ -206,6 +217,8 @@ private:
     double mCharacteristicLength = 1.0;
 
     const Variable<double>* mpDistanceVariable = &DISTANCE;
+
+    const DistanceDatabase mDistanceDatabase = DistanceDatabase::NodeHistorical;
 
     ///@}
     ///@name Private Operators

--- a/kratos/processes/calculate_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_distance_to_skin_process.cpp
@@ -53,6 +53,14 @@ namespace Kratos
 		mRayCastingRelativeTolerance = rParameters["ray_casting_relative_tolerance"].GetDouble();
         CalculateDiscontinuousDistanceToSkinProcess<TDim>::mpElementalDistancesVariable = &KratosComponents<Variable<Vector>>::Get(rParameters["elemental_distances_variable"].GetString());;
         mpDistanceVariable = &KratosComponents<Variable<double>>::Get(rParameters["distance_variable"].GetString());;
+		const std::string distance_database = rParameters["distance_database"].GetString();
+		if (distance_database == "nodal_historical") {
+			mDistanceDatabase = DistanceDatabase::NodeHistorical;
+		} else if (distance_database == "nodal_non_historical") {
+			mDistanceDatabase = DistanceDatabase::NodeNonHistorical;
+		} else {
+			KRATOS_ERROR << "Provided 'distance_database' is '" << distance_database << "'. Available options are 'nodal_historical' and 'nodal_non_historical'." <<  std::endl;
+		}
 	}
 
 	template<std::size_t TDim>
@@ -61,6 +69,7 @@ namespace Kratos
 		Parameters default_parameters = Parameters(R"(
 		{
 			"distance_variable"                     : "DISTANCE",
+			"distance_database"                     : "nodal_historical",
 			"ray_casting_relative_tolerance"        : 1.0e-8
 		})" );
 
@@ -93,7 +102,11 @@ namespace Kratos
 		const double char_length = this->CalculateCharacteristicLength();
 
 		// Initialize the nodal distance values to a maximum positive value
-		VariableUtils().SetVariable(*mpDistanceVariable, char_length, ModelPart1.Nodes());
+		if (mDistanceDatabase == DistanceDatabase::NodeHistorical) {
+			VariableUtils().SetVariable(*mpDistanceVariable, char_length, ModelPart1.Nodes());
+		} else {
+			VariableUtils().SetNonHistoricalVariable(*mpDistanceVariable, char_length, ModelPart1.Nodes());
+		}
 	}
 
 	template<std::size_t TDim>
@@ -109,8 +122,18 @@ namespace Kratos
 			// Use a naive elemental distance computation (without plane optimization)
 			this->CalculateElementalDistances(rIntersectedObjects);
 		}
+
+		// Set the getter function according to the database to be used
+		NodeScalarGetFunctionType node_distance_getter;
+		if (mDistanceDatabase == DistanceDatabase::NodeHistorical) {
+			node_distance_getter = [](NodeType& rNode, const Variable<double>& rDistanceVariable)->double&{return rNode.FastGetSolutionStepValue(rDistanceVariable);};
+		} else {
+			node_distance_getter = [](NodeType& rNode, const Variable<double>& rDistanceVariable)->double&{return rNode.GetValue(rDistanceVariable);};
+		}
+
 		// Get the minimum elemental distance value for each node
-		this->CalculateNodalDistances();
+		this->CalculateNodalDistances(node_distance_getter);
+
 		// Perform raycasting to sign the previous distance field
 		this->CalculateRayDistances();
 	}
@@ -198,19 +221,18 @@ namespace Kratos
 	}
 
 	template<std::size_t TDim>
-	void CalculateDistanceToSkinProcess<TDim>::CalculateNodalDistances()
+	void CalculateDistanceToSkinProcess<TDim>::CalculateNodalDistances(NodeScalarGetFunctionType& rGetDistanceFunction)
 	{
 		ModelPart& ModelPart1 = (CalculateDiscontinuousDistanceToSkinProcess<TDim>::mFindIntersectedObjectsProcess).GetModelPart1();
 
 		constexpr int number_of_tetrahedra_points = TDim + 1;
 		auto& r_elemental_dist_variable = *CalculateDiscontinuousDistanceToSkinProcess<TDim>::mpElementalDistancesVariable;
-		auto& r_distance_variable = *mpDistanceVariable;
 		for (auto& element : ModelPart1.Elements()) {
 			if (element.Is(TO_SPLIT)) {
 				const auto& r_elemental_distances = element.GetValue(r_elemental_dist_variable);
 				for (int i = 0; i < number_of_tetrahedra_points; i++) {
 					Node<3>& r_node = element.GetGeometry()[i];
-					double& r_distance = r_node.GetSolutionStepValue(r_distance_variable);
+					double& r_distance = rGetDistanceFunction(r_node, *mpDistanceVariable);
 					if (std::abs(r_distance) > std::abs(r_elemental_distances[i])){
 						r_distance = r_elemental_distances[i];
 					}
@@ -222,7 +244,11 @@ namespace Kratos
 	template<std::size_t TDim>
 	void CalculateDistanceToSkinProcess<TDim>::CalculateRayDistances()
 	{
-		ApplyRayCastingProcess<TDim> ray_casting_process(CalculateDiscontinuousDistanceToSkinProcess<TDim>::mFindIntersectedObjectsProcess, mRayCastingRelativeTolerance, mpDistanceVariable);
+		ApplyRayCastingProcess<TDim> ray_casting_process(
+			CalculateDiscontinuousDistanceToSkinProcess<TDim>::mFindIntersectedObjectsProcess,
+			mRayCastingRelativeTolerance,
+			mpDistanceVariable,
+			mDistanceDatabase);
 		ray_casting_process.Execute();
 	}
 

--- a/kratos/processes/calculate_distance_to_skin_process.h
+++ b/kratos/processes/calculate_distance_to_skin_process.h
@@ -20,6 +20,7 @@
 // External includes
 
 // Project includes
+#include "processes/apply_ray_casting_process.h"
 #include "processes/find_intersected_geometrical_objects_process.h"
 #include "processes/calculate_discontinuous_distance_to_skin_process.h"
 
@@ -45,14 +46,20 @@ public:
     /// Pointer definition of CalculateDistanceToSkinProcess
     KRATOS_CLASS_POINTER_DEFINITION(CalculateDistanceToSkinProcess);
 
-    //TODO: These using statements have been included to make the old functions able to compile. It is still pending to update them.
-    using ConfigurationType = Internals::DistanceSpatialContainersConfigure;
-    using CellType = OctreeBinaryCell<ConfigurationType>;
-    using OctreeType = OctreeBinary<CellType>;
-    using CellNodeDataType = ConfigurationType::cell_node_data_type;
+    // //TODO: These using statements have been included to make the old functions able to compile. It is still pending to update them.
+    // using ConfigurationType = Internals::DistanceSpatialContainersConfigure;
+    // using CellType = OctreeBinaryCell<ConfigurationType>;
+    // using OctreeType = OctreeBinary<CellType>;
+    // using CellNodeDataType = ConfigurationType::cell_node_data_type;
 
-    typedef Element::GeometryType IntersectionGeometryType;
-    typedef std::vector<std::pair<double, IntersectionGeometryType*> > IntersectionsContainerType;
+    using NodeType = ModelPart::NodeType;
+
+    /// Types from the ApplyRayCastingProcess
+    using DistanceDatabase = typename ApplyRayCastingProcess<TDim>::DistanceDatabase;
+    using IntersectionGeometryType = typename ApplyRayCastingProcess<TDim>::IntersectionGeometryType;
+    using IntersectionsContainerType = typename ApplyRayCastingProcess<TDim>::IntersectionsContainerType;
+    using NodeScalarGetFunctionType = typename ApplyRayCastingProcess<TDim>::NodeScalarGetFunctionType;
+
 
     ///@}
     ///@name Life Cycle
@@ -174,7 +181,7 @@ public:
      * current elemental (discontinuous) value in the node. At the end, the minimum
      * elemental distance value between the neighbour elements is saved at each node.
      */
-    virtual void CalculateNodalDistances();
+    virtual void CalculateNodalDistances(NodeScalarGetFunctionType& rGetDistanceFunction);
 
     /**
      * @brief Compute the raycasting distances and checks inside/outside
@@ -214,6 +221,8 @@ private:
     double mRayCastingRelativeTolerance = 1.0e-8;
 
     const Variable<double>* mpDistanceVariable = &DISTANCE;
+
+    DistanceDatabase mDistanceDatabase = DistanceDatabase::NodeHistorical;
 
     ///@}
     ///@name Private Operators


### PR DESCRIPTION
**📝 Description**
This PR enables saving the nodal distance in the non-historical database. Note that it is compatible with #9568 so now we can use custom variables as well as custom database. The current behavior (historical database) is kept by default.

@pooyan-dadvand I think that this shouldn't break something in your side.
