### PR TITLE
[Core] Fixed ButcherTableau::Name and ::Info

### DIFF
--- a/kratos/solving_strategies/strategies/butcher_tableau.h
+++ b/kratos/solving_strategies/strategies/butcher_tableau.h
@@ -253,7 +253,7 @@ public:
 
     static std::string Name()
     {
-        return "ButcherTableauForwardEuler";
+        return "butcher_tableau_forward_euler";
     }
 };
 
@@ -288,7 +288,7 @@ public:
 
     static std::string Name()
     {
-        return "ButcherTableauMidPointMethod";
+        return "butcher_tableau_midpoint_method";
     }
 };
 
@@ -333,7 +333,7 @@ public:
 
     static std::string Name()
     {
-        return "ButcherTableauRK3TVD";
+        return "butcher_tableau_RK3TVD";
     }
 };
 
@@ -374,7 +374,7 @@ public:
 
     static std::string Name()
     {
-        return "ButcherTableauRK4";
+        return "butcher_tableau_RK4";
     }
 };
 

--- a/kratos/solving_strategies/strategies/butcher_tableau.h
+++ b/kratos/solving_strategies/strategies/butcher_tableau.h
@@ -147,6 +147,8 @@ public:
         return Derived::Name();
     }
 
+    virtual std::string Info() const = 0;
+
 protected:
     ///@name Protected static Member Variables
     ///@{
@@ -255,6 +257,11 @@ public:
     {
         return "butcher_tableau_forward_euler";
     }
+
+    std::string Info() const override
+    {
+        return "ButcherTableauForwardEuler";
+    }
 };
 
 
@@ -289,6 +296,11 @@ public:
     static std::string Name()
     {
         return "butcher_tableau_midpoint_method";
+    }
+
+    std::string Info() const override
+    {
+        return "ButcherTableauMidPointMethod";
     }
 };
 
@@ -335,6 +347,11 @@ public:
     {
         return "butcher_tableau_RK3TVD";
     }
+
+    std::string Info() const override
+    {
+        return "ButcherTableauRK3TVD";
+    }
 };
 
 
@@ -375,6 +392,11 @@ public:
     static std::string Name()
     {
         return "butcher_tableau_RK4";
+    }
+
+    std::string Info() const override
+    {
+        return "ButcherTableauRK4";
     }
 };
 

--- a/kratos/solving_strategies/strategies/explicit_solving_strategy_runge_kutta.h
+++ b/kratos/solving_strategies/strategies/explicit_solving_strategy_runge_kutta.h
@@ -183,18 +183,6 @@ public:
         return default_parameters;
     }
 
-    /**
-     * @brief Returns the name of the class as used in the settings (snake_case format)
-     * @return The name of the class
-     */
-    static std::string Name()
-    {
-        std::stringstream s;
-        s << "explicit_solving_strategy_runge_kutta"
-          << "[TButcherTableau=" << TButcherTableau::Name() << "]";
-        return s.str();
-    }
-
     ///@}
     ///@name Operators
     ///@{
@@ -214,11 +202,22 @@ public:
     ///@name Input and output
     ///@{
 
-    /// Turn back information as a string.
+    /**
+     * @brief Returns the name of the class as used in the settings (snake_case format)
+     * @return The name of the class
+     */
+    static std::string Name()
+    {
+        std::stringstream s;
+        s << "explicit_solving_strategy_runge_kutta_" << TButcherTableau::Name();
+        return s.str();
+    }
+
+    /// Return information as a string.
     std::string Info() const override
     {
         std::stringstream ss;
-        ss << "ExplicitSolvingStrategyRungeKutta with tableau " << mButcherTableau.Name();
+        ss << "ExplicitSolvingStrategyRungeKutta<" << mButcherTableau.Info() << ">";
         return ss.str();
     }
 


### PR DESCRIPTION
**📝 Description**
Generally in Kratos, static method Name() returns the name of the class in snake_case. Butcher tableau class instead does so in CamelCase, which is inconsistent. This PR fizes this.

The motivation for this fix is the Name of the RungeKutta strategy, which 

**🆕 Changelog**
- ButcherTableau::Name() now returns string in snake_case
- ButcherTableau::Info() implemented. Returns string in CamelCase
- ExplicitSolvingStrategyRungeKutta Name and Info now use these