### PR TITLE
Add link to guidelines for MPI compilation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -369,13 +369,13 @@ The result should be:
    ' /   __| _` | __|  _ \   __|
    . \  |   (   | |   (   |\__ \
   _|\_\_|  \__,_|\__|\___/ ____/
-           Multi-Physics 8.0
+           Multi-Physics 9.1
 ```
 
 
 ## Advanced Configuration
 
-### Parallel Compilation
+### Compilation of Kratos in parallel
 
 We provide several flavours in order to parallelize Kratos compilation. We have divided this option according to the operating system specifics.
 
@@ -436,19 +436,15 @@ try to update this section with the specifics.
 It is possible to configure the build environment for Kratos, that is: where the source is located, which will be the install dir, and how the python files are going to be installed.
 
 `KRATOS_SOURCE=Path`
-
 Path to the source of Kratos. It will target the directory above this script by default.
 
 `KRATOS_BUILD=Path`
-
 Build directory for Kratos. Makefiles, vsprojects and other artifacts will be stored here. It defaults to Kratos/Build
 
 `KRATOS_APP_DIR=Path`
-
 Path where your applications are located. This variable is not necessary but it helps to organize the list of applications to be compiled. It defaults to Kratos/Applications
 
 `KRATOS_INSTALL_PYTHON_USING_LINKS=ON/OFF`
-
 Controls wether the python files are installed by making copies or creating symlinks to the files in the source directory. This options is specially usefull if you are developing python files and don't want to reinstall every time you touch a script.
 
 Using this option in windows requires elevated privileges (you must run the script as admin)
@@ -458,46 +454,35 @@ Using this option in windows requires elevated privileges (you must run the scri
 
 It is also possible to use more advanced configuration options. To use any of these options please add them directly to the cmake configuration line just as any other flag
 
-
 `-DCMAKE_C_COMPILER=String`
-
 Path to the C compiler. Overrides `CC` environment variable
 
 `-DCMAKE_CXX_COMPILER=String`
-
 Path to the C++ compiler. Overrides `CXX` environment variable
 
 `-DCMAKE_INSTALL_PREFIX=String`
-
 Install path for Kratos. If not set the installation will be done in `bin/[build_type]`
 
 `-DCMAKE_C_FLAGS=String`
-
 User defined flags for the C compiler.
 
 `-DCMAKE_CXX_FLAGS=String`
-
 User defined flags for the C++ compiler.
 
 `-DBOOST_ROOT=String`
-
 Root directory for boost. Overrided by BOOST_ROOT environmental variable if defined.
 
 `-DPYTHON_EXECUTABLE=String`
-
 Python executable to be used. It is recommended to set this option if more than one version of python is present in the system (For example while using ubuntu). Overrided by PYTHON_EXECUTABLE environmental variable if defined.
 
 `-DINSTALL_RUNKRATOS=ON/OFF`
-
 Enables(Default) or Disables the compilation of the embedded python interpreter (aka Runkratos).
 
 `-DKRATOS_BUILD_TESTING=ON/OFF`
-
 Enables(Default) or Disables the compilation of the C++ unitary tests for Kratos and Applications.
 
 ### Unitary Builds
 `-DCMAKE_UNITY_BUILD=ON/OFF`
-
 Enables or Disables(default) the use of [cmake unity build](https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html) to speedup compilation by using unitary builds.
 Please notice that enabling this options can greatly increase the amount of memory needed to compile some targets, specially if combined with -jx.
 
@@ -518,13 +503,13 @@ Please, beware that using this flag along with a parallel compilation may cause 
 We recommed you to disable parallel compilation unless you know what you are doing.
 
 ### Parallelism
-`-DUSE_MPI=ON/OFF`
 
-Enables or Disables(default) the modules and code for mpi. This option is needed if you want to compile Trilinos, Metis, etc...
+Building Kratos with support for MPI requires an advanced configuration of its building script,
+as well as the building of dependencies and parallel applications.
+Here you can find [guidelines](https://github.com/KratosMultiphysics/Kratos/wiki/Compiling-Kratos-with-MPI-support) for the compilation of Kratos and its dependencies.
 
 ### Logging
 `-DKRATOS_COLORED_OUTPUT=ON/OFF`
-
 Enables colored output of the Logger. If switched on, e.g. warning level messages will be printed in yellow to the terminal. Please notice that colored output is not supported by all terminals.
 
 ### TPL-Libraries

--- a/applications/MetisApplication/README.md
+++ b/applications/MetisApplication/README.md
@@ -1,18 +1,36 @@
 ## Metis Application
 
-The Metis application provides an interface to the [Metis](http://glaros.dtc.umn.edu/gkhome/metis/metis/overview) graph partitioning library. This is used within Kratos Multiphysics to generate mesh partitions for MPI runs.
+The Metis application provides an interface to the
+[METIS](https://github.com/KarypisLab/METIS) graph partitioning library.
+This is used within Kratos Multiphysics to generate mesh partitions for MPI runs.
 
-The applicaiton is organized in a series of processes, each one of them providing an interface to a different partitioning algorithm. The most commonly used one for finite elements is ```metis_divide_heterogeneous_input_process.h```, which generates a partition of the mesh based on the nodal graph and can be used for meshes combining multiple element types.
+The applicaiton is organized in a series of processes, each one of them providing an interface to a different partitioning algorithm. The most commonly used one for finite elements is `metis_divide_heterogeneous_input_process.h`, which generates a partition of the mesh based on the nodal graph and can be used for meshes combining multiple element types.
 
-### Compilation
-From Ubuntu 18.04 onwards, Metis can be installed with the following command:
-
-```Shell
-sudo apt-get install libmetis-dev
+### Build instructions
+Building the `MetisApplication` requires the Metis libraries and their dependencies already installed on the system.
+The easiest way to get them is by the package manager of the Linux distribution.
+For example, in Ubuntu:
+```bash
+sudo apt install libmetis-dev
 ```
+However, there may be situations where downloading the packages may not be possible.
+In this case, other (potentially trickier) option is to download the source code and build the libraries.
+For more detailed and updated instructions for compiling METIS, GKlib, and other necessary pakages,
+refer to [Compiling Kratos with MPI support](https://github.com/KratosMultiphysics/Kratos/wiki/Compiling-Kratos-with-MPI-support) in the wiki.
 
-If not automatically detected, use
+Assuming that the dependencies are installed, the following steps are:
 
-`-DMETIS_ROOT_DIR=String`
-
-to specify the root directory for Metis library.
+1. Add the `MetisApplication` to the list of applications to be compiled in the building script for Kratos,
+as described in the [install instructions](https://github.com/KratosMultiphysics/Kratos/blob/master/INSTALL.md#adding-applications).
+```bash
+export KRATOS_APPLICATIONS=
+...
+add_app ${KRATOS_APP_DIR}/MetisApplication
+```
+2. Tell CMake where are located the libraries and includes of METIS, in case CMake does not find them.
+For example:
+```bash
+cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}" \
+...
+-DMETIS_ROOT_DIR="${HOME}/Projects/METIS/build"
+```

--- a/applications/MetisApplication/README.md
+++ b/applications/MetisApplication/README.md
@@ -1,13 +1,15 @@
 ## Metis Application
 
 The Metis application provides an interface to the
-[METIS](https://github.com/KarypisLab/METIS) graph partitioning library.
-This is used within Kratos Multiphysics to generate mesh partitions for MPI runs.
+[METIS](https://github.com/KarypisLab/METIS) graph partitioning library,
+used within Kratos Multiphysics to generate mesh partitions for MPI runs.
 
-The applicaiton is organized in a series of processes, each one of them providing an interface to a different partitioning algorithm. The most commonly used one for finite elements is `metis_divide_heterogeneous_input_process.h`, which generates a partition of the mesh based on the nodal graph and can be used for meshes combining multiple element types.
+The applicaiton is organized in a series of processes, each one of them providing an interface to a different partitioning algorithm.
+The algorithm most commonly used for finite elements is `metis_divide_heterogeneous_input_process.h`,
+which generates a partition of the mesh based on the nodal graph and can be used for meshes combining multiple element types.
 
 ### Build instructions
-Building the `MetisApplication` requires the Metis libraries and their dependencies already installed on the system.
+Building the `MetisApplication` requires METIS libraries and their dependencies already installed on the system.
 The easiest way to get them is by the package manager of the Linux distribution.
 For example, in Ubuntu:
 ```bash
@@ -15,7 +17,7 @@ sudo apt install libmetis-dev
 ```
 However, there may be situations where downloading the packages may not be possible.
 In this case, other (potentially trickier) option is to download the source code and build the libraries.
-For more detailed and updated instructions for compiling METIS, GKlib, and other necessary pakages,
+For more detailed and updated instructions for compiling METIS, GKlib, and other necessary packages,
 refer to [Compiling Kratos with MPI support](https://github.com/KratosMultiphysics/Kratos/wiki/Compiling-Kratos-with-MPI-support) in the wiki.
 
 Assuming that the dependencies are installed, the following steps are:
@@ -27,7 +29,7 @@ export KRATOS_APPLICATIONS=
 ...
 add_app ${KRATOS_APP_DIR}/MetisApplication
 ```
-2. Tell CMake where are located the libraries and includes of METIS, in case CMake does not find them.
+2. Tell CMake where are located the libraries and headers of METIS, if CMake does not find them automatically.
 For example:
 ```bash
 cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}" \

--- a/applications/MetisApplication/README.md
+++ b/applications/MetisApplication/README.md
@@ -1,4 +1,4 @@
-## Metis Application
+# Metis Application
 
 The Metis application provides an interface to the
 [METIS](https://github.com/KarypisLab/METIS) graph partitioning library,
@@ -8,13 +8,16 @@ The applicaiton is organized in a series of processes, each one of them providin
 The algorithm most commonly used for finite elements is `metis_divide_heterogeneous_input_process.h`,
 which generates a partition of the mesh based on the nodal graph and can be used for meshes combining multiple element types.
 
-### Build instructions
+## Build instructions
+
 Building the `MetisApplication` requires METIS libraries and their dependencies already installed on the system.
 The easiest way to get them is by the package manager of the Linux distribution.
 For example, in Ubuntu:
+
 ```bash
 sudo apt install libmetis-dev
 ```
+
 However, there may be situations where downloading the packages may not be possible.
 In this case, other (potentially trickier) option is to download the source code and build the libraries.
 For more detailed and updated instructions for compiling METIS, GKlib, and other necessary packages,
@@ -22,15 +25,17 @@ refer to [Compiling Kratos with MPI support](https://github.com/KratosMultiphysi
 
 Assuming that the dependencies are installed, the following steps are:
 
-1. Add the `MetisApplication` to the list of applications to be compiled in the building script for Kratos,
+1.Add the `MetisApplication` to the list of applications to be compiled in the building script for Kratos,
 as described in the [install instructions](https://github.com/KratosMultiphysics/Kratos/blob/master/INSTALL.md#adding-applications).
+
 ```bash
 export KRATOS_APPLICATIONS=
 ...
 add_app ${KRATOS_APP_DIR}/MetisApplication
 ```
-2. Tell CMake where are located the libraries and headers of METIS, if CMake does not find them automatically.
-For example:
+
+2.Tell CMake where are located the libraries and headers of METIS, if CMake does not find them automatically. For example:
+
 ```bash
 cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}" \
 ...

--- a/applications/TrilinosApplication/README.md
+++ b/applications/TrilinosApplication/README.md
@@ -58,7 +58,7 @@ refer to [Compiling Kratos with MPI support](https://github.com/KratosMultiphysi
 
 Assuming that the dependencies are installed, the following steps are:
 
-1. Add the `TrilinosApplication` to the list of applications to compile in the building script for Kratos,
+1. Add the `TrilinosApplication` to the list of applications to be compiled in the building script for Kratos,
 as described in the [install instructions](https://github.com/KratosMultiphysics/Kratos/blob/master/INSTALL.md#adding-applications).
 ```bash
 export KRATOS_APPLICATIONS=
@@ -116,7 +116,7 @@ sudo apt install \
 ```
 
 - It is possible to do a minimal installation of the TrilinosApplication only using the Epetra package.
-Other packages can be disable with the following flags:
+Other packages can be disabled with the following flags:
 ```bash
 -DTRILINOS_EXCLUDE_ML_SOLVER=ON  # exclude the interface to the Trilinos ML solver package
 -DTRILINOS_EXCLUDE_AZTEC_SOLVER=ON  # exclude solvers from the Trilinos AztecOO package

--- a/applications/TrilinosApplication/README.md
+++ b/applications/TrilinosApplication/README.md
@@ -53,7 +53,7 @@ sudo apt install trilinos-all-dev
 ```
 However, there may be situations where downloading the packages may not be possible.
 In this case, other (potentially trickier) option is to download the source code and build the libraries.
-For more detailed and updated instructions for compiling Trilinos and other necessary pakages,
+For more detailed and updated instructions for compiling Trilinos and other necessary packages,
 refer to [Compiling Kratos with MPI support](https://github.com/KratosMultiphysics/Kratos/wiki/Compiling-Kratos-with-MPI-support), in the wiki.
 
 Assuming that the dependencies are installed, the following steps are:
@@ -65,7 +65,7 @@ export KRATOS_APPLICATIONS=
 ...
 add_app ${KRATOS_APP_DIR}/TrilinosApplication
 ```
-2. Tell cmake where are located the libraries and includes of Trilinos.
+2. Tell cmake where are located the libraries and headers of Trilinos.
 If Trilinos was compiled (instead of downloaded with a package manager),
 it is usually enough to point the `TRILINOS_ROOT` variable to the build directory.
 For example:
@@ -80,7 +80,7 @@ Moreover, the name of the libraries may not be standard.
 In this case, instead of setting `TRILINOS_ROOT`, set 
 `-DTRILINOS_INCLUDE_DIR=String` with the path to the include dir, 
 `-DTRILINOS_LIBRARY_DIR=String` with the path to the library dir, and set
-`-DTRILINOS_LIBRARY_PREFIX=String` with the prefix to use when looking for the trilinos libraries, i.e.,
+`-DTRILINOS_LIBRARY_PREFIX=String` with the prefix to use when looking for the Trilinos libraries, i.e.,
 ```
 libepetra.so  # No need to set TRILINOS_PREFIX
 libtrilinos_epetra.so  # -DTRILINOS_PREFIX="trilinos_"

--- a/applications/TrilinosApplication/README.md
+++ b/applications/TrilinosApplication/README.md
@@ -51,7 +51,7 @@ For example, in Ubuntu:
 ```Shell
 sudo apt install trilinos-all-dev
 ```
-However, there may be situations where downloading the package may not be possible.
+However, there may be situations where downloading the packages may not be possible.
 In this case, other (potentially trickier) option is to download the source code and build the libraries.
 For more detailed and updated instructions for compiling Trilinos and other necessary pakages,
 refer to [Compiling Kratos with MPI support](https://github.com/KratosMultiphysics/Kratos/wiki/Compiling-Kratos-with-MPI-support), in the wiki.
@@ -66,7 +66,7 @@ export KRATOS_APPLICATIONS=
 add_app ${KRATOS_APP_DIR}/TrilinosApplication
 ```
 2. Tell cmake where are located the libraries and includes of Trilinos.
-If Trilinos was compiled (instead of download with a package manager),
+If Trilinos was compiled (instead of downloaded with a package manager),
 it is usually enough to point the `TRILINOS_ROOT` variable to the build directory.
 For example:
 ```bash
@@ -86,7 +86,7 @@ libepetra.so  # No need to set TRILINOS_PREFIX
 libtrilinos_epetra.so  # -DTRILINOS_PREFIX="trilinos_"
 ```
 
-For example, in the case of Ubuntu, installed Trilinos installed by `apt`:
+For example, in the case of Ubuntu with Trilinos installed by `sudo apt install trilinos-all-dev`:
 ```
 -DTRILINOS_INCLUDE_DIR="/usr/include/trilinos"
 -DTRILINOS_LIBRARY_DIR="/usr/lib/x86_64-linux-gnu"
@@ -98,7 +98,7 @@ For example, in the case of Ubuntu, installed Trilinos installed by `apt`:
 - Trilinos is a large project and not all of its packages are being used in Kratos.
 Check the [docker of the CI](https://github.com/KratosMultiphysics/Kratos/blob/master/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile)
 to see which packages are necessary in order to compile the TrilinosApplication.
-At the moment, the list of packages installed is:
+At the moment, the list of required packages is:
 ```bash
 sudo apt install \
         libtrilinos-amesos-dev \
@@ -115,8 +115,8 @@ sudo apt install \
         libtrilinos-shylu-dev
 ```
 
-- It is possible to do a minimal installation of the TrilinosApplication with only using the Epetra package.
-Other packages can be disable be disabled with the following flags:
+- It is possible to do a minimal installation of the TrilinosApplication only using the Epetra package.
+Other packages can be disable with the following flags:
 ```bash
 -DTRILINOS_EXCLUDE_ML_SOLVER=ON  # exclude the interface to the Trilinos ML solver package
 -DTRILINOS_EXCLUDE_AZTEC_SOLVER=ON  # exclude solvers from the Trilinos AztecOO package

--- a/applications/TrilinosApplication/README.md
+++ b/applications/TrilinosApplication/README.md
@@ -127,7 +127,7 @@ sudo apt install \
         libtrilinos-shylu-dev
 ```
 
-- It is possible to do a minimal installation of the TrilinosApplication only using the Epetra package.
+-It is possible to do a minimal installation of the TrilinosApplication only using the Epetra package.
 Other packages can be disabled with the following flags:
 
 ```bash

--- a/applications/TrilinosApplication/README.md
+++ b/applications/TrilinosApplication/README.md
@@ -1,10 +1,11 @@
-## Trilinos Application
+# Trilinos Application
 
-### Distributed matrices and linear solvers
+## Distributed matrices and linear solvers
 
 Kratos Multiphysics uses several components of the [Trilinos project](https://trilinos.org/) for its MPI capabilities. The most relevant of these are the __distributed-memory matrix and vector classes__ from the Epetra module and the __linear solvers__ provided by the AztecOO, Amesos and ML packages. In addition, it also contains the MPI version of the AMGCL solver.
 
-#### Main solver classes
+### Main solver classes
+
 - TrilinosLinearSolver
 - AztecSolver
 - AmesosSolver
@@ -12,45 +13,51 @@ Kratos Multiphysics uses several components of the [Trilinos project](https://tr
 - MultiLevelSolver
 - AMGCL Mpi-based Solver
 
-### Kratos interface extension
+## Kratos interface extension
 
 The Trilinos application also provides __MPI versions of most of the core classes of Kratos__, adapted to work with Epetra distributed matrices where necessary. Hence it provide its own version of the following Kratos classes:
 
-#### Builder and solvers
+### Builder and solvers
+
 - TrilinosResidualBasedBuilderAndSolver
 - TrilinosEliminationBuilderAndSolver
 - TrilinosBlockBuilderAndSolver
 - TrilinosBlockBuilderAndSolverPeriodic
 
-#### Convergence Criterias
+### Convergence Criterias
+
 - TrilinosDisplacementCriteria
 - TrilinosResidualCriteria
 - TrilinosAndCriteria
 - TrilinosOrCriteria
 - TrilinosMixedGenericCriteria
 
-#### Solving Strategies
+### Solving Strategies
+
 - TrilinosSolvingStrategy
 - TrilinosLinearStrategy
 - TrilinosNewtonRaphsonStrategy
 
 For more information about these please refer to their serial version (without _Trilinos_ prefix) in the main Kratos documentation.
 
-### Components reference
-* [__Epetra__](https://trilinos.github.io/epetra.html)
-* [__Aztec__](https://trilinos.github.io/aztecoo.html)
-* [__Amesos__](https://trilinos.github.io/amesos.html)
-* [__Amesos2__](https://trilinos.github.io/amesos2.html)
-* [__Teuchos__](https://trilinos.github.io/teuchos.html)
+## Components reference
 
+-[__Epetra__](https://trilinos.github.io/epetra.html)
+-[__Aztec__](https://trilinos.github.io/aztecoo.html)
+-[__Amesos__](https://trilinos.github.io/amesos.html)
+-[__Amesos2__](https://trilinos.github.io/amesos2.html)
+-[__Teuchos__](https://trilinos.github.io/teuchos.html)
 
-### Build instructions
+## Build instructions
+
 Building the `TrilinosApplication` requires the Trilinos libraries and their dependencies already installed on the system.
 The easiest way to get them is by the package manager of the Linux distribution.
 For example, in Ubuntu:
+
 ```Shell
 sudo apt install trilinos-all-dev
 ```
+
 However, there may be situations where downloading the packages may not be possible.
 In this case, other (potentially trickier) option is to download the source code and build the libraries.
 For more detailed and updated instructions for compiling Trilinos and other necessary packages,
@@ -58,17 +65,20 @@ refer to [Compiling Kratos with MPI support](https://github.com/KratosMultiphysi
 
 Assuming that the dependencies are installed, the following steps are:
 
-1. Add the `TrilinosApplication` to the list of applications to be compiled in the building script for Kratos,
+1.Add the `TrilinosApplication` to the list of applications to be compiled in the building script for Kratos,
 as described in the [install instructions](https://github.com/KratosMultiphysics/Kratos/blob/master/INSTALL.md#adding-applications).
+
 ```bash
 export KRATOS_APPLICATIONS=
 ...
 add_app ${KRATOS_APP_DIR}/TrilinosApplication
 ```
-2. Tell cmake where are located the libraries and headers of Trilinos.
+
+2.Tell cmake where are located the libraries and headers of Trilinos.
 If Trilinos was compiled (instead of downloaded with a package manager),
 it is usually enough to point the `TRILINOS_ROOT` variable to the build directory.
 For example:
+
 ```bash
 cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}" \
 ...
@@ -77,28 +87,30 @@ cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}" \
 
 Or, if Trilinos is installed with a package manager, then libraries and headers may be in different locations.
 Moreover, the name of the libraries may not be standard.
-In this case, instead of setting `TRILINOS_ROOT`, set 
-`-DTRILINOS_INCLUDE_DIR=String` with the path to the include dir, 
+In this case, instead of setting `TRILINOS_ROOT`, set
+`-DTRILINOS_INCLUDE_DIR=String` with the path to the include dir,
 `-DTRILINOS_LIBRARY_DIR=String` with the path to the library dir, and set
 `-DTRILINOS_LIBRARY_PREFIX=String` with the prefix to use when looking for the Trilinos libraries, i.e.,
-```
+
+```bash
 libepetra.so  # No need to set TRILINOS_PREFIX
 libtrilinos_epetra.so  # -DTRILINOS_PREFIX="trilinos_"
 ```
 
 For example, in the case of Ubuntu with Trilinos installed by `sudo apt install trilinos-all-dev`:
-```
+
+```bash
 -DTRILINOS_INCLUDE_DIR="/usr/include/trilinos"
 -DTRILINOS_LIBRARY_DIR="/usr/lib/x86_64-linux-gnu"
 -DTRILINOS_LIBRARY_PREFIX="trilinos_"
 ```
 
-**Notes**
-
-- Trilinos is a large project and not all of its packages are being used in Kratos.
+_Notes_:
+-Trilinos is a large project and not all of its packages are being used in Kratos.
 Check the [docker of the CI](https://github.com/KratosMultiphysics/Kratos/blob/master/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile)
 to see which packages are necessary in order to compile the TrilinosApplication.
 At the moment, the list of required packages is:
+
 ```bash
 sudo apt install \
         libtrilinos-amesos-dev \
@@ -117,6 +129,7 @@ sudo apt install \
 
 - It is possible to do a minimal installation of the TrilinosApplication only using the Epetra package.
 Other packages can be disabled with the following flags:
+
 ```bash
 -DTRILINOS_EXCLUDE_ML_SOLVER=ON  # exclude the interface to the Trilinos ML solver package
 -DTRILINOS_EXCLUDE_AZTEC_SOLVER=ON  # exclude solvers from the Trilinos AztecOO package

--- a/applications/TrilinosApplication/README.md
+++ b/applications/TrilinosApplication/README.md
@@ -45,29 +45,48 @@ For more information about these please refer to their serial version (without _
 
 
 ### Build instructions
-First add the `TrilinosApplication` to the compiled apps, as described in the [install instructions](https://github.com/KratosMultiphysics/Kratos/blob/master/INSTALL.md#adding-applications).
+Building the `TrilinosApplication` requires the Trilinos libraries and their dependencies already installed on the system.
+The easiest way to get them is by the package repository of the Linux distribution.
+For example, in Ubuntu:
+```Shell
+sudo apt install trilinos-all-dev
+```
+Usually the only option is to download the source code and build the libraries, which may be more difficult than the previous one.
 
-Use the following settings to add Trilinos:
+For more detailed and updated instructions for compiling Trilinos and other necessary pakages,
+refer to [Compiling Kratos with MPI support](https://github.com/KratosMultiphysics/Kratos/wiki/Compiling-Kratos-with-MPI-support), in the wiki.
 
-`-DTRILINOS_ROOT=String`
+- First add the `TrilinosApplication` to the list of applications to compile in the building script for Kratos,
+as described in the [install instructions](https://github.com/KratosMultiphysics/Kratos/blob/master/INSTALL.md#adding-applications).
+```bash
+export KRATOS_APPLICATIONS=
+...
+add_app ${KRATOS_APP_DIR}/TrilinosApplication
+```
+- Then it is necessary to tell cmake where are located the libraries and includes:
+If trilinos is compiled, it is usually enough to set the `TRILINOS_ROOT` variable the the build directory.
+For example:
+```bash
+cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}" \
+...
+-DTRILINOS_ROOT="${HOME}/Projects/Trilinos/build"
+```
 
-Root directory for Trilinos library.
+Or, if Trilinos is installed with a package manager, libraries and headers are in different locations, and name may not be standard.
 
-`-DTRILINOS_INCLUDE_DIR=String`
+So, instead of setting `TRILINOS_ROOT`, set 
 
-Not required if `TRILINOS_ROOT` is set. Path to trilinos include dir.
+`-DTRILINOS_INCLUDE_DIR=String` Path to trilinos include dir.
+`-DTRILINOS_LIBRARY_DIR=String` Path to trilinos library dir.
+and set:
 
-`-DTRILINOS_LIBRARY_DIR=String`
-
-Not required if `TRILINOS_ROOT` is set. Path to trilinos library dir.
-
-`-DTRILINOS_LIBRARY_PREFIX=String`
-Indicates the prefix of the trilinos libraries in case they have:
+`-DTRILINOS_LIBRARY_PREFIX=String` Indicates the prefix of the trilinos libraries in case they have, i.e.,
 ```
 libepetra.so          -> No prefix
 libtrilinos_epetra.so -> -DTRILINOS_PREFIX="trilinos_"
 ```
-If trilinos was installed using the package manager usually the following lines have to be used:
+
+For example, in the case of Ubuntu, installed Trilinos installed by `apt`:
 ```
 -DTRILINOS_INCLUDE_DIR="/usr/include/trilinos" \
 -DTRILINOS_LIBRARY_DIR="/usr/lib/x86_64-linux-gnu" \
@@ -81,12 +100,3 @@ Furthermore it is possible to do a minimal installation of the TrilinosApplicati
 - *TRILINOS_EXCLUDE_AZTEC_SOLVER*: Setting this flag to `ON` in the configure file will exclude solvers from the Trilinos AztecOO package
 - *TRILINOS_EXCLUDE_AMESOS_SOLVER*: Setting this flag to `ON` in the configure file will exclude solvers using features of the Trilinos Amesos package
 - *TRILINOS_EXCLUDE_AMESOS2_SOLVER*: Setting this flag to `ON` in the configure file will exclude solvers using features of the Trilinos Amesos2 package
-
-
-From Ubuntu 18.04 onwards, Trilinos can be installed with the following command:
-
-```Shell
-sudo apt-get install trilinos-all-dev
-```
-
-

--- a/applications/TrilinosApplication/README.md
+++ b/applications/TrilinosApplication/README.md
@@ -46,25 +46,28 @@ For more information about these please refer to their serial version (without _
 
 ### Build instructions
 Building the `TrilinosApplication` requires the Trilinos libraries and their dependencies already installed on the system.
-The easiest way to get them is by the package repository of the Linux distribution.
+The easiest way to get them is by the package manager of the Linux distribution.
 For example, in Ubuntu:
 ```Shell
 sudo apt install trilinos-all-dev
 ```
-Usually the only option is to download the source code and build the libraries, which may be more difficult than the previous one.
-
+However, there may be situations where downloading the package may not be possible.
+In this case, other (potentially trickier) option is to download the source code and build the libraries.
 For more detailed and updated instructions for compiling Trilinos and other necessary pakages,
 refer to [Compiling Kratos with MPI support](https://github.com/KratosMultiphysics/Kratos/wiki/Compiling-Kratos-with-MPI-support), in the wiki.
 
-- First add the `TrilinosApplication` to the list of applications to compile in the building script for Kratos,
+Assuming that the dependencies are installed, the following steps are:
+
+1. Add the `TrilinosApplication` to the list of applications to compile in the building script for Kratos,
 as described in the [install instructions](https://github.com/KratosMultiphysics/Kratos/blob/master/INSTALL.md#adding-applications).
 ```bash
 export KRATOS_APPLICATIONS=
 ...
 add_app ${KRATOS_APP_DIR}/TrilinosApplication
 ```
-- Then it is necessary to tell cmake where are located the libraries and includes:
-If trilinos is compiled, it is usually enough to set the `TRILINOS_ROOT` variable the the build directory.
+2. Tell cmake where are located the libraries and includes of Trilinos.
+If Trilinos was compiled (instead of download with a package manager),
+it is usually enough to point the `TRILINOS_ROOT` variable to the build directory.
 For example:
 ```bash
 cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}" \
@@ -72,31 +75,51 @@ cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}" \
 -DTRILINOS_ROOT="${HOME}/Projects/Trilinos/build"
 ```
 
-Or, if Trilinos is installed with a package manager, libraries and headers are in different locations, and name may not be standard.
-
-So, instead of setting `TRILINOS_ROOT`, set 
-
-`-DTRILINOS_INCLUDE_DIR=String` Path to trilinos include dir.
-`-DTRILINOS_LIBRARY_DIR=String` Path to trilinos library dir.
-and set:
-
-`-DTRILINOS_LIBRARY_PREFIX=String` Indicates the prefix of the trilinos libraries in case they have, i.e.,
+Or, if Trilinos is installed with a package manager, then libraries and headers may be in different locations.
+Moreover, the name of the libraries may not be standard.
+In this case, instead of setting `TRILINOS_ROOT`, set 
+`-DTRILINOS_INCLUDE_DIR=String` with the path to the include dir, 
+`-DTRILINOS_LIBRARY_DIR=String` with the path to the library dir, and set
+`-DTRILINOS_LIBRARY_PREFIX=String` with the prefix to use when looking for the trilinos libraries, i.e.,
 ```
-libepetra.so          -> No prefix
-libtrilinos_epetra.so -> -DTRILINOS_PREFIX="trilinos_"
+libepetra.so  # No need to set TRILINOS_PREFIX
+libtrilinos_epetra.so  # -DTRILINOS_PREFIX="trilinos_"
 ```
 
 For example, in the case of Ubuntu, installed Trilinos installed by `apt`:
 ```
--DTRILINOS_INCLUDE_DIR="/usr/include/trilinos" \
--DTRILINOS_LIBRARY_DIR="/usr/lib/x86_64-linux-gnu" \
--DTRILINOS_LIBRARY_PREFIX="trilinos_" \
+-DTRILINOS_INCLUDE_DIR="/usr/include/trilinos"
+-DTRILINOS_LIBRARY_DIR="/usr/lib/x86_64-linux-gnu"
+-DTRILINOS_LIBRARY_PREFIX="trilinos_"
 ```
 
-### Notes for compilation
-Trilinos is a large project and not all of its packages are being used in Kratos. Check the [docker of the CI](https://github.com/KratosMultiphysics/Kratos/blob/master/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile) to see which packages are necessary in order to compile the TrilinosApplication.
-Furthermore it is possible to do a minimal installation of the TrilinosApplication with only using the Epetra package. Using the other packages is enabled by default, but can be disabled with the following flags:
-- *TRILINOS_EXCLUDE_ML_SOLVER*: Setting this flag to `ON` in the configure file will exclude the interface to the Trilinos ML solver package
-- *TRILINOS_EXCLUDE_AZTEC_SOLVER*: Setting this flag to `ON` in the configure file will exclude solvers from the Trilinos AztecOO package
-- *TRILINOS_EXCLUDE_AMESOS_SOLVER*: Setting this flag to `ON` in the configure file will exclude solvers using features of the Trilinos Amesos package
-- *TRILINOS_EXCLUDE_AMESOS2_SOLVER*: Setting this flag to `ON` in the configure file will exclude solvers using features of the Trilinos Amesos2 package
+**Notes**
+
+- Trilinos is a large project and not all of its packages are being used in Kratos.
+Check the [docker of the CI](https://github.com/KratosMultiphysics/Kratos/blob/master/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile)
+to see which packages are necessary in order to compile the TrilinosApplication.
+At the moment, the list of packages installed is:
+```bash
+sudo apt install \
+        libtrilinos-amesos-dev \
+        libtrilinos-amesos2-dev \
+        libtrilinos-aztecoo-dev \
+        libtrilinos-epetra-dev \
+        libtrilinos-epetraext-dev \
+        libtrilinos-ifpack-dev \
+        libtrilinos-ml-dev \
+        libtrilinos-teuchos-dev \
+        libtrilinos-tpetra-dev \
+        libtrilinos-kokkos-dev \
+        libtrilinos-kokkos-kernels-dev \
+        libtrilinos-shylu-dev
+```
+
+- It is possible to do a minimal installation of the TrilinosApplication with only using the Epetra package.
+Other packages can be disable be disabled with the following flags:
+```bash
+-DTRILINOS_EXCLUDE_ML_SOLVER=ON  # exclude the interface to the Trilinos ML solver package
+-DTRILINOS_EXCLUDE_AZTEC_SOLVER=ON  # exclude solvers from the Trilinos AztecOO package
+-DTRILINOS_EXCLUDE_AMESOS_SOLVER=ON  # exclude solvers using features of the Trilinos Amesos package
+-DTRILINOS_EXCLUDE_AMESOS2_SOLVER=ON  # exclude solvers using features of the Trilinos Amesos2 package
+```


### PR DESCRIPTION
Added a link in the Advanced Configuration / Parallelism subsection, pointing to the guidelines for compiling Kratos with support for MPI and its dependencies.