### PR TITLE
[FastPR][Fluid] Minors in two-fluid alpha element

### DIFF
--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes_alpha_method.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes_alpha_method.cpp
@@ -77,7 +77,7 @@ Element::Pointer TwoFluidNavierStokesAlphaMethod<TElementData>::Create(
 template <>
 void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<2, 3>>::CalculateStrainRate(TwoFluidNavierStokesAlphaMethodData<2, 3>& rData) const
 {
-    const double alpha_f=1/(1+rData.MaxSprectraRadius);
+    const double alpha_f = 1/(1+rData.MaxSpectralRadius);
     const BoundedMatrix<double,3,2> velocity_alpha = rData.Velocity_OldStep1+ alpha_f*(rData.Velocity-rData.Velocity_OldStep1);
     auto& rDNDX = rData.DN_DX;
     auto& r_strain_rate = rData.StrainRate;
@@ -92,7 +92,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<2, 3>>:
 template <>
 void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<3, 4>>::CalculateStrainRate(TwoFluidNavierStokesAlphaMethodData<3, 4>& rData) const
 {
-    const double alpha_f=1/(1+rData.MaxSprectraRadius);
+    const double alpha_f = 1/(1+rData.MaxSpectralRadius);
     const BoundedMatrix<double,4,3> velocity_alpha = rData.Velocity_OldStep1+ alpha_f*(rData.Velocity-rData.Velocity_OldStep1);
     auto& rDNDX = rData.DN_DX;
     auto& r_strain_rate = rData.StrainRate;
@@ -120,12 +120,12 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<2, 3>>:
     const double dt = rData.DeltaTime;
 
     const double dyn_tau = rData.DynamicTau;
-    const double max_spectral_radius=rData.MaxSprectraRadius;
+    const double max_spectral_radius = rData.MaxSpectralRadius;
     const auto &v = rData.Velocity;
     const auto &vn = rData.Velocity_OldStep1;
     const auto &vmesh = rData.MeshVelocity;
     const auto &vmeshn = rData.MeshVelocityOldStep;
-    const double alpha_f=1/(1+rData.MaxSprectraRadius);
+    const double alpha_f = 1/(1+rData.MaxSpectralRadius);
     const BoundedMatrix<double,3,2> vconv =(vn-vmeshn)+ alpha_f*((v-vmesh)-(vn-vmeshn));
 
     // Get constitutive matrix
@@ -375,7 +375,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<3, 4>>:
     const double rho = rData.Density;
     const double mu = rData.EffectiveViscosity;
     const double h = rData.ElementSize;
-    const double max_spectral_radius=rData.MaxSprectraRadius;
+    const double max_spectral_radius = rData.MaxSpectralRadius;
     const double dt = rData.DeltaTime;
     const double alpha_f=1/(1+max_spectral_radius);
 
@@ -1041,7 +1041,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<2, 3>>:
 
     const double dt = rData.DeltaTime;
     const auto &acceleration_alpha_method=rData.AccelerationAlphaMethod;
-    const double max_spectral_radius=rData.MaxSprectraRadius;
+    const double max_spectral_radius = rData.MaxSpectralRadius;
     const double alpha_f=1/(1+max_spectral_radius);
 
     const double dyn_tau = rData.DynamicTau;
@@ -1066,7 +1066,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<2, 3>>:
     constexpr double stab_c2 = 2.0;
 
     // Mass correction term
-    const double volume_error_ratio = rData.VolumeError;
+    const double volume_error_ratio = rData.VolumeErrorRate;
 
     auto &rhs = rData.rhs;
 
@@ -1153,7 +1153,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<3, 4>>:
 
     const double h = rData.ElementSize;
     const auto &acceleration_alpha_method=rData.AccelerationAlphaMethod;
-    const double max_spectral_radius=rData.MaxSprectraRadius;
+    const double max_spectral_radius = rData.MaxSpectralRadius;
     const double dt = rData.DeltaTime;
     const double alpha_f=1/(1+max_spectral_radius);
     const double dyn_tau = rData.DynamicTau;
@@ -1177,7 +1177,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<3, 4>>:
     constexpr double stab_c2 = 2.0;
 
     // Mass correction term
-    const double volume_error_ratio = rData.VolumeError;
+    const double volume_error_ratio = rData.VolumeErrorRate;
 
     auto &rhs = rData.rhs;
 
@@ -1300,7 +1300,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<2, 3>>:
 
     const double h = rData.ElementSize;
     const auto &acceleration_alpha_method=rData.AccelerationAlphaMethod;
-    const double max_spectral_radius=rData.MaxSprectraRadius;
+    const double max_spectral_radius = rData.MaxSpectralRadius;
     const double dt = rData.DeltaTime;
     const double alpha_f=1/(1+max_spectral_radius);
 
@@ -1327,7 +1327,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<2, 3>>:
     constexpr double stab_c2 = 2.0;
 
     // Mass correction term
-    const double volume_error_ratio = rData.VolumeError;
+    const double volume_error_ratio = rData.VolumeErrorRate;
 
     auto &V = rData.V;
     auto &H = rData.H;
@@ -1480,7 +1480,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<3, 4>>:
 
     const double h = rData.ElementSize;
     const auto &acceleration_alpha_method=rData.AccelerationAlphaMethod;
-    const double max_spectral_radius=rData.MaxSprectraRadius;
+    const double max_spectral_radius = rData.MaxSpectralRadius;
     const double dt = rData.DeltaTime;
     const double alpha_f=1/(1-max_spectral_radius);
 
@@ -1507,7 +1507,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<3, 4>>:
     constexpr double stab_c2 = 2.0;
 
     // Mass correction term
-    const double volume_error_ratio = rData.VolumeError;
+    const double volume_error_ratio = rData.VolumeErrorRate;
 
     auto &V = rData.V;
     auto &H = rData.H;
@@ -1826,7 +1826,7 @@ void TwoFluidNavierStokesAlphaMethod<TElementData>::PressureGradientStabilizatio
     const double dt = rData.DeltaTime;
     const auto &v=rData.Velocity;
     const auto &vn = rData.Velocity_OldStep1;
-    const double alpha_m=0.5*((3-rData.MaxSprectraRadius)/(1+rData.MaxSprectraRadius));
+    const double alpha_m = 0.5*((3-rData.MaxSpectralRadius)/(1+rData.MaxSpectralRadius));
 
     const auto vmesh=rData.MeshVelocity;
     const auto vmeshn=rData.MeshVelocityOldStep;

--- a/applications/FluidDynamicsApplication/custom_utilities/two_fluid_navier_stokes_alpha_method_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/two_fluid_navier_stokes_alpha_method_data.h
@@ -52,7 +52,6 @@ typedef GeometryType::ShapeFunctionsGradientsType ShapeFunctionsGradientsType;
 NodalVectorData Velocity;
 NodalVectorData Velocity_OldStep1;
 NodalScalarData Pressure;
-NodalScalarData Pressure_OldStep1;
 NodalVectorData AccelerationAlphaMethod;
 
 NodalVectorData MeshVelocity;
@@ -74,8 +73,8 @@ double Density;
 double DynamicViscosity;
 double DeltaTime;		   // Time increment
 double DynamicTau;         // Dynamic tau considered in ASGS stabilization coefficients
-double VolumeError; //TODO: RENAME TO VolumeErrorTimeRatio
-double MaxSprectraRadius;
+double VolumeErrorRate;    // Mass loss time rate (m^3/s) to be used as source term in the mass conservation equation
+double MaxSpectralRadius;
 
 // Auxiliary containers for the symbolically-generated matrices
 BoundedMatrix<double,TNumNodes*(TDim+1),TNumNodes*(TDim+1)> lhs;
@@ -120,7 +119,6 @@ void Initialize(const Element& rElement, const ProcessInfo& rProcessInfo) overri
     this->FillFromHistoricalNodalData(Velocity,VELOCITY,r_geometry);
     this->FillFromHistoricalNodalData(Velocity_OldStep1,VELOCITY,r_geometry,1);
     this->FillFromHistoricalNodalData(Pressure,PRESSURE,r_geometry);
-    this->FillFromHistoricalNodalData(Pressure_OldStep1,PRESSURE,r_geometry,1);
 
     this->FillFromHistoricalNodalData(Distance, DISTANCE, r_geometry);
 
@@ -137,7 +135,7 @@ void Initialize(const Element& rElement, const ProcessInfo& rProcessInfo) overri
     this->FillFromNonHistoricalNodalData(AccelerationAlphaMethod,ACCELERATION,r_geometry);
     this->FillFromProcessInfo(DeltaTime,DELTA_TIME,rProcessInfo);
     this->FillFromProcessInfo(DynamicTau,DYNAMIC_TAU,rProcessInfo);
-    this->FillFromProcessInfo(MaxSprectraRadius,SPECTRAL_RADIUS_LIMIT,rProcessInfo);
+    this->FillFromProcessInfo(MaxSpectralRadius,SPECTRAL_RADIUS_LIMIT,rProcessInfo);
 
 
     noalias(lhs) = ZeroMatrix(TNumNodes*(TDim+1),TNumNodes*(TDim+1));
@@ -161,12 +159,16 @@ void Initialize(const Element& rElement, const ProcessInfo& rProcessInfo) overri
     // Also note that we do consider time varying time step but a constant theta (we incur in a small error when switching from BE to CN)
     // Note as well that there is a minus sign (this comes from the divergence sign)
     if (IsCut()) {
+        // Get the previous time increment. Note that we check its value in case the previous ProcessInfo is empty (e.g. first step)
         double previous_dt = rProcessInfo.GetPreviousTimeStepInfo()[DELTA_TIME];
+        if (previous_dt < 1.0e-12) {
+            previous_dt = rProcessInfo[DELTA_TIME];
+        }
+        // Get the absolute volume error from the ProcessInfo and calculate the time rate
         this->FillFromProcessInfo(VolumeError,VOLUME_ERROR,rProcessInfo);
-        // double ratio_dt = (1.0-theta)*previous_dt + theta*DeltaTime;
-        VolumeError /= -previous_dt;
+        VolumeErrorRate /= -previous_dt;
     } else {
-        VolumeError = 0.0;
+        VolumeErrorRate = 0.0;
     }
 
 }
@@ -270,7 +272,7 @@ void CalculateAirMaterialResponse() {
 
 void ComputeStrain()
 {
-    const double rho_inf=this->MaxSprectraRadius;
+    const double rho_inf=this->MaxSpectralRadius;
     const double alpha_f= 1/(rho_inf+1);
     const BoundedMatrix<double, TNumNodes, TDim>& v = Velocity_OldStep1+alpha_f*(Velocity-Velocity_OldStep1);
     const BoundedMatrix<double, TNumNodes, TDim>& DN = this->DN_DX;

--- a/applications/FluidDynamicsApplication/custom_utilities/two_fluid_navier_stokes_alpha_method_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/two_fluid_navier_stokes_alpha_method_data.h
@@ -165,7 +165,7 @@ void Initialize(const Element& rElement, const ProcessInfo& rProcessInfo) overri
             previous_dt = rProcessInfo[DELTA_TIME];
         }
         // Get the absolute volume error from the ProcessInfo and calculate the time rate
-        this->FillFromProcessInfo(VolumeError,VOLUME_ERROR,rProcessInfo);
+        this->FillFromProcessInfo(VolumeErrorRate,VOLUME_ERROR,rProcessInfo);
         VolumeErrorRate /= -previous_dt;
     } else {
         VolumeErrorRate = 0.0;

--- a/applications/FluidDynamicsApplication/symbolic_generation/two_fluid_navier_stokes/generate_two_fluid_navier_stokes.py
+++ b/applications/FluidDynamicsApplication/symbolic_generation/two_fluid_navier_stokes/generate_two_fluid_navier_stokes.py
@@ -65,7 +65,6 @@ for dim in dim_vector:
     vn = DefineMatrix('vn',nnodes,dim)          # Previous step velocity
     vnn = DefineMatrix('vnn',nnodes,dim)        # 2 previous step velocity
     p = DefineVector('p',nnodes)                # Pressure
-    pn = DefineVector('pn',nnodes)              # Previous step Pressure
     penr= DefineVector('penr',nnodes)	        # Enriched Pressure
 
     ## Test functions definition

--- a/applications/FluidDynamicsApplication/symbolic_generation/two_fluid_navier_stokes/two_fluid_navier_stokes_alpha_method_template.cpp
+++ b/applications/FluidDynamicsApplication/symbolic_generation/two_fluid_navier_stokes/two_fluid_navier_stokes_alpha_method_template.cpp
@@ -77,7 +77,7 @@ Element::Pointer TwoFluidNavierStokesAlphaMethod<TElementData>::Create(
 template <>
 void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<2, 3>>::CalculateStrainRate(TwoFluidNavierStokesAlphaMethodData<2, 3>& rData) const
 {
-    const double alpha_f=1/(1+rData.MaxSprectraRadius);
+    const double alpha_f = 1/(1+rData.MaxSpectralRadius);
     const BoundedMatrix<double,3,2> velocity_alpha = rData.Velocity_OldStep1+ alpha_f*(rData.Velocity-rData.Velocity_OldStep1);
     auto& rDNDX = rData.DN_DX;
     auto& r_strain_rate = rData.StrainRate;
@@ -92,7 +92,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<2, 3>>:
 template <>
 void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<3, 4>>::CalculateStrainRate(TwoFluidNavierStokesAlphaMethodData<3, 4>& rData) const
 {
-    const double alpha_f=1/(1+rData.MaxSprectraRadius);
+    const double alpha_f = 1/(1+rData.MaxSpectralRadius);
     const BoundedMatrix<double,4,3> velocity_alpha = rData.Velocity_OldStep1+ alpha_f*(rData.Velocity-rData.Velocity_OldStep1);
     auto& rDNDX = rData.DN_DX;
     auto& r_strain_rate = rData.StrainRate;
@@ -120,12 +120,12 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<2, 3>>:
     const double dt = rData.DeltaTime;
 
     const double dyn_tau = rData.DynamicTau;
-    const double max_spectral_radius=rData.MaxSprectraRadius;
+    const double max_spectral_radius = rData.MaxSpectralRadius;
     const auto &v = rData.Velocity;
     const auto &vn = rData.Velocity_OldStep1;
     const auto &vmesh = rData.MeshVelocity;
     const auto &vmeshn = rData.MeshVelocityOldStep;
-    const double alpha_f=1/(1+rData.MaxSprectraRadius);
+    const double alpha_f = 1/(1+rData.MaxSpectralRadius);
     const BoundedMatrix<double,3,2> vconv =(vn-vmeshn)+ alpha_f*((v-vmesh)-(vn-vmeshn));
 
     // Get constitutive matrix
@@ -155,7 +155,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<3, 4>>:
     const double rho = rData.Density;
     const double mu = rData.EffectiveViscosity;
     const double h = rData.ElementSize;
-    const double max_spectral_radius=rData.MaxSprectraRadius;
+    const double max_spectral_radius = rData.MaxSpectralRadius;
     const double dt = rData.DeltaTime;
     const double alpha_f=1/(1+max_spectral_radius);
 
@@ -200,7 +200,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<2, 3>>:
 
     const double dt = rData.DeltaTime;
     const auto &acceleration_alpha_method=rData.AccelerationAlphaMethod;
-    const double max_spectral_radius=rData.MaxSprectraRadius;
+    const double max_spectral_radius = rData.MaxSpectralRadius;
     const double alpha_f=1/(1+max_spectral_radius);
 
     const double dyn_tau = rData.DynamicTau;
@@ -225,7 +225,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<2, 3>>:
     constexpr double stab_c2 = 2.0;
 
     // Mass correction term
-    const double volume_error_ratio = rData.VolumeError;
+    const double volume_error_ratio = rData.VolumeErrorRate;
 
     auto &rhs = rData.rhs;
 
@@ -244,7 +244,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<3, 4>>:
 
     const double h = rData.ElementSize;
     const auto &acceleration_alpha_method=rData.AccelerationAlphaMethod;
-    const double max_spectral_radius=rData.MaxSprectraRadius;
+    const double max_spectral_radius = rData.MaxSpectralRadius;
     const double dt = rData.DeltaTime;
     const double alpha_f=1/(1+max_spectral_radius);
     const double dyn_tau = rData.DynamicTau;
@@ -268,7 +268,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<3, 4>>:
     constexpr double stab_c2 = 2.0;
 
     // Mass correction term
-    const double volume_error_ratio = rData.VolumeError;
+    const double volume_error_ratio = rData.VolumeErrorRate;
 
     auto &rhs = rData.rhs;
 
@@ -290,7 +290,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<2, 3>>:
 
     const double h = rData.ElementSize;
     const auto &acceleration_alpha_method=rData.AccelerationAlphaMethod;
-    const double max_spectral_radius=rData.MaxSprectraRadius;
+    const double max_spectral_radius = rData.MaxSpectralRadius;
     const double dt = rData.DeltaTime;
     const double alpha_f=1/(1+max_spectral_radius);
 
@@ -317,7 +317,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<2, 3>>:
     constexpr double stab_c2 = 2.0;
 
     // Mass correction term
-    const double volume_error_ratio = rData.VolumeError;
+    const double volume_error_ratio = rData.VolumeErrorRate;
 
     auto &V = rData.V;
     auto &H = rData.H;
@@ -354,7 +354,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<3, 4>>:
 
     const double h = rData.ElementSize;
     const auto &acceleration_alpha_method=rData.AccelerationAlphaMethod;
-    const double max_spectral_radius=rData.MaxSprectraRadius;
+    const double max_spectral_radius = rData.MaxSpectralRadius;
     const double dt = rData.DeltaTime;
     const double alpha_f=1/(1-max_spectral_radius);
 
@@ -381,7 +381,7 @@ void TwoFluidNavierStokesAlphaMethod<TwoFluidNavierStokesAlphaMethodData<3, 4>>:
     constexpr double stab_c2 = 2.0;
 
     // Mass correction term
-    const double volume_error_ratio = rData.VolumeError;
+    const double volume_error_ratio = rData.VolumeErrorRate;
 
     auto &V = rData.V;
     auto &H = rData.H;
@@ -480,7 +480,7 @@ void TwoFluidNavierStokesAlphaMethod<TElementData>::PressureGradientStabilizatio
     const double dt = rData.DeltaTime;
     const auto &v=rData.Velocity;
     const auto &vn = rData.Velocity_OldStep1;
-    const double alpha_m=0.5*((3-rData.MaxSprectraRadius)/(1+rData.MaxSprectraRadius));
+    const double alpha_m = 0.5*((3-rData.MaxSpectralRadius)/(1+rData.MaxSpectralRadius));
 
     const auto vmesh=rData.MeshVelocity;
     const auto vmeshn=rData.MeshVelocityOldStep;


### PR DESCRIPTION
**📝 Description**
Minor amendments in the two-fluid alpha element. Basically these are:
- Removing unused p_{n} pressure variable
- Fix typos and TODOs
- Check previous step time increment in the calculation of the volume error rate as a zero value yields a nan in the RHS calculation. This makes possible to reduce the buffer size from three to two in the alpha scheme case, which is the expected value.
