### PR TITLE
[Core] Adding missing Access methods to PointerVectorSet 

### DIFF
--- a/kratos/containers/pointer_vector_map.h
+++ b/kratos/containers/pointer_vector_map.h
@@ -486,14 +486,6 @@ public:
     /**
      * @brief Get the maximum size of buffer used in the container.
      */
-    size_type GetMaxBufferSize()
-    {
-        return mMaxBufferSize;
-    }
-
-    /**
-     * @brief Get the maximum size of buffer used in the container (const version)
-     */
     size_type GetMaxBufferSize() const 
     {
         return mMaxBufferSize;
@@ -511,14 +503,6 @@ public:
 
     /**
      * @brief Get the sorted part size of buffer used in the container.
-     */
-    size_type GetSortedPartSize()
-    {
-        return mSortedPartSize;
-    }
-
-    /**
-     * @brief Get the sorted part size of buffer used in the container. (const version)
      */
     size_type GetSortedPartSize() const 
     {

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -489,15 +489,7 @@ public:
     }
 
     /**
-     * @brief Get the maximum size of buffer used in the container.
-     */
-    size_type GetMaxBufferSize()
-    {
-        return mMaxBufferSize;
-    }
-
-    /**
-     * @brief Get the maximum size of buffer used in the container (const version)
+     * @brief Get the maximum size of buffer used in the container
      */
     size_type GetMaxBufferSize() const 
     {
@@ -515,15 +507,7 @@ public:
     }
 
     /**
-     * @brief Get the sorted part size of buffer used in the container.
-     */
-    size_type GetSortedPartSize()
-    {
-        return mSortedPartSize;
-    }
-
-    /**
-     * @brief Get the sorted part size of buffer used in the container. (const version)
+     * @brief Get the sorted part size of buffer used in the container. 
      */
     size_type GetSortedPartSize() const 
     {

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -488,19 +488,56 @@ public:
         return mData;
     }
 
+    /**
+     * @brief Get the maximum size of buffer used in the container.
+     */
+    size_type GetMaxBufferSize()
+    {
+        return mMaxBufferSize;
+    }
 
-    /** Set the maximum size of buffer used in the container.
+    /**
+     * @brief Get the maximum size of buffer used in the container (const version)
+     */
+    size_type GetMaxBufferSize() const 
+    {
+        return mMaxBufferSize;
+    }
 
-    This container uses a buffer which keep data unsorted. After
-    buffer size arrived to the MaxBufferSize it will sort all
-    container and empties buffer.
-
-    @param NewSize Is the new buffer maximum size. */
-    void SetMaxBufferSize(size_type NewSize)
+    /** 
+     * @brief Set the maximum size of buffer used in the container.
+     * @details This container uses a buffer which keep data unsorted. After buffer size arrived to the MaxBufferSize it will sort all container and empties buffer.
+     * @param NewSize Is the new buffer maximum size. 
+     */
+    void SetMaxBufferSize(const size_type NewSize)
     {
         mMaxBufferSize = NewSize;
     }
 
+    /**
+     * @brief Get the sorted part size of buffer used in the container.
+     */
+    size_type GetSortedPartSize()
+    {
+        return mSortedPartSize;
+    }
+
+    /**
+     * @brief Get the sorted part size of buffer used in the container. (const version)
+     */
+    size_type GetSortedPartSize() const 
+    {
+        return mSortedPartSize;
+    }
+
+    /** 
+     * @brief Set the sorted part size of buffer used in the container.
+     * @param NewSize Is the new buffer maximum size. 
+     */
+    void SetSortedPartSize(const size_type NewSize)
+    {
+        mSortedPartSize = NewSize;
+    }
 
     ///@}
     ///@name Inquiry


### PR DESCRIPTION
**📝 Description**
Adding missing Access methods to PointerVectorSet, making the inteface inconsistent. this is part of afuture and more complex PR.

**🆕 Changelog**
- Added GetMaxBufferSize
- Added GetSortedPartSize/SetSortedPartSize