### PR TITLE
[MappingApplication] Minor name correction in header

### DIFF
--- a/applications/MappingApplication/custom_utilities/mapping_intersection_utilities.h
+++ b/applications/MappingApplication/custom_utilities/mapping_intersection_utilities.h
@@ -4,14 +4,14 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
-//  Main authors:    Philipp  DetectosIntersectosOverlapposAndMappos
+//  Main authors:    Philipp Bucher
+//                   Peter Wilson
 //
 
-#if !defined(KRATOS_MAPPING_INTERSECTION_UTILITIES_H_INCLUDED)
-#define  KRATOS_MAPPING_INTERSECTION_UTILITIES_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -59,5 +59,3 @@ namespace MappingIntersectionUtilities
 }  // namespace MappingIntersectionUtilities.
 
 }  // namespace Kratos.
-
-#endif // KRATOS_MAPPING_INTERSECTION_UTILITIES_H_INCLUDED  defined


### PR DESCRIPTION
**📝 Description**

Minor name correction in header. Maybe I am wrong and Philipp DetectosIntersectosOverlapposAndMappos actually exists

**🆕 Changelog**

- [Minor name correction in header](https://github.com/KratosMultiphysics/Kratos/commit/ff5e013fc23674e8841aea66b8ff91f2aaa067a1)
