### PR TITLE
Adding artificial viscosity to the two fluid newtonian constitutive law.

### DIFF
--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_2d_law.cpp
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_2d_law.cpp
@@ -20,7 +20,7 @@
 #include "includes/cfd_variables.h"
 #include "utilities/element_size_calculator.h"
 #include "custom_constitutive/newtonian_two_fluid_2d_law.h"
-#include "fluid_dynamics_application.h"
+#include "fluid_dynamics_application_variables.h"
 
 namespace Kratos
 {

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_2d_law.cpp
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_2d_law.cpp
@@ -20,6 +20,7 @@
 #include "includes/cfd_variables.h"
 #include "utilities/element_size_calculator.h"
 #include "custom_constitutive/newtonian_two_fluid_2d_law.h"
+#include "fluid_dynamics_application.h"
 
 namespace Kratos
 {
@@ -77,6 +78,13 @@ double NewtonianTwoFluid2DLaw::GetEffectiveViscosity(ConstitutiveLaw::Parameters
     double viscosity;
     EvaluateInPoint(viscosity, DYNAMIC_VISCOSITY, rParameters);
     const Properties& prop = rParameters.GetMaterialProperties();
+    const GeometryType &rGeom = rParameters.GetElementGeometry();
+
+    if (rGeom.Has(ARTIFICIAL_DYNAMIC_VISCOSITY))
+        {
+            double artificial_visocisty = rGeom.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY);
+            viscosity += artificial_visocisty;
+        }
 
     if (prop.Has(C_SMAGORINSKY)) {
         const double csmag = prop[C_SMAGORINSKY];

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_2d_law.cpp
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_2d_law.cpp
@@ -80,10 +80,9 @@ double NewtonianTwoFluid2DLaw::GetEffectiveViscosity(ConstitutiveLaw::Parameters
     const Properties& prop = rParameters.GetMaterialProperties();
     const auto& r_geom = rParameters.GetElementGeometry();
 
-    if (rGeom.Has(ARTIFICIAL_DYNAMIC_VISCOSITY))
-        {
-            viscosity += rGeom.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY);;
-        }
+    if (r_geom.Has(ARTIFICIAL_DYNAMIC_VISCOSITY)){
+        viscosity += r_geom.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY);
+    }
 
     if (prop.Has(C_SMAGORINSKY)) {
         const double csmag = prop[C_SMAGORINSKY];

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_2d_law.cpp
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_2d_law.cpp
@@ -78,7 +78,7 @@ double NewtonianTwoFluid2DLaw::GetEffectiveViscosity(ConstitutiveLaw::Parameters
     double viscosity;
     EvaluateInPoint(viscosity, DYNAMIC_VISCOSITY, rParameters);
     const Properties& prop = rParameters.GetMaterialProperties();
-    const GeometryType &rGeom = rParameters.GetElementGeometry();
+    const auto& r_geom = rParameters.GetElementGeometry();
 
     if (rGeom.Has(ARTIFICIAL_DYNAMIC_VISCOSITY))
         {

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_2d_law.cpp
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_2d_law.cpp
@@ -82,8 +82,7 @@ double NewtonianTwoFluid2DLaw::GetEffectiveViscosity(ConstitutiveLaw::Parameters
 
     if (rGeom.Has(ARTIFICIAL_DYNAMIC_VISCOSITY))
         {
-            double artificial_visocisty = rGeom.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY);
-            viscosity += artificial_visocisty;
+            viscosity += rGeom.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY);;
         }
 
     if (prop.Has(C_SMAGORINSKY)) {

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_3d_law.cpp
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_3d_law.cpp
@@ -19,7 +19,7 @@
 #include "includes/checks.h"
 #include "custom_constitutive/newtonian_two_fluid_3d_law.h"
 #include "utilities/element_size_calculator.h"
-#include "fluid_dynamics_application.h"
+#include "fluid_dynamics_application_variables.h"
 
 namespace Kratos
 {

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_3d_law.cpp
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_3d_law.cpp
@@ -83,8 +83,7 @@ double NewtonianTwoFluid3DLaw::GetEffectiveViscosity(ConstitutiveLaw::Parameters
 
     if (rGeom.Has(ARTIFICIAL_DYNAMIC_VISCOSITY))
     {
-        double artificial_visocisty = rGeom.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY);
-        viscosity += artificial_visocisty;
+        viscosity += rGeom.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY);
     }
 
     if (prop.Has(C_SMAGORINSKY)) {

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_3d_law.cpp
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_3d_law.cpp
@@ -81,24 +81,23 @@ double NewtonianTwoFluid3DLaw::GetEffectiveViscosity(ConstitutiveLaw::Parameters
     const Properties& prop = rParameters.GetMaterialProperties();
     const GeometryType &rGeom = rParameters.GetElementGeometry();
 
-    if(rGeom.Has(ARTIFICIAL_DYNAMIC_VISCOSITY)){
-            double artificial_visocisty = rGeom.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY);
-            viscosity +=artificial_visocisty;
+    if (rGeom.Has(ARTIFICIAL_DYNAMIC_VISCOSITY))
+    {
+        double artificial_visocisty = rGeom.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY);
+        viscosity += artificial_visocisty;
     }
 
-    if (prop.Has(C_SMAGORINSKY))
-    {
+    if (prop.Has(C_SMAGORINSKY)) {
         const double csmag = prop[C_SMAGORINSKY];
-        if (csmag > 0.0)
-        {
+        if (csmag > 0.0) {
             double density;
             EvaluateInPoint(density, DENSITY, rParameters);
             const double strain_rate = EquivalentStrainRate(rParameters);
-            const BoundedMatrix<double, 4, 3> &DN_DX = rParameters.GetShapeFunctionsDerivatives();
-            const double elem_size = ElementSizeCalculator<3, 4>::GradientsElementSize(DN_DX);
+            const BoundedMatrix<double, 4, 3>& DN_DX = rParameters.GetShapeFunctionsDerivatives();
+            const double elem_size = ElementSizeCalculator<3,4>::GradientsElementSize(DN_DX);
             const double length_scale = std::pow(csmag * elem_size, 2);
             // length_scale *= length_scale;
-            viscosity += 2.0 * length_scale * strain_rate * density;
+            viscosity += 2.0*length_scale * strain_rate * density;
         }
     }
     return viscosity;

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_3d_law.cpp
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_3d_law.cpp
@@ -81,9 +81,8 @@ double NewtonianTwoFluid3DLaw::GetEffectiveViscosity(ConstitutiveLaw::Parameters
     const Properties& prop = rParameters.GetMaterialProperties();
     const auto& r_geom = rParameters.GetElementGeometry();
 
-    if (rGeom.Has(ARTIFICIAL_DYNAMIC_VISCOSITY))
-    {
-        viscosity += rGeom.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY);
+    if (r_geom.Has(ARTIFICIAL_DYNAMIC_VISCOSITY)){
+        viscosity += r_geom.GetValue(ARTIFICIAL_DYNAMIC_VISCOSITY);
     }
 
     if (prop.Has(C_SMAGORINSKY)) {

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_3d_law.cpp
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_two_fluid_3d_law.cpp
@@ -79,7 +79,7 @@ double NewtonianTwoFluid3DLaw::GetEffectiveViscosity(ConstitutiveLaw::Parameters
     double viscosity;
     EvaluateInPoint(viscosity, DYNAMIC_VISCOSITY, rParameters);
     const Properties& prop = rParameters.GetMaterialProperties();
-    const GeometryType &rGeom = rParameters.GetElementGeometry();
+    const auto& r_geom = rParameters.GetElementGeometry();
 
     if (rGeom.Has(ARTIFICIAL_DYNAMIC_VISCOSITY))
     {


### PR DESCRIPTION
**📝 Description**
To reduce local numerical noise in  two-fluid simulations  we will add the option to activate a **shock capturing** technique. To accomplish this, we must first add an artificial viscosity to the two fluid constitutive law.
Consequently, the effective viscosity is modified for the 2D and 3D cases in this PR. 

**🆕 Changelog**
- newtonian_two_fluid_2d_law.cpp
- newtonian_two_fluid_3d_law.cpp



