### PR TITLE
[Core][IO] WriteModelPart - correcting const

### DIFF
--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -750,6 +750,8 @@ KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(GCC diagnostic ignored "-Wdeprecated-decla
 #define KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING \
 __pragma(warning(push))\
 __pragma(warning(disable: 4996))
+#else
+#define KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING // not implemented for other compilers, hence does nothing
 #endif
 
 // The following block defines the macro KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING which ends the scope for
@@ -763,6 +765,8 @@ _Pragma("GCC diagnostic pop")
 #elif defined(_MSC_VER)
 #define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING \
 __pragma(warning(pop))
+#else
+#define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING // not implemented for other compilers, hence does nothing
 #endif
 
 

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -741,7 +741,7 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
 #define KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING \
 KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(clang diagnostic push) \
 KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(clang diagnostic ignored "-Wdeprecated-declarations")
-#elif defined(__GNUC__) || defined(__GNUG__) && !defined(__INTEL_COMPILER)
+#elif defined(__GNUC__) || defined(__GNUG__)
 #define KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(x) _Pragma(#x)
 #define KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING \
 KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(GCC diagnostic push) \
@@ -750,6 +750,8 @@ KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(GCC diagnostic ignored "-Wdeprecated-decla
 #define KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING \
 __pragma(warning(push))\
 __pragma(warning(disable: 4996))
+#else
+#define KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING // do nothing
 #endif
 
 // The following block defines the macro KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING which ends the scope for
@@ -757,12 +759,14 @@ __pragma(warning(disable: 4996))
 #if defined(__clang__)
 #define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING \
 _Pragma("clang diagnostic pop")
-#elif defined(__GNUC__) || defined(__GNUG__) && !defined(__INTEL_COMPILER)
+#elif defined(__GNUC__) || defined(__GNUG__)
 #define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING \
 _Pragma("GCC diagnostic pop")
 #elif defined(_MSC_VER)
 #define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING \
 __pragma(warning(pop))
+#else
+#define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING // do nothing
 #endif
 
 

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -736,7 +736,9 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
 // The scope ends where KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING is called.
 // NOTE!! this macro is not intented for extensive use, it's just for temporary use in methods exported to Python which
 // are still calling a C++ deprecated function.
-#if defined(__clang__)
+#if defined(__INTEL_COMPILER)
+#define KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING // do nothing
+#elif defined(__clang__)
 #define KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(x) _Pragma(#x)
 #define KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING \
 KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(clang diagnostic push) \
@@ -750,13 +752,13 @@ KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(GCC diagnostic ignored "-Wdeprecated-decla
 #define KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING \
 __pragma(warning(push))\
 __pragma(warning(disable: 4996))
-#else
-#define KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING // do nothing
 #endif
 
 // The following block defines the macro KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING which ends the scope for
 // ignoring the warnings of type 'deprecated function'.
-#if defined(__clang__)
+#if defined(__INTEL_COMPILER)
+#define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING // do nothing
+elif defined(__clang__)
 #define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING \
 _Pragma("clang diagnostic pop")
 #elif defined(__GNUC__) || defined(__GNUG__)
@@ -765,8 +767,6 @@ _Pragma("GCC diagnostic pop")
 #elif defined(_MSC_VER)
 #define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING \
 __pragma(warning(pop))
-#else
-#define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING // do nothing
 #endif
 
 

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -758,7 +758,7 @@ __pragma(warning(disable: 4996))
 // ignoring the warnings of type 'deprecated function'.
 #if defined(__INTEL_COMPILER)
 #define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING // do nothing
-elif defined(__clang__)
+#elif defined(__clang__)
 #define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING \
 _Pragma("clang diagnostic pop")
 #elif defined(__GNUC__) || defined(__GNUG__)

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -736,14 +736,12 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
 // The scope ends where KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING is called.
 // NOTE!! this macro is not intented for extensive use, it's just for temporary use in methods exported to Python which
 // are still calling a C++ deprecated function.
-#if defined(__INTEL_COMPILER)
-#define KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING // do nothing
-#elif defined(__clang__)
+#if defined(__clang__)
 #define KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(x) _Pragma(#x)
 #define KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING \
 KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(clang diagnostic push) \
 KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(clang diagnostic ignored "-Wdeprecated-declarations")
-#elif defined(__GNUC__) || defined(__GNUG__)
+#elif defined(__GNUG__) && !defined(__INTEL_COMPILER)
 #define KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(x) _Pragma(#x)
 #define KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING \
 KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(GCC diagnostic push) \
@@ -756,12 +754,10 @@ __pragma(warning(disable: 4996))
 
 // The following block defines the macro KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING which ends the scope for
 // ignoring the warnings of type 'deprecated function'.
-#if defined(__INTEL_COMPILER)
-#define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING // do nothing
-#elif defined(__clang__)
+#if defined(__clang__)
 #define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING \
 _Pragma("clang diagnostic pop")
-#elif defined(__GNUC__) || defined(__GNUG__)
+#elif defined(__GNUG__) && !defined(__INTEL_COMPILER)
 #define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING \
 _Pragma("GCC diagnostic pop")
 #elif defined(_MSC_VER)

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -741,7 +741,7 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
 #define KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING \
 KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(clang diagnostic push) \
 KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(clang diagnostic ignored "-Wdeprecated-declarations")
-#elif defined(__GNUC__) || defined(__GNUG__)
+#elif defined(__GNUC__) || defined(__GNUG__) && !defined(__INTEL_COMPILER)
 #define KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(x) _Pragma(#x)
 #define KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING \
 KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(GCC diagnostic push) \
@@ -757,7 +757,7 @@ __pragma(warning(disable: 4996))
 #if defined(__clang__)
 #define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING \
 _Pragma("clang diagnostic pop")
-#elif defined(__GNUC__) || defined(__GNUG__)
+#elif defined(__GNUC__) || defined(__GNUG__) && !defined(__INTEL_COMPILER)
 #define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING \
 _Pragma("GCC diagnostic pop")
 #elif defined(_MSC_VER)

--- a/kratos/includes/io.h
+++ b/kratos/includes/io.h
@@ -393,9 +393,26 @@ public:
      * @brief This method writes the model part
      * @param rThisModelPart The model part to be written
      */
+    KRATOS_DEPRECATED_MESSAGE("'WriteModelPart' with a non-const ModelPart as input is deprecated. Please use the version of this function that accepts a const ModelPart instead.")
     virtual void WriteModelPart(ModelPart & rThisModelPart)
     {
         KRATOS_ERROR << "Calling base class method (WriteModelPart). Please check the definition of derived class" << std::endl;
+    }
+
+    /**
+     * @brief This method writes the model part
+     * @param rThisModelPart The model part to be written
+     */
+    virtual void WriteModelPart(const ModelPart& rThisModelPart)
+    {
+        // legacy for backward compatibility
+        ModelPart& non_const_model_part = const_cast<ModelPart&>(rThisModelPart);
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
+        this->WriteModelPart(non_const_model_part);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
+
+        // activate this error once the legacy code is removed
+        // KRATOS_ERROR << "Calling base class method (WriteModelPart). Please check the definition of derived class" << std::endl;
     }
 
     /**

--- a/kratos/includes/io.h
+++ b/kratos/includes/io.h
@@ -10,8 +10,7 @@
 //  Main authors:    Pooyan Dadvand
 //
 
-#if !defined(KRATOS_IO_H_INCLUDED )
-#define  KRATOS_IO_H_INCLUDED
+#pragma once
 
 // System includes
 #include <string>
@@ -645,5 +644,3 @@ inline std::ostream& operator << (std::ostream& rOStream,
 
 
 }  // namespace Kratos.
-
-#endif // KRATOS_IO_H_INCLUDED  defined

--- a/kratos/python/add_io_to_python.cpp
+++ b/kratos/python/add_io_to_python.cpp
@@ -70,8 +70,9 @@ void  AddIOToPython(pybind11::module& m)
     .def("ReadInitialValues",&ReadInitialValues2)
     .def("ReadMesh",&IO::ReadMesh)
     .def("ReadModelPart",&IO::ReadModelPart)
-    .def("WriteModelPart",&IO::WriteModelPart)
+    .def("WriteModelPart", py::overload_cast<const ModelPart&>(&IO::WriteModelPart)) // overload_cast can be removed once the legacy version is removed
     ;
+
     io_python_interface.attr("READ") = IO::READ;
     io_python_interface.attr("WRITE") =IO::WRITE;
     io_python_interface.attr("APPEND") = IO::APPEND;


### PR DESCRIPTION
The `WriteModelPart` of `IO` takes a non-const `ModelPart` as input, which is wrong and should be corrected. I added a new overload which takes it as `const`. It is fully backward compatible, same principle as in #7381 is applied, which has proven to work very well

This way the derived classes can be adapted one-by-one

I also fixed the deprecation start/stop macros for the intel compiler