### PR TITLE
[Adjoint][Fluid] Adjoint advance in time minors

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/adjoint_fluid_analysis.py
+++ b/applications/FluidDynamicsApplication/python_scripts/adjoint_fluid_analysis.py
@@ -16,6 +16,14 @@ class AdjointFluidAnalysis(AnalysisStage):
 
         problem_data = self.project_parameters["problem_data"]
 
+        # check that old input is not provided
+        if problem_data.Has("nsteps"):
+            raise Exception("'nsteps' is no longer supported. Use 'start_time' and 'end_time' instead")
+        if problem_data.Has("start_step"):
+            raise Exception("'start_step' is no longer supported. Use 'start_time' and 'end_time' instead")
+        if problem_data.Has("end_step"):
+            raise Exception("'end_step' is no longer supported. Use 'start_time' and 'end_time' instead")
+
         # compute delta time
         delta_time = self._GetSolver()._ComputeDeltaTime()
         if delta_time >= 0.0:

--- a/applications/FluidDynamicsApplication/python_scripts/adjoint_fluid_analysis.py
+++ b/applications/FluidDynamicsApplication/python_scripts/adjoint_fluid_analysis.py
@@ -12,33 +12,27 @@ class AdjointFluidAnalysis(AnalysisStage):
     '''Main script for adjoint sensitivity optimization in fluid dynamics simulations.'''
 
     def __init__(self,model,parameters):
-        # Deprecation warnings
-        solver_settings = parameters["solver_settings"]
-        if not solver_settings.Has("domain_size"):
-            Kratos.Logger.PrintWarning(self.__class__.__name__, "Using the old way to pass the domain_size, this will be removed!")
-            solver_settings.AddEmptyValue("domain_size")
-            solver_settings["domain_size"].SetInt(parameters["problem_data"]["domain_size"].GetInt())
+        super().__init__(model, parameters)
 
-        if not solver_settings.Has("model_part_name"):
-            Kratos.Logger.PrintWarning(self.__class__.__name__, "Using the old way to pass the model_part_name, this will be removed!")
-            solver_settings.AddEmptyValue("model_part_name")
-            solver_settings["model_part_name"].SetString(parameters["problem_data"]["model_part_name"].GetString())
+        problem_data = self.project_parameters["problem_data"]
 
-        if not parameters["problem_data"].Has("end_time"):
-            parameters["problem_data"].AddEmptyValue("end_time")
-            parameters["problem_data"]["end_time"].SetDouble( \
-                            parameters["problem_data"]["start_step"].GetDouble() + \
-                            parameters["problem_data"]["nsteps"].GetInt()*solver_settings["time_stepping"]["time_step"].GetDouble()
-                        )
+        # compute delta time
+        delta_time = self._GetSolver()._ComputeDeltaTime()
+        if delta_time >= 0.0:
+            raise Exception("Adjoints are solved in reverse in time. Hence, delta_time should be negative. [ delta_time = " + str(delta_time) + "].")
 
-        if not parameters["problem_data"].Has("start_time"):
-            parameters["problem_data"].AddEmptyValue("start_time")
-            parameters["problem_data"]["start_time"].SetDouble( \
-                            parameters["problem_data"]["start_step"].GetDouble() \
-                            )
-        self.number_of_steps = parameters["problem_data"]["nsteps"].GetInt()
+        # update start time and end time. Adjoints are solved reverse in time,
+        # hence we include an additional time step at the end
+        # to properly initialize initial conditions for adjoint problem
+        # and start time is also shifted by one to keep the same number
+        # of steps
+        delta_time *= -1.0
+        self.start_time = problem_data["start_time"].GetDouble() + delta_time
+        self.end_time = problem_data["end_time"].GetDouble() + delta_time
 
-        super(AdjointFluidAnalysis, self).__init__(model, parameters)
+        # now set start_time, end_time of the problem_data bt flipping them
+        self.project_parameters["problem_data"]["start_time"].SetDouble(self.end_time)
+        self.project_parameters["problem_data"]["end_time"].SetDouble(self.start_time)
 
     def Initialize(self):
         super(AdjointFluidAnalysis, self).Initialize()
@@ -49,61 +43,11 @@ class AdjointFluidAnalysis(AnalysisStage):
     def _CreateSolver(self):
         return python_solvers_wrapper_adjoint_fluid.CreateSolver(self.model, self.project_parameters)
 
-    def _CreateProcesses(self, parameter_name, initialization_order):
-        """Create a list of Processes
-        This method is TEMPORARY to not break existing code
-        It will be removed in the future
+    def KeepAdvancingSolutionLoop(self):
+        """This function specifies the stopping criteria for breaking the solution loop
+        Note that as the adjoint problem is solved backward in time, the stopping criteria is current time being larger than the start one
         """
-        list_of_processes = super(AdjointFluidAnalysis, self)._CreateProcesses(parameter_name, initialization_order)
-
-        # The list of processes will contain a list with each individual process already constructed (boundary conditions, initial conditions and gravity)
-        # Note 1: gravity is constructed first. Outlet process might need its information.
-        # Note 2: initial conditions are constructed before BCs. Otherwise, they may overwrite the BCs information.
-        if parameter_name == "processes":
-            processes_block_names = ["gravity", "initial_conditions_process_list", "boundary_conditions_process_list", "auxiliar_process_list"]
-            if len(list_of_processes) == 0: # Processes are given in the old format
-                Kratos.Logger.PrintWarning(self.__class__.__name__, "Using the old way to create the processes, this will be removed!")
-                factory = KratosProcessFactory(self.model)
-                for process_name in processes_block_names:
-                    if (self.project_parameters.Has(process_name) is True):
-                        list_of_processes += factory.ConstructListOfProcesses(self.project_parameters[process_name])
-            else: # Processes are given in the new format
-                for process_name in processes_block_names:
-                    if (self.project_parameters.Has(process_name) is True):
-                        raise Exception("Mixing of process initialization is not alowed!")
-        elif parameter_name == "output_processes":
-            if self.project_parameters.Has("output_configuration"):
-                Kratos.Logger.PrintWarning(self.__class__.__name__, "Using the old way to create the gid-output, this will be removed!")
-                gid_output= self._SetUpGiDOutput()
-                list_of_processes += [gid_output,]
-        else:
-            raise NameError("wrong parameter name")
-
-        return list_of_processes
-
-    def _SetUpGiDOutput(self):
-        '''Initialize a GiD output instance'''
-        if self.parallel_type == "OpenMP":
-            from KratosMultiphysics.gid_output_process import GiDOutputProcess as OutputProcess
-        elif self.parallel_type == "MPI":
-            from KratosMultiphysics.mpi.distributed_gid_output_process import DistributedGiDOutputProcess as OutputProcess
-
-        output = OutputProcess(self._GetSolver().GetComputingModelPart(),
-                                self.project_parameters["problem_data"]["problem_name"].GetString() ,
-                                self.project_parameters["output_configuration"])
-
-        return output
-
-    def RunSolutionLoop(self):
-        """Note that the adjoint problem is solved in reverse time
-        """
-        for step in range(self.number_of_steps):
-            self.time = self._GetSolver().AdvanceInTime(self.time)
-            self.InitializeSolutionStep()
-            self._GetSolver().Predict()
-            self._GetSolver().SolveSolutionStep()
-            self.FinalizeSolutionStep()
-            self.OutputSolutionStep()
+        return self.time > self.start_time
 
     def _GetOrderOfProcessesInitialization(self):
         return ["gravity",

--- a/applications/FluidDynamicsApplication/python_scripts/adjoint_fluid_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/adjoint_fluid_solver.py
@@ -93,10 +93,22 @@ class AdjointFluidSolver(FluidSolver):
         KratosMultiphysics.ReplaceElementsAndConditionsProcess(self.main_model_part, self.settings["element_replace_settings"]).Execute()
 
     def _ComputeDeltaTime(self):
+        """This function returns the delta time
+        Note that the adjoint fluid analysis does not support the automatic time stepping
+        Also note that as it requires to go backwards in time, here we return minus the user time step
+        """
         if self.settings["time_stepping"]["automatic_time_step"].GetBool():
             raise Exception("Automatic time stepping is not supported by adjoint fluid solver.")
 
         delta_time = self.settings["time_stepping"]["time_step"].GetDouble()
+        if delta_time > 0.0:
+            # Expected positive time_step is reversed to advance backwards in time
+            delta_time *= -1.0
+        else:
+            # TODO: Remove this check after the backwards compatibility period
+            # In order to keep backwards compatibility, we throw a warning if a negative time_step is provided
+            KratosMultiphysics.Logger.PrintWarning("Setting a negative 'time_step' is no longer needed by 'AdjointFluidSolver'.")
+
         return delta_time
 
     def _SetNodalProperties(self):

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/cylinder_slip_test_adjoint_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/cylinder_slip_test_adjoint_parameters.json
@@ -1,8 +1,8 @@
 {
     "problem_data": {
         "problem_name": "cylinder_test",
-        "start_step": 0.11,
-        "nsteps": 10,
+        "start_time": 1.0e-12,
+        "end_time": 0.1,
         "echo_level": 0,
         "parallel_type": "<PARALLEL_TYPE>"
     },
@@ -56,7 +56,7 @@
         },
         "time_stepping": {
             "automatic_time_step": false,
-            "time_step": -0.01
+            "time_step": 0.01
         }
     },
     "processes": {

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/cylinder_test_adjoint_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/cylinder_test_adjoint_parameters.json
@@ -1,9 +1,9 @@
 {
     "problem_data"                     : {
         "problem_name"    : "cylinder_test",
-        "start_step"      : 0.11,
-        "nsteps"          : 10,
         "echo_level"      : 0,
+        "start_time"      : 1.0e-12,
+        "end_time"        : 0.1,
         "parallel_type"   : "OpenMP"
     },
     "_output_processes" : {
@@ -79,7 +79,7 @@
         },
         "time_stepping"               : {
             "automatic_time_step" : false,
-            "time_step"           : -0.01
+            "time_step"           : 0.01
         }
     },
     "processes": {

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/one_element_test_adjoint_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/one_element_test_adjoint_parameters.json
@@ -1,8 +1,8 @@
 {
     "problem_data" : {
         "problem_name"    : "one_element",
-        "start_step"      : 4.0,
-        "nsteps"          : 3,
+        "start_time"      : 0.0,
+        "end_time"        : 3.0,
         "echo_level"      : 0,
         "parallel_type"   : "OpenMP"
     },
@@ -77,7 +77,7 @@
         },
         "time_stepping"                : {
             "automatic_time_step" : false,
-            "time_step"           : -1.0
+            "time_step"           : 1.0
         }
     },
     "processes": {

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/steady_cylinder_slip_test_norm_adjoint_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/steady_cylinder_slip_test_norm_adjoint_parameters.json
@@ -1,8 +1,8 @@
 {
     "problem_data": {
         "problem_name": "steady_cylinder_test",
-        "start_step": 2.0,
-        "nsteps": 1,
+        "start_time": 1.0e-12,
+        "end_time": 1.0,
         "echo_level": 0,
         "parallel_type": "<PARALLEL_TYPE>"
     },
@@ -55,7 +55,7 @@
         },
         "time_stepping": {
             "automatic_time_step": false,
-            "time_step": -1.0
+            "time_step": 1.0
         }
     },
     "processes": {

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/steady_cylinder_test_adjoint_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/steady_cylinder_test_adjoint_parameters.json
@@ -1,8 +1,8 @@
 {
     "problem_data"                     : {
         "problem_name"    : "steady_cylinder_test",
-        "start_step"      : 2.0,
-        "nsteps"          : 1,
+        "start_time"      : 0.0,
+        "end_time"        : 1.0,
         "echo_level"      : 0,
         "parallel_type"   : "OpenMP"
     },
@@ -78,7 +78,7 @@
         },
         "time_stepping"               : {
             "automatic_time_step" : false,
-            "time_step"           : -1.0
+            "time_step"           : 1.0
         }
     },
     "processes": {

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/two_elements_bossak_test_adjoint_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/two_elements_bossak_test_adjoint_parameters.json
@@ -1,8 +1,8 @@
 {
     "problem_data" : {
         "problem_name"    : "one_element",
-        "start_step"      : 6.0,
-        "nsteps"          : 5,
+        "start_time"      : 0.0,
+        "end_time"        : 5.0,
         "echo_level"      : 0,
         "parallel_type"   : "OpenMP"
     },
@@ -45,7 +45,7 @@
         },
         "time_stepping"                : {
             "automatic_time_step" : false,
-            "time_step"           : -1.0
+            "time_step"           : 1.0
         }
     },
     "processes": {

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/two_elements_steady_test_adjoint_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/two_elements_steady_test_adjoint_parameters.json
@@ -1,8 +1,8 @@
 {
     "problem_data" : {
         "problem_name"    : "one_element",
-        "start_step"      : 2.0,
-        "nsteps"          : 1,
+        "start_time"      : 0.0,
+        "end_time"        : 1.0,
         "echo_level"      : 0,
         "parallel_type"   : "OpenMP"
     },
@@ -45,7 +45,7 @@
         },
         "time_stepping"                : {
             "automatic_time_step" : false,
-            "time_step"           : -1.0
+            "time_step"           : 1.0
         }
     },
     "processes": {


### PR DESCRIPTION
**📝 Description**
Following @sunethwarna indications, in here I'm slightly changing the time marching of the adjoint fluid solvers. The main changes are
- Now we use `start_time` and `end_time` as input parameters (no more `nsteps` and start/end step).
- The `time_step` is now a positive magnitude and is internally reversed by the adjoint solver.

Long story short, thanks to this the user doesn't need to change the primal problem time stepping settings to solve the adjoint one. Also note that we first check if the old input is provided to throw the corresponding message to the user.

As soon as we merge this, I will update the cases in the example repository.

Related to #9592.


