### PR TITLE
Extending the list of exclusions

### DIFF
--- a/.github/workflows/ci-dummy.yml
+++ b/.github/workflows/ci-dummy.yml
@@ -7,9 +7,10 @@ on:
   pull_request:
     branches:
       - master
-    paths: # this must be the same as .github/workflows/ci.yml - "paths-ignore" !
+    paths:              # This must be the same as .github/workflows/ci.yml - "paths-ignore" !
       - '**.md'
       - '/documents/**'
+      - '/scripts/**'
 
 jobs:
   ubuntu:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,10 @@ on:
   pull_request:
     branches:
       - master
-    paths-ignore: # this must be the same as .github/workflows/ci_dummy.yml - "paths" !
+    paths-ignore:       # This must be the same as .github/workflows/ci_dummy.yml - "paths" !
       - '**.md'
       - '/documents/**'
+      - '/scripts/**'   # Docker builds will be triggered by `build_docker_image_****.yml` workflows.
 
   workflow_dispatch:
 


### PR DESCRIPTION
**📝 Description**
As suggested in #10201. 

@sunethwarna I've notice that part of the CMake/python files for the generation of the python hints exist in this folder. We should move that inside the source, scripts folder content should not interact with the actual compilation (at most trigger it).

Dockerfile builds will still happen in other workflows.

**🆕 Changelog**
- Extending CI exclusion to scripts and docker files.
