### PR TITLE
[Fluid] ComputeDragProcess now flushes its output every step

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/compute_drag_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/compute_drag_process.py
@@ -82,6 +82,7 @@ class ComputeDragProcess(KratosMultiphysics.Process):
                 file_header = self._GetFileHeader()
                 self.output_file = TimeBasedAsciiFileWriterUtility(self.model_part,
                     file_handler_params, file_header).file
+                self.output_file.flush()
 
     def ExecuteFinalizeSolutionStep(self):
         current_step = self.model_part.ProcessInfo[KratosMultiphysics.STEP]
@@ -101,6 +102,7 @@ class ComputeDragProcess(KratosMultiphysics.Process):
                 # in the file writer when restarting
                 if (self.write_drag_output_file):
                     self.output_file.write(str(current_time)+" "+format(drag_force[0],self.format)+" "+format(drag_force[1],self.format)+" "+format(drag_force[2],self.format)+"\n")
+                    self.output_file.flush()
 
     def ExecuteFinalize(self):
         if (self.write_drag_output_file):

--- a/applications/FluidDynamicsApplication/tests/compute_drag_process_test.py
+++ b/applications/FluidDynamicsApplication/tests/compute_drag_process_test.py
@@ -1,0 +1,69 @@
+import os
+
+import KratosMultiphysics
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+from KratosMultiphysics.FluidDynamicsApplication import compute_drag_process
+
+
+class ComputeDragProcessTest(KratosUnittest.TestCase):
+
+    def tearDown(self):
+        if os.path.exists("main_drag.dat"):
+            os.remove("main_drag.dat")
+
+    class DummyDragProcess(compute_drag_process.ComputeDragProcess):
+        def _GetFileHeader(self):
+            return '# HEADER\n# Time Fx Fy Fz\n'
+
+        def _PrintToScreen(self, result_msg):
+            KratosMultiphysics.Logger.PrintInfo("ComputeEmbeddedDragProcess", "DUMMY DRAG RESULTS:")
+            KratosMultiphysics.Logger.PrintInfo("ComputeEmbeddedDragProcess", "Current time: " + result_msg)
+
+        def _GetCorrespondingDragForce(self):
+            return [1.0, 2.0, 3.0]
+
+    def testProperFlushing(self):
+        model = KratosMultiphysics.Model()
+        mpart = model.CreateModelPart("main")
+
+        settings = KratosMultiphysics.Parameters("""
+        {
+            "model_part_name" : "main",
+            "print_drag_to_screen"      : false,
+            "write_drag_output_file"    : true,
+            "output_file_settings" : {
+                "file_extension": "dat",
+                "file_name": "main_drag.dat",
+                "write_buffer_size": -1
+            }
+        }""")
+
+        process = self.DummyDragProcess(model, settings)
+
+        process.ExecuteInitialize()
+
+        # After initialization
+        with open("main_drag.dat") as f:
+            number_of_lines_printed = len(f.readlines())
+            self.assertEqual(number_of_lines_printed, 2)
+
+        # First step
+        process.ExecuteFinalizeSolutionStep()
+        with open("main_drag.dat") as f:
+            number_of_lines_printed = len(f.readlines())
+            self.assertEqual(number_of_lines_printed, 3)
+
+        # Intermediate step
+        process.ExecuteFinalizeSolutionStep()
+        with open("main_drag.dat") as f:
+            number_of_lines_printed = len(f.readlines())
+            self.assertEqual(number_of_lines_printed, 4)
+
+        # End of program
+        process.ExecuteFinalize()
+        with open("main_drag.dat") as f:
+            number_of_lines_printed = len(f.readlines())
+            self.assertEqual(number_of_lines_printed, 4)
+
+if __name__ == '__main__':
+    KratosUnittest.main()

--- a/applications/FluidDynamicsApplication/tests/test_FluidDynamicsApplication.py
+++ b/applications/FluidDynamicsApplication/tests/test_FluidDynamicsApplication.py
@@ -51,6 +51,7 @@ if sympy_available:
     from compressible_navier_stokes_symbolic_generator_formulation_test import CompressibleNavierStokesSymbolicGeneratorFormulationTest
 from compressible_slip_wall_process_test import TestCompressibleSlipWallProcess
 from compute_pressure_coefficient_process_test import ComputePressureCoefficientProcessTest
+from compute_drag_process_test import ComputeDragProcessTest
 
 
 def AssembleTestSuites():
@@ -89,6 +90,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([InitializeWithCompressiblePotentialSolutionProcessTest]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCompressibleSlipWallProcess]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([ComputePressureCoefficientProcessTest]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([ComputeDragProcessTest]))
 
     # Create a test suite with the selected tests plus all small tests
     nightSuite = suites['nightly']


### PR DESCRIPTION
**📝 Description**
This PR solves the problem pointed out in the Fluid Dynamics project: 

https://github.com/KratosMultiphysics/Kratos/projects/10#card-37224441.
> Drag process only prints at the end of the simulation. This is a problem if the simulation crashes or if it is intentionally stopped by the user.
Open and close the file to write the drag each time it is computed.

Instead of opening and closing every time, I added a flush.

**🆕 Changelog**
- Added flush after write-to-file 
- Added unit test to validate it. I tested commenting the flushes out and it didn't pass, however I'm not certain on how deterministic this test is (as in: it will always pass when there is no problem, but may sometimes pass even if there is a problem).