### PR TITLE
[Core] Fix error when properties exists in read STL io

### DIFF
--- a/kratos/input_output/stl_io.cpp
+++ b/kratos/input_output/stl_io.cpp
@@ -45,7 +45,7 @@ StlIO::StlIO(std::iostream* pInputStream)
 
 void StlIO::ReadModelPart(ModelPart & rThisModelPart)
 {
-    if(!rThisModelPart.HasProperties(0))
+    if(!rThisModelPart.RecursivelyHasProperties(0))
         rThisModelPart.CreateNewProperties(0);
         
     while(!mpInputStream->eof())


### PR DESCRIPTION
**📝 Description**
This PR adds a minor fix when the properties exist but are not present in the destination modelpart, useful for combining mdpa's
