### PR TITLE
[CI] compiling centos in release

### DIFF
--- a/.github/workflows/centos_configure.sh
+++ b/.github/workflows/centos_configure.sh
@@ -42,8 +42,8 @@ cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
 ${KRATOS_CMAKE_OPTIONS_FLAGS} \
 -DUSE_MPI=OFF \
 -DPYBIND11_PYTHON_VERSION="3.8" \
--DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall" \
--DCMAKE_UNITY_BUILD=ON                              \
+-DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall -Werror=maybe-uninitialized" \
+-DCMAKE_UNITY_BUILD=ON
 
 # Buid
 cmake --build "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" --target install -- -j2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
   centos:
     runs-on: ubuntu-latest
     env:
-      KRATOS_BUILD_TYPE: Custom
+      KRATOS_BUILD_TYPE: Release
 
     container:
       image: kratosmultiphysics/kratos-image-ci-centos7:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
   centos:
     runs-on: ubuntu-latest
     env:
-      KRATOS_BUILD_TYPE: Release
+      KRATOS_BUILD_TYPE: Custom
 
     container:
       image: kratosmultiphysics/kratos-image-ci-centos7:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
   centos:
     runs-on: ubuntu-latest
     env:
-      KRATOS_BUILD_TYPE: Custom
+      KRATOS_BUILD_TYPE: Release
 
     container:
       image: kratosmultiphysics/kratos-image-ci-centos7:latest
@@ -199,8 +199,8 @@ jobs:
 
     - name: Running python tests
       run: |
-        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
+        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${KRATOS_BUILD_TYPE}
+        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${KRATOS_BUILD_TYPE}/libs
         python3.8 kratos/python_scripts/testing/run_tests.py -l nightly -c python3.8
 
 


### PR DESCRIPTION
**📝 Description**
I found why centos was failing in our CI if we did not remove the maybe-uninitialized warnings. It seems that this warning only appears when compiling in Release mode. When I created the centos CI I used Custom as I saw that this was used in other compilations. Is there any reason why we should use Custom? 

@roigcarlo @philbucher @KratosMultiphysics/technical-committee ?