### PR TITLE
[HDF5] Fix Forwarded Process Parameters

### DIFF
--- a/applications/HDF5Application/python_scripts/point_set_output_process.py
+++ b/applications/HDF5Application/python_scripts/point_set_output_process.py
@@ -10,7 +10,7 @@ def Factory(parameters: KratosMultiphysics.Parameters,
             model: KratosMultiphysics.Model):
     if not isinstance(parameters, KratosMultiphysics.Parameters):
         raise Exception("expecting input parameters of type KratosMultiphysics.Parameters, but got {}".format(type(parameters)))
-    return PointSetOutputProcess(model, parameters)
+    return PointSetOutputProcess(model, parameters["Parameters"])
 
 
 

--- a/applications/HDF5Application/tests/test_point_set_output_process.py
+++ b/applications/HDF5Application/tests/test_point_set_output_process.py
@@ -38,7 +38,9 @@ class TestPointSetOutputProcess(UnitTest.TestCase):
         number_of_steps = 10
 
         # Write coordinates and variables
-        point_set_output_process = PointSetOutputProcessFactory(parameters, model)
+        process_parameters = KratosMultiphysics.Parameters()
+        process_parameters.AddValue("Parameters", parameters)
+        point_set_output_process = PointSetOutputProcessFactory(process_parameters, model)
         point_set_output_process.ExecuteInitialize()
 
         for i_step in range(number_of_steps):


### PR DESCRIPTION
Parameters forwarded from ```point_set_output_process.Factory``` were incorrect.