### PR TITLE
[HDF5] Fix XDMF Tests

### DIFF
--- a/applications/HDF5Application/tests/test_hdf5_xdmf.py
+++ b/applications/HDF5Application/tests/test_hdf5_xdmf.py
@@ -260,14 +260,14 @@ class TestFindMatchingFiles(KratosUnittest.TestCase):
 class TestCreateXdmfTemporalGridFromMultifile(KratosUnittest.TestCase):
 
     def setUp(self):
-        with h5py.File("kratos.h5") as f0:
+        with h5py.File("kratos.h5", "w") as f0:
             f0.create_dataset(
             "/ModelPart/Nodes/Local/Coordinates", (15, 3), "float64")
             elem2d4n = f0.create_group("/ModelPart/Xdmf/Elements/Element2D4N")
             elem2d4n.attrs["Dimension"] = 2
             elem2d4n.attrs["NumberOfNodes"] = 4
             elem2d4n.create_dataset("Connectivities", (10, 4), "int32")
-        with h5py.File("kratos-1.0.h5") as f1:
+        with h5py.File("kratos-1.0.h5", "w") as f1:
             f1.create_dataset(
             "/Results/NodalSolutionStepData/VELOCITY", (15, 3), "float64")
 


### PR DESCRIPTION
If no flag is passed to the ```h5py.File``` context, ```h5py``` opens files for reading by default, which led to errors in the XDMF test setups. This commit adds the necessary flag to open files for writing.