### PR TITLE
[Core] Expose DataCommunicator Broadcast for Vector and Matrix

### DIFF
--- a/kratos/mpi/tests/test_mpi_data_communicator_python.py
+++ b/kratos/mpi/tests/test_mpi_data_communicator_python.py
@@ -162,6 +162,8 @@ class TestMPIDataCommunicatorPython(UnitTest.TestCase):
         broadcast_int = self.world.Broadcast(self.rank, source_rank)
         broadcast_double = self.world.Broadcast(2.0*self.rank, source_rank)
         broadcast_string = self.world.Broadcast(str(self.rank), source_rank)
+        broadcast_vector = self.world.Broadcast(Kratos.Vector(3, self.rank + 1), source_rank)
+        broadcast_matrix = self.world.Broadcast(Kratos.Matrix(3, 3, self.rank + 1), source_rank)
         broadcast_int_list = self.world.BroadcastInts([self.rank,-self.rank], source_rank)
         broadcast_double_list = self.world.BroadcastDoubles([2.0*self.rank,-2.0*self.rank], source_rank)
         broadcast_string_list = self.world.BroadcastStrings([f"{self.rank}_{i}" for i in range(3)], source_rank)
@@ -172,6 +174,8 @@ class TestMPIDataCommunicatorPython(UnitTest.TestCase):
         self.assertEqual(broadcast_int_list, [source_rank, -source_rank])
         self.assertEqual(broadcast_double_list, [2.0*source_rank, -2.0*source_rank])
         self.assertEqual(broadcast_string_list, [f"{source_rank}_{i}" for i in range(3)])
+        self.assertVectorAlmostEqual(broadcast_vector, Kratos.Vector(3, source_rank + 1), 12)
+        self.assertMatrixAlmostEqual(broadcast_matrix, Kratos.Matrix(3, 3, source_rank + 1), 12)
 
     def testScatterOperations(self):
         source_rank = self.size-1

--- a/kratos/python/add_data_communicator_to_python.cpp
+++ b/kratos/python/add_data_communicator_to_python.cpp
@@ -110,7 +110,15 @@ void AddDataCommunicatorToPython(pybind11::module &m)
         rSelf.Broadcast(SourceMessage,SourceRank);
         return SourceMessage;
     })
-    .def("Broadcast", [](DataCommunicator& rSelf, const std::string& rSourceMessage, const int SourceRank){
+    .def("Broadcast", [](DataCommunicator& rSelf, std::string& rSourceMessage, const int SourceRank){
+        rSelf.Broadcast(rSourceMessage, SourceRank);
+        return rSourceMessage;
+    })
+    .def("Broadcast", [](DataCommunicator& rSelf, Vector& rSourceMessage, const int SourceRank){
+        rSelf.Broadcast(rSourceMessage, SourceRank);
+        return rSourceMessage;
+    })
+    .def("Broadcast", [](DataCommunicator& rSelf, Matrix& rSourceMessage, const int SourceRank){
         rSelf.Broadcast(rSourceMessage, SourceRank);
         return rSourceMessage;
     })


### PR DESCRIPTION
**📝 Description**
As stated in the title. I found one minor detail for the `std::string&` exposure, which was made to `const std::string&`. This is also rectified.

**🆕 Changelog**
- Exposed the `DataCommunicator::Broadcast` for `Kratos::Vector` and `Kratos::Matrix`
- Added a test.
