### PR TITLE
Adding PATH parser for windows

### DIFF
--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -1,5 +1,17 @@
 import os
 import sys
+
+# This is a "dirty" fix to force python to keep loading shared libraries from
+# the PATH in windows (See https://docs.python.org/3/library/os.html#os.add_dll_directory)
+# THIS NEEDS TO BE EXECUTED BEFORE ANY DLL / DEPENDENCY IS LOADED.
+if os.name == 'nt': # This means "Windows"
+    for lib_path in os.environ["PATH"].split(os.pathsep):
+        try:
+            os.add_dll_directory(lib_path.replace("\\","/"))
+        except Exception as e:
+            # We need to capture possible invalid paths.
+            pass
+
 from . import kratos_globals
 from . import python_registry
 


### PR DESCRIPTION
**📝 Description**
Adds the PATH directories to the search table of shared libs for python >= 3.8 in windows.

This is a quick fix until a better solution is found. Should fix MKL / PARDISO / FEAST / HDF5, etc... problems in win with 3.8

**🆕 Changelog**
- Adding PATH entries to the shared lib lookup locations for python 3.8
