### PR TITLE
Fixed a few slicing issues reported by SonarQube

### DIFF
--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.cpp
@@ -190,26 +190,22 @@ void UPwFaceLoadInterfaceCondition<3,4>::CheckJointWidth(double& rJointWidth, bo
                                                             const double& MinimumJointWidth, const Element::GeometryType& Geom)
 {
     //Quadrilateral_interface_3d_4
-    array_1d<double, 3> pmid0;
-    array_1d<double, 3> pmid1;
-    array_1d<double,3> P2 = Geom.GetPoint( 2 );
-    noalias(pmid0) = 0.5 * (Geom.GetPoint( 0 ) + Geom.GetPoint( 3 ));
-    noalias(pmid1) = 0.5 * (Geom.GetPoint( 1 ) + P2);
+    const auto& rP2 = Geom.GetPoint( 2 );
+    const auto pmid0 = 0.5 * (Geom.GetPoint( 0 ) + Geom.GetPoint( 3 ));
+    const auto pmid1 = 0.5 * (Geom.GetPoint( 1 ) + rP2);
     
     //Unitary vector in local x direction
-    array_1d<double,3> Vx;
-    noalias(Vx) = pmid1 - pmid0;
-    double inv_norm_x = 1.0/norm_2(Vx);
+    array_1d<double,3> Vx = pmid1 - pmid0;
+    const double inv_norm_x = 1.0/norm_2(Vx);
     Vx[0] *= inv_norm_x;
     Vx[1] *= inv_norm_x;
     Vx[2] *= inv_norm_x;
     
     //Unitary vector in local z direction
-    array_1d<double,3> Vy;
-    noalias(Vy) = P2 - pmid0;
+    array_1d<double, 3> Vy = rP2 - pmid0;
     array_1d<double,3> Vz;
-    MathUtils<double>::CrossProduct(Vz,Vx,Vy);
-    double norm_z = norm_2(Vz);
+    MathUtils<double>::CrossProduct(Vz, Vx, Vy);
+    const double norm_z = norm_2(Vz);
     if(norm_z > 1.0e-8)
     {
         Vz[0] *= 1.0/norm_z;

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.cpp
@@ -618,23 +618,19 @@ template< >
 void UPwLysmerAbsorbingCondition<3, 4>::CalculateRotationMatrix( BoundedMatrix<double, 3, 3>& rRotationMatrix, const Element::GeometryType& rGeom)
 {
     //Quadrilateral_3d_4
-    array_1d<double, 3> pmid0;
-    array_1d<double, 3> pmid1;
-    const array_1d<double, 3> P2 = array_1d<double, 3>(rGeom.GetPoint(2));
-    noalias(pmid0) = 0.5 * (rGeom.GetPoint(0) + rGeom.GetPoint(3));
-    noalias(pmid1) = 0.5 * (rGeom.GetPoint(1) + P2);
+    const auto& rP2 = rGeom.GetPoint(2);
+    const auto pmid0 = 0.5 * (rGeom.GetPoint(0) + rGeom.GetPoint(3));
+    const auto pmid1 = 0.5 * (rGeom.GetPoint(1) + rP2);
 
     //Unitary vector in local x direction
-    array_1d<double, 3> Vx;
-    noalias(Vx) = pmid1 - pmid0;
+    array_1d<double, 3> Vx = pmid1 - pmid0;
     const double inv_norm_x = 1.0 / norm_2(Vx);
     Vx[0] *= inv_norm_x;
     Vx[1] *= inv_norm_x;
     Vx[2] *= inv_norm_x;
 
     //Unitary vector in local z direction
-    array_1d<double, 3> Vy;
-    noalias(Vy) = P2 - pmid0;
+    array_1d<double, 3> Vy = rP2 - pmid0;
     array_1d<double, 3> Vz;
     MathUtils<double>::CrossProduct(Vz, Vx, Vy);
     const double norm_z = norm_2(Vz);


### PR DESCRIPTION
**📝 Description**
Due to copying of polymorphic objects slicing occurred. To remedy the problem I have replaced some copies by references. Also, I have used explicit type names when needed, and type deduction otherwise.

**🆕 Changelog**
- Replaced some values by references to objects
- Replaced some explicit type names by `auto`
- Only for `Vx`, `Vy`, and `Vz` I wanted to be explicit about their types, to avoid problems when using these objects