### PR TITLE
[Core][ReorderConsecutiveModelPartIO] inherit constructors

### DIFF
--- a/kratos/includes/reorder_consecutive_model_part_io.h
+++ b/kratos/includes/reorder_consecutive_model_part_io.h
@@ -10,35 +10,15 @@
 //  Main authors:    Pooyan Dadvand
 //
 
-
-
-
-
-
-
-
-
-
-
-
 #if !defined(KRATOS_REORDER_CONSECUTIVE_MODEL_PART_IO_H_INCLUDED )
 #define  KRATOS_REORDER_CONSECUTIVE_MODEL_PART_IO_H_INCLUDED
 
-
-
 // System includes
-#include <string>
-#include <fstream>
-#include <set>
-
 
 // External includes
 
-
 // Project includes
-#include "includes/define.h"
 #include "includes/model_part_io.h"
-#include "utilities/timer.h"
 
 
 namespace Kratos
@@ -93,7 +73,7 @@ public:
 
     typedef BaseType::OutputFilesContainerType OutputFilesContainerType;
 
-	typedef std::map<SizeType, SizeType> IdMapType;
+    typedef std::map<SizeType, SizeType> IdMapType;
 
     typedef std::size_t SizeType;
 
@@ -101,10 +81,13 @@ public:
     ///@name Life Cycle
     ///@{
 
-    /// Constructor with  filenames.
-	ReorderConsecutiveModelPartIO(
-        std::string const& Filename,
-        const Flags Options = IO::READ | IO::IGNORE_VARIABLES_ERROR.AsFalse());
+    // inherit constructors of baseclass
+    using ModelPartIO::ModelPartIO;
+
+    // this (inherited) constructor cannot be used with this class
+    ReorderConsecutiveModelPartIO(
+        Kratos::shared_ptr<std::iostream> Stream,
+        const Flags Options) = delete;
 
     ///@}
     ///@name Operators
@@ -123,9 +106,9 @@ protected:
 
     ///@}
     ///@name Protected member Variables
-	SizeType mNumberOfNodes = 0;
-	SizeType mNumberOfElements = 0;
-	SizeType mNumberOfConditions = 0;
+    SizeType mNumberOfNodes = 0;
+    SizeType mNumberOfElements = 0;
+    SizeType mNumberOfConditions = 0;
     ///@{
 
 
@@ -139,9 +122,9 @@ protected:
     ///@{
 
 
-	SizeType ReorderedNodeId(ModelPartIO::SizeType NodeId) override;
-	SizeType ReorderedElementId(ModelPartIO::SizeType ElementId) override;
-	SizeType ReorderedConditionId(ModelPartIO::SizeType ConditionId) override;
+    SizeType ReorderedNodeId(ModelPartIO::SizeType NodeId) override;
+    SizeType ReorderedElementId(ModelPartIO::SizeType ElementId) override;
+    SizeType ReorderedConditionId(ModelPartIO::SizeType ConditionId) override;
 
     ///@}
     ///@name Protected  Access
@@ -165,9 +148,9 @@ private:
     ///@name Member Variables
     ///@{
 
-	IdMapType mNodeIdMap = {};
-	IdMapType mElementIdMap = {};
-	IdMapType mConditionIdMap = {};
+    IdMapType mNodeIdMap = {};
+    IdMapType mElementIdMap = {};
+    IdMapType mConditionIdMap = {};
 
     ///@}
     ///@name Private  Access

--- a/kratos/sources/reorder_consecutive_model_part_io.cpp
+++ b/kratos/sources/reorder_consecutive_model_part_io.cpp
@@ -10,59 +10,41 @@
 //  Main authors:    Pooyan Dadvand
 //
 
-
-
-
-
-
-
-
-
-
-
-
 // Project includes
 #include "includes/reorder_consecutive_model_part_io.h"
 
 
-
 namespace Kratos
 {
-    /// Constructor with  filenames.
-    ReorderConsecutiveModelPartIO::ReorderConsecutiveModelPartIO(std::string const& Filename, const Flags Options )
-        : ModelPartIO(Filename, Options)
-    {
-    }
-	ModelPartIO::SizeType ReorderConsecutiveModelPartIO::ReorderedNodeId(ModelPartIO::SizeType NodeId)
-	{
-		IdMapType::iterator i = mNodeIdMap.find(NodeId);
-		if(i != mNodeIdMap.end())
-			return i->second;
 
-		mNodeIdMap.insert(IdMapType::value_type(NodeId, ++mNumberOfNodes));
-		return mNumberOfNodes;
-	}
-	ModelPartIO::SizeType ReorderConsecutiveModelPartIO::ReorderedElementId(ModelPartIO::SizeType ElementId)
-	{
-		IdMapType::iterator i = mElementIdMap.find(ElementId);
-		if(i != mElementIdMap.end())
-			return i->second;
+ModelPartIO::SizeType ReorderConsecutiveModelPartIO::ReorderedNodeId(ModelPartIO::SizeType NodeId)
+{
+    IdMapType::iterator i = mNodeIdMap.find(NodeId);
+    if(i != mNodeIdMap.end())
+        return i->second;
 
-		mElementIdMap.insert(IdMapType::value_type(ElementId, ++mNumberOfElements));
-		return mNumberOfElements;
-	}
+    mNodeIdMap.insert(IdMapType::value_type(NodeId, ++mNumberOfNodes));
+    return mNumberOfNodes;
+}
 
-	ModelPartIO::SizeType ReorderConsecutiveModelPartIO::ReorderedConditionId(ModelPartIO::SizeType ConditionId)
-	{
-		IdMapType::iterator i = mConditionIdMap.find(ConditionId);
-		if(i != mConditionIdMap.end())
-			return i->second;
+ModelPartIO::SizeType ReorderConsecutiveModelPartIO::ReorderedElementId(ModelPartIO::SizeType ElementId)
+{
+    IdMapType::iterator i = mElementIdMap.find(ElementId);
+    if(i != mElementIdMap.end())
+        return i->second;
 
-		mConditionIdMap.insert(IdMapType::value_type(ConditionId, ++mNumberOfConditions));
-		return mNumberOfConditions;
-	}
+    mElementIdMap.insert(IdMapType::value_type(ElementId, ++mNumberOfElements));
+    return mNumberOfElements;
+}
 
+ModelPartIO::SizeType ReorderConsecutiveModelPartIO::ReorderedConditionId(ModelPartIO::SizeType ConditionId)
+{
+    IdMapType::iterator i = mConditionIdMap.find(ConditionId);
+    if(i != mConditionIdMap.end())
+        return i->second;
 
+    mConditionIdMap.insert(IdMapType::value_type(ConditionId, ++mNumberOfConditions));
+    return mNumberOfConditions;
+}
 
-}  // namespace Kratos.
-
+} // namespace Kratos.


### PR DESCRIPTION
using new C++ features to inherit the Constructors

=> this way code duplication is reduced
This is also a bugfix, as the default flags were changed at some point in the baseclass but not in the derived one
