### PR TITLE
[Core] Add is keys subset with equivalent values to method to Parameters

### DIFF
--- a/kratos/includes/kratos_parameters.h
+++ b/kratos/includes/kratos_parameters.h
@@ -801,6 +801,14 @@ public:
         ) const;
 
     /**
+     * @brief Checks if the names and values are the same, no importance to the order and whether this is a subset of the rParameters.
+     * @details Lists have to be ordered, though! Take into account that in Kratos some physical vectors are represented with a list.
+     * @param rParameters The parameters which are equal or larger set
+     * @return True if it has, false othersise
+     */
+    bool IsKeysSubSetWithEquivalentValuesTo(const Parameters& rParameters) const;
+
+    /**
      * @brief Checks if the names and values are the same, no importance to the order.
      * @details Lists have to be ordered, though! Take into account that in Kratos some physical vectors are represented with a list.
      * @param rParameters The parameters to be checked

--- a/kratos/python/add_kratos_parameters_to_python.cpp
+++ b/kratos/python/add_kratos_parameters_to_python.cpp
@@ -88,6 +88,7 @@ void  AddKratosParametersToPython(pybind11::module& m)
     .def("ValidateDefaults", &Parameters::ValidateDefaults)
     .def("RecursivelyValidateDefaults", &Parameters::RecursivelyValidateDefaults)
     .def("IsEquivalentTo",&Parameters::IsEquivalentTo)
+    .def("IsKeysSubSetWithEquivalentValuesTo", &Parameters::IsKeysSubSetWithEquivalentValuesTo)
     .def("HasSameKeysAndTypeOfValuesAs",&Parameters::HasSameKeysAndTypeOfValuesAs)
     //.def("GetValue", GetValue) //Do not export this method. users shall adopt the operator [] syntax
     .def("IsNull", &Parameters::IsNull)

--- a/kratos/sources/kratos_parameters.cpp
+++ b/kratos/sources/kratos_parameters.cpp
@@ -1022,21 +1022,20 @@ void Parameters::RecursivelyFindValue(
 /***********************************************************************************/
 /***********************************************************************************/
 
-bool Parameters::IsEquivalentTo(Parameters& rParameters)
-{
+bool Parameters::IsKeysSubSetWithEquivalentValuesTo(const Parameters& rParameters) const {
     for (auto itr = this->mpValue->begin(); itr != this->mpValue->end(); ++itr) {
         const std::string& r_item_name = itr.key();
 
         bool found = false;
 
-        for (auto& r_parameter_reference : rParameters.items()) {
+        for (const auto& r_parameter_reference : rParameters.items()) {
             if (r_item_name == r_parameter_reference.key()) {
                 found = true;
-                Parameters subobject = (*this)[r_item_name];
-                Parameters reference_subobject = rParameters[r_item_name];
+                const Parameters& subobject = (*this)[r_item_name];
+                const Parameters& reference_subobject = rParameters[r_item_name];
 
                 if (itr->is_object()) {
-                    if (!subobject.IsEquivalentTo(reference_subobject))
+                    if (!subobject.IsKeysSubSetWithEquivalentValuesTo(reference_subobject))
                         return false;
                 } else {
                     if (itr.value() != r_parameter_reference.value())
@@ -1050,25 +1049,15 @@ bool Parameters::IsEquivalentTo(Parameters& rParameters)
             return false;
     }
 
-    // Reverse check: the rParameters can contain fields that are missing in the object
-    for (auto& r_parameter : rParameters.items()) {
-        const std::string& r_item_name = r_parameter.key();
-
-        bool found = false;
-
-        for (auto& r_parameter_reference : this->items()) {
-            if (r_item_name == r_parameter_reference.key()) {
-                found = true;
-                // No need to check the values here, if they were found in the previous loop, values were checked there
-                break;
-            }
-        }
-
-        if (!found)
-            return false;
-    }
-
     return true;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+bool Parameters::IsEquivalentTo(Parameters& rParameters)
+{
+    return this->IsKeysSubSetWithEquivalentValuesTo(rParameters) && rParameters.IsKeysSubSetWithEquivalentValuesTo(*this);
 }
 
 /***********************************************************************************/

--- a/kratos/tests/test_kratos_parameters.py
+++ b/kratos/tests/test_kratos_parameters.py
@@ -979,6 +979,65 @@ class TestParameters(KratosUnittest.TestCase):
 
         self.assertListEqual(new_string_array, string_array)
 
+    def test_is_keys_sub_set_with_equivalent_values_to(self):
+        new_param = Parameters("""{
+            "key1": {
+                "subkey1": "value_1",
+                "subkey2": 1.0,
+                "subkey3": [1.0, 2.0, 3.0],
+                "subkey4": ["1.0", "2.0", "3.0"]
+            },
+            "key2": [
+                {
+                    "listsubkey1": "value_1",
+                    "listsubkey2": 1.0,
+                    "listsubkey3": [1.0, 2.0, 3.0],
+                    "listsubkey4": ["1.0", "2.0", "3.0"]
+                },
+                {
+                    "listsubkey1": "value_1",
+                    "listsubkey2": 1.0,
+                    "listsubkey3": [1.0, 2.0, 3.0],
+                    "listsubkey4": ["1.0", "2.0", "3.0"]
+                }
+            ],
+            "key3": "value_3"
+        }""")
+
+        defaults = Parameters("""{
+            "key1": {
+                "subkey1": "value_1",
+                "subkey2": 1.0,
+                "subkey3": [1.0, 2.0, 3.0],
+                "subkey4": ["1.0", "2.0", "3.0"],
+                "subkey5": "default_value_5"
+            },
+            "key2": [
+                {
+                    "listsubkey1": "value_1",
+                    "listsubkey2": 1.0,
+                    "listsubkey3": [1.0, 2.0, 3.0],
+                    "listsubkey4": ["1.0", "2.0", "3.0"]
+                },
+                {
+                    "listsubkey1": "value_1",
+                    "listsubkey2": 1.0,
+                    "listsubkey3": [1.0, 2.0, 3.0],
+                    "listsubkey4": ["1.0", "2.0", "3.0"]
+                }
+            ],
+            "key3": "value_3",
+            "key4": "default_value_4"
+        }""")
+
+        self.assertTrue(new_param.IsKeysSubSetWithEquivalentValuesTo(defaults))
+
+        # adding a key to a list of parameters will make "key2" value to be not equal to that of new_param.
+        # hence this should return false
+        defaults["key2"][0].AddEmptyValue("listsubkey5")
+        defaults["key2"][0]["listsubkey5"].SetString("value_5")
+        self.assertFalse(new_param.IsKeysSubSetWithEquivalentValuesTo(defaults))
+
     @KratosUnittest.skipUnless(have_pickle_module, "Pickle module error: : " + pickle_message)
     def test_stream_serialization(self):
         tmp = Parameters(defaults)


### PR DESCRIPTION
**📝 Description**
This adds `IsKeysSubSetWithEquivalentValuesTo` method to `Kratos::Parameters` class. This is usefull in following scenario.

- Comparing user defined settings (without some defaults) against defaults in kratos

Example:
user_given_settings:
```json
{
   "key1": "value_1",
   "key2": {
      "subkey1": "sub_value_1",
      "subkey2": "sub_value_2"
   }
}
```

defaults:
```json
{
   "key1": "value_1",
   "key2": {
      "subkey1": "sub_value_1",
      "subkey2": "sub_value_2",
      "subkey3": "default_sub_value_3",
   },
   "key3": "default_value_3"
}
```

```python
user_given_settings.IsKeysSubSetWithEquivalentValuesTo(defaults)
```

Above will return `True`

Please mark the PR with appropriate tags: 
- Feature

**🆕 Changelog**
- added `IsKeysSubSetWithEquivalentValuesTo` to `Kratos::Parameters`
- exposed in python
- added a test
