### PR TITLE
[Core] Templatized IntervalUtility Parameters Setters/Getters

### DIFF
--- a/kratos/includes/kratos_parameters.h
+++ b/kratos/includes/kratos_parameters.h
@@ -518,6 +518,14 @@ public:
     bool IsMatrix() const;
 
     /**
+     * @brief Templetized type checker for supported types.
+     * @details Supported types: double, int, bool, std::string, @ref Vector, @ref Matrix.
+     * @tparam TValue: type of the value to parse.
+     */
+    template <class TValue>
+    bool Is() const;
+
+    /**
      * @brief This method checks if the parameter is a subparameter
      * @return True if it is a suparameter, false otherwise
      */
@@ -566,6 +574,14 @@ public:
     Matrix GetMatrix() const;
 
     /**
+     * @brief Templetized getter for supported types.
+     * @details Supported types: double, int, bool, std::string, @ref Vector, @ref Matrix.
+     * @tparam TValue: type of the value to parse and return.
+     */
+    template <class TValue>
+    TValue Get() const;
+
+    /**
      * @brief This method sets the double contained in the current Parameter
      * @param Value The double value
      */
@@ -606,6 +622,15 @@ public:
      * @param Value The matrix value
      */
     void SetMatrix(const Matrix& rValue);
+
+    /**
+     * @brief Templetized setter for supported types.
+     * @details Supported types: double, int, bool, std::string, @ref Vector, @ref Matrix.
+     * @tparam TValue: type of the value to be set.
+     * @param rValue: value to be written to the JSON.
+     */
+    template <class TValue>
+    void Set(const TValue& rValue);
 
     /**
      * @brief This method adds a new double Parameter

--- a/kratos/includes/kratos_parameters.h
+++ b/kratos/includes/kratos_parameters.h
@@ -383,7 +383,7 @@ public:
      * @brief Generates a clone of the current document
      * @return A clone of the given Parameters
      */
-    Parameters Clone();
+    Parameters Clone() const;
 
     /**
      * @brief This method returns a string with the corresponding text to the equivalent *.json file

--- a/kratos/sources/kratos_parameters.cpp
+++ b/kratos/sources/kratos_parameters.cpp
@@ -629,6 +629,30 @@ Matrix Parameters::GetMatrix() const
 /***********************************************************************************/
 /***********************************************************************************/
 
+#define KRATOS_DEFINE_PARAMETERS_VALUE_ACCESSORS(TYPE, TYPE_NAME)                                \
+    template <> bool Parameters::Is<TYPE>() const {return this->Is ## TYPE_NAME();}              \
+    template <> TYPE Parameters::Get<TYPE>() const {return this->Get ## TYPE_NAME();}            \
+    template <> void Parameters::Set<TYPE>(const TYPE& rValue) {this->Set ## TYPE_NAME(rValue);}
+
+KRATOS_DEFINE_PARAMETERS_VALUE_ACCESSORS(double, Double)
+
+KRATOS_DEFINE_PARAMETERS_VALUE_ACCESSORS(int, Int)
+
+KRATOS_DEFINE_PARAMETERS_VALUE_ACCESSORS(bool, Bool)
+
+KRATOS_DEFINE_PARAMETERS_VALUE_ACCESSORS(std::string, String)
+
+//KRATOS_DEFINE_PARAMETERS_VALUE_ACCESSORS(std::vector<std::string>, StringArray) // <== missing Parameters::IsStringArray()
+
+KRATOS_DEFINE_PARAMETERS_VALUE_ACCESSORS(Vector, Vector)
+
+KRATOS_DEFINE_PARAMETERS_VALUE_ACCESSORS(Matrix, Matrix)
+
+#undef KRATOS_DEFINE_PARAMETERS_VALUE_ACCESSORS
+
+/***********************************************************************************/
+/***********************************************************************************/
+
 void Parameters::SetDouble(const double Value)
 {
     *mpValue=Value;

--- a/kratos/sources/kratos_parameters.cpp
+++ b/kratos/sources/kratos_parameters.cpp
@@ -303,7 +303,7 @@ Parameters& Parameters::operator=(Parameters&& rOther)
 /***********************************************************************************/
 /***********************************************************************************/
 
-Parameters Parameters::Clone()
+Parameters Parameters::Clone() const
 {
     //TODO: make a clone
     //TODO: find a better way to make the copy

--- a/kratos/sources/kratos_parameters.cpp
+++ b/kratos/sources/kratos_parameters.cpp
@@ -658,27 +658,6 @@ bool Parameters::Is<Parameters>() const
     return this->IsSubParameter();
 }
 
-template <>
-Parameters Parameters::Get<Parameters>() const
-{
-    // To return by "reference" (return *this) or not to return by "reference" (return this->Clone())?
-    // Other specializations of this function template return by value
-    // (cannot change the value stored here), so this should behave
-    // similarly as well, at the expense of performance.
-    return this->Clone();
-}
-
-template <>
-void Parameters::Set<Parameters>(const Parameters& rValue)
-{
-    // This is dangerous when the value to be set is
-    // a subparameter of the current object. The user
-    // is expected to consider and avoid this possibility,
-    // and this scenario is not checked here for performance
-    // reasons.
-    *this = rValue;
-}
-
 /***********************************************************************************/
 /***********************************************************************************/
 

--- a/kratos/sources/kratos_parameters.cpp
+++ b/kratos/sources/kratos_parameters.cpp
@@ -650,6 +650,35 @@ KRATOS_DEFINE_PARAMETERS_VALUE_ACCESSORS(Matrix, Matrix)
 
 #undef KRATOS_DEFINE_PARAMETERS_VALUE_ACCESSORS
 
+// Is, Get, and Set for subparameters
+
+template <>
+bool Parameters::Is<Parameters>() const
+{
+    return this->IsSubParameter();
+}
+
+template <>
+Parameters Parameters::Get<Parameters>() const
+{
+    // To return by "reference" (return *this) or not to return by "reference" (return this->Clone())?
+    // Other specializations of this function template return by value
+    // (cannot change the value stored here), so this should behave
+    // similarly as well, at the expense of performance.
+    return this->Clone();
+}
+
+template <>
+void Parameters::Set<Parameters>(const Parameters& rValue)
+{
+    // This is dangerous when the value to be set is
+    // a subparameter of the current object. The user
+    // is expected to consider and avoid this possibility,
+    // and this scenario is not checked here for performance
+    // reasons.
+    *this = rValue;
+}
+
 /***********************************************************************************/
 /***********************************************************************************/
 


### PR DESCRIPTION
## Description
This commit makes querying and manipulating values in ```Parameters``` template-friendly, eliminating potential code duplication later on. The following member templates (and their explicit specializations) are added to ```Parameters```:
- ```template <class TValue> bool Parameters::Is() const;```
- ```template <class TValue> TValue Parameters::Get() const;```
- ```template <class TValue> void Parameters::Set(const TValue&);```

These specializations redirect to their corresponding setters/getters (eg.: ```Parameters::GetDouble```), but the implementations of the original members could be trivially moved into the specializations, should we later decide to keep only the templated interface. Updating the rest of the repository would then involve just a simple grep+replace.

## Example
Let's say you wanted to extend ```IntervalUtility``` to ```int``` in order to check ```STEP``` as well as ```TIME``` intervals (```IntervalUtility``` isn't implemented like this but just go with the example). Setting the interval currently would require overloads or specialization, resulting in a lot of duplicate code.
```cpp
template <class TValue>
class IntervalUtility {...};

void IntervalUtility<double>::SetInterval(Parameters IntervalParameters)
{
    begin_parameter = IntervalParameters["interval"][0];
    end_parameter = IntervalParameters["interval"][1];

    mBegin = begin_parameter.GetDouble();
    if (end_parameter.IsString()) {
        if (end_parameter.GetString() == "End") {
            mEnd = std::numeric_limits<double>::max();
        } else {
            KRATOS_ERROR << ...;
        }
    } else if (end_parameter.IsDouble()) {
        mEnd = end_parameter.GetDouble();
    } else {
        KRATOS_ERROR << ...;
    }
}

void IntervalUtility<int>::SetInterval(Parameters IntervalParameters)
{
    begin_parameter = IntervalParameters["interval"][0];
    end_parameter = IntervalParameters["interval"][1];

    mBegin = begin_parameter.GetInt();
    if (end_parameter.IsString()) {
        if (end_parameter.GetString() == "End") {
            mEnd = std::numeric_limits<int>::max();
        } else {
            KRATOS_ERROR << ...;
        }
    } else if (end_parameter.IsInt()) {
        mEnd = end_parameter.GetInt();
    } else {
        KRATOS_ERROR << ...;
    }
}
```
Templatized queries and modifiers in ```Parameters``` would eliminate the need for most code duplication:
```cpp
template <class TValue>
class IntervalUtility {...};

template <class TValue>
void IntervalUtility<TValue>::SetInterval(Parameters IntervalParameters)
{
    begin_parameter = IntervalParameters["interval"][0];
    end_parameter = IntervalParameters["interval"][1];

    mBegin = begin_parameter.Get<TValue>();
    if (end_parameter.IsString()) {
        if (end_parameter.GetString() == "End") {
            mEnd = std::numeric_limits<TValue>::max();
        } else {
            KRATOS_ERROR << ...;
        }
    } else if (end_parameter.Is<TValue>()) {
        mEnd = end_parameter.Get<TValue>();
    } else {
        KRATOS_ERROR << ...;
    }
}
```

Furthermore, ```Parameters::Set``` confroms to ```Parameters::Append``` overloads (since the template parameter is deduced).