### PR TITLE
[Core] find nodal global elemental neighs - removing kratos api

### DIFF
--- a/kratos/processes/find_global_nodal_elemental_neighbours_process.h
+++ b/kratos/processes/find_global_nodal_elemental_neighbours_process.h
@@ -34,7 +34,7 @@ namespace Kratos
 /// Short class definition.
 /** Detail class definition.
 */
-class KRATOS_API(KRATOS_CORE) FindGlobalNodalElementalNeighboursProcess
+class FindGlobalNodalElementalNeighboursProcess
     : public FindGlobalNodalEntityNeighboursProcess<ModelPart::ElementsContainerType>
 {
 public:


### PR DESCRIPTION
**📝 Description**
This is no longer need as it is only a header file. In fact this is failing in our CI when we include it from other cpp files.
