### PR TITLE
[Core] Improving CSR interface and low overhead conversion to PETSc

### DIFF
--- a/kratos/mpi/python/add_distributed_sparse_matrices_to_python.cpp
+++ b/kratos/mpi/python/add_distributed_sparse_matrices_to_python.cpp
@@ -23,6 +23,8 @@
 #include "containers/distributed_csr_matrix.h"
 #include "add_distributed_sparse_matrices_to_python.h"
 #include "mpi/utilities/amgcl_distributed_csr_spmm_utilities.h"
+#include <pybind11/numpy.h>
+
 namespace Kratos {
 namespace Python {
 
@@ -120,11 +122,11 @@ void AddDistributedSparseMatricesToPython(pybind11::module& m)
         .def("Mult", [](DistributedSystemVector<double,IndexType>& self, const double value){ self*=value; } )
         .def("Div", [](DistributedSystemVector<double,IndexType>& self, const double value){ self/=value; } )
         //out of place
-        .def("__mul__", [](const DistributedSystemVector<double,IndexType>& self, const double factor){
+        .def("__mul__", [](const DistributedSystemVector<double,IndexType>& self, const double factor) -> DistributedSystemVector<double,IndexType>::Pointer{
             auto paux = std::make_shared<DistributedSystemVector<double,IndexType>>(self);
             (*paux) *= factor;
             return paux;}, py::is_operator())
-        .def("__rmul__", [](const DistributedSystemVector<double,IndexType>& self, const double factor){
+        .def("__rmul__", [](const DistributedSystemVector<double,IndexType>& self, const double factor) -> DistributedSystemVector<double,IndexType>::Pointer{
             auto paux = std::make_shared<DistributedSystemVector<double,IndexType>>(self);
             (*paux) *= factor;
             return paux;}, py::is_operator())
@@ -175,8 +177,18 @@ void AddDistributedSparseMatricesToPython(pybind11::module& m)
             const IndexType i,
             const IndexType j){
             return self.GetLocalDataByGlobalId(i,j);} )
-        .def("GetDiagonalIndex2DataInGlobalNumbering", &DistributedCsrMatrix<double,IndexType>::GetDiagonalIndex2DataInGlobalNumbering)
-        .def("GetOffDiagonalIndex2DataInGlobalNumbering", &DistributedCsrMatrix<double,IndexType>::GetOffDiagonalIndex2DataInGlobalNumbering)
+        .def("GetDiagonalIndex2DataInGlobalNumbering", [](DistributedCsrMatrix<double,IndexType>& self) {
+            return py::array_t<IndexType>(
+                self.GetDiagonalIndex2DataInGlobalNumbering().size(),
+                self.GetDiagonalIndex2DataInGlobalNumbering().data().begin()
+            );
+        } )
+        .def("GetOffDiagonalIndex2DataInGlobalNumbering", [](DistributedCsrMatrix<double,IndexType>& self) {
+            return py::array_t<IndexType>(
+                self.GetOffDiagonalIndex2DataInGlobalNumbering().size(),
+                self.GetOffDiagonalIndex2DataInGlobalNumbering().data().begin()
+            );
+        } )
         .def("SpMV", [](DistributedCsrMatrix<double,IndexType>& rA,
                         DistributedSystemVector<double,IndexType>& x,
                         DistributedSystemVector<double,IndexType>& y){

--- a/kratos/mpi/python/add_distributed_sparse_matrices_to_python.cpp
+++ b/kratos/mpi/python/add_distributed_sparse_matrices_to_python.cpp
@@ -13,6 +13,7 @@
 // System includes
 
 // External includes
+#include <pybind11/numpy.h>
 
 // Project includes
 #include "containers/distributed_system_vector.h"
@@ -23,7 +24,6 @@
 #include "containers/distributed_csr_matrix.h"
 #include "add_distributed_sparse_matrices_to_python.h"
 #include "mpi/utilities/amgcl_distributed_csr_spmm_utilities.h"
-#include <pybind11/numpy.h>
 
 namespace Kratos {
 namespace Python {

--- a/kratos/python/add_sparse_matrices_to_python.cpp
+++ b/kratos/python/add_sparse_matrices_to_python.cpp
@@ -24,6 +24,7 @@
 #include "containers/csr_matrix.h"
 #include "containers/system_vector.h"
 #include "utilities/amgcl_csr_spmm_utilities.h"
+#include <pybind11/numpy.h>
 
 namespace Kratos
 {
@@ -93,20 +94,26 @@ void AddSparseMatricesToPython(pybind11::module& m)
     .def("size1", &CsrMatrix<double,IndexType>::size1)
     .def("size2", &CsrMatrix<double,IndexType>::size2)
     .def("nnz", &CsrMatrix<double,IndexType>::nnz)
-    .def("index1_data", [](CsrMatrix<double,IndexType>& rA){
-        const auto& data = rA.index1_data();
-        std::vector<IndexType> v(data.begin(), data.end());
-        return v;
+    .def("index1_data", [](CsrMatrix<double,IndexType>& self){
+            return py::array_t<IndexType>(
+                self.index1_data().size(),
+                self.index1_data().begin(),
+                py::cast(self) //this is fundamental to avoid copying
+            );
     }, py::return_value_policy::reference_internal)
-    .def("index2_data", [](CsrMatrix<double,IndexType>& rA){
-        const auto& data = rA.index2_data();
-        std::vector<IndexType> v(data.begin(), data.end());
-        return v;
+    .def("index2_data", [](CsrMatrix<double,IndexType>& self){
+            return py::array_t<IndexType>(
+                self.index2_data().size(),
+                self.index2_data().begin(),
+                py::cast(self) //this is fundamental to avoid copying
+            );
     }, py::return_value_policy::reference_internal)
-    .def("value_data", [](CsrMatrix<double,IndexType>& rA){
-        const auto& data = rA.value_data();
-        std::vector<double> v(data.begin(), data.end());
-        return v;
+    .def("value_data", [](CsrMatrix<double,IndexType>& self){
+            return py::array_t<double>(
+                self.value_data().size(),
+                self.value_data().begin(),
+                py::cast(self) //this is fundamental to avoid copying
+            );
     }, py::return_value_policy::reference_internal)
     .def("__setitem__", [](CsrMatrix<double,IndexType>& self, const std::pair<int,int> index, const  double value)
         {

--- a/kratos/python/add_sparse_matrices_to_python.cpp
+++ b/kratos/python/add_sparse_matrices_to_python.cpp
@@ -14,6 +14,7 @@
 // System includes
 
 // External includes
+#include <pybind11/numpy.h>
 
 // Project includes
 #include "includes/define_python.h"
@@ -24,7 +25,6 @@
 #include "containers/csr_matrix.h"
 #include "containers/system_vector.h"
 #include "utilities/amgcl_csr_spmm_utilities.h"
-#include <pybind11/numpy.h>
 
 namespace Kratos
 {

--- a/kratos/python_scripts/petsc_conversion_tools.py
+++ b/kratos/python_scripts/petsc_conversion_tools.py
@@ -1,0 +1,53 @@
+# Import Kratos
+import KratosMultiphysics
+import numpy as np
+
+import petsc4py
+from petsc4py import PETSc
+
+#gives a view of Kratos DistributedCSRMatrix as a petsc matrix.
+#values are NOT copied. 
+#Indices are copied ONLY if kratos IndexType and the one used within Petsc (by defauly int32) do not coincide
+
+class PetscCSRWrapper:
+    def __init__(self, A):  #Kratos DistributedCsrMatrix
+        self.A = A 
+        m = A.local_size1()
+        M = A.GetRowNumbering().Size()
+        n = A.GetColNumbering().LocalSize()
+        N = A.GetColNumbering().Size()
+
+        ##pointers to the kratos arrays of values
+        self.a = np.array(A.GetDiagonalBlock().value_data(), copy=False)
+        self.oa = np.array(A.GetOffDiagonalBlock().value_data(), copy=False)
+
+        if(type(m) == type(PETSc.IntType)): #we can avoid doing copies
+            #indices of diagonal block
+            self.i = np.array(A.GetDiagonalBlock().index1_data(), copy=False)
+            self.j = np.array(A.GetDiagonalBlock().index2_data(), copy=False)
+            
+            #indices of offdiagonal block
+            self.oi = np.array(A.GetOffDiagonalBlock().index1_data(), copy=False)
+            self.oj = np.array(A.GetOffDiagonalIndex2DataInGlobalNumbering(), copy=False)        
+
+        else: #WE NEED TO COPY INDICES! since the size of the IndexType is not compatible between Kratos and PETSc
+            if(A.GetComm().Rank() == 0):
+                print("WARNING: a copy has been needed in the conversion to petsc since the IndexType did not match between Kratos and PETSc")
+            #indices of diagonal block
+            self.i = np.array(A.GetDiagonalBlock().index1_data(), dtype="int32")
+            self.j = np.array(A.GetDiagonalBlock().index2_data(), dtype="int32")
+            
+            #indices of offdiagonal block
+            self.oi = np.array(A.GetOffDiagonalBlock().index1_data(), dtype="int32")
+            self.oj = np.array(A.GetOffDiagonalIndex2DataInGlobalNumbering(), dtype="int32")
+        
+        size = ((m, M), (n, N)) # local,global row,column sizes of the matrix
+        csr = ((self.i, self.j, self.a), (self.oi, self.oj, self.oa)) # numpy arrays with the diagonal and off-diagonal arrays containing the CSR (or AIJ) structure
+        self.Apetsc = PETSc.Mat().createAIJWithArrays(size, csr)
+
+    def __del__(self):
+        del self.Apetsc #we need to ensure that this is deleted before the rest
+
+    def GetPETScMatrix(self):
+        return self.Apetsc
+


### PR DESCRIPTION
**📝 Description**
Provide copy free access to indices and values_vector and a low overhead interface to PETSC matrix.

Interface is in python only so no compile dependency is added. Dependency at runtime is needed only if one explicitly imports the feature

**🆕 Changelog**
- Provide copy free access to indices and values_vector and a low overhead interface to PETSC matrix.
