### PR TITLE
[Fluid] Changed shock capturing processes to run at InitializeSolutionStep

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/shock_capturing_entropy_viscosity_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/shock_capturing_entropy_viscosity_process.cpp
@@ -141,9 +141,13 @@ double ShockCapturingEntropyViscosityProcess::TotalDerivativeUtil::Divergence(
 
 void ShockCapturingEntropyViscosityProcess::ExecuteInitializeSolutionStep()
 {
-    if(!mIsInitialized)
+    if (mComputeAreasEveryStep || !mIsInitialized)
     {
         UpdateNodalAreaProcess();
+    }
+
+    if(!mIsInitialized)
+    {
         ComputeNodalEntropies(1);
         /* ^ Necessary in order to compute derivative in first step.
          *   Stored in buffer index 1 to prevent it from being overwritten at the
@@ -152,16 +156,6 @@ void ShockCapturingEntropyViscosityProcess::ExecuteInitializeSolutionStep()
          *      processes don't run until ExecuteInitializeSolutionStep
          */
         mIsInitialized = true;
-    }
-}
-
-
-void ShockCapturingEntropyViscosityProcess::ExecuteFinalizeSolutionStep()
-{
-
-    if (mComputeAreasEveryStep)
-    {
-        UpdateNodalAreaProcess();
     }
 
     ComputeNodalEntropies();

--- a/applications/FluidDynamicsApplication/custom_processes/shock_capturing_entropy_viscosity_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/shock_capturing_entropy_viscosity_process.h
@@ -174,8 +174,6 @@ public:
 
     void ExecuteInitializeSolutionStep() override;
 
-    void ExecuteFinalizeSolutionStep() override;
-
     int Check() override;
 
     const Parameters GetDefaultParameters() const override;

--- a/applications/FluidDynamicsApplication/custom_processes/shock_capturing_physics_based_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/shock_capturing_physics_based_process.cpp
@@ -34,7 +34,7 @@ namespace Kratos
     {
         Check();
         ExecuteInitialize();
-        ExecuteFinalizeSolutionStep();
+        ExecuteInitializeSolutionStep();
     }
 
     void ShockCapturingPhysicsBasedProcess::ExecuteInitialize()
@@ -73,7 +73,7 @@ namespace Kratos
         nodal_area_process.Execute();
     }
 
-    void ShockCapturingPhysicsBasedProcess::ExecuteFinalizeSolutionStep()
+    void ShockCapturingPhysicsBasedProcess::ExecuteInitializeSolutionStep()
     {
         CalculatePhysicsBasedShockCapturing();
     }

--- a/applications/FluidDynamicsApplication/custom_processes/shock_capturing_physics_based_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/shock_capturing_physics_based_process.h
@@ -139,7 +139,7 @@ public:
 
     void ExecuteInitialize() override;
 
-    void ExecuteFinalizeSolutionStep() override;
+    void ExecuteInitializeSolutionStep() override;
 
     int Check() override;
 

--- a/applications/FluidDynamicsApplication/custom_strategies/strategies/compressible_navier_stokes_explicit_solving_strategy.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/strategies/compressible_navier_stokes_explicit_solving_strategy.h
@@ -242,7 +242,7 @@ public:
     {
         BaseType::InitializeSolutionStep();
 
-        if (ConservativeMagnitudeCalculationEnabled()) {
+        if (mFirstStep) {
             CalculateNonConservativeMagnitudes();
         }
 
@@ -277,6 +277,8 @@ public:
         if (ShockCapturingEnabled()) {
             GetShockCapturingProcess()->ExecuteFinalizeSolutionStep();
         }
+
+        mFirstStep = false;
     }
 
     /// Turn back information as a string.
@@ -528,6 +530,7 @@ private:
     ///@name Member Variables
     ///@{
 
+    bool mFirstStep = true;
     bool mApplySlipCondition = true;
     bool mCalculateNonConservativeMagnitudes = true;
     Process::UniquePointer mpShockCapturingProcess = nullptr;

--- a/applications/FluidDynamicsApplication/custom_strategies/strategies/compressible_navier_stokes_explicit_solving_strategy.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/strategies/compressible_navier_stokes_explicit_solving_strategy.h
@@ -242,7 +242,8 @@ public:
     {
         BaseType::InitializeSolutionStep();
 
-        if (mFirstStep) {
+        if (mFirstStep && ConservativeMagnitudeCalculationEnabled()) {
+            // This needs to be here because the initial conditions are set during ExecuteInitializeSolutionStep.
             CalculateNonConservativeMagnitudes();
         }
 


### PR DESCRIPTION
**📝 Description**
The issue this PR solves is that, since until now shock capturing was computed during ExecutFinalizeSolutionStep, the first time-step had no shock capturing.

The shock capturing has been moved to ExecuteInitializeSolutionStep in order to fix this.

