### PR TITLE
Correcting AMGCL Utility Type

### DIFF
--- a/kratos/utilities/amgcl_csr_spmm_utilities.h
+++ b/kratos/utilities/amgcl_csr_spmm_utilities.h
@@ -45,13 +45,13 @@ public:
         const CsrMatrix<TDataType, TIndexType>& rB
     )
     {
-        auto pAamgcl = AmgclCSRConversionUtilities::ConvertToAmgcl<TDataType,IndexType>(rA);
-        auto pBamgcl = AmgclCSRConversionUtilities::ConvertToAmgcl<TDataType,IndexType>(rB);
+        auto pAamgcl = AmgclCSRConversionUtilities::ConvertToAmgcl<TDataType,TIndexType>(rA);
+        auto pBamgcl = AmgclCSRConversionUtilities::ConvertToAmgcl<TDataType,TIndexType>(rB);
 
         auto Camgcl = amgcl::backend::product(*pAamgcl, *pBamgcl);
         amgcl::backend::sort_rows(*Camgcl);
 
-        return AmgclCSRConversionUtilities::ConvertToCsrMatrix<TDataType,IndexType>(*Camgcl);
+        return AmgclCSRConversionUtilities::ConvertToCsrMatrix<TDataType,TIndexType>(*Camgcl);
     }
 
 


### PR DESCRIPTION
**📝 Description**
IndexType -> TIndexType to get the internal type. It will cause to fail if someone decides to change the IndexType outside the function

**🆕 Changelog**
- Fixed Type in amgc utililty
