### PR TITLE
[Core][Geometries] Improve domain size computation in geometries

### DIFF
--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -17,8 +17,7 @@
 //                   Vicente Mataix Ferrandiz
 //
 
-#if !defined(KRATOS_GEOMETRY_H_INCLUDED )
-#define  KRATOS_GEOMETRY_H_INCLUDED
+#pragma once
 
 // System includes
 #include <typeinfo>
@@ -2937,8 +2936,7 @@ public:
         if( rResult.size() != this->IntegrationPointsNumber( ThisMethod ) )
             rResult.resize( this->IntegrationPointsNumber( ThisMethod ), false );
 
-        for ( unsigned int pnt = 0; pnt < this->IntegrationPointsNumber( ThisMethod ); pnt++ )
-        {
+        for ( unsigned int pnt = 0; pnt < this->IntegrationPointsNumber( ThisMethod ); pnt++ ) {
             this->Jacobian( rResult[pnt], pnt, ThisMethod);
         }
 
@@ -2967,8 +2965,7 @@ public:
         if( rResult.size() != this->IntegrationPointsNumber( ThisMethod ) )
             rResult.resize( this->IntegrationPointsNumber( ThisMethod ), false );
 
-        for ( unsigned int pnt = 0; pnt < this->IntegrationPointsNumber( ThisMethod ); pnt++ )
-        {
+        for ( unsigned int pnt = 0; pnt < this->IntegrationPointsNumber( ThisMethod ); pnt++ ) {
             this->Jacobian( rResult[pnt], pnt, ThisMethod, DeltaPosition);
         }
         return rResult;
@@ -3188,9 +3185,8 @@ public:
         if( rResult.size() != this->IntegrationPointsNumber( ThisMethod ) )
             rResult.resize( this->IntegrationPointsNumber( ThisMethod ), false );
 
-        Matrix J;
-        for ( unsigned int pnt = 0; pnt < this->IntegrationPointsNumber( ThisMethod ); pnt++ )
-        {
+        Matrix J( this->WorkingSpaceDimension(), this->LocalSpaceDimension());
+        for ( unsigned int pnt = 0; pnt < this->IntegrationPointsNumber( ThisMethod ); pnt++ ) {
             this->Jacobian( J, pnt, ThisMethod);
             rResult[pnt] = MathUtils<double>::GeneralizedDet(J);
         }
@@ -3238,7 +3234,7 @@ public:
     */
     virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const
     {
-        Matrix J;
+        Matrix J( this->WorkingSpaceDimension(), this->LocalSpaceDimension());
         this->Jacobian( J, IntegrationPointIndex, ThisMethod);
         return MathUtils<double>::GeneralizedDet(J);
     }
@@ -3258,7 +3254,7 @@ public:
     */
     virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const
     {
-        Matrix J;
+        Matrix J( this->WorkingSpaceDimension(), this->LocalSpaceDimension());
         this->Jacobian( J, rPoint);
         return MathUtils<double>::GeneralizedDet(J);
     }
@@ -3301,8 +3297,7 @@ public:
 
         double detJ;
         Matrix Jinv(this->WorkingSpaceDimension(), this->WorkingSpaceDimension());
-        for ( unsigned int pnt = 0; pnt < this->IntegrationPointsNumber( ThisMethod ); pnt++ )
-        {
+        for ( unsigned int pnt = 0; pnt < this->IntegrationPointsNumber( ThisMethod ); pnt++ ) {
             MathUtils<double>::GeneralizedInvertMatrix(rResult[pnt], Jinv, detJ);
             noalias(rResult[pnt]) = Jinv;
         }
@@ -3905,7 +3900,6 @@ public:
     ///@name Friends
     ///@{
 
-
     ///@}
 
 protected:
@@ -3939,8 +3933,8 @@ protected:
      * @return The inradius to circumradius quality metric.
      */
     virtual double InradiusToCircumradiusQuality() const {
-      KRATOS_ERROR << "Calling base class 'InradiusToCircumradiusQuality' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-      return 0.0;
+        KRATOS_ERROR << "Calling base class 'InradiusToCircumradiusQuality' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+        return 0.0;
     }
 
     /** Calculates the minimum to maximum edge length quality metric.
@@ -3954,8 +3948,8 @@ protected:
      * @return The Inradius to Circumradius Quality metric.
      */
     virtual double AreaToEdgeLengthRatio() const {
-      KRATOS_ERROR << "Calling base class 'AreaToEdgeLengthRatio' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-      return 0.0;
+        KRATOS_ERROR << "Calling base class 'AreaToEdgeLengthRatio' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+        return 0.0;
     }
 
     /** Calculates the shortest altitude to edge length quality metric.
@@ -3969,8 +3963,8 @@ protected:
      * @return The shortest altitude to edge length quality metric.
      */
     virtual double ShortestAltitudeToEdgeLengthRatio() const {
-      KRATOS_ERROR << "Calling base class 'ShortestAltitudeToEdgeLengthRatio' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-      return 0.0;
+        KRATOS_ERROR << "Calling base class 'ShortestAltitudeToEdgeLengthRatio' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+        return 0.0;
     }
 
     /** Calculates the inradius to longest edge quality metric.
@@ -3984,8 +3978,8 @@ protected:
      * @return The inradius to longest edge quality metric.
      */
     virtual double InradiusToLongestEdgeQuality() const {
-      KRATOS_ERROR << "Calling base class 'InradiusToLongestEdgeQuality' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-      return 0.0;
+        KRATOS_ERROR << "Calling base class 'InradiusToLongestEdgeQuality' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+        return 0.0;
     }
 
     /** Calculates the shortest to longest edge quality metric.
@@ -3999,8 +3993,8 @@ protected:
      * @return [description]
      */
     virtual double ShortestToLongestEdgeQuality() const {
-      KRATOS_ERROR << "Calling base class 'ShortestToLongestEdgeQuality' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-      return 0.0;
+        KRATOS_ERROR << "Calling base class 'ShortestToLongestEdgeQuality' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+        return 0.0;
     }
 
     /** Calculates the Regularity quality metric.
@@ -4015,8 +4009,8 @@ protected:
      * @return regularity quality.
      */
     virtual double RegularityQuality() const {
-      KRATOS_ERROR << "Calling base class 'RegularityQuality' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-      return 0.0;
+        KRATOS_ERROR << "Calling base class 'RegularityQuality' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+        return 0.0;
     }
 
     /** Calculates the volume to surface area quality metric.
@@ -4031,8 +4025,8 @@ protected:
      * @return volume to surface quality.
      */
     virtual double VolumeToSurfaceAreaQuality() const {
-      KRATOS_ERROR << "Calling base class 'VolumeToSurfaceAreaQuality' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-      return 0.0;
+        KRATOS_ERROR << "Calling base class 'VolumeToSurfaceAreaQuality' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+        return 0.0;
     }
 
     /** Calculates the Volume to edge length quaility metric.
@@ -4047,8 +4041,8 @@ protected:
      * @return Volume to edge length quality.
      */
     virtual double VolumeToEdgeLengthQuality() const {
-      KRATOS_ERROR << "Calling base class 'VolumeToEdgeLengthQuality' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-      return 0.0;
+        KRATOS_ERROR << "Calling base class 'VolumeToEdgeLengthQuality' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+        return 0.0;
     }
 
     /** Calculates the volume to average edge lenght quality metric.
@@ -4063,8 +4057,8 @@ protected:
      * @return [description]
      */
     virtual double VolumeToAverageEdgeLength() const {
-      KRATOS_ERROR << "Calling base class 'VolumeToAverageEdgeLength' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-      return 0.0;
+        KRATOS_ERROR << "Calling base class 'VolumeToAverageEdgeLength' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+        return 0.0;
     }
 
     /** Calculates the volume to average edge length quality metric.
@@ -4080,8 +4074,8 @@ protected:
      * @return [description]
      */
     virtual double VolumeToRMSEdgeLength() const {
-      KRATOS_ERROR << "Calling base class 'VolumeToRMSEdgeLength' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-      return 0.0;
+        KRATOS_ERROR << "Calling base class 'VolumeToRMSEdgeLength' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+        return 0.0;
     }
 
     /** Calculates the min dihedral angle quality metric.
@@ -4091,8 +4085,8 @@ protected:
      * @return [description]
      */
     virtual double MinDihedralAngle() const {
-      KRATOS_ERROR << "Calling base class 'MinDihedralAngle' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-      return 0.0;
+        KRATOS_ERROR << "Calling base class 'MinDihedralAngle' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+        return 0.0;
     }
 
     /** Calculates the max dihedral angle quality metric.
@@ -4113,19 +4107,17 @@ protected:
      * @return [description]
      */
     virtual double MinSolidAngle() const {
-      KRATOS_ERROR << "Calling base class 'MinSolidAngle' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
-      return 0.0;
+        KRATOS_ERROR << "Calling base class 'MinSolidAngle' method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
+        return 0.0;
     }
 
     ///@}
     ///@name Protected  Access
     ///@{
 
-
     ///@}
     ///@name Protected Inquiry
     ///@{
-
 
     ///@}
     ///@name Protected LifeCycle
@@ -4135,11 +4127,7 @@ protected:
     Avoids object to be created Except for derived classes
     */
 
-
     ///@}
-
-
-
 private:
     ///@name Member Variables
     ///@{
@@ -4316,5 +4304,3 @@ const GeometryDimension Geometry<TPointType>::msGeometryDimension(
     3, 3, 3);
 
 }  // namespace Kratos.
-
-#endif // KRATOS_GEOMETRY_H_INCLUDED  defined

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -3296,7 +3296,7 @@ public:
         Jacobian(rResult, ThisMethod); //this will be overwritten
 
         double detJ;
-        Matrix Jinv(this->WorkingSpaceDimension(), this->WorkingSpaceDimension());
+        Matrix Jinv(this->LocalSpaceDimension(), this->WorkingSpaceDimension());
         for ( unsigned int pnt = 0; pnt < this->IntegrationPointsNumber( ThisMethod ); pnt++ ) {
             MathUtils<double>::GeneralizedInvertMatrix(rResult[pnt], Jinv, detJ);
             noalias(rResult[pnt]) = Jinv;

--- a/kratos/geometries/geometry_data.h
+++ b/kratos/geometries/geometry_data.h
@@ -422,7 +422,7 @@ public:
     ///@name Integration
     ///@{
 
-    /** Number of integtation points for default integration
+    /** Number of integration points for default integration
     method. This method just call IntegrationPointsNumber(enum
     IntegrationMethod ThisMethod) with default integration
     method.

--- a/kratos/geometries/hexahedra_3d_20.h
+++ b/kratos/geometries/hexahedra_3d_20.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Janosch Stascheit
@@ -14,8 +14,7 @@
 //                   Josep Maria Carbonell
 //
 
-#if !defined(KRATOS_HEXAHEDRA_3D_20_H_INCLUDED )
-#define  KRATOS_HEXAHEDRA_3D_20_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -23,6 +22,7 @@
 
 // Project includes
 #include "geometries/quadrilateral_3d_8.h"
+#include "utilities/integration_utilities.h"
 #include "integration/hexahedron_gauss_legendre_integration_points.h"
 
 namespace Kratos
@@ -441,27 +441,18 @@ public:
 
     }
 
-
-
-    double Volume() const override //Not a closed formula for a hexahedra
+    /** 
+     * @brief This method calculate and return volume of this geometry. 
+     * @details For one and two dimensional geometry it returns zero and for three dimensional it gives volume of geometry.
+     * @return double value contains volume.
+     * @see Length()
+     * @see Area()
+     * @see DomainSize()
+     */
+    double Volume() const override
     {
-
-        Vector temp;
-        this->DeterminantOfJacobian( temp, msGeometryData.DefaultIntegrationMethod() );
-        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints( msGeometryData.DefaultIntegrationMethod() );
-        double Volume = 0.00;
-
-        for ( unsigned int i = 0; i < integration_points.size(); i++ )
-        {
-            Volume += temp[i] * integration_points[i].Weight();
-        }
-
-        //KRATOS_WATCH(temp)
-        return Volume;
+        return IntegrationUtilities::ComputeVolume3DGeometry(*this);
     }
-
-
-
 
     /**
      * This method calculate and return length, area or volume of
@@ -1619,5 +1610,3 @@ GeometryDimension Hexahedra3D20<TPointType>::msGeometryDimension(
     3, 3, 3);
 
 }// namespace Kratos.
-
-#endif // KRATOS_HEXAHEDRA_3D_20_H_INCLUDED  defined

--- a/kratos/geometries/hexahedra_3d_27.h
+++ b/kratos/geometries/hexahedra_3d_27.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Janosch Stascheit
@@ -14,8 +14,7 @@
 //                   Josep Maria Carbonell
 //
 
-#if !defined(KRATOS_HEXAHEDRA_3D_27_H_INCLUDED )
-#define  KRATOS_HEXAHEDRA_3D_27_H_INCLUDED
+#pragma once 
 
 // System includes
 
@@ -23,8 +22,8 @@
 
 // Project includes
 #include "geometries/quadrilateral_3d_9.h"
+#include "utilities/integration_utilities.h"
 #include "integration/hexahedron_gauss_legendre_integration_points.h"
-
 
 namespace Kratos
 {
@@ -466,27 +465,18 @@ public:
         return Volume();
     }
 
-
-
-    double Volume() const override  //Not a closed formula for a hexahedra
+    /** 
+     * @brief This method calculate and return volume of this geometry. 
+     * @details For one and two dimensional geometry it returns zero and for three dimensional it gives volume of geometry.
+     * @return double value contains volume.
+     * @see Length()
+     * @see Area()
+     * @see DomainSize()
+     */
+    double Volume() const override
     {
-
-        Vector temp;
-        this->DeterminantOfJacobian( temp, msGeometryData.DefaultIntegrationMethod() );
-        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints( msGeometryData.DefaultIntegrationMethod() );
-        double Volume = 0.00;
-
-        for ( unsigned int i = 0; i < integration_points.size(); i++ )
-        {
-            Volume += temp[i] * integration_points[i].Weight();
-        }
-
-        //KRATOS_WATCH(temp)
-        return Volume;
+        return IntegrationUtilities::ComputeVolume3DGeometry(*this);
     }
-
-
-
 
     /**
      * This method calculate and return length, area or volume of
@@ -1492,5 +1482,3 @@ const GeometryDimension Hexahedra3D27<TPointType>::msGeometryDimension(
     3, 3, 3);
 
 }// namespace Kratos.
-
-#endif // KRATOS_HEXAHEDRA_3D_27_H_INCLUDED  defined

--- a/kratos/geometries/hexahedra_3d_8.h
+++ b/kratos/geometries/hexahedra_3d_8.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Janosch Stascheit
@@ -15,8 +15,7 @@
 //                   Bodhinanda Chandra
 //
 
-#if !defined(KRATOS_HEXAHEDRA_3D_8_H_INCLUDED )
-#define  KRATOS_HEXAHEDRA_3D_8_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -24,6 +23,7 @@
 
 // Project includes
 #include "geometries/quadrilateral_3d_4.h"
+#include "utilities/integration_utilities.h"
 #include "integration/hexahedron_gauss_legendre_integration_points.h"
 #include "integration/hexahedron_gauss_lobatto_integration_points.h"
 
@@ -387,7 +387,7 @@ public:
      */
     double Length() const override
     {
-        return sqrt( fabs( this->DeterminantOfJacobian( PointType() ) ) );
+        return std::sqrt( std::abs( this->DeterminantOfJacobian( PointType() ) ) );
     }
 
     /**
@@ -409,21 +409,18 @@ public:
         return Volume();
     }
 
-    double Volume() const override //Not a closed formula for a hexahedra
+    /** 
+     * @brief This method calculate and return volume of this geometry. 
+     * @details For one and two dimensional geometry it returns zero and for three dimensional it gives volume of geometry.
+     * @return double value contains volume.
+     * @see Length()
+     * @see Area()
+     * @see DomainSize()
+     */
+    double Volume() const override
     {
-        Vector temp;
-        this->DeterminantOfJacobian( temp, msGeometryData.DefaultIntegrationMethod() );
-        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints( msGeometryData.DefaultIntegrationMethod() );
-        double Volume = 0.00;
-
-        for ( unsigned int i = 0; i < integration_points.size(); i++ )
-        {
-            Volume += temp[i] * integration_points[i].Weight();
-        }
-
-        return Volume;
+        return IntegrationUtilities::ComputeVolume3DGeometry(*this);
     }
-
 
     /**
      * This method calculate and return length, area or volume of
@@ -504,12 +501,9 @@ public:
     {
         this->PointLocalCoordinates( rResult, rPoint );
 
-        if ( std::abs( rResult[0] ) <= (1.0 + Tolerance) )
-        {
-            if ( std::abs( rResult[1] ) <= (1.0 + Tolerance) )
-            {
-                if ( std::abs( rResult[2] ) <= (1.0 + Tolerance) )
-                {
+        if ( std::abs( rResult[0] ) <= (1.0 + Tolerance) ) {
+            if ( std::abs( rResult[1] ) <= (1.0 + Tolerance) ) {
+                if ( std::abs( rResult[2] ) <= (1.0 + Tolerance) ) {
                     return true;
                 }
             }
@@ -666,7 +660,6 @@ public:
 
         return false;
     }
-
 
     /**
      * Shape Function
@@ -882,7 +875,6 @@ public:
 
         return rResult;
     }
-
 
     /**
      * Input and output
@@ -1288,5 +1280,3 @@ GeometryDimension Hexahedra3D8<TPointType>::msGeometryDimension(
     3, 3, 3);
 
 }// namespace Kratos.
-
-#endif // KRATOS_HEXAHEDRA_3D_8_H_INCLUDED  defined

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -350,8 +350,7 @@ public:
     double Length() const override
     {
         const IntegrationMethod integration_method = IntegrationUtilities::GetIntegrationMethodForExactMassMatrixEvaluation(*this);
-        const IntegrationPointsArrayType& r_integration_points = this->IntegrationPoints( integration_method );
-        return IntegrationUtilities::ComputeDomainSize(*this, r_integration_points);
+        return IntegrationUtilities::ComputeDomainSize(*this, integration_method);
     }
 
     /** This method calculate and return area or surface area of

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Janosch Stascheit
@@ -349,17 +349,9 @@ public:
     */
     double Length() const override
     {
-        Vector temp;
         const IntegrationMethod integration_method = IntegrationUtilities::GetIntegrationMethodForExactMassMatrixEvaluation(*this);
-        this->DeterminantOfJacobian( temp, integration_method );
         const IntegrationPointsArrayType& r_integration_points = this->IntegrationPoints( integration_method );
-        double length = 0.0;
-
-        for (std::size_t i = 0; i < r_integration_points.size(); ++i) {
-            length += temp[i] * r_integration_points[i].Weight();
-        }
-
-        return length;
+        return IntegrationUtilities::ComputeDomainSize(*this, r_integration_points);
     }
 
     /** This method calculate and return area or surface area of

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -341,8 +341,7 @@ public:
     double Length() const override
     {
         const IntegrationMethod integration_method = IntegrationUtilities::GetIntegrationMethodForExactMassMatrixEvaluation(*this);
-        const IntegrationPointsArrayType& r_integration_points = this->IntegrationPoints( integration_method );
-        return IntegrationUtilities::ComputeDomainSize(*this, r_integration_points);
+        return IntegrationUtilities::ComputeDomainSize(*this, integration_method);
     }
 
     /** This method calculate and return area or surface area of

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -340,17 +340,9 @@ public:
     */
     double Length() const override
     {
-        Vector temp;
         const IntegrationMethod integration_method = IntegrationUtilities::GetIntegrationMethodForExactMassMatrixEvaluation(*this);
-        this->DeterminantOfJacobian( temp, integration_method );
         const IntegrationPointsArrayType& r_integration_points = this->IntegrationPoints( integration_method );
-        double length = 0.0;
-
-        for (std::size_t i = 0; i < r_integration_points.size(); ++i) {
-            length += temp[i] * r_integration_points[i].Weight();
-        }
-
-        return length;
+        return IntegrationUtilities::ComputeDomainSize(*this, r_integration_points);
     }
 
     /** This method calculate and return area or surface area of

--- a/kratos/geometries/prism_3d_15.h
+++ b/kratos/geometries/prism_3d_15.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Janosch Stascheit
@@ -15,8 +15,7 @@
 //                   Vicente Mataix Ferrandiz
 //
 
-#if !defined(KRATOS_PRISM_3D_15_H_INCLUDED )
-#define  KRATOS_PRISM_3D_15_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -25,6 +24,7 @@
 // Project includes
 #include "geometries/triangle_3d_6.h"
 #include "geometries/quadrilateral_3d_8.h"
+#include "utilities/integration_utilities.h"
 #include "integration/prism_gauss_legendre_integration_points.h"
 
 namespace Kratos
@@ -380,31 +380,17 @@ public:
         return this->Volume();
     }
 
-    /**
-     * This method calculates and returns the volume of this geometry.
-     * This method calculates and returns the volume of this geometry.
-     *
-     * This method uses the V = (A x B) * C / 6 formula.
-     *
-     * @return double value contains length, area or volume.
-     *
+    /** 
+     * @brief This method calculate and return volume of this geometry. 
+     * @details For one and two dimensional geometry it returns zero and for three dimensional it gives volume of geometry.
+     * @return double value contains volume.
      * @see Length()
      * @see Area()
-     * @see Volume()
-     *
+     * @see DomainSize()
      */
     double Volume() const override
     {
-        Vector temp;
-        this->DeterminantOfJacobian( temp, msGeometryData.DefaultIntegrationMethod() );
-        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints( msGeometryData.DefaultIntegrationMethod() );
-        double volume = 0.0;
-
-        for ( unsigned int i = 0; i < integration_points.size(); i++ ) {
-            volume += temp[i] * integration_points[i].Weight();
-        }
-
-        return volume;
+        return IntegrationUtilities::ComputeVolume3DGeometry(*this);
     }
 
     double Area() const override
@@ -1127,5 +1113,3 @@ GeometryDimension Prism3D15<TPointType>::msGeometryDimension(
     3, 3, 3);
 
 }// namespace Kratos.
-
-#endif // KRATOS_PRISM_3D_15_H_INCLUDED  defined

--- a/kratos/geometries/prism_3d_6.h
+++ b/kratos/geometries/prism_3d_6.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Janosch Stascheit
@@ -14,8 +14,7 @@
 //                   Josep Maria Carbonell
 //
 
-#if !defined(KRATOS_PRISM_3D_6_H_INCLUDED )
-#define  KRATOS_PRISM_3D_6_H_INCLUDED
+#pragma once 
 
 // System includes
 
@@ -24,6 +23,7 @@
 // Project includes
 #include "geometries/triangle_3d_3.h"
 #include "geometries/quadrilateral_3d_4.h"
+#include "utilities/integration_utilities.h"
 #include "integration/prism_gauss_legendre_integration_points.h"
 
 namespace Kratos
@@ -406,33 +406,17 @@ public:
         return std::abs( this->DeterminantOfJacobian( PointType() ) ) * 0.5;
     }
 
-
-    /**
-     * This method calculates and returns the volume of this geometry.
-     * This method calculates and returns the volume of this geometry.
-     *
-     * This method uses the V = (A x B) * C / 6 formula.
-     *
-     * @return double value contains length, area or volume.
-     *
+    /** 
+     * @brief This method calculate and return volume of this geometry. 
+     * @details For one and two dimensional geometry it returns zero and for three dimensional it gives volume of geometry.
+     * @return double value contains volume.
      * @see Length()
      * @see Area()
-     * @see Volume()
-     *
-     * :TODO: might be necessary to reimplement
+     * @see DomainSize()
      */
     double Volume() const override
     {
-        Vector temp;
-        this->DeterminantOfJacobian( temp, msGeometryData.DefaultIntegrationMethod() );
-        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints( msGeometryData.DefaultIntegrationMethod() );
-        double volume = 0.0;
-
-        for ( unsigned int i = 0; i < integration_points.size(); i++ ) {
-            volume += temp[i] * integration_points[i].Weight();
-        }
-
-        return volume;
+        return IntegrationUtilities::ComputeVolume3DGeometry(*this);
     }
 
     /**
@@ -1096,5 +1080,3 @@ GeometryDimension Prism3D6<TPointType>::msGeometryDimension(
     3, 3, 3);
 
 }// namespace Kratos.
-
-#endif // KRATOS_PRISM_3D_6_H_INCLUDED  defined

--- a/kratos/geometries/pyramid_3d_13.h
+++ b/kratos/geometries/pyramid_3d_13.h
@@ -10,8 +10,7 @@
 //  Main authors:    Philipp Bucher (https://github.com/philbucher)
 //                   Ashish Darekar
 
-#if !defined (KRATOS_PYRAMID_3D_13_H_INCLUDED)
-#define KRATOS_PYRAMID_3D_13_H_INCLUDED
+#pragma once
 
 // System includes
 #include <cmath> // std::abs for double
@@ -21,8 +20,8 @@
 // Project includes
 #include "includes/define.h"
 #include "geometries/geometry.h"
+#include "utilities/integration_utilities.h"
 #include "integration/pyramid_gauss_legendre_integration_points.h"
-
 
 namespace Kratos {
 
@@ -334,27 +333,17 @@ public:
         return 5;
     }
 
-    /** This method calculate and return volume of this
-     geometry. For one and two dimensional geometry it returns
-    zero and for three dimensional it gives volume of geometry.
-
-    @return double value contains volume.
-    @see Length()
-    @see Area()
-    @see DomainSize()
-    */
+    /** 
+     * @brief This method calculate and return volume of this geometry. 
+     * @details For one and two dimensional geometry it returns zero and for three dimensional it gives volume of geometry.
+     * @return double value contains volume.
+     * @see Length()
+     * @see Area()
+     * @see DomainSize()
+     */
     double Volume() const override
     {
-        Vector temp;
-        this->DeterminantOfJacobian(temp, msGeometryData.DefaultIntegrationMethod());
-        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints(msGeometryData.DefaultIntegrationMethod());
-        double vol = 0.00;
-
-        for (std::size_t i=0; i<integration_points.size(); ++i) {
-            vol += temp[i] * integration_points[i].Weight();
-        }
-
-        return vol;
+        return IntegrationUtilities::ComputeVolume3DGeometry(*this);
     }
 
     /**
@@ -881,5 +870,3 @@ GeometryDimension Pyramid3D13<TPointType>::msGeometryDimension(
     3, 3, 3);
 
 }  // namespace Kratos.
-
-#endif // KRATOS_PYRAMID_3D_13_H_INCLUDED defined

--- a/kratos/geometries/pyramid_3d_5.h
+++ b/kratos/geometries/pyramid_3d_5.h
@@ -5,14 +5,13 @@
 //                   Multi-Physics
 //
 //  License:         BSD License
-//	                 Kratos default license: kratos/license.txt
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher (https://github.com/philbucher)
 //                   Ashish Darekar
 //
 
-#if !defined (KRATOS_PYRAMID_3D_5_H_INCLUDED)
-#define KRATOS_PYRAMID_3D_5_H_INCLUDED
+#pragma once
 
 // System includes
 #include <cmath> // std::abs for double
@@ -22,8 +21,8 @@
 // Project includes
 #include "includes/define.h"
 #include "geometries/geometry.h"
+#include "utilities/integration_utilities.h"
 #include "integration/pyramid_gauss_legendre_integration_points.h"
-
 
 namespace Kratos {
 
@@ -318,27 +317,17 @@ public:
         return 5;
     }
 
-    /** This method calculate and return volume of this
-     geometry. For one and two dimensional geometry it returns
-    zero and for three dimensional it gives volume of geometry.
-
-    @return double value contains volume.
-    @see Length()
-    @see Area()
-    @see DomainSize()
-    */
+    /** 
+     * @brief This method calculate and return volume of this geometry. 
+     * @details For one and two dimensional geometry it returns zero and for three dimensional it gives volume of geometry.
+     * @return double value contains volume.
+     * @see Length()
+     * @see Area()
+     * @see DomainSize()
+     */
     double Volume() const override
     {
-        Vector temp;
-        this->DeterminantOfJacobian(temp, msGeometryData.DefaultIntegrationMethod());
-        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints(msGeometryData.DefaultIntegrationMethod());
-        double vol = 0.00;
-
-        for (std::size_t i=0; i<integration_points.size(); ++i) {
-            vol += temp[i] * integration_points[i].Weight();
-        }
-
-        return vol;
+        return IntegrationUtilities::ComputeVolume3DGeometry(*this);
     }
 
     /**
@@ -785,5 +774,3 @@ GeometryDimension Pyramid3D5<TPointType>::msGeometryDimension(
     3, 3, 3);
 
 }  // namespace Kratos.
-
-#endif // KRATOS_PYRAMID_3D_5_H_INCLUDED defined

--- a/kratos/geometries/quadrature_point_geometry.h
+++ b/kratos/geometries/quadrature_point_geometry.h
@@ -338,7 +338,7 @@ public:
     /// Returns the domain size of this quadrature point.
     double DomainSize() const override
     {
-        return IntegrationUtilities::ComputeDomainSize(*this, this->IntegrationPoints());
+        return IntegrationUtilities::ComputeDomainSize(*this);
     }
 
     /**

--- a/kratos/geometries/quadrature_point_geometry.h
+++ b/kratos/geometries/quadrature_point_geometry.h
@@ -10,8 +10,7 @@
 //  Main authors:    Tobias Teschemacher
 //
 
-#if !defined(KRATOS_QUADRATURE_POINT_GEOMETRY_H_INCLUDED )
-#define  KRATOS_QUADRATURE_POINT_GEOMETRY_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -21,6 +20,7 @@
 #include "includes/variables.h"
 #include "geometries/geometry.h"
 #include "geometries/geometry_dimension.h"
+#include "utilities/integration_utilities.h"
 
 namespace Kratos
 {
@@ -338,15 +338,7 @@ public:
     /// Returns the domain size of this quadrature point.
     double DomainSize() const override
     {
-        Vector temp;
-        temp = this->DeterminantOfJacobian(temp);
-        const IntegrationPointsArrayType& r_integration_points = this->IntegrationPoints();
-        double domain_size = 0.0;
-
-        for (std::size_t i = 0; i < r_integration_points.size(); ++i) {
-            domain_size += temp[i] * r_integration_points[i].Weight();
-        }
-        return domain_size;
+        return IntegrationUtilities::ComputeDomainSize(*this, this->IntegrationPoints());
     }
 
     /**
@@ -684,5 +676,3 @@ const GeometryDimension QuadraturePointGeometry<
 ///@}
 
 }  // namespace Kratos.
-
-#endif // KRATOS_QUADRATURE_POINT_GEOMETRY_H_INCLUDED  defined

--- a/kratos/geometries/quadrilateral_2d_4.h
+++ b/kratos/geometries/quadrilateral_2d_4.h
@@ -14,9 +14,7 @@
 //                   Josep Maria Carbonell
 //
 
-
-#if !defined(KRATOS_QUADRILATERAL_2D_4_H_INCLUDED )
-#define  KRATOS_QUADRILATERAL_2D_4_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -25,6 +23,7 @@
 // Project includes
 #include "geometries/line_2d_2.h"
 #include "geometries/triangle_2d_3.h"
+#include "utilities/integration_utilities.h"
 #include "integration/quadrilateral_gauss_legendre_integration_points.h"
 #include "integration/quadrilateral_collocation_integration_points.h"
 
@@ -449,16 +448,7 @@ public:
      */
     double Area() const override
     {
-        Vector temp;
-        this->DeterminantOfJacobian( temp, msGeometryData.DefaultIntegrationMethod() );
-        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints( msGeometryData.DefaultIntegrationMethod() );
-        double area = 0.0;
-
-        for ( unsigned int i = 0; i < integration_points.size(); i++ ) {
-            area += temp[i] * integration_points[i].Weight();
-        }
-
-        return area;
+        return IntegrationUtilities::ComputeArea2DGeometry(*this);
     }
 
     /**
@@ -1168,5 +1158,3 @@ GeometryDimension Quadrilateral2D4<TPointType>::msGeometryDimension(
     2, 2, 2);
 
 }// namespace Kratos.
-
-#endif // KRATOS_QUADRILATERAL_2D_4_H_INCLUDED  defined

--- a/kratos/geometries/quadrilateral_2d_8.h
+++ b/kratos/geometries/quadrilateral_2d_8.h
@@ -14,9 +14,7 @@
 //                   Josep Maria Carbonell
 //
 
-#if !defined(KRATOS_QUADRILATERAL_2D_8_H_INCLUDED )
-#define  KRATOS_QUADRILATERAL_2D_8_H_INCLUDED
-
+#pragma once 
 
 // System includes
 
@@ -24,8 +22,8 @@
 
 // Project includes
 #include "geometries/line_2d_3.h"
+#include "utilities/integration_utilities.h"
 #include "integration/quadrilateral_gauss_legendre_integration_points.h"
-
 
 namespace Kratos
 {
@@ -423,16 +421,7 @@ public:
      */
     double Area() const override
     {
-        Vector temp;
-        this->DeterminantOfJacobian( temp, msGeometryData.DefaultIntegrationMethod() );
-        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints( msGeometryData.DefaultIntegrationMethod() );
-        double area = 0.0;
-
-        for ( unsigned int i = 0; i < integration_points.size(); i++ ) {
-            area += temp[i] * integration_points[i].Weight();
-        }
-
-        return area;
+        return IntegrationUtilities::ComputeArea2DGeometry(*this);
     }
 
     // TODO: Code activated in June 2023
@@ -702,9 +691,6 @@ public:
     }
 
     /**
-     * TODO: implemented but not yet tested
-     */
-    /**
      * Determinant of jacobians for given integration method.
      * This method calculate determinant of jacobian in all
      * integrations points of given integration method.
@@ -721,21 +707,14 @@ public:
         IntegrationMethod ThisMethod
         ) const override
     {
-        // Workaround by riccardo
-        if ( rResult.size() != this->IntegrationPointsNumber( ThisMethod ) )
-        {
-            // KLUDGE: While there is a bug in ublas
-            // vector resize, I have to put this beside resizing!!
-            Vector temp( this->IntegrationPointsNumber( ThisMethod ) );
-            rResult.swap( temp );
-        }
+        if( rResult.size() != this->IntegrationPointsNumber( ThisMethod ) )
+            rResult.resize( this->IntegrationPointsNumber( ThisMethod ), false );
 
-        //for all integration points
-        for ( unsigned int pnt = 0; pnt < this->IntegrationPointsNumber( ThisMethod ); pnt++ )
-        {
-            rResult[pnt] = DeterminantOfJacobian( pnt, ThisMethod );
+        Matrix J( this->WorkingSpaceDimension(), this->LocalSpaceDimension());
+        for ( unsigned int pnt = 0; pnt < this->IntegrationPointsNumber( ThisMethod ); pnt++ ) {
+            this->Jacobian( J, pnt, ThisMethod);
+            rResult[pnt] = (( J( 0, 0 )*J( 1, 1 ) ) - ( J( 0, 1 )*J( 1, 0 ) ) );
         }
-
         return rResult;
     }
 
@@ -763,7 +742,7 @@ public:
      */
     double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
-        Matrix jacobian = ZeroMatrix( 2, 2 );
+        Matrix jacobian( 2, 2 );
         jacobian = Jacobian( jacobian, IntegrationPointIndex, ThisMethod );
         return(( jacobian( 0, 0 )*jacobian( 1, 1 ) ) - ( jacobian( 0, 1 )*jacobian( 1, 0 ) ) );
     }
@@ -787,7 +766,7 @@ public:
      */
     double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
     {
-        Matrix jacobian = ZeroMatrix( 2, 2 );
+        Matrix jacobian( 2, 2 );
         jacobian = Jacobian( jacobian, rPoint );
         return(( jacobian( 0, 0 )*jacobian( 1, 1 ) ) - ( jacobian( 0, 1 )*jacobian( 1, 0 ) ) );
     }
@@ -1777,5 +1756,3 @@ const GeometryDimension Quadrilateral2D8<TPointType>::msGeometryDimension(
     2, 2, 2);
 
 }  // namespace Kratos.
-
-#endif // KRATOS_QUADRILATERAL_2D_8_H_INCLUDED  defined

--- a/kratos/geometries/quadrilateral_2d_9.h
+++ b/kratos/geometries/quadrilateral_2d_9.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Janosch Stascheit
@@ -14,8 +14,7 @@
 //                   Josep Maria Carbonell
 //
 
-#if !defined(KRATOS_QUADRILATERAL_2D_9_H_INCLUDED )
-#define  KRATOS_QUADRILATERAL_2D_9_H_INCLUDED
+#pragma once 
 
 // System includes
 
@@ -23,6 +22,7 @@
 
 // Project includes
 #include "geometries/line_2d_3.h"
+#include "utilities/integration_utilities.h"
 #include "integration/quadrilateral_gauss_legendre_integration_points.h"
 
 
@@ -405,7 +405,7 @@ public:
      */
     double Length() const override
     {
-        return sqrt( fabs( this->DeterminantOfJacobian( PointType() ) ) );
+        return std::sqrt( std::abs( this->DeterminantOfJacobian( PointType() ) ) );
     }
 
     /** This method calculates and returns area or surface area of
@@ -422,16 +422,7 @@ public:
      */
     double Area() const override
     {
-        Vector temp;
-        this->DeterminantOfJacobian( temp, msGeometryData.DefaultIntegrationMethod() );
-        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints( msGeometryData.DefaultIntegrationMethod() );
-        double Area = 0.0;
-
-        for ( unsigned int i = 0; i < integration_points.size(); i++ ) {
-            Area += temp[i] * integration_points[i].Weight();
-        }
-
-        return Area;
+        return IntegrationUtilities::ComputeArea2DGeometry(*this);
     }
 
     /**
@@ -482,10 +473,8 @@ public:
     {
         this->PointLocalCoordinates( rResult, rPoint );
 
-        if ( (rResult[0] >= (-1.0-Tolerance)) && (rResult[0] <= (1.0+Tolerance)) )
-        {
-            if ( (rResult[1] >= (-1.0-Tolerance)) && (rResult[1] <= (1.0+Tolerance)) )
-            {
+        if ( (rResult[0] >= (-1.0-Tolerance)) && (rResult[0] <= (1.0+Tolerance)) ) {
+            if ( (rResult[1] >= (-1.0-Tolerance)) && (rResult[1] <= (1.0+Tolerance)) ) {
                 return true;
             }
         }
@@ -1326,5 +1315,3 @@ const GeometryDimension Quadrilateral2D9<TPointType>::msGeometryDimension(
     2, 2, 2);
 
 }  // namespace Kratos.
-
-#endif // KRATOS_QUADRILATERAL_2D_9_H_INCLUDED  defined

--- a/kratos/geometries/quadrilateral_3d_4.h
+++ b/kratos/geometries/quadrilateral_3d_4.h
@@ -454,8 +454,7 @@ public:
     double Area() const override
     {
         const IntegrationMethod integration_method = msGeometryData.DefaultIntegrationMethod();
-        const IntegrationPointsArrayType& r_integration_points = this->IntegrationPoints( integration_method );
-        return IntegrationUtilities::ComputeDomainSize(*this, r_integration_points);
+        return IntegrationUtilities::ComputeDomainSize(*this, integration_method);
     }
 
     /**

--- a/kratos/geometries/quadrilateral_3d_4.h
+++ b/kratos/geometries/quadrilateral_3d_4.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Janosch Stascheit
@@ -15,8 +15,7 @@
 //                   Bodhinanda Chandra
 //
 
-#if !defined(KRATOS_QUADRILATERAL_3D_4_H_INCLUDED )
-#define  KRATOS_QUADRILATERAL_3D_4_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -25,6 +24,7 @@
 // Project includes
 #include "geometries/line_3d_2.h"
 #include "geometries/triangle_3d_3.h"
+#include "utilities/integration_utilities.h"
 #include "integration/quadrilateral_gauss_legendre_integration_points.h"
 #include "integration/quadrilateral_collocation_integration_points.h"
 #include "utilities/geometrical_projection_utilities.h"
@@ -453,16 +453,9 @@ public:
      */
     double Area() const override
     {
-        Vector temp;
-        this->DeterminantOfJacobian( temp, GeometryData::IntegrationMethod::GI_GAUSS_3 );
-        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints( GeometryData::IntegrationMethod::GI_GAUSS_3 );
-        double area = 0.0;
-
-        for ( unsigned int i = 0; i < integration_points.size(); i++ ) {
-            area += temp[i] * integration_points[i].Weight();
-        }
-
-        return area;
+        const IntegrationMethod integration_method = msGeometryData.DefaultIntegrationMethod();
+        const IntegrationPointsArrayType& r_integration_points = this->IntegrationPoints( integration_method );
+        return IntegrationUtilities::ComputeDomainSize(*this, r_integration_points);
     }
 
     /**
@@ -1923,5 +1916,3 @@ const GeometryDimension Quadrilateral3D4<TPointType>::msGeometryDimension(
     2, 3, 2);
 
 }// namespace Kratos.
-
-#endif // KRATOS_QUADRILATERAL_3D_4_H_INCLUDED  defined

--- a/kratos/geometries/quadrilateral_3d_8.h
+++ b/kratos/geometries/quadrilateral_3d_8.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Janosch Stascheit
@@ -14,8 +14,7 @@
 //                   Josep Maria Carbonell
 //
 
-#if !defined(KRATOS_QUADRILATERAL_3D_8_H_INCLUDED )
-#define  KRATOS_QUADRILATERAL_3D_8_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -23,8 +22,8 @@
 
 // Project includes
 #include "geometries/line_3d_3.h"
+#include "utilities/integration_utilities.h"
 #include "integration/quadrilateral_gauss_legendre_integration_points.h"
-
 
 namespace Kratos
 {
@@ -413,16 +412,9 @@ public:
      */
     double Area() const override
     {
-        Vector temp;
-        this->DeterminantOfJacobian( temp, msGeometryData.DefaultIntegrationMethod() );
-        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints( msGeometryData.DefaultIntegrationMethod() );
-        double Area = 0.0;
-
-        for ( unsigned int i = 0; i < integration_points.size(); i++ ) {
-            Area += temp[i] * integration_points[i].Weight();
-        }
-
-        return Area;
+        const IntegrationMethod integration_method = msGeometryData.DefaultIntegrationMethod();
+        const IntegrationPointsArrayType& r_integration_points = this->IntegrationPoints( integration_method );
+        return IntegrationUtilities::ComputeDomainSize(*this, r_integration_points);
     }
 
     /**
@@ -1702,5 +1694,3 @@ const GeometryDimension Quadrilateral3D8<TPointType>::msGeometryDimension(
     2, 3, 2);
 
 }  // namespace Kratos.
-
-#endif // KRATOS_QUADRILATERAL_3D_8_H_INCLUDED  defined

--- a/kratos/geometries/quadrilateral_3d_8.h
+++ b/kratos/geometries/quadrilateral_3d_8.h
@@ -413,8 +413,7 @@ public:
     double Area() const override
     {
         const IntegrationMethod integration_method = msGeometryData.DefaultIntegrationMethod();
-        const IntegrationPointsArrayType& r_integration_points = this->IntegrationPoints( integration_method );
-        return IntegrationUtilities::ComputeDomainSize(*this, r_integration_points);
+        return IntegrationUtilities::ComputeDomainSize(*this, integration_method);
     }
 
     /**

--- a/kratos/geometries/quadrilateral_3d_9.h
+++ b/kratos/geometries/quadrilateral_3d_9.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Janosch Stascheit
@@ -14,8 +14,7 @@
 //                   Josep Maria Carbonell
 //
 
-#if !defined(KRATOS_QUADRILATERAL_3D_9_H_INCLUDED )
-#define  KRATOS_QUADRILATERAL_3D_9_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -23,8 +22,8 @@
 
 // Project includes
 #include "geometries/line_3d_3.h"
+#include "utilities/integration_utilities.h"
 #include "integration/quadrilateral_gauss_legendre_integration_points.h"
-
 
 namespace Kratos
 {
@@ -422,16 +421,9 @@ public:
      */
     double Area() const override
     {
-        Vector temp;
-        this->DeterminantOfJacobian( temp, msGeometryData.DefaultIntegrationMethod() );
-        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints( msGeometryData.DefaultIntegrationMethod() );
-        double Area = 0.0;
-
-        for ( unsigned int i = 0; i < integration_points.size(); i++ ) {
-            Area += temp[i] * integration_points[i].Weight();
-        }
-
-        return Area;
+        const IntegrationMethod integration_method = msGeometryData.DefaultIntegrationMethod();
+        const IntegrationPointsArrayType& r_integration_points = this->IntegrationPoints( integration_method );
+        return IntegrationUtilities::ComputeDomainSize(*this, r_integration_points);
     }
 
     /**
@@ -1786,5 +1778,3 @@ const GeometryDimension Quadrilateral3D9<TPointType>::msGeometryDimension(
     2, 3, 2);
 
 }  // namespace Kratos.
-
-#endif // KRATOS_QUADRILATERAL_3D_9_H_INCLUDED  defined

--- a/kratos/geometries/quadrilateral_3d_9.h
+++ b/kratos/geometries/quadrilateral_3d_9.h
@@ -422,8 +422,7 @@ public:
     double Area() const override
     {
         const IntegrationMethod integration_method = msGeometryData.DefaultIntegrationMethod();
-        const IntegrationPointsArrayType& r_integration_points = this->IntegrationPoints( integration_method );
-        return IntegrationUtilities::ComputeDomainSize(*this, r_integration_points);
+        return IntegrationUtilities::ComputeDomainSize(*this, integration_method);
     }
 
     /**

--- a/kratos/geometries/tetrahedra_3d_10.h
+++ b/kratos/geometries/tetrahedra_3d_10.h
@@ -4,18 +4,17 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Janosch Stascheit
 //                   Felix Nagel
-//  contributors:    Hoang Giang Bui
+//  Contributors:    Hoang Giang Bui
 //                   Josep Maria Carbonell
 //
 
-#if !defined(KRATOS_TETRAHEDRA_3D_10_H_INCLUDED )
-#define  KRATOS_TETRAHEDRA_3D_10_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -23,8 +22,8 @@
 
 // Project includes
 #include "geometries/triangle_3d_6.h"
+#include "utilities/integration_utilities.h"
 #include "integration/tetrahedron_gauss_legendre_integration_points.h"
-
 
 namespace Kratos
 {
@@ -439,24 +438,18 @@ public:
         return Volume();
     }
 
-
-    double Volume() const override //Not a closed formula for a quadratic tetrahedra
+    /** 
+     * @brief This method calculate and return volume of this geometry. 
+     * @details For one and two dimensional geometry it returns zero and for three dimensional it gives volume of geometry.
+     * @return double value contains volume.
+     * @see Length()
+     * @see Area()
+     * @see DomainSize()
+     */
+    double Volume() const override
     {
-
-        Vector temp;
-        this->DeterminantOfJacobian( temp, msGeometryData.DefaultIntegrationMethod() );
-        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints( msGeometryData.DefaultIntegrationMethod() );
-        double Volume = 0.00;
-
-        for ( unsigned int i = 0; i < integration_points.size(); i++ )
-        {
-            Volume += temp[i] * integration_points[i].Weight();
-        }
-
-        //KRATOS_WATCH(temp)
-        return Volume;
+        return IntegrationUtilities::ComputeVolume3DGeometry(*this);
     }
-
 
     /**
      * This method calculate and return length, area or volume of
@@ -1076,5 +1069,3 @@ GeometryDimension Tetrahedra3D10<TPointType>::msGeometryDimension(
     3, 3, 3);
 
 }// namespace Kratos.
-
-#endif // KRATOS_TETRAHEDRA_3D_4_H_INCLUDED  defined

--- a/kratos/geometries/triangle_2d_6.h
+++ b/kratos/geometries/triangle_2d_6.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Janosch Stascheit
@@ -14,9 +14,7 @@
 //                   Josep Maria Carbonell
 //
 
-
-#if !defined(KRATOS_TRIANGLE_2D_6_H_INCLUDED )
-#define  KRATOS_TRIANGLE_2D_6_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -458,7 +456,7 @@ public:
      */
     double Length() const override
     {
-        return sqrt( fabs( Area() ) );
+        return std::sqrt( std::abs( Area() ) );
     }
 
     /** 
@@ -472,16 +470,7 @@ public:
      */
     double Area() const override
     {
-        Vector temp;
-        this->DeterminantOfJacobian( temp, msGeometryData.DefaultIntegrationMethod() );
-        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints( msGeometryData.DefaultIntegrationMethod() );
-        double area = 0.0;
-
-        for ( unsigned int i = 0; i < integration_points.size(); i++ ) {
-            area += temp[i] * integration_points[i].Weight();
-        }
-
-        return area;
+        return IntegrationUtilities::ComputeArea2DGeometry(*this);
     }
 
     // TODO: Code activated in June 2023
@@ -1202,5 +1191,3 @@ const GeometryDimension Triangle2D6<TPointType>::msGeometryDimension(
     2, 2, 2);
 
 }// namespace Kratos.
-
-#endif // KRATOS_QUADRILATERAL_2D_4_H_INCLUDED  defined

--- a/kratos/geometries/triangle_3d_6.h
+++ b/kratos/geometries/triangle_3d_6.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Janosch Stascheit
@@ -14,8 +14,7 @@
 //                   Josep Maria Carbonell
 //
 
-#if !defined(KRATOS_TRIANGLE_3D_6_H_INCLUDED )
-#define  KRATOS_TRIANGLE_3D_6_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -464,16 +463,9 @@ public:
      */
     double Area() const override
     {
-        Vector temp;
-        this->DeterminantOfJacobian( temp, msGeometryData.DefaultIntegrationMethod() );
-        const IntegrationPointsArrayType& integration_points = this->IntegrationPoints( msGeometryData.DefaultIntegrationMethod() );
-        double area = 0.0;
-
-        for ( unsigned int i = 0; i < integration_points.size(); i++ ) {
-            area += temp[i] * integration_points[i].Weight();
-        }
-
-        return area;
+        const IntegrationMethod integration_method = msGeometryData.DefaultIntegrationMethod();
+        const IntegrationPointsArrayType& r_integration_points = this->IntegrationPoints( integration_method );
+        return IntegrationUtilities::ComputeDomainSize(*this, r_integration_points);
     }
 
     // TODO: Code activated in June 2023
@@ -1155,5 +1147,3 @@ GeometryDimension Triangle3D6<TPointType>::msGeometryDimension(
     2, 3, 2);
 
 }// namespace Kratos.
-
-#endif // KRATOS_TRIANGLE_3D_6_H_INCLUDED defined

--- a/kratos/geometries/triangle_3d_6.h
+++ b/kratos/geometries/triangle_3d_6.h
@@ -464,8 +464,7 @@ public:
     double Area() const override
     {
         const IntegrationMethod integration_method = msGeometryData.DefaultIntegrationMethod();
-        const IntegrationPointsArrayType& r_integration_points = this->IntegrationPoints( integration_method );
-        return IntegrationUtilities::ComputeDomainSize(*this, r_integration_points);
+        return IntegrationUtilities::ComputeDomainSize(*this, integration_method);
     }
 
     // TODO: Code activated in June 2023

--- a/kratos/utilities/integration_utilities.h
+++ b/kratos/utilities/integration_utilities.h
@@ -56,19 +56,40 @@ public:
     /** 
      * @brief This method calculates and returns the domain size of the geometry from any geometry in a generic manner
      * @param rGeometry The geometry considered
-     * @param rIntegrationPoints The integration points considered
+     * @tparam TGeometryType The geometry type
+     * @return double value contains volume.
+     */
+    template<class TGeometryType>
+    static inline double ComputeDomainSize(const TGeometryType& rGeometry)
+    {
+        const auto& r_integration_points = rGeometry.IntegrationPoints();
+        const auto number_gp = r_integration_points.size();
+        Vector temp(number_gp);
+        temp = rGeometry.DeterminantOfJacobian(temp);
+        double domain_size = 0.0;
+        for (unsigned int i = 0; i < number_gp; ++i) {
+            domain_size += temp[i] * r_integration_points[i].Weight();
+        }
+        return domain_size;
+    }
+
+    /** 
+     * @brief This method calculates and returns the domain size of the geometry from any geometry in a generic manner
+     * @param rGeometry The geometry considered
+     * @param IntegrationMethod The integration method considered
      * @tparam TPointType The Point type
      * @return double value contains volume.
      */
     template<class TPointType>
     static inline double ComputeDomainSize(
         const Geometry<TPointType>& rGeometry,
-        const typename Geometry<TPointType>::IntegrationPointsArrayType& rIntegrationPoints
+        const typename Geometry<TPointType>::IntegrationMethod IntegrationMethod
         )
     {
-        const auto number_gp = rIntegrationPoints.size();
+        const auto& r_integration_points = this->IntegrationPoints( IntegrationMethod );
+        const auto number_gp = r_integration_points.size();
         Vector temp(number_gp);
-        temp = rGeometry.DeterminantOfJacobian(temp);
+        temp = rGeometry.DeterminantOfJacobian(temp, IntegrationMethod);
         double domain_size = 0.0;
         for (unsigned int i = 0; i < number_gp; ++i) {
             domain_size += temp[i] * rIntegrationPoints[i].Weight();

--- a/kratos/utilities/integration_utilities.h
+++ b/kratos/utilities/integration_utilities.h
@@ -8,6 +8,7 @@
 //                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
+//                   Vicente Mataix Ferrandiz
 //
 
 #pragma once
@@ -21,11 +22,24 @@
 
 namespace Kratos
 {
+
+/**
+ * @class IntegrationUtilities
+ * @ingroup KratosCore
+ * @brief Utilities to integrate in different cases
+ * @author Vicente Mataix Ferrandiz
+ */
 class IntegrationUtilities
 {
 public:
+    /** 
+     * @brief This method returns the integration order for the exact mass matrix evaluation
+     * @param rGeometry The geometry considered
+     * @tparam TPointType The Point type
+     * @return The integration order
+     */
     template<class TPointType>
-    static GeometryData::IntegrationMethod GetIntegrationMethodForExactMassMatrixEvaluation(Geometry<TPointType> const& rGeometry)
+    static GeometryData::IntegrationMethod GetIntegrationMethodForExactMassMatrixEvaluation(const Geometry<TPointType>& rGeometry)
     {
         GeometryData::IntegrationMethod integration_method = rGeometry.GetDefaultIntegrationMethod();
         if (integration_method == GeometryData::IntegrationMethod::GI_GAUSS_1)
@@ -38,6 +52,72 @@ public:
             integration_method = GeometryData::IntegrationMethod::GI_GAUSS_5;
         return integration_method;
     }
+
+    /** 
+     * @brief This method calculates and returns the domain size of the geometry from any geometry in a generic manner
+     * @param rGeometry The geometry considered
+     * @param rIntegrationPoints The integration points considered
+     * @tparam TPointType The Point type
+     * @return double value contains volume.
+     */
+    template<class TPointType>
+    static inline double ComputeDomainSize(
+        const Geometry<TPointType>& rGeometry,
+        const typename Geometry<TPointType>::IntegrationPointsArrayType& rIntegrationPoints
+        )
+    {
+        const auto number_gp = rIntegrationPoints.size();
+        Vector temp(number_gp);
+        temp = rGeometry.DeterminantOfJacobian(temp);
+        double domain_size = 0.0;
+        for (unsigned int i = 0; i < number_gp; ++i) {
+            domain_size += temp[i] * rIntegrationPoints[i].Weight();
+        }
+        return domain_size;
+    }
+
+    /** 
+     * @brief This method calculates and returns the volume of the geometry from a 3D geometry
+     * @param rGeometry The geometry considered
+     * @tparam TPointType The Point type
+     * @return double value contains volume.
+     */
+    template<class TPointType>
+    static inline double ComputeArea2DGeometry(const Geometry<TPointType>& rGeometry)
+    {
+        const auto integration_method = rGeometry.GetDefaultIntegrationMethod();
+        const auto& r_integration_points = rGeometry.IntegrationPoints( integration_method );
+        double volume = 0.0;
+        Matrix J(2, 2);
+        for ( unsigned int i = 0; i < r_integration_points.size(); i++ ) {
+            rGeometry.Jacobian( J, i, integration_method);
+            volume += (J(0,0)*J(1,1)-J(0,1)*J(1,0)) * r_integration_points[i].Weight();
+        }
+
+        return volume;
+    }
+
+    /** 
+     * @brief This method calculates and returns the volume of the geometry from a 3D geometry
+     * @param rGeometry The geometry considered
+     * @tparam TPointType The Point type
+     * @return double value contains volume.
+     */
+    template<class TPointType>
+    static inline double ComputeVolume3DGeometry(const Geometry<TPointType>& rGeometry)
+    {
+        const auto integration_method = rGeometry.GetDefaultIntegrationMethod();
+        const auto& r_integration_points = rGeometry.IntegrationPoints( integration_method );
+        double volume = 0.0;
+        Matrix J(3, 3);
+        for ( unsigned int i = 0; i < r_integration_points.size(); i++ ) {
+            rGeometry.Jacobian( J, i, integration_method);
+            volume += J(0,0)*(J(1,1)*J(2,2) - J(1,2)*J(2,1)) - J(0,1)*(J(1,0)*J(2,2) - J(1,2)*J(2,0)) + J(0,2)*(J(1,0)*J(2,1) - J(1,1)*J(2,0)) * r_integration_points[i].Weight();
+        }
+
+        return volume;
+    }
+
 };
 
 }  // namespace Kratos.

--- a/kratos/utilities/integration_utilities.h
+++ b/kratos/utilities/integration_utilities.h
@@ -19,7 +19,6 @@
 
 // Project includes
 #include "geometries/geometry.h"
-
 namespace Kratos
 {
 
@@ -112,7 +111,7 @@ public:
         Matrix J(2, 2);
         for ( unsigned int i = 0; i < r_integration_points.size(); i++ ) {
             rGeometry.Jacobian( J, i, integration_method);
-            volume += (J(0,0)*J(1,1)-J(0,1)*J(1,0)) * r_integration_points[i].Weight();
+            volume += MathUtils<double>::Det2(J) * r_integration_points[i].Weight();
         }
 
         return volume;
@@ -133,7 +132,7 @@ public:
         Matrix J(3, 3);
         for ( unsigned int i = 0; i < r_integration_points.size(); i++ ) {
             rGeometry.Jacobian( J, i, integration_method);
-            volume += J(0,0)*(J(1,1)*J(2,2) - J(1,2)*J(2,1)) - J(0,1)*(J(1,0)*J(2,2) - J(1,2)*J(2,0)) + J(0,2)*(J(1,0)*J(2,1) - J(1,1)*J(2,0)) * r_integration_points[i].Weight();
+            volume += MathUtils<double>::Det3(J) * r_integration_points[i].Weight();
         }
 
         return volume;

--- a/kratos/utilities/integration_utilities.h
+++ b/kratos/utilities/integration_utilities.h
@@ -86,13 +86,13 @@ public:
         const typename Geometry<TPointType>::IntegrationMethod IntegrationMethod
         )
     {
-        const auto& r_integration_points = this->IntegrationPoints( IntegrationMethod );
+        const auto& r_integration_points = rGeometry.IntegrationPoints( IntegrationMethod );
         const auto number_gp = r_integration_points.size();
         Vector temp(number_gp);
         temp = rGeometry.DeterminantOfJacobian(temp, IntegrationMethod);
         double domain_size = 0.0;
         for (unsigned int i = 0; i < number_gp; ++i) {
-            domain_size += temp[i] * rIntegrationPoints[i].Weight();
+            domain_size += temp[i] * r_integration_points[i].Weight();
         }
         return domain_size;
     }


### PR DESCRIPTION
**📝 Description**

By suggestion of @pooyan-dadvand in some domain size (length, area, volume) it is possible to hardcode the calculus for the sake of efficiency. In here we allocate the vector and values when possible and compute directly if possible. I also refactor to reduce code duplication.

**🆕 Changelog**

- [Extend integration utilities](https://github.com/KratosMultiphysics/Kratos/commit/5a8c8cd9bb59f9285191ddfd6898c1c61a4ac731)
- [Typo in GeometryData](https://github.com/KratosMultiphysics/Kratos/commit/e1fb6c730b5d619a0d59f0d5397e172ba92ab022)
- [Minor improvement in base class](https://github.com/KratosMultiphysics/Kratos/commit/0cc0f44f146a6182546e4477ee6da86af41fa794)
- [Reduce code duplication with IntegrationUtilities](https://github.com/KratosMultiphysics/Kratos/commit/77dd3abd5dcd6ab442f4506ff0dd0825042bc963)
- [Reduce code duplication with IntegrationUtilities in quadratic lines](https://github.com/KratosMultiphysics/Kratos/commit/c4ced60b3c19ac3ef25c9c06b290d9ce1f6b6399)
- [Replace volume computation in prisms with IntegrationUtilities](https://github.com/KratosMultiphysics/Kratos/commit/03b823fa95c9ace85e16a0c1f94f306e1c169f8f)
- [Replace volume computation in pyramids with IntegrationUtilities](https://github.com/KratosMultiphysics/Kratos/commit/9068a0991a4906e7e9cd3b11b62950a247bf36d5)
- [Replace area computation in quadrilaterals with IntegrationUtilities](https://github.com/KratosMultiphysics/Kratos/commit/2dc0c7351b37a6e0281014fb5c3b7449070ed156)
- [Replace area computation in quadratic triangle with IntegrationUtilities](https://github.com/KratosMultiphysics/Kratos/commit/75c9f1386f17b0bde967e7c1120a83f1215fc473)