### PR TITLE
[Meshing] Convert linear tets to quadratic  - use root model part

### DIFF
--- a/applications/MeshingApplication/custom_utilities/linear_to_quadratic_tetrahedra_mesh_converter_utility.cpp
+++ b/applications/MeshingApplication/custom_utilities/linear_to_quadratic_tetrahedra_mesh_converter_utility.cpp
@@ -130,7 +130,7 @@ namespace Kratos {
 
         // Now replace the elements in SubModelParts
         if ( NewElements.size() > 0 ) {
-            ReplaceElementsInSubModelPart(rThisModelPart);
+            ReplaceElementsInSubModelPart(rThisModelPart.GetRootModelPart());
         }
     }
 


### PR DESCRIPTION
**📝 Description**
I found a bug while using this utility to convert linear tests to quadratic ones. The replacement is not being done in the root model part, and therefore this root model part still has the original linear elements.

This is even worse if you call later the replace element and conditions process as this process aslways uses the elements from the root model part, so you will end up with linear elements again.
