### PR TITLE
[Core] Level set convection - allowing using a custom element

### DIFF
--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -802,8 +802,13 @@ private:
         // Convection element formulation settings
         std::string element_type = ThisParameters["element_type"].GetString();
         const auto element_list = GetConvectionElementsList();
-        KRATOS_ERROR_IF(std::find(element_list.begin(), element_list.end(), element_type) == element_list.end()) << "Specified \'" << element_type << "\' is not in the available elements list." << std::endl;
-        mConvectionElementType = GetConvectionElementName(element_type);
+        if (std::find(element_list.begin(), element_list.end(), element_type) == element_list.end()) {
+            KRATOS_INFO("") << "Specified \'" << element_type << "\' is not in the available elements list. " <<
+            "Attempting to use custom specified element." << std::endl;
+            mConvectionElementType = element_type;
+        } else {
+            mConvectionElementType = GetConvectionElementName(element_type);
+        }
         std::string element_register_name = mConvectionElementType + std::to_string(TDim) + "D" + std::to_string(TDim + 1) + "N";
         mpConvectionFactoryElement = &KratosComponents<Element>::Get(element_register_name);
         mElementRequiresLimiter =  ThisParameters["element_settings"].Has("include_anti_diffusivity_terms") ? ThisParameters["element_settings"]["include_anti_diffusivity_terms"].GetBool() : false;
@@ -816,7 +821,7 @@ private:
             ThisParameters["element_settings"]["requires_distance_gradient"].SetBool(mElementRequiresLimiter);
         }
 
-        mElementRequiresLevelSetGradient = ThisParameters["element_settings"]["requires_distance_gradient"].GetBool();;
+        mElementRequiresLevelSetGradient =  ThisParameters["element_settings"].Has("requires_distance_gradient") ? ThisParameters["element_settings"]["requires_distance_gradient"].GetBool() : false;
 
         // Convection related settings
         mMaxAllowedCFL = ThisParameters["max_CFL"].GetDouble();
@@ -893,7 +898,7 @@ private:
                 "time_integration_theta" : 0.5
             })");
         } else {
-            KRATOS_ERROR << "Default parameters are not implemented for the specified \'" << ElementType << "\' element. Available options are \n\t- \'levelset_convection_supg\'\n\t- \'levelset_convection_algebraic_stabilization\'" << std::endl;
+            default_parameters = Parameters();
         }
 
         return default_parameters;

--- a/kratos/tests/test_levelset_convection.py
+++ b/kratos/tests/test_levelset_convection.py
@@ -33,6 +33,28 @@ class TestLevelSetConvection(KratosUnittest.TestCase):
         except :
             pass
 
+    def test_wrong_element_name(self):
+        current_model = KratosMultiphysics.Model()
+        model_part = current_model.CreateModelPart("Main")
+        levelset_convection_settings = KratosMultiphysics.Parameters("""{
+            "max_CFL" : 1.0,
+            "max_substeps" : 0,
+            "eulerian_error_compensation" : false,
+            "element_type" : "IDontExistOhGodWhy"
+        }""")
+        from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory
+        linear_solver = linear_solver_factory.ConstructSolver(
+            KratosMultiphysics.Parameters("""{"solver_type" : "skyline_lu_factorization"}"""))
+        
+        expected_error_msg = "Error: Specified 'IDontExistOhGodWhy' is not in the available elements list: "
+        expected_error_msg+= "\\[levelset_convection_supg, levelset_convection_algebraic_stabilization\\]"
+        expected_error_msg+= " and it is nor registered as a kratos element either. Please check your settings"
+        with self.assertRaisesRegex(RuntimeError, expected_error_msg):
+            KratosMultiphysics.LevelSetConvectionProcess2D(
+                model_part,
+                linear_solver,
+                levelset_convection_settings).Execute()
+
     def test_levelset_convection(self):
         current_model = KratosMultiphysics.Model()
         model_part = current_model.CreateModelPart("Main")


### PR DESCRIPTION
**📝 Description**
We are very interested in altair in being able to use the level set convection process from kratos core. However, the main problem is that we want to be able to use our own elements, as their formulation cannot be shared openly.

With these minimum changes we will be able to do so. My proposal here is to check if the "element_type" matches the available element types in the process. If it is not there, we throw a messa and try to use this string directly and get the element from Kratos Components.

I think it is not big harm for the rest of the users and will help us a lot.


**🆕 Changelog**
- Adding option to use custom element in level set convection process.
