### PR TITLE
[Core] Move ExecuteBeforeSolutionLoop just before executing solution loop in base analysis

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/co_simulation_analysis.py
+++ b/applications/CoSimulationApplication/python_scripts/co_simulation_analysis.py
@@ -53,6 +53,9 @@ class CoSimulationAnalysis(AnalysisStage):
         else:
             # flush by default only in OpenMP, can decrease performance in MPI
             self.flush_stdout = (self.parallel_type == "OpenMP")
+        
+        # Define a dummy list of processes, since the baseclass expects it
+        self._list_of_processes = []
 
         self._GetSolver() # this creates the solver
 

--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -58,6 +58,11 @@ class AnalysisStage(object):
         """This function executes the solution loop of the AnalysisStage
         It can be overridden by derived classes
         """
+        # We execute the processes before the solution loop
+        for process in self._GetListOfProcesses():
+            process.ExecuteBeforeSolutionLoop()
+
+        # Now we execute the solution loop
         while self.KeepAdvancingSolutionLoop():
             self.time = self._GetSolver().AdvanceInTime(self.time)
             self.InitializeSolutionStep()
@@ -94,9 +99,6 @@ class AnalysisStage(object):
         self.Check()
 
         self.ModifyAfterSolverInitialize()
-
-        for process in self._GetListOfProcesses():
-            process.ExecuteBeforeSolutionLoop()
 
         ## Stepping and time settings
         self.end_time = self.project_parameters["problem_data"]["end_time"].GetDouble()


### PR DESCRIPTION
**📝 Description**

As in #10217, this PR is a minor change in the base analysis class in order to unify what we do in @KratosMultiphysics/altair. A priori with this change there should not be any significant change. 

**🆕 Changelog**

- Move ExecuteBeforeSolutionLoop just before executing solution loop in base analysis
