### PR TITLE
[Core] Correcting an error for rectangular matrices

### DIFF
--- a/kratos/python/add_sparse_matrices_to_python.cpp
+++ b/kratos/python/add_sparse_matrices_to_python.cpp
@@ -133,7 +133,7 @@ void AddSparseMatricesToPython(pybind11::module& m)
         return py;
     }, py::is_operator())
     .def("__matmul__", [](const CsrMatrix<double,IndexType>& rA,const Vector& x){
-        auto py  = std::make_shared<SystemVector<double,IndexType>>(x.size());
+        auto py  = std::make_shared<SystemVector<double,IndexType>>(rA.size1());
         py->SetValue(0.0);
         rA.SpMV(x,*py);
         return py;


### PR DESCRIPTION
**📝 Description**
Hotfix. Wrongly defined size of output vector in python interface

**🆕 Changelog**
- Correcting the size of output in y=A@x
