### PR TITLE
[Fluid] Fixed automatic Fourier number for compressible fluids.

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
@@ -162,6 +162,8 @@ class NavierStokesCompressibleExplicitSolver(FluidSolver):
         """This method overloads FluidSolver in order to enforce:
         ```
         self.settings["time_stepping"]["consider_compressibility_in_CFL"] == True
+        self.settings["time_stepping"]["nodal_density_formulation"] == True
+        self.settings["time_stepping"]["consider_artificial_diffusion"] == SHOCK_CAPTURING_SWITCH
         ```
         """
         self._OverrideBoolParameterWithWarning(self.settings["time_stepping"], "consider_compressibility_in_CFL", True)

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_explicit_solver.py
@@ -165,6 +165,7 @@ class NavierStokesCompressibleExplicitSolver(FluidSolver):
         ```
         """
         self._OverrideBoolParameterWithWarning(self.settings["time_stepping"], "consider_compressibility_in_CFL", True)
+        self._OverrideBoolParameterWithWarning(self.settings["time_stepping"], "nodal_density_formulation", True)
 
         sc_enabled = self.GetComputingModelPart().ProcessInfo[KratosFluid.SHOCK_CAPTURING_SWITCH]
         self._OverrideBoolParameterWithWarning(self.settings["time_stepping"], "consider_artificial_diffusion", sc_enabled)


### PR DESCRIPTION
**📝 Description**
By default, automatic time step utilities reads the density from the element properties, as it makes sense for 99% of the fluid dynamics application. I just happened to be working on the other 1%.

In my case, density in the properties database was undefined, which made it default to 0.0, therefore Fourier numbers became infinity and the solver got stuck to the minimum time-step.

Now, the compressible solver will set `nodal_density_formulation` to `true` by default.

**🆕 Changelog**
Added override of default parameters in `navier_stokes_compressible_explicit_solver.py`.