### PR TITLE
Fixing bugs in function_parser_utility

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_function_parser_utility.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_function_parser_utility.cpp
@@ -67,6 +67,24 @@ KRATOS_TEST_CASE_IN_SUITE(GenericFunctionUtility1, KratosCoreFastSuite)
     KRATOS_CHECK_STRING_EQUAL(function6.FunctionBody(), "(1.0)*(50*(exp(t)-2))");
     KRATOS_CHECK_DOUBLE_EQUAL(function6.CallFunction(0.0,0.0,0.0,0.0), -50);
 
+    {
+        auto fun = GenericFunctionUtility("2 + 0xB0B0");
+        KRATOS_CHECK_IS_FALSE(fun.DependsOnSpace());
+    }
+    {
+        auto fun = GenericFunctionUtility("3*y");
+        KRATOS_CHECK(fun.DependsOnSpace());
+    }
+    {
+        auto fun = GenericFunctionUtility("Z");
+        KRATOS_CHECK(fun.DependsOnSpace());
+    }
+    {
+        auto fun = GenericFunctionUtility("x + 0x34321");
+        KRATOS_CHECK(fun.DependsOnSpace());
+    }
+    
+
     KRATOS_CHECK_EXCEPTION_IS_THROWN(GenericFunctionUtility("NotAValidExpression"), "Error: \nParsing error in function: NotAValidExpression\nError occurred near here :                   ^ (char [18])\nCheck your locale (e.g. if \".\" or \",\" is used as decimal point)");
 }
 

--- a/kratos/utilities/function_parser_utility.cpp
+++ b/kratos/utilities/function_parser_utility.cpp
@@ -27,16 +27,12 @@
 namespace Kratos
 {
 
-/***********************************************************************************/
-/***********************************************************************************/
-
 /**
- * Ternary version of adjacent_find, with padding.
- * 
- * Scans a sequence with a 3-window, passing it to a predicate.
+ * @brief Ternary version of adjacent_find, with padding.
+ * @details Scans a sequence with a 3-window, passing it to a predicate.
  * The window is padded such that every element of the sequence
  * is the middle element of the window once.
- * Returns the iterator to the middle of the first window to
+ * @return Returns the iterator to the middle of the first window to
  * fulfill the predicate.
  */
 template<typename ForwardIterator, typename TernaryPredicate>
@@ -44,7 +40,8 @@ ForwardIterator PaddedWindowFind(
     ForwardIterator Begin,
     ForwardIterator End,
     typename std::iterator_traits<ForwardIterator>::value_type Padding,
-    TernaryPredicate&& Pred)
+    TernaryPredicate&& Pred
+    )
 {
     // Edge case: length 0
     if(Begin == End) {
@@ -71,16 +68,15 @@ ForwardIterator PaddedWindowFind(
     return Pred(*Begin, *wmiddle, Padding) ? wmiddle : End;
 }
 
-
 /** 
-* CHECKING IF THE FUNCTION DEPENDS ON SPACE f(var in {x,y,z,X,Y,Z})
- * Appearances of these letters that are not a dependence in space:
+ * @brief CHECKING IF THE FUNCTION DEPENDS ON SPACE f(var in {x,y,z,X,Y,Z})
+ * @details Appearances of these letters that are not a dependence in space:
  *  - Variable containing the letter: Starts with a letter, followed by letters, numbers, or underscores
  *  - Hex number:                     Starts with 0x, followed by numbers or abcdefABCDEF
  *  - Function containing x:          exp
  */
-bool ExpressionDependsOnSpace(std::string const& expression) {
-    return PaddedWindowFind(expression.cbegin(), expression.cend(), '\0', 
+bool ExpressionDependsOnSpace(std::string const& rExpression) {
+    return PaddedWindowFind(rExpression.cbegin(), rExpression.cend(), '\0', 
         [] (char lead, char middle, char last) {
             constexpr auto const& variables = "xyzXYZ";
             if(std::find(std::begin(variables), std::end(variables), middle) == std::end(variables)) {
@@ -88,8 +84,11 @@ bool ExpressionDependsOnSpace(std::string const& expression) {
             }
             return !std::isalnum(lead) && !std::isalnum(last);
         }
-    ) != expression.cend();
+    ) != rExpression.cend();
 }
+
+/***********************************************************************************/
+/***********************************************************************************/
 
 BasicGenericFunctionUtility::BasicGenericFunctionUtility(const std::string& rFunctionBody)
     : mFunctionBody(rFunctionBody)

--- a/kratos/utilities/function_parser_utility.cpp
+++ b/kratos/utilities/function_parser_utility.cpp
@@ -80,9 +80,9 @@ ForwardIterator PaddedWindowFind(
  *  - Function containing x:          exp
  */
 bool ExpressionDependsOnSpace(std::string const& expression) {
-    constexpr auto const& variables = "xyzXYZ";
     return PaddedWindowFind(expression.cbegin(), expression.cend(), '\0', 
-        [&] (char lead, char middle, char last) {
+        [] (char lead, char middle, char last) {
+            constexpr auto const& variables = "xyzXYZ";
             if(std::find(std::begin(variables), std::end(variables), middle) == std::end(variables)) {
                 return false; // Middle character is not xyzXYZ
             }


### PR DESCRIPTION
## 📝 Description
This PR fixes two bugs:
 - #10041
 - #10077

Ideally we'd use a regex (even more ideally [CTRE](https://github.com/hanickadot/compile-time-regular-expressions)) and be done, but aparently that is not possible on Centos.
This PR fixes the bugs in the fallback case, and unifies behaviour into a single path.

Splitting it into two paths only allowed for bugs to lay dormant.

## Implementation details
I created a fancy version of adjacent_find, but with 3 instead of 2 adjacent elements passed to the predicate.
```
    Hello, world
      ~~~
     Pred('l', 'l', 'o')       window analyses three entries at a time
```
```
    Hello, world
   ~~~        ~~~
              Pred('l', 'd', '\0')    first and last iterations are padded
   Pred('\0', 'H', 'e')
```
Then the logic is implemented for an arbitrary set of three contiguous characters. Basically manually appplying the following regex:
```regex
/\b[xyzXYZ]\b/
```
based on the documentation of tinyexpr.

## Alternative solution
Keeping the regex when not in centos, and hardcoding DependsOnSpace=true when in centos. This check is only an optimization to avoid recomputing the function at every node, so we could do without it if we prefered so.