### PR TITLE
added getElementalGradient function

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
@@ -92,6 +92,20 @@ class StrainEnergyResponseFunction(ResponseFunctionInterface):
             gradient[node.Id] = node.GetSolutionStepValue(variable)
         return gradient
 
+    def GetElementalGradient(self, variable):
+        if variable not in [
+                            StructuralMechanicsApplication.YOUNG_MODULUS_SENSITIVITY,
+                            StructuralMechanicsApplication.THICKNESS_SENSITIVITY,
+                            StructuralMechanicsApplication.I22_SENSITIVITY,
+                            StructuralMechanicsApplication.I33_SENSITIVITY,
+                            ]:
+            raise RuntimeError("GetElementalGradient: No gradient for {}!".format(variable.Name))
+        gradient = {}
+        for element in self.primal_model_part.Elements:
+            gradient[element.Id] = element.GetValue(variable)
+            #gradient[element.Id] = element.GetSolutionStepValue(variable)
+        return gradient
+
 # ==============================================================================
 class EigenFrequencyResponseFunction(StrainEnergyResponseFunction):
     """Eigenfrequency response function. The internal procedure is the same as
@@ -135,6 +149,8 @@ class EigenFrequencyResponseFunction(StrainEnergyResponseFunction):
 
         self.primal_analysis = StructuralMechanicsAnalysis(model, ProjectParametersPrimal)
         self.primal_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.SHAPE_SENSITIVITY)
+        self.primal_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.YOUNGS_MODULUS_SENSITIVITY)
+
 
         self.response_function_utility = StructuralMechanicsApplication.EigenfrequencyResponseFunctionUtility(self.primal_model_part, response_settings)
 
@@ -213,6 +229,18 @@ class MassResponseFunction(ResponseFunctionInterface):
             gradient[node.Id] = node.GetSolutionStepValue(variable)
         return gradient
 
+    def GetElementalGradient(self, variable):
+        if variable not in [
+                            StructuralMechanicsApplication.YOUNG_MODULUS_SENSITIVITY,
+                            StructuralMechanicsApplication.THICKNESS_SENSITIVITY,
+                            StructuralMechanicsApplication.I22_SENSITIVITY,
+                            StructuralMechanicsApplication.I33_SENSITIVITY,
+                            ]:
+            raise RuntimeError("GetElementalGradient: No gradient for {}!".format(variable.Name))
+        gradient = {}
+        for element in self.model_part.Elements:
+            gradient[element.Id] = element.GetValue(variable)
+        return gradient
 # ==============================================================================
 class AdjointResponseFunction(ResponseFunctionInterface):
     """Linear static adjoint strain energy response function.
@@ -294,6 +322,21 @@ class AdjointResponseFunction(ResponseFunctionInterface):
         for node in self.adjoint_model_part.Nodes:
             gradient[node.Id] = node.GetSolutionStepValue(variable)
         return gradient
+
+    def GetElementalGradient(self, variable):
+        if variable not in [
+                            StructuralMechanicsApplication.YOUNG_MODULUS_SENSITIVITY,
+                            StructuralMechanicsApplication.THICKNESS_SENSITIVITY,
+                            StructuralMechanicsApplication.I22_SENSITIVITY,
+                            StructuralMechanicsApplication.I33_SENSITIVITY,
+                            ]:
+            raise RuntimeError("GetElementalGradient: No gradient for {}!".format(variable.Name))
+        gradient = {}
+        for element in self.adjoint_model_part.Elements:
+            gradient[element.Id] = element.GetValue(variable)
+            #gradient[element.Id] = element.GetSolutionStepValue(variable)
+        return gradient
+
 
     def Finalize(self):
         self.primal_analysis.Finalize()

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
@@ -93,17 +93,7 @@ class StrainEnergyResponseFunction(ResponseFunctionInterface):
         return gradient
 
     def GetElementalGradient(self, variable):
-        if variable not in [
-                            StructuralMechanicsApplication.YOUNG_MODULUS_SENSITIVITY,
-                            StructuralMechanicsApplication.THICKNESS_SENSITIVITY,
-                            StructuralMechanicsApplication.I22_SENSITIVITY,
-                            StructuralMechanicsApplication.I33_SENSITIVITY,
-                            ]:
-            raise RuntimeError("GetElementalGradient: No gradient for {}!".format(variable.Name))
-        gradient = {}
-        for element in self.primal_model_part.Elements:
-            gradient[element.Id] = element.GetValue(variable)
-        return gradient
+        raise NotImplementedError("GetElementalGradient needs to be implemented for StrainEnergyResponseFunction")
 
 # ==============================================================================
 class EigenFrequencyResponseFunction(StrainEnergyResponseFunction):
@@ -148,7 +138,6 @@ class EigenFrequencyResponseFunction(StrainEnergyResponseFunction):
 
         self.primal_analysis = StructuralMechanicsAnalysis(model, ProjectParametersPrimal)
         self.primal_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.SHAPE_SENSITIVITY)
-        self.primal_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.YOUNG_MODULUS_SENSITIVITY)
 
 
         self.response_function_utility = StructuralMechanicsApplication.EigenfrequencyResponseFunctionUtility(self.primal_model_part, response_settings)
@@ -229,17 +218,8 @@ class MassResponseFunction(ResponseFunctionInterface):
         return gradient
 
     def GetElementalGradient(self, variable):
-        if variable not in [
-                            StructuralMechanicsApplication.YOUNG_MODULUS_SENSITIVITY,
-                            StructuralMechanicsApplication.THICKNESS_SENSITIVITY,
-                            StructuralMechanicsApplication.I22_SENSITIVITY,
-                            StructuralMechanicsApplication.I33_SENSITIVITY,
-                            ]:
-            raise RuntimeError("GetElementalGradient: No gradient for {}!".format(variable.Name))
-        gradient = {}
-        for element in self.model_part.Elements:
-            gradient[element.Id] = element.GetValue(variable)
-        return gradient
+        raise NotImplementedError("GetElementalGradient needs to be implemented for MassResponseFunction")
+
 # ==============================================================================
 class AdjointResponseFunction(ResponseFunctionInterface):
     """Linear static adjoint strain energy response function.

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
@@ -103,7 +103,6 @@ class StrainEnergyResponseFunction(ResponseFunctionInterface):
         gradient = {}
         for element in self.primal_model_part.Elements:
             gradient[element.Id] = element.GetValue(variable)
-            #gradient[element.Id] = element.GetSolutionStepValue(variable)
         return gradient
 
 # ==============================================================================
@@ -334,7 +333,6 @@ class AdjointResponseFunction(ResponseFunctionInterface):
         gradient = {}
         for element in self.adjoint_model_part.Elements:
             gradient[element.Id] = element.GetValue(variable)
-            #gradient[element.Id] = element.GetSolutionStepValue(variable)
         return gradient
 
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
@@ -148,7 +148,7 @@ class EigenFrequencyResponseFunction(StrainEnergyResponseFunction):
 
         self.primal_analysis = StructuralMechanicsAnalysis(model, ProjectParametersPrimal)
         self.primal_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.SHAPE_SENSITIVITY)
-        self.primal_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.YOUNGS_MODULUS_SENSITIVITY)
+        self.primal_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.YOUNG_MODULUS_SENSITIVITY)
 
 
         self.response_function_utility = StructuralMechanicsApplication.EigenfrequencyResponseFunctionUtility(self.primal_model_part, response_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
@@ -148,7 +148,7 @@ class EigenFrequencyResponseFunction(StrainEnergyResponseFunction):
 
         self.primal_analysis = StructuralMechanicsAnalysis(model, ProjectParametersPrimal)
         self.primal_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.SHAPE_SENSITIVITY)
-        self.primal_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.YOUNGS_MODULUS_SENSITIVITY)
+        self.primal_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.YOUNGS_MODULUS_SENSITIVITY)
 
 
         self.response_function_utility = StructuralMechanicsApplication.EigenfrequencyResponseFunctionUtility(self.primal_model_part, response_settings)


### PR DESCRIPTION
**📝 Description**
Quick fix by adding GetElementalGradient function analogously to GetNodalGradient to allow usage like:
`stressNablaE = response_function.GetElementalGradient(sm.YOUNG_MODULUS_SENSITIVITY)`

**🆕 Changelog**
- Added function GetElementalGradient to structural_response.py
