### PR TITLE
improving constructors interface

### DIFF
--- a/kratos/containers/csr_matrix.h
+++ b/kratos/containers/csr_matrix.h
@@ -705,7 +705,8 @@ public:
     /// Print information about this object.
     void PrintInfo(std::ostream& rOStream) const
     {
-        rOStream << "CsrMatrix";
+        rOStream << "CsrMatrix" << std::endl;
+        PrintData(rOStream);
     }
 
     /// Print object's data.

--- a/kratos/containers/distributed_csr_matrix.h
+++ b/kratos/containers/distributed_csr_matrix.h
@@ -210,19 +210,18 @@ public:
         mpComm(rOtherMatrix.mpComm),
         mpRowNumbering(Kratos::make_unique< DistributedNumbering<TIndexType> >( rOtherMatrix.GetRowNumbering())),
         mpColNumbering(Kratos::make_unique< DistributedNumbering<TIndexType> >( rOtherMatrix.GetColNumbering())),
-        mpDiagonalBlock(Kratos::make_unique<TDataType,IndexType>(rOtherMatrix.GetDiagonalBlock())),
-        mpOffDiagonalBlock(Kratos::make_unique<TDataType,IndexType>(rOtherMatrix.GetOffDiagonalBlock())),
+        mpDiagonalBlock(Kratos::make_unique<CsrMatrix<TDataType,TIndexType>>(rOtherMatrix.GetDiagonalBlock())),
+        mpOffDiagonalBlock(Kratos::make_unique<CsrMatrix<TDataType,TIndexType>>(rOtherMatrix.GetOffDiagonalBlock())),
         mNonLocalData(rOtherMatrix.mNonLocalData),
-        mSendCachedIJ(rOtherMatrix.mSendCachedIJ),
-        mRecvCachedIJ(rOtherMatrix.mRecvCachedIJ),
         mOffDiagonalLocalIds(rOtherMatrix.mOffDiagonalLocalIds),
         mOffDiagonalGlobalIds(rOtherMatrix.mOffDiagonalGlobalIds),
         mfem_assemble_colors(rOtherMatrix.mfem_assemble_colors),
-        mpVectorImporter(rOtherMatrix.mpVectorImporter)
+        mRecvCachedIJ(rOtherMatrix.mRecvCachedIJ),
+        mSendCachedIJ(rOtherMatrix.mSendCachedIJ),
+        mpVectorImporter(Kratos::make_unique<DistributedVectorImporter<TDataType,TIndexType>>(*rOtherMatrix.mpVectorImporter))
     {
         ReconstructDirectAccessVectors();
     }
-
 
     //move constructor
     DistributedCsrMatrix(DistributedCsrMatrix<TDataType,TIndexType>&& rOtherMatrix)
@@ -796,7 +795,8 @@ public:
     /// Print information about this object.
     void PrintInfo(std::ostream& rOStream) const
     {
-        rOStream << "DistributedCsrMatrix";
+        rOStream << "DistributedCsrMatrix" << std::endl;
+        PrintData(rOStream);
     }
 
     /// Print object's data.

--- a/kratos/containers/distributed_system_vector.h
+++ b/kratos/containers/distributed_system_vector.h
@@ -361,7 +361,12 @@ public:
     }
 
     /// Print information about this object.
-    void PrintInfo(std::ostream& rOStream) const {rOStream << "DistributedSystemVector";}
+    void PrintInfo(std::ostream& rOStream) const 
+    {
+        rOStream << "DistributedSystemVector LOCAL DATA:" << std::endl;
+        PrintData(rOStream);
+        
+    }
 
     /// Print object's data.
     void PrintData(std::ostream& rOStream) const {

--- a/kratos/containers/system_vector.h
+++ b/kratos/containers/system_vector.h
@@ -88,7 +88,9 @@ public:
         mData.resize(size,false);
     }
 
-    SystemVector(const Vector& data, DataCommunicator& rComm=ParallelEnvironment::GetDataCommunicator("Serial")){
+    SystemVector(
+        const Vector& data,
+        DataCommunicator& rComm = ParallelEnvironment::GetDataCommunicator("Serial")) {
         if(rComm.IsDistributed())
             KRATOS_ERROR << "Attempting to construct a serial system_vector with a distributed communicator" << std::endl;
         mpComm = &rComm;
@@ -278,7 +280,7 @@ public:
     void PrintInfo(std::ostream& rOStream) const {
         rOStream << "SystemVector" << std::endl;
         PrintData(rOStream);
-        }
+    }
 
     /// Print object's data.
     void PrintData(std::ostream& rOStream) const {

--- a/kratos/containers/system_vector.h
+++ b/kratos/containers/system_vector.h
@@ -88,6 +88,13 @@ public:
         mData.resize(size,false);
     }
 
+    SystemVector(const Vector& data, DataCommunicator& rComm=ParallelEnvironment::GetDataCommunicator("Serial")){
+        if(rComm.IsDistributed())
+            KRATOS_ERROR << "Attempting to construct a serial system_vector with a distributed communicator" << std::endl;
+        mpComm = &rComm;
+        mData.resize(data.size(),false);
+        noalias(mData) = data;
+    }
     /// Copy constructor.
     explicit SystemVector(const SystemVector<TDataType,TIndexType>& rOtherVector){
         mpComm = rOtherVector.mpComm;
@@ -268,7 +275,10 @@ public:
     }
 
     /// Print information about this object.
-    void PrintInfo(std::ostream& rOStream) const {rOStream << "SystemVector";}
+    void PrintInfo(std::ostream& rOStream) const {
+        rOStream << "SystemVector" << std::endl;
+        PrintData(rOStream);
+        }
 
     /// Print object's data.
     void PrintData(std::ostream& rOStream) const {

--- a/kratos/mpi/python/add_distributed_sparse_matrices_to_python.cpp
+++ b/kratos/mpi/python/add_distributed_sparse_matrices_to_python.cpp
@@ -88,6 +88,9 @@ void AddDistributedSparseMatricesToPython(pybind11::module& m)
         .def(py::init<const DistributedSparseGraph<IndexType>&>())
         .def(py::init<DistributedSystemVector<double,IndexType>&>())
         .def(py::init<const DistributedNumbering<IndexType>&>())
+        .def("copy", [](const DistributedSystemVector<double,IndexType>& self){
+            return Kratos::make_shared<DistributedSystemVector<double,IndexType>>(self);
+        })
         .def("GetComm", &DistributedSystemVector<double,IndexType>::GetComm, py::return_value_policy::reference_internal)
         .def("LocalSize", [](const DistributedSystemVector<double,IndexType>& self)
             {return self.LocalSize();})
@@ -149,6 +152,10 @@ void AddDistributedSparseMatricesToPython(pybind11::module& m)
 
     py::class_<DistributedCsrMatrix<double,IndexType>, DistributedCsrMatrix<double,IndexType>::Pointer>(m,"DistributedCsrMatrix")
         .def(py::init<const DistributedSparseGraph<IndexType>&>())
+        .def(py::init<const DistributedCsrMatrix<double,IndexType>&>())
+        .def("copy", [](const DistributedCsrMatrix<double,IndexType>& self){
+            return Kratos::make_shared<DistributedCsrMatrix<double,IndexType>>(self);
+        })
         .def("GetComm", &DistributedCsrMatrix<double,IndexType>::GetComm, py::return_value_policy::reference_internal)
         .def("GetRowNumbering", &DistributedCsrMatrix<double,IndexType>::GetRowNumbering, py::return_value_policy::reference_internal)
         .def("GetColNumbering", &DistributedCsrMatrix<double,IndexType>::GetColNumbering, py::return_value_policy::reference_internal)

--- a/kratos/python/add_sparse_matrices_to_python.cpp
+++ b/kratos/python/add_sparse_matrices_to_python.cpp
@@ -85,8 +85,12 @@ void AddSparseMatricesToPython(pybind11::module& m)
     py::class_<CsrMatrix<double,IndexType>, CsrMatrix<double,IndexType>::Pointer >(m, "CsrMatrix")
     .def(py::init<>())
     .def(py::init<const DataCommunicator&>())
+    .def(py::init<const CsrMatrix<double,IndexType>&>())
     .def(py::init<SparseGraph<IndexType>&>())
     .def(py::init<SparseContiguousRowGraph<IndexType>&>())
+    .def("copy", [](const CsrMatrix<double,IndexType>& self){
+        return Kratos::make_shared<CsrMatrix<double,IndexType>>(self);
+    })
     .def("GetComm", &CsrMatrix<double,IndexType>::GetComm, py::return_value_policy::reference_internal)
     .def("SetValue", &CsrMatrix<double,IndexType>::SetValue)
     .def("Size1", &CsrMatrix<double,IndexType>::size1)
@@ -186,6 +190,10 @@ void AddSparseMatricesToPython(pybind11::module& m)
     .def(py::init<IndexType, DataCommunicator&>())
     .def(py::init<SparseGraph<IndexType>&>())
     .def(py::init<SparseContiguousRowGraph<IndexType>&>())
+    .def(py::init<Vector&>())
+    .def("copy", [](const SystemVector<double,IndexType>& self){
+        return Kratos::make_shared<SystemVector<double,IndexType>>(self);
+    })
     .def("GetComm", &SystemVector<double,IndexType>::GetComm, py::return_value_policy::reference_internal)
     .def("Size", &SystemVector<double,IndexType>::size)
     .def("size", &SystemVector<double,IndexType>::size)


### PR DESCRIPTION
**📝 Description**
Exports sparse matrix and vector constructors to python, and improves the PrintInfo (papercuts in the practical usage)

Please mark the PR with appropriate tags: 
- Feature
-
**🆕 Changelog**
Exports Sparse Vector constructors
Exports sparse csr matrix constructors
adds copy method to mimic numpy
