### PR TITLE
[CI] Set omp_num_threads to 1 in mpi tests

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -78,6 +78,7 @@ jobs:
       shell: bash
       run: |
         source /opt/intel/oneapi/setvars.sh
+        export OMP_NUM_THREADS=1
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${KRATOS_BUILD_TYPE}
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${KRATOS_BUILD_TYPE}/libs
         python3 kratos/python_scripts/testing/run_python_mpi_tests.py -l nightly -n 2
@@ -86,6 +87,7 @@ jobs:
       shell: bash
       run: |
         source /opt/intel/oneapi/setvars.sh
+        export OMP_NUM_THREADS=1
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${KRATOS_BUILD_TYPE}
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${KRATOS_BUILD_TYPE}/libs
         python3 kratos/python_scripts/testing/run_python_mpi_tests.py -l nightly -n 3
@@ -94,6 +96,7 @@ jobs:
       shell: bash
       run: |
         source /opt/intel/oneapi/setvars.sh
+        export OMP_NUM_THREADS=1
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${KRATOS_BUILD_TYPE}
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${KRATOS_BUILD_TYPE}/libs
         python3 kratos/python_scripts/testing/run_python_mpi_tests.py -l nightly -n 4


### PR DESCRIPTION
**📝 Description**
Closes #10450 

Setting OMP_NUM_THREADS=1 when running MPI tests. Tests should run faster. 

This was already set in the `ci.yml` but not in the nightly. 

Please mark the PR with appropriate tags: 
- Api Breaker, Mpi, etc...

**🆕 Changelog**
- Set OMP_NUM_THREADS=1 in MPI tests
