### PR TITLE
[Core] Fixed a compilation warning

### DIFF
--- a/kratos/processes/structured_mesh_generator_process.cpp
+++ b/kratos/processes/structured_mesh_generator_process.cpp
@@ -267,7 +267,7 @@ int StructuredMeshGeneratorProcess::Check()
     KRATOS_CHECK(CheckDomainGeometry());
     KRATOS_CHECK(KratosComponents<Element>::Has(mElementName));
 
-    if ((mrGeometry.GetGeometryType() != GeometryData::KratosGeometryType::Kratos_Quadrilateral2D4) &
+    if ((mrGeometry.GetGeometryType() != GeometryData::KratosGeometryType::Kratos_Quadrilateral2D4) &&
         (mrGeometry.GetGeometryType() != GeometryData::KratosGeometryType::Kratos_Hexahedra3D8))
         KRATOS_ERROR << "An unsupported geometry was given. Only Quadrilateral2D4 and Hexahedra3D8 are supported and given geometry is : " << mrGeometry << std::endl;
 


### PR DESCRIPTION
**📝 Description**
A warning I found while compiling.

**🆕 Changelog**
- Fixed a bool that was using a bitwise comparisson
```
/home/egomez/Work/Kratos/kratos/processes/structured_mesh_generator_process.cpp:270:9: warning: use of bitwise '&' with boolean operands [-Wbitwise-instead-of-logical]
    if ((mrGeometry.GetGeometryType() != GeometryData::KratosGeometryType::Kratos_Quadrilateral2D4) &
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                                                                    &&
/home/egomez/Work/Kratos/kratos/processes/structured_mesh_generator_process.cpp:270:9: note: cast one or both operands to int to silence this warning
```

