### PR TITLE
[Core] Unify argument parsing between the MPI and regular tests

### DIFF
--- a/kratos/python_scripts/testing/run_python_mpi_tests.py
+++ b/kratos/python_scripts/testing/run_python_mpi_tests.py
@@ -6,6 +6,7 @@ from KratosMultiphysics.testing import utilities as testing_utils
 
 import sys, os
 import argparse
+import multiprocessing
 from pathlib import Path
 
 if KM.IsDistributedRun():
@@ -23,7 +24,7 @@ def main():
     parser.add_argument('-l', '--level', default='all', choices=['all', 'nightly', 'small', 'validation'])
     parser.add_argument('-v', '--verbosity', default=1, type=int, choices=[0, 1, 2])
     # parser.add_argument('-a', '--applications', default=applications, choices=applications) # TODO
-    parser.add_argument('-n', '--processes', type=int, default=4)
+    parser.add_argument('-n', '--processes', type=int, default=multiprocessing.cpu_count())
     parser.add_argument('-m', '--mpi_command', default="mpiexec")
     parser.add_argument('-f', '--mpi_flags', default="")
     parser.add_argument('-p', '--num_processes_flag', default="-np")

--- a/kratos/python_scripts/testing/run_python_mpi_tests.py
+++ b/kratos/python_scripts/testing/run_python_mpi_tests.py
@@ -51,9 +51,9 @@ def main():
         signalTime = int(args.timer)
     else:
         if args.level == 'small':
-            signalTime = 90
+            signalTime = int(90)
         elif args.level == 'nightly':
-            signalTime = 900
+            signalTime = int(900)
 
     # Create the commands
     commander = testing_utils.Commander()

--- a/kratos/python_scripts/testing/run_python_mpi_tests.py
+++ b/kratos/python_scripts/testing/run_python_mpi_tests.py
@@ -20,15 +20,15 @@ def main():
     # parse command line options
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('-c', '--command', default=testing_utils.GetPython3Command())
-    parser.add_argument('-l', '--level', default='all', choices=['all', 'nightly', 'small', 'validation'])
-    parser.add_argument('-v', '--verbosity', default=1, type=int, choices=[0, 1, 2])
-    # parser.add_argument('-a', '--applications', default=applications, choices=applications) # TODO
-    parser.add_argument('-n', '--processes', type=int, default=multiprocessing.cpu_count())
-    parser.add_argument('-m', '--mpi_command', default="mpiexec")
-    parser.add_argument('-f', '--mpi_flags', default="")
-    parser.add_argument('-p', '--num_processes_flag', default="-np")
-    parser.add_argument('-t', '--timer', default=-1)
+    parser.add_argument('-c', '--command', default=testing_utils.GetPython3Command(), help="Use the provided command to launch test cases. If not provided, the default \'runkratos\' executable is used")
+    parser.add_argument('-l', '--level', default='all', choices=['all', 'nightly', 'small', 'validation'], help="Minimum level of detail of the tests: \'all\'(Default) \'(nightly)\' \'(small)\'")
+    parser.add_argument('-v', '--verbosity', default=1, type=int, choices=[0, 1, 2], help="Verbosity level: 0, 1 (Default), 2")
+    # parser.add_argument('-a', '--applications', default=applications, choices=applications, help="List of applications to run separated by \':\'. All compiled applications will be run by default") # TODO
+    parser.add_argument('-n', '--processes', type=int, default=multiprocessing.cpu_count(), help="Number of processes considered. Default is the number of cores of the system")
+    parser.add_argument('-m', '--mpi_command', default="mpiexec", help="MPI command considered. Default is mpiexec")
+    parser.add_argument('-f', '--mpi_flags', default="", help="The additional MPI flags considered. Default is empty")
+    parser.add_argument('-p', '--num_processes_flag', default="-np", help="Flag used in order to introduce the number of processes considered")
+    parser.add_argument('-t', '--timer', default=-1, help="Use the provided custom time limit for the execution. If not provided, the default values are used")
 
     args = parser.parse_args()
 

--- a/kratos/python_scripts/testing/run_python_mpi_tests.py
+++ b/kratos/python_scripts/testing/run_python_mpi_tests.py
@@ -23,7 +23,7 @@ def main():
     parser.add_argument('-c', '--command', default=testing_utils.GetPython3Command(), help="Use the provided command to launch test cases. If not provided, the default \'runkratos\' executable is used")
     parser.add_argument('-l', '--level', default='all', choices=['all', 'nightly', 'small', 'validation'], help="Minimum level of detail of the tests: \'all\'(Default) \'(nightly)\' \'(small)\'")
     parser.add_argument('-v', '--verbosity', default=1, type=int, choices=[0, 1, 2], help="Verbosity level: 0, 1 (Default), 2")
-    # parser.add_argument('-a', '--applications', default=applications, choices=applications, help="List of applications to run separated by \':\'. All compiled applications will be run by default") # TODO
+    parser.add_argument('-a', '--applications', default=applications, choices=applications, help="List of applications to run separated by \':\'. All compiled applications will be run by default")
     parser.add_argument('-n', '--processes', type=int, default=multiprocessing.cpu_count(), help="Number of processes considered. Default is the number of cores of the system")
     parser.add_argument('-m', '--mpi_command', default="mpiexec", help="MPI command considered. Default is mpiexec")
     parser.add_argument('-f', '--mpi_flags', default="", help="The additional MPI flags considered. Default is empty")
@@ -31,6 +31,19 @@ def main():
     parser.add_argument('-t', '--timer', default=-1, help="Use the provided custom time limit for the execution. If not provided, the default values are used")
 
     args = parser.parse_args()
+
+    # Parser the applications
+    if args.applications is str:
+        parsedApps = args.applications.split(':')
+    else:
+        parsedApps = args.applications
+    for a in parsedApps:
+        if a not in applications + ['KratosCore']:
+            print('Warning: Application {} does not exist'.format(a))
+            sys.exit()
+    applications = parsedApps
+    if 'KratosCore' in applications:
+        applications.remove('KratosCore')
 
     # Set timeout of the different levels
     signalTime = None

--- a/kratos/python_scripts/testing/run_python_mpi_tests.py
+++ b/kratos/python_scripts/testing/run_python_mpi_tests.py
@@ -34,8 +34,8 @@ def main():
 
     # Set timeout of the different levels
     signalTime = None
-    if args.timer > 0:
-        signalTime = args.timer
+    if int(args.timer) > 0:
+        signalTime = int(args.timer)
     else:
         if args.level == 'small':
             signalTime = 90

--- a/kratos/python_scripts/testing/run_tests.py
+++ b/kratos/python_scripts/testing/run_tests.py
@@ -182,12 +182,6 @@ def main():
 
     args = parser.parse_args()
 
-    # Set verbosity
-    verbosity = args.verbosity
-
-    # Set level
-    level = args.level
-
     # Set if mpi
     if args.using_mpi:
         level = "mpi_" + level
@@ -228,8 +222,8 @@ def main():
             'KratosCore',
             'kratos',
             os.path.dirname(kratos_utils.GetKratosMultiphysicsPath()),
-            level,
-            verbosity,
+            args.level,
+            args.verbosity,
             cmd,
             signalTime
         )
@@ -246,8 +240,8 @@ def main():
                 application,
                 application,
                 KM.KratosPaths.kratos_applications+'/',
-                level,
-                verbosity,
+                args.level,
+                args.verbosity,
                 cmd,
                 signalTime
             )

--- a/kratos/python_scripts/testing/run_tests.py
+++ b/kratos/python_scripts/testing/run_tests.py
@@ -205,9 +205,9 @@ def main():
         signalTime = int(args.timer)
     else:
         if args.level == 'small':
-            signalTime = 90
+            signalTime = int(90)
         elif args.level == 'nightly':
-            signalTime = 900
+            signalTime = int(900)
 
     # Create the commands
     commander = Commander()

--- a/kratos/python_scripts/testing/run_tests.py
+++ b/kratos/python_scripts/testing/run_tests.py
@@ -1,34 +1,14 @@
-import os
-import re
-import sys
-import getopt
+import KratosMultiphysics as KM
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+import KratosMultiphysics.kratos_utilities as kratos_utils
+
+from KratosMultiphysics.testing import utilities as testing_utils
+
+import sys, os
+import argparse
 import subprocess
 
 from importlib import import_module
-
-import KratosMultiphysics as KtsMp
-import KratosMultiphysics.KratosUnittest as KtsUt
-import KratosMultiphysics.kratos_utilities as KtsUtls
-
-
-def Usage():
-    ''' Prints the usage of the script '''
-
-    lines = [
-        'Usage:',
-        '\t python kratos_run_tests [-l level] [-v verbosity] [-a app1:[app2:...]]',  # noqa
-        'Options',
-        '\t -h, --help: Shows this command',
-        '\t -l, --level: Minimum level of detail of the tests: \'all\'(Default) \'(nightly)\' \'(small)\'',  # noqa
-        '\t -a, --applications: List of applications to run separated by \':\'. All compiled applications will be run by default',  # noqa
-        '\t -v, --verbose: Verbosity level: 0, 1 (Default), 2',
-        '\t -c, --command: Use the provided command to launch test cases. If not provided, the default \'runkratos\' executable is used',
-        '\t -t, --timer: Use the provided custom time limit for the execution. If not provided, the default values are used',
-        '\t --using-mpi: If running in MPI and executing the MPI-tests'
-    ]
-    for l in lines:
-        KtsMp.Logger.PrintInfo(l) # using the logger to only print once in MPI
-
 
 class Commander(object):
     def __init__(self):
@@ -156,8 +136,8 @@ class Commander(object):
             import_module("KratosMultiphysics." + application)
 
         try:
-            KtsMp.Tester.SetVerbosity(KtsMp.Tester.Verbosity.PROGRESS)
-            self.exitCode = KtsMp.Tester.RunAllTestCases()
+            KM.Tester.SetVerbosity(KM.Tester.Verbosity.PROGRESS)
+            self.exitCode = KM.Tester.RunAllTestCases()
         except Exception as e:
             print('[Warning]:', e, file=sys.stderr)
             self.exitCode = 1
@@ -181,108 +161,59 @@ def print_summary(exit_codes):
 
 def main():
     # Define the command
-    cmd = os.path.join(os.path.dirname(KtsUtls.GetKratosMultiphysicsPath()), 'runkratos')
-
-    verbose_values = [0, 1, 2]
-    level_values = ['all', 'nightly', 'small', 'validation']
-
-    # Set default values
-    applications = KtsUtls.GetListOfAvailableApplications()
-    verbosity = 1
-    level = 'all'
-    is_mpi = False
-    timer = -1
+    cmd = testing_utils.GetPython3Command()
+    
+    # List of application 
+    applications = kratos_utils.GetListOfAvailableApplications()
 
     # Keep the worst exit code
     exit_code = 0
 
     # Parse Commandline
-    try:
-        opts, args = getopt.getopt(
-            sys.argv[1:],
-            'ha:v:l:c:', [
-                'help',
-                'applications=',
-                'verbose=',
-                'level=',
-                'command=',
-                'using-mpi'
-            ])
-    except getopt.GetoptError as err:
-        print(str(err))
-        Usage()
-        sys.exit(2)
+    # parse command line options
+    parser = argparse.ArgumentParser()
 
-    for o, a in opts:
-        if o in ('-v', '--verbose'):
-            if int(a) in verbose_values:
-                verbosity = int(a)
-            else:
-                print('Error: {} is not a valid verbose level.'.format(a))
-                Usage()
-                sys.exit()
-        elif o in ('-h', '--help'):
-            Usage()
-            sys.exit()
-        elif o in ('-l', '--level'):
-            if a in level_values:
-                level = a
-            else:
-                print('Error: {} is not a valid level.'.format(a))
-                Usage()
-                sys.exit()
-        elif o in ('-a', '--applications'):
-            try:
-                parsedApps = a.split(':')
-            except:
-                print('Error: Cannot parse applications.')
-                Usage()
-                sys.exit()
+    parser.add_argument('-c', '--command', default=cmd, help="Use the provided command to launch test cases. If not provided, the default \'runkratos\' executable is used")
+    parser.add_argument('-l', '--level', default='all', choices=['all', 'nightly', 'small', 'validation'], help="Minimum level of detail of the tests: \'all\'(Default) \'(nightly)\' \'(small)\'")
+    parser.add_argument('-v', '--verbosity', default=1, type=int, choices=[0, 1, 2], help="Verbosity level: 0, 1 (Default), 2")
+    parser.add_argument('-a', '--applications', default=applications, choices=applications, help="List of applications to run separated by \':\'. All compiled applications will be run by default")
+    parser.add_argument('-m', '--using-mpi', default=False, help="If running in MPI and executing the MPI-tests")
+    parser.add_argument('-t', '--timer', default=-1, help="Use the provided custom time limit for the execution. If not provided, the default values are used")
 
-            for a in parsedApps:
-                if a not in applications + ['KratosCore']:
-                    print('Warning: Application {} does not exist'.format(a))
-                    sys.exit()
+    args = parser.parse_args()
 
-            applications = parsedApps
+    # Set verbosity
+    verbosity = args.verbosity
 
-            if 'KratosCore' in applications:
-                applications.remove('KratosCore')
+    # Set level
+    level = args.level
 
-        elif o in ('-c', '--command'):
-            try:
-                cmd = str(a)
-            except:
-                print('Error: Cannot parse command name {0}.'.format(a))
-                Usage()
-                sys.exit()
-
-        elif o in ('--using-mpi'):
-            is_mpi = True
-
-        elif o in ('-t', '--timer'):
-            try:
-                timer = int(a)
-            except:
-                print('Error: Cannot parse command name {0}.'.format(a))
-                Usage()
-                sys.exit()
-
-        else:
-            assert False, 'unhandled option'
-
-    if is_mpi:
+    # Set if mpi
+    if args.using_mpi:
         level = "mpi_" + level
+
+    # Parser the applications
+    if args.applications is str:
+        parsedApps = args.applications.split(':')
+    else:
+        parsedApps = args.applications
+    for a in parsedApps:
+        if a not in applications + ['KratosCore']:
+            print('Warning: Application {} does not exist'.format(a))
+            sys.exit()
+    applications = parsedApps
+    if 'KratosCore' in applications:
+        applications.remove('KratosCore')
 
     # Set timeout of the different levels
     signalTime = None
-    if timer > 0:
-        signalTime = timer
+    if int(args.timer) > 0:
+        signalTime = int(args.timer)
     else:
-        if level == 'small':
-            signalTime = int(90)
-        elif level == 'nightly':
-            signalTime = int(900)
+        if args.level == 'small':
+            signalTime = 90
+        elif args.level == 'nightly':
+            signalTime = 900
 
     # Create the commands
     commander = Commander()
@@ -292,11 +223,11 @@ def main():
     # KratosCore must always be runned
     print_test_header("KratosCore")
 
-    with KtsUt.SupressConsoleOutput():
+    with KratosUnittest.SupressConsoleOutput():
         commander.RunTestSuit(
             'KratosCore',
             'kratos',
-            os.path.dirname(KtsUtls.GetKratosMultiphysicsPath()),
+            os.path.dirname(kratos_utils.GetKratosMultiphysicsPath()),
             level,
             verbosity,
             cmd,
@@ -310,11 +241,11 @@ def main():
     for application in applications:
         print_test_header(application)
 
-        with KtsUt.SupressConsoleOutput():
+        with KratosUnittest.SupressConsoleOutput():
             commander.RunTestSuit(
                 application,
                 application,
-                KtsMp.KratosPaths.kratos_applications+'/',
+                KM.KratosPaths.kratos_applications+'/',
                 level,
                 verbosity,
                 cmd,
@@ -326,7 +257,7 @@ def main():
 
     # Run the cpp tests (does the same as run_cpp_tests.py)
     print_test_header("cpp")
-    with KtsUt.SupressConsoleOutput():
+    with KratosUnittest.SupressConsoleOutput():
         commander.RunCppTests(applications)
     print_test_footer("cpp", commander.exitCode)
     exit_codes["cpp"] = commander.exitCode


### PR DESCRIPTION
**📝 Description**

Unify argument parsing between the MPI and regular tests

**🆕 Changelog**

- [Refactor run_tests with argsparse](https://github.com/KratosMultiphysics/Kratos/commit/9c3582a345287f0e1bacf6dfec2d776267b39687)
- [Use multiprocessing in mpi tests](https://github.com/KratosMultiphysics/Kratos/commit/17e3a57114470831d48e1a53f24dd337297e5c38)
- [Adding help in mpi tests](https://github.com/KratosMultiphysics/Kratos/commit/a22f01b6459dc71842df4388b9357d3fc88259b2)
- [Adding application to mpi tests](https://github.com/KratosMultiphysics/Kratos/commit/b797eb1c072e37c5dbc5c6cc33d04da998a9a29c)
