### PR TITLE
[Core] ModelPredicate

### DIFF
--- a/kratos/python/add_predicates_to_python.cpp
+++ b/kratos/python/add_predicates_to_python.cpp
@@ -24,8 +24,6 @@ namespace Kratos::Python
 class KRATOS_API(KratosCore) ModelPredicateTrampoline : public ModelPredicate
 {
 public:
-    using ModelPredicate::ModelPredicate;
-
     bool operator()(const Model& rModel) const override
     {
         using ReturnType = bool;
@@ -43,7 +41,6 @@ public:
 void AddPredicatesToPython(pybind11::module& rModule)
 {
     pybind11::class_<ModelPredicate, ModelPredicate::Pointer, ModelPredicateTrampoline>(rModule, "ModelPredicate")
-        .def(pybind11::init<>())
         .def("__call__", &ModelPredicate::operator())
         ;
 }

--- a/kratos/python/add_predicates_to_python.cpp
+++ b/kratos/python/add_predicates_to_python.cpp
@@ -13,6 +13,7 @@
 // --- Core Includes ---
 #include "add_predicates_to_python.h"
 #include "utilities/model_predicate.h"
+#include "includes/define.h"
 
 
 namespace Kratos::Python
@@ -20,7 +21,7 @@ namespace Kratos::Python
 
 
 /// @brief Wrapper class for binding a pure virtual class.
-class ModelPredicateTrampoline : public ModelPredicate
+class KRATOS_API(KratosCore) ModelPredicateTrampoline : public ModelPredicate
 {
 public:
     using ModelPredicate::ModelPredicate;

--- a/kratos/python/add_predicates_to_python.cpp
+++ b/kratos/python/add_predicates_to_python.cpp
@@ -1,0 +1,51 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   license: HDF5Application/license.txt
+//
+//  Main author:     Máté Kelemen
+//
+
+// --- Core Includes ---
+#include "add_predicates_to_python.h"
+#include "utilities/model_predicate.h"
+
+
+namespace Kratos::Python
+{
+
+
+/// @brief Wrapper class for binding a pure virtual class.
+class ModelPredicateTrampoline : public ModelPredicate
+{
+public:
+    using ModelPredicate::ModelPredicate;
+
+    bool operator()(const Model& rModel) const override
+    {
+        using ReturnType = bool;
+        using BaseType = ModelPredicate;
+        PYBIND11_OVERRIDE_PURE(
+            ReturnType,
+            BaseType,
+            operator(),
+            rModel
+        );
+    }
+}; // class ModelPredicateTrampoline
+
+
+void AddPredicatesToPython(pybind11::module& rModule)
+{
+    pybind11::class_<ModelPredicate, ModelPredicate::Pointer, ModelPredicateTrampoline>(rModule, "ModelPredicate")
+        .def(pybind11::init<>())
+        .def("__call__", &ModelPredicate::operator())
+        ;
+}
+
+
+} // namespace Kratos::Python

--- a/kratos/python/add_predicates_to_python.h
+++ b/kratos/python/add_predicates_to_python.h
@@ -1,0 +1,26 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   license: HDF5Application/license.txt
+//
+//  Main author:     Máté Kelemen
+//
+
+#pragma once
+
+// --- External Includes ---
+#include "pybind11/pybind11.h"
+
+
+namespace Kratos::Python
+{
+
+
+void AddPredicatesToPython(pybind11::module& rModule);
+
+
+} // namespace Kratos::Python

--- a/kratos/python/kratos_python.cpp
+++ b/kratos/python/kratos_python.cpp
@@ -33,6 +33,7 @@
 #include "add_matrix_to_python.h"
 #include "add_quaternion_to_python.h"
 #include "add_points_to_python.h"
+#include "add_predicates_to_python.h"
 #include "add_geometries_to_python.h"
 #include "add_bounding_box_to_python.h"
 #include "add_containers_to_python.h"
@@ -92,6 +93,7 @@ PYBIND11_MODULE(Kratos, m)
     AddVectorToPython(m);
     AddMatrixToPython(m);
     AddPointsToPython(m);
+    AddPredicatesToPython(m);
     AddKernelToPython(m);
     AddContainersToPython(m);
     AddModelPartToPython(m);

--- a/kratos/utilities/model_predicate.h
+++ b/kratos/utilities/model_predicate.h
@@ -1,0 +1,35 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   license: HDF5Application/license.txt
+//
+//  Main author:     Máté Kelemen
+//
+
+#pragma once
+
+// Core includes
+#include "containers/model.h"
+#include "includes/define.h"
+
+
+namespace Kratos
+{
+
+
+/// @brief Base class for functors that take a @ref Model and return a bool.
+struct KRATOS_API(KratosCore) ModelPredicate
+{
+    KRATOS_CLASS_POINTER_DEFINITION(ModelPredicate);
+
+    virtual ~ModelPredicate() {}
+
+    virtual bool operator()(const Model& rModel) const = 0;
+}; // struct ModelPredicate
+
+
+} // namespace Kratos


### PR DESCRIPTION
## Description

Add a generic interface for making decisions based on the state of a `Model`. This class is meant to be used primarily in controllers from #10617, but is also suitable for input verification, result validation, state checks (eg.: is every required variable available in the model), etc.

I highly recommend using it in tandem with pipes #10659.

Not much to say about what it does: `Model` goes in, `bool` comes out. The specifics are to be implemented in derived classes. Ideally, the predicate is stateless and doesn't mutate anything but there's no way of enforcing that in a base class.
