### PR TITLE
Revert "[Core] Added const to condition's GetIntegrationMethod (#9767)"

### DIFF
--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -283,14 +283,9 @@ public:
      * @return default integration method of the used Geometry
      * this method is: OPTIONAL ( is recommended to reimplement it in the derived class )
      */
-    virtual IntegrationMethod GetIntegrationMethod() const
+    virtual IntegrationMethod GetIntegrationMethod()
     {
         return pGetGeometry()->GetDefaultIntegrationMethod();
-    }
-
-    KRATOS_DEPRECATED virtual IntegrationMethod GetIntegrationMethod()
-    {
-        return const_cast<const Condition&>(*this).GetIntegrationMethod();
     }
 
     /**


### PR DESCRIPTION
**📝 Description**
This reverts #9767.

That PR created a new method `virtual GetIntegrationMethod() const`. This causes diferent behaviour depending on the const-qualifier of the condition that calls it. Here is a small example for explanatory purposes:
```C++
#include <iostream>

struct Condition {
    [[deprecated]] virtual int Get() { return 0; }
    virtual int Get() const          { return 0; }
};

struct CustomCondition : public Condition {
    int Get() override { return 1; } // Legacy implementation
    // const Get not implemented, only legacy implementation exists
};

int main()
{
    CustomCondition condition{};
    
    Condition& A = condition;
    const Condition& B = condition;

    std::cout << A.Get() << std::endl; // Calls base method: prints 0
    std::cout << B.Get() << std::endl; // Calls override: prints 1
}
```
This is solved by reverting the change that deprecated the non-const version and added the const one.

**🆕 Changelog**
Reverted #9767
