### PR TITLE
[Core] Variational distance - Unset blocked flag exiting process

### DIFF
--- a/kratos/processes/variational_distance_calculation_process.h
+++ b/kratos/processes/variational_distance_calculation_process.h
@@ -344,8 +344,8 @@ public:
 
         // Unfix the distances
         VariableUtils().ApplyFixity(DISTANCE, false, r_distance_model_part.Nodes());
+        VariableUtils().SetFlag(BOUNDARY, false, r_distance_model_part.Nodes());
         VariableUtils().SetFlag(BLOCKED, false, r_distance_model_part.Nodes());
-
 
         KRATOS_CATCH("")
     }

--- a/kratos/processes/variational_distance_calculation_process.h
+++ b/kratos/processes/variational_distance_calculation_process.h
@@ -344,6 +344,8 @@ public:
 
         // Unfix the distances
         VariableUtils().ApplyFixity(DISTANCE, false, r_distance_model_part.Nodes());
+        VariableUtils().SetFlag(BLOCKED, false, r_distance_model_part.Nodes());
+
 
         KRATOS_CATCH("")
     }


### PR DESCRIPTION
**📝 Description**
After #9891, I introduced a bug when using the variational distance and the MMG process.

The MMG process uses the BLOCKED flag to fix the entities that will not be remeshed. Since the variational distance process now uses this flag, this was causing an unexpected behaviour when using MMG in level set cases.

For this reason, now I add a call to unset the blocked flag when exiting the variational distance process. 


**🆕 Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Unset BLOCKED flag when exiting Variational distance process. 