### PR TITLE
[FastPR][All] Upgrade minimum Python version to 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,7 @@ endif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 # After all the compiler check we can print the final flags
 message(STATUS "CMAKE_CXX_FLAGS = ${CMAKE_CXX_FLAGS}")
 message(STATUS "CMAKE_C_FLAGS = ${CMAKE_C_FLAGS}")
-  
+
 # Old non-compatible versions of VS
 if(${MSVC})
   if(${MSVC_TOOLSET_VERSION} LESS 141)
@@ -291,8 +291,8 @@ endif(NOT DEFINED KRATOS_ENABLE_LTO)
 message("AR VERSION: ${CMAKE_AR}")
 
 # check version of Python, needs to be done after including pybind
-if(${PYTHON_VERSION_MAJOR} LESS 3 OR (${PYTHON_VERSION_MAJOR} EQUAL 3 AND ${PYTHON_VERSION_MINOR} LESS 6))
-    message( FATAL_ERROR "Kratos only supports Python version 3.6 and above")
+if(${PYTHON_VERSION_MAJOR} LESS 3 OR (${PYTHON_VERSION_MAJOR} EQUAL 3 AND ${PYTHON_VERSION_MINOR} LESS 8))
+    message( FATAL_ERROR "Kratos only supports Python version 3.8 and above")
 endif()
 set(PYTHON_INTERFACE_VERSION "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -93,7 +93,7 @@ Additionaly, Visual Studio is required to compile in *Windows*.
 
       - Python
 
-          You will need at least *Python* 3.7 (recommended 3.8/3.9/3.10) in your computer in order to compile *Kratos*. You can download python from its official webpage:
+          You will need at least *Python* 3.8 (recommended 3.8/3.9/3.10) in your computer in order to compile *Kratos*. You can download python from its official webpage:
 
           * [Download Python](http://www.python.org/downloads/)
 
@@ -144,7 +144,7 @@ Additionaly, Visual Studio is required to compile in *Windows*.
         ```
 
     - Python 
-        You will need at least *Python* 3.7 (recommended 3.8/3.9/3.10) in your computer in order to compile *Kratos*. You can download python from its official webpage:
+        You will need at least *Python* 3.8 (recommended 3.8/3.9/3.10) in your computer in order to compile *Kratos*. You can download python from its official webpage:
 
         * [Download Python](http://www.python.org/downloads/)
 
@@ -419,7 +419,7 @@ export KRATOS_INSTALL_PYTHON_USING_LINKS=ON
 # Set basic configuration
 export KRATOS_BUILD_TYPE="Release"
 export BOOST_ROOT="/path/to/boost"
-export PYTHON_EXECUTABLE="/Library/Frameworks/Python.framework/Versions/3.7/bin/python3"
+export PYTHON_EXECUTABLE="/Library/Frameworks/Python.framework/Versions/3.8/bin/python3"
 
 # Set applications to compile
 export KRATOS_APPLICATIONS=
@@ -506,7 +506,7 @@ The result should be:
  . \  |   (   | |   (   |\__ \  
 _|\_\_|  \__,_|\__|\___/ ____/
            Multi-Physics 9.2."0"-4afb88094a-Release-ARM64
-           Compiled for GNU/Linux and Python3.6 with GCC-8.5
+           Compiled for GNU/Linux and Python3.8 with GCC-8.5
 Compiled with threading and MPI support.
 Maximum number of threads: 1.
 Running without MPI.

--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -1,10 +1,9 @@
 import os
-import re
 import sys
 from . import kratos_globals
 
-if sys.version_info < (3, 6):
-    raise Exception("Kratos only supports Python version 3.6 and above")
+if sys.version_info < (3, 8):
+    raise Exception("Kratos only supports Python version 3.8 and above")
 
 class KratosPaths(object):
     kratos_install_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
@@ -87,7 +86,7 @@ if sys.version_info.major != int(kratos_version_info[0]) and sys.version_info.mi
         sys.version_info.major, sys.version_info.minor,
         kratos_version_info[0], kratos_version_info[1]
     ))
-    
+
 # Print the process id e.g. for attatching a debugger
 if KratosGlobals.Kernel.BuildType() != "Release":
     Logger.PrintInfo("Process Id", os.getpid())


### PR DESCRIPTION
**📝 Description**
Dear @KratosMultiphysics/all , as described in #10420 we require to upgrade minimum Python version to 3.8. Note that the current version we are using, the 3.6, reached it's end of life past December.
