### PR TITLE
[Structural] making IsElementRotated virtual

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -915,7 +915,7 @@ protected:
      * @brief This method checks is an element has to be rotated
      * according to a set of local axes
      */
-    bool IsElementRotated() const;
+    virtual bool IsElementRotated() const;
 
     /**
      * @brief This method rotates the F or strain according to local axis from


### PR DESCRIPTION
This is failing in one of our elements in altair because the constitutive law vector is not created at this point. As our element is quite specific we can just skip this step, so that is why I want to make this function virtual and re-implement it in our element.