### PR TITLE
[CI] Adding missing scipy to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,7 @@ jobs:
       run: |
         pip install numpy
         pip install sympy
+        pip install scipy
         pip install h5py
 
     - name: Build
@@ -338,6 +339,7 @@ jobs:
       run: |
         pip install numpy
         pip install sympy
+        pip install scipy
 
     - name: Build
       shell: cmd

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -112,6 +112,7 @@ jobs:
         pip install numpy
         pip install h5py
         pip install sympy
+        pip install scipy
 
     - name: Build
       shell: cmd


### PR DESCRIPTION
**📝 Description**

I realized that we installed sympy some time ago in the CI:

https://github.com/KratosMultiphysics/Kratos/pull/9549

For me this was strange, as we thought it was a confusion because we use it scipy. Then I realized that we use sympy as well is some tests, so it makes sense. But It would make even more sense to also install scipy, as it is used in many tests that right now the CI must be skipping:

https://github.com/KratosMultiphysics/Kratos/search?q=scipy

**🆕 Changelog**

- [Adding missing scipy to CI](https://github.com/KratosMultiphysics/Kratos/commit/90cd49aef07a23faa23f6f5a0d35c3be69777abf)