### PR TITLE
[CoSim] Fix python deprecation and re-enable test

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/convergence_accelerators/mvqn.py
+++ b/applications/CoSimulationApplication/python_scripts/convergence_accelerators/mvqn.py
@@ -54,13 +54,13 @@ class MVQNConvergenceAccelerator(CoSimulationConvergenceAccelerator):
 
         ## For the first iteration
         if k == 0:
-            if self.J == []:
+            if len(self.J) == 0:
                 return self.alpha * r  # if no Jacobian, do relaxation
             else:
                 return np.linalg.solve( self.J, -r ) # use the Jacobian from previous step
 
         ## Let the initial Jacobian correspond to a constant relaxation
-        if self.J == []:
+        if len(self.J) == 0:
             self.J = - np.identity( row ) / self.alpha # correspongding to constant relaxation
 
         ## Construct matrix V (differences of residuals)
@@ -78,7 +78,7 @@ class MVQNConvergenceAccelerator(CoSimulationConvergenceAccelerator):
         ## Solve least norm problem
         rhs = V - np.dot(self.J, W)
         b = np.identity( row )
-        W_right_inverse = np.linalg.lstsq(W, b)[0]
+        W_right_inverse = np.linalg.lstsq(W, b, rcond=-1)[0]
         J_tilde = np.dot(rhs, W_right_inverse)
         self.J_hat = self.J + J_tilde
         delta_r = -self.R[0]
@@ -89,7 +89,7 @@ class MVQNConvergenceAccelerator(CoSimulationConvergenceAccelerator):
     ## FinalizeSolutionStep()
     # Finalizes the current time step and initializes the next time step.
     def FinalizeSolutionStep( self ):
-        if self.J == []:
+        if len(self.J) == 0:
             return
 
         row = self.J.shape[0]

--- a/applications/CoSimulationApplication/tests/test_CoSimulationApplication.py
+++ b/applications/CoSimulationApplication/tests/test_CoSimulationApplication.py
@@ -79,8 +79,8 @@ def AssembleTestSuites():
     nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestSmallCoSimulationCases]))
     
     # This one has errors in GCC
-    # nightSuite.addTest(TestMokFSI('test_mok_fsi_mvqn'))
-    # nightSuite.addTest(TestMokFSI('test_mok_fsi_aitken'))
+    nightSuite.addTest(TestMokFSI('test_mok_fsi_mvqn'))
+    nightSuite.addTest(TestMokFSI('test_mok_fsi_aitken'))
     
     nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCoSimIOPyExposure]))
     nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestKratosCoSimIO]))


### PR DESCRIPTION
It fixes some python deprecation warnings, which were perhaps triggering the failure of tests with GCC. Re-enabling tests.

These were the only fixes I could see necessary doing. I could not trigger an actual failure, but there were some obvious warnings needing these remedies.

As a result of the discussion in #10007.