### PR TITLE
[Core][VariableUtils] Variadic set to zero methods

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_variable_utils.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_variable_utils.cpp
@@ -1,0 +1,154 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+// System includes
+#include <limits>
+
+// External includes
+
+// Project includes
+#include "containers/model.h"
+#include "testing/testing.h"
+#include "utilities/variable_utils.h"
+
+namespace Kratos
+{
+namespace Testing
+{
+
+    KRATOS_TEST_CASE_IN_SUITE(VariableUtilsSetHistoricalVariablesToZero, KratosCoreFastSuite)
+    {
+        // Set auxilary nodal structure
+        Model test_model;
+        auto& r_test_model_part = test_model.CreateModelPart("TestModelPart");
+        r_test_model_part.AddNodalSolutionStepVariable(PRESSURE);
+        r_test_model_part.AddNodalSolutionStepVariable(VELOCITY);
+        r_test_model_part.AddNodalSolutionStepVariable(TEMPERATURE);
+        r_test_model_part.AddNodalSolutionStepVariable(DISPLACEMENT);
+        r_test_model_part.AddNodalSolutionStepVariable(DEFORMATION_GRADIENT);
+        for (std::size_t i = 0; i < 10; ++i) {
+            r_test_model_part.CreateNewNode(i,0.0,0.0,0.0);
+        }
+
+        // Set fake values in the historical database
+        array_1d<double,3> aux_vect;
+        Matrix aux_mat = ZeroMatrix(3,3);
+        for (std::size_t i = 0; i < 3; ++i) {
+            aux_vect[i] = 1.0;
+            for (std::size_t j = 0; j < 3; ++j) {
+                aux_mat(i,j) = 1.0;
+            }
+        }
+        for (auto& r_node : r_test_model_part.Nodes()) {
+            r_node.FastGetSolutionStepValue(PRESSURE) = 1.0;
+            r_node.FastGetSolutionStepValue(TEMPERATURE) = 1.0;
+            noalias(r_node.FastGetSolutionStepValue(VELOCITY)) = aux_vect;
+            noalias(r_node.FastGetSolutionStepValue(DISPLACEMENT)) = aux_vect;
+            r_node.FastGetSolutionStepValue(DEFORMATION_GRADIENT) = aux_mat;
+        }
+
+        // Set some values to zero in the non-historical database
+        VariableUtils::SetHistoricalVariablesToZero(r_test_model_part.Nodes(), PRESSURE, TEMPERATURE, VELOCITY, DISPLACEMENT, DEFORMATION_GRADIENT);
+
+        // Values are properly allocated
+        const double tolerance = 1.0e-12;
+        for (const auto& r_node : r_test_model_part.Nodes()) {
+            KRATOS_CHECK_NEAR(r_node.FastGetSolutionStepValue(PRESSURE), 0.0, tolerance);
+            KRATOS_CHECK_NEAR(r_node.FastGetSolutionStepValue(TEMPERATURE), 0.0, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(r_node.FastGetSolutionStepValue(VELOCITY), ZeroVector(3), tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(r_node.FastGetSolutionStepValue(DISPLACEMENT), ZeroVector(3), tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(r_node.FastGetSolutionStepValue(DEFORMATION_GRADIENT), ZeroMatrix(3,3), tolerance);
+        }
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(VariableUtilsSetNonHistoricalVariablesToZeroNodes, KratosCoreFastSuite)
+    {
+        // Set auxilary nodal structure
+        Model test_model;
+        auto& r_test_model_part = test_model.CreateModelPart("TestModelPart");
+        for (std::size_t i = 0; i < 10; ++i) {
+            r_test_model_part.CreateNewNode(i,0.0,0.0,0.0);
+        }
+
+        // Set some values to zero in the non-historical database
+        VariableUtils::SetNonHistoricalVariablesToZero(r_test_model_part.Nodes(), PRESSURE, TEMPERATURE, VELOCITY, DISPLACEMENT, DEFORMATION_GRADIENT);
+
+        // Values are properly allocated
+        const double tolerance = 1.0e-12;
+        for (const auto& r_node : r_test_model_part.Nodes()) {
+            KRATOS_CHECK_NEAR(r_node.GetValue(PRESSURE), 0.0, tolerance);
+            KRATOS_CHECK_NEAR(r_node.GetValue(TEMPERATURE), 0.0, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(r_node.GetValue(VELOCITY), ZeroVector(3), tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(r_node.GetValue(DISPLACEMENT), ZeroVector(3), tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(r_node.GetValue(DEFORMATION_GRADIENT), ZeroMatrix(3,3), tolerance);
+        }
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(VariableUtilsSetNonHistoricalVariablesToZeroElements, KratosCoreFastSuite)
+    {
+        // Set auxilary elemental structure
+        Model test_model;
+        auto& r_test_model_part = test_model.CreateModelPart("TestModelPart");
+        for (std::size_t i = 0; i < 5; ++i) {
+            r_test_model_part.CreateNewNode(i,0.0,0.0,0.0);
+        }
+        auto p_prop = Kratos::make_shared<Properties>(0);
+        r_test_model_part.CreateNewElement("Element2D2N",1,{{1,2}},p_prop);
+        r_test_model_part.CreateNewElement("Element2D2N",2,{{2,3}},p_prop);
+        r_test_model_part.CreateNewElement("Element2D2N",3,{{3,4}},p_prop);
+        r_test_model_part.CreateNewElement("Element2D2N",4,{{4,5}},p_prop);
+
+        // Set some values to zero in the non-historical database
+        VariableUtils::SetNonHistoricalVariablesToZero(r_test_model_part.Elements(), PRESSURE, TEMPERATURE, VELOCITY, DISPLACEMENT, DEFORMATION_GRADIENT);
+
+        // Values are properly allocated
+        const double tolerance = 1.0e-12;
+        for (const auto& r_element : r_test_model_part.Elements()) {
+            KRATOS_CHECK_NEAR(r_element.GetValue(PRESSURE), 0.0, tolerance);
+            KRATOS_CHECK_NEAR(r_element.GetValue(TEMPERATURE), 0.0, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(r_element.GetValue(VELOCITY), ZeroVector(3), tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(r_element.GetValue(DISPLACEMENT), ZeroVector(3), tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(r_element.GetValue(DEFORMATION_GRADIENT), ZeroMatrix(3,3), tolerance);
+        }
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(VariableUtilsSetNonHistoricalVariablesToZeroConditions, KratosCoreFastSuite)
+    {
+        // Set auxilary elemental structure
+        Model test_model;
+        auto& r_test_model_part = test_model.CreateModelPart("TestModelPart");
+        for (std::size_t i = 0; i < 5; ++i) {
+            r_test_model_part.CreateNewNode(i,0.0,0.0,0.0);
+        }
+        auto p_prop = Kratos::make_shared<Properties>(0);
+        r_test_model_part.CreateNewCondition("LineCondition2D2N",1,{{1,2}},p_prop);
+        r_test_model_part.CreateNewCondition("LineCondition2D2N",2,{{2,3}},p_prop);
+        r_test_model_part.CreateNewCondition("LineCondition2D2N",3,{{3,4}},p_prop);
+        r_test_model_part.CreateNewCondition("LineCondition2D2N",4,{{4,5}},p_prop);
+
+        // Set some values to zero in the non-historical database
+        VariableUtils::SetNonHistoricalVariablesToZero(r_test_model_part.Conditions(), PRESSURE, TEMPERATURE, VELOCITY, DISPLACEMENT, DEFORMATION_GRADIENT);
+
+        // Values are properly allocated
+        const double tolerance = 1.0e-12;
+        for (const auto& r_condition : r_test_model_part.Conditions()) {
+            KRATOS_CHECK_NEAR(r_condition.GetValue(PRESSURE), 0.0, tolerance);
+            KRATOS_CHECK_NEAR(r_condition.GetValue(TEMPERATURE), 0.0, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(r_condition.GetValue(VELOCITY), ZeroVector(3), tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(r_condition.GetValue(DISPLACEMENT), ZeroVector(3), tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(r_condition.GetValue(DEFORMATION_GRADIENT), ZeroMatrix(3,3), tolerance);
+        }
+    }
+
+} // namespace Testing
+}  // namespace Kratos.
+

--- a/kratos/tests/cpp_tests/utilities/test_variable_utils.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_variable_utils.cpp
@@ -66,7 +66,7 @@ namespace Testing
             KRATOS_CHECK_NEAR(r_node.FastGetSolutionStepValue(TEMPERATURE), 0.0, tolerance);
             KRATOS_CHECK_VECTOR_NEAR(r_node.FastGetSolutionStepValue(VELOCITY), ZeroVector(3), tolerance);
             KRATOS_CHECK_VECTOR_NEAR(r_node.FastGetSolutionStepValue(DISPLACEMENT), ZeroVector(3), tolerance);
-            KRATOS_CHECK_MATRIX_NEAR(r_node.FastGetSolutionStepValue(DEFORMATION_GRADIENT), ZeroMatrix(3,3), tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(r_node.FastGetSolutionStepValue(DEFORMATION_GRADIENT), ZeroMatrix(0,0), tolerance);
         }
     }
 
@@ -98,7 +98,7 @@ namespace Testing
         // Set auxilary elemental structure
         Model test_model;
         auto& r_test_model_part = test_model.CreateModelPart("TestModelPart");
-        for (std::size_t i = 0; i < 5; ++i) {
+        for (std::size_t i = 0; i < 6; ++i) {
             r_test_model_part.CreateNewNode(i,0.0,0.0,0.0);
         }
         auto p_prop = Kratos::make_shared<Properties>(0);
@@ -126,7 +126,7 @@ namespace Testing
         // Set auxilary elemental structure
         Model test_model;
         auto& r_test_model_part = test_model.CreateModelPart("TestModelPart");
-        for (std::size_t i = 0; i < 5; ++i) {
+        for (std::size_t i = 0; i < 6; ++i) {
             r_test_model_part.CreateNewNode(i,0.0,0.0,0.0);
         }
         auto p_prop = Kratos::make_shared<Properties>(0);

--- a/kratos/tests/cpp_tests/utilities/test_variable_utils.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_variable_utils.cpp
@@ -89,7 +89,7 @@ namespace Testing
             KRATOS_CHECK_NEAR(r_node.GetValue(TEMPERATURE), 0.0, tolerance);
             KRATOS_CHECK_VECTOR_NEAR(r_node.GetValue(VELOCITY), ZeroVector(3), tolerance);
             KRATOS_CHECK_VECTOR_NEAR(r_node.GetValue(DISPLACEMENT), ZeroVector(3), tolerance);
-            KRATOS_CHECK_MATRIX_NEAR(r_node.GetValue(DEFORMATION_GRADIENT), ZeroMatrix(3,3), tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(r_node.GetValue(DEFORMATION_GRADIENT), ZeroMatrix(0,0), tolerance);
         }
     }
 
@@ -117,7 +117,7 @@ namespace Testing
             KRATOS_CHECK_NEAR(r_element.GetValue(TEMPERATURE), 0.0, tolerance);
             KRATOS_CHECK_VECTOR_NEAR(r_element.GetValue(VELOCITY), ZeroVector(3), tolerance);
             KRATOS_CHECK_VECTOR_NEAR(r_element.GetValue(DISPLACEMENT), ZeroVector(3), tolerance);
-            KRATOS_CHECK_MATRIX_NEAR(r_element.GetValue(DEFORMATION_GRADIENT), ZeroMatrix(3,3), tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(r_element.GetValue(DEFORMATION_GRADIENT), ZeroMatrix(0,0), tolerance);
         }
     }
 
@@ -145,7 +145,7 @@ namespace Testing
             KRATOS_CHECK_NEAR(r_condition.GetValue(TEMPERATURE), 0.0, tolerance);
             KRATOS_CHECK_VECTOR_NEAR(r_condition.GetValue(VELOCITY), ZeroVector(3), tolerance);
             KRATOS_CHECK_VECTOR_NEAR(r_condition.GetValue(DISPLACEMENT), ZeroVector(3), tolerance);
-            KRATOS_CHECK_MATRIX_NEAR(r_condition.GetValue(DEFORMATION_GRADIENT), ZeroMatrix(3,3), tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(r_condition.GetValue(DEFORMATION_GRADIENT), ZeroMatrix(0,0), tolerance);
         }
     }
 

--- a/kratos/utilities/variable_utils.cpp
+++ b/kratos/utilities/variable_utils.cpp
@@ -323,6 +323,24 @@ KRATOS_API(KRATOS_CORE) const ModelPart::ConditionsContainerType& VariableUtils:
     return rModelPart.Conditions();
 }
 
+template<class TDataType>
+void VariableUtils::AuxiliaryHistoricalValueSetter(
+    const Variable<TDataType>& rVariable,
+    const TDataType& rValue,
+    NodeType& rNode)
+{
+    rNode.FastGetSolutionStepValue(rVariable) = rValue;
+}
+
+template<>
+void VariableUtils::AuxiliaryHistoricalValueSetter(
+    const Variable<array_1d<double,3>>& rVariable,
+    const array_1d<double,3>& rValue,
+    NodeType& rNode)
+{
+    noalias(rNode.FastGetSolutionStepValue(rVariable)) = rValue;
+}
+
 template <class TDataType, class TContainerType, class TWeightDataType>
 void VariableUtils::WeightedAccumulateVariableOnNodes(
     ModelPart& rModelPart,
@@ -373,7 +391,7 @@ void VariableUtils::WeightedAccumulateVariableOnNodes(
 
 
 KRATOS_API(KRATOS_CORE) Vector VariableUtils::GetCurrentPositionsVector(
-    const ModelPart::NodesContainerType& rNodes, 
+    const ModelPart::NodesContainerType& rNodes,
     const unsigned int Dimension)
 {
     KRATOS_ERROR_IF((Dimension>3)) << " Only Dimension<=3 is admitted by the function" << std::endl;
@@ -390,7 +408,7 @@ KRATOS_API(KRATOS_CORE) Vector VariableUtils::GetCurrentPositionsVector(
 }
 
 KRATOS_API(KRATOS_CORE) Vector VariableUtils::GetInitialPositionsVector(
-    const ModelPart::NodesContainerType& rNodes, 
+    const ModelPart::NodesContainerType& rNodes,
     const unsigned int Dimension)
 {
     KRATOS_ERROR_IF((Dimension>3)) << " Only Dimension<=3 is admitted by the function" << std::endl;
@@ -407,7 +425,7 @@ KRATOS_API(KRATOS_CORE) Vector VariableUtils::GetInitialPositionsVector(
 }
 
 KRATOS_API(KRATOS_CORE) void VariableUtils::SetCurrentPositionsVector(
-    ModelPart::NodesContainerType& rNodes, 
+    ModelPart::NodesContainerType& rNodes,
     const Vector& rPositions)
 {
     KRATOS_ERROR_IF(rPositions.size()%rNodes.size()!=0) << "Incompatible number of nodes and position data" << std::endl;
@@ -424,7 +442,7 @@ KRATOS_API(KRATOS_CORE) void VariableUtils::SetCurrentPositionsVector(
 }
 
 KRATOS_API(KRATOS_CORE) void VariableUtils::SetInitialPositionsVector(
-    ModelPart::NodesContainerType& rNodes, 
+    ModelPart::NodesContainerType& rNodes,
     const Vector& rPositions)
 {
     KRATOS_ERROR_IF(rPositions.size()%rNodes.size()!=0) << "Incompatible number of nodes and position data" << std::endl;
@@ -440,7 +458,7 @@ KRATOS_API(KRATOS_CORE) void VariableUtils::SetInitialPositionsVector(
     );
 }
 
-KRATOS_API(KRATOS_CORE) Vector VariableUtils::GetSolutionStepValuesVector(  
+KRATOS_API(KRATOS_CORE) Vector VariableUtils::GetSolutionStepValuesVector(
                             const ModelPart::NodesContainerType& rNodes,
                             const Variable<array_1d<double,3>>& rVar,
                             const unsigned int Step,
@@ -459,7 +477,7 @@ KRATOS_API(KRATOS_CORE) Vector VariableUtils::GetSolutionStepValuesVector(
     return out;
 }
 
-KRATOS_API(KRATOS_CORE) Vector VariableUtils::GetSolutionStepValuesVector(  
+KRATOS_API(KRATOS_CORE) Vector VariableUtils::GetSolutionStepValuesVector(
                             const ModelPart::NodesContainerType& rNodes,
                             const Variable<double>& rVar,
                             const unsigned int Step
@@ -475,7 +493,7 @@ KRATOS_API(KRATOS_CORE) Vector VariableUtils::GetSolutionStepValuesVector(
     return out;
 }
 
-KRATOS_API(KRATOS_CORE) void VariableUtils::SetSolutionStepValuesVector(  
+KRATOS_API(KRATOS_CORE) void VariableUtils::SetSolutionStepValuesVector(
                             ModelPart::NodesContainerType& rNodes,
                             const Variable<array_1d<double,3>>& rVar,
                             const Vector& rData,
@@ -495,7 +513,7 @@ KRATOS_API(KRATOS_CORE) void VariableUtils::SetSolutionStepValuesVector(
         );
 }
 
-KRATOS_API(KRATOS_CORE) void VariableUtils::SetSolutionStepValuesVector(  
+KRATOS_API(KRATOS_CORE) void VariableUtils::SetSolutionStepValuesVector(
                             ModelPart::NodesContainerType& rNodes,
                             const Variable<double>& rVar,
                             const Vector& rData,
@@ -532,5 +550,10 @@ template KRATOS_API(KRATOS_CORE) void VariableUtils::WeightedAccumulateVariableO
     ModelPart&, const Variable<double>&, const Variable<double>&, const bool);
 template KRATOS_API(KRATOS_CORE) void VariableUtils::WeightedAccumulateVariableOnNodes<array_1d<double, 3>, ModelPart::ElementsContainerType, double>(
     ModelPart&, const Variable<array_1d<double, 3>>&, const Variable<double>&, const bool);
+
+template void VariableUtils::AuxiliaryHistoricalValueSetter<int>(const Variable<int>&, const int&, NodeType&);
+template void VariableUtils::AuxiliaryHistoricalValueSetter<double>(const Variable<double>&, const double&, NodeType&);
+template void VariableUtils::AuxiliaryHistoricalValueSetter<Vector>(const Variable<Vector>&, const Vector&, NodeType&);
+template void VariableUtils::AuxiliaryHistoricalValueSetter<Matrix>(const Variable<Matrix>&, const Matrix&, NodeType&);
 
 } /* namespace Kratos.*/

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -753,11 +753,6 @@ public:
     {
         block_for_each(rNodes, [&](NodeType& rNode){(
             AuxiliaryHistoricalValueSetter<TVariableArgs::Type>(rVariableArgs, rVariableArgs.Zero(), rNode), ...);
-            //if constexpr (std::is_same<TVariableArgs::Type,array_1d<double,3>>::value) {
-            //    noalias(rNode.FastGetSolutionStepValue(rVariableArgs)) = ZeroVector(3);
-            //} else {
-            //    rNode.FastGetSolutionStepValue(rVariableArgs) = rVariableArgs.Zero();
-            //}, ...);
         });
     }
 

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -707,6 +707,24 @@ public:
     }
 
     /**
+     * @brief Set the Non Historical Variables To Zero
+     * This method sets the provided list of variables to zero in the non-historical database
+     * @tparam TContainerType Container type (nodes, elements or conditions)
+     * @tparam TVariableArgs Variadic template argument representing the variables types
+     * @param rContainer Container to be initialized to zero
+     * @param rVariableArgs Variables to be set to zero
+     */
+    template<class TContainerType, class... TVariableArgs>
+    static void SetNonHistoricalVariablesToZero(
+        TContainerType& rContainer,
+        const TVariableArgs&... rVariableArgs)
+    {
+        block_for_each(rContainer, [&](auto& rEntity){
+            (rEntity.SetValue(rVariableArgs, rVariableArgs.Zero()), ...);
+        });
+    }
+
+    /**
      * @brief Sets the nodal value of any variable to zero
      * @param rVariable reference to the scalar variable to be set
      * @param rNodes reference to the objective node set
@@ -719,6 +737,30 @@ public:
         KRATOS_TRY
         this->SetVariable(rVariable, rVariable.Zero(), rNodes);
         KRATOS_CATCH("")
+    }
+
+    /**
+     * @brief Set the Historical Variables To Zero
+     * This method sets the provided list of variables to zero in the nodal historical database
+     * @tparam TVariableArgs Variadic template argument representing the variables types
+     * @param rNodes Nodes container to be initialized to zero
+     * @param rVariableArgs Variables to be set to zero
+     */
+    template<class... TVariableArgs>
+    static void SetHistoricalVariablesToZero(
+        NodesContainerType& rNodes,
+        const TVariableArgs&... rVariableArgs)
+    {
+        block_for_each(rNodes, [&](NodeType& rNode){(
+            [&](){
+                //rNode.FastGetSolutionStepValue(rVariableArgs) = rVariableArgs.Zero();
+                if constexpr (std::is_same<TVariableArgs::Type,array_1d<double,3>>::value) {
+                    noalias(rNode.FastGetSolutionStepValue(rVariableArgs)) = ZeroVector(3);
+                } else {
+                    rNode.FastGetSolutionStepValue(rVariableArgs) = rVariableArgs.Zero();
+                }
+            }, ...);
+        });
     }
 
     /**
@@ -1391,7 +1433,7 @@ public:
 
     /**
      * @brief This function returns the CURRENT coordinates of all the nodes in a consecutive vector.
-     * it allows working in 1D,2D or 3D 
+     * it allows working in 1D,2D or 3D
      * For each node, this method takes the value of the provided variable and updates the
      * current position as the initial position (X0, Y0, Z0) plus such variable value
      * in case Dimension == 1 the vector is in the form (X X X ....)
@@ -1401,13 +1443,13 @@ public:
      * @param Dimension number of desired components
      */
     Vector GetCurrentPositionsVector(
-        const ModelPart::NodesContainerType& rNodes, 
+        const ModelPart::NodesContainerType& rNodes,
         const unsigned int Dimension
         );
 
     /**
      * @brief This function returns the INITIAL coordinates of all the nodes in a consecutive vector.
-     * it allows working in 1D,2D or 3D 
+     * it allows working in 1D,2D or 3D
      * For each node, this method takes the value of the provided variable and updates the
      * current position as the initial position (X0, Y0, Z0) plus such variable value
      * in case Dimension == 1 the vector is in the form (X0 X0 X0 ....)
@@ -1417,56 +1459,56 @@ public:
      * @param Dimension number of desired components
      */
     Vector GetInitialPositionsVector(
-        const ModelPart::NodesContainerType& rNodes, 
+        const ModelPart::NodesContainerType& rNodes,
         const unsigned int Dimension
         );
 
     /**
      * @brief This function represent the "set" counterpart of GetCurrentPositionsVector and allows
      * setting the CURRENT coordinates of all the nodes considering them stored in a consecutive 1D vector.
-     * it allows working in 1D,2D or 3D 
+     * it allows working in 1D,2D or 3D
      * For each node, this method takes the value of the provided variable and updates the
      * current position as the initial position (X, Y, Z) plus such variable value
      * in case Dimension == 1 the expected input vector is in the form (X X X ....)
      * in case Dimension == 2 the expected input vector is in the form (X Y X Y X Y ....)
      * in case Dimension == 3 the expected input vector is in the form (X Y Z X Y Z ....)
      * @param rNodes array of nodes from which coordinates will be extracted
-     * @param rPositions vector containing the CURRENT positions 
+     * @param rPositions vector containing the CURRENT positions
      */
      void SetCurrentPositionsVector(
-        ModelPart::NodesContainerType& rNodes, 
+        ModelPart::NodesContainerType& rNodes,
         const Vector& rPositions
         );
 
     /**
      * @brief This function represent the "set" counterpart of GetInitialPositionsVector and allows
      * setting the INITIAL coordinates of all the nodes considering them stored in a consecutive 1D vector.
-     * it allows working in 1D,2D or 3D 
+     * it allows working in 1D,2D or 3D
      * For each node, this method takes the value of the provided variable and updates the
      * current position as the initial position (X0, Y0, Z0) plus such variable value
      * in case Dimension == 1 the expected input vector is in the form (X0 X0 X0 ....)
      * in case Dimension == 2 the expected input vector is in the form (X0 Y0 X0 Y0 X0 Y0 ....)
      * in case Dimension == 3 the expected input vector is in the form (X0 Y0 Z0 X0 Y0 Z0 ....)
      * @param rNodes array of nodes from which coordinates will be extracted
-     * @param rPositions vector containing the INITIAL positions 
+     * @param rPositions vector containing the INITIAL positions
      */
     void SetInitialPositionsVector(
-        ModelPart::NodesContainerType& rNodes, 
+        ModelPart::NodesContainerType& rNodes,
         const Vector& rPositions
         );
 
     /**
      * @brief This function allows getting the database entries corresponding to rVar contained on all rNodes
      * flattened so that the components of interest appear in the output vector.
-     * This version works with VECTOR VARIABLES (of type Variable<array_1d<double,3>>) 
-     * In case Dimension is 1 one would obtain only the first component, for Dimension 2 the x and y component 
+     * This version works with VECTOR VARIABLES (of type Variable<array_1d<double,3>>)
+     * In case Dimension is 1 one would obtain only the first component, for Dimension 2 the x and y component
      * and for Dimension==3 the 3 components at once
      * @param rNodes array of nodes from which data will be extracted
-     * @param rVar the variable being addressed 
+     * @param rVar the variable being addressed
      * @param Step step in the database
      * @param Dimension number of components in output
      */
-    Vector GetSolutionStepValuesVector(  
+    Vector GetSolutionStepValuesVector(
                                 const ModelPart::NodesContainerType& rNodes,
                                 const Variable<array_1d<double,3>>& rVar,
                                 const unsigned int Step,
@@ -1477,13 +1519,13 @@ public:
      * @brief This function allows getting the database entries corresponding to rVar contained on all rNodes
      * flattened so that the components of interest appear in the output vector.
      * This version works with SCALAR VARIABLES (of type Variable<double>)
-     * In case Dimension is 1 one would obtain only the first component, for Dimension 2 the x and y component 
+     * In case Dimension is 1 one would obtain only the first component, for Dimension 2 the x and y component
      * and for Dimension==3 the 3 components at once
      * @param rNodes array of nodes from which data will be extracted
-     * @param rVar the variable being addressed 
+     * @param rVar the variable being addressed
      * @param Step step in the database
      */
-    Vector GetSolutionStepValuesVector(  
+    Vector GetSolutionStepValuesVector(
                                 const ModelPart::NodesContainerType& rNodes,
                                 const Variable<double>& rVar,
                                 const unsigned int Step
@@ -1492,13 +1534,13 @@ public:
     /**
      * @brief This function allows setting the database entries corresponding to rVar contained on all rNodes
      * given a flat array in which all the variable components are present consecutively.
-     * This version works with VECTOR VARIABLES (of type Variable<array_1d<double,3>>) 
+     * This version works with VECTOR VARIABLES (of type Variable<array_1d<double,3>>)
      * @param rNodes array of nodes from which data will be extracted
-     * @param rVar the variable being addressed 
+     * @param rVar the variable being addressed
      * @param rData input vector (must be of size rNodes.size()*Dimension)
      * @param Step database step to which we will write
      */
-    void SetSolutionStepValuesVector(  
+    void SetSolutionStepValuesVector(
                                 ModelPart::NodesContainerType& rNodes,
                                 const Variable<array_1d<double,3>>& rVar,
                                 const Vector& rData,
@@ -1508,13 +1550,13 @@ public:
     /**
      * @brief This function allows setting the database entries corresponding to rVar contained on all rNodes
      * given a flat array in which all the variable components are present consecutively.
-     * This version works with SCALAR VARIABLES (of type Variable<double>) 
+     * This version works with SCALAR VARIABLES (of type Variable<double>)
      * @param rNodes array of nodes from which data will be extracted
-     * @param rVar the variable being addressed 
+     * @param rVar the variable being addressed
      * @param rData input vector (must be of size rNodes.size()*Dimension)
      * @param Step database step to which we will write
      */
-    void SetSolutionStepValuesVector(  
+    void SetSolutionStepValuesVector(
                                 ModelPart::NodesContainerType& rNodes,
                                 const Variable<double>& rVar,
                                 const Vector& rData,

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -752,14 +752,12 @@ public:
         const TVariableArgs&... rVariableArgs)
     {
         block_for_each(rNodes, [&](NodeType& rNode){(
-            [&](){
-                //rNode.FastGetSolutionStepValue(rVariableArgs) = rVariableArgs.Zero();
-                if constexpr (std::is_same<TVariableArgs::Type,array_1d<double,3>>::value) {
-                    noalias(rNode.FastGetSolutionStepValue(rVariableArgs)) = ZeroVector(3);
-                } else {
-                    rNode.FastGetSolutionStepValue(rVariableArgs) = rVariableArgs.Zero();
-                }
-            }, ...);
+            AuxiliaryHistoricalValueSetter<TVariableArgs::Type>(rVariableArgs, rVariableArgs.Zero(), rNode), ...);
+            //if constexpr (std::is_same<TVariableArgs::Type,array_1d<double,3>>::value) {
+            //    noalias(rNode.FastGetSolutionStepValue(rVariableArgs)) = ZeroVector(3);
+            //} else {
+            //    rNode.FastGetSolutionStepValue(rVariableArgs) = rVariableArgs.Zero();
+            //}, ...);
         });
     }
 
@@ -1626,6 +1624,12 @@ private:
 
     template <class TContainerType>
     const TContainerType& GetContainer(const ModelPart& rModelPart);
+
+    template<class TDataType>
+    static void AuxiliaryHistoricalValueSetter(
+        const Variable<TDataType>& rVariable,
+        const TDataType& rValue,
+        NodeType& rNode);
 
     template <class TContainerType, class TSetterFunction, class TGetterFunction>
     void CopyModelPartFlaggedVariable(

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -752,7 +752,7 @@ public:
         const TVariableArgs&... rVariableArgs)
     {
         block_for_each(rNodes, [&](NodeType& rNode){(
-            AuxiliaryHistoricalValueSetter<TVariableArgs::Type>(rVariableArgs, rVariableArgs.Zero(), rNode), ...);
+            AuxiliaryHistoricalValueSetter<typename TVariableArgs::Type>(rVariableArgs, rVariableArgs.Zero(), rNode), ...);
         });
     }
 


### PR DESCRIPTION
**📝 Description**
In this PR I'm adding two new `SetNonHistoricalVariablesToZero` and `SetHistoricalVariablesToZero` methods. Nice thing is that thanks to fold expressions feature from c++17 we can easily implement these with variadic templates, so now we can set more than one variable to zero when looping the nodes.

Bad thing is that the variables to be set to zero need to be known at compile time, so we (or at least I don't know how) cannot export it to Python.

In the future we can do something similar with the method to set values in the `VariableUtils` by passing variable-value pairs in a variadic manner.

Finally, I point that I decided to (finally) make these `static` as they will be only used in c++.

In subsequent PRs we can start populating these.
