### PR TITLE
[Core] DomainSize is not needed for Metis

### DIFF
--- a/kratos/mpi/python_scripts/distributed_import_model_part_utility.py
+++ b/kratos/mpi/python_scripts/distributed_import_model_part_utility.py
@@ -63,7 +63,7 @@ class DistributedImportModelPartUtility:
 
                 # Partition of the original .mdpa file
                 number_of_partitions = self.comm.Size() # Number of partitions equals the number of processors
-                domain_size = self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE]
+                domain_size = 0 # this is not used by Metis, it will be refactored in the future
                 verbosity = self.settings["echo_level"].GetInt()
 
                 # Make sure that the condition goes to the same partition as the element is a face of

--- a/kratos/python_scripts/testing/utilities.py
+++ b/kratos/python_scripts/testing/utilities.py
@@ -24,9 +24,6 @@ def ReadModelPart(mdpa_file_name, model_part, settings=None):
         mdpa_file_name (str): Name of the mdpa file (without ".mdpa" extension)
         model_part (Kratos.ModelPart): ModelPart to be filled
     """
-    if Kratos.DOMAIN_SIZE not in model_part.ProcessInfo:
-        raise Exception('"DOMAIN_SIZE" needs to be specified in ProcessInfo!')
-
     if model_part.NumberOfNodes() > 0:
         raise Exception("ModelPart must not contain Nodes!")
 


### PR DESCRIPTION
The domain size is not used, I realized this during my recent refactorings

I will remove the leftovers soon within the scope of some other refactorings, but for now we can lift some restrictions in the tests :)
