### PR TITLE
[Fluid] Fixed formula for energy in physics-based shock captuting

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/shock_capturing_physics_based_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/shock_capturing_physics_based_process.h
@@ -283,7 +283,7 @@ private:
             double midpoint_p;
             FluidCalculationUtilities::EvaluateInPoint(r_geom, r_N, std::tie(r_midpoint_v, VELOCITY), std::tie(midpoint_p, PRESSURE), std::tie(midpoint_rho, DENSITY));
             // If the formulation is not energy coupled, the total energy equals the kinetic energy plus the potential one
-            midpoint_tot_ener = 0.5 * midpoint_rho * inner_prod(r_midpoint_v, r_midpoint_v) + midpoint_p;
+            midpoint_tot_ener = 0.5 * midpoint_rho * inner_prod(r_midpoint_v, r_midpoint_v) + midpoint_p/(gamma - 1);
         }
 
         // Calculate common values


### PR DESCRIPTION
**📝 Description**
Small error in thermal sensor. Typicaly the formula is presented as:
```
etot = rho * (v*v/2 + cp*T)
```
Using the transformation `p = rho R T` and `R = cv * (gamma - 1)`:
```
etot = rho*v*v/2 + p/(gamma - 1)
                    ^~~~~~~~~~~~~
                    |
                    This part was missing
```


**🆕 Changelog**
Fixed formula.
