### PR TITLE
[Core] Core QR decomposition (from AMGCL) API

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_dense_householder_qr_decomposition.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_dense_householder_qr_decomposition.cpp
@@ -37,6 +37,7 @@ KRATOS_TEST_CASE_IN_SUITE(DenseHouseholderQRDecomposition, KratosCoreFastSuite)
     A_matrix(0,1) = 0.28760;
     A_matrix(1,0) = 0.72886;
     A_matrix(1,1) = 0.40541;
+    Matrix A_copy = A_matrix; // Note that A will be modified. We keep a copy for the testing.
 
     // Calculate the QR decomposition
     using DenseSpace = UblasSpace<double, Matrix, Vector>;
@@ -46,7 +47,7 @@ KRATOS_TEST_CASE_IN_SUITE(DenseHouseholderQRDecomposition, KratosCoreFastSuite)
     // Check decomposition is correct
     constexpr double tolerance = 1e-10;
     const Matrix QR_matrix = prod(Q_matrix, R_matrix);
-    KRATOS_CHECK_MATRIX_NEAR(QR_matrix, A_matrix, tolerance);
+    KRATOS_CHECK_MATRIX_NEAR(QR_matrix, A_copy, tolerance);
 
     // Check values
     KRATOS_CHECK_NEAR(R_matrix(0,1), -0.49637670012, tolerance);

--- a/kratos/tests/cpp_tests/utilities/test_dense_householder_qr_decomposition.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_dense_householder_qr_decomposition.cpp
@@ -1,0 +1,105 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+// System includes
+#include <limits>
+
+// External includes
+
+// Project includes
+#include "spaces/ublas_space.h"
+#include "utilities/dense_householder_qr_decomposition.h"
+#include "testing/testing.h"
+
+namespace Kratos
+{
+namespace Testing
+{
+
+KRATOS_TEST_CASE_IN_SUITE(DenseHouseholderQRDecomposition, KratosCoreFastSuite)
+{
+    // Allocate matrices
+    Matrix A_matrix(2,2);
+    Matrix Q_matrix(2,2);
+    Matrix R_matrix(2,2);
+
+    // Set the matrix to be decomposed
+    A_matrix(0,0) = 0.57690;
+    A_matrix(0,1) = 0.28760;
+    A_matrix(1,0) = 0.72886;
+    A_matrix(1,1) = 0.40541;
+
+    // Calculate the QR decomposition
+    using DenseSpace = UblasSpace<double, Matrix, Vector>;
+    DenseHouseholderQRDecomposition<DenseSpace> qr_decomposition;
+    qr_decomposition.Compute(A_matrix, Q_matrix, R_matrix);
+
+    // Check decomposition is correct
+    constexpr double tolerance = 1e-10;
+    const Matrix QR_matrix = prod(Q_matrix, R_matrix);
+    KRATOS_CHECK_MATRIX_NEAR(QR_matrix, A_matrix, tolerance);
+
+    // Check values
+    KRATOS_CHECK_NEAR(R_matrix(0,1), -0.49637670012, tolerance);
+    KRATOS_CHECK_NEAR(R_matrix(1,1), 0.0260998022652, tolerance);
+    KRATOS_CHECK_NEAR(Q_matrix(0,0), -0.620627440497, tolerance);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DenseHouseholderQRSolve, KratosCoreFastSuite)
+{
+    // Allocate matrices
+    Vector x_vector(4);
+    Vector b_vector(4);
+    Matrix A_matrix(4,4);
+
+    // Set the system to be solved
+    A_matrix(0, 0) = 0.0;
+    A_matrix(0, 1) = 0.979749;
+    A_matrix(0, 2) = 0.494393;
+    A_matrix(0, 3) = 0.23073;
+    A_matrix(1, 0) = 1.79224;
+    A_matrix(1, 1) = 0.198842;
+    A_matrix(1, 2) = 0.074485;
+    A_matrix(1, 3) = 1.45717;
+    A_matrix(2, 0) = 1.6039;
+    A_matrix(2, 1) = 0.673926;
+    A_matrix(2, 2) = 2.63817;
+    A_matrix(2, 3) = 1.0287;
+    A_matrix(3, 0) = 0.366503;
+    A_matrix(3, 1) = 3.02634;
+    A_matrix(3, 2) = 1.24104;
+    A_matrix(3, 3) = 3.62022;
+
+    b_vector[0] = 0.0;
+    b_vector[1] = 1.0;
+    b_vector[2] = 2.0;
+    b_vector[3] = 3.0;
+
+    // Calculate the QR decomposition
+    using DenseSpace = UblasSpace<double, Matrix, Vector>;
+    DenseHouseholderQRDecomposition<DenseSpace> qr_decomposition;
+    qr_decomposition.Compute(A_matrix);
+    qr_decomposition.Solve(b_vector, x_vector);
+
+    // Check solve result
+    Vector x_ref(4);
+    x_ref[0] = -0.328709086647;
+    x_ref[1] = -0.605571254325;
+    x_ref[2] = 0.668500192182;
+    x_ref[3] = 1.13901969982;
+    constexpr double tolerance = 1e-10;
+    KRATOS_CHECK_VECTOR_NEAR(x_vector, x_ref, tolerance);
+}
+
+} // namespace Testing
+}  // namespace Kratos.
+

--- a/kratos/tests/cpp_tests/utilities/test_dense_householder_qr_decomposition.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_dense_householder_qr_decomposition.cpp
@@ -54,7 +54,7 @@ KRATOS_TEST_CASE_IN_SUITE(DenseHouseholderQRDecomposition, KratosCoreFastSuite)
     KRATOS_CHECK_NEAR(Q_matrix(0,0), -0.620627440497, tolerance);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(DenseHouseholderQRSolve, KratosCoreFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(DenseHouseholderQRSolveVector, KratosCoreFastSuite)
 {
     // Allocate matrices
     Vector x_vector(4);
@@ -100,6 +100,59 @@ KRATOS_TEST_CASE_IN_SUITE(DenseHouseholderQRSolve, KratosCoreFastSuite)
     KRATOS_CHECK_VECTOR_NEAR(x_vector, x_ref, tolerance);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(DenseHouseholderQRSolveMatrix, KratosCoreFastSuite)
+{
+    // Allocate matrices
+    Matrix X_matrix(4,2);
+    Matrix B_matrix(4,2);
+    Matrix A_matrix(4,4);
+
+    // Set the system to be solved
+    A_matrix(0, 0) = 0.0;
+    A_matrix(0, 1) = 0.979749;
+    A_matrix(0, 2) = 0.494393;
+    A_matrix(0, 3) = 0.23073;
+    A_matrix(1, 0) = 1.79224;
+    A_matrix(1, 1) = 0.198842;
+    A_matrix(1, 2) = 0.074485;
+    A_matrix(1, 3) = 1.45717;
+    A_matrix(2, 0) = 1.6039;
+    A_matrix(2, 1) = 0.673926;
+    A_matrix(2, 2) = 2.63817;
+    A_matrix(2, 3) = 1.0287;
+    A_matrix(3, 0) = 0.366503;
+    A_matrix(3, 1) = 3.02634;
+    A_matrix(3, 2) = 1.24104;
+    A_matrix(3, 3) = 3.62022;
+
+    B_matrix(0,0) = 0.0;
+    B_matrix(1,0) = 1.0;
+    B_matrix(2,0) = 2.0;
+    B_matrix(3,0) = 3.0;
+    B_matrix(0,1) = 0.0;
+    B_matrix(1,1) = 1.0;
+    B_matrix(2,1) = 2.0;
+    B_matrix(3,1) = 3.0;
+
+    // Calculate the QR decomposition
+    using DenseSpace = UblasSpace<double, Matrix, Vector>;
+    DenseHouseholderQRDecomposition<DenseSpace> qr_decomposition;
+    qr_decomposition.Compute(A_matrix);
+    qr_decomposition.Solve(B_matrix, X_matrix);
+
+    // Check solve result
+    Matrix X_ref(4,2);
+    X_ref(0,0) = -0.328709086647;
+    X_ref(1,0) = -0.605571254325;
+    X_ref(2,0) = 0.668500192182;
+    X_ref(3,0) = 1.13901969982;
+    X_ref(0,1) = -0.328709086647;
+    X_ref(1,1) = -0.605571254325;
+    X_ref(2,1) = 0.668500192182;
+    X_ref(3,1) = 1.13901969982;
+    constexpr double tolerance = 1e-10;
+    KRATOS_CHECK_MATRIX_NEAR(X_matrix, X_ref, tolerance);
+}
+
 } // namespace Testing
 }  // namespace Kratos.
-

--- a/kratos/utilities/dense_householder_qr_decomposition.h
+++ b/kratos/utilities/dense_householder_qr_decomposition.h
@@ -92,7 +92,7 @@ public:
     {
         // Set input data
         // Note that we need a copy as QR decomposition is modifying the input
-        mpA = make_unique<MatrixType>(rInputMatrix);
+        mpA = std::make_unique<MatrixType>(rInputMatrix);
         DataType *p_0_0 = &((*mpA)(0,0));
         const std::size_t m = rInputMatrix.size1();
         const std::size_t n = rInputMatrix.size2();
@@ -115,7 +115,7 @@ public:
     {
         // Set input data
         // Note that we need a copy as QR decomposition is modifying the input
-        mpA = make_unique<MatrixType>(rInputMatrix);
+        mpA = std::make_unique<MatrixType>(rInputMatrix);
         DataType *p_0_0 = &((*mpA)(0,0));
         const std::size_t m = rInputMatrix.size1();
         const std::size_t n = rInputMatrix.size2();

--- a/kratos/utilities/dense_householder_qr_decomposition.h
+++ b/kratos/utilities/dense_householder_qr_decomposition.h
@@ -91,8 +91,9 @@ public:
     virtual void Compute(MatrixType& rInputMatrix)
     {
         // Set input data
-        mpA = &rInputMatrix;
-        DataType* p_0_0 = &(rInputMatrix)(0, 0);
+        // Note that we need a copy as QR decomposition is modifying the input
+        mpA = make_unique<MatrixType>(rInputMatrix);
+        DataType *p_0_0 = &(*mpA)(0, 0);
         const std::size_t m = rInputMatrix.size1();
         const std::size_t n = rInputMatrix.size2();
 
@@ -113,8 +114,9 @@ public:
         MatrixType& rMatrixR)
     {
         // Set input data
-        mpA = &rInputMatrix;
-        DataType *p_0_0 = &(rInputMatrix)(0, 0);
+        // Note that we need a copy as QR decomposition is modifying the input
+        mpA = make_unique<MatrixType>(rInputMatrix);
+        DataType *p_0_0 = &(*mpA)(0, 0);
         const std::size_t m = rInputMatrix.size1();
         const std::size_t n = rInputMatrix.size2();
 
@@ -283,9 +285,9 @@ private:
     ///@name Private member Variables
     ///@{
 
-    MatrixType* mpA = nullptr;
-
     AMGCLQRType mHouseholderQR;
+
+    std::unique_ptr<MatrixType> mpA = nullptr;
 
     ///@}
     ///@name Private Operators

--- a/kratos/utilities/dense_householder_qr_decomposition.h
+++ b/kratos/utilities/dense_householder_qr_decomposition.h
@@ -305,7 +305,7 @@ private:
 
     AMGCLQRType mHouseholderQR;
 
-    Kratos::unique_ptr<MatrixType> mpA = nullptr;
+    Kratos::unique_ptr<MatrixType> mpA = Kratos::unique_ptr<MatrixType>(nullptr);
 
     ///@}
     ///@name Private Operators

--- a/kratos/utilities/dense_householder_qr_decomposition.h
+++ b/kratos/utilities/dense_householder_qr_decomposition.h
@@ -86,13 +86,14 @@ public:
     /**
      * @brief Compute the QR
      * Computes the QR Decomposition (QR) of the given imput matrix
+     * Note that the input matrix is modidifed
      * @param rInputMatrix Matrix to compute the QR decomposition
      */
     void Compute(MatrixType& rInputMatrix) override
     {
         // Set input data
         // Note that we need a copy as QR decomposition is modifying the input
-        mpA = Kratos::make_unique<MatrixType>(rInputMatrix);
+        mpA = &rInputMatrix;
         DataType *p_0_0 = &((*mpA)(0,0));
         const std::size_t m = rInputMatrix.size1();
         const std::size_t n = rInputMatrix.size2();
@@ -104,6 +105,7 @@ public:
     /**
      * @brief Compute the QR
      * Computes the QR (QR) of the given input matrix
+     * Note that the input matrix is modidifed
      * @param rInputMatrix Matrix to compute the QR decomposition
      * @param rMatrixQ Unitary matrix
      * @param rMatrixR Upper triangular matrix
@@ -115,7 +117,7 @@ public:
     {
         // Set input data
         // Note that we need a copy as QR decomposition is modifying the input
-        mpA = Kratos::make_unique<MatrixType>(rInputMatrix);
+        mpA = &rInputMatrix;
         DataType *p_0_0 = &((*mpA)(0,0));
         const std::size_t m = rInputMatrix.size1();
         const std::size_t n = rInputMatrix.size2();
@@ -125,7 +127,7 @@ public:
 
         // Check sizes and fill Q values
         if (rMatrixQ.size1() != m || rMatrixQ.size2() != n) {
-            rMatrixQ.resize(m,n);
+            rMatrixQ.resize(m,n,false);
         }
         for (std::size_t i = 0; i < m; ++i) {
             for (std::size_t j = 0; j < n; ++j) {
@@ -158,7 +160,7 @@ public:
         // Check output matrix size
         const std::size_t l = rB.size2();
         if (rX.size1() != n || rX.size2() != l) {
-            rX.resize(n, l);
+            rX.resize(n, l, false);
         }
 
         // Call the QR solve method for each column
@@ -198,7 +200,7 @@ public:
 
         // Check output vector size
         if (rX.size() != n) {
-            rX.resize(n);
+            rX.resize(n, false);
         }
 
         // Call the QR solve method
@@ -232,7 +234,7 @@ public:
         // Check input size
         const std::size_t n = mpA->size2();
         if (rMatrixR.size1() != n || rMatrixR.size2() != n) {
-            rMatrixR.resize(n,n);
+            rMatrixR.resize(n,n,false);
         }
 
         // Get R values from QR util
@@ -305,7 +307,7 @@ private:
 
     AMGCLQRType mHouseholderQR;
 
-    Kratos::unique_ptr<MatrixType> mpA = Kratos::unique_ptr<MatrixType>(nullptr);
+    MatrixType* mpA = nullptr;
 
     ///@}
     ///@name Private Operators

--- a/kratos/utilities/dense_householder_qr_decomposition.h
+++ b/kratos/utilities/dense_householder_qr_decomposition.h
@@ -92,7 +92,7 @@ public:
     {
         // Set input data
         // Note that we need a copy as QR decomposition is modifying the input
-        mpA = std::make_unique<MatrixType>(rInputMatrix);
+        mpA = Kratos::make_unique<MatrixType>(rInputMatrix);
         DataType *p_0_0 = &((*mpA)(0,0));
         const std::size_t m = rInputMatrix.size1();
         const std::size_t n = rInputMatrix.size2();
@@ -115,7 +115,7 @@ public:
     {
         // Set input data
         // Note that we need a copy as QR decomposition is modifying the input
-        mpA = std::make_unique<MatrixType>(rInputMatrix);
+        mpA = Kratos::make_unique<MatrixType>(rInputMatrix);
         DataType *p_0_0 = &((*mpA)(0,0));
         const std::size_t m = rInputMatrix.size1();
         const std::size_t n = rInputMatrix.size2();
@@ -287,7 +287,7 @@ private:
 
     AMGCLQRType mHouseholderQR;
 
-    std::unique_ptr<MatrixType> mpA = nullptr;
+    Kratos::unique_ptr<MatrixType> mpA = nullptr;
 
     ///@}
     ///@name Private Operators

--- a/kratos/utilities/dense_householder_qr_decomposition.h
+++ b/kratos/utilities/dense_householder_qr_decomposition.h
@@ -88,12 +88,12 @@ public:
      * Computes the QR Decomposition (QR) of the given imput matrix
      * @param rInputMatrix Matrix to compute the QR decomposition
      */
-    virtual void Compute(MatrixType& rInputMatrix)
+    void Compute(MatrixType& rInputMatrix) override
     {
         // Set input data
         // Note that we need a copy as QR decomposition is modifying the input
         mpA = make_unique<MatrixType>(rInputMatrix);
-        DataType *p_0_0 = &(*mpA)(0, 0);
+        DataType *p_0_0 = &((*mpA)(0,0));
         const std::size_t m = rInputMatrix.size1();
         const std::size_t n = rInputMatrix.size2();
 
@@ -108,15 +108,15 @@ public:
      * @param rMatrixQ Unitary matrix
      * @param rMatrixR Upper triangular matrix
      */
-    virtual void Compute(
+    void Compute(
         MatrixType& rInputMatrix,
         MatrixType& rMatrixQ,
-        MatrixType& rMatrixR)
+        MatrixType& rMatrixR) override
     {
         // Set input data
         // Note that we need a copy as QR decomposition is modifying the input
         mpA = make_unique<MatrixType>(rInputMatrix);
-        DataType *p_0_0 = &(*mpA)(0, 0);
+        DataType *p_0_0 = &((*mpA)(0,0));
         const std::size_t m = rInputMatrix.size1();
         const std::size_t n = rInputMatrix.size2();
 
@@ -143,16 +143,16 @@ public:
      * @param rB The Right Hand Side (RHS) matrix
      * @param rX The solution matrix
      */
-    virtual void Solve(
+    void Solve(
         MatrixType& rB,
-        MatrixType& rX) const
+        MatrixType& rX) const override
     {
         // Check that QR decomposition has been already computed
         KRATOS_ERROR_IF(!mpA) << "QR decomposition not computed yet. Please call 'Compute' before 'Solve'." << std::endl;
 
         // Set input data
-        DataType* p_b_0 = &(rB)(0);
-        DataType* p_x_0 = &(rX)(0);
+        DataType* p_b_0 = &((rB)(0));
+        DataType* p_x_0 = &((rX)(0));
         DataType *p_A_0_0 = &((*mpA)(0,0));
         const std::size_t m = mpA->size1();
         const std::size_t n = mpA->size2();
@@ -169,16 +169,16 @@ public:
      * @param rB The Right Hand Side (RHS) vector
      * @param rX The solution vector
      */
-    virtual void Solve(
+    void Solve(
         const VectorType& rB,
-        VectorType& rX) const
+        VectorType& rX) const override
     {
         // Check that QR decomposition has been already computed
         KRATOS_ERROR_IF(!mpA) << "QR decomposition not computed yet. Please call 'Compute' before 'Solve'." << std::endl;
 
         // Set input data
-        DataType* p_b_0 = &(const_cast<VectorType&>(rB))(0);
-        DataType* p_x_0 = &(rX)(0);
+        DataType* p_b_0 = &((const_cast<VectorType&>(rB))(0));
+        DataType* p_x_0 = &((rX)(0));
         DataType *p_A_0_0 = &((*mpA)(0,0));
         const std::size_t m = mpA->size1();
         const std::size_t n = mpA->size2();
@@ -194,7 +194,7 @@ public:
      * If computed, this method sets the unitary matrix in the provided array
      * @param rMatrixQ Unitary matrix
      */
-    virtual void MatrixQ(MatrixType& rMatrixQ) const
+    void MatrixQ(MatrixType& rMatrixQ) const override
     {
         // We intentionally avoid to implement this method as it requires to call the factorize of QR include
         // Otherwise we would need to always do the factorize call, which is more expensive than the simpler compute one
@@ -206,7 +206,7 @@ public:
      * If computed, this method sets the upper triangular matrix in the provided array
      * @param rMatrixR Upper triangular matrix
      */
-    virtual void MatrixR(MatrixType& rMatrixR) const
+    void MatrixR(MatrixType& rMatrixR) const override
     {
         // Check that QR has been already computed
         KRATOS_ERROR_IF(!mpA) << "QR decomposition not computed yet. Please call 'Compute' before 'MatrixR'." << std::endl;
@@ -230,7 +230,7 @@ public:
      * If computed, this method sets the pivoting matrix
      * @param rMatrixP Pivoting matrix
      */
-    virtual void MatrixP(MatrixType& rMatrixP) const
+    void MatrixP(MatrixType& rMatrixP) const override
     {
         KRATOS_ERROR << "Householder QR decomposition does not implement the P matrix return" << std::endl;
     }
@@ -240,7 +240,7 @@ public:
      * Calculates and returns the rank of the array decomposed with the QR
      * @return std::size_t Rank of the provided array
      */
-    virtual std::size_t Rank() const
+    std::size_t Rank() const override
     {
         KRATOS_ERROR << "Householder QR decomposition is not rank revealing." << std::endl;
     }
@@ -250,7 +250,7 @@ public:
      * Outputs the QR class information
      * @param rOStream Information output
      */
-    virtual void PrintInfo(std::ostream &rOStream) const
+    void PrintInfo(std::ostream &rOStream) const override
     {
         rOStream << "Decomposition <" << Name() << "> finished.";
     }

--- a/kratos/utilities/dense_householder_qr_decomposition.h
+++ b/kratos/utilities/dense_householder_qr_decomposition.h
@@ -151,8 +151,8 @@ public:
         KRATOS_ERROR_IF(!mpA) << "QR decomposition not computed yet. Please call 'Compute' before 'Solve'." << std::endl;
 
         // Set input data
-        DataType* p_b_0 = &((rB)(0));
-        DataType* p_x_0 = &((rX)(0));
+        DataType* p_b_0 = &(rB(0));
+        DataType* p_x_0 = &(rX(0));
         DataType *p_A_0_0 = &((*mpA)(0,0));
         const std::size_t m = mpA->size1();
         const std::size_t n = mpA->size2();
@@ -178,7 +178,7 @@ public:
 
         // Set input data
         DataType* p_b_0 = &((const_cast<VectorType&>(rB))(0));
-        DataType* p_x_0 = &((rX)(0));
+        DataType* p_x_0 = &(rX(0));
         DataType *p_A_0_0 = &((*mpA)(0,0));
         const std::size_t m = mpA->size1();
         const std::size_t n = mpA->size2();

--- a/kratos/utilities/dense_householder_qr_decomposition.h
+++ b/kratos/utilities/dense_householder_qr_decomposition.h
@@ -1,0 +1,335 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+#if !defined(KRATOS_DENSE_HOUSEHOLDER_QR_H_INCLUDED)
+#define KRATOS_DENSE_HOUSEHOLDER_QR_H_INCLUDED
+
+// External includes
+#include "amgcl/detail/qr.hpp"
+
+// Project includes
+#include "dense_qr_decomposition.h"
+
+namespace Kratos {
+
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+template <class TDenseSpaceType>
+class DenseHouseholderQRDecomposition : public DenseQRDecomposition<TDenseSpaceType>
+{
+public:
+
+    ///@name Type Definitions
+    ///@{
+
+    /// Definition of the shared pointer of the class
+    KRATOS_CLASS_POINTER_DEFINITION(DenseHouseholderQRDecomposition);
+
+    using DataType = typename TDenseSpaceType::DataType;
+    using VectorType = typename TDenseSpaceType::VectorType;
+    using MatrixType = typename TDenseSpaceType::MatrixType;
+    using AMGCLQRType = amgcl::detail::QR<DataType>;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    DenseHouseholderQRDecomposition() = default;
+
+    virtual ~DenseHouseholderQRDecomposition() = default;
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Name of the QR
+     * Returns a string containing the name of the current QR decomposition
+     * @return std::string Name of the QR decomposition
+     */
+    static std::string Name()
+    {
+        return "dense_householder_qr_decomposition";
+    }
+
+    /**
+     * @brief Compute the QR
+     * Computes the QR Decomposition (QR) of the given imput matrix
+     * @param rInputMatrix Matrix to compute the QR decomposition
+     */
+    virtual void Compute(MatrixType& rInputMatrix)
+    {
+        // Set input data
+        mpA = &rInputMatrix;
+        DataType* p_0_0 = &(rInputMatrix)(0, 0);
+        const std::size_t m = rInputMatrix.size1();
+        const std::size_t n = rInputMatrix.size2();
+
+        // Compute the Householder QR decomposition
+        mHouseholderQR.compute(m, n, p_0_0);
+    }
+
+    /**
+     * @brief Compute the QR
+     * Computes the QR (QR) of the given input matrix
+     * @param rInputMatrix Matrix to compute the QR decomposition
+     * @param rMatrixQ Unitary matrix
+     * @param rMatrixR Upper triangular matrix
+     */
+    virtual void Compute(
+        MatrixType& rInputMatrix,
+        MatrixType& rMatrixQ,
+        MatrixType& rMatrixR)
+    {
+        // Set input data
+        mpA = &rInputMatrix;
+        DataType *p_0_0 = &(rInputMatrix)(0, 0);
+        const std::size_t m = rInputMatrix.size1();
+        const std::size_t n = rInputMatrix.size2();
+
+        // Compute the Householder QR decomposition
+        mHouseholderQR.factorize(m, n, p_0_0);
+
+        // Check sizes and fill Q values
+        if (rMatrixQ.size1() != m || rMatrixQ.size2() != n) {
+            rMatrixQ.resize(m,n);
+        }
+        for (std::size_t i = 0; i < m; ++i) {
+            for (std::size_t j = 0; j < n; ++j) {
+                rMatrixQ(i,j) = mHouseholderQR.Q(i,j);
+            }
+        }
+
+        // Check sizes and fill R values
+        MatrixR(rMatrixR);
+    }
+
+    /**
+     * @brief Solves the problem Ax=b
+     * Being A the input matrix, this method solves the problem Ax = b
+     * @param rB The Right Hand Side (RHS) matrix
+     * @param rX The solution matrix
+     */
+    virtual void Solve(
+        MatrixType& rB,
+        MatrixType& rX) const
+    {
+        // Check that QR decomposition has been already computed
+        KRATOS_ERROR_IF(!mpA) << "QR decomposition not computed yet. Please call 'Compute' before 'Solve'." << std::endl;
+
+        // Set input data
+        DataType* p_b_0 = &(rB)(0);
+        DataType* p_x_0 = &(rX)(0);
+        DataType *p_A_0_0 = &((*mpA)(0,0));
+        const std::size_t m = mpA->size1();
+        const std::size_t n = mpA->size2();
+
+        // Call the QR solve method
+        const bool qr_computed = true;
+        auto storage_order = amgcl::detail::storage_order::row_major;
+        const_cast<AMGCLQRType&>(mHouseholderQR).solve(m, n, p_A_0_0, p_b_0, p_x_0, storage_order, qr_computed);
+    }
+
+    /**
+     * @brief Solves the problem Ax=b
+     * Being A the input matrix, this method solves the problem Ax = b
+     * @param rB The Right Hand Side (RHS) vector
+     * @param rX The solution vector
+     */
+    virtual void Solve(
+        const VectorType& rB,
+        VectorType& rX) const
+    {
+        // Check that QR decomposition has been already computed
+        KRATOS_ERROR_IF(!mpA) << "QR decomposition not computed yet. Please call 'Compute' before 'Solve'." << std::endl;
+
+        // Set input data
+        DataType* p_b_0 = &(const_cast<VectorType&>(rB))(0);
+        DataType* p_x_0 = &(rX)(0);
+        DataType *p_A_0_0 = &((*mpA)(0,0));
+        const std::size_t m = mpA->size1();
+        const std::size_t n = mpA->size2();
+
+        // Call the QR solve method
+        const bool qr_computed = true;
+        auto storage_order = amgcl::detail::storage_order::row_major;
+        const_cast<AMGCLQRType&>(mHouseholderQR).solve(m, n, p_A_0_0, p_b_0, p_x_0, storage_order, qr_computed);
+    }
+
+    /**
+     * @brief Unitary matrix getter
+     * If computed, this method sets the unitary matrix in the provided array
+     * @param rMatrixQ Unitary matrix
+     */
+    virtual void MatrixQ(MatrixType& rMatrixQ) const
+    {
+        // We intentionally avoid to implement this method as it requires to call the factorize of QR include
+        // Otherwise we would need to always do the factorize call, which is more expensive than the simpler compute one
+        KRATOS_ERROR << "This method is not implemented. Please use the 'Compute' interface with Q and R return." << std::endl;
+    }
+
+    /**
+     * @brief Upper triangular matrix getter
+     * If computed, this method sets the upper triangular matrix in the provided array
+     * @param rMatrixR Upper triangular matrix
+     */
+    virtual void MatrixR(MatrixType& rMatrixR) const
+    {
+        // Check that QR has been already computed
+        KRATOS_ERROR_IF(!mpA) << "QR decomposition not computed yet. Please call 'Compute' before 'MatrixR'." << std::endl;
+
+        // Check input size
+        const std::size_t n = mpA->size2();
+        if (rMatrixR.size1() != n || rMatrixR.size2() != n) {
+            rMatrixR.resize(n,n);
+        }
+
+        // Get R values from QR util
+        for (std::size_t i = 0; i < n; ++i) {
+            for (std::size_t j = 0; j < n; ++j) {
+                rMatrixR(i,j) = mHouseholderQR.R(i,j);
+            }
+        }
+    }
+
+    /**
+     * @brief Pivoting matrix getter
+     * If computed, this method sets the pivoting matrix
+     * @param rMatrixP Pivoting matrix
+     */
+    virtual void MatrixP(MatrixType& rMatrixP) const
+    {
+        KRATOS_ERROR << "Householder QR decomposition does not implement the P matrix return" << std::endl;
+    }
+
+    /**
+     * @brief Rank of the provided array
+     * Calculates and returns the rank of the array decomposed with the QR
+     * @return std::size_t Rank of the provided array
+     */
+    virtual std::size_t Rank() const
+    {
+        KRATOS_ERROR << "Householder QR decomposition is not rank revealing." << std::endl;
+    }
+
+    /**
+     * @brief QR information
+     * Outputs the QR class information
+     * @param rOStream Information output
+     */
+    virtual void PrintInfo(std::ostream &rOStream) const
+    {
+        rOStream << "Decomposition <" << Name() << "> finished.";
+    }
+
+    ///@}
+    ///@name Access
+    ///@{
+
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+private:
+    ///@name Private static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Private member Variables
+    ///@{
+
+    MatrixType* mpA = nullptr;
+
+    AMGCLQRType mHouseholderQR;
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+
+    ///@}
+    ///@name Private Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Private LifeCycle
+    ///@{
+
+
+    ///@}
+    ///@name Unaccessible methods
+    ///@{
+
+
+    ///@}
+};
+
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+
+///@}
+} // namespace Kratos
+
+#endif // defined(KRATOS_DENSE_HOUSEHOLDER_QR_H_INCLUDED)


### PR DESCRIPTION
**📝 Description**
So far the `qr_utilities` in the core were using their custom API. Recently we added a base virtual class for QR decompositions. In this PR I'm interfacing the QR in the Kratos core to use this.

Important thing to comment is that the QR decomposition we have in the Core is from AMGCL library. Years ago, when we included it AMGCL was not part of the Kratos core, so basically what we did in the `qr_utilities.h` was to copy & paste it from the library. Now the AMGCL is part of Kratos core, so what this PR does is to interface to the one in `external_libraries/amgcl/detail/qr.hpp `. With this we automatically make sure that the QR is updated each time we update the library (the old one we were using so far is way outdated because of this...).

In an upcoming PR I'll remove the old `qr_utility.h` as well as its usage.

EDIT: Tests have been added accordingly.
