### PR TITLE
[BDF Scheme] Reducing verbosity: Print warning if it's relevant

### DIFF
--- a/kratos/solving_strategies/schemes/residual_based_bdf_scheme.h
+++ b/kratos/solving_strategies/schemes/residual_based_bdf_scheme.h
@@ -251,7 +251,7 @@ public:
 
         const double dt_0 = r_current_process_info[DELTA_TIME];
         const double dt_1 = r_current_process_info.GetPreviousTimeStepInfo(1)[DELTA_TIME];
-        KRATOS_WARNING_IF("ResidualBasedBDFScheme", mOrder > 2 && std::abs(dt_0 -dt_1) > std::numeric_limits<double>::epsilon())
+        KRATOS_ERROR_IF("ResidualBasedBDFScheme", mOrder > 2 && std::abs(dt_0 -dt_1) > std::numeric_limits<double>::epsilon())
         << "For higher orders than 2 the time step must be constant.\n";
 
         KRATOS_CATCH( "" );

--- a/kratos/solving_strategies/schemes/residual_based_bdf_scheme.h
+++ b/kratos/solving_strategies/schemes/residual_based_bdf_scheme.h
@@ -251,8 +251,8 @@ public:
 
         const double dt_0 = r_current_process_info[DELTA_TIME];
         const double dt_1 = r_current_process_info.GetPreviousTimeStepInfo(1)[DELTA_TIME];
-        KRATOS_ERROR_IF("ResidualBasedBDFScheme", mOrder > 2 && std::abs(dt_0 -dt_1) > std::numeric_limits<double>::epsilon())
-        << "For higher orders than 2 the time step must be constant.\n";
+        KRATOS_ERROR_IF(mOrder > 2 && std::abs(dt_0 -dt_1) > std::numeric_limits<double>::epsilon())
+        << "ResidualBasedBDFScheme. For higher orders than 2 the time step must be constant.\n";
 
         KRATOS_CATCH( "" );
     }

--- a/kratos/solving_strategies/schemes/residual_based_bdf_scheme.h
+++ b/kratos/solving_strategies/schemes/residual_based_bdf_scheme.h
@@ -249,8 +249,10 @@ public:
         mpBDFUtility->ComputeAndSaveBDFCoefficients(r_current_process_info);
         mBDF = r_current_process_info[BDF_COEFFICIENTS];
 
-        KRATOS_WARNING_IF("ResidualBasedBDFScheme", mOrder > 2)
-        << "For higher orders than 2 the time step is assumed to be constant.\n";
+        const double dt_0 = r_current_process_info[DELTA_TIME];
+        const double dt_1 = r_current_process_info.GetPreviousTimeStepInfo(1)[DELTA_TIME];
+        KRATOS_WARNING_IF("ResidualBasedBDFScheme", mOrder > 2 && std::abs(dt_0 -dt_1) > std::numeric_limits<double>::epsilon())
+        << "For higher orders than 2 the time step must be constant.\n";
 
         KRATOS_CATCH( "" );
     }


### PR DESCRIPTION
**📝 Description**
For orders higher than 2, the warning was thrown at every step, even if the time step is constant.
Now, the warning is thrown if the order is higher than 2 and the time step is variable.

**🆕 Changelog**
- Reduce the verbosity
