### PR TITLE
[FastPR][Structural] More generic CalculateB

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.h
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.h
@@ -105,14 +105,14 @@ void ComputeEquivalentF(
  */
 template<class TMatrixType1, class TMatrixType2>
 void CalculateB(
-    const Element& rElement,
+    const GeometricalObject& rElement,
     const TMatrixType1& rDN_DX,
     TMatrixType2& rB
     )
 {
     const auto& r_geometry = rElement.GetGeometry();
     const SizeType number_of_nodes = r_geometry.PointsNumber();
-    const SizeType dimension = r_geometry.WorkingSpaceDimension();
+    const SizeType dimension = rDN_DX.size2();
 
     rB.clear();
 


### PR DESCRIPTION
**📝 Description**
These minors make possible to use it in more generic cases. For instance, right now I'm developing a condition that relies on base geometries with random number of nodes. These two minor changes make possible to use both conditions and elements and do not break in the case of a generic geometry (the `WorkingSpaceDimension` is always 3 in this case, regardless if these are used in a 2D or 3D problem).
