### PR TITLE
removes papercuts in printing out distributed objects

### DIFF
--- a/kratos/containers/distributed_csr_matrix.h
+++ b/kratos/containers/distributed_csr_matrix.h
@@ -796,7 +796,6 @@ public:
     void PrintInfo(std::ostream& rOStream) const
     {
         rOStream << "DistributedCsrMatrix" << std::endl;
-        PrintData(rOStream);
     }
 
     /// Print object's data.

--- a/kratos/containers/distributed_numbering.h
+++ b/kratos/containers/distributed_numbering.h
@@ -232,7 +232,9 @@ public:
     }
 
     /// Print object's data.
-    void PrintData(std::ostream& rOStream) const {}
+    void PrintData(std::ostream& rOStream) const {
+        rOStream << "DistributedNumbering: CpuBounds = " << mCpuBounds << std::endl; 
+    }
 
 
 protected:

--- a/kratos/containers/distributed_system_vector.h
+++ b/kratos/containers/distributed_system_vector.h
@@ -363,13 +363,14 @@ public:
     /// Print information about this object.
     void PrintInfo(std::ostream& rOStream) const 
     {
-        rOStream << "DistributedSystemVector LOCAL DATA:" << std::endl;
-        PrintData(rOStream);
-        
+        rOStream << "DistributedSystemVector LOCAL DATA:" << std::endl;        
     }
 
     /// Print object's data.
     void PrintData(std::ostream& rOStream) const {
+        const auto k = GetComm().Rank();
+        std::cout << "Local Size=" << LocalSize() << " Total Size=" << GetNumbering().Size() << std::endl; 
+        std::cout << "Numbering begins with " << GetNumbering().GetCpuBounds()[k] << " ends at " << GetNumbering().GetCpuBounds()[k+1] << std::endl;
         std::cout << mLocalData << std::endl;
     }
 


### PR DESCRIPTION
improves a little the printout interface of distributed objects. Also… reverts addition of PrintData otherwise the data were printed twice

**📝 Description**
minor changes in PrintData for distributed objects

Please mark the PR with appropriate tags: 
- feature

**🆕 Changelog**
