### PR TITLE
Fix compilation with python 3.11 and greater

### DIFF
--- a/cmake_modules/FindPythonLibsNew.cmake
+++ b/cmake_modules/FindPythonLibsNew.cmake
@@ -73,13 +73,28 @@ endif()
 #
 # The library suffix is from the config var LDVERSION sometimes, otherwise
 # VERSION. VERSION will typically be like "2.7" on unix, and "27" on windows.
-execute_process(COMMAND "${PYTHON_EXECUTABLE}" "-c"
-    "from distutils import sysconfig as s;import sys;import struct;
+execute_process(
+  COMMAND
+    "${PYTHON_EXECUTABLE}" "-c" "
+import sys;import struct;
+import sysconfig as s
+USE_SYSCONFIG = sys.version_info >= (3, 10)
+if not USE_SYSCONFIG:
+    from distutils import sysconfig as ds
 print('.'.join(str(v) for v in sys.version_info));
 print(sys.prefix);
-print(s.get_python_inc(plat_specific=True));
-print(s.get_python_lib(plat_specific=True));
-print(s.get_config_var('SO'));
+if USE_SYSCONFIG:
+    scheme = s.get_default_scheme()
+    if scheme == 'posix_local':
+        # Debian's default scheme installs to /usr/local/ but we want to find headers in /usr/
+        scheme = 'posix_prefix'
+    print(s.get_path('platinclude', scheme))
+    print(s.get_path('platlib'))
+    print(s.get_config_var('EXT_SUFFIX') or s.get_config_var('SO'))
+else:
+    print(ds.get_python_inc(plat_specific=True));
+    print(ds.get_python_lib(plat_specific=True));
+    print(ds.get_config_var('EXT_SUFFIX') or ds.get_config_var('SO'));
 print(hasattr(sys, 'gettotalrefcount')+0);
 print(struct.calcsize('@P'));
 print(s.get_config_var('LDVERSION') or s.get_config_var('VERSION'));


### PR DESCRIPTION
**📝 Description**
SO was deprecated from 3.11 so extension appeared as None and caused compiled libs to have incorrect names. Porting the solution from Pybind.

Ping @AlejandroCornejo (I think you also mentioned problems with this) and @tteschemacher. That should solve your problems. 

**🆕 Changelog**
- Using `USE_SYSCONFIG`to obtain the module extension.
