### PR TITLE
[ShapeOpt] Iteration restart

### DIFF
--- a/applications/ShapeOptimizationApplication/python_scripts/analyzers/analyzer_internal.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/analyzers/analyzer_internal.py
@@ -17,6 +17,8 @@ import KratosMultiphysics as KM
 # Additional imports
 from KratosMultiphysics.ShapeOptimizationApplication.analyzers.analyzer_base import AnalyzerBaseClass
 from KratosMultiphysics.ShapeOptimizationApplication.response_functions import response_function_factory as sho_response_factory
+from .response_data_io import GetObjectiveValue
+from .response_data_io import GetObjectiveSensitivityValues
 try:
     from KratosMultiphysics.StructuralMechanicsApplication import structural_response_function_factory as csm_response_factory
 except ImportError:
@@ -81,6 +83,7 @@ class KratosInternalAnalyzer( AnalyzerBaseClass ):
             optimization_model_part.ProcessInfo.SetValue(KM.DELTA_TIME, 0)
 
             # now we scope in to the directory where response operations are done
+            optimization_path = str(pathlib.Path(".").absolute())            
             with IterationScope(identifier, optimizationIteration, response.IsEvaluatedInFolder()):
                 response.UpdateDesign(optimization_model_part, KM.SHAPE_SENSITIVITY)
 
@@ -88,13 +91,11 @@ class KratosInternalAnalyzer( AnalyzerBaseClass ):
 
                 # response values
                 if communicator.isRequestingValueOf(identifier):
-                    response.CalculateValue()
-                    communicator.reportValue(identifier, response.GetValue())
+                    communicator.reportValue(identifier, GetObjectiveValue(response, identifier, optimizationIteration, optimization_path, self.model_part_controller.IsIterationRestartFilesWritten()))
 
                 # response gradients
                 if communicator.isRequestingGradientOf(identifier):
-                    response.CalculateGradient()
-                    communicator.reportGradient(identifier, response.GetNodalGradient(KM.SHAPE_SENSITIVITY))
+                    communicator.reportGradient(identifier, GetObjectiveSensitivityValues(response, identifier, optimizationIteration, optimization_path, self.model_part_controller.IsIterationRestartFilesWritten()))
 
                 response.FinalizeSolutionStep()
 

--- a/applications/ShapeOptimizationApplication/python_scripts/analyzers/analyzer_internal.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/analyzers/analyzer_internal.py
@@ -17,8 +17,8 @@ import KratosMultiphysics as KM
 # Additional imports
 from KratosMultiphysics.ShapeOptimizationApplication.analyzers.analyzer_base import AnalyzerBaseClass
 from KratosMultiphysics.ShapeOptimizationApplication.response_functions import response_function_factory as sho_response_factory
-from .response_data_io import GetObjectiveValue
-from .response_data_io import GetObjectiveSensitivityValues
+from KratosMultiphysics.ShapeOptimizationApplication.response_data_io import GetObjectiveValue
+from KratosMultiphysics.ShapeOptimizationApplication.response_data_io import GetObjectiveSensitivityValues
 try:
     from KratosMultiphysics.StructuralMechanicsApplication import structural_response_function_factory as csm_response_factory
 except ImportError:

--- a/applications/ShapeOptimizationApplication/python_scripts/model_part_controller_factory.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/model_part_controller_factory.py
@@ -47,7 +47,8 @@ class ModelPartController:
             },
             "mesh_motion" : {
                 "apply_mesh_solver" : false
-            }
+            },
+            "write_iteration_restart_files": false            
         }""")
 
         self.model_settings.ValidateAndAssignDefaults(default_settings)
@@ -76,6 +77,7 @@ class ModelPartController:
         self.design_surface = None
         self.damping_utility = None
         self.direction_dampings = []
+        self.is_iteration_restart_files_written = self.model_settings["write_iteration_restart_files"].GetBool()
 
     # --------------------------------------------------------------------------
     def Initialize(self):
@@ -149,6 +151,10 @@ class ModelPartController:
     # --------------------------------------------------------------------------
     def GetDesignSurface(self):
         return self.design_surface
+
+    # --------------------------------------------------------------------------
+    def IsIterationRestartFilesWritten(self):
+        return self.is_iteration_restart_files_written        
 
     # --------------------------------------------------------------------------
     def DampNodalSensitivityVariableIfSpecified(self, variable):

--- a/applications/ShapeOptimizationApplication/python_scripts/response_data_io.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/response_data_io.py
@@ -1,0 +1,77 @@
+import json
+from pathlib import Path
+
+import KratosMultiphysics as Kratos
+from KratosMultiphysics.response_functions.response_function_interface import ResponseFunctionInterface
+
+def GetObjectiveValue(response: ResponseFunctionInterface, identifier: str, optimization_iteration: int, optimization_results_absolute_path: str, is_iteration_restart_files_written: bool) -> float:
+    if is_iteration_restart_files_written:
+        iteration_data_file_path = Path(optimization_results_absolute_path) / Path("Raw_Data/iteration_{:05d}.json".format(optimization_iteration))
+
+        if not iteration_data_file_path.is_file():
+            iteration_data_file_path.parent.mkdir(parents=True, exist_ok=True)
+            # write dummy dict to create the file
+            with open(str(iteration_data_file_path), "w") as file_output:
+                file_output.write(json.dumps({}, indent=4, sort_keys=True))
+
+        with open(str(iteration_data_file_path), "r") as file_input:
+            data_dict = json.loads(file_input.read())
+
+        if identifier not in data_dict.keys():
+            data_dict[identifier] = {}
+
+        if "value" not in data_dict[identifier].keys():
+            response.CalculateValue()
+            response_value = response.GetValue()
+            data_dict[identifier]["value"] = response_value
+
+            # now write the objective value
+            with open(str(iteration_data_file_path), "w") as file_output:
+                file_output.write(json.dumps(data_dict, indent=4, sort_keys=True))
+        else:
+            response_value = data_dict[identifier]["value"]
+            Kratos.Logger.PrintInfo("ShapeOpt", "Found recorded objective value for iteration {:d} {:s} objective. Remove \"{:s}/value\" entry from {:s} to re-calculate objective value for this iteration.".format(optimization_iteration, identifier, identifier, str(iteration_data_file_path.absolute())))
+    else:
+        response.CalculateValue()
+        response_value = response.GetValue()
+
+    return response_value
+
+def GetObjectiveSensitivityValues(response: ResponseFunctionInterface, identifier: str, optimization_iteration: int, optimization_results_absolute_path: str, is_iteration_restart_files_written: bool) -> dict:
+    if is_iteration_restart_files_written:
+        iteration_data_file_path = Path(optimization_results_absolute_path) / Path("Raw_Data/iteration_{:05d}.json".format(optimization_iteration))
+
+        if not iteration_data_file_path.is_file():
+            iteration_data_file_path.parent.mkdir(parents=True, exist_ok=True)
+            # write dummy dict to create the file
+            with open(str(iteration_data_file_path), "w") as file_output:
+                file_output.write(json.dumps({}, indent=4, sort_keys=True))
+
+        with open(str(iteration_data_file_path), "r") as file_input:
+            data_dict = json.loads(file_input.read())
+
+        if identifier not in data_dict.keys():
+            data_dict[identifier] = {}
+
+        if "sensitivities" not in data_dict[identifier].keys():
+            response.CalculateGradient()
+            sensitivities = response.GetNodalGradient(Kratos.SHAPE_SENSITIVITY)
+            converted_sensitivities = {}
+            for node_id, nodal_sensitivity in sensitivities.items():
+                converted_sensitivities[node_id] = [nodal_sensitivity[0], nodal_sensitivity[1], nodal_sensitivity[2]]
+            data_dict[identifier]["sensitivities"] = converted_sensitivities
+
+            # now write the sensitivities
+            with open(str(iteration_data_file_path), "w") as file_output:
+                file_output.write(json.dumps(data_dict, indent=4, sort_keys=True))
+        else:
+            sensitivities = {}
+            converted_sensitivities = data_dict[identifier]["sensitivities"]
+            for node_id, nodal_sensitivity in converted_sensitivities.items():
+                sensitivities[int(node_id)] = Kratos.Array3(nodal_sensitivity)
+            Kratos.Logger.PrintInfo("ShapeOpt", "Found recorded sensitivity values for iteration {:d} {:s} objective. Remove \"{:s}/sensitivities\" entry from {:s} to re-calculate objective sensitivities for this iteration.".format(optimization_iteration, identifier, identifier, str(iteration_data_file_path.absolute())))
+    else:
+        response.CalculateGradient()
+        sensitivities = response.GetNodalGradient(Kratos.SHAPE_SENSITIVITY)
+
+    return sensitivities


### PR DESCRIPTION
**📝 Description**
This adds restart capability for each iteration primal and adjoint solutions seperately. It does not change the existing behaviour. These restart files are not written by default.

The cost of reading and writing files is negligible in the fluid optimization problems compared to structural optimization problems. Therefore this is made optional.

**🆕 Changelog**
- Add iteration restart capability to shape opt.
