### PR TITLE
[FastPR][Core] Minor improvement in automatic differentiation utilities

### DIFF
--- a/kratos/python_scripts/sympy_fe_utilities.py
+++ b/kratos/python_scripts/sympy_fe_utilities.py
@@ -193,9 +193,10 @@ def DoubleContraction(A,B):
     - A -- Left tensor
     - B -- Right tensor
     """
+    rank_A = len(A.shape)
     AB = sympy.tensorproduct(A,B)
-    tmp = sympy.tensorcontraction(AB, (A.rank()-1,A.rank()+1))
-    output = sympy.tensorcontraction(tmp, (A.rank()-2,A.rank()-1))
+    tmp = sympy.tensorcontraction(AB, (rank_A-1,rank_A+1))
+    output = sympy.tensorcontraction(tmp, (rank_A-2,rank_A-1))
     return output
 
 def MatrixB(DN):
@@ -391,6 +392,7 @@ def Compute_RHS(functional, testfunc, do_simplifications=False):
     """
     rhs = sympy.Matrix(sympy.zeros(testfunc.shape[0],1))
     for i in range(testfunc.shape[0]):
+        print(i)
         rhs[i] = sympy.diff(functional[0,0], testfunc[i])
 
         if do_simplifications:

--- a/kratos/python_scripts/sympy_fe_utilities.py
+++ b/kratos/python_scripts/sympy_fe_utilities.py
@@ -392,7 +392,6 @@ def Compute_RHS(functional, testfunc, do_simplifications=False):
     """
     rhs = sympy.Matrix(sympy.zeros(testfunc.shape[0],1))
     for i in range(testfunc.shape[0]):
-        print(i)
         rhs[i] = sympy.diff(functional[0,0], testfunc[i])
 
         if do_simplifications:


### PR DESCRIPTION
**📝 Description**
I've experienced some weird things when using the `DoubleContraction` implemented in the `sympy_fe_utilities.py` with symbolic arrays. These are caused by the `rank` function, which is not returning the expected value. Besides, it is extremely slow. Instead, the length of the matrix shape can be used. 
