### PR TITLE
[StructuralMechanicsApp] Minor inconsistencies in rotations in Init and Fin solution step methods

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -827,6 +827,8 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 for (IndexType point_number = 0; point_number < number_of_integration_points; point_number++) {
                     // Compute element kinematics B, F, DN_DX ...
                     CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
+                    // Compute constitutive law variables
+                    SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
                     // Compute material reponse
                     CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, GetStressMeasure());
@@ -888,7 +890,8 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
             for (IndexType point_number = 0; point_number < number_of_integration_points; ++point_number) {
                 // Compute element kinematics B, F, DN_DX ...
                 CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
-
+                // Compute constitutive law variables
+                SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
                 // Compute material reponse, not encessary to rotate since it's an invariant
                 CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, GetStressMeasure());
 
@@ -1037,6 +1040,8 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
             for ( IndexType point_number = 0; point_number < number_of_integration_points; ++point_number ) {
                 // Compute element kinematics B, F, DN_DX ...
                 CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
+                // Compute constitutive law variables
+                SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
                 if (is_rotated)
                     RotateToLocalAxes(Values, this_kinematic_variables);
@@ -1089,7 +1094,8 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
             for ( IndexType point_number = 0; point_number < number_of_integration_points; ++point_number ) {
                 // Compute element kinematics B, F, DN_DX ...
                 CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
-
+                // Compute constitutive law variables
+                SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
                 // Compute material reponse
                 CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, this_stress_measure);
 
@@ -1216,7 +1222,8 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
             for ( IndexType point_number = 0; point_number < mConstitutiveLawVector.size(); ++point_number ) {
                 // Compute element kinematics B, F, DN_DX ...
                 CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
-
+                // Compute constitutive law variables
+                SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
                 if (is_rotated)
                     RotateToLocalAxes(Values, this_kinematic_variables);
 
@@ -1552,9 +1559,6 @@ void BaseSolidElement::CalculateConstitutiveVariables(
     const ConstitutiveLaw::StressMeasure ThisStressMeasure
     )
 {
-    // Setting the variables for the CL
-    SetConstitutiveVariables(rThisKinematicVariables, rThisConstitutiveVariables, rValues, PointNumber, IntegrationPoints);
-
     // Actually do the computations in the ConstitutiveLaw in local axes
     mConstitutiveLawVector[PointNumber]->CalculateMaterialResponse(rValues, ThisStressMeasure); //here the calculations are actually done
 }

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -128,6 +128,9 @@ void BaseSolidElement::InitializeSolutionStep( const ProcessInfo& rCurrentProces
                 // Compute constitutive law variables
                 SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
+                // rotate to local axes strain/F
+                RotateToLocalAxes(rValues, this_kinematic_variables);
+
                 // Call the constitutive law to update material variables
                 mConstitutiveLawVector[point_number]->InitializeMaterialResponse(Values, GetStressMeasure());
 

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -725,7 +725,6 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
     )
 {
     const GeometryType::IntegrationPointsArrayType &integration_points = this->IntegrationPoints(this->GetIntegrationMethod());
-    const bool is_rotated = IsElementRotated();
 
     const std::size_t number_of_integration_points = integration_points.size();
     const auto& r_geometry = GetGeometry();

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -82,7 +82,13 @@ void BaseSolidElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 
 void BaseSolidElement::InitializeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
-    const bool required = mConstitutiveLawVector[0]->RequiresInitializeMaterialResponse();
+    bool required = false;
+    for ( IndexType point_number = 0; point_number < mConstitutiveLawVector.size(); ++point_number ) {
+        if (mConstitutiveLawVector[point_number]->RequiresInitializeMaterialResponse()) {
+            required = true;
+            break;
+        }
+    }
     if (required) {
         const bool is_rotated = IsElementRotated();
         const auto& r_geom = GetGeometry();
@@ -167,7 +173,13 @@ void BaseSolidElement::FinalizeNonLinearIteration( const ProcessInfo& rCurrentPr
 
 void BaseSolidElement::FinalizeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
-    const bool required = mConstitutiveLawVector[0]->RequiresFinalizeMaterialResponse();
+    bool required = false;
+    for ( IndexType point_number = 0; point_number < mConstitutiveLawVector.size(); ++point_number ) {
+        if (mConstitutiveLawVector[point_number]->RequiresFinalizeMaterialResponse()) {
+            required = true;
+            break;
+        }
+    }
     if (required) {
         const bool is_rotated = IsElementRotated();
         const auto &r_geometry = GetGeometry();

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -120,7 +120,7 @@ void BaseSolidElement::InitializeSolutionStep( const ProcessInfo& rCurrentProces
             // Compute constitutive law variables
             SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
-            // rotate to local axes strain/F
+            // Rotate to local axes strain/F
             RotateToLocalAxes(Values, this_kinematic_variables);
 
             // Call the constitutive law to update material variables
@@ -202,7 +202,7 @@ void BaseSolidElement::FinalizeSolutionStep( const ProcessInfo& rCurrentProcessI
             // Compute constitutive law variables
             SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
-            // rotate to local axes strain/F
+            // Rotate to local axes strain/F
             RotateToLocalAxes(Values, this_kinematic_variables);
 
             // Call the constitutive law to update material variables
@@ -1537,7 +1537,7 @@ void BaseSolidElement::CalculateConstitutiveVariables(
     // Setting the variables for the CL
     SetConstitutiveVariables(rThisKinematicVariables, rThisConstitutiveVariables, rValues, PointNumber, IntegrationPoints);
 
-    // rotate to local axes strain/F
+    // Rotate to local axes strain/F
     RotateToLocalAxes(rValues, rThisKinematicVariables);
 
     // Actually do the computations in the ConstitutiveLaw in local axes
@@ -1598,7 +1598,7 @@ void BaseSolidElement::RotateToLocalAxes(
                 ConstitutiveLawUtilities<3>::CalculateRotationOperatorVoigt(rotation_matrix, voigt_rotation_matrix);
                 rValues.GetStrainVector() = prod(voigt_rotation_matrix, rValues.GetStrainVector());
             }
-        } else { // rotate F
+        } else { // Rotate F
             BoundedMatrix<double, 3, 3> inv_rotation_matrix;
             double aux_det;
             MathUtils<double>::InvertMatrix3(rotation_matrix, inv_rotation_matrix, aux_det);

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -83,8 +83,8 @@ void BaseSolidElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 void BaseSolidElement::InitializeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
     const bool required = mConstitutiveLawVector[0]->RequiresInitializeMaterialResponse();
-    const bool is_rotated = IsElementRotated();
     if (required) {
+        const bool is_rotated = IsElementRotated();
         const auto& r_geom = GetGeometry();
         const SizeType number_of_nodes = r_geom.size();
         const SizeType dimension = r_geom.WorkingSpaceDimension();
@@ -168,8 +168,8 @@ void BaseSolidElement::FinalizeNonLinearIteration( const ProcessInfo& rCurrentPr
 void BaseSolidElement::FinalizeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
     const bool required = mConstitutiveLawVector[0]->RequiresFinalizeMaterialResponse();
-    const bool is_rotated = IsElementRotated();
     if (required) {
+        const bool is_rotated = IsElementRotated();
         const auto &r_geometry = GetGeometry();
         const Properties& r_properties = GetProperties();
         const SizeType number_of_nodes = r_geometry.size();
@@ -889,7 +889,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 // Compute element kinematics B, F, DN_DX ...
                 CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
 
-                // Compute material reponse
+                // Compute material reponse, not encessary to rotate since it's an invariant
                 CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, GetStressMeasure());
 
                 // Compute VM stress

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -62,7 +62,7 @@ void BaseSolidElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
             } else {
                 mThisIntegrationMethod = GetGeometry().GetDefaultIntegrationMethod();
             }
-        } 
+        }
 
         const GeometryType::IntegrationPointsArrayType& integration_points = this->IntegrationPoints();
 
@@ -1775,7 +1775,6 @@ double BaseSolidElement::CalculateDerivativesOnCurrentConfiguration(
         MathUtils<double>::InvertMatrix( rJ, rInvJ, detJ );
         GeometryUtils::ShapeFunctionsGradients(DN_De, rInvJ, rDN_DX);
     }
-    
     return detJ;
 }
 

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -212,19 +212,20 @@ void BaseSolidElement::FinalizeSolutionStep( const ProcessInfo& rCurrentProcessI
         const GeometryType::IntegrationPointsArrayType& integration_points = this->IntegrationPoints(mThisIntegrationMethod);
 
         for ( IndexType point_number = 0; point_number < mConstitutiveLawVector.size(); ++point_number ) {
-            if (mConstitutiveLawVector[point_number]->RequiresFinalizeMaterialResponse()) {
-                // Compute element kinematics B, F, DN_DX ...
-                CalculateKinematicVariables(this_kinematic_variables, point_number, mThisIntegrationMethod);
+            // Compute element kinematics B, F, DN_DX ...
+            CalculateKinematicVariables(this_kinematic_variables, point_number, mThisIntegrationMethod);
 
-                // Compute constitutive law variables
-                SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
+            // Compute constitutive law variables
+            SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
-                // Call the constitutive law to update material variables
-                mConstitutiveLawVector[point_number]->FinalizeMaterialResponse(Values, GetStressMeasure());
+            // rotate to local axes strain/F
+            RotateToLocalAxes(rValues, rThisKinematicVariables);
 
-                // TODO: Deprecated, remove this
-                mConstitutiveLawVector[point_number]->FinalizeSolutionStep( r_properties, r_geometry, row( N_values, point_number ), rCurrentProcessInfo);
-            }
+            // Call the constitutive law to update material variables
+            mConstitutiveLawVector[point_number]->FinalizeMaterialResponse(Values, GetStressMeasure());
+
+            // TODO: Deprecated, remove this
+            mConstitutiveLawVector[point_number]->FinalizeSolutionStep( r_properties, r_geometry, row( N_values, point_number ), rCurrentProcessInfo);
         }
     }
 }

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -82,14 +82,7 @@ void BaseSolidElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 
 void BaseSolidElement::InitializeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
-    // We initialize the material reponse if required
-    bool required = false;
-    for ( IndexType point_number = 0; point_number < mConstitutiveLawVector.size(); ++point_number ) {
-        if (mConstitutiveLawVector[point_number]->RequiresInitializeMaterialResponse()) {
-            required = true;
-            break;
-        }
-    }
+    const bool required = mConstitutiveLawVector[0]->RequiresInitializeMaterialResponse();
     if (required) {
         const auto& r_geom = GetGeometry();
         const SizeType number_of_nodes = r_geom.size();
@@ -172,14 +165,7 @@ void BaseSolidElement::FinalizeNonLinearIteration( const ProcessInfo& rCurrentPr
 
 void BaseSolidElement::FinalizeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
-    // We finalize the material reponse if required
-    bool required = false;
-    for ( IndexType point_number = 0; point_number < mConstitutiveLawVector.size(); ++point_number ) {
-        if (mConstitutiveLawVector[point_number]->RequiresFinalizeMaterialResponse()) {
-            required = true;
-            break;
-        }
-    }
+    const bool required = mConstitutiveLawVector[0]->RequiresFinalizeMaterialResponse();
     if (required) {
         const auto &r_geometry = GetGeometry();
         const Properties& r_properties = GetProperties();

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -128,7 +128,7 @@ void BaseSolidElement::InitializeSolutionStep( const ProcessInfo& rCurrentProces
             SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
             // rotate to local axes strain/F
-            RotateToLocalAxes(rValues, this_kinematic_variables);
+            RotateToLocalAxes(Values, this_kinematic_variables);
 
             // Call the constitutive law to update material variables
             mConstitutiveLawVector[point_number]->InitializeMaterialResponse(Values, GetStressMeasure());
@@ -217,7 +217,7 @@ void BaseSolidElement::FinalizeSolutionStep( const ProcessInfo& rCurrentProcessI
             SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
             // rotate to local axes strain/F
-            RotateToLocalAxes(rValues, this_kinematic_variables);
+            RotateToLocalAxes(Values, this_kinematic_variables);
 
             // Call the constitutive law to update material variables
             mConstitutiveLawVector[point_number]->FinalizeMaterialResponse(Values, GetStressMeasure());

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -121,22 +121,20 @@ void BaseSolidElement::InitializeSolutionStep( const ProcessInfo& rCurrentProces
         const GeometryType::IntegrationPointsArrayType& integration_points = this->IntegrationPoints();
 
         for ( IndexType point_number = 0; point_number < mConstitutiveLawVector.size(); ++point_number ) {
-            if (mConstitutiveLawVector[point_number]->RequiresInitializeMaterialResponse()) {
-                // Compute element kinematics B, F, DN_DX ...
-                CalculateKinematicVariables(this_kinematic_variables, point_number, mThisIntegrationMethod);
+            // Compute element kinematics B, F, DN_DX ...
+            CalculateKinematicVariables(this_kinematic_variables, point_number, mThisIntegrationMethod);
 
-                // Compute constitutive law variables
-                SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
+            // Compute constitutive law variables
+            SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
-                // rotate to local axes strain/F
-                RotateToLocalAxes(rValues, this_kinematic_variables);
+            // rotate to local axes strain/F
+            RotateToLocalAxes(rValues, this_kinematic_variables);
 
-                // Call the constitutive law to update material variables
-                mConstitutiveLawVector[point_number]->InitializeMaterialResponse(Values, GetStressMeasure());
+            // Call the constitutive law to update material variables
+            mConstitutiveLawVector[point_number]->InitializeMaterialResponse(Values, GetStressMeasure());
 
-                // TODO: Deprecated, remove this
-                mConstitutiveLawVector[point_number]->InitializeSolutionStep( r_properties, r_geom, row( N_values, point_number ), rCurrentProcessInfo);
-            }
+            // TODO: Deprecated, remove this
+            mConstitutiveLawVector[point_number]->InitializeSolutionStep( r_properties, r_geom, row( N_values, point_number ), rCurrentProcessInfo);
         }
     }
 }
@@ -219,7 +217,7 @@ void BaseSolidElement::FinalizeSolutionStep( const ProcessInfo& rCurrentProcessI
             SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
             // rotate to local axes strain/F
-            RotateToLocalAxes(rValues, rThisKinematicVariables);
+            RotateToLocalAxes(rValues, this_kinematic_variables);
 
             // Call the constitutive law to update material variables
             mConstitutiveLawVector[point_number]->FinalizeMaterialResponse(Values, GetStressMeasure());

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -1562,7 +1562,7 @@ void BaseSolidElement::CalculateConstitutiveVariables(
 
     // We undo the rotation of strain/F, C, stress
     if (IsElementRotated)
-        RotateToGlobalAxes(rValues, rThisKinematicVariables)
+        RotateToGlobalAxes(rValues, rThisKinematicVariables);
 }
 
 /***********************************************************************************/

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -774,7 +774,8 @@ protected:
         ConstitutiveLaw::Parameters& rValues,
         const IndexType PointNumber,
         const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
-        const ConstitutiveLaw::StressMeasure ThisStressMeasure = ConstitutiveLaw::StressMeasure_PK2
+        const ConstitutiveLaw::StressMeasure ThisStressMeasure = ConstitutiveLaw::StressMeasure_PK2,
+        const bool IsElementRotated
         );
 
     /**

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -910,6 +910,32 @@ protected:
     */
     void CalculateShapeGradientOfMassMatrix(MatrixType& rMassMatrix, ShapeParameter Deriv) const;
 
+    /**
+     * @brief This method checks is an element has to be rotated
+     * according to a set of local axes
+     */
+    bool IsElementRotated() const;
+
+    /**
+     * @brief This method rotates the F or strain according to local axis from
+     * global to local coordinates
+     * @param rValues The constitutive laws parameters
+     * @param rThisKinematicVariables The Kinematic parameters
+     */
+    void RotateToLocalAxes(
+        ConstitutiveLaw::Parameters &rValues,
+        KinematicVariables& rThisKinematicVariables);
+
+    /**
+     * @brief This method rotates the F or strain according to local axis from
+     * local de global
+     * @param rValues The constitutive laws parameters
+     * @param rThisKinematicVariables The Kinematic parameters
+     */
+    void RotateToGlobalAxes(
+        ConstitutiveLaw::Parameters &rValues,
+        KinematicVariables& rThisKinematicVariables);
+
     ///@}
     ///@name Protected  Access
     ///@{
@@ -979,37 +1005,11 @@ private:
     }
 
     /**
-     * @brief This method rotates the F or strain according to local axis from
-     * global to local coordinates
-     * @param rValues The constitutive laws parameters
-     * @param rThisKinematicVariables The Kinematic parameters
-     */
-    void RotateToLocalAxes(
-        ConstitutiveLaw::Parameters &rValues,
-        KinematicVariables& rThisKinematicVariables);
-
-    /**
-     * @brief This method rotates the F or strain according to local axis from
-     * local de global
-     * @param rValues The constitutive laws parameters
-     * @param rThisKinematicVariables The Kinematic parameters
-     */
-    void RotateToGlobalAxes(
-        ConstitutiveLaw::Parameters &rValues,
-        KinematicVariables& rThisKinematicVariables);
-
-    /**
      * @brief This method builds the rotation matrices and local axes
      */
     void BuildRotationSystem(
         BoundedMatrix<double, 3, 3> &rRotationMatrix,
         const SizeType StrainSize);
-
-    /**
-     * @brief This method checks is an element has to be rotated
-     * according to a set of local axes
-     */
-    bool IsElementRotated() const;
 
     /**
      * @brief This method computes directly in the CL

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -775,7 +775,7 @@ protected:
         const IndexType PointNumber,
         const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
         const ConstitutiveLaw::StressMeasure ThisStressMeasure = ConstitutiveLaw::StressMeasure_PK2,
-        const bool IsElementRotated
+        const bool IsElementRotated = true
         );
 
     /**

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -1053,6 +1053,9 @@ private:
             // Compute material reponse
             this->SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
+            // rotate to local axes strain/F
+            RotateToLocalAxes(Values, this_kinematic_variables);
+
             rOutput[point_number] = mConstitutiveLawVector[point_number]->CalculateValue( Values, rVariable, rOutput[point_number] );
         }
     }

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -1026,6 +1026,7 @@ private:
         const ProcessInfo& rCurrentProcessInfo
         )
     {
+        const bool is_rotated = IsElementRotated();
         const GeometryType::IntegrationPointsArrayType& integration_points = GetGeometry().IntegrationPoints( this->GetIntegrationMethod() );
 
         const SizeType number_of_nodes = GetGeometry().size();
@@ -1054,7 +1055,8 @@ private:
             this->SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
             // rotate to local axes strain/F
-            RotateToLocalAxes(Values, this_kinematic_variables);
+            if (is_rotated)
+                RotateToLocalAxes(Values, this_kinematic_variables);
 
             rOutput[point_number] = mConstitutiveLawVector[point_number]->CalculateValue( Values, rVariable, rOutput[point_number] );
         }

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
@@ -165,16 +165,9 @@ void SmallDisplacement::CalculateAll(
 
         // Compute element kinematics B, F, DN_DX ...
         CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
-        // Compute constitutive law variables
-        SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
-        if (is_rotated)
-            RotateToLocalAxes(Values, this_kinematic_variables);
 
         // Compute material reponse
-        CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, GetStressMeasure());
-
-        if (is_rotated)
-            RotateToGlobalAxes(Values, this_kinematic_variables);
+        CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, GetStressMeasure(), is_rotated);
 
         // Calculating weights for integration on the reference configuration
         int_to_reference_weight = GetIntegrationWeight(integration_points, point_number, this_kinematic_variables.detJ0);

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
@@ -165,7 +165,8 @@ void SmallDisplacement::CalculateAll(
 
         // Compute element kinematics B, F, DN_DX ...
         CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
-
+        // Compute constitutive law variables
+        SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
         if (is_rotated)
             RotateToLocalAxes(Values, this_kinematic_variables);
 

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
@@ -113,6 +113,7 @@ void SmallDisplacement::CalculateAll(
     const SizeType number_of_nodes = r_geometry.size();
     const SizeType dimension = r_geometry.WorkingSpaceDimension();
     const SizeType strain_size = GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
+    const bool is_rotated = IsElementRotated();
 
     KinematicVariables this_kinematic_variables(strain_size, dimension, number_of_nodes);
     ConstitutiveVariables this_constitutive_variables(strain_size);
@@ -165,8 +166,14 @@ void SmallDisplacement::CalculateAll(
         // Compute element kinematics B, F, DN_DX ...
         CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
 
+        if (is_rotated)
+            RotateToLocalAxes(Values, this_kinematic_variables);
+
         // Compute material reponse
         CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, GetStressMeasure());
+
+        if (is_rotated)
+            RotateToGlobalAxes(Values, this_kinematic_variables);
 
         // Calculating weights for integration on the reference configuration
         int_to_reference_weight = GetIntegrationWeight(integration_points, point_number, this_kinematic_variables.detJ0);

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
@@ -936,6 +936,7 @@ void SmallDisplacementBbar::FinalizeSolutionStep( const ProcessInfo& rCurrentPro
     const SizeType number_of_nodes = GetGeometry().size();
     const SizeType dimension = GetGeometry().WorkingSpaceDimension();
     const SizeType strain_size = mConstitutiveLawVector[0]->GetStrainSize();
+    const bool is_rotated = IsElementRotated();
 
     KinematicVariablesBbar this_kinematic_variables(strain_size, dimension, number_of_nodes);
     ConstitutiveVariables this_constitutive_variables(strain_size);
@@ -967,8 +968,14 @@ void SmallDisplacementBbar::FinalizeSolutionStep( const ProcessInfo& rCurrentPro
         // Compute constitutive law variables
         SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
+        if (is_rotated)
+            RotateToLocalAxes(Values, this_kinematic_variables);
+
         // Call the constitutive law to update material variables
         mConstitutiveLawVector[point_number]->FinalizeMaterialResponse(Values, GetStressMeasure());
+
+        if (is_rotated)
+            RotateToGlobalAxes(Values, this_kinematic_variables);
 
         // TODO: To be deprecated
         mConstitutiveLawVector[point_number]->FinalizeSolutionStep(

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
@@ -149,6 +149,8 @@ void SmallDisplacementBbar::CalculateAll(
 
         // Compute element kinematics B, F, DN_DX ...
         CalculateKinematicVariablesBbar(this_kinematic_variables, point_number, integration_points);
+        // Compute constitutive law variables
+        SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
         if (is_rotated)
             RotateToLocalAxes(Values, this_kinematic_variables);
@@ -306,9 +308,6 @@ void SmallDisplacementBbar::CalculateConstitutiveVariables(
     const ConstitutiveLaw::StressMeasure ThisStressMeasure
     )
 {
-    // Set the constitutive variables
-    SetConstitutiveVariables(rThisKinematicVariables, rThisConstitutiveVariables, rValues, PointNumber, IntegrationPoints);
-
     // Actually do the computations in the ConstitutiveLaw
     mConstitutiveLawVector[PointNumber]->CalculateMaterialResponse(rValues, ThisStressMeasure); //here the calculations are actually done
 }
@@ -607,7 +606,8 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
         for(IndexType point_number = 0; point_number < integration_points.size(); point_number++) {
             // Compute element kinematics B, F, DN_DX ...
             CalculateKinematicVariablesBbar(this_kinematic_variables, point_number, integration_points);
-
+            // Compute constitutive law variables
+            SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
             // Compute material reponse
             CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables,
                                            Values, point_number, integration_points,
@@ -687,6 +687,8 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
         {
             // Compute element kinematics B, F, DN_DX ...
             CalculateKinematicVariablesBbar(this_kinematic_variables, point_number, integration_points);
+            // Compute constitutive law variables
+            SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
             if (is_rotated)
 	            RotateToLocalAxes(Values, this_kinematic_variables);
@@ -750,7 +752,8 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
         for ( IndexType point_number = 0; point_number < integration_points.size(); point_number++ ) {
             // Compute element kinematics B, F, DN_DX ...
             CalculateKinematicVariablesBbar(this_kinematic_variables, point_number, integration_points);
-
+            // Compute constitutive law variables
+            SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
             // Compute material reponse
             CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables,
                                            Values, point_number, integration_points, this_stress_measure);
@@ -842,7 +845,8 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
         for(IndexType point_number = 0; point_number < mConstitutiveLawVector.size(); point_number++) {
             // Compute element kinematics B, F, DN_DX ...
             CalculateKinematicVariablesBbar(this_kinematic_variables, point_number, integration_points);
-
+            // Compute constitutive law variables
+            SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
             if (is_rotated)
                 RotateToLocalAxes(Values, this_kinematic_variables);
             // Compute material reponse
@@ -880,7 +884,8 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
         for(IndexType point_number = 0; point_number < mConstitutiveLawVector.size(); point_number++ ) {
             // Compute element kinematics B, F, DN_DX ...
             CalculateKinematicVariablesBbar(this_kinematic_variables, point_number, integration_points);
-
+            // Compute constitutive law variables
+            SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
             // Compute material reponse
             CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables,
                                            Values, point_number, integration_points,

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
@@ -974,9 +974,6 @@ void SmallDisplacementBbar::FinalizeSolutionStep( const ProcessInfo& rCurrentPro
         // Call the constitutive law to update material variables
         mConstitutiveLawVector[point_number]->FinalizeMaterialResponse(Values, GetStressMeasure());
 
-        if (is_rotated)
-            RotateToGlobalAxes(Values, this_kinematic_variables);
-
         // TODO: To be deprecated
         mConstitutiveLawVector[point_number]->FinalizeSolutionStep(
                 GetProperties(),

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
@@ -657,6 +657,7 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
 
     if ( rVariable == CAUCHY_STRESS_VECTOR || rVariable == PK2_STRESS_VECTOR ) {
         // Create and initialize element variables:
+        const bool is_rotated = IsElementRotated();
         const SizeType number_of_nodes = GetGeometry().size();
         const SizeType dimension = GetGeometry().WorkingSpaceDimension();
         const SizeType strain_size = mConstitutiveLawVector[0]->GetStrainSize();
@@ -687,6 +688,8 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
             // Compute element kinematics B, F, DN_DX ...
             CalculateKinematicVariablesBbar(this_kinematic_variables, point_number, integration_points);
 
+            if (is_rotated)
+	            RotateToLocalAxes(Values, this_kinematic_variables);
             //call the constitutive law to update material variables
             if( rVariable == CAUCHY_STRESS_VECTOR) {
                 // Compute material reponse
@@ -706,6 +709,8 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
                                                integration_points,
                                                ConstitutiveLaw::StressMeasure_PK2);
             }
+            if (is_rotated)
+                RotateToGlobalAxes(Values, this_kinematic_variables);
 
             if ( rOutput[point_number].size() != strain_size )
                 rOutput[point_number].resize( strain_size, false );

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.h
@@ -256,23 +256,6 @@ protected:
         const GeometryType::IntegrationPointsArrayType& IntegrationPoints
         ) override;
 
-    /**
-     * This functions updates the constitutive variables
-     * @param rThisKinematicVariables The kinematic variables to be calculated
-     * @param rThisConstitutiveVariables The constitutive variables
-     * @param rValues The CL parameters
-     * @param PointNumber The integration point considered
-     * @param IntegrationPoints The list of integration points
-     * @param ThisStressMeasure The stress measure considered
-     */
-    void CalculateConstitutiveVariables(
-        KinematicVariables& rThisKinematicVariables,
-        ConstitutiveVariables& rThisConstitutiveVariables,
-        ConstitutiveLaw::Parameters& rValues,
-        const IndexType PointNumber,
-        const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
-        const ConstitutiveLaw::StressMeasure ThisStressMeasure
-        ) override;
 
     /**
     * This functions calculates both the RHS and the LHS

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
@@ -218,17 +218,9 @@ void TotalLagrangian::CalculateAll(
 
         // Compute element kinematics B, F, DN_DX ...
         this->CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
-        // Compute constitutive law variables
-        SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
-
-        if (is_rotated)
-            RotateToLocalAxes(Values, this_kinematic_variables);
 
         // Compute material reponse
-        this->CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, this->GetStressMeasure());
-
-        if (is_rotated)
-            RotateToGlobalAxes(Values, this_kinematic_variables);
+        this->CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, this->GetStressMeasure(), is_rotated);
 
         // Calculating weights for integration on the reference configuration
         int_to_reference_weight = GetIntegrationWeight(integration_points, point_number, this_kinematic_variables.detJ0);

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
@@ -218,6 +218,8 @@ void TotalLagrangian::CalculateAll(
 
         // Compute element kinematics B, F, DN_DX ...
         this->CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
+        // Compute constitutive law variables
+        SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
         if (is_rotated)
             RotateToLocalAxes(Values, this_kinematic_variables);

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
@@ -218,8 +218,14 @@ void TotalLagrangian::CalculateAll(
         // Compute element kinematics B, F, DN_DX ...
         this->CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
 
+        if (is_rotated)
+            RotateToLocalAxes(Values, this_kinematic_variables);
+
         // Compute material reponse
         this->CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, this->GetStressMeasure());
+
+        if (is_rotated)
+            RotateToGlobalAxes(Values, this_kinematic_variables);
 
         // Calculating weights for integration on the reference configuration
         int_to_reference_weight = GetIntegrationWeight(integration_points, point_number, this_kinematic_variables.detJ0);

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
@@ -166,6 +166,7 @@ void TotalLagrangian::CalculateAll(
     const SizeType number_of_nodes = this->GetGeometry().size();
     const SizeType dimension = this->GetGeometry().WorkingSpaceDimension();
     const auto strain_size = GetStrainSize();
+    const bool is_rotated = IsElementRotated();
 
     KinematicVariables this_kinematic_variables(strain_size, dimension, number_of_nodes);
     ConstitutiveVariables this_constitutive_variables(strain_size);

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian_q1p0_mixed_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian_q1p0_mixed_element.cpp
@@ -180,7 +180,7 @@ void TotalLagrangianQ1P0MixedElement::CalculateAll(
         this->CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
 
         // Compute material reponse
-        this->CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, this->GetStressMeasure());
+        this->CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, this->GetStressMeasure(), false);
 
         const Matrix& r_C = prod(trans(this_kinematic_variables.F), this_kinematic_variables.F);
         MathUtils<double>::InvertMatrix3(r_C, inv_C, det);

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -263,8 +263,14 @@ void UpdatedLagrangian::CalculateAll(
         // Compute element kinematics B, F, DN_DX ...
         this->CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
 
+        if (is_rotated)
+            RotateToLocalAxes(Values, this_kinematic_variables);
+
         // Compute material reponse
         this->CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, this->GetStressMeasure());
+
+        if (is_rotated)
+            RotateToGlobalAxes(Values, this_kinematic_variables);
 
         // Calculating weights for integration on the reference configuration
         int_to_reference_weight = this->GetIntegrationWeight(integration_points, point_number, this_kinematic_variables.detJ0);

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -264,17 +264,8 @@ void UpdatedLagrangian::CalculateAll(
         // Compute element kinematics B, F, DN_DX ...
         this->CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
 
-        // Compute constitutive law variables
-        SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
-
-        if (is_rotated)
-            RotateToLocalAxes(Values, this_kinematic_variables);
-
         // Compute material reponse
-        this->CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, this->GetStressMeasure());
-
-        if (is_rotated)
-            RotateToGlobalAxes(Values, this_kinematic_variables);
+        this->CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, this->GetStressMeasure(), is_rotated);
 
         // Calculating weights for integration on the reference configuration
         int_to_reference_weight = this->GetIntegrationWeight(integration_points, point_number, this_kinematic_variables.detJ0);

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -211,6 +211,7 @@ void UpdatedLagrangian::CalculateAll(
     const SizeType number_of_nodes = GetGeometry().size();
     const SizeType dimension = GetGeometry().WorkingSpaceDimension();
     const SizeType strain_size = GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
+    const bool is_rotated = IsElementRotated();
 
     KinematicVariables this_kinematic_variables(strain_size, dimension, number_of_nodes);
     ConstitutiveVariables this_constitutive_variables(strain_size);

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -264,6 +264,9 @@ void UpdatedLagrangian::CalculateAll(
         // Compute element kinematics B, F, DN_DX ...
         this->CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
 
+        // Compute constitutive law variables
+        SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
+
         if (is_rotated)
             RotateToLocalAxes(Values, this_kinematic_variables);
 


### PR DESCRIPTION
**📝 Description**
Together with @lagoncalvesjr we noticed that, for cases in which we rotate the local axis of the elements a few rotations when missing when doing the `InitializeSolutionStep`, `FinalizeSolutionStep` and `CalculateOnConstitutiveLaw` methods.

I've solved this issues together with removing redundant checks in the `InitializeSolutionStep` and in the `FinalizeSolutionStep`.
