### PR TITLE
[Core] Extend set historical variables to zero in Variable utils

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_variable_utils.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_variable_utils.cpp
@@ -31,6 +31,7 @@ namespace Testing
         // Set auxilary nodal structure
         Model test_model;
         auto& r_test_model_part = test_model.CreateModelPart("TestModelPart");
+        r_test_model_part.SetBufferSize(2);
         r_test_model_part.AddNodalSolutionStepVariable(PRESSURE);
         r_test_model_part.AddNodalSolutionStepVariable(VELOCITY);
         r_test_model_part.AddNodalSolutionStepVariable(TEMPERATURE);
@@ -55,10 +56,17 @@ namespace Testing
             noalias(r_node.FastGetSolutionStepValue(VELOCITY)) = aux_vect;
             noalias(r_node.FastGetSolutionStepValue(DISPLACEMENT)) = aux_vect;
             r_node.FastGetSolutionStepValue(DEFORMATION_GRADIENT) = aux_mat;
+
+            r_node.FastGetSolutionStepValue(PRESSURE, 1) = 1.0;
+            r_node.FastGetSolutionStepValue(TEMPERATURE, 1) = 1.0;
+            noalias(r_node.FastGetSolutionStepValue(VELOCITY, 1)) = aux_vect;
+            noalias(r_node.FastGetSolutionStepValue(DISPLACEMENT, 1)) = aux_vect;
+            r_node.FastGetSolutionStepValue(DEFORMATION_GRADIENT, 1) = aux_mat;
         }
 
         // Set some values to zero in the non-historical database
         VariableUtils::SetHistoricalVariablesToZero(r_test_model_part.Nodes(), PRESSURE, TEMPERATURE, VELOCITY, DISPLACEMENT, DEFORMATION_GRADIENT);
+        VariableUtils::SetHistoricalVariablesToZero(r_test_model_part.Nodes(), 1, PRESSURE, TEMPERATURE, VELOCITY, DISPLACEMENT, DEFORMATION_GRADIENT);
 
         // Values are properly allocated
         const double tolerance = 1.0e-12;
@@ -68,6 +76,12 @@ namespace Testing
             KRATOS_CHECK_VECTOR_NEAR(r_node.FastGetSolutionStepValue(VELOCITY), ZeroVector(3), tolerance);
             KRATOS_CHECK_VECTOR_NEAR(r_node.FastGetSolutionStepValue(DISPLACEMENT), ZeroVector(3), tolerance);
             KRATOS_CHECK_MATRIX_NEAR(r_node.FastGetSolutionStepValue(DEFORMATION_GRADIENT), ZeroMatrix(0,0), tolerance);
+
+            KRATOS_CHECK_NEAR(r_node.FastGetSolutionStepValue(PRESSURE, 1), 0.0, tolerance);
+            KRATOS_CHECK_NEAR(r_node.FastGetSolutionStepValue(TEMPERATURE, 1), 0.0, tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(r_node.FastGetSolutionStepValue(VELOCITY, 1), ZeroVector(3), tolerance);
+            KRATOS_CHECK_VECTOR_NEAR(r_node.FastGetSolutionStepValue(DISPLACEMENT, 1), ZeroVector(3), tolerance);
+            KRATOS_CHECK_MATRIX_NEAR(r_node.FastGetSolutionStepValue(DEFORMATION_GRADIENT, 1), ZeroMatrix(0,0), tolerance);
         }
     }
 

--- a/kratos/utilities/variable_utils.cpp
+++ b/kratos/utilities/variable_utils.cpp
@@ -322,24 +322,6 @@ KRATOS_API(KRATOS_CORE) const ModelPart::ConditionsContainerType& VariableUtils:
     return rModelPart.Conditions();
 }
 
-template<class TDataType>
-void VariableUtils::AuxiliaryHistoricalValueSetter(
-    const Variable<TDataType>& rVariable,
-    const TDataType& rValue,
-    NodeType& rNode)
-{
-    rNode.FastGetSolutionStepValue(rVariable) = rValue;
-}
-
-template<>
-void VariableUtils::AuxiliaryHistoricalValueSetter(
-    const Variable<array_1d<double,3>>& rVariable,
-    const array_1d<double,3>& rValue,
-    NodeType& rNode)
-{
-    noalias(rNode.FastGetSolutionStepValue(rVariable)) = rValue;
-}
-
 template <class TDataType, class TContainerType, class TWeightDataType>
 void VariableUtils::WeightedAccumulateVariableOnNodes(
     ModelPart& rModelPart,
@@ -618,10 +600,5 @@ template KRATOS_API(KRATOS_CORE) void VariableUtils::WeightedAccumulateVariableO
     ModelPart&, const Variable<double>&, const Variable<double>&, const bool);
 template KRATOS_API(KRATOS_CORE) void VariableUtils::WeightedAccumulateVariableOnNodes<array_1d<double, 3>, ModelPart::ElementsContainerType, double>(
     ModelPart&, const Variable<array_1d<double, 3>>&, const Variable<double>&, const bool);
-
-template void VariableUtils::AuxiliaryHistoricalValueSetter<int>(const Variable<int>&, const int&, NodeType&);
-template void VariableUtils::AuxiliaryHistoricalValueSetter<double>(const Variable<double>&, const double&, NodeType&);
-template void VariableUtils::AuxiliaryHistoricalValueSetter<Vector>(const Variable<Vector>&, const Vector&, NodeType&);
-template void VariableUtils::AuxiliaryHistoricalValueSetter<Matrix>(const Variable<Matrix>&, const Matrix&, NodeType&);
 
 } /* namespace Kratos.*/

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -767,7 +767,7 @@ public:
         const int Step,
         const TVariableArgs&... rVariableArgs)
     {
-        block_for_each(rNodes, [&](NodeType& rNode){(
+        block_for_each(rNodes, [&](auto& rNode){(
             AuxiliaryHistoricalValueSetter<typename TVariableArgs::Type>(rVariableArgs, rVariableArgs.Zero(), rNode, Step), ...);
         });
     }

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -752,6 +752,25 @@ public:
             AuxiliaryHistoricalValueSetter<typename TVariableArgs::Type>(rVariableArgs, rVariableArgs.Zero(), rNode), ...);
         });
     }
+    
+    /**
+     * @brief Set the Historical Variables To Zero
+     * This method sets the provided list of variables to zero in the nodal historical database
+     * @tparam TVariableArgs Variadic template argument representing the variables types
+     * @param rNodes Nodes container to be initialized to zero
+     * @param Step Step of the solution step data which needs to be set to zero
+     * @param rVariableArgs Variables to be set to zero
+     */
+    template<class... TVariableArgs>
+    static void SetHistoricalVariablesToZero(
+        NodesContainerType& rNodes,
+        const int Step,
+        const TVariableArgs&... rVariableArgs)
+    {
+        block_for_each(rNodes, [&](NodeType& rNode){(
+            AuxiliaryHistoricalValueSetter<typename TVariableArgs::Type>(rVariableArgs, rVariableArgs.Zero(), rNode, Step), ...);
+        });
+    }
 
     /**
      * @brief Sets the container value of any type of non historical variable
@@ -1703,10 +1722,18 @@ private:
     const TContainerType& GetContainer(const ModelPart& rModelPart);
 
     template<class TDataType>
-    static void AuxiliaryHistoricalValueSetter(
+    static void inline AuxiliaryHistoricalValueSetter(
         const Variable<TDataType>& rVariable,
         const TDataType& rValue,
-        NodeType& rNode);
+        NodeType& rNode,
+        const int Step = 0)
+    {
+        if constexpr(std::is_integral_v<TDataType> || std::is_floating_point_v<TDataType>) {
+            rNode.FastGetSolutionStepValue(rVariable, Step) = rValue;
+        } else {
+            noalias(rNode.FastGetSolutionStepValue(rVariable, Step)) = rValue;
+        }
+    }
 
     template <class TContainerType, class TSetterFunction, class TGetterFunction>
     void CopyModelPartFlaggedVariable(

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -752,7 +752,7 @@ public:
             AuxiliaryHistoricalValueSetter<typename TVariableArgs::Type>(rVariableArgs, rVariableArgs.Zero(), rNode), ...);
         });
     }
-    
+
     /**
      * @brief Set the Historical Variables To Zero
      * This method sets the provided list of variables to zero in the nodal historical database
@@ -1728,7 +1728,7 @@ private:
         NodeType& rNode,
         const int Step = 0)
     {
-        if constexpr(std::is_integral_v<TDataType> || std::is_floating_point_v<TDataType>) {
+        if constexpr(std::is_integral_v<TDataType> || std::is_floating_point_v<TDataType> || std::is_same_v<TDataType, Matrix> || std::is_same_v<TDataType, Vector>) {
             rNode.FastGetSolutionStepValue(rVariable, Step) = rValue;
         } else {
             noalias(rNode.FastGetSolutionStepValue(rVariable, Step)) = rValue;


### PR DESCRIPTION
**📝 Description**
As stated in the title, to support step as well in `VariableUtils::SetHistoricalVariablesToZero`.

** Todo:

- [x]  Add test

**🆕 Changelog**
- Extend  `VariableUtils::SetHistoricalVariablesToZero` to support `Step`
