### PR TITLE
[IO] Simplify partitioning interfaces

### DIFF
--- a/applications/MetisApplication/custom_processes/metis_divide_heterogeneous_input_in_memory_process.cpp
+++ b/applications/MetisApplication/custom_processes/metis_divide_heterogeneous_input_in_memory_process.cpp
@@ -37,9 +37,9 @@ void MetisDivideHeterogeneousInputInMemoryProcess::Execute()
     // Main process calculates the partitions and writes the result into temporal streams
     if(mpi_rank == 0) {
 
-        auto part_info(Kratos::make_shared<PartitioningInfo>());
+        PartitioningInfo part_info;
 
-        ExecutePartitioning(*part_info);
+        ExecutePartitioning(part_info);
 
         // prepare partitioning streams
         std::vector<Kratos::shared_ptr<std::iostream>> streams(mpi_size);
@@ -53,13 +53,7 @@ void MetisDivideHeterogeneousInputInMemoryProcess::Execute()
         mrIO.DivideInputToPartitions(
             streams.data(),
             mNumberOfPartitions,
-            part_info->Graph,
-            part_info->NodesPartitions,
-            part_info->ElementsPartitions,
-            part_info->ConditionsPartitions,
-            part_info->NodesAllPartitions,
-            part_info->ElementsAllPartitions,
-            part_info->ConditionsAllPartitions);
+            part_info);
 
         // prepare buffer to scatter to other partitions
         send_buffer.resize(mpi_size);

--- a/applications/MetisApplication/custom_processes/metis_divide_heterogeneous_input_process.cpp
+++ b/applications/MetisApplication/custom_processes/metis_divide_heterogeneous_input_process.cpp
@@ -125,20 +125,14 @@ if (mVerbosity > 2)
 void MetisDivideHeterogeneousInputProcess::Execute()
 {
 
-    auto part_info(Kratos::make_shared<PartitioningInfo>());
+    PartitioningInfo part_info;
 
-    ExecutePartitioning(*part_info);
+    ExecutePartitioning(part_info);
 
     // Write files
     mrIO.DivideInputToPartitions(
         mNumberOfPartitions,
-        part_info->Graph,
-        part_info->NodesPartitions,
-        part_info->ElementsPartitions,
-        part_info->ConditionsPartitions,
-        part_info->NodesAllPartitions,
-        part_info->ElementsAllPartitions,
-        part_info->ConditionsAllPartitions);
+        part_info);
 }
 
 

--- a/applications/MetisApplication/custom_processes/metis_divide_heterogeneous_input_process.h
+++ b/applications/MetisApplication/custom_processes/metis_divide_heterogeneous_input_process.h
@@ -138,17 +138,6 @@ protected:
     ///@name Protected LifeCycle
     ///@{
 
-    struct PartitioningInfo
-    {
-        GraphType Graph;
-        PartitionIndicesType NodesPartitions; // partition where the Node is local
-        PartitionIndicesType ElementsPartitions; // partition where the Element is local
-        PartitionIndicesType ConditionsPartitions; // partition where the Condition is local
-        PartitionIndicesContainerType NodesAllPartitions; // partitions, in which the Node is present (local & ghost)
-        PartitionIndicesContainerType ElementsAllPartitions; // partitions, in which the Element is present (local & ghost)
-        PartitionIndicesContainerType ConditionsAllPartitions; // partitions, in which the Condition is present (local & ghost)
-    };
-
     ///@}
     ///@name Member Variables
     ///@{

--- a/applications/MetisApplication/custom_processes/metis_divide_heterogeneous_input_process.h
+++ b/applications/MetisApplication/custom_processes/metis_divide_heterogeneous_input_process.h
@@ -43,6 +43,7 @@ public:
 
     using SizeType = IO::SizeType;
     using GraphType = IO::GraphType;
+    using PartitioningInfo = IO::PartitioningInfo;
     using PartitionIndicesType = IO::PartitionIndicesType;
     using PartitionIndicesContainerType = IO::PartitionIndicesContainerType;
     using idxtype = idx_t; // from metis

--- a/kratos/includes/io.h
+++ b/kratos/includes/io.h
@@ -20,10 +20,6 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
-#include "includes/mesh.h"
-#include "includes/element.h"
-#include "includes/condition.h"
 #include "includes/model_part.h"
 
 namespace Kratos
@@ -101,6 +97,18 @@ public:
     typedef std::size_t SizeType;
 
     typedef DenseMatrix<int> GraphType;
+
+    // auxiliary struct containg information about the partitioning of the entities in a ModelPart
+    struct PartitioningInfo
+    {
+        GraphType Graph;
+        PartitionIndicesType NodesPartitions; // partition where the Node is local
+        PartitionIndicesType ElementsPartitions; // partition where the Element is local
+        PartitionIndicesType ConditionsPartitions; // partition where the Condition is local
+        PartitionIndicesContainerType NodesAllPartitions; // partitions, in which the Node is present (local & ghost)
+        PartitionIndicesContainerType ElementsAllPartitions; // partitions, in which the Element is present (local & ghost)
+        PartitionIndicesContainerType ConditionsAllPartitions; // partitions, in which the Condition is present (local & ghost)
+    };
 
     ///@}
     ///@name Life Cycle
@@ -443,6 +451,18 @@ public:
     /**
      * @brief This method divides a model part into partitions
      * @param NumberOfPartitions The number of partitions
+     * @param rPartitioningInfo Information about partitioning of entities
+     */
+    virtual void DivideInputToPartitions(SizeType NumberOfPartitions,
+                                         const PartitioningInfo& rPartitioningInfo)
+    {
+        DivideInputToPartitions(NumberOfPartitions, rPartitioningInfo.Graph, rPartitioningInfo.NodesPartitions, rPartitioningInfo.ElementsPartitions, rPartitioningInfo.ConditionsPartitions, rPartitioningInfo.NodesAllPartitions, rPartitioningInfo.ElementsAllPartitions, rPartitioningInfo.ConditionsAllPartitions); // for backward compatibility
+        // KRATOS_ERROR << "Calling base class method (DivideInputToPartitions). Please check the definition of derived class" << std::endl; // enable this once the old version of this function is removed
+    }
+
+    /**
+     * @brief This method divides a model part into partitions
+     * @param NumberOfPartitions The number of partitions
      * @param rDomainsColoredGraph The colors of the partition graph
      * @param rNodesPartitions The partitions indices of the nodes
      * @param rElementsPartitions The partitions indices of the elements
@@ -451,6 +471,7 @@ public:
      * @param rElementsAllPartitions The partitions of the elements
      * @param rConditionsAllPartitions The partitions of the conditions
      */
+    KRATOS_DEPRECATED_MESSAGE("'This version of \"DivideInputToPartitions\" is deprecated, please use the interface that accepts a \"PartitioningInfo\"")
     virtual void DivideInputToPartitions(SizeType NumberOfPartitions,
                                          GraphType const& rDomainsColoredGraph,
                                          PartitionIndicesType const& rNodesPartitions,
@@ -467,6 +488,20 @@ public:
      * @brief This method divides a model part into partitions
      * @param pStreams The stream pointer
      * @param NumberOfPartitions The number of partitions
+     * @param rPartitioningInfo Information about partitioning of entities
+     */
+    virtual void DivideInputToPartitions(Kratos::shared_ptr<std::iostream> * pStreams,
+                                         SizeType NumberOfPartitions,
+                                         const PartitioningInfo& rPartitioningInfo)
+    {
+        DivideInputToPartitions(pStreams, NumberOfPartitions, rPartitioningInfo.Graph, rPartitioningInfo.NodesPartitions, rPartitioningInfo.ElementsPartitions, rPartitioningInfo.ConditionsPartitions, rPartitioningInfo.NodesAllPartitions, rPartitioningInfo.ElementsAllPartitions, rPartitioningInfo.ConditionsAllPartitions); // for backward compatibility
+        // KRATOS_ERROR << "Calling base class method (DivideInputToPartitions). Please check the definition of derived class" << std::endl; // enable this once the old version of this function is removed
+    }
+
+    /**
+     * @brief This method divides a model part into partitions
+     * @param pStreams The stream pointer
+     * @param NumberOfPartitions The number of partitions
      * @param rDomainsColoredGraph The colors of the partition graph
      * @param rNodesPartitions The partitions indices of the nodes
      * @param rElementsPartitions The partitions indices of the elements
@@ -475,6 +510,7 @@ public:
      * @param rElementsAllPartitions The partitions of the elements
      * @param rConditionsAllPartitions The partitions of the conditions
      */
+    KRATOS_DEPRECATED_MESSAGE("'This version of \"DivideInputToPartitions\" is deprecated, please use the interface that accepts a \"PartitioningInfo\"")
     virtual void DivideInputToPartitions(Kratos::shared_ptr<std::iostream> * pStreams,
                                          SizeType NumberOfPartitions,
                                          GraphType const& rDomainsColoredGraph,


### PR DESCRIPTION
This moves an auxiliary struct to the baseclass

My main motivation is to extend the partitioning to Geometries, which without this change would require many interface changes. By adding it to the struct it can be easily achieved

The changes are fully backward compatible, I will update the ModelPartIO in a followup PR