### PR TITLE
[HDF5] Add missing params instead of validation 

### DIFF
--- a/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
@@ -374,7 +374,7 @@ ContainerComponentIO<TContainerType, TContainerItemType, TComponents...>::Contai
             "list_of_variables": []
         })");
 
-    Settings.ValidateAndAssignDefaults(default_params);
+    Settings.AddMissingParameters(default_params);
 
     mComponentPath = Settings["prefix"].GetString() + rComponentPath;
     mComponentNames = Settings["list_of_variables"].GetStringArray();

--- a/applications/HDF5Application/custom_io/hdf5_file.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file.cpp
@@ -105,7 +105,7 @@ File::File(Parameters Settings)
                 "echo_level" : 0
             })");
 
-    Settings.RecursivelyValidateAndAssignDefaults(default_params);
+    Settings.RecursivelyAddMissingParameters(default_params);
 
     m_file_name = Settings["file_name"].GetString();
     KRATOS_ERROR_IF(m_file_name == "PLEASE_SPECIFY_HDF5_FILENAME") << "Invalid file name: " << m_file_name << std::endl;

--- a/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_data_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_nodal_solution_step_data_io.cpp
@@ -85,7 +85,7 @@ NodalSolutionStepDataIO::NodalSolutionStepDataIO(Parameters Settings, File::Poin
             "list_of_variables": []
         })");
 
-    Settings.ValidateAndAssignDefaults(default_params);
+    Settings.AddMissingParameters(default_params);
 
     mPrefix = Settings["prefix"].GetString();
     mVariableNames = Settings["list_of_variables"].GetStringArray();

--- a/applications/HDF5Application/custom_io/hdf5_vertex_container_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_vertex_container_io.cpp
@@ -28,7 +28,7 @@ VertexContainerIO::VertexContainerIO(Parameters parameters, File::Pointer pFile)
 {
     KRATOS_TRY
 
-    parameters.ValidateAndAssignDefaults(VertexContainerIO::GetDefaultParameters());
+    parameters.AddMissingParameters(VertexContainerIO::GetDefaultParameters());
 
     KRATOS_CATCH("");
 }
@@ -48,7 +48,7 @@ Parameters VertexContainerIO::FormatParameters(Parameters parameters)
     KRATOS_TRY
 
     Parameters output = parameters.Clone();
-    output.ValidateAndAssignDefaults(VertexContainerIO::GetDefaultParameters());
+    output.AddMissingParameters(VertexContainerIO::GetDefaultParameters());
     output["prefix"].SetString("");
     return output;
 
@@ -60,7 +60,7 @@ std::string VertexContainerIO::GetPath(Parameters parameters)
 {
     KRATOS_TRY
 
-    parameters.ValidateAndAssignDefaults(VertexContainerIO::GetDefaultParameters());
+    parameters.AddMissingParameters(VertexContainerIO::GetDefaultParameters());
     return parameters["prefix"].GetString();
 
     KRATOS_CATCH("");
@@ -73,7 +73,7 @@ VertexContainerCoordinateIO::VertexContainerCoordinateIO(Parameters parameters,
 {
     KRATOS_TRY
 
-    parameters.ValidateAndAssignDefaults(VertexContainerCoordinateIO::GetDefaultParameters());
+    parameters.AddMissingParameters(VertexContainerCoordinateIO::GetDefaultParameters());
     mWriteIDs = parameters["write_vertex_ids"].GetBool();
 
     KRATOS_CATCH("");
@@ -164,7 +164,7 @@ Parameters VertexContainerCoordinateIO::FormatParameters(Parameters parameters)
 {
     KRATOS_TRY
 
-    parameters.ValidateAndAssignDefaults(VertexContainerCoordinateIO::GetDefaultParameters());
+    parameters.AddMissingParameters(VertexContainerCoordinateIO::GetDefaultParameters());
 
     Parameters output = parameters.Clone();
     output.RemoveValue("write_vertex_ids");
@@ -172,7 +172,6 @@ Parameters VertexContainerCoordinateIO::FormatParameters(Parameters parameters)
     return output;
 
     KRATOS_CATCH("");
-
 }
 
 


### PR DESCRIPTION
## Description
Call `Parameters::AddMissingParameters` instead of `Parameters::ValidateAndAssignDefaults` on the C++ level. The reason is that objects in the HDF5 application are **always** nested, which means that the `Parameters` they get constructed by always go through multiple layers, possibly requiring a set of settings that gets narrower with each level.

Consider the following setup:
```py
class Inner
  def __init__(self, params):
    # Expects {
    #    "io_settings" : {}
    # }
    pass

class Outer
  def __init__(self, params):
    # Expects {
    #    "model_part_name" : "",
    #    "io_settings" : {}
    # }
    ...
    self.inner = Inner(...)
```

If `Parameters::ValidateAndAssignDefaults` is called on the passed parameters, the `params` that `Outer` gets constructed with needs to be cleaned of extra entries first. This PR encourages objects to get initialized using only a subset of the settings they get passed, instead of rejecting extra settings they don't recognize.

The benefit is that modifications to specific settings propagate back to the original user-defined `Parameters` object, and there's less need to nest `Parameters` into each other. The drawback is that typos go unnoticed, and default settings get applied instead. 

