### PR TITLE
[Core] Remove not required include from MathUtils

### DIFF
--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -26,7 +26,6 @@
 /* External includes */
 #include "input_output/logger.h"
 #include "includes/ublas_interface.h"
-#include "containers/array_1d.h"
 
 namespace Kratos
 {


### PR DESCRIPTION
**📝 Description**

Remove not required include from MathUtils

**🆕 Changelog**

- [Remove not required include from MathUtils](https://github.com/KratosMultiphysics/Kratos/commit/2c4f327db0632a087a900dc81d89f2785fc932b1)
