### PR TITLE
Relaxing 3.8 errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,7 +292,7 @@ message("AR VERSION: ${CMAKE_AR}")
 
 # check version of Python, needs to be done after including pybind
 if(${PYTHON_VERSION_MAJOR} LESS 3 OR (${PYTHON_VERSION_MAJOR} EQUAL 3 AND ${PYTHON_VERSION_MINOR} LESS 8))
-    message( FATAL_ERROR "Kratos only supports Python version 3.8 and above")
+    message(WARNING "Kratos only supports Python version 3.8 and above")
 endif()
 set(PYTHON_INTERFACE_VERSION "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,9 +290,20 @@ endif(NOT DEFINED KRATOS_ENABLE_LTO)
 
 message("AR VERSION: ${CMAKE_AR}")
 
-# check version of Python, needs to be done after including pybind
+# Enforce python version.
+if(NOT DEFINED KRATOS_ENFORCE_PYTHON_VERSION)
+  SET (KRATOS_ENFORCE_PYTHON_VERSION True)
+else()
+  message(WARNING "PYTHON VERSION CHECK HAS BEEN MANUALY DISABLED")
+endif()
+
+# Check version of Python, needs to be done after including pybind
 if(${PYTHON_VERSION_MAJOR} LESS 3 OR (${PYTHON_VERSION_MAJOR} EQUAL 3 AND ${PYTHON_VERSION_MINOR} LESS 8))
+  if(KRATOS_ENFORCE_PYTHON_VERSION)
+    message(FATAL_ERROR "Kratos only supports Python version 3.8 and above")
+  else()
     message(WARNING "Kratos only supports Python version 3.8 and above")
+  endif()
 endif()
 set(PYTHON_INTERFACE_VERSION "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
 

--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -4,7 +4,7 @@ from . import kratos_globals
 from . import python_registry
 
 if sys.version_info < (3, 8):
-    raise Exception("Kratos only supports Python version 3.8 and above")
+    print("Warning: Kratos only supports Python version 3.8 and above")
 
 class KratosPaths(object):
     kratos_install_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))


### PR DESCRIPTION
**📝 Description**
If defined `KRATOS_ENFORCE_PYTHON_VERSION` to false will ignore the python version check (which should be causing your CI to fail)

Should fix problems in #10428. @KratosMultiphysics/altair  We did not understand that it was a complex change to make from your side.

**🆕 Changelog**
Using versions prior to 3.8 should only issue a warning.
