### PR TITLE
[Core] fix generic find elements neighbors in mpi

### DIFF
--- a/kratos/processes/generic_find_elements_neighbours_process.h
+++ b/kratos/processes/generic_find_elements_neighbours_process.h
@@ -155,7 +155,8 @@ private:
 
 
     GlobalPointer<Element> CheckForNeighbourElems (const Geometry<Node<3> >& rBoundaryGeom,
-                                                   Element & rElement);
+                                                   Element & rElement,
+                                                   const int Rank);
 
 
     ///@}


### PR DESCRIPTION
**📝 Description**
This process was failing in mpi as some point, (line 83), it was asking the id of the element to make sure it was not the same as the main one.
Of course, this cannot be done in mpi as you cannot access the element if its in another region. However, if the element is in a different region we do not need to check the id, as for sure, it will not be the same element if they are in different cores.

Adding @pablobecker as the change comes mainly from him.


**🆕 Changelog**
- Fix segmentation fault in mpi in the generic process to find elements neighbours
