### PR TITLE
[MetisApplication] Inconsistent libraries linking in CMake

### DIFF
--- a/applications/MetisApplication/CMakeLists.txt
+++ b/applications/MetisApplication/CMakeLists.txt
@@ -28,7 +28,7 @@ endif(${KRATOS_BUILD_TESTING} MATCHES ON)
 
 
 add_library(KratosMetisCore SHARED ${KRATOS_METIS_APPLICATION_CORE} ${KRATOS_METIS_APPLICATION_TESTING_SOURCES})
-target_link_libraries(KratosMetisCore PUBLIC KratosCore ${METIS_LIBRARY})
+target_link_libraries(KratosMetisCore PUBLIC KratosCore ${METIS_LIBRARIES})
 set_target_properties(KratosMetisCore PROPERTIES COMPILE_DEFINITIONS "METIS_APPLICATION=EXPORT,API")
 
 ###############################################################


### PR DESCRIPTION
**📝 Description**

Inconsistent libraries linking in CMake. The variable defined and used in general is `METIS_LIBRARIES`, not `METIS_LIBRARY`

**🆕 Changelog**

- [Inconsistent libraries linking in CMake](https://github.com/KratosMultiphysics/Kratos/commit/bd076b7341104ce1fbbcf1ccdf5692ee9300ba2a)
