### PR TITLE
[Several] Remove numpy check in several apps

### DIFF
--- a/applications/CableNetApplication/tests/test_empirical_spring.py
+++ b/applications/CableNetApplication/tests/test_empirical_spring.py
@@ -7,18 +7,15 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 
 from KratosMultiphysics.CableNetApplication import empirical_spring_element_process
 
-
-numpy_available = False
 numpy_polyfit_available = False
 
+import numpy as np
+
 try:
-    import numpy as np
-    numpy_available = True
-    try:
-        from numpy import polyfit
-        numpy_polyfit_available = True
-    except: pass
+    from numpy import polyfit
+    numpy_polyfit_available = True
 except: pass
+
 
 import sys
 
@@ -191,7 +188,6 @@ class EmpiricalSpringTests(KratosUnittest.TestCase):
         return current_model,mp,bcs_neumann
 
     def test_quasi_static(self):
-        if not numpy_available: self.skipTest("python package \"numpy\" not available")
         mp,bcs_neumann = self._set_up_standard_test(is_process_test=False)
 
         #apply boundary conditions

--- a/applications/CoSimulationApplication/tests/co_simulation_test_factory.py
+++ b/applications/CoSimulationApplication/tests/co_simulation_test_factory.py
@@ -7,12 +7,6 @@ data_comm = KM.Testing.GetDefaultDataCommunicator()
 import co_simulation_test_case
 import os
 
-try:
-    import numpy
-    numpy_available = True
-except ImportError:
-    numpy_available = False
-
 have_fsi_dependencies = kratos_utils.CheckIfApplicationsAvailable("FluidDynamicsApplication", "StructuralMechanicsApplication", "MappingApplication", "MeshMovingApplication", "LinearSolversApplication")
 have_potential_fsi_dependencies = kratos_utils.CheckIfApplicationsAvailable("CompressiblePotentialFlowApplication", "StructuralMechanicsApplication", "MappingApplication", "MeshMovingApplication", "LinearSolversApplication")
 have_mpm_fem_dependencies = kratos_utils.CheckIfApplicationsAvailable("ParticleMechanicsApplication", "StructuralMechanicsApplication", "MappingApplication", "LinearSolversApplication", "ConstitutiveLawsApplication")
@@ -28,8 +22,6 @@ class TestTinyFetiCoSimulationCases(co_simulation_test_case.CoSimulationTestCase
     '''This class contains "tiny" FETI CoSimulation-Cases, small enough to run in the CI
     '''
     def test_FEM_FEM_small_2d_plate_feti_explict_explicit(self):
-        if not numpy_available:
-            self.skipTest("Numpy not available")
         if not have_fem_fem_dependencies:
             self.skipTest("FEM-FEM dependencies are not available!")
 
@@ -39,8 +31,6 @@ class TestTinyFetiCoSimulationCases(co_simulation_test_case.CoSimulationTestCase
             self._runTest()
 
     def test_FEM_FEM_small_2d_plate_feti_implict_explicit(self):
-        if not numpy_available:
-            self.skipTest("Numpy not available")
         if not have_fem_fem_dependencies:
             self.skipTest("FEM-FEM dependencies are not available!")
 
@@ -50,8 +40,6 @@ class TestTinyFetiCoSimulationCases(co_simulation_test_case.CoSimulationTestCase
             self._runTest()
 
     def test_FEM_FEM_small_2d_plate_feti_implict_implicit(self):
-        if not numpy_available:
-            self.skipTest("Numpy not available")
         if not have_fem_fem_dependencies:
             self.skipTest("FEM-FEM dependencies are not available!")
 
@@ -61,8 +49,6 @@ class TestTinyFetiCoSimulationCases(co_simulation_test_case.CoSimulationTestCase
             self._runTest()
 
     def test_FEM_FEM_small_2d_plate_feti_implict_explicit_mixed(self):
-        if not numpy_available:
-            self.skipTest("Numpy not available")
         if not have_fem_fem_dependencies:
             self.skipTest("FEM-FEM dependencies are not available!")
 
@@ -72,8 +58,6 @@ class TestTinyFetiCoSimulationCases(co_simulation_test_case.CoSimulationTestCase
             self._runTest()
 
     def test_MPMDEMCoupling(self):
-        if not numpy_available:
-            self.skipTest("Numpy not available")
         if not have_mpm_dem_dependencies:
             self.skipTest("MPM DEM dependencies are not available!")
 
@@ -94,8 +78,6 @@ class TestSmallCoSimulationCases(co_simulation_test_case.CoSimulationTestCase):
     '''
 
     def test_FEM_FEM_small_2d_plate_dual_mortar(self):
-        if not numpy_available:
-            self.skipTest("Numpy not available")
         if not have_fem_fem_dependencies:
             self.skipTest("FEM-FEM dependencies are not available!")
 
@@ -105,8 +87,6 @@ class TestSmallCoSimulationCases(co_simulation_test_case.CoSimulationTestCase):
             self._runTest()
 
     def test_FEM_FEM_small_2d_plate_full_mortar(self):
-        if not numpy_available:
-            self.skipTest("Numpy not available")
         if not have_fem_fem_dependencies:
             self.skipTest("FEM-FEM dependencies are not available!")
 
@@ -116,8 +96,6 @@ class TestSmallCoSimulationCases(co_simulation_test_case.CoSimulationTestCase):
             self._runTest()
 
     def test_FEM_FEM_Neumann_Neumann_Jacobi_Solver(self):
-        if not numpy_available:
-            self.skipTest("Numpy not available")
         if not have_fem_fem_dependencies:
             self.skipTest("FEM-FEM dependencies are not available!")
 
@@ -127,8 +105,6 @@ class TestSmallCoSimulationCases(co_simulation_test_case.CoSimulationTestCase):
             self._runTest()
 
     #def test_FEM_FEM_dynamic_2d_cantilever_implicit_implicit(self):
-    #    if not numpy_available:
-    #        self.skipTest("Numpy not available")
     #    if not have_fem_fem_dependencies:
     #        self.skipTest("FEM-FEM dependencies are not available!")
     #
@@ -138,8 +114,6 @@ class TestSmallCoSimulationCases(co_simulation_test_case.CoSimulationTestCase):
     #        self._runTest()
     #
     #def test_FEM_FEM_dynamic_2d_cantilever_implicit_implicit_nonconforming(self):
-    #    if not numpy_available:
-    #        self.skipTest("Numpy not available")
     #    if not have_fem_fem_dependencies:
     #        self.skipTest("FEM-FEM dependencies are not available!")
     #
@@ -149,8 +123,6 @@ class TestSmallCoSimulationCases(co_simulation_test_case.CoSimulationTestCase):
     #        self._runTest()
     #
     #def test_FEM_FEM_dynamic_2d_cantilever_implicit_implicit_mixed_timestep(self):
-    #    if not numpy_available:
-    #        self.skipTest("Numpy not available")
     #    if not have_fem_fem_dependencies:
     #        self.skipTest("FEM-FEM dependencies are not available!")
     #
@@ -160,8 +132,6 @@ class TestSmallCoSimulationCases(co_simulation_test_case.CoSimulationTestCase):
     #        self._runTest()
     #
     #def test_FEM_FEM_dynamic_2d_cantilever_implicit_explicit_mixed_nonconforming(self):
-    #    if not numpy_available:
-    #        self.skipTest("Numpy not available")
     #    if not have_fem_fem_dependencies:
     #        self.skipTest("FEM-FEM dependencies are not available!")
     #
@@ -171,8 +141,6 @@ class TestSmallCoSimulationCases(co_simulation_test_case.CoSimulationTestCase):
     #        self._runTest()
 
     def test_sdof_static_fsi(self):
-        if not numpy_available:
-            self.skipTest("Numpy not available")
         if not have_potential_fsi_dependencies:
             self.skipTest("FSI dependencies are not available!")
 
@@ -187,8 +155,6 @@ class TestCoSimulationCases(co_simulation_test_case.CoSimulationTestCase):
     '''
 
     def test_MPM_FEM_beam_penalty(self):
-        if not numpy_available:
-            self.skipTest("Numpy not available")
         if not have_mpm_fem_dependencies:
             self.skipTest("MPM-FEM dependencies are not available!")
 
@@ -198,8 +164,6 @@ class TestCoSimulationCases(co_simulation_test_case.CoSimulationTestCase):
             self._runTest()
 
     def test_WallFSI(self):
-        if not numpy_available:
-            self.skipTest("Numpy not available")
         if not have_fsi_dependencies:
             self.skipTest("FSI dependencies are not available!")
 
@@ -208,8 +172,6 @@ class TestCoSimulationCases(co_simulation_test_case.CoSimulationTestCase):
             self._runTest()
 
     def test_DEMFEMCableNet(self):
-        if not numpy_available:
-            self.skipTest("Numpy not available")
         if not have_dem_fem_dependencies:
             self.skipTest("DEM FEM dependencies are not available!")
 
@@ -225,8 +187,6 @@ class TestCoSimulationCases(co_simulation_test_case.CoSimulationTestCase):
         self.addCleanup(kratos_utils.DeleteDirectoryIfExisting, GetFilePath("dem_fem_cable_net/cableNet_Results_and_Data"))
 
     def test_sdof_fsi(self):
-        if not numpy_available:
-            self.skipTest("Numpy not available")
         if not have_fsi_dependencies:
             self.skipTest("FSI dependencies are not available!")
 
@@ -245,8 +205,6 @@ class TestCoSimulationCases(co_simulation_test_case.CoSimulationTestCase):
 
     @KratosUnittest.skipUnless(False, "this test result is not evaluated")
     def test_PFEM_FEM_water_slide_2d(self):
-        if not numpy_available:
-            self.skipTest("Numpy not available")
         if not have_pfem_fem_dependencies:
             self.skipTest("PFEM FEM dependencies are not available!")
 

--- a/applications/CoSimulationApplication/tests/test_CoSimulationApplication.py
+++ b/applications/CoSimulationApplication/tests/test_CoSimulationApplication.py
@@ -1,12 +1,6 @@
 # Import Kratos "wrapper" for unittests
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 
-try:
-    import numpy
-    numpy_available = True
-except:
-    numpy_available = False
-
 from co_simulation_test_factory import TestTinyFetiCoSimulationCases
 from co_simulation_test_factory import TestSmallCoSimulationCases
 from co_simulation_test_factory import TestCoSimulationCases
@@ -14,22 +8,20 @@ from test_function_callback_utility import TestGenericCallFunction
 from test_ping_pong_coupling import TestPingPong
 from test_processes import TestCreatePointBasedEntitiesProcess
 from test_mok_fsi import TestMokFSI
-
-if numpy_available:
-    from test_coupling_interface_data import TestCouplingInterfaceData
-    from test_data_transfer_operators import TestDataTransferOperators
-    from test_coupling_operations import TestScalingOperation
-    from test_flower_coupling import TestFLOWerCoupling
-    from test_sdof_solver import TestSdofSolver
-    from test_sdof_static_solver import TestSdofStaticSolver
-    from test_convergence_criteria import TestConvergenceCriteria
-    from test_convergence_criteria import TestConvergenceCriteriaWrapper
-    from test_convergence_accelerators import TestConvergenceAcceleratorWrapper
-    from test_co_simulation_coupled_solver import TestCoupledSolverGetSolver
-    from test_co_simulation_coupled_solver import TestCoupledSolverModelAccess
-    from test_co_simulation_coupled_solver import TestCoupledSolverPassingModel
-    from test_co_simulation_coupled_solver import TestCoupledSolverCouplingInterfaceDataAccess
-    from test_model_part_utilties import TestModelPartUtiliites
+from test_coupling_interface_data import TestCouplingInterfaceData
+from test_data_transfer_operators import TestDataTransferOperators
+from test_coupling_operations import TestScalingOperation
+from test_flower_coupling import TestFLOWerCoupling
+from test_sdof_solver import TestSdofSolver
+from test_sdof_static_solver import TestSdofStaticSolver
+from test_convergence_criteria import TestConvergenceCriteria
+from test_convergence_criteria import TestConvergenceCriteriaWrapper
+from test_convergence_accelerators import TestConvergenceAcceleratorWrapper
+from test_co_simulation_coupled_solver import TestCoupledSolverGetSolver
+from test_co_simulation_coupled_solver import TestCoupledSolverModelAccess
+from test_co_simulation_coupled_solver import TestCoupledSolverPassingModel
+from test_co_simulation_coupled_solver import TestCoupledSolverCouplingInterfaceDataAccess
+from test_model_part_utilties import TestModelPartUtiliites
 
 from test_cosim_EMPIRE_API import TestCoSim_EMPIRE_API
 from test_co_sim_io_py_exposure import TestCoSimIOPyExposure
@@ -56,22 +48,21 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCreatePointBasedEntitiesProcess]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCoSim_EMPIRE_API]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCoSimIOPyExposure_aux_tests]))
-    if numpy_available:
-        smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCouplingInterfaceData]))
-        smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestDataTransferOperators]))
-        smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestScalingOperation]))
-        smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestSdofSolver]))
-        smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestSdofStaticSolver]))
-        smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestConvergenceCriteria]))
-        smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestConvergenceCriteriaWrapper]))
-        smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCoupledSolverGetSolver]))
-        smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCoupledSolverModelAccess]))
-        smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCoupledSolverPassingModel]))
-        smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCoupledSolverCouplingInterfaceDataAccess]))
-        smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestModelPartUtiliites]))
-        smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestPingPong]))
-        smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestConvergenceAcceleratorWrapper]))
-        smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestTinyFetiCoSimulationCases]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCouplingInterfaceData]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestDataTransferOperators]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestScalingOperation]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestSdofSolver]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestSdofStaticSolver]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestConvergenceCriteria]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestConvergenceCriteriaWrapper]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCoupledSolverGetSolver]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCoupledSolverModelAccess]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCoupledSolverPassingModel]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCoupledSolverCouplingInterfaceDataAccess]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestModelPartUtiliites]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestPingPong]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestConvergenceAcceleratorWrapper]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestTinyFetiCoSimulationCases]))
 
 
     ################################################################################
@@ -93,8 +84,7 @@ def AssembleTestSuites():
     validationSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCoSimulationCases]))
     validationSuite.addTest(TestMokFSI('test_mok_fsi_mvqn_external_structure'))
     validationSuite.addTest(TestMokFSI('test_mok_fsi_mvqn_external_structure_remote_controlled'))
-    # if numpy_available:
-    #     validationSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestFLOWerCoupling]))
+    # validationSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestFLOWerCoupling]))
 
     ################################################################################
     # Create a test suit that contains all the tests:

--- a/applications/CoSimulationApplication/tests/test_mok_fsi.py
+++ b/applications/CoSimulationApplication/tests/test_mok_fsi.py
@@ -7,12 +7,6 @@ from KratosMultiphysics.testing.utilities import GetPython3Command
 import co_simulation_test_case
 import os
 
-try:
-    import numpy
-    numpy_available = True
-except ImportError:
-    numpy_available = False
-
 have_fsi_dependencies = kratos_utils.CheckIfApplicationsAvailable("FluidDynamicsApplication", "StructuralMechanicsApplication", "MappingApplication", "MeshMovingApplication", "LinearSolversApplication")
 
 def GetFilePath(fileName):
@@ -22,8 +16,6 @@ class TestMokFSI(co_simulation_test_case.CoSimulationTestCase):
     cfd_tes_file_name = "fsi_mok/ProjectParametersCFD_for_test.json"
 
     def setUp(self):
-        if not numpy_available:
-            self.skipTest("Numpy not available")
         if not have_fsi_dependencies:
             self.skipTest("FSI dependencies are not available!")
 

--- a/applications/RomApplication/tests/test_compressible_potiential_rom.py
+++ b/applications/RomApplication/tests/test_compressible_potiential_rom.py
@@ -1,11 +1,5 @@
 import os
 
-try:
-    import numpy as np
-    numpy_available = True
-except ModuleNotFoundError:
-    numpy_available = False
-
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utilities
@@ -29,7 +23,6 @@ class TestCompressiblePotentialRom(KratosUnittest.TestCase):
             for file_name in files_to_remove:
                 kratos_utilities.DeleteFileIfExisting(file_name)
 
-    @KratosUnittest.skipUnless(numpy_available, "numpy is required for RomApplication")
     def testCompressiblePotentialRom(self):
         parameters_filename = "ProjectParameters.json"
         expected_output_filename = "ExpectedOutput.npy"

--- a/applications/RomApplication/tests/test_empirical_cubature_method.py
+++ b/applications/RomApplication/tests/test_empirical_cubature_method.py
@@ -3,13 +3,9 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utilities
 
 #import python packages
-try:
-    import numpy as np
-    from KratosMultiphysics.RomApplication.empirical_cubature_method import EmpiricalCubatureMethod
-    from KratosMultiphysics.RomApplication.randomized_singular_value_decomposition import RandomizedSingularValueDecomposition
-    numpy_available = True
-except:
-    numpy_available = False
+import numpy as np
+from KratosMultiphysics.RomApplication.empirical_cubature_method import EmpiricalCubatureMethod
+from KratosMultiphysics.RomApplication.randomized_singular_value_decomposition import RandomizedSingularValueDecomposition
 
 def synthetic_matrix(degree, rows = 100):
     TestMatrix = np.zeros((rows,degree+1))
@@ -25,7 +21,6 @@ def calculate_basis(TestMatrix):
 
 class TestEmpiricalCubatureMethod(KratosUnittest.TestCase):
 
-    @KratosUnittest.skipUnless(numpy_available, "numpy is required for RomApplication")
     def test_empirical_cubature_method(self):
 
         for degree in range(5,10):

--- a/applications/RomApplication/tests/test_fluid_rom.py
+++ b/applications/RomApplication/tests/test_fluid_rom.py
@@ -1,12 +1,6 @@
 import os
 import types
 
-try:
-    import numpy as np
-    numpy_available = True
-except:
-    numpy_available = False
-
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utilities
@@ -20,7 +14,6 @@ class TestFluidRom(KratosUnittest.TestCase):
     def setUp(self):
         self.relative_tolerance = 1.0e-12
 
-    @KratosUnittest.skipUnless(numpy_available, "numpy is required for RomApplication")
     def testFluidRom2D(self):
         self.work_folder = "fluid_dynamics_test_files"
         parameters_filename = "ProjectParameters.json"

--- a/applications/RomApplication/tests/test_randomized_singular_value_decomposition.py
+++ b/applications/RomApplication/tests/test_randomized_singular_value_decomposition.py
@@ -3,13 +3,9 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utilities
 
 #import python packages
-try:
-    import numpy as np
-    import numpy.matlib
-    from KratosMultiphysics.RomApplication.randomized_singular_value_decomposition import RandomizedSingularValueDecomposition
-    numpy_available = True
-except:
-    numpy_available = False
+import numpy as np
+import numpy.matlib
+from KratosMultiphysics.RomApplication.randomized_singular_value_decomposition import RandomizedSingularValueDecomposition
 
 def synthetic_matrix(degree, rows = 100,repetitions=20):
     TestMatrix = np.zeros((rows,degree))
@@ -20,7 +16,6 @@ def synthetic_matrix(degree, rows = 100,repetitions=20):
 
 class TestRandomizedSVD(KratosUnittest.TestCase):
 
-    @KratosUnittest.skipUnless(numpy_available, "numpy is required for RomApplication")
     def test_radomized_svd(self):
 
         svd_truncation_tolerance = 1e-5

--- a/applications/RomApplication/tests/test_structural_rom.py
+++ b/applications/RomApplication/tests/test_structural_rom.py
@@ -1,12 +1,6 @@
 import os
 import types
 
-try:
-    import numpy as np
-    numpy_available = True
-except:
-    numpy_available = False
-
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utilities
@@ -20,7 +14,6 @@ class TestStructuralRom(KratosUnittest.TestCase):
     def setUp(self):
         self.relative_tolerance = 1.0e-12
 
-    @KratosUnittest.skipUnless(numpy_available, "numpy is required for RomApplication")
     def testStructuralStaticRom2D(self):
         self.work_folder = "structural_static_test_files/ROM/"
         parameters_filename = "ProjectParametersROM.json"
@@ -51,7 +44,6 @@ class TestStructuralRom(KratosUnittest.TestCase):
             l2 = np.sqrt(numerator/denominator)*100
             self.assertLess(l2, self.relative_tolerance)
 
-    @KratosUnittest.skipUnless(numpy_available, "numpy is required for RomApplication")
     def testStructuralStaticHRom2D(self):
         self.work_folder = "structural_static_test_files/HROM/"
         parameters_filename = "ProjectParametersHROM.json"
@@ -85,7 +77,6 @@ class TestStructuralRom(KratosUnittest.TestCase):
             l2 = np.sqrt(numerator/denominator)*100
             self.assertLess(l2, self.relative_tolerance)
 
-    @KratosUnittest.skipUnless(numpy_available, "numpy is required for RomApplication")
     def testStructuralDynamicRom2D(self):
         self.work_folder = "structural_dynamic_test_files"
         parameters_filename = "ProjectParameters.json"

--- a/applications/RomApplication/tests/test_thermal_rom.py
+++ b/applications/RomApplication/tests/test_thermal_rom.py
@@ -1,12 +1,6 @@
 import os
 import types
 
-try:
-    import numpy as np
-    numpy_available = True
-except:
-    numpy_available = False
-
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utilities
@@ -20,7 +14,6 @@ class TestThermalRom(KratosUnittest.TestCase):
     def setUp(self):
         self.relative_tolerance = 1.0e-12
 
-    @KratosUnittest.skipUnless(numpy_available, "numpy is required for RomApplication")
     def testConvDiffStationaryRom2D(self):
         self.work_folder = "thermal_static_test_files"
         parameters_filename = "ProjectParameters.json"
@@ -44,7 +37,6 @@ class TestThermalRom(KratosUnittest.TestCase):
             l2 = np.sqrt((sum(nodal_area*((1 - obtained_output/expected_output )**2)))/(sum(nodal_area)))*100
             self.assertLess(l2, self.relative_tolerance)
 
-    @KratosUnittest.skipUnless(numpy_available, "numpy is required for RomApplication")
     def testConvDiffDynamicRom2D(self):
         self.work_folder = "thermal_dynamic_test_files"
         parameters_filename = "ProjectParameters.json"

--- a/applications/ShallowWaterApplication/tests/shallow_water_test_factory.py
+++ b/applications/ShallowWaterApplication/tests/shallow_water_test_factory.py
@@ -4,12 +4,6 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 from KratosMultiphysics.ShallowWaterApplication.shallow_water_analysis import ShallowWaterAnalysis
 
 try:
-    import numpy
-    numpy_available = True
-except ImportError:
-    numpy_available = False
-
-try:
     import scipy
     scipy_available = True
 except ImportError:
@@ -19,8 +13,6 @@ class ShallowWaterTestFactory(KratosUnittest.TestCase):
     need_numpy = False
     need_scipy = False
     def test_execution(self):
-        if self.need_numpy and not numpy_available:
-            self.skipTest("numpy not available")
         if self.need_scipy and not scipy_available:
             self.skipTest("scipy not available")
         with KratosUnittest.WorkFolderScope(self.execution_directory, __file__):


### PR DESCRIPTION
**📝 Description**

Numpy is now a default dependency, removing check

**🆕 Changelog**

- [Remove numpy check in ShallowWaterApplication](https://github.com/KratosMultiphysics/Kratos/commit/f3866e9a97fe21badb06d67a1835833cf4a73490)
- [Remove numpy check in RomApplication](https://github.com/KratosMultiphysics/Kratos/commit/ea81506cf891114785ad56df9c3aee96f2f8a3f9)
- [Remove numpy check in CoSimulationApplication](https://github.com/KratosMultiphysics/Kratos/commit/7129c51025a8f93cda02f7e8526d68f56667a183)
- [Remove numpy check in CableNetApplication](https://github.com/KratosMultiphysics/Kratos/commit/97bce68cc954756e24d9b10dfc61eb4d00fef7c5)
