### PR TITLE
[Compilation][MSVC][C++17] Fix error during compilation due to deprecated warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,9 @@ if(${MSVC})
   string( REPLACE "/W3" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS} )
   string( REPLACE "/W3" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} )
   # Remove deprecated warnings of C++17
-  add_compile_definitions(_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS)
+  if(${_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS})
+    add_compile_definitions(_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS)
+  endif(${_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS})
 endif(${MSVC})
 
 # Specific flags for different versions of MSVC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,6 +244,8 @@ if(${MSVC})
   SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W1 /bigobj /EHsc /Zc:__cplusplus -DBOOST_ALL_NO_LIB -D_SCL_SECURE_NO_WARNINGS")
   string( REPLACE "/W3" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS} )
   string( REPLACE "/W3" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} )
+  # Remove deprecated warnings of C++17
+  add_compile_definitions(_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS)
 endif(${MSVC})
 
 # Specific flags for different versions of MSVC


### PR DESCRIPTION
**📝 Description**

Fixes #10137

**🆕 Changelog**

- [Fix error during compilation](https://github.com/KratosMultiphysics/Kratos/commit/b571a0d3b8f186bc1d76ce4e956a8c0f5de8069b)
