### PR TITLE
[CoSimulationApplication] Adding custom base class to coupling solvers

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
@@ -14,8 +14,6 @@ from KratosMultiphysics.CoSimulationApplication.coupling_interface_data import B
 # Other imports
 from collections import OrderedDict
 
-def Create(settings = None, models = None, solver_name = None, base_type = None):
-    return CoSimulationCoupledSolver(settings, models, solver_name)
 
 class UndefinedSolver:
     def __init__(self, name, settings):
@@ -52,55 +50,54 @@ class CoSimulationCoupledSolver(CoSimulationSolverWrapper):
     - Synchronization of Input and Output
     - Handles the coupling sequence
     """
-    def __init__(self, settings = None, models = None, solver_name = None):
-        if isinstance(settings, KM.Parameters):
-            # Perform some initial checks
-            if not settings.Has("coupling_sequence"):
-                err_msg  = 'No "coupling_sequence" was specified for coupled solver\n'
-                err_msg += '"{}" of type "{}"'.format(solver_name, self._ClassName())
-                raise Exception(err_msg)
+    def __init__(self, settings, models, solver_name):
+        # perform some initial checks
+        if not settings.Has("coupling_sequence"):
+            err_msg  = 'No "coupling_sequence" was specified for coupled solver\n'
+            err_msg += '"{}" of type "{}"'.format(solver_name, self._ClassName())
+            raise Exception(err_msg)
 
-            if settings["coupling_sequence"].size() == 0:
-                err_msg  = '"coupling_sequence" is empty for coupled solver\n'
-                err_msg += '"{}" of type "{}"'.format(solver_name, self._ClassName())
-                raise Exception(err_msg)
+        if settings["coupling_sequence"].size() == 0:
+            err_msg  = '"coupling_sequence" is empty for coupled solver\n'
+            err_msg += '"{}" of type "{}"'.format(solver_name, self._ClassName())
+            raise Exception(err_msg)
 
-            if not settings.Has("solvers"):
-                err_msg  = 'No "solvers" are specified for coupled solver\n'
-                err_msg += '"{}" of type "{}"'.format(solver_name, self._ClassName())
-                raise Exception(err_msg)
+        if not settings.Has("solvers"):
+            err_msg  = 'No "solvers" are specified for coupled solver\n'
+            err_msg += '"{}" of type "{}"'.format(solver_name, self._ClassName())
+            raise Exception(err_msg)
 
-            if len(settings["solvers"].keys()) == 0:
-                err_msg  = '"solvers" is empty for coupled solver\n'
-                err_msg += '"{}" of type "{}"'.format(solver_name, self._ClassName())
-                raise Exception(err_msg)
+        if len(settings["solvers"].keys()) == 0:
+            err_msg  = '"solvers" is empty for coupled solver\n'
+            err_msg += '"{}" of type "{}"'.format(solver_name, self._ClassName())
+            raise Exception(err_msg)
 
-            if not isinstance(models, dict) and not models is None:
-                err_msg  = 'A coupled solver can either be passed a dict of Models\n'
-                err_msg += 'or None, got object of type "{}"'.format(type(models))
-                raise Exception(err_msg)
+        if not isinstance(models, dict) and not models is None:
+            err_msg  = 'A coupled solver can either be passed a dict of Models\n'
+            err_msg += 'or None, got object of type "{}"'.format(type(models))
+            raise Exception(err_msg)
 
-            super().__init__(settings, None, solver_name)
+        super().__init__(settings, None, solver_name)
 
-            self.process_info = KM.ProcessInfo()
+        self.process_info = KM.ProcessInfo()
 
-            # TODO initialize this in a restart
-            self.process_info[KM.STEP] = 0
-            self.process_info[KM.TIME] = 0.0
-            self.process_info[KM.IS_RESTARTED] = False
+        # TODO initialize this in a restart
+        self.process_info[KM.STEP] = 0
+        self.process_info[KM.TIME] = 0.0
+        self.process_info[KM.IS_RESTARTED] = False
 
-            self.solver_wrappers = self.__CreateSolverWrappers(models)
+        self.solver_wrappers = self.__CreateSolverWrappers(models)
 
-            # overwriting the Model created in the BaseClass
-            # CoupledSolvers only forward calls to its solvers
-            # this is done with the ModelAccessor
-            self.model = ModelAccessor(self.solver_wrappers)
+        # overwriting the Model created in the BaseClass
+        # CoupledSolvers only forward calls to its solvers
+        # this is done with the ModelAccessor
+        self.model = ModelAccessor(self.solver_wrappers)
 
-            self.coupling_sequence = self.__GetSolverCoSimulationDetails()
+        self.coupling_sequence = self.__GetSolverCoSimulationDetails()
 
-            for solver in self.solver_wrappers.values():
-                solver.CreateIO(self.echo_level)
-                # using the echo_level of the coupled solver, since IO is needed by the coupling
+        for solver in self.solver_wrappers.values():
+            solver.CreateIO(self.echo_level)
+            # using the echo_level of the coupled solver, since IO is needed by the coupling
 
     def _GetSolver(self, solver_name):
         solver_name, *sub_solver_names = solver_name.split(".")

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
@@ -160,6 +160,7 @@ class CoSimulationSolverWrapper:
     def _GetDefaultParameters(cls):
         return KM.Parameters("""{
             "type"                    : "",
+            "base_type"               : "",
             "solver_wrapper_settings" : {},
             "io_settings"             : {},
             "data"                    : {},

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
@@ -159,7 +159,7 @@ class CoSimulationSolverWrapper:
     def _GetDefaultParameters(cls):
         return KM.Parameters("""{
             "type"                    : "",
-            "base_type"               : "",
+            "base_type"               : {},
             "solver_wrapper_settings" : {},
             "io_settings"             : {},
             "data"                    : {},

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
@@ -83,7 +83,6 @@ class CoSimulationSolverWrapper:
     def SolveSolutionStep(self):
         pass
 
-
     def CreateIO(self, io_echo_level):
         if self.__HasIO():
             raise Exception('IO for solver "{}" is already created!'.format(self.name))

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/feti_dynamic_coupled_solver.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/feti_dynamic_coupled_solver.py
@@ -13,7 +13,7 @@ def Create(settings, models, solver_name, base_class = CoSimulationCoupledSolver
     return GetFetiDynamicCoupledSolver(base_class)(settings, models, solver_name)
 
 def GetFetiDynamicCoupledSolver(base):
-    class FetiDynamicCoupledSolver(CoSimulationCoupledSolver):
+    class FetiDynamicCoupledSolver(base):
         def __init__(self, settings, models, solver_name):
             super().__init__(settings, models, solver_name)
 

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/feti_dynamic_coupled_solver.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/feti_dynamic_coupled_solver.py
@@ -9,262 +9,265 @@ from KratosMultiphysics.CoSimulationApplication.base_classes.co_simulation_coupl
 # Other imports
 from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory
 
-def Create(settings, models, solver_name):
-    return FetiDynamicCoupledSolver(settings, models, solver_name)
+def Create(settings, models, solver_name, base_class = CoSimulationCoupledSolver):
+    return GetFetiDynamicCoupledSolver(base_class)(settings, models, solver_name)
 
-class FetiDynamicCoupledSolver(CoSimulationCoupledSolver):
-    def __init__(self, settings, models, solver_name):
-        super().__init__(settings, models, solver_name)
+def GetFetiDynamicCoupledSolver(base):
+    class TemplatedFetiDynamicCoupledSolver(CoSimulationCoupledSolver):
+        def __init__(self, settings, models, solver_name):
+            super().__init__(settings, models, solver_name)
 
-        if len(self.solver_wrappers.items()) != 2:
-            raise Exception("FETI solver only works with two solvers!")
+            if len(self.solver_wrappers.items()) != 2:
+                raise Exception("FETI solver only works with two solvers!")
 
-        # Add solution step variables while models are empty
-        self.__CheckSolversCompatibility()
-        self.__AddNodalSolutionStepVariables()
-        self.is_initial_step = True
+            # Add solution step variables while models are empty
+            self.__CheckSolversCompatibility()
+            self.__AddNodalSolutionStepVariables()
+            self.is_initial_step = True
 
-    def Initialize(self):
-        super().Initialize()
+        def Initialize(self):
+            super().Initialize()
 
-    def AdvanceInTime(self, current_time):
-        # The CoSimulation runs at the SMALLEST Timestep.
-        # The solver with the smallest timestep will dictate the CoSimulation.
-        # The solver(s) with the larger timesteps will be called only at times that match their time
-        advanced_time = current_time
-        self.departing_time = current_time # the time we are departing from - this is used to sync everything
+        def AdvanceInTime(self, current_time):
+            # The CoSimulation runs at the SMALLEST Timestep.
+            # The solver with the smallest timestep will dictate the CoSimulation.
+            # The solver(s) with the larger timesteps will be called only at times that match their time
+            advanced_time = current_time
+            self.departing_time = current_time # the time we are departing from - this is used to sync everything
 
-        if self.is_initial_step:
-            self._solver_delta_times = {}
-            advanced_time = 1E20
-            for solver_name, solver in self.solver_wrappers.items():
-                self._solver_delta_times[solver_name] = solver.AdvanceInTime(current_time)
-                advanced_time = min(advanced_time,self._solver_delta_times[solver_name])
+            if self.is_initial_step:
+                self._solver_delta_times = {}
+                advanced_time = 1E20
+                for solver_name, solver in self.solver_wrappers.items():
+                    self._solver_delta_times[solver_name] = solver.AdvanceInTime(current_time)
+                    advanced_time = min(advanced_time,self._solver_delta_times[solver_name])
 
-            self.is_initial_step = False
+                self.is_initial_step = False
 
-            # Initialize the FETI utilites
-            self.__InitializeFetiMethod()
-        else:
+                # Initialize the FETI utilites
+                self.__InitializeFetiMethod()
+            else:
+                for solver_name, solver in self.solver_wrappers.items():
+                    if self.SolverSolvesAtThisTime(solver_name):
+                        solver_time = solver.AdvanceInTime(self.departing_time)
+                        if self._solver_origin_dest_dict[solver_name] == CoSim.FetiSolverIndexType.Destination:
+                            advanced_time = solver_time #only advance global time finely
+
+            if advanced_time == current_time:
+                raise Exception("No solvers advanced any timestep.")
+            else:
+                return advanced_time
+
+        def SolverSolvesAtThisTime(self, solver_name):
+            solver_delta_time = self._solver_delta_times[solver_name]
+            # the following only works if timesteps are multiple of each other
+            time_error = (self.departing_time % solver_delta_time)
+            if time_error < 1E-12 or abs(time_error - solver_delta_time) < 1E-12:
+                return True
+            else:
+                return False
+
+        def InitializeSolutionStep(self):
             for solver_name, solver in self.solver_wrappers.items():
                 if self.SolverSolvesAtThisTime(solver_name):
-                    solver_time = solver.AdvanceInTime(self.departing_time)
-                    if self._solver_origin_dest_dict[solver_name] == CoSim.FetiSolverIndexType.Destination:
-                        advanced_time = solver_time #only advance global time finely
+                    solver.InitializeSolutionStep()
 
-        if advanced_time == current_time:
-            raise Exception("No solvers advanced any timestep.")
-        else:
-            return advanced_time
+            for coupling_op_name, coupling_op in self.coupling_operations_dict.items():
+                if self.__CouplingOpActsNow(coupling_op_name):
+                    coupling_op.InitializeSolutionStep()
 
-    def SolverSolvesAtThisTime(self, solver_name):
-        solver_delta_time = self._solver_delta_times[solver_name]
-        # the following only works if timesteps are multiple of each other
-        time_error = (self.departing_time % solver_delta_time)
-        if time_error < 1E-12 or abs(time_error - solver_delta_time) < 1E-12:
+        def Predict(self):
+            for solver_name, solver in self.solver_wrappers.items():
+                if self.SolverSolvesAtThisTime(solver_name):
+                    solver.Predict()
+
+        def FinalizeSolutionStep(self):
+            for solver_name, solver in self.solver_wrappers.items():
+                if self.SolverSolvesAtThisTime(solver_name):
+                    solver.FinalizeSolutionStep()
+
+            for coupling_op_name, coupling_op in self.coupling_operations_dict.items():
+                if self.__CouplingOpActsNow(coupling_op_name):
+                    coupling_op.FinalizeSolutionStep()
+
+        def OutputSolutionStep(self):
+            for solver_name, solver in self.solver_wrappers.items():
+                if self.SolverSolvesAtThisTime(solver_name):
+                    solver.OutputSolutionStep()
+
+        def SolveSolutionStep(self):
+            for coupling_op_name, coupling_op in self.coupling_operations_dict.items():
+                if self.__CouplingOpActsNow(coupling_op_name):
+                    coupling_op.InitializeCouplingIteration()
+
+            for solver_name, solver in self.solver_wrappers.items():
+                if self.SolverSolvesAtThisTime(solver_name):
+                    #self._SynchronizeInputData(solver_name) @phil not needed since corrections are applied within the feti cpp
+                    solver.SolveSolutionStep()
+                    #self._SynchronizeOutputData(solver_name) @phil not needed since corrections are applied within the feti cpp
+                    self.__SendStiffnessMatrixToUtility(solver_name)
+
+            self.feti_coupling.EquilibrateDomains()
+
+            for coupling_op_name, coupling_op in self.coupling_operations_dict.items():
+                if self.__CouplingOpActsNow(coupling_op_name):
+                    coupling_op.FinalizeCouplingIteration()
+
             return True
-        else:
-            return False
 
-    def InitializeSolutionStep(self):
-        for solver_name, solver in self.solver_wrappers.items():
-            if self.SolverSolvesAtThisTime(solver_name):
-                solver.InitializeSolutionStep()
+        def __AddNodalSolutionStepVariables(self):
+            for solver_name, solver in self.solver_wrappers.items():
+                structure = solver.model.GetModelPart("Structure")
+                structure.AddNodalSolutionStepVariable(KM.VECTOR_LAGRANGE_MULTIPLIER)
 
-        for coupling_op_name, coupling_op in self.coupling_operations_dict.items():
-            if self.__CouplingOpActsNow(coupling_op_name):
-                coupling_op.InitializeSolutionStep()
+        def __InitializeFetiMethod(self):
+            # Create vector of solver indices for convenience
+            self.__CreateSolverOriginDestDict()
 
-    def Predict(self):
-        for solver_name, solver in self.solver_wrappers.items():
-            if self.SolverSolvesAtThisTime(solver_name):
-                solver.Predict()
+            # Check timestep ratio is valid and add to settings
+            timestep_ratio = self._CalculateAndCheckTimestepRatio()
+            self.settings.AddInt('timestep_ratio',int(timestep_ratio))
 
-    def FinalizeSolutionStep(self):
-        for solver_name, solver in self.solver_wrappers.items():
-            if self.SolverSolvesAtThisTime(solver_name):
-                solver.FinalizeSolutionStep()
+            # get mapper parameters
+            self.mapper_parameters = self.data_transfer_operators_dict["mapper"].settings["mapper_settings"]
+            mapper_type = self.mapper_parameters["mapper_type"].GetString()
 
-        for coupling_op_name, coupling_op in self.coupling_operations_dict.items():
-            if self.__CouplingOpActsNow(coupling_op_name):
-                coupling_op.FinalizeSolutionStep()
+            # get mapper origin and destination modelparts
+            origin_modelpart_name = self.mapper_parameters["modeler_parameters"]["origin_interface_sub_model_part_name"].GetString()
+            destination_modelpart_name = self.mapper_parameters["modeler_parameters"]["destination_interface_sub_model_part_name"].GetString()
+            for solver_name, solver in self.solver_wrappers.items():
+                if self._solver_origin_dest_dict[solver_name] == CoSim.FetiSolverIndexType.Origin:
+                    self.model_part_origin_interface = self.solver_wrappers[solver_name].model.GetModelPart(origin_modelpart_name)
+                else:
+                    self.model_part_destination_interface = self.solver_wrappers[solver_name].model.GetModelPart(destination_modelpart_name)
 
-    def OutputSolutionStep(self):
-        for solver_name, solver in self.solver_wrappers.items():
-            if self.SolverSolvesAtThisTime(solver_name):
-                solver.OutputSolutionStep()
+            # manually create mapper
+            mapper_create_fct = KratosMapping.MapperFactory.CreateMapper
+            self.mapper = mapper_create_fct(self.model_part_origin_interface, self.model_part_destination_interface, self.mapper_parameters.Clone())
 
-    def SolveSolutionStep(self):
-        for coupling_op_name, coupling_op in self.coupling_operations_dict.items():
-            if self.__CouplingOpActsNow(coupling_op_name):
-                coupling_op.InitializeCouplingIteration()
+            # get interface modelparts created by the mapper modeler
+            self.modelpart_interface_origin_from_mapper = self.mapper.GetInterfaceModelPartOrigin()
+            self.modelpart_interface_destination_from_mapper = self.mapper.GetInterfaceModelPartDestination()
 
-        for solver_name, solver in self.solver_wrappers.items():
-            if self.SolverSolvesAtThisTime(solver_name):
-                #self._SynchronizeInputData(solver_name) @phil not needed since corrections are applied within the feti cpp
-                solver.SolveSolutionStep()
-                #self._SynchronizeOutputData(solver_name) @phil not needed since corrections are applied within the feti cpp
-                self.__SendStiffnessMatrixToUtility(solver_name)
+            # Create feti class instance
+            self.feti_coupling = CoSim.FetiDynamicCouplingUtilities(
+                self.modelpart_interface_origin_from_mapper,
+                self.modelpart_interface_destination_from_mapper,
+                self.settings)
 
-        self.feti_coupling.EquilibrateDomains()
-
-        for coupling_op_name, coupling_op in self.coupling_operations_dict.items():
-            if self.__CouplingOpActsNow(coupling_op_name):
-                coupling_op.FinalizeCouplingIteration()
-
-        return True
-
-    def __AddNodalSolutionStepVariables(self):
-        for solver_name, solver in self.solver_wrappers.items():
-            structure = solver.model.GetModelPart("Structure")
-            structure.AddNodalSolutionStepVariable(KM.VECTOR_LAGRANGE_MULTIPLIER)
-
-    def __InitializeFetiMethod(self):
-        # Create vector of solver indices for convenience
-        self.__CreateSolverOriginDestDict()
-
-        # Check timestep ratio is valid and add to settings
-        timestep_ratio = self._CalculateAndCheckTimestepRatio()
-        self.settings.AddInt('timestep_ratio',int(timestep_ratio))
-
-        # get mapper parameters
-        self.mapper_parameters = self.data_transfer_operators_dict["mapper"].settings["mapper_settings"]
-        mapper_type = self.mapper_parameters["mapper_type"].GetString()
-
-        # get mapper origin and destination modelparts
-        origin_modelpart_name = self.mapper_parameters["modeler_parameters"]["origin_interface_sub_model_part_name"].GetString()
-        destination_modelpart_name = self.mapper_parameters["modeler_parameters"]["destination_interface_sub_model_part_name"].GetString()
-        for solver_name, solver in self.solver_wrappers.items():
-            if self._solver_origin_dest_dict[solver_name] == CoSim.FetiSolverIndexType.Origin:
-                self.model_part_origin_interface = self.solver_wrappers[solver_name].model.GetModelPart(origin_modelpart_name)
+            # set the mapper
+            if mapper_type == "coupling_geometry":
+                self.feti_coupling.SetMappingMatrix(self.mapper.GetMappingMatrix())
             else:
-                self.model_part_destination_interface = self.solver_wrappers[solver_name].model.GetModelPart(destination_modelpart_name)
+                raise Exception("Dynamic coupled solver currently only compatible with the coupling_geometry mapper.")
 
-        # manually create mapper
-        mapper_create_fct = KratosMapping.MapperFactory.CreateMapper
-        self.mapper = mapper_create_fct(self.model_part_origin_interface, self.model_part_destination_interface, self.mapper_parameters.Clone())
+            # The origin and destination interfaces from the mapper submitted above are both
+            # stored within the origin modelpart. Now we submit the 'original' origin and destination
+            # interface model parts stored on the origin and destination models to get access to the
+            # origin and destination models.
+            self.feti_coupling.SetOriginAndDestinationDomainsWithInterfaceModelParts(
+                self.model_part_origin_interface,
+                self.model_part_destination_interface)
 
-        # get interface modelparts created by the mapper modeler
-        self.modelpart_interface_origin_from_mapper = self.mapper.GetInterfaceModelPartOrigin()
-        self.modelpart_interface_destination_from_mapper = self.mapper.GetInterfaceModelPartDestination()
+            # create the solver
+            linear_solver = self._CreateLinearSolver()
+            self.feti_coupling.SetLinearSolver(linear_solver)
 
-        # Create feti class instance
-        self.feti_coupling = CoSim.FetiDynamicCouplingUtilities(
-            self.modelpart_interface_origin_from_mapper,
-            self.modelpart_interface_destination_from_mapper,
-            self.settings)
+            # Set origin initial velocities
+            self.feti_coupling.SetOriginInitialKinematics()
 
-        # set the mapper
-        if mapper_type == "coupling_geometry":
-            self.feti_coupling.SetMappingMatrix(self.mapper.GetMappingMatrix())
-        else:
-            raise Exception("Dynamic coupled solver currently only compatible with the coupling_geometry mapper.")
+            # Create output-solver relation dict to ensure mixed timestep ouput is handled properly
+            self.__CreateOutputSolverDict()
 
-        # The origin and destination interfaces from the mapper submitted above are both
-        # stored within the origin modelpart. Now we submit the 'original' origin and destination
-        # interface model parts stored on the origin and destination models to get access to the
-        # origin and destination models.
-        self.feti_coupling.SetOriginAndDestinationDomainsWithInterfaceModelParts(
-            self.model_part_origin_interface,
-            self.model_part_destination_interface)
+        def __CreateSolverOriginDestDict(self):
+            self._solver_origin_dest_dict = {}
+            for solver_index in range(self.settings["coupling_sequence"].size()):
+                ordered_solver_name = self.settings["coupling_sequence"][solver_index]["name"].GetString()
+                if solver_index == 0:
+                    self._solver_origin_dest_dict[ordered_solver_name] = CoSim.FetiSolverIndexType.Origin
+                else:
+                    self._solver_origin_dest_dict[ordered_solver_name] = CoSim.FetiSolverIndexType.Destination
 
-        # create the solver
-        linear_solver = self._CreateLinearSolver()
-        self.feti_coupling.SetLinearSolver(linear_solver)
-
-        # Set origin initial velocities
-        self.feti_coupling.SetOriginInitialKinematics()
-
-        # Create output-solver relation dict to ensure mixed timestep ouput is handled properly
-        self.__CreateOutputSolverDict()
-
-    def __CreateSolverOriginDestDict(self):
-        self._solver_origin_dest_dict = {}
-        for solver_index in range(self.settings["coupling_sequence"].size()):
-            ordered_solver_name = self.settings["coupling_sequence"][solver_index]["name"].GetString()
-            if solver_index == 0:
-                self._solver_origin_dest_dict[ordered_solver_name] = CoSim.FetiSolverIndexType.Origin
+        def __SendStiffnessMatrixToUtility(self, solver_name):
+            beta = 0.0
+            solver_index = self._solver_origin_dest_dict[solver_name]
+            if solver_index == CoSim.FetiSolverIndexType.Origin:
+                beta = self.settings["origin_newmark_beta"].GetDouble()
             else:
-                self._solver_origin_dest_dict[ordered_solver_name] = CoSim.FetiSolverIndexType.Destination
+                beta = self.settings["destination_newmark_beta"].GetDouble()
 
-    def __SendStiffnessMatrixToUtility(self, solver_name):
-        beta = 0.0
-        solver_index = self._solver_origin_dest_dict[solver_name]
-        if solver_index == CoSim.FetiSolverIndexType.Origin:
-            beta = self.settings["origin_newmark_beta"].GetDouble()
-        else:
-            beta = self.settings["destination_newmark_beta"].GetDouble()
+            if abs(beta-0.25) < 1e-9:
+                    system_matrix = self._GetSolverStrategy(solver_name).GetSystemMatrix()
+                    self.feti_coupling.SetEffectiveStiffnessMatrixImplicit(system_matrix,solver_index)
+            else:
+                self.feti_coupling.SetEffectiveStiffnessMatrixExplicit(solver_index)
 
-        if abs(beta-0.25) < 1e-9:
-                system_matrix = self._GetSolverStrategy(solver_name).GetSystemMatrix()
-                self.feti_coupling.SetEffectiveStiffnessMatrixImplicit(system_matrix,solver_index)
-        else:
-            self.feti_coupling.SetEffectiveStiffnessMatrixExplicit(solver_index)
+        def _CreateLinearSolver(self):
+            linear_solver_configuration = self.settings["linear_solver_settings"]
+            if linear_solver_configuration.Has("solver_type"): # user specified a linear solver
+                return linear_solver_factory.ConstructSolver(linear_solver_configuration)
+            else:
+                KM.Logger.PrintInfo('::[FETISolver]:: No linear solver was specified, using fastest available solver')
+                return linear_solver_factory.CreateFastestAvailableDirectLinearSolver()
 
-    def _CreateLinearSolver(self):
-        linear_solver_configuration = self.settings["linear_solver_settings"]
-        if linear_solver_configuration.Has("solver_type"): # user specified a linear solver
-            return linear_solver_factory.ConstructSolver(linear_solver_configuration)
-        else:
-            KM.Logger.PrintInfo('::[FETISolver]:: No linear solver was specified, using fastest available solver')
-            return linear_solver_factory.CreateFastestAvailableDirectLinearSolver()
+        def _CalculateAndCheckTimestepRatio(self):
+            # Check timestep ratio is valid
+            timesteps = [0.0] * len(self._solver_delta_times)
+            for solver_index in range(self.settings["coupling_sequence"].size()):
+                ordered_solver_name = self.settings["coupling_sequence"][solver_index]["name"].GetString()
+                timesteps[solver_index] = self._solver_delta_times[ordered_solver_name]
+            timestep_ratio = timesteps[0] / timesteps[1]
+            if timestep_ratio < 0.99 or int(timestep_ratio) % timestep_ratio > 1E-12:
+                raise Exception("The timestep ratio between origin and destination domains is invalid. It must be a positive integer greater than 1.")
+            return timestep_ratio
 
-    def _CalculateAndCheckTimestepRatio(self):
-        # Check timestep ratio is valid
-        timesteps = [0.0] * len(self._solver_delta_times)
-        for solver_index in range(self.settings["coupling_sequence"].size()):
-            ordered_solver_name = self.settings["coupling_sequence"][solver_index]["name"].GetString()
-            timesteps[solver_index] = self._solver_delta_times[ordered_solver_name]
-        timestep_ratio = timesteps[0] / timesteps[1]
-        if timestep_ratio < 0.99 or int(timestep_ratio) % timestep_ratio > 1E-12:
-            raise Exception("The timestep ratio between origin and destination domains is invalid. It must be a positive integer greater than 1.")
-        return timestep_ratio
+        def _GetSolverStrategy(self,solverName):
+            # This is a utility method to get access to the solver's strategy, later used to access the system matrix.
+            # Provision to expand to other solver wrappers in the future.
+            solver_type = str(self.solver_wrappers[solverName]._ClassName())
+            if solver_type == "StructuralMechanicsWrapper":
+                return self.solver_wrappers[solverName]._analysis_stage._GetSolver()._GetSolutionStrategy()
+            else:
+                raise Exception("_GetSolverStrategy not implemented for solver wrapper = " + solver_type)
 
-    def _GetSolverStrategy(self,solverName):
-        # This is a utility method to get access to the solver's strategy, later used to access the system matrix.
-        # Provision to expand to other solver wrappers in the future.
-        solver_type = str(self.solver_wrappers[solverName]._ClassName())
-        if solver_type == "StructuralMechanicsWrapper":
-            return self.solver_wrappers[solverName]._analysis_stage._GetSolver()._GetSolutionStrategy()
-        else:
-            raise Exception("_GetSolverStrategy not implemented for solver wrapper = " + solver_type)
+        def __CheckSolversCompatibility(self):
+            compatible_solver_wrappers = ['StructuralMechanicsWrapper']
+            for solver_name, solver in self.solver_wrappers.items():
+                solver_type = str(solver._ClassName())
+                if solver_type not in compatible_solver_wrappers:
+                    raise Exception("The coupled solver '" + solver_type + "' is not yet compatible with the FETI coupling")
 
-    def __CheckSolversCompatibility(self):
-        compatible_solver_wrappers = ['StructuralMechanicsWrapper']
-        for solver_name, solver in self.solver_wrappers.items():
-            solver_type = str(solver._ClassName())
-            if solver_type not in compatible_solver_wrappers:
-                raise Exception("The coupled solver '" + solver_type + "' is not yet compatible with the FETI coupling")
+        def __CreateOutputSolverDict(self):
+            # This function links each coupling output entry with a solver (if applicable)
+            # This means we can now apply SolverSolvesAtThisTime() to the coupling output
+            self.output_solver_dict = {}
+            for coupling_op_name in self.coupling_operations_dict.keys():
+                coupling_op_type = self.settings["coupling_operations"][coupling_op_name]["type"].GetString()
+                if coupling_op_type == "coupling_output":
+                    coupling_output_solver_name = self.settings["coupling_operations"][coupling_op_name]["solver"].GetString()
+                    self.output_solver_dict[coupling_op_name] = coupling_output_solver_name
 
-    def __CreateOutputSolverDict(self):
-        # This function links each coupling output entry with a solver (if applicable)
-        # This means we can now apply SolverSolvesAtThisTime() to the coupling output
-        self.output_solver_dict = {}
-        for coupling_op_name in self.coupling_operations_dict.keys():
-            coupling_op_type = self.settings["coupling_operations"][coupling_op_name]["type"].GetString()
-            if coupling_op_type == "coupling_output":
-                coupling_output_solver_name = self.settings["coupling_operations"][coupling_op_name]["solver"].GetString()
-                self.output_solver_dict[coupling_op_name] = coupling_output_solver_name
+        def __CouplingOpActsNow(self,couplingOpName):
+            if couplingOpName in self.output_solver_dict:
+                solver_name = self.output_solver_dict[couplingOpName]
+                return self.SolverSolvesAtThisTime(solver_name)
+            else:
+                return True #only restrict coupling operations for outputs
 
-    def __CouplingOpActsNow(self,couplingOpName):
-        if couplingOpName in self.output_solver_dict:
-            solver_name = self.output_solver_dict[couplingOpName]
-            return self.SolverSolvesAtThisTime(solver_name)
-        else:
-            return True #only restrict coupling operations for outputs
+        @classmethod
+        def _GetDefaultParameters(cls):
+            this_defaults = KM.Parameters("""{
+                "origin_newmark_beta" : -1.0,
+                "origin_newmark_gamma" : -1.0,
+                "destination_newmark_beta" : -1.0,
+                "destination_newmark_gamma" : -1.0,
+                "equilibrium_variable" : "VELOCITY",
+                "is_disable_coupling" : false,
+                "is_linear" : false,
+                "linear_solver_settings" : {}
+            }""")
+            this_defaults.AddMissingParameters(super()._GetDefaultParameters())
 
-    @classmethod
-    def _GetDefaultParameters(cls):
-        this_defaults = KM.Parameters("""{
-            "origin_newmark_beta" : -1.0,
-            "origin_newmark_gamma" : -1.0,
-            "destination_newmark_beta" : -1.0,
-            "destination_newmark_gamma" : -1.0,
-            "equilibrium_variable" : "VELOCITY",
-            "is_disable_coupling" : false,
-            "is_linear" : false,
-            "linear_solver_settings" : {}
-        }""")
-        this_defaults.AddMissingParameters(super()._GetDefaultParameters())
-
-        return this_defaults
+            return this_defaults
+            
+    return TemplatedFetiDynamicCoupledSolver

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/feti_dynamic_coupled_solver.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/feti_dynamic_coupled_solver.py
@@ -13,7 +13,7 @@ def Create(settings, models, solver_name, base_class = CoSimulationCoupledSolver
     return GetFetiDynamicCoupledSolver(base_class)(settings, models, solver_name)
 
 def GetFetiDynamicCoupledSolver(base):
-    class TemplatedFetiDynamicCoupledSolver(CoSimulationCoupledSolver):
+    class FetiDynamicCoupledSolver(CoSimulationCoupledSolver):
         def __init__(self, settings, models, solver_name):
             super().__init__(settings, models, solver_name)
 
@@ -270,4 +270,4 @@ def GetFetiDynamicCoupledSolver(base):
 
             return this_defaults
             
-    return TemplatedFetiDynamicCoupledSolver
+    return FetiDynamicCoupledSolver

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_strong.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_strong.py
@@ -10,150 +10,152 @@ import KratosMultiphysics.CoSimulationApplication.co_simulation_tools as cs_tool
 import KratosMultiphysics.CoSimulationApplication.factories.helpers as factories_helper
 import KratosMultiphysics.CoSimulationApplication.colors as colors
 
-def Create(settings, models, solver_name):
-    return GaussSeidelStrongCoupledSolver(settings, models, solver_name)
+def Create(settings, models, solver_name, base_class = CoSimulationCoupledSolver):
+    return GetGaussSeidelStrongCoupledSolver(base_class)(settings, models, solver_name)
 
-class GaussSeidelStrongCoupledSolver(CoSimulationCoupledSolver):
-    def __init__(self, settings, models, solver_name):
-        super().__init__(settings, models, solver_name)
+def GetGaussSeidelStrongCoupledSolver(base):
+    class TemplatedGaussSeidelStrongCoupledSolver(base):
+        def __init__(self, settings, models, solver_name):
+            super().__init__(settings, models, solver_name)
 
-        self.num_coupling_iterations = self.settings["num_coupling_iterations"].GetInt()
+            self.num_coupling_iterations = self.settings["num_coupling_iterations"].GetInt()
 
-    def Initialize(self):
-        super().Initialize()
+        def Initialize(self):
+            super().Initialize()
 
-        self.convergence_accelerators_list = factories_helper.CreateConvergenceAccelerators(
-            self.settings["convergence_accelerators"],
-            self.solver_wrappers,
-            self.data_communicator,
-            self.echo_level)
+            self.convergence_accelerators_list = factories_helper.CreateConvergenceAccelerators(
+                self.settings["convergence_accelerators"],
+                self.solver_wrappers,
+                self.data_communicator,
+                self.echo_level)
 
-        self.convergence_criteria_list = factories_helper.CreateConvergenceCriteria(
-            self.settings["convergence_criteria"],
-            self.solver_wrappers,
-            self.data_communicator,
-            self.echo_level)
-
-        for conv_acc in self.convergence_accelerators_list:
-            conv_acc.Initialize()
-
-        for conv_crit in self.convergence_criteria_list:
-            conv_crit.Initialize()
-
-    def Finalize(self):
-        super().Finalize()
-
-        for conv_acc in self.convergence_accelerators_list:
-            conv_acc.Finalize()
-
-        for conv_crit in self.convergence_criteria_list:
-            conv_crit.Finalize()
-
-    def InitializeSolutionStep(self):
-        super().InitializeSolutionStep()
-
-        for conv_acc in self.convergence_accelerators_list:
-            conv_acc.InitializeSolutionStep()
-
-        for conv_crit in self.convergence_criteria_list:
-            conv_crit.InitializeSolutionStep()
-
-        self.process_info[KratosCoSim.COUPLING_ITERATION_NUMBER] = 0
-
-    def FinalizeSolutionStep(self):
-        super().FinalizeSolutionStep()
-
-        for conv_acc in self.convergence_accelerators_list:
-            conv_acc.FinalizeSolutionStep()
-
-        for conv_crit in self.convergence_criteria_list:
-            conv_crit.FinalizeSolutionStep()
-
-
-    def SolveSolutionStep(self):
-        for k in range(self.num_coupling_iterations):
-            self.process_info[KratosCoSim.COUPLING_ITERATION_NUMBER] += 1
-
-            if self.echo_level > 0:
-                cs_tools.cs_print_info(self._ClassName(), colors.cyan("Coupling iteration:"), colors.bold(str(k+1)+" / " + str(self.num_coupling_iterations)))
-
-            for coupling_op in self.coupling_operations_dict.values():
-                coupling_op.InitializeCouplingIteration()
+            self.convergence_criteria_list = factories_helper.CreateConvergenceCriteria(
+                self.settings["convergence_criteria"],
+                self.solver_wrappers,
+                self.data_communicator,
+                self.echo_level)
 
             for conv_acc in self.convergence_accelerators_list:
-                conv_acc.InitializeNonLinearIteration()
+                conv_acc.Initialize()
 
             for conv_crit in self.convergence_criteria_list:
-                conv_crit.InitializeNonLinearIteration()
+                conv_crit.Initialize()
 
-            for solver_name, solver in self.solver_wrappers.items():
-                self._SynchronizeInputData(solver_name)
-                solver.SolveSolutionStep()
-                self._SynchronizeOutputData(solver_name)
-
-            for coupling_op in self.coupling_operations_dict.values():
-                coupling_op.FinalizeCouplingIteration()
+        def Finalize(self):
+            super().Finalize()
 
             for conv_acc in self.convergence_accelerators_list:
-                conv_acc.FinalizeNonLinearIteration()
+                conv_acc.Finalize()
 
             for conv_crit in self.convergence_criteria_list:
-                conv_crit.FinalizeNonLinearIteration()
+                conv_crit.Finalize()
 
-            is_converged = all([conv_crit.IsConverged() for conv_crit in self.convergence_criteria_list])
+        def InitializeSolutionStep(self):
+            super().InitializeSolutionStep()
 
-            if is_converged:
-                if self.echo_level > 0:
-                    cs_tools.cs_print_info(self._ClassName(), colors.green("### CONVERGENCE WAS ACHIEVED ###"))
-                self.__CommunicateIfTimeStepNeedsToBeRepeated(False)
-                return True
-
-            if k+1 >= self.num_coupling_iterations:
-                if self.echo_level > 0:
-                    cs_tools.cs_print_info(self._ClassName(), colors.red("XXX CONVERGENCE WAS NOT ACHIEVED XXX"))
-                self.__CommunicateIfTimeStepNeedsToBeRepeated(False)
-                return False
-
-            # if it reaches here it means that the coupling has not converged and this was not the last coupling iteration
-            self.__CommunicateIfTimeStepNeedsToBeRepeated(True)
-
-            # do relaxation only if this iteration is not the last iteration of this timestep
             for conv_acc in self.convergence_accelerators_list:
-                conv_acc.ComputeAndApplyUpdate()
+                conv_acc.InitializeSolutionStep()
+
+            for conv_crit in self.convergence_criteria_list:
+                conv_crit.InitializeSolutionStep()
+
+            self.process_info[KratosCoSim.COUPLING_ITERATION_NUMBER] = 0
+
+        def FinalizeSolutionStep(self):
+            super().FinalizeSolutionStep()
+
+            for conv_acc in self.convergence_accelerators_list:
+                conv_acc.FinalizeSolutionStep()
+
+            for conv_crit in self.convergence_criteria_list:
+                conv_crit.FinalizeSolutionStep()
 
 
-    def Check(self):
-        super().Check()
+        def SolveSolutionStep(self):
+            for k in range(self.num_coupling_iterations):
+                self.process_info[KratosCoSim.COUPLING_ITERATION_NUMBER] += 1
 
-        if len(self.convergence_criteria_list) == 0:
-            raise Exception("At least one convergence criteria has to be specified")
+                if self.echo_level > 0:
+                    cs_tools.cs_print_info(self._ClassName(), colors.cyan("Coupling iteration:"), colors.bold(str(k+1)+" / " + str(self.num_coupling_iterations)))
 
-        # TODO check if an accelerator was specified for a field that is manipulated in the input!
+                for coupling_op in self.coupling_operations_dict.values():
+                    coupling_op.InitializeCouplingIteration()
 
-        for conv_crit in self.convergence_criteria_list:
-            conv_crit.Check()
+                for conv_acc in self.convergence_accelerators_list:
+                    conv_acc.InitializeNonLinearIteration()
 
-        for conv_crit in self.convergence_accelerators_list:
-            conv_crit.Check()
+                for conv_crit in self.convergence_criteria_list:
+                    conv_crit.InitializeNonLinearIteration()
 
-    @classmethod
-    def _GetDefaultParameters(cls):
-        this_defaults = KM.Parameters("""{
-            "convergence_accelerators" : [],
-            "convergence_criteria"     : [],
-            "num_coupling_iterations"  : 10
-        }""")
-        this_defaults.AddMissingParameters(super()._GetDefaultParameters())
+                for solver_name, solver in self.solver_wrappers.items():
+                    self._SynchronizeInputData(solver_name)
+                    solver.SolveSolutionStep()
+                    self._SynchronizeOutputData(solver_name)
 
-        return this_defaults
+                for coupling_op in self.coupling_operations_dict.values():
+                    coupling_op.FinalizeCouplingIteration()
 
-    def __CommunicateIfTimeStepNeedsToBeRepeated(self, repeat_time_step):
-        # Communicate if the time step needs to be repeated with external solvers through IO
-        export_config = {
-            "type" : "repeat_time_step",
-            "repeat_time_step" : repeat_time_step
-        }
+                for conv_acc in self.convergence_accelerators_list:
+                    conv_acc.FinalizeNonLinearIteration()
 
-        for solver in self.solver_wrappers.values():
-            solver.ExportData(export_config)
+                for conv_crit in self.convergence_criteria_list:
+                    conv_crit.FinalizeNonLinearIteration()
 
+                is_converged = all([conv_crit.IsConverged() for conv_crit in self.convergence_criteria_list])
+
+                if is_converged:
+                    if self.echo_level > 0:
+                        cs_tools.cs_print_info(self._ClassName(), colors.green("### CONVERGENCE WAS ACHIEVED ###"))
+                    self.__CommunicateIfTimeStepNeedsToBeRepeated(False)
+                    return True
+
+                if k+1 >= self.num_coupling_iterations:
+                    if self.echo_level > 0:
+                        cs_tools.cs_print_info(self._ClassName(), colors.red("XXX CONVERGENCE WAS NOT ACHIEVED XXX"))
+                    self.__CommunicateIfTimeStepNeedsToBeRepeated(False)
+                    return False
+
+                # if it reaches here it means that the coupling has not converged and this was not the last coupling iteration
+                self.__CommunicateIfTimeStepNeedsToBeRepeated(True)
+
+                # do relaxation only if this iteration is not the last iteration of this timestep
+                for conv_acc in self.convergence_accelerators_list:
+                    conv_acc.ComputeAndApplyUpdate()
+
+
+        def Check(self):
+            super().Check()
+
+            if len(self.convergence_criteria_list) == 0:
+                raise Exception("At least one convergence criteria has to be specified")
+
+            # TODO check if an accelerator was specified for a field that is manipulated in the input!
+
+            for conv_crit in self.convergence_criteria_list:
+                conv_crit.Check()
+
+            for conv_crit in self.convergence_accelerators_list:
+                conv_crit.Check()
+
+        @classmethod
+        def _GetDefaultParameters(cls):
+            this_defaults = KM.Parameters("""{
+                "convergence_accelerators" : [],
+                "convergence_criteria"     : [],
+                "num_coupling_iterations"  : 10
+            }""")
+            this_defaults.AddMissingParameters(super()._GetDefaultParameters())
+
+            return this_defaults
+
+        def __CommunicateIfTimeStepNeedsToBeRepeated(self, repeat_time_step):
+            # Communicate if the time step needs to be repeated with external solvers through IO
+            export_config = {
+                "type" : "repeat_time_step",
+                "repeat_time_step" : repeat_time_step
+            }
+
+            for solver in self.solver_wrappers.values():
+                solver.ExportData(export_config)
+
+    return TemplatedGaussSeidelStrongCoupledSolver

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_strong.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_strong.py
@@ -14,7 +14,7 @@ def Create(settings, models, solver_name, base_class = CoSimulationCoupledSolver
     return GetGaussSeidelStrongCoupledSolver(base_class)(settings, models, solver_name)
 
 def GetGaussSeidelStrongCoupledSolver(base):
-    class TemplatedGaussSeidelStrongCoupledSolver(base):
+    class GaussSeidelStrongCoupledSolver(base):
         def __init__(self, settings, models, solver_name):
             super().__init__(settings, models, solver_name)
 
@@ -158,4 +158,4 @@ def GetGaussSeidelStrongCoupledSolver(base):
             for solver in self.solver_wrappers.values():
                 solver.ExportData(export_config)
 
-    return TemplatedGaussSeidelStrongCoupledSolver
+    return GaussSeidelStrongCoupledSolver

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_weak.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_weak.py
@@ -5,7 +5,7 @@ def Create(settings, models, solver_name, base_class = CoSimulationCoupledSolver
     return GetGaussSeidelWeakCoupledSolver(base_class)(settings, models, solver_name)
 
 def GetGaussSeidelWeakCoupledSolver(base):
-    class TemplatedGaussSeidelWeakCoupledSolver(GetGaussSeidelWeakCoupledSolver):
+    class GaussSeidelWeakCoupledSolver(GetGaussSeidelWeakCoupledSolver):
         def SolveSolutionStep(self):
             for coupling_op in self.coupling_operations_dict.values():
                 coupling_op.InitializeCouplingIteration()
@@ -20,4 +20,4 @@ def GetGaussSeidelWeakCoupledSolver(base):
 
             return True
             
-    return TemplatedGaussSeidelWeakCoupledSolver
+    return GaussSeidelWeakCoupledSolver

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_weak.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_weak.py
@@ -5,7 +5,7 @@ def Create(settings, models, solver_name, base_class = CoSimulationCoupledSolver
     return GetGaussSeidelWeakCoupledSolver(base_class)(settings, models, solver_name)
 
 def GetGaussSeidelWeakCoupledSolver(base):
-    class GaussSeidelWeakCoupledSolver(GetGaussSeidelWeakCoupledSolver):
+    class GaussSeidelWeakCoupledSolver(base):
         def SolveSolutionStep(self):
             for coupling_op in self.coupling_operations_dict.values():
                 coupling_op.InitializeCouplingIteration()

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_weak.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_weak.py
@@ -1,20 +1,23 @@
 # Importing the base class
 from KratosMultiphysics.CoSimulationApplication.base_classes.co_simulation_coupled_solver import CoSimulationCoupledSolver
 
-def Create(settings, models, solver_name):
-    return GaussSeidelWeakCoupledSolver(settings, models, solver_name)
+def Create(settings, models, solver_name, base_class = CoSimulationCoupledSolver):
+    return GetGaussSeidelWeakCoupledSolver(base_class)(settings, models, solver_name)
 
-class GaussSeidelWeakCoupledSolver(CoSimulationCoupledSolver):
-    def SolveSolutionStep(self):
-        for coupling_op in self.coupling_operations_dict.values():
-            coupling_op.InitializeCouplingIteration()
+def GetGaussSeidelWeakCoupledSolver(base):
+    class TemplatedGaussSeidelWeakCoupledSolver(GetGaussSeidelWeakCoupledSolver):
+        def SolveSolutionStep(self):
+            for coupling_op in self.coupling_operations_dict.values():
+                coupling_op.InitializeCouplingIteration()
 
-        for solver_name, solver in self.solver_wrappers.items():
-            self._SynchronizeInputData(solver_name)
-            solver.SolveSolutionStep()
-            self._SynchronizeOutputData(solver_name)
+            for solver_name, solver in self.solver_wrappers.items():
+                self._SynchronizeInputData(solver_name)
+                solver.SolveSolutionStep()
+                self._SynchronizeOutputData(solver_name)
 
-        for coupling_op in self.coupling_operations_dict.values():
-            coupling_op.FinalizeCouplingIteration()
+            for coupling_op in self.coupling_operations_dict.values():
+                coupling_op.FinalizeCouplingIteration()
 
-        return True
+            return True
+            
+    return TemplatedGaussSeidelWeakCoupledSolver

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/jacobi_strong.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/jacobi_strong.py
@@ -9,150 +9,152 @@ import KratosMultiphysics.CoSimulationApplication.co_simulation_tools as cs_tool
 import KratosMultiphysics.CoSimulationApplication.factories.helpers as factories_helper
 import KratosMultiphysics.CoSimulationApplication.colors as colors
 
-def Create(settings, models, solver_name):
-    return JacobiStrongCoupledSolver(settings, models, solver_name)
+def Create(settings, models, solver_name, base_class = CoSimulationCoupledSolver):
+    return GetJacobiStrongCoupledSolver(base_class)(settings, models, solver_name)
 
-class JacobiStrongCoupledSolver(CoSimulationCoupledSolver):
-    def __init__(self, settings, models, solver_name):
-        super().__init__(settings, models, solver_name)
+def GetJacobiStrongCoupledSolver(base):
+    class TemplatedJacobiStrongCoupledSolver(CoSimulationCoupledSolver):
+        def __init__(self, settings, models, solver_name):
+            super().__init__(settings, models, solver_name)
 
-        self.num_coupling_iterations = self.settings["num_coupling_iterations"].GetInt()
+            self.num_coupling_iterations = self.settings["num_coupling_iterations"].GetInt()
 
-    def Initialize(self):
-        super().Initialize()
+        def Initialize(self):
+            super().Initialize()
 
-        self.convergence_accelerators_list = factories_helper.CreateConvergenceAccelerators(
-            self.settings["convergence_accelerators"],
-            self.solver_wrappers,
-            self.data_communicator,
-            self.echo_level)
+            self.convergence_accelerators_list = factories_helper.CreateConvergenceAccelerators(
+                self.settings["convergence_accelerators"],
+                self.solver_wrappers,
+                self.data_communicator,
+                self.echo_level)
 
-        self.convergence_criteria_list = factories_helper.CreateConvergenceCriteria(
-            self.settings["convergence_criteria"],
-            self.solver_wrappers,
-            self.data_communicator,
-            self.echo_level)
-
-        for conv_acc in self.convergence_accelerators_list:
-            conv_acc.Initialize()
-
-        for conv_crit in self.convergence_criteria_list:
-            conv_crit.Initialize()
-
-    def Finalize(self):
-        super().Finalize()
-
-        for conv_acc in self.convergence_accelerators_list:
-            conv_acc.Finalize()
-
-        for conv_crit in self.convergence_criteria_list:
-            conv_crit.Finalize()
-
-    def InitializeSolutionStep(self):
-        super().InitializeSolutionStep()
-
-        for conv_acc in self.convergence_accelerators_list:
-            conv_acc.InitializeSolutionStep()
-
-        for conv_crit in self.convergence_criteria_list:
-            conv_crit.InitializeSolutionStep()
-
-    def FinalizeSolutionStep(self):
-        super().FinalizeSolutionStep()
-
-        for conv_acc in self.convergence_accelerators_list:
-            conv_acc.FinalizeSolutionStep()
-
-        for conv_crit in self.convergence_criteria_list:
-            conv_crit.FinalizeSolutionStep()
-
-
-    def SolveSolutionStep(self):
-        for k in range(self.num_coupling_iterations):
-            if self.echo_level > 0:
-                cs_tools.cs_print_info(self._ClassName(), colors.cyan("Coupling iteration:"), colors.bold(str(k+1)+" / " + str(self.num_coupling_iterations)))
-
-            for coupling_op in self.coupling_operations_dict.values():
-                coupling_op.InitializeCouplingIteration()
+            self.convergence_criteria_list = factories_helper.CreateConvergenceCriteria(
+                self.settings["convergence_criteria"],
+                self.solver_wrappers,
+                self.data_communicator,
+                self.echo_level)
 
             for conv_acc in self.convergence_accelerators_list:
-                conv_acc.InitializeNonLinearIteration()
+                conv_acc.Initialize()
 
             for conv_crit in self.convergence_criteria_list:
-                conv_crit.InitializeNonLinearIteration()
+                conv_crit.Initialize()
 
-            for solver_name, solver in self.solver_wrappers.items():
-                self._SynchronizeInputData(solver_name)
-
-            for solver_name, solver in self.solver_wrappers.items():
-                solver.SolveSolutionStep()
-
-            for solver_name, solver in self.solver_wrappers.items():
-                self._SynchronizeOutputData(solver_name)
-
-            for coupling_op in self.coupling_operations_dict.values():
-                coupling_op.FinalizeCouplingIteration()
+        def Finalize(self):
+            super().Finalize()
 
             for conv_acc in self.convergence_accelerators_list:
-                conv_acc.FinalizeNonLinearIteration()
+                conv_acc.Finalize()
 
             for conv_crit in self.convergence_criteria_list:
-                conv_crit.FinalizeNonLinearIteration()
+                conv_crit.Finalize()
 
-            is_converged = all([conv_crit.IsConverged() for conv_crit in self.convergence_criteria_list])
+        def InitializeSolutionStep(self):
+            super().InitializeSolutionStep()
 
-            if is_converged:
-                if self.echo_level > 0:
-                    cs_tools.cs_print_info(self._ClassName(), colors.green("### CONVERGENCE WAS ACHIEVED ###"))
-                self.__CommunicateIfTimeStepNeedsToBeRepeated(False)
-                return True
-
-            if k+1 >= self.num_coupling_iterations:
-                if self.echo_level > 0:
-                    cs_tools.cs_print_info(self._ClassName(), colors.red("XXX CONVERGENCE WAS NOT ACHIEVED XXX"))
-                self.__CommunicateIfTimeStepNeedsToBeRepeated(False)
-                return False
-
-            # if it reaches here it means that the coupling has not converged and this was not the last coupling iteration
-            self.__CommunicateIfTimeStepNeedsToBeRepeated(True)
-
-            # do relaxation only if this iteration is not the last iteration of this timestep
             for conv_acc in self.convergence_accelerators_list:
-                conv_acc.ComputeAndApplyUpdate()
+                conv_acc.InitializeSolutionStep()
+
+            for conv_crit in self.convergence_criteria_list:
+                conv_crit.InitializeSolutionStep()
+
+        def FinalizeSolutionStep(self):
+            super().FinalizeSolutionStep()
+
+            for conv_acc in self.convergence_accelerators_list:
+                conv_acc.FinalizeSolutionStep()
+
+            for conv_crit in self.convergence_criteria_list:
+                conv_crit.FinalizeSolutionStep()
 
 
-    def Check(self):
-        super().Check()
+        def SolveSolutionStep(self):
+            for k in range(self.num_coupling_iterations):
+                if self.echo_level > 0:
+                    cs_tools.cs_print_info(self._ClassName(), colors.cyan("Coupling iteration:"), colors.bold(str(k+1)+" / " + str(self.num_coupling_iterations)))
 
-        if len(self.convergence_criteria_list) == 0:
-            raise Exception("At least one convergence criteria has to be specified")
+                for coupling_op in self.coupling_operations_dict.values():
+                    coupling_op.InitializeCouplingIteration()
 
-        # TODO check if an accelerator was specified for a field that is manipulated in the input!
+                for conv_acc in self.convergence_accelerators_list:
+                    conv_acc.InitializeNonLinearIteration()
 
-        for conv_crit in self.convergence_criteria_list:
-            conv_crit.Check()
+                for conv_crit in self.convergence_criteria_list:
+                    conv_crit.InitializeNonLinearIteration()
 
-        for conv_crit in self.convergence_accelerators_list:
-            conv_crit.Check()
+                for solver_name, solver in self.solver_wrappers.items():
+                    self._SynchronizeInputData(solver_name)
 
-    @classmethod
-    def _GetDefaultParameters(cls):
-        this_defaults = KM.Parameters("""{
-            "convergence_accelerators" : [],
-            "convergence_criteria"     : [],
-            "num_coupling_iterations"  : 10
-        }""")
-        this_defaults.AddMissingParameters(super()._GetDefaultParameters())
+                for solver_name, solver in self.solver_wrappers.items():
+                    solver.SolveSolutionStep()
 
-        return this_defaults
+                for solver_name, solver in self.solver_wrappers.items():
+                    self._SynchronizeOutputData(solver_name)
 
-    def __CommunicateIfTimeStepNeedsToBeRepeated(self, repeat_time_step):
-        # Communicate if the time step needs to be repeated with external solvers through IO
-        export_config = {
-            "type" : "repeat_time_step",
-            "repeat_time_step" : repeat_time_step
-        }
+                for coupling_op in self.coupling_operations_dict.values():
+                    coupling_op.FinalizeCouplingIteration()
 
-        for solver in self.solver_wrappers.values():
-            solver.ExportData(export_config)
+                for conv_acc in self.convergence_accelerators_list:
+                    conv_acc.FinalizeNonLinearIteration()
 
+                for conv_crit in self.convergence_criteria_list:
+                    conv_crit.FinalizeNonLinearIteration()
+
+                is_converged = all([conv_crit.IsConverged() for conv_crit in self.convergence_criteria_list])
+
+                if is_converged:
+                    if self.echo_level > 0:
+                        cs_tools.cs_print_info(self._ClassName(), colors.green("### CONVERGENCE WAS ACHIEVED ###"))
+                    self.__CommunicateIfTimeStepNeedsToBeRepeated(False)
+                    return True
+
+                if k+1 >= self.num_coupling_iterations:
+                    if self.echo_level > 0:
+                        cs_tools.cs_print_info(self._ClassName(), colors.red("XXX CONVERGENCE WAS NOT ACHIEVED XXX"))
+                    self.__CommunicateIfTimeStepNeedsToBeRepeated(False)
+                    return False
+
+                # if it reaches here it means that the coupling has not converged and this was not the last coupling iteration
+                self.__CommunicateIfTimeStepNeedsToBeRepeated(True)
+
+                # do relaxation only if this iteration is not the last iteration of this timestep
+                for conv_acc in self.convergence_accelerators_list:
+                    conv_acc.ComputeAndApplyUpdate()
+
+
+        def Check(self):
+            super().Check()
+
+            if len(self.convergence_criteria_list) == 0:
+                raise Exception("At least one convergence criteria has to be specified")
+
+            # TODO check if an accelerator was specified for a field that is manipulated in the input!
+
+            for conv_crit in self.convergence_criteria_list:
+                conv_crit.Check()
+
+            for conv_crit in self.convergence_accelerators_list:
+                conv_crit.Check()
+
+        @classmethod
+        def _GetDefaultParameters(cls):
+            this_defaults = KM.Parameters("""{
+                "convergence_accelerators" : [],
+                "convergence_criteria"     : [],
+                "num_coupling_iterations"  : 10
+            }""")
+            this_defaults.AddMissingParameters(super()._GetDefaultParameters())
+
+            return this_defaults
+
+        def __CommunicateIfTimeStepNeedsToBeRepeated(self, repeat_time_step):
+            # Communicate if the time step needs to be repeated with external solvers through IO
+            export_config = {
+                "type" : "repeat_time_step",
+                "repeat_time_step" : repeat_time_step
+            }
+
+            for solver in self.solver_wrappers.values():
+                solver.ExportData(export_config)
+
+    return TemplatedJacobiStrongCoupledSolver

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/jacobi_strong.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/jacobi_strong.py
@@ -13,7 +13,7 @@ def Create(settings, models, solver_name, base_class = CoSimulationCoupledSolver
     return GetJacobiStrongCoupledSolver(base_class)(settings, models, solver_name)
 
 def GetJacobiStrongCoupledSolver(base):
-    class JacobiStrongCoupledSolver(CoSimulationCoupledSolver):
+    class JacobiStrongCoupledSolver(base):
         def __init__(self, settings, models, solver_name):
             super().__init__(settings, models, solver_name)
 

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/jacobi_strong.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/jacobi_strong.py
@@ -13,7 +13,7 @@ def Create(settings, models, solver_name, base_class = CoSimulationCoupledSolver
     return GetJacobiStrongCoupledSolver(base_class)(settings, models, solver_name)
 
 def GetJacobiStrongCoupledSolver(base):
-    class TemplatedJacobiStrongCoupledSolver(CoSimulationCoupledSolver):
+    class JacobiStrongCoupledSolver(CoSimulationCoupledSolver):
         def __init__(self, settings, models, solver_name):
             super().__init__(settings, models, solver_name)
 
@@ -157,4 +157,4 @@ def GetJacobiStrongCoupledSolver(base):
             for solver in self.solver_wrappers.values():
                 solver.ExportData(export_config)
 
-    return TemplatedJacobiStrongCoupledSolver
+    return JacobiStrongCoupledSolver

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/jacobi_weak.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/jacobi_weak.py
@@ -1,24 +1,27 @@
 # Importing the base class
 from KratosMultiphysics.CoSimulationApplication.base_classes.co_simulation_coupled_solver import CoSimulationCoupledSolver
 
-def Create(settings, models, solver_name):
-    return JacobiWeakCoupledSolver(settings, models, solver_name)
+def Create(settings, models, solver_name, base_class = CoSimulationCoupledSolver): 
+    return GetJacobiWeakCoupledSolver(base_class)(settings, models, solver_name)
 
-class JacobiWeakCoupledSolver(CoSimulationCoupledSolver):
-    def SolveSolutionStep(self):
-        for coupling_op in self.coupling_operations_dict.values():
-            coupling_op.InitializeCouplingIteration()
+def GetJacobiWeakCoupledSolver(base):
+    class TemplatedJacobiWeakCoupledSolver(base):
+        def SolveSolutionStep(self):
+            for coupling_op in self.coupling_operations_dict.values():
+                coupling_op.InitializeCouplingIteration()
 
-        for solver_name, solver in self.solver_wrappers.items():
-            self._SynchronizeInputData(solver_name)
+            for solver_name, solver in self.solver_wrappers.items():
+                self._SynchronizeInputData(solver_name)
 
-        for solver_name, solver in self.solver_wrappers.items():
-            solver.SolveSolutionStep()
+            for solver_name, solver in self.solver_wrappers.items():
+                solver.SolveSolutionStep()
 
-        for solver_name, solver in self.solver_wrappers.items():
-            self._SynchronizeOutputData(solver_name)
+            for solver_name, solver in self.solver_wrappers.items():
+                self._SynchronizeOutputData(solver_name)
 
-        for coupling_op in self.coupling_operations_dict.values():
-            coupling_op.FinalizeCouplingIteration()
+            for coupling_op in self.coupling_operations_dict.values():
+                coupling_op.FinalizeCouplingIteration()
 
-        return True
+            return True
+
+    return TemplatedJacobiWeakCoupledSolver

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/jacobi_weak.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/jacobi_weak.py
@@ -5,7 +5,7 @@ def Create(settings, models, solver_name, base_class = CoSimulationCoupledSolver
     return GetJacobiWeakCoupledSolver(base_class)(settings, models, solver_name)
 
 def GetJacobiWeakCoupledSolver(base):
-    class TemplatedJacobiWeakCoupledSolver(base):
+    class JacobiWeakCoupledSolver(base):
         def SolveSolutionStep(self):
             for coupling_op in self.coupling_operations_dict.values():
                 coupling_op.InitializeCouplingIteration()
@@ -24,4 +24,4 @@ def GetJacobiWeakCoupledSolver(base):
 
             return True
 
-    return TemplatedJacobiWeakCoupledSolver
+    return JacobiWeakCoupledSolver

--- a/applications/CoSimulationApplication/python_scripts/factories/solver_wrapper_factory.py
+++ b/applications/CoSimulationApplication/python_scripts/factories/solver_wrapper_factory.py
@@ -1,5 +1,30 @@
+# Importing the import module in order to be able to select a base class
+from importlib import import_module
+
+# Importing the base factory
 from KratosMultiphysics.CoSimulationApplication.factories import base_factory
 
 def CreateSolverWrapper(settings, models, solver_name):
     """This function creates and returns the Wrapper for the Solver used for CoSimulation"""
-    return base_factory.Create(settings, [models, solver_name], "KratosMultiphysics.CoSimulationApplication")
+    use_base_type = False if not settings.Has("base_type") else (True if settings["base_type"].Has("module") else False)
+    if use_base_type:
+        base_type_settings = settings["base_type"]
+        base_type_module = base_type_settings["module"].GetString()
+        full_module_path = ".".join(["KratosMultiphysics.CoSimulationApplication", base_type_module])
+        try:
+            base_type_imported_module = import_module(full_module_path)
+        except ImportError:
+            try:
+                base_type_imported_module = import_module(base_type_module)
+            except ImportError:
+                raise ImportError('Base type for coupled solver "{}" could neither be imported from CoSimulation nor from PYTHONPATH'.format(base_type_module))
+        if base_type_settings.Has("class"):
+            base_type_class = base_type_settings["class"].GetString()
+        else:
+            module_name = base_type_module.split(".")[-1]
+            import string
+            base_type_class = string.capwords(module_name.replace("_", " ")).replace(" ", "")
+        base_type = getattr(base_type_imported_module, base_type_class)
+        return base_factory.Create(settings, [models, solver_name, base_type], "KratosMultiphysics.CoSimulationApplication")
+    else:
+        return base_factory.Create(settings, [models, solver_name], "KratosMultiphysics.CoSimulationApplication")


### PR DESCRIPTION
**📝 Description**

Please @philbucher don't kill me. In order to use the CoSimulationApplication in the internal implementations of @KratosMultiphysics/altair I need to be able to select a custom base class in the coupling solvers, as our strategies differ from the standard one (see #10238 and #10217, and many more, unify this will take forever), and therefore we are not able to use the CoSimulationApplication without this change.

**🆕 Changelog**

- [Adding custom base class to coupling solvers](https://github.com/KratosMultiphysics/Kratos/commit/94312e4cfc3252c1610d4f0f625340f7bcea9279)
- [Improve the solver_wrapper_factory to import custom base classes](https://github.com/KratosMultiphysics/Kratos/commit/ef2f7b2b99d0261366ba4bcd82b2b93a56038fec)
