### PR TITLE
[Core] Thread Local Storage for external methods

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_smp_storage.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_smp_storage.cpp
@@ -1,0 +1,57 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Suneth Warnakulasuriya
+//
+
+// System includes
+#include <vector>
+
+// Project includes
+#include "utilities/reduction_utilities.h"
+#include "utilities/parallel_utilities.h"
+#include "utilities/smp_storage.h"
+#include "testing/testing.h"
+
+namespace Kratos {
+namespace Testing {
+
+KRATOS_TEST_CASE_IN_SUITE(SMPStorage, KratosCoreFastSuite)
+{
+    class Scheme
+    {
+    public:
+        void CalculateLocalSystem(int& LHS, int ProcessInfo) {
+            auto& tls = mSMPStorage.GetThreadLocalStorage();
+            tls.b = ProcessInfo * 3;
+            LHS = tls.b;
+        }
+    private:
+        struct TLS
+        {
+            int b;
+        };
+
+        SMPStorage<TLS> mSMPStorage;
+    };
+
+    Scheme scheme;
+
+    int n = 1e+4;
+    const int result = IndexPartition<int>(n).for_each<SumReduction<int>>([&](const int ProcessInfo) -> int {
+        int lhs;
+        scheme.CalculateLocalSystem(lhs, ProcessInfo);
+        return lhs;
+    });
+
+    KRATOS_CHECK_EQUAL(result, n * (n-1) * 3 / 2);
+}
+
+}
+}

--- a/kratos/utilities/smp_storage.h
+++ b/kratos/utilities/smp_storage.h
@@ -1,0 +1,100 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Suneth Warnakulasuriya
+//
+
+#if !defined(KRATOS_SMP_STORAGE_H_INCLUDED )
+#define  KRATOS_SMP_STORAGE_H_INCLUDED
+
+// System includes
+#ifdef KRATOS_SMP_OPENMP
+#include <vector>
+#include "utilities/openmp_utils.h"
+#endif
+
+// Project includes
+#include "includes/define.h"
+#include "utilities/parallel_utilities.h"
+
+namespace Kratos
+{
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Classes
+///@{
+
+template<class TStorageType>
+class SMPStorage
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+    SMPStorage(){
+        #ifdef KRATOS_SMP_OPENMP
+            mThreadLocalStorageContainer.resize(ParallelUtilities::GetNumThreads());
+        #endif
+    }
+
+    /// Destructor.
+    ~SMPStorage() = default;
+
+    /// Deleted copy constructor
+    SMPStorage(SMPStorage const& rOther) = delete;
+
+    /// Deleted assignment operator
+    SMPStorage& operator=(SMPStorage const& rOther) = delete;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    TStorageType& GetThreadLocalStorage()
+    {
+        #ifdef KRATOS_SMP_OPENMP
+            return mThreadLocalStorageContainer[OpenMPUtils::ThisThread()];
+        #elif defined(KRATOS_SMP_CXX11)
+            thread_local TStorageType tls;
+            return tls;
+        #else
+            return mThreadLocalStorageContainer;
+        #endif
+    }
+
+    ///@}
+private:
+    ///@}
+    ///@name Private Members
+    ///@{
+
+#ifdef KRATOS_SMP_OPENMP
+    std::vector<TStorageType> mThreadLocalStorageContainer;
+#elif defined(KRATOS_SMP_CXX11)
+#else
+    TStorageType mThreadLocalStorageContainer;
+#endif
+
+    ///@}
+
+}; // Class SMPStorage
+
+///@}
+
+///@} addtogroup block
+
+}  // namespace Kratos.
+
+#endif // KRATOS_SMP_STORAGE_H_INCLUDED  defined

--- a/kratos/utilities/smp_storage.h
+++ b/kratos/utilities/smp_storage.h
@@ -20,7 +20,6 @@
 #endif
 
 // Project includes
-#include "includes/define.h"
 #include "utilities/parallel_utilities.h"
 
 namespace Kratos
@@ -35,10 +34,6 @@ template<class TStorageType>
 class SMPStorage
 {
 public:
-    ///@name Type Definitions
-    ///@{
-
-    ///@}
     ///@name Life Cycle
     ///@{
 
@@ -93,7 +88,7 @@ private:
 
 ///@}
 
-///@} addtogroup block
+///@} addtogroup KratosCore
 
 }  // namespace Kratos.
 

--- a/kratos/utilities/smp_storage.h
+++ b/kratos/utilities/smp_storage.h
@@ -62,7 +62,7 @@ public:
     ///@name Operations
     ///@{
 
-    TStorageType& GetThreadLocalStorage()
+    inline TStorageType& GetThreadLocalStorage()
     {
         #ifdef KRATOS_SMP_OPENMP
             return mThreadLocalStorageContainer[OpenMPUtils::ThisThread()];


### PR DESCRIPTION
**📝 Description**
This adds the templated class `SMPStorage`. All of the methods in `parallel_utilities.h` has the ability to use thread local storage. But in the case where this parallelized block (ex: `block_for_each`) is initiated in one place and it calls to some method in a different place which is external to the parallelization block (ex: as in `Scheme::CalculateLocalSystem`), then it is not possible to have a thread local storage for the calling method. This class acts as a wrapper thread local storage for such cases. An example is also added to illustrate the use case. 

`SMPStorage` class should work with both `OpenMP` parallelism and `C++` SMP parallelism.

The snippet of the use case is as follows:
```c++
    class Scheme
    {
    public:
        void CalculateLocalSystem(int& LHS, int ProcessInfo) {
            auto& tls = mSMPStorage.GetThreadLocalStorage();
            tls.b = ProcessInfo * 3;
            LHS = tls.b;
        }
    private:
        struct TLS
        {
            int b;
        };

        SMPStorage<TLS> mSMPStorage;
    };

    Scheme scheme;

    int n = 1e+4;
    const int result = IndexPartition<int>(n).for_each<SumReduction<int>>([&](const int ProcessInfo) -> int {
        int lhs;
        scheme.CalculateLocalSystem(lhs, ProcessInfo);
        return lhs;
    });
```

**🆕 Changelog**
- Adds `SMPStorage` class
- Adds tests
