### PR TITLE
[CoSimulationApplication] Replace `np.bool` (deprecated) with `bool`

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/coupling_interface_data.py
+++ b/applications/CoSimulationApplication/python_scripts/coupling_interface_data.py
@@ -259,7 +259,7 @@ def SetSolutionStepValue(entity, variable, solution_step_index, value):
 def GetNumpyDataType(variable_type):
     # https://docs.scipy.org/doc/numpy/user/basics.types.html
     dtype_map = {
-        "Bool" : np.bool,
+        "Bool" : bool,
         "Integer" : np.intc,
         "Unsigned Integer" : np.uintc,
         "Double" : np.double,


### PR DESCRIPTION
**📝 Description**

In order to silence the following deprecation warning:

~~~sh
Kratos\bin\Release\KratosMultiphysics\CoSimulationApplication\coupling_interface_data.py:262: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  "Bool" : np.bool,
~~~

**🆕 Changelog**

- [Replace `np.bool` (deprecated) with `bool`l](https://github.com/KratosMultiphysics/Kratos/commit/2e27741499f9aabbc9e16cb5271b534e55a0004a)
