### PR TITLE
[Core][MPI] Adding RemoveOrphanNodesFromSubModelPartsto clean up submodelparts partitions

### DIFF
--- a/kratos/mpi/python_scripts/distributed_import_model_part_utility.py
+++ b/kratos/mpi/python_scripts/distributed_import_model_part_utility.py
@@ -92,7 +92,6 @@ class DistributedImportModelPartUtility:
                     partitioner = KratosMetis.MetisDivideHeterogeneousInputInMemoryProcess(model_part_io, serial_model_part_io, self.comm , domain_size, verbosity, sync_conditions)
                     partitioner.Execute()
                     serial_model_part_io.ReadModelPart(self.main_model_part)
-                    KratosMultiphysics.AuxiliarModelPartUtilities(self.main_model_part).RemoveNodesFromSubModePartsWithoutCorrespondingEntities()
 
                 KratosMultiphysics.Logger.PrintInfo("::[DistributedImportModelPartUtility]::", "Metis divide finished in {0:.{1}f} [s]".format(time()-start_time,1),data_communicator=self.comm)
 

--- a/kratos/mpi/python_scripts/distributed_import_model_part_utility.py
+++ b/kratos/mpi/python_scripts/distributed_import_model_part_utility.py
@@ -92,6 +92,7 @@ class DistributedImportModelPartUtility:
                     partitioner = KratosMetis.MetisDivideHeterogeneousInputInMemoryProcess(model_part_io, serial_model_part_io, self.comm , domain_size, verbosity, sync_conditions)
                     partitioner.Execute()
                     serial_model_part_io.ReadModelPart(self.main_model_part)
+                    KratosMultiphysics.AuxiliarModelPartUtilities(self.main_model_part).RemoveNodesFromSubModePartsWithoutCorrespondingEntities()
 
                 KratosMultiphysics.Logger.PrintInfo("::[DistributedImportModelPartUtility]::", "Metis divide finished in {0:.{1}f} [s]".format(time()-start_time,1),data_communicator=self.comm)
 

--- a/kratos/python/add_other_utilities_to_python.cpp
+++ b/kratos/python/add_other_utilities_to_python.cpp
@@ -410,7 +410,7 @@ void AddOtherUtilitiesToPython(pybind11::module &m)
         .def("RemoveConditionAndBelongingsFromAllLevels", [](AuxiliarModelPartUtilities& rAuxiliarModelPartUtilities, ModelPart::ConditionType::Pointer pThisCondition, Flags IdentifierFlag) { rAuxiliarModelPartUtilities.RemoveConditionAndBelongingsFromAllLevels(pThisCondition, IdentifierFlag);})
         .def("RemoveConditionAndBelongingsFromAllLevels", [](AuxiliarModelPartUtilities& rAuxiliarModelPartUtilities, ModelPart::ConditionType::Pointer pThisCondition, Flags IdentifierFlag, ModelPart::IndexType ThisIndex) { rAuxiliarModelPartUtilities.RemoveConditionAndBelongingsFromAllLevels(pThisCondition, IdentifierFlag, ThisIndex);})
         .def("RemoveConditionsAndBelongingsFromAllLevels", &Kratos::AuxiliarModelPartUtilities::RemoveConditionsAndBelongingsFromAllLevels)
-        .def("RemoveNodesFromSubModePartsWithoutCorrespondingEntities", &Kratos::AuxiliarModelPartUtilities::RemoveNodesFromSubModePartsWithoutCorrespondingEntities)
+        .def("RemoveOrphanNodesFromSubModelParts", &Kratos::AuxiliarModelPartUtilities::RemoveOrphanNodesFromSubModelParts)
         ;
 
     // Sparse matrix multiplication utility

--- a/kratos/python/add_other_utilities_to_python.cpp
+++ b/kratos/python/add_other_utilities_to_python.cpp
@@ -410,6 +410,7 @@ void AddOtherUtilitiesToPython(pybind11::module &m)
         .def("RemoveConditionAndBelongingsFromAllLevels", [](AuxiliarModelPartUtilities& rAuxiliarModelPartUtilities, ModelPart::ConditionType::Pointer pThisCondition, Flags IdentifierFlag) { rAuxiliarModelPartUtilities.RemoveConditionAndBelongingsFromAllLevels(pThisCondition, IdentifierFlag);})
         .def("RemoveConditionAndBelongingsFromAllLevels", [](AuxiliarModelPartUtilities& rAuxiliarModelPartUtilities, ModelPart::ConditionType::Pointer pThisCondition, Flags IdentifierFlag, ModelPart::IndexType ThisIndex) { rAuxiliarModelPartUtilities.RemoveConditionAndBelongingsFromAllLevels(pThisCondition, IdentifierFlag, ThisIndex);})
         .def("RemoveConditionsAndBelongingsFromAllLevels", &Kratos::AuxiliarModelPartUtilities::RemoveConditionsAndBelongingsFromAllLevels)
+        .def("RemoveNodesFromSubModePartsWithoutCorrespondingEntities", &Kratos::AuxiliarModelPartUtilities::RemoveNodesFromSubModePartsWithoutCorrespondingEntities)
         ;
 
     // Sparse matrix multiplication utility

--- a/kratos/python_scripts/testing/utilities.py
+++ b/kratos/python_scripts/testing/utilities.py
@@ -51,7 +51,7 @@ def ReadSerialModelPart(mdpa_file_name, model_part):
 
 
 @KratosUnittest.skipIfApplicationsNotAvailable("MetisApplication")
-def ReadDistributedModelPart(mdpa_file_name, model_part, importer_settings=None):
+def ReadDistributedModelPart(mdpa_file_name, model_part, importer_settings=None, clean_orphan_nodes = False):
     """Reads mdpa file
 
     This method reads mdpa file and fills given model_part accordingly using MPI
@@ -78,7 +78,8 @@ def ReadDistributedModelPart(mdpa_file_name, model_part, importer_settings=None)
         model_part, importer_settings)
     model_part_import_util.ImportModelPart()
     model_part_import_util.CreateCommunicators()
-    Kratos.AuxiliarModelPartUtilities(model_part).RemoveNodesFromSubModePartsWithoutCorrespondingEntities()
+    if clean_orphan_nodes:
+        Kratos.AuxiliarModelPartUtilities(model_part).RemoveNodesFromSubModePartsWithoutCorrespondingEntities()
 
 def PrintTestHeader(application):
     Kratos.Logger.Flush()

--- a/kratos/python_scripts/testing/utilities.py
+++ b/kratos/python_scripts/testing/utilities.py
@@ -79,7 +79,7 @@ def ReadDistributedModelPart(mdpa_file_name, model_part, importer_settings=None,
     model_part_import_util.ImportModelPart()
     model_part_import_util.CreateCommunicators()
     if clean_orphan_nodes:
-        Kratos.AuxiliarModelPartUtilities(model_part).RemoveNodesFromSubModePartsWithoutCorrespondingEntities()
+        Kratos.AuxiliarModelPartUtilities(model_part).RemoveOrphanNodesFromSubModelParts()
 
 def PrintTestHeader(application):
     Kratos.Logger.Flush()

--- a/kratos/python_scripts/testing/utilities.py
+++ b/kratos/python_scripts/testing/utilities.py
@@ -78,7 +78,7 @@ def ReadDistributedModelPart(mdpa_file_name, model_part, importer_settings=None)
         model_part, importer_settings)
     model_part_import_util.ImportModelPart()
     model_part_import_util.CreateCommunicators()
-
+    Kratos.AuxiliarModelPartUtilities(model_part).RemoveNodesFromSubModePartsWithoutCorrespondingEntities()
 
 def PrintTestHeader(application):
     Kratos.Logger.Flush()

--- a/kratos/utilities/auxiliar_model_part_utilities.cpp
+++ b/kratos/utilities/auxiliar_model_part_utilities.cpp
@@ -383,28 +383,21 @@ void AuxiliarModelPartUtilities::RemoveNodesFromSubModePartsWithoutCorresponding
         if (r_sub_model_part.NumberOfNodes() > 0) {
             auto& r_array_nodes = r_sub_model_part.Nodes();
             variable_utils.ResetFlag(TO_ERASE, r_array_nodes);
-            // If no entities remove all
-            if (r_sub_model_part.NumberOfElements() == 0 && r_sub_model_part.NumberOfConditions() == 0) {
-                variable_utils.SetFlag(TO_ERASE, true, r_array_nodes);
-            } else { // Check orphans nodes
-                std::unordered_set<IndexType> not_orphan_node;
+            variable_utils.SetFlag(TO_ERASE, true, r_array_nodes);
+            // Check orphans nodes
+            if (r_sub_model_part.NumberOfElements() > 0 || r_sub_model_part.NumberOfConditions() > 0) {
                 for (auto& r_elem : r_sub_model_part.Elements()) {
                     auto& r_geometry = r_elem.GetGeometry();
                     for (auto& r_node : r_geometry) {
-                        not_orphan_node.insert(r_node.Id());
+                        r_node.Set(TO_ERASE, false);
                     }
                 }
                 for (auto& r_cond : r_sub_model_part.Conditions()) {
                     auto& r_geometry = r_cond.GetGeometry();
                     for (auto& r_node : r_geometry) {
-                        not_orphan_node.insert(r_node.Id());
+                        r_node.Set(TO_ERASE, false);
                     }
                 }
-                block_for_each(r_array_nodes,[&not_orphan_node](ModelPart::NodeType& rNode) {
-                    if (not_orphan_node.find(rNode.Id()) == not_orphan_node.end()) {
-                        rNode.Set(TO_ERASE);
-                    }
-                }); 
             }
             r_sub_model_part.RemoveNodes(TO_ERASE);
         }

--- a/kratos/utilities/auxiliar_model_part_utilities.cpp
+++ b/kratos/utilities/auxiliar_model_part_utilities.cpp
@@ -376,7 +376,7 @@ void AuxiliarModelPartUtilities::RemoveConditionsAndBelongingsFromAllLevels(cons
 /***********************************************************************************/
 /***********************************************************************************/
 
-void AuxiliarModelPartUtilities::RemoveNodesFromSubModePartsWithoutCorrespondingEntities()
+void AuxiliarModelPartUtilities::RemoveOrphanNodesFromSubModelParts()
 {
     VariableUtils variable_utils;
     for (auto& r_sub_model_part : mrModelPart.SubModelParts()) {

--- a/kratos/utilities/auxiliar_model_part_utilities.cpp
+++ b/kratos/utilities/auxiliar_model_part_utilities.cpp
@@ -376,6 +376,45 @@ void AuxiliarModelPartUtilities::RemoveConditionsAndBelongingsFromAllLevels(cons
 /***********************************************************************************/
 /***********************************************************************************/
 
+void AuxiliarModelPartUtilities::RemoveNodesFromSubModePartsWithoutCorrespondingEntities()
+{
+    VariableUtils variable_utils;
+    for (auto& r_sub_model_part : mrModelPart.SubModelParts()) {
+        if (r_sub_model_part.NumberOfNodes() > 0) {
+            auto& r_array_nodes = r_sub_model_part.Nodes();
+            variable_utils.ResetFlag(TO_ERASE, r_array_nodes);
+            // If no entities remove all
+            if (r_sub_model_part.NumberOfElements() == 0 && r_sub_model_part.NumberOfConditions() == 0) {
+                variable_utils.SetFlag(TO_ERASE, true, r_array_nodes);
+            } else { // Check orphans nodes
+                std::unordered_set<IndexType> not_orphan_node;
+                for (auto& r_elem : r_sub_model_part.Elements()) {
+                    auto& r_geometry = r_elem.GetGeometry();
+                    for (auto& r_node : r_geometry) {
+                        not_orphan_node.insert(r_node.Id());
+                    }
+                }
+                for (auto& r_cond : r_sub_model_part.Conditions()) {
+                    auto& r_geometry = r_cond.GetGeometry();
+                    for (auto& r_node : r_geometry) {
+                        not_orphan_node.insert(r_node.Id());
+                    }
+                }
+                block_for_each(r_array_nodes,[&not_orphan_node](ModelPart::NodeType& rNode) {
+                    if (not_orphan_node.find(rNode.Id()) == not_orphan_node.end()) {
+                        rNode.Set(TO_ERASE);
+                    }
+                }); 
+            }
+            r_sub_model_part.RemoveNodes(TO_ERASE);
+        }
+    }
+    variable_utils.ResetFlag(TO_ERASE, mrModelPart.Nodes());
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
 ModelPart& AuxiliarModelPartUtilities::DeepCopyModelPart(
     const std::string& rNewModelPartName,
     Model* pModel

--- a/kratos/utilities/auxiliar_model_part_utilities.h
+++ b/kratos/utilities/auxiliar_model_part_utilities.h
@@ -292,7 +292,7 @@ public:
     /**
      * @brief This method removed nodes from submodelparts not contained neither in the elements or conditions
      */
-    void RemoveNodesFromSubModePartsWithoutCorrespondingEntities();
+    void RemoveOrphanNodesFromSubModelParts();
 
     /// To Export a Scalar data (Double/int/...)
     template<class TContainerType>

--- a/kratos/utilities/auxiliar_model_part_utilities.h
+++ b/kratos/utilities/auxiliar_model_part_utilities.h
@@ -289,6 +289,10 @@ public:
      */
     void RemoveConditionsAndBelongingsFromAllLevels(const Flags IdentifierFlag = TO_ERASE);
 
+    /**
+     * @brief This method removed nodes from submodelparts not contained neither in the elements or conditions
+     */
+    void RemoveNodesFromSubModePartsWithoutCorrespondingEntities();
 
     /// To Export a Scalar data (Double/int/...)
     template<class TContainerType>
@@ -647,36 +651,6 @@ public:
     {
         rOStream << Info() << std::endl;
     }
-
-protected:
-
-    ///@name Protected static Member Variables
-    ///@{
-
-    ///@}
-    ///@name Protected member Variables
-    ///@{
-
-    ///@}
-    ///@name Protected Operators
-    ///@{
-
-    ///@}
-    ///@name Protected Operations
-    ///@{
-
-    ///@}
-    ///@name Protected  Access
-    ///@{
-
-    ///@}
-    ///@name Protected Inquiry
-    ///@{
-
-    ///@}
-    ///@name Protected LifeCycle
-    ///@{
-    ///@}
 
 private:
     ///@name Static Member Variables


### PR DESCRIPTION
**📝 Description**

Looking for the failing tests in #10487 I found that the submodelparts in the partitions may be empty (no elements/conditions) but still have nodes. This adds RemoveOrphanNodesFromSubModelParts so we can clean up that submodelparts

This doesn't fix my problem, but I share the changes if it is interesting

**🆕 Changelog**

- [Adding RemoveOrphanNodesFromSubModelParts](https://github.com/KratosMultiphysics/Kratos/commit/1e2f53e9c8aaf99674b61a483ebf4dcf098a21ce)
- [Using for MPI partitioning](https://github.com/KratosMultiphysics/Kratos/commit/400787c27784fea298a0d6b41048910cf3dee7e5)
- [Refactor](https://github.com/KratosMultiphysics/Kratos/commit/da39dd4debd039c044b4c80b34268424c4e5e14c)
