### PR TITLE
[Python] 3.6 is now minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,8 +317,9 @@ endif(NOT DEFINED KRATOS_ENABLE_LTO)
 message("AR VERSION: ${CMAKE_AR}")
 
 # check version of Python, needs to be done after including pybind
-if(${PYTHON_VERSION_MAJOR} LESS 3 OR (${PYTHON_VERSION_MAJOR} EQUAL 3 AND ${PYTHON_VERSION_MINOR} LESS 5))
-message( FATAL_ERROR "Kratos only supports Python version 3.5 and above")
+PYTHON_VERSION
+if(${PYTHON_VERSION_MAJOR} LESS 3 OR (${PYTHON_VERSION_MAJOR} EQUAL 3 AND ${PYTHON_VERSION_MINOR} LESS 6))
+message( FATAL_ERROR "Kratos only supports Python version 3.6 and above")
 endif()
 set(PYTHON_INTERFACE_VERSION "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,7 +317,6 @@ endif(NOT DEFINED KRATOS_ENABLE_LTO)
 message("AR VERSION: ${CMAKE_AR}")
 
 # check version of Python, needs to be done after including pybind
-PYTHON_VERSION
 if(${PYTHON_VERSION_MAJOR} LESS 3 OR (${PYTHON_VERSION_MAJOR} EQUAL 3 AND ${PYTHON_VERSION_MINOR} LESS 6))
 message( FATAL_ERROR "Kratos only supports Python version 3.6 and above")
 endif()

--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -3,8 +3,8 @@ import re
 import sys
 from . import kratos_globals
 
-if sys.version_info < (3, 5):
-    raise Exception("Kratos only supports Python version 3.5 and above")
+if sys.version_info < (3, 6):
+    raise Exception("Kratos only supports Python version 3.6 and above")
 
 class KratosPaths(object):
     kratos_install_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))


### PR DESCRIPTION
**📝 Description**
Python 3.5 reached its EOL [2 years ago](https://endoflife.date/python). Pybind doesn't support it any more with the latest version, hence I think it is time to update
Plus python3.6 brings cool things like f-strings!

(BTW also 3.6 reached its EOL [8 months ago](https://endoflife.date/python))

FYI @KratosMultiphysics/altair 