### PR TITLE
[CI] 1/2 Add mmg and parmmg stable versions to ubuntu dockerfiles

### DIFF
--- a/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
@@ -61,6 +61,14 @@ RUN apt-get update -y && apt-get upgrade -y && \
     cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_5_1" -DUSE_SCOTCH=OFF -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
     make -j2 install && \
     cd / && \
+    # install MMG v5.5.6
+    git clone -b 'v5.5.6' --depth 1 https://github.com/MmgTools/mmg /tmp/mmg_5_5_6 && \
+    mkdir /tmp/mmg_5_5_6/build && \
+    mkdir -p /external_libraries/mmg/mmg_5_5_6 && \
+    cd /tmp/mmg_5_5_6/build && \
+    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_5_6" -DUSE_SCOTCH=OFF -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
+    make -j2 install && \
+    cd / && \
     # install PARMMG
     git clone https://github.com/MmgTools/ParMmg /tmp/ParMmg_5ffc6ad && \
     mkdir /tmp/ParMmg_5ffc6ad/build && \
@@ -70,6 +78,16 @@ RUN apt-get update -y && apt-get upgrade -y && \
     make -j2 install && \
     rm -r /tmp/mmg_5_5_1 && \
     rm -r /tmp/ParMmg_5ffc6ad && \
+    cd / && \
+    # install ParMmg v1.4.0
+    git clone -b 'v1.4.0' --depth 1 https://github.com/MmgTools/ParMmg /tmp/ParMmg_1_4_0 && \
+    mkdir /tmp/ParMmg_1_4_0/build && \
+    mkdir -p /external_libraries/ParMmg_1_4_0 && \
+    cd /tmp/ParMmg_1_4_0/build && \
+    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/external_libraries/ParMmg_1_4_0" -DUSE_SCOTCH=OFF -DLIBPARMMG_SHARED=ON -DDOWNLOAD_MMG=OFF -DMMG_DIR="/tmp/mmg_5_5_6" -DMMG_BUILDDIR="/tmp/mmg_5_5_6/build" -DDOWNLOAD_METIS=OFF -DMETIS_DIR="/usr/include" && \
+    make -j2 install && \
+    rm -r /tmp/mmg_5_5_6 && \
+    rm -r /tmp/ParMmg_1_4_0 && \
     cd / && \
     # remove some now unnecessary packages
     apt-get -y remove \

--- a/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
@@ -61,14 +61,6 @@ RUN apt-get update -y && apt-get upgrade -y && \
     cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_5_1" -DUSE_SCOTCH=OFF -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
     make -j2 install && \
     cd / && \
-    # install MMG v5.5.6
-    git clone -b 'v5.5.6' --depth 1 https://github.com/MmgTools/mmg /tmp/mmg_5_5_6 && \
-    mkdir /tmp/mmg_5_5_6/build && \
-    mkdir -p /external_libraries/mmg/mmg_5_5_6 && \
-    cd /tmp/mmg_5_5_6/build && \
-    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_5_6" -DUSE_SCOTCH=OFF -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
-    make -j2 install && \
-    cd / && \
     # install PARMMG
     git clone https://github.com/MmgTools/ParMmg /tmp/ParMmg_5ffc6ad && \
     mkdir /tmp/ParMmg_5ffc6ad/build && \
@@ -78,16 +70,6 @@ RUN apt-get update -y && apt-get upgrade -y && \
     make -j2 install && \
     rm -r /tmp/mmg_5_5_1 && \
     rm -r /tmp/ParMmg_5ffc6ad && \
-    cd / && \
-    # install ParMmg v1.4.0
-    git clone -b 'v1.4.0' --depth 1 https://github.com/MmgTools/ParMmg /tmp/ParMmg_1_4_0 && \
-    mkdir /tmp/ParMmg_1_4_0/build && \
-    mkdir -p /external_libraries/ParMmg_1_4_0 && \
-    cd /tmp/ParMmg_1_4_0/build && \
-    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/external_libraries/ParMmg_1_4_0" -DUSE_SCOTCH=OFF -DLIBPARMMG_SHARED=ON -DDOWNLOAD_MMG=OFF -DMMG_DIR="/tmp/mmg_5_5_6" -DMMG_BUILDDIR="/tmp/mmg_5_5_6/build" -DDOWNLOAD_METIS=OFF -DMETIS_DIR="/usr/include" && \
-    make -j2 install && \
-    rm -r /tmp/mmg_5_5_6 && \
-    rm -r /tmp/ParMmg_1_4_0 && \
     cd / && \
     # remove some now unnecessary packages
     apt-get -y remove \

--- a/scripts/docker_files/docker_file_ci_ubuntu_22_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_22_04/DockerFile
@@ -64,6 +64,14 @@ RUN apt-get update -y && apt-get upgrade -y && \
     cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_5_1" -DUSE_SCOTCH=OFF -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
     make -j2 install && \
     cd / && \
+    # install MMG v5.5.6
+    git clone -b 'v5.5.6' --depth 1 https://github.com/MmgTools/mmg /tmp/mmg_5_5_6 && \
+    mkdir /tmp/mmg_5_5_6/build && \
+    mkdir -p /external_libraries/mmg/mmg_5_5_6 && \
+    cd /tmp/mmg_5_5_6/build && \
+    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_5_6" -DUSE_SCOTCH=OFF -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
+    make -j2 install && \
+    cd / && \
     # install PARMMG
     git clone https://github.com/MmgTools/ParMmg /tmp/ParMmg_5ffc6ad && \
     mkdir /tmp/ParMmg_5ffc6ad/build && \
@@ -73,6 +81,16 @@ RUN apt-get update -y && apt-get upgrade -y && \
     make -j2 install && \
     rm -r /tmp/mmg_5_5_1 && \
     rm -r /tmp/ParMmg_5ffc6ad && \
+    cd / && \
+    # install ParMmg v1.4.0
+    git clone -b 'v1.4.0' --depth 1 https://github.com/MmgTools/ParMmg /tmp/ParMmg_1_4_0 && \
+    mkdir /tmp/ParMmg_1_4_0/build && \
+    mkdir -p /external_libraries/ParMmg_1_4_0 && \
+    cd /tmp/ParMmg_1_4_0/build && \
+    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/external_libraries/ParMmg_1_4_0" -DUSE_SCOTCH=OFF -DLIBPARMMG_SHARED=ON -DDOWNLOAD_MMG=OFF -DMMG_DIR="/tmp/mmg_5_5_6" -DMMG_BUILDDIR="/tmp/mmg_5_5_6/build" -DDOWNLOAD_METIS=OFF -DMETIS_DIR="/usr/include" && \
+    make -j2 install && \
+    rm -r /tmp/mmg_5_5_6 && \
+    rm -r /tmp/ParMmg_1_4_0 && \
     cd / && \
     # remove some now unnecessary packages
     apt-get -y remove \

--- a/scripts/docker_files/docker_file_ci_ubuntu_22_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_22_04/DockerFile
@@ -64,12 +64,12 @@ RUN apt-get update -y && apt-get upgrade -y && \
     cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_5_1" -DUSE_SCOTCH=OFF -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
     make -j2 install && \
     cd / && \
-    # install MMG v5.5.6
-    git clone -b 'v5.5.6' --depth 1 https://github.com/MmgTools/mmg /tmp/mmg_5_5_6 && \
-    mkdir /tmp/mmg_5_5_6/build && \
-    mkdir -p /external_libraries/mmg/mmg_5_5_6 && \
-    cd /tmp/mmg_5_5_6/build && \
-    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_5_6" -DUSE_SCOTCH=OFF -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
+    # install MMG v5.6.0
+    git clone -b 'v5.6.0' --depth 1 https://github.com/MmgTools/mmg /tmp/mmg_5_6_0 && \
+    mkdir /tmp/mmg_5_6_0/build && \
+    mkdir -p /external_libraries/mmg/mmg_5_6_0 && \
+    cd /tmp/mmg_5_6_0/build && \
+    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_6_0" -DUSE_SCOTCH=OFF -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
     make -j2 install && \
     cd / && \
     # install PARMMG
@@ -87,9 +87,9 @@ RUN apt-get update -y && apt-get upgrade -y && \
     mkdir /tmp/ParMmg_1_4_0/build && \
     mkdir -p /external_libraries/ParMmg_1_4_0 && \
     cd /tmp/ParMmg_1_4_0/build && \
-    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/external_libraries/ParMmg_1_4_0" -DUSE_SCOTCH=OFF -DLIBPARMMG_SHARED=ON -DDOWNLOAD_MMG=OFF -DMMG_DIR="/tmp/mmg_5_5_6" -DMMG_BUILDDIR="/tmp/mmg_5_5_6/build" -DDOWNLOAD_METIS=OFF -DMETIS_DIR="/usr/include" && \
+    cmake .. -DCMAKE_RULE_MESSAGES=OFF -DCMAKE_C_FLAGS="-w" -DCMAKE_CXX_FLAGS="-w" -DCMAKE_INSTALL_PREFIX="/external_libraries/ParMmg_1_4_0" -DUSE_SCOTCH=OFF -DLIBPARMMG_SHARED=ON -DDOWNLOAD_MMG=OFF -DMMG_DIR="/tmp/mmg_5_6_0" -DMMG_BUILDDIR="/tmp/mmg_5_6_0/build" -DDOWNLOAD_METIS=OFF -DMETIS_DIR="/usr/include" && \
     make -j2 install && \
-    rm -r /tmp/mmg_5_5_6 && \
+    rm -r /tmp/mmg_5_6_0 && \
     rm -r /tmp/ParMmg_1_4_0 && \
     cd / && \
     # remove some now unnecessary packages


### PR DESCRIPTION
**📝 Description**

Adding a stable version of ParMmg (v1.4.0) which requires version 5.6.0 of MMG.

The idea is to do the upgrade in three different PRs:
- [ ]  Add new mmg and parmmg to Dockerfiles
- [ ]  Change versions used in ci.yml and nightly.yml
- [ ] Remove old versions from Dockerfile.

It may help #10450. This upgrade also removes all the annoying warnings that currently appear in the logs.

**🆕 Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Adding ParMmg v1.4.0 and Mmg v5.5.6 
