### PR TITLE
[CI] dependencies are in docker file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Installing dependencies
-      shell: bash
-      run: |
-        python3 -m pip install parameterized
+    # - name: Installing dependencies
+    # => must be added to the docker container to avoid reinstalling it in every CI run
 
     - name: Build
       shell: bash
@@ -190,10 +188,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Installing dependencies
-      shell: bash
-      run: |
-        python3.8 -m pip install parameterized
+    # - name: Installing dependencies
+    # => must be added to the docker container to avoid reinstalling it in every CI run
 
     - name: Build
       run: |
@@ -412,10 +408,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Installing dependencies
-      shell: bash
-      run: |
-        python3 -m pip install parameterized
+    # - name: Installing dependencies
+    # => must be added to the docker container to avoid reinstalling it in every CI run
 
     - name: Build
       shell: bash


### PR DESCRIPTION
to avoid installing in each CI run, they need to be added to the CI run (already done in a previous PR)