### PR TITLE
[Core][MPI] Adding absolute min/max sync in communicators

### DIFF
--- a/kratos/includes/communicator.h
+++ b/kratos/includes/communicator.h
@@ -360,6 +360,18 @@ public:
     virtual bool SynchronizeNonHistoricalDataToMax(Variable<double> const& ThisVariable);
 
     /** 
+     * @brief Synchronize variable in nodal solution step data to the absolute maximum value across all processes.
+     * @param ThisVariable The variable to be synchronized.
+     */
+    virtual bool SynchronizeCurrentDataToAbsMax(Variable<double> const& ThisVariable);
+
+    /** 
+     * @brief Synchronize variable in nodal data to the absolute maximum value across all processes.
+     * @param ThisVariable The variable to be synchronized.
+     */
+    virtual bool SynchronizeNonHistoricalDataToAbsMax(Variable<double> const& ThisVariable);
+
+    /** 
      * @brief Synchronize variable in nodal solution step data to the minimum value across all processes.
      * @param ThisVariable The variable to be synchronized.
      */
@@ -370,6 +382,18 @@ public:
      * @param ThisVariable The variable to be synchronized.
      */
     virtual bool SynchronizeNonHistoricalDataToMin(Variable<double> const& ThisVariable);
+
+    /** 
+     * @brief Synchronize variable in nodal solution step data to the absolute minimum value across all processes.
+     * @param ThisVariable The variable to be synchronized.
+     */
+    virtual bool SynchronizeCurrentDataToAbsMin(Variable<double> const& ThisVariable);
+
+    /**
+     * @brief Synchronize variable in nodal data to the absolute minimum value across all processes. 
+     * @param ThisVariable The variable to be synchronized.
+     */
+    virtual bool SynchronizeNonHistoricalDataToAbsMin(Variable<double> const& ThisVariable);
 
     virtual bool SynchronizeElementalFlags();
 

--- a/kratos/mpi/includes/mpi_communicator.h
+++ b/kratos/mpi/includes/mpi_communicator.h
@@ -583,7 +583,9 @@ enum class OperationType {
     Replace,
     SumValues,
     MinValues,
+    AbsMinValues,
     MaxValues,
+    AbsMaxValues,
     OrAccessedFlags,
     AndAccessedFlags,
     ReplaceAccessedFlags
@@ -955,6 +957,40 @@ public:
         return true;
     }
 
+    bool SynchronizeCurrentDataToAbsMax(Variable<double> const& ThisVariable) override
+    {
+        constexpr MeshAccess<DistributedType::Local> local_meshes;
+        constexpr MeshAccess<DistributedType::Ghost> ghost_meshes;
+        constexpr Operation<OperationType::Replace> replace;
+        constexpr Operation<OperationType::AbsMaxValues> max;
+        MPIInternals::NodalSolutionStepValueAccess<double> nodal_solution_step_access(ThisVariable);
+
+        // Calculate max on owner rank
+        TransferDistributedValues(ghost_meshes, local_meshes, nodal_solution_step_access, max);
+
+        // Synchronize result on ghost copies
+        TransferDistributedValues(local_meshes, ghost_meshes, nodal_solution_step_access, replace);
+
+        return true;
+    }
+
+    bool SynchronizeNonHistoricalDataToAbsMax(Variable<double> const& ThisVariable) override
+    {
+        constexpr MeshAccess<DistributedType::Local> local_meshes;
+        constexpr MeshAccess<DistributedType::Ghost> ghost_meshes;
+        constexpr Operation<OperationType::Replace> replace;
+        constexpr Operation<OperationType::AbsMaxValues> max;
+        MPIInternals::NodalDataAccess<double> nodal_data_access(ThisVariable);
+
+        // Calculate max on owner rank
+        TransferDistributedValues(ghost_meshes, local_meshes, nodal_data_access, max);
+
+        // Synchronize result on ghost copies
+        TransferDistributedValues(local_meshes, ghost_meshes, nodal_data_access, replace);
+
+        return true;
+    }
+
     bool SynchronizeCurrentDataToMin(Variable<double> const& ThisVariable) override
     {
         constexpr MeshAccess<DistributedType::Local> local_meshes;
@@ -978,6 +1014,40 @@ public:
         constexpr MeshAccess<DistributedType::Ghost> ghost_meshes;
         constexpr Operation<OperationType::Replace> replace;
         constexpr Operation<OperationType::MinValues> min;
+        MPIInternals::NodalDataAccess<double> nodal_data_access(ThisVariable);
+
+        // Calculate min on owner rank
+        TransferDistributedValues(ghost_meshes, local_meshes, nodal_data_access, min);
+
+        // Synchronize result on ghost copies
+        TransferDistributedValues(local_meshes, ghost_meshes, nodal_data_access, replace);
+
+        return true;
+    }
+
+    bool SynchronizeCurrentDataToAbsMin(Variable<double> const& ThisVariable) override
+    {
+        constexpr MeshAccess<DistributedType::Local> local_meshes;
+        constexpr MeshAccess<DistributedType::Ghost> ghost_meshes;
+        constexpr Operation<OperationType::Replace> replace;
+        constexpr Operation<OperationType::AbsMinValues> min;
+        MPIInternals::NodalSolutionStepValueAccess<double> nodal_solution_step_access(ThisVariable);
+
+        // Calculate min on owner rank
+        TransferDistributedValues(ghost_meshes, local_meshes, nodal_solution_step_access, min);
+
+        // Synchronize result on ghost copies
+        TransferDistributedValues(local_meshes, ghost_meshes, nodal_solution_step_access, replace);
+
+        return true;
+    }
+
+    bool SynchronizeNonHistoricalDataToAbsMin(Variable<double> const& ThisVariable) override
+    {
+        constexpr MeshAccess<DistributedType::Local> local_meshes;
+        constexpr MeshAccess<DistributedType::Ghost> ghost_meshes;
+        constexpr Operation<OperationType::Replace> replace;
+        constexpr Operation<OperationType::AbsMinValues> min;
         MPIInternals::NodalDataAccess<double> nodal_data_access(ThisVariable);
 
         // Calculate min on owner rank
@@ -1659,6 +1729,22 @@ private:
         const typename TDatabaseAccess::SendType* pBuffer,
         TDatabaseAccess& rAccess,
         typename TDatabaseAccess::IteratorType ContainerIterator,
+        Operation<OperationType::AbsMaxValues>)
+    {
+        using ValueType = typename TDatabaseAccess::ValueType;
+        ValueType& r_current = rAccess.GetValue(ContainerIterator);
+        ValueType recv_value(r_current); // creating by copy to have the correct size in dynamic types
+        MPIInternals::SendTools<ValueType>::ReadBuffer(pBuffer, recv_value);
+        if (std::abs(recv_value) > std::abs(r_current)) r_current = recv_value;
+
+        return MPIInternals::BufferAllocation<TDatabaseAccess>::GetSendSize(recv_value);
+    }
+    
+    template<class TDatabaseAccess>
+    std::size_t ReduceValues(
+        const typename TDatabaseAccess::SendType* pBuffer,
+        TDatabaseAccess& rAccess,
+        typename TDatabaseAccess::IteratorType ContainerIterator,
         Operation<OperationType::MinValues>)
     {
         using ValueType = typename TDatabaseAccess::ValueType;
@@ -1666,6 +1752,22 @@ private:
         ValueType recv_value(r_current); // creating by copy to have the correct size in dynamic types
         MPIInternals::SendTools<ValueType>::ReadBuffer(pBuffer, recv_value);
         if (recv_value < r_current) r_current = recv_value;
+
+        return MPIInternals::BufferAllocation<TDatabaseAccess>::GetSendSize(recv_value);
+    }
+
+    template<class TDatabaseAccess>
+    std::size_t ReduceValues(
+        const typename TDatabaseAccess::SendType* pBuffer,
+        TDatabaseAccess& rAccess,
+        typename TDatabaseAccess::IteratorType ContainerIterator,
+        Operation<OperationType::AbsMinValues>)
+    {
+        using ValueType = typename TDatabaseAccess::ValueType;
+        ValueType& r_current = rAccess.GetValue(ContainerIterator);
+        ValueType recv_value(r_current); // creating by copy to have the correct size in dynamic types
+        MPIInternals::SendTools<ValueType>::ReadBuffer(pBuffer, recv_value);
+        if (std::abs(recv_value) < std::abs(r_current)) r_current = recv_value;
 
         return MPIInternals::BufferAllocation<TDatabaseAccess>::GetSendSize(recv_value);
     }

--- a/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
+++ b/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
@@ -600,8 +600,8 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSy
     int rank = comm_world.Rank();
     int size = comm_world.Size();
 
-    for (auto i_node = r_model_part.NodesBegin(); i_node != r_model_part.NodesEnd(); ++i_node) {
-        i_node->FastGetSolutionStepValue(TEMPERATURE, 0) = 10.0*rank;
+    for (auto& r_node : r_model_part.Nodes()) {
+        r_node.FastGetSolutionStepValue(TEMPERATURE, 0) = 10.0*rank;
     }
 
     Communicator& r_comm = r_model_part.GetCommunicator();
@@ -634,8 +634,8 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToMax,
     const int rank = comm_world.Rank();
     const int size = comm_world.Size();
 
-    for (auto i_node = r_model_part.NodesBegin(); i_node != r_model_part.NodesEnd(); ++i_node) {
-        i_node->SetValue(TEMPERATURE, 10.0*rank);
+    for (auto& r_node : r_model_part.Nodes()) {
+        r_node.SetValue(TEMPERATURE, 10.0*rank);
     }
 
     Communicator& r_comm = r_model_part.GetCommunicator();
@@ -657,6 +657,75 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToMax,
     KRATOS_CHECK_EQUAL(r_ghost.GetValue(TEMPERATURE), expected_ghost);
 }
 
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSyncToAbsMax, KratosMPICoreFastSuite)
+{
+    Model model;
+    ModelPart& r_model_part = model.CreateModelPart("TestModelPart");
+    r_model_part.AddNodalSolutionStepVariable(PARTITION_INDEX);
+    r_model_part.AddNodalSolutionStepVariable(TEMPERATURE);
+
+    MPIDataCommunicator comm_world(MPI_COMM_WORLD);
+    Internals::ModelPartForMPICommunicatorTests(r_model_part, comm_world);
+    int rank = comm_world.Rank();
+    int size = comm_world.Size();
+
+    for (auto& r_node : r_model_part.Nodes()) {
+        r_node.FastGetSolutionStepValue(TEMPERATURE, 0) = - 10.0*rank;
+    }
+
+    Communicator& r_comm = r_model_part.GetCommunicator();
+
+    // center is local to rank 0 and ghost in all other ranks
+    Node<3>& r_center = r_model_part.Nodes()[1];
+    // local and ghost nodes are each known in two ranks
+    const unsigned int local_id = rank + 2;
+    const unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    auto& r_local = r_model_part.Nodes()[local_id];
+    auto& r_ghost = r_model_part.Nodes()[ghost_id];
+
+    const int expected_local = (rank == 0) ? - 10.0*(size-1) : - 10.0*rank;
+    const int expected_ghost = (rank + 1 < size) ? - 10.0*(rank+1) : - W10.0*(size-1);
+
+    r_comm.SynchronizeCurrentDataToAbsMax(TEMPERATURE);
+    KRATOS_CHECK_EQUAL(r_center.FastGetSolutionStepValue(TEMPERATURE, 0), 10.0*(size-1));
+    KRATOS_CHECK_EQUAL(r_local.FastGetSolutionStepValue(TEMPERATURE, 0), expected_local);
+    KRATOS_CHECK_EQUAL(r_ghost.FastGetSolutionStepValue(TEMPERATURE, 0), expected_ghost);
+}
+
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToAbsMax, KratosMPICoreFastSuite)
+{
+    Model model;
+    ModelPart& r_model_part = model.CreateModelPart("TestModelPart");
+    r_model_part.AddNodalSolutionStepVariable(PARTITION_INDEX);
+
+    MPIDataCommunicator comm_world(MPI_COMM_WORLD);  
+    Internals::ModelPartForMPICommunicatorTests(r_model_part, comm_world);
+    const int rank = comm_world.Rank();
+    const int size = comm_world.Size();
+
+    for (auto& r_node : r_model_part.Nodes()) {
+        r_node.SetValue(TEMPERATURE, - 10.0*rank);
+    }
+
+    Communicator& r_comm = r_model_part.GetCommunicator();
+
+    // center is local to rank 0 and ghost in all other ranks
+    Node<3>& r_center = r_model_part.Nodes()[1];
+    // local and ghost nodes are each known in two ranks
+    const unsigned int local_id = rank + 2;
+    const unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    auto& r_local = r_model_part.Nodes()[local_id];
+    auto& r_ghost = r_model_part.Nodes()[ghost_id];
+
+    const int expected_local = (rank == 0) ? - 10.0*(size-1) : - 10.0*rank;
+    const int expected_ghost = (rank + 1 < size) ? - 10.0*(rank+1) : - 10.0*(size-1);
+
+    r_comm.SynchronizeNonHistoricalDataToAbsMax(TEMPERATURE);
+    KRATOS_CHECK_EQUAL(r_center.GetValue(TEMPERATURE), 10.0*(size-1));
+    KRATOS_CHECK_EQUAL(r_local.GetValue(TEMPERATURE), expected_local);
+    KRATOS_CHECK_EQUAL(r_ghost.GetValue(TEMPERATURE), expected_ghost);
+}
+
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSyncToMin, KratosMPICoreFastSuite)
 {
     Model model;
@@ -669,9 +738,8 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSy
     int rank = comm_world.Rank();
     int size = comm_world.Size();
 
-    for (auto i_node = r_model_part.NodesBegin(); i_node != r_model_part.NodesEnd(); ++i_node)
-    {
-        i_node->FastGetSolutionStepValue(TEMPERATURE, 0) = 10.0*rank;
+    for (auto& r_node : r_model_part.Nodes()) {
+        r_node.FastGetSolutionStepValue(TEMPERATURE, 0) = 10.0*rank;
     }
 
     Communicator& r_comm = r_model_part.GetCommunicator();
@@ -704,9 +772,8 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToMin,
     int rank = comm_world.Rank();
     int size = comm_world.Size();
 
-    for (auto i_node = r_model_part.NodesBegin(); i_node != r_model_part.NodesEnd(); ++i_node)
-    {
-        i_node->SetValue(TEMPERATURE, 10.0*rank);
+    for (auto& r_node : r_model_part.Nodes()) {
+        r_node.SetValue(TEMPERATURE, 10.0*rank);
     }
 
     Communicator& r_comm = r_model_part.GetCommunicator();
@@ -723,6 +790,75 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToMin,
     int expected_ghost = (rank + 1 < size) ? 10.0*rank : 0.0;
 
     r_comm.SynchronizeNonHistoricalDataToMin(TEMPERATURE);
+    KRATOS_CHECK_EQUAL(r_center.GetValue(TEMPERATURE), 0.0);
+    KRATOS_CHECK_EQUAL( r_local.GetValue(TEMPERATURE), expected_local);
+    KRATOS_CHECK_EQUAL( r_ghost.GetValue(TEMPERATURE), expected_ghost);
+}
+
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSyncToAbsMin, KratosMPICoreFastSuite)
+{
+    Model model;
+    ModelPart& r_model_part = model.CreateModelPart("TestModelPart");
+    r_model_part.AddNodalSolutionStepVariable(PARTITION_INDEX);
+    r_model_part.AddNodalSolutionStepVariable(TEMPERATURE);
+
+    MPIDataCommunicator comm_world(MPI_COMM_WORLD);
+    Internals::ModelPartForMPICommunicatorTests(r_model_part, comm_world);
+    int rank = comm_world.Rank();
+    int size = comm_world.Size();
+
+    for (auto& r_node : r_model_part.Nodes()) {
+        r_node.FastGetSolutionStepValue(TEMPERATURE, 0) = - 10.0*rank;
+    }
+
+    Communicator& r_comm = r_model_part.GetCommunicator();
+
+    // center is local to rank 0 and ghost in all other ranks
+    Node<3>& r_center = r_model_part.Nodes()[1];
+    // local and ghost nodes are each known in two ranks
+    const unsigned int local_id = rank + 2;
+    unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    Node<3>& r_local = r_model_part.Nodes()[local_id];
+    Node<3>& r_ghost = r_model_part.Nodes()[ghost_id];
+
+    int expected_local = (rank > 0) ? - 10.0*(rank-1) : 0.0;
+    int expected_ghost = (rank + 1 < size) ? - 10.0*rank : 0.0;
+
+    r_comm.SynchronizeCurrentDataToAbsMin(TEMPERATURE);
+    KRATOS_CHECK_EQUAL(r_center.FastGetSolutionStepValue(TEMPERATURE,0), 0.0);
+    KRATOS_CHECK_EQUAL( r_local.FastGetSolutionStepValue(TEMPERATURE,0), expected_local);
+    KRATOS_CHECK_EQUAL( r_ghost.FastGetSolutionStepValue(TEMPERATURE,0), expected_ghost);
+}
+
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToAbsMin, KratosMPICoreFastSuite)
+{
+    Model model;
+    ModelPart& r_model_part = model.CreateModelPart("TestModelPart");
+    r_model_part.AddNodalSolutionStepVariable(PARTITION_INDEX);
+
+    MPIDataCommunicator comm_world(MPI_COMM_WORLD);
+    Internals::ModelPartForMPICommunicatorTests(r_model_part, comm_world);
+    int rank = comm_world.Rank();
+    int size = comm_world.Size();
+
+    for (auto& r_node : r_model_part.Nodes()) {
+        r_node.SetValue(TEMPERATURE, - 10.0*rank);
+    }
+
+    Communicator& r_comm = r_model_part.GetCommunicator();
+
+    // center is local to rank 0 and ghost in all other ranks
+    Node<3>& r_center = r_model_part.Nodes()[1];
+    // local and ghost nodes are each known in two ranks
+    const unsigned int local_id = rank + 2;
+    unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    Node<3>& r_local = r_model_part.Nodes()[local_id];
+    Node<3>& r_ghost = r_model_part.Nodes()[ghost_id];
+
+    int expected_local = (rank > 0) ? - 10.0*(rank-1) : 0.0;
+    int expected_ghost = (rank + 1 < size) ? - 10.0*rank : 0.0;
+
+    r_comm.SynchronizeNonHistoricalDataToAbsMin(TEMPERATURE);
     KRATOS_CHECK_EQUAL(r_center.GetValue(TEMPERATURE), 0.0);
     KRATOS_CHECK_EQUAL( r_local.GetValue(TEMPERATURE), expected_local);
     KRATOS_CHECK_EQUAL( r_ghost.GetValue(TEMPERATURE), expected_ghost);

--- a/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
+++ b/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
@@ -684,7 +684,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSy
     auto& r_ghost = r_model_part.Nodes()[ghost_id];
 
     const int expected_local = (rank == 0) ? - 10.0*(size-1) : - 10.0*rank;
-    const int expected_ghost = (rank + 1 < size) ? - 10.0*(rank+1) : - W10.0*(size-1);
+    const int expected_ghost = (rank + 1 < size) ? - 10.0*(rank+1) : - 10.0*(size-1);
 
     r_comm.SynchronizeCurrentDataToAbsMax(TEMPERATURE);
     KRATOS_CHECK_EQUAL(r_center.FastGetSolutionStepValue(TEMPERATURE, 0), 10.0*(size-1));

--- a/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
+++ b/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
@@ -687,7 +687,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSy
     const int expected_ghost = (rank + 1 < size) ? - 10.0*(rank+1) : - 10.0*(size-1);
 
     r_comm.SynchronizeCurrentDataToAbsMax(TEMPERATURE);
-    KRATOS_CHECK_EQUAL(r_center.FastGetSolutionStepValue(TEMPERATURE, 0), 10.0*(size-1));
+    KRATOS_CHECK_EQUAL(r_center.FastGetSolutionStepValue(TEMPERATURE, 0), -10.0*(size-1));
     KRATOS_CHECK_EQUAL(r_local.FastGetSolutionStepValue(TEMPERATURE, 0), expected_local);
     KRATOS_CHECK_EQUAL(r_ghost.FastGetSolutionStepValue(TEMPERATURE, 0), expected_ghost);
 }
@@ -721,7 +721,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToAbsM
     const int expected_ghost = (rank + 1 < size) ? - 10.0*(rank+1) : - 10.0*(size-1);
 
     r_comm.SynchronizeNonHistoricalDataToAbsMax(TEMPERATURE);
-    KRATOS_CHECK_EQUAL(r_center.GetValue(TEMPERATURE), 10.0*(size-1));
+    KRATOS_CHECK_EQUAL(r_center.GetValue(TEMPERATURE), -10.0*(size-1));
     KRATOS_CHECK_EQUAL(r_local.GetValue(TEMPERATURE), expected_local);
     KRATOS_CHECK_EQUAL(r_ghost.GetValue(TEMPERATURE), expected_ghost);
 }

--- a/kratos/sources/communicator.cpp
+++ b/kratos/sources/communicator.cpp
@@ -454,12 +454,32 @@ bool Communicator::SynchronizeNonHistoricalDataToMax(Variable<double> const& Thi
     return true;
 }
 
+bool Communicator::SynchronizeCurrentDataToAbsMax(Variable<double> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeNonHistoricalDataToAbsMax(Variable<double> const& ThisVariable)
+{
+    return true;
+}
+
 bool Communicator::SynchronizeCurrentDataToMin(Variable<double> const& ThisVariable)
 {
     return true;
 }
 
 bool Communicator::SynchronizeNonHistoricalDataToMin(Variable<double> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeCurrentDataToAbsMin(Variable<double> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeNonHistoricalDataToAbsMin(Variable<double> const& ThisVariable)
 {
     return true;
 }


### PR DESCRIPTION
**📝 Description**

Adding absolute min/max sync in communicators. This could be interesting for signed values like DISTANCE for example.

**🆕 Changelog**

- [Adding absolute min/max sync in communicators](https://github.com/KratosMultiphysics/Kratos/commit/d380ab1b3ed636ea1d9275fd4fc736c4a230346e)
- [Adding test](https://github.com/KratosMultiphysics/Kratos/commit/7cf7d6d2d67958888a4b8a2b897bc0d94aceb8ae)