### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/build_docker_image_wheelbuilder_linux.yml
+++ b/.github/workflows/build_docker_image_wheelbuilder_linux.yml
@@ -9,6 +9,9 @@ on:
       - 'scripts/docker_files/docker_file_wheelbuilder_linux/*'
       - '.github/workflows/build_docker_image_wheelbuilder_linux.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_docker_image_wheelbuilder_windows.yml
+++ b/.github/workflows/build_docker_image_wheelbuilder_windows.yml
@@ -9,6 +9,9 @@ on:
       - 'scripts/docker_files/docker_file_wheelbuilder_windows/*'
       - '.github/workflows/build_docker_image_wheelbuilder_windows.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/build_docker_images_with_kratos.yml
+++ b/.github/workflows/build_docker_images_with_kratos.yml
@@ -11,6 +11,9 @@ on:
   schedule:
     - cron: '0 0 * * *' # update it every night
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-dummy.yml
+++ b/.github/workflows/ci-dummy.yml
@@ -12,6 +12,9 @@ on:
       - 'documents/**'
       - 'scripts/**'
 
+permissions:
+  contents: read
+
 jobs:
   ubuntu:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows.

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes.
Here is an example of the permissions in one of the workflow runs:
https://github.com/KratosMultiphysics/Kratos/runs/6968891772?check_suite_focus=true#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflows:

- build_docker_image_wheelbuilder_linux.yml
- build_docker_image_wheelbuilder_windows.yml
- build_docker_images_with_kratos.yml
- ci-dummy.yml

The following workflows already have the least privileged token permission set:

- ci.yml
- nightly_build.yml
- build_docker_images_for_ci.yml
- ci-dummy.yml	


### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- GitHub recommends defining minimum GITHUB_TOKEN permissions.
  https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>
