### PR TITLE
[FastPR][SwimmingDEM] Fix tolerance Chien drag test

### DIFF
--- a/applications/SwimmingDEMApplication/tests/drag_tests/chien_law/chien_drag_test_analysis.py
+++ b/applications/SwimmingDEMApplication/tests/drag_tests/chien_law/chien_drag_test_analysis.py
@@ -15,7 +15,7 @@ class ChienDragAnalysis(SwimmingDEMAnalysis, KratosUnittest.TestCase):
         super().FinalizeSolutionStep()
 
     def CheckValues(self, x_vel):
-        tol = 1.0e-18
+        tol = 1.0e-12
         x_vel_ref = 0.9886575480896711 #ChienDragLaw
 
         # Other results.


### PR DESCRIPTION
**📝 Description**
The tolerance of this test is beyond machine precision, which makes no sense. In another branch I'm working on this is raising the error
```
AssertionError: 0.9886575480903799 != 0.9886575480896711 within 1e-18 delta (7.087663789206999e-13 difference)
```
I put 1.0e-12 which is consider is precise enough.

(I don't understand how this didn't pop up yet...)
