### PR TITLE
[Core] Use all constraints to construct structure in BlockBuilderAndSolver

### DIFF
--- a/kratos/solving_strategies/builder_and_solvers/builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/builder_and_solver.h
@@ -675,7 +675,7 @@ public:
     {
         return mEchoLevel;
     }
-    
+
     /**
      * @brief This method returns constraint relation (T) matrix
      * @return The constraint relation (T) matrix

--- a/kratos/solving_strategies/builder_and_solvers/builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/builder_and_solver.h
@@ -11,8 +11,7 @@
 //
 //
 
-#if !defined(KRATOS_BUILDER_AND_SOLVER )
-#define  KRATOS_BUILDER_AND_SOLVER
+#pragma once
 
 /* System includes */
 #include <set>
@@ -676,6 +675,24 @@ public:
     {
         return mEchoLevel;
     }
+    
+    /**
+     * @brief This method returns constraint relation (T) matrix
+     * @return The constraint relation (T) matrix
+     */
+    virtual typename TSparseSpace::MatrixType& GetConstraintRelationMatrix()
+    {
+        KRATOS_ERROR << "GetConstraintRelationMatrix is not implemented in base BuilderAndSolver" << std::endl;
+    }
+
+    /**
+     * @brief This method returns constraint constant vector
+     * @return The constraint constant vector
+     */
+    virtual typename TSparseSpace::VectorType& GetConstraintConstantVector()
+    {
+        KRATOS_ERROR << "GetConstraintConstantVector is not implemented in base BuilderAndSolver" << std::endl;
+    }
 
     ///@}
     ///@name Inquiry
@@ -821,5 +838,3 @@ private:
 ///@}
 
 } /* namespace Kratos.*/
-
-#endif /* KRATOS_BUILDER_AND_SOLVER  defined */

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -1144,6 +1144,24 @@ public:
     ///@name Access
     ///@{
 
+    /**
+     * @brief This method returns constraint relation (T) matrix
+     * @return The constraint relation (T) matrix
+     */
+    TSystemMatrixType& GetConstraintRelationMatrix()
+    {
+        return mT;
+    }
+
+    /**
+     * @brief This method returns constraint constant vector
+     * @return The constraint constant vector
+     */
+    TSystemVectorType& GetConstraintConstantVector()
+    {
+        return mConstantVector;
+    }
+
     ///@}
     ///@name Inquiry
     ///@{

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -255,7 +255,6 @@ public:
 
         KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolver", this->GetEchoLevel() >= 1) << "Build time: " << timer.ElapsedSeconds() << std::endl;
 
-
         KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolver", (this->GetEchoLevel() > 2 && rModelPart.GetCommunicator().MyPID() == 0)) << "Finished parallel building" << std::endl;
 
         KRATOS_CATCH("")
@@ -316,7 +315,6 @@ public:
                     // Assemble the elemental contribution
                     AssembleLHS(rA, lhs_contribution, equation_id);
                 }
-
             }
 
             #pragma omp for  schedule(guided, 512)
@@ -328,8 +326,7 @@ public:
                 if (it_cond->IsDefined(ACTIVE))
                     condition_is_active = it_cond->Is(ACTIVE);
 
-                if (condition_is_active)
-                {
+                if (condition_is_active) {
                     // Calculate elemental contribution
                     pScheme->CalculateLHSContribution(*it_cond, lhs_contribution, equation_id, r_current_process_info);
 
@@ -547,7 +544,7 @@ public:
         ) override
     {
         Timer::Start("Linearizing on Old iteration");
-             
+
         KRATOS_INFO_IF("BlockBuilderAndSolver", this->GetEchoLevel() > 0) << "Linearizing on Old iteration" << std::endl;
 
         KRATOS_ERROR_IF(rModelPart.GetBufferSize() == 1) << "BlockBuilderAndSolver: \n"
@@ -586,13 +583,13 @@ public:
         if (MoveMesh) {
             VariableUtils().UpdateCurrentPosition(rModelPart.Nodes(),DISPLACEMENT,0);
         }
-             
+
         Timer::Stop("Linearizing on Old iteration");
 
         Timer::Start("Build");
-             
+
         this->Build(pScheme, rModelPart, rA, rb);
-             
+
         Timer::Stop("Build");
 
         // Put back the prediction into the database
@@ -622,11 +619,11 @@ public:
             KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolver", this->GetEchoLevel() >=1) << "Constraints build time: " << timer_constraints.ElapsedSeconds() << std::endl;
         }
         this->ApplyDirichletConditions(pScheme, rModelPart, rA, rDx, rb);
-             
+
         KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolver", ( this->GetEchoLevel() == 3)) << "Before the solution of the system" << "\nSystem Matrix = " << rA << "\nUnknowns vector = " << rDx << "\nRHS vector = " << rb << std::endl;
-            
+
         const auto timer = BuiltinTimer();
-             
+
         Timer::Start("Solve");
 
         this->SystemSolveWithPhysics(rA, rDx, rb, rModelPart);
@@ -635,7 +632,6 @@ public:
         KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolver", this->GetEchoLevel() >=1) << "System solve time: " << timer.ElapsedSeconds() << std::endl;
 
         KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolver", ( this->GetEchoLevel() == 3)) << "After the solution of the system" << "\nSystem Matrix = " << rA << "\nUnknowns vector = " << rDx << "\nRHS vector = " << rb << std::endl;
-
     }
 
     /**
@@ -675,7 +671,6 @@ public:
 
         Timer::Stop("Solve");
         KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolver", this->GetEchoLevel() >=1) << "System solve time: " << timer.ElapsedSeconds() << std::endl;
-
 
         KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolver", ( this->GetEchoLevel() == 3)) << "After the solution of the system" << "\nSystem Matrix = " << rA << "\nUnknowns vector = " << rDx << "\nRHS vector = " << rb << std::endl;
 

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -969,7 +969,7 @@ public:
         });
 
         // Detect if there is a line of all zeros and set the diagonal to a 1 if this happens
-        mScaleFactor = TSparseSpace::CheckAndCorrectZeroDiagonalValues(rModelPart.GetProcessInfo(), rA, rb, mScalingDiagonal); 
+        mScaleFactor = TSparseSpace::CheckAndCorrectZeroDiagonalValues(rModelPart.GetProcessInfo(), rA, rb, mScalingDiagonal);
 
         double* Avalues = rA.value_data().begin();
         std::size_t* Arow_indices = rA.index1_data().begin();
@@ -1148,7 +1148,7 @@ public:
      * @brief This method returns constraint relation (T) matrix
      * @return The constraint relation (T) matrix
      */
-    TSystemMatrixType& GetConstraintRelationMatrix()
+    typename TSparseSpace::MatrixType& GetConstraintRelationMatrix() override
     {
         return mT;
     }
@@ -1157,7 +1157,7 @@ public:
      * @brief This method returns constraint constant vector
      * @return The constraint constant vector
      */
-    TSystemVectorType& GetConstraintConstantVector()
+    typename TSparseSpace::VectorType& GetConstraintConstantVector() override
     {
         return mConstantVector;
     }

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -5,7 +5,7 @@
 //                   Multi-Physics
 //
 //  License:         BSD License
-//                     Kratos default license: kratos/license.txt
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //  Collaborators:   Vicente Mataix
@@ -1290,16 +1290,13 @@ protected:
             Timer::Start("ConstraintsRelationMatrixStructure");
             const ProcessInfo& r_current_process_info = rModelPart.GetProcessInfo();
 
-            // Vector containing the localization in the system of the different terms
-            DofsVectorType slave_dof_list, master_dof_list;
-
             // Constraint initial iterator
             const auto it_const_begin = rModelPart.MasterSlaveConstraints().begin();
             std::vector<std::unordered_set<IndexType>> indices(BaseType::mDofSet.size());
 
             std::vector<LockObject> lock_array(indices.size());
 
-            #pragma omp parallel firstprivate(slave_dof_list, master_dof_list)
+            #pragma omp parallel
             {
                 Element::EquationIdVectorType slave_ids(3);
                 Element::EquationIdVectorType master_ids(3);

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -1392,9 +1392,6 @@ protected:
         // The current process info
         const ProcessInfo& r_current_process_info = rModelPart.GetProcessInfo();
 
-        // Vector containing the localization in the system of the different terms
-        DofsVectorType slave_dof_list, master_dof_list;
-
         // Contributions to the system
         Matrix transformation_matrix = LocalSystemMatrixType(0, 0);
         Vector constant_vector = LocalSystemVectorType(0);

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -1308,21 +1308,11 @@ protected:
                 #pragma omp for schedule(guided, 512) nowait
                 for (int i_const = 0; i_const < static_cast<int>(rModelPart.MasterSlaveConstraints().size()); ++i_const) {
                     auto it_const = it_const_begin + i_const;
+                    it_const->EquationIdVector(slave_ids, master_ids, r_current_process_info);
 
-                    // Detect if the constraint is active or not. If the user did not make any choice the constraint
-                    // It is active by default
-                    bool constraint_is_active = true;
-                    if( it_const->IsDefined(ACTIVE) ) {
-                        constraint_is_active = it_const->Is(ACTIVE);
-                    }
-
-                    if(constraint_is_active) {
-                        it_const->EquationIdVector(slave_ids, master_ids, r_current_process_info);
-
-                        // Slave DoFs
-                        for (auto &id_i : slave_ids) {
-                            temp_indices[id_i].insert(master_ids.begin(), master_ids.end());
-                        }
+                    // Slave DoFs
+                    for (auto &id_i : slave_ids) {
+                        temp_indices[id_i].insert(master_ids.begin(), master_ids.end());
                     }
                 }
 

--- a/kratos/tests/cpp_tests/strategies/builder_and_solvers/test_builder_and_solver.cpp
+++ b/kratos/tests/cpp_tests/strategies/builder_and_solvers/test_builder_and_solver.cpp
@@ -435,7 +435,7 @@ namespace Kratos::Testing
         constexpr double tolerance = 1e-8;
         KRATOS_CHECK(rA.size1() == 6);
         KRATOS_CHECK(rA.size2() == 6);
-        KRATOS_CHECK_RELATIVE_NEAR(rA(0,0), 2069000000.0, tolerance);    
+        KRATOS_CHECK_RELATIVE_NEAR(rA(0,0), 2069000000.0, tolerance);
         KRATOS_CHECK_RELATIVE_NEAR(rA(1,1), 1.0, tolerance);
         KRATOS_CHECK_RELATIVE_NEAR(rA(2,2), 2069000000.0, tolerance);
         KRATOS_CHECK_RELATIVE_NEAR(rA(3,3), 1.0, tolerance);
@@ -502,6 +502,56 @@ namespace Kratos::Testing
         KRATOS_CHECK_RELATIVE_NEAR(rA(3,3), 1.0, tolerance);
         KRATOS_CHECK_RELATIVE_NEAR(rA(4,4), 2069000000.0, tolerance);
         KRATOS_CHECK_RELATIVE_NEAR(rA(5,5), 1.0, tolerance);
+    }
+
+    /**
+    * Checks if the block builder and solver with inactive constraints performs correctly the assemble of the system
+    */
+    KRATOS_TEST_CASE_IN_SUITE(BasicDisplacementBlockBuilderAndSolverWithInactiveConstraints, KratosCoreFastSuite)
+    {
+        Model current_model;
+        ModelPart& r_model_part = current_model.CreateModelPart("Main", 3);
+
+        BasicTestBuilderAndSolverDisplacement(r_model_part, true);
+
+        // Deactivate the constraints (there is only one, but this code can be reused if needed in other tests)
+        for (auto& r_const : r_model_part.MasterSlaveConstraints()) {
+            r_const.Set(ACTIVE, false);
+        }
+
+        SchemeType::Pointer p_scheme = SchemeType::Pointer( new ResidualBasedIncrementalUpdateStaticSchemeType() );
+        LinearSolverType::Pointer p_solver = LinearSolverType::Pointer( new SkylineLUFactorizationSolverType() );
+        BuilderAndSolverType::Pointer p_builder_and_solver = BuilderAndSolverType::Pointer( new ResidualBasedBlockBuilderAndSolverType(p_solver) );
+
+        const SparseSpaceType::MatrixType& rA = BuildSystem(r_model_part, p_scheme, p_builder_and_solver);
+
+        // // To create the solution of reference
+        // DebugLHS(rA);
+        // The solution check
+        constexpr double tolerance = 1e-8;
+        KRATOS_CHECK(rA.size1() == 6);
+        KRATOS_CHECK(rA.size2() == 6);
+        KRATOS_CHECK_RELATIVE_NEAR(rA(0,0), 2069000000.0, tolerance);
+        KRATOS_CHECK_RELATIVE_NEAR(rA(1,1), 1.0, tolerance);
+        KRATOS_CHECK_RELATIVE_NEAR(rA(2,2), 4138000000.0, tolerance);
+        KRATOS_CHECK_RELATIVE_NEAR(rA(2,4), -2069000000.0, tolerance);
+        KRATOS_CHECK_RELATIVE_NEAR(rA(3,3), 1.0, tolerance);
+        KRATOS_CHECK_RELATIVE_NEAR(rA(4,2), -2069000000.0, tolerance);
+        KRATOS_CHECK_RELATIVE_NEAR(rA(4,4), 2069000000.0, tolerance);
+        KRATOS_CHECK_RELATIVE_NEAR(rA(5,5), 1.0, tolerance);
+
+        // Check the T matrix
+        const auto& r_T = p_builder_and_solver->GetConstraintRelationMatrix();
+
+        // // To create the solution of reference
+        // DebugLHS(r_T);
+
+        // Check T matrix, must be an identity matrix
+        KRATOS_CHECK(r_T.size1() == 6);
+        KRATOS_CHECK(r_T.size2() == 6);
+        for (int i = 0; i < 6; ++i) {
+            KRATOS_CHECK_RELATIVE_NEAR(r_T(i,i), 1.0, tolerance);
+        }
     }
 
     /**


### PR DESCRIPTION
**📝 Description**

I am running a 3d print case where I need to start with all constraints turned off and activate them sequentially. I am getting an error because the matrix structure for the constraints is being created in the first time step, only with the active ones. I dont know all the details of this implementation, but I understand that the structure should be created with all the constraints. Later, when we build the actual matrix, we will add only the active ones.

**🆕 Changelog**

- [Use all constraints to construct structure](https://github.com/KratosMultiphysics/Kratos/pull/10751/commits/b4e89fd80660c8459708b9293849e765e476514b)
- [Remove unused](https://github.com/KratosMultiphysics/Kratos/pull/10751/commits/c2570d3fba459d2dde41a5720ff8f80740d2e403)
- [Adding missing access methods](https://github.com/KratosMultiphysics/Kratos/pull/10751/commits/d06231ac1cca7786f2316c86a217b41aeef13bc9)
- [Expose mT and mConstantVector](https://github.com/KratosMultiphysics/Kratos/pull/10751/commits/4e02a91ab9f946d74ff06392ed9b61c930279db9)
- [Adding BasicDisplacementBlockBuilderAndSolverWithInactiveConstraints](https://github.com/KratosMultiphysics/Kratos/pull/10751/commits/b1cc7b65c1bfe3ba5126570685d69fccaf09b26f)
