### PR TITLE
increasing runtime for small tests

### DIFF
--- a/kratos/python_scripts/run_tests.py
+++ b/kratos/python_scripts/run_tests.py
@@ -264,7 +264,7 @@ def main():
     # Set timeout of the different levels
     signalTime = None
     if level == 'small':
-        signalTime = int(60)
+        signalTime = int(90)
     elif level == 'nightly':
         signalTime = int(900)
 

--- a/kratos/python_scripts/testing/run_python_mpi_tests.py
+++ b/kratos/python_scripts/testing/run_python_mpi_tests.py
@@ -33,7 +33,7 @@ def main():
     # Set timeout of the different levels
     signalTime = None
     if args.level == 'small':
-        signalTime = 60
+        signalTime = 90
     elif args.level == 'nightly':
         signalTime = 900
 


### PR DESCRIPTION
**📝 Description**
Increases the runtime for the small suit, as the number of tests is too large to run only under 60 sec.

Note this is not good, and we should lower the test runtime, but in the meantime....

**🆕 Changelog**
- Increasing small runtime by 30 sec.
