### PR TITLE
[Mapping] Serial output process - error in python35

### DIFF
--- a/applications/MappingApplication/python_scripts/serial_output_process.py
+++ b/applications/MappingApplication/python_scripts/serial_output_process.py
@@ -58,7 +58,7 @@ class SerialOutputProcess(KM.OutputProcess):
 
         self.destination_rank = settings["destination_rank"].GetInt()
         if self.destination_rank >= self.data_comm.Size():
-            raise Exception(f'Destination rank {self.destination_rank} larger than avilable size {self.data_comm.Size()}')
+            raise Exception("Destination rank %i larger than available size %i" %(self.destination_rank, self.data_comm.Size()))
 
         if self.data_comm.Rank() == self.destination_rank:
             if mdpa_file_name_destination != "":


### PR DESCRIPTION
**📝 Description**
The f-strings are only available in python 3.6 and forward. We are using python3.5 in centos so this is throwing an error.
