### PR TITLE
[Core] Adding CopyValuesFromExistingParameters to Kratos Parameters

### DIFF
--- a/kratos/includes/kratos_parameters.h
+++ b/kratos/includes/kratos_parameters.h
@@ -809,7 +809,7 @@ public:
      */
     void CopyValuesFromExistingParameters(
         const Parameters OriginParameters,
-        std::vector<std::string>& rListParametersToCopy
+        const std::vector<std::string>& rListParametersToCopy
         );
 
     /**

--- a/kratos/includes/kratos_parameters.h
+++ b/kratos/includes/kratos_parameters.h
@@ -4,16 +4,14 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Vicente Mataix Ferrandiz
 //
 
-
-#if !defined(KRATOS_KRATOS_PARAMETERS_H_INCLUDED )
-#define  KRATOS_KRATOS_PARAMETERS_H_INCLUDED
+#pragma once
 
 // External includes
 #include "json/json_fwd.hpp" // Import forward declaration nlohmann json library
@@ -24,7 +22,6 @@
 
 // STL includes
 #include <filesystem>
-
 
 namespace Kratos
 {
@@ -806,6 +803,16 @@ public:
     void Append(const Parameters& rValue);
 
     /**
+     * @brief This method can be used in order to copy the values from existing Parameters object
+     * @param OriginParameters The Parameters to be copied
+     * @param rListParametersToCopy The list of Parameters to copy
+     */
+    void CopyValuesFromExistingParameters(
+        const Parameters OriginParameters,
+        std::vector<std::string>& rListParametersToCopy
+        );
+
+    /**
      * @brief This method looks in a recursive way in the json structure
      * @param rBaseValue The value where to find
      * @param rValueToFind The value to look
@@ -879,7 +886,6 @@ public:
      */
     void RecursivelyValidateDefaults(const Parameters& rDefaultParameters) const;
 
-
     ///@}
     ///@name Access
     ///@{
@@ -910,36 +916,6 @@ public:
     {
 //         rOStream << "Parameters Object " << Info();
     };
-
-protected:
-    ///@name Protected static Member Variables
-    ///@{
-
-    ///@}
-    ///@name Protected member Variables
-    ///@{
-
-    ///@}
-    ///@name Protected Operators
-    ///@{
-
-    ///@}
-    ///@name Protected Operations
-    ///@{
-
-    ///@}
-    ///@name Protected  Access
-    ///@{
-
-    ///@}
-    ///@name Protected Inquiry
-    ///@{
-
-    ///@}
-    ///@name Protected LifeCycle
-    ///@{
-
-    ///@}
 
 private:
     ///@name Static Member Variables
@@ -1088,5 +1064,3 @@ inline std::ostream& operator << (std::ostream& rOStream,
 ///@} addtogroup block
 
 }  // namespace Kratos.
-
-#endif // KRATOS_KRATOS_PARAMETERS_H_INCLUDED  defined

--- a/kratos/python/add_kratos_parameters_to_python.cpp
+++ b/kratos/python/add_kratos_parameters_to_python.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //
@@ -140,6 +140,7 @@ void  AddKratosParametersToPython(pybind11::module& m)
     .def("Append", Append<Matrix>) // created due to ambiguous overload int/bool...
     .def("Append", Append<std::string>) // created due to ambiguous overload int/bool...
     .def("Append", Append<Parameters>) // created due to ambiguous overload int/bool...
+    .def("CopyValuesFromExistingParameters", &Parameters::CopyValuesFromExistingParameters)
     ;
 }
 

--- a/kratos/python/add_kratos_parameters_to_python.h
+++ b/kratos/python/add_kratos_parameters_to_python.h
@@ -4,16 +4,13 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics 
 //
-//  License:		 BSD License 
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License 
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //
 
-#if !defined(KRATOS_ADD_KRATOS_PARAMETERS_TO_PYTHON_H_INCLUDED )
-#define  KRATOS_ADD_KRATOS_PARAMETERS_TO_PYTHON_H_INCLUDED
-
-
+#pragma once
 
 // System includes
 #include <pybind11/pybind11.h>
@@ -35,5 +32,3 @@ void  AddKratosParametersToPython(pybind11::module& m);
 }  // namespace Python.
 
 }  // namespace Kratos.
-
-#endif // KRATOS_ADD_KRATOS_PARAMETERS_TO_PYTHON_H_INCLUDED  defined 

--- a/kratos/sources/kratos_parameters.cpp
+++ b/kratos/sources/kratos_parameters.cpp
@@ -1101,7 +1101,7 @@ void Parameters::CopyValuesFromExistingParameters(
                 this->AddValue(r_value_name, OriginParameters[r_value_name]);
             }
         } else {
-            KRATOS_ERROR << r_value_name << " not defined in origin Parameters:\n\n" << OriginParameters << std::endl;
+            KRATOS_ERROR << r_value_name << " not defined in origin Parameters:\n\n" << OriginParameters.PrettyPrintJsonString() << std::endl;
         }
     }
 }

--- a/kratos/sources/kratos_parameters.cpp
+++ b/kratos/sources/kratos_parameters.cpp
@@ -1094,7 +1094,15 @@ void Parameters::CopyValuesFromExistingParameters(
     )
 {
     for (const auto& r_value_name : rListParametersToCopy) {
-        this->AddValue(r_value_name, OriginParameters[r_value_name]);
+        if (OriginParameters.Has(r_value_name)) {
+            if (this->Has(r_value_name)) {
+                KRATOS_ERROR << r_value_name << " already defined in destination (check keyword is not duplicated in the list) Parameters:\n\n" << this->PrettyPrintJsonString() << std::endl;
+            } else {
+                this->AddValue(r_value_name, OriginParameters[r_value_name]);
+            }
+        } else {
+            KRATOS_ERROR << r_value_name << " not defined in origin Parameters:\n\n" << OriginParameters << std::endl;
+        }
     }
 }
 

--- a/kratos/sources/kratos_parameters.cpp
+++ b/kratos/sources/kratos_parameters.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Vicente Mataix Ferrandiz
@@ -1083,6 +1083,19 @@ void Parameters::Append(const Parameters& rValue)
     KRATOS_ERROR_IF_NOT(mpValue->is_array()) << "It must be an Array parameter to append" << std::endl;
     nlohmann::json j_object = nlohmann::json( nlohmann::json::parse( rValue.WriteJsonString(), nullptr, true, true));
     mpValue->push_back(j_object);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void Parameters::CopyValuesFromExistingParameters(
+    const Parameters OriginParameters,
+    std::vector<std::string>& rListParametersToCopy
+    )
+{
+    for (auto& r_value_name : rListParametersToCopy) {
+        this->AddValue(r_value_name, OriginParameters[r_value_name]);
+    }
 }
 
 /***********************************************************************************/

--- a/kratos/sources/kratos_parameters.cpp
+++ b/kratos/sources/kratos_parameters.cpp
@@ -1090,7 +1090,7 @@ void Parameters::Append(const Parameters& rValue)
 
 void Parameters::CopyValuesFromExistingParameters(
     const Parameters OriginParameters,
-    std::vector<std::string>& rListParametersToCopy
+    const std::vector<std::string>& rListParametersToCopy
     )
 {
     for (const auto& r_value_name : rListParametersToCopy) {

--- a/kratos/sources/kratos_parameters.cpp
+++ b/kratos/sources/kratos_parameters.cpp
@@ -1093,7 +1093,7 @@ void Parameters::CopyValuesFromExistingParameters(
     std::vector<std::string>& rListParametersToCopy
     )
 {
-    for (auto& r_value_name : rListParametersToCopy) {
+    for (const auto& r_value_name : rListParametersToCopy) {
         this->AddValue(r_value_name, OriginParameters[r_value_name]);
     }
 }

--- a/kratos/tests/test_kratos_parameters.py
+++ b/kratos/tests/test_kratos_parameters.py
@@ -1011,6 +1011,25 @@ class TestParameters(KratosUnittest.TestCase):
 
         self.assertListEqual(new_string_array, string_array)
 
+    def test_copy_values_from_existing_parameters(self):
+        initial = Parameters("""{
+            "parameter1": ["foo", "bar"],
+            "parameter2": true,
+            "parameter3": "Hello",
+            "parameter4": 15
+        } """)
+        parameter_list = ["parameter2", "parameter3"]
+
+        new_param = Parameters()
+        new_param.CopyValuesFromExistingParameters(initial, parameter_list)
+
+        self.assertFalse(new_param.Has("parameter1"))
+        self.assertTrue(new_param.Has("parameter2"))
+        self.assertEqual(new_param["parameter2"].GetBool(), True)
+        self.assertTrue(new_param.Has("parameter3"))
+        self.assertEqual(new_param["parameter3"].GetString(),"Hello")
+        self.assertFalse(new_param.Has("parameter4"))
+
     @KratosUnittest.skipUnless(have_pickle_module, "Pickle module error: : " + pickle_message)
     def test_stream_serialization(self):
         tmp = Parameters(defaults)


### PR DESCRIPTION
**📝 Description**

 Adding CopyValuesFromExistingParameters to Kratos Parameters. This will allow reducing a lot of verbose code when manually copying parameters 

**🆕 Changelog**

- [Adding CopyValuesFromExistingParameters](https://github.com/KratosMultiphysics/Kratos/commit/15e524d0469134cf5d7b507c4a67c4884bb72d85)
- [Expose to python](https://github.com/KratosMultiphysics/Kratos/commit/aa84268cb5a833a6bd5828028b751876535f1069)
- [Adding test](https://github.com/KratosMultiphysics/Kratos/commit/019b8c3774def5963277d549be032af500edf47b)
- Minor clean up
