### PR TITLE
[Core] Consistent `AddNode` and `AddElement` with `AddCondition`

### DIFF
--- a/kratos/python/add_model_part_to_python.cpp
+++ b/kratos/python/add_model_part_to_python.cpp
@@ -5,18 +5,16 @@
 //                   Multi-Physics
 //
 //  License:         BSD License
-//                     Kratos default license: kratos/license.txt
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //
 //
 
-
 // System includes
 
 // External includes
 #include <pybind11/stl.h>
-
 
 // Project includes
 #include "includes/define_python.h"
@@ -650,19 +648,39 @@ void RemoveSubModelPart2(ModelPart& rModelPart, ModelPart& ThisSubModelPart)
     rModelPart.RemoveSubModelPart(ThisSubModelPart);
 }
 
+void AddNode1(ModelPart& rModelPart, ModelPart::NodeType::Pointer pNode)
+{
+    rModelPart.AddNode(pNode);
+}
+
+void AddNode2(ModelPart& rModelPart, ModelPart::NodeType::Pointer pNode, const ModelPart::IndexType MeshId )
+{
+    rModelPart.AddNode(pNode, MeshId);
+}
+
 void AddNodesByIds(ModelPart& rModelPart, std::vector< ModelPart::IndexType >& NodesIds )
 {
     rModelPart.AddNodes(NodesIds);
 }
 
-void AddConditionsByIds(ModelPart& rModelPart,std::vector< ModelPart::IndexType >& ConditionsIds )
+void AddElement1(ModelPart& rModelPart, ModelPart::Element::Pointer pElement)
 {
-    rModelPart.AddConditions(ConditionsIds);
+    rModelPart.AddElement(pElement);
+}
+
+void AddElement2(ModelPart& rModelPart, ModelPart::Element::Pointer pElement, const ModelPart::IndexType MeshId )
+{
+    rModelPart.AddElement(pElement, MeshId);
 }
 
 void AddElementsByIds(ModelPart& rModelPart, std::vector< ModelPart::IndexType >& ElementsIds )
 {
     rModelPart.AddElements(ElementsIds);
+}
+
+void AddConditionsByIds(ModelPart& rModelPart,std::vector< ModelPart::IndexType >& ConditionsIds )
+{
+    rModelPart.AddConditions(ConditionsIds);
 }
 
 const ModelPart::SubModelPartIterator GetSubModelPartBegin(ModelPart& rModelPart)
@@ -766,6 +784,8 @@ void AddModelPartToPython(pybind11::module& m)
         .def("SetNodes", ModelPartSetNodes1)
         .def("GetNodes", ModelPartGetNodes2)
         .def("SetNodes", ModelPartSetNodes2)
+        .def("AddNode", AddNode1)
+        .def("AddNode", AddNode2)
         .def("RemoveNode", ModelPartRemoveNode1)
         .def("RemoveNode", ModelPartRemoveNode2)
         .def("RemoveNode", ModelPartRemoveNode3)
@@ -804,6 +824,8 @@ void AddModelPartToPython(pybind11::module& m)
         .def("SetElements", ModelPartSetElements1)
         .def("GetElements", ModelPartGetElements2)
         .def("SetElements", ModelPartSetElements2)
+        .def("AddElement", AddElement1)
+        .def("AddElement", AddElement2)
         .def("RemoveElement", ModelPartRemoveElement1)
         .def("RemoveElement", ModelPartRemoveElement2)
         .def("RemoveElement", ModelPartRemoveElement3)
@@ -891,11 +913,8 @@ void AddModelPartToPython(pybind11::module& m)
         .def("Check", &ModelPart::Check)
         .def("IsSubModelPart", &ModelPart::IsSubModelPart)
         .def("IsDistributed", &ModelPart::IsDistributed)
-        .def("AddNode", &ModelPart::AddNode)
         .def("AddNodes",AddNodesByIds)
-        .def("AddCondition", &ModelPart::AddCondition)
         .def("AddConditions",AddConditionsByIds)
-        .def("AddElement", &ModelPart::AddElement)
         .def("AddElements",AddElementsByIds)
         .def("GetParentModelPart", [](ModelPart& self) -> ModelPart& {return self.GetParentModelPart();}, py::return_value_policy::reference_internal)
         .def("GetRootModelPart",   [](ModelPart& self) -> ModelPart& {return self.GetRootModelPart();},   py::return_value_policy::reference_internal)

--- a/kratos/python/add_model_part_to_python.cpp
+++ b/kratos/python/add_model_part_to_python.cpp
@@ -663,12 +663,12 @@ void AddNodesByIds(ModelPart& rModelPart, std::vector< ModelPart::IndexType >& N
     rModelPart.AddNodes(NodesIds);
 }
 
-void AddElement1(ModelPart& rModelPart, ModelPart::Element::Pointer pElement)
+void AddElement1(ModelPart& rModelPart, Element::Pointer pElement)
 {
     rModelPart.AddElement(pElement);
 }
 
-void AddElement2(ModelPart& rModelPart, ModelPart::Element::Pointer pElement, const ModelPart::IndexType MeshId )
+void AddElement2(ModelPart& rModelPart, Element::Pointer pElement, const ModelPart::IndexType MeshId )
 {
     rModelPart.AddElement(pElement, MeshId);
 }


### PR DESCRIPTION
**📝 Description**

Consistent `AddNode` and `AddElement` with `AddCondition` where  `MeshId` is not mandatory

**🆕 Changelog**

- [Consistent AddNode and AddElement with AddCondition](https://github.com/KratosMultiphysics/Kratos/commit/c6d6c81b37a4684400622acb5c664b93b4d54a68)