### PR TITLE
Fluid/feature/model part preprocessing utilities

### DIFF
--- a/applications/FluidDynamicsApplication/CMakeLists.txt
+++ b/applications/FluidDynamicsApplication/CMakeLists.txt
@@ -24,6 +24,7 @@ set( KRATOS_FLUID_DYNAMICS_APPLICATION_CORE_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/acceleration_limitation_utilities.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/fluid_adjoint_utilities.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/fluid_adjoint_slip_utilities.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/fluid_model_part_preprocessing_utilities.cpp
 
   # elements
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/vms.cpp

--- a/applications/FluidDynamicsApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/FluidDynamicsApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -38,6 +38,7 @@
 #include "custom_utilities/periodic_condition_utilities.h"
 #include "custom_utilities/compressible_element_rotation_utility.h"
 #include "custom_utilities/acceleration_limitation_utilities.h"
+#include "custom_utilities/fluid_model_part_preprocessing_utilities.h"
 
 #include "utilities/split_tetrahedra.h"
 
@@ -180,6 +181,11 @@ void  AddCustomUtilitiesToPython(pybind11::module& m)
         .def_static("CalculateFluidNegativeVolume", &FluidAuxiliaryUtilities::CalculateFluidNegativeVolume)
         ;
 
+    py::class_<FluidModelPartPreProcessingUtilities>(m, "FluidModelPartPreProcessingUtilities")
+        .def_static("CreateModelPartForCommenInterface", &FluidModelPartPreProcessingUtilities::CreateModelPartForCommenInterface)
+        .def_static("GetElementIdsWithAllNodesOnBoundaries", &FluidModelPartPreProcessingUtilities::GetElementIdsWithAllNodesOnBoundaries)
+        .def_static("BreakElements", &FluidModelPartPreProcessingUtilities::BreakElements)
+        ;
 }
 
 }  // namespace Python.

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_model_part_preprocessing_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_model_part_preprocessing_utilities.cpp
@@ -205,14 +205,16 @@ void FluidModelPartPreProcessingUtilities::BreakElements(
     IndexType new_node_id = rModelPart.GetCommunicator().GetDataCommunicator().MaxAll(local_max_node_id) + 1;
 
     const IndexType local_max_element_id  = block_for_each<MaxReduction<IndexType>>(rModelPart.Elements(), [&](ModelPart::ElementType& rElement) -> IndexType {
-        rElement.Set(TO_ERASE, std::find(rElementIds.begin(), rElementIds.end(), rElement.Id()) != rElementIds.end());
+        rElement.Set(TO_ERASE, false);
         return rElement.Id();
     });
     IndexType new_element_id = rModelPart.GetCommunicator().GetDataCommunicator().MaxAll(local_max_element_id) + 1;
 
     IndexType number_of_created_elements = 0;
     for (const auto& element_id : rElementIds) {
-        number_of_created_elements += BreakElement(rModelPart, rModelPart.GetElement(element_id), new_node_id, new_element_id, rNewElementName);
+        auto& r_element = rModelPart.GetElement(element_id);
+        r_element.Set(TO_ERASE, true);
+        number_of_created_elements += BreakElement(rModelPart, r_element, new_node_id, new_element_id, rNewElementName);
     }
 
     rModelPart.RemoveElementsFromAllLevels();

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_model_part_preprocessing_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_model_part_preprocessing_utilities.cpp
@@ -1,0 +1,227 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Suneth Warnakulasuriya
+//
+
+// System includes
+#include <string>
+#include <vector>
+
+// External includes
+
+// Project includes
+
+// Application includes
+#include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
+
+// Include base h
+#include "fluid_model_part_preprocessing_utilities.h"
+
+namespace Kratos
+{
+///@addtogroup FluidDynamicsApplication
+///@{
+
+///@name Kratos classes
+///@{
+
+template<class TContainerType>
+class FluidModelPartPreProcessingUtilitiesHelperClass
+{
+public:
+
+    using IndexType = std::size_t;
+
+    using TEntityType = typename TContainerType::data_type;
+
+    static TContainerType& GetContainer(ModelPart& rModelPart);
+
+    static void AddEntities(ModelPart& rModelPart, const std::vector<IndexType>& rListOfIndices);
+
+    static IndexType FindAndAddCommonEntities(
+        ModelPart& rMainModelPart,
+        ModelPart& rOutputModelPart,
+        const std::vector<std::string>& rListOfInterfaceModelPartNames)
+    {
+        KRATOS_TRY
+
+        auto& r_container = GetContainer(rMainModelPart);
+
+        block_for_each(r_container, [](TEntityType& rEntity) {
+            rEntity.SetValue(DOMAIN_SIZE, 0);
+        });
+
+        for (const auto& r_adjacent_model_part_name : rListOfInterfaceModelPartNames) {
+            auto& r_adjacent_model_part = rMainModelPart.GetSubModelPart(r_adjacent_model_part_name);
+            block_for_each(GetContainer(r_adjacent_model_part), [](TEntityType& rEntity) {
+                rEntity.GetValue(DOMAIN_SIZE) += 1;
+            });
+        }
+
+        std::vector<IndexType> list_of_indices;
+        for (auto& r_entity : r_container) {
+            if (r_entity.GetValue(DOMAIN_SIZE) > 1) {
+                list_of_indices.push_back(r_entity.Id());
+            }
+        }
+
+        AddEntities(rOutputModelPart, list_of_indices);
+
+        return list_of_indices.size();
+
+        KRATOS_CATCH("");
+    }
+};
+
+template<> ModelPart::NodesContainerType& FluidModelPartPreProcessingUtilitiesHelperClass<ModelPart::NodesContainerType>::GetContainer(ModelPart& rModelPart) { return rModelPart.Nodes(); }
+template<> ModelPart::ConditionsContainerType& FluidModelPartPreProcessingUtilitiesHelperClass<ModelPart::ConditionsContainerType>::GetContainer(ModelPart& rModelPart) { return rModelPart.Conditions(); }
+template<> ModelPart::ElementsContainerType& FluidModelPartPreProcessingUtilitiesHelperClass<ModelPart::ElementsContainerType>::GetContainer(ModelPart& rModelPart) { return rModelPart.Elements(); }
+
+template<> void FluidModelPartPreProcessingUtilitiesHelperClass<ModelPart::NodesContainerType>::AddEntities(ModelPart& rModelPart, const std::vector<IndexType>& rListOfIndices) { rModelPart.AddNodes(rListOfIndices); }
+template<> void FluidModelPartPreProcessingUtilitiesHelperClass<ModelPart::ConditionsContainerType>::AddEntities(ModelPart& rModelPart, const std::vector<IndexType>& rListOfIndices) { rModelPart.AddConditions(rListOfIndices); }
+template<> void FluidModelPartPreProcessingUtilitiesHelperClass<ModelPart::ElementsContainerType>::AddEntities(ModelPart& rModelPart, const std::vector<IndexType>& rListOfIndices) { rModelPart.AddElements(rListOfIndices); }
+
+IndexType FluidModelPartPreProcessingUtilities::BreakElement(
+    ModelPart& rModelPart,
+    ModelPart::ElementType& rElement,
+    IndexType& NewNodeId,
+    IndexType& NewElementId,
+    const std::string& rNewElementName)
+{
+    KRATOS_TRY
+
+    auto& r_geometry = rElement.GetGeometry();
+    const IndexType number_of_nodes = r_geometry.PointsNumber();
+
+    array_1d<double, 3> new_coordinates{0.0, 0.0, 0.0};
+    for (const auto& r_node : r_geometry) {
+        new_coordinates += (r_node.Coordinates() / number_of_nodes);
+    }
+
+    auto p_new_node = rModelPart.CreateNewNode(NewNodeId++, new_coordinates[0], new_coordinates[1], new_coordinates[2]);
+
+    auto p_properties = rElement.pGetProperties();
+    std::vector<IndexType> list_of_node_ids(number_of_nodes);
+    for (IndexType i = 0; i < number_of_nodes; ++i) {
+        for (IndexType j = 0; j < number_of_nodes - 1; ++j) {
+            list_of_node_ids[j] = r_geometry[(i + j) % number_of_nodes].Id();
+        }
+        list_of_node_ids[number_of_nodes - 1] = p_new_node->Id();
+        rModelPart.CreateNewElement(rNewElementName, NewElementId++, list_of_node_ids, p_properties);
+    }
+
+    return number_of_nodes;
+
+    KRATOS_CATCH("");
+}
+
+bool FluidModelPartPreProcessingUtilities::CreateModelPartForCommenInterface(
+    ModelPart& rModelPart,
+    const std::string& rCommonInterfaceModelPartName,
+    const std::vector<std::string>& rListOfInterfaceModelPartNames)
+{
+    KRATOS_TRY
+
+    std::stringstream model_part_names;
+    for (const auto& r_model_part_name : rListOfInterfaceModelPartNames) {
+        model_part_names << r_model_part_name;
+    }
+
+    auto& r_output_model_part = rModelPart.CreateSubModelPart(rCommonInterfaceModelPartName);
+
+    const IndexType number_of_common_nodes = FluidModelPartPreProcessingUtilitiesHelperClass<ModelPart::NodesContainerType>::FindAndAddCommonEntities(rModelPart, r_output_model_part, rListOfInterfaceModelPartNames);
+    KRATOS_INFO("FluidModelPartPreProcessingUtilities") << "--- Found " << number_of_common_nodes << " common node(s) in " << rModelPart.FullName() << " using " << model_part_names.str() << "as interface model parts.";
+
+    const IndexType number_of_common_conditions = FluidModelPartPreProcessingUtilitiesHelperClass<ModelPart::ConditionsContainerType>::FindAndAddCommonEntities(rModelPart, r_output_model_part, rListOfInterfaceModelPartNames);
+    KRATOS_INFO("FluidModelPartPreProcessingUtilities") << "--- Found " << number_of_common_conditions << " common condition(s) in " << rModelPart.FullName() << " using " << model_part_names.str() << "as interface model parts.";
+
+    const IndexType number_of_common_elements = FluidModelPartPreProcessingUtilitiesHelperClass<ModelPart::ElementsContainerType>::FindAndAddCommonEntities(rModelPart, r_output_model_part, rListOfInterfaceModelPartNames);
+    KRATOS_INFO("FluidModelPartPreProcessingUtilities") << "--- Found " << number_of_common_elements << " common element(s) in " << rModelPart.FullName() << " using " << model_part_names.str() << "as interface model parts.";
+
+    return !(number_of_common_nodes == 0 && number_of_common_conditions == 0 && number_of_common_elements == 0);
+
+    KRATOS_CATCH("");
+}
+
+std::vector<IndexType> FluidModelPartPreProcessingUtilities::GetElementIdsWithAllNodesOnBoundaries(
+    ModelPart& rModelPart,
+    const std::vector<std::string>& rListOfBoundaryModelPartNames)
+{
+    KRATOS_TRY
+
+    block_for_each(rModelPart.Nodes(), [](ModelPart::NodeType& rNode) {
+        rNode.Set(VISITED, false);
+    });
+
+    for (const auto& r_boundary_model_part_name : rListOfBoundaryModelPartNames) {
+        auto& r_boundary_model_part = rModelPart.GetSubModelPart(r_boundary_model_part_name);
+        block_for_each(r_boundary_model_part.Nodes(), [](ModelPart::NodeType& rNode) {
+            rNode.Set(VISITED, true);
+        });
+    }
+
+    auto problematic_element_ids = block_for_each<AccumReduction<IndexType>>(rModelPart.Elements(), [](ModelPart::ElementType& rElement) -> IndexType {
+        bool is_all_nodes_on_boundary = true;
+        for (const auto& r_node : rElement.GetGeometry()) {
+            if (!r_node.Is(VISITED)) {
+                is_all_nodes_on_boundary = false;
+                break;
+            }
+        }
+
+        if (is_all_nodes_on_boundary) {
+            return rElement.Id();
+        } else {
+            return 0;
+        }
+    });
+
+    std::sort(problematic_element_ids.begin(), problematic_element_ids.end());
+    problematic_element_ids.erase(problematic_element_ids.begin(), std::find_if(problematic_element_ids.begin(), problematic_element_ids.end(), [](const IndexType Value) { return Value > 0;}));
+
+    return problematic_element_ids;
+
+    KRATOS_CATCH("");
+}
+
+void FluidModelPartPreProcessingUtilities::BreakElements(
+    ModelPart& rModelPart,
+    const std::string& rNewElementName,
+    const std::vector<IndexType>& rElementIds)
+{
+    KRATOS_TRY
+
+    const IndexType local_max_node_id = block_for_each<MaxReduction<IndexType>>(rModelPart.Nodes(), [](ModelPart::NodeType& rNode) -> IndexType {
+        return rNode.Id();
+    });
+    IndexType new_node_id = rModelPart.GetCommunicator().GetDataCommunicator().MaxAll(local_max_node_id) + 1;
+
+    const IndexType local_max_element_id  = block_for_each<MaxReduction<IndexType>>(rModelPart.Elements(), [&](ModelPart::ElementType& rElement) -> IndexType {
+        rElement.Set(TO_ERASE, std::find(rElementIds.begin(), rElementIds.end(), rElement.Id()) != rElementIds.end());
+        return rElement.Id();
+    });
+    IndexType new_element_id = rModelPart.GetCommunicator().GetDataCommunicator().MaxAll(local_max_element_id) + 1;
+
+    IndexType number_of_created_elements = 0;
+    for (const auto& element_id : rElementIds) {
+        number_of_created_elements += BreakElement(rModelPart, rModelPart.GetElement(element_id), new_node_id, new_element_id, rNewElementName);
+    }
+
+    rModelPart.RemoveElementsFromAllLevels();
+
+    KRATOS_INFO("FluidModelPartPreProcessingUtilities") << "--- Created " << number_of_created_elements << " element(s) in " << rModelPart.FullName() << " while breaking elements with given ids.";
+
+    KRATOS_CATCH("");
+}
+
+
+} // namespace Kratos
+

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_model_part_preprocessing_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_model_part_preprocessing_utilities.h
@@ -1,0 +1,83 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Suneth Warnakulasuriya
+//
+
+#if !defined(FLUID_MODEL_PART_PREPROCESSING_UTILITIES)
+#define FLUID_MODEL_PART_PREPROCESSING_UTILITIES
+
+// System includes
+#include <string>
+#include <vector>
+
+// External includes
+
+// Project includes
+#include "includes/model_part.h"
+
+// Application includes
+
+namespace Kratos
+{
+///@addtogroup FluidDynamicsApplication
+///@{
+
+///@name Kratos classes
+///@{
+
+class KRATOS_API(FLUID_DYNAMICS_APPLICATION) FluidModelPartPreProcessingUtilities
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    using IndexType = std::size_t;
+
+    ///@}
+    ///@name Public Static Operations
+    ///@{
+
+    bool static CreateModelPartForCommenInterface(
+        ModelPart& rModelPart,
+        const std::string& rCommonInterfaceModelPartName,
+        const std::vector<std::string>& rListOfInterfaceModelPartNames
+    );
+
+    std::vector<IndexType> static GetElementIdsWithAllNodesOnBoundaries(
+        ModelPart& rModelPart,
+        const std::vector<std::string>& rListOfBoundaryModelPartNames
+    );
+
+    void static BreakElements(
+        ModelPart& rModelPart,
+        const std::string& rNewElementName,
+        const std::vector<IndexType>& rElementIds
+    );
+
+    ///@}
+
+private:
+    ///@name Private member functions
+    ///@{
+
+    IndexType static BreakElement(
+        ModelPart& rModelPart,
+        ModelPart::ElementType& rElement,
+        IndexType& NewNodeId,
+        IndexType& NewElementId,
+        const std::string& rNewElementName
+    );
+
+    ///@}
+};
+
+} // namespace Kratos
+
+#endif // FLUID_MODEL_PART_PREPROCESSING_UTILITIES

--- a/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
+++ b/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
@@ -1,4 +1,5 @@
 import KratosMultiphysics
+import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 
 def Factory(settings, Model):
     if(type(settings) != KratosMultiphysics.Parameters):
@@ -47,6 +48,11 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
             self.volume_model_part = self.main_model_part
         else:
             self.volume_model_part = self.main_model_part.GetSubModelPart(self.volume_model_part_name)
+
+        element_ids_with_all_nodes_on_boundaries = KratosFluid.FluidModelPartPreProcessingUtilities.GetElementIdsWithAllNodesOnBoundaries(self.main_model_part, self.skin_name_list.GetStringArray())
+        total_number_of_elements_with_all_nodes_on_boundaries = self.main_model_part.GetCommunicator().GetDataCommunicator().SumAll(len(element_ids_with_all_nodes_on_boundaries))
+        if total_number_of_elements_with_all_nodes_on_boundaries > 0:
+            KratosMultiphysics.Logger.PrintWarning(self.__class__.__name__, "Found {:d} elements with all nodes on boundaries in {:s}.".format(total_number_of_elements_with_all_nodes_on_boundaries, self.main_model_part.FullName()))
 
         skin_parts = []
         for i in range(self.skin_name_list.size()):

--- a/applications/FluidDynamicsApplication/tests/test_FluidDynamicsApplication.py
+++ b/applications/FluidDynamicsApplication/tests/test_FluidDynamicsApplication.py
@@ -51,6 +51,7 @@ if sympy_available:
 from compressible_slip_wall_process_test import TestCompressibleSlipWallProcess
 from compute_pressure_coefficient_process_test import ComputePressureCoefficientProcessTest
 from compute_drag_process_test import ComputeDragProcessTest
+from test_fluid_model_part_preprocessing_utilities import TestFluidModelPartPreprocessingUtilities
 
 
 def AssembleTestSuites():
@@ -89,6 +90,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCompressibleSlipWallProcess]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([ComputePressureCoefficientProcessTest]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([ComputeDragProcessTest]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestFluidModelPartPreprocessingUtilities]))
 
     # Create a test suite with the selected tests plus all small tests
     nightSuite = suites['nightly']

--- a/applications/FluidDynamicsApplication/tests/test_fluid_model_part_preprocessing_utilities.py
+++ b/applications/FluidDynamicsApplication/tests/test_fluid_model_part_preprocessing_utilities.py
@@ -1,0 +1,107 @@
+import KratosMultiphysics as Kratos
+import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
+
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+
+class TestFluidModelPartPreprocessingUtilities(KratosUnittest.TestCase):
+    def test_CreateModelPartForCommenInterface(self):
+        model = Kratos.Model()
+        model_part = model.CreateModelPart("test")
+
+        model_part.CreateNewNode(1, 0.0, 0.0, 0.0)
+        model_part.CreateNewNode(2, 0.0, 1.0, 0.0)
+        model_part.CreateNewNode(3, 1.0, 1.0, 0.0)
+        model_part.CreateNewNode(4, 1.0, 0.0, 0.0)
+
+        wall_model_part = model_part.CreateSubModelPart("wall")
+        wall_model_part.AddNodes([1, 2, 4])
+        side_model_part = model_part.CreateSubModelPart("side")
+        side_model_part.AddNodes([1, 2])
+        none_model_part = model_part.CreateSubModelPart("none")
+        none_model_part.AddNodes([3, 4])
+
+        self.assertTrue(KratosFluid.FluidModelPartPreProcessingUtilities.CreateModelPartForCommenInterface(model_part, "side_wall", ["wall", "side"]))
+        self.assertFalse(KratosFluid.FluidModelPartPreProcessingUtilities.CreateModelPartForCommenInterface(model_part, "side_none", ["none", "side"]))
+
+        for check_node in model["test.side_wall"].Nodes:
+            self.assertTrue((check_node.Id in [node.Id for node in wall_model_part.Nodes]) and (check_node.Id in [node.Id for node in side_model_part.Nodes]))
+
+        self.assertEqual(model["test.side_none"].NumberOfNodes(), 0)
+
+    def test_GetElementIdsWithAllNodesOnBoundaries(self):
+        model = Kratos.Model()
+        model_part = model.CreateModelPart("test")
+        model_part.ProcessInfo[Kratos.DOMAIN_SIZE] = 2
+
+        model_part.CreateNewNode(1, 0.0, 0.0, 0.0)
+        model_part.CreateNewNode(2, 0.0, 1.0, 0.0)
+        model_part.CreateNewNode(3, 1.0, 1.0, 0.0)
+        model_part.CreateNewNode(4, 1.0, 0.0, 0.0)
+        model_part.CreateNewNode(5, 2.0, 1.0, 0.0)
+        model_part.CreateNewNode(6, 2.0, 0.0, 0.0)
+
+        wall_model_part = model_part.CreateSubModelPart("wall")
+        wall_model_part.AddNodes([1, 2, 4])
+
+        side_model_part = model_part.CreateSubModelPart("side")
+        side_model_part.AddNodes([4, 6, 5])
+
+        properties = model_part.GetProperties()[0]
+        model_part.CreateNewElement("Element2D3N", 1, [1, 2, 4], properties)
+        model_part.CreateNewElement("Element2D3N", 2, [2, 3, 4], properties)
+        model_part.CreateNewElement("Element2D3N", 3, [3, 5, 4], properties)
+        model_part.CreateNewElement("Element2D3N", 4, [4, 5, 6], properties)
+
+        element_ids = KratosFluid.FluidModelPartPreProcessingUtilities.GetElementIdsWithAllNodesOnBoundaries(model_part, ["wall", "side"])
+        self.assertEqual(element_ids, [1, 4])
+
+    def test_FixBoundaryElementsTriangle(self):
+        model = Kratos.Model()
+        model_part = model.CreateModelPart("test")
+        model_part.ProcessInfo[Kratos.DOMAIN_SIZE] = 2
+
+        model_part.CreateNewNode(1, 0.0, 0.0, 0.0)
+        model_part.CreateNewNode(2, 0.0, 1.0, 0.0)
+        model_part.CreateNewNode(3, 1.0, 1.0, 0.0)
+        model_part.CreateNewNode(4, 1.0, 0.0, 0.0)
+
+        wall_model_part = model_part.CreateSubModelPart("wall")
+        wall_model_part.AddNodes([1, 2, 4])
+
+        properties = model_part.GetProperties()[0]
+        model_part.CreateNewElement("Element2D3N", 1, [1, 2, 4], properties)
+        model_part.CreateNewElement("Element2D3N", 2, [2, 3, 4], properties)
+
+        element_ids = KratosFluid.FluidModelPartPreProcessingUtilities.GetElementIdsWithAllNodesOnBoundaries(model_part, ["wall"])
+        self.assertEqual(element_ids, [1])
+        KratosFluid.FluidModelPartPreProcessingUtilities.BreakElements(model_part, "Element2D3N", element_ids)
+        element_ids = KratosFluid.FluidModelPartPreProcessingUtilities.GetElementIdsWithAllNodesOnBoundaries(model_part, ["wall"])
+        self.assertEqual(element_ids, [])
+        # Kratos.ModelPartIO("test", Kratos.IO.IGNORE_VARIABLES_ERROR | Kratos.IO.WRITE | Kratos.IO.MESH_ONLY).WriteModelPart(model_part)
+
+    def test_FixBoundaryElementsTetrahedra(self):
+        model = Kratos.Model()
+        model_part = model.CreateModelPart("test")
+
+        model_part.CreateNewNode(1, 0.0, 0.0, 0.0)
+        model_part.CreateNewNode(2, 0.0, 1.0, 0.0)
+        model_part.CreateNewNode(3, 1.0, 0.0, 0.0)
+        model_part.CreateNewNode(4, 0.5, 0.5, 1.0)
+        model_part.CreateNewNode(5, 1.0, 1.0, 1.0)
+
+        wall_model_part = model_part.CreateSubModelPart("wall")
+        wall_model_part.AddNodes([1, 2, 3, 4])
+
+        properties = model_part.GetProperties()[0]
+        model_part.CreateNewElement("Element3D4N", 1, [1, 2, 3, 4], properties)
+        model_part.CreateNewElement("Element3D4N", 2, [2, 3, 4, 5], properties)
+
+        element_ids = KratosFluid.FluidModelPartPreProcessingUtilities.GetElementIdsWithAllNodesOnBoundaries(model_part, ["wall"])
+        self.assertEqual(element_ids, [1])
+        KratosFluid.FluidModelPartPreProcessingUtilities.BreakElements(model_part, "Element3D4N", element_ids)
+        element_ids = KratosFluid.FluidModelPartPreProcessingUtilities.GetElementIdsWithAllNodesOnBoundaries(model_part, ["wall"])
+        self.assertEqual(element_ids, [])
+        # Kratos.ModelPartIO("test", Kratos.IO.IGNORE_VARIABLES_ERROR | Kratos.IO.WRITE | Kratos.IO.MESH_ONLY).WriteModelPart(model_part)
+
+if __name__ == '__main__':
+    KratosUnittest.main()


### PR DESCRIPTION
**📝 Description**
This PR adds `FluidModelPartPreProcessingUtilities` to pre-process model parts if required. Especially this adds the method `FluidModelPartPreProcessingUtilities::GetElementIdsWithAllNodesOnBoundaries` which throws a warning if there are elements in the model part which has all nodes on boundaries which causes convergence problems. Additionally it adds `FluidModelPartPreProcessingUtilities::CreateModelPartForCommenInterface` which creates a new sub model part having all the common entities among all the given model parts names list. The method `FluidModelPartPreProcessingUtilities::BreakElements` can be used to break the elements into smaller elements which is usefull if one wants to break elements which have all nodes on boundaries.

Added tests for all of these methods.

**🆕 Changelog**
- Added `FluidModelPartPreProcessingUtilities`
- Added tests
- Added a warning in `CheckAndPrepareModelProcess` if there are any elements which has all nodes in boundaries
