### PR TITLE
Testing shape functions second derivatives

### DIFF
--- a/kratos/utilities/geometry_tester.cpp
+++ b/kratos/utilities/geometry_tester.cpp
@@ -215,7 +215,7 @@ bool GeometryTesterUtility::StreamTestTriangle2D3N(
     VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_4, rErrorMessage);
 //         VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_5, rErrorMessage);
 
-    array_1d<double,3> point_in(geometry.Dimension(),1.0/3.0);
+    array_1d<double,2> point_in(2,1.0/3.0);
     if( !VerifyShapeFunctionsSecondDerivativesValues(geometry,point_in,rErrorMessage) ) successful = false;
 
     rErrorMessage << std::endl;
@@ -257,7 +257,7 @@ bool GeometryTesterUtility::StreamTestTriangle2D6N(
     VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_4, rErrorMessage);
 //         VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_5, rErrorMessage);
 
-    array_1d<double,3> point_in(3,1.0/3.0);
+    array_1d<double,2> point_in(2,1.0/3.0);
     if( !VerifyShapeFunctionsSecondDerivativesValues(geometry,point_in,rErrorMessage) ) successful = false;
 
     rErrorMessage << std::endl;
@@ -298,7 +298,7 @@ bool GeometryTesterUtility::StreamTestQuadrilateral2D4N(
     VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_4, rErrorMessage);
 //         VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_5, rErrorMessage);
 
-    array_1d<double,3> point_in(3,1.0/3.0);
+    array_1d<double,2> point_in(2,1.0/3.0);
     if( !VerifyShapeFunctionsSecondDerivativesValues(geometry,point_in,rErrorMessage) ) successful = false;
 
     rErrorMessage << std::endl;
@@ -341,7 +341,7 @@ bool GeometryTesterUtility::StreamTestQuadrilateral2D9N(
     VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_4, rErrorMessage);
 //         VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_5, rErrorMessage);
 
-    array_1d<double,3> point_in(3,1.0/3.0);
+    array_1d<double,2> point_in(2,1.0/3.0);
     if( !VerifyShapeFunctionsSecondDerivativesValues(geometry,point_in,rErrorMessage) ) successful = false;
 
     rErrorMessage << std::endl;
@@ -372,7 +372,7 @@ bool GeometryTesterUtility::StreamTestQuadrilateralInterface2D4N(
         successful=false;
     }
 
-    array_1d<double,3> point_in(3,1.0/3.0);
+    array_1d<double,2> point_in(2,1.0/3.0);
     if( !VerifyShapeFunctionsSecondDerivativesValues(geometry,point_in,rErrorMessage) ) successful = false;
 
     return successful;
@@ -982,7 +982,7 @@ bool GeometryTesterUtility::VerifyShapeFunctionsSecondDerivativesValues(
     Vector ei,ej,f;
 
     double delta = 1e-1;
-    unsigned int dim = rGeometry.WorkingSpaceDimension();
+    unsigned int dim = rGeometry.Dimension();
     rGeometry.ShapeFunctionsSecondDerivatives(DDN_DX,local_coordinates);
 
     if ( H.size() != rGeometry.size() )

--- a/kratos/utilities/geometry_tester.cpp
+++ b/kratos/utilities/geometry_tester.cpp
@@ -991,13 +991,13 @@ bool GeometryTesterUtility::VerifyShapeFunctionsSecondDerivativesValues(
     }
 
 
-    for ( unsigned int i = 0; i < rGeometry.size(); ++i ) H[i].resize(dim, dim, false);
+    for ( unsigned int i = 0; i < rGeometry.size(); i++ ) H[i].resize(dim, dim, false);
 
     for (unsigned int i = 0; i<dim;i++){
         for (unsigned int j = 0; j<dim;j++){
-            ei = ZeroVector(dim);
+            ei = ZeroVector(3);
             ei[i] = 1.0;
-            ej = ZeroVector(dim);
+            ej = ZeroVector(3);
             ej[j] = 1.0;
             std::transform(ei.begin(), ei.end(), ei.begin(), [delta](double &c){ return c*delta; });
             std::transform(ej.begin(), ej.end(), ej.begin(), [delta](double &c){ return c*delta; });

--- a/kratos/utilities/geometry_tester.cpp
+++ b/kratos/utilities/geometry_tester.cpp
@@ -584,9 +584,6 @@ bool GeometryTesterUtility::StreamTestPrism3D6N(
     VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_4, rErrorMessage);
     VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_5, rErrorMessage);
 
-    array_1d<double,3> point_in(3,1.0/3.0);
-    if( !VerifyShapeFunctionsSecondDerivativesValues(geometry,point_in,rErrorMessage) ) successful = false;
-
     rErrorMessage << std::endl;
 
     return successful;

--- a/kratos/utilities/geometry_tester.cpp
+++ b/kratos/utilities/geometry_tester.cpp
@@ -256,7 +256,7 @@ bool GeometryTesterUtility::StreamTestTriangle2D6N(
     VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_4, rErrorMessage);
 //         VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_5, rErrorMessage);
 
-    array_1d<double,3> point_in(geometry.Dimension(),1.0/3.0);
+    array_1d<double,3> point_in(3,1.0/3.0);
     if( !VerifyShapeFunctionsSecondDerivativesValues(geometry,point_in,rErrorMessage) ) successful = false;
 
     rErrorMessage << std::endl;
@@ -297,7 +297,7 @@ bool GeometryTesterUtility::StreamTestQuadrilateral2D4N(
     VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_4, rErrorMessage);
 //         VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_5, rErrorMessage);
 
-    array_1d<double,3> point_in(geometry.Dimension(),1.0/3.0);
+    array_1d<double,3> point_in(3,1.0/3.0);
     if( !VerifyShapeFunctionsSecondDerivativesValues(geometry,point_in,rErrorMessage) ) successful = false;
 
     rErrorMessage << std::endl;
@@ -340,7 +340,7 @@ bool GeometryTesterUtility::StreamTestQuadrilateral2D9N(
     VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_4, rErrorMessage);
 //         VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_5, rErrorMessage);
 
-    array_1d<double,3> point_in(geometry.Dimension(),1.0/3.0);
+    array_1d<double,3> point_in(3,1.0/3.0);
     if( !VerifyShapeFunctionsSecondDerivativesValues(geometry,point_in,rErrorMessage) ) successful = false;
 
     rErrorMessage << std::endl;
@@ -371,7 +371,7 @@ bool GeometryTesterUtility::StreamTestQuadrilateralInterface2D4N(
         successful=false;
     }
 
-    array_1d<double,3> point_in(geometry.Dimension(),1.0/3.0);
+    array_1d<double,3> point_in(3,1.0/3.0);
     if( !VerifyShapeFunctionsSecondDerivativesValues(geometry,point_in,rErrorMessage) ) successful = false;
 
     return successful;
@@ -1001,8 +1001,8 @@ bool GeometryTesterUtility::VerifyShapeFunctionsSecondDerivativesValues(
             ei[i] = 1.0;
             ej = ZeroVector(dim);
             ej[j] = 1.0;
-            transform(ei.begin(), ei.end(), ei.begin(), [delta](double &c){ return c*delta; });
-            transform(ej.begin(), ej.end(), ej.begin(), [delta](double &c){ return c*delta; });
+            std::transform(ei.begin(), ei.end(), ei.begin(), [delta](double &c){ return c*delta; });
+            std::transform(ej.begin(), ej.end(), ej.begin(), [delta](double &c){ return c*delta; });
             rGeometry.ShapeFunctionsValues(f_1,local_coordinates + ei + ej);
             rGeometry.ShapeFunctionsValues(f_2,local_coordinates + ei - ej);
             rGeometry.ShapeFunctionsValues(f_3,local_coordinates - ei + ej);

--- a/kratos/utilities/geometry_tester.cpp
+++ b/kratos/utilities/geometry_tester.cpp
@@ -999,14 +999,14 @@ bool GeometryTesterUtility::VerifyShapeFunctionsSecondDerivativesValues(
             ei[i] = 1.0;
             ej = ZeroVector(3);
             ej[j] = 1.0;
-            std::transform(ei.begin(), ei.end(), ei.begin(), [delta](double &c){ return c*delta; });
-            std::transform(ej.begin(), ej.end(), ej.begin(), [delta](double &c){ return c*delta; });
+            std::transform(ei.begin(), ei.end(), ei.begin(), [delta](double c){ return c*delta; });
+            std::transform(ej.begin(), ej.end(), ej.begin(), [delta](double c){ return c*delta; });
             rGeometry.ShapeFunctionsValues(f_1,local_coordinates + ei + ej);
             rGeometry.ShapeFunctionsValues(f_2,local_coordinates + ei - ej);
             rGeometry.ShapeFunctionsValues(f_3,local_coordinates - ei + ej);
             rGeometry.ShapeFunctionsValues(f_4,local_coordinates - ei - ej);
             f = f_1-f_2-f_3+f_4;
-            std::transform(f.begin(), f.end(), f.begin(), [delta](double &c){ return c/(4.0*std::pow(delta,2)); });
+            std::transform(f.begin(), f.end(), f.begin(), [delta](double c){ return c/(4.0*std::pow(delta,2)); });
             for (unsigned int k = 0; k<rGeometry.size();k++){
                 H[k](i,j) = f[k];
             }

--- a/kratos/utilities/geometry_tester.cpp
+++ b/kratos/utilities/geometry_tester.cpp
@@ -981,7 +981,7 @@ bool GeometryTesterUtility::VerifyShapeFunctionsSecondDerivativesValues(
     Vector ei,ej,f;
 
     double delta = 1e-1;
-    unsigned int dim = rGeometry.Dimension();
+    unsigned int dim = rGeometry.WorkingSpaceDimension();
     rGeometry.ShapeFunctionsSecondDerivatives(DDN_DX,local_coordinates);
 
     if ( H.size() != rGeometry.size() )

--- a/kratos/utilities/geometry_tester.cpp
+++ b/kratos/utilities/geometry_tester.cpp
@@ -215,7 +215,7 @@ bool GeometryTesterUtility::StreamTestTriangle2D3N(
     VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_4, rErrorMessage);
 //         VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_5, rErrorMessage);
 
-    array_1d<double,2> point_in(2,1.0/3.0);
+    array_1d<double,3> point_in(3,1.0/3.0);
     if( !VerifyShapeFunctionsSecondDerivativesValues(geometry,point_in,rErrorMessage) ) successful = false;
 
     rErrorMessage << std::endl;
@@ -257,7 +257,7 @@ bool GeometryTesterUtility::StreamTestTriangle2D6N(
     VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_4, rErrorMessage);
 //         VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_5, rErrorMessage);
 
-    array_1d<double,2> point_in(2,1.0/3.0);
+    array_1d<double,3> point_in(3,1.0/3.0);
     if( !VerifyShapeFunctionsSecondDerivativesValues(geometry,point_in,rErrorMessage) ) successful = false;
 
     rErrorMessage << std::endl;
@@ -298,7 +298,7 @@ bool GeometryTesterUtility::StreamTestQuadrilateral2D4N(
     VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_4, rErrorMessage);
 //         VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_5, rErrorMessage);
 
-    array_1d<double,2> point_in(2,1.0/3.0);
+    array_1d<double,3> point_in(3,1.0/3.0);
     if( !VerifyShapeFunctionsSecondDerivativesValues(geometry,point_in,rErrorMessage) ) successful = false;
 
     rErrorMessage << std::endl;
@@ -341,7 +341,7 @@ bool GeometryTesterUtility::StreamTestQuadrilateral2D9N(
     VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_4, rErrorMessage);
 //         VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_5, rErrorMessage);
 
-    array_1d<double,2> point_in(2,1.0/3.0);
+    array_1d<double,3> point_in(3,1.0/3.0);
     if( !VerifyShapeFunctionsSecondDerivativesValues(geometry,point_in,rErrorMessage) ) successful = false;
 
     rErrorMessage << std::endl;
@@ -372,7 +372,7 @@ bool GeometryTesterUtility::StreamTestQuadrilateralInterface2D4N(
         successful=false;
     }
 
-    array_1d<double,2> point_in(2,1.0/3.0);
+    array_1d<double,3> point_in(3,1.0/3.0);
     if( !VerifyShapeFunctionsSecondDerivativesValues(geometry,point_in,rErrorMessage) ) successful = false;
 
     return successful;

--- a/kratos/utilities/geometry_tester.cpp
+++ b/kratos/utilities/geometry_tester.cpp
@@ -15,6 +15,7 @@
 // System includes
 
 // External includes
+#include "spaces/ublas_space.h"
 
 // Project includes
 #include "utilities/geometry_tester.h"

--- a/kratos/utilities/geometry_tester.cpp
+++ b/kratos/utilities/geometry_tester.cpp
@@ -1006,7 +1006,7 @@ bool GeometryTesterUtility::VerifyShapeFunctionsSecondDerivativesValues(
             rGeometry.ShapeFunctionsValues(f_3,local_coordinates - ei + ej);
             rGeometry.ShapeFunctionsValues(f_4,local_coordinates - ei - ej);
             f = f_1-f_2-f_3+f_4;
-            transform(f.begin(), f.end(), f.begin(), [delta](double &c){ return c/(4.0*std::pow(delta,2)); });
+            std::transform(f.begin(), f.end(), f.begin(), [delta](double &c){ return c/(4.0*std::pow(delta,2)); });
             for (unsigned int k = 0; k<rGeometry.size();k++){
                 H[k](i,j) = f[k];
             }

--- a/kratos/utilities/geometry_tester.cpp
+++ b/kratos/utilities/geometry_tester.cpp
@@ -15,11 +15,8 @@
 // System includes
 
 // External includes
-#include <cmath>
-// Project includes
-#include "utilities/math_utils.h"
-#include "spaces/ublas_space.h"
 
+// Project includes
 #include "utilities/geometry_tester.h"
 #include "includes/element.h"
 

--- a/kratos/utilities/geometry_tester.cpp
+++ b/kratos/utilities/geometry_tester.cpp
@@ -1012,16 +1012,16 @@ bool GeometryTesterUtility::VerifyShapeFunctionsSecondDerivativesValues(
             rGeometry.ShapeFunctionsValues(f_4,local_coordinates - ei - ej);
             f = f_1-f_2-f_3+f_4;
             transform(f.begin(), f.end(), f.begin(), [delta](double &c){ return c/(4.0*std::pow(delta,2)); });
-            for (unsigned int g = 0; g<rGeometry.size();g++){
-                H[g](i,j) = f[g];
+            for (unsigned int k = 0; k<rGeometry.size();k++){
+                H[k](i,j) = f[k];
             }
         }
     }
 
-    for (unsigned int g = 0; g<rGeometry.size();g++){
-        if(norm_frobenius(DDN_DX[g] - H[g])/norm_frobenius(H[g]) > 1e-13) {
-            rErrorMessage << "     error: shape function second derivatives are wrongly calculated in function ShapeFunctionsSecondDerivatives: DDN_DX[point_number] " << DDN_DX[g] << " vs " << H[g] << std::endl;
-            rErrorMessage << " norm_frobenius(DDN_DX[point_number] - H[point_number])/norm_frobenius(H[point_number]) = " << norm_frobenius(DDN_DX[g] - H[g])/norm_frobenius(H[g]) <<std::endl;
+    for (unsigned int i = 0; i<rGeometry.size();i++){
+        if(norm_frobenius(DDN_DX[i] - H[i]) > 1e-13) {
+            rErrorMessage << "     error: shape function second derivatives are wrongly calculated in function ShapeFunctionsSecondDerivatives: DDN_DX[point_number] " << DDN_DX[i] << " vs " << H[i] << std::endl;
+            rErrorMessage << " norm_frobenius(DDN_DX[point_number] - H[point_number])/norm_frobenius(H[point_number]) = " << norm_frobenius(DDN_DX[i] - H[i])/norm_frobenius(H[i]) <<std::endl;
             return false;
         }
     }

--- a/kratos/utilities/geometry_tester.h
+++ b/kratos/utilities/geometry_tester.h
@@ -70,6 +70,8 @@ public:
     /// Geometry type
     typedef Geometry<NodeType> GeometryType;
 
+    typedef typename GeometryType::ShapeFunctionsSecondDerivativesType ShapeFunctionsSecondDerivativesType;
+
     ///@}
     ///@name Life Cycle
     ///@{
@@ -444,10 +446,10 @@ private:
      * @param ReferenceArea The reference area
      * @param rErrorMessage The error message
      */
-    bool VerifyAreaByIntegration( 
-        GeometryType& rGeometry, 
-        GeometryType::IntegrationMethod ThisMethod, 
-        const double ReferanceArea, 
+    bool VerifyAreaByIntegration(
+        GeometryType& rGeometry,
+        GeometryType::IntegrationMethod ThisMethod,
+        const double ReferanceArea,
         std::stringstream& rErrorMessage
         );
 
@@ -458,9 +460,9 @@ private:
      * @param ThisMethod The integration method
      * @param rErrorMessage The error message
      */
-    void VerifyStrainExactness( 
-        GeometryType& rGeometry,  
-        GeometryType::IntegrationMethod ThisMethod, 
+    void VerifyStrainExactness(
+        GeometryType& rGeometry,
+        GeometryType::IntegrationMethod ThisMethod,
         std::stringstream& rErrorMessage
         );
 
@@ -507,13 +509,26 @@ private:
         );
 
     /**
+     * @brief This function verifies the shape functions second derivatives
+     * @param rGeometry The geometry
+     * @param rGlobalCoordinates The global coordinates
+     * @param rErrorMessage The error message
+     * @return true If teh test fails, true otherwise¡
+     */
+    bool VerifyShapeFunctionsSecondDerivativesValues(
+        GeometryType& rGeometry,
+        GeometryType::CoordinatesArrayType& rGlobalCoordinates,
+        std::stringstream& rErrorMessage
+        );
+
+    /**
      * @brief Get the name of the intergration method
      * @param rGeometry The geometry
      * @param ThisMethod The integration method
      * @return The integration method name
      */
     std::string GetIntegrationName(
-        GeometryType& rGeometry, 
+        GeometryType& rGeometry,
         GeometryType::IntegrationMethod ThisMethod
         );
 


### PR DESCRIPTION
**📝 Description**
This PR is aimed to test the shape functions second derivatives. The Hessian matrix of the shape functions is computed and compared with the provided from `ShapeFunctionsSecondDerivatives`.

Tags: 
- Testing

**🆕 Changelog**

- Adding `VerifyShapeFunctionsSecondDerivativesValues` function in `geometry_tester.cpp`