### PR TITLE
[Core] Allowing to consider two different types for scalar AtomicAdd

### DIFF
--- a/kratos/utilities/atomic_utilities.h
+++ b/kratos/utilities/atomic_utilities.h
@@ -37,7 +37,7 @@ namespace Kratos
  * @param target variable being atomically updated by doing target += value
  * @param value value being added
  */
-template<class TDataType>
+template<class TDataType1, class TDataType2 = TDataType1>
 inline void AtomicAdd(TDataType& target, const TDataType& value)
 {
     #pragma omp atomic

--- a/kratos/utilities/atomic_utilities.h
+++ b/kratos/utilities/atomic_utilities.h
@@ -38,8 +38,10 @@ namespace Kratos
  * @param value value being added
  */
 template<class TDataType1, class TDataType2 = TDataType1>
-inline void AtomicAdd(TDataType& target, const TDataType& value)
+inline void AtomicAdd(TDataType1& target, const TDataType2& value)
 {
+    KRATOS_DEBUG_ERROR_IF(sizeof(TDataType1) < sizeof(TDataType2)) << "AtomicAdd not possible, you are trying to sum a variable of higher size to a variable of lower size, this will induce an overflow - Sizes are: " << sizeof(TDataType1) << " for target and " << sizeof(TDataType2) << " for value " << std::endl;
+
     #pragma omp atomic
     target += value;
 }


### PR DESCRIPTION
**📝 Description**

Allowing to consider two different types for scalar AtomicAdd. This is done in the vector types as well.

**🆕 Changelog**

-  [Allowing to consider two different types for scalar AtomicAdd](https://github.com/KratosMultiphysics/Kratos/commit/92c9253e1e7c1b8da4480e886ddb0dd84161d438)
- [Check not overflow in debug](https://github.com/KratosMultiphysics/Kratos/commit/dcaa4e7d1d33d99f474dc21f3967b3f9005c6e1a)
