### PR TITLE
[MPM] Substituted deprecated newton raphson strategy

### DIFF
--- a/applications/ParticleMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/ParticleMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -82,7 +82,7 @@ namespace Python{
         // MPM Residual Based Newton Raphson Strategy Type
         py::class_< MPMResidualBasedNewtonRaphsonStrategyType,typename MPMResidualBasedNewtonRaphsonStrategyType::Pointer, BaseSolvingStrategyType >(m,"MPMResidualBasedNewtonRaphsonStrategy")
             .def(py::init< ModelPart&, BaseSchemeType::Pointer, LinearSolverType::Pointer, ConvergenceCriteriaType::Pointer, int, bool, bool, bool >() )
-            .def(py::init< ModelPart&, BaseSchemeType::Pointer, LinearSolverType::Pointer, ConvergenceCriteriaType::Pointer, BuilderAndSolverType::Pointer, int, bool, bool, bool >() )
+            .def(py::init< ModelPart&, BaseSchemeType::Pointer, ConvergenceCriteriaType::Pointer, BuilderAndSolverType::Pointer, int, bool, bool, bool >() )
             ;
 
         // MPM Explicit Strategy Type

--- a/applications/ParticleMechanicsApplication/custom_strategies/strategies/mpm_residual_based_newton_raphson_strategy.hpp
+++ b/applications/ParticleMechanicsApplication/custom_strategies/strategies/mpm_residual_based_newton_raphson_strategy.hpp
@@ -106,7 +106,7 @@ public:
 
     /** Constructors.
      */
-    
+
      MPMResidualBasedNewtonRaphsonStrategy(
         ModelPart& rModelPart,
         bool MoveMeshFlag = false
@@ -133,7 +133,6 @@ public:
     MPMResidualBasedNewtonRaphsonStrategy(
         ModelPart& rModelPart,
         typename TSchemeType::Pointer pScheme,
-        typename TLinearSolver::Pointer pNewLinearSolver,
         typename TConvergenceCriteriaType::Pointer pNewConvergenceCriteria,
         typename TBuilderAndSolverType::Pointer pNewBuilderAndSolver,
         int MaxIterations = 30,
@@ -141,9 +140,8 @@ public:
         bool ReformDofSetAtEachStep = false,
         bool MoveMeshFlag = false
     ) : ResidualBasedNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(
-            rModelPart, pScheme, pNewLinearSolver,
-            pNewConvergenceCriteria, pNewBuilderAndSolver, MaxIterations,
-            CalculateReactions, ReformDofSetAtEachStep, MoveMeshFlag)
+            rModelPart, pScheme, pNewConvergenceCriteria, pNewBuilderAndSolver,
+            MaxIterations, CalculateReactions, ReformDofSetAtEachStep, MoveMeshFlag)
     {
     }
 
@@ -152,7 +150,7 @@ public:
     virtual ~MPMResidualBasedNewtonRaphsonStrategy()
     {
     }
-    
+
     /**
      * @brief Solves the current step. This function returns true if a solution has been found, false otherwise.
      */
@@ -160,7 +158,7 @@ public:
     {
         typename TSchemeType::Pointer p_scheme = this->GetScheme();
         typename TBuilderAndSolverType::Pointer p_builder_and_solver = this->GetBuilderAndSolver();
-        
+
         TSystemMatrixType& rA = *(this->mpA);
         TSystemVectorType& rDx = *(this->mpDx);
         TSystemVectorType& rb = *(this->mpb);

--- a/applications/ParticleMechanicsApplication/python_scripts/mpm_solver.py
+++ b/applications/ParticleMechanicsApplication/python_scripts/mpm_solver.py
@@ -400,13 +400,11 @@ class MPMSolver(PythonSolver):
     def _CreateNewtonRaphsonStrategy(self):
         computing_model_part = self.GetComputingModelPart()
         solution_scheme = self._GetSolutionScheme()
-        linear_solver = self._GetLinearSolver()
         convergence_criterion = self._GetConvergenceCriteria()
         builder_and_solver = self._GetBuilderAndSolver()
         reform_dofs_at_each_step = False ## hard-coded, but can be changed upon implementation
         return KratosParticle.MPMResidualBasedNewtonRaphsonStrategy(computing_model_part,
                                                                         solution_scheme,
-                                                                        linear_solver,
                                                                         convergence_criterion,
                                                                         builder_and_solver,
                                                                         self.settings["max_iteration"].GetInt(),


### PR DESCRIPTION
**📝 Description**
Substituted deprecated constructor newton raphson strategy with the one without linear solver. 

**🆕 Changelog**
- mpm_residual_based_newton_raphson_strategy.hpp
- add_custom_strategies_to_python.cpp

