### PR TITLE
[Core] Tets10 - adding HasIntersection for planar geoms

### DIFF
--- a/kratos/geometries/tetrahedra_3d_10.h
+++ b/kratos/geometries/tetrahedra_3d_10.h
@@ -1065,10 +1065,10 @@ private:
     bool FacesArePlanar() const
     {
         constexpr double tol = 1e-6;
-        for (auto edge : this->GenerateEdges()) {
-            const double a = MathUtils<double>::Norm3(edge.GetPoint(0)-edge.GetPoint(1));
-            const double b = MathUtils<double>::Norm3(edge.GetPoint(1)-edge.GetPoint(2));
-            const double c = MathUtils<double>::Norm3(edge.GetPoint(2)-edge.GetPoint(0));
+        for (auto& r_edge : this->GenerateEdges()) {
+            const double a = MathUtils<double>::Norm3(r_edge.GetPoint(0)-r_edge.GetPoint(1));
+            const double b = MathUtils<double>::Norm3(r_edge.GetPoint(1)-r_edge.GetPoint(2));
+            const double c = MathUtils<double>::Norm3(r_edge.GetPoint(2)-r_edge.GetPoint(0));
             if (b + c > a + c*tol) {
                 return false;
             }

--- a/kratos/geometries/tetrahedra_3d_10.h
+++ b/kratos/geometries/tetrahedra_3d_10.h
@@ -1069,7 +1069,7 @@ private:
             const double a = MathUtils<double>::Norm3(edge.GetPoint(0)-edge.GetPoint(1));
             const double b = MathUtils<double>::Norm3(edge.GetPoint(1)-edge.GetPoint(2));
             const double c = MathUtils<double>::Norm3(edge.GetPoint(2)-edge.GetPoint(0));
-            if (b + c > a + c*tol) {
+            if (b + c > a*(1.0+tol) ) {
                 return false;
             }
         }

--- a/kratos/geometries/tetrahedra_3d_10.h
+++ b/kratos/geometries/tetrahedra_3d_10.h
@@ -23,6 +23,7 @@
 
 // Project includes
 #include "geometries/triangle_3d_6.h"
+#include "geometries/tetrahedra_3d_4.h"
 #include "utilities/integration_utilities.h"
 #include "integration/tetrahedron_gauss_legendre_integration_points.h"
 
@@ -769,6 +770,29 @@ public:
         return rResult;
     }
 
+    /** Tests the intersection of the geometry with
+     * a 3D box defined by rLowPoint and rHighPoint.
+     * The method is only implemented for simple tets
+     * where the faces are planar.
+     *
+     * @param  rLowPoint  Lower point of the box to test the intersection
+     * @param  rHighPoint Higher point of the box to test the intersection
+     * @return            True if the geometry intersects the box, False in any other case.
+     */
+    bool HasIntersection(const Point& rLowPoint, const Point& rHighPoint) const override
+    {
+        if (this->FacesArePlanar()) {
+            return Tetrahedra3D4<TPointType>(
+                this->pGetPoint(0),
+                this->pGetPoint(1),
+                this->pGetPoint(2),
+                this->pGetPoint(3)).HasIntersection(rLowPoint, rHighPoint);
+        } else {
+             KRATOS_ERROR << "\"HasIntersection\" is not implemented for non-planar 10 noded tetrahedra.";
+        }
+        return false;
+    }
+
 
     /**
      * Input and output
@@ -1029,6 +1053,27 @@ private:
             }
         };
         return shape_functions_local_gradients;
+    }
+
+    /**
+     * Checks if faces are planar. We iterate for all edges and check
+     * that the sum of 0-2 and 2-1 segments is no bigger than 0-1.
+     *
+     * @return bool faces are planar or not
+     *
+     */
+    bool FacesArePlanar() const
+    {
+        constexpr double tol = 1e-6;
+        for (auto edge : this->GenerateEdges()) {
+            const double a = MathUtils<double>::Norm3(edge.GetPoint(0)-edge.GetPoint(1));
+            const double b = MathUtils<double>::Norm3(edge.GetPoint(1)-edge.GetPoint(2));
+            const double c = MathUtils<double>::Norm3(edge.GetPoint(2)-edge.GetPoint(0));
+            if (b + c > a + c*tol) {
+                return false;
+            }
+        }
+        return true;
     }
 
 

--- a/kratos/tests/cpp_tests/geometries/test_tetrahedra_3d_10.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_tetrahedra_3d_10.cpp
@@ -168,5 +168,22 @@ namespace{
     KRATOS_CHECK_NEAR(geom->AverageEdgeLength(), 1.20710678119, 1e-7);
   }
 
+  KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D10HasIntersection, KratosCoreGeometriesFastSuite) {
+    const Point LowPoint(0.1,0.1,-0.1);
+    const Point HighPoint(0.1,0.1,1.1);
+    
+    const Point OutLowPoint(1.1,0.1,-0.1);
+    const Point OutHighPoint(1.1,0.1,1.1);
+
+    auto geom = GenerateReferenceTetrahedra3D10();
+    KRATOS_CHECK(geom->HasIntersection(LowPoint, HighPoint));
+    KRATOS_CHECK_IS_FALSE(geom->HasIntersection(OutLowPoint, OutHighPoint));
+
+    auto curved_geom = GenerateCurvedTetrahedra3D10();
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+      curved_geom->HasIntersection(LowPoint, HighPoint),
+      "\"HasIntersection\" is not implemented for non-planar 10 noded tetrahedra.");
+  }
+
 } // namespace Testing.
 } // namespace Kratos.


### PR DESCRIPTION
**📝 Description**
This PR implements the method HasIntersections for tets10 if they have planar faces. When we are in this case, we can simply use the implementation from tet4.

The reason for this PR is that we need to have this function to be able to use the bin locator in our cases in Altair with quadratical tets. In our problems, the quadratic mesh is always generated from linear tets so that is why we only need to cover this case.

Of course, the ideal case would be to implement this function for any tet10, but there is no analytical solution for quadratic geometries and the implementation will be quite difficult. I hope we can this merged so we can use it for our problems.

