### PR TITLE
Updated the CODEOWNERS github file to point to kratos geomechanics team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,3 +32,4 @@
 /applications/MultilevelMonteCarloApplication/         @KratosMultiphysics/uncertainty-quantification
 /applications/ParticleMechanicsApplication/            @KratosMultiphysics/mpm
 /applications/RomApplication/                          @KratosMultiphysics/rom
+/applications/GeoMechanicsApplication/.................@KratosMultiphysics/geomechanics


### PR DESCRIPTION
**📝 Description**
Forwarding codeowner changes from #9981 

Since there has been an increment in PR to the Geomechanics app and the original PR seems to be stuck because of some problems in Debug I think it will be usefull to fast-lane the owner changes so all people involved in Geomechanics gets notified when changes are made.


**🆕 Changelog**
- Forwarding Codeowner changes for Geomechanics