### PR TITLE
[Core] Correct `Length` `Line3D3`

### DIFF
--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -719,11 +719,11 @@ public:
 
 
     /** FacesNumber
-    @return SizeType containes number of this geometry edges/faces.
+    @return SizeType containes number of this geometry faces.
     */
     SizeType FacesNumber() const override
     {
-      return EdgesNumber();
+      return 0;
     }
 
     ///@}

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -503,6 +503,7 @@ public:
      *
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
+     * @todo We must check if this override methods are faster than the base class methods
      */
     JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
     {
@@ -547,6 +548,7 @@ public:
      *
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
+     * @todo We must check if this override methods are faster than the base class methods
      */
     JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix& rDeltaPosition ) const override
     {
@@ -593,6 +595,7 @@ public:
      * integration method.
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
+     * @todo We must check if this override methods are faster than the base class methods
      */
     Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
@@ -629,6 +632,7 @@ public:
      *
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
+     * @todo We must check if this override methods are faster than the base class methods
      */
     Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
@@ -700,6 +704,10 @@ public:
         this->Jacobian( J, rPoint);
         return std::sqrt(std::pow(J(0,0), 2) + std::pow(J(1,0), 2));
     }
+
+    ///@}
+    ///@name Edges and faces
+    ///@{
 
     /** EdgesNumber
     @return SizeType containes number of this geometry edges.

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -340,11 +340,12 @@ public:
     double Length() const override
     {
         Vector temp;
-        this->DeterminantOfJacobian( temp, msGeometryData.DefaultIntegrationMethod() );
-        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints( msGeometryData.DefaultIntegrationMethod() );
+        const auto& r_integration_order_required_analytical_solution = GeometryData::IntegrationMethod::GI_GAUSS_3;
+        this->DeterminantOfJacobian( temp, r_integration_order_required_analytical_solution );
+        const IntegrationPointsArrayType& r_integration_points = this->IntegrationPoints( r_integration_order_required_analytical_solution );
         double length = 0.0;
-        for ( unsigned int i = 0; i < integration_points.size(); i++ ) {
-            length += temp[i] * integration_points[i].Weight();
+        for ( unsigned int i = 0; i < r_integration_points.size(); i++ ) {
+            length += temp[i] * r_integration_points[i].Weight();
         }
 
         return length;

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -434,7 +434,9 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    double DeterminantOfJacobian(
+        IndexType IntegrationPointIndex,
+        IntegrationMethod ThisMethod ) const override
     {
         Matrix J(3, 1);
         this->Jacobian( J, IntegrationPointIndex, ThisMethod);

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -405,6 +405,56 @@ public:
         return false;
     }
 
+    /**
+     * @brief Determinant of jacobians for given integration method.
+     * @details This method calculate determinant of jacobian in all integrations points of given integration method.
+     * @return Vector of double which is vector of determinants of jacobians \f$ |J|_i \f$ where \f$ i=1,2,...,n \f$ is the integration point index of given integration method.
+     * @see Jacobian
+     * @see InverseOfJacobian
+     */
+    Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const override
+    {
+        const std::size_t number_of_integration_points = this->IntegrationPointsNumber( ThisMethod );
+        if( rResult.size() != number_of_integration_points)
+            rResult.resize( number_of_integration_points, false );
+
+        Matrix J(3, 1);
+        for (std::size_t pnt = 0; pnt < number_of_integration_points; ++pnt) {
+            this->Jacobian( J, pnt, ThisMethod);
+            rResult[pnt] = std::sqrt(std::pow(J(0,0), 2) + std::pow(J(1,0), 2) + std::pow(J(2,0), 2));
+        }
+        return rResult;
+    }
+
+    /**
+     * @brief Determinant of jacobian in specific integration point of given integration method. This method calculate determinant of jacobian in given integration point of given integration method.
+     * @param IntegrationPointIndex index of integration point which jacobians has to be calculated in it.
+     * @param IntegrationPointIndex index of integration point which determinant of jacobians has to be calculated in it.
+     * @return Determinamt of jacobian matrix \f$ |J|_i \f$ where \f$ i \f$ is the given integration point index of given integration method.
+     * @see Jacobian
+     * @see InverseOfJacobian
+     */
+    double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    {
+        Matrix J(3, 1);
+        this->Jacobian( J, IntegrationPointIndex, ThisMethod);
+        return std::sqrt(std::pow(J(0,0), 2) + std::pow(J(1,0), 2) + std::pow(J(2,0), 2));
+    }
+
+    /**
+     * @brief Determinant of jacobian in given point. This method calculate determinant of jacobian matrix in given point.
+     * @param rPoint point which determinant of jacobians has to be calculated in it.
+     * @return Determinamt of jacobian matrix \f$ |J| \f$ in given point.
+     * @see DeterminantOfJacobian
+     * @see InverseOfJacobian
+     */
+    double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
+    {
+        Matrix J(3, 1);
+        this->Jacobian( J, rPoint);
+        return std::sqrt(std::pow(J(0,0), 2) + std::pow(J(1,0), 2) + std::pow(J(2,0), 2));
+    }
+
     ///@}
     ///@name Edges and faces
     ///@{

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -346,15 +346,15 @@ public:
     */
     double Length() const override
     {
-        const TPointType& point0 = BaseType::GetPoint(0);
-        const TPointType& point1 = BaseType::GetPoint(2);
-        const double lx = point0.X() - point1.X();
-        const double ly = point0.Y() - point1.Y();
-        const double lz = point0.Z() - point1.Z();
+        Vector temp;
+        this->DeterminantOfJacobian( temp, msGeometryData.DefaultIntegrationMethod() );
+        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints( msGeometryData.DefaultIntegrationMethod() );
+        double length = 0.0;
+        for ( unsigned int i = 0; i < integration_points.size(); i++ ) {
+            length += temp[i] * integration_points[i].Weight();
+        }
 
-        const double length = lx * lx + ly * ly + lz * lz;
-
-        return std::sqrt( length );
+        return length;
     }
 
     /** This method calculate and return area or surface area of
@@ -590,100 +590,7 @@ public:
 
         return rResult;
     }
-
-    /** Determinant of jacobians for given integration method. This
-     * method calculate determinant of jacobian in all
-     * integrations points of given integration method.
-     *
-     * @return Vector of double which is vector of determinants of
-     * jacobians \f$ |J|_i \f$ where \f$ i=1,2,...,n \f$ is the
-     * integration point index of given integration method.
-     *
-     * @see Jacobian
-     * @see InverseOfJacobian
-     */
-    Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const override
-    {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
-    }
-
-    /** Determinant of jacobian in specific integration point of
-     * given integration method. This method calculate determinant
-     * of jacobian in given integration point of given integration
-     * method.
-     *
-     * @param IntegrationPointIndex index of integration point which jacobians has to
-     * be calculated in it.
-     *
-     * @param IntegrationPointIndex index of integration point
-     * which determinant of jacobians has to be calculated in it.
-     *
-     * @return Determinamt of jacobian matrix \f$ |J|_i \f$ where \f$
-     * i \f$ is the given integration point index of given
-     * integration method.
-
-    * Inverse of jacobians for given integration method. This method
-     * calculate inverse of jacobians matrices in all integrations points of
-     * given integration method.
-     *
-     * @param ThisMethod integration method which inverse of jacobians has to
-     * be calculated in its integration points.
-     *
-     * @return Inverse of jacobian
-     * matrices \f$ J^{-1}_i \f$ where \f$ i=1,2,...,n \f$ is the integration
-     * point index of given integration method.
-     *
-     * @see Jacobian
-     * @see DeterminantOfJacobian
-     */
-    JacobiansType& InverseOfJacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
-    {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
-    }
-
-    /** Inverse of jacobian in specific integration point of given integration
-     * method. This method calculate Inverse of jacobian matrix in given
-     * integration point of given integration method.
-     *
-     * @param IntegrationPointIndex index of integration point which inverse of jacobians has to
-     * be calculated in it.
-     *
-     * @param ThisMethod integration method which inverse of jacobians has to
-     * be calculated in its integration points.
-     *
-     * @return Inverse of jacobian matrix \f$ J^{-1}_i \f$ where \f$
-     * i \f$ is the given integration point index of given
-     * integration method.
-     *
-     * @see Jacobian
-     * @see DeterminantOfJacobian
-     */
-    Matrix& InverseOfJacobian( Matrix& rResult, IndexType IntegrationPointIndex,
-                                       IntegrationMethod ThisMethod ) const override
-    {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
-    }
-
-    /** Inverse of jacobian in given point. This method calculate inverse of jacobian
-     * matrix in given point.
-     *
-     * @param rPoint point which inverse of jacobians has to
-     * be calculated in it.
-     *
-     * @return Inverse of jacobian matrix \f$ J^{-1} \f$ in given point.
-     *
-     * @see DeterminantOfJacobian
-     * @see InverseOfJacobian
-     */
-    Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
-    {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return rResult;
-    }
-
+    
 
     /** EdgesNumber
     @return SizeType containes number of this geometry edges.
@@ -752,25 +659,6 @@ public:
         }
 
         return 0;
-    }
-
-    ///@}
-    ///@name Shape Function Integration Points Gradient
-    ///@{
-
-    void ShapeFunctionsIntegrationPointsGradients(
-        ShapeFunctionsGradientsType &rResult,
-        IntegrationMethod ThisMethod) const override
-    {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-    }
-
-    void ShapeFunctionsIntegrationPointsGradients(
-        ShapeFunctionsGradientsType &rResult,
-        Vector &rDeterminantsOfJacobian,
-        IntegrationMethod ThisMethod) const override
-    {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
     }
 
     ///@}

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -342,7 +342,7 @@ public:
         Vector temp;
         const auto& r_integration_order_required_analytical_solution = GeometryData::IntegrationMethod::GI_GAUSS_3;
         this->DeterminantOfJacobian( temp, r_integration_order_required_analytical_solution );
-        const IntegrationPointsArrayType& r_integration_points = this->IntegrationPoints( r_integration_order_required_analytical_solution );
+        const auto& r_integration_points = this->IntegrationPoints( r_integration_order_required_analytical_solution );
         double length = 0.0;
         for ( unsigned int i = 0; i < r_integration_points.size(); i++ ) {
             length += temp[i] * r_integration_points[i].Weight();

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -471,7 +471,7 @@ public:
 
     SizeType FacesNumber() const override
     {
-        return EdgesNumber();
+        return 0;
     }
 
     ///@}

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Janosch Stascheit
@@ -24,6 +24,7 @@
 #include "geometries/geometry.h"
 #include "integration/line_gauss_legendre_integration_points.h"
 #include "integration/line_collocation_integration_points.h"
+#include "utilities/integration_utilities.h"
 
 namespace Kratos
 {
@@ -313,7 +314,7 @@ public:
         const typename BaseType::LumpingMethods LumpingMethod = BaseType::LumpingMethods::ROW_SUM
         )  const override
     {
-	    if(rResult.size() != 3)
+        if(rResult.size() != 3)
            rResult.resize( 3, false );
         rResult[0] = 1.0/6.0;
         rResult[2] = 2.0/3.0;
@@ -340,11 +341,12 @@ public:
     double Length() const override
     {
         Vector temp;
-        const auto& r_integration_order_required_analytical_solution = GeometryData::IntegrationMethod::GI_GAUSS_3;
-        this->DeterminantOfJacobian( temp, r_integration_order_required_analytical_solution );
-        const auto& r_integration_points = this->IntegrationPoints( r_integration_order_required_analytical_solution );
+        const IntegrationMethod integration_method = IntegrationUtilities::GetIntegrationMethodForExactMassMatrixEvaluation(*this);
+        this->DeterminantOfJacobian( temp, integration_method );
+        const IntegrationPointsArrayType& r_integration_points = this->IntegrationPoints( integration_method );
         double length = 0.0;
-        for ( unsigned int i = 0; i < r_integration_points.size(); i++ ) {
+
+        for (std::size_t i = 0; i < r_integration_points.size(); ++i) {
             length += temp[i] * r_integration_points[i].Weight();
         }
 

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_3.cpp
@@ -23,60 +23,60 @@
 #include "tests/cpp_tests/geometries/cross_check_shape_functions_values.h"
 
 namespace Kratos::Testing {
-    namespace {
-        /// Factory functions
+namespace {
+    /// Factory functions
 
-        /** Generates a point type sample Line2D3N
-        * @return  Pointer to a Line2D3N
-        */
-        Line2D3<Point>::Pointer GeneratePointsUnitXDirectionLine2D3() {
-            return Kratos::make_shared<Line2D3<Point>>(
-            Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-            Kratos::make_shared<Point>(1.0, 0.0, 0.0),
-            Kratos::make_shared<Point>(0.5, 0.0, 0.0)
-            );
-        }
-
-        // /** Generates a point type sample Line2D3N
-        // * @return  Pointer to a Line2D3N
-        // */
-        // Line2D3<Point>::Pointer GeneratePointsUnitYDirectionLine2D3() {
-        //     return Kratos::make_shared<Line2D3<Point>>(
-        //     Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-        //     Kratos::make_shared<Point>(0.0, 1.0, 0.0),
-        //     Kratos::make_shared<Point>(0.0, 0.5, 0.0)
-        //     );
-        // }
-
-        /** Generates a point type sample Line2D3N
-        * @return  Pointer to a Line2D3N
-        */
-        Line2D3<Point>::Pointer GeneratePointsDiagonalLine2D3() {
-            return Kratos::make_shared<Line2D3<Point>>(
-            Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-            Kratos::make_shared<Point>(1.0, 1.0, 0.0),
-            Kratos::make_shared<Point>(0.5, 0.5, 0.0)
-            );
-        }
-
-        /** Generates a point type sample Line2D3N
-        * @return  Pointer to a Line2D3N
-        */
-        Line2D3<Point>::Pointer GeneratePointsParabolaLine2D3() {
-            return Kratos::make_shared<Line2D3<Point>>(
-            Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-            Kratos::make_shared<Point>(1.0, 0.0, 0.0),
-            Kratos::make_shared<Point>(0.5, 0.5, 0.0)
-            );
-        }
-
-        // /** Generates a point type sample Line2D3N.
-        // * @return  Pointer to a Line2D3N
-        // */
-        // Line2D3<Point>::Pointer GenerateLine2D3WithPoints(Point::Pointer pPointOne, Point::Pointer pPointTwo, Point::Pointer pPointThree ) {
-        //     return Kratos::make_shared<Line2D3<Point>>(pPointOne, pPointTwo, pPointThree);
-        // }
+    /** Generates a point type sample Line2D3N
+    * @return  Pointer to a Line2D3N
+    */
+    Line2D3<Point>::Pointer GeneratePointsUnitXDirectionLine2D3() {
+        return Kratos::make_shared<Line2D3<Point>>(
+        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+        Kratos::make_shared<Point>(1.0, 0.0, 0.0),
+        Kratos::make_shared<Point>(0.5, 0.0, 0.0)
+        );
     }
+
+    // /** Generates a point type sample Line2D3N
+    // * @return  Pointer to a Line2D3N
+    // */
+    // Line2D3<Point>::Pointer GeneratePointsUnitYDirectionLine2D3() {
+    //     return Kratos::make_shared<Line2D3<Point>>(
+    //     Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+    //     Kratos::make_shared<Point>(0.0, 1.0, 0.0),
+    //     Kratos::make_shared<Point>(0.0, 0.5, 0.0)
+    //     );
+    // }
+
+    /** Generates a point type sample Line2D3N
+    * @return  Pointer to a Line2D3N
+    */
+    Line2D3<Point>::Pointer GeneratePointsDiagonalLine2D3() {
+        return Kratos::make_shared<Line2D3<Point>>(
+        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+        Kratos::make_shared<Point>(1.0, 1.0, 0.0),
+        Kratos::make_shared<Point>(0.5, 0.5, 0.0)
+        );
+    }
+
+    /** Generates a point type sample Line2D3N
+    * @return  Pointer to a Line2D3N
+    */
+    Line2D3<Point>::Pointer GeneratePointsParabolaLine2D3() {
+        return Kratos::make_shared<Line2D3<Point>>(
+        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+        Kratos::make_shared<Point>(1.0, 0.0, 0.0),
+        Kratos::make_shared<Point>(0.5, 0.5, 0.0)
+        );
+    }
+
+    // /** Generates a point type sample Line2D3N.
+    // * @return  Pointer to a Line2D3N
+    // */
+    // Line2D3<Point>::Pointer GenerateLine2D3WithPoints(Point::Pointer pPointOne, Point::Pointer pPointTwo, Point::Pointer pPointThree ) {
+    //     return Kratos::make_shared<Line2D3<Point>>(pPointOne, pPointTwo, pPointThree);
+    // }
+}
 
     /** Checks if the number of edges is correct.
     * Checks if the number of edges is correct.

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_3.cpp
@@ -22,8 +22,7 @@
 #include "tests/cpp_tests/geometries/test_shape_function_derivatives.h"
 #include "tests/cpp_tests/geometries/cross_check_shape_functions_values.h"
 
-namespace Kratos {
-namespace Testing {
+namespace Kratos::Testing {
 
     /// Factory functions
 
@@ -91,7 +90,7 @@ namespace Testing {
     */
     KRATOS_TEST_CASE_IN_SUITE(Line2D3FacesNumber, KratosCoreGeometriesFastSuite) {
         auto p_geometry = GeneratePointsUnitXDirectionLine2D3();
-        KRATOS_CHECK_EQUAL(p_geometry->FacesNumber(), 2);
+        KRATOS_CHECK_EQUAL(p_geometry->FacesNumber(), 0);
     }
 
     /** Checks if the length of the line is calculated correctly.
@@ -376,5 +375,4 @@ namespace Testing {
         TestAllShapeFunctionsLocalGradients(*p_p_geom_nodes);
     }
 
-} // namespace Testing.
-} // namespace Kratos.
+} // namespace Kratos::Testing.

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_3.cpp
@@ -23,58 +23,59 @@
 #include "tests/cpp_tests/geometries/cross_check_shape_functions_values.h"
 
 namespace Kratos::Testing {
+    namespace {
+        /// Factory functions
 
-    /// Factory functions
+        /** Generates a point type sample Line2D3N
+        * @return  Pointer to a Line2D3N
+        */
+        Line2D3<Point>::Pointer GeneratePointsUnitXDirectionLine2D3() {
+            return Kratos::make_shared<Line2D3<Point>>(
+            Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+            Kratos::make_shared<Point>(1.0, 0.0, 0.0),
+            Kratos::make_shared<Point>(0.5, 0.0, 0.0)
+            );
+        }
 
-    /** Generates a point type sample Line2D3N
-    * @return  Pointer to a Line2D3N
-    */
-    Line2D3<Point>::Pointer GeneratePointsUnitXDirectionLine2D3() {
-        return Kratos::make_shared<Line2D3<Point>>(
-        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-        Kratos::make_shared<Point>(1.0, 0.0, 0.0),
-        Kratos::make_shared<Point>(0.5, 0.0, 0.0)
-        );
-    }
+        /** Generates a point type sample Line2D3N
+        * @return  Pointer to a Line2D3N
+        */
+        Line2D3<Point>::Pointer GeneratePointsUnitYDirectionLine2D3() {
+            return Kratos::make_shared<Line2D3<Point>>(
+            Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+            Kratos::make_shared<Point>(0.0, 1.0, 0.0),
+            Kratos::make_shared<Point>(0.0, 0.5, 0.0)
+            );
+        }
 
-    /** Generates a point type sample Line2D3N
-    * @return  Pointer to a Line2D3N
-    */
-    Line2D3<Point>::Pointer GeneratePointsUnitYDirectionLine2D3() {
-        return Kratos::make_shared<Line2D3<Point>>(
-        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-        Kratos::make_shared<Point>(0.0, 1.0, 0.0),
-        Kratos::make_shared<Point>(0.0, 0.5, 0.0)
-        );
-    }
+        /** Generates a point type sample Line2D3N
+        * @return  Pointer to a Line2D3N
+        */
+        Line2D3<Point>::Pointer GeneratePointsDiagonalLine2D3() {
+            return Kratos::make_shared<Line2D3<Point>>(
+            Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+            Kratos::make_shared<Point>(1.0, 1.0, 0.0),
+            Kratos::make_shared<Point>(0.5, 0.5, 0.0)
+            );
+        }
 
-    /** Generates a point type sample Line2D3N
-    * @return  Pointer to a Line2D3N
-    */
-    Line2D3<Point>::Pointer GeneratePointsDiagonalLine2D3() {
-        return Kratos::make_shared<Line2D3<Point>>(
-        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-        Kratos::make_shared<Point>(1.0, 1.0, 0.0),
-        Kratos::make_shared<Point>(0.5, 0.5, 0.0)
-        );
-    }
+        /** Generates a point type sample Line2D3N
+        * @return  Pointer to a Line2D3N
+        */
+        Line2D3<Point>::Pointer GeneratePointsParabolaLine2D3() {
+            return Kratos::make_shared<Line2D3<Point>>(
+            Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+            Kratos::make_shared<Point>(1.0, 0.0, 0.0),
+            Kratos::make_shared<Point>(0.5, 0.5, 0.0)
+            );
+        }
 
-    /** Generates a point type sample Line2D3N
-    * @return  Pointer to a Line2D3N
-    */
-    Line2D3<Point>::Pointer GeneratePointsParabolaLine2D3() {
-        return Kratos::make_shared<Line2D3<Point>>(
-        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-        Kratos::make_shared<Point>(1.0, 0.0, 0.0),
-        Kratos::make_shared<Point>(0.5, 0.5, 0.0)
-        );
-    }
-
-    /** Generates a point type sample Line2D3N.
-    * @return  Pointer to a Line2D3N
-    */
-    Line2D3<Point>::Pointer GenerateLine2D3WithPoints(Point::Pointer pPointOne, Point::Pointer pPointTwo, Point::Pointer pPointThree ) {
-        return Kratos::make_shared<Line2D3<Point>>(pPointOne, pPointTwo, pPointThree);
+        /** Generates a point type sample Line2D3N.
+        * @return  Pointer to a Line2D3N
+        */
+        Line2D3<Point>::Pointer GenerateLine2D3WithPoints(Point::Pointer pPointOne, Point::Pointer pPointTwo, Point::Pointer pPointThree ) {
+            return Kratos::make_shared<Line2D3<Point>>(pPointOne, pPointTwo, pPointThree);
+        }
     }
 
     /** Checks if the number of edges is correct.

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_3.cpp
@@ -37,16 +37,16 @@ namespace Kratos::Testing {
             );
         }
 
-        /** Generates a point type sample Line2D3N
-        * @return  Pointer to a Line2D3N
-        */
-        Line2D3<Point>::Pointer GeneratePointsUnitYDirectionLine2D3() {
-            return Kratos::make_shared<Line2D3<Point>>(
-            Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-            Kratos::make_shared<Point>(0.0, 1.0, 0.0),
-            Kratos::make_shared<Point>(0.0, 0.5, 0.0)
-            );
-        }
+        // /** Generates a point type sample Line2D3N
+        // * @return  Pointer to a Line2D3N
+        // */
+        // Line2D3<Point>::Pointer GeneratePointsUnitYDirectionLine2D3() {
+        //     return Kratos::make_shared<Line2D3<Point>>(
+        //     Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+        //     Kratos::make_shared<Point>(0.0, 1.0, 0.0),
+        //     Kratos::make_shared<Point>(0.0, 0.5, 0.0)
+        //     );
+        // }
 
         /** Generates a point type sample Line2D3N
         * @return  Pointer to a Line2D3N
@@ -70,12 +70,12 @@ namespace Kratos::Testing {
             );
         }
 
-        /** Generates a point type sample Line2D3N.
-        * @return  Pointer to a Line2D3N
-        */
-        Line2D3<Point>::Pointer GenerateLine2D3WithPoints(Point::Pointer pPointOne, Point::Pointer pPointTwo, Point::Pointer pPointThree ) {
-            return Kratos::make_shared<Line2D3<Point>>(pPointOne, pPointTwo, pPointThree);
-        }
+        // /** Generates a point type sample Line2D3N.
+        // * @return  Pointer to a Line2D3N
+        // */
+        // Line2D3<Point>::Pointer GenerateLine2D3WithPoints(Point::Pointer pPointOne, Point::Pointer pPointTwo, Point::Pointer pPointThree ) {
+        //     return Kratos::make_shared<Line2D3<Point>>(pPointOne, pPointTwo, pPointThree);
+        // }
     }
 
     /** Checks if the number of edges is correct.

--- a/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
@@ -24,60 +24,60 @@
 
 namespace Kratos::Testing {
 
-    namespace {
-        /// Factory functions
+namespace {
+    /// Factory functions
 
-        /** Generates a point type sample Line3D3N
-        * @return  Pointer to a Line3D3N
-        */
-        Line3D3<Point>::Pointer GeneratePointsUnitXDirectionLine3D3() {
-            return Kratos::make_shared<Line3D3<Point>>(
-            Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-            Kratos::make_shared<Point>(1.0, 0.0, 0.0),
-            Kratos::make_shared<Point>(0.5, 0.0, 0.0)
-            );
-        }
-
-        // /** Generates a point type sample Line3D3N
-        // * @return  Pointer to a Line3D3N
-        // */
-        // Line3D3<Point>::Pointer GeneratePointsUnitYDirectionLine3D3() {
-        //     return Kratos::make_shared<Line3D3<Point>>(
-        //     Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-        //     Kratos::make_shared<Point>(0.0, 1.0, 0.0),
-        //     Kratos::make_shared<Point>(0.0, 0.5, 0.0)
-        //     );
-        // }
-
-        /** Generates a point type sample Line3D3N
-        * @return  Pointer to a Line3D3N
-        */
-        Line3D3<Point>::Pointer GeneratePointsDiagonalLine3D3() {
-            return Kratos::make_shared<Line3D3<Point>>(
-            Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-            Kratos::make_shared<Point>(1.0, 1.0, 0.0),
-            Kratos::make_shared<Point>(0.5, 0.5, 0.0)
-            );
-        }
-
-        /** Generates a point type sample Line3D3N
-        * @return  Pointer to a Line3D3N
-        */
-        Line3D3<Point>::Pointer GeneratePointsParabolaLine3D3() {
-            return Kratos::make_shared<Line3D3<Point>>(
-            Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-            Kratos::make_shared<Point>(1.0, 0.0, 0.0),
-            Kratos::make_shared<Point>(0.5, 0.5, 0.0)
-            );
-        }
-
-        // /** Generates a point type sample Line3D3N.
-        // * @return  Pointer to a Line3D3N
-        // */
-        // Line3D3<Point>::Pointer GenerateLine3D3WithPoints(Point::Pointer pPointOne, Point::Pointer pPointTwo, Point::Pointer pPointThree ) {
-        //     return Kratos::make_shared<Line3D3<Point>>(pPointOne, pPointTwo, pPointThree);
-        // }
+    /** Generates a point type sample Line3D3N
+    * @return  Pointer to a Line3D3N
+    */
+    Line3D3<Point>::Pointer GeneratePointsUnitXDirectionLine3D3() {
+        return Kratos::make_shared<Line3D3<Point>>(
+        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+        Kratos::make_shared<Point>(1.0, 0.0, 0.0),
+        Kratos::make_shared<Point>(0.5, 0.0, 0.0)
+        );
     }
+
+    // /** Generates a point type sample Line3D3N
+    // * @return  Pointer to a Line3D3N
+    // */
+    // Line3D3<Point>::Pointer GeneratePointsUnitYDirectionLine3D3() {
+    //     return Kratos::make_shared<Line3D3<Point>>(
+    //     Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+    //     Kratos::make_shared<Point>(0.0, 1.0, 0.0),
+    //     Kratos::make_shared<Point>(0.0, 0.5, 0.0)
+    //     );
+    // }
+
+    /** Generates a point type sample Line3D3N
+    * @return  Pointer to a Line3D3N
+    */
+    Line3D3<Point>::Pointer GeneratePointsDiagonalLine3D3() {
+        return Kratos::make_shared<Line3D3<Point>>(
+        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+        Kratos::make_shared<Point>(1.0, 1.0, 0.0),
+        Kratos::make_shared<Point>(0.5, 0.5, 0.0)
+        );
+    }
+
+    /** Generates a point type sample Line3D3N
+    * @return  Pointer to a Line3D3N
+    */
+    Line3D3<Point>::Pointer GeneratePointsParabolaLine3D3() {
+        return Kratos::make_shared<Line3D3<Point>>(
+        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+        Kratos::make_shared<Point>(1.0, 0.0, 0.0),
+        Kratos::make_shared<Point>(0.5, 0.5, 0.0)
+        );
+    }
+
+    // /** Generates a point type sample Line3D3N.
+    // * @return  Pointer to a Line3D3N
+    // */
+    // Line3D3<Point>::Pointer GenerateLine3D3WithPoints(Point::Pointer pPointOne, Point::Pointer pPointTwo, Point::Pointer pPointThree ) {
+    //     return Kratos::make_shared<Line3D3<Point>>(pPointOne, pPointTwo, pPointThree);
+    // }
+}
 
     /** Checks if the number of edges is correct.
     * Checks if the number of edges is correct.

--- a/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
@@ -131,169 +131,169 @@ namespace Testing {
         KRATOS_CHECK_NEAR(high_point.Y(), (p_geom->pGetPoint(2))->Y(), TOLERANCE);
     }
 
-    // /** Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
-    // * Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
-    // */
-    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianArray1, KratosCoreGeometriesFastSuite) {
-    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
-    //     const double expected_jacobian = 0.5;
+    /** Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
+    * Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianArray1, KratosCoreGeometriesFastSuite) {
+        auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+        const double expected_jacobian = 0.5;
 
-    //     Vector jacobians_determinants;
-    //     p_geometry->DeterminantOfJacobian( jacobians_determinants, GeometryData::IntegrationMethod::GI_GAUSS_1 );
+        Vector jacobians_determinants;
+        p_geometry->DeterminantOfJacobian( jacobians_determinants, GeometryData::IntegrationMethod::GI_GAUSS_1 );
 
-    //     for (unsigned int i=0; i<jacobians_determinants.size(); ++i) {
-    //         KRATOS_CHECK_NEAR(jacobians_determinants[i], expected_jacobian, TOLERANCE);
-    //     }
-    // }
+        for (unsigned int i=0; i<jacobians_determinants.size(); ++i) {
+            KRATOS_CHECK_NEAR(jacobians_determinants[i], expected_jacobian, TOLERANCE);
+        }
+    }
 
-    // /** Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
-    // * Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
-    // */
-    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianArray2, KratosCoreGeometriesFastSuite) {
-    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
-    //     const double expected_jacobian = 0.5;
+    /** Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
+    * Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianArray2, KratosCoreGeometriesFastSuite) {
+        auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+        const double expected_jacobian = 0.5;
 
-    //     Vector jacobians_determinants;
-    //     p_geometry->DeterminantOfJacobian( jacobians_determinants, GeometryData::IntegrationMethod::GI_GAUSS_2 );
+        Vector jacobians_determinants;
+        p_geometry->DeterminantOfJacobian( jacobians_determinants, GeometryData::IntegrationMethod::GI_GAUSS_2 );
 
-    //     for (unsigned int i=0; i<jacobians_determinants.size(); ++i) {
-    //         KRATOS_CHECK_NEAR(jacobians_determinants[i], expected_jacobian, TOLERANCE);
-    //     }
-    // }
+        for (unsigned int i=0; i<jacobians_determinants.size(); ++i) {
+            KRATOS_CHECK_NEAR(jacobians_determinants[i], expected_jacobian, TOLERANCE);
+        }
+    }
 
-    // /** Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
-    // * Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
-    // */
-    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianArray3, KratosCoreGeometriesFastSuite) {
-    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
-    //     const double expected_jacobian = 0.5;
+    /** Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
+    * Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianArray3, KratosCoreGeometriesFastSuite) {
+        auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+        const double expected_jacobian = 0.5;
 
-    //     Vector jacobians_determinants;
-    //     p_geometry->DeterminantOfJacobian( jacobians_determinants, GeometryData::IntegrationMethod::GI_GAUSS_3 );
+        Vector jacobians_determinants;
+        p_geometry->DeterminantOfJacobian( jacobians_determinants, GeometryData::IntegrationMethod::GI_GAUSS_3 );
 
-    //     for (unsigned int i=0; i<jacobians_determinants.size(); ++i) {
-    //         KRATOS_CHECK_NEAR(jacobians_determinants[i], expected_jacobian, TOLERANCE);
-    //     }
-    // }
+        for (unsigned int i=0; i<jacobians_determinants.size(); ++i) {
+            KRATOS_CHECK_NEAR(jacobians_determinants[i], expected_jacobian, TOLERANCE);
+        }
+    }
 
-    // /** Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
-    // * Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
-    // */
-    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianArray4, KratosCoreGeometriesFastSuite) {
-    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
-    //     const double expected_jacobian = 0.5;
+    /** Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+    * Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianArray4, KratosCoreGeometriesFastSuite) {
+        auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+        const double expected_jacobian = 0.5;
 
-    //     Vector jacobians_determinants;
-    //     p_geometry->DeterminantOfJacobian( jacobians_determinants, GeometryData::IntegrationMethod::GI_GAUSS_4 );
+        Vector jacobians_determinants;
+        p_geometry->DeterminantOfJacobian( jacobians_determinants, GeometryData::IntegrationMethod::GI_GAUSS_4 );
 
-    //     for (unsigned int i=0; i<jacobians_determinants.size(); ++i) {
-    //         KRATOS_CHECK_NEAR(jacobians_determinants[i], expected_jacobian, TOLERANCE);
-    //     }
-    // }
+        for (unsigned int i=0; i<jacobians_determinants.size(); ++i) {
+            KRATOS_CHECK_NEAR(jacobians_determinants[i], expected_jacobian, TOLERANCE);
+        }
+    }
 
-    // /** Tests the Jacobian determinants using 'GI_GAUSS_5' integration method.
-    // * Tests the Jacobian determinants using 'GI_GAUSS_5' integration method.
-    // */
-    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianArray5, KratosCoreGeometriesFastSuite) {
-    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
-    //     const double expected_jacobian = 0.5;
+    /** Tests the Jacobian determinants using 'GI_GAUSS_5' integration method.
+    * Tests the Jacobian determinants using 'GI_GAUSS_5' integration method.
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianArray5, KratosCoreGeometriesFastSuite) {
+        auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+        const double expected_jacobian = 0.5;
 
-    //     Vector jacobians_determinants;
-    //     p_geometry->DeterminantOfJacobian( jacobians_determinants, GeometryData::IntegrationMethod::GI_GAUSS_5 );
+        Vector jacobians_determinants;
+        p_geometry->DeterminantOfJacobian( jacobians_determinants, GeometryData::IntegrationMethod::GI_GAUSS_5 );
 
-    //     for (unsigned int i=0; i<jacobians_determinants.size(); ++i) {
-    //         KRATOS_CHECK_NEAR(jacobians_determinants[i], expected_jacobian, TOLERANCE);
-    //     }
-    // }
+        for (unsigned int i=0; i<jacobians_determinants.size(); ++i) {
+            KRATOS_CHECK_NEAR(jacobians_determinants[i], expected_jacobian, TOLERANCE);
+        }
+    }
 
-    // /** Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
-    // * Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
-    // */
-    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianIndex1, KratosCoreGeometriesFastSuite) {
-    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
-    //     const double expected_jacobian = 0.5;
+    /** Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
+    * Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianIndex1, KratosCoreGeometriesFastSuite) {
+        auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+        const double expected_jacobian = 0.5;
 
-    //     double jacobian_determinant = p_geometry->DeterminantOfJacobian( 0, GeometryData::IntegrationMethod::GI_GAUSS_1 );
-    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
-    // }
+        double jacobian_determinant = p_geometry->DeterminantOfJacobian( 0, GeometryData::IntegrationMethod::GI_GAUSS_1 );
+        KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+    }
 
-    // /** Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
-    // * Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
-    // */
-    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianIndex2, KratosCoreGeometriesFastSuite) {
-    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
-    //     double jacobian_determinant = 0.0;
-    //     const double expected_jacobian = 0.5;
+    /** Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
+    * Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianIndex2, KratosCoreGeometriesFastSuite) {
+        auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+        double jacobian_determinant = 0.0;
+        const double expected_jacobian = 0.5;
 
-    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 0, GeometryData::IntegrationMethod::GI_GAUSS_2 );
-    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+        jacobian_determinant = p_geometry->DeterminantOfJacobian( 0, GeometryData::IntegrationMethod::GI_GAUSS_2 );
+        KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
 
-    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 1, GeometryData::IntegrationMethod::GI_GAUSS_2 );
-    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
-    // }
+        jacobian_determinant = p_geometry->DeterminantOfJacobian( 1, GeometryData::IntegrationMethod::GI_GAUSS_2 );
+        KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+    }
 
-    // /** Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
-    // * Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
-    // */
-    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianIndex3, KratosCoreGeometriesFastSuite) {
-    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
-    //     double jacobian_determinant = 0.0;
-    //     const double expected_jacobian = 0.5;
+    /** Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
+    * Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianIndex3, KratosCoreGeometriesFastSuite) {
+        auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+        double jacobian_determinant = 0.0;
+        const double expected_jacobian = 0.5;
 
-    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 0, GeometryData::IntegrationMethod::GI_GAUSS_3 );
-    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+        jacobian_determinant = p_geometry->DeterminantOfJacobian( 0, GeometryData::IntegrationMethod::GI_GAUSS_3 );
+        KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
 
-    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 1, GeometryData::IntegrationMethod::GI_GAUSS_3 );
-    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+        jacobian_determinant = p_geometry->DeterminantOfJacobian( 1, GeometryData::IntegrationMethod::GI_GAUSS_3 );
+        KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
 
-    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 2, GeometryData::IntegrationMethod::GI_GAUSS_3 );
-    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
-    // }
+        jacobian_determinant = p_geometry->DeterminantOfJacobian( 2, GeometryData::IntegrationMethod::GI_GAUSS_3 );
+        KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+    }
 
-    // /** Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
-    // * Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
-    // */
-    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianIndex4, KratosCoreGeometriesFastSuite) {
-    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
-    //     double jacobian_determinant = 0.0;
-    //     const double expected_jacobian = 0.5;
+    /** Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+    * Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianIndex4, KratosCoreGeometriesFastSuite) {
+        auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+        double jacobian_determinant = 0.0;
+        const double expected_jacobian = 0.5;
 
-    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 0, GeometryData::IntegrationMethod::GI_GAUSS_4 );
-    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+        jacobian_determinant = p_geometry->DeterminantOfJacobian( 0, GeometryData::IntegrationMethod::GI_GAUSS_4 );
+        KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
 
-    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 1, GeometryData::IntegrationMethod::GI_GAUSS_4 );
-    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+        jacobian_determinant = p_geometry->DeterminantOfJacobian( 1, GeometryData::IntegrationMethod::GI_GAUSS_4 );
+        KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
 
-    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 2, GeometryData::IntegrationMethod::GI_GAUSS_4 );
-    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+        jacobian_determinant = p_geometry->DeterminantOfJacobian( 2, GeometryData::IntegrationMethod::GI_GAUSS_4 );
+        KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
 
-    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 3, GeometryData::IntegrationMethod::GI_GAUSS_4 );
-    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
-    // }
+        jacobian_determinant = p_geometry->DeterminantOfJacobian( 3, GeometryData::IntegrationMethod::GI_GAUSS_4 );
+        KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+    }
 
-    // /** Tests the Jacobian determinants using 'GI_GAUSS_5' integration method.
-    // * Tests the Jacobian determinants using 'GI_GAUSS_5' integration method.
-    // */
-    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianIndex5, KratosCoreGeometriesFastSuite) {
-    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
-    //     double jacobian_determinant = 0.0;
-    //     const double expected_jacobian = 0.5;
+    /** Tests the Jacobian determinants using 'GI_GAUSS_5' integration method.
+    * Tests the Jacobian determinants using 'GI_GAUSS_5' integration method.
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianIndex5, KratosCoreGeometriesFastSuite) {
+        auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+        double jacobian_determinant = 0.0;
+        const double expected_jacobian = 0.5;
 
-    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 0, GeometryData::IntegrationMethod::GI_GAUSS_5 );
-    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+        jacobian_determinant = p_geometry->DeterminantOfJacobian( 0, GeometryData::IntegrationMethod::GI_GAUSS_5 );
+        KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
 
-    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 1, GeometryData::IntegrationMethod::GI_GAUSS_5 );
-    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+        jacobian_determinant = p_geometry->DeterminantOfJacobian( 1, GeometryData::IntegrationMethod::GI_GAUSS_5 );
+        KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
 
-    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 2, GeometryData::IntegrationMethod::GI_GAUSS_5 );
-    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+        jacobian_determinant = p_geometry->DeterminantOfJacobian( 2, GeometryData::IntegrationMethod::GI_GAUSS_5 );
+        KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
 
-    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 3, GeometryData::IntegrationMethod::GI_GAUSS_5 );
-    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+        jacobian_determinant = p_geometry->DeterminantOfJacobian( 3, GeometryData::IntegrationMethod::GI_GAUSS_5 );
+        KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
 
-    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 4, GeometryData::IntegrationMethod::GI_GAUSS_5 );
-    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
-    // }
+        jacobian_determinant = p_geometry->DeterminantOfJacobian( 4, GeometryData::IntegrationMethod::GI_GAUSS_5 );
+        KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+    }
 
     KRATOS_TEST_CASE_IN_SUITE(Line3D3ShapeFunctionsValues, KratosCoreGeometriesFastSuite) {
         auto p_geometry = GeneratePointsParabolaLine3D3();

--- a/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
@@ -24,57 +24,59 @@
 
 namespace Kratos::Testing {
 
-    /// Factory functions
+    namespace {
+        /// Factory functions
 
-    /** Generates a point type sample Line3D3N
-    * @return  Pointer to a Line3D3N
-    */
-    Line3D3<Point>::Pointer GeneratePointsUnitXDirectionLine3D3() {
-        return Kratos::make_shared<Line3D3<Point>>(
-        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-        Kratos::make_shared<Point>(1.0, 0.0, 0.0),
-        Kratos::make_shared<Point>(0.5, 0.0, 0.0)
-        );
-    }
+        /** Generates a point type sample Line3D3N
+        * @return  Pointer to a Line3D3N
+        */
+        Line3D3<Point>::Pointer GeneratePointsUnitXDirectionLine3D3() {
+            return Kratos::make_shared<Line3D3<Point>>(
+            Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+            Kratos::make_shared<Point>(1.0, 0.0, 0.0),
+            Kratos::make_shared<Point>(0.5, 0.0, 0.0)
+            );
+        }
 
-    /** Generates a point type sample Line3D3N
-    * @return  Pointer to a Line3D3N
-    */
-    Line3D3<Point>::Pointer GeneratePointsUnitYDirectionLine3D3() {
-        return Kratos::make_shared<Line3D3<Point>>(
-        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-        Kratos::make_shared<Point>(0.0, 1.0, 0.0),
-        Kratos::make_shared<Point>(0.0, 0.5, 0.0)
-        );
-    }
+        /** Generates a point type sample Line3D3N
+        * @return  Pointer to a Line3D3N
+        */
+        Line3D3<Point>::Pointer GeneratePointsUnitYDirectionLine3D3() {
+            return Kratos::make_shared<Line3D3<Point>>(
+            Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+            Kratos::make_shared<Point>(0.0, 1.0, 0.0),
+            Kratos::make_shared<Point>(0.0, 0.5, 0.0)
+            );
+        }
 
-    /** Generates a point type sample Line3D3N
-    * @return  Pointer to a Line3D3N
-    */
-    Line3D3<Point>::Pointer GeneratePointsDiagonalLine3D3() {
-        return Kratos::make_shared<Line3D3<Point>>(
-        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-        Kratos::make_shared<Point>(1.0, 1.0, 0.0),
-        Kratos::make_shared<Point>(0.5, 0.5, 0.0)
-        );
-    }
+        /** Generates a point type sample Line3D3N
+        * @return  Pointer to a Line3D3N
+        */
+        Line3D3<Point>::Pointer GeneratePointsDiagonalLine3D3() {
+            return Kratos::make_shared<Line3D3<Point>>(
+            Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+            Kratos::make_shared<Point>(1.0, 1.0, 0.0),
+            Kratos::make_shared<Point>(0.5, 0.5, 0.0)
+            );
+        }
 
-    /** Generates a point type sample Line3D3N
-    * @return  Pointer to a Line3D3N
-    */
-    Line3D3<Point>::Pointer GeneratePointsParabolaLine3D3() {
-        return Kratos::make_shared<Line3D3<Point>>(
-        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-        Kratos::make_shared<Point>(1.0, 0.0, 0.0),
-        Kratos::make_shared<Point>(0.5, 0.5, 0.0)
-        );
-    }
+        /** Generates a point type sample Line3D3N
+        * @return  Pointer to a Line3D3N
+        */
+        Line3D3<Point>::Pointer GeneratePointsParabolaLine3D3() {
+            return Kratos::make_shared<Line3D3<Point>>(
+            Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+            Kratos::make_shared<Point>(1.0, 0.0, 0.0),
+            Kratos::make_shared<Point>(0.5, 0.5, 0.0)
+            );
+        }
 
-    /** Generates a point type sample Line3D3N.
-    * @return  Pointer to a Line3D3N
-    */
-    Line3D3<Point>::Pointer GenerateLine3D3WithPoints(Point::Pointer pPointOne, Point::Pointer pPointTwo, Point::Pointer pPointThree ) {
-        return Kratos::make_shared<Line3D3<Point>>(pPointOne, pPointTwo, pPointThree);
+        /** Generates a point type sample Line3D3N.
+        * @return  Pointer to a Line3D3N
+        */
+        Line3D3<Point>::Pointer GenerateLine3D3WithPoints(Point::Pointer pPointOne, Point::Pointer pPointTwo, Point::Pointer pPointThree ) {
+            return Kratos::make_shared<Line3D3<Point>>(pPointOne, pPointTwo, pPointThree);
+        }
     }
 
     /** Checks if the number of edges is correct.

--- a/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
@@ -90,7 +90,7 @@ namespace Kratos::Testing {
     */
     KRATOS_TEST_CASE_IN_SUITE(Line3D3FacesNumber, KratosCoreGeometriesFastSuite) {
         auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
-        KRATOS_CHECK_EQUAL(p_geometry->FacesNumber(), 2);
+        KRATOS_CHECK_EQUAL(p_geometry->FacesNumber(), 0);
     }
 
     /** Checks if the length of the line is calculated correctly.

--- a/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
@@ -22,8 +22,7 @@
 #include "tests/cpp_tests/geometries/test_shape_function_derivatives.h"
 #include "tests/cpp_tests/geometries/cross_check_shape_functions_values.h"
 
-namespace Kratos {
-namespace Testing {
+namespace Kratos::Testing {
 
     /// Factory functions
 

--- a/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
@@ -1,0 +1,335 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+// System includes
+#include <limits>
+
+// External includes
+
+// Project includes
+#include "testing/testing.h"
+#include "geometries/line_3d_3.h"
+#include "tests/cpp_tests/geometries/test_geometry.h"
+#include "tests/cpp_tests/geometries/test_shape_function_derivatives.h"
+#include "tests/cpp_tests/geometries/cross_check_shape_functions_values.h"
+
+namespace Kratos {
+namespace Testing {
+
+    /// Factory functions
+
+    /** Generates a point type sample Line3D3N
+    * @return  Pointer to a Line3D3N
+    */
+    Line3D3<Point>::Pointer GeneratePointsUnitXDirectionLine3D3() {
+        return Kratos::make_shared<Line3D3<Point>>(
+        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+        Kratos::make_shared<Point>(1.0, 0.0, 0.0),
+        Kratos::make_shared<Point>(0.5, 0.0, 0.0)
+        );
+    }
+
+    /** Generates a point type sample Line3D3N
+    * @return  Pointer to a Line3D3N
+    */
+    Line3D3<Point>::Pointer GeneratePointsUnitYDirectionLine3D3() {
+        return Kratos::make_shared<Line3D3<Point>>(
+        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+        Kratos::make_shared<Point>(0.0, 1.0, 0.0),
+        Kratos::make_shared<Point>(0.0, 0.5, 0.0)
+        );
+    }
+
+    /** Generates a point type sample Line3D3N
+    * @return  Pointer to a Line3D3N
+    */
+    Line3D3<Point>::Pointer GeneratePointsDiagonalLine3D3() {
+        return Kratos::make_shared<Line3D3<Point>>(
+        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+        Kratos::make_shared<Point>(1.0, 1.0, 0.0),
+        Kratos::make_shared<Point>(0.5, 0.5, 0.0)
+        );
+    }
+
+    /** Generates a point type sample Line3D3N
+    * @return  Pointer to a Line3D3N
+    */
+    Line3D3<Point>::Pointer GeneratePointsParabolaLine3D3() {
+        return Kratos::make_shared<Line3D3<Point>>(
+        Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+        Kratos::make_shared<Point>(1.0, 0.0, 0.0),
+        Kratos::make_shared<Point>(0.5, 0.5, 0.0)
+        );
+    }
+
+    /** Generates a point type sample Line3D3N.
+    * @return  Pointer to a Line3D3N
+    */
+    Line3D3<Point>::Pointer GenerateLine3D3WithPoints(Point::Pointer pPointOne, Point::Pointer pPointTwo, Point::Pointer pPointThree ) {
+        return Kratos::make_shared<Line3D3<Point>>(pPointOne, pPointTwo, pPointThree);
+    }
+
+    /** Checks if the number of edges is correct.
+    * Checks if the number of edges is correct.
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line3D3EdgesNumber, KratosCoreGeometriesFastSuite) {
+        auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+        KRATOS_CHECK_EQUAL(p_geometry->EdgesNumber(), 2);
+    }
+
+    /** Checks if the number of faces is correct.
+    * Checks if the number of faces is correct.
+    */
+    KRATOS_TEST_CASE_IN_SUITE(Line3D3FacesNumber, KratosCoreGeometriesFastSuite) {
+        auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+        KRATOS_CHECK_EQUAL(p_geometry->FacesNumber(), 2);
+    }
+
+    /** Checks if the length of the line is calculated correctly.
+    * Checks if the length of the line is calculated correctly.
+    */
+    KRATOS_TEST_CASE_IN_SUITE(LengthLine3D3, KratosCoreGeometriesFastSuite) {
+        auto p_geometry = GeneratePointsDiagonalLine3D3();
+
+        KRATOS_CHECK_NEAR(p_geometry->Length(), std::sqrt(2.0), TOLERANCE);
+
+        p_geometry = GeneratePointsParabolaLine3D3();
+
+        KRATOS_CHECK_NEAR(p_geometry->Length(), 1.46884, 1.0e-5); // NOTE: Analytic 1.47894
+    }
+
+    /** Checks if the bounding box of the line is calculated correctly.
+    * Checks if the bounding box of the line is calculated correctly.
+    */
+    KRATOS_TEST_CASE_IN_SUITE(BoundingBoxLine3D3, KratosCoreGeometriesFastSuite) {
+        auto p_geom = GeneratePointsDiagonalLine3D3();
+
+        Point low_point, high_point;
+        p_geom->BoundingBox(low_point, high_point);
+
+        KRATOS_CHECK_NEAR(low_point.X(), (p_geom->pGetPoint(0))->X(), TOLERANCE);
+        KRATOS_CHECK_NEAR(low_point.Y(), (p_geom->pGetPoint(0))->Y(), TOLERANCE);
+        KRATOS_CHECK_NEAR(high_point.X(), (p_geom->pGetPoint(1))->X(), TOLERANCE);
+        KRATOS_CHECK_NEAR(high_point.Y(), (p_geom->pGetPoint(1))->Y(), TOLERANCE);
+
+        p_geom = GeneratePointsParabolaLine3D3();
+
+        p_geom->BoundingBox(low_point, high_point);
+
+        KRATOS_CHECK_NEAR(low_point.X(), (p_geom->pGetPoint(0))->X(), TOLERANCE);
+        KRATOS_CHECK_NEAR(low_point.Y(), (p_geom->pGetPoint(0))->Y(), TOLERANCE);
+        KRATOS_CHECK_NEAR(high_point.X(), (p_geom->pGetPoint(1))->X(), TOLERANCE);
+        KRATOS_CHECK_NEAR(high_point.Y(), (p_geom->pGetPoint(2))->Y(), TOLERANCE);
+    }
+
+    // /** Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
+    // * Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
+    // */
+    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianArray1, KratosCoreGeometriesFastSuite) {
+    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+    //     const double expected_jacobian = 0.5;
+
+    //     Vector jacobians_determinants;
+    //     p_geometry->DeterminantOfJacobian( jacobians_determinants, GeometryData::IntegrationMethod::GI_GAUSS_1 );
+
+    //     for (unsigned int i=0; i<jacobians_determinants.size(); ++i) {
+    //         KRATOS_CHECK_NEAR(jacobians_determinants[i], expected_jacobian, TOLERANCE);
+    //     }
+    // }
+
+    // /** Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
+    // * Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
+    // */
+    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianArray2, KratosCoreGeometriesFastSuite) {
+    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+    //     const double expected_jacobian = 0.5;
+
+    //     Vector jacobians_determinants;
+    //     p_geometry->DeterminantOfJacobian( jacobians_determinants, GeometryData::IntegrationMethod::GI_GAUSS_2 );
+
+    //     for (unsigned int i=0; i<jacobians_determinants.size(); ++i) {
+    //         KRATOS_CHECK_NEAR(jacobians_determinants[i], expected_jacobian, TOLERANCE);
+    //     }
+    // }
+
+    // /** Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
+    // * Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
+    // */
+    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianArray3, KratosCoreGeometriesFastSuite) {
+    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+    //     const double expected_jacobian = 0.5;
+
+    //     Vector jacobians_determinants;
+    //     p_geometry->DeterminantOfJacobian( jacobians_determinants, GeometryData::IntegrationMethod::GI_GAUSS_3 );
+
+    //     for (unsigned int i=0; i<jacobians_determinants.size(); ++i) {
+    //         KRATOS_CHECK_NEAR(jacobians_determinants[i], expected_jacobian, TOLERANCE);
+    //     }
+    // }
+
+    // /** Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+    // * Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+    // */
+    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianArray4, KratosCoreGeometriesFastSuite) {
+    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+    //     const double expected_jacobian = 0.5;
+
+    //     Vector jacobians_determinants;
+    //     p_geometry->DeterminantOfJacobian( jacobians_determinants, GeometryData::IntegrationMethod::GI_GAUSS_4 );
+
+    //     for (unsigned int i=0; i<jacobians_determinants.size(); ++i) {
+    //         KRATOS_CHECK_NEAR(jacobians_determinants[i], expected_jacobian, TOLERANCE);
+    //     }
+    // }
+
+    // /** Tests the Jacobian determinants using 'GI_GAUSS_5' integration method.
+    // * Tests the Jacobian determinants using 'GI_GAUSS_5' integration method.
+    // */
+    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianArray5, KratosCoreGeometriesFastSuite) {
+    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+    //     const double expected_jacobian = 0.5;
+
+    //     Vector jacobians_determinants;
+    //     p_geometry->DeterminantOfJacobian( jacobians_determinants, GeometryData::IntegrationMethod::GI_GAUSS_5 );
+
+    //     for (unsigned int i=0; i<jacobians_determinants.size(); ++i) {
+    //         KRATOS_CHECK_NEAR(jacobians_determinants[i], expected_jacobian, TOLERANCE);
+    //     }
+    // }
+
+    // /** Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
+    // * Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
+    // */
+    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianIndex1, KratosCoreGeometriesFastSuite) {
+    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+    //     const double expected_jacobian = 0.5;
+
+    //     double jacobian_determinant = p_geometry->DeterminantOfJacobian( 0, GeometryData::IntegrationMethod::GI_GAUSS_1 );
+    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+    // }
+
+    // /** Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
+    // * Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
+    // */
+    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianIndex2, KratosCoreGeometriesFastSuite) {
+    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+    //     double jacobian_determinant = 0.0;
+    //     const double expected_jacobian = 0.5;
+
+    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 0, GeometryData::IntegrationMethod::GI_GAUSS_2 );
+    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+
+    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 1, GeometryData::IntegrationMethod::GI_GAUSS_2 );
+    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+    // }
+
+    // /** Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
+    // * Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
+    // */
+    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianIndex3, KratosCoreGeometriesFastSuite) {
+    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+    //     double jacobian_determinant = 0.0;
+    //     const double expected_jacobian = 0.5;
+
+    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 0, GeometryData::IntegrationMethod::GI_GAUSS_3 );
+    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+
+    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 1, GeometryData::IntegrationMethod::GI_GAUSS_3 );
+    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+
+    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 2, GeometryData::IntegrationMethod::GI_GAUSS_3 );
+    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+    // }
+
+    // /** Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+    // * Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+    // */
+    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianIndex4, KratosCoreGeometriesFastSuite) {
+    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+    //     double jacobian_determinant = 0.0;
+    //     const double expected_jacobian = 0.5;
+
+    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 0, GeometryData::IntegrationMethod::GI_GAUSS_4 );
+    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+
+    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 1, GeometryData::IntegrationMethod::GI_GAUSS_4 );
+    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+
+    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 2, GeometryData::IntegrationMethod::GI_GAUSS_4 );
+    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+
+    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 3, GeometryData::IntegrationMethod::GI_GAUSS_4 );
+    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+    // }
+
+    // /** Tests the Jacobian determinants using 'GI_GAUSS_5' integration method.
+    // * Tests the Jacobian determinants using 'GI_GAUSS_5' integration method.
+    // */
+    // KRATOS_TEST_CASE_IN_SUITE(Line3D3DeterminantOfJacobianIndex5, KratosCoreGeometriesFastSuite) {
+    //     auto p_geometry = GeneratePointsUnitXDirectionLine3D3();
+    //     double jacobian_determinant = 0.0;
+    //     const double expected_jacobian = 0.5;
+
+    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 0, GeometryData::IntegrationMethod::GI_GAUSS_5 );
+    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+
+    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 1, GeometryData::IntegrationMethod::GI_GAUSS_5 );
+    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+
+    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 2, GeometryData::IntegrationMethod::GI_GAUSS_5 );
+    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+
+    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 3, GeometryData::IntegrationMethod::GI_GAUSS_5 );
+    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+
+    //     jacobian_determinant = p_geometry->DeterminantOfJacobian( 4, GeometryData::IntegrationMethod::GI_GAUSS_5 );
+    //     KRATOS_CHECK_NEAR(jacobian_determinant, expected_jacobian, TOLERANCE);
+    // }
+
+    KRATOS_TEST_CASE_IN_SUITE(Line3D3ShapeFunctionsValues, KratosCoreGeometriesFastSuite) {
+        auto p_geometry = GeneratePointsParabolaLine3D3();
+        auto& r_geom = *p_geometry;
+        auto p_p_geom_nodes = Kratos::make_shared<Line3D3<Node<3>>>(
+        Kratos::make_intrusive<Node<3>>(1, r_geom[0].X(), r_geom[0].Y(), r_geom[0].Z()),
+        Kratos::make_intrusive<Node<3>>(2, r_geom[1].X(), r_geom[1].Y(), r_geom[1].Z()),
+        Kratos::make_intrusive<Node<3>>(3, r_geom[2].X(), r_geom[2].Y(), r_geom[2].Z())
+        );
+        CrossCheckShapeFunctionsValues(*p_p_geom_nodes);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(Line3D3ShapeFunctionsValuesMatrix, KratosCoreGeometriesFastSuite) {
+
+        Geometry<Point>::Pointer p_geom = GeneratePointsDiagonalLine3D3();
+
+        const Matrix N_values_geom = p_geom->ShapeFunctionsValues(GeometryData::IntegrationMethod::GI_GAUSS_2);
+
+        KRATOS_CHECK_NEAR(N_values_geom(0, 0), 0.455342, TOLERANCE);
+        KRATOS_CHECK_NEAR(N_values_geom(0, 1), -0.122008, TOLERANCE);
+        KRATOS_CHECK_NEAR(N_values_geom(0, 2), 0.666667, TOLERANCE);
+        KRATOS_CHECK_NEAR(N_values_geom(1, 0), -0.122008, TOLERANCE);
+        KRATOS_CHECK_NEAR(N_values_geom(1, 1), 0.455342, TOLERANCE);
+        KRATOS_CHECK_NEAR(N_values_geom(1, 2), 0.666667, TOLERANCE);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(Line3D3ShapeFunctionsLocalGradients, KratosCoreGeometriesFastSuite) {
+        auto p_geometry = GeneratePointsParabolaLine3D3();
+        auto& r_geom = *p_geometry;
+        auto p_p_geom_nodes = Kratos::make_shared<Line3D3<Node<3>>>(
+        Kratos::make_intrusive<Node<3>>(1, r_geom[0].X(), r_geom[0].Y(), r_geom[0].Z()),
+        Kratos::make_intrusive<Node<3>>(2, r_geom[1].X(), r_geom[1].Y(), r_geom[1].Z()),
+        Kratos::make_intrusive<Node<3>>(3, r_geom[2].X(), r_geom[2].Y(), r_geom[2].Z())
+        );
+        TestAllShapeFunctionsLocalGradients(*p_p_geom_nodes);
+    }
+
+} // namespace Testing.
+} // namespace Kratos.

--- a/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
@@ -330,5 +330,4 @@ namespace Kratos::Testing {
         TestAllShapeFunctionsLocalGradients(*p_p_geom_nodes);
     }
 
-} // namespace Testing.
-} // namespace Kratos.
+} // namespace Kratos::Testing.

--- a/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_3d_3.cpp
@@ -38,16 +38,16 @@ namespace Kratos::Testing {
             );
         }
 
-        /** Generates a point type sample Line3D3N
-        * @return  Pointer to a Line3D3N
-        */
-        Line3D3<Point>::Pointer GeneratePointsUnitYDirectionLine3D3() {
-            return Kratos::make_shared<Line3D3<Point>>(
-            Kratos::make_shared<Point>(0.0, 0.0, 0.0),
-            Kratos::make_shared<Point>(0.0, 1.0, 0.0),
-            Kratos::make_shared<Point>(0.0, 0.5, 0.0)
-            );
-        }
+        // /** Generates a point type sample Line3D3N
+        // * @return  Pointer to a Line3D3N
+        // */
+        // Line3D3<Point>::Pointer GeneratePointsUnitYDirectionLine3D3() {
+        //     return Kratos::make_shared<Line3D3<Point>>(
+        //     Kratos::make_shared<Point>(0.0, 0.0, 0.0),
+        //     Kratos::make_shared<Point>(0.0, 1.0, 0.0),
+        //     Kratos::make_shared<Point>(0.0, 0.5, 0.0)
+        //     );
+        // }
 
         /** Generates a point type sample Line3D3N
         * @return  Pointer to a Line3D3N
@@ -71,12 +71,12 @@ namespace Kratos::Testing {
             );
         }
 
-        /** Generates a point type sample Line3D3N.
-        * @return  Pointer to a Line3D3N
-        */
-        Line3D3<Point>::Pointer GenerateLine3D3WithPoints(Point::Pointer pPointOne, Point::Pointer pPointTwo, Point::Pointer pPointThree ) {
-            return Kratos::make_shared<Line3D3<Point>>(pPointOne, pPointTwo, pPointThree);
-        }
+        // /** Generates a point type sample Line3D3N.
+        // * @return  Pointer to a Line3D3N
+        // */
+        // Line3D3<Point>::Pointer GenerateLine3D3WithPoints(Point::Pointer pPointOne, Point::Pointer pPointTwo, Point::Pointer pPointThree ) {
+        //     return Kratos::make_shared<Line3D3<Point>>(pPointOne, pPointTwo, pPointThree);
+        // }
     }
 
     /** Checks if the number of edges is correct.

--- a/kratos/utilities/integration_utilities.h
+++ b/kratos/utilities/integration_utilities.h
@@ -1,25 +1,22 @@
 //    |  /           |
 //    ' /   __| _` | __|  _ \   __|
-//    . \  |   (   | |   (   |\__ \.
+//    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//                       license: license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
-//  License:          BSD License
-//  Main authors:     Riccardo Rossi
+//  Main authors:    Riccardo Rossi
 //
 
-#if !defined(KRATOS_INTEGRATION_UTILITIES_INCLUDED )
-#define  KRATOS_INTEGRATION_UTILITIES_INCLUDED
+#pragma once
 
 // System includes
 
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "geometries/geometry.h"
 
 namespace Kratos
@@ -37,10 +34,10 @@ public:
             integration_method = GeometryData::IntegrationMethod::GI_GAUSS_3;
         else if(integration_method == GeometryData::IntegrationMethod::GI_GAUSS_3)
             integration_method = GeometryData::IntegrationMethod::GI_GAUSS_4;
+        else if(integration_method == GeometryData::IntegrationMethod::GI_GAUSS_4)
+            integration_method = GeometryData::IntegrationMethod::GI_GAUSS_5;
         return integration_method;
     }
 };
 
 }  // namespace Kratos.
-
-#endif // KRATOS_INTEGRATION_UTILITIES_INCLUDED  defined


### PR DESCRIPTION
**📝 Description**

Correct `Length` `Line3D3`. Removing unused methods, already implemented in base class (in addition they were wrong). #10538

**🆕 Changelog**

- [Correct Length line 3D 3](https://github.com/KratosMultiphysics/Kratos/commit/efaa1b3ce00b559098ea2fce3a92e1e105f6aea3)
- [Test](https://github.com/KratosMultiphysics/Kratos/commit/83855ad008e70a0748ea7db90f83fe4ee4d6b327)
- [Cleaning Line3D3](https://github.com/KratosMultiphysics/Kratos/commit/5690b3fe8627104304269d0647202d8bf9ef55a6)
- [Higher order to proper capture](https://github.com/KratosMultiphysics/Kratos/commit/46fdc94df88a5f9a091574f8f6724540089d6a1f)
- [More tests](https://github.com/KratosMultiphysics/Kratos/commit/788a9ad653faf97c82165c370acfb30e5c8a05cb)
