### PR TITLE
[Core] [TimerProcess] Enable print on screen

### DIFF
--- a/kratos/python_scripts/timer_process.py
+++ b/kratos/python_scripts/timer_process.py
@@ -67,6 +67,6 @@ class TimerProcess(KratosMultiphysics.Process):
         self -- It signifies an instance of a class.
         """
         self.timer.Stop(self.interval_name)
+        self.timer.PrintTimingInformation(self.timer)
         if self.output_filename != "":
-            self.timer.PrintTimingInformation(self.timer)
             self.timer.CloseOuputFile()

--- a/kratos/python_scripts/timer_process.py
+++ b/kratos/python_scripts/timer_process.py
@@ -4,6 +4,8 @@ import KratosMultiphysics
 def Factory(settings, Model):
     if not isinstance(settings, KratosMultiphysics.Parameters):
         raise Exception("expected input shall be a Parameters object, encapsulating a json string")
+    if not settings.Has("Parameters"):
+        settings.AddValue("Parameters", KratosMultiphysics.Parameters())
     return TimerProcess(Model, settings["Parameters"])
 
 # All the processes python processes should be derived from "Process"


### PR DESCRIPTION
**📝 Description**
I've discovered this interesting process. With just this PR and adding the following settings to a process list:
```json
{
            "python_module" : "timer_process",
            "kratos_module" : "KratosMultiphysics"
}
```
this nice print will appear on screen at the end of the analysis:
```
                                     Repeat #		Total       	Max         	Min         	Average       	Time%
000./Reading Input......................    1		3.6499E-02     	3.6499E-02     	3.6499E-02     	3.6499E-02     	0.181%
001./Analysis...........................    1		1.9942E+01     	1.9942E+01     	1.9942E+01     	1.9942E+01     	98.845%
002./Analysis/MatrixStructure...........    1		5.7260E-03     	5.7260E-03     	5.7260E-03     	5.7260E-03     	0.028%
003./Analysis/Build.....................  904		7.7278E+00     	3.0100E-02     	8.3156E-03     	8.5485E-03     	38.304%
004./Analysis/Solve.....................  904		9.2614E+00     	1.4507E-02     	1.0147E-02     	1.0245E-02     	45.906%
```


**🆕 Changelog**
- Enable print on screen
- Add default parameters
