### PR TITLE
[Dam] Use absolute water level, not relative to ground level

### DIFF
--- a/applications/DamApplication/custom_processes/dam_added_mass_condition_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_added_mass_condition_process.hpp
@@ -100,8 +100,6 @@ class DamAddedMassConditionProcess : public Process
         else
             direction = 2;
 
-        double ref_coord = mReferenceCoordinate + mWaterLevel;
-
         if (nnodes != 0)
         {
             ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
@@ -111,14 +109,14 @@ class DamAddedMassConditionProcess : public Process
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
 
-                double y_water = ref_coord - (it->Coordinates()[direction]);
+                double y_water = mWaterLevel - (it->Coordinates()[direction]);
 
                 if (y_water < 0.0)
                 {
                     y_water = 0.0;
                 }
 
-                added_mass = 0.875 * mSpecific * sqrt(y_water * mWaterLevel);
+                added_mass = 0.875 * mSpecific * sqrt(y_water * (mWaterLevel - mReferenceCoordinate));
 
                 it->FastGetSolutionStepValue(var) = added_mass;
 
@@ -154,8 +152,6 @@ class DamAddedMassConditionProcess : public Process
         else
             direction = 2;
 
-        double ref_coord = mReferenceCoordinate + mWaterLevel;
-
         if (nnodes != 0)
         {
             ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
@@ -165,14 +161,14 @@ class DamAddedMassConditionProcess : public Process
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
 
-                double y_water = ref_coord - (it->Coordinates()[direction]);
+                double y_water = mWaterLevel - (it->Coordinates()[direction]);
 
                 if (y_water < 0.0)
                 {
                     y_water = 0.0;
                 }
 
-                added_mass = 0.875 * mSpecific * sqrt(y_water * mWaterLevel);
+                added_mass = 0.875 * mSpecific * sqrt(y_water * (mWaterLevel - mReferenceCoordinate));
 
                 it->FastGetSolutionStepValue(var) = added_mass;
 

--- a/applications/DamApplication/custom_processes/dam_bofang_condition_temperature_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_bofang_condition_temperature_process.hpp
@@ -139,7 +139,7 @@ class DamBofangConditionTemperatureProcess : public Process
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
 
-                double aux = (mReferenceCoordinate + mWaterLevel) - it->Coordinates()[direction];
+                double aux = mWaterLevel - it->Coordinates()[direction];
                 if (aux >= 0.0)
                 {
                     if (mIsFixed)
@@ -200,7 +200,7 @@ class DamBofangConditionTemperatureProcess : public Process
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
 
-                double aux = (mReferenceCoordinate + mWaterLevel) - it->Coordinates()[direction];
+                double aux = mWaterLevel - it->Coordinates()[direction];
                 if (aux >= 0.0)
                 {
                     if (mIsFixed)

--- a/applications/DamApplication/custom_processes/dam_hydro_condition_load_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_hydro_condition_load_process.hpp
@@ -112,8 +112,6 @@ class DamHydroConditionLoadProcess : public Process
         else
             direction = 2;
 
-        double ref_coord = mReferenceCoordinate + mWaterLevel;
-
         if (nnodes != 0)
         {
             ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
@@ -123,7 +121,7 @@ class DamHydroConditionLoadProcess : public Process
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
 
-                double pressure = (mSpecific * (ref_coord - it->Coordinates()[direction]));
+                double pressure = (mSpecific * (mWaterLevel - it->Coordinates()[direction]));
 
                 if (pressure > 0.0)
                 {
@@ -167,8 +165,6 @@ class DamHydroConditionLoadProcess : public Process
         else
             direction = 2;
 
-        double ref_coord = mReferenceCoordinate + mWaterLevel;
-
         if (nnodes != 0)
         {
             ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
@@ -178,7 +174,7 @@ class DamHydroConditionLoadProcess : public Process
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
 
-                double pressure = (mSpecific * (ref_coord - it->Coordinates()[direction]));
+                double pressure = (mSpecific * (mWaterLevel - it->Coordinates()[direction]));
 
                 if (pressure > 0.0)
                 {

--- a/applications/DamApplication/custom_processes/dam_nodal_reference_temperature_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_nodal_reference_temperature_process.hpp
@@ -98,7 +98,10 @@ public:
         {
             ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
-            if ((mInputFile == "") || (mInputFile == "- No file") || (mInputFile == "- Add new file"))
+            std::string no_file_str = "- No file";
+            std::string add_file_str = "- Add new file";
+
+            if ((mInputFile == "") || strstr(mInputFile.c_str(),no_file_str.c_str()) || strstr(mInputFile.c_str(),add_file_str.c_str()))
             {
                 #pragma omp parallel for
                 for(int i = 0; i<nnodes; i++)
@@ -140,7 +143,10 @@ public:
         {
             ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
-            if ((mInputFile == "") || (mInputFile == "- No file") || (mInputFile == "- Add new file"))
+            std::string no_file_str = "- No file";
+            std::string add_file_str = "- Add new file";
+
+            if ((mInputFile == "") || strstr(mInputFile.c_str(),no_file_str.c_str()) || strstr(mInputFile.c_str(),add_file_str.c_str()))
             {
                 #pragma omp parallel for
                 for(int i = 0; i<nnodes; i++)

--- a/applications/DamApplication/custom_processes/dam_reservoir_constant_temperature_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_reservoir_constant_temperature_process.hpp
@@ -128,7 +128,7 @@ class DamReservoirConstantTemperatureProcess : public Process
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
 
-                double aux = (mReferenceCoordinate + mWaterLevel) - it->Coordinates()[direction];
+                double aux = mWaterLevel - it->Coordinates()[direction];
                 if (aux >= 0.0)
                 {
                     if (mIsFixed)
@@ -187,7 +187,7 @@ class DamReservoirConstantTemperatureProcess : public Process
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
 
-                double aux = (mReferenceCoordinate + mWaterLevel) - it->Coordinates()[direction];
+                double aux = mWaterLevel - it->Coordinates()[direction];
                 if (aux >= 0.0)
                 {
                     if (mIsFixed)

--- a/applications/DamApplication/custom_processes/dam_reservoir_monitoring_temperature_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_reservoir_monitoring_temperature_process.hpp
@@ -162,7 +162,7 @@ class DamReservoirMonitoringTemperatureProcess : public Process
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
 
                 double aux = it->Coordinates()[direction];
-                if (aux < (mReferenceCoordinate + mWaterLevel))
+                if (aux < mWaterLevel)
                 {
                     if (mIsFixed)
                     {
@@ -170,7 +170,7 @@ class DamReservoirMonitoringTemperatureProcess : public Process
                     }
                     if (aux > mZCoord1)
                     {
-                        double Temperature = ((mAmbientTemp - mWaterTemp1)/((mReferenceCoordinate + mWaterLevel) - mZCoord1)) * (aux - mZCoord1) + mWaterTemp1;
+                        double Temperature = ((mAmbientTemp - mWaterTemp1)/(mWaterLevel - mZCoord1)) * (aux - mZCoord1) + mWaterTemp1;
                         it->FastGetSolutionStepValue(var) = Temperature;
                     }
                     else if ((aux <= mZCoord1) && (aux > mZCoord2))
@@ -260,7 +260,7 @@ class DamReservoirMonitoringTemperatureProcess : public Process
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
 
                 double aux = it->Coordinates()[direction];
-                if (aux < (mReferenceCoordinate + mWaterLevel))
+                if (aux < mWaterLevel)
                 {
                     if (mIsFixed)
                     {
@@ -268,7 +268,7 @@ class DamReservoirMonitoringTemperatureProcess : public Process
                     }
                     if (aux > mZCoord1)
                     {
-                        double Temperature = ((mAmbientTemp - mWaterTemp1)/((mReferenceCoordinate + mWaterLevel) - mZCoord1)) * (aux - mZCoord1) + mWaterTemp1;
+                        double Temperature = ((mAmbientTemp - mWaterTemp1)/(mWaterLevel - mZCoord1)) * (aux - mZCoord1) + mWaterTemp1;
                         it->FastGetSolutionStepValue(var) = Temperature;
                     }
                     else if ((aux <= mZCoord1) && (aux > mZCoord2))

--- a/applications/DamApplication/custom_processes/dam_uplift_circular_condition_load_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_uplift_circular_condition_load_process.hpp
@@ -170,12 +170,10 @@ class DamUpliftCircularConditionLoadProcess : public Process
         {
             ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
-            double ref_coord = mReferenceCoordinate + mWaterLevel;
-
             if (mDrain == true)
             {
                 double coefficient_effectiveness = 1.0 - mEffectivenessDrain;
-                double aux_drain = coefficient_effectiveness * (mWaterLevel - mHeightDrain) * ((width_dam - mDistanceDrain) / width_dam) + mHeightDrain;
+                double aux_drain = coefficient_effectiveness * ((mWaterLevel - mReferenceCoordinate) - mHeightDrain) * ((width_dam - mDistanceDrain) / width_dam) + mHeightDrain;
 
 #pragma omp parallel for
                 for (int i = 0; i < nnodes; i++)
@@ -190,7 +188,7 @@ class DamUpliftCircularConditionLoadProcess : public Process
                     double current_radius = sqrt(auxiliar_vector[radius_comp_1] * auxiliar_vector[radius_comp_1] + auxiliar_vector[radius_comp_2] * auxiliar_vector[radius_comp_2]);
 
                     //// We compute the first part of the uplift law
-                    mUpliftPressure = mSpecific * ((ref_coord - aux_drain) - (r_coordinates[direction])) * (1.0 - ((1.0 / mDistanceDrain) * (fabs(current_radius - up_radius)))) + (mSpecific * aux_drain);
+                    mUpliftPressure = mSpecific * ((mWaterLevel - aux_drain) - (r_coordinates[direction])) * (1.0 - ((1.0 / mDistanceDrain) * (fabs(current_radius - up_radius)))) + (mSpecific * aux_drain);
 
                     //// If uplift pressure is greater than the limit we compute the second part and we update the value
                     if (mUpliftPressure <= mSpecific * aux_drain)
@@ -222,7 +220,7 @@ class DamUpliftCircularConditionLoadProcess : public Process
                     // Computing the current distance to the focus.
                     double current_radius = sqrt(auxiliar_vector[radius_comp_1] * auxiliar_vector[radius_comp_1] + auxiliar_vector[radius_comp_2] * auxiliar_vector[radius_comp_2]);
 
-                    mUpliftPressure = mSpecific * (ref_coord - (r_coordinates[direction])) * (1.0 - (1.0 / width_dam) * (fabs(current_radius - up_radius)));
+                    mUpliftPressure = mSpecific * (mWaterLevel - (r_coordinates[direction])) * (1.0 - (1.0 / width_dam) * (fabs(current_radius - up_radius)));
 
                     if (mUpliftPressure < 0.0)
                     {
@@ -295,12 +293,10 @@ class DamUpliftCircularConditionLoadProcess : public Process
         {
             ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
-            double ref_coord = mReferenceCoordinate + mWaterLevel;
-
             if (mDrain == true)
             {
                 double coefficient_effectiveness = 1.0 - mEffectivenessDrain;
-                double aux_drain = coefficient_effectiveness * (mWaterLevel - mHeightDrain) * ((width_dam - mDistanceDrain) / width_dam) + mHeightDrain;
+                double aux_drain = coefficient_effectiveness * ((mWaterLevel - mReferenceCoordinate) - mHeightDrain) * ((width_dam - mDistanceDrain) / width_dam) + mHeightDrain;
 
 #pragma omp parallel for
                 for (int i = 0; i < nnodes; i++)
@@ -315,7 +311,7 @@ class DamUpliftCircularConditionLoadProcess : public Process
                     double current_radius = sqrt(auxiliar_vector[radius_comp_1] * auxiliar_vector[radius_comp_1] + auxiliar_vector[radius_comp_2] * auxiliar_vector[radius_comp_2]);
 
                     //// We compute the first part of the uplift law
-                    mUpliftPressure = mSpecific * ((ref_coord - aux_drain) - (r_coordinates[direction])) * (1.0 - ((1.0 / mDistanceDrain) * (fabs(current_radius - up_radius)))) + (mSpecific * aux_drain);
+                    mUpliftPressure = mSpecific * ((mWaterLevel - aux_drain) - (r_coordinates[direction])) * (1.0 - ((1.0 / mDistanceDrain) * (fabs(current_radius - up_radius)))) + (mSpecific * aux_drain);
 
                     //// If uplift pressure is greater than the limit we compute the second part and we update the value
                     if (mUpliftPressure <= mSpecific * aux_drain)
@@ -347,7 +343,7 @@ class DamUpliftCircularConditionLoadProcess : public Process
                     // Computing the current distance to the focus.
                     double current_radius = sqrt(auxiliar_vector[radius_comp_1] * auxiliar_vector[radius_comp_1] + auxiliar_vector[radius_comp_2] * auxiliar_vector[radius_comp_2]);
 
-                    mUpliftPressure = mSpecific * (ref_coord - (r_coordinates[direction])) * (1.0 - (1.0 / width_dam) * (fabs(current_radius - up_radius)));
+                    mUpliftPressure = mSpecific * (mWaterLevel - (r_coordinates[direction])) * (1.0 - (1.0 / width_dam) * (fabs(current_radius - up_radius)));
 
                     if (mUpliftPressure < 0.0)
                     {

--- a/applications/DamApplication/custom_processes/dam_uplift_condition_load_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_uplift_condition_load_process.hpp
@@ -159,12 +159,10 @@ class DamUpliftConditionLoadProcess : public Process
         {
             ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
-            double ref_coord = mReferenceCoordinate + mWaterLevel;
-
             if (mDrain == true)
             {
                 double coefficient_effectiveness = 1.0 - mEffectivenessDrain;
-                double aux_drain = coefficient_effectiveness * (mWaterLevel - mHeightDrain) * ((mBaseDam - mDistanceDrain) / mBaseDam) + mHeightDrain;
+                double aux_drain = coefficient_effectiveness * ((mWaterLevel - mReferenceCoordinate) - mHeightDrain) * ((mBaseDam - mDistanceDrain) / mBaseDam) + mHeightDrain;
 
 #pragma omp parallel for
                 for (int i = 0; i < nnodes; i++)
@@ -179,7 +177,7 @@ class DamUpliftConditionLoadProcess : public Process
                     newCoordinate = prod(RotationMatrix, auxiliar_vector);
 
                     // We compute the first part of the uplift law
-                    mUpliftPressure = (mSpecific * ((ref_coord - aux_drain) - (r_coordinates[direction]))) * (1.0 - ((1.0 / (mDistanceDrain)) * (fabs((newCoordinate(0)) - reference_vector(0))))) + mSpecific * aux_drain;
+                    mUpliftPressure = (mSpecific * ((mWaterLevel - aux_drain) - (r_coordinates[direction]))) * (1.0 - ((1.0 / (mDistanceDrain)) * (fabs((newCoordinate(0)) - reference_vector(0))))) + mSpecific * aux_drain;
 
                     // If uplift pressure is greater than the limit we compute the second part and we update the value
                     if (mUpliftPressure <= mSpecific * aux_drain)
@@ -210,7 +208,7 @@ class DamUpliftConditionLoadProcess : public Process
 
                     newCoordinate = prod(RotationMatrix, auxiliar_vector);
 
-                    mUpliftPressure = (mSpecific * (ref_coord - (r_coordinates[direction]))) * (1.0 - ((1.0 / mBaseDam) * (fabs(newCoordinate(0) - reference_vector(0)))));
+                    mUpliftPressure = (mSpecific * (mWaterLevel - (r_coordinates[direction]))) * (1.0 - ((1.0 / mBaseDam) * (fabs(newCoordinate(0) - reference_vector(0)))));
 
                     if (mUpliftPressure < 0.0)
                     {
@@ -272,12 +270,10 @@ class DamUpliftConditionLoadProcess : public Process
         {
             ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
-            double ref_coord = mReferenceCoordinate + mWaterLevel;
-
             if (mDrain == true)
             {
                 double coefficient_effectiveness = 1.0 - mEffectivenessDrain;
-                double aux_drain = coefficient_effectiveness * (mWaterLevel - mHeightDrain) * ((mBaseDam - mDistanceDrain) / mBaseDam) + mHeightDrain;
+                double aux_drain = coefficient_effectiveness * ((mWaterLevel - mReferenceCoordinate) - mHeightDrain) * ((mBaseDam - mDistanceDrain) / mBaseDam) + mHeightDrain;
 
 #pragma omp parallel for
                 for (int i = 0; i < nnodes; i++)
@@ -292,7 +288,7 @@ class DamUpliftConditionLoadProcess : public Process
                     newCoordinate = prod(RotationMatrix, auxiliar_vector);
 
                     // We compute the first part of the uplift law
-                    mUpliftPressure = (mSpecific * ((ref_coord - aux_drain) - (r_coordinates[direction]))) * (1.0 - ((1.0 / (mDistanceDrain)) * (fabs((newCoordinate(0)) - reference_vector(0))))) + mSpecific * aux_drain;
+                    mUpliftPressure = (mSpecific * ((mWaterLevel - aux_drain) - (r_coordinates[direction]))) * (1.0 - ((1.0 / (mDistanceDrain)) * (fabs((newCoordinate(0)) - reference_vector(0))))) + mSpecific * aux_drain;
 
                     // If uplift pressure is greater than the limit we compute the second part and we update the value
                     if (mUpliftPressure <= mSpecific * aux_drain)
@@ -323,7 +319,7 @@ class DamUpliftConditionLoadProcess : public Process
 
                     newCoordinate = prod(RotationMatrix, auxiliar_vector);
 
-                    mUpliftPressure = (mSpecific * (ref_coord - (r_coordinates[direction]))) * (1.0 - ((1.0 / mBaseDam) * (fabs(newCoordinate(0) - reference_vector(0)))));
+                    mUpliftPressure = (mSpecific * (mWaterLevel - (r_coordinates[direction]))) * (1.0 - ((1.0 / mBaseDam) * (fabs(newCoordinate(0) - reference_vector(0)))));
 
                     if (mUpliftPressure < 0.0)
                     {

--- a/applications/DamApplication/custom_processes/dam_westergaard_condition_load_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_westergaard_condition_load_process.hpp
@@ -119,7 +119,6 @@ class DamWestergaardConditionLoadProcess : public Process
         else
             direction = 2;
 
-        double ref_coord = mReferenceCoordinate + mWaterLevel;
         double unit_acceleration = mAcceleration / 9.81;
 
         if (nnodes != 0)
@@ -131,14 +130,14 @@ class DamWestergaardConditionLoadProcess : public Process
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
 
-                double y_water = ref_coord - (it->Coordinates()[direction]);
+                double y_water = mWaterLevel - (it->Coordinates()[direction]);
 
                 if (y_water < 0.0)
                 {
                     y_water = 0.0;
                 }
 
-                pressure = (mSpecific * (y_water)) + 0.875 * (unit_acceleration)*mSpecific * sqrt(y_water * mWaterLevel);
+                pressure = (mSpecific * (y_water)) + 0.875 * (unit_acceleration)*mSpecific * sqrt(y_water * (mWaterLevel - mReferenceCoordinate));
                 it->FastGetSolutionStepValue(var) = pressure;
             }
         }
@@ -181,7 +180,6 @@ class DamWestergaardConditionLoadProcess : public Process
         else
             direction = 2;
 
-        double ref_coord = mReferenceCoordinate + mWaterLevel;
         double unit_acceleration = mAcceleration / 9.81;
 
         if (nnodes != 0)
@@ -193,7 +191,7 @@ class DamWestergaardConditionLoadProcess : public Process
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
 
-                double y_water = ref_coord - (it->Coordinates()[direction]);
+                double y_water = mWaterLevel - (it->Coordinates()[direction]);
 
                 if (y_water < 0.0)
                 {
@@ -203,7 +201,7 @@ class DamWestergaardConditionLoadProcess : public Process
                 // Hydrodynamics Westergaard effects just contribute when the acceleration goes in the upstream direction
                 if (unit_acceleration < 0.0)
                 {
-                    pressure = (mSpecific * (y_water)) + 0.875 * (-1.0 * unit_acceleration) * mSpecific * sqrt(y_water * mWaterLevel);
+                    pressure = (mSpecific * (y_water)) + 0.875 * (-1.0 * unit_acceleration) * mSpecific * sqrt(y_water * (mWaterLevel - mReferenceCoordinate));
                 }
                 else
                 {

--- a/applications/DamApplication/python_scripts/impose_nodal_reference_temperature_process.py
+++ b/applications/DamApplication/python_scripts/impose_nodal_reference_temperature_process.py
@@ -24,7 +24,7 @@ class ImposeNodalReferenceTemperatureProcess(Process):
         else:
             input_file_name = ""
 
-        if ((input_file_name == "") or (input_file_name == "- No file") or (input_file_name == "- Add new file")):
+        if ((input_file_name == "") or ("- No file" in input_file_name) or ("- Add new file" in input_file_name)):
             self.table = PiecewiseLinearTable()
         else:
             self.table = PiecewiseLinearTable()


### PR DESCRIPTION
**📝 Description**
After this RP, the water level of the dam will be the absolute water level, as in the monitored data.

**🆕 Changelog**
- Water level is now the actual water level, not (water_level + bottom_ref_coordinate)
- Fixed bug when no table is included for nodal reference temperature