### PR TITLE
[Core] Specifying the return type on add_distributed_sparse_matrices_to_python

### DIFF
--- a/kratos/mpi/python/add_distributed_sparse_matrices_to_python.cpp
+++ b/kratos/mpi/python/add_distributed_sparse_matrices_to_python.cpp
@@ -120,11 +120,11 @@ void AddDistributedSparseMatricesToPython(pybind11::module& m)
         .def("Mult", [](DistributedSystemVector<double,IndexType>& self, const double value){ self*=value; } )
         .def("Div", [](DistributedSystemVector<double,IndexType>& self, const double value){ self/=value; } )
         //out of place
-        .def("__mul__", [](const DistributedSystemVector<double,IndexType>& self, const double factor){
+        .def("__mul__", [](const DistributedSystemVector<double,IndexType>& self, const double factor) -> DistributedSystemVector<double,IndexType>::Pointer{
             auto paux = std::make_shared<DistributedSystemVector<double,IndexType>>(self);
             (*paux) *= factor;
             return paux;}, py::is_operator())
-        .def("__rmul__", [](const DistributedSystemVector<double,IndexType>& self, const double factor){
+        .def("__rmul__", [](const DistributedSystemVector<double,IndexType>& self, const double factor) -> DistributedSystemVector<double,IndexType>::Pointer{
             auto paux = std::make_shared<DistributedSystemVector<double,IndexType>>(self);
             (*paux) *= factor;
             return paux;}, py::is_operator())


### PR DESCRIPTION
otherwise 

b=1.0*(A@x) 

does not work (although b = b + 1.0*(A@x) did work)

**📝 Description**
solves a papercut 

**🆕 Changelog**

