### PR TITLE
[Core] Adding additional information to the kernel

### DIFF
--- a/kratos/includes/kernel.h
+++ b/kratos/includes/kernel.h
@@ -134,6 +134,12 @@ class KRATOS_API(KRATOS_CORE) Kernel {
 
     static std::string BuildType();
 
+    static std::string OSName();
+
+    static std::string PythonVersion();
+
+    static std::string Compiler();
+
     void PrintParallelismSupportInfo() const;
 
     ///@}

--- a/kratos/python/add_kernel_to_python.cpp
+++ b/kratos/python/add_kernel_to_python.cpp
@@ -183,6 +183,9 @@ void AddKernelToPython(pybind11::module& m)
         .def("GetConstitutiveLaw", GetConstitutiveLaw, py::return_value_policy::reference_internal)
         .def_static("Version", &Kernel::Version)
         .def_static("BuildType", &Kernel::BuildType)
+        .def_static("OSName", &Kernel::OSName)
+        .def_static("PythonVersion", &Kernel::PythonVersion)
+        .def_static("Compiler", &Kernel::Compiler)
         ;
 }
 

--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -73,18 +73,16 @@ def __ModuleInitDetail():
                 ]
                 Logger.PrintWarning("KRATOS INITIALIZATION WARNING:", "".join(msg))
 
-    # Try to detect kratos library version
-    try:
-        kre = re.compile('Kratos\.([^\d]+)(\d+).+')
-        kratos_version_info = [(kre.match(f))[2] for f in os.listdir(KratosPaths.kratos_libs) if kre.match(f)][0]
+    # Detect kratos library version
+    python_version = Kernel(using_mpi).PythonVersion()
+    python_version = python_version.replace("Python","")
+    kratos_version_info = python_version.split(".")
 
-        if sys.version_info.major != int(kratos_version_info[0]) and sys.version_info.minor != int(kratos_version_info[1]):
-            print("Warning: Kratos is running with python {}.{} but was compiled with python {}.{}. Please ensure the versions match.".format(
-                sys.version_info.major, sys.version_info.minor,
-                kratos_version_info[0], kratos_version_info[1]
-            ))
-    except:
-        print("Warning: Could not determine python version used to build kratos.")
+    if sys.version_info.major != int(kratos_version_info[0]) and sys.version_info.minor != int(kratos_version_info[1]):
+        print("Warning: Kratos is running with python {}.{} but was compiled with python {}.{}. Please ensure the versions match.".format(
+            sys.version_info.major, sys.version_info.minor,
+            kratos_version_info[0], kratos_version_info[1]
+        ))
 
     return kratos_globals.KratosGlobalsImpl(Kernel(using_mpi), KratosPaths.kratos_applications)
 

--- a/kratos/sources/kernel.cpp
+++ b/kratos/sources/kernel.cpp
@@ -117,6 +117,18 @@ std::string Kernel::Version() {
     return GetVersionString();
 }
 
+std::string Kernel::OSName() {
+    return GetOSName();
+}
+
+std::string Kernel::PythonVersion() {
+    return GetPythonVersion();
+}
+
+std::string Kernel::Compiler() {
+    return GetCompiler();
+}
+
 void Kernel::PrintParallelismSupportInfo() const
 {
     #ifdef KRATOS_SMP_NONE


### PR DESCRIPTION
**📝 Description**

This PR exposes to the `Kernel` (including python):

- `OSName`
- `PythonVersion`
- `Compiler`

This can be also used to avoid to deduce the python version from the python module

**🆕 Changelog**

- [Adding addtional information to the kernel](https://github.com/KratosMultiphysics/Kratos/commit/4abc45a416f2d8784d9e4d3980555004c257ce6b)
- [Determine version from PythonVersion](https://github.com/KratosMultiphysics/Kratos/commit/963c39bcf76a0dbe367a20cb7167442839115c86)