### PR TITLE
[PfemFluid] Cleaning and change of builder and solver

### DIFF
--- a/applications/DelaunayMeshingApplication/custom_utilities/boundary_normals_calculation_utilities.hpp
+++ b/applications/DelaunayMeshingApplication/custom_utilities/boundary_normals_calculation_utilities.hpp
@@ -9,15 +9,12 @@
 
 #include "includes/model_part.h"
 
-#if !defined(KRATOS_BOUNDARY_NORMALS_CALCULATION_UTILITIES_H_INCLUDED )
-#define  KRATOS_BOUNDARY_NORMALS_CALCULATION_UTILITIES_H_INCLUDED
-
+#if !defined(KRATOS_BOUNDARY_NORMALS_CALCULATION_UTILITIES_H_INCLUDED)
+#define KRATOS_BOUNDARY_NORMALS_CALCULATION_UTILITIES_H_INCLUDED
 
 // System includes
 
-
 // External includes
-
 
 // Project includes
 #include "delaunay_meshing_application_variables.h"
@@ -26,353 +23,280 @@
 namespace Kratos
 {
 
-///@name Kratos Globals
-///@{
+  ///@name Kratos Globals
+  ///@{
 
-///@}
-///@name Type Definitions
-///@{
-
-///@}
-///@name  Enum's
-///@{
-
-///@}
-///@name  Functions
-///@{
-
-///@}
-///@name Kratos Classes
-///@{
-
-/// Short class definition.
-/// Tool to evaluate the normals on nodes based on the normals of a set of surface conditions
-class BoundaryNormalsCalculationUtilities
-{
- public:
-
+  ///@}
   ///@name Type Definitions
   ///@{
 
-  typedef ModelPart::NodesContainerType               NodesArrayType;
-  typedef ModelPart::ElementsContainerType     ElementsContainerType;
-  typedef ModelPart::ConditionsContainerType ConditionsContainerType;
-  typedef ModelPart::MeshType                               MeshType;
-
-  typedef GlobalPointersVector<Node<3> > NodeWeakPtrVectorType;
-  typedef GlobalPointersVector<Element> ElementWeakPtrVectorType;
-  typedef GlobalPointersVector<Condition> ConditionWeakPtrVectorType;
-
   ///@}
-  ///@name Life Cycle
-  ///@{
-  ///@}
-  ///@name Operators
-  ///@{
-  ///@}
-  ///@name Operations
+  ///@name  Enum's
   ///@{
 
+  ///@}
+  ///@name  Functions
+  ///@{
 
-  /// Calculates the area normal (vector oriented as the normal with a dimension proportional to the area).
-  /** This is done on the base of the Conditions provided which should be
-   * understood as the surface elements of the area of interest.
-   * @param rModelPart ModelPart of the problem. Must have a set of conditions defining the "skin" of the domain
-   * @param dimension Spatial dimension (2 or 3)
-   * @note Use this fuction instead of its overload taking a Conditions array for MPI applications,
-   * as it will take care of communication between partitions.
-   */
+  ///@}
+  ///@name Kratos Classes
+  ///@{
 
-  /// Calculates the area normal (unitary vector oriented as the normal).
-
-  void CalculateUnitBoundaryNormals(ModelPart& rModelPart, int EchoLevel = 0)
+  /// Short class definition.
+  /// Tool to evaluate the normals on nodes based on the normals of a set of surface conditions
+  class BoundaryNormalsCalculationUtilities
   {
+  public:
+    ///@name Type Definitions
+    ///@{
 
-    mEchoLevel = EchoLevel;
+    typedef ModelPart::NodesContainerType NodesArrayType;
+    typedef ModelPart::ElementsContainerType ElementsContainerType;
+    typedef ModelPart::ConditionsContainerType ConditionsContainerType;
+    typedef ModelPart::MeshType MeshType;
 
-    if( !rModelPart.IsSubModelPart() ){
+    typedef GlobalPointersVector<Node<3>> NodeWeakPtrVectorType;
+    typedef GlobalPointersVector<Element> ElementWeakPtrVectorType;
+    typedef GlobalPointersVector<Condition> ConditionWeakPtrVectorType;
 
-      this->ResetBodyNormals(rModelPart); //clear boundary normals
+    ///@}
+    ///@name Life Cycle
+    ///@{
+    ///@}
+    ///@name Operators
+    ///@{
+    ///@}
+    ///@name Operations
+    ///@{
 
-      //FLUID Domains
-      for(auto& i_mp : rModelPart.SubModelParts())
+    /// Calculates the area normal (vector oriented as the normal with a dimension proportional to the area).
+    /** This is done on the base of the Conditions provided which should be
+     * understood as the surface elements of the area of interest.
+     * @param rModelPart ModelPart of the problem. Must have a set of conditions defining the "skin" of the domain
+     * @param dimension Spatial dimension (2 or 3)
+     * @note Use this fuction instead of its overload taking a Conditions array for MPI applications,
+     * as it will take care of communication between partitions.
+     */
+
+    /// Calculates the area normal (unitary vector oriented as the normal).
+
+    void CalculateUnitBoundaryNormals(ModelPart &rModelPart, int EchoLevel = 0)
+    {
+
+      mEchoLevel = EchoLevel;
+
+      if (!rModelPart.IsSubModelPart())
       {
-        if( i_mp.Is(FLUID) && i_mp.IsNot(ACTIVE) && i_mp.IsNot(BOUNDARY) && i_mp.IsNot(CONTACT) ){
 
-          CalculateBoundaryNormals(i_mp);
+        this->ResetBodyNormals(rModelPart); // clear boundary normals
 
-          //standard assignation // fails in sharp edges angle<90
-          AddNormalsToNodes(i_mp);
+        // FLUID Domains
+        for (auto &i_mp : rModelPart.SubModelParts())
+        {
+          if ((i_mp.Is(FLUID) || i_mp.Is(SOLID) || i_mp.Is(RIGID)) && i_mp.IsNot(ACTIVE) && i_mp.IsNot(BOUNDARY) && i_mp.IsNot(CONTACT))
+          {
+
+            CalculateBoundaryNormals(i_mp);
+
+            // standard assignation // fails in sharp edges angle<90
+            AddNormalsToNodes(i_mp);
+          }
+        }
+
+      }
+      else
+      {
+
+        this->ResetBodyNormals(rModelPart); // clear boundary normals
+
+        CalculateBoundaryNormals(rModelPart);
+
+        // standard assignation // fails in sharp edges angle<90
+        AddNormalsToNodes(rModelPart);
+      }
+
+      // For MPI: correct values on partition boundaries
+      rModelPart.GetCommunicator().AssembleCurrentData(NORMAL);
+    }
+
+    /// Calculates the area normal (unitary vector oriented as the normal) and weight the normal to shrink
+    void CalculateWeightedBoundaryNormals(ModelPart &rModelPart, int EchoLevel = 0)
+    {
+
+      std::cout << "DO NOT ENTER HERE ----   CalculateWeightedBoundaryNormals " << std::endl;
+      mEchoLevel = EchoLevel;
+
+      if (!rModelPart.IsSubModelPart())
+      {
+
+        this->ResetBodyNormals(rModelPart); // clear boundary normals
+
+        // FLUID Domains
+        for (auto &i_mp : rModelPart.SubModelParts())
+        {
+          if (i_mp.Is(FLUID) && i_mp.IsNot(ACTIVE) && i_mp.IsNot(BOUNDARY) && i_mp.IsNot(CONTACT))
+          {
+
+            CalculateBoundaryNormals(i_mp);
+
+            // assignation for solid boundaries : Unity Normals on nodes and Shrink_Factor on nodes
+            AddWeightedNormalsToNodes(i_mp);
+          }
+        }
+        // SOLID Domains
+        for (auto &i_mp : rModelPart.SubModelParts())
+        {
+          if (i_mp.Is(SOLID) && i_mp.IsNot(ACTIVE) && i_mp.IsNot(BOUNDARY) && i_mp.IsNot(CONTACT))
+          {
+
+            CalculateBoundaryNormals(i_mp);
+
+            // assignation for solid boundaries : Unity Normals on nodes and Shrink_Factor on nodes
+            AddWeightedNormalsToNodes(i_mp);
+          }
+        }
+        // RIGID Domains
+        for (auto &i_mp : rModelPart.SubModelParts())
+        {
+          if (i_mp.Is(RIGID) && i_mp.IsNot(ACTIVE) && i_mp.IsNot(BOUNDARY) && i_mp.IsNot(CONTACT))
+          {
+
+            CalculateBoundaryNormals(i_mp);
+
+            // assignation for solid boundaries : Unity Normals on nodes and Shrink_Factor on nodes
+            AddWeightedNormalsToNodes(i_mp);
+          }
         }
       }
-      //SOLID Domains
-      for(auto& i_mp : rModelPart.SubModelParts())
+      else
       {
-        if( i_mp.Is(SOLID) && i_mp.IsNot(ACTIVE) && i_mp.IsNot(BOUNDARY) && i_mp.IsNot(CONTACT) ){
 
-          CalculateBoundaryNormals(i_mp);
+        this->ResetBodyNormals(rModelPart); // clear boundary normals
 
-          //standard assignation // fails in sharp edges angle<90
-          AddNormalsToNodes(i_mp);
+        CalculateBoundaryNormals(rModelPart);
+
+        // assignation for solid boundaries: Unity Normals on nodes and Shrink_Factor on nodes
+        //  AddWeightedNormalsToNodes(rModelPart);
+      }
+
+      // For MPI: correct values on partition boundaries
+      rModelPart.GetCommunicator().AssembleCurrentData(NORMAL);
+      rModelPart.GetCommunicator().AssembleCurrentData(SHRINK_FACTOR);
+    }
+
+    ///@}
+    ///@name Access
+    ///@{
+    ///@}
+    ///@name Inquiry
+    ///@{
+    ///@}
+    ///@name Input and output
+    ///@{
+    ///@}
+    ///@name Friends
+    ///@{
+    ///@}
+  protected:
+    ///@name Protected static Member Variables
+    ///@{
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+    ///@}
+    ///@name Protected Operators
+    ///@{
+    ///@}
+    ///@name Protected Operations
+    ///@{
+    ///@}
+    ///@name Protected  Access
+    ///@{
+    ///@}
+    ///@name Protected Inquiry
+    ///@{
+    ///@}
+    ///@name Protected LifeCycle
+    ///@{
+    ///@}
+
+  private:
+    ///@name Static Member Variables
+    ///@{
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+    int mEchoLevel;
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+    ///@}
+    ///@name Private Operations
+    ///@{
+    ///@}
+
+    /// Calculates the normals of the BOUNDARY for a given model part
+    void CalculateBoundaryNormals(ModelPart &rModelPart)
+    {
+      KRATOS_TRY
+
+      const unsigned int dimension = rModelPart.GetProcessInfo()[SPACE_DIMENSION];
+
+      if (rModelPart.NumberOfConditions() && this->CheckConditionsLocalSpace(rModelPart, dimension - 1))
+      {
+
+        if (mEchoLevel > 0)
+          std::cout << "   [" << rModelPart.Name() << "] (BC)" << std::endl;
+
+        this->CalculateBoundaryNormals(rModelPart.Conditions());
+      }
+      else if (rModelPart.NumberOfElements())
+      {
+
+        if (this->CheckElementsLocalSpace(rModelPart, dimension))
+        {
+
+          if (mEchoLevel > 0)
+            std::cout << "   [" << rModelPart.Name() << "] (BVE)" << std::endl;
+
+          this->CalculateVolumeBoundaryNormals(rModelPart);
+        }
+        else if (this->CheckElementsLocalSpace(rModelPart, dimension - 1))
+        {
+
+          if (mEchoLevel > 0)
+            std::cout << "   [" << rModelPart.Name() << "] (BE)" << std::endl;
+
+          ElementsContainerType &rElements = rModelPart.Elements();
+
+          this->CalculateBoundaryNormals(rElements);
         }
       }
-      //RIGID Domains
-      for(auto& i_mp : rModelPart.SubModelParts())
-      {
-        if( i_mp.Is(RIGID) && i_mp.IsNot(ACTIVE) && i_mp.IsNot(BOUNDARY) && i_mp.IsNot(CONTACT) ){
 
-          CalculateBoundaryNormals(i_mp);
-
-          //standard assignation // fails in sharp edges angle<90
-          AddNormalsToNodes(i_mp);
-        }
-      }
-    }
-    else{
-
-      this->ResetBodyNormals(rModelPart); //clear boundary normals
-
-      CalculateBoundaryNormals(rModelPart);
-
-      //standard assignation // fails in sharp edges angle<90
-      AddNormalsToNodes(rModelPart);
-
+      KRATOS_CATCH("")
     }
 
+    // this function adds the Contribution of one of the geometries
+    // to the corresponding nodes
+    static void CalculateUnitNormal2D(Condition &rCondition, array_1d<double, 3> &An)
+    {
+      Geometry<Node<3>> &rGeometry = rCondition.GetGeometry();
 
-    // For MPI: correct values on partition boundaries
-    rModelPart.GetCommunicator().AssembleCurrentData(NORMAL);
+      // Attention: normal criterion changed for line conditions (vs line elements)
+      An[0] = rGeometry[1].Y() - rGeometry[0].Y();
+      An[1] = -(rGeometry[1].X() - rGeometry[0].X());
+      An[2] = 0.00;
 
-  }
-
-
-  /// Calculates the area normal (unitary vector oriented as the normal) and weight the normal to shrink
-  void CalculateWeightedBoundaryNormals(ModelPart& rModelPart, int EchoLevel = 0)
-  {
-
-    mEchoLevel = EchoLevel;
-
-    if( !rModelPart.IsSubModelPart() ){
-
-      this->ResetBodyNormals(rModelPart); //clear boundary normals
-
-      //FLUID Domains
-      for(auto& i_mp : rModelPart.SubModelParts())
-      {
-        if( i_mp.Is(FLUID) && i_mp.IsNot(ACTIVE) && i_mp.IsNot(BOUNDARY) && i_mp.IsNot(CONTACT) ){
-
-          CalculateBoundaryNormals(i_mp);
-
-          //assignation for solid boundaries : Unity Normals on nodes and Shrink_Factor on nodes
-          AddWeightedNormalsToNodes(i_mp);
-        }
-      }
-      //SOLID Domains
-      for(auto& i_mp : rModelPart.SubModelParts())
-      {
-        if( i_mp.Is(SOLID) && i_mp.IsNot(ACTIVE) && i_mp.IsNot(BOUNDARY) && i_mp.IsNot(CONTACT) ){
-
-          CalculateBoundaryNormals(i_mp);
-
-          //assignation for solid boundaries : Unity Normals on nodes and Shrink_Factor on nodes
-          AddWeightedNormalsToNodes(i_mp);
-        }
-      }
-      //RIGID Domains
-      for(auto& i_mp : rModelPart.SubModelParts())
-      {
-        if( i_mp.Is(RIGID) && i_mp.IsNot(ACTIVE) && i_mp.IsNot(BOUNDARY) && i_mp.IsNot(CONTACT) ){
-
-          CalculateBoundaryNormals(i_mp);
-
-          //assignation for solid boundaries : Unity Normals on nodes and Shrink_Factor on nodes
-          AddWeightedNormalsToNodes(i_mp);
-        }
-      }
-    }
-    else{
-
-      this->ResetBodyNormals(rModelPart); //clear boundary normals
-
-      CalculateBoundaryNormals(rModelPart);
-
-      //assignation for solid boundaries: Unity Normals on nodes and Shrink_Factor on nodes
-      AddWeightedNormalsToNodes(rModelPart);
+      array_1d<double, 3> &normal = rCondition.GetValue(NORMAL);
+      noalias(normal) = An / norm_2(An);
     }
 
-    // For MPI: correct values on partition boundaries
-    rModelPart.GetCommunicator().AssembleCurrentData(NORMAL);
-    rModelPart.GetCommunicator().AssembleCurrentData(SHRINK_FACTOR);
-  }
-
-  ///@}
-  ///@name Access
-  ///@{
-  ///@}
-  ///@name Inquiry
-  ///@{
-  ///@}
-  ///@name Input and output
-  ///@{
-  ///@}
-  ///@name Friends
-  ///@{
-  ///@}
-protected:
-
-  ///@name Protected static Member Variables
-  ///@{
-  ///@}
-  ///@name Protected member Variables
-  ///@{
-  ///@}
-  ///@name Protected Operators
-  ///@{
-  ///@}
-  ///@name Protected Operations
-  ///@{
-  ///@}
-  ///@name Protected  Access
-  ///@{
-  ///@}
-  ///@name Protected Inquiry
-  ///@{
-  ///@}
-  ///@name Protected LifeCycle
-  ///@{
-  ///@}
-
- private:
-
-  ///@name Static Member Variables
-  ///@{
-  ///@}
-  ///@name Member Variables
-  ///@{
-
-  int mEchoLevel;
-
-  ///@}
-  ///@name Private Operators
-  ///@{
-  ///@}
-  ///@name Private Operations
-  ///@{
-  ///@}
-
-  /// Calculates the normals of the BOUNDARY for a given model part
-  void CalculateBoundaryNormals(ModelPart& rModelPart)
-  {
-    KRATOS_TRY
-
-    const unsigned int dimension = rModelPart.GetProcessInfo()[SPACE_DIMENSION];
-
-    if( rModelPart.NumberOfConditions() && this->CheckConditionsLocalSpace(rModelPart, dimension-1) ){
-
-      if(mEchoLevel > 0)
-        std::cout<<"   ["<<rModelPart.Name()<<"] (BC)"<<std::endl;
-
-      this->CalculateBoundaryNormals(rModelPart.Conditions());
-
-    }
-    else if( rModelPart.NumberOfElements() ){
-
-      if( this->CheckElementsLocalSpace(rModelPart, dimension) ){
-
-        if(mEchoLevel > 0)
-          std::cout<<"   ["<<rModelPart.Name()<<"] (BVE)"<<std::endl;
-
-        this->CalculateVolumeBoundaryNormals(rModelPart);
-
-      }
-      else if( this->CheckElementsLocalSpace(rModelPart, dimension-1) ){
-
-        if(mEchoLevel > 0)
-          std::cout<<"   ["<<rModelPart.Name()<<"] (BE)"<<std::endl;
-
-        ElementsContainerType& rElements = rModelPart.Elements();
-
-        this->CalculateBoundaryNormals(rElements);
-
-      }
-
-    }
-
-    KRATOS_CATCH( "" )
-
-  }
-
-
-  //this function adds the Contribution of one of the geometries
-  //to the corresponding nodes
-  static void CalculateUnitNormal2D(Condition& rCondition, array_1d<double,3>& An)
-  {
-    Geometry<Node<3> >& rGeometry = rCondition.GetGeometry();
-
-    //Attention: normal criterion changed for line conditions (vs line elements)
-    An[0] =    rGeometry[1].Y()-rGeometry[0].Y();
-    An[1] =  -(rGeometry[1].X()-rGeometry[0].X());
-    An[2] =    0.00;
-
-    array_1d<double,3>& normal = rCondition.GetValue(NORMAL);
-    noalias(normal) = An/norm_2(An);
-  }
-
-  static void CalculateUnitNormal3D(Condition& rCondition, array_1d<double,3>& An,
-                                     array_1d<double,3>& v1,array_1d<double,3>& v2 )
-  {
-    Geometry<Node<3> >& rGeometry = rCondition.GetGeometry();
-
-    v1[0] = rGeometry[1].X() - rGeometry[0].X();
-    v1[1] = rGeometry[1].Y() - rGeometry[0].Y();
-    v1[2] = rGeometry[1].Z() - rGeometry[0].Z();
-
-    v2[0] = rGeometry[2].X() - rGeometry[0].X();
-    v2[1] = rGeometry[2].Y() - rGeometry[0].Y();
-    v2[2] = rGeometry[2].Z() - rGeometry[0].Z();
-
-    MathUtils<double>::CrossProduct(An,v1,v2);
-
-    array_1d<double,3>& normal = rCondition.GetValue(NORMAL);
-
-    noalias(normal) = An/norm_2(An);
-
-  }
-
-
-  //this function adds the Contribution of one of the geometries
-  //to the corresponding nodes
-  static void CalculateUnitNormal2D(Element& rElement, array_1d<double,3>& An)
-  {
-    Geometry<Node<3> >& rGeometry = rElement.GetGeometry();
-
-    if(rGeometry.size()<2){
-      std::cout<<" Warning 2D geometry with only "<<rGeometry.size()<<" node :: multiple normal definitions "<<std::endl;
-      rElement.GetValue(NORMAL).clear();
-    }
-    else{
-
-      An[0] = -(rGeometry[1].Y()-rGeometry[0].Y());
-      An[1] =   rGeometry[1].X()-rGeometry[0].X();
-      An[2] =   0.00;
-
-      array_1d<double,3>& normal = rElement.GetValue(NORMAL);
-      noalias(normal) = An/norm_2(An);
-
-    }
-
-  }
-
-  static void CalculateUnitNormal3D(Element& rElement, array_1d<double,3>& An,
-                                    array_1d<double,3>& v1,array_1d<double,3>& v2 )
-  {
-    Geometry<Node<3> >& rGeometry = rElement.GetGeometry();
-
-    if(rGeometry.size()<3){
-      std::cout<<" Warning 3D geometry with only "<<rGeometry.size()<<" nodes :: multiple normal definitions "<<std::endl;
-      rElement.GetValue(NORMAL).clear();
-    }
-    else{
+    static void CalculateUnitNormal3D(Condition &rCondition, array_1d<double, 3> &An,
+                                      array_1d<double, 3> &v1, array_1d<double, 3> &v2)
+    {
+      Geometry<Node<3>> &rGeometry = rCondition.GetGeometry();
 
       v1[0] = rGeometry[1].X() - rGeometry[0].X();
       v1[1] = rGeometry[1].Y() - rGeometry[0].Y();
@@ -382,1357 +306,1426 @@ protected:
       v2[1] = rGeometry[2].Y() - rGeometry[0].Y();
       v2[2] = rGeometry[2].Z() - rGeometry[0].Z();
 
-      MathUtils<double>::CrossProduct(An,v1,v2);
-      An *= 0.5;
+      MathUtils<double>::CrossProduct(An, v1, v2);
 
-      array_1d<double,3>& normal = rElement.GetValue(NORMAL);
+      array_1d<double, 3> &normal = rCondition.GetValue(NORMAL);
 
-      noalias(normal) = An/norm_2(An);
-
+      noalias(normal) = An / norm_2(An);
     }
-  }
 
-
-  void ResetBodyNormals(ModelPart& rModelPart)
-  {
-    //resetting the normals
-    for(auto& i_node : rModelPart.Nodes())
+    // this function adds the Contribution of one of the geometries
+    // to the corresponding nodes
+    static void CalculateUnitNormal2D(Element &rElement, array_1d<double, 3> &An)
     {
-      i_node.GetSolutionStepValue(NORMAL).clear();
-    }
-  }
+      Geometry<Node<3>> &rGeometry = rElement.GetGeometry();
 
-  void CheckBodyNormals(ModelPart& rModelPart)
-  {
-    //resetting the normals
-    for(const auto& i_node : rModelPart.Nodes())
-    {
-      std::cout<<" ID: "<<i_node.Id()<<" normal: "<<i_node.GetSolutionStepValue(NORMAL)<<std::endl;
-    }
-  }
-
-  /// Calculates the "area normal" (vector oriented as the normal with a magnitude proportional to the area).
-  /** This is done on the base of the Conditions provided which should be
-   * understood as the surface elements of the area of interest.
-   * @param rConditions A set of conditions defining the "skin" of a model
-   * @param dimension Spatial dimension (2 or 3)
-   * @note This function is not recommended for distributed (MPI) runs, as
-   * the user has to ensure that the calculated normals are assembled between
-   * processes. The overload of this function that takes a ModelPart is
-   * preferable in this case, as it performs the required communication.
-   */
-  void CalculateBoundaryNormals(ConditionsContainerType& rConditions)
-  {
-    KRATOS_TRY
-
-    //resetting the normals
-    // for(ConditionsContainerType::iterator it =  rConditions.begin();
-    //     it != rConditions.end(); ++it)
-    //   {
-    //     Element::GeometryType& rNodes = it->GetGeometry();
-    //     for(unsigned int in = 0; in<rNodes.size(); ++in)
-    //       ((rNodes[in]).GetSolutionStepValue(NORMAL)).clear();
-    //   }
-
-    const unsigned int dimension = rConditions.begin()->GetGeometry().WorkingSpaceDimension();
-
-    //std::cout<<" condition geometry: "<<(rConditions.begin())->GetGeometry()<<std::endl;
-
-    //calculating the normals and storing on the conditions
-    array_1d<double,3> An;
-    if(dimension == 2)
-    {
-      for(auto& i_cond : rConditions)
+      if (rGeometry.size() < 2)
       {
-        if(i_cond.IsNot(CONTACT) && i_cond.Is(BOUNDARY) )
-          CalculateUnitNormal2D(i_cond,An);
+        std::cout << " Warning 2D geometry with only " << rGeometry.size() << " node :: multiple normal definitions " << std::endl;
+        rElement.GetValue(NORMAL).clear();
       }
-
-    }
-    else if(dimension == 3)
-    {
-      array_1d<double,3> v1;
-      array_1d<double,3> v2;
-      for(auto& i_cond : rConditions)
+      else
       {
-        //calculate the normal on the given condition
-        if(i_cond.IsNot(CONTACT) && i_cond.Is(BOUNDARY)){
-          CalculateUnitNormal3D(i_cond,An,v1,v2);
-        }
+
+        An[0] = -(rGeometry[1].Y() - rGeometry[0].Y());
+        An[1] = rGeometry[1].X() - rGeometry[0].X();
+        An[2] = 0.00;
+
+        array_1d<double, 3> &normal = rElement.GetValue(NORMAL);
+        noalias(normal) = An / norm_2(An);
       }
     }
 
-    KRATOS_CATCH( "" )
-  }
-
-
-  /// Calculates the "area normal" (vector oriented as the normal with a magnitude proportional to the area).
-  /** This is done on the base of the Elements provided which should be
-   * understood as the surface elements of the area of interest.
-   * @param rElements A set of elements defining the "skin" of a model
-   * @param dimension Spatial dimension (2 or 3)
-   * @note This function is not recommended for distributed (MPI) runs, as
-   * the user has to ensure that the calculated normals are assembled between
-   * processes. The overload of this function that takes a ModelPart is
-   * preferable in this case, as it performs the required communication.
-   */
-  void CalculateBoundaryNormals(ElementsContainerType& rElements)
-
-  {
-    KRATOS_TRY
-
-    //resetting the normals
-    // for(ElementsContainerType::iterator it =  rElements.begin(); it != rElements.end(); ++it)
-    //   {
-    //     Element::GeometryType& rNodes = it->GetGeometry();
-    //     for(unsigned int in = 0; in<rNodes.size(); ++in)
-    //       ((rNodes[in]).GetSolutionStepValue(NORMAL)).clear();
-    //   }
-
-    const unsigned int dimension = (rElements.begin())->GetGeometry().WorkingSpaceDimension();
-
-    //std::cout<<" element geometry: "<<(rElements.begin())->GetGeometry()<<std::endl;
-
-    //calculating the normals and storing on elements
-    array_1d<double,3> An;
-    if(dimension == 2)
+    static void CalculateUnitNormal3D(Element &rElement, array_1d<double, 3> &An,
+                                      array_1d<double, 3> &v1, array_1d<double, 3> &v2)
     {
-      for(auto& i_elem : rElements)
+      Geometry<Node<3>> &rGeometry = rElement.GetGeometry();
+
+      if (rGeometry.size() < 3)
       {
-        if(i_elem.IsNot(CONTACT)){
-          i_elem.Set(BOUNDARY); //give an error in set flags (for the created rigid body)
-          CalculateUnitNormal2D(i_elem,An);
-        }
+        std::cout << " Warning 3D geometry with only " << rGeometry.size() << " nodes :: multiple normal definitions " << std::endl;
+        rElement.GetValue(NORMAL).clear();
       }
-    }
-    else if(dimension == 3)
-    {
-      array_1d<double,3> v1;
-      array_1d<double,3> v2;
-      for(auto& i_elem : rElements)
+      else
       {
-        //calculate the normal on the given surface element
-        if(i_elem.IsNot(CONTACT)){
-          i_elem.Set(BOUNDARY); //give an error in set flags (for the created rigid body)
-          CalculateUnitNormal3D(i_elem,An,v1,v2);
-        }
+
+        v1[0] = rGeometry[1].X() - rGeometry[0].X();
+        v1[1] = rGeometry[1].Y() - rGeometry[0].Y();
+        v1[2] = rGeometry[1].Z() - rGeometry[0].Z();
+
+        v2[0] = rGeometry[2].X() - rGeometry[0].X();
+        v2[1] = rGeometry[2].Y() - rGeometry[0].Y();
+        v2[2] = rGeometry[2].Z() - rGeometry[0].Z();
+
+        MathUtils<double>::CrossProduct(An, v1, v2);
+        An *= 0.5;
+
+        array_1d<double, 3> &normal = rElement.GetValue(NORMAL);
+
+        noalias(normal) = An / norm_2(An);
       }
     }
 
-    KRATOS_CATCH( "" )
-  }
-
-
-  //Check if the mesh has elements with the spatial dimension
-  bool CheckElementsDimension(ModelPart& rModelPart, unsigned int dimension)
-  {
-    KRATOS_TRY
-
-    ElementsContainerType& rElements = rModelPart.Elements();
-
-    ElementsContainerType::iterator it =  rElements.begin();
-
-    if( (it)->GetGeometry().Dimension() == dimension ){
-      return true;
-    }
-    else{
-      return false;
-    }
-
-    KRATOS_CATCH( "" )
-  }
-
-
-  //Check if the mesh has boundary conditions with the spatial dimension
-  bool CheckConditionsDimension(ModelPart& rModelPart, unsigned int dimension)
-  {
-    KRATOS_TRY
-
-    if( rModelPart.Conditions().begin()->GetGeometry().Dimension() == dimension ){
-      return true;
-    }
-    else{
-      return false;
-    }
-
-    KRATOS_CATCH( "" )
-  }
-
-
-  //Check if the elements local space is equal to the spatial dimension
-  bool CheckElementsLocalSpace(ModelPart& rModelPart, unsigned int dimension)
-  {
-    KRATOS_TRY
-
-    if( rModelPart.Elements().begin()->GetGeometry().LocalSpaceDimension() == dimension ){
-      return true;
-    }
-    else{
-      return false;
-    }
-
-    KRATOS_CATCH( "" )
-  }
-
-
-  //Check if the conditions local space is equal to the spatial dimension
-  bool CheckConditionsLocalSpace(ModelPart& rModelPart, unsigned int dimension)
-  {
-    KRATOS_TRY
-
-    if( rModelPart.Conditions().begin()->GetGeometry().LocalSpaceDimension() == dimension ){
-      return true;
-    }
-    else{
-      return false;
-    }
-
-    KRATOS_CATCH( "" )
-  }
-
-
-  /// Calculates the normals of the BOUNDARY nodes given a mesh
-  //  using a consistent way: SOTO & CODINA
-  //  fails in sharp edges angle<90
-  void CalculateVolumeBoundaryNormals(ModelPart& rModelPart)
-  {
-    KRATOS_TRY
-
-    const unsigned int dimension = rModelPart.GetProcessInfo()[SPACE_DIMENSION];
-
-    //Reset normals
-    ModelPart::NodesContainerType&    rNodes = rModelPart.Nodes();
-    ModelPart::ElementsContainerType& rElements = rModelPart.Elements();
-
-    //Check if the neigbours search is already done and set
-    bool neighsearch=false;
-    unsigned int number_of_nodes = rElements.begin()->GetGeometry().PointsNumber();
-    for(unsigned int i=0; i<number_of_nodes; ++i)
-      if( (rElements.begin()->GetGeometry()[i].GetValue(NEIGHBOUR_ELEMENTS)).size() > 1 )
-        neighsearch=true;
-
-    if( !neighsearch )
-      std::cout<<" WARNING :: Neighbour Search Not PERFORMED "<<std::endl;
-
-    for(auto& i_node : rNodes)
+    void ResetBodyNormals(ModelPart &rModelPart)
     {
-      i_node.GetSolutionStepValue(NORMAL).clear();
-      if(!neighsearch){
-        i_node.GetValue(NEIGHBOUR_ELEMENTS).clear();
-        i_node.Reset(BOUNDARY);
+      // resetting the normals
+      for (auto &i_node : rModelPart.Nodes())
+      {
+        i_node.GetSolutionStepValue(NORMAL).clear();
       }
     }
 
-    if(!neighsearch){
-      for(auto i_elem(rElements.begin()); i_elem != rElements.end(); ++i_elem)
+    void CheckBodyNormals(ModelPart &rModelPart)
+    {
+      // resetting the normals
+      for (const auto &i_node : rModelPart.Nodes())
       {
-        Element::GeometryType& rGeometry = i_elem->GetGeometry();
-        for(unsigned int i = 0; i < rGeometry.size(); ++i)
+        std::cout << " ID: " << i_node.Id() << " normal: " << i_node.GetSolutionStepValue(NORMAL) << std::endl;
+      }
+    }
+
+    /// Calculates the "area normal" (vector oriented as the normal with a magnitude proportional to the area).
+    /** This is done on the base of the Conditions provided which should be
+     * understood as the surface elements of the area of interest.
+     * @param rConditions A set of conditions defining the "skin" of a model
+     * @param dimension Spatial dimension (2 or 3)
+     * @note This function is not recommended for distributed (MPI) runs, as
+     * the user has to ensure that the calculated normals are assembled between
+     * processes. The overload of this function that takes a ModelPart is
+     * preferable in this case, as it performs the required communication.
+     */
+    void CalculateBoundaryNormals(ConditionsContainerType &rConditions)
+    {
+      KRATOS_TRY
+
+      // resetting the normals
+      //  for(ConditionsContainerType::iterator it =  rConditions.begin();
+      //      it != rConditions.end(); ++it)
+      //    {
+      //      Element::GeometryType& rNodes = it->GetGeometry();
+      //      for(unsigned int in = 0; in<rNodes.size(); ++in)
+      //        ((rNodes[in]).GetSolutionStepValue(NORMAL)).clear();
+      //    }
+
+      const unsigned int dimension = rConditions.begin()->GetGeometry().WorkingSpaceDimension();
+
+      // std::cout<<" condition geometry: "<<(rConditions.begin())->GetGeometry()<<std::endl;
+
+      // calculating the normals and storing on the conditions
+      array_1d<double, 3> An;
+      if (dimension == 2)
+      {
+        for (auto &i_cond : rConditions)
         {
-          rGeometry[i].GetValue(NEIGHBOUR_ELEMENTS).push_back(*i_elem.base());
+          if (i_cond.IsNot(CONTACT) && i_cond.Is(BOUNDARY))
+            CalculateUnitNormal2D(i_cond, An);
         }
       }
+      else if (dimension == 3)
+      {
+        array_1d<double, 3> v1;
+        array_1d<double, 3> v2;
+        for (auto &i_cond : rConditions)
+        {
+          // calculate the normal on the given condition
+          if (i_cond.IsNot(CONTACT) && i_cond.Is(BOUNDARY))
+          {
+            CalculateUnitNormal3D(i_cond, An, v1, v2);
+          }
+        }
+      }
+
+      KRATOS_CATCH("")
     }
 
-    //calculating the normals and storing it on nodes
+    /// Calculates the "area normal" (vector oriented as the normal with a magnitude proportional to the area).
+    /** This is done on the base of the Elements provided which should be
+     * understood as the surface elements of the area of interest.
+     * @param rElements A set of elements defining the "skin" of a model
+     * @param dimension Spatial dimension (2 or 3)
+     * @note This function is not recommended for distributed (MPI) runs, as
+     * the user has to ensure that the calculated normals are assembled between
+     * processes. The overload of this function that takes a ModelPart is
+     * preferable in this case, as it performs the required communication.
+     */
+    void CalculateBoundaryNormals(ElementsContainerType &rElements)
 
-    Vector An(3);
-    Element::IntegrationMethod mIntegrationMethod = Element::GeometryDataType::IntegrationMethod::GI_GAUSS_1; //one gauss point
-    int PointNumber = 0; //one gauss point
-    Matrix J;
-    Matrix InvJ;
-    double detJ;
-    Matrix DN_DX;
-
-    unsigned int assigned       = 0;
-    unsigned int not_assigned   = 0;
-    unsigned int boundary_nodes = 0;
-    //int boundarycounter=0;
-    for(auto& i_node : rNodes)
     {
-      noalias(An) = ZeroVector(3);
+      KRATOS_TRY
 
-      //if(i_node.Is(BOUNDARY)){
+      // resetting the normals
+      //  for(ElementsContainerType::iterator it =  rElements.begin(); it != rElements.end(); ++it)
+      //    {
+      //      Element::GeometryType& rNodes = it->GetGeometry();
+      //      for(unsigned int in = 0; in<rNodes.size(); ++in)
+      //        ((rNodes[in]).GetSolutionStepValue(NORMAL)).clear();
+      //    }
 
-      ElementWeakPtrVectorType& nElements = i_node.GetValue(NEIGHBOUR_ELEMENTS);
+      const unsigned int dimension = (rElements.begin())->GetGeometry().WorkingSpaceDimension();
 
-      for(auto& i_nelem : nElements)
+      // std::cout<<" element geometry: "<<(rElements.begin())->GetGeometry()<<std::endl;
+
+      // calculating the normals and storing on elements
+      array_1d<double, 3> An;
+      if (dimension == 2)
       {
-
-        Element::GeometryType& rGeometry = i_nelem.GetGeometry();
-
-        if( rGeometry.EdgesNumber() > 1 &&  rGeometry.LocalSpaceDimension() == dimension ){
-
-
-          //********** Compute the element integral ******//
-          const Element::GeometryType::IntegrationPointsArrayType& integration_points = rGeometry.IntegrationPoints( mIntegrationMethod );
-          const Element::GeometryType::ShapeFunctionsGradientsType& DN_De = rGeometry.ShapeFunctionsLocalGradients( mIntegrationMethod );
-
-
-          J.resize(dimension, dimension, false);
-          J = rGeometry.Jacobian( J, PointNumber , mIntegrationMethod );
-
-          InvJ.clear();
-          detJ=0;
-          //Calculating the inverse of the jacobian and the parameters needed
-          if(dimension==2){
-            MathUtils<double>::InvertMatrix2( J, InvJ, detJ);
-          }else if(dimension==3){
-            MathUtils<double>::InvertMatrix3( J, InvJ, detJ);
-          }else{
-            MathUtils<double>::InvertMatrix( J, InvJ, detJ);
-          }
-
-
-          //Compute cartesian derivatives for one gauss point
-          DN_DX = prod( DN_De[PointNumber] , InvJ );
-
-          double IntegrationWeight = integration_points[PointNumber].Weight() * detJ;
-
-
-          for(unsigned int i = 0; i < rGeometry.size(); ++i)
+        for (auto &i_elem : rElements)
+        {
+          if (i_elem.IsNot(CONTACT))
           {
-            if(i_node.Id() == rGeometry[i].Id()){
+            i_elem.Set(BOUNDARY); // give an error in set flags (for the created rigid body)
+            CalculateUnitNormal2D(i_elem, An);
+          }
+        }
+      }
+      else if (dimension == 3)
+      {
+        array_1d<double, 3> v1;
+        array_1d<double, 3> v2;
+        for (auto &i_elem : rElements)
+        {
+          // calculate the normal on the given surface element
+          if (i_elem.IsNot(CONTACT))
+          {
+            i_elem.Set(BOUNDARY); // give an error in set flags (for the created rigid body)
+            CalculateUnitNormal3D(i_elem, An, v1, v2);
+          }
+        }
+      }
 
-              for(unsigned int d=0; d<dimension; ++d)
+      KRATOS_CATCH("")
+    }
+
+    // Check if the mesh has elements with the spatial dimension
+    bool CheckElementsDimension(ModelPart &rModelPart, unsigned int dimension)
+    {
+      KRATOS_TRY
+
+      ElementsContainerType &rElements = rModelPart.Elements();
+
+      ElementsContainerType::iterator it = rElements.begin();
+
+      if ((it)->GetGeometry().Dimension() == dimension)
+      {
+        return true;
+      }
+      else
+      {
+        return false;
+      }
+
+      KRATOS_CATCH("")
+    }
+
+    // Check if the mesh has boundary conditions with the spatial dimension
+    bool CheckConditionsDimension(ModelPart &rModelPart, unsigned int dimension)
+    {
+      KRATOS_TRY
+
+      if (rModelPart.Conditions().begin()->GetGeometry().Dimension() == dimension)
+      {
+        return true;
+      }
+      else
+      {
+        return false;
+      }
+
+      KRATOS_CATCH("")
+    }
+
+    // Check if the elements local space is equal to the spatial dimension
+    bool CheckElementsLocalSpace(ModelPart &rModelPart, unsigned int dimension)
+    {
+      KRATOS_TRY
+
+      if (rModelPart.Elements().begin()->GetGeometry().LocalSpaceDimension() == dimension)
+      {
+        return true;
+      }
+      else
+      {
+        return false;
+      }
+
+      KRATOS_CATCH("")
+    }
+
+    // Check if the conditions local space is equal to the spatial dimension
+    bool CheckConditionsLocalSpace(ModelPart &rModelPart, unsigned int dimension)
+    {
+      KRATOS_TRY
+
+      if (rModelPart.Conditions().begin()->GetGeometry().LocalSpaceDimension() == dimension)
+      {
+        return true;
+      }
+      else
+      {
+        return false;
+      }
+
+      KRATOS_CATCH("")
+    }
+
+    /// Calculates the normals of the BOUNDARY nodes given a mesh
+    //  using a consistent way: SOTO & CODINA
+    //  fails in sharp edges angle<90
+    void CalculateVolumeBoundaryNormals(ModelPart &rModelPart)
+    {
+      KRATOS_TRY
+
+      const unsigned int dimension = rModelPart.GetProcessInfo()[SPACE_DIMENSION];
+
+      // Reset normals
+      ModelPart::NodesContainerType &rNodes = rModelPart.Nodes();
+      ModelPart::ElementsContainerType &rElements = rModelPart.Elements();
+
+      // Check if the neigbours search is already done and set
+      bool neighsearch = false;
+      unsigned int number_of_nodes = rElements.begin()->GetGeometry().PointsNumber();
+      for (unsigned int i = 0; i < number_of_nodes; ++i)
+        if ((rElements.begin()->GetGeometry()[i].GetValue(NEIGHBOUR_ELEMENTS)).size() > 1)
+          neighsearch = true;
+
+      if (!neighsearch)
+        std::cout << " WARNING :: Neighbour Search Not PERFORMED " << std::endl;
+
+      for (auto &i_node : rNodes)
+      {
+        i_node.GetSolutionStepValue(NORMAL).clear();
+        if (!neighsearch)
+        {
+          i_node.GetValue(NEIGHBOUR_ELEMENTS).clear();
+          i_node.Reset(BOUNDARY);
+        }
+      }
+
+      if (!neighsearch)
+      {
+        for (auto i_elem(rElements.begin()); i_elem != rElements.end(); ++i_elem)
+        {
+          Element::GeometryType &rGeometry = i_elem->GetGeometry();
+          for (unsigned int i = 0; i < rGeometry.size(); ++i)
+          {
+            rGeometry[i].GetValue(NEIGHBOUR_ELEMENTS).push_back(*i_elem.base());
+          }
+        }
+      }
+
+      // calculating the normals and storing it on nodes
+
+      Vector An(3);
+      Element::IntegrationMethod mIntegrationMethod = Element::GeometryDataType::IntegrationMethod::GI_GAUSS_1; // one gauss point
+      int PointNumber = 0;                                                                                      // one gauss point
+      Matrix J;
+      Matrix InvJ;
+      double detJ;
+      Matrix DN_DX;
+
+      unsigned int assigned = 0;
+      unsigned int not_assigned = 0;
+      unsigned int boundary_nodes = 0;
+      // int boundarycounter=0;
+      for (auto &i_node : rNodes)
+      {
+        noalias(An) = ZeroVector(3);
+
+        // if(i_node.Is(BOUNDARY)){
+
+        ElementWeakPtrVectorType &nElements = i_node.GetValue(NEIGHBOUR_ELEMENTS);
+
+        for (auto &i_nelem : nElements)
+        {
+
+          Element::GeometryType &rGeometry = i_nelem.GetGeometry();
+
+          if (rGeometry.EdgesNumber() > 1 && rGeometry.LocalSpaceDimension() == dimension)
+          {
+
+            //********** Compute the element integral ******//
+            const Element::GeometryType::IntegrationPointsArrayType &integration_points = rGeometry.IntegrationPoints(mIntegrationMethod);
+            const Element::GeometryType::ShapeFunctionsGradientsType &DN_De = rGeometry.ShapeFunctionsLocalGradients(mIntegrationMethod);
+
+            J.resize(dimension, dimension, false);
+            J = rGeometry.Jacobian(J, PointNumber, mIntegrationMethod);
+
+            InvJ.clear();
+            detJ = 0;
+            // Calculating the inverse of the jacobian and the parameters needed
+            if (dimension == 2)
+            {
+              MathUtils<double>::InvertMatrix2(J, InvJ, detJ);
+            }
+            else if (dimension == 3)
+            {
+              MathUtils<double>::InvertMatrix3(J, InvJ, detJ);
+            }
+            else
+            {
+              MathUtils<double>::InvertMatrix(J, InvJ, detJ);
+            }
+
+            // Compute cartesian derivatives for one gauss point
+            DN_DX = prod(DN_De[PointNumber], InvJ);
+
+            double IntegrationWeight = integration_points[PointNumber].Weight() * detJ;
+
+            for (unsigned int i = 0; i < rGeometry.size(); ++i)
+            {
+              if (i_node.Id() == rGeometry[i].Id())
               {
-                An[d] += DN_DX(i,d) * IntegrationWeight;
-              }
-            }
-          }
 
-          //********** Compute the element integral ******//
-
-        }
-
-        if(norm_2(An)>1e-12){
-          noalias(i_node.FastGetSolutionStepValue(NORMAL)) = An/norm_2(An);
-          assigned +=1;
-          if(!neighsearch){
-            i_node.Set(BOUNDARY);
-          }
-        }
-        else{
-          (i_node.FastGetSolutionStepValue(NORMAL)).clear();
-          //std::cout<<" ERROR: normal not set "<<std::endl;
-          not_assigned +=1;
-          if(!neighsearch){
-            i_node.Set(BOUNDARY,false);
-          }
-        }
-
-      }
-
-      if(i_node.Is(BOUNDARY))
-        boundary_nodes +=1;
-
-      //boundarycounter++;
-      //}
-    }
-
-
-    if(mEchoLevel > 0)
-      std::cout<<"  [ Boundary_Normals  (Mesh Nodes:"<<rNodes.size()<<")[Boundary nodes: "<<boundary_nodes<<" (SET:"<<assigned<<" / NOT_SET:"<<not_assigned<<")] ]"<<std::endl;
-
-
-    //std::cout<<" Boundary COUNTER "<<boundarycounter<<std::endl;
-    KRATOS_CATCH( "" )
-
-  }
-
-  //**************************************************************************
-  //**************************************************************************
-
-  void AddNormalsToNodes(ModelPart& rModelPart)
-  {
-    KRATOS_TRY
-
-    const unsigned int dimension = rModelPart.GetProcessInfo()[SPACE_DIMENSION];
-
-    if( rModelPart.NumberOfConditions() && this->CheckConditionsDimension(rModelPart, dimension-1) ){
-
-    //   ConditionsContainerType& rConditions = rModelPart.Conditions();
-
-      //adding the normals to the nodes
-      for(auto& i_cond : rModelPart.Conditions())
-      {
-        Geometry<Node<3> >& rGeometry = i_cond.GetGeometry();
-        double coeff = 1.00/rGeometry.size();
-        const array_1d<double,3>& An = i_cond.GetValue(NORMAL);
-
-        for(unsigned int i = 0; i<rGeometry.size(); ++i)
-        {
-          noalias(rGeometry[i].FastGetSolutionStepValue(NORMAL)) += coeff * An;
-        }
-      }
-
-    }
-    else if( rModelPart.NumberOfElements() && this->CheckElementsDimension(rModelPart, dimension-1) ){
-
-      //adding the normals to the nodes
-      for(auto& i_elem : rModelPart.Elements() )
-      {
-        Geometry<Node<3> >& rGeometry = i_elem.GetGeometry();
-        double coeff = 1.00/rGeometry.size();
-        const array_1d<double,3>& An = i_elem.GetValue(NORMAL);
-
-        for(unsigned int i = 0; i<rGeometry.size(); ++i)
-        {
-          noalias(rGeometry[i].FastGetSolutionStepValue(NORMAL)) += coeff * An;
-        }
-      }
-
-    }
-
-    KRATOS_CATCH( "" )
-  }
-
-  //**************************************************************************
-  //**************************************************************************
-
-  void AddWeightedNormalsToNodes(ModelPart& rModelPart)
-  {
-    KRATOS_TRY
-
-    const unsigned int dimension = rModelPart.GetProcessInfo()[SPACE_DIMENSION];
-
-    ModelPart::NodesContainerType& rNodes = rModelPart.Nodes();
-
-    unsigned int MaxNodeId = MesherUtilities::GetMaxNodeId(rModelPart);
-    std::vector<int> NodeNeighboursIds(MaxNodeId+1);
-    std::fill( NodeNeighboursIds.begin(), NodeNeighboursIds.end(), 0 );
-
-    if(mEchoLevel > 1)
-      std::cout<<"   ["<<rModelPart.Name()<<"] [conditions:"<<rModelPart.NumberOfConditions()<<", elements:"<<rModelPart.NumberOfElements()<<"] dimension: "<<dimension<<std::endl;
-
-
-    if( rModelPart.NumberOfConditions() && this->CheckConditionsLocalSpace(rModelPart, dimension-1) ){
-
-      if(mEchoLevel > 0)
-        std::cout<<"   ["<<rModelPart.Name()<<"] (C)"<<std::endl;
-
-      //add the neighbour boundary conditions to all the nodes in the mesh
-      std::vector<ConditionWeakPtrVectorType > Neighbours(rNodes.size()+1);
-
-      unsigned int id = 1;
-      for(auto i_cond(rModelPart.Conditions().begin()); i_cond != rModelPart.Conditions().end(); ++i_cond)
-      {
-        if(i_cond->IsNot(CONTACT) && i_cond->Is(BOUNDARY)){
-
-          Condition::GeometryType& rGeometry = i_cond->GetGeometry();
-
-          if( mEchoLevel > 2 )
-            std::cout<<" Condition ID "<<i_cond->Id()<<" id "<<id<<std::endl;
-
-          for(unsigned int i = 0; i < rGeometry.size(); ++i)
-          {
-            if( mEchoLevel > 2 ){
-              if(NodeNeighboursIds.size()<=rGeometry[i].Id())
-                std::cout<<" Shrink node in geom "<<rGeometry[i].Id()<<" number of nodes "<<NodeNeighboursIds.size()<<std::endl;
-            }
-
-            if(NodeNeighboursIds[rGeometry[i].Id()]==0){
-              NodeNeighboursIds[rGeometry[i].Id()]=id;
-              Neighbours[id].push_back( *i_cond.base() );
-              id++;
-            }
-            else{
-              Neighbours[NodeNeighboursIds[rGeometry[i].Id()]].push_back(*i_cond.base());
-            }
-
-          }
-
-        }
-      }
-
-
-      //**********Set Boundary Nodes Only
-      if( id > 1 ){
-        ModelPart::NodesContainerType::iterator nodes_begin = rNodes.begin();
-        ModelPart::NodesContainerType  BoundaryNodes;
-
-        if( rModelPart.Is(FLUID) ){
-          for(unsigned int i = 0; i<rNodes.size(); ++i)
-          {
-            if((nodes_begin + i)->Is(BOUNDARY) && (nodes_begin + i)->IsNot(RIGID) && NodeNeighboursIds[(nodes_begin+i)->Id()]!=0){
-              BoundaryNodes.push_back( *(nodes_begin+i).base() );
-            }
-          }
-        }
-        else{
-
-          for(unsigned int i = 0; i<rNodes.size(); ++i)
-          {
-            if((nodes_begin + i)->Is(BOUNDARY) && NodeNeighboursIds[(nodes_begin+i)->Id()]!=0){
-              BoundaryNodes.push_back( *(nodes_begin+i).base() );
-            }
-          }
-        }
-
-        ComputeBoundaryShrinkage<Condition>(BoundaryNodes, Neighbours, NodeNeighboursIds, dimension);
-      }
-
-    }
-    else if( rModelPart.NumberOfElements() && this->CheckElementsLocalSpace(rModelPart, dimension-1)){
-
-      if(mEchoLevel > 0)
-        std::cout<<"   ["<<rModelPart.Name()<<"] (E) "<<std::endl;
-
-      //add the neighbour boundary elements to all the nodes in the mesh
-      ModelPart::ElementsContainerType& rElements = rModelPart.Elements();
-
-      std::vector<ElementWeakPtrVectorType> Neighbours(rNodes.size()+1);
-
-      unsigned int id = 1;
-      for(auto i_elem(rElements.begin()); i_elem != rElements.end(); ++i_elem)
-      {
-        if(i_elem->IsNot(CONTACT) && i_elem->Is(BOUNDARY)){
-
-          Condition::GeometryType& rGeometry = i_elem->GetGeometry();
-
-          if( mEchoLevel > 2 )
-            std::cout<<" Element ID "<<i_elem->Id()<<" id "<<id<<std::endl;
-
-          for(unsigned int i = 0; i < rGeometry.size(); ++i)
-          {
-            if( mEchoLevel > 2 ){
-              if(NodeNeighboursIds.size()<=rGeometry[i].Id())
-                std::cout<<" Shrink node in geom "<<rGeometry[i].Id()<<" number of nodes "<<NodeNeighboursIds.size()<<" Ids[id] "<<NodeNeighboursIds[rGeometry[i].Id()]<<std::endl;
-            }
-
-            if(NodeNeighboursIds[rGeometry[i].Id()]==0){
-              NodeNeighboursIds[rGeometry[i].Id()]=id;
-              Neighbours[id].push_back(*i_elem.base());
-              id++;
-            }
-            else{
-              Neighbours[NodeNeighboursIds[rGeometry[i].Id()]].push_back(*i_elem.base());
-            }
-
-          }
-
-        }
-      }
-
-      //**********Set Boundary Nodes Only
-      if( id > 1 ){
-        ModelPart::NodesContainerType::iterator nodes_begin = rNodes.begin();
-        ModelPart::NodesContainerType  BoundaryNodes;
-
-        for(unsigned int i = 0; i<rNodes.size(); ++i)
-        {
-          if((nodes_begin + i)->Is(BOUNDARY) && NodeNeighboursIds[(nodes_begin+i)->Id()]!=0 ){
-            BoundaryNodes.push_back( *((nodes_begin+i).base()) );
-          }
-        }
-
-        ComputeBoundaryShrinkage<Element>(BoundaryNodes, Neighbours, NodeNeighboursIds, dimension);
-      }
-
-    }
-
-    KRATOS_CATCH( "" )
-  }
-
-  //**************************************************************************
-  //**************************************************************************
-
-  template<class TClassType>
-  void ComputeBoundaryShrinkage(ModelPart::NodesContainerType& rNodes, const std::vector<GlobalPointersVector<TClassType> >& rNeighbours, const std::vector<int>& rNodeNeighboursIds, const unsigned int& dimension )
-  {
-    KRATOS_TRY
-
-    //********** Construct the normals in order to have a good direction and length for applying a contraction
-    ModelPart::NodesContainerType::iterator NodesBegin = rNodes.begin();
-    int NumberOfNodes = rNodes.size();
-
-    int not_assigned = 0;
-
-    #pragma omp parallel for reduction(+:not_assigned)
-    for(int pn=0; pn<NumberOfNodes; ++pn)
-    {
-      ModelPart::NodesContainerType::iterator iNode = NodesBegin + pn;
-      unsigned int Id = rNodeNeighboursIds[(iNode)->Id()];
-
-      double MeanCosinus=0;
-
-      // are integer values that will be used as quotients
-      double TotalFaces=0;
-      double ProjectionValue=0;
-      double NumberOfNormals=0;
-
-      int SingleFaces=0;
-      int TipAcuteAngles=0;
-
-      array_1d<double,3>&  rNormal = (iNode)->FastGetSolutionStepValue(NORMAL);
-      double&        rShrinkFactor = (iNode)->FastGetSolutionStepValue(SHRINK_FACTOR);
-
-      //Initialize
-      unsigned int NumberOfNeighbourNormals = rNeighbours[Id].size();
-      if( NumberOfNeighbourNormals != 0 )
-      {
-        noalias(rNormal) = ZeroVector(3);
-        rShrinkFactor = 0;
-      }
-
-      if( mEchoLevel > 1 ){
-
-        std::cout<<" Id "<<Id<<" normals size "<<NumberOfNeighbourNormals<<" normal "<<rNormal<<" shrink "<<rShrinkFactor<<std::endl;
-        for (unsigned int i_norm=0; i_norm<NumberOfNeighbourNormals; ++i_norm)//loop over node neighbour faces
-        {
-          std::cout<<" normal ["<<i_norm<<"]["<<(iNode)->Id()<<"]: "<<rNeighbours[Id][i_norm].GetValue(NORMAL)<<std::endl;
-        }
-      }
-
-      Vector FaceNormals(NumberOfNeighbourNormals);
-      noalias(FaceNormals) = ZeroVector(NumberOfNeighbourNormals);
-      Vector TipNormals(NumberOfNeighbourNormals);
-      noalias(TipNormals) = ZeroVector(NumberOfNeighbourNormals);
-
-      //Check coincident faces-normals
-      //Boundary normal is the reference normal:
-      //Neighbour normals : FaceNormals[i] = 0 (not coincident and not similar normal) 1 (coincident) 2 (similar) -> other(quotient or similar normals)
-      for(unsigned int i_norm=0; i_norm<NumberOfNeighbourNormals; ++i_norm)//loop over node neighbour faces
-      {
-
-        const array_1d<double,3>& rEntityNormal = rNeighbours[Id][i_norm].GetValue(NORMAL); //conditions-elements
-
-        if( FaceNormals[i_norm] != 1 ){ //if is not marked as coincident
-
-          double CloseProjection=0;
-          for (unsigned int j_norm=i_norm+1; j_norm<NumberOfNeighbourNormals; ++j_norm)//loop over node neighbour faces
-          {
-
-            const array_1d<double,3>& rNormalVector = rNeighbours[Id][j_norm].GetValue(NORMAL); //conditions-elements
-
-            ProjectionValue = inner_prod(rEntityNormal,rNormalVector);
-
-            if( FaceNormals[j_norm]==0 ){ //in order to not have coincident normals
-              //coincident normal
-              if( ProjectionValue > 0.995 ){
-                FaceNormals[j_norm] = 1;
-              }
-              //close normal
-              else if( ProjectionValue > 0.955 ){
-                CloseProjection    += 1;
-                FaceNormals[j_norm] = 2;
-                FaceNormals[i_norm] = 2;
-              }
-            }
-
-            if( ProjectionValue < -0.005 ){
-              TipAcuteAngles     +=1;
-              TipNormals[j_norm] +=1;
-              TipNormals[i_norm] +=1;
-            }
-
-          }//end for the j_norm for
-
-          for (unsigned int j_norm=i_norm; j_norm<NumberOfNeighbourNormals; ++j_norm)//loop over node neighbour faces
-          {
-            if(FaceNormals[j_norm]==2 && CloseProjection>0)
-              FaceNormals[j_norm]=(1.0/(CloseProjection+1));
-          }
-
-          if( FaceNormals[i_norm]!=0 ){ //it is assigned
-            rNormal += rEntityNormal*FaceNormals[i_norm]; //outer normal
-            NumberOfNormals += FaceNormals[i_norm];
-          }
-          else{
-            rNormal += rEntityNormal; //outer normal
-            NumberOfNormals += 1;
-          }
-
-          TotalFaces+=1;
-        }
-
-      }
-
-      //Modify direction of tip normals in 3D  --------- start ----------
-
-      if(dimension==3 && NumberOfNormals>=3 && TipAcuteAngles>0){
-
-        std::vector< array_1d<double,3> > NormalsTriad(3);
-        SingleFaces=0;
-
-        if(NumberOfNormals==3){ //Deterministic solution when there are 3 no-coplanar planes
-
-          for (unsigned int i_norm=0;i_norm<NumberOfNeighbourNormals;++i_norm)//loop over node neighbour faces
-          {
-            if(TipNormals[i_norm]>=1 && FaceNormals[i_norm]==0){ //tip normal and no coincident, no similar face normal
-
-              const array_1d<double,3>& rEntityNormal = rNeighbours[Id][i_norm].GetValue(NORMAL); //conditions
-              NormalsTriad[SingleFaces]=rEntityNormal;
-              SingleFaces+=1;
-            }
-          }
-
-        }
-        else if (NumberOfNormals>3) { //Reduction to the deterministic solution with 3 planes
-
-          std::vector<int> SignificativeNormals(NumberOfNeighbourNormals);
-          std::fill(SignificativeNormals.begin(), SignificativeNormals.end(), -1 );
-
-          double MaxProjection=0;
-          double Projection=0;
-
-          //get the positive largest projection between planes
-          for(unsigned int i_norm=0;i_norm<NumberOfNeighbourNormals;++i_norm)//loop over node neighbour faces
-          {
-            MaxProjection=std::numeric_limits<double>::min();
-
-            if(TipNormals[i_norm]>=1 && FaceNormals[i_norm]!=1){ //tip normal and no coincident face normal
-
-              const array_1d<double,3>& rEntityNormal = rNeighbours[Id][i_norm].GetValue(NORMAL); //conditions
-
-              for (unsigned int j_norm=0;j_norm<NumberOfNeighbourNormals;++j_norm) //loop over node neighbour faces to check the most coplanar ones
-              {
-                if(TipNormals[j_norm]>=1 && FaceNormals[j_norm]!=1 && i_norm!=j_norm){ //tip normal and no coincident face normal
-
-                  const array_1d<double,3>& rNormalVector = rNeighbours[Id][j_norm].GetValue(NORMAL); //conditions
-                  Projection=inner_prod(rEntityNormal,rNormalVector);
-
-                  if(MaxProjection<Projection && Projection>0.3){ //most coplanar normals with a projection largest than 0.3
-                    MaxProjection=Projection;
-                    SignificativeNormals[i_norm]=j_norm; //set in SignificativeNormals
-                  }
-
+                for (unsigned int d = 0; d < dimension; ++d)
+                {
+                  An[d] += DN_DX(i, d) * IntegrationWeight;
                 }
               }
             }
+
+            //********** Compute the element integral ******//
           }
 
-          // std::cout<<" SignificativeNormals [ ";
-          // for(unsigned int i_norm=0;i_norm<NumberOfNeighbourNormals;++i_norm)//loop over node neighbour faces
-          // {
-          //   std::cout <<SignificativeNormals[i_norm] <<" ";
-          // }
-          // std::cout<<"]"<<std::endl;
-          // std::cout<<" Face: "<<FaceNormals<<" Tip: "<<TipNormals<<" Id: "<<(iNode)->Id()<<" NumberOfNormals "<<NumberOfNormals<<" SingleFaces "<<SingleFaces<<std::endl;
+          if (norm_2(An) > 1e-12)
+          {
+            noalias(i_node.FastGetSolutionStepValue(NORMAL)) = An / norm_2(An);
+            assigned += 1;
+            if (!neighsearch)
+            {
+              i_node.Set(BOUNDARY);
+            }
+          }
+          else
+          {
+            (i_node.FastGetSolutionStepValue(NORMAL)).clear();
+            // std::cout<<" ERROR: normal not set "<<std::endl;
+            not_assigned += 1;
+            if (!neighsearch)
+            {
+              i_node.Set(BOUNDARY, false);
+            }
+          }
+        }
 
-          //get the most obtuse planes normals
-          for (unsigned int i_norm=0;i_norm<NumberOfNeighbourNormals;++i_norm)//loop over node neighbour faces
+        if (i_node.Is(BOUNDARY))
+          boundary_nodes += 1;
+
+        // boundarycounter++;
+        // }
+      }
+
+      if (mEchoLevel > 0)
+        std::cout << "  [ Boundary_Normals  (Mesh Nodes:" << rNodes.size() << ")[Boundary nodes: " << boundary_nodes << " (SET:" << assigned << " / NOT_SET:" << not_assigned << ")] ]" << std::endl;
+
+      // std::cout<<" Boundary COUNTER "<<boundarycounter<<std::endl;
+      KRATOS_CATCH("")
+    }
+
+    //**************************************************************************
+    //**************************************************************************
+
+    void AddNormalsToNodes(ModelPart &rModelPart)
+    {
+      KRATOS_TRY
+
+      const unsigned int dimension = rModelPart.GetProcessInfo()[SPACE_DIMENSION];
+
+      if (rModelPart.NumberOfConditions() && this->CheckConditionsDimension(rModelPart, dimension - 1))
+      {
+
+        //   ConditionsContainerType& rConditions = rModelPart.Conditions();
+
+        // adding the normals to the nodes
+        for (auto &i_cond : rModelPart.Conditions())
+        {
+          Geometry<Node<3>> &rGeometry = i_cond.GetGeometry();
+          double coeff = 1.00 / rGeometry.size();
+          const array_1d<double, 3> &An = i_cond.GetValue(NORMAL);
+
+          for (unsigned int i = 0; i < rGeometry.size(); ++i)
+          {
+            noalias(rGeometry[i].FastGetSolutionStepValue(NORMAL)) += coeff * An;
+          }
+        }
+      }
+      else if (rModelPart.NumberOfElements() && this->CheckElementsDimension(rModelPart, dimension - 1))
+      {
+
+        // adding the normals to the nodes
+        for (auto &i_elem : rModelPart.Elements())
+        {
+          Geometry<Node<3>> &rGeometry = i_elem.GetGeometry();
+          double coeff = 1.00 / rGeometry.size();
+          const array_1d<double, 3> &An = i_elem.GetValue(NORMAL);
+
+          for (unsigned int i = 0; i < rGeometry.size(); ++i)
+          {
+            noalias(rGeometry[i].FastGetSolutionStepValue(NORMAL)) += coeff * An;
+          }
+        }
+      }
+
+      KRATOS_CATCH("")
+    }
+
+    //**************************************************************************
+    //**************************************************************************
+
+    void AddWeightedNormalsToNodes(ModelPart &rModelPart)
+    {
+      KRATOS_TRY
+
+      const unsigned int dimension = rModelPart.GetProcessInfo()[SPACE_DIMENSION];
+
+      ModelPart::NodesContainerType &rNodes = rModelPart.Nodes();
+
+      unsigned int MaxNodeId = MesherUtilities::GetMaxNodeId(rModelPart);
+      std::vector<int> NodeNeighboursIds(MaxNodeId + 1);
+      std::fill(NodeNeighboursIds.begin(), NodeNeighboursIds.end(), 0);
+
+      if (mEchoLevel > 1)
+        std::cout << "   [" << rModelPart.Name() << "] [conditions:" << rModelPart.NumberOfConditions() << ", elements:" << rModelPart.NumberOfElements() << "] dimension: " << dimension << std::endl;
+
+      if (rModelPart.NumberOfConditions() && this->CheckConditionsLocalSpace(rModelPart, dimension - 1))
+      {
+
+        if (mEchoLevel > 0)
+          std::cout << "   [" << rModelPart.Name() << "] (C)" << std::endl;
+
+        // add the neighbour boundary conditions to all the nodes in the mesh
+        std::vector<ConditionWeakPtrVectorType> Neighbours(rNodes.size() + 1);
+
+        unsigned int id = 1;
+        for (auto i_cond(rModelPart.Conditions().begin()); i_cond != rModelPart.Conditions().end(); ++i_cond)
+        {
+          if (i_cond->IsNot(CONTACT) && i_cond->Is(BOUNDARY))
           {
 
-            if(SingleFaces<3){
+            Condition::GeometryType &rGeometry = i_cond->GetGeometry();
 
-              if(TipNormals[i_norm]>=1 && FaceNormals[i_norm]!=1){ //tip normal and no coincident face normal
+            if (mEchoLevel > 2)
+              std::cout << " Condition ID " << i_cond->Id() << " id " << id << std::endl;
 
-                array_1d<double,3> EntityNormal = rNeighbours[Id][i_norm].GetValue(NORMAL); //conditions
+            for (unsigned int i = 0; i < rGeometry.size(); ++i)
+            {
+              if (mEchoLevel > 2)
+              {
+                if (NodeNeighboursIds.size() <= rGeometry[i].Id())
+                  std::cout << " Shrink node in geom " << rGeometry[i].Id() << " number of nodes " << NodeNeighboursIds.size() << std::endl;
+              }
 
-                if(FaceNormals[i_norm]!=0) // similar face normal
-                  EntityNormal*=FaceNormals[i_norm];
+              if (NodeNeighboursIds[rGeometry[i].Id()] == 0)
+              {
+                NodeNeighboursIds[rGeometry[i].Id()] = id;
+                Neighbours[id].push_back(*i_cond.base());
+                id++;
+              }
+              else
+              {
+                Neighbours[NodeNeighboursIds[rGeometry[i].Id()]].push_back(*i_cond.base());
+              }
+            }
+          }
+        }
 
-                for (unsigned int j_norm=i_norm+1;j_norm<NumberOfNeighbourNormals;++j_norm)//loop over node neighbour faces to check the most obtuse planes
+        //**********Set Boundary Nodes Only
+        if (id > 1)
+        {
+          ModelPart::NodesContainerType::iterator nodes_begin = rNodes.begin();
+          ModelPart::NodesContainerType BoundaryNodes;
+
+          if (rModelPart.Is(FLUID))
+          {
+            for (unsigned int i = 0; i < rNodes.size(); ++i)
+            {
+              if ((nodes_begin + i)->Is(BOUNDARY) && (nodes_begin + i)->IsNot(RIGID) && NodeNeighboursIds[(nodes_begin + i)->Id()] != 0)
+              {
+                BoundaryNodes.push_back(*(nodes_begin + i).base());
+              }
+            }
+          }
+          else
+          {
+
+            for (unsigned int i = 0; i < rNodes.size(); ++i)
+            {
+              if ((nodes_begin + i)->Is(BOUNDARY) && NodeNeighboursIds[(nodes_begin + i)->Id()] != 0)
+              {
+                BoundaryNodes.push_back(*(nodes_begin + i).base());
+              }
+            }
+          }
+
+          ComputeBoundaryShrinkage<Condition>(BoundaryNodes, Neighbours, NodeNeighboursIds, dimension);
+        }
+      }
+      else if (rModelPart.NumberOfElements() && this->CheckElementsLocalSpace(rModelPart, dimension - 1))
+      {
+
+        if (mEchoLevel > 0)
+          std::cout << "   [" << rModelPart.Name() << "] (E) " << std::endl;
+
+        // add the neighbour boundary elements to all the nodes in the mesh
+        ModelPart::ElementsContainerType &rElements = rModelPart.Elements();
+
+        std::vector<ElementWeakPtrVectorType> Neighbours(rNodes.size() + 1);
+
+        unsigned int id = 1;
+        for (auto i_elem(rElements.begin()); i_elem != rElements.end(); ++i_elem)
+        {
+          if (i_elem->IsNot(CONTACT) && i_elem->Is(BOUNDARY))
+          {
+
+            Condition::GeometryType &rGeometry = i_elem->GetGeometry();
+
+            if (mEchoLevel > 2)
+              std::cout << " Element ID " << i_elem->Id() << " id " << id << std::endl;
+
+            for (unsigned int i = 0; i < rGeometry.size(); ++i)
+            {
+              if (mEchoLevel > 2)
+              {
+                if (NodeNeighboursIds.size() <= rGeometry[i].Id())
+                  std::cout << " Shrink node in geom " << rGeometry[i].Id() << " number of nodes " << NodeNeighboursIds.size() << " Ids[id] " << NodeNeighboursIds[rGeometry[i].Id()] << std::endl;
+              }
+
+              if (NodeNeighboursIds[rGeometry[i].Id()] == 0)
+              {
+                NodeNeighboursIds[rGeometry[i].Id()] = id;
+                Neighbours[id].push_back(*i_elem.base());
+                id++;
+              }
+              else
+              {
+                Neighbours[NodeNeighboursIds[rGeometry[i].Id()]].push_back(*i_elem.base());
+              }
+            }
+          }
+        }
+
+        //**********Set Boundary Nodes Only
+        if (id > 1)
+        {
+          ModelPart::NodesContainerType::iterator nodes_begin = rNodes.begin();
+          ModelPart::NodesContainerType BoundaryNodes;
+
+          for (unsigned int i = 0; i < rNodes.size(); ++i)
+          {
+            if ((nodes_begin + i)->Is(BOUNDARY) && NodeNeighboursIds[(nodes_begin + i)->Id()] != 0)
+            {
+              BoundaryNodes.push_back(*((nodes_begin + i).base()));
+            }
+          }
+
+          ComputeBoundaryShrinkage<Element>(BoundaryNodes, Neighbours, NodeNeighboursIds, dimension);
+        }
+      }
+
+      KRATOS_CATCH("")
+    }
+
+    //**************************************************************************
+    //**************************************************************************
+
+    template <class TClassType>
+    void ComputeBoundaryShrinkage(ModelPart::NodesContainerType &rNodes, const std::vector<GlobalPointersVector<TClassType>> &rNeighbours, const std::vector<int> &rNodeNeighboursIds, const unsigned int &dimension)
+    {
+      KRATOS_TRY
+
+      //********** Construct the normals in order to have a good direction and length for applying a contraction
+      ModelPart::NodesContainerType::iterator NodesBegin = rNodes.begin();
+      int NumberOfNodes = rNodes.size();
+
+      int not_assigned = 0;
+
+#pragma omp parallel for reduction(+ \
+                                   : not_assigned)
+      for (int pn = 0; pn < NumberOfNodes; ++pn)
+      {
+        ModelPart::NodesContainerType::iterator iNode = NodesBegin + pn;
+        unsigned int Id = rNodeNeighboursIds[(iNode)->Id()];
+
+        double MeanCosinus = 0;
+
+        // are integer values that will be used as quotients
+        double TotalFaces = 0;
+        double ProjectionValue = 0;
+        double NumberOfNormals = 0;
+
+        int SingleFaces = 0;
+        int TipAcuteAngles = 0;
+
+        array_1d<double, 3> &rNormal = (iNode)->FastGetSolutionStepValue(NORMAL);
+        double &rShrinkFactor = (iNode)->FastGetSolutionStepValue(SHRINK_FACTOR);
+
+        // Initialize
+        unsigned int NumberOfNeighbourNormals = rNeighbours[Id].size();
+        if (NumberOfNeighbourNormals != 0)
+        {
+          noalias(rNormal) = ZeroVector(3);
+          rShrinkFactor = 0;
+        }
+
+        if (mEchoLevel > 1)
+        {
+
+          std::cout << " Id " << Id << " normals size " << NumberOfNeighbourNormals << " normal " << rNormal << " shrink " << rShrinkFactor << std::endl;
+          for (unsigned int i_norm = 0; i_norm < NumberOfNeighbourNormals; ++i_norm) // loop over node neighbour faces
+          {
+            std::cout << " normal [" << i_norm << "][" << (iNode)->Id() << "]: " << rNeighbours[Id][i_norm].GetValue(NORMAL) << std::endl;
+          }
+        }
+
+        Vector FaceNormals(NumberOfNeighbourNormals);
+        noalias(FaceNormals) = ZeroVector(NumberOfNeighbourNormals);
+        Vector TipNormals(NumberOfNeighbourNormals);
+        noalias(TipNormals) = ZeroVector(NumberOfNeighbourNormals);
+
+        // Check coincident faces-normals
+        // Boundary normal is the reference normal:
+        // Neighbour normals : FaceNormals[i] = 0 (not coincident and not similar normal) 1 (coincident) 2 (similar) -> other(quotient or similar normals)
+        for (unsigned int i_norm = 0; i_norm < NumberOfNeighbourNormals; ++i_norm) // loop over node neighbour faces
+        {
+
+          const array_1d<double, 3> &rEntityNormal = rNeighbours[Id][i_norm].GetValue(NORMAL); // conditions-elements
+
+          if (FaceNormals[i_norm] != 1)
+          { // if is not marked as coincident
+
+            double CloseProjection = 0;
+            for (unsigned int j_norm = i_norm + 1; j_norm < NumberOfNeighbourNormals; ++j_norm) // loop over node neighbour faces
+            {
+
+              const array_1d<double, 3> &rNormalVector = rNeighbours[Id][j_norm].GetValue(NORMAL); // conditions-elements
+
+              ProjectionValue = inner_prod(rEntityNormal, rNormalVector);
+
+              if (FaceNormals[j_norm] == 0)
+              { // in order to not have coincident normals
+                // coincident normal
+                if (ProjectionValue > 0.995)
                 {
-                  if(TipNormals[j_norm]>=1 && FaceNormals[j_norm]!=1){ //tip normal and no coincident face normal
+                  FaceNormals[j_norm] = 1;
+                }
+                // close normal
+                else if (ProjectionValue > 0.955)
+                {
+                  CloseProjection += 1;
+                  FaceNormals[j_norm] = 2;
+                  FaceNormals[i_norm] = 2;
+                }
+              }
 
-                    if(i_norm==(unsigned int)SignificativeNormals[j_norm]){ //i_norm is a significative normal with a close coincident projection
+              if (ProjectionValue < -0.005)
+              {
+                TipAcuteAngles += 1;
+                TipNormals[j_norm] += 1;
+                TipNormals[i_norm] += 1;
+              }
 
-                      const array_1d<double,3>& rNormalVector = rNeighbours[Id][i_norm].GetValue(NORMAL); //conditions
+            } // end for the j_norm for
 
-                      if(FaceNormals[i_norm]!=0){ // similar face normal
-                        EntityNormal+=rNormalVector*FaceNormals[i_norm]; //product with the quotient
-                      }
-                      else{
-                        EntityNormal+=rNormalVector;
-                      }
+            for (unsigned int j_norm = i_norm; j_norm < NumberOfNeighbourNormals; ++j_norm) // loop over node neighbour faces
+            {
+              if (FaceNormals[j_norm] == 2 && CloseProjection > 0)
+                FaceNormals[j_norm] = (1.0 / (CloseProjection + 1));
+            }
 
-                      if(norm_2(EntityNormal)!=0)
-                        EntityNormal=EntityNormal/norm_2(EntityNormal);
+            if (FaceNormals[i_norm] != 0)
+            {                                                 // it is assigned
+              rNormal += rEntityNormal * FaceNormals[i_norm]; // outer normal
+              NumberOfNormals += FaceNormals[i_norm];
+            }
+            else
+            {
+              rNormal += rEntityNormal; // outer normal
+              NumberOfNormals += 1;
+            }
 
-                      FaceNormals[j_norm]=1; //mark as coincident in order to not use this plane again
+            TotalFaces += 1;
+          }
+        }
 
+        // Modify direction of tip normals in 3D  --------- start ----------
+
+        if (dimension == 3 && NumberOfNormals >= 3 && TipAcuteAngles > 0)
+        {
+
+          std::vector<array_1d<double, 3>> NormalsTriad(3);
+          SingleFaces = 0;
+
+          if (NumberOfNormals == 3)
+          { // Deterministic solution when there are 3 no-coplanar planes
+
+            for (unsigned int i_norm = 0; i_norm < NumberOfNeighbourNormals; ++i_norm) // loop over node neighbour faces
+            {
+              if (TipNormals[i_norm] >= 1 && FaceNormals[i_norm] == 0)
+              { // tip normal and no coincident, no similar face normal
+
+                const array_1d<double, 3> &rEntityNormal = rNeighbours[Id][i_norm].GetValue(NORMAL); // conditions
+                NormalsTriad[SingleFaces] = rEntityNormal;
+                SingleFaces += 1;
+              }
+            }
+          }
+          else if (NumberOfNormals > 3)
+          { // Reduction to the deterministic solution with 3 planes
+
+            std::vector<int> SignificativeNormals(NumberOfNeighbourNormals);
+            std::fill(SignificativeNormals.begin(), SignificativeNormals.end(), -1);
+
+            double MaxProjection = 0;
+            double Projection = 0;
+
+            // get the positive largest projection between planes
+            for (unsigned int i_norm = 0; i_norm < NumberOfNeighbourNormals; ++i_norm) // loop over node neighbour faces
+            {
+              MaxProjection = std::numeric_limits<double>::min();
+
+              if (TipNormals[i_norm] >= 1 && FaceNormals[i_norm] != 1)
+              { // tip normal and no coincident face normal
+
+                const array_1d<double, 3> &rEntityNormal = rNeighbours[Id][i_norm].GetValue(NORMAL); // conditions
+
+                for (unsigned int j_norm = 0; j_norm < NumberOfNeighbourNormals; ++j_norm) // loop over node neighbour faces to check the most coplanar ones
+                {
+                  if (TipNormals[j_norm] >= 1 && FaceNormals[j_norm] != 1 && i_norm != j_norm)
+                  { // tip normal and no coincident face normal
+
+                    const array_1d<double, 3> &rNormalVector = rNeighbours[Id][j_norm].GetValue(NORMAL); // conditions
+                    Projection = inner_prod(rEntityNormal, rNormalVector);
+
+                    if (MaxProjection < Projection && Projection > 0.3)
+                    { // most coplanar normals with a projection largest than 0.3
+                      MaxProjection = Projection;
+                      SignificativeNormals[i_norm] = j_norm; // set in SignificativeNormals
                     }
                   }
                 }
+              }
+            }
 
-                NormalsTriad[SingleFaces]=EntityNormal;
-                ++SingleFaces;
+            // std::cout<<" SignificativeNormals [ ";
+            // for(unsigned int i_norm=0;i_norm<NumberOfNeighbourNormals;++i_norm)//loop over node neighbour faces
+            // {
+            //   std::cout <<SignificativeNormals[i_norm] <<" ";
+            // }
+            // std::cout<<"]"<<std::endl;
+            // std::cout<<" Face: "<<FaceNormals<<" Tip: "<<TipNormals<<" Id: "<<(iNode)->Id()<<" NumberOfNormals "<<NumberOfNormals<<" SingleFaces "<<SingleFaces<<std::endl;
 
+            // get the most obtuse planes normals
+            for (unsigned int i_norm = 0; i_norm < NumberOfNeighbourNormals; ++i_norm) // loop over node neighbour faces
+            {
+
+              if (SingleFaces < 3)
+              {
+
+                if (TipNormals[i_norm] >= 1 && FaceNormals[i_norm] != 1)
+                { // tip normal and no coincident face normal
+
+                  array_1d<double, 3> EntityNormal = rNeighbours[Id][i_norm].GetValue(NORMAL); // conditions
+
+                  if (FaceNormals[i_norm] != 0) // similar face normal
+                    EntityNormal *= FaceNormals[i_norm];
+
+                  for (unsigned int j_norm = i_norm + 1; j_norm < NumberOfNeighbourNormals; ++j_norm) // loop over node neighbour faces to check the most obtuse planes
+                  {
+                    if (TipNormals[j_norm] >= 1 && FaceNormals[j_norm] != 1)
+                    { // tip normal and no coincident face normal
+
+                      if (i_norm == (unsigned int)SignificativeNormals[j_norm])
+                      { // i_norm is a significative normal with a close coincident projection
+
+                        const array_1d<double, 3> &rNormalVector = rNeighbours[Id][i_norm].GetValue(NORMAL); // conditions
+
+                        if (FaceNormals[i_norm] != 0)
+                        {                                                      // similar face normal
+                          EntityNormal += rNormalVector * FaceNormals[i_norm]; // product with the quotient
+                        }
+                        else
+                        {
+                          EntityNormal += rNormalVector;
+                        }
+
+                        if (norm_2(EntityNormal) != 0)
+                          EntityNormal = EntityNormal / norm_2(EntityNormal);
+
+                        FaceNormals[j_norm] = 1; // mark as coincident in order to not use this plane again
+                      }
+                    }
+                  }
+
+                  NormalsTriad[SingleFaces] = EntityNormal;
+                  ++SingleFaces;
+                }
               }
             }
           }
 
-        }
-
-        if(SingleFaces<3){
-
-          for (unsigned int i_norm=0;i_norm<NumberOfNeighbourNormals;++i_norm)//loop over node neighbour faces
+          if (SingleFaces < 3)
           {
-            if(SingleFaces==3)
-              break;
 
-            if(TipNormals[i_norm]>=1 && FaceNormals[i_norm]!=0 && FaceNormals[i_norm]!=1){ //tip normal and similar face normal
-              const array_1d<double,3>& rEntityNormal = rNeighbours[Id][i_norm].GetValue(NORMAL); //conditions
-              NormalsTriad[SingleFaces]=rEntityNormal;
-              ++SingleFaces;
+            for (unsigned int i_norm = 0; i_norm < NumberOfNeighbourNormals; ++i_norm) // loop over node neighbour faces
+            {
+              if (SingleFaces == 3)
+                break;
+
+              if (TipNormals[i_norm] >= 1 && FaceNormals[i_norm] != 0 && FaceNormals[i_norm] != 1)
+              {                                                                                      // tip normal and similar face normal
+                const array_1d<double, 3> &rEntityNormal = rNeighbours[Id][i_norm].GetValue(NORMAL); // conditions
+                NormalsTriad[SingleFaces] = rEntityNormal;
+                ++SingleFaces;
+              }
+
+              if (TipNormals[i_norm] == 0 && FaceNormals[i_norm] == 0 && SingleFaces > 0)
+              {                                                                                      // if only two of the tip normals are acute one is not set
+                const array_1d<double, 3> &rEntityNormal = rNeighbours[Id][i_norm].GetValue(NORMAL); // conditions
+                NormalsTriad[SingleFaces] = rEntityNormal;
+                ++SingleFaces;
+              }
             }
-
-            if(TipNormals[i_norm]==0 && FaceNormals[i_norm]==0 && SingleFaces>0){ //if only two of the tip normals are acute one is not set
-              const array_1d<double,3>& rEntityNormal = rNeighbours[Id][i_norm].GetValue(NORMAL); //conditions
-              NormalsTriad[SingleFaces]=rEntityNormal;
-              ++SingleFaces;
-            }
-
           }
 
-        }
-
-        if(SingleFaces==2){
-
-          for (unsigned int i_norm=0;i_norm<NumberOfNeighbourNormals;++i_norm)//loop over node neighbour faces
+          if (SingleFaces == 2)
           {
-            if(SingleFaces==3)
-              break;
 
-            if(TipNormals[i_norm]==0 && FaceNormals[i_norm]!=0 && FaceNormals[i_norm]!=1 && SingleFaces>0){ //if only two of the tip normals are acute one is not set
-              NormalsTriad[SingleFaces]=rNormal;
-              ++SingleFaces;
+            for (unsigned int i_norm = 0; i_norm < NumberOfNeighbourNormals; ++i_norm) // loop over node neighbour faces
+            {
+              if (SingleFaces == 3)
+                break;
+
+              if (TipNormals[i_norm] == 0 && FaceNormals[i_norm] != 0 && FaceNormals[i_norm] != 1 && SingleFaces > 0)
+              { // if only two of the tip normals are acute one is not set
+                NormalsTriad[SingleFaces] = rNormal;
+                ++SingleFaces;
+              }
             }
           }
-        }
 
+          if (SingleFaces == 3)
+          {
 
-        if(SingleFaces==3){
+            array_1d<double, 3> CrossProductN;
+            MathUtils<double>::CrossProduct(CrossProductN, NormalsTriad[1], NormalsTriad[2]);
+            double Projection = inner_prod(NormalsTriad[0], CrossProductN);
 
-          array_1d<double,3> CrossProductN;
-          MathUtils<double>::CrossProduct(CrossProductN,NormalsTriad[1],NormalsTriad[2]);
-          double Projection =inner_prod(NormalsTriad[0],CrossProductN);
+            if (fabs(Projection) > 1e-15)
+            {
+              rNormal = CrossProductN;
+              MathUtils<double>::CrossProduct(CrossProductN, NormalsTriad[2], NormalsTriad[0]);
+              rNormal += CrossProductN;
+              MathUtils<double>::CrossProduct(CrossProductN, NormalsTriad[0], NormalsTriad[1]);
+              rNormal += CrossProductN;
 
-          if(fabs(Projection) > 1e-15){
-            rNormal = CrossProductN;
-            MathUtils<double>::CrossProduct(CrossProductN,NormalsTriad[2],NormalsTriad[0]);
-            rNormal += CrossProductN;
-            MathUtils<double>::CrossProduct(CrossProductN,NormalsTriad[0],NormalsTriad[1]);
-            rNormal += CrossProductN;
-
-            rNormal /= Projection;  //intersection of three planes
+              rNormal /= Projection; // intersection of three planes
+            }
+            else
+            {
+              rNormal = 0.5 * (NormalsTriad[1] + NormalsTriad[2]);
+              // std::cout<<" Projection of the THREE planes value "<<Projection<<" Id: "<<(iNode)->Id()<<std::endl;
+              // std::cout<<" Face: "<<FaceNormals<<" Tip: "<<TipNormals<<" Id: "<<(iNode)->Id()<<" NumberOfNormals "<<NumberOfNormals<<" SingleFaces "<<SingleFaces<<" Normals: "<<NormalsTriad[0]<<" "<<NormalsTriad[1]<<" "<<NormalsTriad[2]<<std::endl;
+            }
           }
-          else{
-            rNormal = 0.5 * (NormalsTriad[1] + NormalsTriad[2]);
-            // std::cout<<" Projection of the THREE planes value "<<Projection<<" Id: "<<(iNode)->Id()<<std::endl;
-            // std::cout<<" Face: "<<FaceNormals<<" Tip: "<<TipNormals<<" Id: "<<(iNode)->Id()<<" NumberOfNormals "<<NumberOfNormals<<" SingleFaces "<<SingleFaces<<" Normals: "<<NormalsTriad[0]<<" "<<NormalsTriad[1]<<" "<<NormalsTriad[2]<<std::endl;
+          else if (SingleFaces == 2)
+          {
+            rNormal = 0.5 * (NormalsTriad[0] + NormalsTriad[1]);
+            // std::cout<<" WARNING something was wrong in normal calculation Triad Not found" <<std::endl;
+            // std::cout<<" Face: "<<FaceNormals<<" Tip: "<<TipNormals<<" Id: "<<(iNode)->Id()<<" NumberOfNormals "<<NumberOfNormals<<" SingleFaces "<<SingleFaces<<std::endl;
+          }
+          else
+          {
+            std::cout << " WARNING something was wrong in normal calculation Triad Not found" << std::endl;
+            std::cout << " Face: " << FaceNormals << " Tip: " << TipNormals << " Id: " << (iNode)->Id() << " NumberOfNormals " << NumberOfNormals << " SingleFaces " << SingleFaces << std::endl;
           }
 
+          // Check Boundary
+          if (norm_2(rNormal) > 2)
+          { // not an attractive solution but needed to ensure consistency
+            rNormal = rNormal / norm_2(rNormal);
+            rNormal *= 1.2;
+          }
+
+          // Check inconsistencies
+          //  unsigned int inverted = 0;
+          //  for (unsigned int i_norm=0;i_norm<NumberOfNeighbourNormals;++i_norm)//loop over node neighbour faces
+          //  {
+          //    const array_1d<double,3>& rEntityNormal = rNeighbours[Id][i_norm]->GetValue(NORMAL); //conditions
+          //    if( inner_prod(rEntityNormal,rNormal) < 0 )
+          //      ++inverted;
+          //  }
+
+          // if( inverted == NumberOfNeighbourNormals )
+          //   std::cout<<" DIRECTION NEGATIVE "<<rNormal<<" Id: "<<(iNode)->Id()<<std::endl;
+
+          // if( norm_2(rNormal) < 1e-5 )
+          //   std::cout<<" ZERO NORMAL "<<rNormal<<" Id: "<<(iNode)->Id()<<std::endl;
+
+          // Modify direction of tip normals in 3D ----------- end  -----------
         }
-        else if( SingleFaces == 2 ){
-          rNormal = 0.5 * (NormalsTriad[0] + NormalsTriad[1]);
-          // std::cout<<" WARNING something was wrong in normal calculation Triad Not found" <<std::endl;
-          // std::cout<<" Face: "<<FaceNormals<<" Tip: "<<TipNormals<<" Id: "<<(iNode)->Id()<<" NumberOfNormals "<<NumberOfNormals<<" SingleFaces "<<SingleFaces<<std::endl;
-        }
-        else{
-          std::cout<<" WARNING something was wrong in normal calculation Triad Not found" <<std::endl;
-          std::cout<<" Face: "<<FaceNormals<<" Tip: "<<TipNormals<<" Id: "<<(iNode)->Id()<<" NumberOfNormals "<<NumberOfNormals<<" SingleFaces "<<SingleFaces<<std::endl;
-        }
-
-        //Check Boundary
-        if(norm_2(rNormal)>2){ //not an attractive solution but needed to ensure consistency
-          rNormal =rNormal/norm_2(rNormal);
-          rNormal*=1.2;
-        }
-
-        //Check inconsistencies
-        // unsigned int inverted = 0;
-        // for (unsigned int i_norm=0;i_norm<NumberOfNeighbourNormals;++i_norm)//loop over node neighbour faces
-        // {
-        //   const array_1d<double,3>& rEntityNormal = rNeighbours[Id][i_norm]->GetValue(NORMAL); //conditions
-        //   if( inner_prod(rEntityNormal,rNormal) < 0 )
-        //     ++inverted;
-        // }
-
-        // if( inverted == NumberOfNeighbourNormals )
-        //   std::cout<<" DIRECTION NEGATIVE "<<rNormal<<" Id: "<<(iNode)->Id()<<std::endl;
-
-        // if( norm_2(rNormal) < 1e-5 )
-        //   std::cout<<" ZERO NORMAL "<<rNormal<<" Id: "<<(iNode)->Id()<<std::endl;
-
-
-        //Modify direction of tip normals in 3D ----------- end  -----------
-
-      }
-      else{
-
-        if(norm_2(rNormal)!=0)
-          rNormal=rNormal/norm_2(rNormal);
-
-        for(unsigned int i_norm=0;i_norm<NumberOfNeighbourNormals;++i_norm)//loop over node neigbour faces
+        else
         {
-          if (FaceNormals[i_norm]!=1){ //not coincident normal
 
-            array_1d<double,3> rEntityNormal = rNeighbours[Id][i_norm].GetValue(NORMAL); //conditions
+          if (norm_2(rNormal) != 0)
+            rNormal = rNormal / norm_2(rNormal);
 
-            if(norm_2(rEntityNormal))
-              rEntityNormal/=norm_2(rEntityNormal);
+          for (unsigned int i_norm = 0; i_norm < NumberOfNeighbourNormals; ++i_norm) // loop over node neigbour faces
+          {
+            if (FaceNormals[i_norm] != 1)
+            { // not coincident normal
 
-            ProjectionValue=inner_prod(rEntityNormal,rNormal);
+              array_1d<double, 3> rEntityNormal = rNeighbours[Id][i_norm].GetValue(NORMAL); // conditions
 
-            MeanCosinus+=ProjectionValue;
+              if (norm_2(rEntityNormal))
+                rEntityNormal /= norm_2(rEntityNormal);
+
+              ProjectionValue = inner_prod(rEntityNormal, rNormal);
+
+              MeanCosinus += ProjectionValue;
+            }
+          }
+
+          if (TotalFaces != 0)
+            MeanCosinus *= (1.0 / TotalFaces);
+
+          // acute angles are problematic, reduction of the modulus in that cases
+          if (MeanCosinus <= 0.3)
+          {
+            MeanCosinus = 0.8;
+          }
+
+          if (MeanCosinus > 3)
+            std::cout << " WARNING WRONG MeanCosinus " << MeanCosinus << std::endl;
+
+          if (MeanCosinus != 0 && MeanCosinus > 1e-3)
+          { // to ensure consistency
+            MeanCosinus = 1.0 / MeanCosinus;
+            rNormal *= MeanCosinus; // only to put the correct length
+          }
+          else
+          {
+            std::cout << " Mean Cosinus not consistent " << MeanCosinus << " [" << (iNode)->Id() << "] rNormal " << rNormal[0] << " " << rNormal[1] << " " << rNormal[2] << std::endl;
           }
         }
 
+        // Now Normalize Normal and store the Shrink_Factor
+        rShrinkFactor = norm_2(rNormal);
 
-        if(TotalFaces!=0)
-          MeanCosinus*=(1.0/TotalFaces);
-
-        //acute angles are problematic, reduction of the modulus in that cases
-        if (MeanCosinus<=0.3){
-          MeanCosinus=0.8;
+        if (rShrinkFactor != 0)
+        {
+          if (mEchoLevel > 1)
+            std::cout << "[Id " << (iNode)->Id() << " shrink_factor " << rShrinkFactor << " Normal " << rNormal[0] << " " << rNormal[1] << " " << rNormal[2] << " MeanCosinus " << MeanCosinus << "] shrink " << std::endl;
+          rNormal /= rShrinkFactor;
         }
+        else
+        {
 
-        if(MeanCosinus>3)
-          std::cout<<" WARNING WRONG MeanCosinus "<<MeanCosinus<<std::endl;
+          if (mEchoLevel > 1)
+            std::cout << "[Id " << (iNode)->Id() << " Normal " << rNormal[0] << " " << rNormal[1] << " " << rNormal[2] << " MeanCosinus " << MeanCosinus << "] no shrink " << std::endl;
 
-        if (MeanCosinus!=0 && MeanCosinus>1e-3) { //to ensure consistency
-          MeanCosinus=1.0/MeanCosinus;
-          rNormal*=MeanCosinus;               //only to put the correct length
-        }
-        else{
-          std::cout<<" Mean Cosinus not consistent "<<MeanCosinus<<" ["<<(iNode)->Id()<<"] rNormal "<<rNormal[0]<<" "<<rNormal[1]<<" "<<rNormal[2]<<std::endl;
+          noalias(rNormal) = ZeroVector(3);
+          rShrinkFactor = 1;
+
+          ++not_assigned;
         }
       }
 
-      //Now Normalize Normal and store the Shrink_Factor
-      rShrinkFactor=norm_2(rNormal);
+      if (mEchoLevel > 0)
+        std::cout << "   [NORMALS SHRINKAGE (BOUNDARY NODES:" << NumberOfNodes << ") [SET:" << NumberOfNodes - not_assigned << " / NOT_SET:" << not_assigned << "] " << std::endl;
 
-      if(rShrinkFactor!=0)
-      {
-        if( mEchoLevel > 1 )
-          std::cout<<"[Id "<<(iNode)->Id()<<" shrink_factor "<<rShrinkFactor<<" Normal "<<rNormal[0]<<" "<<rNormal[1]<<" "<<rNormal[2]<<" MeanCosinus "<<MeanCosinus<<"] shrink "<<std::endl;
-        rNormal/=rShrinkFactor;
-
-      }
-      else{
-
-        if( mEchoLevel > 1 )
-          std::cout<<"[Id "<<(iNode)->Id()<<" Normal "<<rNormal[0]<<" "<<rNormal[1]<<" "<<rNormal[2]<<" MeanCosinus "<<MeanCosinus<<"] no shrink "<<std::endl;
-
-        noalias(rNormal) = ZeroVector(3);
-        rShrinkFactor=1;
-
-        ++not_assigned;
-      }
-
-
+      KRATOS_CATCH("")
     }
 
+    // template<class TClassType>
+    // void ComputeBoundaryShrinkage(ModelPart::NodesContainerType& rNodes, const std::vector<GlobalPointersVector<TClassType> >& rNeighbours, const std::vector<int>& rIds, const unsigned int& dimension )
+    // {
 
-    if(mEchoLevel > 0)
-      std::cout<<"   [NORMALS SHRINKAGE (BOUNDARY NODES:"<<NumberOfNodes<<") [SET:"<<NumberOfNodes-not_assigned<<" / NOT_SET:"<<not_assigned<<"] "<<std::endl;
+    //   KRATOS_TRY
+
+    //   //********** Construct the normals in order to have a good direction and length for applying a contraction
+    //   std::vector<double> storenorm;
+    //   std::vector<double> tipnormal;
 
+    //   ModelPart::NodesContainerType::iterator boundary_nodes_begin = rNodes.begin();
+    //   int boundary_nodes = rNodes.size();
 
-    KRATOS_CATCH( "" )
-  }
+    //   int not_assigned = 0;
 
+    //   int pn=0;
+    //   // #pragma omp parallel for private(pn,storenorm,tipnormal)
+    //   for (pn=0; pn<boundary_nodes; ++pn)
+    //     {
 
-  // template<class TClassType>
-  // void ComputeBoundaryShrinkage(ModelPart::NodesContainerType& rNodes, const std::vector<GlobalPointersVector<TClassType> >& rNeighbours, const std::vector<int>& rIds, const unsigned int& dimension )
-  // {
+    //       double cosmedio=0;
+    //       double totalnorm=0;
+    //       double directiontol=0;
+    //       double numnorm=0;
+    //       int indepnorm=0,acuteangle=0;
 
-  //   KRATOS_TRY
+    //       array_1d<double,3>&  Normal=(boundary_nodes_begin + pn)->FastGetSolutionStepValue(NORMAL);
+    //       double&       shrink_factor=(boundary_nodes_begin + pn)->FastGetSolutionStepValue(SHRINK_FACTOR);
 
-  //   //********** Construct the normals in order to have a good direction and length for applying a contraction
-  //   std::vector<double> storenorm;
-  //   std::vector<double> tipnormal;
+    //       //initialize
 
-  //   ModelPart::NodesContainerType::iterator boundary_nodes_begin = rNodes.begin();
-  //   int boundary_nodes = rNodes.size();
+    //       unsigned int normals_size = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]].size();
+    //       if( normals_size != 0 )
+    //       {
+    //         Normal.clear();
+    //         shrink_factor=0;
+    //       }
 
-  //   int not_assigned = 0;
+    //       if( mEchoLevel > 1 ){
+    //         std::cout<<" Id "<<rIds[(boundary_nodes_begin + pn)->Id()]<<" normals size "<<normals_size<<" normal "<<Normal<<" shrink "<<shrink_factor<<std::endl;
+    //         for (unsigned int esnod=0; esnod<normals_size; ++esnod)//loop over node neighbor faces
+    //         {
+    //           std::cout<<" normal ["<<esnod<<"]["<<(boundary_nodes_begin + pn)->Id()<<"]: "<<rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL)<<std::endl;
+    //         }
+    //       }
 
-  //   int pn=0;
-  //   // #pragma omp parallel for private(pn,storenorm,tipnormal)
-  //   for (pn=0; pn<boundary_nodes; ++pn)
-  //     {
+    //       storenorm.resize(normals_size);
+    //       std::fill(storenorm.begin(), storenorm.end(), 0 );
 
-  //       double cosmedio=0;
-  //       double totalnorm=0;
-  //       double directiontol=0;
-  //       double numnorm=0;
-  //       int indepnorm=0,acuteangle=0;
+    //       tipnormal.resize(normals_size);
+    //       std::fill(tipnormal.begin(), tipnormal.end(), 0 );
 
-  //       array_1d<double,3>&  Normal=(boundary_nodes_begin + pn)->FastGetSolutionStepValue(NORMAL);
-  //       double&       shrink_factor=(boundary_nodes_begin + pn)->FastGetSolutionStepValue(SHRINK_FACTOR);
+    //       //Check coincident faces-normals
+    //       for (unsigned int esnod=0; esnod<normals_size; ++esnod)//loop over node neighbor faces
+    //         {
 
-  //       //initialize
+    //           const array_1d<double,3>& AuxVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL); //conditions
 
-  //       unsigned int normals_size = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]].size();
-  //       if( normals_size != 0 )
-  //       {
-  //         Normal.clear();
-  //         shrink_factor=0;
-  //       }
+    //           if (storenorm[esnod]!=1){ //if is not marked as coincident
 
-  //       if( mEchoLevel > 1 ){
-  //         std::cout<<" Id "<<rIds[(boundary_nodes_begin + pn)->Id()]<<" normals size "<<normals_size<<" normal "<<Normal<<" shrink "<<shrink_factor<<std::endl;
-  //         for (unsigned int esnod=0; esnod<normals_size; ++esnod)//loop over node neighbor faces
-  //         {
-  //           std::cout<<" normal ["<<esnod<<"]["<<(boundary_nodes_begin + pn)->Id()<<"]: "<<rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL)<<std::endl;
-  //         }
-  //       }
+    //     	if (esnod+1<normals_size){
 
+    //     	  double tooclose=0;
+    //     	  for (unsigned int esn=esnod+1; esn<normals_size; ++esn)//loop over node neighbor faces
+    //     	    {
 
-  //       storenorm.resize(normals_size);
-  //       std::fill(storenorm.begin(), storenorm.end(), 0 );
+    //     	      const array_1d<double,3>& NormalVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esn].GetValue(NORMAL); //conditions
 
-  //       tipnormal.resize(normals_size);
-  //       std::fill(tipnormal.begin(), tipnormal.end(), 0 );
+    //     	      directiontol=inner_prod(AuxVector,NormalVector);
 
+    //     	      //std::cout<<"  -- > direction tol"<<directiontol<<" AuxVector "<<AuxVector<<" NormalVector "<<NormalVector<<std::endl;
 
-  //       //Check coincident faces-normals
-  //       for (unsigned int esnod=0; esnod<normals_size; ++esnod)//loop over node neighbor faces
-  //         {
+    //     	      if (directiontol>0.995 && storenorm[esn]==0){//to not have coincident normals
+    //     		storenorm[esn]=1;
+    //     	      }
+    //     	      else{
+    //     		if (directiontol>0.95 && directiontol<0.995 && storenorm[esn]==0){//to not have close normals
+    //     		  tooclose+=1;
+    //     		  storenorm[esn]  =2;
+    //     		  storenorm[esnod]=2;
+    //     		}
+    //     		else{
+    //     		  if(directiontol<-0.005){
+    //     		    //std::cout<<" acute angle "<<directiontol<<std::endl;
+    //     		    acuteangle      +=1;
+    //     		    tipnormal[esn]  +=1;
+    //     		    tipnormal[esnod]+=1;
+    //     		  }
+    //     		}
+    //     	      }
 
-  //           const array_1d<double,3>& AuxVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL); //conditions
+    //     	    }//end for the esnod for
 
-  //           if (storenorm[esnod]!=1){ //if is not marked as coincident
+    //     	  for (unsigned int esn=esnod; esn<normals_size; ++esn)//loop over node neighbour faces
+    //     	    {
+    //     	      if(storenorm[esn]==2 && tooclose>0)
+    //     		storenorm[esn]=(1.0/(tooclose+1));
+    //     	    }
 
-  //     	if (esnod+1<normals_size){
+    //     	}
 
-  //     	  double tooclose=0;
-  //     	  for (unsigned int esn=esnod+1; esn<normals_size; ++esn)//loop over node neighbor faces
-  //     	    {
+    //     	if(storenorm[esnod]!=0){ //!=1
 
-  //     	      const array_1d<double,3>& NormalVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esn].GetValue(NORMAL); //conditions
+    //     	  Normal+=AuxVector*storenorm[esnod]; //outer normal
+    //     	  numnorm  +=storenorm[esnod];
 
-  //     	      directiontol=inner_prod(AuxVector,NormalVector);
+    //     	}
+    //     	else{
 
-  //     	      //std::cout<<"  -- > direction tol"<<directiontol<<" AuxVector "<<AuxVector<<" NormalVector "<<NormalVector<<std::endl;
+    //     	  Normal+=AuxVector; //outer normal
+    //     	  numnorm  +=1;
 
-  //     	      if (directiontol>0.995 && storenorm[esn]==0){//to not have coincident normals
-  //     		storenorm[esn]=1;
-  //     	      }
-  //     	      else{
-  //     		if (directiontol>0.95 && directiontol<0.995 && storenorm[esn]==0){//to not have close normals
-  //     		  tooclose+=1;
-  //     		  storenorm[esn]  =2;
-  //     		  storenorm[esnod]=2;
-  //     		}
-  //     		else{
-  //     		  if(directiontol<-0.005){
-  //     		    //std::cout<<" acute angle "<<directiontol<<std::endl;
-  //     		    acuteangle      +=1;
-  //     		    tipnormal[esn]  +=1;
-  //     		    tipnormal[esnod]+=1;
-  //     		  }
-  //     		}
-  //     	      }
+    //     	}
 
-  //     	    }//end for the esnod for
+    //     	totalnorm+=1;
 
-  //     	  for (unsigned int esn=esnod; esn<normals_size; ++esn)//loop over node neighbour faces
-  //     	    {
-  //     	      if(storenorm[esn]==2 && tooclose>0)
-  //     		storenorm[esn]=(1.0/(tooclose+1));
-  //     	    }
+    //           }
 
+    //         }
 
-  //     	}
+    //       //std::cout<<" Normal "<<Normal<<" ID "<<(boundary_nodes_begin + pn)->Id()<<std::endl;
 
-  //     	if(storenorm[esnod]!=0){ //!=1
+    //       //Modify direction of tip normals in 3D  --------- start ----------
 
-  //     	  Normal+=AuxVector*storenorm[esnod]; //outer normal
-  //     	  numnorm  +=storenorm[esnod];
+    //       if(dimension==3 && numnorm>=3 && acuteangle){
 
-  //     	}
-  //     	else{
+    //         //std::cout<<" pn "<<pn<<" normal number: "<<numnorm<<" acute angles: "<<acuteangle<<std::endl;
+    //         //std::cout<<"storenormal"<<storenorm<<std::endl;
+    //         //std::cout<<"tipnormal"<<tipnormal<<std::endl;
 
-  //     	  Normal+=AuxVector; //outer normal
-  //     	  numnorm  +=1;
+    //         std::vector< array_1d<double,3> > N(3);
+    //         indepnorm=0;
 
-  //     	}
+    //         if(numnorm==3){ //Definite solution for 3 planes
 
-  //     	totalnorm+=1;
+    //           for (unsigned int esnod=0;esnod<normals_size;++esnod)//loop over node neighbor faces
+    //     	{
+    //     	  if(tipnormal[esnod]>=1 && storenorm[esnod]==0){ //tip node correction
 
+    //     	    const array_1d<double,3>& AuxVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL); //conditions
+    //     	    N[indepnorm]=AuxVector;
+    //     	    indepnorm+=1;
+    //     	  }
+    //     	}
 
-  //           }
+    //         }
+    //         else{ //I must select only 3 planes
 
-  //         }
+    //           double maxprojection=0;
+    //           double projection=0;
+    //           std::vector<int> pronormal(normals_size);
+    //           pronormal.clear();
 
+    //           //get the positive biggest projection between planes
+    //           for (unsigned int esnod=0;esnod<normals_size;++esnod)//loop over node neighbor faces
+    //     	{
+    //     	  maxprojection=0;
 
-  //       //std::cout<<" Normal "<<Normal<<" ID "<<(boundary_nodes_begin + pn)->Id()<<std::endl;
+    //     	  if(tipnormal[esnod]>=1 && storenorm[esnod]!=1){
 
-  //       //Modify direction of tip normals in 3D  --------- start ----------
+    //     	    const array_1d<double,3>& AuxVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL); //conditions
 
-  //       if(dimension==3 && numnorm>=3 && acuteangle){
+    //     	    for (unsigned int esn=0;esn<normals_size;++esn)//loop over node neighbor faces to check the most coplanar
+    //     	      {
+    //     		if(tipnormal[esn]>=1 && storenorm[esn]!=1 && esnod!=esn){
 
-  //         //std::cout<<" pn "<<pn<<" normal number: "<<numnorm<<" acute angles: "<<acuteangle<<std::endl;
-  //         //std::cout<<"storenormal"<<storenorm<<std::endl;
-  //         //std::cout<<"tipnormal"<<tipnormal<<std::endl;
+    //     		  const array_1d<double,3>& NormalVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esn].GetValue(NORMAL); //conditions
+    //     		  projection=inner_prod(AuxVector,NormalVector);
 
+    //     		  if(maxprojection<projection && projection>0.5){
+    //     		    maxprojection=projection;
+    //     		    pronormal[esnod]=esn+1; //set in pronormal one position added to the real one the most coplanar planes
+    //     		  }
+    //     		}
+    //     	      }
 
-  //         std::vector< array_1d<double,3> > N(3);
-  //         indepnorm=0;
+    //     	  }
 
-  //         if(numnorm==3){ //Definite solution for 3 planes
+    //     	}
 
-  //           for (unsigned int esnod=0;esnod<normals_size;++esnod)//loop over node neighbor faces
-  //     	{
-  //     	  if(tipnormal[esnod]>=1 && storenorm[esnod]==0){ //tip node correction
+    //           // 	    std::cout<<" PROJECTIONS "<<pn<<" pronormal"<<pronormal<<std::endl;
 
-  //     	    const array_1d<double,3>& AuxVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL); //conditions
-  //     	    N[indepnorm]=AuxVector;
-  //     	    indepnorm+=1;
-  //     	  }
-  //     	}
+    //           //get the most obtuse normals
+    //           for (unsigned int esnod=0;esnod<normals_size;++esnod)//loop over node neighbor faces
+    //     	{
 
-  //         }
-  //         else{ //I must select only 3 planes
+    //     	  if(indepnorm<3){
 
-  //           double maxprojection=0;
-  //           double projection=0;
-  //           std::vector<int> pronormal(normals_size);
-  //           pronormal.clear();
+    //     	    if(tipnormal[esnod]>=1 && storenorm[esnod]!=1){ //tip node correction
 
-  //           //get the positive biggest projection between planes
-  //           for (unsigned int esnod=0;esnod<normals_size;++esnod)//loop over node neighbor faces
-  //     	{
-  //     	  maxprojection=0;
+    //     	      array_1d<double,3> AuxVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL); //conditions
 
-  //     	  if(tipnormal[esnod]>=1 && storenorm[esnod]!=1){
+    //     	      if(storenorm[esnod]!=0) //!=1
+    //     		AuxVector*=storenorm[esnod];
 
-  //     	    const array_1d<double,3>& AuxVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL); //conditions
+    //     	      for (unsigned int esn=esnod+1;esn<normals_size;++esn)//loop over node neighbor faces to check the most coplanar
+    //     		{
+    //     		  if(tipnormal[esn]>=1 && storenorm[esn]!=1){ //tip node correction
 
-  //     	    for (unsigned int esn=0;esn<normals_size;++esn)//loop over node neighbor faces to check the most coplanar
-  //     	      {
-  //     		if(tipnormal[esn]>=1 && storenorm[esn]!=1 && esnod!=esn){
+    //     		    if(esnod+1==(unsigned int)pronormal[esn]){
 
+    //     		      const array_1d<double,3>& NormalVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL); //conditions
 
-  //     		  const array_1d<double,3>& NormalVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esn].GetValue(NORMAL); //conditions
-  //     		  projection=inner_prod(AuxVector,NormalVector);
+    //     		      if(storenorm[esnod]!=0){ //!=1
+    //     			AuxVector+=NormalVector*storenorm[esnod];
+    //     		      }
+    //     		      else{
+    //     			AuxVector+=NormalVector;
+    //     		      }
+    //     		      AuxVector=AuxVector/norm_2(AuxVector);
+    //     		      //std::cout<<" plane "<<esnod<<" esn "<<esn<<std::endl;
+    //     		      storenorm[esn]=1; //to not use this plane again
+    //     		    }
+    //     		  }
 
-  //     		  if(maxprojection<projection && projection>0.5){
-  //     		    maxprojection=projection;
-  //     		    pronormal[esnod]=esn+1; //set in pronormal one position added to the real one the most coplanar planes
-  //     		  }
-  //     		}
-  //     	      }
+    //     		}
 
-  //     	  }
+    //     	      N[indepnorm]=AuxVector;
+    //     	      indepnorm+=1;
 
-  //     	}
+    //     	    }
 
-  //           // 	    std::cout<<" PROJECTIONS "<<pn<<" pronormal"<<pronormal<<std::endl;
+    //     	  }
+    //     	  // 		else{
 
-  //           //get the most obtuse normals
-  //           for (unsigned int esnod=0;esnod<normals_size;++esnod)//loop over node neighbor faces
-  //     	{
+    //     	  // 		  std::cout<<" pn "<<pn<<" pronormal"<<pronormal<<std::endl;
+    //     	  // 		}
 
-  //     	  if(indepnorm<3){
+    //     	}
 
-  //     	    if(tipnormal[esnod]>=1 && storenorm[esnod]!=1){ //tip node correction
+    //         }
 
-  //     	      array_1d<double,3> AuxVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL); //conditions
+    //         //std::cout<<" indepnorm "<<indepnorm<<std::endl;
 
-  //     	      if(storenorm[esnod]!=0) //!=1
-  //     		AuxVector*=storenorm[esnod];
+    //         if(indepnorm<3){
 
-  //     	      for (unsigned int esn=esnod+1;esn<normals_size;++esn)//loop over node neighbor faces to check the most coplanar
-  //     		{
-  //     		  if(tipnormal[esn]>=1 && storenorm[esn]!=1){ //tip node correction
+    //           for (unsigned int esnod=0;esnod<normals_size;++esnod)//loop over node neighbor faces
+    //     	{
+    //     	  if(indepnorm==3)
+    //     	    break;
 
-  //     		    if(esnod+1==(unsigned int)pronormal[esn]){
+    //     	  if(tipnormal[esnod]>=1 && storenorm[esnod]!=0 && storenorm[esnod]!=1){ //tip node correction
+    //     	    const array_1d<double,3>& AuxVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL); //conditions
+    //     	    N[indepnorm]=AuxVector;
+    //     	    indepnorm+=1;
+    //     	  }
 
-  //     		      const array_1d<double,3>& NormalVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL); //conditions
+    //     	  if(storenorm[esnod]==0 && tipnormal[esnod]==0 && indepnorm>0){ //if only two of the tip normals are acute one is not stored (corrected here 05/09/2011)
+    //     	    const array_1d<double,3>& AuxVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL); //conditions
+    //     	    N[indepnorm]=AuxVector;
+    //     	    indepnorm+=1;
+    //     	  }
 
-  //     		      if(storenorm[esnod]!=0){ //!=1
-  //     			AuxVector+=NormalVector*storenorm[esnod];
-  //     		      }
-  //     		      else{
-  //     			AuxVector+=NormalVector;
-  //     		      }
-  //     		      AuxVector=AuxVector/norm_2(AuxVector);
-  //     		      //std::cout<<" plane "<<esnod<<" esn "<<esn<<std::endl;
-  //     		      storenorm[esn]=1; //to not use this plane again
-  //     		    }
-  //     		  }
+    //     	}
+    //         }
 
-  //     		}
+    //         if(indepnorm==3){
+    //           array_1d<double,3> CrossProductN;
+    //           MathUtils<double>::CrossProduct(CrossProductN,N[1],N[2]);
+    //           double aux=inner_prod(N[0],CrossProductN);
+    //           if(aux!=0){
+    //     	MathUtils<double>::CrossProduct(CrossProductN,N[1],N[2]);
+    //     	Normal = CrossProductN;
+    //     	MathUtils<double>::CrossProduct(CrossProductN,N[2],N[0]);
+    //     	Normal += CrossProductN;
+    //     	MathUtils<double>::CrossProduct(CrossProductN,N[0],N[1]);
+    //     	Normal += CrossProductN;
+    //     	if( aux > 1e-15 )
+    //     	  Normal /= aux;  //intersection of three planes
+    //           }
+    //           // else{
+    //           //   std::cout<<" aux "<<aux<<" Normals :";
+    //           // }
 
+    //         }
 
-  //     	      N[indepnorm]=AuxVector;
-  //     	      indepnorm+=1;
+    //         //Check Boundary
+    //         if(norm_2(Normal)>2){ //a bad solution... but too ensure consistency
+    //           //Normal.write(" TO LARGE NORMAL ");
+    //           //std::cout<<" modulus 1 "<<Normal.modulus()<<std::endl;
+    //           Normal=Normal/norm_2(Normal);
+    //           Normal*=1.2;
+    //           //Normal.write(" CORRRECTION ");
+    //           //std::cout<<" modulus 2 "<<Normal.modulus()<<std::endl;
+    //         }
 
-  //     	    }
+    //         //Modify direction of tip normals in 3D ----------- end  -----------
 
-  //     	  }
-  //     	  // 		else{
+    //       }
+    //       else{
 
-  //     	  // 		  std::cout<<" pn "<<pn<<" pronormal"<<pronormal<<std::endl;
-  //     	  // 		}
+    //         //std::cout<<" Normal "<<Normal<<std::endl;
 
+    //         if(norm_2(Normal)!=0)
+    //           Normal=Normal/norm_2(Normal); //normalize normal *this/modulus();
 
-  //     	}
+    //         for(unsigned int esnod=0;esnod<normals_size;++esnod)//loop over node neigbour faces
+    //           {
+    //     	if (storenorm[esnod]!=1){
 
-  //         }
+    //     	  array_1d<double,3> AuxVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL); //conditions
 
-  //         //std::cout<<" indepnorm "<<indepnorm<<std::endl;
+    //     	  if(norm_2(AuxVector))
+    //     	    AuxVector/=norm_2(AuxVector);
 
-  //         if(indepnorm<3){
+    //     	  directiontol=inner_prod(AuxVector,Normal);
 
-  //           for (unsigned int esnod=0;esnod<normals_size;++esnod)//loop over node neighbor faces
-  //     	{
-  //     	  if(indepnorm==3)
-  //     	    break;
+    //     	  cosmedio+=directiontol;
 
-  //     	  if(tipnormal[esnod]>=1 && storenorm[esnod]!=0 && storenorm[esnod]!=1){ //tip node correction
-  //     	    const array_1d<double,3>& AuxVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL); //conditions
-  //     	    N[indepnorm]=AuxVector;
-  //     	    indepnorm+=1;
-  //     	  }
+    //     	}
+    //           }
 
-  //     	  if(storenorm[esnod]==0 && tipnormal[esnod]==0 && indepnorm>0){ //if only two of the tip normals are acute one is not stored (corrected here 05/09/2011)
-  //     	    const array_1d<double,3>& AuxVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL); //conditions
-  //     	    N[indepnorm]=AuxVector;
-  //     	    indepnorm+=1;
-  //     	  }
+    //         if (totalnorm!=0)
+    //           cosmedio*=(1.0/totalnorm);
 
-  //     	}
-  //         }
+    //         //acute angles are problematic, reduction of the modulus in that cases
+    //         if (cosmedio<=0.3){
+    //           cosmedio=0.8;
+    //           //std::cout<<" acute correction "<<std::endl;
+    //         }
 
+    //         if(cosmedio>3)
+    //           std::cout<<" cosmedio "<<cosmedio<<std::endl;
 
+    //         //if (cosmedio!=0) {
+    //         if (cosmedio!=0 && cosmedio>1e-3) { //to ensure consistency
+    //           cosmedio=1.0/cosmedio;
+    //           Normal*=cosmedio;               //only to put the correct length
+    //           //(boundary_nodes_begin + pn)->SetValue(Normal);
+    //           //std::cout<<pn<<" cosmedio "<<cosmedio<<" Normal "<<Normal[0]<<" "<<Normal[1]<<" "<<Normal[2]<<std::endl;
+    //         }
+    //       }
 
-  //         if(indepnorm==3){
-  //           array_1d<double,3> CrossProductN;
-  //           MathUtils<double>::CrossProduct(CrossProductN,N[1],N[2]);
-  //           double aux=inner_prod(N[0],CrossProductN);
-  //           if(aux!=0){
-  //     	MathUtils<double>::CrossProduct(CrossProductN,N[1],N[2]);
-  //     	Normal = CrossProductN;
-  //     	MathUtils<double>::CrossProduct(CrossProductN,N[2],N[0]);
-  //     	Normal += CrossProductN;
-  //     	MathUtils<double>::CrossProduct(CrossProductN,N[0],N[1]);
-  //     	Normal += CrossProductN;
-  //     	if( aux > 1e-15 )
-  //     	  Normal /= aux;  //intersection of three planes
-  //           }
-  //           // else{
-  //           //   std::cout<<" aux "<<aux<<" Normals :";
-  //           // }
+    //       //std::cout<<(boundary_nodes_begin + pn)->Id()<<" Normal "<<Normal[0]<<" "<<Normal[1]<<" "<<Normal[2]<<std::endl;
 
-  //         }
+    //       //Now Normalize Normal and store the Shrink_Factor
+    //       shrink_factor=norm_2(Normal);
 
+    //       if(shrink_factor!=0)
+    //         {
+    //           if( mEchoLevel > 2 )
+    //     	std::cout<<"[Id "<<rIds[(boundary_nodes_begin + pn)->Id()]<<" shrink_factor "<<shrink_factor<<" Normal "<<Normal[0]<<" "<<Normal[1]<<" "<<Normal[2]<<" cosmedio "<<cosmedio<<"] shrink "<<std::endl;
+    //           Normal/=shrink_factor;
 
-  //         //Check Boundary
-  //         if(norm_2(Normal)>2){ //a bad solution... but too ensure consistency
-  //           //Normal.write(" TO LARGE NORMAL ");
-  //           //std::cout<<" modulus 1 "<<Normal.modulus()<<std::endl;
-  //           Normal=Normal/norm_2(Normal);
-  //           Normal*=1.2;
-  //           //Normal.write(" CORRRECTION ");
-  //           //std::cout<<" modulus 2 "<<Normal.modulus()<<std::endl;
-  //         }
+    //         }
+    //       else{
 
-  //         //Modify direction of tip normals in 3D ----------- end  -----------
+    //         if( mEchoLevel > 1 )
+    //           std::cout<<"[Id "<<rIds[(boundary_nodes_begin + pn)->Id()]<<" Normal "<<Normal[0]<<" "<<Normal[1]<<" "<<Normal[2]<<" cosmedio "<<cosmedio<<"] no shrink "<<std::endl;
 
-  //       }
-  //       else{
+    //         Normal.clear();
+    //         shrink_factor=1;
 
-  //         //std::cout<<" Normal "<<Normal<<std::endl;
+    //         //std::cout<<" ERROR: normal shrinkage calculation failed "<<std::endl;
+    //         not_assigned +=1;
+    //       }
 
-  //         if(norm_2(Normal)!=0)
-  //           Normal=Normal/norm_2(Normal); //normalize normal *this/modulus();
+    //     }
 
-  //         for(unsigned int esnod=0;esnod<normals_size;++esnod)//loop over node neigbour faces
-  //           {
-  //     	if (storenorm[esnod]!=1){
+    //   if(mEchoLevel > 0)
+    //     std::cout<<"   [NORMALS SHRINKAGE (BOUNDARY NODES:"<<boundary_nodes<<") [SET:"<<boundary_nodes-not_assigned<<" / NOT_SET:"<<not_assigned<<"] "<<std::endl;
 
-  //     	  array_1d<double,3> AuxVector = rNeighbours[rIds[(boundary_nodes_begin + pn)->Id()]][esnod].GetValue(NORMAL); //conditions
+    //   KRATOS_CATCH( "" )
 
-  //     	  if(norm_2(AuxVector))
-  //     	    AuxVector/=norm_2(AuxVector);
+    // }
 
-  //     	  directiontol=inner_prod(AuxVector,Normal);
+    ///@}
+    ///@name Private  Access
+    ///@{
+    ///@}
+    ///@name Serialization
+    ///@{
+    ///@name Private Inquiry
+    ///@{
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+    ///@}
 
-  //     	  cosmedio+=directiontol;
-
-  //     	}
-  //           }
-
-
-  //         if (totalnorm!=0)
-  //           cosmedio*=(1.0/totalnorm);
-
-  //         //acute angles are problematic, reduction of the modulus in that cases
-  //         if (cosmedio<=0.3){
-  //           cosmedio=0.8;
-  //           //std::cout<<" acute correction "<<std::endl;
-  //         }
-
-  //         if(cosmedio>3)
-  //           std::cout<<" cosmedio "<<cosmedio<<std::endl;
-
-  //         //if (cosmedio!=0) {
-  //         if (cosmedio!=0 && cosmedio>1e-3) { //to ensure consistency
-  //           cosmedio=1.0/cosmedio;
-  //           Normal*=cosmedio;               //only to put the correct length
-  //           //(boundary_nodes_begin + pn)->SetValue(Normal);
-  //           //std::cout<<pn<<" cosmedio "<<cosmedio<<" Normal "<<Normal[0]<<" "<<Normal[1]<<" "<<Normal[2]<<std::endl;
-  //         }
-  //       }
-
-  //       //std::cout<<(boundary_nodes_begin + pn)->Id()<<" Normal "<<Normal[0]<<" "<<Normal[1]<<" "<<Normal[2]<<std::endl;
-
-  //       //Now Normalize Normal and store the Shrink_Factor
-  //       shrink_factor=norm_2(Normal);
-
-  //       if(shrink_factor!=0)
-  //         {
-  //           if( mEchoLevel > 2 )
-  //     	std::cout<<"[Id "<<rIds[(boundary_nodes_begin + pn)->Id()]<<" shrink_factor "<<shrink_factor<<" Normal "<<Normal[0]<<" "<<Normal[1]<<" "<<Normal[2]<<" cosmedio "<<cosmedio<<"] shrink "<<std::endl;
-  //           Normal/=shrink_factor;
-
-  //         }
-  //       else{
-
-  //         if( mEchoLevel > 1 )
-  //           std::cout<<"[Id "<<rIds[(boundary_nodes_begin + pn)->Id()]<<" Normal "<<Normal[0]<<" "<<Normal[1]<<" "<<Normal[2]<<" cosmedio "<<cosmedio<<"] no shrink "<<std::endl;
-
-  //         Normal.clear();
-  //         shrink_factor=1;
-
-  //         //std::cout<<" ERROR: normal shrinkage calculation failed "<<std::endl;
-  //         not_assigned +=1;
-  //       }
-
-
-  //     }
-
-
-  //   if(mEchoLevel > 0)
-  //     std::cout<<"   [NORMALS SHRINKAGE (BOUNDARY NODES:"<<boundary_nodes<<") [SET:"<<boundary_nodes-not_assigned<<" / NOT_SET:"<<not_assigned<<"] "<<std::endl;
-
-
-  //   KRATOS_CATCH( "" )
-
-  // }
+  }; // Class BoundaryNormalsCalculationUtilities
 
   ///@}
-  ///@name Private  Access
+
+  ///@name Type Definitions
   ///@{
+
   ///@}
-  ///@name Serialization
-  ///@{
-  ///@name Private Inquiry
-  ///@{
-  ///@}
-  ///@name Un accessible methods
+  ///@name Input and output
   ///@{
   ///@}
 
-}; // Class BoundaryNormalsCalculationUtilities
-
-///@}
-
-///@name Type Definitions
-///@{
-
-
-///@}
-///@name Input and output
-///@{
-///@}
-
-}  // namespace Kratos.
+} // namespace Kratos.
 
 #endif // KRATOS_BOUNDARY_NORMALS_CALCULATION_UTILITIES_H_INCLUDED  defined

--- a/applications/DelaunayMeshingApplication/python_scripts/meshing_strategy.py
+++ b/applications/DelaunayMeshingApplication/python_scripts/meshing_strategy.py
@@ -171,11 +171,6 @@ class MeshingStrategy(object):
 
         self.SetMeshInfo()
 
-        info_parameters    = self.MeshingParameters.GetInfoParameters()
-        smoothing_required = info_parameters.CheckMechanicalSmoothing()
-
-        refining_parameters = self.MeshingParameters.GetRefiningParameters()
-
         if( self.global_transfer == True ):
             self.MeshDataTransfer.TransferNodalValuesToElements(self.TransferParameters,self.model_part)
 

--- a/applications/PfemFluidDynamicsApplication/custom_processes/build_model_part_boundary_for_fluids_process.hpp
+++ b/applications/PfemFluidDynamicsApplication/custom_processes/build_model_part_boundary_for_fluids_process.hpp
@@ -33,114 +33,138 @@
 
 #include "delaunay_meshing_application_variables.h"
 
-///VARIABLES used:
-//Data:     MASTER_ELEMENTS(set), MASTER_NODES(set), NEIGHBOUR_ELEMENTS
-//Flags:    (checked) CONTACT
-//          (set)     BOUNDARY(set)
-//          (modified)
-//          (reset)
+/// VARIABLES used:
+// Data:     MASTER_ELEMENTS(set), MASTER_NODES(set), NEIGHBOUR_ELEMENTS
+// Flags:    (checked) CONTACT
+//           (set)     BOUNDARY(set)
+//           (modified)
+//           (reset)
 //(set):=(set in this process)
 
 namespace Kratos
 {
 
-///@name Kratos Globals
-///@{
+	///@name Kratos Globals
+	///@{
 
-///@}
-///@name Type Definitions
-///@{
-typedef ModelPart::NodesContainerType NodesContainerType;
-typedef ModelPart::ElementsContainerType ElementsContainerType;
-typedef ModelPart::ConditionsContainerType ConditionsContainerType;
-
-typedef GlobalPointersVector<Node<3>> NodeWeakPtrVectorType;
-typedef GlobalPointersVector<Element> ElementWeakPtrVectorType;
-
-///@}
-///@name  Enum's
-///@{
-
-///@}
-///@name  Functions
-///@{
-
-///@}
-///@name Kratos Classes
-///@{
-
-/// Short class definition.
-/** Detail class definition.
-   */
-class BuildModelPartBoundaryForFluidsProcess
-	: public MesherProcess
-{
-public:
+	///@}
 	///@name Type Definitions
 	///@{
+	typedef ModelPart::NodesContainerType NodesContainerType;
+	typedef ModelPart::ElementsContainerType ElementsContainerType;
+	typedef ModelPart::ConditionsContainerType ConditionsContainerType;
 
-	/// Pointer definition of BuildModelPartBoundaryForFluidsProcess
-	KRATOS_CLASS_POINTER_DEFINITION(BuildModelPartBoundaryForFluidsProcess);
-
-	///@}
-	///@name Life Cycle
-	///@{
-
-	/// Default constructor.
-	BuildModelPartBoundaryForFluidsProcess(ModelPart &rModelPart,
-										   std::string const rModelPartName,
-										   int EchoLevel = 0)
-		: mrModelPart(rModelPart)
-	{
-		mModelPartName = rModelPartName;
-		mEchoLevel = EchoLevel;
-	}
-
-	/// Destructor.
-	virtual ~BuildModelPartBoundaryForFluidsProcess()
-	{
-	}
+	typedef GlobalPointersVector<Node<3>> NodeWeakPtrVectorType;
+	typedef GlobalPointersVector<Element> ElementWeakPtrVectorType;
 
 	///@}
-	///@name Operators
+	///@name  Enum's
 	///@{
-
-	void operator()()
-	{
-		Execute();
-	}
 
 	///@}
-	///@name Operations
+	///@name  Functions
 	///@{
 
-	void Execute() override
+	///@}
+	///@name Kratos Classes
+	///@{
+
+	/// Short class definition.
+	/** Detail class definition.
+	 */
+	class BuildModelPartBoundaryForFluidsProcess
+		: public MesherProcess
 	{
+	public:
+		///@name Type Definitions
+		///@{
 
-		KRATOS_TRY
+		/// Pointer definition of BuildModelPartBoundaryForFluidsProcess
+		KRATOS_CLASS_POINTER_DEFINITION(BuildModelPartBoundaryForFluidsProcess);
 
-		bool success = false;
+		///@}
+		///@name Life Cycle
+		///@{
 
-		// double begin_time = OpenMPUtils::GetCurrentTime();
+		/// Default constructor.
+		BuildModelPartBoundaryForFluidsProcess(ModelPart &rModelPart,
+											   std::string const rModelPartName,
+											   int EchoLevel = 0)
+			: mrModelPart(rModelPart)
+		{
+			mModelPartName = rModelPartName;
+			mEchoLevel = EchoLevel;
+		}
 
-		unsigned int NumberOfSubModelParts = mrModelPart.NumberOfSubModelParts();
+		/// Destructor.
+		virtual ~BuildModelPartBoundaryForFluidsProcess()
+		{
+		}
 
-		this->ResetNodesBoundaryFlag(mrModelPart);
+		///@}
+		///@name Operators
+		///@{
 
-		if (mModelPartName == mrModelPart.Name())
+		void operator()()
+		{
+			Execute();
+		}
+
+		///@}
+		///@name Operations
+		///@{
+
+		void Execute() override
 		{
 
-			for (ModelPart::SubModelPartIterator i_mp = mrModelPart.SubModelPartsBegin(); i_mp != mrModelPart.SubModelPartsEnd(); ++i_mp)
+			KRATOS_TRY
+
+			bool success = false;
+
+			// double begin_time = OpenMPUtils::GetCurrentTime();
+
+			unsigned int NumberOfSubModelParts = mrModelPart.NumberOfSubModelParts();
+
+			this->ResetNodesBoundaryFlag(mrModelPart);
+
+			if (mModelPartName == mrModelPart.Name())
+			{
+
+				for (ModelPart::SubModelPartIterator i_mp = mrModelPart.SubModelPartsBegin(); i_mp != mrModelPart.SubModelPartsEnd(); ++i_mp)
+				{
+
+					if (mEchoLevel >= 1)
+						std::cout << " [ Construct Boundary on ModelPart [" << i_mp->Name() << "] ]" << std::endl;
+
+					success = UniqueSkinSearch(*i_mp);
+
+					if (!success)
+					{
+						std::cout << "  ERROR: BOUNDARY CONSTRUCTION FAILED ModelPart : [" << i_mp->Name() << "] " << std::endl;
+					}
+					// else
+					// {
+					// 	if (mEchoLevel >= 1)
+					// 	{
+					// 		double end_time = OpenMPUtils::GetCurrentTime();
+					// 		std::cout << " [ Performed in Time = " << end_time - begin_time << " ]" << std::endl;
+					// 	}
+					// 	//PrintSkin(*i_mp);
+					// }
+				}
+			}
+			else
 			{
 
 				if (mEchoLevel >= 1)
-					std::cout << " [ Construct Boundary on ModelPart [" << i_mp->Name() << "] ]" << std::endl;
+					std::cout << " [ Construct Boundary on ModelPart[" << mModelPartName << "] ]" << std::endl;
 
-				success = UniqueSkinSearch(*i_mp);
+				ModelPart &rModelPart = mrModelPart.GetSubModelPart(mModelPartName);
+				success = UniqueSkinSearch(rModelPart);
 
 				if (!success)
 				{
-					std::cout << "  ERROR: BOUNDARY CONSTRUCTION FAILED ModelPart : [" << i_mp->Name() << "] " << std::endl;
+					std::cout << "  ERROR: BOUNDARY CONSTRUCTION FAILED on ModelPart : [" << rModelPart.Name() << "] " << std::endl;
 				}
 				// else
 				// {
@@ -149,1066 +173,1042 @@ public:
 				// 		double end_time = OpenMPUtils::GetCurrentTime();
 				// 		std::cout << " [ Performed in Time = " << end_time - begin_time << " ]" << std::endl;
 				// 	}
-				// 	//PrintSkin(*i_mp);
+				// 	//PrintSkin(rModelPart);
 				// }
 			}
-		}
-		else
-		{
+
+			if (NumberOfSubModelParts > 1)
+			{
+				SetMainModelPartConditions();
+				SetComputingModelPart();
+			}
+
+			// ComputeBoundaryNormals BoundUtils;
+			BoundaryNormalsCalculationUtilities BoundaryComputation;
+			if (mModelPartName == mrModelPart.Name())
+			{
+				BoundaryComputation.CalculateUnitBoundaryNormals(mrModelPart, mEchoLevel);
+			}
+			else
+			{
+				ModelPart &rModelPart = mrModelPart.GetSubModelPart(mModelPartName);
+				BoundaryComputation.CalculateUnitBoundaryNormals(rModelPart, mEchoLevel);
+			}
 
 			if (mEchoLevel >= 1)
-				std::cout << " [ Construct Boundary on ModelPart[" << mModelPartName << "] ]" << std::endl;
+				std::cout << "  Boundary Normals Computed and Assigned ] " << std::endl;
 
-			ModelPart &rModelPart = mrModelPart.GetSubModelPart(mModelPartName);
-			success = UniqueSkinSearch(rModelPart);
+			KRATOS_CATCH("")
+		}
 
-			if (!success)
+		//**************************************************************************
+		//**************************************************************************
+
+		bool SearchConditionMasters()
+		{
+
+			KRATOS_TRY
+
+			int composite_conditions = 0;
+			int total_conditions = 0;
+			int counter = 0;
+
+			bool found = false;
+
+			for (ModelPart::ConditionsContainerType::iterator i_cond = mrModelPart.ConditionsBegin(); i_cond != mrModelPart.ConditionsEnd(); ++i_cond)
 			{
-				std::cout << "  ERROR: BOUNDARY CONSTRUCTION FAILED on ModelPart : [" << rModelPart.Name() << "] " << std::endl;
-			}
-			// else
-			// {
-			// 	if (mEchoLevel >= 1)
-			// 	{
-			// 		double end_time = OpenMPUtils::GetCurrentTime();
-			// 		std::cout << " [ Performed in Time = " << end_time - begin_time << " ]" << std::endl;
-			// 	}
-			// 	//PrintSkin(rModelPart);
-			// }
-		}
 
-		if (NumberOfSubModelParts > 1)
-		{
-			SetMainModelPartConditions();
-			SetComputingModelPart();
-		}
+				if (i_cond->Is(BOUNDARY)) // composite condition
+					composite_conditions++;
 
-		//ComputeBoundaryNormals BoundUtils;
-		BoundaryNormalsCalculationUtilities BoundaryComputation;
-		if (mModelPartName == mrModelPart.Name())
-		{
-			BoundaryComputation.CalculateWeightedBoundaryNormals(mrModelPart, mEchoLevel);
-		}
-		else
-		{
-			ModelPart &rModelPart = mrModelPart.GetSubModelPart(mModelPartName);
-			BoundaryComputation.CalculateWeightedBoundaryNormals(rModelPart, mEchoLevel);
-		}
+				// std::cout<<" BeforeSearch::Condition ("<<i_cond->Id()<<") ME="<<i_cond->GetValue(MASTER_ELEMENTS)[0]->Id()<<", MN= "<<i_cond->GetValue(MASTER_NODES)[0]->Id()<<std::endl;
 
-		if (mEchoLevel >= 1)
-			std::cout << "  Boundary Normals Computed and Assigned ] " << std::endl;
+				//********************************************************************
 
-		KRATOS_CATCH("")
-	}
+				DenseMatrix<unsigned int> lpofa; // connectivities of points defining faces
+				DenseVector<unsigned int> lnofa; // number of points defining faces
 
-	//**************************************************************************
-	//**************************************************************************
+				Geometry<Node<3>> &rConditionGeometry = i_cond->GetGeometry();
+				unsigned int size = rConditionGeometry.size();
 
-	bool SearchConditionMasters()
-	{
+				bool perform_search = true;
+				for (unsigned int i = 0; i < size; ++i)
+				{
+					if (rConditionGeometry[i].Is(RIGID)) // if is a rigid wall do not search else do search
+						perform_search = false;
+				}
 
-		KRATOS_TRY
-
-		int composite_conditions = 0;
-		int total_conditions = 0;
-		int counter = 0;
-
-		bool found = false;
-
-		for (ModelPart::ConditionsContainerType::iterator i_cond = mrModelPart.ConditionsBegin(); i_cond != mrModelPart.ConditionsEnd(); ++i_cond)
-		{
-
-			if (i_cond->Is(BOUNDARY)) //composite condition
-				composite_conditions++;
-
-			//std::cout<<" BeforeSearch::Condition ("<<i_cond->Id()<<") ME="<<i_cond->GetValue(MASTER_ELEMENTS)[0]->Id()<<", MN= "<<i_cond->GetValue(MASTER_NODES)[0]->Id()<<std::endl;
-
-			//********************************************************************
-
-			DenseMatrix<unsigned int> lpofa; //connectivities of points defining faces
-			DenseVector<unsigned int> lnofa; //number of points defining faces
-
-			Geometry<Node<3>> &rConditionGeometry = i_cond->GetGeometry();
-			unsigned int size = rConditionGeometry.size();
-
-			bool perform_search = true;
-			for (unsigned int i = 0; i < size; ++i)
-			{
-				if (rConditionGeometry[i].Is(RIGID)) //if is a rigid wall do not search else do search
+				if (i_cond->Is(CONTACT))
 					perform_search = false;
-			}
 
-			if (i_cond->Is(CONTACT))
-				perform_search = false;
+				//********************************************************************
+				found = false;
 
-			//********************************************************************
-			found = false;
-
-			if (perform_search)
-			{
-
-				if (size == 2)
+				if (perform_search)
 				{
 
-					ElementWeakPtrVectorType &rE1 = rConditionGeometry[0].GetValue(NEIGHBOUR_ELEMENTS);
-					ElementWeakPtrVectorType &rE2 = rConditionGeometry[1].GetValue(NEIGHBOUR_ELEMENTS);
-
-					if (rE1.size() == 0 || rE2.size() == 0)
-						std::cout << " NO SIZE in NEIGHBOUR_ELEMENTS " << std::endl;
-
-					for (ElementWeakPtrVectorType::iterator ie = rE1.begin(); ie != rE1.end(); ++ie)
+					if (size == 2)
 					{
-						for (ElementWeakPtrVectorType::iterator ne = rE2.begin(); ne != rE2.end(); ++ne)
+
+						ElementWeakPtrVectorType &rE1 = rConditionGeometry[0].GetValue(NEIGHBOUR_ELEMENTS);
+						ElementWeakPtrVectorType &rE2 = rConditionGeometry[1].GetValue(NEIGHBOUR_ELEMENTS);
+
+						if (rE1.size() == 0 || rE2.size() == 0)
+							std::cout << " NO SIZE in NEIGHBOUR_ELEMENTS " << std::endl;
+
+						for (ElementWeakPtrVectorType::iterator ie = rE1.begin(); ie != rE1.end(); ++ie)
 						{
-
-							if ((ne)->Id() == (ie)->Id() && !found)
+							for (ElementWeakPtrVectorType::iterator ne = rE2.begin(); ne != rE2.end(); ++ne)
 							{
-								ElementWeakPtrVectorType MasterElements;
-								MasterElements.push_back(*ie.base());
-								if (mEchoLevel >= 1)
+
+								if ((ne)->Id() == (ie)->Id() && !found)
 								{
-									//if(i_cond->GetValue(MASTER_ELEMENTS)[0]->Id() != MasterElements[0]->Id())
-									//std::cout<<"Condition "<<i_cond->Id()<<" WARNING: master elements ("<<i_cond->GetValue(MASTER_ELEMENTS)[0]->Id()<<" != "<<MasterElements[0]->Id()<<")"<<std::endl;
-								}
-								i_cond->SetValue(MASTER_ELEMENTS, MasterElements);
-
-								Geometry<Node<3>> &rElementGeometry = (ie)->GetGeometry();
-
-								//get matrix nodes in faces
-								rElementGeometry.NodesInFaces(lpofa);
-								rElementGeometry.NumberNodesInFaces(lnofa);
-
-								int node = 0;
-								for (unsigned int iface = 0; iface < rElementGeometry.size(); ++iface)
-								{
-									MesherUtilities MesherUtils;
-									found = MesherUtils.FindCondition(rConditionGeometry, rElementGeometry, lpofa, lnofa, iface);
-
-									if (found)
-									{
-										node = iface;
-										break;
-									}
-								}
-
-								if (found)
-								{
-									NodeWeakPtrVectorType MasterNodes;
-									MasterNodes.push_back(rElementGeometry(lpofa(0, node)));
+									ElementWeakPtrVectorType MasterElements;
+									MasterElements.push_back(*ie.base());
 									if (mEchoLevel >= 1)
 									{
-										if (i_cond->GetValue(MASTER_NODES)[0].Id() != MasterNodes[0].Id())
-											std::cout << "Condition " << i_cond->Id() << " WARNING: master nodes (" << i_cond->GetValue(MASTER_NODES)[0].Id() << " != " << MasterNodes[0].Id() << ")" << std::endl;
-										i_cond->SetValue(MASTER_NODES, MasterNodes);
+										// if(i_cond->GetValue(MASTER_ELEMENTS)[0]->Id() != MasterElements[0]->Id())
+										// std::cout<<"Condition "<<i_cond->Id()<<" WARNING: master elements ("<<i_cond->GetValue(MASTER_ELEMENTS)[0]->Id()<<" != "<<MasterElements[0]->Id()<<")"<<std::endl;
 									}
-								}
-								else
-								{
-									std::cout << " MASTER_NODE not FOUND : something is wrong " << std::endl;
-								}
-							}
-						}
-					}
-				}
-				if (size == 3)
-				{
+									i_cond->SetValue(MASTER_ELEMENTS, MasterElements);
 
-					ElementWeakPtrVectorType &rE1 = rConditionGeometry[0].GetValue(NEIGHBOUR_ELEMENTS);
-					ElementWeakPtrVectorType &rE2 = rConditionGeometry[1].GetValue(NEIGHBOUR_ELEMENTS);
-					ElementWeakPtrVectorType &rE3 = rConditionGeometry[2].GetValue(NEIGHBOUR_ELEMENTS);
+									Geometry<Node<3>> &rElementGeometry = (ie)->GetGeometry();
 
-					if (rE1.size() == 0 || rE2.size() == 0 || rE3.size() == 0)
-						std::cout << " NO SIZE in NEIGHBOUR_ELEMENTS " << std::endl;
+									// get matrix nodes in faces
+									rElementGeometry.NodesInFaces(lpofa);
+									rElementGeometry.NumberNodesInFaces(lnofa);
 
-					for (ElementWeakPtrVectorType::iterator ie = rE1.begin(); ie != rE1.end(); ++ie)
-					{
-						for (ElementWeakPtrVectorType::iterator je = rE2.begin(); je != rE2.end(); ++je)
-						{
-
-							if ((je)->Id() == (ie)->Id() && !found)
-							{
-
-								for (ElementWeakPtrVectorType::iterator ke = rE3.begin(); ke != rE3.end(); ++ke)
-								{
-
-									if ((ke)->Id() == (ie)->Id() && !found)
+									int node = 0;
+									for (unsigned int iface = 0; iface < rElementGeometry.size(); ++iface)
 									{
-
-										ElementWeakPtrVectorType MasterElements;
-										MasterElements.push_back(*ie.base());
-										if (mEchoLevel >= 1)
-										{
-											if (i_cond->GetValue(MASTER_ELEMENTS)[0].Id() != MasterElements[0].Id())
-												std::cout << "Condition " << i_cond->Id() << " WARNING: master elements (" << i_cond->GetValue(MASTER_ELEMENTS)[0].Id() << " != " << MasterElements[0].Id() << ")" << std::endl;
-										}
-										i_cond->SetValue(MASTER_ELEMENTS, MasterElements);
-
-										Geometry<Node<3>> &rElementGeometry = (ie)->GetGeometry();
-
-										//get matrix nodes in faces
-										rElementGeometry.NodesInFaces(lpofa);
-										rElementGeometry.NumberNodesInFaces(lnofa);
-
-										int node = 0;
-										for (unsigned int iface = 0; iface < rElementGeometry.size(); ++iface)
-										{
-											MesherUtilities MesherUtils;
-											found = MesherUtils.FindCondition(rConditionGeometry, rElementGeometry, lpofa, lnofa, iface);
-
-											if (found)
-											{
-												node = iface;
-												break;
-											}
-										}
+										MesherUtilities MesherUtils;
+										found = MesherUtils.FindCondition(rConditionGeometry, rElementGeometry, lpofa, lnofa, iface);
 
 										if (found)
 										{
-											NodeWeakPtrVectorType MasterNodes;
-											MasterNodes.push_back(rElementGeometry(lpofa(0, node)));
-											if (mEchoLevel >= 1)
-											{
-												if (i_cond->GetValue(MASTER_NODES)[0].Id() != MasterNodes[0].Id())
-													std::cout << "Condition " << i_cond->Id() << " WARNING: master nodes (" << i_cond->GetValue(MASTER_NODES)[0].Id() << " != " << MasterNodes[0].Id() << ")" << std::endl;
-											}
+											node = iface;
+											break;
+										}
+									}
+
+									if (found)
+									{
+										NodeWeakPtrVectorType MasterNodes;
+										MasterNodes.push_back(rElementGeometry(lpofa(0, node)));
+										if (mEchoLevel >= 1)
+										{
+											if (i_cond->GetValue(MASTER_NODES)[0].Id() != MasterNodes[0].Id())
+												std::cout << "Condition " << i_cond->Id() << " WARNING: master nodes (" << i_cond->GetValue(MASTER_NODES)[0].Id() << " != " << MasterNodes[0].Id() << ")" << std::endl;
 											i_cond->SetValue(MASTER_NODES, MasterNodes);
 										}
-										else
+									}
+									else
+									{
+										std::cout << " MASTER_NODE not FOUND : something is wrong " << std::endl;
+									}
+								}
+							}
+						}
+					}
+					if (size == 3)
+					{
+
+						ElementWeakPtrVectorType &rE1 = rConditionGeometry[0].GetValue(NEIGHBOUR_ELEMENTS);
+						ElementWeakPtrVectorType &rE2 = rConditionGeometry[1].GetValue(NEIGHBOUR_ELEMENTS);
+						ElementWeakPtrVectorType &rE3 = rConditionGeometry[2].GetValue(NEIGHBOUR_ELEMENTS);
+
+						if (rE1.size() == 0 || rE2.size() == 0 || rE3.size() == 0)
+							std::cout << " NO SIZE in NEIGHBOUR_ELEMENTS " << std::endl;
+
+						for (ElementWeakPtrVectorType::iterator ie = rE1.begin(); ie != rE1.end(); ++ie)
+						{
+							for (ElementWeakPtrVectorType::iterator je = rE2.begin(); je != rE2.end(); ++je)
+							{
+
+								if ((je)->Id() == (ie)->Id() && !found)
+								{
+
+									for (ElementWeakPtrVectorType::iterator ke = rE3.begin(); ke != rE3.end(); ++ke)
+									{
+
+										if ((ke)->Id() == (ie)->Id() && !found)
 										{
-											std::cout << " MASTER_NODE not FOUND : something is wrong " << std::endl;
+
+											ElementWeakPtrVectorType MasterElements;
+											MasterElements.push_back(*ie.base());
+											if (mEchoLevel >= 1)
+											{
+												if (i_cond->GetValue(MASTER_ELEMENTS)[0].Id() != MasterElements[0].Id())
+													std::cout << "Condition " << i_cond->Id() << " WARNING: master elements (" << i_cond->GetValue(MASTER_ELEMENTS)[0].Id() << " != " << MasterElements[0].Id() << ")" << std::endl;
+											}
+											i_cond->SetValue(MASTER_ELEMENTS, MasterElements);
+
+											Geometry<Node<3>> &rElementGeometry = (ie)->GetGeometry();
+
+											// get matrix nodes in faces
+											rElementGeometry.NodesInFaces(lpofa);
+											rElementGeometry.NumberNodesInFaces(lnofa);
+
+											int node = 0;
+											for (unsigned int iface = 0; iface < rElementGeometry.size(); ++iface)
+											{
+												MesherUtilities MesherUtils;
+												found = MesherUtils.FindCondition(rConditionGeometry, rElementGeometry, lpofa, lnofa, iface);
+
+												if (found)
+												{
+													node = iface;
+													break;
+												}
+											}
+
+											if (found)
+											{
+												NodeWeakPtrVectorType MasterNodes;
+												MasterNodes.push_back(rElementGeometry(lpofa(0, node)));
+												if (mEchoLevel >= 1)
+												{
+													if (i_cond->GetValue(MASTER_NODES)[0].Id() != MasterNodes[0].Id())
+														std::cout << "Condition " << i_cond->Id() << " WARNING: master nodes (" << i_cond->GetValue(MASTER_NODES)[0].Id() << " != " << MasterNodes[0].Id() << ")" << std::endl;
+												}
+												i_cond->SetValue(MASTER_NODES, MasterNodes);
+											}
+											else
+											{
+												std::cout << " MASTER_NODE not FOUND : something is wrong " << std::endl;
+											}
 										}
 									}
 								}
 							}
 						}
 					}
+
+					total_conditions++;
 				}
 
-				total_conditions++;
+				//********************************************************************
+
+				// std::cout<<" AfterSearch::Condition ("<<i_cond->Id()<<") : ME="<<i_cond->GetValue(MASTER_ELEMENTS)[0].Id()<<", MN= "<<i_cond->GetValue(MASTER_NODES)[0].Id()<<std::endl;
+
+				if (found)
+					counter++;
 			}
 
-			//********************************************************************
+			if (counter == total_conditions)
+			{
+				if (mEchoLevel >= 1)
+					std::cout << "   Condition Masters (ModelPart " << mrModelPart.Name() << "): LOCATED [" << counter << "]" << std::endl;
+				found = true;
+			}
+			else
+			{
+				if (mEchoLevel >= 1)
+					std::cout << "   Condition Masters (ModelPart " << mrModelPart.Name() << "): not LOCATED [" << counter - total_conditions << "]" << std::endl;
+				found = false;
+			}
 
-			//std::cout<<" AfterSearch::Condition ("<<i_cond->Id()<<") : ME="<<i_cond->GetValue(MASTER_ELEMENTS)[0].Id()<<", MN= "<<i_cond->GetValue(MASTER_NODES)[0].Id()<<std::endl;
+			if (counter != composite_conditions)
+				if (mEchoLevel >= 1)
+					std::cout << "   Condition Masters (ModelPart " << mrModelPart.Name() << "): LOCATED [" << counter << "] COMPOSITE [" << composite_conditions << "] NO MATCH" << std::endl;
 
-			if (found)
-				counter++;
+			return found;
+
+			std::cout << " Condition Masters Found " << std::endl;
+
+			KRATOS_CATCH("")
 		}
 
-		if (counter == total_conditions)
+		///@}
+		///@name Access
+		///@{
+
+		///@}
+		///@name Inquiry
+		///@{
+
+		///@}
+		///@name Input and output
+		///@{
+
+		/// Turn back information as a string.
+		std::string Info() const override
 		{
-			if (mEchoLevel >= 1)
-				std::cout << "   Condition Masters (ModelPart " << mrModelPart.Name() << "): LOCATED [" << counter << "]" << std::endl;
-			found = true;
-		}
-		else
-		{
-			if (mEchoLevel >= 1)
-				std::cout << "   Condition Masters (ModelPart " << mrModelPart.Name() << "): not LOCATED [" << counter - total_conditions << "]" << std::endl;
-			found = false;
-		}
-
-		if (counter != composite_conditions)
-			if (mEchoLevel >= 1)
-				std::cout << "   Condition Masters (ModelPart " << mrModelPart.Name() << "): LOCATED [" << counter << "] COMPOSITE [" << composite_conditions << "] NO MATCH" << std::endl;
-
-		return found;
-
-		std::cout << " Condition Masters Found " << std::endl;
-
-		KRATOS_CATCH("")
-	}
-
-	///@}
-	///@name Access
-	///@{
-
-	///@}
-	///@name Inquiry
-	///@{
-
-	///@}
-	///@name Input and output
-	///@{
-
-	/// Turn back information as a string.
-	std::string Info() const override
-	{
-		return "BuildModelPartBoundaryForFluidsProcess";
-	}
-
-	/// Print information about this object.
-	void PrintInfo(std::ostream &rOStream) const override
-	{
-		rOStream << "BuildModelPartBoundaryForFluidsProcess";
-	}
-
-	/// Print object's data.
-	void PrintData(std::ostream &rOStream) const override
-	{
-	}
-
-	///@}
-	///@name Friends
-	///@{
-
-	///@}
-
-protected:
-	///@name Protected static Member Variables
-	///@{
-
-	///@}
-	///@name Protected member Variables
-	///@{
-
-	ModelPart &mrModelPart;
-
-	std::string mModelPartName;
-
-	int mEchoLevel;
-
-	///@}
-	///@name Protected Operators
-	///@{
-
-	///@}
-	///@name Protected Operations
-	///@{
-
-	//**************************************************************************
-	//**************************************************************************
-
-	bool ClearMasterEntities(ModelPart &rModelPart, ModelPart::ConditionsContainerType &rTemporaryConditions)
-	{
-		KRATOS_TRY
-
-		for (ModelPart::ConditionsContainerType::iterator ic = rTemporaryConditions.begin(); ic != rTemporaryConditions.end(); ++ic)
-		{
-			ElementWeakPtrVectorType &MasterElements = ic->GetValue(MASTER_ELEMENTS);
-			MasterElements.erase(MasterElements.begin(), MasterElements.end());
-
-			NodeWeakPtrVectorType &MasterNodes = ic->GetValue(MASTER_NODES);
-			MasterNodes.erase(MasterNodes.begin(), MasterNodes.end());
+			return "BuildModelPartBoundaryForFluidsProcess";
 		}
 
-		return true;
-
-		KRATOS_CATCH("")
-	}
-
-	//**************************************************************************
-	//**************************************************************************
-
-	bool UniqueSkinSearch(ModelPart &rModelPart)
-	{
-
-		KRATOS_TRY
-
-		if (mEchoLevel > 0)
+		/// Print information about this object.
+		void PrintInfo(std::ostream &rOStream) const override
 		{
-			std::cout << " [ Initial Conditions : " << rModelPart.Conditions().size() << std::endl;
+			rOStream << "BuildModelPartBoundaryForFluidsProcess";
 		}
 
-		if (!rModelPart.Elements().size() || (rModelPart.Is(ACTIVE)))
+		/// Print object's data.
+		void PrintData(std::ostream &rOStream) const override
 		{
+		}
+
+		///@}
+		///@name Friends
+		///@{
+
+		///@}
+
+	protected:
+		///@name Protected static Member Variables
+		///@{
+
+		///@}
+		///@name Protected member Variables
+		///@{
+
+		ModelPart &mrModelPart;
+
+		std::string mModelPartName;
+
+		int mEchoLevel;
+
+		///@}
+		///@name Protected Operators
+		///@{
+
+		///@}
+		///@name Protected Operations
+		///@{
+
+		//**************************************************************************
+		//**************************************************************************
+
+		bool ClearMasterEntities(ModelPart &rModelPart, ModelPart::ConditionsContainerType &rTemporaryConditions)
+		{
+			KRATOS_TRY
+
+			for (ModelPart::ConditionsContainerType::iterator ic = rTemporaryConditions.begin(); ic != rTemporaryConditions.end(); ++ic)
+			{
+				ElementWeakPtrVectorType &MasterElements = ic->GetValue(MASTER_ELEMENTS);
+				MasterElements.erase(MasterElements.begin(), MasterElements.end());
+
+				NodeWeakPtrVectorType &MasterNodes = ic->GetValue(MASTER_NODES);
+				MasterNodes.erase(MasterNodes.begin(), MasterNodes.end());
+			}
+
+			return true;
+
+			KRATOS_CATCH("")
+		}
+
+		//**************************************************************************
+		//**************************************************************************
+
+		bool UniqueSkinSearch(ModelPart &rModelPart)
+		{
+
+			KRATOS_TRY
+
 			if (mEchoLevel > 0)
 			{
-				std::cout << " [ Final Conditions   : " << rModelPart.Conditions().size() << std::endl;
+				std::cout << " [ Initial Conditions : " << rModelPart.Conditions().size() << std::endl;
 			}
-			return true;
-		}
 
-		//check if a remesh process has been performed and there is any node to erase
-		bool any_node_to_erase = false;
-		for (ModelPart::NodesContainerType::const_iterator in = rModelPart.NodesBegin(); in != rModelPart.NodesEnd(); ++in)
-		{
-			if (any_node_to_erase == false)
-				if (in->Is(TO_ERASE))
-					any_node_to_erase = true;
-		}
-
-		this->SetBoundaryAndFreeSurface(rModelPart);
-		// //swap conditions for a temporary use
-		// unsigned int ConditionId=1;
-		// ModelPart::ConditionsContainerType TemporaryConditions;
-
-		// //if there are no conditions check main modelpart mesh conditions
-		// if( !rModelPart.Conditions().size() ){
-
-		// 	for(ModelPart::ConditionsContainerType::iterator i_cond = rModelPart.GetParentModelPart().ConditionsBegin(); i_cond!= rModelPart.GetParentModelPart().ConditionsEnd(); ++i_cond)
-		// 	  {
-		// 	    TemporaryConditions.push_back(*(i_cond.base()));
-		// 	    i_cond->SetId(ConditionId);
-		// 	    ConditionId++;
-		// 	  }
-
-		// }
-		// else{
-
-		// 	TemporaryConditions.reserve(rModelPart.Conditions().size());
-		// 	TemporaryConditions.swap(rModelPart.Conditions());
-
-		// 	//set consecutive ids in the mesh conditions
-		// 	if( any_node_to_erase ){
-		// 	  for(ModelPart::ConditionsContainerType::iterator i_cond = TemporaryConditions.begin(); i_cond!= TemporaryConditions.end(); ++i_cond)
-		// 	    {
-		// 	      Geometry< Node<3> >& rConditionGeometry = i_cond->GetGeometry();
-		// 	      for( unsigned int i=0; i<rConditionGeometry.size(); i++ )
-		// 		{
-		// 		  if( rConditionGeometry[i].Is(TO_ERASE)){
-		// 		    i_cond->Set(TO_ERASE);
-		// 		    break;
-		// 		  }
-		// 		}
-
-		// 	      i_cond->SetId(ConditionId);
-		// 	      ConditionId++;
-		// 	    }
-		// 	}
-		// 	else{
-		// 	  for(ModelPart::ConditionsContainerType::iterator i_cond = TemporaryConditions.begin(); i_cond!= TemporaryConditions.end(); ++i_cond)
-		// 	    {
-
-		// 	      i_cond->SetId(ConditionId);
-		// 	      ConditionId++;
-		// 	    }
-		// 	}
-
-		// }
-
-		// //control the previous mesh conditions
-		// std::vector<int> PreservedConditions( TemporaryConditions.size() + 1 );
-		// std::fill( PreservedConditions.begin(), PreservedConditions.end(), 0 );
-
-		// //build new skin for the Modelpart
-		// this->BuildCompositeConditions(rModelPart, TemporaryConditions, PreservedConditions, ConditionId);
-
-		// //add other conditions out of the skin space dimension
-		// this->AddOtherConditions(rModelPart, TemporaryConditions, PreservedConditions, ConditionId);
-
-		return true;
-
-		KRATOS_CATCH("")
-	}
-
-	//**************************************************************************
-	//**************************************************************************
-
-	virtual bool SetBoundaryAndFreeSurface(ModelPart &rModelPart)
-	{
-
-		KRATOS_TRY
-
-		//properties to be used in the generation
-		int number_properties = rModelPart.GetParentModelPart().NumberOfProperties();
-		Properties::Pointer properties = rModelPart.GetParentModelPart().pGetProperties(number_properties - 1);
-
-		ModelPart::ElementsContainerType::iterator elements_begin = rModelPart.ElementsBegin();
-		ModelPart::ElementsContainerType::iterator elements_end = rModelPart.ElementsEnd();
-
-		for (ModelPart::ElementsContainerType::iterator ie = elements_begin; ie != elements_end; ie++)
-		{
-			Geometry<Node<3>> &rElementGeometry = ie->GetGeometry();
-
-			if (rElementGeometry.FacesNumber() >= 3)
-			{ //3 or 4
-
-				//********************************************************************
-				/*each face is opposite to the corresponding node number so in 2D triangle
-	      0 ----- 1 2
-	      1 ----- 2 0
-	      2 ----- 0 1
-	    */
-
-				/*each face is opposite to the corresponding node number so in 3D tetrahedron
-	      0 ----- 1 2 3
-	      1 ----- 2 0 3
-	      2 ----- 0 1 3
-	      3 ----- 0 2 1
-	    */
-				//********************************************************************
-
-				//finding boundaries and creating the "skin"
-				boost::numeric::ublas::matrix<unsigned int> lpofa; //connectivities of points defining faces
-				boost::numeric::ublas::vector<unsigned int> lnofa; //number of points defining faces
-
-				ElementWeakPtrVectorType &rE = ie->GetValue(NEIGHBOUR_ELEMENTS);
-
-				//get matrix nodes in faces
-				rElementGeometry.NodesInFaces(lpofa);
-				rElementGeometry.NumberNodesInFaces(lnofa);
-
-				//loop on neighbour elements of an element
-				unsigned int iface = 0;
-				for (ElementWeakPtrVectorType::iterator ne = rE.begin(); ne != rE.end(); ne++)
+			if (!rModelPart.Elements().size() || (rModelPart.Is(ACTIVE)))
+			{
+				if (mEchoLevel > 0)
 				{
-					unsigned int NumberNodesInFace = lnofa[iface];
+					std::cout << " [ Final Conditions   : " << rModelPart.Conditions().size() << std::endl;
+				}
+				return true;
+			}
 
-					if ((ne)->Id() == ie->Id())
+			// check if a remesh process has been performed and there is any node to erase
+			bool any_node_to_erase = false;
+			for (ModelPart::NodesContainerType::const_iterator in = rModelPart.NodesBegin(); in != rModelPart.NodesEnd(); ++in)
+			{
+				if (any_node_to_erase == false)
+					if (in->Is(TO_ERASE))
+						any_node_to_erase = true;
+			}
+
+			this->SetBoundaryAndFreeSurface(rModelPart);
+			// //swap conditions for a temporary use
+			// unsigned int ConditionId=1;
+			// ModelPart::ConditionsContainerType TemporaryConditions;
+
+			// //if there are no conditions check main modelpart mesh conditions
+			// if( !rModelPart.Conditions().size() ){
+
+			// 	for(ModelPart::ConditionsContainerType::iterator i_cond = rModelPart.GetParentModelPart().ConditionsBegin(); i_cond!= rModelPart.GetParentModelPart().ConditionsEnd(); ++i_cond)
+			// 	  {
+			// 	    TemporaryConditions.push_back(*(i_cond.base()));
+			// 	    i_cond->SetId(ConditionId);
+			// 	    ConditionId++;
+			// 	  }
+
+			// }
+			// else{
+
+			// 	TemporaryConditions.reserve(rModelPart.Conditions().size());
+			// 	TemporaryConditions.swap(rModelPart.Conditions());
+
+			// 	//set consecutive ids in the mesh conditions
+			// 	if( any_node_to_erase ){
+			// 	  for(ModelPart::ConditionsContainerType::iterator i_cond = TemporaryConditions.begin(); i_cond!= TemporaryConditions.end(); ++i_cond)
+			// 	    {
+			// 	      Geometry< Node<3> >& rConditionGeometry = i_cond->GetGeometry();
+			// 	      for( unsigned int i=0; i<rConditionGeometry.size(); i++ )
+			// 		{
+			// 		  if( rConditionGeometry[i].Is(TO_ERASE)){
+			// 		    i_cond->Set(TO_ERASE);
+			// 		    break;
+			// 		  }
+			// 		}
+
+			// 	      i_cond->SetId(ConditionId);
+			// 	      ConditionId++;
+			// 	    }
+			// 	}
+			// 	else{
+			// 	  for(ModelPart::ConditionsContainerType::iterator i_cond = TemporaryConditions.begin(); i_cond!= TemporaryConditions.end(); ++i_cond)
+			// 	    {
+
+			// 	      i_cond->SetId(ConditionId);
+			// 	      ConditionId++;
+			// 	    }
+			// 	}
+
+			// }
+
+			// //control the previous mesh conditions
+			// std::vector<int> PreservedConditions( TemporaryConditions.size() + 1 );
+			// std::fill( PreservedConditions.begin(), PreservedConditions.end(), 0 );
+
+			// //build new skin for the Modelpart
+			// this->BuildCompositeConditions(rModelPart, TemporaryConditions, PreservedConditions, ConditionId);
+
+			// //add other conditions out of the skin space dimension
+			// this->AddOtherConditions(rModelPart, TemporaryConditions, PreservedConditions, ConditionId);
+
+			return true;
+
+			KRATOS_CATCH("")
+		}
+
+		//**************************************************************************
+		//**************************************************************************
+
+		virtual bool SetBoundaryAndFreeSurface(ModelPart &rModelPart)
+		{
+
+			KRATOS_TRY
+
+			// properties to be used in the generation
+			int number_properties = rModelPart.GetParentModelPart().NumberOfProperties();
+			Properties::Pointer properties = rModelPart.GetParentModelPart().pGetProperties(number_properties - 1);
+
+			ModelPart::ElementsContainerType::iterator elements_begin = rModelPart.ElementsBegin();
+			ModelPart::ElementsContainerType::iterator elements_end = rModelPart.ElementsEnd();
+
+			for (ModelPart::ElementsContainerType::iterator ie = elements_begin; ie != elements_end; ie++)
+			{
+				Geometry<Node<3>> &rElementGeometry = ie->GetGeometry();
+
+				if (rElementGeometry.FacesNumber() >= 3)
+				{ // 3 or 4
+
+					//********************************************************************
+					/*each face is opposite to the corresponding node number so in 2D triangle
+			  0 ----- 1 2
+			  1 ----- 2 0
+			  2 ----- 0 1
+			*/
+
+					/*each face is opposite to the corresponding node number so in 3D tetrahedron
+			  0 ----- 1 2 3
+			  1 ----- 2 0 3
+			  2 ----- 0 1 3
+			  3 ----- 0 2 1
+			*/
+					//********************************************************************
+
+					// finding boundaries and creating the "skin"
+					boost::numeric::ublas::matrix<unsigned int> lpofa; // connectivities of points defining faces
+					boost::numeric::ublas::vector<unsigned int> lnofa; // number of points defining faces
+
+					ElementWeakPtrVectorType &rE = ie->GetValue(NEIGHBOUR_ELEMENTS);
+
+					// get matrix nodes in faces
+					rElementGeometry.NodesInFaces(lpofa);
+					rElementGeometry.NumberNodesInFaces(lnofa);
+
+					// loop on neighbour elements of an element
+					unsigned int iface = 0;
+					for (ElementWeakPtrVectorType::iterator ne = rE.begin(); ne != rE.end(); ne++)
 					{
-						//if no neighbour is present => the face is free surface
-						bool freeSurfaceFace = false;
-						for (unsigned int j = 1; j <= NumberNodesInFace; j++)
+						unsigned int NumberNodesInFace = lnofa[iface];
+
+						if ((ne)->Id() == ie->Id())
 						{
-							rElementGeometry[lpofa(j, iface)].Set(BOUNDARY);
-							if (rElementGeometry[lpofa(j, iface)].IsNot(RIGID))
-							{
-								freeSurfaceFace = true;
-							}
-						}
-						if (freeSurfaceFace == true)
-						{
+							// if no neighbour is present => the face is free surface
+							bool freeSurfaceFace = false;
 							for (unsigned int j = 1; j <= NumberNodesInFace; j++)
 							{
-								rElementGeometry[lpofa(j, iface)].Set(FREE_SURFACE);
+								rElementGeometry[lpofa(j, iface)].Set(BOUNDARY);
+								if (rElementGeometry[lpofa(j, iface)].IsNot(RIGID))
+								{
+									freeSurfaceFace = true;
+								}
 							}
-						}
+							if (freeSurfaceFace == true)
+							{
+								for (unsigned int j = 1; j <= NumberNodesInFace; j++)
+								{
+									rElementGeometry[lpofa(j, iface)].Set(FREE_SURFACE);
+								}
+							}
 
-					} //end face condition
+						} // end face condition
 
-					iface += 1;
-				} //end loop neighbours
+						iface += 1;
+					} // end loop neighbours
+				}
 			}
+
+			return true;
+
+			KRATOS_CATCH("")
 		}
 
-		return true;
-
-		KRATOS_CATCH("")
-	}
-
-	virtual bool BuildCompositeConditions(ModelPart &rModelPart, ModelPart::ConditionsContainerType &rTemporaryConditions, std::vector<int> &rPreservedConditions, unsigned int &rConditionId)
-	{
-
-		KRATOS_TRY
-
-		//master conditions must be deleted and set them again in the build
-		this->ClearMasterEntities(rModelPart, rTemporaryConditions);
-
-		//properties to be used in the generation
-		int number_properties = rModelPart.GetParentModelPart().NumberOfProperties();
-		Properties::Pointer properties = rModelPart.GetParentModelPart().pGetProperties(number_properties - 1);
-
-		ModelPart::ElementsContainerType::iterator elements_begin = rModelPart.ElementsBegin();
-		ModelPart::ElementsContainerType::iterator elements_end = rModelPart.ElementsEnd();
-
-		//clear nodal boundary flag
-		for (ModelPart::ElementsContainerType::iterator ie = elements_begin; ie != elements_end; ++ie)
+		virtual bool BuildCompositeConditions(ModelPart &rModelPart, ModelPart::ConditionsContainerType &rTemporaryConditions, std::vector<int> &rPreservedConditions, unsigned int &rConditionId)
 		{
-			Geometry<Node<3>> &rElementGeometry = ie->GetGeometry();
 
-			for (unsigned int j = 0; j < rElementGeometry.size(); ++j)
+			KRATOS_TRY
+
+			// master conditions must be deleted and set them again in the build
+			this->ClearMasterEntities(rModelPart, rTemporaryConditions);
+
+			// properties to be used in the generation
+			int number_properties = rModelPart.GetParentModelPart().NumberOfProperties();
+			Properties::Pointer properties = rModelPart.GetParentModelPart().pGetProperties(number_properties - 1);
+
+			ModelPart::ElementsContainerType::iterator elements_begin = rModelPart.ElementsBegin();
+			ModelPart::ElementsContainerType::iterator elements_end = rModelPart.ElementsEnd();
+
+			// clear nodal boundary flag
+			for (ModelPart::ElementsContainerType::iterator ie = elements_begin; ie != elements_end; ++ie)
 			{
-				rElementGeometry[j].Reset(BOUNDARY);
+				Geometry<Node<3>> &rElementGeometry = ie->GetGeometry();
+
+				for (unsigned int j = 0; j < rElementGeometry.size(); ++j)
+				{
+					rElementGeometry[j].Reset(BOUNDARY);
+				}
 			}
+
+			rConditionId = 0;
+			for (ModelPart::ElementsContainerType::iterator ie = elements_begin; ie != elements_end; ++ie)
+			{
+				Geometry<Node<3>> &rElementGeometry = ie->GetGeometry();
+
+				const unsigned int dimension = rElementGeometry.WorkingSpaceDimension();
+
+				if (rElementGeometry.FacesNumber() >= (dimension + 1))
+				{ // 3 or 4
+
+					//********************************************************************
+					/*each face is opposite to the corresponding node number so in 2D triangle
+			  0 ----- 1 2
+			  1 ----- 2 0
+			  2 ----- 0 1
+			*/
+
+					/*each face is opposite to the corresponding node number so in 3D tetrahedron
+			  0 ----- 1 2 3
+			  1 ----- 2 0 3
+			  2 ----- 0 1 3
+			  3 ----- 0 2 1
+			*/
+					//********************************************************************
+
+					// finding boundaries and creating the "skin"
+					DenseMatrix<unsigned int> lpofa; // connectivities of points defining faces
+					DenseVector<unsigned int> lnofa; // number of points defining faces
+
+					ElementWeakPtrVectorType &rE = ie->GetValue(NEIGHBOUR_ELEMENTS);
+
+					// get matrix nodes in faces
+					rElementGeometry.NodesInFaces(lpofa);
+					rElementGeometry.NumberNodesInFaces(lnofa);
+
+					// loop on neighbour elements of an element
+					unsigned int iface = 0;
+					for (ElementWeakPtrVectorType::iterator ne = rE.begin(); ne != rE.end(); ++ne)
+					{
+						unsigned int NumberNodesInFace = lnofa[iface];
+
+						if ((ne)->Id() == ie->Id())
+						{
+							// if no neighbour is present => the face is free surface
+							for (unsigned int j = 1; j <= NumberNodesInFace; ++j)
+							{
+								rElementGeometry[lpofa(j, iface)].Set(BOUNDARY);
+								// std::cout<<" node ["<<j<<"]"<<rElementGeometry[lpofa(j,iface)].Id()<<std::endl;
+							}
+
+							// 1.- create geometry: points array and geometry type
+							Condition::NodesArrayType FaceNodes;
+							Condition::GeometryType::Pointer ConditionVertices;
+
+							FaceNodes.reserve(NumberNodesInFace);
+
+							for (unsigned int j = 1; j <= NumberNodesInFace; ++j)
+							{
+								FaceNodes.push_back(rElementGeometry(lpofa(j, iface)));
+							}
+
+							if (NumberNodesInFace == 2)
+							{
+								if (dimension == 2)
+									ConditionVertices = Kratos::make_shared<Line2D2<Node<3>>>(FaceNodes);
+								else
+									ConditionVertices = Kratos::make_shared<Line3D2<Node<3>>>(FaceNodes);
+							}
+							else if (NumberNodesInFace == 3)
+							{
+								if (dimension == 2)
+									ConditionVertices = Kratos::make_shared<Line2D3<Node<3>>>(FaceNodes);
+								else
+									ConditionVertices = Kratos::make_shared<Triangle3D3<Node<3>>>(FaceNodes);
+							}
+
+							rConditionId += 1;
+
+							// Create a composite condition
+							CompositeCondition::Pointer p_cond = Kratos::make_intrusive<CompositeCondition>(rConditionId, ConditionVertices, properties);
+
+							bool condition_found = false;
+							bool point_condition = false;
+
+							// Search for existing conditions: start
+							for (ModelPart::ConditionsContainerType::iterator i_cond = rTemporaryConditions.begin(); i_cond != rTemporaryConditions.end(); ++i_cond)
+							{
+								Geometry<Node<3>> &rConditionGeometry = i_cond->GetGeometry();
+
+								MesherUtilities MesherUtils;
+								condition_found = MesherUtils.FindCondition(rConditionGeometry, rElementGeometry, lpofa, lnofa, iface);
+
+								if (condition_found)
+								{
+
+									p_cond->AddChild(*(i_cond.base()));
+
+									rPreservedConditions[i_cond->Id()] += 1;
+
+									if (rConditionGeometry.PointsNumber() == 1)
+										point_condition = true;
+								}
+							}
+							// Search for existing conditions: end
+
+							if (!point_condition)
+							{
+								// usually one MasterElement and one MasterNode for 2D and 3D simplex
+								// can be more than one in other geometries -> it has to be extended to that cases
+
+								// std::cout<<" ID "<<p_cond->Id()<<" MASTER ELEMENT "<<ie->Id()<<std::endl;
+								// std::cout<<" MASTER NODE "<<rElementGeometry[lpofa(0,iface)].Id()<<" or "<<rElementGeometry[lpofa(NumberNodesInFace,iface)].Id()<<std::endl;
+
+								ElementWeakPtrVectorType &MasterElements = p_cond->GetValue(MASTER_ELEMENTS);
+								MasterElements.push_back((*(ie.base())));
+								p_cond->SetValue(MASTER_ELEMENTS, MasterElements);
+
+								NodeWeakPtrVectorType &MasterNodes = p_cond->GetValue(MASTER_NODES);
+								MasterNodes.push_back(rElementGeometry(lpofa(0, iface)));
+								p_cond->SetValue(MASTER_NODES, MasterNodes);
+							}
+
+							rModelPart.Conditions().push_back(Condition::Pointer(p_cond));
+							// Set new conditions: end
+
+						} // end face condition
+
+						iface += 1;
+					} // end loop neighbours
+				}
+				else
+				{
+					// set nodes to BOUNDARY for elements outside of the working space dimension
+					for (unsigned int j = 0; j < rElementGeometry.size(); ++j)
+					{
+						rElementGeometry[j].Set(BOUNDARY);
+					}
+				}
+			}
+
+			return true;
+
+			KRATOS_CATCH("")
 		}
 
-		rConditionId = 0;
-		for (ModelPart::ElementsContainerType::iterator ie = elements_begin; ie != elements_end; ++ie)
+		//**************************************************************************
+		//**************************************************************************
+
+		bool FindConditionID(ModelPart &rModelPart, Geometry<Node<3>> &rConditionGeometry)
 		{
-			Geometry<Node<3>> &rElementGeometry = ie->GetGeometry();
+			KRATOS_TRY
 
-			const unsigned int dimension = rElementGeometry.WorkingSpaceDimension();
-
-			if (rElementGeometry.FacesNumber() >= (dimension + 1))
-			{ //3 or 4
-
-				//********************************************************************
-				/*each face is opposite to the corresponding node number so in 2D triangle
-	      0 ----- 1 2
-	      1 ----- 2 0
-	      2 ----- 0 1
-	    */
-
-				/*each face is opposite to the corresponding node number so in 3D tetrahedron
-	      0 ----- 1 2 3
-	      1 ----- 2 0 3
-	      2 ----- 0 1 3
-	      3 ----- 0 2 1
-	    */
-				//********************************************************************
-
-				//finding boundaries and creating the "skin"
-				DenseMatrix<unsigned int> lpofa; //connectivities of points defining faces
-				DenseVector<unsigned int> lnofa; //number of points defining faces
-
-				ElementWeakPtrVectorType &rE = ie->GetValue(NEIGHBOUR_ELEMENTS);
-
-				//get matrix nodes in faces
-				rElementGeometry.NodesInFaces(lpofa);
-				rElementGeometry.NumberNodesInFaces(lnofa);
-
-				//loop on neighbour elements of an element
-				unsigned int iface = 0;
-				for (ElementWeakPtrVectorType::iterator ne = rE.begin(); ne != rE.end(); ++ne)
+			// check if the condition exists and belongs to the modelpart checking node Ids
+			for (unsigned int i = 0; i < rConditionGeometry.size(); ++i)
+			{
+				for (ModelPart::NodesContainerType::const_iterator in = rModelPart.NodesBegin(); in != rModelPart.NodesEnd(); ++in)
 				{
-					unsigned int NumberNodesInFace = lnofa[iface];
+					if (rConditionGeometry[i].Id() == in->Id())
+						return true;
+				}
+			}
 
-					if ((ne)->Id() == ie->Id())
+			return false;
+
+			KRATOS_CATCH("")
+		}
+
+		//**************************************************************************
+		//**************************************************************************
+
+		void PrintSkin(ModelPart &rModelPart)
+		{
+
+			KRATOS_TRY
+
+			// PRINT SKIN:
+			std::cout << " CONDITIONS: geometry nodes (" << rModelPart.Conditions().size() << ")" << std::endl;
+
+			ConditionsContainerType &rCond = rModelPart.Conditions();
+			for (ConditionsContainerType::iterator i_cond = rCond.begin(); i_cond != rCond.end(); ++i_cond)
+			{
+
+				Geometry<Node<3>> &rConditionGeometry = i_cond->GetGeometry();
+				std::cout << "[" << i_cond->Id() << "]:" << std::endl;
+				// i_cond->PrintInfo(std::cout);
+				std::cout << "( ";
+				for (unsigned int i = 0; i < rConditionGeometry.size(); ++i)
+				{
+					std::cout << rConditionGeometry[i].Id() << ", ";
+				}
+				std::cout << " ): ";
+
+				i_cond->GetValue(MASTER_ELEMENTS)[0].PrintInfo(std::cout);
+
+				std::cout << std::endl;
+			}
+			std::cout << std::endl;
+
+			KRATOS_CATCH("")
+		}
+
+		//**************************************************************************
+		//**************************************************************************
+
+		bool AddOtherConditions(ModelPart &rModelPart, ModelPart::ConditionsContainerType &rTemporaryConditions, std::vector<int> &rPreservedConditions, unsigned int &rConditionId)
+		{
+
+			KRATOS_TRY
+
+			unsigned int counter = 0;
+
+			// add all previous conditions not found in the skin search:
+			for (ModelPart::ConditionsContainerType::iterator i_cond = rTemporaryConditions.begin(); i_cond != rTemporaryConditions.end(); ++i_cond)
+			{
+
+				if (rPreservedConditions[i_cond->Id()] == 0)
+				{ // I have not used the condition and any node of the condition
+
+					if (this->CheckAcceptedCondition(rModelPart, *i_cond))
 					{
-						//if no neighbour is present => the face is free surface
-						for (unsigned int j = 1; j <= NumberNodesInFace; ++j)
-						{
-							rElementGeometry[lpofa(j, iface)].Set(BOUNDARY);
-							//std::cout<<" node ["<<j<<"]"<<rElementGeometry[lpofa(j,iface)].Id()<<std::endl;
-						}
 
-						//1.- create geometry: points array and geometry type
+						Geometry<Node<3>> &rConditionGeometry = i_cond->GetGeometry();
+
 						Condition::NodesArrayType FaceNodes;
-						Condition::GeometryType::Pointer ConditionVertices;
 
-						FaceNodes.reserve(NumberNodesInFace);
+						FaceNodes.reserve(rConditionGeometry.size());
 
-						for (unsigned int j = 1; j <= NumberNodesInFace; ++j)
+						for (unsigned int j = 0; j < rConditionGeometry.size(); ++j)
 						{
-							FaceNodes.push_back(rElementGeometry(lpofa(j, iface)));
+							FaceNodes.push_back(rConditionGeometry(j));
 						}
 
-						if (NumberNodesInFace == 2)
-						{
-							if (dimension == 2)
-								ConditionVertices = Kratos::make_shared<Line2D2<Node<3>>>(FaceNodes);
-							else
-								ConditionVertices = Kratos::make_shared<Line3D2<Node<3>>>(FaceNodes);
-						}
-						else if (NumberNodesInFace == 3)
-						{
-							if (dimension == 2)
-								ConditionVertices = Kratos::make_shared<Line2D3<Node<3>>>(FaceNodes);
-							else
-								ConditionVertices = Kratos::make_shared<Triangle3D3<Node<3>>>(FaceNodes);
-						}
+						rPreservedConditions[i_cond->Id()] += 1;
 
 						rConditionId += 1;
 
-						//Create a composite condition
-						CompositeCondition::Pointer p_cond = Kratos::make_intrusive<CompositeCondition>(rConditionId, ConditionVertices, properties);
+						Condition::Pointer p_cond = i_cond->Clone(rConditionId, FaceNodes);
+						// p_cond->Data() = i_cond->Data();
 
-						bool condition_found = false;
-						bool point_condition = false;
+						this->AddConditionToModelPart(rModelPart, p_cond);
 
-						// Search for existing conditions: start
-						for (ModelPart::ConditionsContainerType::iterator i_cond = rTemporaryConditions.begin(); i_cond != rTemporaryConditions.end(); ++i_cond)
-						{
-							Geometry<Node<3>> &rConditionGeometry = i_cond->GetGeometry();
-
-							MesherUtilities MesherUtils;
-							condition_found = MesherUtils.FindCondition(rConditionGeometry, rElementGeometry, lpofa, lnofa, iface);
-
-							if (condition_found)
-							{
-
-								p_cond->AddChild(*(i_cond.base()));
-
-								rPreservedConditions[i_cond->Id()] += 1;
-
-								if (rConditionGeometry.PointsNumber() == 1)
-									point_condition = true;
-							}
-						}
-						// Search for existing conditions: end
-
-						if (!point_condition)
-						{
-							// usually one MasterElement and one MasterNode for 2D and 3D simplex
-							// can be more than one in other geometries -> it has to be extended to that cases
-
-							// std::cout<<" ID "<<p_cond->Id()<<" MASTER ELEMENT "<<ie->Id()<<std::endl;
-							// std::cout<<" MASTER NODE "<<rElementGeometry[lpofa(0,iface)].Id()<<" or "<<rElementGeometry[lpofa(NumberNodesInFace,iface)].Id()<<std::endl;
-
-							ElementWeakPtrVectorType &MasterElements = p_cond->GetValue(MASTER_ELEMENTS);
-							MasterElements.push_back((*(ie.base())));
-							p_cond->SetValue(MASTER_ELEMENTS, MasterElements);
-
-							NodeWeakPtrVectorType &MasterNodes = p_cond->GetValue(MASTER_NODES);
-							MasterNodes.push_back(rElementGeometry(lpofa(0, iface)));
-							p_cond->SetValue(MASTER_NODES, MasterNodes);
-						}
-
-						rModelPart.Conditions().push_back(Condition::Pointer(p_cond));
-						// Set new conditions: end
-
-					} //end face condition
-
-					iface += 1;
-				} //end loop neighbours
-			}
-			else
-			{
-				//set nodes to BOUNDARY for elements outside of the working space dimension
-				for (unsigned int j = 0; j < rElementGeometry.size(); ++j)
-				{
-					rElementGeometry[j].Set(BOUNDARY);
-				}
-			}
-		}
-
-		return true;
-
-		KRATOS_CATCH("")
-	}
-
-	//**************************************************************************
-	//**************************************************************************
-
-	bool FindConditionID(ModelPart &rModelPart, Geometry<Node<3>> &rConditionGeometry)
-	{
-		KRATOS_TRY
-
-		//check if the condition exists and belongs to the modelpart checking node Ids
-		for (unsigned int i = 0; i < rConditionGeometry.size(); ++i)
-		{
-			for (ModelPart::NodesContainerType::const_iterator in = rModelPart.NodesBegin(); in != rModelPart.NodesEnd(); ++in)
-			{
-				if (rConditionGeometry[i].Id() == in->Id())
-					return true;
-			}
-		}
-
-		return false;
-
-		KRATOS_CATCH("")
-	}
-
-	//**************************************************************************
-	//**************************************************************************
-
-	void PrintSkin(ModelPart &rModelPart)
-	{
-
-		KRATOS_TRY
-
-		//PRINT SKIN:
-		std::cout << " CONDITIONS: geometry nodes (" << rModelPart.Conditions().size() << ")" << std::endl;
-
-		ConditionsContainerType &rCond = rModelPart.Conditions();
-		for (ConditionsContainerType::iterator i_cond = rCond.begin(); i_cond != rCond.end(); ++i_cond)
-		{
-
-			Geometry<Node<3>> &rConditionGeometry = i_cond->GetGeometry();
-			std::cout << "[" << i_cond->Id() << "]:" << std::endl;
-			//i_cond->PrintInfo(std::cout);
-			std::cout << "( ";
-			for (unsigned int i = 0; i < rConditionGeometry.size(); ++i)
-			{
-				std::cout << rConditionGeometry[i].Id() << ", ";
-			}
-			std::cout << " ): ";
-
-			i_cond->GetValue(MASTER_ELEMENTS)[0].PrintInfo(std::cout);
-
-			std::cout << std::endl;
-		}
-		std::cout << std::endl;
-
-		KRATOS_CATCH("")
-	}
-
-	//**************************************************************************
-	//**************************************************************************
-
-	bool AddOtherConditions(ModelPart &rModelPart, ModelPart::ConditionsContainerType &rTemporaryConditions, std::vector<int> &rPreservedConditions, unsigned int &rConditionId)
-	{
-
-		KRATOS_TRY
-
-		unsigned int counter = 0;
-
-		//add all previous conditions not found in the skin search:
-		for (ModelPart::ConditionsContainerType::iterator i_cond = rTemporaryConditions.begin(); i_cond != rTemporaryConditions.end(); ++i_cond)
-		{
-
-			if (rPreservedConditions[i_cond->Id()] == 0)
-			{ //I have not used the condition and any node of the condition
-
-				if (this->CheckAcceptedCondition(rModelPart, *i_cond))
-				{
-
-					Geometry<Node<3>> &rConditionGeometry = i_cond->GetGeometry();
-
-					Condition::NodesArrayType FaceNodes;
-
-					FaceNodes.reserve(rConditionGeometry.size());
-
-					for (unsigned int j = 0; j < rConditionGeometry.size(); ++j)
-					{
-						FaceNodes.push_back(rConditionGeometry(j));
+						counter++;
 					}
-
-					rPreservedConditions[i_cond->Id()] += 1;
-
-					rConditionId += 1;
-
-					Condition::Pointer p_cond = i_cond->Clone(rConditionId, FaceNodes);
-					//p_cond->Data() = i_cond->Data();
-
-					this->AddConditionToModelPart(rModelPart, p_cond);
-
-					counter++;
 				}
 			}
-		}
 
-		//std::cout<<"   recovered conditions "<<counter<<std::endl;
+			// std::cout<<"   recovered conditions "<<counter<<std::endl;
 
-		//control if all previous conditions have been added:
-		bool all_assigned = true;
-		unsigned int lost_conditions = 0;
-		for (unsigned int i = 1; i < rPreservedConditions.size(); ++i)
-		{
-			if (rPreservedConditions[i] == 0)
+			// control if all previous conditions have been added:
+			bool all_assigned = true;
+			unsigned int lost_conditions = 0;
+			for (unsigned int i = 1; i < rPreservedConditions.size(); ++i)
 			{
-				all_assigned = false;
-				lost_conditions++;
-			}
-		}
-
-		if (mEchoLevel >= 1)
-		{
-
-			std::cout << "   Final Conditions   : " << rModelPart.NumberOfConditions() << std::endl;
-
-			if (all_assigned == true)
-				std::cout << "   ALL_PREVIOUS_CONDITIONS_RELOCATED " << std::endl;
-			else
-				std::cout << "   SOME_PREVIOUS_CONDITIONS_ARE_LOST [lost_conditions:" << lost_conditions << "]" << std::endl;
-		}
-
-		return all_assigned;
-
-		KRATOS_CATCH("")
-	}
-
-	//**************************************************************************
-	//**************************************************************************
-
-	virtual bool CheckAcceptedCondition(ModelPart &rModelPart, Condition &rCondition)
-	{
-		KRATOS_TRY
-
-		Geometry<Node<3>> &rConditionGeometry = rCondition.GetGeometry();
-
-		return FindConditionID(rModelPart, rConditionGeometry);
-
-		KRATOS_CATCH("")
-	}
-
-	//**************************************************************************
-	//**************************************************************************
-
-	virtual void AddConditionToModelPart(ModelPart &rModelPart, Condition::Pointer pCondition)
-	{
-		KRATOS_TRY
-
-		rModelPart.AddCondition(pCondition);
-		//rModelPart.Conditions().push_back(pCondition);
-
-		KRATOS_CATCH("")
-	}
-
-	///@}
-	///@name Protected  Access
-	///@{
-
-	///@}
-	///@name Protected Inquiry
-	///@{
-
-	///@}
-	///@name Protected LifeCycle
-	///@{
-
-	///@}
-
-private:
-	///@name Static Member Variables
-	///@{
-
-	///@}
-	///@name Member Variables
-	///@{
-
-	///@}
-	///@name Private Operators
-	///@{
-
-	///@}
-	///@name Private Operations
-	///@{
-
-	//**************************************************************************
-	//**************************************************************************
-
-	void SetComputingModelPart()
-	{
-
-		KRATOS_TRY
-
-		std::string ComputingModelPartName;
-		for (ModelPart::SubModelPartIterator i_mp = mrModelPart.SubModelPartsBegin(); i_mp != mrModelPart.SubModelPartsEnd(); ++i_mp)
-		{
-			if (i_mp->Is(ACTIVE))
-				ComputingModelPartName = i_mp->Name();
-		}
-
-		ModelPart &rModelPart = mrModelPart.GetSubModelPart(ComputingModelPartName);
-
-		if (mEchoLevel >= 1)
-		{
-			std::cout << " [" << ComputingModelPartName << " :: CONDITIONS [OLD:" << rModelPart.NumberOfConditions();
-		}
-
-		ModelPart::ConditionsContainerType KeepConditions;
-
-		for (ModelPart::SubModelPartIterator i_mp = mrModelPart.SubModelPartsBegin(); i_mp != mrModelPart.SubModelPartsEnd(); ++i_mp)
-		{
-
-			if (i_mp->NumberOfElements() && ComputingModelPartName != i_mp->Name())
-			{ //conditions of model_parts with elements only
-
-				for (ModelPart::ConditionsContainerType::iterator i_cond = i_mp->ConditionsBegin(); i_cond != i_mp->ConditionsEnd(); ++i_cond)
+				if (rPreservedConditions[i] == 0)
 				{
-					// i_cond->PrintInfo(std::cout);
-					// std::cout<<" -- "<<std::endl;
-
-					KeepConditions.push_back(*(i_cond.base()));
-
-					// KeepConditions.back().PrintInfo(std::cout);
-					// std::cout<<std::endl;
+					all_assigned = false;
+					lost_conditions++;
 				}
 			}
+
+			if (mEchoLevel >= 1)
+			{
+
+				std::cout << "   Final Conditions   : " << rModelPart.NumberOfConditions() << std::endl;
+
+				if (all_assigned == true)
+					std::cout << "   ALL_PREVIOUS_CONDITIONS_RELOCATED " << std::endl;
+				else
+					std::cout << "   SOME_PREVIOUS_CONDITIONS_ARE_LOST [lost_conditions:" << lost_conditions << "]" << std::endl;
+			}
+
+			return all_assigned;
+
+			KRATOS_CATCH("")
 		}
 
-		rModelPart.Conditions().swap(KeepConditions);
+		//**************************************************************************
+		//**************************************************************************
 
-		if (mEchoLevel >= 1)
+		virtual bool CheckAcceptedCondition(ModelPart &rModelPart, Condition &rCondition)
 		{
-			std::cout << " / NEW:" << rModelPart.NumberOfConditions() << "] " << std::endl;
+			KRATOS_TRY
+
+			Geometry<Node<3>> &rConditionGeometry = rCondition.GetGeometry();
+
+			return FindConditionID(rModelPart, rConditionGeometry);
+
+			KRATOS_CATCH("")
 		}
 
-		KRATOS_CATCH("")
-	}
+		//**************************************************************************
+		//**************************************************************************
 
-	//**************************************************************************
-	//**************************************************************************
-
-	void SetMainModelPartConditions()
-	{
-
-		KRATOS_TRY
-
-		if (mEchoLevel >= 1)
+		virtual void AddConditionToModelPart(ModelPart &rModelPart, Condition::Pointer pCondition)
 		{
-			std::cout << " [" << mrModelPart.Name() << " :: CONDITIONS [OLD:" << mrModelPart.NumberOfConditions();
+			KRATOS_TRY
+
+			rModelPart.AddCondition(pCondition);
+			// rModelPart.Conditions().push_back(pCondition);
+
+			KRATOS_CATCH("")
 		}
 
-		//contact conditions are located on Mesh_0
-		ModelPart::ConditionsContainerType KeepConditions;
+		///@}
+		///@name Protected  Access
+		///@{
 
-		unsigned int condId = 1;
-		if (mModelPartName == mrModelPart.Name())
+		///@}
+		///@name Protected Inquiry
+		///@{
+
+		///@}
+		///@name Protected LifeCycle
+		///@{
+
+		///@}
+
+	private:
+		///@name Static Member Variables
+		///@{
+
+		///@}
+		///@name Member Variables
+		///@{
+
+		///@}
+		///@name Private Operators
+		///@{
+
+		///@}
+		///@name Private Operations
+		///@{
+
+		//**************************************************************************
+		//**************************************************************************
+
+		void SetComputingModelPart()
 		{
+
+			KRATOS_TRY
+
+			std::string ComputingModelPartName;
+			for (ModelPart::SubModelPartIterator i_mp = mrModelPart.SubModelPartsBegin(); i_mp != mrModelPart.SubModelPartsEnd(); ++i_mp)
+			{
+				if (i_mp->Is(ACTIVE))
+					ComputingModelPartName = i_mp->Name();
+			}
+
+			ModelPart &rModelPart = mrModelPart.GetSubModelPart(ComputingModelPartName);
+
+			if (mEchoLevel >= 1)
+			{
+				std::cout << " [" << ComputingModelPartName << " :: CONDITIONS [OLD:" << rModelPart.NumberOfConditions();
+			}
+
+			ModelPart::ConditionsContainerType KeepConditions;
 
 			for (ModelPart::SubModelPartIterator i_mp = mrModelPart.SubModelPartsBegin(); i_mp != mrModelPart.SubModelPartsEnd(); ++i_mp)
 			{
-				if (!(i_mp->Is(ACTIVE)) && !(i_mp->Is(CONTACT)))
-				{
-					//std::cout<<" ModelPartName "<<i_mp->Name()<<" conditions "<<i_mp->NumberOfConditions()<<std::endl;
+
+				if (i_mp->NumberOfElements() && ComputingModelPartName != i_mp->Name())
+				{ // conditions of model_parts with elements only
+
 					for (ModelPart::ConditionsContainerType::iterator i_cond = i_mp->ConditionsBegin(); i_cond != i_mp->ConditionsEnd(); ++i_cond)
 					{
 						// i_cond->PrintInfo(std::cout);
 						// std::cout<<" -- "<<std::endl;
 
 						KeepConditions.push_back(*(i_cond.base()));
-						KeepConditions.back().SetId(condId);
-						condId += 1;
 
 						// KeepConditions.back().PrintInfo(std::cout);
 						// std::cout<<std::endl;
 					}
 				}
 			}
+
+			rModelPart.Conditions().swap(KeepConditions);
+
+			if (mEchoLevel >= 1)
+			{
+				std::cout << " / NEW:" << rModelPart.NumberOfConditions() << "] " << std::endl;
+			}
+
+			KRATOS_CATCH("")
 		}
 
-		for (ModelPart::ConditionsContainerType::iterator i_cond = mrModelPart.ConditionsBegin(); i_cond != mrModelPart.ConditionsEnd(); ++i_cond)
-		{
-			if (i_cond->Is(CONTACT))
-			{
-				KeepConditions.push_back(*(i_cond.base()));
-				KeepConditions.back().SetId(condId);
-				condId += 1;
+		//**************************************************************************
+		//**************************************************************************
 
-				//std::cout<<" -- "<<std::endl;
-				//KeepConditions.back().PrintInfo(std::cout);
-				//std::cout<<std::endl;
+		void SetMainModelPartConditions()
+		{
+
+			KRATOS_TRY
+
+			if (mEchoLevel >= 1)
+			{
+				std::cout << " [" << mrModelPart.Name() << " :: CONDITIONS [OLD:" << mrModelPart.NumberOfConditions();
+			}
+
+			// contact conditions are located on Mesh_0
+			ModelPart::ConditionsContainerType KeepConditions;
+
+			unsigned int condId = 1;
+			if (mModelPartName == mrModelPart.Name())
+			{
+
+				for (ModelPart::SubModelPartIterator i_mp = mrModelPart.SubModelPartsBegin(); i_mp != mrModelPart.SubModelPartsEnd(); ++i_mp)
+				{
+					if (!(i_mp->Is(ACTIVE)) && !(i_mp->Is(CONTACT)))
+					{
+						// std::cout<<" ModelPartName "<<i_mp->Name()<<" conditions "<<i_mp->NumberOfConditions()<<std::endl;
+						for (ModelPart::ConditionsContainerType::iterator i_cond = i_mp->ConditionsBegin(); i_cond != i_mp->ConditionsEnd(); ++i_cond)
+						{
+							// i_cond->PrintInfo(std::cout);
+							// std::cout<<" -- "<<std::endl;
+
+							KeepConditions.push_back(*(i_cond.base()));
+							KeepConditions.back().SetId(condId);
+							condId += 1;
+
+							// KeepConditions.back().PrintInfo(std::cout);
+							// std::cout<<std::endl;
+						}
+					}
+				}
+			}
+
+			for (ModelPart::ConditionsContainerType::iterator i_cond = mrModelPart.ConditionsBegin(); i_cond != mrModelPart.ConditionsEnd(); ++i_cond)
+			{
+				if (i_cond->Is(CONTACT))
+				{
+					KeepConditions.push_back(*(i_cond.base()));
+					KeepConditions.back().SetId(condId);
+					condId += 1;
+
+					// std::cout<<" -- "<<std::endl;
+					// KeepConditions.back().PrintInfo(std::cout);
+					// std::cout<<std::endl;
+				}
+			}
+
+			mrModelPart.Conditions().swap(KeepConditions);
+
+			if (mEchoLevel >= 1)
+			{
+				std::cout << " / NEW:" << mrModelPart.NumberOfConditions() << "] " << std::endl;
+			}
+
+			KRATOS_CATCH("")
+		}
+
+		void ResetNodesBoundaryFlag(ModelPart &rModelPart)
+		{
+			// reset the boundary flag in all nodes
+			for (ModelPart::NodesContainerType::const_iterator in = rModelPart.NodesBegin(); in != rModelPart.NodesEnd(); ++in)
+			{
+				in->Reset(BOUNDARY);
 			}
 		}
 
-		mrModelPart.Conditions().swap(KeepConditions);
+		///@}
+		///@name Private  Access
+		///@{
 
-		if (mEchoLevel >= 1)
-		{
-			std::cout << " / NEW:" << mrModelPart.NumberOfConditions() << "] " << std::endl;
-		}
+		///@}
+		///@name Private Inquiry
+		///@{
 
-		KRATOS_CATCH("")
-	}
+		///@}
+		///@name Un accessible methods
+		///@{
 
-	void ResetNodesBoundaryFlag(ModelPart &rModelPart)
+		/// Assignment operator.
+		BuildModelPartBoundaryForFluidsProcess &operator=(BuildModelPartBoundaryForFluidsProcess const &rOther);
+
+		/// Copy constructor.
+		// BuildModelPartBoundaryForFluidsProcess(BuildModelPartBoundaryForFluidsProcess const& rOther);
+
+		///@}
+
+	}; // Class BuildModelPartBoundaryForFluidsProcess
+
+	///@}
+
+	///@name Type Definitions
+	///@{
+
+	///@}
+	///@name Input and output
+	///@{
+
+	/// input stream function
+	inline std::istream &operator>>(std::istream &rIStream,
+									BuildModelPartBoundaryForFluidsProcess &rThis);
+
+	/// output stream function
+	inline std::ostream &operator<<(std::ostream &rOStream,
+									const BuildModelPartBoundaryForFluidsProcess &rThis)
 	{
-		//reset the boundary flag in all nodes
-		for (ModelPart::NodesContainerType::const_iterator in = rModelPart.NodesBegin(); in != rModelPart.NodesEnd(); ++in)
-		{
-			in->Reset(BOUNDARY);
-		}
+		rThis.PrintInfo(rOStream);
+		rOStream << std::endl;
+		rThis.PrintData(rOStream);
+
+		return rOStream;
 	}
-
 	///@}
-	///@name Private  Access
-	///@{
-
-	///@}
-	///@name Private Inquiry
-	///@{
-
-	///@}
-	///@name Un accessible methods
-	///@{
-
-	/// Assignment operator.
-	BuildModelPartBoundaryForFluidsProcess &operator=(BuildModelPartBoundaryForFluidsProcess const &rOther);
-
-	/// Copy constructor.
-	//BuildModelPartBoundaryForFluidsProcess(BuildModelPartBoundaryForFluidsProcess const& rOther);
-
-	///@}
-
-}; // Class BuildModelPartBoundaryForFluidsProcess
-
-///@}
-
-///@name Type Definitions
-///@{
-
-///@}
-///@name Input and output
-///@{
-
-/// input stream function
-inline std::istream &operator>>(std::istream &rIStream,
-								BuildModelPartBoundaryForFluidsProcess &rThis);
-
-/// output stream function
-inline std::ostream &operator<<(std::ostream &rOStream,
-								const BuildModelPartBoundaryForFluidsProcess &rThis)
-{
-	rThis.PrintInfo(rOStream);
-	rOStream << std::endl;
-	rThis.PrintData(rOStream);
-
-	return rOStream;
-}
-///@}
 
 } // namespace Kratos.
 

--- a/applications/PfemFluidDynamicsApplication/custom_processes/model_start_end_meshing_for_fluids_process.hpp
+++ b/applications/PfemFluidDynamicsApplication/custom_processes/model_start_end_meshing_for_fluids_process.hpp
@@ -346,17 +346,12 @@ namespace Kratos
 
       // rModelPart.Conditions().swap(PreservedConditions);
 
-      //Sort
-      rModelPart.Nodes().Sort();
-      rModelPart.Elements().Sort();
-      // rModelPart.Conditions().Sort();
-
-      //Unique
+      // Unique (it includes sort())
       rModelPart.Nodes().Unique();
       rModelPart.Elements().Unique();
       // rModelPart.Conditions().Unique();
 
-      //Sort Again to have coherent numeration for nodes (mesh with shared nodes)
+      // Sort Again to have coherent numeration for nodes (mesh with shared nodes)
       unsigned int consecutive_index = 1;
       for (ModelPart::NodesContainerType::iterator in = rModelPart.NodesBegin(); in != rModelPart.NodesEnd(); in++)
         in->SetId(consecutive_index++);

--- a/applications/PfemFluidDynamicsApplication/custom_processes/model_start_end_meshing_for_fluids_process.hpp
+++ b/applications/PfemFluidDynamicsApplication/custom_processes/model_start_end_meshing_for_fluids_process.hpp
@@ -443,7 +443,7 @@ namespace Kratos
 
       //BOUNDARY NORMALS SEARCH and SHRINKAGE FACTOR
       BoundaryNormalsCalculationUtilities BoundaryComputation;
-      BoundaryComputation.CalculateWeightedBoundaryNormals(mrMainModelPart, mEchoLevel);
+      BoundaryComputation.CalculateUnitBoundaryNormals(mrMainModelPart, mEchoLevel);
 
       KRATOS_CATCH(" ")
     }

--- a/applications/PfemFluidDynamicsApplication/custom_processes/model_start_end_meshing_for_fluids_process.hpp
+++ b/applications/PfemFluidDynamicsApplication/custom_processes/model_start_end_meshing_for_fluids_process.hpp
@@ -411,12 +411,12 @@ namespace Kratos
         }
       }
 
-      //Sort
-      rComputingModelPart.Nodes().Sort();
-      rComputingModelPart.Elements().Sort();
-      // rComputingModelPart.Conditions().Sort();
+      // // // Sort
+      // // rComputingModelPart.Nodes().Sort();
+      // // rComputingModelPart.Elements().Sort();
+      // // // rComputingModelPart.Conditions().Sort();
 
-      //Unique
+      // Unique (Sort is included)
       rComputingModelPart.Nodes().Unique();
       rComputingModelPart.Elements().Unique();
       // rComputingModelPart.Conditions().Unique();

--- a/applications/PfemFluidDynamicsApplication/custom_processes/split_elements_process.hpp
+++ b/applications/PfemFluidDynamicsApplication/custom_processes/split_elements_process.hpp
@@ -297,9 +297,9 @@ public:
           }
         }
 
-        //Sort
-        rComputingModelPart.Nodes().Sort();
-        rComputingModelPart.Elements().Sort();
+        // //Sort
+        // rComputingModelPart.Nodes().Sort();
+        // rComputingModelPart.Elements().Sort();
 
         //Unique
         rComputingModelPart.Nodes().Unique();

--- a/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/nodal_two_step_v_p_strategy.h
+++ b/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/nodal_two_step_v_p_strategy.h
@@ -1190,7 +1190,7 @@ namespace Kratos
 			this->CalculateDisplacementsAndResetNodalVariables();
 			BaseType::MoveMesh();
 			BoundaryNormalsCalculationUtilities BoundaryComputation;
-			BoundaryComputation.CalculateWeightedBoundaryNormals(rModelPart, echoLevel);
+            BoundaryComputation.CalculateUnitBoundaryNormals(rModelPart, echoLevel);
 
 			KRATOS_CATCH("");
 		}

--- a/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/nodal_two_step_v_p_strategy_for_FSI.h
+++ b/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/nodal_two_step_v_p_strategy_for_FSI.h
@@ -77,7 +77,7 @@ namespace Kratos
 		KRATOS_CLASS_POINTER_DEFINITION(NodalTwoStepVPStrategyForFSI);
 
 		/// Counted pointer of NodalTwoStepVPStrategy
-		//typedef boost::shared_ptr< NodalTwoStepVPStrategy<TSparseSpace, TDenseSpace, TLinearSolver> > Pointer;
+		// typedef boost::shared_ptr< NodalTwoStepVPStrategy<TSparseSpace, TDenseSpace, TLinearSolver> > Pointer;
 
 		typedef NodalTwoStepVPStrategy<TSparseSpace, TDenseSpace, TLinearSolver> BaseType;
 
@@ -91,7 +91,7 @@ namespace Kratos
 
 		typedef std::size_t SizeType;
 
-		//typedef typename BaseType::DofSetType DofSetType;
+		// typedef typename BaseType::DofSetType DofSetType;
 
 		typedef typename BaseType::DofsArrayType DofsArrayType;
 
@@ -165,14 +165,14 @@ namespace Kratos
 			typedef typename BuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>::Pointer BuilderSolverTypePointer;
 			typedef ImplicitSolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver> BaseType;
 
-			//initializing fractional velocity solution step
+			// initializing fractional velocity solution step
 			typedef Scheme<TSparseSpace, TDenseSpace> SchemeType;
 			typename SchemeType::Pointer pScheme;
 
 			typename SchemeType::Pointer Temp = typename SchemeType::Pointer(new ResidualBasedIncrementalUpdateStaticScheme<TSparseSpace, TDenseSpace>());
 			pScheme.swap(Temp);
 
-			//CONSTRUCTION OF VELOCITY
+			// CONSTRUCTION OF VELOCITY
 			BuilderSolverTypePointer vel_build = BuilderSolverTypePointer(new NodalResidualBasedEliminationBuilderAndSolverForFSI<TSparseSpace, TDenseSpace, TLinearSolver>(pVelocityLinearSolver));
 
 			this->mpMomentumStrategy = typename BaseType::Pointer(new GaussSeidelLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(rModelPart, pScheme, pVelocityLinearSolver, vel_build, ReformDofAtEachIteration, CalculateNormDxFlag));
@@ -287,8 +287,8 @@ namespace Kratos
 
 				if (it == maxNonLinearIterations - 1 || ((continuityConverged && momentumConverged) && it > 1))
 				{
-					//this->ComputeErrorL2NormCaseImposedG();
-					//this->ComputeErrorL2NormCasePoiseuille();
+					// this->ComputeErrorL2NormCaseImposedG();
+					// this->ComputeErrorL2NormCasePoiseuille();
 					this->CalculateAccelerations();
 					// std::ofstream myfile;
 					// myfile.open ("maxConvergedIteration.txt",std::ios::app);
@@ -610,9 +610,9 @@ namespace Kratos
 				const double youngModulus = itNode->FastGetSolutionStepValue(YOUNG_MODULUS);
 				const double poissonRatio = itNode->FastGetSolutionStepValue(POISSON_RATIO);
 
-				//deviatoricCoeff=deltaT*secondLame
+				// deviatoricCoeff=deltaT*secondLame
 				deviatoricCoeff = timeInterval * youngModulus / (1.0 + poissonRatio) * 0.5;
-				//volumetricCoeff=bulk*deltaT=deltaT*(firstLame+2*secondLame/3)
+				// volumetricCoeff=bulk*deltaT=deltaT*(firstLame+2*secondLame/3)
 				volumetricCoeff = timeInterval * poissonRatio * youngModulus / ((1.0 + poissonRatio) * (1.0 - 2.0 * poissonRatio)) + 2.0 * deviatoricCoeff / 3.0;
 			}
 			else if (itNode->Is(FLUID) || itNode->Is(RIGID))
@@ -632,7 +632,7 @@ namespace Kratos
 
 			const double currFirstLame = volumetricCoeff - 2.0 * deviatoricCoeff / 3.0;
 
-			//currFirstLame=deltaT*firstLame
+			// currFirstLame=deltaT*firstLame
 			itNode->FastGetSolutionStepValue(VOLUMETRIC_COEFFICIENT) = currFirstLame;
 			itNode->FastGetSolutionStepValue(DEVIATORIC_COEFFICIENT) = deviatoricCoeff;
 		}
@@ -658,7 +658,7 @@ namespace Kratos
 			typename ElementsArrayType::iterator ElemBegin = pElements.begin() + element_partition[k];
 			typename ElementsArrayType::iterator ElemEnd = pElements.begin() + element_partition[k + 1];
 
-			for (typename ElementsArrayType::iterator itElem = ElemBegin; itElem != ElemEnd; itElem++) //MSI: To be parallelized
+			for (typename ElementsArrayType::iterator itElem = ElemBegin; itElem != ElemEnd; itElem++) // MSI: To be parallelized
 			{
 				Element::GeometryType &geometry = itElem->GetGeometry();
 				double elementalVolume = 0;
@@ -715,7 +715,7 @@ namespace Kratos
 			typename ElementsArrayType::iterator ElemBegin = pElements.begin() + element_partition[k];
 			typename ElementsArrayType::iterator ElemEnd = pElements.begin() + element_partition[k + 1];
 
-			for (typename ElementsArrayType::iterator itElem = ElemBegin; itElem != ElemEnd; itElem++) //MSI: To be parallelized
+			for (typename ElementsArrayType::iterator itElem = ElemBegin; itElem != ElemEnd; itElem++) // MSI: To be parallelized
 			{
 				Element::GeometryType &geometry = itElem->GetGeometry();
 				double elementalVolume = 0;
@@ -1077,10 +1077,10 @@ namespace Kratos
 						noalias(interfaceFgrad) = ZeroMatrix(dimension, dimension);
 						noalias(interfaceFgradVel) = ZeroMatrix(dimension, dimension);
 
-						//I have to compute the stresses and strains two times because one time is for the solid and the other for the fluid
-						// Matrix interfaceFgrad=ZeroMatrix(dimension,dimension);
-						// Matrix interfaceFgradVel=ZeroMatrix(dimension,dimension);
-						//the following function is more expensive than the general one because there is one loop more over neighbour nodes. This is why I do it here also for fluid interface nodes.
+						// I have to compute the stresses and strains two times because one time is for the solid and the other for the fluid
+						//  Matrix interfaceFgrad=ZeroMatrix(dimension,dimension);
+						//  Matrix interfaceFgradVel=ZeroMatrix(dimension,dimension);
+						// the following function is more expensive than the general one because there is one loop more over neighbour nodes. This is why I do it here also for fluid interface nodes.
 						ComputeAndStoreNodalDeformationGradientForInterfaceNode(itNode, nodalSFDneighboursId, rNodalSFDneigh, theta, interfaceFgrad, interfaceFgradVel);
 						// itNode->FastGetSolutionStepValue(NODAL_DEFORMATION_GRAD)=interfaceFgrad;
 						// itNode->FastGetSolutionStepValue(NODAL_DEFORMATION_GRAD_VEL)=interfaceFgradVel;
@@ -1218,7 +1218,7 @@ namespace Kratos
 				MathUtils<double>::InvertMatrix3(Fgrad, InvFgrad, detFgrad);
 			}
 
-			//it computes the spatial velocity gradient tensor --> [L_ij]=dF_ik*invF_kj
+			// it computes the spatial velocity gradient tensor --> [L_ij]=dF_ik*invF_kj
 			SpatialVelocityGrad = prod(FgradVel, InvFgrad);
 
 			if (dimension == 2)
@@ -1390,7 +1390,7 @@ namespace Kratos
 				MathUtils<double>::InvertMatrix3(Fgrad, InvFgrad, detFgrad);
 			}
 
-			//it computes the spatial velocity gradient tensor --> [L_ij]=dF_ik*invF_kj
+			// it computes the spatial velocity gradient tensor --> [L_ij]=dF_ik*invF_kj
 			SpatialVelocityGrad = prod(FgradVel, InvFgrad);
 
 			if (dimension == 2)
@@ -1579,7 +1579,7 @@ namespace Kratos
 			// }else{
 			// 	std::cout<<"NOT INTERFACE currFirstLame "<<currFirstLame<<"  deviatoricCoeff "<<deviatoricCoeff<<std::endl;
 			// }
-			//it computes the spatial velocity gradient tensor --> [L_ij]=dF_ik*invF_kj
+			// it computes the spatial velocity gradient tensor --> [L_ij]=dF_ik*invF_kj
 			SpatialVelocityGrad = prod(FgradVel, InvFgrad);
 
 			if (dimension == 2)
@@ -1752,7 +1752,7 @@ namespace Kratos
 			nodalFgrad = itNode->FastGetSolutionStepValue(SOLID_NODAL_DEFORMATION_GRAD);
 			FgradVel = itNode->FastGetSolutionStepValue(SOLID_NODAL_DEFORMATION_GRAD_VEL);
 
-			//Inverse
+			// Inverse
 
 			if (dimension == 2)
 			{
@@ -1763,7 +1763,7 @@ namespace Kratos
 				MathUtils<double>::InvertMatrix3(nodalFgrad, InvFgrad, detFgrad);
 			}
 
-			//it computes the spatial velocity gradient tensor --> [L_ij]=dF_ik*invF_kj
+			// it computes the spatial velocity gradient tensor --> [L_ij]=dF_ik*invF_kj
 			SpatialVelocityGrad = prod(FgradVel, InvFgrad);
 
 			if (dimension == 2)
@@ -1824,7 +1824,7 @@ namespace Kratos
 			double detFgrad = 1.0;
 			Matrix InvFgrad = ZeroMatrix(dimension, dimension);
 			Matrix SpatialVelocityGrad = ZeroMatrix(dimension, dimension);
-			//Inverse
+			// Inverse
 
 			if (dimension == 2)
 			{
@@ -1835,7 +1835,7 @@ namespace Kratos
 				MathUtils<double>::InvertMatrix3(Fgrad, InvFgrad, detFgrad);
 			}
 
-			//it computes the spatial velocity gradient tensor --> [L_ij]=dF_ik*invF_kj
+			// it computes the spatial velocity gradient tensor --> [L_ij]=dF_ik*invF_kj
 			SpatialVelocityGrad = prod(FgradVel, InvFgrad);
 
 			if (dimension == 2)
@@ -1912,7 +1912,7 @@ namespace Kratos
 
 					if (nodalVolume > 0)
 					{
-						//I have to compute the strains two times because one time is for the solid and the other for the fluid
+						// I have to compute the strains two times because one time is for the solid and the other for the fluid
 						Vector nodalSFDneighboursId = itNode->FastGetSolutionStepValue(NODAL_SFD_NEIGHBOURS_ORDER);
 						Vector rNodalSFDneigh = itNode->FastGetSolutionStepValue(NODAL_SFD_NEIGHBOURS);
 
@@ -1930,7 +1930,7 @@ namespace Kratos
 
 						// Matrix interfaceFgrad    = ZeroMatrix(dimension,dimension);
 						// Matrix interfaceFgradVel = ZeroMatrix(dimension,dimension);
-						//the following function is more expensive than the general one because there is one loop more over neighbour nodes. This is why I do it here also for fluid interface nodes.
+						// the following function is more expensive than the general one because there is one loop more over neighbour nodes. This is why I do it here also for fluid interface nodes.
 						ComputeAndStoreNodalDeformationGradientForInterfaceNode(itNode, nodalSFDneighboursId, rNodalSFDneigh, theta, interfaceFgrad, interfaceFgradVel);
 						// itNode->FastGetSolutionStepValue(NODAL_DEFORMATION_GRAD)=interfaceFgrad;
 						// itNode->FastGetSolutionStepValue(NODAL_DEFORMATION_GRAD_VEL)=interfaceFgradVel;
@@ -2027,7 +2027,7 @@ namespace Kratos
 
 				if (neighSize > 0)
 				{
-					for (unsigned int i = 0; i < neighSize - 1; i++) //neigh_nodes has one cell less than nodalSFDneighboursId becuase this has also the considered node ID at the beginning
+					for (unsigned int i = 0; i < neighSize - 1; i++) // neigh_nodes has one cell less than nodalSFDneighboursId becuase this has also the considered node ID at the beginning
 					{
 						dNdXi = rNodalSFDneigh[firstRow];
 						dNdYi = rNodalSFDneigh[firstRow + 1];
@@ -2175,7 +2175,7 @@ namespace Kratos
 
 				if (neighSize > 0)
 				{
-					for (unsigned int i = 0; i < neighSize - 1; i++) //neigh_nodes has one cell less than nodalSFDneighboursId becuase this has also the considered node ID at the beginning
+					for (unsigned int i = 0; i < neighSize - 1; i++) // neigh_nodes has one cell less than nodalSFDneighboursId becuase this has also the considered node ID at the beginning
 					{
 						unsigned int other_neigh_nodes_id = nodalSFDneighboursId[i + 1];
 						for (unsigned int k = 0; k < neighNodesSize; k++)
@@ -2306,7 +2306,8 @@ namespace Kratos
 			CalculateDisplacementsAndResetNodalVariables();
 			BaseType::MoveMesh();
 			BoundaryNormalsCalculationUtilities BoundaryComputation;
-			BoundaryComputation.CalculateWeightedBoundaryNormals(rModelPart, echoLevel);
+			BoundaryComputation.CalculateUnitBoundaryNormals(rModelPart, echoLevel);
+
 			// std::cout<<"                 UpdateTopology DONE"<<std::endl;
 
 			KRATOS_CATCH("");

--- a/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/three_step_v_p_strategy.h
+++ b/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/three_step_v_p_strategy.h
@@ -133,8 +133,8 @@ namespace Kratos
       pScheme.swap(Temp);
 
       //CONSTRUCTION OF VELOCITY
-      BuilderSolverTypePointer vel_build = BuilderSolverTypePointer(new ResidualBasedEliminationBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>(pVelocityLinearSolver));
-      /* BuilderSolverTypePointer vel_build = BuilderSolverTypePointer(new ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver > (pVelocityLinearSolver)); */
+      //BuilderSolverTypePointer vel_build = BuilderSolverTypePointer(new ResidualBasedEliminationBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>(pVelocityLinearSolver));
+      BuilderSolverTypePointer vel_build = BuilderSolverTypePointer(new ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver > (pVelocityLinearSolver));
 
       this->mpMomentumStrategy = typename BaseType::Pointer(new GaussSeidelLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(rModelPart, pScheme, pVelocityLinearSolver, vel_build, ReformDofAtEachIteration, CalculateNormDxFlag));
 

--- a/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/two_step_v_p_strategy.h
+++ b/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/two_step_v_p_strategy.h
@@ -133,8 +133,8 @@ namespace Kratos
       pScheme.swap(Temp);
 
       //CONSTRUCTION OF VELOCITY
-      BuilderSolverTypePointer vel_build = BuilderSolverTypePointer(new ResidualBasedEliminationBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>(pVelocityLinearSolver));
-      /* BuilderSolverTypePointer vel_build = BuilderSolverTypePointer(new ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver > (pVelocityLinearSolver)); */
+      //BuilderSolverTypePointer vel_build = BuilderSolverTypePointer(new ResidualBasedEliminationBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>(pVelocityLinearSolver));
+      BuilderSolverTypePointer vel_build = BuilderSolverTypePointer(new ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver > (pVelocityLinearSolver));
 
       this->mpMomentumStrategy = typename BaseType::Pointer(new GaussSeidelLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(rModelPart, pScheme, pVelocityLinearSolver, vel_build, ReformDofAtEachIteration, CalculateNormDxFlag));
 


### PR DESCRIPTION
This PR adds a criterion in nodes removal close to walls for 3d cases, cleans some modules with repeated operations (unique and sort), and changes the builder and solver. It was found that the eliminationBuilderAndSolver gives memory accumulation when the remeshing employed. The blockBuilderSolver does not give this issue and it gives analagous computational cost than EliminationBuilderAndSolver