### PR TITLE
[FastPR][Core]Missing Create() in modelers

### DIFF
--- a/kratos/python_scripts/modelers/delete_model_parts_modeler.py
+++ b/kratos/python_scripts/modelers/delete_model_parts_modeler.py
@@ -12,6 +12,10 @@ class DeleteModelPartsModeler(KratosMultiphysics.Modeler):
         self.model = model
         self.settings = settings
 
+    @staticmethod
+    def Create(model, settings):
+        return DeleteModelPartsModeler(model, settings)
+
     def SetupGeometryModel(self):
         super().SetupGeometryModel()
 

--- a/kratos/python_scripts/modelers/import_mdpa_modeler.py
+++ b/kratos/python_scripts/modelers/import_mdpa_modeler.py
@@ -21,6 +21,10 @@ class ImportMDPAModeler(KratosMultiphysics.Modeler):
         else:
             self.model_part = model.CreateModelPart(model_part_name)
 
+    @staticmethod
+    def Create(model, settings):
+        return ImportMDPAModeler(model, settings)
+
     def SetupGeometryModel(self):
         super().SetupGeometryModel()
 


### PR DESCRIPTION
**📝 Description**
This adds the missing `Create` method to these two Python modelers. These will be used later on by the multistage factory call.
