### PR TITLE
Uninitialized integration method in base_solid_element of StructuralMechanicsApplication

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -178,7 +178,7 @@ public:
     BaseSolidElement( IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties ):Element(NewId,pGeometry,pProperties)
     {
         // This is needed to prevent uninitiased integration method in inactive elements
-        mThisIntegrationMethod = this->GetDefaultIntegrationMethod();
+        mThisIntegrationMethod = GetGeometry().GetDefaultIntegrationMethod();
     };
 
     // Copy constructor

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -177,7 +177,7 @@ public:
     // Constructor using an array of nodes with properties
     BaseSolidElement( IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties ):Element(NewId,pGeometry,pProperties)
     {
-        // this is needed to prevent uninitiased integration method in inactive elements
+        // This is needed to prevent uninitiased integration method in inactive elements
         mThisIntegrationMethod = this->GetDefaultIntegrationMethod();
     };
 

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -177,7 +177,7 @@ public:
     // Constructor using an array of nodes with properties
     BaseSolidElement( IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties ):Element(NewId,pGeometry,pProperties)
     {
-        // This is needed to prevent uninitiased integration method in inactive elements
+        // This is needed to prevent uninitialised integration method in inactive elements
         mThisIntegrationMethod = GetGeometry().GetDefaultIntegrationMethod();
     };
 

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -176,7 +176,10 @@ public:
 
     // Constructor using an array of nodes with properties
     BaseSolidElement( IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties ):Element(NewId,pGeometry,pProperties)
-    {};
+    {
+        // this is needed to prevent uninitiased integration method in inactive elements
+        mThisIntegrationMethod = this->GetDefaultIntegrationMethod();
+    };
 
     // Copy constructor
     BaseSolidElement(BaseSolidElement const& rOther)


### PR DESCRIPTION

The base_solid_element uses a user-defined integration method (https://github.com/KratosMultiphysics/Kratos/blob/master/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h#L644). This is initialized it in https://github.com/KratosMultiphysics/Kratos/blob/master/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp#L37-L62. 

Kratos does not initialize inactive elements, this leads to segmentation fault in https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/includes/gid_gauss_point_container.h#L71-L72.

A simple way to solve this issue is to set integration method to the default one during the construction.
