### PR TITLE
[FastPR][Core] Operations addition

### DIFF
--- a/kratos/operations/operation.h
+++ b/kratos/operations/operation.h
@@ -1,0 +1,203 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Carlos Roig
+//                   Ruben Zorrilla
+//
+
+#pragma once
+
+// System includes
+#include <string>
+#include <iostream>
+
+// External includes
+
+// Project includes
+#include "containers/model.h"
+#include "includes/define.h"
+#include "includes/kratos_flags.h"
+#include "includes/kratos_parameters.h"
+
+namespace Kratos
+{
+
+///@name Kratos Classes
+///@{
+
+/**
+ * @class Operation
+ * @ingroup KratosCore
+ * @brief The base class for all operations in Kratos.
+ * @details The operation is the base class for all operations and defines the interface for them.
+ * Execute method is used to execute all the Operation algorithms. Operation parameters must be passed at construction time.
+  @author Carlos Roig
+  @author Ruben Zorrilla
+*/
+class Operation
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of Operation
+    KRATOS_CLASS_POINTER_DEFINITION(Operation);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+    explicit Operation() {}
+
+    /// Destructor.
+    virtual ~Operation() {}
+
+    /// Copy constructor.
+    //TODO: Check. It is required by the registry
+    Operation(Operation const& rOther) {}
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /// This operator is provided to call the process as a function and simply calls the Execute method.
+    void operator()()
+    {
+        Execute();
+    }
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief This method creates an pointer of the process
+     * @details We consider as input a Mmodel and a set of Parameters for the sake of generality
+     * @warning Must be overrided in each process implementation
+     * @param rModel The model to be consider
+     * @param ThisParameters The configuration parameters
+     */
+    virtual Operation::Pointer Create(
+        Model& rModel,
+        Parameters ThisParameters) const
+    {
+        KRATOS_ERROR << "Calling base class Create. Please override this method in the corresonding Operation" << std::endl;
+        return nullptr;
+    }
+
+    /**
+     * @brief Execute method is used to execute the Operation algorithms.
+     */
+    virtual void Execute()
+    {
+        KRATOS_ERROR << "Calling base class Execute. Please override this method in the corresonding Operation" << std::endl;
+    }
+
+    /**
+     * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
+     */
+    virtual const Parameters GetDefaultParameters() const
+    {
+        KRATOS_ERROR << "Calling the base Operation class GetDefaultParameters. Please implement the GetDefaultParameters in your derived process class." << std::endl;
+        const Parameters default_parameters = Parameters(R"({})" );
+
+        return default_parameters;
+    }
+
+    ///@}
+    ///@name Access
+    ///@{
+
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const
+    {
+        return "Operation";
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const
+    {
+        rOStream << "Operation";
+    }
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const
+    {
+    }
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+private:
+    ///@name Un accessible methods
+    ///@{
+
+    /// Assignment operator.
+    Operation& operator=(Operation const& rOther) = delete;
+
+    ///@}
+}; // Class Operation
+
+///@name Type Definitions
+///@{
+
+#ifndef KRATOS_REGISTER_OPERATION
+#define KRATOS_REGISTER_OPERATION(                                                                              \
+    module_name,                                                                                                \
+    operation_name,                                                                                             \
+    operation_prototype)                                                                                        \
+    {                                                                                                           \
+        std::string all_path = std::string("Operations.All.") + operation_name;                                 \
+        if (!Registry::HasItem(all_path)) {                                                                     \
+            auto& r_operation_item = Registry::AddItem<RegistryItem>(all_path);                                 \
+            r_operation_item.AddItem<RegistryValueItem<Operation>>("Prototype", operation_prototype);           \
+        } else {                                                                                                \
+            KRATOS_ERROR << "Operation '" << operation_name << "' is already registered." << std::endl;         \
+        }                                                                                                       \
+        std::string module_path = std::string("Operations.") + module_name + std::string(".") + operation_name; \
+        if (!Registry::HasItem(module_path)) {                                                                  \
+            auto& r_operation_item = Registry::AddItem<RegistryItem>(module_path);                              \
+            r_operation_item.AddItem<RegistryValueItem<Operation>>("Prototype", operation_prototype);           \
+        }                                                                                                       \
+    }
+#endif
+
+///@}
+///@name Input and output
+///@{
+
+/// input stream function
+inline std::istream& operator >> (std::istream& rIStream, Operation& rThis);
+
+/// output stream function
+inline std::ostream& operator << (std::ostream& rOStream, const Operation& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+
+///@}
+}  // namespace Kratos.

--- a/kratos/operations/operation.h
+++ b/kratos/operations/operation.h
@@ -24,6 +24,7 @@
 #include "includes/define.h"
 #include "includes/kratos_flags.h"
 #include "includes/kratos_parameters.h"
+#include "includes/registry.h"
 
 namespace Kratos
 {

--- a/kratos/operations/operation.h
+++ b/kratos/operations/operation.h
@@ -14,14 +14,11 @@
 #pragma once
 
 // System includes
-#include <string>
-#include <iostream>
 
 // External includes
 
 // Project includes
 #include "containers/model.h"
-#include "includes/define.h"
 #include "includes/kratos_flags.h"
 #include "includes/kratos_parameters.h"
 #include "includes/registry.h"
@@ -55,7 +52,7 @@ public:
     ///@{
 
     /// Default constructor.
-    explicit Operation() {}
+    explicit Operation() = default;
 
     /// Destructor.
     virtual ~Operation() {}
@@ -67,6 +64,9 @@ public:
     ///@}
     ///@name Operators
     ///@{
+
+    /// Assignment operator.
+    Operation& operator=(Operation const& rOther) = delete;
 
     /// This operator is provided to call the process as a function and simply calls the Execute method.
     void operator()()
@@ -142,19 +142,6 @@ public:
     void PrintData(std::ostream& rOStream) const
     {
     }
-
-    ///@}
-    ///@name Friends
-    ///@{
-
-
-    ///@}
-private:
-    ///@name Un accessible methods
-    ///@{
-
-    /// Assignment operator.
-    Operation& operator=(Operation const& rOther) = delete;
 
     ///@}
 }; // Class Operation

--- a/kratos/python/add_operations_to_python.cpp
+++ b/kratos/python/add_operations_to_python.cpp
@@ -1,0 +1,39 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ \.
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Carlos Roig
+//                   Ruben Zorrilla
+//
+
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define_python.h"
+#include "operations/operation.h"
+
+namespace Kratos::Python
+{
+
+void AddOperationsToPython(pybind11::module& m)
+{
+    namespace py = pybind11;
+
+    py::class_<Operation, Operation::Pointer>(m,"Operation")
+    .def(py::init<>())
+    .def("Create", &Operation::Create)
+    .def("Execute", &Operation::Execute)
+    .def("GetDefaultParameters", &Operation::GetDefaultParameters)
+    .def("__str__", PrintObject<Operation>)
+    ;
+}
+
+} // Namespace Kratos::Python

--- a/kratos/python/add_operations_to_python.cpp
+++ b/kratos/python/add_operations_to_python.cpp
@@ -17,7 +17,6 @@
 // External includes
 
 // Project includes
-#include "includes/define_python.h"
 #include "operations/operation.h"
 
 namespace Kratos::Python

--- a/kratos/python/add_operations_to_python.cpp
+++ b/kratos/python/add_operations_to_python.cpp
@@ -17,6 +17,7 @@
 // External includes
 
 // Project includes
+#include "add_operations_to_python.h"
 #include "operations/operation.h"
 
 namespace Kratos::Python

--- a/kratos/python/add_operations_to_python.h
+++ b/kratos/python/add_operations_to_python.h
@@ -1,0 +1,30 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ \.
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Carlos Roig
+//                   Ruben Zorrilla
+//
+
+#pragma once
+
+// System includes
+#include <pybind11/pybind11.h>
+
+// External includes
+
+
+// Project includes
+
+
+namespace Kratos::Python
+{
+
+void  AddOperationsToPython(pybind11::module& m);
+
+}  // namespace Kratos::Python

--- a/kratos/python/add_operations_to_python.h
+++ b/kratos/python/add_operations_to_python.h
@@ -14,12 +14,11 @@
 #pragma once
 
 // System includes
-#include <pybind11/pybind11.h>
 
 // External includes
 
-
 // Project includes
+#include "includes/define_python.h"
 
 
 namespace Kratos::Python

--- a/kratos/python/kratos_python.cpp
+++ b/kratos/python/kratos_python.cpp
@@ -36,6 +36,7 @@
 #include "add_geometries_to_python.h"
 #include "add_bounding_box_to_python.h"
 #include "add_containers_to_python.h"
+#include "add_operations_to_python.h"
 #include "add_processes_to_python.h"
 #include "add_model_to_python.h"
 #include "add_io_to_python.h"
@@ -108,6 +109,7 @@ PYBIND11_MODULE(Kratos, m)
     AddDeprecatedVariablesToPython(m);
     AddGlobalPointersToPython(m);
 
+    AddOperationsToPython(m);
     AddProcessesToPython(m);
     AddIOToPython(m);
     AddModelToPython(m);


### PR DESCRIPTION
**📝 Description**
This PR adds the base class for `Operations`. This will be used later on in the multistage.

@KratosMultiphysics/technical-committee I decided to separate it from the registry / multistage stuff to make the final review easier.

EDIT: @KratosMultiphysics/technical-committee note that I already added the registry macro at the bottom of `operation.h`.