### PR TITLE
[CoSimulationApplication] Allowing direct parameters instead of input_file

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/solver_wrappers/kratos/kratos_base_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/solver_wrappers/kratos/kratos_base_wrapper.py
@@ -33,12 +33,16 @@ class KratosBaseWrapper(CoSimulationSolverWrapper):
     It uses the AnalysisStage as black-box interface to Kratos
     """
     def __init__(self, settings, model, solver_name):
-        input_file_name = settings["solver_wrapper_settings"]["input_file"].GetString()
-        if not input_file_name.endswith(".json"):
-            input_file_name += ".json"
+        # We try to read the input file
+        if settings["solver_wrapper_settings"].Has("input_file"):
+            input_file_name = settings["solver_wrapper_settings"]["input_file"].GetString()
+            if not input_file_name.endswith(".json"):
+                input_file_name += ".json"
 
-        with open(input_file_name,'r') as parameter_file:
-            self.project_parameters = KM.Parameters(parameter_file.read())
+            with open(input_file_name,'r') as parameter_file:
+                self.project_parameters = KM.Parameters(parameter_file.read())
+        else: # The settings are in the root Parameters
+            self.project_parameters = settings["solver_wrapper_settings"]
 
         super().__init__(settings, model, solver_name)
 


### PR DESCRIPTION
**📝 Description**

Allowing direct parameters instead of input_file. This will allow defining everything in one file (or using the future includes). This is because in @KratosMultiphysics/altair we like to have all the settings in one Parameter object that at the end of the simulation is exported (with all the missing parameters added), so we can know exactly what consisted the whole input.

**🆕 Changelog**

- [Allowing direct parameters instead of input_file](https://github.com/KratosMultiphysics/Kratos/commit/3f355780661d4059a8adf38e387b827796076c40)
