### PR TITLE
[CMAKE] Enable new lists policy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,11 @@ if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW)
 endif(POLICY CMP0074)
 
+# Lists
+if(POLICY CMP0057)
+  cmake_policy(SET CMP0057 NEW)
+endif(POLICY CMP0057)
+
 # Set here the version number **** only update upon tagging a release!
 set (KratosMultiphysics_MAJOR_VERSION 9)
 set (KratosMultiphysics_MINOR_VERSION 2)


### PR DESCRIPTION
**📝 Description**
This corrects the behavior of `IN_LIST` keyword for lists. (Some Trilinos 13 > components make use of it) 

Did not find any trouble enabling it, if someone has a explicit reason no to do it we can delay its inclusion.

**🆕 Changelog**
- Enabling `NEW` behavior for `CMP0057`
