### PR TITLE
Updating standard C++ to 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 project (KratosMultiphysics)
 cmake_minimum_required (VERSION 2.8.6)
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 14)
 
 # Setting some policies
 # No recursive dereferencing


### PR DESCRIPTION
**📝 Description**
Seems that some of the dependencies that we use (boost) are deprecating C++11. Without this change boost::geometry will start to fail at compile time in newer editions. (since 1.75 [source](https://github.com/boostorg/geometry))

This is important because (for example, not to blame) the cosim app requires a fairly new version of boost (1.71 onward) so this leaves a very narrow marge of versions that are compatible out of the box.

@KratosMultiphysics/altair ping because centos.

**🆕 Changelog**
 - Setting C++14 as default
