### PR TITLE
[Core][Serializer] using data

### DIFF
--- a/kratos/includes/serializer.h
+++ b/kratos/includes/serializer.h
@@ -1162,9 +1162,9 @@ private:
         SizeType size;
         mpBuffer->read((char *)(&size),sizeof(SizeType));
         rValue.resize(size);
-	if (size>0) {
-	    mpBuffer->read(&rValue.front(),size);
-	}
+        if (size>0) {
+            mpBuffer->read(rValue.data(), size);
+        }
 
         KRATOS_SERIALIZER_MODE_ASCII
 


### PR DESCRIPTION
follow up of #9572, since we now have C++17 we can use `data` which makes more sense than `front`
