### PR TITLE
[Core][MPI] Adding SynchronizeCurrentDataToMax and SynchronizeNonHistoricalDataToMax to MPI communicator

### DIFF
--- a/kratos/includes/communicator.h
+++ b/kratos/includes/communicator.h
@@ -347,13 +347,27 @@ public:
 
     virtual bool SynchronizeNonHistoricalVariable(Variable<Quaternion<double>> const& rThisVariable);
 
-    /// Synchronize variable in nodal solution step data to the minimum value across all processes.
-    /** @param ThisVariable The variable to be synchronized.
+    /** 
+     * @brief Synchronize variable in nodal solution step data to the maximum value across all processes.
+     * @param ThisVariable The variable to be synchronized.
+     */
+    virtual bool SynchronizeCurrentDataToMax(Variable<double> const& ThisVariable);
+
+    /** 
+     * @brief Synchronize variable in nodal data to the maximum value across all processes.
+     * @param ThisVariable The variable to be synchronized.
+     */
+    virtual bool SynchronizeNonHistoricalDataToMax(Variable<double> const& ThisVariable);
+
+    /** 
+     * @brief Synchronize variable in nodal solution step data to the minimum value across all processes.
+     * @param ThisVariable The variable to be synchronized.
      */
     virtual bool SynchronizeCurrentDataToMin(Variable<double> const& ThisVariable);
 
-    /// Synchronize variable in nodal data to the minimum value across all processes.
-    /** @param ThisVariable The variable to be synchronized.
+    /**
+     * @brief Synchronize variable in nodal data to the minimum value across all processes. 
+     * @param ThisVariable The variable to be synchronized.
      */
     virtual bool SynchronizeNonHistoricalDataToMin(Variable<double> const& ThisVariable);
 

--- a/kratos/mpi/includes/mpi_communicator.h
+++ b/kratos/mpi/includes/mpi_communicator.h
@@ -583,6 +583,7 @@ enum class OperationType {
     Replace,
     SumValues,
     MinValues,
+    MaxValues,
     OrAccessedFlags,
     AndAccessedFlags,
     ReplaceAccessedFlags

--- a/kratos/mpi/includes/mpi_communicator.h
+++ b/kratos/mpi/includes/mpi_communicator.h
@@ -1643,6 +1643,22 @@ private:
         const typename TDatabaseAccess::SendType* pBuffer,
         TDatabaseAccess& rAccess,
         typename TDatabaseAccess::IteratorType ContainerIterator,
+        Operation<OperationType::MaxValues>)
+    {
+        using ValueType = typename TDatabaseAccess::ValueType;
+        ValueType& r_current = rAccess.GetValue(ContainerIterator);
+        ValueType recv_value(r_current); // creating by copy to have the correct size in dynamic types
+        MPIInternals::SendTools<ValueType>::ReadBuffer(pBuffer, recv_value);
+        if (recv_value > r_current) r_current = recv_value;
+
+        return MPIInternals::BufferAllocation<TDatabaseAccess>::GetSendSize(recv_value);
+    }
+
+    template<class TDatabaseAccess>
+    std::size_t ReduceValues(
+        const typename TDatabaseAccess::SendType* pBuffer,
+        TDatabaseAccess& rAccess,
+        typename TDatabaseAccess::IteratorType ContainerIterator,
         Operation<OperationType::MinValues>)
     {
         using ValueType = typename TDatabaseAccess::ValueType;

--- a/kratos/mpi/includes/mpi_communicator.h
+++ b/kratos/mpi/includes/mpi_communicator.h
@@ -920,6 +920,40 @@ public:
         return true;
     }
 
+    bool SynchronizeCurrentDataToMax(Variable<double> const& ThisVariable) override
+    {
+        constexpr MeshAccess<DistributedType::Local> local_meshes;
+        constexpr MeshAccess<DistributedType::Ghost> ghost_meshes;
+        constexpr Operation<OperationType::Replace> replace;
+        constexpr Operation<OperationType::MaxValues> max;
+        MPIInternals::NodalSolutionStepValueAccess<double> nodal_solution_step_access(ThisVariable);
+
+        // Calculate max on owner rank
+        TransferDistributedValues(ghost_meshes, local_meshes, nodal_solution_step_access, max);
+
+        // Synchronize result on ghost copies
+        TransferDistributedValues(local_meshes, ghost_meshes, nodal_solution_step_access, replace);
+
+        return true;
+    }
+
+    bool SynchronizeNonHistoricalDataToMax(Variable<double> const& ThisVariable) override
+    {
+        constexpr MeshAccess<DistributedType::Local> local_meshes;
+        constexpr MeshAccess<DistributedType::Ghost> ghost_meshes;
+        constexpr Operation<OperationType::Replace> replace;
+        constexpr Operation<OperationType::MaxValues> max;
+        MPIInternals::NodalDataAccess<double> nodal_data_access(ThisVariable);
+
+        // Calculate max on owner rank
+        TransferDistributedValues(ghost_meshes, local_meshes, nodal_data_access, max);
+
+        // Synchronize result on ghost copies
+        TransferDistributedValues(local_meshes, ghost_meshes, nodal_data_access, replace);
+
+        return true;
+    }
+
     bool SynchronizeCurrentDataToMin(Variable<double> const& ThisVariable) override
     {
         constexpr MeshAccess<DistributedType::Local> local_meshes;

--- a/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
+++ b/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
@@ -588,6 +588,74 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataSynchronize, Krato
     }
 }
 
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSyncToMax, KratosMPICoreFastSuite)
+{
+    Model model;
+    ModelPart& r_model_part = model.CreateModelPart("TestModelPart");
+    r_model_part.AddNodalSolutionStepVariable(PARTITION_INDEX);
+    r_model_part.AddNodalSolutionStepVariable(TEMPERATURE);
+
+    MPIDataCommunicator comm_world(MPI_COMM_WORLD);
+    Internals::ModelPartForMPICommunicatorTests(r_model_part, comm_world);
+    int rank = comm_world.Rank();
+    int size = comm_world.Size();
+
+    for (auto i_node = r_model_part.NodesBegin(); i_node != r_model_part.NodesEnd(); ++i_node) {
+        i_node->FastGetSolutionStepValue(TEMPERATURE, 0) = 10.0*rank;
+    }
+
+    Communicator& r_comm = r_model_part.GetCommunicator();
+
+    // center is local to rank 0 and ghost in all other ranks
+    Node<3>& r_center = r_model_part.Nodes()[1];
+    // local and ghost nodes are each known in two ranks
+    const unsigned int local_id = rank + 2;
+    const unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    auto& r_local = r_model_part.Nodes()[local_id];
+    auto& r_ghost = r_model_part.Nodes()[ghost_id];
+
+    const int expected_local = (rank == 0) ? 10.0*(size-1) : 10.0*rank;
+    const int expected_ghost = (rank + 1 < size) ? 10.0*(rank+1) : 10.0*(size-1);
+
+    r_comm.SynchronizeCurrentDataToMax(TEMPERATURE);
+    KRATOS_CHECK_EQUAL(r_center.FastGetSolutionStepValue(TEMPERATURE, 0), 10.0*(size-1));
+    KRATOS_CHECK_EQUAL(r_local.FastGetSolutionStepValue(TEMPERATURE, 0), expected_local);
+    KRATOS_CHECK_EQUAL(r_ghost.FastGetSolutionStepValue(TEMPERATURE, 0), expected_ghost);
+}
+
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToMax, KratosMPICoreFastSuite)
+{
+    Model model;
+    ModelPart& r_model_part = model.CreateModelPart("TestModelPart");
+    r_model_part.AddNodalSolutionStepVariable(PARTITION_INDEX);
+
+    MPIDataCommunicator comm_world(MPI_COMM_WORLD);  
+    Internals::ModelPartForMPICommunicatorTests(r_model_part, comm_world);
+    const int rank = comm_world.Rank();
+    const int size = comm_world.Size();
+
+    for (auto i_node = r_model_part.NodesBegin(); i_node != r_model_part.NodesEnd(); ++i_node) {
+        i_node->SetValue(TEMPERATURE, 10.0*rank);
+    }
+
+    Communicator& r_comm = r_model_part.GetCommunicator();
+
+    // center is local to rank 0 and ghost in all other ranks
+    Node<3>& r_center = r_model_part.Nodes()[1];
+    // local and ghost nodes are each known in two ranks
+    const unsigned int local_id = rank + 2;
+    const unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    auto& r_local = r_model_part.Nodes()[local_id];
+    auto& r_ghost = r_model_part.Nodes()[ghost_id];
+
+    const int expected_local = (rank == 0) ? 10.0*(size-1) : 10.0*rank;
+    const int expected_ghost = (rank + 1 < size) ? 10.0*(rank+1) : 10.0*(size-1);
+
+    r_comm.SynchronizeNonHistoricalDataToMax(TEMPERATURE);
+    KRATOS_CHECK_EQUAL(r_center.GetValue(TEMPERATURE), 10.0*(size-1));
+    KRATOS_CHECK_EQUAL(r_local.GetValue(TEMPERATURE), expected_local);
+    KRATOS_CHECK_EQUAL(r_ghost.GetValue(TEMPERATURE), expected_ghost);
+}
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSyncToMin, KratosMPICoreFastSuite)
 {
@@ -658,40 +726,6 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToMin,
     KRATOS_CHECK_EQUAL(r_center.GetValue(TEMPERATURE), 0.0);
     KRATOS_CHECK_EQUAL( r_local.GetValue(TEMPERATURE), expected_local);
     KRATOS_CHECK_EQUAL( r_ghost.GetValue(TEMPERATURE), expected_ghost);
-}
-
-KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToMax, KratosMPICoreFastSuite)
-{
-    Model model;
-    ModelPart& r_model_part = model.CreateModelPart("TestModelPart");
-    r_model_part.AddNodalSolutionStepVariable(PARTITION_INDEX);
-
-    MPIDataCommunicator comm_world(MPI_COMM_WORLD);  
-    Internals::ModelPartForMPICommunicatorTests(r_model_part, comm_world);
-    const int rank = comm_world.Rank();
-    const int size = comm_world.Size();
-
-    for (auto i_node = r_model_part.NodesBegin(); i_node != r_model_part.NodesEnd(); ++i_node) {
-        i_node->SetValue(TEMPERATURE, 10.0*rank);
-    }
-
-    Communicator& r_comm = r_model_part.GetCommunicator();
-
-    // center is local to rank 0 and ghost in all other ranks
-    Node<3>& r_center = r_model_part.Nodes()[1];
-    // local and ghost nodes are each known in two ranks
-    const unsigned int local_id = rank + 2;
-    const unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
-    auto& r_local = r_model_part.Nodes()[local_id];
-    auto& r_ghost = r_model_part.Nodes()[ghost_id];
-
-    const int expected_local = (rank == 0) ? 10.0*(size-1) : 10.0*rank;
-    const int expected_ghost = (rank + 1 < size) ? 10.0*(rank+1) : 10.0*(size-1);
-
-    r_comm.SynchronizeNonHistoricalDataToMax(TEMPERATURE);
-    KRATOS_CHECK_EQUAL(r_center.GetValue(TEMPERATURE), 10.0*(size-1));
-    KRATOS_CHECK_EQUAL(r_local.GetValue(TEMPERATURE), expected_local);
-    KRATOS_CHECK_EQUAL(r_ghost.GetValue(TEMPERATURE), expected_ghost);
 }
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepDataSynchronize, KratosMPICoreFastSuite)

--- a/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
+++ b/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
@@ -660,7 +660,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataariableSyncToMin, 
     KRATOS_CHECK_EQUAL( r_ghost.GetValue(TEMPERATURE), expected_ghost);
 }
 
-KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataariableSyncToMax, KratosMPICoreFastSuite2)
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataariableSyncToMax, KratosMPICoreFastSuite)
 {
     Model model;
     ModelPart& r_model_part = model.CreateModelPart("TestModelPart");
@@ -685,13 +685,13 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataariableSyncToMax, 
     auto& r_local = r_model_part.Nodes()[local_id];
     auto& r_ghost = r_model_part.Nodes()[ghost_id];
 
-    const int expected_local = (rank > 0) ? 10.0*(rank-1) : 0.0;
-    const int expected_ghost = (rank + 1 < size) ? 10.0*rank : 0.0;
+    const int expected_local = (rank == 0) ? 10.0*(size-1) : 10.0*rank;
+    const int expected_ghost = (rank + 1 < size) ? 10.0*(rank+1) : 10.0*(size-1);
 
     r_comm.SynchronizeNonHistoricalDataToMax(TEMPERATURE);
     KRATOS_CHECK_EQUAL(r_center.GetValue(TEMPERATURE), 10.0*(size-1));
-    // KRATOS_CHECK_EQUAL(r_local.GetValue(TEMPERATURE), expected_local);
-    // KRATOS_CHECK_EQUAL(r_ghost.GetValue(TEMPERATURE), expected_ghost);
+    KRATOS_CHECK_EQUAL(r_local.GetValue(TEMPERATURE), expected_local);
+    KRATOS_CHECK_EQUAL(r_ghost.GetValue(TEMPERATURE), expected_ghost);
 }
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepDataSynchronize, KratosMPICoreFastSuite)

--- a/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
+++ b/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
@@ -660,6 +660,39 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataariableSyncToMin, 
     KRATOS_CHECK_EQUAL( r_ghost.GetValue(TEMPERATURE), expected_ghost);
 }
 
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataariableSyncToMax, KratosMPICoreFastSuite2)
+{
+    Model model;
+    ModelPart& r_model_part = model.CreateModelPart("TestModelPart");
+    r_model_part.AddNodalSolutionStepVariable(PARTITION_INDEX);
+
+    MPIDataCommunicator comm_world(MPI_COMM_WORLD);  
+    Internals::ModelPartForMPICommunicatorTests(r_model_part, comm_world);
+    const int rank = comm_world.Rank();
+    const int size = comm_world.Size();
+
+    for (auto i_node = r_model_part.NodesBegin(); i_node != r_model_part.NodesEnd(); ++i_node) {
+        i_node->SetValue(TEMPERATURE, 10.0*rank);
+    }
+
+    Communicator& r_comm = r_model_part.GetCommunicator();
+
+    // center is local to rank 0 and ghost in all other ranks
+    Node<3>& r_center = r_model_part.Nodes()[1];
+    // local and ghost nodes are each known in two ranks
+    const unsigned int local_id = rank + 2;
+    const unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    auto& r_local = r_model_part.Nodes()[local_id];
+    auto& r_ghost = r_model_part.Nodes()[ghost_id];
+
+    const int expected_local = (rank > 0) ? 10.0*(rank-1) : 0.0;
+    const int expected_ghost = (rank + 1 < size) ? 10.0*rank : 0.0;
+
+    r_comm.SynchronizeNonHistoricalDataToMax(TEMPERATURE);
+    KRATOS_CHECK_EQUAL(r_center.GetValue(TEMPERATURE), 0.0);
+    KRATOS_CHECK_EQUAL(r_local.GetValue(TEMPERATURE), expected_local);
+    KRATOS_CHECK_EQUAL(r_ghost.GetValue(TEMPERATURE), expected_ghost);
+}
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepDataSynchronize, KratosMPICoreFastSuite)
 {

--- a/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
+++ b/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
@@ -689,9 +689,9 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataariableSyncToMax, 
     const int expected_ghost = (rank + 1 < size) ? 10.0*rank : 0.0;
 
     r_comm.SynchronizeNonHistoricalDataToMax(TEMPERATURE);
-    KRATOS_CHECK_EQUAL(r_center.GetValue(TEMPERATURE), 0.0);
-    KRATOS_CHECK_EQUAL(r_local.GetValue(TEMPERATURE), expected_local);
-    KRATOS_CHECK_EQUAL(r_ghost.GetValue(TEMPERATURE), expected_ghost);
+    KRATOS_CHECK_EQUAL(r_center.GetValue(TEMPERATURE), 10.0*(size-1));
+    // KRATOS_CHECK_EQUAL(r_local.GetValue(TEMPERATURE), expected_local);
+    // KRATOS_CHECK_EQUAL(r_ghost.GetValue(TEMPERATURE), expected_ghost);
 }
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepDataSynchronize, KratosMPICoreFastSuite)

--- a/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
+++ b/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
@@ -625,7 +625,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSy
     KRATOS_CHECK_EQUAL( r_ghost.FastGetSolutionStepValue(TEMPERATURE,0), expected_ghost);
 }
 
-KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataariableSyncToMin, KratosMPICoreFastSuite)
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToMin, KratosMPICoreFastSuite)
 {
     Model model;
     ModelPart& r_model_part = model.CreateModelPart("TestModelPart");
@@ -660,7 +660,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataariableSyncToMin, 
     KRATOS_CHECK_EQUAL( r_ghost.GetValue(TEMPERATURE), expected_ghost);
 }
 
-KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataariableSyncToMax, KratosMPICoreFastSuite)
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToMax, KratosMPICoreFastSuite)
 {
     Model model;
     ModelPart& r_model_part = model.CreateModelPart("TestModelPart");

--- a/kratos/sources/communicator.cpp
+++ b/kratos/sources/communicator.cpp
@@ -444,6 +444,16 @@ bool Communicator::SynchronizeNonHistoricalVariable(Variable<Quaternion<double>>
     return true;
 }
 
+bool Communicator::SynchronizeCurrentDataToMax(Variable<double> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeNonHistoricalDataToMax(Variable<double> const& ThisVariable)
+{
+    return true;
+}
+
 bool Communicator::SynchronizeCurrentDataToMin(Variable<double> const& ThisVariable)
 {
     return true;


### PR DESCRIPTION
**📝 Description**

Adding SynchronizeCurrentDataToMax and SynchronizeNonHistoricalDataToMax. Fixes https://github.com/KratosMultiphysics/Kratos/issues/10129

**🆕 Changelog**

- Added max value in ReduceValues
- Adding SynchronizeCurrentDataToMax and SynchronizeNonHistoricalDataToMax
- Added tests
