### PR TITLE
[HDF5] Fix some random HDF5 deadlocks

### DIFF
--- a/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
@@ -386,6 +386,8 @@ ContainerComponentIO<TContainerType, TContainerItemType, TComponents...>::Contai
     for (std::size_t i = 0; i < num_components; ++i)
         mComponentNames[i] = Settings["list_of_variables"].GetArrayItem(i).GetString();
 
+    std::sort(mComponentNames.begin(), mComponentNames.end());
+
     KRATOS_CATCH("");
 }
 

--- a/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
@@ -377,14 +377,7 @@ ContainerComponentIO<TContainerType, TContainerItemType, TComponents...>::Contai
     Settings.ValidateAndAssignDefaults(default_params);
 
     mComponentPath = Settings["prefix"].GetString() + rComponentPath;
-
-    const std::size_t num_components = Settings["list_of_variables"].size();
-
-    if (mComponentNames.size() != num_components)
-        mComponentNames.resize(num_components);
-
-    for (std::size_t i = 0; i < num_components; ++i)
-        mComponentNames[i] = Settings["list_of_variables"].GetArrayItem(i).GetString();
+    mComponentNames = Settings["list_of_variables"].GetStringArray();
 
     // Sort component names to make sure they're in the same order on each rank.
     // The basic assumption is that the set of components is identical on every

--- a/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
@@ -386,6 +386,11 @@ ContainerComponentIO<TContainerType, TContainerItemType, TComponents...>::Contai
     for (std::size_t i = 0; i < num_components; ++i)
         mComponentNames[i] = Settings["list_of_variables"].GetArrayItem(i).GetString();
 
+    // Sort component names to make sure they're in the same order on each rank.
+    // The basic assumption is that the set of components is identical on every
+    // rank, but they may not be in the same order (which would lead to ranks
+    // trying to write different variables at the same time, resulting in
+    // a deadlock), hence the sorting.
     std::sort(mComponentNames.begin(), mComponentNames.end());
 
     KRATOS_CATCH("");

--- a/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_data_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_data_io.cpp
@@ -6,6 +6,7 @@
 #include "includes/communicator.h"
 #include "custom_utilities/registered_component_lookup.h"
 #include "custom_utilities/local_ghost_splitting_utility.h"
+#include "includes/debug_helpers.h"
 
 namespace Kratos
 {
@@ -92,6 +93,8 @@ NodalSolutionStepDataIO::NodalSolutionStepDataIO(Parameters Settings, File::Poin
     mVariableNames.resize(Settings["list_of_variables"].size());
     for (unsigned i = 0; i < mVariableNames.size(); ++i)
         mVariableNames[i] = Settings["list_of_variables"].GetArrayItem(i).GetString();
+
+    std::sort(mVariableNames.begin(), mVariableNames.end());
 
     KRATOS_CATCH("");
 }

--- a/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_data_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_data_io.cpp
@@ -6,7 +6,6 @@
 #include "includes/communicator.h"
 #include "custom_utilities/registered_component_lookup.h"
 #include "custom_utilities/local_ghost_splitting_utility.h"
-#include "includes/debug_helpers.h"
 
 namespace Kratos
 {

--- a/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_data_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_data_io.cpp
@@ -88,10 +88,7 @@ NodalSolutionStepDataIO::NodalSolutionStepDataIO(Parameters Settings, File::Poin
     Settings.ValidateAndAssignDefaults(default_params);
 
     mPrefix = Settings["prefix"].GetString();
-
-    mVariableNames.resize(Settings["list_of_variables"].size());
-    for (unsigned i = 0; i < mVariableNames.size(); ++i)
-        mVariableNames[i] = Settings["list_of_variables"].GetArrayItem(i).GetString();
+    mVariableNames = Settings["list_of_variables"].GetStringArray();
 
     // Sort variable names to make sure they're in the same order on each rank.
     // The basic assumption is that the set of variables is identical on every

--- a/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_data_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_data_io.cpp
@@ -93,6 +93,11 @@ NodalSolutionStepDataIO::NodalSolutionStepDataIO(Parameters Settings, File::Poin
     for (unsigned i = 0; i < mVariableNames.size(); ++i)
         mVariableNames[i] = Settings["list_of_variables"].GetArrayItem(i).GetString();
 
+    // Sort variable names to make sure they're in the same order on each rank.
+    // The basic assumption is that the set of variables is identical on every
+    // rank, but they may not be in the same order (which would lead to ranks
+    // trying to write different variables at the same time, resulting in
+    // a deadlock), hence the sorting.
     std::sort(mVariableNames.begin(), mVariableNames.end());
 
     KRATOS_CATCH("");

--- a/applications/HDF5Application/tests/test_hdf5_condition_data_value_io.cpp
+++ b/applications/HDF5Application/tests/test_hdf5_condition_data_value_io.cpp
@@ -31,12 +31,11 @@ namespace Testing
 {
 KRATOS_TEST_CASE_IN_SUITE(HDF5PointsData_ReadConditionResults, KratosHDF5TestSuite)
 {
-    Parameters file_params(R"(
-        {
-            "file_name" : "test.h5",
-            "file_access_mode": "exclusive",
-            "file_driver": "core"
-        })");
+    Parameters file_params(R"({
+        "file_name" : "test.h5",
+        "file_access_mode": "exclusive",
+        "file_driver": "core"
+    })");
     auto p_test_file = Kratos::make_shared<HDF5::FileSerial>(file_params);
 
     Model this_model;
@@ -51,7 +50,19 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5PointsData_ReadConditionResults, KratosHDF5TestSui
     r_write_model_part.SetBufferSize(2);
 
     std::vector<std::string> variables_list = {
-        {"DISPLACEMENT"}, {"PRESSURE"}, {"REFINEMENT_LEVEL"}, {"GREEN_LAGRANGE_STRAIN_TENSOR"}};
+        "DISPLACEMENT",
+        "PRESSURE",
+        "REFINEMENT_LEVEL",
+        "GREEN_LAGRANGE_STRAIN_TENSOR"
+    };
+
+    // "shuffle" the list of variables to check whether it's handled
+    // without deadlocks.
+    std::rotate(
+        variables_list.begin(),
+        variables_list.begin() + (r_read_model_part.GetCommunicator().GetDataCommunicator().Rank() % variables_list.size()),
+        variables_list.end()
+    );
 
     for (auto& r_condition : r_write_model_part.Conditions())
     {
@@ -59,11 +70,11 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5PointsData_ReadConditionResults, KratosHDF5TestSui
             r_condition.GetData(), r_condition, variables_list);
     }
 
-    Parameters io_params(R"(
-        {
-            "prefix": "/Step",
-            "list_of_variables": ["DISPLACEMENT", "PRESSURE", "REFINEMENT_LEVEL", "GREEN_LAGRANGE_STRAIN_TENSOR"]
-        })");
+    Parameters io_params(R"({
+        "prefix": "/Step",
+        "list_of_variables": []
+    })");
+    io_params["list_of_variables"].SetStringArray(variables_list);
 
     HDF5::ConditionDataValueIO data_io(io_params, p_test_file);
     data_io.WriteConditionResults(r_write_model_part.Conditions());

--- a/applications/HDF5Application/tests/test_hdf5_element_data_value_io.cpp
+++ b/applications/HDF5Application/tests/test_hdf5_element_data_value_io.cpp
@@ -31,12 +31,11 @@ namespace Testing
 {
 KRATOS_TEST_CASE_IN_SUITE(HDF5PointsData_ReadElementResults, KratosHDF5TestSuite)
 {
-    Parameters file_params(R"(
-        {
-            "file_name" : "test.h5",
-            "file_access_mode": "exclusive",
-            "file_driver": "core"
-        })");
+    Parameters file_params(R"({
+        "file_name" : "test.h5",
+        "file_access_mode": "exclusive",
+        "file_driver": "core"
+    })");
     auto p_test_file = Kratos::make_shared<HDF5::FileSerial>(file_params);
 
     Model this_model;
@@ -50,31 +49,42 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5PointsData_ReadElementResults, KratosHDF5TestSuite
     r_write_model_part.SetBufferSize(2);
 
     std::vector<std::string> variables_list = {
-        {"DISPLACEMENT"}, {"PRESSURE"}, {"REFINEMENT_LEVEL"}, {"GREEN_LAGRANGE_STRAIN_TENSOR"}};
+        "DISPLACEMENT",
+        "PRESSURE",
+        "REFINEMENT_LEVEL",
+        "GREEN_LAGRANGE_STRAIN_TENSOR"
+    };
 
-    for (auto& r_element : r_write_model_part.Elements())
-    {
+    // "shuffle" the list of variables to check whether it's handled
+    // without deadlocks.
+    std::rotate(
+        variables_list.begin(),
+        variables_list.begin() + (r_read_model_part.GetCommunicator().GetDataCommunicator().Rank() % variables_list.size()),
+        variables_list.end()
+    );
+
+
+    for (auto& r_element : r_write_model_part.Elements()) {
         TestModelPartFactory::AssignDataValueContainer(
-            r_element.Data(), r_element, variables_list);
+            r_element.GetData(), r_element, variables_list);
     }
 
-    Parameters io_params(R"(
-        {
-            "prefix": "/Step",
-            "list_of_variables": ["DISPLACEMENT", "PRESSURE", "REFINEMENT_LEVEL", "GREEN_LAGRANGE_STRAIN_TENSOR"]
-        })");
+    Parameters io_params(R"({
+        "prefix": "/Step",
+        "list_of_variables": []
+    })");
+    io_params["list_of_variables"].SetStringArray(variables_list);
 
     HDF5::ElementDataValueIO data_io(io_params, p_test_file);
     data_io.WriteElementResults(r_write_model_part.Elements());
     data_io.ReadElementResults(r_read_model_part.Elements(),
                                r_read_model_part.GetCommunicator());
 
-    for (auto& r_write_element : r_write_model_part.Elements())
-    {
+    for (auto& r_write_element : r_write_model_part.Elements()) {
         HDF5::ElementType& r_read_element =
             r_read_model_part.Elements()[r_write_element.Id()];
-        CompareDataValueContainers(r_read_element.Data(), r_read_element,
-                                   r_write_element.Data(), r_write_element);
+        CompareDataValueContainers(r_read_element.GetData(), r_read_element,
+                                   r_write_element.GetData(), r_write_element);
     }
 }
 

--- a/applications/HDF5Application/tests/test_hdf5_element_flag_value_io.cpp
+++ b/applications/HDF5Application/tests/test_hdf5_element_flag_value_io.cpp
@@ -49,31 +49,41 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5PointsData_ReadElementFlags, KratosHDF5TestSuite)
     r_read_model_part.SetBufferSize(2);
     r_write_model_part.SetBufferSize(2);
 
-    std::vector<std::string> variables_list = {{"SLIP"}, {"ACTIVE"}, {"STRUCTURE"}};
+    std::vector<std::string> variables_list = {
+        "SLIP",
+        "ACTIVE",
+        "STRUCTURE"
+    };
 
-    for (auto& r_element : r_write_model_part.Elements())
-    {
+    // "shuffle" the list of variables to check whether it's handled
+    // without deadlocks.
+    std::rotate(
+        variables_list.begin(),
+        variables_list.begin() + (r_read_model_part.GetCommunicator().GetDataCommunicator().Rank() % variables_list.size()),
+        variables_list.end()
+    );
+
+    for (auto& r_element : r_write_model_part.Elements()) {
         TestModelPartFactory::AssignDataValueContainer(
-            r_element.Data(), r_element, variables_list);
+            r_element.GetData(), r_element, variables_list);
     }
 
-    Parameters io_params(R"(
-        {
-            "prefix": "/Step",
-            "list_of_variables": ["SLIP", "ACTIVE", "STRUCTURE"]
-        })");
+    Parameters io_params(R"({
+        "prefix": "/Step",
+        "list_of_variables": []
+    })");
+    io_params["list_of_variables"].SetStringArray(variables_list);
 
     HDF5::ElementFlagValueIO data_io(io_params, p_test_file);
     data_io.WriteElementFlags(r_write_model_part.Elements());
     data_io.ReadElementFlags(r_read_model_part.Elements(),
                              r_read_model_part.GetCommunicator());
 
-    for (auto& r_write_element : r_write_model_part.Elements())
-    {
+    for (auto& r_write_element : r_write_model_part.Elements()) {
         HDF5::ElementType& r_read_element =
             r_read_model_part.Elements()[r_write_element.Id()];
-        CompareDataValueContainers(r_read_element.Data(), r_read_element,
-                                   r_write_element.Data(), r_write_element);
+        CompareDataValueContainers(r_read_element.GetData(), r_read_element,
+                                   r_write_element.GetData(), r_write_element);
     }
 }
 

--- a/applications/HDF5Application/tests/test_hdf5_nodal_solution_step_data_io.cpp
+++ b/applications/HDF5Application/tests/test_hdf5_nodal_solution_step_data_io.cpp
@@ -32,6 +32,24 @@ namespace Testing
 
 KRATOS_TEST_CASE_IN_SUITE(HDF5PointsData_ReadNodalResults2, KratosHDF5TestSuite)
 {
+    Model this_model;
+    ModelPart& r_read_model_part = this_model.CreateModelPart("test_read");
+    ModelPart& r_write_model_part = this_model.CreateModelPart("test_write");
+
+    std::vector<std::string> variables_list {
+        "DISPLACEMENT",
+        "PRESSURE",
+        "REFINEMENT_LEVEL"
+    };
+
+    // "shuffle" the list of variables to check whether it's handled
+    // without deadlocks.
+    std::rotate(
+        variables_list.begin(),
+        variables_list.begin() + (r_read_model_part.GetCommunicator().GetDataCommunicator().Rank() % variables_list.size()),
+        variables_list.end()
+    );
+
     Parameters file_params(R"(
         {
             "file_name" : "test.h5",
@@ -40,9 +58,6 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5PointsData_ReadNodalResults2, KratosHDF5TestSuite)
         })");
     auto p_test_file = Kratos::make_shared<HDF5::FileSerial>(file_params);
 
-    Model this_model;
-    ModelPart& r_read_model_part = this_model.CreateModelPart("test_read");
-    ModelPart& r_write_model_part = this_model.CreateModelPart("test_write");
     r_read_model_part.AddNodalSolutionStepVariable(DISPLACEMENT); // array_1d
     r_read_model_part.AddNodalSolutionStepVariable(PRESSURE); // double
     r_read_model_part.AddNodalSolutionStepVariable(REFINEMENT_LEVEL); // int
@@ -64,11 +79,12 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5PointsData_ReadNodalResults2, KratosHDF5TestSuite)
         r_node.FastGetSolutionStepValue(REFINEMENT_LEVEL) = r_node.Id() + 4;
     }
 
-    Parameters io_params(R"(
-        {
-            "prefix": "/Step",
-            "list_of_variables": ["DISPLACEMENT", "PRESSURE", "REFINEMENT_LEVEL"]
-        })");
+    Parameters io_params(R"({
+        "prefix": "/Step",
+        "list_of_variables": []
+    })");
+    io_params["list_of_variables"].SetStringArray(variables_list);
+
     HDF5::NodalSolutionStepDataIO data_io(io_params, p_test_file);
     data_io.WriteNodalResults(r_write_model_part);
     data_io.ReadNodalResults(r_read_model_part);


### PR DESCRIPTION
## Changes
Sort variable names before executing IO operations.

## Reason
For any given HDF5 IO operation, the set of variable names is expected to be identical on all ranks, but their order might not always be the same. This can happen if the variable list was not provided by the user but is the result of some rank-local scanning and a related MPI synchronization, which guarantees that every item is on every rank, but makes no guarantees about their order.

As a result, it might happen that different ranks are trying to write different variables at the same time, resulting in a deadlock. Sorting the incoming name list solves this issue.