### PR TITLE
[Core][ModelPartIO] use std::filesystem to handle input file path

### DIFF
--- a/kratos/includes/define_python.h
+++ b/kratos/includes/define_python.h
@@ -21,6 +21,7 @@
 PYBIND11_DECLARE_HOLDER_TYPE(T, Kratos::intrusive_ptr<T>);
 
 #include <pybind11/stl.h>
+#include <pybind11/stl/filesystem.h>
 
 #include "includes/define.h"
 

--- a/kratos/includes/model_part_io.h
+++ b/kratos/includes/model_part_io.h
@@ -18,16 +18,14 @@
 // System includes
 #include <string>
 #include <fstream>
-#include <set>
-#include <typeinfo>
 #include <unordered_set>
 
 // External includes
 
 // Project includes
 #include "includes/define.h"
+#include "includes/kratos_filesystem.h"
 #include "includes/io.h"
-#include "utilities/timer.h"
 #include "containers/flags.h"
 
 namespace Kratos
@@ -84,9 +82,9 @@ public:
     ///@name Life Cycle
     ///@{
 
-    /// Constructor with filenames.
+    /// Constructor with filename.
     ModelPartIO(
-        std::string const& Filename,
+        std::filesystem::path const& Filename,
         const Flags Options = IO::READ | IO::IGNORE_VARIABLES_ERROR.AsFalse() | IO::SKIP_TIMER);
 
     /// Constructor with stream.
@@ -447,8 +445,7 @@ private:
 
     SizeType mNumberOfLines;
 
-    std::string mBaseFilename;
-    std::string mFilename;
+    std::filesystem::path mBaseFilename;
     Flags mOptions;
 
     Kratos::shared_ptr<std::iostream> mpStream;

--- a/kratos/python/add_io_to_python.cpp
+++ b/kratos/python/add_io_to_python.cpp
@@ -82,15 +82,16 @@ void  AddIOToPython(pybind11::module& m)
 
     py::class_<ModelPartIO, ModelPartIO::Pointer, IO>(
        m, "ModelPartIO")
-        .def(py::init<std::string const&>())
-        .def(py::init<std::string const&, const Flags>())
+        .def(py::init<const std::filesystem::path&>())
+        .def(py::init<const std::filesystem::path&, const Flags>())
     ;
 
 
     py::class_<ReorderConsecutiveModelPartIO, ReorderConsecutiveModelPartIO::Pointer, ModelPartIO>(m,"ReorderConsecutiveModelPartIO")
-        .def(py::init<std::string const&>())
-        .def(py::init<std::string const&, const Flags>())
+        .def(py::init<const std::filesystem::path&>())
+        .def(py::init<const std::filesystem::path&, const Flags>())
     ;
+
 #ifdef JSON_INCLUDED
     py::class_<KratosJsonIO, KratosJsonIO::Pointer, IO>(m,
          "JsonIO",init<std::string const&>())

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -49,17 +49,19 @@ ModelPartIO::ModelPartIO(std::filesystem::path const& Filename, const Flags Opti
         OpenMode = std::fstream::in;
     }
 
-    std::filesystem::path full_file_name(Filename);
-    full_file_name.replace_extension("mdpa");
+    std::filesystem::path mdpa_file_name(Filename);
+    mdpa_file_name += ".mdpa";
+    std::filesystem::path time_file_name(Filename);
+    time_file_name += ".time";
 
-    pFile->open(full_file_name.c_str(), OpenMode);
+    pFile->open(mdpa_file_name.c_str(), OpenMode);
 
-    KRATOS_ERROR_IF_NOT(pFile->is_open()) << "Error opening mdpa file : " << full_file_name << std::endl;
+    KRATOS_ERROR_IF_NOT(pFile->is_open()) << "Error opening mdpa file : " << mdpa_file_name << std::endl;
 
     // Store the pointer as a regular std::iostream
     mpStream = pFile;
 
-    if (mOptions.IsNot(IO::SKIP_TIMER)) Timer::SetOuputFile(full_file_name.replace_extension("time").string());
+    if (mOptions.IsNot(IO::SKIP_TIMER)) Timer::SetOuputFile(time_file_name.string());
 }
 
 /// Constructor with stream

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -13,25 +13,24 @@
 //
 
 // System includes
-#include <unordered_set>
+#include <set>
 
 // Project includes
 #include "includes/model_part_io.h"
-#include "includes/kratos_filesystem.h"
 #include "input_output/logger.h"
-#include "utilities/quaternion.h"
-#include "utilities/openmp_utils.h"
 #include "utilities/compare_elements_and_conditions_utility.h"
+#include "utilities/openmp_utils.h"
+#include "utilities/quaternion.h"
+#include "utilities/timer.h"
 
 // External includes
 
 namespace Kratos
 {
 /// Constructor with  filenames.
-ModelPartIO::ModelPartIO(std::string const& Filename, const Flags Options)
+ModelPartIO::ModelPartIO(std::filesystem::path const& Filename, const Flags Options)
     : mNumberOfLines(1)
     , mBaseFilename(Filename)
-    , mFilename(Filename + ".mdpa")
     , mOptions(Options)
 {
     Kratos::shared_ptr<std::fstream> pFile = Kratos::make_shared<std::fstream>();
@@ -50,14 +49,17 @@ ModelPartIO::ModelPartIO(std::string const& Filename, const Flags Options)
         OpenMode = std::fstream::in;
     }
 
-    pFile->open(mFilename.c_str(), OpenMode);
+    std::filesystem::path full_file_name(Filename);
+    full_file_name.replace_extension("mdpa");
 
-    KRATOS_ERROR_IF_NOT(pFile->is_open()) << "Error opening mdpa file : " << mFilename.c_str() << std::endl;
+    pFile->open(full_file_name.c_str(), OpenMode);
+
+    KRATOS_ERROR_IF_NOT(pFile->is_open()) << "Error opening mdpa file : " << full_file_name << std::endl;
 
     // Store the pointer as a regular std::iostream
     mpStream = pFile;
 
-    if (mOptions.IsNot(IO::SKIP_TIMER)) Timer::SetOuputFile(Filename + ".time");
+    if (mOptions.IsNot(IO::SKIP_TIMER)) Timer::SetOuputFile(full_file_name.replace_extension("time").string());
 }
 
 /// Constructor with stream
@@ -993,10 +995,8 @@ void ModelPartIO::DivideInputToPartitions(SizeType NumberOfPartitions, GraphType
     OutputFilesContainerType output_files;
 
     // create folder for partitioned files
-    const std::filesystem::path base_path(mBaseFilename);
-
-    const std::filesystem::path raw_file_name = base_path.stem();
-    const std::filesystem::path folder_name = base_path.parent_path() / raw_file_name += "_partitioned";
+    const auto raw_file_name = mBaseFilename.stem();
+    const auto folder_name = mBaseFilename.parent_path() / raw_file_name += "_partitioned";
 
     std::filesystem::remove_all(folder_name); // to remove leftovers
     FilesystemExtensions::MPISafeCreateDirectories(folder_name.string());

--- a/kratos/tests/test_model_part_io.py
+++ b/kratos/tests/test_model_part_io.py
@@ -1,5 +1,5 @@
 import os
-import sys
+from pathlib import Path
 
 # Importing the Kratos Library
 import KratosMultiphysics
@@ -27,13 +27,23 @@ class TestModelPartIO(KratosUnittest.TestCase):
         KratosUtils.DeleteFileIfExisting(GetFilePath("test_model_part_io_write_mesh_only.time"))
 
     def test_model_part_io_read_model_part(self):
+        input_mdpa = GetFilePath("auxiliar_files_for_python_unittest/mdpa_files/test_model_part_io_read")
+
+        with self.subTest("string"):
+            self.execute_test_model_part_io_read_model_part(str(input_mdpa))
+
+        with self.subTest("pathlib.Path"):
+            self.execute_test_model_part_io_read_model_part(Path(input_mdpa))
+
+    def execute_test_model_part_io_read_model_part(self, input):
         current_model = KratosMultiphysics.Model()
 
         model_part = current_model.CreateModelPart("Main")
         model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
         model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VISCOSITY)
         model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
-        model_part_io = KratosMultiphysics.ModelPartIO(GetFilePath("auxiliar_files_for_python_unittest/mdpa_files/test_model_part_io_read"))
+
+        model_part_io = KratosMultiphysics.ModelPartIO(input)
         model_part_io.ReadModelPart(model_part)
 
         self.assertEqual(model_part.NumberOfSubModelParts(), 2)

--- a/kratos/tests/test_model_part_io.py
+++ b/kratos/tests/test_model_part_io.py
@@ -35,7 +35,7 @@ class TestModelPartIO(KratosUnittest.TestCase):
         with self.subTest("pathlib.Path"):
             self.execute_test_model_part_io_read_model_part(Path(input_mdpa))
 
-    def execute_test_model_part_io_read_model_part(self, input):
+    def execute_test_model_part_io_read_model_part(self, input_mdpa):
         current_model = KratosMultiphysics.Model()
 
         model_part = current_model.CreateModelPart("Main")
@@ -43,7 +43,7 @@ class TestModelPartIO(KratosUnittest.TestCase):
         model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VISCOSITY)
         model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
 
-        model_part_io = KratosMultiphysics.ModelPartIO(input)
+        model_part_io = KratosMultiphysics.ModelPartIO(input_mdpa)
         model_part_io.ReadModelPart(model_part)
 
         self.assertEqual(model_part.NumberOfSubModelParts(), 2)


### PR DESCRIPTION
Now instead of using `std::string` to give the input filename, this PR changes it to use `std::filesystem::path`.

This might help with #1511, @maceligueta can you test this please?

Note that this change is fully backward compatible as `filesystem::path` has a non-explicit CTor that takes an `std::string`

test is added to make sure both inputs work