### PR TITLE
[Core][BugFix] Hotfix PointLocalCoordinates in Line2D2

### DIFF
--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -1078,11 +1078,19 @@ public:
         if (length_1 <= (length + tolerance) && length_2 <= (length + tolerance)) {
             rResult[0] = 2.0 * length_1/(length + tolerance) - 1.0;
         } else if (length_1 > (length + tolerance)) {
-            rResult[0] = 2.0 * length_1/(length + tolerance) - 1.0; // NOTE: The same value as before, but it will be > than 1
+            if (length_1 > length_2) {
+                rResult[0] = 2.0 * length_1/(length + tolerance) - 1.0;
+            } else {
+                rResult[0] = -2.0 * length_1/(length + tolerance) - 1.0;
+            }
         } else if (length_2 > (length + tolerance)) {
-            rResult[0] = 1.0 - 2.0 * length_2/(length + tolerance);
+            if (length_1 > length_2) {
+                rResult[0] = 2.0 * length_1/(length + tolerance) - 1.0;
+            } else {
+                rResult[0] = -2.0 * length_1/(length + tolerance) - 1.0;
+            }
         } else {
-            rResult[0] = 2.0; // Out of the line!!!
+            KRATOS_ERROR << "Unreachable PointLocalCoordinates case." << std::endl;
         }
 
         return rResult ;

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -1077,20 +1077,12 @@ public:
 
         if (length_1 <= (length + tolerance) && length_2 <= (length + tolerance)) {
             rResult[0] = 2.0 * length_1/(length + tolerance) - 1.0;
-        } else if (length_1 > (length + tolerance)) {
-            if (length_1 > length_2) {
-                rResult[0] = 2.0 * length_1/(length + tolerance) - 1.0;
-            } else {
-                rResult[0] = -2.0 * length_1/(length + tolerance) - 1.0;
-            }
-        } else if (length_2 > (length + tolerance)) {
-            if (length_1 > length_2) {
-                rResult[0] = 2.0 * length_1/(length + tolerance) - 1.0;
-            } else {
-                rResult[0] = -2.0 * length_1/(length + tolerance) - 1.0;
-            }
         } else {
-            KRATOS_ERROR << "Unreachable PointLocalCoordinates case." << std::endl;
+            if (length_1 > length_2) {
+                rResult[0] = 2.0 * length_1/(length + tolerance) - 1.0;
+            } else {
+                rResult[0] = -2.0 * length_1/(length + tolerance) - 1.0;
+            }
         }
 
         return rResult ;

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_2.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_2.cpp
@@ -199,7 +199,7 @@ namespace Testing {
         auto geom = GeneratePointsDiagonalLine2D2();
 
         // Set the point to be checked
-        Point test_point({1.5,1.5,0.0});
+        Point test_point(1.5,1.5,0.0);
 
         // Compute the centre local coordinates
         array_1d<double, 3> test_point_local_coords;
@@ -219,7 +219,7 @@ namespace Testing {
         auto geom = GeneratePointsDiagonalLine2D2();
 
         // Set the point to be checked
-        Point test_point({2.5,2.5,0.0});
+        Point test_point(2.5,2.5,0.0);
 
         // Compute the centre local coordinates
         array_1d<double, 3> test_point_local_coords;
@@ -239,7 +239,7 @@ namespace Testing {
         auto geom = GeneratePointsDiagonalLine2D2();
 
         // Set the point to be checked
-        Point test_point({-0.25,-0.25,0.0});
+        Point test_point(-0.25,-0.25,0.0);
 
         // Compute the centre local coordinates
         array_1d<double, 3> test_point_local_coords;
@@ -259,7 +259,7 @@ namespace Testing {
         auto geom = GeneratePointsDiagonalLine2D2();
 
         // Set the point to be checked
-        Point test_point({-1.5,-1.5,0.0});
+        Point test_point(-1.5,-1.5,0.0);
 
         // Compute the centre local coordinates
         array_1d<double, 3> test_point_local_coords;

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_2.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_2.cpp
@@ -190,6 +190,86 @@ namespace Testing {
         KRATOS_CHECK_NEAR(centre_local_coords(2), 0.0, TOLERANCE);
     }
 
+    /** Checks the point local coordinates for a given point respect to the line.
+    * A point outside but aligned with the line is selected. In this case the distance from second node is smaller than the length
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line2D2PointLocalCoordinatesOutsidePoint1, KratosCoreGeometriesFastSuite)
+    {
+        // Create the test line
+        auto geom = GeneratePointsDiagonalLine2D2();
+
+        // Set the point to be checked
+        Point test_point({1.5,1.5,0.0});
+
+        // Compute the centre local coordinates
+        array_1d<double, 3> test_point_local_coords;
+        geom->PointLocalCoordinates(test_point_local_coords, test_point);
+
+        KRATOS_CHECK_NEAR(test_point_local_coords(0), 2.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(test_point_local_coords(1), 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(test_point_local_coords(2), 0.0, TOLERANCE);
+    }
+
+    /** Checks the point local coordinates for a given point respect to the line.
+    * A point outside but aligned with the line is selected. In this case the distance from second node is larger than the length
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line2D2PointLocalCoordinatesOutsidePoint2, KratosCoreGeometriesFastSuite)
+    {
+        // Create the test line
+        auto geom = GeneratePointsDiagonalLine2D2();
+
+        // Set the point to be checked
+        Point test_point({2.5,2.5,0.0});
+
+        // Compute the centre local coordinates
+        array_1d<double, 3> test_point_local_coords;
+        geom->PointLocalCoordinates(test_point_local_coords, test_point);
+
+        KRATOS_CHECK_NEAR(test_point_local_coords(0), 4.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(test_point_local_coords(1), 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(test_point_local_coords(2), 0.0, TOLERANCE);
+    }
+
+    /** Checks the point local coordinates for a given point respect to the line.
+    * A point outside but aligned with the line is selected. In this case the distance from first node is smaller than the length
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line2D2PointLocalCoordinatesOutsidePoint3, KratosCoreGeometriesFastSuite)
+    {
+        // Create the test line
+        auto geom = GeneratePointsDiagonalLine2D2();
+
+        // Set the point to be checked
+        Point test_point({-0.25,-0.25,0.0});
+
+        // Compute the centre local coordinates
+        array_1d<double, 3> test_point_local_coords;
+        geom->PointLocalCoordinates(test_point_local_coords, test_point);
+
+        KRATOS_CHECK_NEAR(test_point_local_coords(0), -1.5, TOLERANCE);
+        KRATOS_CHECK_NEAR(test_point_local_coords(1), 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(test_point_local_coords(2), 0.0, TOLERANCE);
+    }
+
+    /** Checks the point local coordinates for a given point respect to the line.
+    * A point outside but aligned with the line is selected. In this case the distance from first node is larger than the length
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line2D2PointLocalCoordinatesOutsidePoint4, KratosCoreGeometriesFastSuite)
+    {
+        // Create the test line
+        auto geom = GeneratePointsDiagonalLine2D2();
+
+        // Set the point to be checked
+        Point test_point({-1.5,-1.5,0.0});
+
+        // Compute the centre local coordinates
+        array_1d<double, 3> test_point_local_coords;
+        geom->PointLocalCoordinates(test_point_local_coords, test_point);
+
+        KRATOS_CHECK_NEAR(test_point_local_coords(0), -4.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(test_point_local_coords(1), 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(test_point_local_coords(2), 0.0, TOLERANCE);
+    }
+
     /** Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
     * Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
     */


### PR DESCRIPTION
**📝 Description**
The `PointLocalCoordinates` of the `Line2D2` was not considering all the possible cases of a point lying aligned but outside the line. This PR fixes these.

@RiccardoRossi @playpaolo @bcsnvs this is the cause of the missbehaviors we observed in the master-slave search done by the `BinBasedFastPointLocator` within the `PeriodicityUtility`. 
