### PR TITLE
[Timer] [GidIO] PrintTimingInformation must be called once

### DIFF
--- a/kratos/includes/gid_io.h
+++ b/kratos/includes/gid_io.h
@@ -176,8 +176,6 @@ public:
     ///Destructor.
     ~GidIO() override
     {
-        Timer::PrintTimingInformation();
-
         if ( mResultFileOpen ) {
             GiD_fClosePostResultFile( mResultFile );
             mResultFileOpen = false;


### PR DESCRIPTION
**📝 Description**
The timer is enabled here:
https://github.com/KratosMultiphysics/Kratos/blob/c85ad6f4bb6a46eed1d32955b2bbe88093e99f60/kratos/python_scripts/timer_process.py#L57-L60

But `GidIO` is calling PrintTimingInformation. Consequently, every instance of `GidIO` will repeat the print.

**🆕 Changelog**
- Remove extra call of `PrintTimingInformation`
