### PR TITLE
[HDF5Application] Remove repeated mocking

### DIFF
--- a/applications/HDF5Application/tests/test_hdf5_processes.py
+++ b/applications/HDF5Application/tests/test_hdf5_processes.py
@@ -51,8 +51,6 @@ class TestHDF5Processes(KratosUnittest.TestCase):
         self.HDF5NodalFlagValueIO = self.patcher8.start()
         self.HDF5ConditionFlagValueIO = self.patcher9.start()
         self.HDF5ConditionDataValueIO = self.patcher10.start()
-        self.HDF5ConditionDataValueIO = self.patcher10.start()
-        self.HDF5ConditionDataValueIO = self.patcher10.start()
         self.HDF5ElementGaussPointOutput = self.patcher11.start()
         self.HDF5ConditionGaussPointOutput = self.patcher12.start()
 


### PR DESCRIPTION
**📝 Description**
Changes to ```unittest``` in python 3.10 lead to exceptions when multiple attempts are made at mocking an object. This PR fixes the resulting issues in ```HDF5Application```. 
