### PR TITLE
New windows base image

### DIFF
--- a/.github/workflows/build_docker_images_for_ci_centos.yml
+++ b/.github/workflows/build_docker_images_for_ci_centos.yml
@@ -7,23 +7,23 @@ on:
     branches:
       - 'master'
     paths:
-      - 'scripts/docker_files/docker_file_ci_windows/*'
-      - '.github/workflows/build_docker_images_for_ci_windows.yml'
+      - 'scripts/docker_files/docker_file_ci_centos_7/*'
+      - '.github/workflows/build_docker_images_for_ci_centos.yml'
   pull_request:
     branches:
       - 'master'
     paths:
-      - 'scripts/docker_files/docker_file_ci_windows/*'
-      - '.github/workflows/build_docker_images_for_ci_windows.yml'
+      - 'scripts/docker_files/docker_file_ci_centos_7/*'
+      - '.github/workflows/build_docker_images_for_ci_centos.yml'
 
 jobs:
-  build-docker-windows:
-    runs-on: windows-2022
+  build-docker-centos:
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
     - name: Build the Docker image
-      run: docker build . --file scripts/docker_files/docker_file_ci_windows/DockerFile --tag kratosmultiphysics/kratos-image-ci-windows
+      run: docker build . --file scripts/docker_files/docker_file_ci_centos_7/DockerFile --tag kratosmultiphysics/kratos-image-ci-centos7
     - name: Docker Login
       uses: azure/docker-login@v1
       with:
@@ -32,4 +32,4 @@ jobs:
     - name: Publish the Docker image
       if: ${{ github.event_name == 'push'}}
       # only push the new image when the changes are merged to master
-      run: docker push kratosmultiphysics/kratos-image-ci-windows
+      run: docker push kratosmultiphysics/kratos-image-ci-centos7

--- a/.github/workflows/build_docker_images_for_ci_ubuntu.yml
+++ b/.github/workflows/build_docker_images_for_ci_ubuntu.yml
@@ -8,15 +8,13 @@ on:
       - 'master'
     paths:
       - 'scripts/docker_files/docker_file_ci_ubuntu_20_04/*'
-      - 'scripts/docker_files/docker_file_ci_centos_7/*'
-      - '.github/workflows/build_docker_images_for_ci.yml'
+      - '.github/workflows/build_docker_images_for_ci_ubuntu.yml'
   pull_request:
     branches:
       - 'master'
     paths:
       - 'scripts/docker_files/docker_file_ci_ubuntu_20_04/*'
-      - 'scripts/docker_files/docker_file_ci_centos_7/*'
-      - '.github/workflows/build_docker_images_for_ci.yml'
+      - '.github/workflows/build_docker_images_for_ci_ubuntu.yml'
 
 jobs:
   build-docker-ubuntu:
@@ -35,20 +33,3 @@ jobs:
       if: ${{ github.event_name == 'push'}}
       # only push the new image when the changes are merged to master
       run: docker push kratosmultiphysics/kratos-image-ci-ubuntu-20-04
-
-  build-docker-centos:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Build the Docker image
-      run: docker build . --file scripts/docker_files/docker_file_ci_centos_7/DockerFile --tag kratosmultiphysics/kratos-image-ci-centos7
-    - name: Docker Login
-      uses: azure/docker-login@v1
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
-    - name: Publish the Docker image
-      if: ${{ github.event_name == 'push'}}
-      # only push the new image when the changes are merged to master
-      run: docker push kratosmultiphysics/kratos-image-ci-centos7

--- a/.github/workflows/build_docker_images_for_ci_windows.yml
+++ b/.github/workflows/build_docker_images_for_ci_windows.yml
@@ -1,0 +1,35 @@
+name: Build Docker Images for CI
+# this workflow creates the Docker-Images used in the Continuous Integration (CI)
+# It intentionally creates all images, such that they are on the same state
+
+on:
+  push:
+    branches:
+      - 'master'
+    paths:
+      - 'scripts/docker_files/docker_file_ci_windows/*'
+      - '.github/workflows/build_docker_images_for_ci_windows.yml'
+  pull_request:
+    branches:
+      - 'master'
+    paths:
+      - 'scripts/docker_files/docker_file_ci_windows/*'
+      - '.github/workflows/build_docker_images_for_ci_windows.yml'
+
+jobs:
+  build-docker-ubuntu:
+    runs-on: windows-2022
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file scripts/docker_files/docker_file_ci_windows/DockerFile --tag kratosmultiphysics/kratos-image-ci-windows
+    - name: Docker Login
+      uses: azure/docker-login@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+    - name: Publish the Docker image
+      if: ${{ github.event_name == 'push'}}
+      # only push the new image when the changes are merged to master
+      run: docker push kratosmultiphysics/kratos-image-ci-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,26 +125,12 @@ jobs:
     runs-on: windows-2022
     env:
       KRATOS_BUILD_TYPE: Custom
+    container:
+      image: kratosmultiphysics/kratos-image-ci-windows:latest
+      options: --user 1001
 
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: '3.8'
-
-    - name: Download boost
-      run: |
-        $url = "https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.gz/download"
-        (New-Object System.Net.WebClient).DownloadFile($url, "$env:TEMP\boost.tar.gz")
-        7z.exe x "$env:TEMP\boost.tar.gz" -o"$env:TEMP\boostArchive" -y | Out-Null
-        7z.exe x "$env:TEMP\boostArchive" -o"$env:TEMP\boost" -y | Out-Null
-
-    - name: Installing dependencies
-      shell: cmd
-      run: |
-        pip install numpy
-        pip install sympy
-        pip install h5py
 
     - name: Build
       shell: cmd
@@ -157,7 +143,7 @@ jobs:
       run: |
         set PYTHONPATH=%PYTHONPATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%
         set PATH=%PATH%;%GITHUB_WORKSPACE%/bin/%KRATOS_BUILD_TYPE%/libs
-        python kratos/python_scripts/run_tests.py -l nightly -c python
+        c:\python\38\python.exe kratos/python_scripts/run_tests.py -l nightly -c c:\python\38\python.exe
 
   centos:
     runs-on: ubuntu-latest

--- a/.github/workflows/configure.cmd
+++ b/.github/workflows/configure.cmd
@@ -7,6 +7,9 @@ set KRATOS_SOURCE=%cd%
 set KRATOS_BUILD=%cd%\build
 set KRATOS_APP_DIR=applications
 
+set BOOST_ROOT=%BOOST%
+set PYTHON_EXECUTABLE="c:\python\38\python.exe"
+
 set KRATOS_APPLICATIONS=
 set KRATOS_APPLICATIONS=%KRATOS_APPLICATIONS%%KRATOS_APP_DIR%\ConvectionDiffusionApplication;
 set KRATOS_APPLICATIONS=%KRATOS_APPLICATIONS%%KRATOS_APP_DIR%\FluidDynamicsApplication;

--- a/scripts/docker_files/docker_file_ci_windows/Dockerfile
+++ b/scripts/docker_files/docker_file_ci_windows/Dockerfile
@@ -39,9 +39,14 @@ RUN powershell.exe -Command \
 #download and extract boost
 RUN powershell.exe -Command \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.gz/download -OutFile c:\TEMP\boost.zip; \
-    mkdir c:\boost; \
-    7z x c:\TEMP\boost.zip -o"c:\boost"
+    wget https://altushost-swe.dl.sourceforge.net/project/boost/boost/1.74.0/boost_1_74_0.tar.gz -OutFile c:\TEMP\boost.tar.gz; \
+    mkdir c:\boost;
+
+#Decompress and clean
+RUN powershell.exe -Command \
+    ls c:\TEMP; \
+    7z x "c:\TEMP\boost.tar.gz" -o"c:\boost"; \
+    rm "c:\TEMP\boost.tar.gz"
 
 #Install python 3.8
 RUN powershell.exe -Command \
@@ -59,8 +64,6 @@ ENV VCVARS      "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTo
 ENV BOOST       "C:\\boost\\boost_1_71_0"
 ENV PYTHONROOT  "C:\\python"
 
-COPY start.ps1 c:\\scripts\\start.ps1
-
 # Default to PowerShell if no other command specified.
-ENTRYPOINT ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass", "-Command", "c:\\scripts\\start.ps1"]
+CMD ["powershell.exe"]
 

--- a/scripts/docker_files/docker_file_ci_windows/Dockerfile
+++ b/scripts/docker_files/docker_file_ci_windows/Dockerfile
@@ -39,7 +39,7 @@ RUN powershell.exe -Command \
 #download and extract boost
 RUN powershell.exe -Command \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.zip -OutFile c:\TEMP\boost.zip; \
+    wget https://sourceforge.net/projects/boost/files/boost/1.74.0/boost_1_74_0.tar.gz/download -OutFile c:\TEMP\boost.zip; \
     mkdir c:\boost; \
     7z x c:\TEMP\boost.zip -o"c:\boost"
 

--- a/scripts/docker_files/docker_file_ci_windows/Dockerfile
+++ b/scripts/docker_files/docker_file_ci_windows/Dockerfile
@@ -41,7 +41,7 @@ RUN powershell.exe -Command \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
     wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.zip -OutFile c:\TEMP\boost.zip; \
     mkdir c:\boost; \
-    7z x c:\TEMP\boost.zip -o "c:\boost"
+    7z x c:\TEMP\boost.zip -o"c:\boost"
 
 #Install python 3.8
 RUN powershell.exe -Command \

--- a/scripts/docker_files/docker_file_ci_windows/Dockerfile
+++ b/scripts/docker_files/docker_file_ci_windows/Dockerfile
@@ -1,0 +1,66 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2019
+
+# Restore the default Windows shell for correct batch processing below.
+SHELL ["cmd", "/S", "/C"]
+
+# Download the Build Tools bootstrapper.
+RUN powershell.exe -Command \
+	mkdir c:\TEMP; \
+    wget https://aka.ms/vs/16/release/vs_buildtools.exe -OutFile c:\TEMP\vs_buildtools.exe
+
+# Install Build Tools
+RUN C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache \
+    --add Microsoft.VisualStudio.Product.BuildTools \
+    --add Microsoft.VisualStudio.Workload.VCTools \
+    --add Microsoft.VisualStudio.Component.VC.CMake.Project \
+    --add Microsoft.VisualStudio.Component.Windows10SDK.17763 \
+    --add Microsoft.VisualStudio.Component.TestTools.BuildTools \
+    --add Microsoft.VisualStudio.Component.VC.140 \
+ || IF "%ERRORLEVEL%"=="3010" EXIT 0 ; \
+ 	$ErrorActionPreference = 'Stop'
+
+#install chocolatey
+RUN powershell.exe -Command \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    iex ((New-Object System.Net.WebClient).DownloadString('http://chocolatey.org/install.ps1'))
+
+#install git
+RUN powershell.exe -Command \
+    choco install -y 7zip.install
+
+#install git
+RUN powershell.exe -Command \
+    choco install -y git
+
+#install cmake
+RUN powershell.exe -Command \
+    choco install -y cmake
+
+#download and extract boost
+RUN powershell.exe -Command \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    wget https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.zip -OutFile c:\TEMP\boost.zip; \
+    mkdir c:\boost; \
+    7z x c:\TEMP\boost.zip -o "c:\boost"
+
+#Install python 3.8
+RUN powershell.exe -Command \
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+    wget https://www.python.org/ftp/python/3.8.2/python-3.8.2-amd64.exe -OutFile c:\temp\python38.exe; \
+    mkdir c:\python\38; \
+    Start-Process c:\temp\python38.exe -ArgumentList '/quiet InstallAllUsers=1 PrependPath=0 TargetDir=c:\\python\\38' -Wait; \
+    c:\python\38\python.exe -m pip install --upgrade pip; \
+    c:\python\38\python.exe -m pip install --upgrade numpy sympy h5py
+
+#set env variables
+ENV CMAKE       "C:\\cmake\\cmake-3.14.1-win64-x64\\bin\\cmake.exe"
+ENV SEVEN_ZIP   "C:\\7zip\\7z.exe"
+ENV VCVARS      "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Auxiliary\\Build\\vcvars64.bat\\"
+ENV BOOST       "C:\\boost\\boost_1_71_0"
+ENV PYTHONROOT  "C:\\python"
+
+COPY start.ps1 c:\\scripts\\start.ps1
+
+# Default to PowerShell if no other command specified.
+ENTRYPOINT ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass", "-Command", "c:\\scripts\\start.ps1"]
+

--- a/scripts/docker_files/docker_file_ci_windows/Dockerfile
+++ b/scripts/docker_files/docker_file_ci_windows/Dockerfile
@@ -6,14 +6,14 @@ SHELL ["cmd", "/S", "/C"]
 # Download the Build Tools bootstrapper.
 RUN powershell.exe -Command \
 	mkdir c:\TEMP; \
-    wget https://aka.ms/vs/16/release/vs_buildtools.exe -OutFile c:\TEMP\vs_buildtools.exe
+    wget https://aka.ms/vs/17/release/vs_buildtools.exe -OutFile c:\TEMP\vs_buildtools.exe
 
 # Install Build Tools
 RUN C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache \
     --add Microsoft.VisualStudio.Product.BuildTools \
     --add Microsoft.VisualStudio.Workload.VCTools \
     --add Microsoft.VisualStudio.Component.VC.CMake.Project \
-    --add Microsoft.VisualStudio.Component.Windows10SDK.17763 \
+    --add Microsoft.VisualStudio.Component.Windows10SDK.19041 \
     --add Microsoft.VisualStudio.Component.TestTools.BuildTools \
     --add Microsoft.VisualStudio.Component.VC.140 \
  || IF "%ERRORLEVEL%"=="3010" EXIT 0 ; \


### PR DESCRIPTION
**📝 Description**
A new base image that include boost + pip dependencies so we don't have to download them every time. That should prevent most of the latest error about "boost cannot be downloaded" because Sourceforge...

Also I split the current docker build workflows and created a new one so only the proper image get re-built when changes happen.

**🆕 Changelog**
- Added new default windows building env.
- Split the build workflows for ubuntu and centos
- Added new workflow to build win