### PR TITLE
[Levelset] Parallel Redistancing: Interface Preserving

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -86,6 +86,7 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
             },
             "distance_reinitialization": "variational",
             "parallel_redistance_max_layers" : 25,
+            "parallel_redistance_preserve_interface" : false,
             "distance_smoothing": false,
             "distance_smoothing_coefficient": 1.0,
             "distance_modification_settings": {
@@ -527,12 +528,15 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
         elif (self._reinitialization_type == "parallel"):
             #TODO: move all this to solver settings
             layers = self.settings["parallel_redistance_max_layers"].GetInt()
+            interface_preserving = self.settings["parallel_redistance_preserve_interface"].GetBool()
             parallel_distance_settings = KratosMultiphysics.Parameters("""{
-                "max_levels" : 25,
-                "max_distance" : 1.0,
+                "max_levels" : 100,
+                "max_distance" : 1.0e2,
+                "preserve_interface_strictly" : false,
                 "calculate_exact_distances_to_plane" : true
             }""")
             parallel_distance_settings["max_levels"].SetInt(layers)
+            parallel_distance_settings["preserve_interface_strictly"].SetBool(interface_preserving)
             if self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 2:
                 distance_reinitialization_process = KratosMultiphysics.ParallelDistanceCalculationProcess2D(
                     self.main_model_part,

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -532,7 +532,7 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
             parallel_distance_settings = KratosMultiphysics.Parameters("""{
                 "max_levels" : 100,
                 "max_distance" : 1.0e2,
-                "preserve_interface_strictly" : false,
+                "preserve_interface" : false,
                 "calculate_exact_distances_to_plane" : true
             }""")
             parallel_distance_settings["max_levels"].SetInt(layers)

--- a/kratos/processes/parallel_distance_calculation_process.cpp
+++ b/kratos/processes/parallel_distance_calculation_process.cpp
@@ -76,7 +76,7 @@ const Parameters ParallelDistanceCalculationProcess<TDim>::GetDefaultParameters(
         "distance_database" : "nodal_historical",
         "max_levels" : 25,
         "max_distance" : 1.0,
-        "preserve_interface_strictly" : false,
+        "preserve_interface" : false,
         "calculate_exact_distances_to_plane" : false
     })");
 }

--- a/kratos/processes/parallel_distance_calculation_process.cpp
+++ b/kratos/processes/parallel_distance_calculation_process.cpp
@@ -47,7 +47,7 @@ ParallelDistanceCalculationProcess<TDim>::ParallelDistanceCalculationProcess(
 
     mMaxLevels = Settings["max_levels"].GetInt();
     mMaxDistance = Settings["max_distance"].GetDouble();
-    mPreserveInterface = Settings["preserve_interface_strictly"].GetBool();
+    mPreserveInterface = Settings["preserve_interface"].GetBool();
     mCalculateExactDistancesToPlane = Settings["calculate_exact_distances_to_plane"].GetBool();
 
     const std::string distance_database = Settings["distance_database"].GetString();

--- a/kratos/processes/parallel_distance_calculation_process.h
+++ b/kratos/processes/parallel_distance_calculation_process.h
@@ -165,6 +165,7 @@ protected:
         const Variable<double>* mpAreaVar;
         unsigned int mMaxLevels;
         double mMaxDistance;
+        bool mPreserveInterface;
         bool mCalculateExactDistancesToPlane;
 
 
@@ -223,6 +224,8 @@ private:
     void ResetVariables();
 
     void CalculateExactDistancesOnDividedElements();
+
+    void AbsDistancesOnDividedElements();
 
 	void ExtendDistancesByLayer();
 


### PR DESCRIPTION
**📝 Description**
Avoiding recalculation of distance for the cut elements. It is an essential functionality missed in the cleaning of the code.

Please mark the PR with appropriate tags: 
- Feature

**🆕 Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- parallel_distance_calculation_process
- navier_stokes_two_fluids_solver
