### PR TITLE
[Core] fix error in omp in monotonicity preserving in OMP

### DIFF
--- a/kratos/linear_solvers/monotonicity_preserving_solver.h
+++ b/kratos/linear_solvers/monotonicity_preserving_solver.h
@@ -210,12 +210,15 @@ public:
                     if (value > 0.0) {
                         const auto j = index2_vector[k];
                         if (j > i) {
-                            rA(i,i) += value;
                             rA(i,j) -= value;
                             rA(j,i) -= value;
-                            rA(j,j) += value;
-                            rB[i] += value*dofs_values[j] - value*dofs_values[i];
-                            rB[j] += value*dofs_values[i] - value*dofs_values[j];
+                            #pragma omp critical
+                            {
+                                rA(i,i) += value;
+                                rA(j,j) += value;
+                                rB[i] += value*dofs_values[j] - value*dofs_values[i];
+                                rB[j] += value*dofs_values[i] - value*dofs_values[j];
+                            }
                         }
                     }
                 }

--- a/kratos/linear_solvers/monotonicity_preserving_solver.h
+++ b/kratos/linear_solvers/monotonicity_preserving_solver.h
@@ -212,13 +212,15 @@ public:
                         if (j > i) {
                             rA(i,j) -= value;
                             rA(j,i) -= value;
-                            #pragma omp critical
-                            {
-                                rA(i,i) += value;
-                                rA(j,j) += value;
-                                rB[i] += value*dofs_values[j] - value*dofs_values[i];
-                                rB[j] += value*dofs_values[i] - value*dofs_values[j];
-                            }
+                            // Values conflicting with other threads
+                            auto& r_aii = rA(i,i).ref();
+                            AtomicAdd(r_aii, value);
+                            auto& r_ajj = rA(j,j).ref();
+                            AtomicAdd(r_ajj, value);
+                            auto& r_bi = rB[i];
+                            AtomicAdd(r_bi, value*dofs_values[j] - value*dofs_values[i]);
+                            auto& r_bj = rB[j];
+                            AtomicAdd(r_bj, value*dofs_values[i] - value*dofs_values[j]);
                         }
                     }
                 }


### PR DESCRIPTION
**📝 Description**
I found that there is an error in monotonicity preserving solver. In the for loop it makes sure that for a given (i,j) that j is greater than i. However it might that for the same i, there are two j values that satisfies rA(i,j) > 0.0 and therefore, there might be two threads that try to modify at the same time rA(i,i) or rA(j,j) and same for rB. Adding a critical to avoid this.

**🆕 Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Fixing OMP bug in monotonicity preserving solver
