### PR TITLE
[CI] adding centos nightly tests

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -136,3 +136,26 @@ jobs:
         set PYTHONPATH=%PYTHONPATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%
         set PATH=%PATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%/libs
         python kratos/python_scripts/run_tests.py -l nightly -c python
+
+  centos-nightly:
+    runs-on: ubuntu-latest
+    env:
+      KRATOS_BUILD_TYPE: Custom
+
+    container:
+      image: kratosmultiphysics/kratos-image-ci-centos7-python35:latest
+      options: --user 1001
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build
+      run: |
+        cp .github/workflows/centos_configure.sh centos_configure.sh
+        bash centos_configure.sh
+
+    - name: Running nightly tests
+      run: |
+        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
+        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
+        python3.5 kratos/python_scripts/run_tests.py -l nightly -c python3.5


### PR DESCRIPTION
**📝 Description**
This MR adds a new job to run the nightly tests in centos. We've had some problems in the past in altair side with this, so I think it is safer to add this here.

FYI @KratosMultiphysics/altair 
