### PR TITLE
[CompressiblePotential] Fixed compilation warning

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.cpp
@@ -168,10 +168,9 @@ void EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::CalculateKuttaWake
 
     MatrixType laplacian_matrix = ZeroMatrix(2 * NumNodes, 2 * NumNodes);
 
-    PotentialFlowUtilities::ElementalData<NumNodes,Dim> data;
+    PotentialFlowUtilities::ElementalData<NumNodes,Dim> data{this->GetGeometry()};
 
     // Calculate shape functions
-    GeometryUtils::CalculateGeometryData(this->GetGeometry(), data.DN_DX, data.N, data.vol);
     data.distances = PotentialFlowUtilities::GetWakeDistances<Dim, NumNodes>(*this);
 
     const double density = BaseType::ComputeDensity(rCurrentProcessInfo);

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.cpp
@@ -132,10 +132,7 @@ void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateKuttaWa
     rLeftHandSideMatrix.clear();
     rRightHandSideVector.clear();
 
-    PotentialFlowUtilities::ElementalData<NumNodes,Dim> data;
-
-    // Calculate shape functions
-    GeometryUtils::CalculateGeometryData(this->GetGeometry(), data.DN_DX, data.N, data.vol);
+    PotentialFlowUtilities::ElementalData<NumNodes,Dim> data{this->GetGeometry()};
 
     const double free_stream_density = rCurrentProcessInfo[FREE_STREAM_DENSITY];
 

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_transonic_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_transonic_perturbation_potential_flow_element.cpp
@@ -153,11 +153,8 @@ void EmbeddedTransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::Calcula
     }
     rRightHandSideVector.clear();
 
-    ElementalData data;
-
-    // Calculate shape functions
     const auto& r_geometry = this->GetGeometry();
-    GeometryUtils::CalculateGeometryData(r_geometry, data.DN_DX, data.N, data.vol);
+    ElementalData data{r_geometry};
 
     const array_1d<double, 3>& free_stream_velocity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
     array_1d<double, TDim> upper_velocity = PotentialFlowUtilities::ComputeVelocityUpperWakeElement<TDim,TNumNodes>(*this);
@@ -200,10 +197,7 @@ void EmbeddedTransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::Calcula
     }
     rLeftHandSideMatrix.clear();
 
-    ElementalData data;
-
-    // Calculate shape functions
-    GeometryUtils::CalculateGeometryData(this->GetGeometry(), data.DN_DX, data.N, data.vol);
+    ElementalData data{this->GetGeometry()};
 
     // Compute upper and lower velocities
     const array_1d<double, TDim> upper_velocity = PotentialFlowUtilities::ComputePerturbedVelocity<TDim,TNumNodes>(*this, rCurrentProcessInfo);
@@ -340,8 +334,7 @@ void EmbeddedTransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::Assembl
         densityDerivativeWRTVelocity, densityDerivativeWRTUpwindVelocity, velocity, upwindVelocity, rCurrentProcessInfo);
 
     // Calculate shape functions
-    ElementalData data;
-    GeometryUtils::CalculateGeometryData(this->GetGeometry(), data.DN_DX, data.N, data.vol);
+    ElementalData data{this->GetGeometry()};
 
     const double density = PotentialFlowUtilities::ComputeUpwindedDensity<TDim, TNumNodes>(velocity, upwindVelocity, rCurrentProcessInfo);
 

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.cpp
@@ -559,8 +559,7 @@ void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::CalculateLeftHa
     const ProcessInfo& rCurrentProcessInfo)
 {
     // Calculate shape functions
-    ElementalData data;
-    GeometryUtils::CalculateGeometryData(GetGeometry(), data.DN_DX, data.N, data.vol);
+    ElementalData data{GetGeometry()};
 
     const array_1d<double, TDim> velocity = PotentialFlowUtilities::ComputePerturbedVelocity<TDim,TNumNodes>(*this, rCurrentProcessInfo);
 
@@ -623,8 +622,7 @@ void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::CalculateRightH
     const array_1d<double, TDim>& rVelocity)
 {
     // Calculate shape functions
-    ElementalData data;
-    GeometryUtils::CalculateGeometryData(GetGeometry(), data.DN_DX, data.N, data.vol);
+    ElementalData data{GetGeometry()};
 
     rRhs_total = - data.vol * rDensity * prod(data.DN_DX, rVelocity);
 }
@@ -696,10 +694,8 @@ void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::CalculateLeftHa
     }
     rLeftHandSideMatrix.clear();
 
-    ElementalData data;
+    ElementalData data{GetGeometry()};
 
-    // Calculate shape functions
-    GeometryUtils::CalculateGeometryData(GetGeometry(), data.DN_DX, data.N, data.vol);
     GetWakeDistances(data.distances);
 
     // Compute upper and lower velocities
@@ -777,11 +773,9 @@ void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::CalculateRightH
     }
     rRightHandSideVector.clear();
 
-    ElementalData data;
-
-    // Calculate shape functions
     const auto& r_geometry = this->GetGeometry();
-    GeometryUtils::CalculateGeometryData(r_geometry, data.DN_DX, data.N, data.vol);
+
+    ElementalData data{r_geometry};
     GetWakeDistances(data.distances);
 
     const array_1d<double, 3>& free_stream_velocity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
@@ -905,10 +899,7 @@ void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::CalculateLeftHa
     Matrix& lhs_negative,
     const ProcessInfo& rCurrentProcessInfo)
 {
-    ElementalData data;
-
-    // Calculate shape functions
-    GeometryUtils::CalculateGeometryData(GetGeometry(), data.DN_DX, data.N, data.vol);
+    ElementalData data{GetGeometry()};
 
     GetWakeDistances(data.distances);
 
@@ -987,10 +978,7 @@ void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::CalculateVolume
     double& rLower_vol,
     const ProcessInfo& rCurrentProcessInfo)
 {
-    ElementalData data;
-
-    // Calculate shape functions
-    GeometryUtils::CalculateGeometryData(GetGeometry(), data.DN_DX, data.N, data.vol);
+    ElementalData data{GetGeometry()};
 
     GetWakeDistances(data.distances);
 
@@ -1147,8 +1135,7 @@ void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::AssembleSuperso
         densityDerivativeWRTVelocity, densityDerivativeWRTUpwindVelocity, velocity, upwindVelocity, rCurrentProcessInfo);
 
     // Calculate shape functions
-    ElementalData data;
-    GeometryUtils::CalculateGeometryData(GetGeometry(), data.DN_DX, data.N, data.vol);
+    ElementalData data{GetGeometry()};
 
     const double density = PotentialFlowUtilities::ComputeUpwindedDensity<TDim, TNumNodes>(velocity, upwindVelocity, rCurrentProcessInfo);
 
@@ -1185,11 +1172,8 @@ BoundedVector<double, TNumNodes + 1> TransonicPerturbationPotentialFlowElement<T
 
     const array_1d<size_t, TNumNodes> upwind_node_key = GetAssemblyKey(r_geom, r_upwind_geom, rCurrentProcessInfo);
 
-    ElementalData currentElementdata;
-    ElementalData upwindElementdata;
-
-    GeometryUtils::CalculateGeometryData(r_geom, currentElementdata.DN_DX, currentElementdata.N, currentElementdata.vol);
-    GeometryUtils::CalculateGeometryData(r_upwind_geom, upwindElementdata.DN_DX, upwindElementdata.N, upwindElementdata.vol);
+    ElementalData currentElementdata{r_geom};
+    ElementalData upwindElementdata{r_upwind_geom};
 
     const BoundedVector<double, TNumNodes> current_DNV = densityDerivativeWRTVelocitySquared * prod(currentElementdata.DN_DX, velocity);
     const BoundedVector<double, TNumNodes> upwind_DNV = densityDerivativeWRTUpwindVelocitySquared * prod(upwindElementdata.DN_DX, upwindVelocity);

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
@@ -269,10 +269,7 @@ double ComputeVelocityMagnitude(
 template <int Dim, int NumNodes>
 array_1d<double, Dim> ComputeVelocityNormalElement(const Element& rElement)
 {
-    ElementalData<NumNodes, Dim> data;
-
-    // Calculate shape functions
-    GeometryUtils::CalculateGeometryData(rElement.GetGeometry(), data.DN_DX, data.N, data.vol);
+    ElementalData<NumNodes, Dim> data{rElement.GetGeometry()};
 
     data.potentials = GetPotentialOnNormalElement<Dim,NumNodes>(rElement);
 
@@ -282,10 +279,7 @@ array_1d<double, Dim> ComputeVelocityNormalElement(const Element& rElement)
 template <int Dim, int NumNodes>
 array_1d<double, Dim> ComputeVelocityUpperWakeElement(const Element& rElement)
 {
-    ElementalData<NumNodes, Dim> data;
-
-    // Calculate shape functions
-    GeometryUtils::CalculateGeometryData(rElement.GetGeometry(), data.DN_DX, data.N, data.vol);
+    ElementalData<NumNodes, Dim> data{rElement.GetGeometry()};
 
     const auto& r_distances = GetWakeDistances<Dim,NumNodes>(rElement);
 
@@ -297,10 +291,7 @@ array_1d<double, Dim> ComputeVelocityUpperWakeElement(const Element& rElement)
 template <int Dim, int NumNodes>
 array_1d<double, Dim> ComputeVelocityLowerWakeElement(const Element& rElement)
 {
-    ElementalData<NumNodes, Dim> data;
-
-    // Calculate shape functions
-    GeometryUtils::CalculateGeometryData(rElement.GetGeometry(), data.DN_DX, data.N, data.vol);
+    ElementalData<NumNodes, Dim> data{rElement.GetGeometry()};
 
     const auto& r_distances = GetWakeDistances<Dim,NumNodes>(rElement);
 
@@ -1024,10 +1015,9 @@ void AddKuttaConditionPenaltyTerm(const Element& rElement,
 {
     const int wake = rElement.GetValue(WAKE);
 
-    PotentialFlowUtilities::ElementalData<NumNodes,Dim> data;
+    PotentialFlowUtilities::ElementalData<NumNodes,Dim> data{rElement.GetGeometry()};
     const double free_stream_density = rCurrentProcessInfo[FREE_STREAM_DENSITY];
 
-    GeometryUtils::CalculateGeometryData(rElement.GetGeometry(), data.DN_DX, data.N, data.vol);
     data.potentials = PotentialFlowUtilities::GetPotentialOnNormalElement<Dim,NumNodes>(rElement);
 
     const double angle_in_deg = rCurrentProcessInfo[ROTATION_ANGLE];
@@ -1073,10 +1063,9 @@ void AddKuttaConditionPenaltyPerturbationLHS(const Element& rElement,
 {
     const int wake = rElement.GetValue(WAKE);
 
-    PotentialFlowUtilities::ElementalData<NumNodes,Dim> data;
+    PotentialFlowUtilities::ElementalData<NumNodes,Dim> data{rElement.GetGeometry()};
     const double free_stream_density = rCurrentProcessInfo[FREE_STREAM_DENSITY];
 
-    GeometryUtils::CalculateGeometryData(rElement.GetGeometry(), data.DN_DX, data.N, data.vol);
     data.potentials = PotentialFlowUtilities::GetPotentialOnNormalElement<Dim,NumNodes>(rElement);
 
     const double angle_in_deg = rCurrentProcessInfo[ROTATION_ANGLE];
@@ -1118,11 +1107,10 @@ void AddKuttaConditionPenaltyPerturbationRHS(const Element& rElement,
     const int wake = rElement.GetValue(WAKE);
     const double penalty = rCurrentProcessInfo[PENALTY_COEFFICIENT];
 
-    PotentialFlowUtilities::ElementalData<NumNodes,Dim> data;
+    PotentialFlowUtilities::ElementalData<NumNodes,Dim> data{rElement.GetGeometry()};
     const double free_stream_density = rCurrentProcessInfo[FREE_STREAM_DENSITY];
     const array_1d<double, 3> free_stream_velocity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
 
-    GeometryUtils::CalculateGeometryData(rElement.GetGeometry(), data.DN_DX, data.N, data.vol);
     data.potentials = PotentialFlowUtilities::GetPotentialOnNormalElement<Dim,NumNodes>(rElement);
 
     const double angle_in_deg = rCurrentProcessInfo[ROTATION_ANGLE];
@@ -1194,13 +1182,9 @@ void AddPotentialGradientStabilizationTerm(
                     const auto& r_integration_method = r_geometry.GetDefaultIntegrationMethod();
                     const auto& r_integration_points = r_geometry.IntegrationPoints(r_integration_method);
                     Vector detJ0;
-                    const auto neighbour_data = [&]()
-                    {
-                        PotentialFlowUtilities::ElementalData<NumNodes,Dim> neighbour_data;
-                        GeometryUtils::CalculateGeometryData(r_geometry, neighbour_data.DN_DX, neighbour_data.N, neighbour_data.vol);
-                        neighbour_data.potentials = PotentialFlowUtilities::GetPotentialOnNormalElement<Dim, NumNodes>(r_elem);
-                        return neighbour_data;
-                    }();
+                    
+                    PotentialFlowUtilities::ElementalData<NumNodes,Dim> neighbour_data{r_geometry};
+                    neighbour_data.potentials = PotentialFlowUtilities::GetPotentialOnNormalElement<Dim, NumNodes>(r_elem);
 
                     r_geometry.DeterminantOfJacobian(detJ0, r_integration_method);
 
@@ -1250,8 +1234,7 @@ void AddPotentialGradientStabilizationTerm(
     }
     averaged_nodal_gradient = averaged_nodal_gradient/number_of_positive_nodes;
 
-    PotentialFlowUtilities::ElementalData<NumNodes,Dim> data;
-    GeometryUtils::CalculateGeometryData(rElement.GetGeometry(), data.DN_DX, data.N, data.vol);
+    PotentialFlowUtilities::ElementalData<NumNodes,Dim> data{rElement.GetGeometry()};
 
     auto stabilization_term_nodal_gradient = data.vol*prod(data.DN_DX, averaged_nodal_gradient);
     auto stabilization_term_potential = data.vol*prod(data.DN_DX,trans(data.DN_DX));

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
@@ -1194,10 +1194,14 @@ void AddPotentialGradientStabilizationTerm(
                     const auto& r_integration_method = r_geometry.GetDefaultIntegrationMethod();
                     const auto& r_integration_points = r_geometry.IntegrationPoints(r_integration_method);
                     Vector detJ0;
-                    PotentialFlowUtilities::ElementalData<NumNodes,Dim> neighbour_data;
+                    const auto neighbour_data = [&]()
+                    {
+                        PotentialFlowUtilities::ElementalData<NumNodes,Dim> neighbour_data;
+                        GeometryUtils::CalculateGeometryData(r_geometry, neighbour_data.DN_DX, neighbour_data.N, neighbour_data.vol);
+                        neighbour_data.potentials = PotentialFlowUtilities::GetPotentialOnNormalElement<Dim, NumNodes>(r_elem);
+                        return neighbour_data;
+                    }();
 
-                    GeometryUtils::CalculateGeometryData(r_geometry, neighbour_data.DN_DX, neighbour_data.N, neighbour_data.vol);
-                    neighbour_data.potentials = PotentialFlowUtilities::GetPotentialOnNormalElement<Dim, NumNodes>(r_elem);
                     r_geometry.DeterminantOfJacobian(detJ0, r_integration_method);
 
                     const int is_neighbour_wake = r_elem.GetValue(WAKE);

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
@@ -16,6 +16,7 @@
 // Project includes
 #include "containers/array_1d.h"
 #include "includes/ublas_interface.h"
+#include "utilities/geometry_utilities.h"
 
 namespace Kratos
 {
@@ -37,10 +38,10 @@ namespace PotentialFlowUtilities
 template <unsigned int TNumNodes, unsigned int TDim>
 struct ElementalData
 {
-    using GeometryType = ModelPart::GeometryType;
-    ElementalData(const GeometryType& rGeometry)
+    template<typename TGeometryType>
+    ElementalData(const TGeometryType& rGeometry)
     {
-        GeometryUtils::CalculateGeometryData(r_geometry, DN_DX, N, vol);
+        GeometryUtils::CalculateGeometryData(rGeometry, DN_DX, N, vol);
     }
 
     array_1d<double, TNumNodes> potentials, distances;

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
@@ -37,6 +37,7 @@ namespace PotentialFlowUtilities
 template <unsigned int TNumNodes, unsigned int TDim>
 struct ElementalData
 {
+    using GeometryType = ModelPart::GeometryType;
     ElementalData(const GeometryType& rGeometry)
     {
         GeometryUtils::CalculateGeometryData(r_geometry, DN_DX, N, vol);

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
@@ -35,7 +35,13 @@ namespace Kratos
 namespace PotentialFlowUtilities
 {
 template <unsigned int TNumNodes, unsigned int TDim>
-struct ElementalData{
+struct ElementalData
+{
+    ElementalData(const GeometryType& rGeometry)
+    {
+        GeometryUtils::CalculateGeometryData(r_geometry, DN_DX, N, vol);
+    }
+
     array_1d<double, TNumNodes> potentials, distances;
     double vol;
 


### PR DESCRIPTION
**📝 Description**
Solves the following warning by changing the construction of PotentialFlowUtilities::ElementalData.

```
[ 92%] Building CXX object applications/CompressiblePotentialFlowApplication/CMakeFiles/KratosCompressiblePotentialFlowCore.dir/custom_utilities/potential_flow_utilities.cpp.o
/home/egomez/Work/Kratos/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp: In function ‘void Kratos::PotentialFlowUtilities::AddPotentialGradientStabilizationTerm(Kratos::Element&, Kratos::Matrix&, Kratos::Vector&, const Kratos::ProcessInfo&) [with int Dim = 2; int NumNodes = 3]’:
/home/egomez/Work/Kratos/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp:1225:86: warning: ‘neighbour_data.Kratos::PotentialFlowUtilities::ElementalData<3, 2>::N.Kratos::array_1d<double, 3>::data_.std::array<double, 3>::_M_elems[18446744073709551615]’ may be used uninitialized [-Wmaybe-uninitialized]
 1225 |                         nodal_gradient[k] += neighbour_data.N[neighbour_node_id] * gauss_point_volume * neighbour_elemental_gradient[k];
      |                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~

/home/egomez/Work/Kratos/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp:1197:73: note: ‘neighbour_data’ declared here
 1197 |                     PotentialFlowUtilities::ElementalData<NumNodes,Dim> neighbour_data;
      |                                                                         ^~~~~~~~~~~~~~
/home/egomez/Work/Kratos/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp: In function ‘void Kratos::PotentialFlowUtilities::AddPotentialGradientStabilizationTerm(Kratos::Element&, Kratos::Matrix&, Kratos::Vector&, const Kratos::ProcessInfo&) [with int Dim = 3; int NumNodes = 4]’:
/home/egomez/Work/Kratos/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp:1225:86: warning: ‘neighbour_data.Kratos::PotentialFlowUtilities::ElementalData<4, 3>::N.Kratos::array_1d<double, 4>::data_.std::array<double, 4>::_M_elems[18446744073709551615]’ may be used uninitialized [-Wmaybe-uninitialized]
 1225 |                         nodal_gradient[k] += neighbour_data.N[neighbour_node_id] * gauss_point_volume * neighbour_elemental_gradient[k];
      |                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~

/home/egomez/Work/Kratos/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp:1197:73: note: ‘neighbour_data’ declared here
 1197 |                     PotentialFlowUtilities::ElementalData<NumNodes,Dim> neighbour_data;
      | 
```

**🆕 Changelog**
Solved aforementioned warning.