### PR TITLE
[Core] Clean up code using C++17 constexpr instead of explicit template specialization (II)

### DIFF
--- a/kratos/processes/compute_nodal_gradient_process.cpp
+++ b/kratos/processes/compute_nodal_gradient_process.cpp
@@ -4,19 +4,19 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Vicente Mataix Ferrandiz
 //
 //
 
-/* System includes */
+// System includes
 
-/* External includes */
+// External includes
 
-/* Project includes */
+// Project includes
 #include "utilities/variable_utils.h"
 #include "utilities/geometry_utilities.h"
 #include "processes/compute_nodal_gradient_process.h"
@@ -141,8 +141,8 @@ void ComputeNodalGradientProcess<THistorical>::ComputeElementalContributionsAndV
 /***********************************************************************************/
 /***********************************************************************************/
 
-template<>
-ComputeNodalGradientProcess<ComputeNodalGradientProcessSettings::SaveAsHistoricalVariable>::ComputeNodalGradientProcess(
+template<bool THistorical>
+ComputeNodalGradientProcess<THistorical>::ComputeNodalGradientProcess(
     ModelPart& rModelPart,
     const Variable<double>& rOriginVariable,
     const Variable<array_1d<double,3> >& rGradientVariable,
@@ -158,37 +158,16 @@ ComputeNodalGradientProcess<ComputeNodalGradientProcessSettings::SaveAsHistorica
 
     CheckOriginAndAreaVariables();
 
-    // Checking historical gradient variable
-    VariableUtils().CheckVariableExists(rGradientVariable, mrModelPart.Nodes());
-
-    KRATOS_CATCH("")
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template<>
-ComputeNodalGradientProcess<ComputeNodalGradientProcessSettings::SaveAsNonHistoricalVariable>::ComputeNodalGradientProcess(
-    ModelPart& rModelPart,
-    const Variable<double>& rOriginVariable,
-    const Variable<array_1d<double,3> >& rGradientVariable,
-    const Variable<double>& rAreaVariable,
-    const bool NonHistoricalVariable
-    ) : mrModelPart(rModelPart),
-        mpOriginVariable(&rOriginVariable),
-        mpGradientVariable(&rGradientVariable),
-        mpAreaVariable(&rAreaVariable),
-        mNonHistoricalVariable(NonHistoricalVariable)
-{
-    KRATOS_TRY
-
-    CheckOriginAndAreaVariables();
-
-    // In case the area or gradient variable is not initialized we initialize it
-    if (mrModelPart.NumberOfNodes() != 0) {
-        if (!mrModelPart.Nodes().begin()->Has( rGradientVariable )) {
-            const array_1d<double,3> zero_vector = ZeroVector(3);
-            VariableUtils().SetNonHistoricalVariable(rGradientVariable, zero_vector, mrModelPart.Nodes());
+    if constexpr (THistorical) {
+        // Checking historical gradient variable
+        VariableUtils().CheckVariableExists(rGradientVariable, mrModelPart.Nodes());
+    } else {
+        // In case the area or gradient variable is not initialized we initialize it
+        if (mrModelPart.NumberOfNodes() != 0) {
+            if (!mrModelPart.Nodes().begin()->Has( rGradientVariable )) {
+                const array_1d<double,3> zero_vector = ZeroVector(3);
+                VariableUtils().SetNonHistoricalVariable(rGradientVariable, zero_vector, mrModelPart.Nodes());
+            }
         }
     }
 
@@ -278,123 +257,91 @@ void ComputeNodalGradientProcess<THistorical>::CheckOriginAndAreaVariables()
 /***********************************************************************************/
 /***********************************************************************************/
 
-template<>
-void ComputeNodalGradientProcess<ComputeNodalGradientProcessSettings::SaveAsHistoricalVariable>::ClearGradient()
+template<bool THistorical>
+void ComputeNodalGradientProcess<THistorical>::ClearGradient()
 {
-    block_for_each(mrModelPart.Nodes(), [&](Node<3>& rNode){
+    if constexpr (THistorical) {
+        block_for_each(mrModelPart.Nodes(), [&](NodeType& rNode){
             rNode.SetValue(*mpAreaVariable, 0.0);
             rNode.FastGetSolutionStepValue(*mpGradientVariable).clear();
         });
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template <>
-void ComputeNodalGradientProcess<ComputeNodalGradientProcessSettings::SaveAsNonHistoricalVariable>::ClearGradient()
-{
-    const array_1d<double, 3> aux_zero_vector = ZeroVector(3);
-    block_for_each(mrModelPart.Nodes(), [&](Node<3>& rNode){
+    } else {
+        const array_1d<double, 3> aux_zero_vector = ZeroVector(3);
+        block_for_each(mrModelPart.Nodes(), [&](NodeType& rNode){
             rNode.SetValue(*mpAreaVariable, 0.0);
             rNode.SetValue(*mpGradientVariable, aux_zero_vector);
         });
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template <>
-array_1d<double, 3>& ComputeNodalGradientProcess<ComputeNodalGradientProcessSettings::SaveAsHistoricalVariable>::GetGradient(
-    Element::GeometryType& rThisGeometry,
-    unsigned int i
-    )
-{
-    return rThisGeometry[i].FastGetSolutionStepValue(*mpGradientVariable);
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template <>
-array_1d<double, 3>& ComputeNodalGradientProcess<ComputeNodalGradientProcessSettings::SaveAsNonHistoricalVariable>::GetGradient(
-    Element::GeometryType& rThisGeometry,
-    unsigned int i
-    )
-{
-    return rThisGeometry[i].GetValue(*mpGradientVariable);
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template <>
-void ComputeNodalGradientProcess<ComputeNodalGradientProcessSettings::SaveAsHistoricalVariable>::PonderateGradient()
-{
-    block_for_each(mrModelPart.Nodes(), [&](Node<3>& rNode){
-            rNode.FastGetSolutionStepValue(*mpGradientVariable) /=
-                rNode.GetValue(*mpAreaVariable);
-        });
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template <>
-void ComputeNodalGradientProcess<ComputeNodalGradientProcessSettings::SaveAsNonHistoricalVariable>::PonderateGradient()
-{
-    block_for_each(mrModelPart.Nodes(), [&](Node<3>& rNode){
-            rNode.GetValue(*mpGradientVariable) /=
-                rNode.GetValue(*mpAreaVariable);
-        });
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template <>
-void ComputeNodalGradientProcess<ComputeNodalGradientProcessSettings::SaveAsHistoricalVariable>::SynchronizeGradientAndVolume()
-{
-    mrModelPart.GetCommunicator().AssembleCurrentData(*mpGradientVariable);
-    mrModelPart.GetCommunicator().AssembleNonHistoricalData(*mpAreaVariable);
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template <>
-void ComputeNodalGradientProcess<ComputeNodalGradientProcessSettings::SaveAsNonHistoricalVariable>::SynchronizeGradientAndVolume()
-{
-    mrModelPart.GetCommunicator().AssembleNonHistoricalData(*mpGradientVariable);
-    mrModelPart.GetCommunicator().AssembleNonHistoricalData(*mpAreaVariable);
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template <>
-void VariableVectorRetriever<ComputeNodalGradientProcessSettings::GetAsHistoricalVariable>::GetVariableVector(
-    const Geometry<Node<3>>& rGeometry,
-    const Variable<double>& rVariable,
-    Vector& rVector
-    )
-{
-    for(std::size_t i_node=0; i_node < rGeometry.size(); ++i_node) {
-        rVector[i_node] = rGeometry[i_node].FastGetSolutionStepValue(rVariable);
     }
 }
 
 /***********************************************************************************/
 /***********************************************************************************/
 
-template <>
-void VariableVectorRetriever<ComputeNodalGradientProcessSettings::GetAsNonHistoricalVariable>::GetVariableVector(
+template<bool THistorical>
+array_1d<double, 3>& ComputeNodalGradientProcess<THistorical>::GetGradient(
+    Element::GeometryType& rThisGeometry,
+    unsigned int i
+    )
+{
+    if constexpr (THistorical) {
+        return rThisGeometry[i].FastGetSolutionStepValue(*mpGradientVariable);
+    } else {
+        return rThisGeometry[i].GetValue(*mpGradientVariable);
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<bool THistorical>
+void ComputeNodalGradientProcess<THistorical>::PonderateGradient()
+{
+    if constexpr (THistorical) {
+        block_for_each(mrModelPart.Nodes(), [&](NodeType& rNode){
+            rNode.FastGetSolutionStepValue(*mpGradientVariable) /=
+            rNode.GetValue(*mpAreaVariable);
+        });
+    } else {
+        block_for_each(mrModelPart.Nodes(), [&](NodeType& rNode){
+            rNode.GetValue(*mpGradientVariable) /=
+            rNode.GetValue(*mpAreaVariable);
+        });
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<bool THistorical>
+void ComputeNodalGradientProcess<THistorical>::SynchronizeGradientAndVolume()
+{
+    if constexpr (THistorical) {
+        mrModelPart.GetCommunicator().AssembleCurrentData(*mpGradientVariable);
+        mrModelPart.GetCommunicator().AssembleNonHistoricalData(*mpAreaVariable);
+    } else {
+        mrModelPart.GetCommunicator().AssembleNonHistoricalData(*mpGradientVariable);
+        mrModelPart.GetCommunicator().AssembleNonHistoricalData(*mpAreaVariable);
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<bool THistorical>
+void VariableVectorRetriever<THistorical>::GetVariableVector(
     const Geometry<Node<3>>& rGeometry,
     const Variable<double>& rVariable,
     Vector& rVector
     )
 {
-    for(std::size_t i_node=0; i_node < rGeometry.size(); ++i_node) {
-        rVector[i_node] = rGeometry[i_node].GetValue(rVariable);
+    if constexpr (THistorical) {
+        for(std::size_t i_node=0; i_node < rGeometry.size(); ++i_node) {
+            rVector[i_node] = rGeometry[i_node].FastGetSolutionStepValue(rVariable);
+        }
+    } else {
+        for(std::size_t i_node=0; i_node < rGeometry.size(); ++i_node) {
+            rVector[i_node] = rGeometry[i_node].GetValue(rVariable);
+        }
     }
 }
 

--- a/kratos/processes/compute_nodal_gradient_process.h
+++ b/kratos/processes/compute_nodal_gradient_process.h
@@ -4,15 +4,14 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Vicente Mataix Ferrandiz
 //
 
-#if !defined(KRATOS_COMPUTE_GRADIENT_PROCESS_INCLUDED )
-#define  KRATOS_COMPUTE_GRADIENT_PROCESS_INCLUDED
+#pragma once
 
 // System includes
 
@@ -126,6 +125,9 @@ public:
     ///@name Type Definitions
     ///@{
 
+    /// The definition of the node
+    typedef Node<3> NodeType;
+
     /// Pointer definition of ComputeNodalGradientProcess
     KRATOS_CLASS_POINTER_DEFINITION(ComputeNodalGradientProcess);
 
@@ -153,7 +155,6 @@ public:
     {
     }
 
-
     ///@}
     ///@name Operators
     ///@{
@@ -163,7 +164,6 @@ public:
     {
         Execute();
     }
-
 
     ///@}
     ///@name Operations
@@ -184,11 +184,9 @@ public:
     ///@name Access
     ///@{
 
-
     ///@}
     ///@name Inquiry
     ///@{
-
 
     ///@}
     ///@name Input and output
@@ -211,55 +209,43 @@ public:
     {
     }
 
-
     ///@}
     ///@name Friends
     ///@{
 
-
     ///@}
-
 protected:
     ///@name Protected static Member Variables
     ///@{
-
 
     ///@}
     ///@name Protected member Variables
     ///@{
 
-
     ///@}
     ///@name Protected Operators
     ///@{
-
 
     ///@}
     ///@name Protected Operations
     ///@{
 
-
     ///@}
     ///@name Protected  Access
     ///@{
-
 
     ///@}
     ///@name Protected Inquiry
     ///@{
 
-
     ///@}
     ///@name Protected LifeCycle
     ///@{
 
-
     ///@}
-
 private:
     ///@name Static Member Variables
     ///@{
-
 
     ///@}
     ///@name Member Variables
@@ -323,11 +309,9 @@ private:
     ///@name Private  Access
     ///@{
 
-
     ///@}
     ///@name Private Inquiry
     ///@{
-
 
     ///@}
     ///@name Un accessible methods
@@ -339,9 +323,7 @@ private:
     /// Copy constructor.
     //ComputeNodalGradientProcess(ComputeNodalGradientProcess const& rOther);
 
-
     ///@}
-
 }; // Class ComputeNodalGradientProcess
 
 ///@}
@@ -371,7 +353,5 @@ private:
 ///@}
 
 }  // namespace Kratos.
-
-#endif // KRATOS_COMPUTE_GRADIENT_PROCESS_INCLUDED  defined
 
 


### PR DESCRIPTION
**📝 Description**

Clean up code using C++17 `constexpr` instead of explicit template specialization

**🆕 Changelog**

- [Clean up code using C++17 constexpr instead of template specialization](https://github.com/KratosMultiphysics/Kratos/commit/8fdbaf32e8b3af07514240cb43d76398a6fad2e4)