### PR TITLE
[Core] turn FilesystemExtensions into class

### DIFF
--- a/applications/HDF5Application/python_scripts/core/file_io.py
+++ b/applications/HDF5Application/python_scripts/core/file_io.py
@@ -135,7 +135,7 @@ class _FilenameGetterWithDirectoryInitialization(object):
 
     def _InitializeDirectory(self, file_name):
         dirname = Path(file_name).absolute().parent
-        KratosMultiphysics.FilesystemExtensions.MPISafeCreateDirectories(str(dirname))
+        KratosMultiphysics.FilesystemExtensions.MPISafeCreateDirectories(dirname)
 
 def Create(settings, data_comm):
     '''Return the IO object specified by the setting 'io_type'.

--- a/applications/HDF5Application/python_scripts/core/file_io.py
+++ b/applications/HDF5Application/python_scripts/core/file_io.py
@@ -135,7 +135,7 @@ class _FilenameGetterWithDirectoryInitialization(object):
 
     def _InitializeDirectory(self, file_name):
         dirname = Path(file_name).absolute().parent
-        KratosMultiphysics.FilesystemExtensions.MPISafeCreateDirectories(dirname)
+        KratosMultiphysics.FilesystemExtensions.MPISafeCreateDirectories(str(dirname))
 
 def Create(settings, data_comm):
     '''Return the IO object specified by the setting 'io_type'.

--- a/kratos/includes/kratos_filesystem.h
+++ b/kratos/includes/kratos_filesystem.h
@@ -107,7 +107,7 @@ public:
      * @param rPath                               Path
      * @return std::vector<std::filesystem::path> List of files and folders in rPath
      */
-    static [[nodiscard]] std::vector<std::filesystem::path> ListDirectory(const std::filesystem::path& rPath);
+    [[nodiscard]] static std::vector<std::filesystem::path> ListDirectory(const std::filesystem::path& rPath);
 
     /**
      * @brief Create directories in MPI, when sometimes filesystems are slow. Intended to be called by all ranks (that make use of this directory). It returns only after the folder exists
@@ -124,7 +124,7 @@ public:
      *  @note The existence of the final result is not checked and is up to the user.
      *  @note The input is returned if it is not a symlink.
      */
-    static [[nodiscard]] std::filesystem::path ResolveSymlinks(const std::filesystem::path& rPath);
+    [[nodiscard]] static std::filesystem::path ResolveSymlinks(const std::filesystem::path& rPath);
 
 }; // class FilesystemExtensions
 

--- a/kratos/includes/kratos_filesystem.h
+++ b/kratos/includes/kratos_filesystem.h
@@ -69,50 +69,63 @@ std::string KRATOS_API(KRATOS_CORE) filename(const std::string& rPath);
 } // namespace filesystem
 
 
-namespace FilesystemExtensions {
-// helper functions related to filesystem
+class KRATOS_API(KRATOS_CORE) FilesystemExtensions
+{
 
-/**
- * @brief Returns current working directory
- *
- * @return std::string
- */
-KRATOS_DEPRECATED_MESSAGE("Please use std::filesystem directly")
-std::string KRATOS_API(KRATOS_CORE) CurrentWorkingDirectory();
+public:
+    /// Default constructor.
+    FilesystemExtensions() = delete;
 
-/**
- * @brief Join paths
- *
- * @param rPaths                        List of strings to be joined to get final path
- * @return std::string                  Final joined path
- */
-KRATOS_DEPRECATED_MESSAGE("Please use the /-operator directly")
-std::string KRATOS_API(KRATOS_CORE) JoinPaths(const std::vector<std::string>& rPaths);
+    /// Copy constructor.
+    FilesystemExtensions(FilesystemExtensions const& rOther) = delete;
 
-/**
- * @brief Returns list of files and directories in rPath
- *
- * @param rPath                               Path
- * @return std::vector<std::filesystem::path> List of files and folders in rPath
- */
-std::vector<std::filesystem::path> KRATOS_API(KRATOS_CORE) ListDirectory(const std::filesystem::path& rPath);
+    /// Assignment operator.
+    FilesystemExtensions& operator=(FilesystemExtensions const& rOther) = delete;
 
-/**
- * @brief Create directories in MPI, when sometimes filesystems are slow. Intended to be called by all ranks (that make use of this directory). It returns only after the folder exists
- *
- * @param rPath                         Path
- */
-void KRATOS_API(KRATOS_CORE) MPISafeCreateDirectories(const std::filesystem::path& rPath);
+    // helper functions related to filesystem
 
-/** @brief Resolve symlinks recursively.
- *
- *  @param rPath: path to a symbolic link.
- *  @return The result of the recursive dereferencing.
- *  @throws If the input path does not exist or the symlink is cyclic.
- *  @note The existence of the final result is not checked and is up to the user.
- *  @note The input is returned if it is not a symlink.
- */
-std::filesystem::path ResolveSymlinks(const std::filesystem::path& rPath);
+    /**
+     * @brief Returns current working directory
+     *
+     * @return std::string
+     */
+    KRATOS_DEPRECATED_MESSAGE("Please use std::filesystem directly")
+    static std::string CurrentWorkingDirectory();
 
-} // namespace FilesystemExtensions
+    /**
+     * @brief Join paths
+     *
+     * @param rPaths                        List of strings to be joined to get final path
+     * @return std::string                  Final joined path
+     */
+    KRATOS_DEPRECATED_MESSAGE("Please use the /-operator directly")
+    static std::string JoinPaths(const std::vector<std::string>& rPaths);
+
+    /**
+     * @brief Returns list of files and directories in rPath
+     *
+     * @param rPath                               Path
+     * @return std::vector<std::filesystem::path> List of files and folders in rPath
+     */
+    static std::vector<std::filesystem::path> ListDirectory(const std::filesystem::path& rPath);
+
+    /**
+     * @brief Create directories in MPI, when sometimes filesystems are slow. Intended to be called by all ranks (that make use of this directory). It returns only after the folder exists
+     *
+     * @param rPath                         Path
+     */
+    static void MPISafeCreateDirectories(const std::filesystem::path& rPath);
+
+    /** @brief Resolve symlinks recursively.
+     *
+     *  @param rPath: path to a symbolic link.
+     *  @return The result of the recursive dereferencing.
+     *  @throws If the input path does not exist or the symlink is cyclic.
+     *  @note The existence of the final result is not checked and is up to the user.
+     *  @note The input is returned if it is not a symlink.
+     */
+    static std::filesystem::path ResolveSymlinks(const std::filesystem::path& rPath);
+
+}; // class FilesystemExtensions
+
 } // namespace Kratos

--- a/kratos/includes/kratos_filesystem.h
+++ b/kratos/includes/kratos_filesystem.h
@@ -107,7 +107,7 @@ public:
      * @param rPath                               Path
      * @return std::vector<std::filesystem::path> List of files and folders in rPath
      */
-    static std::vector<std::filesystem::path> ListDirectory(const std::filesystem::path& rPath);
+    static [[nodiscard]] std::vector<std::filesystem::path> ListDirectory(const std::filesystem::path& rPath);
 
     /**
      * @brief Create directories in MPI, when sometimes filesystems are slow. Intended to be called by all ranks (that make use of this directory). It returns only after the folder exists
@@ -124,7 +124,7 @@ public:
      *  @note The existence of the final result is not checked and is up to the user.
      *  @note The input is returned if it is not a symlink.
      */
-    static std::filesystem::path ResolveSymlinks(const std::filesystem::path& rPath);
+    static [[nodiscard]] std::filesystem::path ResolveSymlinks(const std::filesystem::path& rPath);
 
 }; // class FilesystemExtensions
 

--- a/kratos/python/add_other_utilities_to_python.cpp
+++ b/kratos/python/add_other_utilities_to_python.cpp
@@ -782,8 +782,10 @@ void AddOtherUtilitiesToPython(pybind11::module &m)
         .def_static("MarkOutsiderParticlesNonHistorical", &ParticlesUtilities::MarkOutsiderParticles<3,unsigned int, false>)
         ;
 
-    auto fs_extensions = m.def_submodule("FilesystemExtensions");
-    fs_extensions.def("MPISafeCreateDirectories", &FilesystemExtensions::MPISafeCreateDirectories );
+
+    py::class_<FilesystemExtensions>(m, "FilesystemExtensions")
+        .def_static("MPISafeCreateDirectories", &FilesystemExtensions::MPISafeCreateDirectories )
+        ;
 
     py::class_<ShiftedBoundaryMeshlessInterfaceUtility, ShiftedBoundaryMeshlessInterfaceUtility::Pointer>(m,"ShiftedBoundaryMeshlessInterfaceUtility")
         .def(py::init<Model&, Parameters>())

--- a/kratos/python_scripts/gid_output_process.py
+++ b/kratos/python_scripts/gid_output_process.py
@@ -755,6 +755,6 @@ class GiDOutputProcess(KM.OutputProcess):
 
         # Make sure that the path to the desired output folder exists
         output_path = Path(file_name).parent
-        KM.FilesystemExtensions.MPISafeCreateDirectories(str(output_path))
+        KM.FilesystemExtensions.MPISafeCreateDirectories(output_path)
 
         return file_name

--- a/kratos/python_scripts/time_based_ascii_file_writer_utility.py
+++ b/kratos/python_scripts/time_based_ascii_file_writer_utility.py
@@ -37,7 +37,7 @@ class TimeBasedAsciiFileWriterUtility:
         self.file_extension = params["file_extension"].GetString()
         if not self.file_extension.startswith("."):
             self.file_extension = "." + self.file_extension
-            
+
         self.__ValidateAndAssignOutputFolderPath()
 
         # size of the buffer in bytes. Set to "0" for flushing always
@@ -145,4 +145,4 @@ class TimeBasedAsciiFileWriterUtility:
         self.file_name = self.output_path / self.file_name
 
         # make sure that the path to the desired output folder exists
-        KratosMultiphysics.FilesystemExtensions.MPISafeCreateDirectories(str(self.output_path))
+        KratosMultiphysics.FilesystemExtensions.MPISafeCreateDirectories(self.output_path)

--- a/kratos/sources/kratos_filesystem.cpp
+++ b/kratos/sources/kratos_filesystem.cpp
@@ -84,14 +84,12 @@ std::string filename(const std::string& rPath)
 } // namespace filesystem
 
 
-namespace FilesystemExtensions {
-
-std::string CurrentWorkingDirectory()
+std::string FilesystemExtensions::CurrentWorkingDirectory()
 {
     return std::filesystem::current_path().string();
 }
 
-std::string JoinPaths(const std::vector<std::string>& rPaths)
+std::string FilesystemExtensions::JoinPaths(const std::vector<std::string>& rPaths)
 {
     auto paths(rPaths); // create local copy
 
@@ -114,7 +112,7 @@ std::string JoinPaths(const std::vector<std::string>& rPaths)
     return full_path;
 }
 
-std::vector<std::filesystem::path> ListDirectory(const std::filesystem::path& rPath)
+std::vector<std::filesystem::path> FilesystemExtensions::ListDirectory(const std::filesystem::path& rPath)
 {
     std::vector<std::filesystem::path> result;
     for (const auto& current_directory : std::filesystem::directory_iterator(rPath)) {
@@ -123,7 +121,7 @@ std::vector<std::filesystem::path> ListDirectory(const std::filesystem::path& rP
     return result;
 }
 
-void MPISafeCreateDirectories(const std::filesystem::path& rPath)
+void FilesystemExtensions::MPISafeCreateDirectories(const std::filesystem::path& rPath)
 {
     if (!std::filesystem::exists(rPath)) {
         std::filesystem::create_directories(rPath);
@@ -134,7 +132,7 @@ void MPISafeCreateDirectories(const std::filesystem::path& rPath)
 }
 
 
-std::filesystem::path ResolveSymlinks(const std::filesystem::path& rPath)
+std::filesystem::path FilesystemExtensions::ResolveSymlinks(const std::filesystem::path& rPath)
 {
     auto status = std::filesystem::symlink_status(rPath);
     KRATOS_ERROR_IF(status.type() == std::filesystem::file_type::not_found) << "File not found: " << rPath;
@@ -152,5 +150,4 @@ std::filesystem::path ResolveSymlinks(const std::filesystem::path& rPath)
     return path;
 }
 
-} // namespace FilesystemExtensions
 } // namespace Kratos

--- a/kratos/tests/cpp_tests/sources/test_filesystem.cpp
+++ b/kratos/tests/cpp_tests/sources/test_filesystem.cpp
@@ -13,6 +13,7 @@
 
 // System includes
 #include <fstream>
+#include <tuple>
 
 // External includes
 
@@ -142,12 +143,12 @@ KRATOS_TEST_CASE_IN_SUITE(ResolveSymlinksToFile, KratosCoreFastSuite)
         // Cyclic indirections 2-4 cycles
         for (const auto& r_symlink : symlinks) {
             ScopedSymlink loopback(file_path, r_symlink);
-            KRATOS_CHECK_EXCEPTION_IS_THROWN(FilesystemExtensions::ResolveSymlinks(r_symlink), "cyclic");
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(std::ignore=FilesystemExtensions::ResolveSymlinks(r_symlink), "cyclic");
         }
 
         // 1-cycle
         ScopedSymlink loopback(file_path, file_path);
-        KRATOS_CHECK_EXCEPTION_IS_THROWN(FilesystemExtensions::ResolveSymlinks(loopback), "cyclic");
+        KRATOS_CHECK_EXCEPTION_IS_THROWN(std::ignore=FilesystemExtensions::ResolveSymlinks(loopback), "cyclic");
     }
 }
 
@@ -188,12 +189,12 @@ KRATOS_TEST_CASE_IN_SUITE(ResolveSymlinksToDirectory, KratosCoreFastSuite)
         // Cyclic indirections 2-4 cycles
         for (const auto& r_symlink : symlinks) {
             ScopedSymlink loopback(directory_path, r_symlink);
-            KRATOS_CHECK_EXCEPTION_IS_THROWN(FilesystemExtensions::ResolveSymlinks(r_symlink), "cyclic");
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(std::ignore=FilesystemExtensions::ResolveSymlinks(r_symlink), "cyclic");
         }
 
         // 1-cycle
         ScopedSymlink loopback(directory_path, directory_path);
-        KRATOS_CHECK_EXCEPTION_IS_THROWN(FilesystemExtensions::ResolveSymlinks(loopback), "cyclic");
+        KRATOS_CHECK_EXCEPTION_IS_THROWN(std::ignore=FilesystemExtensions::ResolveSymlinks(loopback), "cyclic");
     }
 }
 


### PR DESCRIPTION
since we prefer to use classes with static methods over namespaces I thought I could clean this up