### PR TITLE
[Core] KRATOS_WATCH_LINE

### DIFF
--- a/kratos/includes/debug_helpers.h
+++ b/kratos/includes/debug_helpers.h
@@ -51,4 +51,7 @@
                   << values.str() << std::endl;                         \
     }
 
+// Cout a message with appended line and function information.
+#define KRATOS_LINE_WATCH(...) std::cout << __VA_ARGS__ << KRATOS_CODE_LOCATION << std::endl
+
 #endif /* KRATOS_DEBUG_HELPERS_H_INCLUDED  defined */

--- a/kratos/includes/debug_helpers.h
+++ b/kratos/includes/debug_helpers.h
@@ -52,6 +52,6 @@
     }
 
 // Cout a message with appended line and function information.
-#define KRATOS_LINE_WATCH(...) std::cout << __VA_ARGS__ << KRATOS_CODE_LOCATION << std::endl
+#define KRATOS_WATCH_LINE(...) std::cout << __VA_ARGS__ << KRATOS_CODE_LOCATION << std::endl
 
 #endif /* KRATOS_DEBUG_HELPERS_H_INCLUDED  defined */

--- a/kratos/sources/code_location.cpp
+++ b/kratos/sources/code_location.cpp
@@ -179,7 +179,7 @@ namespace Kratos
 	std::ostream & operator <<(std::ostream& rOStream,
 		const CodeLocation& Location)
 	{
-		rOStream << Location.CleanFileName() << ":" << Location.GetLineNumber() << ":" << Location.CleanFunctionName();
+		rOStream << Location.CleanFileName() << ":" << Location.GetLineNumber() << ": " << Location.CleanFunctionName();
 		return rOStream;
 	}
 


### PR DESCRIPTION
- Add a handy utility macro for old-fashioned print-debugging, that prints the code location and function signature along with your message. *Super useful for MPI debugging!*
- Change `CodeLocation` such that its output is followable (Ctrl+LMB click => jump to location) in VSCode's embedded terminal.