### PR TITLE
[Core][Analysis] Define _AdvanceTime in base analysis

### DIFF
--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -59,7 +59,7 @@ class AnalysisStage(object):
         It can be overridden by derived classes
         """
         while self.KeepAdvancingSolutionLoop():
-            self.time = self._GetSolver().AdvanceInTime(self.time)
+            self.time = self._AdvanceTime()
             self.InitializeSolutionStep()
             self._GetSolver().Predict()
             is_converged = self._GetSolver().SolveSolutionStep()
@@ -211,7 +211,13 @@ class AnalysisStage(object):
         """Create the solver
         """
         raise Exception("Creation of the solver must be implemented in the derived class.")
-
+        
+    def _AdvanceTime(self):
+        """ Computes the following time 
+            The default method simply calls the solver
+        """
+        return self._GetSolver().AdvanceInTime(self.time)
+    
     ### Modelers
     def _ModelersSetupGeometryModel(self):
         # Import or generate geometry models from external input.


### PR DESCRIPTION
**📝 Description**

In @KratosMultiphysics/altair  we define in the analysis the method _AdvanceTime, which by default calls the method from the solver as it is done right now in the base analysis class. I think unifying interfaces could benefit, reducing code duplication and extending modularity of current analysis

**🆕 Changelog**

- Define _AdvanceTime in base analysis
