### PR TITLE
[Core] Ensure diagonal blocks are square in distributed_csr_matrix

### DIFF
--- a/kratos/containers/distributed_csr_matrix.h
+++ b/kratos/containers/distributed_csr_matrix.h
@@ -88,7 +88,11 @@ public:
         //compute the columns size
         TIndexType max_col_index = rSparseGraph.ComputeMaxGlobalColumnIndex();
         TIndexType tot_col_size = max_col_index+1;
-        mpColNumbering = Kratos::make_unique<DistributedNumbering<TIndexType>>(*mpComm, tot_col_size, mpComm->Size());
+            
+        if(tot_col_size == mpRowNumbering->Size()) //this ensures that diagonal blocks are square for square matrices
+            mpColNumbering = Kratos::make_unique<DistributedNumbering<TIndexType>>(*mpComm, mpRowNumbering->GetCpuBounds());
+        else
+            mpColNumbering = Kratos::make_unique<DistributedNumbering<TIndexType>>(*mpComm, tot_col_size, mpComm->Size());
 
         mOffDiagonalLocalIds.clear(); //this is the map that allows to transform from global_ids to local Ids for entries in the non_diag block
 

--- a/kratos/containers/distributed_csr_matrix.h
+++ b/kratos/containers/distributed_csr_matrix.h
@@ -89,10 +89,12 @@ public:
         TIndexType max_col_index = rSparseGraph.ComputeMaxGlobalColumnIndex();
         TIndexType tot_col_size = max_col_index+1;
             
-        if(tot_col_size == mpRowNumbering->Size()) //this ensures that diagonal blocks are square for square matrices
+        //this ensures that diagonal blocks are square for square matrices
+        if (tot_col_size == mpRowNumbering->Size()) {
             mpColNumbering = Kratos::make_unique<DistributedNumbering<TIndexType>>(*mpComm, mpRowNumbering->GetCpuBounds());
-        else
+        } else {
             mpColNumbering = Kratos::make_unique<DistributedNumbering<TIndexType>>(*mpComm, tot_col_size, mpComm->Size());
+        }
 
         mOffDiagonalLocalIds.clear(); //this is the map that allows to transform from global_ids to local Ids for entries in the non_diag block
 


### PR DESCRIPTION
This is a small but important change to ensure diagonal blocks are square for square matrices

**📝 Description**
Ensure diagonal blocks are square for square matrices. This is important for the construction of local preconditioners

**🆕 Changelog**
Ensure diagonal blocks are square for square matrices