### PR TITLE
[StructuralMechanics] Parallel utilities in ExplicitCentralDifferencesScheme

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_schemes/explicit_central_differences_scheme.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_schemes/explicit_central_differences_scheme.hpp
@@ -327,8 +327,7 @@ public:
                         // current_rotation[j] = 0.0; // this might be wrong for presribed rotations // NOTE: then you should check if the dof is fixed
                     }
                 };
-            }
-            else {
+            } else {
                 initializer = initializer_base;
             }
 
@@ -396,8 +395,7 @@ public:
                     updater_base(index);
                     this->UpdateRotationalDegreesOfFreedom(it_node_begin + index, rotppos, dim);
                 };
-            }
-            else {
+            } else {
                 updater = updater_base;
             }
 
@@ -616,8 +614,7 @@ public:
                         //current_rotation[j] = 0.0;
                     }
                 };
-            }
-            else {
+            } else {
                 initializer = initializer_base;
             }
 

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_schemes/explicit_central_differences_scheme.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_schemes/explicit_central_differences_scheme.hpp
@@ -578,7 +578,7 @@ public:
             };
 
             if (has_dof_for_rot_z) {
-                initializer = [&zero_array, &rotppos, &initializer_base, DomainSize, this](Node<3>& rNode) {
+                initializer = [&rotppos, &initializer_base, DomainSize, this](Node<3>& rNode) {
                     initializer_base(rNode);
                     const array_1d<double, 3>& nodal_inertia = rNode.GetValue(NODAL_INERTIA);
                     const array_1d<double, 3>& r_current_residual_moment = rNode.FastGetSolutionStepValue(MOMENT_RESIDUAL);

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_schemes/explicit_central_differences_scheme.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_schemes/explicit_central_differences_scheme.hpp
@@ -23,6 +23,7 @@
 #include "solving_strategies/schemes/scheme.h"
 #include "utilities/variable_utils.h"
 #include "custom_utilities/explicit_integration_utilities.h"
+#include "utilities/parallel_utilities.h"
 
 namespace Kratos {
 
@@ -287,46 +288,37 @@ public:
             // The first iterator of the array of nodes
             const auto it_node_begin = rModelPart.NodesBegin();
 
-            /// Initialise the database of the nodes
+            // Construct the node initializer lambda based on whether rot_z exists
+            std::function<void(Node<3>&)> initializer_base, initializer;
             const array_1d<double, 3> zero_array = ZeroVector(3);
-            #pragma omp parallel for schedule(guided,512)
-            for (int i = 0; i < static_cast<int>(r_nodes.size()); ++i) {
-                auto it_node = (it_node_begin + i);
-                it_node->SetValue(NODAL_MASS, 0.0);
-                array_1d<double, 3>& r_middle_velocity = it_node->FastGetSolutionStepValue(MIDDLE_VELOCITY);
-                r_middle_velocity  = ZeroVector(3);
-            }
-            const bool has_dof_for_rot_z = it_node_begin->HasDofFor(ROTATION_Z);
-            if (has_dof_for_rot_z) {
-                #pragma omp parallel for schedule(guided,512)
-                for (int i = 0; i < static_cast<int>(r_nodes.size()); ++i) {
-                    auto it_node = (it_node_begin + i);
-                    it_node->SetValue(NODAL_INERTIA, zero_array);
-                    array_1d<double, 3>& r_middle_angular_velocity = it_node->FastGetSolutionStepValue(MIDDLE_ANGULAR_VELOCITY);
-                    r_middle_angular_velocity  = ZeroVector(3);
-                }
-            }
 
-            #pragma omp parallel for schedule(guided,512)
-            for (int i = 0; i < static_cast<int>(r_nodes.size()); ++i) {
-                auto it_node = (it_node_begin + i);
+            initializer_base = [&zero_array, DomainSize](Node<3>& rNode){
+                rNode.SetValue(NODAL_MASS, 0.0);
+                rNode.FastGetSolutionStepValue(MIDDLE_VELOCITY) = zero_array;
 
-                array_1d<double, 3>& r_middle_velocity = it_node->FastGetSolutionStepValue(MIDDLE_VELOCITY);
-                const array_1d<double, 3>& r_current_velocity = it_node->FastGetSolutionStepValue(VELOCITY);
-                array_1d<double, 3>& r_current_residual = it_node->FastGetSolutionStepValue(FORCE_RESIDUAL);
-                //array_1d<double,3>& r_current_displacement  = it_node->FastGetSolutionStepValue(DISPLACEMENT);
+                array_1d<double, 3>& r_middle_velocity = rNode.FastGetSolutionStepValue(MIDDLE_VELOCITY);
+                const array_1d<double, 3>& r_current_velocity = rNode.FastGetSolutionStepValue(VELOCITY);
+                array_1d<double, 3>& r_current_residual = rNode.FastGetSolutionStepValue(FORCE_RESIDUAL);
+                //array_1d<double,3>& r_current_displacement  = rNode.FastGetSolutionStepValue(DISPLACEMENT);
 
                 for (IndexType j = 0; j < DomainSize; j++) {
                     r_middle_velocity[j] = r_current_velocity[j];
                     r_current_residual[j] = 0.0;
                     //r_current_displacement[j] = 0.0; // this might be wrong for presribed displacement // NOTE: then you should check if the dof is fixed
                 }
+            };
 
-                if (has_dof_for_rot_z) {
-                    array_1d<double, 3>& r_middle_angular_velocity = it_node->FastGetSolutionStepValue(MIDDLE_ANGULAR_VELOCITY);
-                    const array_1d<double, 3>& r_current_angular_velocity = it_node->FastGetSolutionStepValue(ANGULAR_VELOCITY);
-                    array_1d<double, 3>& r_current_residual_moment = it_node->FastGetSolutionStepValue(MOMENT_RESIDUAL);
-                    //array_1d<double,3>& current_rotation = it_node->FastGetSolutionStepValue(ROTATION);
+            const bool has_dof_for_rot_z = it_node_begin->HasDofFor(ROTATION_Z);
+            if (has_dof_for_rot_z) {
+                initializer = [&zero_array, DomainSize, &initializer_base](Node<3>& rNode){
+                    initializer_base(rNode);
+                    rNode.SetValue(NODAL_INERTIA, zero_array);
+                    rNode.FastGetSolutionStepValue(MIDDLE_ANGULAR_VELOCITY) = zero_array;
+
+                    array_1d<double, 3>& r_middle_angular_velocity = rNode.FastGetSolutionStepValue(MIDDLE_ANGULAR_VELOCITY);
+                    const array_1d<double, 3>& r_current_angular_velocity = rNode.FastGetSolutionStepValue(ANGULAR_VELOCITY);
+                    array_1d<double, 3>& r_current_residual_moment = rNode.FastGetSolutionStepValue(MOMENT_RESIDUAL);
+                    //array_1d<double,3>& current_rotation = rNode.FastGetSolutionStepValue(ROTATION);
 
                     const IndexType initial_j = DomainSize == 3 ? 0 : 2; // We do this because in 2D only the rotation Z is needed, then we start with 2, instead of 0
                     for (IndexType j = initial_j; j < 3; j++) {
@@ -334,8 +326,14 @@ public:
                         r_current_residual_moment[j] = 0.0;
                         // current_rotation[j] = 0.0; // this might be wrong for presribed rotations // NOTE: then you should check if the dof is fixed
                     }
-                }
+                };
             }
+            else {
+                initializer = initializer_base;
+            }
+
+            /// Initialize all nodes
+            block_for_each(r_nodes, initializer);
         } // if not nodes.empty()
 
         KRATOS_CATCH("")
@@ -387,18 +385,24 @@ public:
             const IndexType disppos = it_node_begin->GetDofPosition(DISPLACEMENT_X);
             const IndexType rotppos = has_dof_for_rot_z ? it_node_begin->GetDofPosition(ROTATION_X) : 0;
 
-            #pragma omp parallel for schedule(guided,512)
-            for (int i = 0; i < static_cast<int>(r_nodes.size()); ++i) {
-                // Current step information "N+1" (before step update).
-                this->UpdateTranslationalDegreesOfFreedom(it_node_begin + i, disppos, dim);
-            } // for Node parallel
+            // Construct loop lambda
+            std::function<void(SizeType)> updater_base, updater;
+            updater_base = [it_node_begin, dim, &disppos, this](SizeType index){
+                this->UpdateTranslationalDegreesOfFreedom(it_node_begin + index, disppos, dim);
+            };
 
-            if (has_dof_for_rot_z){
-                #pragma omp parallel for schedule(guided,512)
-                for (int i = 0; i < static_cast<int>(r_nodes.size()); ++i) {
-                    this->UpdateRotationalDegreesOfFreedom(it_node_begin + i, rotppos, dim);
-                } // for Node parallel
+            if (has_dof_for_rot_z) {
+                updater = [it_node_begin, dim, &rotppos, this, &updater_base](SizeType index){
+                    updater_base(index);
+                    this->UpdateRotationalDegreesOfFreedom(it_node_begin + index, rotppos, dim);
+                };
             }
+            else {
+                updater = updater_base;
+            }
+
+            // Update nodes
+            IndexPartition<SizeType>(r_nodes.size()).for_each(updater);
         } // if not nodes.empty()
 
         KRATOS_CATCH("")
@@ -521,96 +525,105 @@ public:
         // The array containing the nodes
         NodesArrayType& r_nodes = rModelPart.Nodes();
 
-        // The fisrt node interator
-        const auto it_node_begin = rModelPart.NodesBegin();
+        if (!r_nodes.empty()) {
+            // The fisrt node interator
+            const auto it_node_begin = rModelPart.NodesBegin();
 
-        // If we consider the rotation DoF
-        const bool has_dof_for_rot_z = it_node_begin->HasDofFor(ROTATION_Z);
+            // If we consider the rotation DoF
+            const bool has_dof_for_rot_z = it_node_begin->HasDofFor(ROTATION_Z);
 
-        // Auxiliar zero array
-        const array_1d<double, 3> zero_array = ZeroVector(3);
+            // Auxiliar zero array
+            const array_1d<double, 3> zero_array = ZeroVector(3);
 
-        // Getting dof position
-        const IndexType disppos = it_node_begin->GetDofPosition(DISPLACEMENT_X);
-        const IndexType rotppos = has_dof_for_rot_z ? it_node_begin->GetDofPosition(ROTATION_X) : 0;
+            // Getting dof position
+            const IndexType disppos = it_node_begin->GetDofPosition(DISPLACEMENT_X);
+            const IndexType rotppos = has_dof_for_rot_z ? it_node_begin->GetDofPosition(ROTATION_X) : 0;
 
-        #pragma omp parallel for schedule(guided,512)
-        for (int i = 0; i < static_cast<int>(r_nodes.size()); ++i) {
-            // Current step information "N+1" (before step update).
-            auto it_node = it_node_begin + i;
+            // Construct initializer lambda
+            std::function<void(Node<3>&)> initializer_base, initializer;
 
-            const double nodal_mass = it_node->GetValue(NODAL_MASS);
-            const array_1d<double, 3>& r_current_residual = it_node->FastGetSolutionStepValue(FORCE_RESIDUAL);
+            initializer_base = [&zero_array, &disppos, DomainSize, this](Node<3>& rNode) {
+                const double nodal_mass = rNode.GetValue(NODAL_MASS);
+                const array_1d<double, 3>& r_current_residual = rNode.FastGetSolutionStepValue(FORCE_RESIDUAL);
 
-            array_1d<double, 3>& r_current_velocity = it_node->FastGetSolutionStepValue(VELOCITY);
-//             array_1d<double,3>& r_current_displacement = it_node->FastGetSolutionStepValue(DISPLACEMENT);
-            array_1d<double, 3>& r_middle_velocity = it_node->FastGetSolutionStepValue(MIDDLE_VELOCITY);
+                array_1d<double, 3>& r_current_velocity = rNode.FastGetSolutionStepValue(VELOCITY);
+                //array_1d<double,3>& r_current_displacement = rNode.FastGetSolutionStepValue(DISPLACEMENT);
+                array_1d<double, 3>& r_middle_velocity = rNode.FastGetSolutionStepValue(MIDDLE_VELOCITY);
 
-            array_1d<double, 3>& r_current_acceleration = it_node->FastGetSolutionStepValue(ACCELERATION);
+                array_1d<double, 3>& r_current_acceleration = rNode.FastGetSolutionStepValue(ACCELERATION);
 
-            // Solution of the explicit equation:
-            if (nodal_mass > numerical_limit) {
-                r_current_acceleration = r_current_residual / nodal_mass;
-            } else {
-                r_current_acceleration = zero_array;
+                // Solution of the explicit equation:
+                if (nodal_mass > numerical_limit) {
+                    r_current_acceleration = r_current_residual / nodal_mass;
+                } else {
+                    r_current_acceleration = zero_array;
+                }
+
+                std::array<bool, 3> fix_displacements = {false, false, false};
+
+                fix_displacements[0] = (rNode.GetDof(DISPLACEMENT_X, disppos).IsFixed());
+                fix_displacements[1] = (rNode.GetDof(DISPLACEMENT_Y, disppos + 1).IsFixed());
+                if (DomainSize == 3)
+                    fix_displacements[2] = (rNode.GetDof(DISPLACEMENT_Z, disppos + 2).IsFixed());
+
+                for (IndexType j = 0; j < DomainSize; j++) {
+                    if (fix_displacements[j]) {
+                        r_current_acceleration[j] = 0.0;
+                        r_middle_velocity[j] = 0.0;
+                    }
+
+                    r_middle_velocity[j] = 0.0 + (mTime.Middle - mTime.Previous) * r_current_acceleration[j];
+                    r_current_velocity[j] = r_middle_velocity[j] + (mTime.Previous - mTime.PreviousMiddle) * r_current_acceleration[j]; //+ actual_velocity;
+                    // r_current_displacement[j]  = 0.0;
+
+                } // for DomainSize
+            };
+
+            if (has_dof_for_rot_z) {
+                initializer = [&zero_array, &rotppos, &initializer_base, DomainSize, this](Node<3>& rNode) {
+                    initializer_base(rNode);
+                    const array_1d<double, 3>& nodal_inertia = rNode.GetValue(NODAL_INERTIA);
+                    const array_1d<double, 3>& r_current_residual_moment = rNode.FastGetSolutionStepValue(MOMENT_RESIDUAL);
+                    array_1d<double, 3>& r_current_angular_velocity = rNode.FastGetSolutionStepValue(ANGULAR_VELOCITY);
+                    // array_1d<double,3>& current_rotation = rNode.FastGetSolutionStepValue(ROTATION);
+                    array_1d<double, 3>& r_middle_angular_velocity = rNode.FastGetSolutionStepValue(MIDDLE_ANGULAR_VELOCITY);
+                    array_1d<double, 3>& r_current_angular_acceleration = rNode.FastGetSolutionStepValue(ANGULAR_ACCELERATION);
+
+                    const IndexType initial_k = DomainSize == 3 ? 0 : 2; // We do this because in 2D only the rotation Z is needed, then we start with 2, instead of 0
+                    for (IndexType kk = initial_k; kk < 3; ++kk) {
+                        if (nodal_inertia[kk] > numerical_limit) {
+                            r_current_angular_acceleration[kk] = r_current_residual_moment[kk] / nodal_inertia[kk];
+                        } else {
+                            r_current_angular_acceleration[kk] = 0.0;
+                        }
+                    }
+
+                    std::array<bool, 3> fix_rotation = {false, false, false};
+                    if (DomainSize == 3) {
+                        fix_rotation[0] = (rNode.GetDof(ROTATION_X, rotppos).IsFixed());
+                        fix_rotation[1] = (rNode.GetDof(ROTATION_Y, rotppos + 1).IsFixed());
+                    }
+                    fix_rotation[2] = (rNode.GetDof(ROTATION_Z, rotppos + 2).IsFixed());
+
+                    for (IndexType j = initial_k; j < 3; j++) {
+                        if (fix_rotation[j]) {
+                            r_current_angular_acceleration[j] = 0.0;
+                            r_middle_angular_velocity[j] = 0.0;
+                        }
+
+                        r_middle_angular_velocity[j] = 0.0 +  (mTime.Middle - mTime.Previous) * r_current_angular_acceleration[j];
+                        r_current_angular_velocity[j] = r_middle_angular_velocity[j] +  (mTime.Previous - mTime.PreviousMiddle) *  r_current_angular_acceleration[j];
+                        //current_rotation[j] = 0.0;
+                    }
+                };
+            }
+            else {
+                initializer = initializer_base;
             }
 
-            std::array<bool, 3> fix_displacements = {false, false, false};
-
-            fix_displacements[0] = (it_node->GetDof(DISPLACEMENT_X, disppos).IsFixed());
-            fix_displacements[1] = (it_node->GetDof(DISPLACEMENT_Y, disppos + 1).IsFixed());
-            if (DomainSize == 3)
-                fix_displacements[2] = (it_node->GetDof(DISPLACEMENT_Z, disppos + 2).IsFixed());
-
-            for (IndexType j = 0; j < DomainSize; j++) {
-                if (fix_displacements[j]) {
-                    r_current_acceleration[j] = 0.0;
-                    r_middle_velocity[j] = 0.0;
-                }
-
-                r_middle_velocity[j] = 0.0 + (mTime.Middle - mTime.Previous) * r_current_acceleration[j];
-                r_current_velocity[j] = r_middle_velocity[j] + (mTime.Previous - mTime.PreviousMiddle) * r_current_acceleration[j]; //+ actual_velocity;
-                // r_current_displacement[j]  = 0.0;
-
-            } // for DomainSize
-
-            ////// ROTATION DEGRESS OF FREEDOM
-            if (has_dof_for_rot_z) {
-                const array_1d<double, 3>& nodal_inertia = it_node->GetValue(NODAL_INERTIA);
-                const array_1d<double, 3>& r_current_residual_moment = it_node->FastGetSolutionStepValue(MOMENT_RESIDUAL);
-                array_1d<double, 3>& r_current_angular_velocity = it_node->FastGetSolutionStepValue(ANGULAR_VELOCITY);
-                // array_1d<double,3>& current_rotation = it_node->FastGetSolutionStepValue(ROTATION);
-                array_1d<double, 3>& r_middle_angular_velocity = it_node->FastGetSolutionStepValue(MIDDLE_ANGULAR_VELOCITY);
-                array_1d<double, 3>& r_current_angular_acceleration = it_node->FastGetSolutionStepValue(ANGULAR_ACCELERATION);
-
-                const IndexType initial_k = DomainSize == 3 ? 0 : 2; // We do this because in 2D only the rotation Z is needed, then we start with 2, instead of 0
-                for (IndexType kk = initial_k; kk < 3; ++kk) {
-                    if (nodal_inertia[kk] > numerical_limit) {
-                        r_current_angular_acceleration[kk] = r_current_residual_moment[kk] / nodal_inertia[kk];
-                    } else {
-                        r_current_angular_acceleration[kk] = 0.0;
-                    }
-                }
-
-                std::array<bool, 3> fix_rotation = {false, false, false};
-                if (DomainSize == 3) {
-                    fix_rotation[0] = (it_node->GetDof(ROTATION_X, rotppos).IsFixed());
-                    fix_rotation[1] = (it_node->GetDof(ROTATION_Y, rotppos + 1).IsFixed());
-                }
-                fix_rotation[2] = (it_node->GetDof(ROTATION_Z, rotppos + 2).IsFixed());
-
-                for (IndexType j = initial_k; j < 3; j++) {
-                    if (fix_rotation[j]) {
-                        r_current_angular_acceleration[j] = 0.0;
-                        r_middle_angular_velocity[j] = 0.0;
-                    }
-
-                    r_middle_angular_velocity[j] = 0.0 +  (mTime.Middle - mTime.Previous) * r_current_angular_acceleration[j];
-                    r_current_angular_velocity[j] = r_middle_angular_velocity[j] +  (mTime.Previous - mTime.PreviousMiddle) *  r_current_angular_acceleration[j];
-//                     current_rotation[j] = 0.0;
-                } // trans DoF
-            }   // Rot DoF
-        }     // for node parallel
+            // Initialize all nodes
+            block_for_each(r_nodes, initializer);
+        } // if not nodes.empty()
 
         mTime.Previous = mTime.Current;
         mTime.PreviousMiddle = mTime.Middle;
@@ -667,20 +680,24 @@ public:
         ConditionsArrayType& r_conditions = rModelPart.Conditions();
         ElementsArrayType& r_elements = rModelPart.Elements();
 
-        LocalSystemVectorType RHS_Contribution = LocalSystemVectorType(0);
-        Element::EquationIdVectorType equation_id_vector_dummy; // Dummy
+        using TLS = std::tuple<LocalSystemVectorType,Element::EquationIdVectorType>;
+        TLS thread_local_storage; // {RHS_contribution, equation_id_vector_dummy}
 
-        #pragma omp parallel for firstprivate(RHS_Contribution, equation_id_vector_dummy), schedule(guided,512)
-        for (int i = 0; i < static_cast<int>(r_conditions.size()); ++i) {
-            auto it_cond = r_conditions.begin() + i;
-            CalculateRHSContribution(*it_cond, RHS_Contribution, equation_id_vector_dummy, r_current_process_info);
-        }
+        // Compute on conditions
+        block_for_each(r_conditions, thread_local_storage, [&r_current_process_info, this](Condition& r_condition, TLS& r_rhs_contrib_and_equation_ids){
+            CalculateRHSContribution(r_condition,
+                                     std::get<0>(r_rhs_contrib_and_equation_ids),
+                                     std::get<1>(r_rhs_contrib_and_equation_ids),
+                                     r_current_process_info);
+        });
 
-        #pragma omp parallel for firstprivate(RHS_Contribution, equation_id_vector_dummy), schedule(guided,512)
-        for (int i = 0; i < static_cast<int>(r_elements.size()); ++i) {
-            auto it_elem = r_elements.begin() + i;
-            CalculateRHSContribution(*it_elem, RHS_Contribution, equation_id_vector_dummy, r_current_process_info);
-        }
+        // Compute on elements
+        block_for_each(r_elements, thread_local_storage, [&r_current_process_info, this](Element& r_element, TLS& r_rhs_contrib_and_equation_ids){
+            CalculateRHSContribution(r_element,
+                                     std::get<0>(r_rhs_contrib_and_equation_ids),
+                                     std::get<1>(r_rhs_contrib_and_equation_ids),
+                                     r_current_process_info);
+        });
 
         KRATOS_CATCH("")
     }

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/mechanical_explicit_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/mechanical_explicit_strategy.hpp
@@ -12,6 +12,8 @@
 //
 //
 
+#include "includes/ublas_interface.h"
+#include "includes/variables.h"
 #if !defined(KRATOS_MECHANICAL_EXPLICIT_STRATEGY)
 #define KRATOS_MECHANICAL_EXPLICIT_STRATEGY
 
@@ -22,6 +24,7 @@
 #include "structural_mechanics_application_variables.h"
 #include "utilities/variable_utils.h"
 #include "utilities/constraint_utilities.h"
+#include "utilities/parallel_utilities.h"
 
 namespace Kratos {
 ///@name Kratos Globals
@@ -229,7 +232,6 @@ public:
 
             // Iterate over the elements
             ElementsArrayType& r_elements = r_model_part.Elements();
-            const auto it_elem_begin = r_elements.begin();
             ProcessInfo& r_current_process_info = r_model_part.GetProcessInfo();
 
             Vector dummy_vector;
@@ -240,23 +242,19 @@ public:
                 VariableUtils().SetNonHistoricalVariable(NODAL_INERTIA, zero_array, r_nodes);
                 VariableUtils().SetNonHistoricalVariable(NODAL_ROTATION_DAMPING, zero_array, r_nodes);
 
-                #pragma omp parallel for firstprivate(dummy_vector), schedule(guided,512)
-                for (int i = 0; i < static_cast<int>(r_elements.size()); ++i) {
+                block_for_each(r_elements, dummy_vector, [&r_current_process_info](Element& r_element, Vector& r_dummy_vector){
                     // Getting nodal mass and inertia from element
                     // this function needs to be implemented in the respective
                     // element to provide inertias and nodal masses
-                    auto it_elem = it_elem_begin + i;
-                    it_elem->AddExplicitContribution(dummy_vector, RESIDUAL_VECTOR, NODAL_INERTIA, r_current_process_info);
-                }
+                    r_element.AddExplicitContribution(r_dummy_vector, RESIDUAL_VECTOR, NODAL_INERTIA, r_current_process_info);
+                });
             } else { // Only NODAL_MASS is needed
-                #pragma omp parallel for firstprivate(dummy_vector), schedule(guided,512)
-                for (int i = 0; i < static_cast<int>(r_elements.size()); ++i) {
+                block_for_each(r_elements, dummy_vector, [&r_current_process_info](Element& r_element, Vector& r_dummy_vector){
                     // Getting nodal mass and inertia from element
                     // this function needs to be implemented in the respective
-                    // element to provide nodal masses
-                    auto it_elem = it_elem_begin + i;
-                    it_elem->AddExplicitContribution(dummy_vector, RESIDUAL_VECTOR, NODAL_MASS, r_current_process_info);
-                }
+                    // element to provide inertias and nodal masses
+                    r_element.AddExplicitContribution(r_dummy_vector, RESIDUAL_VECTOR, NODAL_MASS, r_current_process_info);
+                });
             }
 
             // Precompute for masses and inertias
@@ -290,7 +288,6 @@ public:
         if (BaseType::mRebuildLevel > 0) { // TODO: Right now is computed in the Initialize() because is always zero, the option to set the RebuildLevel should be added in the constructor or in some place
             ProcessInfo& r_current_process_info = r_model_part.GetProcessInfo();
             ElementsArrayType& r_elements = r_model_part.Elements();
-            const auto it_elem_begin = r_elements.begin();
 
             // Set Nodal Mass and Damping to zero
             NodesArrayType& r_nodes = r_model_part.Nodes();
@@ -305,23 +302,19 @@ public:
                 VariableUtils().SetNonHistoricalVariable(NODAL_INERTIA, zero_array, r_nodes);
                 VariableUtils().SetNonHistoricalVariable(NODAL_ROTATION_DAMPING, zero_array, r_nodes);
 
-                #pragma omp parallel for firstprivate(dummy_vector), schedule(guided,512)
-                for (int i = 0; i < static_cast<int>(r_elements.size()); ++i) {
+                block_for_each(r_elements, dummy_vector, [&r_current_process_info](Element& r_element, Vector& r_dummy_vector){
                     // Getting nodal mass and inertia from element
                     // this function needs to be implemented in the respective
                     // element to provide inertias and nodal masses
-                    auto it_elem = it_elem_begin + i;
-                    it_elem->AddExplicitContribution(dummy_vector, RESIDUAL_VECTOR, NODAL_INERTIA, r_current_process_info);
-                }
+                    r_element.AddExplicitContribution(r_dummy_vector, RESIDUAL_VECTOR, NODAL_INERTIA, r_current_process_info);
+                });
             } else { // Only NODAL_MASS and NODAL_DISPLACEMENT_DAMPING are needed
-                #pragma omp parallel for firstprivate(dummy_vector), schedule(guided,512)
-                for (int i = 0; i < static_cast<int>(r_elements.size()); ++i) {
+                block_for_each(r_elements, dummy_vector, [&r_current_process_info](Element& r_element, Vector& r_dummy_vector){
                     // Getting nodal mass and inertia from element
                     // this function needs to be implemented in the respective
-                    // element to provide nodal masses
-                    auto it_elem = it_elem_begin + i;
-                    it_elem->AddExplicitContribution(dummy_vector, RESIDUAL_VECTOR, NODAL_MASS, r_current_process_info);
-                }
+                    // element to provide inertias and nodal masses
+                    r_element.AddExplicitContribution(r_dummy_vector, RESIDUAL_VECTOR, NODAL_MASS, r_current_process_info);
+                });
             }
 
             // Precompute for masses and inertias
@@ -514,54 +507,57 @@ private:
             const bool has_dof_for_rot_z = (r_nodes.begin())->HasDofFor(ROTATION_Z);
 
             // Auxiliar values
-            const array_1d<double, 3> zero_array = ZeroVector(3);
-            array_1d<double, 3> force_residual = ZeroVector(3);
-            array_1d<double, 3> moment_residual = ZeroVector(3);
+            const array_1d<double,3> zero_array = ZeroVector(3);
 
             // Getting
             const auto it_node_begin = r_nodes.begin();
             const IndexType disppos = it_node_begin->GetDofPosition(DISPLACEMENT_X);
             const IndexType rotppos = it_node_begin->GetDofPosition(ROTATION_X);
 
-            // Iterating nodes
-            #pragma omp parallel for firstprivate(force_residual, moment_residual), schedule(guided,512)
-            for(int i=0; i<static_cast<int>(r_nodes.size()); ++i) {
-                auto it_node = it_node_begin + i;
+            // Construct loop lambda depending on whether nodes have rot_z
+            std::function<void(Node<3>&)> loop_base, loop;
 
-                noalias(force_residual) = it_node->FastGetSolutionStepValue(FORCE_RESIDUAL);
-                if (has_dof_for_rot_z) {
-                    noalias(moment_residual) = it_node->FastGetSolutionStepValue(MOMENT_RESIDUAL);
-                } else {
-                    noalias(moment_residual) = zero_array;
-                }
+            loop_base = [&disppos](Node<3>& rNode){
+                const auto force_residual = rNode.FastGetSolutionStepValue(FORCE_RESIDUAL);
 
-                if (it_node->GetDof(DISPLACEMENT_X, disppos).IsFixed()) {
-                    double& r_reaction = it_node->FastGetSolutionStepValue(REACTION_X);
+                if (rNode.GetDof(DISPLACEMENT_X, disppos).IsFixed()) {
+                    double& r_reaction = rNode.FastGetSolutionStepValue(REACTION_X);
                     r_reaction = force_residual[0];
                 }
-                if (it_node->GetDof(DISPLACEMENT_Y, disppos + 1).IsFixed()) {
-                    double& r_reaction = it_node->FastGetSolutionStepValue(REACTION_Y);
+                if (rNode.GetDof(DISPLACEMENT_Y, disppos + 1).IsFixed()) {
+                    double& r_reaction = rNode.FastGetSolutionStepValue(REACTION_Y);
                     r_reaction = force_residual[1];
                 }
-                if (it_node->GetDof(DISPLACEMENT_Z, disppos + 2).IsFixed()) {
-                    double& r_reaction = it_node->FastGetSolutionStepValue(REACTION_Z);
+                if (rNode.GetDof(DISPLACEMENT_Z, disppos + 2).IsFixed()) {
+                    double& r_reaction = rNode.FastGetSolutionStepValue(REACTION_Z);
                     r_reaction = force_residual[2];
                 }
-                if (has_dof_for_rot_z) {
-                    if (it_node->GetDof(ROTATION_X, rotppos).IsFixed()) {
-                        double& r_reaction = it_node->FastGetSolutionStepValue(REACTION_MOMENT_X);
+            };
+
+            if (has_dof_for_rot_z) {
+                loop = [&rotppos, &loop_base](Node<3>& rNode){
+                    loop_base(rNode);
+                    const auto moment_residual = rNode.FastGetSolutionStepValue(MOMENT_RESIDUAL);
+                    if (rNode.GetDof(ROTATION_X, rotppos).IsFixed()) {
+                        double& r_reaction = rNode.FastGetSolutionStepValue(REACTION_MOMENT_X);
                         r_reaction = moment_residual[0];
                     }
-                    if (it_node->GetDof(ROTATION_Y, rotppos + 1).IsFixed()) {
-                        double& r_reaction = it_node->FastGetSolutionStepValue(REACTION_MOMENT_Y);
+                    if (rNode.GetDof(ROTATION_Y, rotppos + 1).IsFixed()) {
+                        double& r_reaction = rNode.FastGetSolutionStepValue(REACTION_MOMENT_Y);
                         r_reaction = moment_residual[1];
                     }
-                    if (it_node->GetDof(ROTATION_Z, rotppos + 2).IsFixed()) {
-                        double& r_reaction = it_node->FastGetSolutionStepValue(REACTION_MOMENT_Z);
+                    if (rNode.GetDof(ROTATION_Z, rotppos + 2).IsFixed()) {
+                        double& r_reaction = rNode.FastGetSolutionStepValue(REACTION_MOMENT_Z);
                         r_reaction = moment_residual[2];
                     }
-                }
+                };
             }
+            else {
+                loop = loop_base;
+            }
+
+            // Compute on nodes
+            block_for_each(r_nodes, loop);
         } // if not nodes.empty()
     }
 

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/mechanical_explicit_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/mechanical_explicit_strategy.hpp
@@ -12,12 +12,12 @@
 //
 //
 
-#include "includes/ublas_interface.h"
-#include "includes/variables.h"
 #if !defined(KRATOS_MECHANICAL_EXPLICIT_STRATEGY)
 #define KRATOS_MECHANICAL_EXPLICIT_STRATEGY
 
 /* System includes */
+
+/* External includes */
 
 /* Project includes */
 #include "solving_strategies/strategies/implicit_solving_strategy.h"
@@ -25,6 +25,8 @@
 #include "utilities/variable_utils.h"
 #include "utilities/constraint_utilities.h"
 #include "utilities/parallel_utilities.h"
+#include "includes/ublas_interface.h"
+#include "includes/variables.h"
 
 namespace Kratos {
 ///@name Kratos Globals
@@ -551,8 +553,7 @@ private:
                         r_reaction = moment_residual[2];
                     }
                 };
-            }
-            else {
+            } else {
                 loop = loop_base;
             }
 


### PR DESCRIPTION
**📝 Description**
Convert parallel ```omp``` loops to parallel utilities at the request of @loumalouomega from #9825. Some loops used ```firstprivate``` (now thread local storage) which seemed unnecessary, but I didn't change all of them.