### PR TITLE
Fix typos in `kratos/includes` subdirectory

### DIFF
--- a/kratos/includes/chunk.h
+++ b/kratos/includes/chunk.h
@@ -36,8 +36,8 @@ namespace Kratos
   /** The memory management of Kratos is implemented based on the design
 	  given in Modern C++ Design by A. Alexandrescu and chunk is the lower
 	  layer of it holding a chunk of NumberOfBlocks objects of BlockSize.
-	  This implemnetation is designed for larg chunk size (i.e. 1M)
-	  imposes more overhead than the reference for stroing a header
+	  This implementation is designed for large chunk size (i.e. 1M)
+	  imposes more overhead than the reference for storing a header
 	  containing the chunk size and block size.
   */
   class Chunk 

--- a/kratos/includes/communicator.h
+++ b/kratos/includes/communicator.h
@@ -225,22 +225,22 @@ public:
     /// Set the local mesh pointer to the given mesh
     void SetLocalMesh(MeshType::Pointer pGivenMesh);
 
-    /// Returns pointer to the mesh storing all local entites
+    /// Returns pointer to the mesh storing all local entities
     MeshType::Pointer pLocalMesh();
 
-    /// Returns pointer to the mesh storing all ghost entites
+    /// Returns pointer to the mesh storing all ghost entities
     MeshType::Pointer pGhostMesh();
 
-    /// Returns pointer to the mesh storing all interface entites
+    /// Returns pointer to the mesh storing all interface entities
     MeshType::Pointer pInterfaceMesh();
 
-    /// Returns a constant pointer to the mesh storing all local entites
+    /// Returns a constant pointer to the mesh storing all local entities
     const MeshType::Pointer pLocalMesh() const;
 
-    /// Returns a constant pointer to the mesh storing all ghost entites
+    /// Returns a constant pointer to the mesh storing all ghost entities
     const MeshType::Pointer pGhostMesh() const;
 
-    /// Returns a constant pointer to the mesh storing all interface entites
+    /// Returns a constant pointer to the mesh storing all interface entities
     const MeshType::Pointer pInterfaceMesh() const;
 
     MeshType::Pointer pLocalMesh(IndexType ThisIndex);
@@ -255,22 +255,22 @@ public:
 
     const MeshType::Pointer pInterfaceMesh(IndexType ThisIndex) const;
 
-    /// Returns the reference to the mesh storing all local entites
+    /// Returns the reference to the mesh storing all local entities
     MeshType& LocalMesh();
 
-    /// Returns the reference to the mesh storing all ghost entites
+    /// Returns the reference to the mesh storing all ghost entities
     MeshType& GhostMesh();
 
-    /// Returns the reference to the mesh storing all interface entites
+    /// Returns the reference to the mesh storing all interface entities
     MeshType& InterfaceMesh();
 
-    /// Returns a constant reference to the mesh storing all local entites
+    /// Returns a constant reference to the mesh storing all local entities
     MeshType const& LocalMesh() const;
 
-    /// Returns a constant reference to the mesh storing all ghost entites
+    /// Returns a constant reference to the mesh storing all ghost entities
     MeshType const& GhostMesh() const;
 
-    /// Returns a constant reference to the mesh storing all interface entites
+    /// Returns a constant reference to the mesh storing all interface entities
     MeshType const& InterfaceMesh() const;
 
     MeshType& LocalMesh(IndexType ThisIndex);

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -114,7 +114,7 @@ public:
 
     /**
      * CONDITIONS inherited from this class have to implement next
-     * contructors, copy constructors and destructor: MANDATORY
+     * constructors, copy constructors and destructor: MANDATORY
      */
 
     /**
@@ -476,7 +476,7 @@ public:
 
     /**
      * this is called during the assembling process in order
-     * to calculate the condition left hand side matrix for the first derivatives constributions
+     * to calculate the condition left hand side matrix for the first derivatives contributions
      * @param rLeftHandSideMatrix the condition left hand side matrix
      * @param rCurrentProcessInfo the current process info instance
      */
@@ -490,7 +490,7 @@ public:
 
     /**
      * this is called during the assembling process in order
-     * to calculate the condition right hand side vector for the first derivatives constributions
+     * to calculate the condition right hand side vector for the first derivatives contributions
      * @param rRightHandSideVector the condition right hand side vector
      * @param rCurrentProcessInfo the current process info instance
      */
@@ -533,7 +533,7 @@ public:
 
     /**
      * this is called during the assembling process in order
-     * to calculate the condition left hand side matrix for the second derivatives constributions
+     * to calculate the condition left hand side matrix for the second derivatives contributions
      * @param rLeftHandSideMatrix the condition left hand side matrix
      * @param rCurrentProcessInfo the current process info instance
      */
@@ -547,7 +547,7 @@ public:
 
     /**
      * this is called during the assembling process in order
-     * to calculate the condition right hand side vector for the second derivatives constributions
+     * to calculate the condition right hand side vector for the second derivatives contributions
      * @param rRightHandSideVector the condition right hand side vector
      * @param rCurrentProcessInfo the current process info instance
      */

--- a/kratos/includes/constitutive_law.h
+++ b/kratos/includes/constitutive_law.h
@@ -206,7 +206,7 @@ public:
 
      * GEOMETRIC PARAMETERS:
      * @param mpShapeFunctionsValues pointer to the shape functions values in the current integration point (input data)
-     * @param mpShapeFunctionsDerivatives pointer to the shape functions derivaties values in the current integration point (input data)
+     * @param mpShapeFunctionsDerivatives pointer to the shape functions derivatives values in the current integration point (input data)
      * @param mpElementGeometry pointer to the element's geometry (input data)
 
      * MATERIAL PROPERTIES:
@@ -354,7 +354,7 @@ public:
 
 
       /**
-       *Check deformation gradient, strains ans stresses assigned
+       *Check deformation gradient, strains and stresses assigned
        */
 
       bool CheckMechanicalVariables ()
@@ -1356,7 +1356,7 @@ public:
 
 
     /**
-     * @brief This method is used to check that tow Constitutive Laws are the same type (references)
+     * @brief This method is used to check that two Constitutive Laws are the same type (references)
      * @param rLHS The first argument
      * @param rRHS The second argument
      */
@@ -1365,7 +1365,7 @@ public:
     }
 
     /**
-     * @brief This method is used to check that tow Constitutive Laws are the same type (pointers)
+     * @brief This method is used to check that two Constitutive Laws are the same type (pointers)
      * @param rLHS The first argument
      * @param rRHS The second argument
      */

--- a/kratos/includes/convection_diffusion_settings.h
+++ b/kratos/includes/convection_diffusion_settings.h
@@ -46,12 +46,12 @@ namespace Kratos {
 ///@{
 
 /// Convection diffusion settings. This class contains information to be used by the convection diffusion solver, all the variables that will be needed by the solver.
-/** All the variables needed by any convection diffusion problem are included here. However, many problems do not require such a large ammount of variables.
- * For those cases, variables that are not defined will be set to either zero or one (depending on the varible)
- * For this purpouse, there are flags to ask wether a varible has been defined or not. For each variable, there are three main functions.
- * SetVaribleforXuse: we assing the varible for this use. When doing that we also set the flag that now this variable has been defined.
+/** All the variables needed by any convection diffusion problem are included here. However, many problems do not require such a large amount of variables.
+ * For those cases, variables that are not defined will be set to either zero or one (depending on the variable)
+ * For this purpose, there are flags to ask whether a variable has been defined or not. For each variable, there are three main functions.
+ * SetVariableforXuse: we assign the variable for this use. When doing that we also set the flag that now this variable has been defined.
  * GetVariableforXuse: we return the variable for this use.
- * IsDefinedVariableforXuse: tells wether that variable has been defined or not.
+ * IsDefinedVariableforXuse: tells whether that variable has been defined or not.
 */
 class KRATOS_API(KRATOS_CORE) ConvectionDiffusionSettings
 {

--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -350,7 +350,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         return Kratos::make_unique<DataCommunicator>();
     }
 
-    /// Pause program exectution until all threads reach this call.
+    /// Pause program execution until all threads reach this call.
     /** Wrapper for MPI_Barrier. */
     virtual void Barrier() const {}
 
@@ -598,14 +598,14 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     ///@name Inquiry
     ///@{
 
-    /// Retrun the parallel rank for this DataCommunicator.
+    /// Return the parallel rank for this DataCommunicator.
     /** This is a wrapper for calls to MPI_Comm_rank. */
     virtual int Rank() const
     {
         return 0;
     }
 
-    /// Retrun the parallel size for this DataCommunicator.
+    /// Return the parallel size for this DataCommunicator.
     /** This is a wrapper for calls to MPI_Comm_size. */
     virtual int Size() const
     {
@@ -640,7 +640,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     ///@name Access
     ///@{
 
-    /// Convenience function to retireve the current default DataCommunicator.
+    /// Convenience function to retrieve the current default DataCommunicator.
     /** @return A reference to the DataCommunicator instance registered as default in ParallelEnvironment.
      */
     KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator through the ModelPart (or by name in special cases)")
@@ -869,7 +869,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     }
 
     /// Exchange data with other ranks (generic version).
-    /** This is a wrapper for MPI_Sendrecv that uses serialization to tranfer arbitrary objects.
+    /** This is a wrapper for MPI_Sendrecv that uses serialization to transfer arbitrary objects.
      *  The objects are expected to be serializable and come in an stl-like container supporting size() and resize()
      *  @param[in] rSendValues Objects to send to rank SendDestination.
      *  @param[in] SendDestination Rank the data will be sent to.
@@ -919,7 +919,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     }
 
     /// Exchange data with other ranks (generic version).
-    /** This is a wrapper for MPI_Send that uses serialization to tranfer arbitrary objects.
+    /** This is a wrapper for MPI_Send that uses serialization to transfer arbitrary objects.
      *  The objects are expected to be serializable and come in an stl-like container supporting size() and resize()
      *  @param[in] rSendValues Objects to send to rank SendDestination.
      *  @param[in] SendDestination Rank the data will be sent to.
@@ -956,7 +956,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     }
 
     /// Exchange data with other ranks (generic version).
-    /** This is a wrapper for MPI_Recv that uses serialization to tranfer arbitrary objects.
+    /** This is a wrapper for MPI_Recv that uses serialization to transfer arbitrary objects.
      *  The objects are expected to be serializable and come in an stl-like container supporting size() and resize()
      *  @param[out] rRecvObject Objects to receive from rank RecvSource.
      *  @param[in] RecvSource Rank the data will be received from.

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -734,7 +734,7 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
 // The following block defines the macro KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
 // If written in a file, for the following lines of code the compiler will not print warnings of type 'deprecated function'.
 // The scope ends where KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING is called.
-// NOTE!! this macro is not intented for extensive use, it's just for temporary use in methods exported to Python which
+// NOTE!! this macro is not intended for extensive use, it's just for temporary use in methods exported to Python which
 // are still calling a C++ deprecated function.
 #if defined(__clang__)
 #define KRATOS_PRAGMA_INSIDE_MACRO_DEFINITION(x) _Pragma(#x)

--- a/kratos/includes/dof.h
+++ b/kratos/includes/dof.h
@@ -105,7 +105,7 @@ public:
     ///@{
 
     /** Constructor. This constructor takes all necessary
-    informations to construct a degree of freedom. Also default
+    information to construct a degree of freedom. Also default
     values are used to make it easier to define for simple cases.
 
     @param rThisVariable Variable which this degree of freedom

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -112,7 +112,7 @@ public:
 
     /**
      * ELEMENTS inherited from this class have to implement next
-     * contructors, copy constructors and destructor: MANDATORY
+     * constructors, copy constructors and destructor: MANDATORY
      */
 
     /**
@@ -472,7 +472,7 @@ public:
 
     /**
      * this is called during the assembling process in order
-     * to calculate the elemental left hand side matrix for the first derivatives constributions
+     * to calculate the elemental left hand side matrix for the first derivatives contributions
      * @param rLeftHandSideMatrix the elemental left hand side matrix
      * @param rCurrentProcessInfo the current process info instance
      */
@@ -486,7 +486,7 @@ public:
 
     /**
      * this is called during the assembling process in order
-     * to calculate the elemental right hand side vector for the first derivatives constributions
+     * to calculate the elemental right hand side vector for the first derivatives contributions
      * @param rRightHandSideVector the elemental right hand side vector
      * @param rCurrentProcessInfo the current process info instance
      */
@@ -529,7 +529,7 @@ public:
 
     /**
      * this is called during the assembling process in order
-     * to calculate the elemental left hand side matrix for the second derivatives constributions
+     * to calculate the elemental left hand side matrix for the second derivatives contributions
      * @param rLeftHandSideMatrix the elemental left hand side matrix
      * @param rCurrentProcessInfo the current process info instance
      */
@@ -543,7 +543,7 @@ public:
 
     /**
      * this is called during the assembling process in order
-     * to calculate the elemental right hand side vector for the second derivatives constributions
+     * to calculate the elemental right hand side vector for the second derivatives contributions
      * @param rRightHandSideVector the elemental right hand side vector
      * @param rCurrentProcessInfo the current process info instance
      */

--- a/kratos/includes/exception.h
+++ b/kratos/includes/exception.h
@@ -109,7 +109,7 @@ public:
     ///@name Access
     ///@{
 
-    /// The overide of the base class what method
+    /// The override of the base class what method
     /** This method returns the entire message with where information
     */
 

--- a/kratos/includes/fill_communicator.h
+++ b/kratos/includes/fill_communicator.h
@@ -97,7 +97,7 @@ public:
 
     /**
      * @brief Function to print DETAILED mesh information
-     * WARNING: to be used for debugging only as many informations are plotted
+     * WARNING: to be used for debugging only as many information are plotted
      */
     void PrintDebugInfo();
 

--- a/kratos/includes/gid_mesh_container.h
+++ b/kratos/includes/gid_mesh_container.h
@@ -130,7 +130,7 @@ public:
             {
                 if (elements_per_layer[current_layer] > 0)
                 {
-                    //create an appropiate name
+                    //create an appropriate name
                     std::stringstream current_layer_name (std::stringstream::in | std::stringstream::out);
                     current_layer_name << mMeshTitle << "_" << current_layer ;
                     if ( mMeshElements.begin()->GetGeometry().WorkingSpaceDimension() == 2 )

--- a/kratos/includes/kernel.h
+++ b/kratos/includes/kernel.h
@@ -30,7 +30,7 @@ namespace Kratos {
 ///@name Kratos Classes
 ///@{
 
-/// Kernel is in charge of synchronization the whole system of Kratos itself and its appliction.
+/// Kernel is in charge of synchronization the whole system of Kratos itself and its application.
 /** Kernel is the first component of the Kratos to be created and then used to plug the application into Kratos.
     Kernel takes the list of variables defined in the Variables file in Kratos and then by adding each application
     synchronizes the variables of this application with its variables and add the new ones to the Kratos.
@@ -85,9 +85,9 @@ class KRATOS_API(KRATOS_CORE) Kernel {
     ///@name Operations
     ///@{
 
-    /// Pluging an application into Kratos.
+    /// Plugging an application into Kratos.
     /** This method first call the register method of the new application in order to create the
-        components list of the application and then syncronizes the lists of its components with Kratos ones.
+        components list of the application and then synchronizes the lists of its components with Kratos ones.
         The synchronized lists are
       - Variables
       - Elements
@@ -97,8 +97,8 @@ class KRATOS_API(KRATOS_CORE) Kernel {
     */
     void ImportApplication(KratosApplication::Pointer pNewApplication);
 
-    /// To be deprecated becuase variables have their own hash key.
-    /** The keys of Variables are not sequencial anymore, so this method will be deprecated
+    /// To be deprecated because variables have their own hash key.
+    /** The keys of Variables are not sequential anymore, so this method will be deprecated
     */
     void Initialize();
 

--- a/kratos/includes/key_hash.h
+++ b/kratos/includes/key_hash.h
@@ -262,7 +262,7 @@ namespace Kratos
     /**
      * @brief This is a hasher for indexed objects (pointer)
      * @tparam TpIndexedObject Pointer type to indexed object
-     * @note Must be tenmplated to take into account the shared, intrussive,etc... pointers
+     * @note Must be tenmplated to take into account the shared, intrusive,etc... pointers
      */
     template<class TpIndexedObject>
     struct IndexedObjectPointerHasher
@@ -281,7 +281,7 @@ namespace Kratos
     /**
      * @brief This is a key comparer between two indexed objects (pointer)
      * @tparam TpIndexedObject Pointer type to indexed object
-     * @note Must be tenmplated to take into account the shared, intrussive,etc... pointers
+     * @note Must be tenmplated to take into account the shared, intrusive,etc... pointers
      */
     template<class TpIndexedObject>
     struct IndexedObjectPointerComparator

--- a/kratos/includes/kratos_application.h
+++ b/kratos/includes/kratos_application.h
@@ -79,7 +79,7 @@ namespace Kratos {
 /**
  * @class KratosApplication
  * @brief This class defines the interface with kernel for all applications in Kratos.
- * @details The application class defines the interface necessary for providing the information needed by Kernel in order to configure the whole sistem correctly.
+ * @details The application class defines the interface necessary for providing the information needed by Kernel in order to configure the whole system correctly.
  * @ingroup KratosCore
  * @author Pooyan Dadvand
  * @author Riccardo Rossi

--- a/kratos/includes/kratos_export_api.h
+++ b/kratos/includes/kratos_export_api.h
@@ -35,7 +35,7 @@
 // number of the arguments in API() call.
 #define KRATOS_API_CALL(x,T1,T2,T3,...) T3
 
-// If KRATOS_API_NO_DLL is defined ingore the DLL api
+// If KRATOS_API_NO_DLL is defined ignore the DLL api
 #ifndef KRATOS_API_NO_DLL
     #define KRATOS_API(...) \
         KRATOS_EXPAND(KRATOS_API_CALL(,##__VA_ARGS__,KRATOS_API_EXPORT,KRATOS_API_IMPORT))

--- a/kratos/includes/kratos_parameters.h
+++ b/kratos/includes/kratos_parameters.h
@@ -61,7 +61,7 @@ namespace Kratos
 class KRATOS_API(KRATOS_CORE) Parameters
 {
 private:
-    ///@name Nested clases
+    ///@name Nested classes
     ///@{
     /**
      * @class iterator_adaptor
@@ -142,7 +142,7 @@ private:
 
         /**
          * @brief operator ->
-         * @details This operator acces to the pointer of the Parameter
+         * @details This operator access to the pointer of the Parameter
          * @return The pointer of the parameter
          */
         Parameters* operator->() const;
@@ -152,7 +152,7 @@ private:
         ///@{
 
         /**
-         * @brief This method returs the current iterator
+         * @brief This method returns the current iterator
          * @return The current iterator
          */
         inline value_iterator GetCurrentIterator() const;
@@ -256,7 +256,7 @@ private:
 
         /**
          * @brief operator ->
-         * @details This operator acces to the pointer of the Parameter
+         * @details This operator access to the pointer of the Parameter
          * @return The pointer of the parameter
          */
         const Parameters* operator->() const;
@@ -266,7 +266,7 @@ private:
         ///@{
 
         /**
-         * @brief This method returs the current iterator
+         * @brief This method returns the current iterator
          * @return The current iterator
          */
         inline value_iterator GetCurrentIterator() const;
@@ -304,7 +304,7 @@ public:
     /// Pointer definition of MmgProcess
     KRATOS_CLASS_POINTER_DEFINITION(Parameters);
 
-    /// Definiton of the iterators
+    /// Definition of the iterators
     using iterator = iterator_adaptor;
     using const_iterator = const_iterator_adaptor;
 
@@ -371,14 +371,14 @@ public:
     Parameters operator[](const std::string& rEntry) const;
 
     /**
-     * @brief This method allows to acces to an array item with the operator []
+     * @brief This method allows to access to an array item with the operator []
      * @param Index The index of the term of interest
      * @return The desired Parameter
      */
     Parameters operator[](const IndexType Index);
 
     /**
-     * @brief This method allows to acces to an array item with the operator [] (const version)
+     * @brief This method allows to access to an array item with the operator [] (const version)
      * @param Index The index of the term of interest
      * @return The desired Parameter
      */
@@ -386,7 +386,7 @@ public:
 
     /**
      * @brief This is the move operator
-     * @param rOther The othe parameter to compute the move
+     * @param rOther The other parameter to compute the move
      */
     Parameters& operator=(Parameters&& rOther);
 
@@ -724,7 +724,7 @@ public:
 
     /**
      * @brief This method does a swap between two parameters
-     * @param rOther The othe parameter to compute the swap
+     * @param rOther The other parameter to compute the swap
      */
     void swap(Parameters& rOther) noexcept;
 
@@ -956,7 +956,7 @@ private:
     ///@{
 
     nlohmann::json* mpValue;                   /// This is where the json is actually stored
-    Kratos::shared_ptr<nlohmann::json> mpRoot; /// This is a shared pointer to the root structure (this is what allows us to acces in a tree structure to the JSON database)
+    Kratos::shared_ptr<nlohmann::json> mpRoot; /// This is a shared pointer to the root structure (this is what allows us to access in a tree structure to the JSON database)
 
     ///@}
     ///@name Private Operators

--- a/kratos/includes/master_slave_constraint.h
+++ b/kratos/includes/master_slave_constraint.h
@@ -387,7 +387,7 @@ public:
     }
 
     /**
-     * @brief This method allows to set the Local System in case is not computed on tunning time (internal variable)
+     * @brief This method allows to set the Local System in case is not computed on running time (internal variable)
      * @param rRelationMatrix the matrix which relates the master and slave degree of freedom
      * @param rConstant The constant vector (one entry for each slave)
      * @param rCurrentProcessInfo The current process info instance
@@ -406,7 +406,7 @@ public:
     }
 
     /**
-     * @brief This method allows to get the Local System in case is not computed on tunning time (internal variable)
+     * @brief This method allows to get the Local System in case is not computed on running time (internal variable)
      * @param rRelationMatrix the matrix which relates the master and slave degree of freedom
      * @param rConstant The constant vector (one entry for each slave)
      * @param rCurrentProcessInfo The current process info instance
@@ -471,7 +471,7 @@ public:
 
     /**
      * @brief Returns the string containing a detailed description of this object.
-     * @return the string with informations
+     * @return the string with information
      */
     virtual std::string GetInfo() const
     {
@@ -622,7 +622,7 @@ private:
 
 KRATOS_API_EXTERN template class KRATOS_API(KRATOS_CORE) KratosComponents<MasterSlaveConstraint>;
 
-///@name Input/Output funcitons
+///@name Input/Output functions
 ///@{
 
 /// input stream function

--- a/kratos/includes/matrix_market_interface.h
+++ b/kratos/includes/matrix_market_interface.h
@@ -110,7 +110,7 @@ template <typename CompressedMatrixType> inline bool ReadMatrixMarketMatrix(cons
     // Check for supported types of MM file
     if (!(mm_is_coordinate(mm_code) && mm_is_sparse(mm_code)))
     {
-        printf("ReadMatrixMarketMatrix(): unspported MatrixMarket type, \"%s\".\n",  mm_typecode_to_str(mm_code));
+        printf("ReadMatrixMarketMatrix(): unsupported MatrixMarket type, \"%s\".\n",  mm_typecode_to_str(mm_code));
         fclose(f);
         return false;
     }

--- a/kratos/includes/memory_info.h
+++ b/kratos/includes/memory_info.h
@@ -28,10 +28,10 @@ namespace Kratos {
 ///@name Kratos Classes
 ///@{
 
-/// MemoryInfo gives the OS information about the memory useage by Kratos.
+/// MemoryInfo gives the OS information about the memory usage by Kratos.
 /** This class provides the peak memory usage and current memory usage.
- *  The information is taken bu OS and may vary in each execution depending
- *  on page allocation and other factors.
+ *  The information is taken per OS and may vary in each execution
+ *  depending on page allocation and other factors.
  *  The supported platforms are Windows, Linux and OSX.
 */
 class KRATOS_API(KRATOS_CORE) MemoryInfo {

--- a/kratos/includes/memory_pool.h
+++ b/kratos/includes/memory_pool.h
@@ -99,7 +99,7 @@ namespace Kratos
 	  static FixedSizeMemoryPool* GetPoolWithBlockSize(std::size_t BlockSize) {
 		  PoolsContainerType& r_pools = GetInstance().mPools;
 
-		  // I would avoid it by defining a max block size, but befor that I should profile to see if is really slows done. Pooyan.
+		  // I would avoid it by defining a max block size, but before that I should profile to see if it really slows down. Pooyan.
 		  if (r_pools.size() <= BlockSize) { // This check is extra but is to avoid critical each time
 #pragma omp critical
 		  {

--- a/kratos/includes/mesh.h
+++ b/kratos/includes/mesh.h
@@ -263,7 +263,7 @@ public:
     }
 
     ///@}
-    ///@name Informations
+    ///@name Information
     ///@{
 
     /** Dimensional space of the mesh geometries

--- a/kratos/includes/mmio.h
+++ b/kratos/includes/mmio.h
@@ -28,7 +28,7 @@ KRATOS_API(KRATOS_CORE) int mm_write_mtx_crd_size(FILE *f, int M, int N, int nz)
 KRATOS_API(KRATOS_CORE) int mm_write_mtx_array_size(FILE *f, int M, int N);
 
 
-/********************* MM_typecode query fucntions ***************************/
+/********************* MM_typecode query functions ***************************/
 
 #define mm_is_matrix(typecode)	((typecode)[0]=='M')
 
@@ -50,7 +50,7 @@ KRATOS_API(KRATOS_CORE) int mm_write_mtx_array_size(FILE *f, int M, int N);
 KRATOS_API(KRATOS_CORE) int mm_is_valid(MM_typecode matcode);		/* too complex for a macro */
 
 
-/********************* MM_typecode modify fucntions ***************************/
+/********************* MM_typecode modify functions ***************************/
 
 #define mm_set_matrix(typecode)	((*typecode)[0]='M')
 #define mm_set_coordinate(typecode)	((*typecode)[1]='C')
@@ -91,7 +91,7 @@ KRATOS_API(KRATOS_CORE) int mm_is_valid(MM_typecode matcode);		/* too complex fo
 
    MM_matrix_typecode: 4-character sequence
 
-				    ojbect 		sparse/   	data        storage
+				    object 		sparse/   	data        storage
 						  		dense     	type        scheme
 
    string position:	 [0]        [1]			[2]         [3]

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -229,7 +229,7 @@ public:
 
     /// The Geometry Container.
     /**
-    * Contains all geometries, which can be adressed by specific identifiers.
+    * Contains all geometries, which can be addressed by specific identifiers.
     */
     typedef GeometryContainer<GeometryType> GeometryContainerType;
 
@@ -1270,7 +1270,7 @@ public:
             IndexType Id, Geometry< Node < 3 > >::PointsArrayType pConditionNodes,
             PropertiesType::Pointer pProperties, IndexType ThisIndex = 0);
 
-    /// Creates new condtion with pointer to geometry.
+    /// Creates new condition with pointer to geometry.
     ConditionType::Pointer CreateNewCondition(std::string ConditionName,
             IndexType Id, typename GeometryType::Pointer pGeometry,
             PropertiesType::Pointer pProperties, IndexType ThisIndex = 0);
@@ -1630,13 +1630,13 @@ public:
     }
 
 
-    /// Get geometry map containe
+    /// Get geometry map container
     GeometriesMapType& Geometries()
     {
         return mGeometries.Geometries();
     }
 
-    /// Get geometry map containe
+    /// Get geometry map container
     const GeometriesMapType& Geometries() const
     {
         return mGeometries.Geometries();

--- a/kratos/includes/model_part_io.h
+++ b/kratos/includes/model_part_io.h
@@ -74,7 +74,7 @@ public:
     typedef std::vector<std::ostream*>            OutputFilesContainerType;
     typedef std::size_t                           SizeType;
 
-    // Prevents this class from hidding IO::WriteProperties(Properties)
+    // Prevents this class from hiding IO::WriteProperties(Properties)
     using BaseType::WriteProperties;
 
     ///@}
@@ -758,7 +758,7 @@ private:
     inline void CreatePartition(unsigned int NumberOfThreads,const int NumberOfRows, DenseVector<unsigned int>& partitions);
 
     /// Iterate over a Node block, calling ReorderedNodeId on each node.
-    /** This method allows derived implementations to initalize reordering
+    /** This method allows derived implementations to initialize reordering
      *  without storing the nodes.
      */
     void ScanNodeBlock();

--- a/kratos/includes/mortar_classes.h
+++ b/kratos/includes/mortar_classes.h
@@ -702,7 +702,7 @@ public:
     ///@name Type Definitions
     ///@{
 
-    // Auxiliar types
+    // Auxiliary types
     typedef BoundedMatrix<int, 1, 1> DummyBoundedMatrixType;
 
     typedef array_1d<double, TNumNodes> GeometryArraySlaveType;
@@ -717,7 +717,7 @@ public:
 
     typedef typename std::conditional<TNumNodes == 2, DummyBoundedMatrixType, BoundedMatrix<double, 3, 3>>::type VertexDerivativesMatrixType;
 
-    // Auxiliar sizes
+    // Auxiliary sizes
     static const SizeType DummySize = 1;
 
     static const SizeType DoFSizeSlaveGeometry = (TNumNodes * TDim);
@@ -835,7 +835,7 @@ public:
     {
         // Derivatives
         if constexpr (TDim == 3) { // Derivative of the cell vertex
-            // Auxiliar zero matrix
+            // Auxiliary zero matrix
             const BoundedMatrix<double, 3, 3> aux_zero = ZeroMatrix(3, 3);
             for (IndexType i = 0; i < TNumNodes * TDim; ++i) {
                 noalias(DeltaCellVertex[i]) = aux_zero;
@@ -851,7 +851,7 @@ public:
      */
     void InitializeDeltaAeComponents()
     {
-        // Auxiliar zero matrix
+        // Auxiliary zero matrix
         const GeometryMatrixType aux_zero = ZeroMatrix(TNumNodes, TNumNodes);
 
         // Ae
@@ -1443,7 +1443,7 @@ public:
     typedef BoundedMatrix<double, TNumNodes, TNumNodes> GeometryMatrixSlaveType;
     typedef BoundedMatrix<double, TNumNodes, TNumNodesMaster> GeometryMatrixMasterType;
 
-    // Auxiliar sizes
+    // Auxiliary sizes
     static const SizeType DoFSizeSlaveGeometry = (TNumNodes * TDim);
     static const SizeType DoFSizeMasterGeometry = (TNumNodesMaster * TDim);
 
@@ -1482,7 +1482,7 @@ public:
     {
         BaseClassType::Initialize();
 
-        // Auxiliar zero matrix
+        // Auxiliary zero matrix
         const GeometryMatrixSlaveType aux_zero_slave = ZeroMatrix(TNumNodes, TNumNodes);
         const GeometryMatrixMasterType aux_zero_master = ZeroMatrix(TNumNodes, TNumNodesMaster);
 
@@ -1710,7 +1710,7 @@ public:
 
     virtual ~DualLagrangeMultiplierOperators(){}
 
-    /// The auxiliar operators needed to build the dual LM Ae operator
+    /// The auxiliary operators needed to build the dual LM Ae operator
     GeometryMatrixType Me, De;
 
     ///@}
@@ -1939,10 +1939,10 @@ public:
 
     typedef typename std::conditional<TFrictional, DerivativeDataFrictionalType, DerivativeFrictionalessDataType>::type DerivativeDataType;
 
-    // Auxiliar types
+    // Auxiliary types
     typedef BoundedMatrix<double, TNumNodes, TNumNodes> GeometryMatrixType;
 
-    // Auxiliar sizes
+    // Auxiliary sizes
     static const SizeType DoFSizeSlaveGeometry = (TNumNodes * TDim);
 
     static const SizeType DoFSizeMasterGeometry = (TNumNodesMaster * TDim);

--- a/kratos/includes/node.h
+++ b/kratos/includes/node.h
@@ -701,7 +701,7 @@ public:
             }
         }
 
-        KRATOS_ERROR <<  "Not existant DOF in node #" << Id() << " for variable : " << rDofVariable.Name() << std::endl;
+        KRATOS_ERROR <<  "Non-existent DOF in node #" << Id() << " for variable : " << rDofVariable.Name() << std::endl;
     }
 
     /**
@@ -719,7 +719,7 @@ public:
             }
         }
 
-        KRATOS_ERROR <<  "Not existant DOF in node #" << Id() << " for variable : " << rDofVariable.Name() << std::endl;
+        KRATOS_ERROR <<  "Non-existent DOF in node #" << Id() << " for variable : " << rDofVariable.Name() << std::endl;
 
     }
 
@@ -749,7 +749,7 @@ public:
             }
         }
 
-        KRATOS_ERROR <<  "Not existant DOF in node #" << Id() << " for variable : " << rDofVariable.Name() << std::endl;
+        KRATOS_ERROR <<  "Non-existent DOF in node #" << Id() << " for variable : " << rDofVariable.Name() << std::endl;
 
     }
 
@@ -783,7 +783,7 @@ public:
             }
         }
 
-        KRATOS_ERROR <<  "Not existant DOF in node #" << Id() << " for variable : " << rDofVariable.Name() << std::endl;
+        KRATOS_ERROR <<  "Non-existent DOF in node #" << Id() << " for variable : " << rDofVariable.Name() << std::endl;
     }
 
 

--- a/kratos/includes/parallel_environment.h
+++ b/kratos/includes/parallel_environment.h
@@ -104,7 +104,7 @@ class KRATOS_API(KRATOS_CORE) ParallelEnvironment
     /**
      * @brief Registers the communicator factory
      * This method takes the provided communicator pointer factory and saves it to be used later on
-     * @param CommunicatorFactory Factory function returning a pointer to a (parrallel or serial) communicator
+     * @param CommunicatorFactory Factory function returning a pointer to a (parallel or serial) communicator
      */
     template<class TDataCommunicatorInputType>
     static void RegisterCommunicatorFactory(std::function<Communicator::UniquePointer(ModelPart&, TDataCommunicatorInputType&)> CommunicatorFactory);

--- a/kratos/includes/periodic_condition.h
+++ b/kratos/includes/periodic_condition.h
@@ -68,7 +68,7 @@ namespace Kratos
  * another on both periodic sides.\n
  * Note that the periodic boundary condition is enforced by the builder and solver, this Condition
  * is simply used to provide it the required information to set it up.\n
- * This condtion has to be carefully set up in order to work properly, see PeriodicConditionUtilities,
+ * This condition has to be carefully set up in order to work properly, see PeriodicConditionUtilities,
  * which provides some tools to do so.
  * @note PeriodicCondition is designed designed to work with a builder and solver
  * that recognizes the presence of periodic conditions, as ResidualBasedBlockBuilderAndSolverPeriodic

--- a/kratos/includes/piecewize_linear_table.h
+++ b/kratos/includes/piecewize_linear_table.h
@@ -153,7 +153,7 @@ public:
             if(X <= mData[i].first)
                 return Interpolate(X, mData[i-1].first, mData[i-1].second, mData[i].first, mData[i].second, result);
 
-        // now the x is outside the table and we hae to extrapolate it using last two records of table.
+        // now the x is outside the table and we have to extrapolate it using last two records of table.
         return Interpolate(X, mData[size-2].first, mData[size-2].second, mData[size-1].first, mData[size-1].second, result);
     }
 
@@ -175,7 +175,7 @@ public:
             if(X <= mData[i].first)
                 return ((X - mData[i-1].first) < (mData[i].first - X)) ? mData[i-1].second : mData[i].second;
 
-        // now the x is outside the table and we hae to extrapolate it using last two records of table.
+        // now the x is outside the table and we have to extrapolate it using last two records of table.
         return mData[size-1].second;
     }
 
@@ -197,7 +197,7 @@ public:
             if(X <= mData[i].first)
                 return ((X - mData[i-1].first) < (mData[i].first - X)) ? mData[i-1].second : mData[i].second;
 
-        // now the x is outside the table and we hae to extrapolate it using last two records of table.
+        // now the x is outside the table and we have to extrapolate it using last two records of table.
         return mData[size-1].second;
     }
 

--- a/kratos/includes/prime_numbers.h
+++ b/kratos/includes/prime_numbers.h
@@ -32,7 +32,7 @@ namespace Kratos
   ///@name Kratos Classes
   ///@{
 
-  /// Gives a prime number after or befor of given number.
+  /// Gives a prime number before or after given number.
   /** Has an array of precalculated value up to 1e8 and calculates the rest.
   */
   class PrimeNumbers

--- a/kratos/includes/properties.h
+++ b/kratos/includes/properties.h
@@ -87,7 +87,7 @@ public:
 
     typedef Table<double> TableType;
 
-    typedef std::unordered_map<std::size_t, TableType> TablesContainerType; // This is a provisional implmentation and should be changed to hash. Pooyan.
+    typedef std::unordered_map<std::size_t, TableType> TablesContainerType; // This is a provisional implementation and should be changed to hash. Pooyan.
 
     /// Properties container. A vector set of properties with their Id's as key.
     typedef PointerVectorSet<Properties, IndexedObject> SubPropertiesContainerType;

--- a/kratos/includes/serializer.h
+++ b/kratos/includes/serializer.h
@@ -1434,7 +1434,7 @@ private:
     /// Sets the pointer of the stream buffer at the begnining
     void SeekBegin();
 
-    /// Sets the pointer of the stream buffer at tht end
+    /// Sets the pointer of the stream buffer at the end
     void SeekEnd();
 
     ///@}

--- a/kratos/includes/table.h
+++ b/kratos/includes/table.h
@@ -160,7 +160,7 @@ public:
             if(X <= mData[i].first)
                 return ((X - mData[i-1].first) < (mData[i].first - X)) ? mData[i-1].second : mData[i].second;
 
-        // now the x is outside the table and we hae to extrapolate it using last two records of table.
+        // now the x is outside the table and we have to extrapolate it using last two records of table.
         return mData[size-1].second;
     }
 
@@ -181,7 +181,7 @@ public:
             if(X <= mData[i].first)
                 return ((X - mData[i-1].first) < (mData[i].first - X)) ? mData[i-1].second : mData[i].second;
 
-        // now the x is outside the table and we hae to extrapolate it using last two records of table.
+        // now the x is outside the table and we have to extrapolate it using last two records of table.
         return mData[size-1].second;
     }
 
@@ -255,7 +255,7 @@ public:
     }
     
     /**
-     * @brief This method clears databse
+     * @brief This method clears database
      */
     void Clear()
     {
@@ -533,7 +533,7 @@ public:
             if(X <= mData[i].first)
                 return Interpolate(X, mData[i-1].first, mData[i-1].second[0], mData[i].first, mData[i].second[0], result);
 
-        // now the x is outside the table and we hae to extrapolate it using last two records of table.
+        // now the x is outside the table and we have to extrapolate it using last two records of table.
         return Interpolate(X, mData[size-2].first, mData[size-2].second[0], mData[size-1].first, mData[size-1].second[0], result);
     }
 
@@ -554,7 +554,7 @@ public:
             if(X <= mData[i].first)
                 return ((X - mData[i-1].first) < (mData[i].first - X)) ? mData[i-1].second : mData[i].second;
 
-        // now the x is outside the table and we hae to extrapolate it using last two records of table.
+        // now the x is outside the table and we have to extrapolate it using last two records of table.
         return mData[size-1].second;
     }
 
@@ -575,7 +575,7 @@ public:
             if(X <= mData[i].first)
                 return ((X - mData[i-1].first) < (mData[i].first - X)) ? mData[i-1].second[0] : mData[i].second[0];
 
-        // now the x is outside the table and we hae to extrapolate it using last two records of table.
+        // now the x is outside the table and we have to extrapolate it using last two records of table.
         return mData[size-1].second[0];
     }
 
@@ -596,7 +596,7 @@ public:
             if(X <= mData[i].first)
                 return ((X - mData[i-1].first) < (mData[i].first - X)) ? mData[i-1].second[0] : mData[i].second[0];
 
-        // now the x is outside the table and we hae to extrapolate it using last two records of table.
+        // now the x is outside the table and we have to extrapolate it using last two records of table.
         return mData[size-1].second[0];
     }
 
@@ -695,7 +695,7 @@ public:
     }
     
     /**
-     * @brief This method clears databse
+     * @brief This method clears database
      */
     void Clear()
     {

--- a/kratos/includes/table_stream.h
+++ b/kratos/includes/table_stream.h
@@ -347,7 +347,7 @@ private:
     // Stream related variables
     std::ostream* mOutStream;                // The stream considered
     std::vector<std::string> mColumnHeaders; // This vector contains the header to print in each column
-    std::vector<int> mColumnWidths;          // This vector containts the spaces of each column
+    std::vector<int> mColumnWidths;          // This vector contains the spaces of each column
     std::string mSeparator;                  // The separator considered in each column
 
     // The indexes currently used
@@ -385,7 +385,7 @@ private:
     }
 
     /**
-     * This functions prints into the stream a double or float value with scientific notation (respeting the spaces asigned)
+     * This functions prints into the stream a double or float value with scientific notation (respecting the spaces assigned)
      * @param Input The double or float to print
      */
     template<typename TClass>

--- a/kratos/includes/variables.h
+++ b/kratos/includes/variables.h
@@ -129,7 +129,7 @@ namespace Kratos
     // for geometrical application
     KRATOS_DEFINE_3D_VARIABLE_WITH_COMPONENTS( CHARACTERISTIC_GEOMETRY_LENGTH )
 
-    //sheme info :: pass to elements
+    //scheme info :: pass to elements
     KRATOS_DEFINE_VARIABLE( double, NEWMARK_BETA )
     KRATOS_DEFINE_VARIABLE( double, NEWMARK_GAMMA )
     KRATOS_DEFINE_VARIABLE( double, BOSSAK_ALPHA )


### PR DESCRIPTION
---
name: 🗎 Documentation and Styling
about: Adding or modifying **documentation** or **code style**.

---

**Description**
Fix typos in `kratos/includes` subdir  
Found via `codespell`

**Changelog**

- Fix typos in kratos/includes subdir