### PR TITLE
[Core] Registered Component Names

### DIFF
--- a/kratos/includes/kratos_components.h
+++ b/kratos/includes/kratos_components.h
@@ -28,6 +28,7 @@
 #include "containers/flags.h"
 #include "containers/variable.h"
 #include "utilities/quaternion.h"
+#include "utilities/ranges.h"
 
 namespace Kratos
 {
@@ -56,6 +57,8 @@ public:
 
     typedef std::map<std::string, const TComponentType* > ComponentsContainerType;
     typedef typename ComponentsContainerType::value_type ValueType;
+
+    using NameRange = Range<MapKeyIterator<typename ComponentsContainerType::const_iterator>>;
 
     ///@}
     ///@name Life Cycle
@@ -109,6 +112,11 @@ public:
     static ComponentsContainerType * pGetComponents()
     {
         return &msComponents;
+    }
+
+    static NameRange GetComponentNames()
+    {
+        return MakeConstMapKeyRange(msComponents);
     }
 
     static void Register()
@@ -268,6 +276,8 @@ public:
     typedef std::map<std::string, VariableData* > ComponentsContainerType;
     typedef ComponentsContainerType::value_type ValueType;
 
+    using NameRange = Range<MapKeyIterator<typename ComponentsContainerType::const_iterator>>;
+
     ///@}
     ///@name Life Cycle
     ///@{
@@ -329,6 +339,11 @@ public:
     static ComponentsContainerType * pGetComponents()
     {
         return &msComponents;
+    }
+
+    static NameRange GetComponentNames()
+    {
+        return MakeConstMapKeyRange(msComponents);
     }
 
     static void Register()

--- a/kratos/python/add_kernel_to_python.cpp
+++ b/kratos/python/add_kernel_to_python.cpp
@@ -16,6 +16,8 @@
 // Project includes
 #include "includes/define_python.h"
 #include "includes/kernel.h"
+#include "includes/kratos_components.h"
+#include "utilities/ranges.h"
 #include "python/add_kernel_to_python.h"
 
 // System includes
@@ -74,6 +76,16 @@ std::string GetVariableNames(Kernel& rKernel)
     std::stringstream buffer;
     kratos_components.PrintData(buffer);
     return buffer.str();
+}
+
+template <class TVariable>
+pybind11::list GetComponentNames()
+{
+    pybind11::list flag_names;
+    for (const auto& r_name : KratosComponents<TVariable>::GetComponentNames()) {
+        flag_names.append(r_name);
+    }
+    return flag_names;
 }
 
 void RegisterInPythonKernelVariables()
@@ -178,6 +190,7 @@ void AddKernelToPython(pybind11::module& m)
         .def("GetMatrixVariableNames", GetVariableNames<Variable<Matrix> >)
         .def("GetStringVariableNames", GetVariableNames<Variable<std::string> >)
         .def("GetFlagsVariableNames", GetVariableNames<Variable<Flags> >)
+        .def_static("GetFlagNames", GetComponentNames<Flags>)
         .def("__str__", PrintObject<Kernel>)
         .def("HasConstitutiveLaw", HasConstitutiveLaw)
         .def("GetConstitutiveLaw", GetConstitutiveLaw, py::return_value_policy::reference_internal)

--- a/kratos/utilities/ranges.h
+++ b/kratos/utilities/ranges.h
@@ -46,24 +46,6 @@ private:                                                                     \
     ITERATOR_TYPE mEnd;                                                      \
 }
 
-/**
- *  @brief Class representing a view into a subrange of a container.
- *  @tparam TIterator Iterator type of the target container.
- */
-template <class TIterator, class IsConstRange = void>
-class Range
-KRATOS_DEFINE_RANGE(TIterator, ); // class Range (non-const version)
-
-/**
- *  @brief Class representing a view into a subrange of an immutable container.
- *  @tparam TIterator Iterator type of the target container.
- */
-template <class TIterator>
-class Range<TIterator, typename std::enable_if<std::is_const<TIterator>::value>::type>
-KRATOS_DEFINE_RANGE(TIterator, const); // class Range (const version)
-
-#undef KRATOS_DEFINE_RANGE
-
 
 namespace Detail {
 template <class T>
@@ -84,6 +66,25 @@ struct IsConstIterator
     static constexpr const bool value = IsConstPointer<typename std::iterator_traits<TIterator>::pointer>::value;
 };
 } // namespace Detail
+
+
+/**
+ *  @brief Class representing a view into a subrange of a container.
+ *  @tparam TIterator Iterator type of the target container.
+ */
+template <class TIterator, class IsConstRange = void>
+class Range
+KRATOS_DEFINE_RANGE(TIterator, ); // class Range (non-const version)
+
+/**
+ *  @brief Class representing a view into a subrange of an immutable container.
+ *  @tparam TIterator Iterator type of the target container.
+ */
+template <class TIterator>
+class Range<TIterator, typename std::enable_if<Detail::IsConstIterator<TIterator>::value>::type>
+KRATOS_DEFINE_RANGE(TIterator, const); // class Range (const version)
+
+#undef KRATOS_DEFINE_RANGE
 
 
 /**

--- a/kratos/utilities/ranges.h
+++ b/kratos/utilities/ranges.h
@@ -65,6 +65,7 @@ KRATOS_DEFINE_RANGE(TIterator, const); // class Range (const version)
 #undef KRATOS_DEFINE_RANGE
 
 
+namespace Detail {
 template <class T>
 struct IsConstPointer
 {};
@@ -82,6 +83,7 @@ struct IsConstIterator
 {
     static constexpr const bool value = IsConstPointer<typename std::iterator_traits<TIterator>::pointer>::value;
 };
+} // namespace Detail
 
 
 /**
@@ -95,10 +97,10 @@ public:
     using value_type = typename TIterator::value_type::first_type;
 
     /// const key_type* if const_iterator else key_type*
-    using pointer = typename std::conditional<IsConstIterator<TIterator>::value,const value_type*,value_type*>::type;
+    using pointer = typename std::conditional<Detail::IsConstIterator<TIterator>::value,const value_type*,value_type*>::type;
 
     /// const key_type& if const_iterator else key_type&
-    using reference = typename std::conditional<IsConstIterator<TIterator>::value,const value_type&,value_type&>::type;
+    using reference = typename std::conditional<Detail::IsConstIterator<TIterator>::value,const value_type&,value_type&>::type;
 
     using difference_type = typename TIterator::difference_type;
 

--- a/kratos/utilities/ranges.h
+++ b/kratos/utilities/ranges.h
@@ -46,10 +46,18 @@ private:                                                                     \
     ITERATOR_TYPE mEnd;                                                      \
 }
 
+/**
+ *  @brief Class representing a view into a subrange of a container.
+ *  @tparam TIterator Iterator type of the target container.
+ */
 template <class TIterator, class IsConstRange = void>
 class Range
 KRATOS_DEFINE_RANGE(TIterator, ); // class Range (non-const version)
 
+/**
+ *  @brief Class representing a view into a subrange of an immutable container.
+ *  @tparam TIterator Iterator type of the target container.
+ */
 template <class TIterator>
 class Range<TIterator, typename std::enable_if<std::is_const<TIterator>::value>::type>
 KRATOS_DEFINE_RANGE(TIterator, const); // class Range (const version)
@@ -76,6 +84,10 @@ struct IsConstIterator
 };
 
 
+/**
+ *  @brief Iterator providing access to the keys of an std::map or std::unordered_map.
+ *  @tparam TIterator Iterator type of the map.
+ */
 template <class TIterator>
 class MapKeyIterator
 {
@@ -119,6 +131,10 @@ private:
 }; // class MapKeyIterator
 
 
+/**
+ *  @brief Create a view on the keys of an std::map or std::unordered_map.
+ *  @note This is a convenience function to avoid having to specify template parameters.
+ */
 template <class TMap>
 Range<MapKeyIterator<typename TMap::const_iterator>> MakeConstMapKeyRange(const TMap& rMap)
 {

--- a/kratos/utilities/ranges.h
+++ b/kratos/utilities/ranges.h
@@ -1,0 +1,131 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Máté Kelemen
+//
+//
+
+#ifndef KRATOS_RANGES_H
+#define KRATOS_RANGES_H
+
+// System includes
+#include <iterator>
+#include <type_traits>
+
+
+namespace Kratos {
+
+
+#define KRATOS_DEFINE_RANGE(ITERATOR_TYPE, CONST)                             \
+{                                                                            \
+public:                                                                      \
+    using value_type = typename std::iterator_traits<TIterator>::value_type; \
+    using pointer = typename std::iterator_traits<TIterator>::pointer;       \
+    using reference = typename std::iterator_traits<TIterator>::reference;   \
+    using size_type = std::size_t;                                           \
+                                                                             \
+    Range() : mBegin(), mEnd() {}                                            \
+    Range(ITERATOR_TYPE begin, ITERATOR_TYPE end)                            \
+        : mBegin(begin), mEnd(end) {}                                        \
+    Range(Range&& rOther) noexcept = default;                                \
+    Range(const Range& rOther) noexcept = default;                           \
+                                                                             \
+    ITERATOR_TYPE begin() CONST noexcept {return mBegin;}                    \
+    ITERATOR_TYPE end() CONST noexcept {return mEnd;}                        \
+    size_type size() const noexcept {return std::distance(mBegin, mEnd);}    \
+    bool empty() const noexcept {return mBegin == mEnd;}                     \
+                                                                             \
+private:                                                                     \
+    ITERATOR_TYPE mBegin;                                                    \
+    ITERATOR_TYPE mEnd;                                                      \
+}
+
+template <class TIterator, class IsConstRange = void>
+class Range
+KRATOS_DEFINE_RANGE(TIterator, ); // class Range (non-const version)
+
+template <class TIterator>
+class Range<TIterator, typename std::enable_if<std::is_const<TIterator>::value>::type>
+KRATOS_DEFINE_RANGE(TIterator, const); // class Range (const version)
+
+#undef KRATOS_DEFINE_RANGE
+
+
+template <class T>
+struct IsConstPointer
+{};
+
+template <class T>
+struct IsConstPointer<T*>
+{static constexpr const bool value = false;};
+
+template <class T>
+struct IsConstPointer<const T*>
+{static constexpr const bool value = true;};
+
+template <class TIterator>
+struct IsConstIterator
+{
+    static constexpr const bool value = IsConstPointer<typename std::iterator_traits<TIterator>::pointer>::value;
+};
+
+
+template <class TIterator>
+class MapKeyIterator
+{
+public:
+    using value_type = typename TIterator::value_type::first_type;
+
+    /// const key_type* if const_iterator else key_type*
+    using pointer = typename std::conditional<IsConstIterator<TIterator>::value,const value_type*,value_type*>::type;
+
+    /// const key_type& if const_iterator else key_type&
+    using reference = typename std::conditional<IsConstIterator<TIterator>::value,const value_type&,value_type&>::type;
+
+    using difference_type = typename TIterator::difference_type;
+
+    using iterator_category = std::forward_iterator_tag;
+
+    MapKeyIterator() = default;
+
+    MapKeyIterator(TIterator Wrapped)
+        : mWrapped(Wrapped)
+    {}
+
+    MapKeyIterator(MapKeyIterator&& rOther) noexcept = default;
+
+    MapKeyIterator(const MapKeyIterator& rOther) noexcept = default;
+
+    reference operator*() {return mWrapped->first;}
+
+    pointer operator->() {return &mWrapped->first;}
+
+    MapKeyIterator& operator++() {++mWrapped; return *this;}
+
+    MapKeyIterator operator++(int) {MapKeyIterator copy(*this); ++(*this); return copy;}
+
+    friend bool operator==(MapKeyIterator Left, MapKeyIterator Right) {return Left.mWrapped == Right.mWrapped;}
+
+    friend bool operator!=(MapKeyIterator Left, MapKeyIterator Right) {return !(Left == Right);}
+
+private:
+    TIterator mWrapped;
+}; // class MapKeyIterator
+
+
+template <class TMap>
+Range<MapKeyIterator<typename TMap::const_iterator>> MakeConstMapKeyRange(const TMap& rMap)
+{
+    return Range<MapKeyIterator<typename TMap::const_iterator>>(rMap.begin(), rMap.end());
+}
+
+
+} // namespace Kratos
+
+#endif // KRATOS_RANGES_H


### PR DESCRIPTION
## Motivation
Currently, there's no good way of getting a list of flags' names from ```KratosComponents```, which would be a nice feature to have for the default behaviour of ```OutputProcess```es.

## Changes
- Add a light ```Range``` class, representing a view of an existing container.
- Add ```KratosComponents::GetComponentNames``` that creates a ```Range``` of the registered components' names.
- Add python interface for getting flags' names. 