### PR TITLE
[CoSimulationApplication] Using `CalculateNormals` instead of `CalculateOnSimplex` (more generic)

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/coupling_operations/compute_normals.py
+++ b/applications/CoSimulationApplication/python_scripts/coupling_operations/compute_normals.py
@@ -38,7 +38,7 @@ class ComputeNormalsOperation(CoSimulationCouplingOperation):
         if not self.interface_data.IsDefinedOnThisRank(): return
 
         smp_normal_calculator = self.interface_data.GetModelPart()
-        KM.NormalCalculationUtils().CalculateOnSimplex(smp_normal_calculator, smp_normal_calculator.ProcessInfo[KM.DOMAIN_SIZE])
+        KM.NormalCalculationUtils().CalculateNormals(smp_normal_calculator)
 
     def PrintInfo(self):
         pass


### PR DESCRIPTION
**📝 Description**

Using `CalculateNormals` instead of `CalculateOnSimplex` (more generic)

**🆕 Changelog**

- [Using `CalculateNormals` instead of `CalculateOnSimplex`](https://github.com/KratosMultiphysics/Kratos/commit/e8963bb11309fa4acb23044ad7e70a4fba0df88a)
