### PR TITLE
use the "advanced" version of the bin search

### DIFF
--- a/applications/MeshMovingApplication/custom_utilities/fixed_mesh_ale_utilities.cpp
+++ b/applications/MeshMovingApplication/custom_utilities/fixed_mesh_ale_utilities.cpp
@@ -203,7 +203,7 @@ namespace Kratos
              )
             {
                 // Find the origin model part node in the virtual mesh
-                Vector aux_N(4);
+                Vector aux_N(TDim+1);
                 Element::Pointer p_elem = nullptr;
                 const bool is_found = bin_based_point_locator.FindPointOnMesh(
                     rNode.Coordinates(), 


### PR DESCRIPTION
**📝 Description**
this is a performance fix to avoid the creation of temporary for every node. 

also a large number of maximum results is used which help prevents segfaults in cases in which the maximum number of search results is exceeded. (marked as bugfix because of this reason)

Please mark the PR with appropriate tags: 
- Performance, Bugfix

**🆕 Changelog**
usingthe "advanced" version of the bin search instead of the simplified one so that TLS storage can be used for auxilary search array
