### PR TITLE
[BDF] Constant DT and high order schemes

### DIFF
--- a/kratos/solving_strategies/schemes/residual_based_bdf_scheme.h
+++ b/kratos/solving_strategies/schemes/residual_based_bdf_scheme.h
@@ -251,8 +251,8 @@ public:
 
         const double dt_0 = r_current_process_info[DELTA_TIME];
         const double dt_1 = r_current_process_info.GetPreviousTimeStepInfo(1)[DELTA_TIME];
-        KRATOS_ERROR_IF(mOrder > 2 && std::abs(dt_0 -dt_1) > std::numeric_limits<double>::epsilon())
-        << "ResidualBasedBDFScheme. For higher orders than 2 the time step must be constant.\n";
+        KRATOS_ERROR_IF(mOrder > 2 && std::abs(dt_0 - dt_1) > 1e-10*(dt_0 + dt_1))
+        << "ResidualBasedBDFScheme. For higher orders than 2 the time step must be constant.\nPrevious time step : " << dt_1 << "\nCurrent time step : " << dt_0 << std::endl;
 
         KRATOS_CATCH( "" );
     }


### PR DESCRIPTION
**📝 Description**
In #9901 the verbosity was reduced and the warning was turned into an error.
Now, the comparison of small floats is throwing an error because of the roundoff. This is a problem because the simulation is killed.

**🆕 Changelog**
- Better comparison of small floats
