### PR TITLE
[FastPR][Fluid] More robust gradient_penalty_coefficient default in FM-ALE settings

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
@@ -195,7 +195,7 @@ class NavierStokesEmbeddedMonolithicSolver(FluidSolver):
                 "max_iteration": 1000
             },
             "embedded_nodal_variable_settings": {
-                "gradient_penalty_coefficient": 0.0,
+                "gradient_penalty_coefficient": 1.0e-3,
                 "linear_solver_settings": {
                     "preconditioner_type": "amg",
                     "solver_type": "amgcl",


### PR DESCRIPTION
**📝 Description**
This sets a non-zero default value in the `gradient_penalty_coefficient` in the FM-ALE settings, which results in a much robust default behavior.
