### PR TITLE
[Core] Fixed explicit startegy minor issues

### DIFF
--- a/kratos/solving_strategies/strategies/butcher_tableau.h
+++ b/kratos/solving_strategies/strategies/butcher_tableau.h
@@ -253,7 +253,7 @@ public:
 
     static std::string Name()
     {
-        return "butcher_tableau_forward_euler";
+        return "ButcherTableauForwardEuler";
     }
 };
 
@@ -288,7 +288,7 @@ public:
 
     static std::string Name()
     {
-        return "butcher_tableau_midpoint_method";
+        return "ButcherTableauMidPointMethod";
     }
 };
 
@@ -333,7 +333,7 @@ public:
 
     static std::string Name()
     {
-        return "butcher_tableau_RK3TVD";
+        return "ButcherTableauRK3TVD";
     }
 };
 
@@ -374,7 +374,7 @@ public:
 
     static std::string Name()
     {
-        return "butcher_tableau_RK4";
+        return "ButcherTableauRK4";
     }
 };
 

--- a/kratos/solving_strategies/strategies/butcher_tableau.h
+++ b/kratos/solving_strategies/strategies/butcher_tableau.h
@@ -253,7 +253,7 @@ public:
 
     static std::string Name()
     {
-        return "ButcherTableauForwardEuler";
+        return "butcher_tableau_forward_euler";
     }
 };
 
@@ -288,7 +288,7 @@ public:
 
     static std::string Name()
     {
-        return "ButcherTableauMidPointMethod";
+        return "butcher_tableau_midpoint_method";
     }
 };
 
@@ -333,7 +333,7 @@ public:
 
     static std::string Name()
     {
-        return "ButcherTableauRK3TVD";
+        return "butcher_tableau_RK3TVD";
     }
 };
 
@@ -374,7 +374,7 @@ public:
 
     static std::string Name()
     {
-        return "ButcherTableauRK4";
+        return "butcher_tableau_RK4";
     }
 };
 

--- a/kratos/solving_strategies/strategies/butcher_tableau.h
+++ b/kratos/solving_strategies/strategies/butcher_tableau.h
@@ -7,7 +7,7 @@
 //  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
-//  Main authors:    Edurd Gómez
+//  Main authors:    Eduard Gómez
 //
 //
 

--- a/kratos/solving_strategies/strategies/explicit_solving_strategy.h
+++ b/kratos/solving_strategies/strategies/explicit_solving_strategy.h
@@ -296,7 +296,7 @@ public:
      */
     ExplicitBuilderType& GetExplicitBuilder()
     {
-        KRATOS_DEBUG_ERROR_IF(mpExplicitBuilder == nullptr) << "Asking for builder and solver when it is empty" << std::endl;
+        KRATOS_ERROR_IF(mpExplicitBuilder == nullptr) << "Asking for builder and solver when it is empty" << std::endl;
         return *mpExplicitBuilder;
     };
 
@@ -306,7 +306,7 @@ public:
      */
     const ExplicitBuilderType& GetExplicitBuilder() const
     {
-        KRATOS_DEBUG_ERROR_IF(mpExplicitBuilder == nullptr) << "Asking for builder and solver when it is empty" << std::endl;
+        KRATOS_ERROR_IF(mpExplicitBuilder == nullptr) << "Asking for builder and solver when it is empty" << std::endl;
         return *mpExplicitBuilder;
     };
 

--- a/kratos/solving_strategies/strategies/explicit_solving_strategy.h
+++ b/kratos/solving_strategies/strategies/explicit_solving_strategy.h
@@ -285,9 +285,29 @@ public:
      * @brief Operations to get the pointer to the explicit builder and solver
      * @return mpExplicitBuilder: The explicit builder and solver
      */
-    ExplicitBuilderPointerType& pGetExplicitBuilder()
+    ExplicitBuilderPointerType pGetExplicitBuilder()
     {
         return mpExplicitBuilder;
+    };
+
+    /**
+     * @brief Operations to get the explicit builder and solver
+     * @return mpExplicitBuilder: The explicit builder and solver
+     */
+    ExplicitBuilderType& GetExplicitBuilder()
+    {
+        KRATOS_DEBUG_ERROR_IF(mpExplicitBuilder == nullptr) << "Asking for builder and solver when it is empty" << std::endl;
+        return *mpExplicitBuilder;
+    };
+
+    /**
+     * @brief Operations to get the explicit builder and solver
+     * @return mpExplicitBuilder: The explicit builder and solver
+     */
+    const ExplicitBuilderType& GetExplicitBuilder() const
+    {
+        KRATOS_DEBUG_ERROR_IF(mpExplicitBuilder == nullptr) << "Asking for builder and solver when it is empty" << std::endl;
+        return *mpExplicitBuilder;
     };
 
     /**
@@ -297,11 +317,11 @@ public:
     double GetResidualNorm() override
     {
         // Get the required data from the explicit builder and solver
-        const auto p_explicit_bs = pGetExplicitBuilder();
-        auto& r_dof_set = p_explicit_bs->GetDofSet();
+        auto& r_explicit_bs = GetExplicitBuilder();
+        auto& r_dof_set = r_explicit_bs.GetDofSet();
 
         // Calculate the explicit residual
-        p_explicit_bs->BuildRHS(BaseType::GetModelPart());
+        r_explicit_bs.BuildRHS(BaseType::GetModelPart());
 
         // Calculate the residual norm
         double res_norm = 0.0;

--- a/kratos/solving_strategies/strategies/explicit_solving_strategy.h
+++ b/kratos/solving_strategies/strategies/explicit_solving_strategy.h
@@ -283,7 +283,7 @@ public:
 
     /**
      * @brief Operations to get the pointer to the explicit builder and solver
-     * @return mpExplicitBuilder: The explicit builder and solver
+     * @return mpExplicitBuilder: A pointer to the explicit builder and solver
      */
     ExplicitBuilderPointerType pGetExplicitBuilder()
     {
@@ -292,7 +292,7 @@ public:
 
     /**
      * @brief Operations to get the explicit builder and solver
-     * @return mpExplicitBuilder: The explicit builder and solver
+     * @return The explicit builder and solver
      */
     ExplicitBuilderType& GetExplicitBuilder()
     {
@@ -302,7 +302,7 @@ public:
 
     /**
      * @brief Operations to get the explicit builder and solver
-     * @return mpExplicitBuilder: The explicit builder and solver
+     * @return The explicit builder and solver
      */
     const ExplicitBuilderType& GetExplicitBuilder() const
     {

--- a/kratos/solving_strategies/strategies/explicit_solving_strategy_runge_kutta.h
+++ b/kratos/solving_strategies/strategies/explicit_solving_strategy_runge_kutta.h
@@ -260,10 +260,10 @@ protected:
         KRATOS_TRY
 
         // Get the required data from the explicit builder and solver
-        const auto p_explicit_bs = BaseType::pGetExplicitBuilder();
-        auto& r_dof_set = p_explicit_bs->GetDofSet();
-        const unsigned int dof_size = p_explicit_bs->GetEquationSystemSize();
-        const auto& r_lumped_mass_vector = p_explicit_bs->GetLumpedMassMatrixVector();
+auto& r_explicit_bs = BaseType::GetExplicitBuilder();
+        auto& r_dof_set = r_explicit_bs.GetDofSet();
+        const unsigned int dof_size = r_explicit_bs.GetEquationSystemSize();
+        const auto& r_lumped_mass_vector = r_explicit_bs.GetLumpedMassMatrixVector();
 
         // Set the auxiliary RK vectors
         LocalSystemVectorType u_n(dof_size); // TODO: THIS IS INEFICCIENT. CREATE A UNORDERED_SET WITH THE IDOF AND VALUE AS ENTRIES. THIS HAS TO BE OPTIONAL
@@ -355,9 +355,9 @@ protected:
         KRATOS_TRY
 
         // Get the required data from the explicit builder and solver
-        const auto p_explicit_bs = BaseType::pGetExplicitBuilder();
-        auto& r_dof_set = p_explicit_bs->GetDofSet();
-        const auto& r_lumped_mass_vector = p_explicit_bs->GetLumpedMassMatrixVector();
+        auto& r_explicit_bs = BaseType::GetExplicitBuilder();
+        auto& r_dof_set = r_explicit_bs.GetDofSet();
+        const auto& r_lumped_mass_vector = r_explicit_bs.GetLumpedMassMatrixVector();
 
         // Get model part and information
         const double dt = BaseType::GetDeltaTime();
@@ -375,7 +375,7 @@ protected:
 
         // Perform the intermidate sub step update
         InitializeRungeKuttaIntermediateSubStep();
-        p_explicit_bs->BuildRHS(r_model_part);
+        r_explicit_bs.BuildRHS(r_model_part);
 
         IndexPartition<int>(r_dof_set.size()).for_each(
             [&](int i_dof){
@@ -419,8 +419,8 @@ protected:
         KRATOS_TRY
 
         // Get the required data from the explicit builder and solver
-        const auto p_explicit_bs = BaseType::pGetExplicitBuilder();
-        auto& r_dof_set = p_explicit_bs->GetDofSet();
+        auto& r_explicit_bs = BaseType::GetExplicitBuilder();
+        auto& r_dof_set = r_explicit_bs.GetDofSet();
 
         // Get model part
         auto& r_model_part = BaseType::GetModelPart();
@@ -433,7 +433,7 @@ protected:
 
         // Perform the last sub step residual calculation
         InitializeRungeKuttaLastSubStep();
-        p_explicit_bs->BuildRHS(r_model_part);
+        r_explicit_bs.BuildRHS(r_model_part);
 
         IndexPartition<int>(r_dof_set.size()).for_each(
             [&](int i_dof){

--- a/kratos/solving_strategies/strategies/explicit_solving_strategy_runge_kutta.h
+++ b/kratos/solving_strategies/strategies/explicit_solving_strategy_runge_kutta.h
@@ -260,7 +260,7 @@ protected:
         KRATOS_TRY
 
         // Get the required data from the explicit builder and solver
-auto& r_explicit_bs = BaseType::GetExplicitBuilder();
+        auto& r_explicit_bs = BaseType::GetExplicitBuilder();
         auto& r_dof_set = r_explicit_bs.GetDofSet();
         const unsigned int dof_size = r_explicit_bs.GetEquationSystemSize();
         const auto& r_lumped_mass_vector = r_explicit_bs.GetLumpedMassMatrixVector();

--- a/kratos/solving_strategies/strategies/explicit_solving_strategy_runge_kutta.h
+++ b/kratos/solving_strategies/strategies/explicit_solving_strategy_runge_kutta.h
@@ -7,7 +7,7 @@
 //  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
-//  Main authors:    Ruben Zorrilla, Edurd Gómez
+//  Main authors:    Ruben Zorrilla, Eduard Gómez
 //
 //
 


### PR DESCRIPTION
**📝 Description**
This PR fixes a couple of minor issues with Explicit strategies. It breaks API in a minor way, but Explicit startegies are relatively recent so the harm should be very limited.


**🆕 Changelog**
- pGetExplicitBuilder now returns a shared pointer rather than a reference to a shared pointer. This is for memory safety, since using a reference does not increase the refcount. This is the API breakage.
- Created GetExplicitBuilder, which returns a reference to the object directy. Also a const version.
- Replaced instances of pGetExplicitBuilder with GetExplicitBuilder where the former is not necessary.