### PR TITLE
[Core] Adding SetStiffnessMatrixIsBuilt and GetStiffnessMatrixIsBuilt to ImplicitSolvingStrategy

### DIFF
--- a/kratos/python/add_strategies_to_python.cpp
+++ b/kratos/python/add_strategies_to_python.cpp
@@ -578,6 +578,8 @@ namespace Kratos
             py::class_<ImplicitSolvingStrategyType, typename ImplicitSolvingStrategyType::Pointer, BaseSolvingStrategyType>(m,"ImplicitSolvingStrategy")
                 .def(py::init<ModelPart&, Parameters >() )
                 .def(py::init < ModelPart&, bool >())
+                .def("SetStiffnessMatrixIsBuilt", &ImplicitSolvingStrategyType::SetStiffnessMatrixIsBuilt)
+                .def("GetStiffnessMatrixIsBuilt", &ImplicitSolvingStrategyType::GetStiffnessMatrixIsBuilt)
                 ;
 
             typedef ExplicitSolvingStrategy< SparseSpaceType, LocalSpaceType > BaseExplicitSolvingStrategyType;

--- a/kratos/solving_strategies/strategies/implicit_solving_strategy.h
+++ b/kratos/solving_strategies/strategies/implicit_solving_strategy.h
@@ -163,34 +163,6 @@ public:
         return Kratos::make_shared<ClassType>(rModelPart, ThisParameters);
     }
 
-    /**
-     * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
-     * @return The default parameters
-     */
-    Parameters GetDefaultParameters() const override
-    {
-        Parameters default_parameters = Parameters(R"(
-        {
-            "name"                         : "implicit_solving_strategy",
-            "build_level"                  : 2
-        })");
-
-        // Getting base class default parameters
-        const Parameters base_default_parameters = BaseType::GetDefaultParameters();
-        default_parameters.RecursivelyAddMissingParameters(base_default_parameters);
-
-        return default_parameters;
-    }
-
-    /**
-     * @brief Returns the name of the class as used in the settings (snake_case format)
-     * @return The name of the class
-     */
-    static std::string Name()
-    {
-        return "implicit_solving_strategy";
-    }
-
     ///@}
     ///@name Access
     ///@{
@@ -224,6 +196,34 @@ public:
     int GetRebuildLevel() const override
     {
         return mRebuildLevel;
+    }
+
+    /**
+     * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
+     * @return The default parameters
+     */
+    Parameters GetDefaultParameters() const override
+    {
+        Parameters default_parameters = Parameters(R"(
+        {
+            "name"                         : "implicit_solving_strategy",
+            "build_level"                  : 2
+        })");
+
+        // Getting base class default parameters
+        const Parameters base_default_parameters = BaseType::GetDefaultParameters();
+        default_parameters.RecursivelyAddMissingParameters(base_default_parameters);
+
+        return default_parameters;
+    }
+
+    /**
+     * @brief Returns the name of the class as used in the settings (snake_case format)
+     * @return The name of the class
+     */
+    static std::string Name()
+    {
+        return "implicit_solving_strategy";
     }
 
     /**

--- a/kratos/solving_strategies/strategies/implicit_solving_strategy.h
+++ b/kratos/solving_strategies/strategies/implicit_solving_strategy.h
@@ -164,7 +164,39 @@ public:
     }
 
     /**
-     * This sets the build level
+     * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
+     * @return The default parameters
+     */
+    Parameters GetDefaultParameters() const override
+    {
+        Parameters default_parameters = Parameters(R"(
+        {
+            "name"                         : "implicit_solving_strategy",
+            "build_level"                  : 2
+        })");
+
+        // Getting base class default parameters
+        const Parameters base_default_parameters = BaseType::GetDefaultParameters();
+        default_parameters.RecursivelyAddMissingParameters(base_default_parameters);
+
+        return default_parameters;
+    }
+
+    /**
+     * @brief Returns the name of the class as used in the settings (snake_case format)
+     * @return The name of the class
+     */
+    static std::string Name()
+    {
+        return "implicit_solving_strategy";
+    }
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    /**
+     * @brief This sets the build level
      * @param Level The build level
      * @details
      * {
@@ -195,31 +227,21 @@ public:
     }
 
     /**
-     * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
-     * @return The default parameters
+     * @brief This method sets the flag mStiffnessMatrixIsBuilt
+     * @param StiffnessMatrixIsBuilt The flag that tells if the stiffness matrix is built
      */
-    Parameters GetDefaultParameters() const override
+    void SetStiffnessMatrixIsBuilt(const bool StiffnessMatrixIsBuilt)
     {
-        Parameters default_parameters = Parameters(R"(
-        {
-            "name"                         : "implicit_solving_strategy",
-            "build_level"                  : 2
-        })");
-
-        // Getting base class default parameters
-        const Parameters base_default_parameters = BaseType::GetDefaultParameters();
-        default_parameters.RecursivelyAddMissingParameters(base_default_parameters);
-
-        return default_parameters;
+        mStiffnessMatrixIsBuilt = StiffnessMatrixIsBuilt;
     }
 
     /**
-     * @brief Returns the name of the class as used in the settings (snake_case format)
-     * @return The name of the class
+     * @brief This method gets the flag mStiffnessMatrixIsBuilt
+     * @return mStiffnessMatrixIsBuilt: The flag that tells if the stiffness matrix is built
      */
-    static std::string Name()
+    bool GetStiffnessMatrixIsBuilt() const
     {
-        return "implicit_solving_strategy";
+        return mStiffnessMatrixIsBuilt;
     }
 
     ///@}
@@ -239,8 +261,8 @@ protected:
     ///@{
 
     // Settings for the rebuilding of the stiffness matrix
-    int mRebuildLevel;
-    bool mStiffnessMatrixIsBuilt;
+    int mRebuildLevel;            /// The current rebuild level
+    bool mStiffnessMatrixIsBuilt; /// A flag indicating if the stiffness matrix has been built
 
     ///@}
     ///@name Protected member Variables

--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -86,8 +86,6 @@ class ResidualBasedNewtonRaphsonStrategy
 
     typedef typename BaseType::TSchemeType TSchemeType;
 
-    //typedef typename BaseType::DofSetType DofSetType;
-
     typedef typename BaseType::DofsArrayType DofsArrayType;
 
     typedef typename BaseType::TSystemMatrixType TSystemMatrixType;
@@ -1109,7 +1107,6 @@ class ResidualBasedNewtonRaphsonStrategy
 
     ///@}
     ///@name Access
-
     ///@{
 
     /**
@@ -1144,7 +1141,6 @@ class ResidualBasedNewtonRaphsonStrategy
 
         return mDx;
     }
-
 
     /**
      * @brief Set method for the flag mKeepSystemConstantDuringIterations
@@ -1225,7 +1221,6 @@ class ResidualBasedNewtonRaphsonStrategy
     ///@{
 
     ///@}
-
   protected:
     ///@name Static Member Variables
     ///@{
@@ -1280,7 +1275,6 @@ class ResidualBasedNewtonRaphsonStrategy
      * @param b The RHS vector of the system of equations
      * @param MoveMesh The flag that allows to move the mesh
      */
-
     virtual void UpdateDatabase(
         TSystemMatrixType& rA,
         TSystemVectorType& rDx,
@@ -1343,7 +1337,6 @@ class ResidualBasedNewtonRaphsonStrategy
     /**
      * @brief This method prints information after reach the max number of iterations
      */
-
     virtual void MaxIterationsExceeded()
     {
         KRATOS_INFO_IF("ResidualBasedNewtonRaphsonStrategy", this->GetEchoLevel() > 0)


### PR DESCRIPTION
**📝 Description**

Adding SetStiffnessMatrixIsBuilt and GetStiffnessMatrixIsBuilt to ImplicitSolvingStrategy

Fixes https://github.com/KratosMultiphysics/Kratos/issues/10109

**🆕 Changelog**

- Adding SetStiffnessMatrixIsBuilt and GetStiffnessMatrixIsBuilt to ImplicitSolvingStrategy
- Moving build level methods to Access category
