### PR TITLE
[HDF5] Fix Memory Errors

### DIFF
--- a/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
@@ -155,8 +155,13 @@ public:
 
             // The sizes must be maxed across ranks to avoid
             // those without data writing 0 sizes.
-            std::array<int,2> send = sizes;
-            MPI_Allreduce(send.data(), sizes.data(), 2, MPI_INT, MPI_MAX, MPI_COMM_WORLD); // <== this needs a revamp with DataCommunicator @matekelemen
+            /// @todo This needs a revamp with DataCommunicator @matekelemen
+            int is_distributed;
+            MPI_Initialized(&is_distributed);
+            if (is_distributed) {
+                std::array<int,2> send = sizes;
+                MPI_Allreduce(send.data(), sizes.data(), 2, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+            }
 
             rFile.WriteAttribute(rPath + "/" + rComponent.Name(), "Size1", sizes[0]);
             rFile.WriteAttribute(rPath + "/" + rComponent.Name(), "Size2", sizes[1]);

--- a/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
@@ -718,16 +718,16 @@ void SetDataBuffer(Variable<Vector<double>> const& rVariable,
     if (!rContainerItems.empty()) {
         rData.resize(rContainerItems.size(),
                     rContainerItems.front()->GetValue(rVariable).size(), false);
-        #pragma omp parallel for
-        for (int i = 0; i < static_cast<int>(rContainerItems.size()); ++i) {
-            const TContainerItemType& r_item = *rContainerItems[i];
+
+        IndexPartition<int>(rContainerItems.size()).for_each([&rVariable, &rContainerItems, &rData](int i_item){
+            const TContainerItemType& r_item = *rContainerItems[i_item];
             Vector<double> const& r_vec = r_item.GetValue(rVariable);
             KRATOS_ERROR_IF(r_vec.size() != rData.size2())
                 << "Invalid dimension.\n";
             for (std::size_t j = 0; j < rData.size2(); ++j) {
-                rData(i, j) = r_vec(j);
+                rData(i_item, j) = r_vec(j);
             }
-        } // for item in rContainerItems
+        }); // for item in rContainerItems
     } // // if rContainerItems
 
     KRATOS_CATCH("");
@@ -742,17 +742,16 @@ void SetDataBuffer(Variable<Matrix<double>> const& rVariable,
 
     if (!rContainerItems.empty()) {
         rData.resize(rContainerItems.size(),
-                    rContainerItems.front()->GetValue(rVariable).data().size(), false);
-        #pragma omp parallel for
-        for (int i = 0; i < static_cast<int>(rContainerItems.size()); ++i) {
-            const TContainerItemType& r_item = *rContainerItems[i];
+                     rContainerItems.front()->GetValue(rVariable).data().size(), false);
+        IndexPartition<int>(rContainerItems.size()).for_each([&rVariable, &rContainerItems, &rData](int i_item){
+            const TContainerItemType& r_item = *rContainerItems[i_item];
             const auto& r_data = r_item.GetValue(rVariable).data();
             KRATOS_ERROR_IF(r_data.size() != rData.size2())
                 << "Invalid dimension.\n";
             for (std::size_t j = 0; j < rData.size2(); ++j) {
-                rData(i, j) = r_data[j];
+                rData(i_item, j) = r_data[j];
             }
-        } // for item in rContainerItems
+        }); // for item in rContainerItems
     } // if rContainerItems
 
     KRATOS_CATCH("");

--- a/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_container_component_io.cpp
@@ -156,12 +156,14 @@ public:
             // The sizes must be maxed across ranks to avoid
             // those without data writing 0 sizes.
             /// @todo This needs a revamp with DataCommunicator @matekelemen
-            int is_distributed;
-            MPI_Initialized(&is_distributed);
-            if (is_distributed) {
-                std::array<int,2> send = sizes;
-                MPI_Allreduce(send.data(), sizes.data(), 2, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
-            }
+            #ifdef KRATOS_USING_MPI
+                int is_distributed;
+                MPI_Initialized(&is_distributed);
+                if (is_distributed) {
+                    std::array<int,2> send = sizes;
+                    MPI_Allreduce(send.data(), sizes.data(), 2, MPI_INT, MPI_MAX, MPI_COMM_WORLD);
+                }
+            #endif
 
             rFile.WriteAttribute(rPath + "/" + rComponent.Name(), "Size1", sizes[0]);
             rFile.WriteAttribute(rPath + "/" + rComponent.Name(), "Size2", sizes[1]);

--- a/applications/HDF5Application/custom_io/hdf5_types.h
+++ b/applications/HDF5Application/custom_io/hdf5_types.h
@@ -1,0 +1,65 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   license: HDF5Application/license.txt
+//
+//  Main author:     Máté Kelemen
+//
+
+#pragma once
+
+// --- HDF5 Includes ---
+#include "hdf5_application_define.h"
+
+
+namespace Kratos::HDF5 {
+
+
+template <class TValue>
+struct HDF5ScalarTypeID {};
+
+
+template <>
+struct HDF5ScalarTypeID<int>
+{static inline hid_t value = H5T_NATIVE_INT;};
+
+
+template <>
+struct HDF5ScalarTypeID<double>
+{static inline hid_t value = H5T_NATIVE_DOUBLE;};
+
+
+template <>
+struct HDF5ScalarTypeID<Vector<int>>
+{static inline hid_t value = H5T_NATIVE_INT;};
+
+
+template <>
+struct HDF5ScalarTypeID<Vector<double>>
+{static inline hid_t value = H5T_NATIVE_DOUBLE;};
+
+
+template <>
+struct HDF5ScalarTypeID<Vector<array_1d<double, 3>>>
+{static inline hid_t value = H5T_NATIVE_DOUBLE;};
+
+
+template <>
+struct HDF5ScalarTypeID<Matrix<int>>
+{static inline hid_t value = H5T_NATIVE_INT;};
+
+
+template <>
+struct HDF5ScalarTypeID<Matrix<double>>
+{static inline hid_t value = H5T_NATIVE_DOUBLE;};
+
+
+template <class TValue>
+const inline hid_t HDF5ScalarTypeID_v = HDF5ScalarTypeID<TValue>::value;
+
+
+} // namespace Kratos::HDF5


### PR DESCRIPTION
## Description

Fix two memory errors related to matrix output.

1) an obvious segfault when attempting to query items within a container `rContainerItems.first`, when that container is empty.

2) an out of bounds read triggered by an uninitialized offset `local_dims[1]` within an array of offsets. 