### PR TITLE
[Core] Return by value in Parameter iterators

### DIFF
--- a/applications/ChimeraApplication/custom_processes/apply_chimera_process.cpp
+++ b/applications/ChimeraApplication/custom_processes/apply_chimera_process.cpp
@@ -152,10 +152,10 @@ void ApplyChimera<TDim>::DoChimeraLoop()
     BuiltinTimer do_chimera_loop_time;
 
     int i_current_level = 0;
-    for (auto& current_level : mParameters) {
+    for (auto current_level : mParameters) {
         ChimeraHoleCuttingUtility::Domain domain_type =
             ChimeraHoleCuttingUtility::Domain::MAIN_BACKGROUND;
-        for (auto& background_patch_param :
+        for (auto background_patch_param :
              current_level) { // Gives the current background
             background_patch_param.ValidateAndAssignDefaults(parameters_for_validation);
             Model& current_model = mrMainModelPart.GetModel();
@@ -181,7 +181,7 @@ void ApplyChimera<TDim>::DoChimeraLoop()
 
             for (int i_slave_level = i_current_level + 1;
                  i_slave_level < mNumberOfLevels; ++i_slave_level) {
-                for (auto& slave_patch_param :
+                for (auto slave_patch_param :
                      mParameters[i_slave_level]) // Loop over all other slave
                                                  // patches
                 {

--- a/applications/CoSimulationApplication/custom_utilities/co_sim_io_conversion_utilities.cpp
+++ b/applications/CoSimulationApplication/custom_utilities/co_sim_io_conversion_utilities.cpp
@@ -509,11 +509,11 @@ CoSimIO::Info CoSimIOConversionUtilities::InfoFromParameters(const Parameters rS
     CoSimIO::Info info;
 
     for (auto it = rSettings.begin(); it != rSettings.end(); ++it) {
-        if      (it->IsString())       info.Set<std::string>(it.name(),   it->GetString());
-        else if (it->IsInt())          info.Set<int>(it.name(),           it->GetInt());
-        else if (it->IsBool())         info.Set<bool>(it.name(),          it->GetBool());
-        else if (it->IsDouble())       info.Set<double>(it.name(),        it->GetDouble());
-        else if (it->IsSubParameter()) info.Set<CoSimIO::Info>(it.name(), InfoFromParameters(*it));
+        if      ((*it).IsString())       info.Set<std::string>(it.name(),   (*it).GetString());
+        else if ((*it).IsInt())          info.Set<int>(it.name(),           (*it).GetInt());
+        else if ((*it).IsBool())         info.Set<bool>(it.name(),          (*it).GetBool());
+        else if ((*it).IsDouble())       info.Set<double>(it.name(),        (*it).GetDouble());
+        else if ((*it).IsSubParameter()) info.Set<CoSimIO::Info>(it.name(), InfoFromParameters(*it));
         else KRATOS_WARNING("Kratos-CoSimIO") << "Setting with name \"" << it.name() << "\" cannot be converted to CoSimIO::Info and is ignored!" << std::endl;
     }
 

--- a/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
+++ b/applications/MeshingApplication/custom_processes/mmg/mmg_process.cpp
@@ -32,7 +32,7 @@
 /* The mappers includes */
 #include "spaces/ublas_space.h"
 #include "mappers/mapper_flags.h"
-#include "factories/mapper_factory.h" 
+#include "factories/mapper_factory.h"
 
 // NOTE: The following contains the license of the MMG library
 /* =============================================================================
@@ -590,7 +590,7 @@ void MmgProcess<TMMGLibrary>::ExecuteRemeshing()
             ModelPart& r_old_auxiliar_model_part = r_old_model_part.GetSubModelPart("AUXILIAR_COLLAPSED_PRISMS");
             ModelPart& r_auxiliary_model_part = mrThisModelPart.GetSubModelPart("AUXILIAR_COLLAPSED_PRISMS");
 
-            // Define mapper factory 
+            // Define mapper factory
             DEFINE_MAPPER_FACTORY_SERIAL
             if (MapperFactoryType::HasMapper("nearest_element") && mThisParameters["use_mapper_if_available"].GetBool()) {
                 KRATOS_INFO_IF("MmgProcess", mEchoLevel > 0) << "Using MappingApplication to interpolate values" << std::endl;
@@ -867,7 +867,7 @@ void MmgProcess<TMMGLibrary>::ApplyLocalParameters() {
     // Count number of parameters given by the user
     const auto parameter_array = mThisParameters["advanced_parameters"]["local_entity_parameters_list"];
     IndexType n_parameters = parameter_array.size();
-    for (auto& parameter_settings : parameter_array) {
+    for (auto parameter_settings : parameter_array) {
         n_parameters += parameter_settings["model_part_name_list"].size();
     }
 
@@ -1501,7 +1501,7 @@ const Parameters MmgProcess<TMMGLibrary>::GetDefaultParameters() const
                 "max_num_search_iterations"     : 8,
                 "echo_level"                    : 0
             }
-        }, 
+        },
         "extrapolate_contour_values"           : true,
         "surface_elements"                     : false,
         "search_parameters"                    : {

--- a/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.cpp
+++ b/applications/MeshingApplication/custom_utilities/mmg/mmg_utilities.cpp
@@ -2854,7 +2854,7 @@ void MmgUtilities<MMGLibrary::MMG2D>::SetLocalParameter(
     double HMin,
     double HMax,
     double HausdorffValue
-    ) 
+    )
 {
     if ( MMG2D_Set_localParameter(mMmgMesh, mMmgMet, MMG5_Edg, rColor, HMin, HMax, HausdorffValue) != 1)
         KRATOS_ERROR << "Unable to set local parameter" << std::endl;
@@ -2869,7 +2869,7 @@ void MmgUtilities<MMGLibrary::MMG3D>::SetLocalParameter(
     double HMin,
     double HMax,
     double HausdorffValue
-    ) 
+    )
 {
     if ( MMG3D_Set_localParameter(mMmgMesh, mMmgMet, MMG5_Triangle, rColor, HMin, HMax, HausdorffValue) != 1)
         KRATOS_ERROR << "Unable to set local parameter" << std::endl;
@@ -2884,7 +2884,7 @@ void MmgUtilities<MMGLibrary::MMGS>::SetLocalParameter(
     double HMin,
     double HMax,
     double HausdorffValue
-    ) 
+    )
 {
     if ( MMGS_Set_localParameter(mMmgMesh, mMmgMet, MMG5_Triangle, rColor, HMin, HMax, HausdorffValue) != 1)
         KRATOS_ERROR << "Unable to set local parameter" << std::endl;
@@ -4508,7 +4508,7 @@ void MmgUtilities<TMMGLibrary>::WriteReferenceEntitities(
     Parameters elem_ref_json(elem_infile);
     for (auto it_param = elem_ref_json.begin(); it_param != elem_ref_json.end(); ++it_param) {
         const std::size_t key = std::stoi(it_param.name());;
-        Element const& r_clone_element = KratosComponents<Element>::Get(it_param->GetString());
+        Element const& r_clone_element = KratosComponents<Element>::Get((*it_param).GetString());
         rRefElement[key] = r_clone_element.Create(0, r_clone_element.pGetGeometry(), p_auxiliar_prop);
     }
 
@@ -4518,7 +4518,7 @@ void MmgUtilities<TMMGLibrary>::WriteReferenceEntitities(
     Parameters cond_ref_json(cond_infile);
     for (auto it_param = cond_ref_json.begin(); it_param != cond_ref_json.end(); ++it_param) {
         const std::size_t key = std::stoi(it_param.name());;
-        Condition const& r_clone_element = KratosComponents<Condition>::Get(it_param->GetString());
+        Condition const& r_clone_element = KratosComponents<Condition>::Get((*it_param).GetString());
         rRefCondition[key] = r_clone_element.Create(0, r_clone_element.pGetGeometry(), p_auxiliar_prop);
     }
 

--- a/applications/ShapeOptimizationApplication/custom_utilities/damping/damping_utilities.cpp
+++ b/applications/ShapeOptimizationApplication/custom_utilities/damping/damping_utilities.cpp
@@ -49,10 +49,10 @@ DampingUtilities::DampingUtilities( ModelPart& modelPartToDamp, Parameters Dampi
         }  )" );
 
     // Loop over all regions for which damping is to be applied
-    for (auto& r_region_parameters : mDampingSettings["damping_regions"])
+    for (auto region_parameters : mDampingSettings["damping_regions"])
     {
-        r_region_parameters.ValidateAndAssignDefaults(default_parameters);
-        KRATOS_ERROR_IF(r_region_parameters["damping_radius"].GetDouble() < 0.0) << "DampingUtilities: 'damping_radius' is a mandatory setting and has to be > 0.0!" << std::endl;
+        region_parameters.ValidateAndAssignDefaults(default_parameters);
+        KRATOS_ERROR_IF(region_parameters["damping_radius"].GetDouble() < 0.0) << "DampingUtilities: 'damping_radius' is a mandatory setting and has to be > 0.0!" << std::endl;
     }
 
     BuiltinTimer timer;

--- a/applications/TrilinosApplication/custom_utilities/trilinos_solver_utilities.cpp
+++ b/applications/TrilinosApplication/custom_utilities/trilinos_solver_utilities.cpp
@@ -22,10 +22,10 @@ namespace TrilinosSolverUtilities {
 void SetTeuchosParameters(const Parameters rSettings, Teuchos::ParameterList& rParameterlist)
 {
     for (auto it = rSettings.begin(); it != rSettings.end(); ++it) {
-        if      (it->IsString()) rParameterlist.set(it.name(), it->GetString());
-        else if (it->IsInt())    rParameterlist.set(it.name(), it->GetInt());
-        else if (it->IsBool())   rParameterlist.set(it.name(), it->GetBool());
-        else if (it->IsDouble()) rParameterlist.set(it.name(), it->GetDouble());
+        if      ((*it).IsString()) rParameterlist.set(it.name(), (*it).GetString());
+        else if ((*it).IsInt())    rParameterlist.set(it.name(), (*it).GetInt());
+        else if ((*it).IsBool())   rParameterlist.set(it.name(), (*it).GetBool());
+        else if ((*it).IsDouble()) rParameterlist.set(it.name(), (*it).GetDouble());
     }
 }
 

--- a/applications/TrilinosApplication/external_includes/amesos_solver.h
+++ b/applications/TrilinosApplication/external_includes/amesos_solver.h
@@ -107,10 +107,10 @@ public:
         //assign the amesos parameter list, which may contain parameters IN TRILINOS INTERNAL FORMAT to mParameterList
         mParameterList = Teuchos::ParameterList();
         for(auto it = settings["trilinos_amesos_parameter_list"].begin(); it != settings["trilinos_amesos_parameter_list"].end(); it++) {
-            if(it->IsString()) mParameterList.set(it.name(), it->GetString());
-            else if(it->IsInt()) mParameterList.set(it.name(), it->GetInt());
-            else if(it->IsBool()) mParameterList.set(it.name(), it->GetBool());
-            else if(it->IsDouble()) mParameterList.set(it.name(), it->GetDouble());
+            if((*it).IsString()) mParameterList.set(it.name(), (*it).GetString());
+            else if((*it).IsInt()) mParameterList.set(it.name(), (*it).GetInt());
+            else if((*it).IsBool()) mParameterList.set(it.name(), (*it).GetBool());
+            else if((*it).IsDouble()) mParameterList.set(it.name(), (*it).GetDouble());
         }
 
         mSolverName = settings["amesos_solver_type"].GetString();

--- a/kratos/includes/kratos_parameters.h
+++ b/kratos/includes/kratos_parameters.h
@@ -95,7 +95,7 @@ private:
          * @brief Default constructor (just iterator)
          * @param itValue The iterator to adapt
          */
-        iterator_adaptor(const iterator_adaptor& itValue);
+        iterator_adaptor(const iterator_adaptor& itValue) = default;
 
         ///@}
         ///@name Operators
@@ -135,14 +135,7 @@ private:
          * @details This operator returns the pointer of a given iterator
          * @return The Pointer of the given iterator
          */
-        Parameters& operator*() const;
-
-        /**
-         * @brief operator ->
-         * @details This operator acces to the pointer of the Parameter
-         * @return The pointer of the parameter
-         */
-        Parameters* operator->() const;
+        value_type operator*() const;
 
         ///@}
         ///@name Operations
@@ -168,7 +161,7 @@ private:
 
         std::size_t mDistance = 0;                       /// The iterator distance
         nlohmann::json& mrValue;                         /// The original container
-        std::unique_ptr<Parameters> mpParameters;        /// The unique pointer to the base Parameter
+        Kratos::shared_ptr<nlohmann::json> mpRoot;
 
         ///@}
     };
@@ -209,7 +202,7 @@ private:
          * @param itValue The iterator to adapt
          * @todo Use copy constructor in the following method
          */
-        const_iterator_adaptor(const const_iterator_adaptor& itValue);
+        const_iterator_adaptor(const const_iterator_adaptor& itValue) = default;
 
         ///@}
         ///@name Operators
@@ -249,14 +242,7 @@ private:
          * @details This operator returns the pointer of a given iterator
          * @return The Pointer of the given iterator
          */
-        const Parameters& operator*() const;
-
-        /**
-         * @brief operator ->
-         * @details This operator acces to the pointer of the Parameter
-         * @return The pointer of the parameter
-         */
-        const Parameters* operator->() const;
+        value_type operator*() const;
 
         ///@}
         ///@name Operations
@@ -281,7 +267,7 @@ private:
 
         std::size_t mDistance = 0;                       /// The iterator distance
         nlohmann::json& mrValue;                         /// The original container
-        std::unique_ptr<Parameters> mpParameters;        /// The unique pointer to the base Parameter
+        Kratos::shared_ptr<nlohmann::json> mpRoot;
 
         ///@}
     };

--- a/kratos/processes/assign_scalar_input_to_entities_process.cpp
+++ b/kratos/processes/assign_scalar_input_to_entities_process.cpp
@@ -416,8 +416,8 @@ void AssignScalarInputToEntitiesProcess<TEntity, THistorical>::IdentifyDataJSON(
 
     // Getting number of definitions
     SizeType number_of_definitions = 0;
-    for (auto& r_param : json_input) {
-        if (!r_param.IsVector()) {  // Removing TIME
+    for (auto param : json_input) {
+        if (!param.IsVector()) {  // Removing TIME
             ++number_of_definitions;
         }
     }

--- a/kratos/sources/kratos_parameters.cpp
+++ b/kratos/sources/kratos_parameters.cpp
@@ -27,12 +27,14 @@
 namespace Kratos
 {
 
-Parameters::iterator_adaptor::iterator_adaptor(Parameters::iterator_adaptor::value_iterator itValue, nlohmann::json* pValue,  Kratos::shared_ptr<nlohmann::json> pRoot) :mDistance(std::distance(pValue->begin(), itValue)), mrValue(*pValue), mpParameters(new Parameters(itValue, pValue, pRoot)) {}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-Parameters::iterator_adaptor::iterator_adaptor(const Parameters::iterator_adaptor& itValue) : mDistance(itValue.mDistance), mrValue(itValue.mrValue),  mpParameters(new Parameters(itValue->GetUnderlyingStorage(), itValue->GetUnderlyingRootStorage())) {}
+Parameters::iterator_adaptor::iterator_adaptor(Parameters::iterator_adaptor::value_iterator itValue,
+                                               nlohmann::json* pValue,
+                                               Kratos::shared_ptr<nlohmann::json> pRoot)
+    : mDistance(std::distance(pValue->begin(), itValue)),
+      mrValue(*pValue),
+      mpRoot(pRoot)
+{
+}
 
 /***********************************************************************************/
 /***********************************************************************************/
@@ -72,25 +74,9 @@ bool Parameters::iterator_adaptor::operator!=(const Parameters::iterator_adaptor
 /***********************************************************************************/
 /***********************************************************************************/
 
-Parameters& Parameters::iterator_adaptor::operator*() const
+Parameters::iterator_adaptor::value_type Parameters::iterator_adaptor::operator*() const
 {
-    auto it = GetCurrentIterator();
-    if (it != mrValue.end()) {
-        mpParameters->mpValue = &(*it);
-    }
-    return *mpParameters;
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-Parameters* Parameters::iterator_adaptor::operator->() const
-{
-    auto it = GetCurrentIterator();
-    if (it != mrValue.end()) {
-        mpParameters->mpValue = &(*it);
-    }
-    return mpParameters.get();
+    return Parameters(GetCurrentIterator(), &mrValue, mpRoot);
 }
 
 /***********************************************************************************/
@@ -99,8 +85,7 @@ Parameters* Parameters::iterator_adaptor::operator->() const
 inline Parameters::iterator_adaptor::value_iterator Parameters::iterator_adaptor::GetCurrentIterator() const
 {
     auto it = mrValue.begin();
-    for (std::size_t i = 0; i < mDistance; ++i)
-        it++;
+    std::advance(it, mDistance);
     return it;
 }
 
@@ -116,12 +101,14 @@ const std::string Parameters::iterator_adaptor::name()
 /***********************************************************************************/
 /***********************************************************************************/
 
-Parameters::const_iterator_adaptor::const_iterator_adaptor(value_iterator itValue, nlohmann::json* pValue,  Kratos::shared_ptr<nlohmann::json> pRoot) : mDistance(std::distance(pValue->cbegin(), itValue)), mrValue(*pValue), mpParameters(new Parameters(itValue, pValue, pRoot)) {}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-Parameters::const_iterator_adaptor::const_iterator_adaptor(const const_iterator_adaptor& itValue) : mDistance(itValue.mDistance), mrValue(itValue.mrValue), mpParameters(new Parameters(itValue->GetUnderlyingStorage(), itValue->GetUnderlyingRootStorage()))  {}
+Parameters::const_iterator_adaptor::const_iterator_adaptor(value_iterator itValue,
+                                                           nlohmann::json* pValue,
+                                                           Kratos::shared_ptr<nlohmann::json> pRoot)
+    : mDistance(std::distance(pValue->cbegin(), itValue)),
+      mrValue(*pValue),
+      mpRoot(pRoot)
+{
+}
 
 /***********************************************************************************/
 /***********************************************************************************/
@@ -161,23 +148,9 @@ bool Parameters::const_iterator_adaptor::operator!=(const Parameters::const_iter
 /***********************************************************************************/
 /***********************************************************************************/
 
-const Parameters& Parameters::const_iterator_adaptor::operator*() const
+Parameters::const_iterator_adaptor::value_type Parameters::const_iterator_adaptor::operator*() const
 {
-    auto it = GetCurrentIterator();
-    if (it != mrValue.cend())
-        mpParameters->mpValue = const_cast<nlohmann::json*>(&(*it));
-    return *mpParameters;
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-const Parameters* Parameters::const_iterator_adaptor::operator->() const
-{
-    auto it = GetCurrentIterator();
-    if (it != mrValue.cend())
-        mpParameters->mpValue = const_cast<nlohmann::json*>(&(*it));
-    return mpParameters.get();
+    return Parameters(GetCurrentIterator(), &mrValue, mpRoot);
 }
 
 /***********************************************************************************/
@@ -186,8 +159,7 @@ const Parameters* Parameters::const_iterator_adaptor::operator->() const
 inline Parameters::const_iterator_adaptor::value_iterator Parameters::const_iterator_adaptor::GetCurrentIterator() const
 {
     auto it = mrValue.cbegin();
-    for (std::size_t i = 0; i < mDistance; ++i)
-        it++;
+    std::advance(it, mDistance);
     return it;
 }
 

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -328,9 +328,9 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersChangeParameters, KratosCoreFastSuite)
 
     Parameters my_list = subparams["list_value"];
 
-    for (auto& r_param : my_list) {
-        if (r_param.IsBool()) {
-            KRATOS_CHECK_IS_FALSE(r_param.GetBool())
+    for (auto param : my_list) {
+        if (param.IsBool()) {
+            KRATOS_CHECK_IS_FALSE(param.GetBool())
         }
     }
 
@@ -539,7 +539,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersIterators, KratosCoreFastSuite)
 
     // Iteration by items
     for(auto it=kp.begin(); it!=kp.end(); ++it) {
-        KRATOS_CHECK_STRING_EQUAL(kp[it.name()].PrettyPrintJsonString(), it->PrettyPrintJsonString());
+        KRATOS_CHECK_STRING_EQUAL(kp[it.name()].PrettyPrintJsonString(), (*it).PrettyPrintJsonString());
     }
 
     // Testing values

--- a/kratos/tests/cpp_tests/sources/test_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_parameters.cpp
@@ -41,12 +41,12 @@ namespace Kratos {
             KRATOS_CHECK((*i_parameter).IsBool());
             KRATOS_CHECK_EQUAL((*i_parameter).GetBool(), true);
             ++i_parameter;
-            KRATOS_CHECK(i_parameter->IsDouble());
-            KRATOS_CHECK_EQUAL(i_parameter->GetDouble(), 2.0);
+            KRATOS_CHECK((*i_parameter).IsDouble());
+            KRATOS_CHECK_EQUAL((*i_parameter).GetDouble(), 2.0);
             ++i_parameter;
             KRATOS_CHECK_EQUAL(i_parameter.name(), std::string("int_value"));
-            KRATOS_CHECK(i_parameter->IsInt());
-            KRATOS_CHECK_EQUAL(i_parameter->GetInt(), 10);
+            KRATOS_CHECK((*i_parameter).IsInt());
+            KRATOS_CHECK_EQUAL((*i_parameter).GetInt(), 10);
 
             unsigned int size = 0;
 

--- a/kratos/tests/cpp_tests/utilities/test_assign_unique_model_part_collection_tag_utility.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_assign_unique_model_part_collection_tag_utility.cpp
@@ -285,7 +285,7 @@ namespace Kratos
             for (auto itr = param_write.begin(); itr != param_write.end(); ++itr) {
                 const std::string& r_name = itr.name();
                 KRATOS_CHECK(param_read.Has(r_name));
-                const auto& r_write_string_array = itr->GetStringArray();
+                const auto& r_write_string_array = (*itr).GetStringArray();
                 const auto& r_read_string_array = param_read[r_name].GetStringArray();
                 std::unordered_set<std::string> aux_set;
                 for (auto& r_name : r_read_string_array) {

--- a/kratos/utilities/assign_unique_model_part_collection_tag_utility.cpp
+++ b/kratos/utilities/assign_unique_model_part_collection_tag_utility.cpp
@@ -244,7 +244,7 @@ Parameters AssignUniqueModelPartCollectionTagUtility::ReadTagsFromJson(
     buffer << infile.rdbuf();
     Parameters color_json(buffer.str());
     for (auto it_param = color_json.begin(); it_param != color_json.end(); ++it_param) {
-        const std::vector<std::string>& r_sub_model_part_names = it_param->GetStringArray();
+        const std::vector<std::string>& r_sub_model_part_names = (*it_param).GetStringArray();
         rCollections.insert(std::pair<IndexType,std::vector<std::string>>({std::stoi(it_param.name()), r_sub_model_part_names}));
     }
 


### PR DESCRIPTION
Closes #10649 . See the issue for details.

The member `mpParameters` is removed from `Parameters::iterator_adaptor` and `Parameters::const_iterator_adaptor`. Newly constructed `Parameters` instances are returned instead, which means that `operator->` cannot be used with these iterator adaptors anymore.