### PR TITLE
[All][KratosCore] Deprecate Dimension()

### DIFF
--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -1284,6 +1284,7 @@ public:
     @see WorkingSpaceDimension()
     @see LocalSpaceDimension()
     */
+    KRATOS_DEPRECATED_MESSAGE("'Dimension' is deprecated. Use either 'WorkingSpaceDimension' or 'LocalSpaceDimension' instead.")
     inline SizeType Dimension() const
     {
         return mpGeometryData->Dimension();
@@ -2418,7 +2419,7 @@ public:
         this->GlobalCoordinates(rResult, IntegrationPointIndex, GetDefaultIntegrationMethod());
     }
 
-    /** 
+    /**
     * @brief This method provides the global coordinates to the corresponding integration point
     * @param rResult The global coordinates
     * @param IntegrationPointIndex The index of the integration point
@@ -3829,7 +3830,7 @@ public:
         std::stringstream buffer;
         buffer << "Geometry # "
             << std::to_string(mId) << ": "
-            << Dimension() << " dimensional geometry in "
+            << LocalSpaceDimension() << "-dimensional geometry in "
             << WorkingSpaceDimension() << "D space";
 
         return buffer.str();

--- a/kratos/geometries/geometry_data.h
+++ b/kratos/geometries/geometry_data.h
@@ -367,6 +367,7 @@ public:
     @see WorkingSpaceDimension()
     @see LocalSpaceDimension()
     */
+    KRATOS_DEPRECATED_MESSAGE("'Dimension' is deprecated. Use either 'WorkingSpaceDimension' or 'LocalSpaceDimension' instead.")
     SizeType Dimension() const
     {
         return mpGeometryDimension->Dimension();
@@ -738,8 +739,7 @@ public:
     /// Print object's data.
     virtual void PrintData( std::ostream& rOStream ) const
     {
-        rOStream << "    Dimension               : " << mpGeometryDimension->Dimension() << std::endl;
-        rOStream << "    working space dimension : " << mpGeometryDimension->WorkingSpaceDimension() << std::endl;
+        rOStream << "    Working space dimension : " << mpGeometryDimension->WorkingSpaceDimension() << std::endl;
         rOStream << "    Local space dimension   : " << mpGeometryDimension->LocalSpaceDimension();
     }
 

--- a/kratos/geometries/geometry_dimension.h
+++ b/kratos/geometries/geometry_dimension.h
@@ -115,6 +115,7 @@ public:
     @see WorkingSpaceDimension()
     @see LocalSpaceDimension()
     */
+    KRATOS_DEPRECATED_MESSAGE("'Dimension' is deprecated. Use either 'WorkingSpaceDimension' or 'LocalSpaceDimension' instead.")
     inline SizeType Dimension() const
     {
         return mDimension;
@@ -165,7 +166,6 @@ public:
     /// Print object's data.
     virtual void PrintData( std::ostream& rOStream ) const
     {
-        rOStream << "    Dimension               : " << mDimension << std::endl;
         rOStream << "    Working space dimension : " << mWorkingSpaceDimension << std::endl;
         rOStream << "    Local space dimension   : " << mLocalSpaceDimension;
     }


### PR DESCRIPTION
**📝 Description**
Deprecating the method `Dimension` in `Geometry`, `GeometryData` and `GeometryDimension` in favor of the`WorkingSpaceDimension` and `LocalSpaceDimension` ones. This is the first step in the roadmap established in #9369. 
