### PR TITLE
[FastPR][Nightly][FluidBio] Remove MPI section

### DIFF
--- a/applications/FluidDynamicsBiomedicalApplication/tests/test_FluidDynamicsBiomedicalApplication.py
+++ b/applications/FluidDynamicsBiomedicalApplication/tests/test_FluidDynamicsBiomedicalApplication.py
@@ -51,17 +51,6 @@ if __name__ == '__main__':
     KratosMultiphysics.Tester.RunTestSuite("FluidDynamicsBiomedicalApplicationFastSuite")
     KratosMultiphysics.Logger.PrintInfo("Unittests", "Finished running cpp unit tests!")
 
-    if kratos_utilities.IsMPIAvailable() and kratos_utilities.CheckIfApplicationsAvailable("MetisApplication", "TrilinosApplication"):
-        KratosMultiphysics.Logger.PrintInfo("Unittests", "\nRunning mpi python tests ...")
-        p = subprocess.Popen(
-            ["mpiexec", "-np", "2", "python3", "test_FluidDynamicsBiomedicalApplication_mpi.py"],
-            stdout=subprocess.PIPE,
-            cwd=os.path.dirname(os.path.abspath(__file__)))
-        p.wait()
-        KratosMultiphysics.Logger.PrintInfo("Unittests", "Finished mpi python tests!")
-    else:
-        KratosMultiphysics.Logger.PrintInfo("Unittests", "\nSkipping mpi python tests due to missing dependencies")
-
     KratosMultiphysics.Logger.PrintInfo("Unittests", "\nRunning python tests ...")
     KratosUnittest.runTests(AssembleTestSuites())
     KratosMultiphysics.Logger.PrintInfo("Unittests", "Finished python tests!")


### PR DESCRIPTION
**📝 Description**
This fixes the nightly build. The `FluidDynamicsBiomedicalApplication` has no MPI support yet so I remove the call to the MPI tests (rather than adding the MPI script).
