### PR TITLE
[Core] GenericFindElementsNeighbours using Execute

### DIFF
--- a/applications/ConvectionDiffusionApplication/python_scripts/move_particle_utility_process.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/move_particle_utility_process.py
@@ -42,12 +42,10 @@ class MoveParticleUtilityProcess(KM.Process):
 
     def ExecuteBeforeSolutionLoop(self):
         dimension = self.model_part.ProcessInfo[KM.DOMAIN_SIZE]
-        num_of_avg_elems = 10
-        num_of_avg_nodes = 10
         neighbor_search = KM.FindNodalNeighboursProcess(self.model_part)
         neighbor_search.Execute()
         neighbor_elements_search = KM.GenericFindElementalNeighboursProcess(self.model_part)
-        neighbor_elements_search.ExecuteInitialize()
+        neighbor_elements_search.Execute()
 
         settings = self.model_part.ProcessInfo[KM.CONVECTION_DIFFUSION_SETTINGS]
         self.unknown_var = settings.GetUnknownVariable()

--- a/applications/FemToDemApplication/custom_processes/extend_pressure_condition_process.cpp
+++ b/applications/FemToDemApplication/custom_processes/extend_pressure_condition_process.cpp
@@ -311,7 +311,7 @@ void ExtendPressureConditionProcess<TDim>::Execute()
 {
     // We search the neighbours for the generation of line loads
     auto find_neigh = GenericFindElementalNeighboursProcess(mrModelPart);
-    find_neigh.ExecuteInitialize();
+    find_neigh.Execute();
     auto& r_process_info = mrModelPart.GetProcessInfo();
 
     // Remove previous line loads-> Only the 1st iteration

--- a/applications/FemToDemApplication/custom_processes/regenerate_pfem_pressure_conditions_process.cpp
+++ b/applications/FemToDemApplication/custom_processes/regenerate_pfem_pressure_conditions_process.cpp
@@ -205,7 +205,7 @@ void RegeneratePfemPressureConditionsProcess<TDim>::Execute()
 {
     // We search the neighbours for the generation of line loads
     auto find_neigh = GenericFindElementalNeighboursProcess(mrModelPart);
-    find_neigh.ExecuteInitialize();
+    find_neigh.Execute();
 
     if (!mrModelPart.HasSubModelPart("PFEMPressureConditions")) {
         mrModelPart.CreateSubModelPart("PFEMPressureConditions");

--- a/applications/FemToDemApplication/python_scripts/MainCouplingFemDem.py
+++ b/applications/FemToDemApplication/python_scripts/MainCouplingFemDem.py
@@ -355,7 +355,7 @@ class MainCoupledFemDem_Solution:
             self.nodal_neighbour_finder.Execute()
         else: # 2D
             neighbour_elemental_finder =  KratosMultiphysics.GenericFindElementalNeighboursProcess(self.FEM_Solution.main_model_part)
-            neighbour_elemental_finder.ExecuteInitialize()
+            neighbour_elemental_finder.Execute()
 
 #PerformRemeshingIfNecessary============================================================================================================================
     def PerformRemeshingIfNecessary(self):
@@ -396,7 +396,7 @@ class MainCoupledFemDem_Solution:
                 else: # 2D
                     self.InitializeSolutionAfterRemeshing()
                     neighbour_elemental_finder =  KratosMultiphysics.GenericFindElementalNeighboursProcess(self.FEM_Solution.main_model_part)
-                    neighbour_elemental_finder.ExecuteInitialize()
+                    neighbour_elemental_finder.Execute()
 
 #RefineMappedVariables============================================================================================================================
     def RefineMappedVariables(self):

--- a/applications/FemToDemApplication/python_scripts/MainFEM_for_coupling.py
+++ b/applications/FemToDemApplication/python_scripts/MainFEM_for_coupling.py
@@ -77,7 +77,7 @@ class FEM_for_coupling_Solution(MainFemDem.FEM_Solution):
 
         if (self.ProjectParameters["solver_settings"]["strategy_type"].GetString() == "arc_length"):
             neighbour_elemental_finder =  KratosMultiphysics.GenericFindElementalNeighboursProcess(self.main_model_part)
-            neighbour_elemental_finder.ExecuteInitialize()
+            neighbour_elemental_finder.Execute()
             self.InitializeIntegrationPointsVariables()
             self.model_processes.ExecuteBeforeSolutionLoop()
             self.model_processes.ExecuteInitializeSolutionStep()

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -208,7 +208,7 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
 
         elemental_neighbour_search = KratosMultiphysics.GenericFindElementalNeighboursProcess(
             computing_model_part)
-        elemental_neighbour_search.ExecuteInitialize()
+        elemental_neighbour_search.Execute()
 
         # Set and initialize the solution strategy
         solution_strategy = self._GetSolutionStrategy()

--- a/applications/FluidDynamicsApplication/tests/distance_smoothing_test.py
+++ b/applications/FluidDynamicsApplication/tests/distance_smoothing_test.py
@@ -41,7 +41,7 @@ class TestDistanceSmoothing(KratosUnittest.TestCase):
                 kratos_comm, model_part).Execute()
 
         KratosMultiphysics.GenericFindElementalNeighboursProcess(
-            model_part).ExecuteInitialize()
+            model_part).Execute()
 
         # Set IS_STRUCTURE to define contact with solid
         for node in model_part.Nodes:

--- a/applications/PFEM2Application/python_scripts/frac_step_solverQ.py
+++ b/applications/PFEM2Application/python_scripts/frac_step_solverQ.py
@@ -44,8 +44,8 @@ def AddVariables(model_part,p_model_part):
 
     model_part.AddNodalSolutionStepVariable(MOMENTUM_CM)
 
-   
-    
+
+
     model_part.AddNodalSolutionStepVariable(IS_BOUNDARY)
     #model_part.AddNodalSolutionStepVariable(TO_ERASE)
     model_part.AddNodalSolutionStepVariable(MATERIAL_VARIABLE);
@@ -56,15 +56,15 @@ def AddVariables(model_part,p_model_part):
     model_part.AddNodalSolutionStepVariable(IS_WATER)
     model_part.AddNodalSolutionStepVariable(IS_STRUCTURE);
     model_part.AddNodalSolutionStepVariable(IS_FREE_SURFACE)
-    
 
-    
+
+
     model_part.AddNodalSolutionStepVariable(IS_VISITED)
     model_part.AddNodalSolutionStepVariable(NODAL_H)
 
     model_part.AddNodalSolutionStepVariable(IS_POROUS)
     model_part.AddNodalSolutionStepVariable(IS_EROSIONABLE)
-    
+
 
     model_part.AddNodalSolutionStepVariable(PRESSUREAUX)
 
@@ -111,8 +111,8 @@ def AddVariables(model_part,p_model_part):
 
     p_model_part.AddNodalSolutionStepVariable(MOMENTUM_CM)
 
-   
-    
+
+
     p_model_part.AddNodalSolutionStepVariable(IS_BOUNDARY)
     #p_model_part.AddNodalSolutionStepVariable(ERASE_FLAG)
     p_model_part.AddNodalSolutionStepVariable(MATERIAL_VARIABLE);
@@ -123,15 +123,15 @@ def AddVariables(model_part,p_model_part):
     p_model_part.AddNodalSolutionStepVariable(IS_WATER)
     p_model_part.AddNodalSolutionStepVariable(IS_STRUCTURE);
     p_model_part.AddNodalSolutionStepVariable(IS_FREE_SURFACE)
-    
 
-    
+
+
     p_model_part.AddNodalSolutionStepVariable(IS_VISITED)
     p_model_part.AddNodalSolutionStepVariable(NODAL_H)
 
     p_model_part.AddNodalSolutionStepVariable(IS_POROUS)
     p_model_part.AddNodalSolutionStepVariable(IS_EROSIONABLE)
-    
+
 
     p_model_part.AddNodalSolutionStepVariable(PRESSUREAUX)
 
@@ -141,28 +141,28 @@ def AddVariables(model_part,p_model_part):
 
 
 def AddDofs(model_part,p_model_part):
-  
+
     for node in model_part.Nodes:
-        node.AddDof(PRESSURE); 
+        node.AddDof(PRESSURE);
         node.AddDof(VELOCITY_X);
         node.AddDof(VELOCITY_Y);
         node.AddDof(VELOCITY_Z);
 
-   
+
 
 def ReadRestartFile(FileName,nodes):
    NODES = nodes
    aaa = open(FileName)
    for line in aaa:
        exec(line)
-       
-  
+
+
 
 class FracStepSolver:
-    
+
     def __init__(self,model_part,p_model_part,domain_size):
 
-        
+
         #neighbour search
         number_of_avg_elems = 10
         number_of_avg_nodes = 10
@@ -179,7 +179,7 @@ class FracStepSolver:
         self.max_press_its = 5;
         self.time_order = 2;
         self.CalculateReactions = False;
-        self.ReformDofAtEachIteration = False; 
+        self.ReformDofAtEachIteration = False;
         self.CalculateNormDxFlag = True;
         self.laplacian_form = 2; #1 = laplacian, 2 = Discrete Laplacian
         self.predictor_corrector = False;
@@ -189,7 +189,7 @@ class FracStepSolver:
         #definition of the solvers
         pDiagPrecond = DiagonalPreconditioner()
         #self.velocity_linear_solver = BICGSTABSolver(1e-6, 5000, pDiagPrecond)
-        
+
         self.velocity_linear_solver =  SuperLUSolver()
 
         self.pressure_linear_solver =  BICGSTABSolver(1e-6, 5000,pDiagPrecond)
@@ -202,7 +202,7 @@ class FracStepSolver:
         self.slip_conditions_initialized = False
         self.neigh_finder = FindNodalNeighboursProcess(model_part)
         self.compute_reactions=False
-        self.timer=Timer()    
+        self.timer=Timer()
         #self.particle_utils = ParticleUtils2D()
 
         #self.normal=NormalCalculationUtils()
@@ -216,27 +216,27 @@ class FracStepSolver:
         self.Pfem2_apply_bc_process = Pfem2ApplyBCProcess(model_part);
         self.Pfem2Utils = Pfem2Utils()
         self.mark_outer_nodes_process = MarkOuterNodesProcess(model_part);
-        
+
         if(domain_size == 2):
-            self.particle_utils = ParticleUtils2D()	
+            self.particle_utils = ParticleUtils2D()
             self.Mesher = TriGenPFEMModeler()
-            
+
             self.fluid_neigh_finder = FindNodalNeighboursProcess(model_part)
             #this is needed if we want to also store the conditions a node belongs to
             self.condition_neigh_finder = FindConditionsNeighboursProcess(model_part,2, 10)
-            self.elem_neighbor_finder = GenericFindElementalNeighboursProcess(model_part)	
-            
+            self.elem_neighbor_finder = GenericFindElementalNeighboursProcess(model_part)
+
         elif (domain_size == 3):
             #self.Mesher = TetGenModeler()
             #improved mesher
             self.particle_utils = ParticleUtils3D()
-            
+
             self.Mesher = TetGenPfemModeler()
             self.fluid_neigh_finder = FindNodalNeighboursProcess(model_part)
             #this is needed if we want to also store the conditions a node belongs to
             self.condition_neigh_finder = FindConditionsNeighboursProcess(model_part,3, 20)
             self.elem_neighbor_finder = GenericFindElementalNeighboursProcess(model_part)
-     
+
         self.mark_fluid_process = MarkFluidProcess(model_part);
 
     def Initialize(self):
@@ -261,7 +261,7 @@ class FracStepSolver:
         (self.solver).SetEchoLevel(self.echo_level)
 
         (self.fluid_neigh_finder).Execute();
-        (self.Pfem2_apply_bc_process).Execute();  
+        (self.Pfem2_apply_bc_process).Execute();
 
         for node in self.model_part.Nodes:
             node.SetSolutionStepValue(IS_FREE_SURFACE,0,0.0)
@@ -269,35 +269,35 @@ class FracStepSolver:
 		#self.Remesh2();
         self.RemeshAux(); #solo multifluido
 
-        
+
     def Solve(self):
-	
+
 
         (self.solver).Solve()
 
     def solve3(self):
-	
+
 
         (self.solver).SolveStep3(1.0)
 
     def solve5(self):
-	
+
 
         (self.solver).SolveStep5(1.0)
 
     def solve4(self):
-	
+
 
         (self.solver).SolveStep4(1.0)
 
     def solve5(self):
-	
+
 
         (self.solver).SolveStep5(1.0)
 
 
     def Projections(self):
-	
+
         (self.solver).SolveStep5()
 
     def Reactions(self):
@@ -312,7 +312,7 @@ class FracStepSolver:
 
 
     def Remesh2(self):
-	
+
         h_factor=1.0;
         alpha_shape=1.2;
 
@@ -327,23 +327,23 @@ class FracStepSolver:
 
 
     def RemeshAux(self):
-	
-        
-        h_factor=0.1 
+
+
+        h_factor=0.1
         alpha_shape=1.4;
 
 
         for node in (self.model_part).Nodes:
             node.Set(TO_ERASE, False)
         #dambreak
-        for node in (self.model_part).Nodes: 
-            node.SetSolutionStepValue(NODAL_H,0,0.0011) 
+        for node in (self.model_part).Nodes:
+            node.SetSolutionStepValue(NODAL_H,0,0.0011)
 
         self.node_erase_process = NodeEraseProcess(self.model_part);
-        box_corner1 = Vector(3); 
-        box_corner2 = Vector(3); 
+        box_corner1 = Vector(3);
+        box_corner2 = Vector(3);
 
-        
+
 
         box_corner1[0]=-0.014653
         box_corner1[1]=-0.16#0.31315#-0.1689
@@ -363,8 +363,8 @@ class FracStepSolver:
         box_corner2[1]=10.0
         box_corner2[2]=10.0
 
-        for node in (self.model_part).Nodes: 
-            node.SetSolutionStepValue(NODAL_H,0,0.15) 
+        for node in (self.model_part).Nodes:
+            node.SetSolutionStepValue(NODAL_H,0,0.15)
 
 
         self.box_corner1 = box_corner1
@@ -380,20 +380,20 @@ class FracStepSolver:
         if (self.domain_size == 2):
             (self.Mesher).ReGenerateMesh("QFluid2D","LineCondition2D2N", self.model_part, self.node_erase_process, True, False, alpha_shape, h_factor)
         elif (self.domain_size == 3):
-            
-            (self.Mesher).ReGenerateMesh("QFluid3D","SurfaceCondition3D3N", self.model_part, self.node_erase_process, True, False, alpha_shape, h_factor)            
+
+            (self.Mesher).ReGenerateMesh("QFluid3D","SurfaceCondition3D3N", self.model_part, self.node_erase_process, True, False, alpha_shape, h_factor)
 
 
         (self.fluid_neigh_finder).Execute();
-        (self.elem_neighbor_finder).ExecuteInitialize()
+        (self.elem_neighbor_finder).Execute()
         (self.condition_neigh_finder).Execute();
 
         (self.Pfem2_apply_bc_process).Execute();
         (self.mark_fluid_process).Execute();
-        
+
     def FindNeighbours(self):
         (self.neigh_finder).Execute();
-   
+
 
     def WriteRestartFile(self,FileName):
         restart_file = open(FileName + ".mdpa",'w')
@@ -416,12 +416,12 @@ class FracStepSolver:
         new_restart_utilities.PrintRestart_ScalarVariable(TEMPERATURE,"TEMPERATURE",self.model_part.Nodes,restart_file)
         new_restart_utilities.PrintRestart_ScalarVariable(FACE_HEAT_FLUX,"FACE_HEAT_FLUX",self.model_part.Nodes,restart_file)
         new_restart_utilities.PrintRestart_ScalarVariable(ENTHALPY,"ENTHALPY",self.model_part.Nodes,restart_file)
-        restart_file.close() 
+        restart_file.close()
 
 
 
     def CalculateDistanceAndDiviedSet(self,domain_size):
-        
+
         (self.neigh_finder).Execute();
         distance_tools = ElemBasedDistanceUtilities(self.model_part)
         distance_calculator = BodyDistanceCalculationUtils()
@@ -429,13 +429,13 @@ class FracStepSolver:
         #assign IS_VISITED1 to elem with DISTANCE>=0 and change DSITANCE to posetive for external ones
         ##Assign Zero distance to interface nodes
         for node in (self.model_part).Nodes:
-           
+
             node.SetSolutionStepValue(DISTANCE,0,0.0)
             node.SetValue(IS_VISITED,0.0)
-            
+
         for node in (self.model_part).Nodes:
             if(node.GetSolutionStepValue(IS_INTERFACE)== 1.0):
-                
+
                 node.SetSolutionStepValue(DISTANCE,0,0.0)
                 node.SetValue(IS_VISITED,1.0)
 
@@ -453,22 +453,22 @@ class FracStepSolver:
         else:
             distance_calculator.CalculateDistances3D((self.model_part).Elements,DISTANCE, True);
 
-        #change sign 
+        #change sign
         distance_tools.ChangeSignToDistance()
 
         #mark as visited all of the nodes inside the fluid domain
         ####        distance_tools.MarkInternalAndMixedNodes()
         print ((self.model_part).Elements).Size()
 
-        
+
     def DistToH(self):
-         
-         for node in (self.model_part).Nodes: 
+
+         for node in (self.model_part).Nodes:
              node.SetSolutionStepValue(NODAL_H,0,0.05)
 
     def DistToH1(self):
-         
-         for node in (self.model_part).Nodes: 
+
+         for node in (self.model_part).Nodes:
              current_dist = node.GetSolutionStepValue(DISTANCE,0)
              if(abs(current_dist) <= 0.03):
                  node.SetSolutionStepValue(NODAL_H,0,0.02)
@@ -478,7 +478,7 @@ class FracStepSolver:
              else:
                  node.SetSolutionStepValue(NODAL_H,0,0.012)
 
-         
+
 
 
          for node in (self.model_part).Nodes:
@@ -489,8 +489,8 @@ class FracStepSolver:
          #possible_h = self.CalculateRadius()
          #print possible_h
 
-         
-         for node in (self.model_part).Nodes: 
+
+         for node in (self.model_part).Nodes:
              current_dist = node.GetSolutionStepValue(DISTANCE,0)
              if(abs(current_dist) <= 0.06): #0.15
                  node.SetSolutionStepValue(NODAL_H,0,0.20)
@@ -500,7 +500,7 @@ class FracStepSolver:
              else:
                  node.SetSolutionStepValue(NODAL_H,0,0.012)
 
-         
+
 
 
          for node in (self.model_part).Nodes:
@@ -509,7 +509,7 @@ class FracStepSolver:
 
 
     def DistToH4(self):
-         for node in (self.model_part).Nodes: 
+         for node in (self.model_part).Nodes:
              current_dist = node.GetSolutionStepValue(DISTANCE,0)
              if(abs(current_dist) <= 0.06): #0.15
                  node.SetSolutionStepValue(NODAL_H,0,0.010)
@@ -519,14 +519,14 @@ class FracStepSolver:
              else:
                  node.SetSolutionStepValue(NODAL_H,0,0.010)
 
-         
+
 
 
          for node in (self.model_part).Nodes:
              if node.GetSolutionStepValue(IS_INTERFACE) == 1.0:
                  node.SetSolutionStepValue(NODAL_H,0,0.012)
 
-    def CalculateRadius(self):             
+    def CalculateRadius(self):
         max_radi = 0.0
         for node in (self.model_part).Nodes:
             if node.GetSolutionStepValue(IS_INTERFACE) == 1.0:

--- a/applications/PFEM2Application/python_scripts/pfem_2_process.py
+++ b/applications/PFEM2Application/python_scripts/pfem_2_process.py
@@ -52,7 +52,7 @@ class PFEM2Process(KM.Process):
         neighbor_search = KM.FindNodalNeighboursProcess(self.model_part)
         neighbor_search.Execute()
         neighbor_elements_search = KM.GenericFindElementalNeighboursProcess(self.model_part)
-        neighbor_elements_search.ExecuteInitialize()
+        neighbor_elements_search.Execute()
 
         max_num_of_particles = 8 * dimension
         if dimension == 2:

--- a/applications/PFEM2Application/python_scripts/pfem_2_solver_fractional_step_fluid.py
+++ b/applications/PFEM2Application/python_scripts/pfem_2_solver_fractional_step_fluid.py
@@ -15,12 +15,12 @@ def AddVariables(model_part):
     model_part.AddNodalSolutionStepVariable(PRESS_PROJ);
     model_part.AddNodalSolutionStepVariable(RHS);
     model_part.AddNodalSolutionStepVariable(PROJECTED_VELOCITY);
-    model_part.AddNodalSolutionStepVariable(NORMAL);        
+    model_part.AddNodalSolutionStepVariable(NORMAL);
     model_part.AddNodalSolutionStepVariable(PREVIOUS_ITERATION_PRESSURE);
-    model_part.AddNodalSolutionStepVariable(DELTA_VELOCITY) 
-    model_part.AddNodalSolutionStepVariable(PRESS_PROJ_NO_RO) 
-    model_part.AddNodalSolutionStepVariable(MEAN_SIZE) 
-    model_part.AddNodalSolutionStepVariable(NODAL_AREA) 
+    model_part.AddNodalSolutionStepVariable(DELTA_VELOCITY)
+    model_part.AddNodalSolutionStepVariable(PRESS_PROJ_NO_RO)
+    model_part.AddNodalSolutionStepVariable(MEAN_SIZE)
+    model_part.AddNodalSolutionStepVariable(NODAL_AREA)
     model_part.AddNodalSolutionStepVariable(NODAL_MASS)
     model_part.AddNodalSolutionStepVariable(BODY_FORCE)
 
@@ -37,7 +37,7 @@ class PFEM2Solver:
     #def __init__(self,model_part,linea_model_part,domain_size):
     def __init__(self,model_part,domain_size):
         self.model_part = model_part
-        
+
         self.time_scheme = ResidualBasedIncrementalUpdateStaticScheme()
 
         #definition of the solvers
@@ -45,32 +45,32 @@ class PFEM2Solver:
         tol = 1e-5
         verbosity = 1
         pDiagPrecond = DiagonalPreconditioner()
-        #self.pressure_linear_solver = BICGSTABSolver(1e-5, 5000,pDiagPrecond) # SkylineLUFactorizationSolver() 
+        #self.pressure_linear_solver = BICGSTABSolver(1e-5, 5000,pDiagPrecond) # SkylineLUFactorizationSolver()
         #self.pressure_linear_solver =  ViennaCLSolver(tol,500,OpenCLPrecision.Double,OpenCLSolverType.CG,OpenCLPreconditionerType.NoPreconditioner) #
-        self.pressure_linear_solver=AMGCLSolver(AMGCLSmoother.DAMPED_JACOBI,AMGCLIterativeSolverType.CG,tol,200,verbosity,gmres_size)      #BICGSTABSolver(1e-7, 5000) # SkylineLUFactorizationSolver() 
-        self.conv_criteria = DisplacementCriteria(1e-9,1e-15)  #tolerance for the solver 
-        
+        self.pressure_linear_solver=AMGCLSolver(AMGCLSmoother.DAMPED_JACOBI,AMGCLIterativeSolverType.CG,tol,200,verbosity,gmres_size)      #BICGSTABSolver(1e-7, 5000) # SkylineLUFactorizationSolver()
+        self.conv_criteria = DisplacementCriteria(1e-9,1e-15)  #tolerance for the solver
+
         self.domain_size = domain_size
         self.neighbour_search = FindNodalNeighboursProcess(model_part)
         (self.neighbour_search).Execute()
         self.neighbour_elements_search= GenericFindElementalNeighboursProcess(model_part)
-        (self.neighbour_elements_search).ExecuteInitialize()
+        (self.neighbour_elements_search).Execute()
         ##calculate normals
         self.normal_tools = BodyNormalCalculationUtils()
-        
-        
+
+
     #######################################################################
     #######################################################################
     def Initialize(self):
         #creating the solution strategy
         CalculateReactionFlag = False
-        ReformDofSetAtEachStep = False        
+        ReformDofSetAtEachStep = False
         MoveMeshFlag = False
-        
+
         #build the edge data structure
         #if self.domain_size==2:
         #        self.matrix_container = MatrixContainer2D()
-        #else: 
+        #else:
         #        self.matrix_container = MatrixContainer3D()
         #maximum_number_of_particles= 10*self.domain_size
         maximum_number_of_particles= 8*self.domain_size
@@ -78,7 +78,7 @@ class PFEM2Solver:
         self.ExplicitStrategy=PFEM2_Explicit_Strategy(self.model_part,self.domain_size, MoveMeshFlag)
 
         self.VariableUtils = VariableUtils()
-        
+
         if self.domain_size==2:
              self.moveparticles = MoveParticleUtilityPFEM22D(self.model_part,maximum_number_of_particles)
         else:
@@ -87,7 +87,7 @@ class PFEM2Solver:
         print( "self.domain_size = ", self.domain_size)
         if self.domain_size==2:
              self.calculatewatervolume = CalculateWaterFraction2D(self.model_part)
-        else:        
+        else:
              self.calculatewatervolume = CalculateWaterFraction3D(self.model_part)
 
         self.moveparticles.MountBin()
@@ -95,16 +95,16 @@ class PFEM2Solver:
         self.water_initial_volume=0.0 #we initialize it at zero
         self.mass_correction_factor=0.0
 
-        self.normal_tools.CalculateBodyNormals(self.model_part,self.domain_size);  
+        self.normal_tools.CalculateBodyNormals(self.model_part,self.domain_size);
         condition_number=1
-        
+
         if self.domain_size==2:
               self.addBC = AddFixedVelocityCondition2D(self.model_part)
         else:
               self.addBC = AddFixedVelocityCondition3D(self.model_part)
 
         (self.addBC).AddThem()
-        
+
         if self.domain_size==2:
              self.distance_utils = SignedDistanceCalculationUtils2D()
         else:
@@ -124,10 +124,10 @@ class PFEM2Solver:
         self.total=0.0
 
 
-        
-      
-                 
-    #######################################################################   
+
+
+
+    #######################################################################
     def Solve(self):
         t1 = timer.time()
         #in order to define a reasonable number of substeps we calculate a mean courant in each element
@@ -136,7 +136,7 @@ class PFEM2Solver:
 
         #streamline integration:
         discriminate_streamlines=True
-        (self.moveparticles).MoveParticles(discriminate_streamlines);         
+        (self.moveparticles).MoveParticles(discriminate_streamlines);
         t3 = timer.time()
         self.streamlineintegration = self.streamlineintegration + t3-t2
 
@@ -169,10 +169,10 @@ class PFEM2Solver:
         self.implicitpressure = self.implicitpressure + t9 - t8
         #setting the appropiate BC, with the pressure eq the boundaries are only weakly impermeable
         full_reset=True;
-        (self.moveparticles).ResetBoundaryConditions(full_reset) 
-        
+        (self.moveparticles).ResetBoundaryConditions(full_reset)
+
         #delta_velocity= Velocity(final) - ProjectedVelocity(from the particles), so we add to the particles the correction done in the mesh.
-        (self.moveparticles).CalculateDeltaVelocity();        
+        (self.moveparticles).CalculateDeltaVelocity();
         t11 = timer.time()
         (self.moveparticles).AccelerateParticlesWithoutMovingUsingDeltaVelocity();
         t12 = timer.time()
@@ -180,13 +180,13 @@ class PFEM2Solver:
 
         #reseeding in elements that have few particles to avoid having problems in next iterations:
         post_minimum_number_of_particles=self.domain_size*3;
-        (self.moveparticles).PostReseed(post_minimum_number_of_particles,self.mass_correction_factor);        
+        (self.moveparticles).PostReseed(post_minimum_number_of_particles,self.mass_correction_factor);
         t13 = timer.time()
         self.reseed=self.reseed+ t13-t12
 
         #calculating water volume to correct mass
         self.water_volume = (self.calculatewatervolume).Calculate()
-        if (self.water_initial_volume==0.0): 
+        if (self.water_initial_volume==0.0):
                 self.water_initial_volume=self.water_volume
         water_fraction= self.water_volume/(self.water_initial_volume+1e-9)
         self.mass_correction_factor = (1.0 - water_fraction) * 100.0 * 0.0
@@ -198,8 +198,8 @@ class PFEM2Solver:
         #self.nodaltasks = self.nodaltasks + t11-t9
 
         #print ". erasing  = ", t14-t13
-        self.total = self.total + t13-t1 
-        
+        self.total = self.total + t13-t1
+
         if True:
                 print( "----------TIMES----------")
                 print( "self.streamlineintegration " ,  self.streamlineintegration , "in % = ", 100.0*(self.streamlineintegration)/(self.total))
@@ -212,13 +212,13 @@ class PFEM2Solver:
                 print( "TOTAL ----- " ,  self.total)
                 print( "this time step" ,  t13-t1 )
                 print( "current time in simulation: ", self.model_part.ProcessInfo.GetValue(TIME) , "s")
-        
 
-    #######################################################################   
+
+    #######################################################################
     def CalculatePressureIteration(self, iteration_number):
         self.model_part.ProcessInfo.SetValue(FRACTIONAL_STEP, 2)
         self.model_part.ProcessInfo.SetValue(NL_ITERATION_NUMBER, iteration_number)
-        
+
         (self.pressure_solver).Solve() #implicit resolution of the pressure system. All the other tasks are explicit
         #if iteration_number==1:
         #        for node in self.model_part.Nodes:
@@ -231,14 +231,14 @@ class PFEM2Solver:
         (self.ExplicitStrategy).FinalizeSolutionStep(self.model_part.ProcessInfo);
 
 
-    #######################################################################   
+    #######################################################################
     def CalculateExplicitViscosityContribution(self):
         self.model_part.ProcessInfo.SetValue(FRACTIONAL_STEP, 0) #explicit contribution by viscosity is defined as fract step = 0
         (self.ExplicitStrategy).InitializeSolutionStep(self.model_part.ProcessInfo);
         (self.ExplicitStrategy).AssembleLoop(self.model_part.ProcessInfo);
         (self.ExplicitStrategy).FinalizeSolutionStep(self.model_part.ProcessInfo);
 
-    ####################################################################### 
+    #######################################################################
 
     def SetEchoLevel(self,level):
         (self.solver).SetEchoLevel(level)

--- a/applications/PFEM2Application/python_scripts/pfem_2_solver_fsi.py
+++ b/applications/PFEM2Application/python_scripts/pfem_2_solver_fsi.py
@@ -26,16 +26,16 @@ def AddVariables(model_part):
     model_part.AddNodalSolutionStepVariable(RHS);
     model_part.AddNodalSolutionStepVariable(MESH_VELOCITY);
     #model_part.AddNodalSolutionStepVariable(MESH_PRESSURE);
-    model_part.AddNodalSolutionStepVariable(NORMAL);	
-    #model_part.AddNodalSolutionStepVariable(DENSITY);	
+    model_part.AddNodalSolutionStepVariable(NORMAL);
+    #model_part.AddNodalSolutionStepVariable(DENSITY);
     model_part.AddNodalSolutionStepVariable(TEMP_CONV_PROJ);
     model_part.AddNodalSolutionStepVariable(PREVIOUS_ITERATION_PRESSURE);
     #model_part.AddNodalSolutionStepVariable(FIRST_ITERATION_PRESSURE);
-    model_part.AddNodalSolutionStepVariable(DELTA_VELOCITY) 
-    model_part.AddNodalSolutionStepVariable(PRESS_PROJ_NO_RO) 
-    model_part.AddNodalSolutionStepVariable(MEAN_SIZE) 
-    model_part.AddNodalSolutionStepVariable(NODAL_AREA) 
-    model_part.AddNodalSolutionStepVariable(NODAL_MASS) 
+    model_part.AddNodalSolutionStepVariable(DELTA_VELOCITY)
+    model_part.AddNodalSolutionStepVariable(PRESS_PROJ_NO_RO)
+    model_part.AddNodalSolutionStepVariable(MEAN_SIZE)
+    model_part.AddNodalSolutionStepVariable(NODAL_AREA)
+    model_part.AddNodalSolutionStepVariable(NODAL_MASS)
     model_part.AddNodalSolutionStepVariable(FORCE)
     model_part.AddNodalSolutionStepVariable(TAU)
     model_part.AddNodalSolutionStepVariable(TEMPERATURE)
@@ -66,37 +66,37 @@ class PFEM2Solver:
     #def __init__(self,model_part,linea_model_part,domain_size):
     def __init__(self,model_part,domain_size):
         self.model_part = model_part
-        
+
         self.time_scheme = ResidualBasedIncrementalUpdateStaticScheme()
-        
+
         #definition of the solvers
         gmres_size = 50
         tol = 1e-6
         verbosity = 1
         smoother = AMGCLSmoother.ILU0
-        self.monolitic_linear_solver =  AMGCLSolver(smoother,AMGCLIterativeSolverType.CG,tol,5000,verbosity,gmres_size)      #BICGSTABSolver(1e-7, 5000) # SkylineLUFactorizationSolver()   
-        self.conv_criteria = DisplacementCriteria(1e-6,1e-12)  #tolerance for the solver 
+        self.monolitic_linear_solver =  AMGCLSolver(smoother,AMGCLIterativeSolverType.CG,tol,5000,verbosity,gmres_size)      #BICGSTABSolver(1e-7, 5000) # SkylineLUFactorizationSolver()
+        self.conv_criteria = DisplacementCriteria(1e-6,1e-12)  #tolerance for the solver
         self.domain_size = domain_size
         self.neighbour_search = FindNodalNeighboursProcess(model_part)
         (self.neighbour_search).Execute()
         self.neighbour_elements_search= GenericFindElementalNeighboursProcess(model_part)
-        (self.neighbour_elements_search).ExecuteInitialize()
+        (self.neighbour_elements_search).Execute()
         ##calculate normals
         self.normal_tools = BodyNormalCalculationUtils()
-        
-        
+
+
     #######################################################################
     #######################################################################
     def Initialize(self):
         #creating the solution strategy
         CalculateReactionFlag = False
-        ReformDofSetAtEachStep = False	
+        ReformDofSetAtEachStep = False
         MoveMeshFlag = False
         pDiagPrecond = DiagonalPreconditioner()
         #build the edge data structure
 	#if self.domain_size==2:
 	#	self.matrix_container = MatrixContainer2D()
-	#else: 
+	#else:
 	#	self.matrix_container = MatrixContainer3D()
 	#maximum_number_of_particles= 10*self.domain_size
 	maximum_number_of_particles= 12*self.domain_size
@@ -104,7 +104,7 @@ class PFEM2Solver:
 	self.ExplicitStrategy=PFEM2_Explicit_Strategy(self.model_part,self.domain_size, MoveMeshFlag)
 
 	self.VariableUtils = VariableUtils()
-	
+
 	if self.domain_size==2:
            self.moveparticles = MoveParticleUtilityDiff2D(self.model_part,maximum_number_of_particles)
 	else:
@@ -113,7 +113,7 @@ class PFEM2Solver:
 	print("self.domain_size = ", self.domain_size)
 	if self.domain_size==2:
             self.calculatewatervolume = CalculateWaterFraction2D(self.model_part)
-	else:	
+	else:
            self.calculatewatervolume = CalculateWaterFraction3D(self.model_part)
 
 	self.moveparticles.MountBinDiff()
@@ -122,9 +122,9 @@ class PFEM2Solver:
 	self.water_initial_volume_flag=True #we initialize it at zero
 	self.mass_correction_factor=0.0
 
-	self.normal_tools.CalculateBodyNormals(self.model_part,self.domain_size);  
+	self.normal_tools.CalculateBodyNormals(self.model_part,self.domain_size);
 	condition_number=1
-        ''' 
+        '''
 	if self.domain_size==2:
            self.addBC = AddMonolithicFixedVelocityCondition2D(self.model_part)
 	else:
@@ -136,21 +136,21 @@ class PFEM2Solver:
 
 	self.monolitic_solver = strategy_python.SolvingStrategyPython(self.model_part,self.time_scheme,self.monolitic_linear_solver,self.conv_criteria,CalculateReactionFlag,ReformDofSetAtEachStep,MoveMeshFlag)
 
-        #to measure time spent in solving 
+        #to measure time spent in solving
 	self.total=0.0
 	self.implicit_tasks=0.0
 
-        
-      
-                 
-    #######################################################################   
+
+
+
+    #######################################################################
     def Solve(self):
         add_gravity=False #in the monolitic solver we do not add the gravity, it is added directly in the implicit monolitic system
         viscosity_streamline_integrate=False; #True means explicit integration! False means we will have to solve the fractional velocity system implicetely later, once information has been passed to mesh
 
         t1 = timer.time()
 
-        #calculating RHS by viscous forces using information of the previous time step:	
+        #calculating RHS by viscous forces using information of the previous time step:
         #self.CalculateExplicitViscosityContribution();
         t2 = timer.time()
 
@@ -159,9 +159,9 @@ class PFEM2Solver:
         t2a = timer.time()
 
         #streamline integration:
-        #(self.moveparticles).MoveParticlesDiff(viscosity_streamline_integrate,add_gravity);	
+        #(self.moveparticles).MoveParticlesDiff(viscosity_streamline_integrate,add_gravity);
         t3 = timer.time()
-        
+
         #Reseeding using streamlines in inverse way in case there are too few particles. Not very accurate since particles follow streamlines, no matter if it's water or air.
         #(for 1 fluid should be accurate though
         pre_minimum_number_of_particles=self.domain_size*1;
@@ -170,15 +170,15 @@ class PFEM2Solver:
 
         transfer_pressure=True
         (self.moveparticles).TransferLagrangianToEulerian(transfer_pressure);
-        (self.VariableUtils).CopyVectorVar(VELOCITY,MESH_VELOCITY,self.model_part.Nodes)        
-        (self.VariableUtils).CopyScalarVar(EXTERNAL_PRESSURE,PRESSURE,self.model_part.Nodes)	    
+        (self.VariableUtils).CopyVectorVar(VELOCITY,MESH_VELOCITY,self.model_part.Nodes)
+        (self.VariableUtils).CopyScalarVar(EXTERNAL_PRESSURE,PRESSURE,self.model_part.Nodes)
 
-        (self.VariableUtils).CopyVectorVar(MESH_VELOCITY,VELOCITY,self.model_part.Nodes)	
-        (self.moveparticles).ResetBoundaryConditions(True) 
-        (self.VariableUtils).CopyScalarVar(PRESSURE,SOLID_PRESSURE,self.model_part.Nodes)	
-        (self.VariableUtils).CopyScalarVar(PRESSURE,PRESSUREAUX,self.model_part.Nodes)	
-        (self.VariableUtils).CopyScalarVar(DISTANCE,CORRECTED_DISTANCE,self.model_part.Nodes)	
-        
+        (self.VariableUtils).CopyVectorVar(MESH_VELOCITY,VELOCITY,self.model_part.Nodes)
+        (self.moveparticles).ResetBoundaryConditions(True)
+        (self.VariableUtils).CopyScalarVar(PRESSURE,SOLID_PRESSURE,self.model_part.Nodes)
+        (self.VariableUtils).CopyScalarVar(PRESSURE,PRESSUREAUX,self.model_part.Nodes)
+        (self.VariableUtils).CopyScalarVar(DISTANCE,CORRECTED_DISTANCE,self.model_part.Nodes)
+
         (self.moveparticles).CopyVectorVarToPreviousTimeStep(VELOCITY,self.model_part.Nodes)
         (self.moveparticles).CopyScalarVarToPreviousTimeStep(PRESSURE,self.model_part.Nodes)
 
@@ -199,30 +199,30 @@ class PFEM2Solver:
             (self.monolitic_solver).Solve() #implicit resolution of the system. All the other tasks are explicit
             self.CalculatePressureProjection()
             full_reset=True;
-            (self.moveparticles).ResetBoundaryConditions(full_reset) 
-            
-            (self.moveparticles).UpdateParticleStresses()	
+            (self.moveparticles).ResetBoundaryConditions(full_reset)
+
+            (self.moveparticles).UpdateParticleStresses()
             #finally we save the last pressure for future iterations. No need to do it for the velocity since it is saved in delta_velocity
             (self.VariableUtils).CopyScalarVar(PRESSURE,PRESSUREAUX,self.model_part.Nodes) #we save the pressure of this iteration in order to have the delta_pressure in the next one
-            non_linear_iteration_number =  non_linear_iteration_number +1  
-        
-        (self.VariableUtils).CopyScalarVar(PRESSURE,EXTERNAL_PRESSURE,self.model_part.Nodes)	    
+            non_linear_iteration_number =  non_linear_iteration_number +1
+
+        (self.VariableUtils).CopyScalarVar(PRESSURE,EXTERNAL_PRESSURE,self.model_part.Nodes)
         t11 = timer.time()
         self.implicit_tasks = self.implicit_tasks + t11-t6
-    
+
         #delta_velocity= Velocity(final) - MeshVelocity(from the particles), so we add to the particles the correction done in the mesh.
-        (self.moveparticles).CalculateDeltaVelocity();	
-        
+        (self.moveparticles).CalculateDeltaVelocity();
+
         #transfering the information to the particles:
         (self.moveparticles).AccelerateParticlesWithoutMovingUsingDeltaVelocity(add_gravity);
         t12 = timer.time()
 
         #reseeding in elements that have few particles to avoid having problems in next iterations:
         post_minimum_number_of_particles=self.domain_size*2;
-        #(self.moveparticles).PostReseed(post_minimum_number_of_particles,self.mass_correction_factor);        
+        #(self.moveparticles).PostReseed(post_minimum_number_of_particles,self.mass_correction_factor);
 
         self.water_volume = (self.calculatewatervolume).Calculate()
-        if (self.water_initial_volume_flag): 
+        if (self.water_initial_volume_flag):
         	print("calculated water volume for the first time")
         	self.water_initial_volume=self.water_volume
         	self.water_initial_volume_flag=False
@@ -233,22 +233,22 @@ class PFEM2Solver:
         print("current mass loss is : " , (1.0 - water_fraction) * 100.0 , " % ")
 
         t13 = timer.time()
-        self.total = self.total + t13-t1 
-        
+        self.total = self.total + t13-t1
+
         print("----------TIMES----------")
         print("self.implicit_tasks " ,  self.implicit_tasks , "in % = ", 100.0*(self.implicit_tasks)/(self.total))
         print("TOTAL ----- " ,  self.total)
 
-        
 
-    #######################################################################   
+
+    #######################################################################
     def CalculateExplicitViscosityContribution(self):
         self.model_part.ProcessInfo.SetValue(FRACTIONAL_STEP, 0) #explicit contribution by viscosity is defined as fract step = 0
         (self.ExplicitStrategy).InitializeSolutionStep(self.model_part.ProcessInfo);
         (self.ExplicitStrategy).AssembleLoop(self.model_part.ProcessInfo);
         (self.ExplicitStrategy).FinalizeSolutionStep(self.model_part.ProcessInfo);
 
-    #######################################################################   
+    #######################################################################
     def CalculatePressureProjection(self):
         self.model_part.ProcessInfo.SetValue(FRACTIONAL_STEP, 3) #explicit contribution by viscosity is defined as fract step = 0
         (self.ExplicitStrategy).InitializeSolutionStep(self.model_part.ProcessInfo);
@@ -256,6 +256,6 @@ class PFEM2Solver:
         self.model_part.ProcessInfo.SetValue(FRACTIONAL_STEP, 10)
         (self.ExplicitStrategy).FinalizeSolutionStep(self.model_part.ProcessInfo);
 
-    ####################################################################### 
+    #######################################################################
     def SetEchoLevel(self,level):
         (self.solver).SetEchoLevel(level)

--- a/applications/PFEM2Application/python_scripts/pfem_2_solver_fsi_2resolutions.py
+++ b/applications/PFEM2Application/python_scripts/pfem_2_solver_fsi_2resolutions.py
@@ -22,17 +22,17 @@ def AddVariables(model_part,topographic_model_part):
     model_part.AddNodalSolutionStepVariable(ACCELERATION);
     model_part.AddNodalSolutionStepVariable(PRESS_PROJ);
     model_part.AddNodalSolutionStepVariable(MESH_VELOCITY);
-    model_part.AddNodalSolutionStepVariable(NORMAL);	
-    model_part.AddNodalSolutionStepVariable(DELTA_VELOCITY) 
-    model_part.AddNodalSolutionStepVariable(NODAL_AREA) 
-    model_part.AddNodalSolutionStepVariable(NODAL_MASS) 
+    model_part.AddNodalSolutionStepVariable(NORMAL);
+    model_part.AddNodalSolutionStepVariable(DELTA_VELOCITY)
+    model_part.AddNodalSolutionStepVariable(NODAL_AREA)
+    model_part.AddNodalSolutionStepVariable(NODAL_MASS)
     model_part.AddNodalSolutionStepVariable(TEMPERATURE)
     model_part.AddNodalSolutionStepVariable(TEMPERATURE_OLD_IT)
     model_part.AddNodalSolutionStepVariable(PRESSUREAUX)
     model_part.AddNodalSolutionStepVariable(DISPLACEMENT);
     model_part.AddNodalSolutionStepVariable(RHS);
     model_part.AddNodalSolutionStepVariable(PRESS_PROJ);
-    
+
     topographic_model_part.AddNodalSolutionStepVariable(PRESSURE);
     topographic_model_part.AddNodalSolutionStepVariable(VELOCITY);
     topographic_model_part.AddNodalSolutionStepVariable(DISPLACEMENT);
@@ -61,42 +61,42 @@ class PFEM2Solver:
     def __init__(self,model_part,topographic_model_part,domain_size):
         self.model_part = model_part
         self.topographic_model_part = topographic_model_part
-        
+
         self.time_scheme = ResidualBasedIncrementalUpdateStaticScheme()
 
         #definition of the solvers
         gmres_size = 50
         tol = 1e-5
         verbosity = 1
-        #self.monolitic_linear_solver = SkylineLUFactorizationSolver() 
-        #self.monolitic_linear_solver = BICGSTABSolver(1e-5, 1000,pDiagPrecond) # SkylineLUFactorizationSolver() 
-        #self.monolitic_linear_solver= ViennaCLSolver(tol,10000,OpenCLPrecision.Double,OpenCLSolverType.CG,OpenCLPreconditionerType.AMG_DAMPED_JACOBI) 
-        self.topographic_monolitic_linear_solver= AMGCLSolver(AMGCLSmoother.ILU0,AMGCLIterativeSolverType.CG,tol,1000,verbosity,gmres_size) 
-        self.monolitic_linear_solver =  AMGCLSolver(AMGCLSmoother.ILU0,AMGCLIterativeSolverType.CG,tol,1000,verbosity,gmres_size)      #BICGSTABSolver(1e-7, 5000) # SkylineLUFactorizationSolver() 
-        self.conv_criteria = DisplacementCriteria(1e-2,1e-6)  #tolerance for the solver 
-        
+        #self.monolitic_linear_solver = SkylineLUFactorizationSolver()
+        #self.monolitic_linear_solver = BICGSTABSolver(1e-5, 1000,pDiagPrecond) # SkylineLUFactorizationSolver()
+        #self.monolitic_linear_solver= ViennaCLSolver(tol,10000,OpenCLPrecision.Double,OpenCLSolverType.CG,OpenCLPreconditionerType.AMG_DAMPED_JACOBI)
+        self.topographic_monolitic_linear_solver= AMGCLSolver(AMGCLSmoother.ILU0,AMGCLIterativeSolverType.CG,tol,1000,verbosity,gmres_size)
+        self.monolitic_linear_solver =  AMGCLSolver(AMGCLSmoother.ILU0,AMGCLIterativeSolverType.CG,tol,1000,verbosity,gmres_size)      #BICGSTABSolver(1e-7, 5000) # SkylineLUFactorizationSolver()
+        self.conv_criteria = DisplacementCriteria(1e-2,1e-6)  #tolerance for the solver
+
         self.domain_size = domain_size
         self.neighbour_search = FindNodalNeighboursProcess(model_part)
         (self.neighbour_search).Execute()
         self.neighbour_elements_search= GenericFindElementalNeighboursProcess(model_part)
-        (self.neighbour_elements_search).ExecuteInitialize()
+        (self.neighbour_elements_search).Execute()
         ##calculate normals
         self.normal_tools = BodyNormalCalculationUtils()
-        
-        
+
+
     #######################################################################
     #######################################################################
     def Initialize(self,initial_offset):
         #creating the solution strategy
         CalculateReactionFlag = False
-        ReformDofSetAtEachStep = False	
+        ReformDofSetAtEachStep = False
         MoveMeshFlag = False
         maximum_number_of_particles= 10*self.domain_size
-        
+
         self.ExplicitStrategy=PFEM2_Explicit_Strategy(self.model_part,self.domain_size, MoveMeshFlag)
-        
+
         self.VariableUtils = VariableUtils()
-        
+
         if self.domain_size==2:
                 self.moveparticles = MoveParticleUtilityDiff2D(self.model_part,maximum_number_of_particles)
         else:
@@ -105,10 +105,10 @@ class PFEM2Solver:
         print("self.domain_size = ", self.domain_size)
         if self.domain_size==2:
                 self.calculatewatervolume = CalculateWaterFraction2D(self.model_part)
-        else:	
+        else:
                 self.calculatewatervolume = CalculateWaterFraction3D(self.model_part)
-        
-        #to search particles. 
+
+        #to search particles.
         self.moveparticles.MountBinDiff()
         self.water_volume=0.0  #we initialize it at zero
         self.water_initial_volume=0.0 #we initialize it at zero
@@ -116,12 +116,12 @@ class PFEM2Solver:
         self.mass_correction_factor=0.0
 
 
-        
+
         #body normals, useful for boundary (inlet) conditions
-        self.normal_tools.CalculateBodyNormals(self.model_part,self.domain_size);  
+        self.normal_tools.CalculateBodyNormals(self.model_part,self.domain_size);
         condition_number=1
-        	
-        
+
+
         #solvers:
 	import strategy_python_nonlinear #implicit solver
 	import strategy_python #implicit solver
@@ -140,13 +140,13 @@ class PFEM2Solver:
 	for step in range(0,nsteps):
 		(self.topographic_monolitic_solver).Solve()
 		(self.moveparticles).CalculateElementalMeanStress(self.topographic_model_part)
-        
+
         overwrite_particle_data=True
         #this is the position where we place the calculation domain
         (self.moveparticles).InitializeTransferTool(self.topographic_model_part, initial_offset,overwrite_particle_data)
-      
-                 
-    #######################################################################   
+
+
+    #######################################################################
     def Solve(self,fluid_free_bounding_box_lower_corner,fluid_free_bounding_box_upper_corner):
                 t1 = timer.time()
 
@@ -159,66 +159,66 @@ class PFEM2Solver:
                 t2 = timer.time()
 
                 #streamline integration:
-                (self.moveparticles).MoveParticlesDiff(viscosity_streamline_integrate,add_gravity);	
+                (self.moveparticles).MoveParticlesDiff(viscosity_streamline_integrate,add_gravity);
                 t3 = timer.time()
-                
+
                 #Reseeding using streamlines in inverse way in case there are too few particles. Not very accurate since particles follow streamlines, no matter if it's water or air.
                 #we want at least 2 (or 3 in 3d) per element)
                 pre_minimum_number_of_particles=self.domain_size;
                 (self.moveparticles).PreReseedUsingTopographicDomain(pre_minimum_number_of_particles)
                 t4 = timer.time()
-		
+
 		#transfering data from the particles to the mesh:
 		transfer_pressure=True
                 (self.moveparticles).TransferLagrangianToEulerian(transfer_pressure);
-		
+
                 #storing variables in the right places
                 #for node in self.model_part.Nodes:
                 #        node.SetSolutionStepValue(VELOCITY,node.GetSolutionStepValue(MESH_VELOCITY))
                 #        node.SetSolutionStepValue(MESH_VELOCITY,node.GetSolutionStepValue(VELOCITY))
-                (self.VariableUtils).CopyVectorVar(MESH_VELOCITY,VELOCITY,self.model_part.Nodes)	
-                #(self.VariableUtils).CopyVectorVar(VELOCITY,MESH_VELOCITY,self.model_part.Nodes)	
-                (self.moveparticles).ResetBoundaryConditions(True) 
-                #(self.VariableUtils).CopyScalarVar(SOLID_PRESSURE,PRESSURE,self.model_part.Nodes)	
-                #(self.VariableUtils).CopyScalarVar(SOLID_PRESSURE,PRESSUREAUX,self.model_part.Nodes)	
-                (self.VariableUtils).CopyScalarVar(PRESSURE,SOLID_PRESSURE,self.model_part.Nodes)	
-                #(self.VariableUtils).CopyScalarVar(CORRECTED_DISTANCE,DISTANCE,self.model_part.Nodes)		
+                (self.VariableUtils).CopyVectorVar(MESH_VELOCITY,VELOCITY,self.model_part.Nodes)
+                #(self.VariableUtils).CopyVectorVar(VELOCITY,MESH_VELOCITY,self.model_part.Nodes)
+                (self.moveparticles).ResetBoundaryConditions(True)
+                #(self.VariableUtils).CopyScalarVar(SOLID_PRESSURE,PRESSURE,self.model_part.Nodes)
+                #(self.VariableUtils).CopyScalarVar(SOLID_PRESSURE,PRESSUREAUX,self.model_part.Nodes)
+                (self.VariableUtils).CopyScalarVar(PRESSURE,SOLID_PRESSURE,self.model_part.Nodes)
+                #(self.VariableUtils).CopyScalarVar(CORRECTED_DISTANCE,DISTANCE,self.model_part.Nodes)
                 (self.moveparticles).CopyVectorVarToPreviousTimeStep(VELOCITY,self.model_part.Nodes)
                 (self.moveparticles).CopyScalarVarToPreviousTimeStep(PRESSURE,self.model_part.Nodes)
-                (self.VariableUtils).CopyScalarVar(PRESSURE,PRESSUREAUX,self.model_part.Nodes)	
-                
+                (self.VariableUtils).CopyScalarVar(PRESSURE,PRESSUREAUX,self.model_part.Nodes)
+
                 t5 = timer.time()
-                
+
                 full_reset=False;
-                #(self.moveparticles).ResetBoundaryConditions(full_reset) 
-                
+                #(self.moveparticles).ResetBoundaryConditions(full_reset)
+
                 #implicit solver!
             	self.model_part.ProcessInfo.SetValue(FRACTIONAL_STEP, 20)
                 #(self.monolitic_solver).Solve() #implicit resolution of the pressure system. All the other tasks are explicit
-                
+
                 max_iter=20
                 (self.monolitic_solver).Solve(self.model_part,self.moveparticles,(self.VariableUtils),max_iter)
- 	
+
 
                 t11 = timer.time()
                 self.implicit_tasks = self.implicit_tasks + t11-t5
 
 
                 full_reset=True;
-                (self.moveparticles).ResetBoundaryConditions(full_reset) 
+                (self.moveparticles).ResetBoundaryConditions(full_reset)
 
 
                 #transfering the information to the mesh:
                 modify_particle_pressure=True
                 #delta_velocity= Velocity(final) - MeshVelocity(from the particles), so we add to the particles the correction done in the mesh.
-                (self.moveparticles).CalculateDeltaVelocity();	
+                (self.moveparticles).CalculateDeltaVelocity();
                 (self.moveparticles).AccelerateParticlesWithoutMovingUsingDeltaVelocity(add_gravity);
                 t12 = timer.time()
-                
+
                 #reseeding in elements that have few particles to avoid having problems in next iterations:
                 post_minimum_number_of_particles=self.domain_size*2;
                 self.water_volume = (self.calculatewatervolume).Calculate()
-                if (self.water_initial_volume_flag): 
+                if (self.water_initial_volume_flag):
                         print("calculated water volume for the first time")
                         self.water_initial_volume=self.water_volume
                         self.water_initial_volume_flag=False
@@ -227,20 +227,20 @@ class PFEM2Solver:
                 self.mass_correction_factor = (1.0 - water_fraction) * 100.0 * 0.0
                 print("mass correction factor: ", self.mass_correction_factor)
                 print("current mass loss is : " , (1.0 - water_fraction) * 100.0 , " % ")
-                #(self.moveparticles).PostReseed(post_minimum_number_of_particles,self.mass_correction_factor);		
-                #(self.moveparticles).PostReseedOnlyInBoundingBox(post_minimum_number_of_particles,self.mass_correction_factor,bounding_box_lower_corner,bounding_box_upper_corner);			
-                max_nodal_distance=0.7 #we have to move the domain to include the nodes that have nodal_distance>0.0 and <max_nodal_distance- otherwise there is no movement	
+                #(self.moveparticles).PostReseed(post_minimum_number_of_particles,self.mass_correction_factor);
+                #(self.moveparticles).PostReseedOnlyInBoundingBox(post_minimum_number_of_particles,self.mass_correction_factor,bounding_box_lower_corner,bounding_box_upper_corner);
+                max_nodal_distance=0.7 #we have to move the domain to include the nodes that have nodal_distance>0.0 and <max_nodal_distance- otherwise there is no movement
                 (self.moveparticles).ComputeCalculationDomainDisplacement(fluid_free_bounding_box_lower_corner,fluid_free_bounding_box_upper_corner,max_nodal_distance)
-                
+
                 t13 = timer.time()
-                self.total = self.total + t13-t1 
-                
+                self.total = self.total + t13-t1
+
                 print ("----------TIMES----------")
                 print ("self.implicit_tasks  " , self.implicit_tasks , "in % = ",  100.0*(self.implicit_tasks)/(self.total))
                 print ("TOTAL ----- " ,  self.total)
-		
 
-    #######################################################################   
+
+    #######################################################################
 
     def CalculatePressureProjection(self):
 		self.model_part.ProcessInfo.SetValue(FRACTIONAL_STEP, 3) #explicit contribution by viscosity is defined as fract step = 0
@@ -249,7 +249,7 @@ class PFEM2Solver:
 		self.model_part.ProcessInfo.SetValue(FRACTIONAL_STEP, 10)
 		(self.ExplicitStrategy).FinalizeSolutionStep(self.model_part.ProcessInfo);
 
-    ####################################################################### 
+    #######################################################################
 
     def SetEchoLevel(self,level):
         (self.solver).SetEchoLevel(level)

--- a/applications/PFEM2Application/python_scripts/pfem_2_solver_monolithic.py
+++ b/applications/PFEM2Application/python_scripts/pfem_2_solver_monolithic.py
@@ -20,16 +20,16 @@ def AddVariables(model_part):
     model_part.AddNodalSolutionStepVariable(PRESS_PROJ);
     model_part.AddNodalSolutionStepVariable(RHS);
     model_part.AddNodalSolutionStepVariable(MESH_VELOCITY);
-    model_part.AddNodalSolutionStepVariable(NORMAL);	
-    #model_part.AddNodalSolutionStepVariable(DENSITY);	
+    model_part.AddNodalSolutionStepVariable(NORMAL);
+    #model_part.AddNodalSolutionStepVariable(DENSITY);
     model_part.AddNodalSolutionStepVariable(TEMP_CONV_PROJ);
     model_part.AddNodalSolutionStepVariable(PREVIOUS_ITERATION_PRESSURE);
     #model_part.AddNodalSolutionStepVariable(FIRST_ITERATION_PRESSURE);
-    model_part.AddNodalSolutionStepVariable(DELTA_VELOCITY) 
-    model_part.AddNodalSolutionStepVariable(PRESS_PROJ_NO_RO) 
-    model_part.AddNodalSolutionStepVariable(MEAN_SIZE) 
-    model_part.AddNodalSolutionStepVariable(NODAL_AREA) 
-    model_part.AddNodalSolutionStepVariable(NODAL_MASS) 
+    model_part.AddNodalSolutionStepVariable(DELTA_VELOCITY)
+    model_part.AddNodalSolutionStepVariable(PRESS_PROJ_NO_RO)
+    model_part.AddNodalSolutionStepVariable(MEAN_SIZE)
+    model_part.AddNodalSolutionStepVariable(NODAL_AREA)
+    model_part.AddNodalSolutionStepVariable(NODAL_MASS)
     model_part.AddNodalSolutionStepVariable(SPLIT_ELEMENT)
     model_part.AddNodalSolutionStepVariable(PRESSUREAUX)
 
@@ -50,7 +50,7 @@ def AddDofs(model_part):
 class PFEM2Solver:
     def __init__(self,model_part,domain_size):
         self.model_part = model_part
-        
+
         self.time_scheme = ResidualBasedIncrementalUpdateStaticScheme()
 
         #definition of the solvers
@@ -58,26 +58,26 @@ class PFEM2Solver:
         tol = 1e-5
         verbosity = 1
         pDiagPrecond = DiagonalPreconditioner()
-        #self.monolitic_linear_solver = BICGSTABSolver(1e-5, 1000,pDiagPrecond) # SkylineLUFactorizationSolver() 
-        self.monolitic_linear_solver =  AMGCLSolver(AMGCLSmoother.ILU0,AMGCLIterativeSolverType.BICGSTAB,tol,50,verbosity,gmres_size)      #BICGSTABSolver(1e-7, 5000) # SkylineLUFactorizationSolver() 
+        #self.monolitic_linear_solver = BICGSTABSolver(1e-5, 1000,pDiagPrecond) # SkylineLUFactorizationSolver()
+        self.monolitic_linear_solver =  AMGCLSolver(AMGCLSmoother.ILU0,AMGCLIterativeSolverType.BICGSTAB,tol,50,verbosity,gmres_size)      #BICGSTABSolver(1e-7, 5000) # SkylineLUFactorizationSolver()
         #(self.monolitic_linear_solver).is_symmetric=True;
-        self.conv_criteria = DisplacementCriteria(1e-9,1e-15)  #tolerance for the solver 
-        
+        self.conv_criteria = DisplacementCriteria(1e-9,1e-15)  #tolerance for the solver
+
         self.domain_size = domain_size
         self.neighbour_search = FindNodalNeighboursProcess(model_part)
         (self.neighbour_search).Execute()
         self.neighbour_elements_search= GenericFindElementalNeighboursProcess(model_part)
-        (self.neighbour_elements_search).ExecuteInitialize()
+        (self.neighbour_elements_search).Execute()
         ##calculate normals
         self.normal_tools = BodyNormalCalculationUtils()
-        
-        
+
+
     #######################################################################
     #######################################################################
     def Initialize(self):
         #creating the solution strategy
         CalculateReactionFlag = False
-        ReformDofSetAtEachStep = False	
+        ReformDofSetAtEachStep = False
         MoveMeshFlag = False
         pDiagPrecond = DiagonalPreconditioner()
         maximum_number_of_particles= 8*self.domain_size
@@ -85,16 +85,16 @@ class PFEM2Solver:
         self.ExplicitStrategy=PFEM2_Explicit_Strategy(self.model_part,self.domain_size, MoveMeshFlag)
 
         self.VariableUtils = VariableUtils()
-        
+
         if self.domain_size==2:
                 self.moveparticles = MoveParticleUtilityDiff2D(self.model_part,maximum_number_of_particles)
         else:
                 self.moveparticles = MoveParticleUtilityDiff3D(self.model_part,maximum_number_of_particles)
-        
+
         print "self.domain_size = ", self.domain_size
         if self.domain_size==2:
                 self.calculatewatervolume = CalculateWaterFraction2D(self.model_part)
-        else:	
+        else:
                 self.calculatewatervolume = CalculateWaterFraction3D(self.model_part)
 
         self.moveparticles.MountBinDiff()
@@ -102,9 +102,9 @@ class PFEM2Solver:
         self.water_initial_volume=0.0 #we initialize it at zero
         self.water_initial_volume_flag=True #we initialize it at zero
         self.mass_correction_factor=0.0
-        
 
-        self.normal_tools.CalculateBodyNormals(self.model_part,self.domain_size);  
+
+        self.normal_tools.CalculateBodyNormals(self.model_part,self.domain_size);
         condition_number=1
         '''
         if self.domain_size==2:
@@ -113,7 +113,7 @@ class PFEM2Solver:
         	self.addBC = AddFixedVelocityCondition3D(self.model_part)
 
         (self.addBC).AddThem()
-        '''	
+        '''
 
         import strategy_python #implicit solver
 
@@ -133,10 +133,10 @@ class PFEM2Solver:
         self.thermal=0.0
         self.implicitviscosity=0.0
 
-        
-      
-                 
-    #######################################################################   
+
+
+
+    #######################################################################
     def Solve(self):
                 add_gravity=False #in the monolitic solver we do not add the gravity, it is added directly in the implicit monolitic system
                 transfer_pressure=False
@@ -145,7 +145,7 @@ class PFEM2Solver:
 
                 t1 = timer.time()
 
-                #calculating RHS by viscous forces using information of the previous time step:	
+                #calculating RHS by viscous forces using information of the previous time step:
                 #self.CalculateExplicitViscosityContribution();
                 t2 = timer.time()
                 self.calculateinitialdrag = self.calculateinitialdrag + t2-t1
@@ -155,7 +155,7 @@ class PFEM2Solver:
                 t2a = timer.time()
 
                 #streamline integration:
-                (self.moveparticles).MoveParticlesDiff(viscosity_streamline_integrate,add_gravity);	
+                (self.moveparticles).MoveParticlesDiff(viscosity_streamline_integrate,add_gravity);
                 t3 = timer.time()
                 self.streamlineintegration = self.streamlineintegration + t3-t2a
                 t3a = timer.time()
@@ -183,12 +183,12 @@ class PFEM2Solver:
 
                 #implicit everything
                 full_reset=True;
-                (self.moveparticles).ResetBoundaryConditions(full_reset) 
+                (self.moveparticles).ResetBoundaryConditions(full_reset)
                 (self.monolitic_solver).Solve() #implicit resolution of the pressure system. All the other tasks are explicit
                 full_reset=True;
-                (self.moveparticles).ResetBoundaryConditions(full_reset) 
+                (self.moveparticles).ResetBoundaryConditions(full_reset)
                 #delta_velocity= Velocity(final) - MeshVelocity(from the particles), so we add to the particles the correction done in the mesh.
-                (self.moveparticles).CalculateDeltaVelocity();                
+                (self.moveparticles).CalculateDeltaVelocity();
                 t11 = timer.time()
                 self.implicit_solving = self.implicit_solving + t11-t6
                 #transfering the information to the mesh:
@@ -200,7 +200,7 @@ class PFEM2Solver:
                 #reseeding in elements that have few particles to avoid having problems in next iterations:
                 post_minimum_number_of_particles=self.domain_size+1;
                 self.water_volume = (self.calculatewatervolume).Calculate()
-                if (self.water_initial_volume_flag): 
+                if (self.water_initial_volume_flag):
                 	print "calculated water volume for the first time"
                 	self.water_initial_volume=self.water_volume
                 	self.water_initial_volume_flag=False
@@ -211,14 +211,14 @@ class PFEM2Solver:
                 	 self.mass_correction_factor
                 print "mass correction factor: ", self.mass_correction_factor
                 print "current mass loss is : " , (1.0 - water_fraction) * 100.0 , " % "
-                (self.moveparticles).PostReseed(post_minimum_number_of_particles,self.mass_correction_factor);                
+                (self.moveparticles).PostReseed(post_minimum_number_of_particles,self.mass_correction_factor);
                 t13 = timer.time()
                 self.reseed=self.reseed+ t13-t12
                 #self.nodaltasks = self.nodaltasks + t11-t9
 
                 #print ". erasing  = ", t14-t13
-                self.total = self.total + t13-t1 
-                
+                self.total = self.total + t13-t1
+
 
                 print( "----------TIMES----------"
                 print( "self.calculateinitialdrag  " , self.calculateinitialdrag , "in % = ",  100.0*(self.calculateinitialdrag)/(self.total))
@@ -232,10 +232,10 @@ class PFEM2Solver:
                 print( "TOTAL ----- " ,  self.total)
                 print( "THIS TIME STEP = " , t13-t1)
 
-                
 
 
-    #######################################################################   
+
+    #######################################################################
     def CalculateExplicitViscosityContribution(self):
                 self.model_part.ProcessInfo.SetValue(FRACTIONAL_STEP, 0) #explicit contribution by viscosity is defined as fract step = 0
                 (self.ExplicitStrategy).InitializeSolutionStep(self.model_part.ProcessInfo);

--- a/applications/PFEM2Application/python_scripts/pfem_2_solver_monolithic_autoslip_fluid.py
+++ b/applications/PFEM2Application/python_scripts/pfem_2_solver_monolithic_autoslip_fluid.py
@@ -62,7 +62,7 @@ class PFEM2Solver:
         self.neighbour_search = FindNodalNeighboursProcess(model_part)
         (self.neighbour_search).Execute()
         self.neighbour_elements_search= GenericFindElementalNeighboursProcess(model_part)
-        (self.neighbour_elements_search).ExecuteInitialize()
+        (self.neighbour_elements_search).Execute()
         ##calculate normals
         self.normal_tools = BodyNormalCalculationUtils()
 

--- a/applications/PFEM2Application/python_scripts/pfem_2_solver_monolithic_fluid.py
+++ b/applications/PFEM2Application/python_scripts/pfem_2_solver_monolithic_fluid.py
@@ -93,7 +93,7 @@ class PFEM2Solver:
         self.neighbour_search = FindNodalNeighboursProcess(model_part)
         (self.neighbour_search).Execute()
         self.neighbour_elements_search= GenericFindElementalNeighboursProcess(model_part)
-        (self.neighbour_elements_search).ExecuteInitialize()
+        (self.neighbour_elements_search).Execute()
         ##calculate normals
         self.normal_tools = BodyNormalCalculationUtils()
 

--- a/applications/PFEM2Application/python_scripts/pfem_2_solver_monolithic_fluid_2scales.py
+++ b/applications/PFEM2Application/python_scripts/pfem_2_solver_monolithic_fluid_2scales.py
@@ -20,13 +20,13 @@ def AddVariables(model_part,linea_model_part):
 
     model_part.AddNodalSolutionStepVariable(RHS);
     model_part.AddNodalSolutionStepVariable(MESH_VELOCITY);
-    model_part.AddNodalSolutionStepVariable(NORMAL);	
-    #model_part.AddNodalSolutionStepVariable(DENSITY);	
+    model_part.AddNodalSolutionStepVariable(NORMAL);
+    #model_part.AddNodalSolutionStepVariable(DENSITY);
 
-    model_part.AddNodalSolutionStepVariable(DELTA_VELOCITY) 
-    model_part.AddNodalSolutionStepVariable(MEAN_SIZE) 
-    model_part.AddNodalSolutionStepVariable(NODAL_AREA) 
-    model_part.AddNodalSolutionStepVariable(NODAL_MASS) 
+    model_part.AddNodalSolutionStepVariable(DELTA_VELOCITY)
+    model_part.AddNodalSolutionStepVariable(MEAN_SIZE)
+    model_part.AddNodalSolutionStepVariable(NODAL_AREA)
+    model_part.AddNodalSolutionStepVariable(NODAL_MASS)
     model_part.AddNodalSolutionStepVariable(MASS)
     model_part.AddNodalSolutionStepVariable(FORCE)
     model_part.AddNodalSolutionStepVariable(TAU)
@@ -52,7 +52,7 @@ class PFEM2Solver:
     def __init__(self,model_part,model_part_topo,domain_size):
         self.model_part = model_part
         self.model_part_topo = model_part_topo
-        
+
         self.time_scheme = ResidualBasedIncrementalUpdateStaticScheme()
 
         #definition of the solvers
@@ -61,42 +61,42 @@ class PFEM2Solver:
 	verbosity = 1
 	pDiagPrecond = DiagonalPreconditioner()
 	#self.monolitic_linear_solver= GPUBICGSTABSolverWithDiagonalPreconditioner(tol, 5000)
-	#self.monolitic_linear_solver= ViennaCLSolver(tol,3000,OpenCLPrecision.Double,OpenCLSolverType.CG,OpenCLPreconditionerType.AMG_DAMPED_JACOBI) 
-	#self.monolitic_linear_solver = BICGSTABSolver(1e-5, 1000,pDiagPrecond) # SkylineLUFactorizationSolver() 
-	#self.monolitic_linear_solver = BICGSTABSolver(1e-5, 1000,pDiagPrecond) # SkylineLUFactorizationSolver() 
-	self.monolitic_linear_solver =  AMGCLSolver(AMGCLSmoother.ILU0,AMGCLIterativeSolverType.CG,tol,500,verbosity,gmres_size)      #BICGSTABSolver(1e-7, 5000) # SkylineLUFactorizationSolver() 
-	
+	#self.monolitic_linear_solver= ViennaCLSolver(tol,3000,OpenCLPrecision.Double,OpenCLSolverType.CG,OpenCLPreconditionerType.AMG_DAMPED_JACOBI)
+	#self.monolitic_linear_solver = BICGSTABSolver(1e-5, 1000,pDiagPrecond) # SkylineLUFactorizationSolver()
+	#self.monolitic_linear_solver = BICGSTABSolver(1e-5, 1000,pDiagPrecond) # SkylineLUFactorizationSolver()
+	self.monolitic_linear_solver =  AMGCLSolver(AMGCLSmoother.ILU0,AMGCLIterativeSolverType.CG,tol,500,verbosity,gmres_size)      #BICGSTABSolver(1e-7, 5000) # SkylineLUFactorizationSolver()
+
 	#self.viscosity_linear_solver = AMGCLSolver(AMGCLSmoother.DAMPED_JACOBI,AMGCLIterativeSolverType.CG,tol,200,verbosity,gmres_size)      #BICGSTABSolver(1e-7, 5000) # SkylineLUFactorizationSolver() #
 	#self.pressure_linear_solver = DeflatedCGSolver(1e-5, 3000, True,1000)
 	#self.viscosity_linear_solver = DeflatedCGSolver(1e-6, 3000, True,1000)
 	self.temperature_linear_solver =  BICGSTABSolver(1e-4, 5000,pDiagPrecond) #
 	#self.temperature_linear_solver =  AMGCLSolver(AMGCLSmoother.DAMPED_JACOBI,AMGCLIterativeSolverType.CG,tol,200,verbosity,gmres_size)      #BICGSTABSolver(1e-7, 5000) # SkylineLUFactorizationSolver() #
-        #self.pressure_linear_solver =  SkylineLUFactorizationSolver()  #we set the type of solver that we want 
-        self.conv_criteria = DisplacementCriteria(1e-9,1e-15)  #tolerance for the solver 
-        
+        #self.pressure_linear_solver =  SkylineLUFactorizationSolver()  #we set the type of solver that we want
+        self.conv_criteria = DisplacementCriteria(1e-9,1e-15)  #tolerance for the solver
+
         self.domain_size = domain_size
         self.neighbour_search = FindNodalNeighboursProcess(model_part)
         (self.neighbour_search).Execute()
 	self.neighbour_elements_search= GenericFindElementalNeighboursProcess(model_part)
-	(self.neighbour_elements_search).ExecuteInitialize()
+	(self.neighbour_elements_search).Execute()
 	self.neighbour_elements_search_topo= GenericFindElementalNeighboursProcess(model_part_topo)
-	(self.neighbour_elements_search_topo).ExecuteInitialize()
+	(self.neighbour_elements_search_topo).Execute()
         ##calculate normals
         self.normal_tools = BodyNormalCalculationUtils()
-        
-        
+
+
     #######################################################################
     #######################################################################
     def Initialize(self):
         #creating the solution strategy
         CalculateReactionFlag = False
-        ReformDofSetAtEachStep = False	
+        ReformDofSetAtEachStep = False
         MoveMeshFlag = False
         pDiagPrecond = DiagonalPreconditioner()
         #build the edge data structure
 	#if self.domain_size==2:
 	#	self.matrix_container = MatrixContainer2D()
-	#else: 
+	#else:
 	#	self.matrix_container = MatrixContainer3D()
 	#maximum_number_of_particles= 10*self.domain_size
 	maximum_number_of_particles= 8*self.domain_size
@@ -104,7 +104,7 @@ class PFEM2Solver:
 	self.ExplicitStrategy=PFEM2_Explicit_Strategy(self.model_part,self.domain_size, MoveMeshFlag)
 
 	self.VariableUtils = VariableUtils()
-	
+
 	if self.domain_size==2:
 		self.moveparticles = MoveParticleUtilityDiffFluidOnly2D(self.model_part,maximum_number_of_particles)
 	else:
@@ -113,7 +113,7 @@ class PFEM2Solver:
 	print "self.domain_size = ", self.domain_size
 	if self.domain_size==2:
 		self.calculatewatervolume = CalculateWaterFraction2D(self.model_part)
-	else:	
+	else:
 		self.calculatewatervolume = CalculateWaterFraction3D(self.model_part)
 	print "hola0"
 	self.moveparticles.MountBinDiff()
@@ -124,9 +124,9 @@ class PFEM2Solver:
 	self.water_initial_volume_flag=True #we initialize it at zero
 	self.mass_correction_factor=0.0
 
-        
 
-	self.normal_tools.CalculateBodyNormals(self.model_part,self.domain_size);  
+
+	self.normal_tools.CalculateBodyNormals(self.model_part,self.domain_size);
 	condition_number=1
 	'''
 	if self.domain_size==2:
@@ -135,7 +135,7 @@ class PFEM2Solver:
 		self.addBC = AddFixedVelocityCondition3D(self.model_part)
 
 	(self.addBC).AddThem()
-	'''	
+	'''
 	#RICC TOOLS
 	self.convection_solver = PureConvectionUtilities2D();
 	self.convection_solver.ConstructSystem(self.model_part,DISTANCE,VELOCITY,FORCE);
@@ -166,19 +166,19 @@ class PFEM2Solver:
 	self.thermal=0.0
 	self.implicitviscosity=0.0
 	print "hola2"
-        
+
 	overwrite_particle_data=False
 	intial_offset=Vector(3);
 	intial_offset[0]=0.0
 	intial_offset[1]=0.0
 	intial_offset[2]=0.0
 	(self.moveparticles).IntializeTransferTool(self.model_part_topo, intial_offset,overwrite_particle_data);
-      
-                 
-    #######################################################################   
+
+
+    #######################################################################
     def Solve(self):
 		combustion_problem=False;
-		
+
 
 
 		add_gravity=False #in the monolitic solver we do not add the gravity, it is added directly in the implicit monolitic system
@@ -187,8 +187,8 @@ class PFEM2Solver:
 		transfer_pressure=False
 		temperature_implicit_calculation=False;
 		viscosity_streamline_integrate=False; #True means explicit integration! False means we will have to solve the fractional velocity system implicetely later, once information has been passed to mesh
-		#pressure_gradient_integrate=False; #we use the pressure of the previous step. not reccomended for 2 fluid flows. REMOVED FROM THE CODE	
-		calculate_viscous_contribution_after_everything=False;		
+		#pressure_gradient_integrate=False; #we use the pressure of the previous step. not reccomended for 2 fluid flows. REMOVED FROM THE CODE
+		calculate_viscous_contribution_after_everything=False;
 		#implicit_velocity_correction=False;	# as expected this can not be active the implicit correction is done:
 		#if (calculate_viscous_contribution_after_everything):
 		#	implicit_velocity_correction=False;
@@ -196,7 +196,7 @@ class PFEM2Solver:
 			temperature_implicit_calculation=True;
 		t1 = timer.time()
 
-		#calculating RHS by viscous forces using information of the previous time step:	
+		#calculating RHS by viscous forces using information of the previous time step:
 		#self.CalculateExplicitViscosityContribution();
 		t2 = timer.time()
 		self.calculateinitialdrag = self.calculateinitialdrag + t2-t1
@@ -206,7 +206,7 @@ class PFEM2Solver:
 		t2a = timer.time()
 
 		#streamline integration:
-		(self.moveparticles).MoveParticlesDiff(viscosity_streamline_integrate,add_gravity);	
+		(self.moveparticles).MoveParticlesDiff(viscosity_streamline_integrate,add_gravity);
 		t3 = timer.time()
 		self.streamlineintegration = self.streamlineintegration + t3-t2a
 		t3a = timer.time()
@@ -238,7 +238,7 @@ class PFEM2Solver:
 		#	node.SetSolutionStepValue(DISTANCE,node.GetSolutionStepValue(TEMP_CONV_PROJ))
 		#self.convection_solver.CalculateProjection(self.model_part,DISTANCE,NODAL_AREA,VELOCITY,FORCE,TEMP_CONV_PROJ);
 		#self.convection_solver.ConvectScalarVar(self.model_part,self.linear_solver,DISTANCE,VELOCITY,FORCE,TEMP_CONV_PROJ,1);
-		
+
 		print "hola1"
 
 		#value  = elem_size*0.02
@@ -259,37 +259,37 @@ class PFEM2Solver:
 		#	(self.moveparticles).CalculateFirstStep();
 			#self.model_part.ProcessInfo.SetValue(NL_ITERATION_NUMBER, 0) #1= semiimplicit, =0 fully implciit
 			#(self.solver).Solve()
-		
+
 		t6 = timer.time()
 
 		if (temperature_implicit_calculation):
 			self.model_part.ProcessInfo.SetValue(FRACTIONAL_STEP, 5)
-			print "calculating temperature implicitely"	
+			print "calculating temperature implicitely"
 			(self.temperature_solver).Solve()
 		t7=timer.time()
 		self.thermal = self.thermal + t7-t6
 		print "hola5"
-		
+
 		(self.VariableUtils).CopyVectorVar(MESH_VELOCITY,VELOCITY,self.model_part.Nodes)
 		#self.CalculateExplicitPressureViscousCorrection()
 		#pressure iterations
-		
-		
+
+
 		full_reset=False;
 		#self.CalculateMassMatrix();
-		#(self.moveparticles).ResetBoundaryConditions(full_reset) 
-		
+		#(self.moveparticles).ResetBoundaryConditions(full_reset)
+
 		#implicit everything
 		print "hola6"
 		full_reset=True;
-		(self.moveparticles).ResetBoundaryConditions(full_reset) 
+		(self.moveparticles).ResetBoundaryConditions(full_reset)
 
 		(self.monolitic_solver).Solve() #implicit resolution of the pressure system. All the other tasks are explicit
 		print "hola7"
 		full_reset=True;
-		(self.moveparticles).ResetBoundaryConditions(full_reset) 
+		(self.moveparticles).ResetBoundaryConditions(full_reset)
 		#delta_velocity= Velocity(final) - MeshVelocity(from the particles), so we add to the particles the correction done in the mesh.
-		(self.moveparticles).CalculateDeltaVelocity();		
+		(self.moveparticles).CalculateDeltaVelocity();
 		t11 = timer.time()
 		self.navierstokes = self.navierstokes + t11-t6
 		#transfering the information to the mesh:
@@ -301,7 +301,7 @@ class PFEM2Solver:
 		#reseeding in elements that have few particles to avoid having problems in next iterations:
 		post_minimum_number_of_particles=self.domain_size*2;
 		self.water_volume = (self.calculatewatervolume).Calculate()
-		if (self.water_initial_volume_flag): 
+		if (self.water_initial_volume_flag):
 			print "calculated water volume for the first time"
 			self.water_initial_volume=self.water_volume
 			self.water_initial_volume_flag=False
@@ -320,14 +320,14 @@ class PFEM2Solver:
 		bounding_box_upper_corner[0]=1.0
 		bounding_box_upper_corner[1]=2.0
 		bounding_box_upper_corner[2]=0.0
-		(self.moveparticles).PostReseedOnlyInBoundingBox(post_minimum_number_of_particles,self.mass_correction_factor,bounding_box_lower_corner,bounding_box_upper_corner);		
+		(self.moveparticles).PostReseedOnlyInBoundingBox(post_minimum_number_of_particles,self.mass_correction_factor,bounding_box_lower_corner,bounding_box_upper_corner);
 		t13 = timer.time()
 		self.reseed=self.reseed+ t13-t12
 		#self.nodaltasks = self.nodaltasks + t11-t9
 
 		#print ". erasing  = ", t14-t13
-		self.total = self.total + t13-t1 
-		
+		self.total = self.total + t13-t1
+
 		if combustion_problem==False:
 			print "----------TIMES----------"
 			print "self.calculateinitialdrag  " , self.calculateinitialdrag , "in % = ",  100.0*(self.calculateinitialdrag)/(self.total)
@@ -339,7 +339,7 @@ class PFEM2Solver:
 			print "self.reseed " ,  self.reseed , "in % = ", 100.0*(self.reseed)/(self.total)
 			print "self.prereseed " ,  self.prereseed , "in % = ", 100.0*(self.prereseed)/(self.total)
 			print "TOTAL ----- " ,  self.total
-			print "THIS TIME STEP = " , t13-t1 
+			print "THIS TIME STEP = " , t13-t1
 		else:
 			print "----------TIMES----------"
 			print "self.calculateinitialdrag  " , self.calculateinitialdrag , "in % = ",  100.0*(self.calculateinitialdrag)/(self.total)
@@ -355,14 +355,14 @@ class PFEM2Solver:
 			print "self.reseed " ,  self.reseed , "in % = ", 100.0*(self.reseed)/(self.total)
 			print "self.prereseed " ,  self.prereseed , "in % = ", 100.0*(self.prereseed)/(self.total)
 			print "TOTAL ----- " ,  self.total
-			print "THIS TIME STEP = " , t13-t1 
-		
+			print "THIS TIME STEP = " , t13-t1
 
-    #######################################################################   
+
+    #######################################################################
     def CalculatePressureIteration(self, iteration_number):
 		self.model_part.ProcessInfo.SetValue(FRACTIONAL_STEP, 2)
 		self.model_part.ProcessInfo.SetValue(NL_ITERATION_NUMBER, iteration_number)
-		
+
 		(self.pressure_solver).Solve() #implicit resolution of the pressure system. All the other tasks are explicit
 		#if iteration_number==1:
 		#	for node in self.model_part.Nodes:
@@ -375,14 +375,14 @@ class PFEM2Solver:
 		(self.ExplicitStrategy).FinalizeSolutionStep(self.model_part.ProcessInfo);
 
 
-    #######################################################################   
+    #######################################################################
     def CalculateExplicitViscosityContribution(self):
 		self.model_part.ProcessInfo.SetValue(FRACTIONAL_STEP, 0) #explicit contribution by viscosity is defined as fract step = 0
 		(self.ExplicitStrategy).InitializeSolutionStep(self.model_part.ProcessInfo);
 		(self.ExplicitStrategy).AssembleLoop(self.model_part.ProcessInfo);
 		(self.ExplicitStrategy).FinalizeSolutionStep(self.model_part.ProcessInfo);
 
-    #######################################################################   
+    #######################################################################
 
     def CalculateExplicitPressureViscousCorrection(self):
 		self.model_part.ProcessInfo.SetValue(FRACTIONAL_STEP, 6) #explicit contribution by viscosity is defined as fract step = 0
@@ -390,9 +390,9 @@ class PFEM2Solver:
 		(self.ExplicitStrategy).AssembleLoop(self.model_part.ProcessInfo);
 		(self.ExplicitStrategy).FinalizeSolutionStep(self.model_part.ProcessInfo);
 
-    ####################################################################### 
+    #######################################################################
 
-    #######################################################################   
+    #######################################################################
 
     def CalculateMassMatrix(self):
 		self.model_part.ProcessInfo.SetValue(FRACTIONAL_STEP, 7) #explicit contribution by viscosity is defined as fract step = 0
@@ -400,7 +400,7 @@ class PFEM2Solver:
 		(self.ExplicitStrategy).AssembleLoop(self.model_part.ProcessInfo);
 		#(self.ExplicitStrategy).FinalizeSolutionStep(self.model_part.ProcessInfo);
 
-    ####################################################################### 
+    #######################################################################
 
     def SetEchoLevel(self,level):
         (self.solver).SetEchoLevel(level)

--- a/applications/PFEM2Application/python_scripts/pfem_2_solver_monolithic_fluid_prashanth.py
+++ b/applications/PFEM2Application/python_scripts/pfem_2_solver_monolithic_fluid_prashanth.py
@@ -31,11 +31,11 @@ def AddVariables(model_part):
     model_part.AddNodalSolutionStepVariable(TEMP_CONV_PROJ);
     model_part.AddNodalSolutionStepVariable(PREVIOUS_ITERATION_PRESSURE);
     #model_part.AddNodalSolutionStepVariable(FIRST_ITERATION_PRESSURE);
-    model_part.AddNodalSolutionStepVariable(DELTA_VELOCITY) 
-    model_part.AddNodalSolutionStepVariable(PRESS_PROJ_NO_RO) 
-    model_part.AddNodalSolutionStepVariable(MEAN_SIZE) 
-    model_part.AddNodalSolutionStepVariable(NODAL_AREA) 
-    model_part.AddNodalSolutionStepVariable(NODAL_MASS) 
+    model_part.AddNodalSolutionStepVariable(DELTA_VELOCITY)
+    model_part.AddNodalSolutionStepVariable(PRESS_PROJ_NO_RO)
+    model_part.AddNodalSolutionStepVariable(MEAN_SIZE)
+    model_part.AddNodalSolutionStepVariable(NODAL_AREA)
+    model_part.AddNodalSolutionStepVariable(NODAL_MASS)
     model_part.AddNodalSolutionStepVariable(SPLIT_ELEMENT)
     model_part.AddNodalSolutionStepVariable(PRESSUREAUX)
     model_part.AddNodalSolutionStepVariable(BODY_FORCE)
@@ -58,7 +58,7 @@ def AddDofs(model_part):
 class PFEM2Solver:
     def __init__(self,model_part,domain_size):
         self.model_part = model_part
-        
+
         self.time_scheme = ResidualBasedIncrementalUpdateStaticScheme()
 
         #definition of the solvers
@@ -66,27 +66,27 @@ class PFEM2Solver:
         tol = 1e-5
         verbosity = 1
         pDiagPrecond = DiagonalPreconditioner()
-        #self.linear_solver = BICGSTABSolver(1e-5, 1000,pDiagPrecond) # SkylineLUFactorizationSolver() 
-        self.linear_solver =  AMGCLSolver(AMGCLSmoother.ILU0,AMGCLIterativeSolverType.BICGSTAB,tol,500,verbosity,gmres_size) #SkylineLUFactorizationSolver() 
-        self.monolitic_linear_solver =  AMGCLSolver(AMGCLSmoother.ILU0,AMGCLIterativeSolverType.BICGSTAB,tol,500,verbosity,gmres_size)      #BICGSTABSolver(1e-7, 5000) # SkylineLUFactorizationSolver() 
+        #self.linear_solver = BICGSTABSolver(1e-5, 1000,pDiagPrecond) # SkylineLUFactorizationSolver()
+        self.linear_solver =  AMGCLSolver(AMGCLSmoother.ILU0,AMGCLIterativeSolverType.BICGSTAB,tol,500,verbosity,gmres_size) #SkylineLUFactorizationSolver()
+        self.monolitic_linear_solver =  AMGCLSolver(AMGCLSmoother.ILU0,AMGCLIterativeSolverType.BICGSTAB,tol,500,verbosity,gmres_size)      #BICGSTABSolver(1e-7, 5000) # SkylineLUFactorizationSolver()
         #(self.monolitic_linear_solver).is_symmetric=True;
-        self.conv_criteria = DisplacementCriteria(1e-9,1e-15)  #tolerance for the solver 
-        
+        self.conv_criteria = DisplacementCriteria(1e-9,1e-15)  #tolerance for the solver
+
         self.domain_size = domain_size
         self.neighbour_search = FindNodalNeighboursProcess(model_part)
         (self.neighbour_search).Execute()
         self.neighbour_elements_search= GenericFindElementalNeighboursProcess(model_part)
-        (self.neighbour_elements_search).ExecuteInitialize()
+        (self.neighbour_elements_search).Execute()
         ##calculate normals
         self.normal_tools = BodyNormalCalculationUtils()
-        
-        
+
+
     #######################################################################
     #######################################################################
     def Initialize(self):
         #creating the solution strategy
         CalculateReactionFlag = False
-        ReformDofSetAtEachStep = False 
+        ReformDofSetAtEachStep = False
         MoveMeshFlag = False
         pDiagPrecond = DiagonalPreconditioner()
         maximum_number_of_particles= 8*self.domain_size
@@ -94,7 +94,7 @@ class PFEM2Solver:
         self.ExplicitStrategy=PFEM2_Explicit_Strategy(self.model_part,self.domain_size, MoveMeshFlag)
 
         self.VariableUtils = VariableUtils()
-        
+
         if self.domain_size==2:
                 self.moveparticles = MoveParticleUtilityDiffFluidOnly2D(self.model_part,maximum_number_of_particles)
         else:
@@ -111,18 +111,18 @@ class PFEM2Solver:
         self.water_initial_volume=0.0 #we initialize it at zero
         self.water_initial_volume_flag=True #we initialize it at zero
         self.mass_correction_factor=0.0
-        
 
-        self.normal_tools.CalculateBodyNormals(self.model_part,self.domain_size);  
+
+        self.normal_tools.CalculateBodyNormals(self.model_part,self.domain_size);
         condition_number=1
-        
+
         if self.domain_size==2:
                 self.addBC = AddMonolithicFixedVelocityCondition2D(self.model_part)
         else:
                 self.addBC = AddMonolithicFixedVelocityCondition3D(self.model_part)
 
         (self.addBC).AddThem()
-        
+
 
         ##RICC TOOLS
         #if self.domain_size==2:
@@ -134,7 +134,7 @@ class PFEM2Solver:
         #   self.distance_utils = SignedDistanceCalculationUtils2D()
         #else:
         #    self.distance_utils = SignedDistanceCalculationUtils3D()
-        #self.redistance_step = 0 
+        #self.redistance_step = 0
         ########
 
         import strategy_python #implicit solver
@@ -154,12 +154,12 @@ class PFEM2Solver:
         self.nodaltasks=0.0
         self.thermal=0.0
         self.implicitviscosity=0.0
-        
-        
 
-                 
-    #######################################################################   
-    #######################################################################   
+
+
+
+    #######################################################################
+    #######################################################################
     def Solve(self):
                 add_gravity=False #in the monolitic solver we do not add the gravity, it is added directly in the implicit monolitic system
                 transfer_pressure=False
@@ -167,7 +167,7 @@ class PFEM2Solver:
 
                 t1 = timer.time()
 
-                #calculating RHS by viscous forces using information of the previous time step: 
+                #calculating RHS by viscous forces using information of the previous time step:
                 #self.CalculateExplicitViscosityContribution();
                 t2 = timer.time()
                 self.calculateinitialdrag = self.calculateinitialdrag + t2-t1
@@ -178,7 +178,7 @@ class PFEM2Solver:
 
                 #streamline integration:
                 self.moveparticles.MountBinDiff()
-                (self.moveparticles).MoveParticlesDiff(viscosity_streamline_integrate,add_gravity); 
+                (self.moveparticles).MoveParticlesDiff(viscosity_streamline_integrate,add_gravity);
                 t3 = timer.time()
                 self.streamlineintegration = self.streamlineintegration + t3-t2a
                 t3a = timer.time()
@@ -215,17 +215,17 @@ class PFEM2Solver:
                     node.SetSolutionStepValue(CORRECTED_DISTANCE,distance-2.0)
                 #TransferLagrtoEul copied info to MESH_VEL, but the solver uses simply velocity, so we copy the variable there.
                 (self.VariableUtils).CopyVectorVar(MESH_VELOCITY,VELOCITY,self.model_part.Nodes)
-                
+
                 #implicit everything
                 full_reset=True;
                 self.model_part.ProcessInfo.SetValue(FRACTIONAL_STEP, 20)
-                (self.moveparticles).ResetBoundaryConditions(full_reset) 
+                (self.moveparticles).ResetBoundaryConditions(full_reset)
                 (self.monolitic_solver).Solve() #implicit resolution of the pressure system. All the other tasks are explicit
                 self.CalculatePressureProjection()
                 full_reset=True;
-                (self.moveparticles).ResetBoundaryConditions(full_reset) 
+                (self.moveparticles).ResetBoundaryConditions(full_reset)
                 #delta_velocity= Velocity(final) - MeshVelocity(from the particles), so we add to the particles the correction done in the mesh.
-                (self.moveparticles).CalculateDeltaVelocity();                
+                (self.moveparticles).CalculateDeltaVelocity();
                 t11 = timer.time()
                 self.implicit_solving = self.implicit_solving + t11-t6
                 #transfering the information to the mesh:
@@ -238,7 +238,7 @@ class PFEM2Solver:
                 post_minimum_number_of_particles=self.domain_size*2;
 
                 self.water_volume = (self.calculatewatervolume).Calculate()
-                if (self.water_initial_volume_flag): 
+                if (self.water_initial_volume_flag):
                         print("calculated water volume for the first time")
                         self.water_initial_volume=self.water_volume
                         self.water_initial_volume_flag=False
@@ -249,14 +249,14 @@ class PFEM2Solver:
                         self.mass_correction_factor
                 print("mass correction factor: ", self.mass_correction_factor)
                 print("current mass loss is : " , (1.0 - water_fraction) * 100.0 , " % ")
-                (self.moveparticles).PostReseed(post_minimum_number_of_particles,self.mass_correction_factor);                
+                (self.moveparticles).PostReseed(post_minimum_number_of_particles,self.mass_correction_factor);
                 t13 = timer.time()
                 self.reseed=self.reseed+ t13-t12
                 #self.nodaltasks = self.nodaltasks + t11-t9
 
                 #print ". erasing  = ", t14-t13
-                self.total = self.total + t13-t1 
-                
+                self.total = self.total + t13-t1
+
 
                 print("----------TIMES----------")
                 print("self.calculateinitialdrag  ", self.calculateinitialdrag,"in % = ", 100.0*(self.calculateinitialdrag)/(self.total))
@@ -270,10 +270,10 @@ class PFEM2Solver:
                 print("TOTAL ----- ",  self.total)
                 print("THIS TIME STEP = ", t13-t1)
 
-                
 
 
-    #######################################################################   
+
+    #######################################################################
     def CalculateExplicitViscosityContribution(self):
                 self.model_part.ProcessInfo.SetValue(FRACTIONAL_STEP, 0) #explicit contribution by viscosity is defined as fract step = 0
                 (self.ExplicitStrategy).InitializeSolutionStep(self.model_part.ProcessInfo);

--- a/applications/ShallowWaterApplication/python_scripts/stabilized_shallow_water_solver.py
+++ b/applications/ShallowWaterApplication/python_scripts/stabilized_shallow_water_solver.py
@@ -38,7 +38,7 @@ class StabilizedShallowWaterSolver(ShallowWaterBaseSolver):
         self.main_model_part.ProcessInfo.SetValue(KM.DENSITY, 1e3)
         self.main_model_part.ProcessInfo.SetValue(SW.INTEGRATE_BY_PARTS, False)
         if self.compute_neighbours:
-            KM.GenericFindElementalNeighboursProcess(self.main_model_part).ExecuteInitialize()
+            KM.GenericFindElementalNeighboursProcess(self.main_model_part).Execute()
 
     def FinalizeSolutionStep(self):
         super().FinalizeSolutionStep()

--- a/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/adjoint_nodal_displacement_response_function.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/adjoint_nodal_displacement_response_function.cpp
@@ -200,7 +200,7 @@ namespace Kratos
 
         ModelPart& response_part = mrModelPart.GetSubModelPart(mResponsePartName);
         GenericFindElementalNeighboursProcess neighbour_elements_finder(mrModelPart);
-        neighbour_elements_finder.ExecuteInitialize();
+        neighbour_elements_finder.Execute();
 
         for(auto& node_i : response_part.Nodes()) {
             auto const& r_neighbours = node_i.GetValue(NEIGHBOUR_ELEMENTS);

--- a/applications/ULFapplication/python_scripts/runge_kutta_frac_step_solver.py
+++ b/applications/ULFapplication/python_scripts/runge_kutta_frac_step_solver.py
@@ -171,7 +171,7 @@ class RungeKuttaFracStepSolver:
             node.Set(TO_ERASE, False)
 
         (self.fluid_neigh_finder).Execute();
-        (self.elem_neighbor_finder).ExecuteInitialize()
+        (self.elem_neighbor_finder).Execute()
         (self.condition_neigh_finder).Execute();
 
         (self.mark_free_surface_process).Execute();

--- a/kratos/processes/generic_find_elements_neighbours_process.cpp
+++ b/kratos/processes/generic_find_elements_neighbours_process.cpp
@@ -20,7 +20,7 @@ namespace Kratos
 {
 
 
-void GenericFindElementalNeighboursProcess::ExecuteInitialize()
+void GenericFindElementalNeighboursProcess::Execute()
 {
     KRATOS_TRY
 
@@ -36,15 +36,15 @@ void GenericFindElementalNeighboursProcess::ExecuteInitialize()
         const auto& r_geom = rElement.GetGeometry();
         const auto elem_boundaries = r_geom.LocalSpaceDimension()==3 ? r_geom.GenerateFaces() : r_geom.GenerateEdges() ;
         const unsigned int nBoundaries = elem_boundaries.size();
-        
+
         //initializing elem neighbours
         if (rElement.Has(NEIGHBOUR_ELEMENTS)) {
             auto& r_neighbour_elements = rElement.GetValue(NEIGHBOUR_ELEMENTS);
-            r_neighbour_elements.reserve(nBoundaries); 
+            r_neighbour_elements.reserve(nBoundaries);
             r_neighbour_elements.erase(r_neighbour_elements.begin(),r_neighbour_elements.end() );
         } else {
             ElementPointerVector empty_vector;
-            empty_vector.reserve(nBoundaries); 
+            empty_vector.reserve(nBoundaries);
             rElement.SetValue(NEIGHBOUR_ELEMENTS, empty_vector);
         }
         ElementPointerVector& rElemNeighbours = rElement.GetValue(NEIGHBOUR_ELEMENTS);
@@ -60,6 +60,11 @@ void GenericFindElementalNeighboursProcess::ExecuteInitialize()
     KRATOS_CATCH("Error finding the elemental neighbours")
 }
 
+void GenericFindElementalNeighboursProcess::ExecuteInitialize()
+{
+    KRATOS_WARNING("GenericFindElementalNeighboursProcess") << "'ExecuteInitialize' method is deprecated. Call 'Execute' instead." << std::endl;
+    Execute();
+}
 
 GlobalPointer<Element> GenericFindElementalNeighboursProcess::CheckForNeighbourElems (const Geometry<Node<3> >& rBoundaryGeom,
                                                                                       Element & rElement,
@@ -81,7 +86,7 @@ GlobalPointer<Element> GenericFindElementalNeighboursProcess::CheckForNeighbourE
     //we will take the pointers in the first node as candidates
     const unsigned int nCandidates =  rBoundaryGeom[0].GetValue(NEIGHBOUR_ELEMENTS).size();
     const unsigned int nCompleteList = PointersOfAllBoundaryNodes.size();
-    for( unsigned int j = 0 ; j < nCandidates; j++){ 
+    for( unsigned int j = 0 ; j < nCandidates; j++){
         unsigned int repetitions = 1 ; //the current one must be added
         if(PointersOfAllBoundaryNodes(j).GetRank() != CurrentRank ||
            PointersOfAllBoundaryNodes[j].Id()!=main_elem_id){ //ignoring main node
@@ -102,7 +107,7 @@ GlobalPointer<Element> GenericFindElementalNeighboursProcess::CheckForNeighbourE
 
 std::vector<bool> GenericFindElementalNeighboursProcess::HasNeighboursInFaces(const Element& rElement)
 {
-    std::vector<bool> has_neigh_in_faces;    
+    std::vector<bool> has_neigh_in_faces;
     if (rElement.Has(NEIGHBOUR_ELEMENTS)) {
         const auto& r_neighbour_elements = rElement.GetValue(NEIGHBOUR_ELEMENTS);
         has_neigh_in_faces.resize(r_neighbour_elements.size());

--- a/kratos/processes/generic_find_elements_neighbours_process.cpp
+++ b/kratos/processes/generic_find_elements_neighbours_process.cpp
@@ -62,7 +62,7 @@ void GenericFindElementalNeighboursProcess::Execute()
 
 void GenericFindElementalNeighboursProcess::ExecuteInitialize()
 {
-    KRATOS_WARNING("GenericFindElementalNeighboursProcess") << "'ExecuteInitialize' method is deprecated. Call 'Execute' instead." << std::endl;
+    KRATOS_WARNING("GenericFindElementalNeighboursProcess") << "'ExecuteInitialize' call is deprecated. Use 'Execute' instead." << std::endl;
     Execute();
 }
 

--- a/kratos/processes/generic_find_elements_neighbours_process.h
+++ b/kratos/processes/generic_find_elements_neighbours_process.h
@@ -89,8 +89,10 @@ public:
     ///@name Operations
     ///@{
 
+    void Execute() override;
+
     void ExecuteInitialize() override;
-    
+
 
     std::vector<bool> HasNeighboursInFaces(const Element&) ;
 
@@ -210,4 +212,4 @@ inline std::ostream& operator << (std::ostream& rOStream,
 
 }  // namespace Kratos.
 
-#endif // KRATOS_GENERIC_FIND_ELEMENTAL_NEIGHBOURS_PROCESS_H_INCLUDED  defined 
+#endif // KRATOS_GENERIC_FIND_ELEMENTAL_NEIGHBOURS_PROCESS_H_INCLUDED  defined

--- a/kratos/processes/split_internal_interfaces_process.cpp
+++ b/kratos/processes/split_internal_interfaces_process.cpp
@@ -57,7 +57,7 @@ void SplitInternalInterfacesProcess::ExecuteInitialize()
     }
 
     if(property_ids.size()) {
-        GenericFindElementalNeighboursProcess(mrModelPart).ExecuteInitialize();
+        GenericFindElementalNeighboursProcess(mrModelPart).Execute();
         for (auto it=property_ids.begin(); it!=(--property_ids.end()); ++it) {
             std::size_t id = *it;
             KRATOS_INFO("") << "Splitting the interface between the domain identified with property Id "  << id <<" and properties with bigger Ids ..."<< std::endl;

--- a/kratos/tests/cpp_tests/processes/test_generic_neighbour_elements.cpp
+++ b/kratos/tests/cpp_tests/processes/test_generic_neighbour_elements.cpp
@@ -61,7 +61,7 @@ KRATOS_TEST_CASE_IN_SUITE(HexasGenericFindElementsNeighbourProcessTest,
         28	0	11	1
     End Nodes
     Begin Elements	Element3D8N
-        1	1	1	2	5	4	7	8	11	10	
+        1	1	1	2	5	4	7	8	11	10
         2	1	2	3	6	5	8	9	12	11
         3	1	8	9	12	11	13	14	15	16
         4	1	21	22	23	24	25	26	27	28
@@ -71,9 +71,9 @@ KRATOS_TEST_CASE_IN_SUITE(HexasGenericFindElementsNeighbourProcessTest,
 
     //call process to create vector of neighbours
     auto neigh_process = GenericFindElementalNeighboursProcess(model_part);
-    neigh_process.ExecuteInitialize();
+    neigh_process.Execute();
 
-    //element 1 must have a single neighbour in third face 
+    //element 1 must have a single neighbour in third face
     const auto& elem1_neighs = model_part.Elements()[1].GetValue(NEIGHBOUR_ELEMENTS);
     KRATOS_CHECK_EQUAL(elem1_neighs.size(),6); // 6 faces
     for(unsigned int i_face = 0; i_face<elem1_neighs.size(); i_face++){
@@ -100,7 +100,7 @@ KRATOS_TEST_CASE_IN_SUITE(HexasGenericFindElementsNeighbourProcessTest,
         }
     }
 
-    //element 3 must have a single neighbour in first face 
+    //element 3 must have a single neighbour in first face
     const auto& elem3_neighs = model_part.Elements()[3].GetValue(NEIGHBOUR_ELEMENTS);
     KRATOS_CHECK_EQUAL(elem3_neighs.size(),6); // 6 faces
     for(unsigned int i_face = 0; i_face<elem3_neighs.size(); i_face++){
@@ -148,19 +148,19 @@ KRATOS_TEST_CASE_IN_SUITE(TetrahedraGenericFindElementsNeighbourProcessTest,
         8	1	1	1
     End Nodes
     Begin Elements	Element3D4N
-        1	1	2	6	8	1	
-        2	1	1	2	4	8	
-        3	1	5	7	8	1	
-        4	1	1	3	7	8	
-        5	1	1	5	6	8	
-        6	1	3	4	8	1	
+        1	1	2	6	8	1
+        2	1	1	2	4	8
+        3	1	5	7	8	1
+        4	1	1	3	7	8
+        5	1	1	5	6	8
+        6	1	3	4	8	1
     End Elements
     )input"));
     ModelPartIO(p_input).ReadModelPart(model_part);
-    
+
     //call process to create vector of neighbours
     auto neigh_process = GenericFindElementalNeighboursProcess(model_part);
-    neigh_process.ExecuteInitialize();
+    neigh_process.Execute();
 
     //checking single element, complete model part test was done for hexas
     const auto& elem1_neighs = model_part.Elements()[1].GetValue(NEIGHBOUR_ELEMENTS);
@@ -216,7 +216,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrianglesQuadilateralsGenericFindElementsNeighbourProc
     End Elements
 
     Begin Elements	Element2D4N
-        5	1	5 1 3 9 
+        5	1	5 1 3 9
     End Elements
 
 
@@ -225,7 +225,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrianglesQuadilateralsGenericFindElementsNeighbourProc
 
     //call process to create vector of neighbours
     auto neigh_process = GenericFindElementalNeighboursProcess(model_part);
-    neigh_process.ExecuteInitialize();
+    neigh_process.Execute();
 
     //element 1 must have a two neighs
     const auto& elem1_neighs = model_part.Elements()[1].GetValue(NEIGHBOUR_ELEMENTS);
@@ -239,7 +239,7 @@ KRATOS_TEST_CASE_IN_SUITE(TrianglesQuadilateralsGenericFindElementsNeighbourProc
             KRATOS_CHECK_EQUAL( elem1_neighs[i_face].Id(),3); //element #3 is in this face
         } else {
             KRATOS_CHECK_NOT_EQUAL( elem1_neighs(i_face).get(),nullptr); //real pointer in this face
-            KRATOS_CHECK_EQUAL( elem1_neighs[i_face].Id(),5); //element #5 is in this face 
+            KRATOS_CHECK_EQUAL( elem1_neighs[i_face].Id(),5); //element #5 is in this face
         }
     }
 

--- a/kratos/tests/test_generic_find_elemental_neighbours_process.py
+++ b/kratos/tests/test_generic_find_elemental_neighbours_process.py
@@ -25,7 +25,7 @@ class TestGenericFindElementalNeighboursProcess(KratosUnittest.TestCase):
         model = self._ImportModelPart(GetFilePath(self.work_folder+ "/"+self.file_name)) #MdpaTriangleDummyModel()
         model_part = model["main"]
         proc = KratosMultiphysics.GenericFindElementalNeighboursProcess(model_part)
-        proc.ExecuteInitialize()
+        proc.Execute()
 
         #expected results. faces which have a null pointer (no neigh elem in face)
         has_neigh_in_faces_dict = {
@@ -44,8 +44,8 @@ class TestGenericFindElementalNeighboursProcess(KratosUnittest.TestCase):
             self.assertEqual(len(this_elem_has_neigh_in_faces),4)
             for face in range(len(this_elem_has_neigh_in_faces)):
                 self.assertEqual(this_elem_has_neigh_in_faces[face],this_elem_expected[face])
-                
-        
+
+
 
     def _ImportModelPart(self,model_path):
         Model = KratosMultiphysics.Model()


### PR DESCRIPTION
**📝 Description**
The `GenericFindElementsNeighbours` process uses the `ExecuteInitialize` method instead of the `Execute` one, which is the one the other neighbor calculation processes are using. On top of being inconsistent, this is quite misleading for developers, as calling the `Execute` turns into do nothing as it is calling the base class empty implementation. This turns into a segfault when asking for the neighbors. Figuring this out might not be straightforward for newbies.

Besides, I also realized that the current implementation is not following the base `Process` public API as there is a `public` `HasNeighboursInFaces`. This is only used in the tests so we may remove it (asking @pablobecker since, as far as I understand, he implemented it in #9894). If it can't be removed, I think it should be moved to a separate class and be implemented as a `static` function. Note that this doesn't require anything from the process, but makes it mandatory to keep it alive to be called.
