### PR TITLE
[GeoMechanics] Eliminated two redundant checks and local variables

### DIFF
--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
@@ -147,10 +147,7 @@ protected:
     {
         KRATOS_TRY
 
-        int ierr = MotherType::Check();
-        if(ierr != 0) return ierr;
-
-        return ierr;
+        return MotherType::Check();
 
         KRATOS_CATCH( "" )
     }

--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_ramm_arc_length_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_ramm_arc_length_strategy.hpp
@@ -450,10 +450,7 @@ protected:
     {
         KRATOS_TRY
 
-        int ierr = MotherType::Check();
-        if(ierr != 0) return ierr;
-
-        return ierr;
+        return MotherType::Check();
 
         KRATOS_CATCH( "" )
     }


### PR DESCRIPTION
This fixes two 'bugs' reported by SonarQube.

**📝 Description**
SonarQube reported two bugs of type "Remove this conditional structure or edit its code blocks so that they're not all the same.". See [this SonarCloud page](https://sonarcloud.io/project/issues?resolved=false&types=BUG&sinceLeakPeriod=true&id=KratosGeomechanics).

**🆕 Changelog**
- Removed the redundant checks
- Removed redundant local variables `ierr`
