### PR TITLE
[CLApp] avoid to call InitializeSolutionStep in CL

### DIFF
--- a/applications/ConstitutiveLawsApplication/custom_constitutive/associative_plastic_damage_model.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/associative_plastic_damage_model.h
@@ -177,7 +177,7 @@ public:
      */
     bool RequiresInitializeMaterialResponse() override
     {
-        return true;
+        return false;
     }
 
     /**

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/generic_finite_strain_isotropic_plasticity.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/generic_finite_strain_isotropic_plasticity.h
@@ -186,6 +186,14 @@ public:
     }
 
     /**
+     * @brief If the CL requires to initialize the material response, called by the element in InitializeSolutionStep.
+     */
+    bool RequiresInitializeMaterialResponse() override
+    {
+        return false;
+    }
+
+    /**
      * @brief Returns the value of a specified variable (double)
      * @param rParameterValues the needed parameters for the CL calculation
      * @param rThisVariable the variable to be returned

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/generic_finite_strain_kinematic_plasticity.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/generic_finite_strain_kinematic_plasticity.h
@@ -186,6 +186,14 @@ public:
     }
 
     /**
+     * @brief If the CL requires to initialize the material response, called by the element in InitializeSolutionStep.
+     */
+    bool RequiresInitializeMaterialResponse() override
+    {
+        return false;
+    }
+
+    /**
      * @brief Returns the value of a specified variable (double)
      * @param rParameterValues the needed parameters for the CL calculation
      * @param rThisVariable the variable to be returned

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/generic_small_strain_d_plus_d_minus_damage.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/generic_small_strain_d_plus_d_minus_damage.h
@@ -324,6 +324,14 @@ public:
     }
 
     /**
+     * @brief If the CL requires to initialize the material response, called by the element in InitializeSolutionStep.
+     */
+    bool RequiresInitializeMaterialResponse() override
+    {
+        return false;
+    }
+
+    /**
      * @brief Returns the value of a specified variable (double)
      * @param rParameterValues the needed parameters for the CL calculation
      * @param rThisVariable the variable to be returned

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/generic_small_strain_isotropic_damage.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/generic_small_strain_isotropic_damage.h
@@ -289,6 +289,14 @@ public:
     }
 
     /**
+     * @brief If the CL requires to initialize the material response, called by the element in InitializeSolutionStep.
+     */
+    bool RequiresInitializeMaterialResponse() override
+    {
+        return false;
+    }
+
+    /**
      * @brief Returns the value of a specified variable (double)
      * @param rParameterValues the needed parameters for the CL calculation
      * @param rThisVariable the variable to be returned

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/generic_small_strain_isotropic_plasticity.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/generic_small_strain_isotropic_plasticity.h
@@ -298,7 +298,7 @@ public:
      */
     bool RequiresInitializeMaterialResponse() override
     {
-        return true;
+        return false;
     }
 
     /**

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/generic_small_strain_kinematic_plasticity.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/generic_small_strain_kinematic_plasticity.h
@@ -281,6 +281,14 @@ public:
     }
 
     /**
+     * @brief If the CL requires to initialize the material response, called by the element in InitializeSolutionStep.
+     */
+    bool RequiresInitializeMaterialResponse() override
+    {
+        return false;
+    }
+
+    /**
      * @brief Returns the value of a specified variable (double)
      * @param rParameterValues the needed parameters for the CL calculation
      * @param rThisVariable the variable to be returned

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/generic_small_strain_orthotropic_damage.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/generic_small_strain_orthotropic_damage.h
@@ -262,6 +262,14 @@ public:
     }
 
     /**
+     * @brief If the CL requires to initialize the material response, called by the element in InitializeSolutionStep.
+     */
+    bool RequiresInitializeMaterialResponse() override
+    {
+        return false;
+    }
+
+    /**
      * @brief Returns the value of a specified variable (double)
      * @param rParameterValues the needed parameters for the CL calculation
      * @param rThisVariable the variable to be returned

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/generic_small_strain_plastic_damage_model.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/generic_small_strain_plastic_damage_model.h
@@ -331,7 +331,7 @@ public:
      */
     bool RequiresInitializeMaterialResponse() override
     {
-        return true;
+        return false;
     }
 
     /**

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/generic_small_strain_viscoplasticity_3d.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/generic_small_strain_viscoplasticity_3d.h
@@ -212,6 +212,14 @@ class KRATOS_API(CONSTITUTIVE_LAWS_APPLICATION) GenericSmallStrainViscoplasticit
         return true;
     }
 
+    /**
+     * @brief If the CL requires to initialize the material response, called by the element in InitializeSolutionStep.
+     */
+    bool RequiresInitializeMaterialResponse() override
+    {
+        return false;
+    }
+
     double &CalculateValue(
         Parameters &rParameterValues,
         const Variable<double> &rThisVariable,

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/viscous_generalized_kelvin.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/viscous_generalized_kelvin.h
@@ -231,6 +231,22 @@ public:
         const ProcessInfo& rCurrentProcessInfo
         ) const override;
 
+    /**
+     * @brief If the CL requires to initialize the material response, called by the element in InitializeSolutionStep.
+     */
+    bool RequiresInitializeMaterialResponse() override
+    {
+        return false;
+    }
+
+    /**
+     * @brief If the CL requires to initialize the material response, called by the element in InitializeSolutionStep.
+     */
+    bool RequiresFinalizeMaterialResponse() override
+    {
+        return true;
+    }
+
     ///@}
     ///@name Access
     ///@{

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/viscous_generalized_maxwell.h
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/viscous_generalized_maxwell.h
@@ -230,6 +230,22 @@ class KRATOS_API(CONSTITUTIVE_LAWS_APPLICATION) ViscousGeneralizedMaxwell
         const ProcessInfo& rCurrentProcessInfo
         ) const override;
 
+    /**
+     * @brief If the CL requires to initialize the material response, called by the element in InitializeSolutionStep.
+     */
+    bool RequiresInitializeMaterialResponse() override
+    {
+        return false;
+    }
+
+    /**
+     * @brief If the CL requires to initialize the material response, called by the element in InitializeSolutionStep.
+     */
+    bool RequiresFinalizeMaterialResponse() override
+    {
+        return true;
+    }
+
     ///@}
     ///@name Access
     ///@{


### PR DESCRIPTION
I'm adding the RequiresInitializeSolutionStep to false since it is not necessary. Safe computational cost.

