### PR TITLE
[Core] Remove use of FLAG_VARIABLE in variational distance process

### DIFF
--- a/kratos/processes/variational_distance_calculation_process.h
+++ b/kratos/processes/variational_distance_calculation_process.h
@@ -234,14 +234,14 @@ public:
             // Free the DISTANCE values
             rNode.Free(DISTANCE);
             // Set the fix flag to 0
-            node.Set(BLOCKED, false);
+            rNode.Set(BLOCKED, false);
 
             // Save the distances
             rNode.SetValue(DISTANCE, d);
 
             if(d == 0){
                 d = 1.0e-15;
-                node.Set(BLOCKED, true);
+                rNode.Set(BLOCKED, true);
                 rNode.Fix(DISTANCE);
             } else {
                 if(d > 0.0){
@@ -290,7 +290,7 @@ public:
                     if(std::abs(d) > std::abs(distances[i])){
                         d = distances[i];
                     }
-                    node.Set(BLOCKED, true);
+                    geom[i].Set(BLOCKED, true);
                     geom[i].Fix(DISTANCE);
                     geom[i].UnSetLock();
                 }
@@ -601,7 +601,7 @@ private:
             #pragma omp parallel for
             for(int i_node = 0; i_node < nnodes; ++i_node){
                 auto it_node = r_distance_model_part.NodesBegin() + i_node;
-                if (node.Is(BLOCKED)){
+                if (it_node->Is(BLOCKED)){
                     it_node->Fix(DISTANCE);
                 }
             }

--- a/kratos/processes/variational_distance_calculation_process.h
+++ b/kratos/processes/variational_distance_calculation_process.h
@@ -230,18 +230,18 @@ public:
 
         block_for_each(r_distance_model_part.Nodes(), [](Node<3>& rNode){
             double& d = rNode.FastGetSolutionStepValue(DISTANCE);
-            double& fix_flag = rNode.GetValue(FLAG_VARIABLE);
 
             // Free the DISTANCE values
-            fix_flag = 1.0;
             rNode.Free(DISTANCE);
+            // Set the fix flag to 0
+            node.Set(BLOCKED, false);
 
             // Save the distances
             rNode.SetValue(DISTANCE, d);
 
             if(d == 0){
                 d = 1.0e-15;
-                fix_flag = -1.0;
+                node.Set(BLOCKED, true);
                 rNode.Fix(DISTANCE);
             } else {
                 if(d > 0.0){
@@ -286,12 +286,11 @@ public:
 
                 for(unsigned int i = 0; i < TDim+1; ++i){
                     double &d = geom[i].FastGetSolutionStepValue(DISTANCE);
-                    double &fix_flag = geom[i].GetValue(FLAG_VARIABLE);
                     geom[i].SetLock();
                     if(std::abs(d) > std::abs(distances[i])){
                         d = distances[i];
                     }
-                    fix_flag = -1.0;
+                    node.Set(BLOCKED, true);
                     geom[i].Fix(DISTANCE);
                     geom[i].UnSetLock();
                 }
@@ -443,8 +442,6 @@ protected:
 
         // Check that required nodal variables are present
         VariableUtils().CheckVariableExists<Variable<double > >(DISTANCE, mrBaseModelPart.Nodes());
-        // Initialize flag variable
-        VariableUtils().SetNonHistoricalVariableToZero(FLAG_VARIABLE, mrBaseModelPart.Nodes());
     }
 
     void InitializeSolutionStrategy(BuilderSolverPointerType pBuilderAndSolver)
@@ -597,15 +594,14 @@ private:
             int nnodes = static_cast<int>(r_distance_model_part.NumberOfNodes());
 
             // Synchronize the fixity flag variable to minium
-            // (-1.0 means fixed and 1.0 means free)
-            r_communicator.SynchronizeNonHistoricalDataToMin(FLAG_VARIABLE);
+            // (true means fixed and false means free)
+            r_communicator.SynchronizeOrNodalFlags(BLOCKED);
 
             // Set the fixity according to the synchronized flag
             #pragma omp parallel for
             for(int i_node = 0; i_node < nnodes; ++i_node){
                 auto it_node = r_distance_model_part.NodesBegin() + i_node;
-                const double &r_fix_flag = it_node->GetValue(FLAG_VARIABLE);
-                if (r_fix_flag == -1.0){
+                if (node.Is(BLOCKED)){
                     it_node->Fix(DISTANCE);
                 }
             }

--- a/kratos/tests/test_redistance.py
+++ b/kratos/tests/test_redistance.py
@@ -23,7 +23,6 @@ class TestRedistance(KratosUnittest.TestCase):
 
         model_part = current_model.CreateModelPart("Main")
         model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
-        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.FLAG_VARIABLE)
         KratosMultiphysics.ModelPartIO(GetFilePath("auxiliar_files_for_python_unittest/mdpa_files/coarse_sphere")).ReadModelPart(model_part)
         model_part.SetBufferSize(2)
 
@@ -54,7 +53,6 @@ class TestRedistance(KratosUnittest.TestCase):
 
         model_part = current_model.CreateModelPart("Main")
         model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
-        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.FLAG_VARIABLE)
 
         model_part.CreateNewNode(1, 0.0 , 0.0 , 0.0)
         model_part.CreateNewNode(2, 1.0 , 2.0 , 0.0)
@@ -90,7 +88,6 @@ class TestRedistance(KratosUnittest.TestCase):
 
         model_part = current_model.CreateModelPart("Main")
         model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
-        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.FLAG_VARIABLE)
 
         model_part.CreateNewNode(1, 0.0 , 0.0 , 0.0)
         model_part.CreateNewNode(2, 1.0 , 2.0 , 0.0)


### PR DESCRIPTION
**📝 Description**
This PR removes the use of FLAG_VARIABLE and replaces it with a flag. This will avoid defining it in the solver. 

Is there a reason to use the historical container instead of the non-historical or a flag?


**🆕 Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Use a flag to track the fixity in the variational distance process instead of FLAG_VARIABLE