### PR TITLE
[Core] Add flag to skip inbuilt TRY/CATCH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,6 +358,11 @@ else()
   message(FATAL_ERROR "Invalid option choosen for \"KRATOS_SHARED_MEMORY_PARALLELIZATION\"! Available options are: \"OpenMP\", \"C++11\", \"None\"")
 endif ()
 
+OPTION(KRATOS_NO_TRY_CATCH "Disabled the use of try/catch through the code" OFF)
+if( KRATOS_NO_TRY_CATCH MATCHES ON )
+  add_definitions( -DKRATOS_NO_TRY_CATCH )
+endif( KRATOS_NO_TRY_CATCH MATCHES ON )
+
 ##*****************************
 # Finding and including BOOST library (version should not matter anymore)
 if(DEFINED ENV{BOOST_ROOT})

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -619,6 +619,9 @@ Enables(Default) or Disables the compilation of the embedded python interpreter 
 `-DKRATOS_BUILD_TESTING=ON/OFF`
 Enables(Default) or Disables the compilation of the C++ unitary tests for *Kratos* and Applications.
 
+`-DKRATOS_NO_TRY_CATCH=ON/OFF`
+Enables or Disables(Default) the prevention of code generation in `KRATOS_TRY` and `KRATOS_CATCH` macros to allow direct debug of the code through gdb without having to break at `__cxa_throw`.
+
 ### Unitary Builds
 `-DCMAKE_UNITY_BUILD=ON/OFF`
 Enables or Disables(default) the use of [cmake unity build](https://cmake.org/cmake/help/latest/prop_tgt/UNITY_BUILD.html) to speedup compilation by using unitary builds.

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -95,15 +95,20 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
 #define KRATOS_CATCH_BLOCK_BEGIN class ExceptionBlock{public: void operator()(void){
 #define KRATOS_CATCH_BLOCK_END }} exception_block; exception_block();
 
-#ifndef __SUNPRO_CC
-#define KRATOS_TRY try {
-
-#define KRATOS_CATCH(MoreInfo) \
-  KRATOS_CATCH_WITH_BLOCK(MoreInfo,{})
+#ifndef KRATOS_NO_TRY_CATCH
+    #define KRATOS_TRY_IMPL try {
+    #define KRATOS_CATCH_IMPL(MoreInfo) KRATOS_CATCH_WITH_BLOCK(MoreInfo,{})
 #else
-#define KRATOS_TRY { };
+    #define KRATOS_TRY_IMPL {};
+    #define KRATOS_CATCH_IMPL(MoreInfo) {};
+#endif
 
-#define KRATOS_CATCH(MoreInfo) { };
+#ifndef __SUNPRO_CC
+    #define KRATOS_TRY KRATOS_TRY_IMPL
+    #define KRATOS_CATCH(MoreInfo) KRATOS_CATCH_IMPL(MoreInfo)
+#else
+    #define KRATOS_TRY {};
+    #define KRATOS_CATCH(MoreInfo) {};
 #endif
 
 //-----------------------------------------------------------------


### PR DESCRIPTION
**📝 Description**
Adds a flag to prevent the TRY CATCH blocks of Kratos from generating code.

I've been trying to push different flavors of this for some time and this is IMHO the cleanest way to accomplish this.

The options is disabled in all release flavors and the idea is that it does not need to be activated unless you need to find very specific things.

Essentially this allows someone in GDB to easily generate a correct backtrace if a error is produced inside a `try/catch` block (otherwise a backtrace of the system call handling the exception is produced, which is mostly useless).
While it is possible to do the same with the current code you need to insert a breakpoint in `__cxa_throw` which is not obvious (specially when the exceptions are being propagated) and can complicate things if you want to add other breakpoints or you are not sure where the code breaks exactly.

**🆕 Changelog**
- Adding flag to prevent try/catch
