### PR TITLE
[StructuralMechanicsApp] Bugfix and some optimizations

### DIFF
--- a/applications/ConstitutiveLawsApplication/tests/InitialStateInelasticity/initial_state2_test_parameters.json
+++ b/applications/ConstitutiveLawsApplication/tests/InitialStateInelasticity/initial_state2_test_parameters.json
@@ -63,7 +63,7 @@
             "Parameters"    : {
             "mesh_id"         : 0,
             "model_part_name" : "Structure",
-            "dimension"       : 2,
+            "dimension"       : 3,
             "imposed_strain"  : [0.1,0,0,0,0,0],
             "imposed_stress"  : [0,0,0,0,0,10000],
             "imposed_deformation_gradient"  : [[1,0,0],[0,1,0],[0,0,1]],

--- a/applications/ConstitutiveLawsApplication/tests/InitialStateInelasticity/initial_state3_test_parameters.json
+++ b/applications/ConstitutiveLawsApplication/tests/InitialStateInelasticity/initial_state3_test_parameters.json
@@ -63,7 +63,7 @@
             "Parameters"    : {
             "mesh_id"         : 0,
             "model_part_name" : "Structure",
-            "dimension"       : 2,
+            "dimension"       : 3,
             "imposed_strain"  : [0.1,0,0,0,0,0],
             "imposed_stress"  : [0,0,0,0,0,10000],
             "imposed_deformation_gradient"  : [[1,0,0],[0,1,0],[0,0,1]],

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -1101,8 +1101,6 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 }
             }
         } else if (rVariable == INITIAL_STRAIN_VECTOR) {
-            const SizeType number_of_nodes = GetGeometry().size();
-            const SizeType dimension = GetGeometry().WorkingSpaceDimension();
             const SizeType strain_size = mConstitutiveLawVector[0]->GetStrainSize();
             for ( IndexType point_number = 0; point_number < number_of_integration_points; ++point_number ) {
                 if (mConstitutiveLawVector[point_number]->HasInitialState()) {
@@ -1244,7 +1242,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
     if (rVariable == CONSTITUTIVE_LAW) {
         const SizeType integration_points_number = mConstitutiveLawVector.size();
         if (rValues.size() != integration_points_number) {
-            rValues.resize(integration_points_number, false);
+            rValues.resize(integration_points_number);
         }
         for (IndexType point_number = 0; point_number < integration_points_number; ++point_number) {
             rValues[point_number] = mConstitutiveLawVector[point_number];

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -779,9 +779,6 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
             ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, false);
             ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
 
-            // Reading integration points
-            //const GeometryType::IntegrationPointsArrayType& integration_points = this->IntegrationPoints(this->GetIntegrationMethod());
-
             // If strain has to be computed inside of the constitutive law with PK2
             Values.SetStrainVector(this_constitutive_variables.StrainVector); //this is the input  parameter
 
@@ -814,9 +811,6 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
             ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, UseElementProvidedStrain());
             ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, false);
             ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
-
-            // Reading integration points
-            //const GeometryType::IntegrationPointsArrayType& integration_points = this->IntegrationPoints(  );
 
             //Calculate Cauchy Stresses from the FE solution
             std::vector<Vector> sigma_FE_solution(number_of_nodes);

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -928,7 +928,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
     const SizeType number_of_integration_points = integration_points.size();
     if ( rOutput.size() != number_of_integration_points )
-        rOutput.resize( number_of_integration_points, false );
+        rOutput.resize( number_of_integration_points );
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {
         GetValueOnConstitutiveLaw(rVariable, rOutput);
@@ -975,7 +975,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
     const SizeType number_of_integration_points = integration_points.size();
     if (rOutput.size() != number_of_integration_points)
-        rOutput.resize(number_of_integration_points, false);
+        rOutput.resize(number_of_integration_points);
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {
         GetValueOnConstitutiveLaw(rVariable, rOutput);
@@ -997,7 +997,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
     const SizeType number_of_integration_points = integration_points.size();
     if ( rOutput.size() != number_of_integration_points )
-        rOutput.resize( number_of_integration_points, false );
+        rOutput.resize( number_of_integration_points );
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {
         GetValueOnConstitutiveLaw(rVariable, rOutput);
@@ -1139,7 +1139,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
     const SizeType dimension = GetGeometry().WorkingSpaceDimension();
 
     if ( rOutput.size() != integration_points.size() )
-        rOutput.resize( integration_points.size(), false );
+        rOutput.resize( integration_points.size() );
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {
         GetValueOnConstitutiveLaw(rVariable, rOutput);

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -1092,9 +1092,28 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
                 rOutput[point_number] = this_constitutive_variables.StrainVector;
             }
+        } else if (rVariable == INITIAL_STRESS_VECTOR) {
+            const SizeType number_of_nodes = GetGeometry().size();
+            const SizeType dimension = GetGeometry().WorkingSpaceDimension();
+            const SizeType strain_size = mConstitutiveLawVector[0]->GetStrainSize();
+            for ( IndexType point_number = 0; point_number < number_of_integration_points; ++point_number ) {
+                if (mConstitutiveLawVector[point_number]->HasInitialState()) {
+                    const Vector& r_initial_stress = mConstitutiveLawVector[point_number]->GetInitialState().GetInitialStressVector();
+
+                    if ( rOutput[point_number].size() != strain_size)
+                        rOutput[point_number].resize( strain_size, false );
+
+                    noalias(rOutput[point_number]) = r_initial_stress;
+                } else {
+                    noalias(rOutput[point_number]) = ZeroVector(strain_size);
+                }
+
+            }
         } else {
             CalculateOnConstitutiveLaw(rVariable, rOutput, rCurrentProcessInfo);
         }
+        
+
     }
 }
 

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -944,17 +944,17 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 Point global_point;
                 GetGeometry().GlobalCoordinates(global_point, integration_points[point_number]);
 
-                rOutput[point_number] = global_point.Coordinates();
+                noalias(rOutput[point_number]) = global_point.Coordinates();
             }
         } else if (rVariable == LOCAL_AXIS_1 || rVariable == LOCAL_AXIS_2 || rVariable == LOCAL_AXIS_3) {
             if (this->Has(rVariable)) {
                 for (IndexType point_number = 0; point_number < number_of_integration_points; ++point_number)
-                    rOutput[point_number] = this->GetValue(rVariable);
+                    noalias(rOutput[point_number]) = this->GetValue(rVariable);
             } else if (rVariable == LOCAL_AXIS_3) {
                 const array_1d<double, 3> r_local_axis_1 = this->GetValue(LOCAL_AXIS_1);
                 const array_1d<double, 3> local_axis_2 = this->GetValue(LOCAL_AXIS_2);
                 for (IndexType point_number = 0; point_number < number_of_integration_points; ++point_number)
-                    rOutput[point_number] = MathUtils<double>::CrossProduct(r_local_axis_1, local_axis_2);
+                    noalias(rOutput[point_number]) = MathUtils<double>::CrossProduct(r_local_axis_1, local_axis_2);
             }
         } else {
             CalculateOnConstitutiveLaw(rVariable, rOutput, rCurrentProcessInfo);
@@ -1157,7 +1157,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 if ( rOutput[point_number].size2() != dimension )
                     rOutput[point_number].resize( dimension, dimension, false );
 
-                rOutput[point_number] = MathUtils<double>::StressVectorToTensor(stress_vector[point_number]);
+                noalias(rOutput[point_number]) = MathUtils<double>::StressVectorToTensor(stress_vector[point_number]);
             }
         }
         else if ( rVariable == GREEN_LAGRANGE_STRAIN_TENSOR  || rVariable == ALMANSI_STRAIN_TENSOR) {
@@ -1172,7 +1172,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 if ( rOutput[point_number].size2() != dimension )
                     rOutput[point_number].resize( dimension, dimension, false );
 
-                rOutput[point_number] = MathUtils<double>::StrainVectorToTensor(strain_vector[point_number]);
+                noalias(rOutput[point_number]) = MathUtils<double>::StrainVectorToTensor(strain_vector[point_number]);
             }
         } else if ( rVariable == CONSTITUTIVE_MATRIX ) {
             // Create and initialize element variables:
@@ -1205,7 +1205,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 if( rOutput[point_number].size2() != this_constitutive_variables.D.size2() )
                     rOutput[point_number].resize( this_constitutive_variables.D.size1() , this_constitutive_variables.D.size2() , false );
 
-                rOutput[point_number] = this_constitutive_variables.D;
+                noalias(rOutput[point_number]) = this_constitutive_variables.D;
             }
         } else if ( rVariable == DEFORMATION_GRADIENT ) { // VARIABLE SET FOR TRANSFER PURPOUSES
             // Create and initialize element variables:
@@ -1226,7 +1226,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 if( rOutput[point_number].size2() != this_kinematic_variables.F.size2() )
                     rOutput[point_number].resize( this_kinematic_variables.F.size1() , this_kinematic_variables.F.size2() , false );
 
-                rOutput[point_number] = this_kinematic_variables.F;
+                noalias(rOutput[point_number]) = this_kinematic_variables.F;
             }
         }  else {
             CalculateOnConstitutiveLaw(rVariable, rOutput, rCurrentProcessInfo);

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -68,7 +68,7 @@ void BaseSolidElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 
         //Constitutive Law initialisation
         if ( mConstitutiveLawVector.size() != integration_points.size() )
-            mConstitutiveLawVector.resize( integration_points.size() );
+            mConstitutiveLawVector.resize( integration_points.size(), false );
 
         InitializeMaterial();
 
@@ -355,7 +355,7 @@ void BaseSolidElement::GetDofList(
 
     const SizeType number_of_nodes = GetGeometry().size();
     const SizeType dimension = GetGeometry().WorkingSpaceDimension();
-    rElementalDofList.resize(0);
+    rElementalDofList.resize(0, false);
     rElementalDofList.reserve(dimension*number_of_nodes);
 
     if(dimension == 2) {
@@ -677,7 +677,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
     const SizeType number_of_integration_points = integration_points.size();
     if (rOutput.size() != number_of_integration_points)
-        rOutput.resize(number_of_integration_points);
+        rOutput.resize(number_of_integration_points, false);
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {
         for ( IndexType point_number = 0; point_number <number_of_integration_points; ++point_number ) {
@@ -710,7 +710,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
     const SizeType number_of_integration_points = integration_points.size();
     if (rOutput.size() != number_of_integration_points)
-        rOutput.resize(number_of_integration_points);
+        rOutput.resize(number_of_integration_points, false);
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {
         GetValueOnConstitutiveLaw(rVariable, rOutput);
@@ -928,7 +928,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
     const SizeType number_of_integration_points = integration_points.size();
     if ( rOutput.size() != number_of_integration_points )
-        rOutput.resize( number_of_integration_points );
+        rOutput.resize( number_of_integration_points, false );
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {
         GetValueOnConstitutiveLaw(rVariable, rOutput);
@@ -975,7 +975,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
     const SizeType number_of_integration_points = integration_points.size();
     if (rOutput.size() != number_of_integration_points)
-        rOutput.resize(number_of_integration_points);
+        rOutput.resize(number_of_integration_points, false);
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {
         GetValueOnConstitutiveLaw(rVariable, rOutput);
@@ -997,7 +997,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
     const SizeType number_of_integration_points = integration_points.size();
     if ( rOutput.size() != number_of_integration_points )
-        rOutput.resize( number_of_integration_points );
+        rOutput.resize( number_of_integration_points, false );
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {
         GetValueOnConstitutiveLaw(rVariable, rOutput);
@@ -1139,7 +1139,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
     const SizeType dimension = GetGeometry().WorkingSpaceDimension();
 
     if ( rOutput.size() != integration_points.size() )
-        rOutput.resize( integration_points.size() );
+        rOutput.resize( integration_points.size(), false );
 
     if (mConstitutiveLawVector[0]->Has( rVariable)) {
         GetValueOnConstitutiveLaw(rVariable, rOutput);
@@ -1246,7 +1246,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
     if (rVariable == CONSTITUTIVE_LAW) {
         const SizeType integration_points_number = mConstitutiveLawVector.size();
         if (rValues.size() != integration_points_number) {
-            rValues.resize(integration_points_number);
+            rValues.resize(integration_points_number, false);
         }
         for (IndexType point_number = 0; point_number < integration_points_number; ++point_number) {
             rValues[point_number] = mConstitutiveLawVector[point_number];

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -1107,7 +1107,22 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 } else {
                     noalias(rOutput[point_number]) = ZeroVector(strain_size);
                 }
+            }
+        } else if (rVariable == INITIAL_STRAIN_VECTOR) {
+            const SizeType number_of_nodes = GetGeometry().size();
+            const SizeType dimension = GetGeometry().WorkingSpaceDimension();
+            const SizeType strain_size = mConstitutiveLawVector[0]->GetStrainSize();
+            for ( IndexType point_number = 0; point_number < number_of_integration_points; ++point_number ) {
+                if (mConstitutiveLawVector[point_number]->HasInitialState()) {
+                    const Vector& r_initial_strain = mConstitutiveLawVector[point_number]->GetInitialState().GetInitialStrainVector();
 
+                    if ( rOutput[point_number].size() != strain_size)
+                        rOutput[point_number].resize( strain_size, false );
+
+                    noalias(rOutput[point_number]) = r_initial_strain;
+                } else {
+                    noalias(rOutput[point_number]) = ZeroVector(strain_size);
+                }
             }
         } else {
             CalculateOnConstitutiveLaw(rVariable, rOutput, rCurrentProcessInfo);

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -1055,7 +1055,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 if ( rOutput[point_number].size() != strain_size )
                     rOutput[point_number].resize( strain_size, false );
 
-                rOutput[point_number] = this_constitutive_variables.StressVector;
+                noalias(rOutput[point_number]) = this_constitutive_variables.StressVector;
             }
         } else if( rVariable == GREEN_LAGRANGE_STRAIN_VECTOR  || rVariable == ALMANSI_STRAIN_VECTOR ) {
             // Create and initialize element variables:
@@ -1090,7 +1090,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 if ( rOutput[point_number].size() != strain_size)
                     rOutput[point_number].resize( strain_size, false );
 
-                rOutput[point_number] = this_constitutive_variables.StrainVector;
+                noalias(rOutput[point_number]) = this_constitutive_variables.StrainVector;
             }
         } else if (rVariable == INITIAL_STRESS_VECTOR) {
             const SizeType number_of_nodes = GetGeometry().size();

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -68,7 +68,7 @@ void BaseSolidElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 
         //Constitutive Law initialisation
         if ( mConstitutiveLawVector.size() != integration_points.size() )
-            mConstitutiveLawVector.resize( integration_points.size(), false );
+            mConstitutiveLawVector.resize( integration_points.size() );
 
         InitializeMaterial();
 
@@ -355,7 +355,7 @@ void BaseSolidElement::GetDofList(
 
     const SizeType number_of_nodes = GetGeometry().size();
     const SizeType dimension = GetGeometry().WorkingSpaceDimension();
-    rElementalDofList.resize(0, false);
+    rElementalDofList.resize(0);
     rElementalDofList.reserve(dimension*number_of_nodes);
 
     if(dimension == 2) {

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -1087,8 +1087,6 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 noalias(rOutput[point_number]) = this_constitutive_variables.StrainVector;
             }
         } else if (rVariable == INITIAL_STRESS_VECTOR) {
-            const SizeType number_of_nodes = GetGeometry().size();
-            const SizeType dimension = GetGeometry().WorkingSpaceDimension();
             const SizeType strain_size = mConstitutiveLawVector[0]->GetStrainSize();
             for ( IndexType point_number = 0; point_number < number_of_integration_points; ++point_number ) {
                 if (mConstitutiveLawVector[point_number]->HasInitialState()) {

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
@@ -132,7 +132,7 @@ void SmallDisplacement::CalculateAll(
         if ( rRightHandSideVector.size() != mat_size )
             rRightHandSideVector.resize( mat_size, false );
 
-        rRightHandSideVector = ZeroVector( mat_size ); //resetting RHS
+        noalias(rRightHandSideVector) = ZeroVector( mat_size ); //resetting RHS
     }
 
     // Reading integration points and local gradients
@@ -211,7 +211,7 @@ void SmallDisplacement::CalculateKinematicVariables(
 
     // Compute equivalent F
     GetValuesVector(rThisKinematicVariables.Displacements);
-    Vector strain_vector(GetProperties().GetValue(CONSTITUTIVE_LAW)->GetStrainSize());
+    Vector strain_vector(mConstitutiveLawVector[0]->GetStrainSize());
     noalias(strain_vector) = prod(rThisKinematicVariables.B, rThisKinematicVariables.Displacements);
     ComputeEquivalentF(rThisKinematicVariables.F, strain_vector);
     rThisKinematicVariables.detF = MathUtils<double>::Det(rThisKinematicVariables.F);

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
@@ -211,7 +211,8 @@ void SmallDisplacement::CalculateKinematicVariables(
 
     // Compute equivalent F
     GetValuesVector(rThisKinematicVariables.Displacements);
-    Vector strain_vector = prod(rThisKinematicVariables.B, rThisKinematicVariables.Displacements);
+    Vector strain_vector(GetProperties().GetValue(CONSTITUTIVE_LAW)->GetStrainSize());
+    noalias(strain_vector) = prod(rThisKinematicVariables.B, rThisKinematicVariables.Displacements);
     ComputeEquivalentF(rThisKinematicVariables.F, strain_vector);
     rThisKinematicVariables.detF = MathUtils<double>::Det(rThisKinematicVariables.F);
 }

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -230,7 +230,7 @@ void UpdatedLagrangian::CalculateAll(
         if ( rRightHandSideVector.size() != mat_size )
             rRightHandSideVector.resize( mat_size, false );
 
-        rRightHandSideVector = ZeroVector( mat_size ); //resetting RHS
+        noalias(rRightHandSideVector) = ZeroVector( mat_size ); //resetting RHS
     }
 
     // Reading integration points

--- a/applications/StructuralMechanicsApplication/tests/InitialStateElasticity/initial_state_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/InitialStateElasticity/initial_state_test_parameters.json
@@ -63,7 +63,7 @@
             "Parameters"    : {
             "mesh_id"         : 0,
             "model_part_name" : "Structure",
-            "dimension"       : 2,
+            "dimension"       : 3,
             "imposed_strain"  : [0.1,0,0,0,0,0],
             "imposed_stress"  : [0,0,0,0,0,10000],
             "imposed_deformation_gradient"  : [[1,0,0],[0,1,0],[0,0,1]],

--- a/applications/StructuralMechanicsApplication/tests/InitialStateElasticity/initial_strain_shell_Q4_thick_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/InitialStateElasticity/initial_strain_shell_Q4_thick_test_parameters.json
@@ -88,7 +88,7 @@
             "dimension"       : 2,
             "imposed_strain"  : [1.0e-4,-5.0e-5,-2e-4],
             "imposed_stress"  : [0,0,0],
-            "imposed_deformation_gradient" : [[1,0,0],[0,1,0],[0,0,1]],
+            "imposed_deformation_gradient" : [[1,0],[0,1]],
             "interval"        : [0.0,"End"]
             }
         }],

--- a/kratos/processes/set_initial_state_process.cpp
+++ b/kratos/processes/set_initial_state_process.cpp
@@ -124,14 +124,19 @@ namespace Kratos
     void SetInitialStateProcess<TDim>::ExecuteInitializeSolutionStep()
     {
         KRATOS_TRY
+        const std::size_t strain_size = mInitialStrain.size();
+        InitialState::Pointer p_initial_state = Kratos::make_intrusive<InitialState>(mInitialStrain, mInitialStress, mInitialF);
 
-        Vector aux_initial_strain = mInitialStrain;
-        Vector aux_initial_stress = mInitialStress;
-        Matrix aux_initial_F      = mInitialF;
-        InitialState::Pointer p_initial_state = Kratos::make_intrusive<InitialState>
-            (aux_initial_strain, aux_initial_stress, aux_initial_F);
+        block_for_each(mrModelPart.Elements(), [&](Element &r_element) {
+            Vector aux_initial_strain(strain_size);
+            noalias(aux_initial_strain) = mInitialStrain;
 
-        block_for_each(mrModelPart.Elements(), [&](Element& r_element){
+            Vector aux_initial_stress(strain_size);
+            noalias(aux_initial_stress) = mInitialStress;
+
+            Matrix aux_initial_F(TDim, TDim);
+            noalias(aux_initial_F) = mInitialF;
+
             // If the values are set element-wise have priority
             bool requires_unique_initial_state = false;
             if (r_element.GetGeometry().Has(INITIAL_STRAIN_VECTOR)) {
@@ -159,8 +164,7 @@ namespace Kratos
                 for (IndexType point_number = 0; point_number < constitutive_law_vector.size(); ++point_number) {
                     constitutive_law_vector[point_number]->SetInitialState(p_initial_state);
                 }
-            }
-        });
+            }});
         KRATOS_CATCH("")
     }
 

--- a/kratos/processes/set_initial_state_process.cpp
+++ b/kratos/processes/set_initial_state_process.cpp
@@ -72,7 +72,7 @@ namespace Kratos
     {
         KRATOS_TRY
 
-        const std::size_t voigt_size = (TDim == 3) ? 6 : 3;
+        const std::size_t voigt_size = rInitialStateVector.size();
 
         mInitialStrain.resize(voigt_size, false);
         mInitialStress.resize(voigt_size, false);


### PR DESCRIPTION
In this PR I am solving a bug in which the initial state was not correctly set in parallel if you perform a custom elem->SetValue of the initial stress or strains. Now it is solved.

Besides I have added some optimizations of the elements (noalias missing mainly)