### PR TITLE
[Core] Adding OS, python version and compiler to the banner

### DIFF
--- a/cmake_modules/FindPythonLibsNew.cmake
+++ b/cmake_modules/FindPythonLibsNew.cmake
@@ -130,8 +130,11 @@ endif()
 # The built-in FindPython didn't always give the version numbers
 string(REGEX REPLACE "\\." ";" _PYTHON_VERSION_LIST ${_PYTHON_VERSION_LIST})
 list(GET _PYTHON_VERSION_LIST 0 PYTHON_VERSION_MAJOR)
+add_definitions(-DPYTHON_VERSION_MAJOR=${PYTHON_VERSION_MAJOR})
 list(GET _PYTHON_VERSION_LIST 1 PYTHON_VERSION_MINOR)
+add_definitions(-DPYTHON_VERSION_MINOR=${PYTHON_VERSION_MINOR})
 list(GET _PYTHON_VERSION_LIST 2 PYTHON_VERSION_PATCH)
+add_definitions(-DPYTHON_VERSION_PATCH=${PYTHON_VERSION_PATCH})
 
 # Make sure all directory separators are '/'
 string(REGEX REPLACE "\\\\" "/" PYTHON_PREFIX ${PYTHON_PREFIX})

--- a/kratos/includes/kratos_version.h
+++ b/kratos/includes/kratos_version.h
@@ -59,5 +59,7 @@ KRATOS_API_EXPORT std::string GetPatchVersion();
 KRATOS_API_EXPORT std::string GetCommit();
 KRATOS_API_EXPORT std::string GetBuildType();
 KRATOS_API_EXPORT std::string GetVersionString();
+KRATOS_API_EXPORT std::string GetOSName();
+KRATOS_API_EXPORT std::string GetCompiler();
 
 } // namespace Kratos

--- a/kratos/includes/kratos_version.h
+++ b/kratos/includes/kratos_version.h
@@ -60,6 +60,7 @@ KRATOS_API_EXPORT std::string GetCommit();
 KRATOS_API_EXPORT std::string GetBuildType();
 KRATOS_API_EXPORT std::string GetVersionString();
 KRATOS_API_EXPORT std::string GetOSName();
+KRATOS_API_EXPORT std::string GetPythonVersion();
 KRATOS_API_EXPORT std::string GetCompiler();
 
 } // namespace Kratos

--- a/kratos/input_output/logger_output.cpp
+++ b/kratos/input_output/logger_output.cpp
@@ -47,7 +47,7 @@ namespace Kratos
                  << " . \\  |   (   | |   (   |\\__ \\  \n" 
                  << "_|\\_\\_|  \\__,_|\\__|\\___/ ____/\n"
                  << "           Multi-Physics "<< GetVersionString() << "\n"
-                 << "           Compiled for "<< GetOSName() << " with " << GetCompiler() << std::endl;
+                 << "           Compiled for "<< GetOSName() << " and " << GetPythonVersion() << " with " << GetCompiler() << std::endl;
     }
 
     void LoggerOutput::WriteMessage(LoggerMessage const& TheMessage)

--- a/kratos/input_output/logger_output.cpp
+++ b/kratos/input_output/logger_output.cpp
@@ -42,11 +42,12 @@ namespace Kratos
     void LoggerOutput::WriteHeader()
     {
         auto& r_stream = GetStream();
-        r_stream << " |  /           |             " << std::endl;
-        r_stream << " ' /   __| _` | __|  _ \\   __|" << std::endl;
-        r_stream << " . \\  |   (   | |   (   |\\__ \\ " << std::endl;
-        r_stream << "_|\\_\\_|  \\__,_|\\__|\\___/ ____/" << std::endl;
-        r_stream << "           Multi-Physics "<< GetVersionString() << std::endl;
+        r_stream << " |  /           |                  \n" 
+                 << " ' /   __| _` | __|  _ \\   __|    \n" 
+                 << " . \\  |   (   | |   (   |\\__ \\  \n" 
+                 << "_|\\_\\_|  \\__,_|\\__|\\___/ ____/\n"
+                 << "           Multi-Physics "<< GetVersionString() << "\n"
+                 << "           Compiled for "<< GetOSName() << " with " << GetCompiler() << std::endl;
     }
 
     void LoggerOutput::WriteMessage(LoggerMessage const& TheMessage)

--- a/kratos/python/kratos_python.cpp
+++ b/kratos/python/kratos_python.cpp
@@ -79,7 +79,7 @@ namespace Python
 std::string Hello()
 {
     std::stringstream header;
-    header << "Hello, I am Kratos Multi-Physics " << GetVersionString() << " ;-)";
+    header << "Hello, I am Kratos Multi-Physics " << GetVersionString() << "for" << GetOSName() << " ;-)\n";
     return header.str();
 }
 

--- a/kratos/sources/kernel.cpp
+++ b/kratos/sources/kernel.cpp
@@ -37,11 +37,12 @@ Kernel::Kernel(bool IsDistributedRun) : mpKratosCoreApplication(Kratos::make_sha
 }
 
 void Kernel::Initialize() {
-    KRATOS_INFO("") << " |  /           |\n"
-                    << " ' /   __| _` | __|  _ \\   __|\n"
-                    << " . \\  |   (   | |   (   |\\__ \\\n"
+    KRATOS_INFO("") << " |  /           |                  \n"
+                    << " ' /   __| _` | __|  _ \\   __|    \n"
+                    << " . \\  |   (   | |   (   |\\__ \\  \n"
                     << "_|\\_\\_|  \\__,_|\\__|\\___/ ____/\n"
-                    << "           Multi-Physics " << GetVersionString() << std::endl;
+                    << "           Multi-Physics " << GetVersionString() << "\n"
+                    << "           Compiled for "<< GetOSName() << " with " << GetCompiler() << std::endl;
 
     PrintParallelismSupportInfo();
 

--- a/kratos/sources/kernel.cpp
+++ b/kratos/sources/kernel.cpp
@@ -42,7 +42,7 @@ void Kernel::Initialize() {
                     << " . \\  |   (   | |   (   |\\__ \\  \n"
                     << "_|\\_\\_|  \\__,_|\\__|\\___/ ____/\n"
                     << "           Multi-Physics " << GetVersionString() << "\n"
-                    << "           Compiled for "<< GetOSName() << " with " << GetCompiler() << std::endl;
+                    << "           Compiled for "<< GetOSName() << " and " << GetPythonVersion() << " with " << GetCompiler() << std::endl;
 
     PrintParallelismSupportInfo();
 

--- a/kratos/sources/kratos_version.cpp
+++ b/kratos/sources/kratos_version.cpp
@@ -70,6 +70,16 @@ KRATOS_ARCH_TYPE
     #define KRATOS_OS_NAME "Unknown OS"
 #endif
 
+// Define Python version
+#if defined(PYTHON_VERSION_MAJOR) && defined(PYTHON_VERSION_MINOR)
+    #define KRATOS_PYTHON_VERSION "Python" \
+    KRATOS_TO_STRING(PYTHON_VERSION_MAJOR) \
+    "." \
+    KRATOS_TO_STRING(PYTHON_VERSION_MINOR)
+#else
+    #define KRATOS_PYTHON_VERSION "Unknown Python Version"
+#endif
+
 // Define compiler label
 #if defined(__clang__)
     #define KRATOS_COMPILER_LABEL "Clang-" \
@@ -106,6 +116,10 @@ std::string GetVersionString() {
 
 std::string GetOSName() {
     return KRATOS_OS_NAME;
+}
+
+std::string GetPythonVersion() {
+    return KRATOS_PYTHON_VERSION;
 }
 
 std::string GetCompiler() {

--- a/kratos/sources/kratos_version.cpp
+++ b/kratos/sources/kratos_version.cpp
@@ -59,6 +59,35 @@ KRATOS_SHA1_NUMBER "-" \
 KRATOS_BUILD_TYPE  "-" \
 KRATOS_ARCH_TYPE
 
+// Define OS name
+#if defined(__linux__) || defined(__linux) || defined(linux) || defined(__gnu_linux__)
+    #define KRATOS_OS_NAME "GNU/Linux"
+#elif defined(__APPLE__) && defined(__MACH__)
+    #define KRATOS_OS_NAME "Mac OS"
+#elif defined(_WIN32) || defined(_WIN64)
+    #define KRATOS_OS_NAME "Windows" 
+#else
+    #define KRATOS_OS_NAME "Unknown OS"
+#endif
+
+// Define compiler label
+#if defined(__clang__)
+    #define KRATOS_COMPILER_LABEL "Clang-" \
+    KRATOS_TO_STRING(__clang_major__) \
+    "." \
+    KRATOS_TO_STRING(__clang_minor__)
+#elif defined(__GNUC__) || defined(__GNUG__)
+    #define KRATOS_COMPILER_LABEL "GCC-" \
+    KRATOS_TO_STRING(__GNUC__) \
+    "." \
+    KRATOS_TO_STRING(__GNUC_MINOR__)
+#elif defined(_MSC_VER)
+    #define KRATOS_COMPILER_LABEL "MSVC-" \
+    KRATOS_TO_STRING(_MSC_VER)
+#else
+    #define KRATOS_COMPILER_LABEL "Unknown compiler"
+#endif
+
 std::string GetPatchVersion() {
     return KRATOS_PATCH_VERSION;
 }
@@ -73,6 +102,14 @@ std::string GetBuildType() {
 
 std::string GetVersionString() {
     return KRATOS_VERSION_STRING;
+}
+
+std::string GetOSName() {
+    return KRATOS_OS_NAME;
+}
+
+std::string GetCompiler() {
+    return KRATOS_COMPILER_LABEL;
 }
 
 } // namespace Kratos


### PR DESCRIPTION
**📝 Description**

Adding OS, python version and compiler to the banner

Example:

~~~sh
 |  /           |                  
 ' /   __| _` | __|  _ \   __|    
 . \  |   (   | |   (   |\__ \  
_|\_\_|  \__,_|\__|\___/ ____/
           Multi-Physics 9.2."0"-4afb88094a-Release-ARM64
           Compiled for GNU/Linux and Python3.6 with GCC-8.5
Compiled with threading and MPI support.
Maximum number of threads: 1.
Running without MPI.
~~~~

**🆕 Changelog**

- [Adding OS and compiler](https://github.com/KratosMultiphysics/Kratos/commit/42ea5e2230ce896a52956ce08c98d52d3a88b796)
- [Adding GetPythonVersion](https://github.com/KratosMultiphysics/Kratos/commit/4afb88094a86a3fe077de02bda1e8610cee95dc9)
- [Update main banner](https://github.com/KratosMultiphysics/Kratos/commit/871290732234f4e7e95c9fc89eb3ae9af662ac9c)
- [Add python version definitions](https://github.com/KratosMultiphysics/Kratos/commit/70b9646555cdfada08ca16a3929e1cb81137fac7)
