### PR TITLE
[MeshingApplication] Add support to specify local entity parameters 

### DIFF
--- a/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
+++ b/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
@@ -747,7 +747,7 @@ void MmgProcess<TMMGLibrary>::ApplyLocalParameters() {
     }
 
     // Count number of parameters given by the user
-    auto parameter_array = mThisParameters["advanced_parameters"]["local_entity_parameters_list"];
+    const auto parameter_array = mThisParameters["advanced_parameters"]["local_entity_parameters_list"];
     IndexType n_parameters = parameter_array.size();
     for (auto& parameter_settings : parameter_array) {
         n_parameters += parameter_settings["model_part_name_list"].size();
@@ -760,12 +760,17 @@ void MmgProcess<TMMGLibrary>::ApplyLocalParameters() {
     // apply (triangle or tetra), the reference of these entities and the hmin, hmax and
     // hausdorff values to apply
     for (auto parameter_settings : parameter_array) {
-        for (auto model_part_name : parameter_settings["model_part_name_list"])
+        for (auto model_part_name_object : parameter_settings["model_part_name_list"])
         {
-            double hmin = parameter_settings["hmin"].GetDouble();
-            double hmax = parameter_settings["hmax"].GetDouble();
-            double hausdorff = parameter_settings["hausdorff_value"].GetDouble();
-            const IndexType color = string_to_color[model_part_name.GetString()];
+            KRATOS_ERROR_IF_NOT(parameter_settings.Has("hmin")) << "hmin is missing in the local entity parameters list";
+            const double hmin = parameter_settings["hmin"].GetDouble();
+            KRATOS_ERROR_IF_NOT(parameter_settings.Has("hmax")) << "hmax is missing in the local entity parameters list";
+            const double hmax = parameter_settings["hmax"].GetDouble();
+            KRATOS_ERROR_IF_NOT(parameter_settings.Has("hausdorff_value")) << "hausdorff is missing in the local entity parameters list";
+            const double hausdorff = parameter_settings["hausdorff_value"].GetDouble();
+            const auto model_part_name = model_part_name_object.GetString();
+            KRATOS_ERROR_IF(string_to_color.find(model_part_name) == string_to_color.end()) << "model_part_name " << model_part_name << " is not found in the colors list";
+            const IndexType color = string_to_color[model_part_name];
             mMmgUtilities.SetLocalParameter(color, hmin, hmax, hausdorff);
         }
     }

--- a/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
+++ b/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
@@ -485,6 +485,11 @@ void MmgProcess<TMMGLibrary>::ExecuteRemeshing()
         r_old_auxiliar_model_part.AddElements( r_auxiliar_model_part.ElementsBegin(), r_auxiliar_model_part.ElementsEnd() );
     }
 
+    // Apply local entity parameters if there are any
+    if (mThisParameters["advanced_parameters"]["local_entity_parameters_list"].size() > 0) {
+        ApplyLocalParameters();
+    }
+
     // Calling the library functions
     if (mDiscretization == DiscretizationOption::ISOSURFACE) {
         mMmgUtilities.MMGLibCallIsoSurface(mThisParameters);
@@ -725,6 +730,45 @@ void MmgProcess<TMMGLibrary>::InitializeElementsAndConditions()
     });
 
     KRATOS_CATCH("");
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<MMGLibrary TMMGLibrary>
+void MmgProcess<TMMGLibrary>::ApplyLocalParameters() {
+
+    // Find colors with a unique submodelpart (size == 1)
+    std::unordered_map<std::string, IndexType> string_to_color;
+    for (auto& r_color : mColors) {
+        if (r_color.second.size() == 1)  {
+            string_to_color[r_color.second[0]] = r_color.first;
+        }
+    }
+
+    // Count number of parameters given by the user
+    auto parameter_array = mThisParameters["advanced_parameters"]["local_entity_parameters_list"];
+    IndexType n_parameters = parameter_array.size();
+    for (auto& parameter_settings : parameter_array) {
+        n_parameters += parameter_settings["model_part_name_list"].size();
+    }
+
+    // Set the number of tags references on which you will impose local parameters
+    mMmgUtilities.SetNumberOfLocalParameters(n_parameters);
+
+    // For each local parameter, set the type of the entity on which the parameter will
+    // apply (triangle or tetra), the reference of these entities and the hmin, hmax and
+    // hausdorff values to apply
+    for (auto parameter_settings : parameter_array) {
+        for (auto model_part_name : parameter_settings["model_part_name_list"])
+        {
+            double hmin = parameter_settings["hmin"].GetDouble();
+            double hmax = parameter_settings["hmax"].GetDouble();
+            double hausdorff = parameter_settings["hausdorff_value"].GetDouble();
+            const IndexType color = string_to_color[model_part_name.GetString()];
+            mMmgUtilities.SetLocalParameter(color, hmin, hmax, hausdorff);
+        }
+    }
 }
 
 /***********************************************************************************/
@@ -1318,7 +1362,8 @@ const Parameters MmgProcess<TMMGLibrary>::GetDefaultParameters() const
             "angle_detection_value"               : 45.0,
             "force_gradation_value"               : false,
             "mesh_optimization_only"              : false,
-            "gradation_value"                     : 1.3
+            "gradation_value"                     : 1.3,
+            "local_entity_parameters_list"        : []
         },
         "collapse_prisms_elements"             : false,
         "save_external_files"                  : false,

--- a/applications/MeshingApplication/custom_processes/mmg/mmg_process.h
+++ b/applications/MeshingApplication/custom_processes/mmg/mmg_process.h
@@ -450,6 +450,12 @@ protected:
      */
     virtual void CreateDebugPrePostRemeshOutput(ModelPart& rOldModelPart);
 
+    /**
+     * @brief Applies local hmin, hmax and hausd values to entitities as specified
+     * in the parameters, to locally control the size and curvature of the remeshing.
+    */
+    void ApplyLocalParameters();
+
     ///@}
     ///@name Protected  Access
     ///@{

--- a/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.cpp
+++ b/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.cpp
@@ -2982,6 +2982,64 @@ void MmgUtilities<MMGLibrary::MMGS>::MMGLibCallIsoSurface(Parameters Configurati
 /***********************************************************************************/
 
 template<>
+void MmgUtilities<MMGLibrary::MMG2D>::SetNumberOfLocalParameters(IndexType NumberOfLocalParameter) {
+    if ( MMG3D_Set_iparameter(mMmgMesh,mMmgMet, MMG2D_IPARAM_numberOfLocalParam, NumberOfLocalParameter) != 1)
+        KRATOS_ERROR << "Unable to set the number of local parameters" << std::endl;
+}
+
+
+template<>
+void MmgUtilities<MMGLibrary::MMG3D>::SetNumberOfLocalParameters(IndexType NumberOfLocalParameter) {
+    if ( MMG3D_Set_iparameter(mMmgMesh,mMmgMet,MMG3D_IPARAM_numberOfLocalParam, NumberOfLocalParameter) != 1)
+        KRATOS_ERROR << "Unable to set the number of local parameters" << std::endl;
+}
+
+template<>
+void MmgUtilities<MMGLibrary::MMGS>::SetNumberOfLocalParameters(IndexType NumberOfLocalParameter) {
+    if ( MMG3D_Set_iparameter(mMmgMesh,mMmgMet,MMGS_IPARAM_numberOfLocalParam, NumberOfLocalParameter) != 1)
+        KRATOS_ERROR << "Unable to set the number of local parameters" << std::endl;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+
+template<>
+void MmgUtilities<MMGLibrary::MMG2D>::SetLocalParameter(
+                                    IndexType rColor,
+                                    double HMin,
+                                    double HMax,
+                                    double HausdorffValue) {
+
+    if ( MMG2D_Set_localParameter(mMmgMesh, mMmgMet, MMG5_Edg, rColor, HMin, HMax, HausdorffValue) != 1)
+        KRATOS_ERROR << "Unable to set local parameter" << std::endl;
+}
+
+
+template<>
+void MmgUtilities<MMGLibrary::MMG3D>::SetLocalParameter(
+                                    IndexType rColor,
+                                    double HMin,
+                                    double HMax,
+                                    double HausdorffValue) {
+    if ( MMG3D_Set_localParameter(mMmgMesh, mMmgMet, MMG5_Triangle, rColor, HMin, HMax, HausdorffValue) != 1)
+        KRATOS_ERROR << "Unable to set local parameter" << std::endl;
+}
+
+template<>
+void MmgUtilities<MMGLibrary::MMGS>::SetLocalParameter(
+                                    IndexType rColor,
+                                    double HMin,
+                                    double HMax,
+                                    double HausdorffValue) {
+    if ( MMGS_Set_localParameter(mMmgMesh, mMmgMet, MMG5_Triangle, rColor, HMin, HMax, HausdorffValue) != 1)
+        KRATOS_ERROR << "Unable to set local parameter" << std::endl;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<>
 void MmgUtilities<MMGLibrary::MMG2D>::SetNodes(
     const double X,
     const double Y,

--- a/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.cpp
+++ b/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.cpp
@@ -2983,20 +2983,23 @@ void MmgUtilities<MMGLibrary::MMGS>::MMGLibCallIsoSurface(Parameters Configurati
 
 template<>
 void MmgUtilities<MMGLibrary::MMG2D>::SetNumberOfLocalParameters(IndexType NumberOfLocalParameter) {
-    if ( MMG3D_Set_iparameter(mMmgMesh,mMmgMet, MMG2D_IPARAM_numberOfLocalParam, NumberOfLocalParameter) != 1)
+//mmg2d does not support it for versions below 5.5
+#if MMG_VERSION_GE(5,5)
+    if ( MMG2D_Set_iparameter(mMmgMesh, mMmgMet, MMG2D_IPARAM_numberOfLocalParam, NumberOfLocalParameter) != 1)
         KRATOS_ERROR << "Unable to set the number of local parameters" << std::endl;
+#endif
 }
 
 
 template<>
 void MmgUtilities<MMGLibrary::MMG3D>::SetNumberOfLocalParameters(IndexType NumberOfLocalParameter) {
-    if ( MMG3D_Set_iparameter(mMmgMesh,mMmgMet,MMG3D_IPARAM_numberOfLocalParam, NumberOfLocalParameter) != 1)
+    if ( MMG3D_Set_iparameter(mMmgMesh, mMmgMet, MMG3D_IPARAM_numberOfLocalParam, NumberOfLocalParameter) != 1)
         KRATOS_ERROR << "Unable to set the number of local parameters" << std::endl;
 }
 
 template<>
 void MmgUtilities<MMGLibrary::MMGS>::SetNumberOfLocalParameters(IndexType NumberOfLocalParameter) {
-    if ( MMG3D_Set_iparameter(mMmgMesh,mMmgMet,MMGS_IPARAM_numberOfLocalParam, NumberOfLocalParameter) != 1)
+    if ( MMGS_Set_iparameter(mMmgMesh, mMmgMet, MMGS_IPARAM_numberOfLocalParam, NumberOfLocalParameter) != 1)
         KRATOS_ERROR << "Unable to set the number of local parameters" << std::endl;
 }
 
@@ -3010,9 +3013,11 @@ void MmgUtilities<MMGLibrary::MMG2D>::SetLocalParameter(
                                     double HMin,
                                     double HMax,
                                     double HausdorffValue) {
-
+//mmg2d does not support it for versions below 5.5
+#if MMG_VERSION_GE(5,5)
     if ( MMG2D_Set_localParameter(mMmgMesh, mMmgMet, MMG5_Edg, rColor, HMin, HMax, HausdorffValue) != 1)
         KRATOS_ERROR << "Unable to set local parameter" << std::endl;
+#endif
 }
 
 

--- a/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.h
+++ b/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.h
@@ -730,6 +730,18 @@ public:
      */
     virtual void AssignAndClearAuxiliarSubModelPartForFlags(ModelPart& rModelPart);
 
+    /**
+     * @brief Sets the number of parameters to be defined locally at each reference color.
+     * Required by the library.
+     */
+    void SetNumberOfLocalParameters(IndexType NumberOfLocalParameter);
+
+    /**
+     * @brief Sets the local hmin, hmax and hausdorff value for all entities with the given
+     * color reference.
+     */
+    void SetLocalParameter(IndexType rColor, double HMin, double HMax, double HausdorffValue);
+
     ///@}
     ///@name Access
     ///@{


### PR DESCRIPTION
**📝 Description**
This adds an interface to specify local parameters (hmin, hmax, hausd) to entities with the same reference with MMG.

The need for this started with a fluid dynamics case from @uxuech where the bounding box is not a classical parallelepiped. The issue was that corners of the bounding box were refined. The issue was reported in:

https://forum.mmgtools.org/t/unwanted-refinement-at-domain-corners/633


Using parameters (https://www.mmgtools.org/parameter-file) we were able to fix the issue by providing high local hausdorff values at all faces except the ground (the geometry of interest is touching the ground in this example.


![image](https://user-images.githubusercontent.com/32136457/181732306-2833b946-b18c-455c-a936-ea36ad804ed8.png)

![image](https://user-images.githubusercontent.com/32136457/181732371-fd62f6b5-26f9-43e8-9e75-af137de67d76.png)


This case was run with the following mmg_parameters:

```
KratosMultiphysics.Parameters("""
    {
        "filename"                         : "out",
        "discretization_type"              : "STANDARD",
        "advanced_parameters"                  :
        {
            "local_entity_parameters_list"        : [
                {
                    "model_part_name_list" : ["Top", "Wall2", "Inlet", "Outlet", "Wall1"],
                    "hmin"            : 50.0,
                    "hmax"            : 100.0,
                    "hausdorff_value" : 1000.0
                }]
        }
    }
    """)
```



**🆕 Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Added interface to specify local entities mmg parameters