### PR TITLE
[Core][CoSimulationApplication] Adding BeforeSolutionLoop to PythonSolver

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
@@ -171,6 +171,16 @@ class CoSimulationCoupledSolver(CoSimulationSolverWrapper):
 
         return self.time
 
+    def BeforeSolutionLoop(self):
+        for solver in self.solver_wrappers.values():
+            solver.BeforeSolutionLoop()
+            
+        for predictor in self.predictors_list:
+            predictor.BeforeSolutionLoop()
+
+        for coupling_operation in self.coupling_operations_dict.values():
+            coupling_operation.BeforeSolutionLoop()
+
     def Predict(self):
         for predictor in self.predictors_list:
             predictor.Predict()

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupling_operation.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupling_operation.py
@@ -23,6 +23,8 @@ class CoSimulationCouplingOperation:
     def Finalize(self):
         pass
 
+    def BeforeSolutionLoop(self):
+        pass
 
     def InitializeSolutionStep(self):
         pass

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
@@ -26,6 +26,9 @@ class CoSimulationPredictor:
     def Finalize(self):
         pass
 
+    def BeforeSolutionLoop(self):
+        pass
+
     def InitializeSolutionStep(self):
         pass
 

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
@@ -71,6 +71,9 @@ class CoSimulationSolverWrapper:
     def Predict(self):
         pass
 
+    def BeforeSolutionLoop(self):
+        pass
+
     def InitializeSolutionStep(self):
         pass
 

--- a/applications/CoSimulationApplication/python_scripts/solver_wrappers/kratos/kratos_base_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/solver_wrappers/kratos/kratos_base_wrapper.py
@@ -72,10 +72,6 @@ class KratosBaseWrapper(CoSimulationSolverWrapper):
         self._analysis_stage.time = new_time # only needed to print the time correctly
         return new_time
 
-    def BeforeSolutionLoop(self):
-        with self.thread_manager:
-            self._analysis_stage.BeforeSolutionLoop()
-
     def InitializeSolutionStep(self):
         with self.thread_manager:
             self._analysis_stage.InitializeSolutionStep()

--- a/applications/CoSimulationApplication/python_scripts/solver_wrappers/kratos/kratos_base_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/solver_wrappers/kratos/kratos_base_wrapper.py
@@ -72,6 +72,10 @@ class KratosBaseWrapper(CoSimulationSolverWrapper):
         self._analysis_stage.time = new_time # only needed to print the time correctly
         return new_time
 
+    def BeforeSolutionLoop(self):
+        with self.thread_manager:
+            self._analysis_stage.BeforeSolutionLoop()
+
     def InitializeSolutionStep(self):
         with self.thread_manager:
             self._analysis_stage.InitializeSolutionStep()

--- a/applications/DEMApplication/python_scripts/sphere_strategy.py
+++ b/applications/DEMApplication/python_scripts/sphere_strategy.py
@@ -420,6 +420,9 @@ class ExplicitStrategy():
     def Finalize(self):
         pass
 
+    def BeforeSolutionLoop(self):
+        pass
+
     def InitializeSolutionStep(self):
         time = self.spheres_model_part.ProcessInfo[TIME]
         self.FixDOFsManually(time)

--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -54,6 +54,15 @@ class AnalysisStage(object):
         """
         return self.time < self.end_time
 
+    def RunBeforeSolutionLoop(self):
+        """This function executes the processes before solution loop of the AnalysisStage
+        It can be overridden by derived classes.
+        """
+
+        for process in self._GetListOfProcesses():
+            process.ExecuteBeforeSolutionLoop()
+        self._GetSolver().BeforeSolutionLoop()
+
     def RunSolutionLoop(self):
         """This function executes the solution loop of the AnalysisStage
         It can be overridden by derived classes
@@ -95,8 +104,8 @@ class AnalysisStage(object):
 
         self.ModifyAfterSolverInitialize()
 
-        for process in self._GetListOfProcesses():
-            process.ExecuteBeforeSolutionLoop()
+        # Execute before the solution loop
+        self.RunBeforeSolutionLoop()
 
         ## Stepping and time settings
         self.end_time = self.project_parameters["problem_data"]["end_time"].GetDouble()

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -71,11 +71,6 @@ class PythonSolver:
         """
         raise Exception("This function has to be implemented in the derived class")
 
-    def BeforeSolutionLoop(self):
-        """This function is called before solution loop starts
-        """
-        pass
-
     def ImportModelPart(self):
         """This function reads the ModelPart
         """
@@ -111,6 +106,11 @@ class PythonSolver:
     def Finalize(self):
         """This function finalizes the PythonSolver
         Usage: It is designed to be called ONCE, AFTER the execution of the solution-loop
+        """
+        pass
+
+    def BeforeSolutionLoop(self):
+        """This function is called before solution loop starts
         """
         pass
 

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -71,6 +71,11 @@ class PythonSolver:
         """
         raise Exception("This function has to be implemented in the derived class")
 
+    def BeforeSolutionLoop(self):
+        """This function is called before solution loop starts
+        """
+        pass
+
     def ImportModelPart(self):
         """This function reads the ModelPart
         """


### PR DESCRIPTION
**📝 Description**

In aim to unify with @KratosMultiphysics/altair (we are doing our best to unify from our side, but there are things that are complex to unify, and in addition I consider interesting to bring to Kratos), I propose to add the method BeforeSolutionLoop  to the base python solver (by default it does nothing, so keeping exactly the same behaviour). I extend then this to the @KratosMultiphysics/cosimulation application for consistency.

**🆕 Changelog**

- [Adding BeforeSolutionLoop to PythonSolver](https://github.com/KratosMultiphysics/Kratos/commit/46a1d1c8c0a0b5d3fa522a820df217b989e0386a)
- [Call solver BeforeSolutionLoop in analysis](https://github.com/KratosMultiphysics/Kratos/commit/5a17e18c20799afdd05b6af6d1884d3cdaa0f700)
- [Extend to CoSimulationApplication](https://github.com/KratosMultiphysics/Kratos/commit/62b97a54c9e030cee45f9d83b9a124aab0659e4a)
