### PR TITLE
[Core] Remove pending `typedef` defined in a namespace

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_auxiliar_model_part_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_auxiliar_model_part_utilities.cpp
@@ -27,8 +27,6 @@
 namespace Kratos {
 namespace Testing {
 
-typedef Node<3> NodeType;
-
 /******************************************************************************************/
 /* Helper Functions */
 /******************************************************************************************/
@@ -261,6 +259,8 @@ KRATOS_TEST_CASE_IN_SUITE(AuxiliarModelPartUtilities_DeepCopyModelPart, KratosCo
 
     Properties::Pointer p_prop = r_origin_model_part.CreateNewProperties(0);
     p_prop->SetValue(DENSITY, 1.0);
+
+    using NodeType = Node<3>;
 
     // First we create the nodes
     auto p_node_1 = r_origin_model_part.CreateNewNode(1, 0.0 , 0.0 , 0.00);


### PR DESCRIPTION
**📝 Description**

Remove pending `typedef` defined in a namespace

**🆕 Changelog**

- [Remove pending `typedef` defined in a namespace](https://github.com/KratosMultiphysics/Kratos/commit/65aad2e21f8f41ab8a57baea3fb6dec3844c918d)
