### PR TITLE
disable C++ non-standard compiler specific extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 project (KratosMultiphysics)
 cmake_minimum_required (VERSION 2.8.6)
 set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+set (CMAKE_CXX_EXTENSIONS OFF)
 
 # Setting some policies
 # No recursive dereferencing


### PR DESCRIPTION
**📝 Description**
Wanted to do this for a while, this should help with portability
