### PR TITLE
[CI] Centos - treating warnings as errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,7 @@ jobs:
 
     - name: Build
       run: |
-        export KRATOS_CMAKE_CXX_FLAGS="-Werror -Wno-maybe-uninitialized -Wno-deprecated-declarations -Wignored-qualifiers"
+        export KRATOS_CMAKE_CXX_FLAGS="-Werror -Wno-deprecated-declarations -Wignored-qualifiers"
         cp .github/workflows/centos_configure.sh centos_configure.sh
         bash centos_configure.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,7 @@ jobs:
 
     - name: Build
       run: |
+        export KRATOS_CMAKE_CXX_FLAGS="-Werror -Wno-maybe-uninitialized -Wno-deprecated-declarations -Wignored-qualifiers"
         cp .github/workflows/centos_configure.sh centos_configure.sh
         bash centos_configure.sh
 

--- a/kratos/includes/kratos_filesystem.h
+++ b/kratos/includes/kratos_filesystem.h
@@ -34,15 +34,15 @@
 
 namespace Kratos {
 
-// deprecated namespaces wrongly issue a warning with GCC 9, hence disabling until removed
-#if defined(__GNUG__) && __GNUC__ == 9 && !defined(__clang__) && !defined(__INTEL_COMPILER)
+// deprecated namespaces wrongly issue a warning with GCC < 10, hence disabling until removed
+#if defined(__GNUG__) && __GNUC__ < 10 && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wattributes"
 #endif
 
 namespace KRATOS_DEPRECATED_MESSAGE("Please use std::filesystem directly") filesystem {
 
-#if defined(__GNUG__) && __GNUC__ == 9 && !defined(__clang__) && !defined(__INTEL_COMPILER)
+#if defined(__GNUG__) && __GNUC__ < 10 && !defined(__clang__) && !defined(__INTEL_COMPILER)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
We have been treating warnings as errors for a while in our altair CI system, so in order to not include new ones from core we'd like to add this here too, so we don't break anything.

To be discussed with @KratosMultiphysics/technical-committee 