### PR TITLE
Fixed a CMake syntax error on Windows during installation

### DIFF
--- a/scripts/post_install/CMakeLists.txt
+++ b/scripts/post_install/CMakeLists.txt
@@ -2,5 +2,6 @@ set(KRATOS_GENERATE_PYTHON_STUBS OFF CACHE BOOL "Generate hints for binary pytho
 
 if (${KRATOS_GENERATE_PYTHON_STUBS})
     install(CODE "message(STATUS \"Trying to install python stub files to enable python hinting support for cpp libraries in IDEs...\")")
-    install(CODE "execute_process(COMMAND \"${PYTHON_EXECUTABLE}\" \"${CMAKE_CURRENT_SOURCE_DIR}/stub_generation.py\" \"${CMAKE_INSTALL_PREFIX}\" --quiet)")
+    cmake_path(CONVERT ${PYTHON_EXECUTABLE} TO_CMAKE_PATH_LIST CONVERTED_PY_EXEC)
+    install(CODE "execute_process(COMMAND \"${CONVERTED_PY_EXEC}\" \"${CMAKE_CURRENT_SOURCE_DIR}/stub_generation.py\" \"${CMAKE_INSTALL_PREFIX}\" --quiet)")
 endif()


### PR DESCRIPTION
**📝 Description**
The Windows path to the Python executable was used 'as-is' when defining a CMake string for the command to execute. As a result, a syntax error was reported by CMake (the directory separator `\` was interpreted as an escape character). It has been fixed by converting the path to the Python executable to a CMake path first.

**🆕 Changelog**
Fixes #10652.
