### PR TITLE
[Core] Moving GetDefaultParameters() and Name() from Access to Inquiry block in ImplicitSolvingStrategy

### DIFF
--- a/kratos/solving_strategies/strategies/implicit_solving_strategy.h
+++ b/kratos/solving_strategies/strategies/implicit_solving_strategy.h
@@ -11,8 +11,7 @@
 //
 //
 
-#if !defined(KRATOS_IMPLICIt_SOLVING_STRATEGY)
-#define KRATOS_IMPLICIt_SOLVING_STRATEGY
+#pragma once
 
 /* System includes */
 
@@ -159,6 +158,34 @@ public:
         return Kratos::make_shared<ClassType>(rModelPart, ThisParameters);
     }
 
+    /**
+     * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
+     * @return The default parameters
+     */
+    Parameters GetDefaultParameters() const override
+    {
+        Parameters default_parameters = Parameters(R"(
+        {
+            "name"                         : "implicit_solving_strategy",
+            "build_level"                  : 2
+        })");
+
+        // Getting base class default parameters
+        const Parameters base_default_parameters = BaseType::GetDefaultParameters();
+        default_parameters.RecursivelyAddMissingParameters(base_default_parameters);
+
+        return default_parameters;
+    }
+
+    /**
+     * @brief Returns the name of the class as used in the settings (snake_case format)
+     * @return The name of the class
+     */
+    static std::string Name()
+    {
+        return "implicit_solving_strategy";
+    }
+
     ///@}
     ///@name Access
     ///@{
@@ -192,34 +219,6 @@ public:
     int GetRebuildLevel() const override
     {
         return mRebuildLevel;
-    }
-
-    /**
-     * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
-     * @return The default parameters
-     */
-    Parameters GetDefaultParameters() const override
-    {
-        Parameters default_parameters = Parameters(R"(
-        {
-            "name"                         : "implicit_solving_strategy",
-            "build_level"                  : 2
-        })");
-
-        // Getting base class default parameters
-        const Parameters base_default_parameters = BaseType::GetDefaultParameters();
-        default_parameters.RecursivelyAddMissingParameters(base_default_parameters);
-
-        return default_parameters;
-    }
-
-    /**
-     * @brief Returns the name of the class as used in the settings (snake_case format)
-     * @return The name of the class
-     */
-    static std::string Name()
-    {
-        return "implicit_solving_strategy";
     }
 
     /**
@@ -353,5 +352,3 @@ private:
 ///@}
 
 } /* namespace Kratos.*/
-
-#endif /* KRATOS_IMPLICIt_SOLVING_STRATEGY  defined */

--- a/kratos/solving_strategies/strategies/implicit_solving_strategy.h
+++ b/kratos/solving_strategies/strategies/implicit_solving_strategy.h
@@ -158,6 +158,10 @@ public:
         return Kratos::make_shared<ClassType>(rModelPart, ThisParameters);
     }
 
+    ///@}
+    ///@name Inquiry
+    ///@{
+
     /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      * @return The default parameters


### PR DESCRIPTION
**📝 Description**

Moving GetDefaultParameters() and Name() from Access to Operations block in ImplicitSolvingStrategy. Also using pragma once (the t is not capital, so I could correct it or just replace it with pragma once)

**🆕 Changelog**

- [Moving GetDefaultParameters() and Name() from Access to Operations block in ImplicitSolvingStrategy](https://github.com/KratosMultiphysics/Kratos/commit/8782bc137f232da85119cbb30884d03bd526dbf6)
- Also using pragma once
