### PR TITLE
[ShapeOpt] Enable use of custom python scripts in evaluation folders

### DIFF
--- a/applications/ShapeOptimizationApplication/python_scripts/analyzers/analyzer_internal.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/analyzers/analyzer_internal.py
@@ -9,9 +9,6 @@
 #
 # ==============================================================================
 
-# Making KratosMultiphysics backward compatible with python 2.6 and 2.7
-from __future__ import print_function, absolute_import, division
-
 import os, pathlib, sys
 
 # Kratos Core and Apps

--- a/applications/ShapeOptimizationApplication/python_scripts/analyzers/analyzer_internal.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/analyzers/analyzer_internal.py
@@ -12,7 +12,7 @@
 # Making KratosMultiphysics backward compatible with python 2.6 and 2.7
 from __future__ import print_function, absolute_import, division
 
-import os, pathlib
+import os, pathlib, sys
 
 # Kratos Core and Apps
 import KratosMultiphysics as KM
@@ -47,11 +47,13 @@ class IterationScope:
     def __enter__(self):
         if (self.is_evaluated_in_folder):
             self.scope.mkdir(parents=True, exist_ok=True)
+            sys.path.insert(0, str(self.scope.absolute()))            
             os.chdir(str(self.scope))
 
     def __exit__(self, exc_type, exc_value, traceback):
         if (self.is_evaluated_in_folder):
             os.chdir(self.currentPath)
+            sys.path.remove(str(self.scope.absolute()))            
 
 
 # ==============================================================================


### PR DESCRIPTION
**📝 Description**
This PR adds evaluation path of an iteration to `sys.path` so it enables use of custom python scripts in that folder.

**🆕 Changelog**
- Adds current evaluation path of an interation to `sys.path`
