### PR TITLE
[Shallow] Add check for benchmarking utilities

### DIFF
--- a/applications/ShallowWaterApplication/python_scripts/benchmarks/base_benchmark_process.py
+++ b/applications/ShallowWaterApplication/python_scripts/benchmarks/base_benchmark_process.py
@@ -44,7 +44,7 @@ class BaseBenchmarkProcess(KM.Process):
 
     def ExecuteInitialize(self):
         """Set the topography and the initial conditions."""
-
+        KM.Timer.Start("Benchmark/Initial state")
         time = self.model_part.ProcessInfo[KM.TIME]
         for node in self.model_part.Nodes:
             if self._Topography(node):
@@ -53,11 +53,12 @@ class BaseBenchmarkProcess(KM.Process):
             node.SetSolutionStepValue(KM.VELOCITY, self._Velocity(node, time))
             node.SetSolutionStepValue(KM.MOMENTUM, self._Momentum(node, time))
             node.SetSolutionStepValue(SW.FREE_SURFACE_ELEVATION, self._FreeSurfaceElevation(node, time))
+        KM.Timer.Stop("Benchmark/Initial state")
 
 
     def ExecuteBeforeOutputStep(self):
         """Compute the exact values of the benchmark and the error of the simulation."""
-
+        KM.Timer.Start("Benchmark/Exact values")
         time = self.model_part.ProcessInfo[KM.TIME]
         for (variable, exact_variable, error_variable) in zip(self.variables, self.exact_variables, self.error_variables):
 
@@ -76,6 +77,7 @@ class BaseBenchmarkProcess(KM.Process):
 
                 node.SetValue(exact_variable, exact_value)
                 node.SetValue(error_variable, fem_value - exact_value)
+        KM.Timer.Stop("Benchmark/Exact values")
 
 
     def Check(self):

--- a/applications/ShallowWaterApplication/python_scripts/postprocess/convergence_output_process.py
+++ b/applications/ShallowWaterApplication/python_scripts/postprocess/convergence_output_process.py
@@ -50,6 +50,10 @@ class ConvergenceOutputProcess(KM.Process):
         else:
             self.integrate_over_all_the_domain = False
 
+    def ExecuteInitialize(self):
+        for variable in self.variables:
+            KM.VariableUtils().SetNonHistoricalVariableToZero(variable, self.model_part.Nodes)
+
     def ExecuteBeforeSolutionLoop(self):
         """Look for an existing dataset in the file."""
         self.dset = self._GetDataset()

--- a/applications/ShallowWaterApplication/python_scripts/postprocess/convergence_output_process.py
+++ b/applications/ShallowWaterApplication/python_scripts/postprocess/convergence_output_process.py
@@ -141,6 +141,7 @@ class ConvergenceOutputProcess(KM.Process):
     def _GetDataset(self):
         for name, data in self.f.items():
             if self._CheckAttributes(data.attrs):
+                self._CheckNumberOfFields(data)
                 return data
 
         dset_name = "analysis_{:03d}".format(self.f.items().__len__())
@@ -148,6 +149,15 @@ class ConvergenceOutputProcess(KM.Process):
         dset = self.f.create_dataset(dset_name, (0,), maxshape=(None,), chunks=True, dtype=header)
         self._WriteAttributes(dset)
         return dset
+
+    def _CheckNumberOfFields(self, dset):
+        header = self._GetHeaderDtype()
+        if len(dset.dtype) != len(header):
+            msg  = f"ConvergenceOutputProcess [HDF5]: "
+            msg += f"Trying to write a different number of variables from previous simulations.\n"
+            msg += f"\nThe existing dataset has {len(dset.dtype)} fields -- {dset.dtype}\n"
+            msg += f"\nThe current case has {len(header)} fields -- {header}."
+            raise Exception(msg)
 
     def _GetHeaderDtype(self):
         header = [


### PR DESCRIPTION
**📝 Description**
This PR adds some checks to avoid segfaults related to wrong project user settings when some benchmark tools are used.

**🆕 Changelog**
- ConvergenceOutputProcess [HDF5]: Initialize non historical variable
- ConvergenceOutputProcess [HDF5]: Check the dtype from previous simulations
- BaseBenchmarkProcess: measuring time
