### PR TITLE
[Performance][Core] Using find with an individual character is faster than with a string of one character length

### DIFF
--- a/kratos/containers/model.cpp
+++ b/kratos/containers/model.cpp
@@ -56,7 +56,7 @@ ModelPart& Model::CreateModelPart( const std::string ModelPartName, ModelPart::I
 
     KRATOS_ERROR_IF( ModelPartName.empty() ) << "Please don't use empty names (\"\") when creating a ModelPart" << std::endl;
 
-    const auto delim_pos = ModelPartName.find(".");
+    const auto delim_pos = ModelPartName.find('.');
     const std::string& root_model_part_name = ModelPartName.substr(0, delim_pos);
 
     if (delim_pos == std::string::npos) {
@@ -117,7 +117,7 @@ ModelPart& Model::GetModelPart(const std::string& rFullModelPartName)
     KRATOS_ERROR_IF( rFullModelPartName.empty() ) << "Attempting to find a "
         << "ModelPart with empty name (\"\")!" << std::endl;
 
-    const auto delim_pos = rFullModelPartName.find(".");
+    const auto delim_pos = rFullModelPartName.find('.');
     const std::string& root_model_part_name = rFullModelPartName.substr(0, delim_pos);
 
     if (delim_pos == std::string::npos) { //it is a root model part
@@ -225,7 +225,7 @@ bool Model::HasModelPart(const std::string& rFullModelPartName) const
     KRATOS_ERROR_IF( rFullModelPartName.empty() ) << "Attempting to find a "
         << "ModelPart with empty name (\"\")!" << std::endl;
 
-    const auto delim_pos = rFullModelPartName.find(".");
+    const auto delim_pos = rFullModelPartName.find('.');
     const std::string& root_model_part_name = rFullModelPartName.substr(0, delim_pos);
 
     // token 0 is the root

--- a/kratos/factories/linear_solver_factory.h
+++ b/kratos/factories/linear_solver_factory.h
@@ -103,7 +103,7 @@ public:
         std::string solver_name = Settings["solver_type"].GetString();
         // remove name of the application (if passed)
         // e.g. "LinearSolversApplication.sparse_lu" => "sparse_lu"
-        solver_name = solver_name.substr(solver_name.find(".") + 1);
+        solver_name = solver_name.substr(solver_name.find('.') + 1);
 
         KRATOS_ERROR_IF_NOT(Has(solver_name))
             << "Trying to construct a Linear solver with solver_type:\n\""

--- a/kratos/factories/preconditioner_factory.h
+++ b/kratos/factories/preconditioner_factory.h
@@ -105,7 +105,7 @@ public:
     {
         // remove name of the application (if passed)
         // e.g. "LinearSolversApplication.sparse_lu" => "sparse_lu"
-        const std::string raw_precond_name = rPreconditionerType.substr(rPreconditionerType.find(".") + 1);
+        const std::string raw_precond_name = rPreconditionerType.substr(rPreconditionerType.find('.') + 1);
 
         KRATOS_ERROR_IF_NOT(Has(raw_precond_name))
             << "Trying to construct a preconditioner with preconditioner_type:\n\""

--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -49,7 +49,7 @@ ModelPart::ModelPart(std::string const& NewName, IndexType NewBufferSize,Variabl
 {
     KRATOS_ERROR_IF(NewName.empty()) << "Please don't use empty names (\"\") when creating a ModelPart" << std::endl;
 
-    KRATOS_ERROR_IF_NOT(NewName.find(".") == std::string::npos) << "Please don't use names containing (\".\") when creating a ModelPart (used in \"" << NewName << "\")" << std::endl;
+    KRATOS_ERROR_IF_NOT(NewName.find('.') == std::string::npos) << "Please don't use names containing (\".\") when creating a ModelPart (used in \"" << NewName << "\")" << std::endl;
 
     mName = NewName;
     MeshType mesh;

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -188,7 +188,7 @@ void ModelPartIO::WriteProperties(PropertiesContainerType const& rThisProperties
             std::string::size_type it_constitutive_law_begin = aux_string.find("CONSTITUTIVE_LAW");
 
             if (it_constitutive_law_begin != std::string::npos) {
-            std::string::size_type it_constitutive_law_end = aux_string.find("\n", it_constitutive_law_begin);
+            std::string::size_type it_constitutive_law_end = aux_string.find('\n', it_constitutive_law_begin);
                 aux_string.erase(it_constitutive_law_begin, it_constitutive_law_end);
             }
 

--- a/kratos/utilities/read_materials_utility.cpp
+++ b/kratos/utilities/read_materials_utility.cpp
@@ -501,8 +501,8 @@ void ReadMaterialsUtility::CheckUniqueMaterialAssignment(Parameters Materials)
         parent_model_part_name = model_part_names[i];
 
         // removing the submodelpart-names one-by-one
-        while (parent_model_part_name.find(".") != std::string::npos) {
-            std::size_t found_pos = parent_model_part_name.find_last_of(".");
+        while (parent_model_part_name.find('.') != std::string::npos) {
+            std::size_t found_pos = parent_model_part_name.find_last_of('.');
             parent_model_part_name = parent_model_part_name.substr(0, found_pos);
 
             for (IndexType j = 0; j < i; ++j) {


### PR DESCRIPTION
**📝 Description**

Optimize calls to std::string::find() and friends when the needle passed is a single character string literal. The character literal overload is more efficient.

**🆕 Changelog**

- [Improve find character for ModelPartIO](https://github.com/KratosMultiphysics/Kratos/commit/1d964a192814eaabbf2065ef9211f3337d765b05)
- [Improve find character for ModelPart](https://github.com/KratosMultiphysics/Kratos/commit/953a4479b7d27fe97d0a2c61a8a98a9fef506172)
- [Improve find character for factories](https://github.com/KratosMultiphysics/Kratos/commit/0ba8f7e966143c65b411ea09a3d180e695fe7d93)
- [Improve find character for Model](https://github.com/KratosMultiphysics/Kratos/commit/faa5ea7e26f0b8088bbbf8cfd7c1f114f54c9854)
- [Improve find character for ReadMaterialsUtility](https://github.com/KratosMultiphysics/Kratos/commit/84a5ab64d447bb78e75cd4aeb2936bb86ade784b)
