### PR TITLE
[Everywhere] Removed const from return type of GetDefaultParameters

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_processes/alm_variables_calculation_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/alm_variables_calculation_process.h
@@ -137,7 +137,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override
+    Parameters GetDefaultParameters() const override
     {
         const Parameters default_parameters = Parameters(R"(
         {

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.cpp
@@ -1872,7 +1872,7 @@ bool BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::IsNotInvertedSe
 /***********************************************************************************/
 
 template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
-const Parameters BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::GetDefaultParameters() const
+Parameters BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::GetDefaultParameters() const
 {
     KRATOS_TRY
 

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.h
@@ -235,7 +235,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/contact_search_wrapper_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/contact_search_wrapper_process.cpp
@@ -98,7 +98,7 @@ ContactSearchWrapperProcess::ContactSearchWrapperProcess(
 /***********************************************************************************/
 /***********************************************************************************/
 
-const Parameters ContactSearchWrapperProcess::GetDefaultParameters() const
+Parameters ContactSearchWrapperProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/contact_search_wrapper_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/contact_search_wrapper_process.h
@@ -133,7 +133,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
@@ -358,7 +358,7 @@ void ContactSPRErrorProcess<3>::ComputeNormalTangentMatrices(
 /***********************************************************************************/
 
 template<SizeType TDim>
-const Parameters ContactSPRErrorProcess<TDim>::GetDefaultParameters() const
+Parameters ContactSPRErrorProcess<TDim>::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.h
@@ -120,7 +120,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Operations

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/find_intersected_geometrical_objects_with_obb_for_contact_search_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/find_intersected_geometrical_objects_with_obb_for_contact_search_process.cpp
@@ -197,7 +197,7 @@ void FindIntersectedGeometricalObjectsWithOBBContactSearchProcess::MarkIfInterse
 /***********************************************************************************/
 /***********************************************************************************/
 
-const Parameters FindIntersectedGeometricalObjectsWithOBBContactSearchProcess::GetDefaultParameters() const
+Parameters FindIntersectedGeometricalObjectsWithOBBContactSearchProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/find_intersected_geometrical_objects_with_obb_for_contact_search_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/find_intersected_geometrical_objects_with_obb_for_contact_search_process.h
@@ -132,7 +132,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@name Member Variables
     ///@{

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/mpc_contact_search_wrapper_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/mpc_contact_search_wrapper_process.cpp
@@ -77,7 +77,7 @@ MPCContactSearchWrapperProcess::MPCContactSearchWrapperProcess(
 /***********************************************************************************/
 /***********************************************************************************/
 
-const Parameters MPCContactSearchWrapperProcess::GetDefaultParameters() const
+Parameters MPCContactSearchWrapperProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/mpc_contact_search_wrapper_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/mpc_contact_search_wrapper_process.h
@@ -133,7 +133,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/normal_check_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/normal_check_process.cpp
@@ -259,7 +259,7 @@ void NormalCheckProcess::Execute()
 /***********************************************************************************/
 /***********************************************************************************/
 
-const Parameters NormalCheckProcess::GetDefaultParameters() const
+Parameters NormalCheckProcess::GetDefaultParameters() const
 {
     KRATOS_TRY
 

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/normal_check_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/normal_check_process.h
@@ -120,7 +120,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/FluidDynamicsApplication/custom_processes/apply_compressible_navier_stokes_boundary_conditions_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/apply_compressible_navier_stokes_boundary_conditions_process.cpp
@@ -237,7 +237,7 @@ void ApplyCompressibleNavierStokesBoundaryConditionsProcess::ReadBoundaryConditi
 }
 
 
-const Parameters ApplyCompressibleNavierStokesBoundaryConditionsProcess::GetDefaultParameters() const
+Parameters ApplyCompressibleNavierStokesBoundaryConditionsProcess::GetDefaultParameters() const
 {
     return Parameters(R"(
     {

--- a/applications/FluidDynamicsApplication/custom_processes/apply_compressible_navier_stokes_boundary_conditions_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/apply_compressible_navier_stokes_boundary_conditions_process.h
@@ -160,7 +160,7 @@ namespace Kratos
 
         void ExecuteFinalizeSolutionStep() override;
 
-        const Parameters GetDefaultParameters() const override;
+        Parameters GetDefaultParameters() const override;
 
         ///@}
         ///@name Access

--- a/applications/FluidDynamicsApplication/custom_processes/calulate_levelset_consistent_nodal_gradient_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/calulate_levelset_consistent_nodal_gradient_process.cpp
@@ -105,7 +105,7 @@ bool CalulateLevelsetConsistentNodalGradientProcess::IsSplit(const Vector& rDist
     return is_split;
 }
 
-const Parameters CalulateLevelsetConsistentNodalGradientProcess::GetDefaultParameters() const
+Parameters CalulateLevelsetConsistentNodalGradientProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/FluidDynamicsApplication/custom_processes/calulate_levelset_consistent_nodal_gradient_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/calulate_levelset_consistent_nodal_gradient_process.h
@@ -101,7 +101,7 @@ public:
     /**
      * @brief This method provides the default parameters
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     // ///@}
     // ///@name Inquiry

--- a/applications/FluidDynamicsApplication/custom_processes/compute_pressure_coefficient_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/compute_pressure_coefficient_process.cpp
@@ -45,7 +45,7 @@ ComputePressureCoefficientProcess::ComputePressureCoefficientProcess(
 }
 
 
-const Parameters ComputePressureCoefficientProcess::GetDefaultParameters() const
+Parameters ComputePressureCoefficientProcess::GetDefaultParameters() const
 {
     return Parameters( R"(
     {

--- a/applications/FluidDynamicsApplication/custom_processes/compute_pressure_coefficient_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/compute_pressure_coefficient_process.h
@@ -85,7 +85,7 @@ public:
     ///@name Operations
     ///@{
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     void Execute() override;
 

--- a/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.h
@@ -256,7 +256,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override
+    Parameters GetDefaultParameters() const override
     {
         return StaticGetDefaultParameters();
     }

--- a/applications/FluidDynamicsApplication/custom_processes/shock_capturing_entropy_viscosity_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/shock_capturing_entropy_viscosity_process.cpp
@@ -97,7 +97,7 @@ int ShockCapturingEntropyViscosityProcess::Check()
 }
 
 
-const Parameters ShockCapturingEntropyViscosityProcess::GetDefaultParameters() const
+Parameters ShockCapturingEntropyViscosityProcess::GetDefaultParameters() const
 {
     return Parameters(R"(
     {

--- a/applications/FluidDynamicsApplication/custom_processes/shock_capturing_entropy_viscosity_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/shock_capturing_entropy_viscosity_process.h
@@ -178,7 +178,7 @@ public:
 
     int Check() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/FluidDynamicsApplication/custom_processes/shock_capturing_physics_based_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/shock_capturing_physics_based_process.cpp
@@ -78,7 +78,7 @@ namespace Kratos
         CalculatePhysicsBasedShockCapturing();
     }
 
-    const Parameters ShockCapturingPhysicsBasedProcess::GetDefaultParameters() const
+    Parameters ShockCapturingPhysicsBasedProcess::GetDefaultParameters() const
     {
         const Parameters default_parameters = Parameters(R"({
             "model_part_name" : "",

--- a/applications/FluidDynamicsApplication/custom_processes/shock_capturing_physics_based_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/shock_capturing_physics_based_process.h
@@ -143,7 +143,7 @@ public:
 
     int Check() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/IgaApplication/custom_processes/assign_integration_points_to_background_elements_process.h
+++ b/applications/IgaApplication/custom_processes/assign_integration_points_to_background_elements_process.h
@@ -70,7 +70,7 @@ public:
 
     void ExecuteBeforeOutputStep() override;
 
-    const Parameters GetDefaultParameters() const override
+    Parameters GetDefaultParameters() const override
     {
         const Parameters default_parameters = Parameters(R"(
         {

--- a/applications/IgaApplication/custom_processes/map_nurbs_volume_results_to_embedded_geometry_process.h
+++ b/applications/IgaApplication/custom_processes/map_nurbs_volume_results_to_embedded_geometry_process.h
@@ -72,7 +72,7 @@ public:
 
     void MapNodalValues(const Variable<array_1d<double,3>>& rVariable);
 
-    const Parameters GetDefaultParameters() const override
+    Parameters GetDefaultParameters() const override
     {
         const Parameters default_parameters = Parameters(R"(
         {

--- a/applications/IgaApplication/custom_processes/output_eigen_values_process.cpp
+++ b/applications/IgaApplication/custom_processes/output_eigen_values_process.cpp
@@ -74,7 +74,7 @@ void OutputEigenValuesProcess::ExecuteFinalize()
     file.close();
 }
 
-const Parameters OutputEigenValuesProcess::GetDefaultParameters() const
+Parameters OutputEigenValuesProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/IgaApplication/custom_processes/output_eigen_values_process.h
+++ b/applications/IgaApplication/custom_processes/output_eigen_values_process.h
@@ -63,7 +63,7 @@ public:
     /// Called once before the solution loop and is writing the quadrature domain.
     void ExecuteFinalize() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/IgaApplication/custom_processes/output_quadrature_domain_process.cpp
+++ b/applications/IgaApplication/custom_processes/output_quadrature_domain_process.cpp
@@ -97,7 +97,7 @@ void OutputQuadratureDomainProcess::ExecuteBeforeSolutionLoop()
     file.close();
 }
 
-const Parameters OutputQuadratureDomainProcess::GetDefaultParameters() const
+Parameters OutputQuadratureDomainProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/IgaApplication/custom_processes/output_quadrature_domain_process.h
+++ b/applications/IgaApplication/custom_processes/output_quadrature_domain_process.h
@@ -63,7 +63,7 @@ public:
     /// Called once before the solution loop and is writing the quadrature domain.
     void ExecuteBeforeSolutionLoop() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/MeshingApplication/custom_processes/internal_variables_interpolation_process.cpp
+++ b/applications/MeshingApplication/custom_processes/internal_variables_interpolation_process.cpp
@@ -628,7 +628,7 @@ InternalVariablesInterpolationProcess::InterpolationTypes InternalVariablesInter
 /***********************************************************************************/
 /***********************************************************************************/
 
-const Parameters InternalVariablesInterpolationProcess::GetDefaultParameters() const
+Parameters InternalVariablesInterpolationProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/MeshingApplication/custom_processes/internal_variables_interpolation_process.h
+++ b/applications/MeshingApplication/custom_processes/internal_variables_interpolation_process.h
@@ -161,7 +161,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/MeshingApplication/custom_processes/metrics_error_process.cpp
+++ b/applications/MeshingApplication/custom_processes/metrics_error_process.cpp
@@ -175,7 +175,7 @@ void MetricErrorProcess<TDim>::CalculateMetric()
 /***********************************************************************************/
 
 template<SizeType TDim>
-const Parameters MetricErrorProcess<TDim>::GetDefaultParameters() const
+Parameters MetricErrorProcess<TDim>::GetDefaultParameters() const
 {
     /**
      * We configure using the following parameters:

--- a/applications/MeshingApplication/custom_processes/metrics_error_process.h
+++ b/applications/MeshingApplication/custom_processes/metrics_error_process.h
@@ -123,7 +123,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/MeshingApplication/custom_processes/metrics_hessian_process.cpp
+++ b/applications/MeshingApplication/custom_processes/metrics_hessian_process.cpp
@@ -457,7 +457,7 @@ void ComputeHessianSolMetricProcess::CalculateMetric()
 /***********************************************************************************/
 /***********************************************************************************/
 
-const Parameters ComputeHessianSolMetricProcess::GetDefaultParameters() const
+Parameters ComputeHessianSolMetricProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/MeshingApplication/custom_processes/metrics_hessian_process.h
+++ b/applications/MeshingApplication/custom_processes/metrics_hessian_process.h
@@ -181,7 +181,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/MeshingApplication/custom_processes/metrics_levelset_process.cpp
+++ b/applications/MeshingApplication/custom_processes/metrics_levelset_process.cpp
@@ -253,7 +253,7 @@ double ComputeLevelSetSolMetricProcess<TDim>::CalculateElementSize(
 /***********************************************************************************/
 
 template<SizeType TDim>
-const Parameters ComputeLevelSetSolMetricProcess<TDim>::GetDefaultParameters() const
+Parameters ComputeLevelSetSolMetricProcess<TDim>::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/MeshingApplication/custom_processes/metrics_levelset_process.h
+++ b/applications/MeshingApplication/custom_processes/metrics_levelset_process.h
@@ -115,7 +115,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Operations

--- a/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
+++ b/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
@@ -1275,7 +1275,7 @@ std::string MmgProcess<TMMGLibrary>::GetMmgVersion()
 /***********************************************************************************/
 
 template<MMGLibrary TMMGLibrary>
-const Parameters MmgProcess<TMMGLibrary>::GetDefaultParameters() const
+Parameters MmgProcess<TMMGLibrary>::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/MeshingApplication/custom_processes/mmg/mmg_process.h
+++ b/applications/MeshingApplication/custom_processes/mmg/mmg_process.h
@@ -233,7 +233,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/MeshingApplication/custom_processes/multiscale_refining_process.cpp
+++ b/applications/MeshingApplication/custom_processes/multiscale_refining_process.cpp
@@ -821,7 +821,7 @@ void MultiscaleRefiningProcess::GetLastId(
     }
 }
 
-const Parameters MultiscaleRefiningProcess::GetDefaultParameters() const
+Parameters MultiscaleRefiningProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/MeshingApplication/custom_processes/multiscale_refining_process.h
+++ b/applications/MeshingApplication/custom_processes/multiscale_refining_process.h
@@ -158,7 +158,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     /**
      * @brief Perform a check with the parameters

--- a/applications/MeshingApplication/custom_processes/nodal_values_interpolation_process.cpp
+++ b/applications/MeshingApplication/custom_processes/nodal_values_interpolation_process.cpp
@@ -367,7 +367,7 @@ void NodalValuesInterpolationProcess<TDim>::ComputeNormalSkin(ModelPart& rModelP
 /***********************************************************************************/
 
 template<SizeType TDim>
-const Parameters NodalValuesInterpolationProcess<TDim>::GetDefaultParameters() const
+Parameters NodalValuesInterpolationProcess<TDim>::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/MeshingApplication/custom_processes/nodal_values_interpolation_process.h
+++ b/applications/MeshingApplication/custom_processes/nodal_values_interpolation_process.h
@@ -282,7 +282,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/MeshingApplication/custom_processes/parmmg/pmmg_process.cpp
+++ b/applications/MeshingApplication/custom_processes/parmmg/pmmg_process.cpp
@@ -570,7 +570,7 @@ void ParMmgProcess<TPMMGLibrary>::CreateDebugPrePostRemeshOutput(ModelPart& rOld
 /***********************************************************************************/
 
 template<PMMGLibrary TPMMGLibrary>
-const Parameters ParMmgProcess<TPMMGLibrary>::GetDefaultParameters() const
+Parameters ParMmgProcess<TPMMGLibrary>::GetDefaultParameters() const
 {
     KRATOS_TRY;
 

--- a/applications/MeshingApplication/custom_processes/parmmg/pmmg_process.h
+++ b/applications/MeshingApplication/custom_processes/parmmg/pmmg_process.h
@@ -216,7 +216,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
     */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/RANSApplication/custom_processes/rans_apply_exact_nodal_periodic_condition_process.cpp
+++ b/applications/RANSApplication/custom_processes/rans_apply_exact_nodal_periodic_condition_process.cpp
@@ -247,7 +247,7 @@ void RansApplyExactNodalPeriodicConditionProcess::CalculateRotationMatrix(
     rOutput(2, 1) = 2. * uy * uz * s1 * s1 + ux * s2;
 }
 
-const Parameters RansApplyExactNodalPeriodicConditionProcess::GetDefaultParameters() const
+Parameters RansApplyExactNodalPeriodicConditionProcess::GetDefaultParameters() const
 {
     const auto default_parameters = Parameters(R"(
         {

--- a/applications/RANSApplication/custom_processes/rans_apply_exact_nodal_periodic_condition_process.h
+++ b/applications/RANSApplication/custom_processes/rans_apply_exact_nodal_periodic_condition_process.h
@@ -74,7 +74,7 @@ public:
 
     void ExecuteInitialize() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/RANSApplication/custom_processes/rans_apply_flag_to_skin_process.cpp
+++ b/applications/RANSApplication/custom_processes/rans_apply_flag_to_skin_process.cpp
@@ -126,7 +126,7 @@ void RansApplyFlagToSkinProcess::ApplyConditionFlags(
     KRATOS_CATCH("");
 }
 
-const Parameters RansApplyFlagToSkinProcess::GetDefaultParameters() const
+Parameters RansApplyFlagToSkinProcess::GetDefaultParameters() const
 {
     const auto default_parameters = Parameters(R"(
         {

--- a/applications/RANSApplication/custom_processes/rans_apply_flag_to_skin_process.h
+++ b/applications/RANSApplication/custom_processes/rans_apply_flag_to_skin_process.h
@@ -72,7 +72,7 @@ public:
 
     void ExecuteInitialize() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/RANSApplication/custom_processes/rans_clip_scalar_variable_process.cpp
+++ b/applications/RANSApplication/custom_processes/rans_clip_scalar_variable_process.cpp
@@ -93,7 +93,7 @@ void RansClipScalarVariableProcess::PrintData(std::ostream& rOStream) const
 {
 }
 
-const Parameters RansClipScalarVariableProcess::GetDefaultParameters() const
+Parameters RansClipScalarVariableProcess::GetDefaultParameters() const
 {
     const auto default_parameters = Parameters(R"(
         {

--- a/applications/RANSApplication/custom_processes/rans_clip_scalar_variable_process.h
+++ b/applications/RANSApplication/custom_processes/rans_clip_scalar_variable_process.h
@@ -81,7 +81,7 @@ public:
         Execute();
     }
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/RANSApplication/custom_processes/rans_compute_reactions_process.cpp
+++ b/applications/RANSApplication/custom_processes/rans_compute_reactions_process.cpp
@@ -187,7 +187,7 @@ void RansComputeReactionsProcess::CalculateReactionValues(
     }
 }
 
-const Parameters RansComputeReactionsProcess::GetDefaultParameters() const
+Parameters RansComputeReactionsProcess::GetDefaultParameters() const
 {
     const auto default_parameters = Parameters(R"(
         {

--- a/applications/RANSApplication/custom_processes/rans_compute_reactions_process.h
+++ b/applications/RANSApplication/custom_processes/rans_compute_reactions_process.h
@@ -81,7 +81,7 @@ public:
 
     int Check() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/RANSApplication/custom_processes/rans_epsilon_turbulent_mixing_length_inlet_process.cpp
+++ b/applications/RANSApplication/custom_processes/rans_epsilon_turbulent_mixing_length_inlet_process.cpp
@@ -119,7 +119,7 @@ void RansEpsilonTurbulentMixingLengthInletProcess::PrintData(std::ostream& rOStr
 {
 }
 
-const Parameters RansEpsilonTurbulentMixingLengthInletProcess::GetDefaultParameters() const
+Parameters RansEpsilonTurbulentMixingLengthInletProcess::GetDefaultParameters() const
 {
     const auto default_parameters = Parameters(R"(
         {

--- a/applications/RANSApplication/custom_processes/rans_epsilon_turbulent_mixing_length_inlet_process.h
+++ b/applications/RANSApplication/custom_processes/rans_epsilon_turbulent_mixing_length_inlet_process.h
@@ -83,7 +83,7 @@ public:
 
     int Check() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/RANSApplication/custom_processes/rans_k_turbulent_intensity_inlet_process.cpp
+++ b/applications/RANSApplication/custom_processes/rans_k_turbulent_intensity_inlet_process.cpp
@@ -121,7 +121,7 @@ void RansKTurbulentIntensityInletProcess::PrintData(std::ostream& rOStream) cons
 {
 }
 
-const Parameters RansKTurbulentIntensityInletProcess::GetDefaultParameters() const
+Parameters RansKTurbulentIntensityInletProcess::GetDefaultParameters() const
 {
     const auto default_parameters = Parameters(R"(
         {

--- a/applications/RANSApplication/custom_processes/rans_k_turbulent_intensity_inlet_process.h
+++ b/applications/RANSApplication/custom_processes/rans_k_turbulent_intensity_inlet_process.h
@@ -85,7 +85,7 @@ public:
 
     int Check() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/RANSApplication/custom_processes/rans_line_output_process.cpp
+++ b/applications/RANSApplication/custom_processes/rans_line_output_process.cpp
@@ -604,7 +604,7 @@ std::string RansLineOutputProcess::GetOutputFileName() const
     KRATOS_CATCH("");
 }
 
-const Parameters RansLineOutputProcess::GetDefaultParameters() const
+Parameters RansLineOutputProcess::GetDefaultParameters() const
 {
     const auto default_parameters = Parameters(R"(
         {

--- a/applications/RANSApplication/custom_processes/rans_line_output_process.h
+++ b/applications/RANSApplication/custom_processes/rans_line_output_process.h
@@ -381,7 +381,7 @@ public:
 
     void ExecuteFinalizeSolutionStep() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/RANSApplication/custom_processes/rans_nut_k_epsilon_update_process.cpp
+++ b/applications/RANSApplication/custom_processes/rans_nut_k_epsilon_update_process.cpp
@@ -135,7 +135,7 @@ void RansNutKEpsilonUpdateProcess::PrintData(std::ostream& rOStream) const
 {
 }
 
-const Parameters RansNutKEpsilonUpdateProcess::GetDefaultParameters() const
+Parameters RansNutKEpsilonUpdateProcess::GetDefaultParameters() const
 {
     const auto default_parameters = Parameters(R"(
         {

--- a/applications/RANSApplication/custom_processes/rans_nut_k_epsilon_update_process.h
+++ b/applications/RANSApplication/custom_processes/rans_nut_k_epsilon_update_process.h
@@ -89,7 +89,7 @@ public:
 
     void ExecuteAfterCouplingSolveStep() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/RANSApplication/custom_processes/rans_nut_k_omega_sst_update_process.cpp
+++ b/applications/RANSApplication/custom_processes/rans_nut_k_omega_sst_update_process.cpp
@@ -237,7 +237,7 @@ void RansNutKOmegaSSTUpdateProcess::PrintData(std::ostream& rOStream) const
 {
 }
 
-const Parameters RansNutKOmegaSSTUpdateProcess::GetDefaultParameters() const
+Parameters RansNutKOmegaSSTUpdateProcess::GetDefaultParameters() const
 {
     const auto default_parameters = Parameters(R"(
         {

--- a/applications/RANSApplication/custom_processes/rans_nut_k_omega_sst_update_process.h
+++ b/applications/RANSApplication/custom_processes/rans_nut_k_omega_sst_update_process.h
@@ -91,7 +91,7 @@ public:
 
     void ExecuteAfterCouplingSolveStep() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/RANSApplication/custom_processes/rans_nut_k_omega_update_process.cpp
+++ b/applications/RANSApplication/custom_processes/rans_nut_k_omega_update_process.cpp
@@ -133,7 +133,7 @@ void RansNutKOmegaUpdateProcess::PrintData(std::ostream& rOStream) const
 {
 }
 
-const Parameters RansNutKOmegaUpdateProcess::GetDefaultParameters() const
+Parameters RansNutKOmegaUpdateProcess::GetDefaultParameters() const
 {
     const auto default_parameters = Parameters(R"(
         {

--- a/applications/RANSApplication/custom_processes/rans_nut_k_omega_update_process.h
+++ b/applications/RANSApplication/custom_processes/rans_nut_k_omega_update_process.h
@@ -89,7 +89,7 @@ public:
 
     void ExecuteAfterCouplingSolveStep() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/RANSApplication/custom_processes/rans_nut_nodal_update_process.cpp
+++ b/applications/RANSApplication/custom_processes/rans_nut_nodal_update_process.cpp
@@ -121,7 +121,7 @@ void RansNutNodalUpdateProcess::PrintData(std::ostream& rOStream) const
 {
 }
 
-const Parameters RansNutNodalUpdateProcess::GetDefaultParameters() const
+Parameters RansNutNodalUpdateProcess::GetDefaultParameters() const
 {
     const auto default_parameters = Parameters(R"(
         {

--- a/applications/RANSApplication/custom_processes/rans_nut_nodal_update_process.h
+++ b/applications/RANSApplication/custom_processes/rans_nut_nodal_update_process.h
@@ -86,7 +86,7 @@ public:
 
     void ExecuteAfterCouplingSolveStep() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/RANSApplication/custom_processes/rans_nut_y_plus_wall_function_update_process.cpp
+++ b/applications/RANSApplication/custom_processes/rans_nut_y_plus_wall_function_update_process.cpp
@@ -169,7 +169,7 @@ void RansNutYPlusWallFunctionUpdateProcess::PrintData(std::ostream& rOStream) co
 {
 }
 
-const Parameters RansNutYPlusWallFunctionUpdateProcess::GetDefaultParameters() const
+Parameters RansNutYPlusWallFunctionUpdateProcess::GetDefaultParameters() const
 {
     const auto default_parameters = Parameters(R"(
         {

--- a/applications/RANSApplication/custom_processes/rans_nut_y_plus_wall_function_update_process.h
+++ b/applications/RANSApplication/custom_processes/rans_nut_y_plus_wall_function_update_process.h
@@ -80,7 +80,7 @@ public:
 
     void ExecuteAfterCouplingSolveStep() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/RANSApplication/custom_processes/rans_omega_turbulent_mixing_length_inlet_process.cpp
+++ b/applications/RANSApplication/custom_processes/rans_omega_turbulent_mixing_length_inlet_process.cpp
@@ -129,7 +129,7 @@ void RansOmegaTurbulentMixingLengthInletProcess::PrintData(std::ostream& rOStrea
 {
 }
 
-const Parameters RansOmegaTurbulentMixingLengthInletProcess::GetDefaultParameters() const
+Parameters RansOmegaTurbulentMixingLengthInletProcess::GetDefaultParameters() const
 {
     const auto default_parameters = Parameters(R"(
     {

--- a/applications/RANSApplication/custom_processes/rans_omega_turbulent_mixing_length_inlet_process.h
+++ b/applications/RANSApplication/custom_processes/rans_omega_turbulent_mixing_length_inlet_process.h
@@ -87,7 +87,7 @@ public:
 
     int Check() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/RANSApplication/custom_processes/rans_wall_distance_calculation_process.cpp
+++ b/applications/RANSApplication/custom_processes/rans_wall_distance_calculation_process.cpp
@@ -265,7 +265,7 @@ void RansWallDistanceCalculationProcess::CalculateWallDistances()
     KRATOS_CATCH("");
 }
 
-const Parameters RansWallDistanceCalculationProcess::GetDefaultParameters() const
+Parameters RansWallDistanceCalculationProcess::GetDefaultParameters() const
 {
     const auto default_parameters = Parameters(R"(
         {

--- a/applications/RANSApplication/custom_processes/rans_wall_distance_calculation_process.h
+++ b/applications/RANSApplication/custom_processes/rans_wall_distance_calculation_process.h
@@ -71,7 +71,7 @@ public:
 
     void ExecuteInitializeSolutionStep() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/RANSApplication/custom_processes/rans_wall_function_update_process.cpp
+++ b/applications/RANSApplication/custom_processes/rans_wall_function_update_process.cpp
@@ -185,7 +185,7 @@ void RansWallFunctionUpdateProcess::PrintData(std::ostream& rOStream) const
 {
 }
 
-const Parameters RansWallFunctionUpdateProcess::GetDefaultParameters() const
+Parameters RansWallFunctionUpdateProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
         {

--- a/applications/RANSApplication/custom_processes/rans_wall_function_update_process.h
+++ b/applications/RANSApplication/custom_processes/rans_wall_function_update_process.h
@@ -77,7 +77,7 @@ public:
 
     void ExecuteAfterCouplingSolveStep() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/RomApplication/custom_modelers/hrom_visualization_mesh_modeler.cpp
+++ b/applications/RomApplication/custom_modelers/hrom_visualization_mesh_modeler.cpp
@@ -41,7 +41,7 @@ HRomVisualizationMeshModeler::HRomVisualizationMeshModeler(
     mRomSettingsFilename = rParameters["rom_settings_filename"].GetString();
 }
 
-const Parameters HRomVisualizationMeshModeler::GetDefaultParameters() const
+Parameters HRomVisualizationMeshModeler::GetDefaultParameters() const
 {
     const Parameters default_parameters( R"(
     {

--- a/applications/RomApplication/custom_modelers/hrom_visualization_mesh_modeler.h
+++ b/applications/RomApplication/custom_modelers/hrom_visualization_mesh_modeler.h
@@ -120,7 +120,7 @@ public:
 
     void SetupModelPart() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/ShallowWaterApplication/custom_modelers/mesh_moving_modeler.cpp
+++ b/applications/ShallowWaterApplication/custom_modelers/mesh_moving_modeler.cpp
@@ -156,7 +156,7 @@ void MeshMovingModeler::SetupModelPart()
     ShallowWaterUtilities().OffsetIds(moving_model_part.Conditions(), fixed_model_part.Conditions().size());
 }
 
-const Parameters MeshMovingModeler::GetDefaultParameters() const
+Parameters MeshMovingModeler::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"({
         "input_file_name"                            : "",

--- a/applications/ShallowWaterApplication/custom_modelers/mesh_moving_modeler.h
+++ b/applications/ShallowWaterApplication/custom_modelers/mesh_moving_modeler.h
@@ -169,7 +169,7 @@ private:
     ///@name Private Operations
     ///@{
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
 

--- a/applications/ShallowWaterApplication/custom_processes/apply_sinusoidal_function_process.cpp
+++ b/applications/ShallowWaterApplication/custom_processes/apply_sinusoidal_function_process.cpp
@@ -116,7 +116,7 @@ double ApplySinusoidalFunctionProcess<TVarType>::SmoothFactor(const double& rTim
 
 
 template<class TVarType>
-const Parameters ApplySinusoidalFunctionProcess<TVarType>::GetDefaultParameters() const
+Parameters ApplySinusoidalFunctionProcess<TVarType>::GetDefaultParameters() const
 {
     Parameters default_parameters = Parameters(R"(
     {

--- a/applications/ShallowWaterApplication/custom_processes/apply_sinusoidal_function_process.h
+++ b/applications/ShallowWaterApplication/custom_processes/apply_sinusoidal_function_process.h
@@ -167,7 +167,7 @@ private:
     ///@name Private Operations
     ///@{
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     double Function(const array_1d<double,3>& rCoordinates, const double& rTime);
 

--- a/applications/ShallowWaterApplication/custom_processes/calculate_distance_to_boundary_process.cpp
+++ b/applications/ShallowWaterApplication/custom_processes/calculate_distance_to_boundary_process.cpp
@@ -137,7 +137,7 @@ void CalculateDistanceToBoundaryProcess::ExecuteBeforeSolutionLoop()
 }
 
 
-const Parameters CalculateDistanceToBoundaryProcess::GetDefaultParameters() const
+Parameters CalculateDistanceToBoundaryProcess::GetDefaultParameters() const
 {
     auto default_parameters = Parameters(R"(
     {

--- a/applications/ShallowWaterApplication/custom_processes/calculate_distance_to_boundary_process.h
+++ b/applications/ShallowWaterApplication/custom_processes/calculate_distance_to_boundary_process.h
@@ -126,7 +126,7 @@ public:
 
     void ExecuteBeforeSolutionLoop() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/ShallowWaterApplication/custom_processes/depth_integration_process.cpp
+++ b/applications/ShallowWaterApplication/custom_processes/depth_integration_process.cpp
@@ -27,7 +27,7 @@ namespace Kratos
 {
 
 template<std::size_t TDim>
-const Parameters DepthIntegrationProcess<TDim>::GetDefaultParameters() const
+Parameters DepthIntegrationProcess<TDim>::GetDefaultParameters() const
 {
     auto default_parameters = Parameters(R"(
     {

--- a/applications/ShallowWaterApplication/custom_processes/depth_integration_process.h
+++ b/applications/ShallowWaterApplication/custom_processes/depth_integration_process.h
@@ -108,7 +108,7 @@ public:
 
     int Check() override;
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/ShallowWaterApplication/custom_utilities/move_shallow_mesh_utility.cpp
+++ b/applications/ShallowWaterApplication/custom_utilities/move_shallow_mesh_utility.cpp
@@ -42,7 +42,7 @@ MoveShallowMeshUtility::MoveShallowMeshUtility(
     FillVariablesList(mVectorVariablesToEulerian, ThisParameters["map_variables_to_eulerian"]);
 }
 
-const Parameters MoveShallowMeshUtility::GetDefaultParameters() const
+Parameters MoveShallowMeshUtility::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"({
         "map_variables_to_lagrangian" : ["TOPOGRAPHY","MANNING"],

--- a/applications/ShallowWaterApplication/custom_utilities/move_shallow_mesh_utility.h
+++ b/applications/ShallowWaterApplication/custom_utilities/move_shallow_mesh_utility.h
@@ -178,7 +178,7 @@ private:
     ///@name Private Operations
     ///@{
 
-    const Parameters GetDefaultParameters() const;
+    Parameters GetDefaultParameters() const;
 
     template<class TDataType>
     void FillVariablesList(std::vector<const Variable<TDataType>*>& rVariablesList, const Parameters VariablesNames);

--- a/applications/StructuralMechanicsApplication/custom_processes/impose_rigid_movement_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/impose_rigid_movement_process.cpp
@@ -152,7 +152,7 @@ void ImposeRigidMovementProcess::ExecuteInitialize()
 /***********************************************************************************/
 /***********************************************************************************/
 
-const Parameters ImposeRigidMovementProcess::GetDefaultParameters() const
+Parameters ImposeRigidMovementProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/StructuralMechanicsApplication/custom_processes/impose_rigid_movement_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/impose_rigid_movement_process.h
@@ -124,7 +124,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/StructuralMechanicsApplication/custom_processes/impose_z_strain_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/impose_z_strain_process.cpp
@@ -64,7 +64,7 @@ void ImposeZStrainProcess::ExecuteInitializeSolutionStep()
 /***********************************************************************************/
 /***********************************************************************************/
 
-const Parameters ImposeZStrainProcess::GetDefaultParameters() const
+Parameters ImposeZStrainProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/StructuralMechanicsApplication/custom_processes/impose_z_strain_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/impose_z_strain_process.h
@@ -64,7 +64,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     /// Turn back information as a string.
     std::string Info() const override

--- a/applications/StructuralMechanicsApplication/custom_processes/set_cartesian_local_axes_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_cartesian_local_axes_process.cpp
@@ -79,7 +79,7 @@ void SetCartesianLocalAxesProcess::ExecuteInitializeSolutionStep()
 /***********************************************************************************/
 /***********************************************************************************/
 
-const Parameters SetCartesianLocalAxesProcess::GetDefaultParameters() const
+Parameters SetCartesianLocalAxesProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/StructuralMechanicsApplication/custom_processes/set_cartesian_local_axes_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_cartesian_local_axes_process.h
@@ -57,7 +57,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     /// Turn back information as a string.
     std::string Info() const override

--- a/applications/StructuralMechanicsApplication/custom_processes/set_cylindrical_local_axes_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_cylindrical_local_axes_process.cpp
@@ -74,7 +74,7 @@ void SetCylindricalLocalAxesProcess::ExecuteInitializeSolutionStep()
 /***********************************************************************************/
 /***********************************************************************************/
 
-const Parameters SetCylindricalLocalAxesProcess::GetDefaultParameters() const
+Parameters SetCylindricalLocalAxesProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/StructuralMechanicsApplication/custom_processes/set_cylindrical_local_axes_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_cylindrical_local_axes_process.h
@@ -58,7 +58,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     /// Turn back information as a string.
     std::string Info() const override

--- a/applications/StructuralMechanicsApplication/custom_processes/set_spherical_local_axes_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_spherical_local_axes_process.cpp
@@ -81,7 +81,7 @@ void SetSphericalLocalAxesProcess::ExecuteInitializeSolutionStep()
 /***********************************************************************************/
 /***********************************************************************************/
 
-const Parameters SetSphericalLocalAxesProcess::GetDefaultParameters() const
+Parameters SetSphericalLocalAxesProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/StructuralMechanicsApplication/custom_processes/set_spherical_local_axes_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_spherical_local_axes_process.h
@@ -58,7 +58,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     /// Turn back information as a string.
     std::string Info() const override

--- a/applications/StructuralMechanicsApplication/custom_processes/shell_to_solid_shell_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/shell_to_solid_shell_process.cpp
@@ -655,7 +655,7 @@ inline void ShellToSolidShellProcess<TNumNodes>::CopyVariablesList(
 /***********************************************************************************/
 
 template<SizeType TNumNodes>
-const Parameters ShellToSolidShellProcess<TNumNodes>::GetDefaultParameters() const
+Parameters ShellToSolidShellProcess<TNumNodes>::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/StructuralMechanicsApplication/custom_processes/shell_to_solid_shell_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/shell_to_solid_shell_process.h
@@ -129,7 +129,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.cpp
@@ -305,7 +305,7 @@ inline void SPRErrorProcess<TDim>::FindNodalNeighbours(ModelPart& rModelPart)
 /***********************************************************************************/
 
 template<SizeType TDim>
-const Parameters SPRErrorProcess<TDim>::GetDefaultParameters() const
+Parameters SPRErrorProcess<TDim>::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.h
@@ -134,7 +134,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/applications/SwimmingDEMApplication/custom_processes/hyperbolic_tangential_porosity_solution_and_body_force_process.cpp
+++ b/applications/SwimmingDEMApplication/custom_processes/hyperbolic_tangential_porosity_solution_and_body_force_process.cpp
@@ -103,7 +103,7 @@ void HyperbolicTangentialPorositySolutionAndBodyForceProcess::CalculateFunctionP
 
 }
 
-const Parameters HyperbolicTangentialPorositySolutionAndBodyForceProcess::GetDefaultParameters() const
+Parameters HyperbolicTangentialPorositySolutionAndBodyForceProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters( R"(
     {

--- a/applications/SwimmingDEMApplication/custom_processes/hyperbolic_tangential_porosity_solution_and_body_force_process.h
+++ b/applications/SwimmingDEMApplication/custom_processes/hyperbolic_tangential_porosity_solution_and_body_force_process.h
@@ -122,7 +122,7 @@ public:
 
     void CheckDefaultsAndProcessSettings(Parameters &rParameters);
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     void CalculatePermeability(double &dynamic_viscosity);
 

--- a/applications/SwimmingDEMApplication/custom_processes/porosity_solution_and_body_force_process.cpp
+++ b/applications/SwimmingDEMApplication/custom_processes/porosity_solution_and_body_force_process.cpp
@@ -101,7 +101,7 @@ void PorositySolutionAndBodyForceProcess::CalculatePermeability(double &dynamic_
     mPermeability = dynamic_viscosity * mUchar / (mDamKohlerNumber * (2 * mViscosity * (mUchar/std::pow(mLength,2))));
 }
 
-const Parameters PorositySolutionAndBodyForceProcess::GetDefaultParameters() const
+Parameters PorositySolutionAndBodyForceProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters( R"(
     {

--- a/applications/SwimmingDEMApplication/custom_processes/porosity_solution_and_body_force_process.h
+++ b/applications/SwimmingDEMApplication/custom_processes/porosity_solution_and_body_force_process.h
@@ -106,7 +106,7 @@ public:
 
     void CheckDefaultsAndProcessSettings(Parameters &rParameters);
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     void CalculateKinematicViscosity();
 

--- a/applications/SwimmingDEMApplication/custom_processes/porosity_solution_transient_body_force_process.cpp
+++ b/applications/SwimmingDEMApplication/custom_processes/porosity_solution_transient_body_force_process.cpp
@@ -74,7 +74,7 @@ void PorositySolutionTransientBodyForceProcess::CheckDefaultsAndProcessSettings(
     mInitialConditions = rParameters["benchmark_parameters"]["use_initial_conditions"].GetBool();
 }
 
-const Parameters PorositySolutionTransientBodyForceProcess::GetDefaultParameters() const
+Parameters PorositySolutionTransientBodyForceProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters( R"(
     {

--- a/applications/SwimmingDEMApplication/custom_processes/porosity_solution_transient_body_force_process.h
+++ b/applications/SwimmingDEMApplication/custom_processes/porosity_solution_transient_body_force_process.h
@@ -155,7 +155,7 @@ public:
 
     void CheckDefaultsAndProcessSettings(Parameters &rParameters);
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     void SetInitialBodyForceAndPorosityField();
 

--- a/applications/SwimmingDEMApplication/custom_processes/sinusoidal_porosity_solution_and_body_force_process.cpp
+++ b/applications/SwimmingDEMApplication/custom_processes/sinusoidal_porosity_solution_and_body_force_process.cpp
@@ -129,7 +129,7 @@ void SinusoidalPorositySolutionAndBodyForceProcess::CalculateWaveNumber(
 
 }
 
-const Parameters SinusoidalPorositySolutionAndBodyForceProcess::GetDefaultParameters() const
+Parameters SinusoidalPorositySolutionAndBodyForceProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters( R"(
     {

--- a/applications/SwimmingDEMApplication/custom_processes/sinusoidal_porosity_solution_and_body_force_process.h
+++ b/applications/SwimmingDEMApplication/custom_processes/sinusoidal_porosity_solution_and_body_force_process.h
@@ -125,7 +125,7 @@ public:
 
     void CheckDefaultsAndProcessSettings(Parameters &rParameters);
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     void CalculateKinematicViscosity(
         double &rReynoldsNumber,

--- a/applications/SwimmingDEMApplication/custom_processes/sinusoidal_porosity_solution_transient_body_force_process.cpp
+++ b/applications/SwimmingDEMApplication/custom_processes/sinusoidal_porosity_solution_transient_body_force_process.cpp
@@ -132,7 +132,7 @@ void SinusoidalPorositySolutionTransientBodyForceProcess::CalculateWaveNumber(
 
 }
 
-const Parameters SinusoidalPorositySolutionTransientBodyForceProcess::GetDefaultParameters() const
+Parameters SinusoidalPorositySolutionTransientBodyForceProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters( R"(
     {

--- a/applications/SwimmingDEMApplication/custom_processes/sinusoidal_porosity_solution_transient_body_force_process.h
+++ b/applications/SwimmingDEMApplication/custom_processes/sinusoidal_porosity_solution_transient_body_force_process.h
@@ -125,7 +125,7 @@ public:
 
     void CheckDefaultsAndProcessSettings(Parameters &rParameters);
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     void CalculateKinematicViscosity(
         double &rReynoldsNumber,

--- a/applications/SwimmingDEMApplication/custom_processes/transient_porosity_solution_body_force_process.cpp
+++ b/applications/SwimmingDEMApplication/custom_processes/transient_porosity_solution_body_force_process.cpp
@@ -104,7 +104,7 @@ void TransientPorositySolutionBodyForceProcess::CalculatePermeability(double &dy
 
 }
 
-const Parameters TransientPorositySolutionBodyForceProcess::GetDefaultParameters() const
+Parameters TransientPorositySolutionBodyForceProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters( R"(
     {

--- a/applications/SwimmingDEMApplication/custom_processes/transient_porosity_solution_body_force_process.h
+++ b/applications/SwimmingDEMApplication/custom_processes/transient_porosity_solution_body_force_process.h
@@ -123,7 +123,7 @@ public:
 
     void CheckDefaultsAndProcessSettings(Parameters &rParameters);
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     void CalculateKinematicViscosity();
 

--- a/kratos/modeler/copy_properties_modeler.cpp
+++ b/kratos/modeler/copy_properties_modeler.cpp
@@ -48,7 +48,7 @@ Modeler::Pointer CopyPropertiesModeler::Create(Model& rModel,
     return Kratos::make_shared<CopyPropertiesModeler>(rModel, ModelParameters);
 }
 
-const Parameters CopyPropertiesModeler::GetDefaultParameters() const
+Parameters CopyPropertiesModeler::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"({
         "echo_level"                  : 0,

--- a/kratos/modeler/copy_properties_modeler.h
+++ b/kratos/modeler/copy_properties_modeler.h
@@ -105,7 +105,7 @@ public:
      * @brief Get the Default Parameters object
      * @return * This const 
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Stages

--- a/kratos/modeler/modeler.h
+++ b/kratos/modeler/modeler.h
@@ -99,7 +99,7 @@ public:
     {}
 
     /// This method provides the defaults parameters to avoid conflicts between the different constructors
-    virtual const Parameters GetDefaultParameters() const
+    virtual Parameters GetDefaultParameters() const
     {
         KRATOS_ERROR << "Calling the base Modeler class GetDefaultParameters. Please implement the GetDefaultParameters in your derived model class." << std::endl;
         const Parameters default_parameters = Parameters(R"({})");

--- a/kratos/processes/apply_constant_scalarvalue_process.h
+++ b/kratos/processes/apply_constant_scalarvalue_process.h
@@ -213,7 +213,7 @@ public:
         Execute();
     }
 
-    const Parameters GetDefaultParameters() const override
+    Parameters GetDefaultParameters() const override
     {
         const Parameters default_parameters( R"(
         {

--- a/kratos/processes/apply_periodic_boundary_condition_process.cpp
+++ b/kratos/processes/apply_periodic_boundary_condition_process.cpp
@@ -113,7 +113,7 @@ void ApplyPeriodicConditionProcess::ExecuteInitializeSolutionStep()
 {
 }
 
-const Parameters ApplyPeriodicConditionProcess::GetDefaultParameters() const
+Parameters ApplyPeriodicConditionProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters(R"(
     {

--- a/kratos/processes/apply_periodic_boundary_condition_process.h
+++ b/kratos/processes/apply_periodic_boundary_condition_process.h
@@ -69,7 +69,7 @@ class KRATOS_API(KRATOS_CORE) ApplyPeriodicConditionProcess : public Process
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     /**
      * @brief Function to print the information about this current process

--- a/kratos/processes/assign_scalar_field_to_entities_process.cpp
+++ b/kratos/processes/assign_scalar_field_to_entities_process.cpp
@@ -69,7 +69,7 @@ void AssignScalarFieldToEntitiesProcess<TEntity>::Execute()
 /***********************************************************************************/
 
 template<class TEntity>
-const Parameters AssignScalarFieldToEntitiesProcess<TEntity>::GetDefaultParameters() const
+Parameters AssignScalarFieldToEntitiesProcess<TEntity>::GetDefaultParameters() const
 {
     const Parameters default_parameters( R"(
     {

--- a/kratos/processes/assign_scalar_field_to_entities_process.h
+++ b/kratos/processes/assign_scalar_field_to_entities_process.h
@@ -118,7 +118,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/kratos/processes/assign_scalar_input_to_entities_process.cpp
+++ b/kratos/processes/assign_scalar_input_to_entities_process.cpp
@@ -118,7 +118,7 @@ void AssignScalarInputToEntitiesProcess<TEntity, THistorical>::ExecuteInitialize
 /***********************************************************************************/
 
 template<class TEntity, bool THistorical>
-const Parameters AssignScalarInputToEntitiesProcess<TEntity, THistorical>::GetDefaultParameters() const
+Parameters AssignScalarInputToEntitiesProcess<TEntity, THistorical>::GetDefaultParameters() const
 {
     const Parameters default_parameters( R"(
     {

--- a/kratos/processes/assign_scalar_input_to_entities_process.h
+++ b/kratos/processes/assign_scalar_input_to_entities_process.h
@@ -118,7 +118,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/kratos/processes/assign_scalar_variable_to_entities_process.cpp
+++ b/kratos/processes/assign_scalar_variable_to_entities_process.cpp
@@ -76,7 +76,7 @@ void AssignScalarVariableToEntitiesProcess<TEntity>::Execute()
 /***********************************************************************************/
 
 template<class TEntity>
-const Parameters AssignScalarVariableToEntitiesProcess<TEntity>::GetDefaultParameters() const
+Parameters AssignScalarVariableToEntitiesProcess<TEntity>::GetDefaultParameters() const
 {
     const Parameters default_parameters( R"(
     {

--- a/kratos/processes/assign_scalar_variable_to_entities_process.h
+++ b/kratos/processes/assign_scalar_variable_to_entities_process.h
@@ -104,7 +104,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
@@ -79,7 +79,7 @@ namespace Kratos
     }
 
     template<std::size_t TDim>
-    const Parameters CalculateDiscontinuousDistanceToSkinProcess<TDim>::GetDefaultParameters() const
+    Parameters CalculateDiscontinuousDistanceToSkinProcess<TDim>::GetDefaultParameters() const
     {
         const Parameters default_parameters = Parameters(R"(
         {

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
@@ -166,7 +166,7 @@ public:
     /**
      * @brief Obtain the default parameters to construct the class.
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/kratos/processes/calculate_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_distance_to_skin_process.cpp
@@ -64,7 +64,7 @@ namespace Kratos
 	}
 
 	template<std::size_t TDim>
-	const Parameters CalculateDistanceToSkinProcess<TDim>::GetDefaultParameters() const
+	Parameters CalculateDistanceToSkinProcess<TDim>::GetDefaultParameters() const
 	{
 		Parameters default_parameters = Parameters(R"(
 		{

--- a/kratos/processes/calculate_distance_to_skin_process.h
+++ b/kratos/processes/calculate_distance_to_skin_process.h
@@ -193,7 +193,7 @@ public:
     /**
      * @brief Obtain the default parameters to construct the class.
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
+++ b/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
@@ -361,7 +361,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override
+    Parameters GetDefaultParameters() const override
     {
         return StaticGetDefaultParameters();
     }

--- a/kratos/processes/compute_nodal_gradient_process.cpp
+++ b/kratos/processes/compute_nodal_gradient_process.cpp
@@ -402,7 +402,7 @@ void VariableVectorRetriever<ComputeNodalGradientProcessSettings::GetAsNonHistor
 /***********************************************************************************/
 
 template<bool THistorical>
-const Parameters ComputeNodalGradientProcess<THistorical>::GetDefaultParameters() const
+Parameters ComputeNodalGradientProcess<THistorical>::GetDefaultParameters() const
 {
     Parameters default_parameters = Parameters(R"(
     {

--- a/kratos/processes/compute_nodal_gradient_process.h
+++ b/kratos/processes/compute_nodal_gradient_process.h
@@ -178,7 +178,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/kratos/processes/edge_based_gradient_recovery_process.h
+++ b/kratos/processes/edge_based_gradient_recovery_process.h
@@ -347,7 +347,7 @@ public:
         mpSolvingStrategy->Clear();
     }
 
-    const Parameters GetDefaultParameters() const override
+    Parameters GetDefaultParameters() const override
     {
         Parameters default_parameters = Parameters(R"({
             "echo_level" : 0,

--- a/kratos/processes/entity_erase_process.cpp
+++ b/kratos/processes/entity_erase_process.cpp
@@ -153,7 +153,7 @@ void EntitiesEraseProcess<MasterSlaveConstraint>::Execute()
 /***********************************************************************************/
 
 template<class TEntity>
-const Parameters EntitiesEraseProcess<TEntity>::GetDefaultParameters() const
+Parameters EntitiesEraseProcess<TEntity>::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/kratos/processes/entity_erase_process.h
+++ b/kratos/processes/entity_erase_process.h
@@ -122,7 +122,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/kratos/processes/find_intersected_geometrical_objects_process.cpp
+++ b/kratos/processes/find_intersected_geometrical_objects_process.cpp
@@ -383,7 +383,7 @@ void FindIntersectedGeometricalObjectsProcess::FindIntersectedSkinObjects(
 /***********************************************************************************/
 /***********************************************************************************/
 
-const Parameters FindIntersectedGeometricalObjectsProcess::GetDefaultParameters() const
+Parameters FindIntersectedGeometricalObjectsProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/kratos/processes/find_intersected_geometrical_objects_process.h
+++ b/kratos/processes/find_intersected_geometrical_objects_process.h
@@ -472,7 +472,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Input and output

--- a/kratos/processes/find_intersected_geometrical_objects_with_obb_process.cpp
+++ b/kratos/processes/find_intersected_geometrical_objects_with_obb_process.cpp
@@ -449,7 +449,7 @@ void FindIntersectedGeometricalObjectsWithOBBProcess::CreateDebugOBB3D(
 /***********************************************************************************/
 /***********************************************************************************/
 
-const Parameters FindIntersectedGeometricalObjectsWithOBBProcess::GetDefaultParameters() const
+Parameters FindIntersectedGeometricalObjectsWithOBBProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/kratos/processes/find_intersected_geometrical_objects_with_obb_process.h
+++ b/kratos/processes/find_intersected_geometrical_objects_with_obb_process.h
@@ -133,7 +133,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@name Member Variables
     ///@{

--- a/kratos/processes/from_json_check_result_process.cpp
+++ b/kratos/processes/from_json_check_result_process.cpp
@@ -902,7 +902,7 @@ std::size_t FromJSONCheckResultProcess::ComputeRelevantDigits(const double Value
 /***********************************************************************************/
 /***********************************************************************************/
 
-const Parameters FromJSONCheckResultProcess::GetDefaultParameters() const
+Parameters FromJSONCheckResultProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/kratos/processes/from_json_check_result_process.h
+++ b/kratos/processes/from_json_check_result_process.h
@@ -316,7 +316,7 @@ protected:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Protected  Access

--- a/kratos/processes/integration_values_extrapolation_to_nodes_process.cpp
+++ b/kratos/processes/integration_values_extrapolation_to_nodes_process.cpp
@@ -267,7 +267,7 @@ void IntegrationValuesExtrapolationToNodesProcess::ExecuteFinalize()
 /***********************************************************************************/
 /***********************************************************************************/
 
-const Parameters IntegrationValuesExtrapolationToNodesProcess::GetDefaultParameters() const
+Parameters IntegrationValuesExtrapolationToNodesProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/kratos/processes/integration_values_extrapolation_to_nodes_process.h
+++ b/kratos/processes/integration_values_extrapolation_to_nodes_process.h
@@ -143,7 +143,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -278,7 +278,7 @@ public:
         mError.clear();
     }
 
-    const Parameters GetDefaultParameters() const override
+    Parameters GetDefaultParameters() const override
     {
         Parameters default_parameters = Parameters(R"({
             "model_part_name" : "",

--- a/kratos/processes/parallel_distance_calculation_process.cpp
+++ b/kratos/processes/parallel_distance_calculation_process.cpp
@@ -65,7 +65,7 @@ ParallelDistanceCalculationProcess<TDim>::ParallelDistanceCalculationProcess(
 }
 
 template<unsigned int TDim>
-const Parameters ParallelDistanceCalculationProcess<TDim>::GetDefaultParameters() const
+Parameters ParallelDistanceCalculationProcess<TDim>::GetDefaultParameters() const
 {
     return Parameters(R"({
         "model_part_name" : "PLEASE_SPECIFY_MODEL_PART",

--- a/kratos/processes/parallel_distance_calculation_process.h
+++ b/kratos/processes/parallel_distance_calculation_process.h
@@ -95,7 +95,7 @@ public:
     /// Destructor.
     virtual ~ParallelDistanceCalculationProcess() {};
 
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     int Check() override;
 

--- a/kratos/processes/process.h
+++ b/kratos/processes/process.h
@@ -178,7 +178,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    virtual const Parameters GetDefaultParameters() const
+    virtual Parameters GetDefaultParameters() const
     {
         KRATOS_ERROR << "Calling the base Process class GetDefaultParameters. Please implement the GetDefaultParameters in your derived process class." << std::endl;
         const Parameters default_parameters = Parameters(R"({})" );

--- a/kratos/processes/replace_elements_and_condition_process.h
+++ b/kratos/processes/replace_elements_and_condition_process.h
@@ -108,7 +108,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override
+    Parameters GetDefaultParameters() const override
     {
         const Parameters default_parameters( R"({
             "element_name"   : "PLEASE_CHOOSE_MODEL_PART_NAME",

--- a/kratos/processes/simple_mortar_mapper_process.cpp
+++ b/kratos/processes/simple_mortar_mapper_process.cpp
@@ -1176,7 +1176,7 @@ void SimpleMortarMapperProcess<TDim, TNumNodes, TVarType, TNumNodesMaster>::Upda
 /***********************************************************************************/
 
 template<SizeType TDim, SizeType TNumNodes, class TVarType, const SizeType TNumNodesMaster>
-const Parameters SimpleMortarMapperProcess<TDim, TNumNodes, TVarType, TNumNodesMaster>::GetDefaultParameters() const
+Parameters SimpleMortarMapperProcess<TDim, TNumNodes, TVarType, TNumNodesMaster>::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/kratos/processes/simple_mortar_mapper_process.h
+++ b/kratos/processes/simple_mortar_mapper_process.h
@@ -399,7 +399,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/kratos/processes/simple_mortar_mapper_wrapper_process.h
+++ b/kratos/processes/simple_mortar_mapper_wrapper_process.h
@@ -230,7 +230,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override
+    Parameters GetDefaultParameters() const override
     {
         const Parameters default_parameters = Parameters(R"(
         {

--- a/kratos/processes/skin_detection_process.cpp
+++ b/kratos/processes/skin_detection_process.cpp
@@ -339,7 +339,7 @@ void SkinDetectionProcess<TDim>::SetUpAdditionalSubModelParts(const ModelPart& r
 /***********************************************************************************/
 
 template<SizeType TDim>
-const Parameters SkinDetectionProcess<TDim>::GetDefaultParameters() const
+Parameters SkinDetectionProcess<TDim>::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/kratos/processes/skin_detection_process.h
+++ b/kratos/processes/skin_detection_process.h
@@ -252,7 +252,7 @@ protected:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Protected  Access

--- a/kratos/processes/split_internal_interfaces_process.h
+++ b/kratos/processes/split_internal_interfaces_process.h
@@ -121,7 +121,7 @@ public:
 
     void ExecuteInitialize() override;
 
-    const Parameters GetDefaultParameters() const override
+    Parameters GetDefaultParameters() const override
     {
         const Parameters default_parameters( R"(
         {

--- a/kratos/processes/structured_mesh_generator_process.cpp
+++ b/kratos/processes/structured_mesh_generator_process.cpp
@@ -87,7 +87,7 @@ void StructuredMeshGeneratorProcess::Execute()
 
 }
 
-const Parameters StructuredMeshGeneratorProcess::GetDefaultParameters() const
+Parameters StructuredMeshGeneratorProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters(R"(
     {

--- a/kratos/processes/structured_mesh_generator_process.h
+++ b/kratos/processes/structured_mesh_generator_process.h
@@ -89,7 +89,7 @@ namespace Kratos
       /**
        * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
        */
-      const Parameters GetDefaultParameters() const override;
+      Parameters GetDefaultParameters() const override;
 
       ///@}
       ///@name Access

--- a/kratos/processes/sub_model_part_skin_detection_process.cpp
+++ b/kratos/processes/sub_model_part_skin_detection_process.cpp
@@ -140,7 +140,7 @@ void SubModelPartSkinDetectionProcess<TDim>::CreateConditions(
 }
 
 template<SizeType TDim>
-const Parameters SubModelPartSkinDetectionProcess<TDim>::GetDefaultParameters() const
+Parameters SubModelPartSkinDetectionProcess<TDim>::GetDefaultParameters() const
 {
     Parameters defaults = SkinDetectionProcess<TDim>::GetDefaultParameters();
     defaults.AddEmptyValue("selection_criteria");

--- a/kratos/processes/sub_model_part_skin_detection_process.h
+++ b/kratos/processes/sub_model_part_skin_detection_process.h
@@ -167,7 +167,7 @@ void CreateConditions(
 /**
  * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
  */
-const Parameters GetDefaultParameters() const override;
+Parameters GetDefaultParameters() const override;
 
 ///@}
 

--- a/kratos/processes/time_averaging_process.cpp
+++ b/kratos/processes/time_averaging_process.cpp
@@ -271,7 +271,7 @@ void TimeAveragingProcess::ExecuteFinalizeSolutionStep()
     KRATOS_CATCH("");
 }
 
-const Parameters TimeAveragingProcess::GetDefaultParameters() const
+Parameters TimeAveragingProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/kratos/processes/time_averaging_process.h
+++ b/kratos/processes/time_averaging_process.h
@@ -89,7 +89,7 @@ public:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const override;
+    Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access

--- a/kratos/utilities/model_part_combination_utilities.cpp
+++ b/kratos/utilities/model_part_combination_utilities.cpp
@@ -273,7 +273,7 @@ void ModelPartCombinationUtilities::RecursiveAddEntities(
 /***********************************************************************************/
 /***********************************************************************************/
 
-const Parameters ModelPartCombinationUtilities::GetDefaultParameters() const
+Parameters ModelPartCombinationUtilities::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"(
     {

--- a/kratos/utilities/model_part_combination_utilities.h
+++ b/kratos/utilities/model_part_combination_utilities.h
@@ -198,7 +198,7 @@ private:
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
-    const Parameters GetDefaultParameters() const;
+    Parameters GetDefaultParameters() const;
 
     ///@}
     ///@name Private  Access


### PR DESCRIPTION
Many function signatures look like:
```c++
const Parameters GetDefaultParameters() const override
```
The first `const` is superflous at best, and misleading at worse. Unfortunatelly this breaks API so you may decide wether it's worth it or not.

**🆕 Changelog**
I performed the following three find and replace:

84 changes:
```
Find:    const Parameters GetDefaultParameters() const override
Replace: Parameters GetDefaultParameters() const override
```

4 changes:
```
Find:    const Parameters GetDefaultParameters() const
Replace: Parameters GetDefaultParameters() const
```

75 changes (regex):
```
Find:    const Parameters (.*)::GetDefaultParameters\(\) const
Replace: Parameters \1::GetDefaultParameters() const
```

**Sidenote**
If we wanted to return actual inmutable parameters we have a ccouple of options.

_Alternative 1_
We can re-write the Parameters class to allow for internally holding a pointer to const json object (not worth it in my opinion).

_Alternative 2_
Returning a const reference to a static:
```c++
const Parameters& GetDefaultParameters() const override
{
    static Parameters default_parameters = { /* Whatever */}
    default_parameters.RecursivelyAddMissingParameters(BaseType::GetDefaultParameters());
    return default_parameters;
}
```
Once again, not worth the effort in my opinion. Besides, one could side-step the const because Parameters' implementation is not const-correct (e.g GetValue is marked const while allowing modification of the underlying object).