### PR TITLE
[core] templated divide geometry utility

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
@@ -658,7 +658,7 @@ void EmbeddedSkinVisualizationProcess::CreateVisualizationGeometries()
             }
 
             // Compute the splitting pattern
-            DivideGeometry::Pointer p_split_utility = p_modified_shape_functions->pGetSplittingUtil();
+            DivideGeometry<Node<3>>::Pointer p_split_utility = p_modified_shape_functions->pGetSplittingUtil();
 
             // Create the auxiliar map that will be used to generate the skin
             std::unordered_map<std::pair<unsigned int,bool>, unsigned int, Hash, KeyEqual> new_nodes_map;
@@ -668,7 +668,7 @@ void EmbeddedSkinVisualizationProcess::CreateVisualizationGeometries()
             const auto& r_neg_subdivisions = p_split_utility->GetNegativeSubdivisions();
             const unsigned int n_pos_split_geom = r_pos_subdivisions.size();
             const unsigned int n_neg_split_geom = r_neg_subdivisions.size();
-            std::vector<DivideGeometry::IndexedPointGeometryPointerType> split_geometries;
+            std::vector<DivideGeometry<Node<3>>::IndexedPointGeometryPointerType> split_geometries;
             split_geometries.reserve(n_pos_split_geom + n_neg_split_geom);
             split_geometries.insert(split_geometries.end(), r_pos_subdivisions.begin(), r_pos_subdivisions.end());
             split_geometries.insert(split_geometries.end(), r_neg_subdivisions.begin(), r_neg_subdivisions.end());
@@ -676,14 +676,14 @@ void EmbeddedSkinVisualizationProcess::CreateVisualizationGeometries()
             // Create the split geometries in the visualization model part
             for (unsigned int i_geom = 0; i_geom < split_geometries.size(); ++i_geom){
                 const bool pos_side = i_geom < n_pos_split_geom ? true : false;
-                const DivideGeometry::IndexedPointGeometryPointerType p_sub_geom = split_geometries[i_geom];
+                const DivideGeometry<Node<3>>::IndexedPointGeometryPointerType p_sub_geom = split_geometries[i_geom];
                 const unsigned int sub_geom_n_nodes = p_sub_geom->PointsNumber();
 
                 // Fill the new element nodes array
                 Element::NodesArrayType sub_geom_nodes_array;
                 for (unsigned int i_sub_geom_node = 0; i_sub_geom_node < sub_geom_n_nodes; ++i_sub_geom_node){
 
-                    DivideGeometry::IndexedPointType &sub_geom_node = p_sub_geom->operator[](i_sub_geom_node);
+                    DivideGeometry<Node<3>>::IndexedPointType &sub_geom_node = p_sub_geom->operator[](i_sub_geom_node);
                     const unsigned int local_id = sub_geom_node.Id();
 
                     // Non-intersection node. Get the copied original geometry nodes
@@ -753,7 +753,7 @@ void EmbeddedSkinVisualizationProcess::CreateVisualizationGeometries()
             const unsigned int n_pos_interface_geom = r_pos_interfaces.size();
             const unsigned int n_neg_interface_geom = r_neg_interfaces.size();
 
-            std::vector<DivideGeometry::IndexedPointGeometryPointerType> split_interface_geometries;
+            std::vector<DivideGeometry<Node<3>>::IndexedPointGeometryPointerType> split_interface_geometries;
             split_interface_geometries.reserve(n_pos_interface_geom + n_neg_interface_geom);
             split_interface_geometries.insert(split_interface_geometries.end(), r_pos_interfaces.begin(), r_pos_interfaces.end());
             split_interface_geometries.insert(split_interface_geometries.end(), r_neg_interfaces.begin(), r_neg_interfaces.end());
@@ -761,7 +761,7 @@ void EmbeddedSkinVisualizationProcess::CreateVisualizationGeometries()
             // Create the split interface geometries in the visualization model part
             for (unsigned int i_int_geom = 0; i_int_geom < split_interface_geometries.size(); ++i_int_geom){
                 const bool int_pos_side = (i_int_geom < n_pos_interface_geom) ? true : false;
-                DivideGeometry::IndexedPointGeometryPointerType p_int_sub_geom = split_interface_geometries[i_int_geom];
+                DivideGeometry<Node<3>>::IndexedPointGeometryPointerType p_int_sub_geom = split_interface_geometries[i_int_geom];
                 GeometryData::KratosGeometryType p_int_sub_geom_type = p_int_sub_geom->GetGeometryType();
                 const unsigned int sub_int_geom_n_nodes = p_int_sub_geom->PointsNumber();
 
@@ -769,7 +769,7 @@ void EmbeddedSkinVisualizationProcess::CreateVisualizationGeometries()
                 Condition::NodesArrayType sub_int_geom_nodes_array;
                 for (unsigned int i_node = 0; i_node < sub_int_geom_n_nodes; ++i_node){
 
-                    DivideGeometry::IndexedPointType &sub_int_geom_node = p_int_sub_geom->operator[](i_node);
+                    DivideGeometry<Node<3>>::IndexedPointType &sub_int_geom_node = p_int_sub_geom->operator[](i_node);
                     const unsigned int local_id = sub_int_geom_node.Id();
 
                     // Get the global id from the intersection nodes map

--- a/kratos/modified_shape_functions/modified_shape_functions.cpp
+++ b/kratos/modified_shape_functions/modified_shape_functions.cpp
@@ -54,7 +54,7 @@ namespace Kratos
     };
 
     // Returns a pointer to the splitting utility
-    const DivideGeometry::Pointer ModifiedShapeFunctions::pGetSplittingUtil() const {
+    const DivideGeometry<Node<3>>::Pointer ModifiedShapeFunctions::pGetSplittingUtil() const {
         KRATOS_ERROR << "Trying to retrieve the splitting utility from the modified shape functions base class. \n" <<
                          "Implement the pGetSplittingUtil according to the input geometry in the proper modified shape functions derived class.";
     };

--- a/kratos/modified_shape_functions/modified_shape_functions.h
+++ b/kratos/modified_shape_functions/modified_shape_functions.h
@@ -59,8 +59,8 @@ public:
     typedef GeometryData::ShapeFunctionsGradientsType                                               ShapeFunctionsGradientsType;
     typedef std::vector<array_1d<double,3>> AreaNormalsContainerType;
 
-    typedef DivideGeometry::IndexedPointGeometryType                                                IndexedPointGeometryType;
-    typedef DivideGeometry::IndexedPointGeometryPointerType                                         IndexedPointGeometryPointerType;
+    typedef DivideGeometry<Node<3>>::IndexedPointGeometryType                                                IndexedPointGeometryType;
+    typedef DivideGeometry<Node<3>>::IndexedPointGeometryPointerType                                         IndexedPointGeometryPointerType;
 
     typedef IntegrationPoint<3>                                                                     IntegrationPointType;
     typedef std::vector<IntegrationPointType>                                                       IntegrationPointsArrayType;
@@ -108,7 +108,7 @@ public:
     /**
     * Returns the member pointer to the splitting utility.
     */
-    virtual const DivideGeometry::Pointer pGetSplittingUtil() const;
+    virtual const DivideGeometry<Node<3>>::Pointer pGetSplittingUtil() const;
 
     /**
     * Returns a the member pointer to the input geometry.

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_modified_shape_functions.cpp
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_modified_shape_functions.cpp
@@ -24,7 +24,7 @@ namespace Kratos
 /// Default constructor
 Tetrahedra3D4AusasModifiedShapeFunctions::Tetrahedra3D4AusasModifiedShapeFunctions(const GeometryPointerType pInputGeometry, const Vector& rNodalDistances) :
     AusasModifiedShapeFunctions(pInputGeometry, rNodalDistances),
-    mpTetrahedraSplitter(Kratos::make_shared<DivideTetrahedra3D4>(*pInputGeometry, rNodalDistances)) {
+    mpTetrahedraSplitter(Kratos::make_shared<DivideTetrahedra3D4<Node<3>>>(*pInputGeometry, rNodalDistances)) {
 
     // Perform the element splitting
     mpTetrahedraSplitter->GenerateDivision();
@@ -61,7 +61,7 @@ void Tetrahedra3D4AusasModifiedShapeFunctions::PrintData(std::ostream& rOStream)
 
 
 // Returns a pointer to the splitting utility
-const DivideGeometry::Pointer Tetrahedra3D4AusasModifiedShapeFunctions::pGetSplittingUtil() const {
+const DivideGeometry<Node<3>>::Pointer Tetrahedra3D4AusasModifiedShapeFunctions::pGetSplittingUtil() const {
     return mpTetrahedraSplitter;
 };
 

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_modified_shape_functions.h
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_modified_shape_functions.h
@@ -104,7 +104,7 @@ public:
     /**
     * Returns the member pointer to the splitting utility.
     */
-    const DivideGeometry::Pointer pGetSplittingUtil() const override;
+    const DivideGeometry<Node<3>>::Pointer pGetSplittingUtil() const override;
 
     ///@}
 protected:
@@ -115,7 +115,7 @@ protected:
     ///@name Protected member Variables
     ///@{
 
-    DivideTetrahedra3D4::Pointer mpTetrahedraSplitter;
+    DivideTetrahedra3D4<Node<3>>::Pointer mpTetrahedraSplitter;
 
     ///@}
     ///@name Protected Operators
@@ -181,7 +181,7 @@ private:
     /// Copy constructor.
     Tetrahedra3D4AusasModifiedShapeFunctions(Tetrahedra3D4AusasModifiedShapeFunctions const& rOther) :
         AusasModifiedShapeFunctions(rOther.GetInputGeometry(), rOther.GetNodalDistances()),
-        mpTetrahedraSplitter(new DivideTetrahedra3D4(*rOther.GetInputGeometry(), rOther.GetNodalDistances())) {
+        mpTetrahedraSplitter(new DivideTetrahedra3D4<Node<3>>(*rOther.GetInputGeometry(), rOther.GetNodalDistances())) {
 
         // Perform the element splitting
         mpTetrahedraSplitter->GenerateDivision();

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_modified_shape_functions.cpp
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_modified_shape_functions.cpp
@@ -24,7 +24,7 @@ namespace Kratos
 /// Default constructor
 Tetrahedra3D4ModifiedShapeFunctions::Tetrahedra3D4ModifiedShapeFunctions(const GeometryPointerType pInputGeometry, const Vector& rNodalDistances) :
     ModifiedShapeFunctions(pInputGeometry, rNodalDistances),
-    mpTetrahedraSplitter(Kratos::make_shared<DivideTetrahedra3D4>(*pInputGeometry, rNodalDistances)) {
+    mpTetrahedraSplitter(Kratos::make_shared<DivideTetrahedra3D4<Node<3>>>(*pInputGeometry, rNodalDistances)) {
 
     // Perform the element splitting
     mpTetrahedraSplitter->GenerateDivision();
@@ -60,7 +60,7 @@ void Tetrahedra3D4ModifiedShapeFunctions::PrintData(std::ostream& rOStream) cons
 };
 
 // Returns a pointer to the splitting utility
-const DivideGeometry::Pointer Tetrahedra3D4ModifiedShapeFunctions::pGetSplittingUtil() const {
+const DivideGeometry<Node<3>>::Pointer Tetrahedra3D4ModifiedShapeFunctions::pGetSplittingUtil() const {
     return mpTetrahedraSplitter;
 };
 

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_modified_shape_functions.h
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_modified_shape_functions.h
@@ -104,7 +104,7 @@ public:
     /**
     * Returns the member pointer to the splitting utility.
     */
-    const DivideGeometry::Pointer pGetSplittingUtil() const override;
+    const DivideGeometry<Node<3>>::Pointer pGetSplittingUtil() const override;
 
     ///@}
 
@@ -152,7 +152,7 @@ private:
     ///@name Member Variables
     ///@{
 
-    DivideTetrahedra3D4::Pointer mpTetrahedraSplitter;
+    DivideTetrahedra3D4<Node<3>>::Pointer mpTetrahedraSplitter;
 
     ///@}
     ///@name Serialization
@@ -184,7 +184,7 @@ private:
     /// Copy constructor.
     Tetrahedra3D4ModifiedShapeFunctions(Tetrahedra3D4ModifiedShapeFunctions const& rOther) :
         ModifiedShapeFunctions(rOther.GetInputGeometry(), rOther.GetNodalDistances()),
-        mpTetrahedraSplitter(new DivideTetrahedra3D4(*rOther.GetInputGeometry(), rOther.GetNodalDistances())) {
+        mpTetrahedraSplitter(new DivideTetrahedra3D4<Node<3>>(*rOther.GetInputGeometry(), rOther.GetNodalDistances())) {
 
         // Perform the element splitting
         mpTetrahedraSplitter->GenerateDivision();

--- a/kratos/modified_shape_functions/triangle_2d_3_ausas_modified_shape_functions.cpp
+++ b/kratos/modified_shape_functions/triangle_2d_3_ausas_modified_shape_functions.cpp
@@ -24,7 +24,7 @@ namespace Kratos
 /// Default constructor
 Triangle2D3AusasModifiedShapeFunctions::Triangle2D3AusasModifiedShapeFunctions(const GeometryPointerType pInputGeometry, const Vector& rNodalDistances) :
     AusasModifiedShapeFunctions(pInputGeometry, rNodalDistances),
-    mpTriangleSplitter(Kratos::make_shared<DivideTriangle2D3>(*pInputGeometry, rNodalDistances)) {
+    mpTriangleSplitter(Kratos::make_shared<DivideTriangle2D3<Node<3>>>(*pInputGeometry, rNodalDistances)) {
 
     // Perform the element splitting
     mpTriangleSplitter->GenerateDivision();
@@ -60,7 +60,7 @@ void Triangle2D3AusasModifiedShapeFunctions::PrintData(std::ostream& rOStream) c
 };
 
 // Returns a pointer to the splitting utility
-const DivideGeometry::Pointer Triangle2D3AusasModifiedShapeFunctions::pGetSplittingUtil() const {
+const DivideGeometry<Node<3>>::Pointer Triangle2D3AusasModifiedShapeFunctions::pGetSplittingUtil() const {
     return mpTriangleSplitter;
 };
 

--- a/kratos/modified_shape_functions/triangle_2d_3_ausas_modified_shape_functions.h
+++ b/kratos/modified_shape_functions/triangle_2d_3_ausas_modified_shape_functions.h
@@ -104,7 +104,7 @@ public:
     /**
     * Returns the member pointer to the splitting utility.
     */
-    const DivideGeometry::Pointer pGetSplittingUtil() const override;
+    const DivideGeometry<Node<3>>::Pointer pGetSplittingUtil() const override;
 
     ///@}
 protected:
@@ -115,7 +115,7 @@ protected:
     ///@name Protected member Variables
     ///@{
 
-    DivideTriangle2D3::Pointer mpTriangleSplitter;
+    DivideTriangle2D3<Node<3>>::Pointer mpTriangleSplitter;
 
     ///@}
     ///@name Protected Operators
@@ -181,7 +181,7 @@ private:
     /// Copy constructor.
     Triangle2D3AusasModifiedShapeFunctions(Triangle2D3AusasModifiedShapeFunctions const& rOther) :
         AusasModifiedShapeFunctions(rOther.GetInputGeometry(), rOther.GetNodalDistances()),
-        mpTriangleSplitter(new DivideTriangle2D3(*rOther.GetInputGeometry(), rOther.GetNodalDistances())) {
+        mpTriangleSplitter(new DivideTriangle2D3<Node<3>>(*rOther.GetInputGeometry(), rOther.GetNodalDistances())) {
 
         // Perform the element splitting
         mpTriangleSplitter->GenerateDivision();

--- a/kratos/modified_shape_functions/triangle_2d_3_modified_shape_functions.cpp
+++ b/kratos/modified_shape_functions/triangle_2d_3_modified_shape_functions.cpp
@@ -24,7 +24,7 @@ namespace Kratos
 /// Default constructor
 Triangle2D3ModifiedShapeFunctions::Triangle2D3ModifiedShapeFunctions(const GeometryPointerType pInputGeometry, const Vector& rNodalDistances) :
     ModifiedShapeFunctions(pInputGeometry, rNodalDistances),
-    mpTriangleSplitter(Kratos::make_shared<DivideTriangle2D3>(*pInputGeometry, rNodalDistances)) {
+    mpTriangleSplitter(Kratos::make_shared<DivideTriangle2D3<Node<3>>>(*pInputGeometry, rNodalDistances)) {
 
     // Perform the element splitting
     mpTriangleSplitter->GenerateDivision();
@@ -60,7 +60,7 @@ void Triangle2D3ModifiedShapeFunctions::PrintData(std::ostream& rOStream) const 
 };
 
 // Returns a pointer to the splitting utility
-const DivideGeometry::Pointer Triangle2D3ModifiedShapeFunctions::pGetSplittingUtil() const {
+const DivideGeometry<Node<3>>::Pointer Triangle2D3ModifiedShapeFunctions::pGetSplittingUtil() const {
     return mpTriangleSplitter;
 };
 

--- a/kratos/modified_shape_functions/triangle_2d_3_modified_shape_functions.h
+++ b/kratos/modified_shape_functions/triangle_2d_3_modified_shape_functions.h
@@ -104,7 +104,7 @@ public:
     /**
     * Returns the member pointer to the splitting utility.
     */
-    const DivideGeometry::Pointer pGetSplittingUtil() const override;
+    const DivideGeometry<Node<3>>::Pointer pGetSplittingUtil() const override;
 
     ///@}
 
@@ -152,7 +152,7 @@ private:
     ///@name Member Variables
     ///@{
 
-    DivideTriangle2D3::Pointer mpTriangleSplitter;
+    DivideTriangle2D3<Node<3>>::Pointer mpTriangleSplitter;
 
     ///@}
     ///@name Serialization
@@ -184,7 +184,7 @@ private:
     /// Copy constructor.
     Triangle2D3ModifiedShapeFunctions(Triangle2D3ModifiedShapeFunctions const& rOther) :
         ModifiedShapeFunctions(rOther.GetInputGeometry(), rOther.GetNodalDistances()),
-        mpTriangleSplitter(new DivideTriangle2D3(*rOther.GetInputGeometry(), rOther.GetNodalDistances())) {
+        mpTriangleSplitter(new DivideTriangle2D3<Node<3>>(*rOther.GetInputGeometry(), rOther.GetNodalDistances())) {
 
         // Perform the element splitting
         mpTriangleSplitter->GenerateDivision();

--- a/kratos/tests/cpp_tests/utilities/test_divide_tetrahedra_3d_4.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_divide_tetrahedra_3d_4.cpp
@@ -57,7 +57,7 @@ namespace Kratos
 			Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
 
 			// Build the tetrahedra splitting utility
-			DivideTetrahedra3D4 tetrahedra_splitter(r_geometry, r_elemental_distances);
+			DivideTetrahedra3D4<Node<3>> tetrahedra_splitter(r_geometry, r_elemental_distances);
 
 			// Call the divide geometry method
 			tetrahedra_splitter.GenerateDivision();
@@ -67,7 +67,7 @@ namespace Kratos
 
 			// Call the positive exterior faces generation method
 			std::vector < unsigned int > pos_ext_faces_parent_ids;
-			std::vector < DivideTetrahedra3D4::IndexedPointGeometryPointerType > pos_ext_faces;
+			std::vector < DivideTetrahedra3D4<Node<3>>::IndexedPointGeometryPointerType > pos_ext_faces;
 			tetrahedra_splitter.GenerateExteriorFaces(
 				pos_ext_faces,
 				pos_ext_faces_parent_ids,
@@ -75,7 +75,7 @@ namespace Kratos
 
 			// Call the negative exterior faces generation method
 			std::vector < unsigned int > neg_ext_faces_parent_ids;
-			std::vector < DivideTetrahedra3D4::IndexedPointGeometryPointerType > neg_ext_faces;
+			std::vector < DivideTetrahedra3D4<Node<3>>::IndexedPointGeometryPointerType > neg_ext_faces;
 			tetrahedra_splitter.GenerateExteriorFaces(
 				neg_ext_faces,
 				neg_ext_faces_parent_ids,
@@ -229,7 +229,7 @@ namespace Kratos
 			Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
 
 			// Build the tetrahedra splitting utility
-			DivideTetrahedra3D4 tetrahedra_splitter(r_geometry, r_elemental_distances);
+			DivideTetrahedra3D4<Node<3>> tetrahedra_splitter(r_geometry, r_elemental_distances);
 
 			// Call the divide geometry method
 			tetrahedra_splitter.GenerateDivision();
@@ -239,7 +239,7 @@ namespace Kratos
 
 			// Call the positive exterior faces generation method
 			std::vector < unsigned int > pos_ext_faces_parent_ids;
-			std::vector < DivideTetrahedra3D4::IndexedPointGeometryPointerType > pos_ext_faces;
+			std::vector < DivideTetrahedra3D4<Node<3>>::IndexedPointGeometryPointerType > pos_ext_faces;
 			tetrahedra_splitter.GenerateExteriorFaces(
 				pos_ext_faces,
 				pos_ext_faces_parent_ids,
@@ -247,7 +247,7 @@ namespace Kratos
 
 			// Call the negative exterior faces generation method
 			std::vector < unsigned int > neg_ext_faces_parent_ids;
-			std::vector < DivideTetrahedra3D4::IndexedPointGeometryPointerType > neg_ext_faces;
+			std::vector < DivideTetrahedra3D4<Node<3>>::IndexedPointGeometryPointerType > neg_ext_faces;
 			tetrahedra_splitter.GenerateExteriorFaces(
 				neg_ext_faces,
 				neg_ext_faces_parent_ids,
@@ -426,7 +426,7 @@ namespace Kratos
 			Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
 
 			// Build the tetrahedra splitting utility
-			DivideTetrahedra3D4 tetrahedra_splitter(r_geometry, r_elemental_distances);
+			DivideTetrahedra3D4<Node<3>> tetrahedra_splitter(r_geometry, r_elemental_distances);
 
 			// Call the divide geometry method
 			tetrahedra_splitter.GenerateDivision();
@@ -477,8 +477,8 @@ namespace Kratos
 			auto p_elem_471 = base_model_part.pGetElement(471);
 			auto p_elem_526 = base_model_part.pGetElement(526);
 
-			DivideTetrahedra3D4 tetra_split_471(p_elem_471->GetGeometry(), p_elem_471->GetValue(ELEMENTAL_DISTANCES));
-			DivideTetrahedra3D4 tetra_split_526(p_elem_526->GetGeometry(), p_elem_526->GetValue(ELEMENTAL_DISTANCES));
+			DivideTetrahedra3D4<Node<3>> tetra_split_471(p_elem_471->GetGeometry(), p_elem_471->GetValue(ELEMENTAL_DISTANCES));
+			DivideTetrahedra3D4<Node<3>> tetra_split_526(p_elem_526->GetGeometry(), p_elem_526->GetValue(ELEMENTAL_DISTANCES));
 
 			// Call the divide geometry method
 			tetra_split_471.GenerateDivision();
@@ -487,8 +487,8 @@ namespace Kratos
 			// Call the positive exterior faces generation method
 			std::vector<unsigned int> pos_ext_faces_parent_ids_471;
 			std::vector<unsigned int> pos_ext_faces_parent_ids_526;
-			std::vector<DivideTetrahedra3D4::IndexedPointGeometryPointerType> pos_ext_faces_471;
-			std::vector<DivideTetrahedra3D4::IndexedPointGeometryPointerType> pos_ext_faces_526;
+			std::vector<DivideTetrahedra3D4<Node<3>>::IndexedPointGeometryPointerType> pos_ext_faces_471;
+			std::vector<DivideTetrahedra3D4<Node<3>>::IndexedPointGeometryPointerType> pos_ext_faces_526;
 			tetra_split_471.GenerateExteriorFaces(pos_ext_faces_471, pos_ext_faces_parent_ids_471, tetra_split_471.GetPositiveSubdivisions());
 			tetra_split_526.GenerateExteriorFaces(pos_ext_faces_526, pos_ext_faces_parent_ids_526, tetra_split_526.GetPositiveSubdivisions());
 

--- a/kratos/tests/cpp_tests/utilities/test_divide_triangle_2d_3.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_divide_triangle_2d_3.cpp
@@ -55,7 +55,7 @@ namespace Kratos
 			Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
 
 			// Build the triangle splitting utility
-			DivideTriangle2D3 triangle_splitter(r_geometry, r_elemental_distances);
+			DivideTriangle2D3<Node<3>> triangle_splitter(r_geometry, r_elemental_distances);
 
 			// Call the divide geometry method
 			triangle_splitter.GenerateDivision();
@@ -65,7 +65,7 @@ namespace Kratos
 
 			// Call the positive exterior faces generation method
 			std::vector < unsigned int > pos_ext_faces_parent_ids;
-			std::vector < DivideTriangle2D3::IndexedPointGeometryPointerType > pos_ext_faces;
+			std::vector < DivideTriangle2D3<Node<3>>::IndexedPointGeometryPointerType > pos_ext_faces;
 			triangle_splitter.GenerateExteriorFaces(
 				pos_ext_faces,
 				pos_ext_faces_parent_ids,
@@ -73,7 +73,7 @@ namespace Kratos
 
 			// Call the negative exterior faces generation method
 			std::vector < unsigned int > neg_ext_faces_parent_ids;
-			std::vector < DivideTriangle2D3::IndexedPointGeometryPointerType > neg_ext_faces;
+			std::vector < DivideTriangle2D3<Node<3>>::IndexedPointGeometryPointerType > neg_ext_faces;
 			triangle_splitter.GenerateExteriorFaces(
 				neg_ext_faces,
 				neg_ext_faces_parent_ids,
@@ -205,7 +205,7 @@ namespace Kratos
 			Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
 
 			// Build the triangle splitting utility
-			DivideTriangle2D3 triangle_splitter(r_geometry, r_elemental_distances);
+			DivideTriangle2D3<Node<3>> triangle_splitter(r_geometry, r_elemental_distances);
 
 			// Call the divide geometry method
 			triangle_splitter.GenerateDivision();
@@ -215,7 +215,7 @@ namespace Kratos
 
 			// Call the positive exterior faces generation method
 			std::vector < unsigned int > pos_ext_faces_parent_ids;
-			std::vector < DivideTriangle2D3::IndexedPointGeometryPointerType > pos_ext_faces;
+			std::vector < DivideTriangle2D3<Node<3>>::IndexedPointGeometryPointerType > pos_ext_faces;
 			triangle_splitter.GenerateExteriorFaces(
 				pos_ext_faces,
 				pos_ext_faces_parent_ids,
@@ -223,7 +223,7 @@ namespace Kratos
 
 			// Call the negative exterior faces generation method
 			std::vector < unsigned int > neg_ext_faces_parent_ids;
-			std::vector < DivideTriangle2D3::IndexedPointGeometryPointerType > neg_ext_faces;
+			std::vector < DivideTriangle2D3<Node<3>>::IndexedPointGeometryPointerType > neg_ext_faces;
 			triangle_splitter.GenerateExteriorFaces(
 				neg_ext_faces,
 				neg_ext_faces_parent_ids,
@@ -354,7 +354,7 @@ namespace Kratos
 			Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
 
 			// Build the triangle splitting utility
-			DivideTriangle2D3 triangle_splitter(r_geometry, r_elemental_distances);
+			DivideTriangle2D3<Node<3>> triangle_splitter(r_geometry, r_elemental_distances);
 
 			// Call the divide geometry method
 			triangle_splitter.GenerateDivision();

--- a/kratos/tests/cpp_tests/utilities/test_divide_triangle_3d_3.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_divide_triangle_3d_3.cpp
@@ -54,7 +54,7 @@ KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle3D3, KratosCoreFastSuite)
     Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
 
     // Build the triangle splitting utility
-    DivideTriangle3D3 triangle_splitter(r_geometry, r_elemental_distances);
+    DivideTriangle3D3<Node<3>> triangle_splitter(r_geometry, r_elemental_distances);
 
     // Call the divide geometry method
     triangle_splitter.GenerateDivision();
@@ -65,7 +65,7 @@ KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle3D3, KratosCoreFastSuite)
 
     // Call the positive exterior faces generation method
     std::vector < unsigned int > pos_ext_faces_parent_ids;
-    std::vector < DivideTriangle2D3::IndexedPointGeometryPointerType > pos_ext_faces;
+    std::vector < DivideTriangle2D3<Node<3>>::IndexedPointGeometryPointerType > pos_ext_faces;
     triangle_splitter.GenerateExteriorFaces(
         pos_ext_faces,
         pos_ext_faces_parent_ids,
@@ -73,7 +73,7 @@ KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle3D3, KratosCoreFastSuite)
 
     // Call the negative exterior faces generation method
     std::vector < unsigned int > neg_ext_faces_parent_ids;
-    std::vector < DivideTriangle2D3::IndexedPointGeometryPointerType > neg_ext_faces;
+    std::vector < DivideTriangle2D3<Node<3>>::IndexedPointGeometryPointerType > neg_ext_faces;
     triangle_splitter.GenerateExteriorFaces(
         neg_ext_faces,
         neg_ext_faces_parent_ids,

--- a/kratos/utilities/divide_geometry.cpp
+++ b/kratos/utilities/divide_geometry.cpp
@@ -60,27 +60,32 @@ namespace Kratos
 
     /// DivideGeometry implementation
     /// Default constructor
-    DivideGeometry::DivideGeometry(const GeometryType& rInputGeometry, const Vector& rNodalDistances) :
+    template<class TPointType>
+    DivideGeometry<TPointType>::DivideGeometry(const GeometryType& rInputGeometry, const Vector& rNodalDistances) :
         mrInputGeometry(rInputGeometry),
         mrNodalDistances(rNodalDistances) {
         this->IsSplit(); // Fast operation to state if the element is split or not.
     };
 
     /// Destructor
-    DivideGeometry::~DivideGeometry() {};
+    template<class TPointType>
+    DivideGeometry<TPointType>::~DivideGeometry() {};
 
     /// Turn back information as a string.
-    std::string DivideGeometry::Info() const {
+    template<class TPointType>
+    std::string DivideGeometry<TPointType>::Info() const {
         return "Base class for geometries splitting operations.";
     };
 
     /// Print information about this object.
-    void DivideGeometry::PrintInfo(std::ostream& rOStream) const {
+    template<class TPointType>
+    void DivideGeometry<TPointType>::PrintInfo(std::ostream& rOStream) const {
         rOStream << "Base class for geometries splitting operations.";
     };
 
     /// Print object's data.
-    void DivideGeometry::PrintData(std::ostream& rOStream) const {
+    template<class TPointType>
+    void DivideGeometry<TPointType>::PrintData(std::ostream& rOStream) const {
         rOStream << "Base class for geometries splitting operations constructed with:\n";
         rOStream << "   Geometry type: " << mrInputGeometry.Info() << "\n";
         std::stringstream distances_buffer;
@@ -92,15 +97,18 @@ namespace Kratos
         rOStream << "   Distance values: " << distances_buffer.str();
     };
 
-    DivideGeometry::GeometryType DivideGeometry::GetInputGeometry() const {
+    template<class TPointType>
+    Geometry < TPointType > DivideGeometry<TPointType>::GetInputGeometry() const {
         return mrInputGeometry;
     };
 
-    Vector DivideGeometry::GetNodalDistances() const {
+    template<class TPointType>
+    Vector DivideGeometry<TPointType>::GetNodalDistances() const {
         return mrNodalDistances;
     };
 
-    void DivideGeometry::IsSplit() {
+    template<class TPointType>
+    void DivideGeometry<TPointType>::IsSplit() {
         unsigned int n_pos = 0 , n_neg = 0;
 
         for (unsigned int i = 0; i < mrNodalDistances.size(); ++i) {
@@ -118,33 +126,42 @@ namespace Kratos
         }
     };
 
-    std::vector<DivideGeometry::IndexedPointGeometryPointerType> DivideGeometry::GetPositiveSubdivisions() const
+    template<class TPointType>
+    std::vector<typename DivideGeometry<TPointType>::IndexedPointGeometryPointerType> DivideGeometry<TPointType>::GetPositiveSubdivisions() const
     {
         return mPositiveSubdivisions;
     }
 
-    std::vector<DivideGeometry::IndexedPointGeometryPointerType> DivideGeometry::GetNegativeSubdivisions() const
+    template<class TPointType>
+    std::vector<typename DivideGeometry<TPointType>::IndexedPointGeometryPointerType> DivideGeometry<TPointType>::GetNegativeSubdivisions() const
     {
         return mNegativeSubdivisions;
     }
 
-    std::vector<DivideGeometry::IndexedPointGeometryPointerType> DivideGeometry::GetPositiveInterfaces() const
+    template<class TPointType>
+    std::vector<typename DivideGeometry<TPointType>::IndexedPointGeometryPointerType> DivideGeometry<TPointType>::GetPositiveInterfaces() const
     {
         return mPositiveInterfaces;
     }
 
-    std::vector<DivideGeometry::IndexedPointGeometryPointerType> DivideGeometry::GetNegativeInterfaces() const
+    template<class TPointType>
+    std::vector<typename DivideGeometry<TPointType>::IndexedPointGeometryPointerType> DivideGeometry<TPointType>::GetNegativeInterfaces() const
     {
         return mNegativeInterfaces;
     }
 
-    std::vector<unsigned int> DivideGeometry::GetPositiveInterfacesParentIds() const
+    template<class TPointType>
+    std::vector<unsigned int> DivideGeometry<TPointType>::GetPositiveInterfacesParentIds() const
     {
         return mPositiveInterfacesParentIds;
     }
 
-    std::vector<unsigned int> DivideGeometry::GetNegativeInterfacesParentIds() const
+    template<class TPointType>
+    std::vector<unsigned int> DivideGeometry<TPointType>::GetNegativeInterfacesParentIds() const
     {
         return mNegativeInterfacesParentIds;
     }
+
+    template class DivideGeometry<Node<3>>;
+    template class DivideGeometry<IndexedPoint>;
 };

--- a/kratos/utilities/divide_geometry.h
+++ b/kratos/utilities/divide_geometry.h
@@ -41,7 +41,7 @@ namespace Kratos
 ///@}
 ///@name  Functions
 ///@{
-
+ 
 class KRATOS_API(KRATOS_CORE) IndexedPoint : public Point, public IndexedObject
 {
 public:
@@ -162,6 +162,7 @@ inline std::ostream& operator << (std::ostream& rOStream,
     return rOStream;
 };
 
+template<class TPointType>
 class KRATOS_API(KRATOS_CORE) DivideGeometry
 {
 public:
@@ -173,7 +174,7 @@ public:
     KRATOS_CLASS_POINTER_DEFINITION(DivideGeometry);
 
     // General type definitions
-    typedef Geometry < Node<3> >                                    GeometryType;
+    typedef Geometry < TPointType >                                    GeometryType;
     typedef IndexedPoint                                            IndexedPointType;
     typedef IndexedPoint::Pointer                                   IndexedPointPointerType;
     typedef Geometry < IndexedPoint >                               IndexedPointGeometryType;

--- a/kratos/utilities/divide_tetrahedra_3d_4.cpp
+++ b/kratos/utilities/divide_tetrahedra_3d_4.cpp
@@ -22,24 +22,29 @@
 namespace Kratos
 {
     /// Default constructor
-    DivideTetrahedra3D4::DivideTetrahedra3D4(const GeometryType& rInputGeometry, const Vector& rNodalDistances) :
-        DivideGeometry(rInputGeometry, rNodalDistances) {};
+    template<class TPointType>
+    DivideTetrahedra3D4<TPointType>::DivideTetrahedra3D4(const GeometryType& rInputGeometry, const Vector& rNodalDistances) :
+        DivideGeometry<TPointType>(rInputGeometry, rNodalDistances) {};
 
     /// Destructor
-    DivideTetrahedra3D4::~DivideTetrahedra3D4() {};
+    template<class TPointType>
+    DivideTetrahedra3D4<TPointType>::~DivideTetrahedra3D4() {};
 
     /// Turn back information as a string.
-    std::string DivideTetrahedra3D4::Info() const {
+    template<class TPointType>
+    std::string DivideTetrahedra3D4<TPointType>::Info() const {
         return "Tetrahedra divide operations utility.";
     };
 
     /// Print information about this object.
-    void DivideTetrahedra3D4::PrintInfo(std::ostream& rOStream) const {
+    template<class TPointType>
+    void DivideTetrahedra3D4<TPointType>::PrintInfo(std::ostream& rOStream) const {
         rOStream << "Tetrahedra divide operations utility.";
     };
 
     /// Print object's data.
-    void DivideTetrahedra3D4::PrintData(std::ostream& rOStream) const {
+    template<class TPointType>
+    void DivideTetrahedra3D4<TPointType>::PrintData(std::ostream& rOStream) const {
         const GeometryType geometry = this->GetInputGeometry();
         const Vector nodal_distances = this->GetNodalDistances();
         rOStream << "Tetrahedra divide operations utility constructed with:\n";
@@ -54,57 +59,61 @@ namespace Kratos
     };
 
     // Returns the mEdgeNodeI member vector
-    const std::vector<int>& DivideTetrahedra3D4::GetEdgeIdsI() const {
-        return mEdgeNodeI;
+    template<class TPointType>
+    const std::vector<int>& DivideTetrahedra3D4<TPointType>::GetEdgeIdsI() const {
+        return this->mEdgeNodeI;
     }
 
     // Returns the mEdgeNodeJ member vector
-    const std::vector<int>& DivideTetrahedra3D4::GetEdgeIdsJ() const {
-        return mEdgeNodeJ;
+    template<class TPointType>
+    const std::vector<int>& DivideTetrahedra3D4<TPointType>::GetEdgeIdsJ() const {
+        return this->mEdgeNodeJ;
     }
 
     // Returns the mSplitEdges member vector
-    std::vector<int>& DivideTetrahedra3D4::GetSplitEdges() {
-        return mSplitEdges;
+    template<class TPointType>
+    std::vector<int>& DivideTetrahedra3D4<TPointType>::GetSplitEdges() {
+        return this->mSplitEdges;
     }
 
     // Performs and saves the splitting pattern.
-    void DivideTetrahedra3D4::GenerateDivision() {
+    template<class TPointType>
+    void DivideTetrahedra3D4<TPointType>::GenerateDivision() {
 
-        const GeometryType geometry = GetInputGeometry();
-        const Vector nodal_distances = GetNodalDistances();
+        const GeometryType geometry = this->GetInputGeometry();
+        const Vector nodal_distances = this->GetNodalDistances();
 
         // Fill the auxiliar points vector set
-        if (mIsSplit) {
+        if (this->mIsSplit) {
 
             // Set the Tetrahedra geometry parameters
             const unsigned int n_nodes = 4;
             const unsigned int n_edges = 6;
 
             // Clear the auxiliar vector points set
-            mAuxPointsContainer.clear();
-            mAuxPointsContainer.reserve(10);
+            this->mAuxPointsContainer.clear();
+            this->mAuxPointsContainer.reserve(10);
 
             // Add the original geometry points
-            std::vector<int> gl_ids_split_edges(mSplitEdges);
+            std::vector<int> gl_ids_split_edges(this->mSplitEdges);
             for (unsigned int i = 0; i < n_nodes; ++i) {
                 gl_ids_split_edges[i] = geometry[i].Id();
                 const array_1d<double, 3> aux_point_coords = geometry[i].Coordinates();
                 IndexedPointPointerType paux_point = Kratos::make_shared<IndexedPoint>(aux_point_coords, i);
-                mAuxPointsContainer.push_back(paux_point);
+                this->mAuxPointsContainer.push_back(paux_point);
             }
 
             // Decide the splitting pattern
             unsigned int aux_node_id = n_nodes;
 
             for(unsigned int idedge = 0; idedge < n_edges; ++idedge) {
-                const unsigned int edge_node_i = mEdgeNodeI[idedge];
-                const unsigned int edge_node_j = mEdgeNodeJ[idedge];
+                const unsigned int edge_node_i = this->mEdgeNodeI[idedge];
+                const unsigned int edge_node_j = this->mEdgeNodeJ[idedge];
 
                 // Check if the edge is split
                 if(nodal_distances(edge_node_i) * nodal_distances(edge_node_j) < 0) {
                     // Set the new node id. in the split edge array corresponding slot
-                    mSplitEdges[idedge + n_nodes] = aux_node_id;
+                    this->mSplitEdges[idedge + n_nodes] = aux_node_id;
                     gl_ids_split_edges[idedge + n_nodes] = aux_node_id;
 
                     // Edge nodes coordinates
@@ -120,7 +129,7 @@ namespace Kratos
 
                     // Add the intersection point to the auxiliar points array
                     IndexedPointPointerType paux_point = Kratos::make_shared<IndexedPoint>(aux_point_coords, aux_node_id);
-                    mAuxPointsContainer.push_back(paux_point);
+                    this->mAuxPointsContainer.push_back(paux_point);
                 }
 
                 aux_node_id++;
@@ -133,20 +142,20 @@ namespace Kratos
             // Call the splitting function
             std::vector<int> t(56);     // Ids of the generated subdivisions
             int n_int = 0;              // Number of internal nodes (set to 0 since it is not needed for tetrahedra splitting)
-            TetrahedraSplit::Split_Tetrahedra(edge_ids.data(), t.data(), &mDivisionsNumber, &mSplitEdgesNumber, &n_int);
+            TetrahedraSplit::Split_Tetrahedra(edge_ids.data(), t.data(), &this->mDivisionsNumber, &this->mSplitEdgesNumber, &n_int);
 
             // Fill the subdivisions arrays
-            for (int idivision = 0; idivision < mDivisionsNumber; ++idivision) {
+            for (int idivision = 0; idivision < this->mDivisionsNumber; ++idivision) {
                 // Get the subdivision indices
                 int i0, i1, i2, i3;
-                TetrahedraSplit::TetrahedraGetNewConnectivityGID(idivision, t.data(), mSplitEdges.data(), &i0, &i1, &i2, &i3);
+                TetrahedraSplit::TetrahedraGetNewConnectivityGID(idivision, t.data(), this->mSplitEdges.data(), &i0, &i1, &i2, &i3);
 
                 // Generate a pointer to an auxiliar triangular geometry made with the subdivision points
                 IndexedPointGeometryPointerType p_aux_partition = Kratos::make_shared<IndexedPointTetrahedraType>(
-                    mAuxPointsContainer(i0), 
-                    mAuxPointsContainer(i1), 
-                    mAuxPointsContainer(i2),
-                    mAuxPointsContainer(i3));
+                    this->mAuxPointsContainer(i0), 
+                    this->mAuxPointsContainer(i1), 
+                    this->mAuxPointsContainer(i2),
+                    this->mAuxPointsContainer(i3));
                 
                 // Determine if the subdivision is wether in the negative or the positive side                                                                                                 
                 unsigned int neg = 0, pos = 0;
@@ -163,38 +172,39 @@ namespace Kratos
 
                 // Add the generated tetrahedra to its corresponding partition arrays
                 if (is_positive) {
-                    mPositiveSubdivisions.push_back(p_aux_partition);
+                    this->mPositiveSubdivisions.push_back(p_aux_partition);
                 } else {
-                    mNegativeSubdivisions.push_back(p_aux_partition);
+                    this->mNegativeSubdivisions.push_back(p_aux_partition);
                 }
             }
 
         } else {
-            mDivisionsNumber = 1;
-            mSplitEdgesNumber = 0;
+            this->mDivisionsNumber = 1;
+            this->mSplitEdgesNumber = 0;
         }
     };
 
-    void DivideTetrahedra3D4::GenerateIntersectionsSkin() {
+    template<class TPointType>
+    void DivideTetrahedra3D4<TPointType>::GenerateIntersectionsSkin() {
         // Set some geometry constant parameters
         const int n_nodes = 4;
         const unsigned int n_faces = 4;
 
         // Clear the interfaces vectors
-        mPositiveInterfaces.clear();
-        mNegativeInterfaces.clear();
-        mPositiveInterfacesParentIds.clear();
-        mNegativeInterfacesParentIds.clear();
+        this->mPositiveInterfaces.clear();
+        this->mNegativeInterfaces.clear();
+        this->mPositiveInterfacesParentIds.clear();
+        this->mNegativeInterfacesParentIds.clear();
 
-        if (mIsSplit) {
+        if (this->mIsSplit) {
 
-            const unsigned int n_positive_subdivision = mPositiveSubdivisions.size();
-            const unsigned int n_negative_subdivision = mNegativeSubdivisions.size();
+            const unsigned int n_positive_subdivision = this->mPositiveSubdivisions.size();
+            const unsigned int n_negative_subdivision = this->mNegativeSubdivisions.size();
             
             // Compute the positive side intersection geometries
             for (unsigned int i_subdivision = 0; i_subdivision < n_positive_subdivision; ++i_subdivision) {
                 // Get the subdivision geometry faces
-                const IndexedPointGeometryPointerType p_subdivision_geom = mPositiveSubdivisions[i_subdivision];
+                const IndexedPointGeometryPointerType p_subdivision_geom = this->mPositiveSubdivisions[i_subdivision];
                 const IndexedGeometriesArrayType subdivision_faces = p_subdivision_geom->GenerateFaces();
 
                 // Faces iteration
@@ -210,11 +220,11 @@ namespace Kratos
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
                     if ((node_i_key >= n_nodes) && (node_j_key >= n_nodes) && (node_k_key >= n_nodes)) {
                         // Generate an indexed point triangle geometry pointer with the two interface nodes
-                        IndexedPointGeometryPointerType p_intersection_tri = Kratos::make_shared<IndexedPointTriangleType>(mAuxPointsContainer(node_i_key), 
-                                                                                                                          mAuxPointsContainer(node_j_key),
-                                                                                                                          mAuxPointsContainer(node_k_key));
-                        mPositiveInterfaces.push_back(p_intersection_tri);
-                        mPositiveInterfacesParentIds.push_back(i_subdivision);
+                        IndexedPointGeometryPointerType p_intersection_tri = Kratos::make_shared<IndexedPointTriangleType>(this->mAuxPointsContainer(node_i_key), 
+                                                                                                                          this->mAuxPointsContainer(node_j_key),
+                                                                                                                          this->mAuxPointsContainer(node_k_key));
+                        this->mPositiveInterfaces.push_back(p_intersection_tri);
+                        this->mPositiveInterfacesParentIds.push_back(i_subdivision);
                     }
                 }
             }
@@ -222,7 +232,7 @@ namespace Kratos
             // Compute the negative side intersection geometries
             for (unsigned int i_subdivision = 0; i_subdivision < n_negative_subdivision; ++i_subdivision) {
                 // Get the subdivision geometry
-                const IndexedPointGeometryPointerType p_subdivision_geom = mNegativeSubdivisions[i_subdivision];
+                const IndexedPointGeometryPointerType p_subdivision_geom = this->mNegativeSubdivisions[i_subdivision];
                 const IndexedGeometriesArrayType subdivision_faces = p_subdivision_geom->GenerateFaces();
 
                 // Faces iteration
@@ -238,11 +248,11 @@ namespace Kratos
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
                     if ((node_i_key >= n_nodes) && (node_j_key >= n_nodes) && (node_k_key >= n_nodes)) {
                         // Generate an indexed point triangle geometry pointer with the two interface nodes
-                        IndexedPointGeometryPointerType p_intersection_tri = Kratos::make_shared<IndexedPointTriangleType>(mAuxPointsContainer(node_i_key), 
-                                                                                                                          mAuxPointsContainer(node_j_key),
-                                                                                                                          mAuxPointsContainer(node_k_key));
-                        mNegativeInterfaces.push_back(p_intersection_tri);
-                        mNegativeInterfacesParentIds.push_back(i_subdivision);
+                        IndexedPointGeometryPointerType p_intersection_tri = Kratos::make_shared<IndexedPointTriangleType>(this->mAuxPointsContainer(node_i_key), 
+                                                                                                                          this->mAuxPointsContainer(node_j_key),
+                                                                                                                          this->mAuxPointsContainer(node_k_key));
+                        this->mNegativeInterfaces.push_back(p_intersection_tri);
+                        this->mNegativeInterfacesParentIds.push_back(i_subdivision);
                     }
                 }
             }
@@ -251,7 +261,8 @@ namespace Kratos
         }
     };
 
-    void DivideTetrahedra3D4::GenerateExteriorFaces(
+    template<class TPointType>
+    void DivideTetrahedra3D4<TPointType>::GenerateExteriorFaces(
         std::vector < IndexedPointGeometryPointerType > &rExteriorFacesVector,
         std::vector < unsigned int > &rExteriorFacesParentSubdivisionsIdsVector,
         const std::vector < IndexedPointGeometryPointerType > &rSubdivisionsContainer) {
@@ -279,7 +290,8 @@ namespace Kratos
         }
     };
 
-    void DivideTetrahedra3D4::GenerateExteriorFaces(
+    template<class TPointType>
+    void DivideTetrahedra3D4<TPointType>::GenerateExteriorFaces(
         std::vector < IndexedPointGeometryPointerType > &rExteriorFacesVector,
         std::vector < unsigned int > &rExteriorFacesParentSubdivisionsIdsVector,
         const std::vector < IndexedPointGeometryPointerType > &rSubdivisionsContainer,
@@ -291,7 +303,7 @@ namespace Kratos
         rExteriorFacesVector.clear();
         rExteriorFacesParentSubdivisionsIdsVector.clear();
 
-        if (mIsSplit) {
+        if (this->mIsSplit) {
             // Create the face nodes data
             // The position represents the face while the value the real and intersection nodes in that face edges
             std::array < std::array< unsigned int, 6 >, 4> edges_map = {{
@@ -325,9 +337,9 @@ namespace Kratos
                             if (std::find(faces_edge_nodes.begin(), faces_edge_nodes.end(), node_k_key) != faces_edge_nodes.end()) {
                                 // If both nodes are in the candidate nodes list, the subface is exterior
                                 IndexedPointGeometryPointerType p_subface_triang = Kratos::make_shared<IndexedPointTriangleType>(
-                                    mAuxPointsContainer(node_i_key),
-                                    mAuxPointsContainer(node_j_key),
-                                    mAuxPointsContainer(node_k_key));
+                                    this->mAuxPointsContainer(node_i_key),
+                                    this->mAuxPointsContainer(node_j_key),
+                                    this->mAuxPointsContainer(node_k_key));
                                 rExteriorFacesVector.push_back(p_subface_triang);
                                 rExteriorFacesParentSubdivisionsIdsVector.push_back(i_subdivision);
                             }
@@ -339,5 +351,9 @@ namespace Kratos
             KRATOS_ERROR << "Trying to generate the exterior faces in DivideTetrahedra3D4::GenerateExteriorFaces() for a non-split element.";
         }
     };
+
+    
+    template class DivideTetrahedra3D4<Node<3>>;
+    template class DivideTetrahedra3D4<IndexedPoint>;
         
 };

--- a/kratos/utilities/divide_tetrahedra_3d_4.h
+++ b/kratos/utilities/divide_tetrahedra_3d_4.h
@@ -39,17 +39,20 @@ namespace Kratos
 ///@}
 ///@name  Functions
 ///@{
-
-class KRATOS_API(KRATOS_CORE) DivideTetrahedra3D4 : public DivideGeometry
+template<class TPointType>
+class KRATOS_API(KRATOS_CORE) DivideTetrahedra3D4 : public DivideGeometry<TPointType>
 {
 public:
     ///@name Type Definitions
     ///@{
 
-    typedef DivideGeometry                                              BaseType;
-    typedef BaseType::GeometryType                                      GeometryType;
-    typedef BaseType::IndexedPointType                                  IndexedPointType;
-    typedef BaseType::IndexedPointGeometryType::GeometriesArrayType     IndexedGeometriesArrayType;
+    typedef DivideGeometry<TPointType>                                  BaseType;
+    typedef typename BaseType::GeometryType                                      GeometryType;
+    typedef typename BaseType::IndexedPointType                                  IndexedPointType;
+    typedef typename BaseType::IndexedPointPointerType                           IndexedPointPointerType;
+    typedef typename BaseType::IndexedPointGeometryType                          IndexedPointGeometryType;
+    typedef typename BaseType::IndexedPointGeometryPointerType                   IndexedPointGeometryPointerType;
+    typedef typename BaseType::IndexedPointGeometryType::GeometriesArrayType     IndexedGeometriesArrayType;
     typedef Triangle3D3 < IndexedPointType >                            IndexedPointTriangleType;
     typedef Tetrahedra3D4 < IndexedPointType >                          IndexedPointTetrahedraType;
 
@@ -188,7 +191,7 @@ private:
 
     /// Copy constructor.
     DivideTetrahedra3D4(DivideTetrahedra3D4 const& rOther)
-        : DivideGeometry(rOther.GetInputGeometry(), rOther.GetNodalDistances()) {};
+        : DivideGeometry<TPointType>(rOther.GetInputGeometry(), rOther.GetNodalDistances()) {};
 
     ///@}
 

--- a/kratos/utilities/divide_triangle_2d_3.cpp
+++ b/kratos/utilities/divide_triangle_2d_3.cpp
@@ -21,24 +21,29 @@
 namespace Kratos
 {
     /// Default constructor
-    DivideTriangle2D3::DivideTriangle2D3(const GeometryType& rInputGeometry, const Vector& rNodalDistances) :
-        DivideGeometry(rInputGeometry, rNodalDistances) {};
+    template<class TPointType>
+    DivideTriangle2D3<TPointType>::DivideTriangle2D3(const GeometryType& rInputGeometry, const Vector& rNodalDistances) :
+        DivideGeometry<TPointType>(rInputGeometry, rNodalDistances) {};
 
     /// Destructor
-    DivideTriangle2D3::~DivideTriangle2D3() {};
+    template<class TPointType>
+    DivideTriangle2D3<TPointType>::~DivideTriangle2D3() {};
 
     /// Turn back information as a string.
-    std::string DivideTriangle2D3::Info() const {
+    template<class TPointType>
+    std::string DivideTriangle2D3<TPointType>::Info() const {
         return "Triangle divide operations utility.";
     };
 
     /// Print information about this object.
-    void DivideTriangle2D3::PrintInfo(std::ostream& rOStream) const {
+    template<class TPointType>
+    void DivideTriangle2D3<TPointType>::PrintInfo(std::ostream& rOStream) const {
         rOStream << "Triangle divide operations utility.";
     };
 
     /// Print object's data.
-    void DivideTriangle2D3::PrintData(std::ostream& rOStream) const {
+    template<class TPointType>
+    void DivideTriangle2D3<TPointType>::PrintData(std::ostream& rOStream) const {
         const GeometryType geometry = this->GetInputGeometry();
         const Vector nodal_distances = this->GetNodalDistances();
         rOStream << "Triangle divide operations utility constructed with:\n";
@@ -53,63 +58,67 @@ namespace Kratos
     };
 
     // Returns the mEdgeNodeI member vector
-    const std::vector<int>& DivideTriangle2D3::GetEdgeIdsI() const {
-        return mEdgeNodeI;
+    template<class TPointType>
+    const std::vector<int>& DivideTriangle2D3<TPointType>::GetEdgeIdsI() const {
+        return this->mEdgeNodeI;
     }
 
     // Returns the mEdgeNodeJ member vector
-    const std::vector<int>& DivideTriangle2D3::GetEdgeIdsJ() const {
-        return mEdgeNodeJ;
+    template<class TPointType>
+    const std::vector<int>& DivideTriangle2D3<TPointType>::GetEdgeIdsJ() const {
+        return this->mEdgeNodeJ;
     }
 
     // Returns the mSplitEdges member vector
-    std::vector<int>& DivideTriangle2D3::GetSplitEdges() {
-        return mSplitEdges;
+    template<class TPointType>
+    std::vector<int>& DivideTriangle2D3<TPointType>::GetSplitEdges() {
+        return this->mSplitEdges;
     }
 
     // Performs and saves the splitting pattern.
-    void DivideTriangle2D3::GenerateDivision() {
+    template<class TPointType>
+    void DivideTriangle2D3<TPointType>::GenerateDivision() {
 
-        const GeometryType geometry = GetInputGeometry();
-        const Vector nodal_distances = GetNodalDistances();
+        const GeometryType geometry = this->GetInputGeometry();
+        const Vector nodal_distances = this->GetNodalDistances();
 
         // Fill the auxiliar points vector set
-        if (mIsSplit) {
+        if (this->mIsSplit) {
 
             // Set the triangle geometry parameters
             const unsigned int n_nodes = 3;
             const unsigned int n_edges = 3;
 
             // Clear the auxiliar vector points set
-            mAuxPointsContainer.clear();
-            mAuxPointsContainer.reserve(6);
+            this->mAuxPointsContainer.clear();
+            this->mAuxPointsContainer.reserve(6);
 
             // Clear the subdivision vectors
-            mPositiveSubdivisions.clear();
-            mNegativeSubdivisions.clear();
-            mPositiveSubdivisions.reserve(2);
-            mNegativeSubdivisions.reserve(2);
+            this->mPositiveSubdivisions.clear();
+            this->mNegativeSubdivisions.clear();
+            this->mPositiveSubdivisions.reserve(2);
+            this->mNegativeSubdivisions.reserve(2);
 
             // Add the original geometry points
-            std::vector<int> gl_ids_split_edges(mSplitEdges);
+            std::vector<int> gl_ids_split_edges(this->mSplitEdges);
             for (unsigned int i = 0; i < n_nodes; ++i) {
                 gl_ids_split_edges[i] = geometry[i].Id();
                 const array_1d<double, 3> aux_point_coords = geometry[i].Coordinates();
                 IndexedPointPointerType paux_point = Kratos::make_shared<IndexedPoint>(aux_point_coords, i);
-                mAuxPointsContainer.push_back(paux_point);
+                this->mAuxPointsContainer.push_back(paux_point);
             }
 
             // Decide the splitting pattern
             unsigned int aux_node_id = n_nodes;
 
             for(unsigned int idedge = 0; idedge < n_edges; ++idedge) {
-                const unsigned int edge_node_i = mEdgeNodeI[idedge];
-                const unsigned int edge_node_j = mEdgeNodeJ[idedge];
+                const unsigned int edge_node_i = this->mEdgeNodeI[idedge];
+                const unsigned int edge_node_j = this->mEdgeNodeJ[idedge];
 
                 // Check if the edge is split
                 if(nodal_distances(edge_node_i) * nodal_distances(edge_node_j) < 0) {
                     // Set the new node id. in the split edge array corresponding slot
-                    mSplitEdges[idedge + n_nodes] = aux_node_id;
+                    this->mSplitEdges[idedge + n_nodes] = aux_node_id;
                     gl_ids_split_edges[idedge + n_nodes] = aux_node_id;
 
                     // Edge nodes coordinates
@@ -125,7 +134,7 @@ namespace Kratos
 
                     // Add the intersection point to the auxiliar points array
                     IndexedPointPointerType paux_point = Kratos::make_shared<IndexedPoint>(aux_point_coords, aux_node_id);
-                    mAuxPointsContainer.push_back(paux_point);
+                    this->mAuxPointsContainer.push_back(paux_point);
                 }
 
                 aux_node_id++;
@@ -138,13 +147,13 @@ namespace Kratos
             // Call the splitting function
             std::vector<int> t(12);     // Ids of the generated subdivisions
             int n_int = 0;              // Number of internal nodes (set to 0 since it is not needed for triangle splitting)
-            Split_Triangle(edge_ids.data(), t.data(), &mDivisionsNumber, &mSplitEdgesNumber, &n_int);
+            Split_Triangle(edge_ids.data(), t.data(), &this->mDivisionsNumber, &this->mSplitEdgesNumber, &n_int);
 
             // Fill the subdivisions arrays
-            for (int idivision = 0; idivision < mDivisionsNumber; ++idivision) {
+            for (int idivision = 0; idivision < this->mDivisionsNumber; ++idivision) {
                 // Get the subdivision indices
                 int i0, i1, i2;
-                TriangleGetNewConnectivityGID(idivision, t.data(), mSplitEdges.data(), &i0, &i1, &i2);
+                TriangleGetNewConnectivityGID(idivision, t.data(), this->mSplitEdges.data(), &i0, &i1, &i2);
 
                 // Generate a pointer to an auxiliar triangular geometry made with the subdivision points
                 IndexedPointGeometryPointerType p_aux_partition = GenerateAuxiliaryPartitionTriangle(i0, i1, i2);
@@ -163,43 +172,44 @@ namespace Kratos
 
                 // Add the generated triangle to its corresponding partition arrays
                 if (is_positive) {
-                    mPositiveSubdivisions.push_back(p_aux_partition);
+                    this->mPositiveSubdivisions.push_back(p_aux_partition);
                 } else {
-                    mNegativeSubdivisions.push_back(p_aux_partition);
+                    this->mNegativeSubdivisions.push_back(p_aux_partition);
                 }
             }
 
         } else {
-            mDivisionsNumber = 1;
-            mSplitEdgesNumber = 0;
+            this->mDivisionsNumber = 1;
+            this->mSplitEdgesNumber = 0;
         }
     };
 
-    void DivideTriangle2D3::GenerateIntersectionsSkin() {
+    template<class TPointType>
+    void DivideTriangle2D3<TPointType>::GenerateIntersectionsSkin() {
 
         // Set some geometry constant parameters
         const int n_nodes = 3;
         const unsigned int n_faces = 3;
 
         // Clear the interfaces vectors
-        mPositiveInterfaces.clear();
-        mNegativeInterfaces.clear();
-        mPositiveInterfaces.reserve(1);
-        mNegativeInterfaces.reserve(1);
-        mPositiveInterfacesParentIds.clear();
-        mNegativeInterfacesParentIds.clear();
-        mPositiveInterfacesParentIds.reserve(1);
-        mNegativeInterfacesParentIds.reserve(1);
+        this->mPositiveInterfaces.clear();
+        this->mNegativeInterfaces.clear();
+        this->mPositiveInterfaces.reserve(1);
+        this->mNegativeInterfaces.reserve(1);
+        this->mPositiveInterfacesParentIds.clear();
+        this->mNegativeInterfacesParentIds.clear();
+        this->mPositiveInterfacesParentIds.reserve(1);
+        this->mNegativeInterfacesParentIds.reserve(1);
 
-        if (mIsSplit) {
+        if (this->mIsSplit) {
 
-            const unsigned int n_positive_subdivision = mPositiveSubdivisions.size();
-            const unsigned int n_negative_subdivision = mNegativeSubdivisions.size();
+            const unsigned int n_positive_subdivision = this->mPositiveSubdivisions.size();
+            const unsigned int n_negative_subdivision = this->mNegativeSubdivisions.size();
 
             // Compute the positive side intersection geometries
             for (unsigned int i_subdivision = 0; i_subdivision < n_positive_subdivision; ++i_subdivision) {
                 // Get the subdivision geometry
-                const IndexedPointGeometryType& r_subdivision_geom = *mPositiveSubdivisions[i_subdivision];
+                const IndexedPointGeometryType& r_subdivision_geom = *this->mPositiveSubdivisions[i_subdivision];
 
                 // Faces iteration
                 for (unsigned int i_face = 0; i_face < n_faces; ++i_face) {
@@ -211,9 +221,9 @@ namespace Kratos
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
                     if ((node_i_key >= n_nodes) && (node_j_key >= n_nodes)) {
                         // Generate an indexed point line geometry pointer with the two interface nodes
-                        IndexedPointGeometryPointerType p_intersection_line = GenerateIntersectionLine(node_i_key, node_j_key);
-                        mPositiveInterfaces.push_back(p_intersection_line);
-                        mPositiveInterfacesParentIds.push_back(i_subdivision);
+                        IndexedPointGeometryPointerType p_intersection_line = this->GenerateIntersectionLine(node_i_key, node_j_key);
+                        this->mPositiveInterfaces.push_back(p_intersection_line);
+                        this->mPositiveInterfacesParentIds.push_back(i_subdivision);
 
                         // In triangles, a unique face can belong to the interface
                         break;
@@ -224,7 +234,7 @@ namespace Kratos
             // Compute the negative side intersection geometries
             for (unsigned int i_subdivision = 0; i_subdivision < n_negative_subdivision; ++i_subdivision) {
                 // Get the subdivision geometry
-                const IndexedPointGeometryType& r_subdivision_geom = *mNegativeSubdivisions[i_subdivision];
+                const IndexedPointGeometryType& r_subdivision_geom = *this->mNegativeSubdivisions[i_subdivision];
 
                 // Faces iteration
                 for (unsigned int i_face = 0; i_face < n_faces; ++i_face) {
@@ -236,9 +246,9 @@ namespace Kratos
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
                     if ((node_i_key >= n_nodes) && (node_j_key >= n_nodes)) {
                         // Generate an indexed point line geometry pointer with the two interface nodes
-                        IndexedPointGeometryPointerType p_intersection_line = GenerateIntersectionLine(node_i_key ,node_j_key);
-                        mNegativeInterfaces.push_back(p_intersection_line);
-                        mNegativeInterfacesParentIds.push_back(i_subdivision);
+                        IndexedPointGeometryPointerType p_intersection_line = this->GenerateIntersectionLine(node_i_key ,node_j_key);
+                        this->mNegativeInterfaces.push_back(p_intersection_line);
+                        this->mNegativeInterfacesParentIds.push_back(i_subdivision);
 
                         // In triangles, a unique face can belong to the interface
                         break;
@@ -250,7 +260,8 @@ namespace Kratos
         }
     };
 
-    void DivideTriangle2D3::GenerateExteriorFaces(
+    template<class TPointType>
+    void DivideTriangle2D3<TPointType>::GenerateExteriorFaces(
         std::vector < IndexedPointGeometryPointerType > &rExteriorFacesVector,
         std::vector < unsigned int > &rExteriorFacesParentSubdivisionsIdsVector,
         const std::vector < IndexedPointGeometryPointerType > &rSubdivisionsContainer) {
@@ -280,7 +291,8 @@ namespace Kratos
         }
     };
 
-    void DivideTriangle2D3::GenerateExteriorFaces(
+    template<class TPointType>
+    void DivideTriangle2D3<TPointType>::GenerateExteriorFaces(
         std::vector < IndexedPointGeometryPointerType > &rExteriorFacesVector,
         std::vector < unsigned int > &rExteriorFacesParentSubdivisionsIdsVector,
         const std::vector < IndexedPointGeometryPointerType > &rSubdivisionsContainer,
@@ -294,7 +306,7 @@ namespace Kratos
         rExteriorFacesParentSubdivisionsIdsVector.clear();
         rExteriorFacesParentSubdivisionsIdsVector.reserve(2);
 
-        if (mIsSplit) {
+        if (this->mIsSplit) {
             // Create the face nodes data
             // The position represents the face while the value real and intersection nodes in that face edges
             std::array < std::array < unsigned int, 3 >, 3 > edges_map = {{
@@ -321,7 +333,7 @@ namespace Kratos
                     if (std::find(faces_edge_nodes.begin(), faces_edge_nodes.end(), node_i_key) != faces_edge_nodes.end()) {
                         if (std::find(faces_edge_nodes.begin(), faces_edge_nodes.end(), node_j_key) != faces_edge_nodes.end()) {
                             // If both nodes are in the candidate nodes list, the subface is exterior
-                            IndexedPointGeometryPointerType p_subface_line = GenerateIntersectionLine(node_i_key, node_j_key);
+                            IndexedPointGeometryPointerType p_subface_line = this->GenerateIntersectionLine(node_i_key, node_j_key);
 
                             rExteriorFacesVector.push_back(p_subface_line);
                             rExteriorFacesParentSubdivisionsIdsVector.push_back(i_subdivision);
@@ -334,24 +346,29 @@ namespace Kratos
         }
     };
 
-    DivideTriangle2D3::IndexedPointGeometryPointerType DivideTriangle2D3::GenerateAuxiliaryPartitionTriangle(
+    template<class TPointType>
+    typename DivideTriangle2D3<TPointType>::IndexedPointGeometryPointerType DivideTriangle2D3<TPointType>::GenerateAuxiliaryPartitionTriangle(
         const int I0,
         const int I1,
         const int I2)
     {
         return Kratos::make_shared<IndexedPointTriangleType>(
-            mAuxPointsContainer(I0),
-            mAuxPointsContainer(I1),
-            mAuxPointsContainer(I2));
-    }
+            this->mAuxPointsContainer(I0),
+            this->mAuxPointsContainer(I1),
+            this->mAuxPointsContainer(I2));
+    };
 
-    DivideTriangle2D3::IndexedPointGeometryPointerType DivideTriangle2D3::GenerateIntersectionLine(
+    template<class TPointType>
+    typename DivideTriangle2D3<TPointType>::IndexedPointGeometryPointerType DivideTriangle2D3<TPointType>::GenerateIntersectionLine(
         const int I0,
         const int I1)
     {
         return Kratos::make_shared<IndexedPointLineType>(
-            mAuxPointsContainer(I0),
-            mAuxPointsContainer(I1));
-    }
+            this->mAuxPointsContainer(I0),
+            this->mAuxPointsContainer(I1));
+    };
+
+    template class DivideTriangle2D3<Node<3>>;
+    template class DivideTriangle2D3<IndexedPoint>;
 
 };

--- a/kratos/utilities/divide_triangle_2d_3.h
+++ b/kratos/utilities/divide_triangle_2d_3.h
@@ -40,18 +40,22 @@ namespace Kratos
 ///@name  Functions
 ///@{
 
-class KRATOS_API(KRATOS_CORE) DivideTriangle2D3 : public DivideGeometry
+template<class TPointType>
+class KRATOS_API(KRATOS_CORE) DivideTriangle2D3 : public DivideGeometry<TPointType>
 {
 public:
     ///@name Type Definitions
     ///@{
 
-    typedef DivideGeometry                                              BaseType;
-    typedef BaseType::GeometryType                                      GeometryType;
-    typedef BaseType::IndexedPointType                                  IndexedPointType;
-    typedef BaseType::IndexedPointGeometryType::GeometriesArrayType     IndexedGeometriesArrayType;
-    typedef Line2D2 < IndexedPointType >                                IndexedPointLineType;
-    typedef Triangle2D3 < IndexedPointType >                            IndexedPointTriangleType;
+    typedef DivideGeometry<TPointType>                                           BaseType;
+    typedef typename BaseType::GeometryType                                      GeometryType;
+    typedef typename BaseType::IndexedPointType                                  IndexedPointType;
+    typedef typename BaseType::IndexedPointPointerType                           IndexedPointPointerType;
+    typedef typename BaseType::IndexedPointGeometryType                          IndexedPointGeometryType;
+    typedef typename BaseType::IndexedPointGeometryType::GeometriesArrayType     IndexedGeometriesArrayType;
+    typedef typename BaseType::IndexedPointGeometryPointerType                   IndexedPointGeometryPointerType;
+    typedef Line2D2 < IndexedPointType >                                         IndexedPointLineType;
+    typedef Triangle2D3 < IndexedPointType >                                     IndexedPointTriangleType;
 
     /// Pointer definition of DivideTriangle2D3
     KRATOS_CLASS_POINTER_DEFINITION(DivideTriangle2D3);
@@ -197,7 +201,7 @@ private:
 
     /// Copy constructor.
     DivideTriangle2D3(DivideTriangle2D3 const& rOther)
-        : DivideGeometry(rOther.GetInputGeometry(), rOther.GetNodalDistances()) {};
+        : DivideGeometry<TPointType>(rOther.GetInputGeometry(), rOther.GetNodalDistances()) {};
 
     ///@}
 

--- a/kratos/utilities/divide_triangle_3d_3.cpp
+++ b/kratos/utilities/divide_triangle_3d_3.cpp
@@ -21,29 +21,36 @@
 namespace Kratos
 {
 
-DivideTriangle3D3::DivideTriangle3D3(const GeometryType& rInputGeometry, const Vector& rNodalDistances) :
-    DivideTriangle2D3(rInputGeometry, rNodalDistances) {};
+template<class TPointType>
+DivideTriangle3D3<TPointType>::DivideTriangle3D3(const GeometryType& rInputGeometry, const Vector& rNodalDistances) :
+    DivideTriangle2D3<TPointType>(rInputGeometry, rNodalDistances) {};
 
-DivideTriangle3D3::~DivideTriangle3D3() {};
+template<class TPointType>
+DivideTriangle3D3<TPointType>::~DivideTriangle3D3() {};
 
-DivideTriangle3D3::IndexedPointGeometryPointerType DivideTriangle3D3::GenerateAuxiliaryPartitionTriangle(
+template<class TPointType>
+typename DivideTriangle3D3<TPointType>::IndexedPointGeometryPointerType DivideTriangle3D3<TPointType>::GenerateAuxiliaryPartitionTriangle(
     const int I0,
     const int I1,
     const int I2)
 {
     return Kratos::make_shared<IndexedPointTriangleType>(
-        mAuxPointsContainer(I0),
-        mAuxPointsContainer(I1),
-        mAuxPointsContainer(I2));
+        this->mAuxPointsContainer(I0),
+        this->mAuxPointsContainer(I1),
+        this->mAuxPointsContainer(I2));
 }
 
-DivideTriangle3D3::IndexedPointGeometryPointerType DivideTriangle3D3::GenerateIntersectionLine(
+template<class TPointType>
+typename DivideTriangle3D3<TPointType>::IndexedPointGeometryPointerType DivideTriangle3D3<TPointType>::GenerateIntersectionLine(
     const int I0,
     const int I1)
 {
     return Kratos::make_shared<IndexedPointLineType>(
-        mAuxPointsContainer(I0),
-        mAuxPointsContainer(I1));
+        this->mAuxPointsContainer(I0),
+        this->mAuxPointsContainer(I1));
 }
+
+template class DivideTriangle3D3<Node<3>>;
+template class DivideTriangle3D3<IndexedPoint>;
 
 };

--- a/kratos/utilities/divide_triangle_3d_3.h
+++ b/kratos/utilities/divide_triangle_3d_3.h
@@ -41,15 +41,18 @@ namespace Kratos
 ///@name  Functions
 ///@{
 
-class KRATOS_API(KRATOS_CORE) DivideTriangle3D3 : public DivideTriangle2D3
+template<class TPointType>
+class KRATOS_API(KRATOS_CORE) DivideTriangle3D3 : public DivideTriangle2D3<TPointType>
 {
 public:
     ///@name Type Definitions
     ///@{
-
+    typedef DivideGeometry<TPointType>                                  BaseType;
+    typedef typename BaseType::GeometryType                             GeometryType;
+    typedef typename BaseType::IndexedPointType                         IndexedPointType;
     typedef Line3D2 < IndexedPointType >                                IndexedPointLineType;
     typedef Triangle3D3 < IndexedPointType >                            IndexedPointTriangleType;
-
+    typedef typename BaseType::IndexedPointGeometryPointerType          IndexedPointGeometryPointerType;
     /// Pointer definition of DivideTriangle2D3
     KRATOS_CLASS_POINTER_DEFINITION(DivideTriangle3D3);
 
@@ -130,7 +133,7 @@ private:
 
     /// Copy constructor.
     DivideTriangle3D3(DivideTriangle3D3 const& rOther)
-        : DivideTriangle2D3(rOther.GetInputGeometry(), rOther.GetNodalDistances()) {};
+        : DivideTriangle2D3<TPointType>(rOther.GetInputGeometry(), rOther.GetNodalDistances()) {};
 
     ///@}
 

--- a/kratos/utilities/embedded_skin_utility.cpp
+++ b/kratos/utilities/embedded_skin_utility.cpp
@@ -126,7 +126,7 @@ namespace Kratos
     {
         // Set the split utility and compute the splitting pattern
         const auto &r_geom = pElement->GetGeometry();
-        DivideGeometry::Pointer p_split_utility = this->SetDivideGeometryUtility(r_geom, rNodalDistances);
+        DivideGeometry<Node<3>>::Pointer p_split_utility = this->SetDivideGeometryUtility(r_geom, rNodalDistances);
         p_split_utility->GenerateDivision();
         p_split_utility->GenerateIntersectionsSkin();
 
@@ -319,7 +319,7 @@ namespace Kratos
     }
 
     template<std::size_t TDim>
-    DivideGeometry::Pointer EmbeddedSkinUtility<TDim>::SetDivideGeometryUtility(
+    typename DivideGeometry<Node<3>>::Pointer EmbeddedSkinUtility<TDim>::SetDivideGeometryUtility(
         const Geometry<Node<3>> &rGeometry,
         const Vector& rNodalDistances)
     {
@@ -329,9 +329,9 @@ namespace Kratos
         // Return the divide geometry utility
         switch (geometry_type){
             case GeometryData::KratosGeometryType::Kratos_Triangle2D3:
-                return Kratos::make_shared<DivideTriangle2D3>(rGeometry, rNodalDistances);
+                return Kratos::make_shared<DivideTriangle2D3<Node<3>>>(rGeometry, rNodalDistances);
             case GeometryData::KratosGeometryType::Kratos_Tetrahedra3D4:
-                return Kratos::make_shared<DivideTetrahedra3D4>(rGeometry, rNodalDistances);
+                return Kratos::make_shared<DivideTetrahedra3D4<Node<3>>>(rGeometry, rNodalDistances);
             default:
                 KRATOS_ERROR << "Asking for a non-implemented divide geometry utility.";
         }

--- a/kratos/utilities/embedded_skin_utility.h
+++ b/kratos/utilities/embedded_skin_utility.h
@@ -347,7 +347,7 @@ private:
      * @param rNodalDistances Vector containing the distance values
      * @return A pointer to the divide geometry utility
      */
-    DivideGeometry::Pointer SetDivideGeometryUtility(
+    DivideGeometry<Node<3>>::Pointer SetDivideGeometryUtility(
         const Geometry<Node<3>> &rGeometry,
         const Vector &rNodalDistances);
 


### PR DESCRIPTION
**📝 Description**
This PR templates the divide geometry utility so that the input geometry can be of type node<3> or indexednode type.
This allows to divide recursively the geometries returned by the utilty

Please mark the PR with appropriate tags: 

**🆕 Changelog**
-Modifies divide geometry utility, derived classes and rest of the code that uses them
