### PR TITLE
[OptApp] Restructure 9 - Add vertex morphing

### DIFF
--- a/applications/OptimizationApplication/custom_python/add_custom_mappers_to_python.cpp
+++ b/applications/OptimizationApplication/custom_python/add_custom_mappers_to_python.cpp
@@ -1,0 +1,76 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   license: OptimizationApplication/license.txt
+//
+//  Main author:     Suneth Warnakulasuriya
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+
+// Application includes
+#include "custom_utilities/mappers/container_variable_data_mapper.h"
+#include "custom_utilities/mappers/vertex_morphing_container_variable_data_mapper.h"
+
+// Include base h
+#include "add_custom_mappers_to_python.h"
+
+namespace Kratos {
+namespace Python {
+
+void  AddCustomMappersToPython(pybind11::module& m)
+{
+    namespace py = pybind11;
+
+    using nodal_container_variable_data_mapper = ContainerVariableDataMapper<ModelPart::NodesContainerType>;
+    py::class_<nodal_container_variable_data_mapper, typename nodal_container_variable_data_mapper::Pointer>(m, "NodalContainerVariableDataMapper")
+        .def("Update", &nodal_container_variable_data_mapper::Update)
+        .def("Map", &nodal_container_variable_data_mapper::Map, py::arg("origin_container_data"), py::arg("destination_container_data"))
+        .def("InverseMap", &nodal_container_variable_data_mapper::InverseMap, py::arg("origin_container_data"), py::arg("destination_container_data"))
+        .def("__str__", &nodal_container_variable_data_mapper::Info)
+        ;
+
+    using condition_container_variable_data_mapper = ContainerVariableDataMapper<ModelPart::ConditionsContainerType>;
+    py::class_<condition_container_variable_data_mapper, typename condition_container_variable_data_mapper::Pointer>(m, "ConditionContainerVariableDataMapper")
+        .def("Update", &condition_container_variable_data_mapper::Update)
+        .def("Map", &condition_container_variable_data_mapper::Map, py::arg("origin_container_data"), py::arg("destination_container_data"))
+        .def("InverseMap", &condition_container_variable_data_mapper::InverseMap, py::arg("origin_container_data"), py::arg("destination_container_data"))
+        .def("__str__", &condition_container_variable_data_mapper::Info)
+        ;
+
+    using element_container_variable_data_mapper = ContainerVariableDataMapper<ModelPart::ElementsContainerType>;
+    py::class_<element_container_variable_data_mapper, typename element_container_variable_data_mapper::Pointer>(m, "ElementContainerVariableDataMapper")
+        .def("Update", &element_container_variable_data_mapper::Update)
+        .def("Map", &element_container_variable_data_mapper::Map, py::arg("origin_container_data"), py::arg("destination_container_data"))
+        .def("InverseMap", &element_container_variable_data_mapper::InverseMap, py::arg("origin_container_data"), py::arg("destination_container_data"))
+        .def("__str__", &element_container_variable_data_mapper::Info)
+        ;
+
+    using vertex_morphing_nodal_container_variable_data_mapper = VertexMorphingContainerVariableDataMapper<ModelPart::NodesContainerType>;
+    py::class_<vertex_morphing_nodal_container_variable_data_mapper, typename vertex_morphing_nodal_container_variable_data_mapper::Pointer, nodal_container_variable_data_mapper>(m, "VertexMorphingNodalContainerVariableDataMapper")
+        .def(py::init<ModelPart&, ModelPart&, Parameters>(), py::arg("origin_model_part"), py::arg("destination_model_part"), py::arg("parameters"))
+        ;
+
+    using vertex_morphing_condition_container_variable_data_mapper = VertexMorphingContainerVariableDataMapper<ModelPart::ConditionsContainerType>;
+    py::class_<vertex_morphing_condition_container_variable_data_mapper, typename vertex_morphing_condition_container_variable_data_mapper::Pointer, condition_container_variable_data_mapper>(m, "VertexMorphingConditionContainerVariableDataMapper")
+        .def(py::init<ModelPart&, ModelPart&, Parameters>(), py::arg("origin_model_part"), py::arg("destination_model_part"), py::arg("parameters"))
+        ;
+
+    using vertex_morphing_element_container_variable_data_mapper = VertexMorphingContainerVariableDataMapper<ModelPart::ElementsContainerType>;
+    py::class_<vertex_morphing_element_container_variable_data_mapper, typename vertex_morphing_element_container_variable_data_mapper::Pointer, element_container_variable_data_mapper>(m, "VertexMorphingElementContainerVariableDataMapper")
+        .def(py::init<ModelPart&, ModelPart&, Parameters>(), py::arg("origin_model_part"), py::arg("destination_model_part"), py::arg("parameters"))
+        ;
+
+}
+
+}  // namespace Python.
+} // Namespace Kratos
+

--- a/applications/OptimizationApplication/custom_python/add_custom_mappers_to_python.h
+++ b/applications/OptimizationApplication/custom_python/add_custom_mappers_to_python.h
@@ -1,0 +1,28 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   license: OptimizationApplication/license.txt
+//
+//  Main author:     Suneth Warnakulasuriya
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define_python.h"
+
+namespace Kratos {
+namespace Python {
+
+void AddCustomMappersToPython(pybind11::module& m);
+
+} // namespace Python.
+} // namespace Kratos.

--- a/applications/OptimizationApplication/custom_python/optimization_python_application.cpp
+++ b/applications/OptimizationApplication/custom_python/optimization_python_application.cpp
@@ -1,28 +1,24 @@
-// ==============================================================================
-//  KratosOptimizationApplication
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
 //
 //  License:         BSD License
 //                   license: OptimizationApplication/license.txt
 //
-//  Main authors:    Reza Najian Asl, https://github.com/RezaNajian
+//  Main author:     Reza Najian Asl
+//                   Suneth Warnakulasuriya
 //
-// =================================================================================
 
-#if defined(KRATOS_PYTHON)
-
-// ------------------------------------------------------------------------------
 // System includes
-// ------------------------------------------------------------------------------
-#include <pybind11/pybind11.h>
 
-// ------------------------------------------------------------------------------
 // External includes
-// ------------------------------------------------------------------------------
 
-// ------------------------------------------------------------------------------
 // Project includes
-// ------------------------------------------------------------------------------
 #include "includes/define_python.h"
+
+// Application includes
 #include "optimization_application.h"
 #include "optimization_application_variables.h"
 #include "custom_python/add_custom_controls_to_python.h"
@@ -31,8 +27,7 @@
 #include "custom_python/add_custom_strategies_to_python.h"
 #include "custom_python/add_custom_response_utilities_to_python.h"
 #include "custom_python/add_custom_utilities_to_python.h"
-
-// ==============================================================================
+#include "custom_python/add_custom_mappers_to_python.h"
 
 namespace Kratos {
 namespace Python {
@@ -41,9 +36,7 @@ PYBIND11_MODULE(KratosOptimizationApplication, m)
 {
     namespace py = pybind11;
 
-    py::class_<KratosOptimizationApplication,
-        KratosOptimizationApplication::Pointer,
-        KratosApplication >(m, "KratosOptimizationApplication")
+    py::class_<KratosOptimizationApplication, KratosOptimizationApplication::Pointer, KratosApplication >(m, "KratosOptimizationApplication")
         .def(py::init<>())
         ;
 
@@ -55,6 +48,8 @@ PYBIND11_MODULE(KratosOptimizationApplication, m)
 
     auto response_utils = m.def_submodule("ResponseUtils");
     AddCustomResponseUtilitiesToPython(response_utils);
+    auto mappers = m.def_submodule("Mappers");
+    AddCustomMappersToPython(mappers);
 
     //registering variables in python
 
@@ -181,5 +176,3 @@ PYBIND11_MODULE(KratosOptimizationApplication, m)
 
 }  // namespace Python.
 }  // namespace Kratos.
-
-#endif // KRATOS_PYTHON defined

--- a/applications/OptimizationApplication/custom_utilities/mappers/container_variable_data_mapper.h
+++ b/applications/OptimizationApplication/custom_utilities/mappers/container_variable_data_mapper.h
@@ -1,0 +1,104 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   license: OptimizationApplication/license.txt
+//
+//  Main author:     Suneth Warnakulasuriya
+//
+
+
+#pragma once
+
+// System includes
+#include <string>
+
+// Project includes
+#include "includes/define.h"
+
+// Application includes
+#include "custom_utilities/container_variable_data_holder/container_variable_data_holder_base.h"
+
+namespace Kratos {
+
+///@name Kratos Classes
+///@{
+
+template<class TContainerType>
+class KRATOS_API(OPTIMIZATION_APPLICATION) ContainerVariableDataMapper
+{
+public:
+    ///@name Type definitions
+    ///@{
+
+    using ContainerVariableDataHolderType = ContainerVariableDataHolderBase<TContainerType>;
+
+    /// Pointer definition of ContainerData
+    KRATOS_CLASS_POINTER_DEFINITION(ContainerVariableDataMapper);
+
+    ///@}
+    ///@name Life cycle
+    ///@{
+
+    virtual ~ContainerVariableDataMapper() = default;
+
+    ///@}
+    ///@name Public operations
+
+    virtual void Update()
+    {
+        KRATOS_ERROR << "Calling ContainerVariableDataMapper::Update. This "
+                        "needs to be implemented in the derrived class.";
+    }
+
+    virtual void Map(
+        const ContainerVariableDataHolderType& rOriginDataContainer,
+        ContainerVariableDataHolderType& rDestinationDataContainer) const
+    {
+        KRATOS_ERROR << "Calling ContainerVariableDataMapper::Map. This needs to be "
+                        "implemented in the derrived class.";
+    }
+
+    virtual void InverseMap(
+        ContainerVariableDataHolderType& rOriginDataContainer,
+        const ContainerVariableDataHolderType& rDestinationDataContainer) const
+    {
+        KRATOS_ERROR << "Calling ContainerVariableDataMapper::Map. This needs to be "
+                        "implemented in the derrived class.";
+    }
+
+    virtual std::string Info() const
+    {
+        KRATOS_ERROR << "Calling ContainerVariableDataMapper::Info. This needs to be "
+                        "implemented in the derrived class.";
+        return "";
+    }
+
+    ///@}
+protected:
+    ///@name Life cycle
+    ///@{
+
+    ContainerVariableDataMapper() = default;
+
+    ///@}
+};
+
+///@}
+///@name Input and output
+///@{
+
+/// output stream function
+template<class TContainerType>
+inline std::ostream& operator<<(
+    std::ostream& rOStream,
+    const ContainerVariableDataMapper<TContainerType>& rThis)
+{
+    return rOStream << rThis.Info();
+}
+
+///@}
+} // namespace Kratos

--- a/applications/OptimizationApplication/custom_utilities/mappers/container_variable_data_mapper.h
+++ b/applications/OptimizationApplication/custom_utilities/mappers/container_variable_data_mapper.h
@@ -73,7 +73,7 @@ public:
     virtual std::string Info() const
     {
         KRATOS_ERROR << "Calling ContainerVariableDataMapper::Info. This needs to be "
-                        "implemented in the derrived class.";
+                        "implemented in the derived class.";
         return "";
     }
 

--- a/applications/OptimizationApplication/custom_utilities/mappers/container_variable_data_mapper.h
+++ b/applications/OptimizationApplication/custom_utilities/mappers/container_variable_data_mapper.h
@@ -67,7 +67,7 @@ public:
         const ContainerVariableDataHolderType& rDestinationDataContainer) const
     {
         KRATOS_ERROR << "Calling ContainerVariableDataMapper::Map. This needs to be "
-                        "implemented in the derrived class.";
+                        "implemented in the derived class.";
     }
 
     virtual std::string Info() const

--- a/applications/OptimizationApplication/custom_utilities/mappers/entity_point.cpp
+++ b/applications/OptimizationApplication/custom_utilities/mappers/entity_point.cpp
@@ -1,0 +1,57 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   license: OptimizationApplication/license.txt
+//
+//  Main author:     Suneth Warnakulasuriya
+//
+
+// System includes
+
+// Project includes
+#include "includes/define.h"
+#include "geometries/point.h"
+#include "includes/model_part.h"
+
+// Application includes
+
+// Include base h
+#include "entity_point.h"
+
+namespace Kratos {
+
+template<class TEntityType>
+EntityPoint<TEntityType>::EntityPoint(
+    const TEntityType& rEntity,
+    const IndexType Id)
+    : Point(GetPoint(rEntity)),
+      mId(Id)
+{
+}
+
+template<class TEntityType>
+IndexType EntityPoint<TEntityType>::Id() const
+{
+    return mId;
+}
+
+template<class TEntityType>
+constexpr Point EntityPoint<TEntityType>::GetPoint(const TEntityType& rEntity)
+{
+    if constexpr(std::is_same_v<TEntityType, ModelPart::NodeType>) {
+        return rEntity;
+    } else {
+        return rEntity.GetGeometry().Center();
+    }
+}
+
+//template instantiations
+template class EntityPoint<ModelPart::NodeType>;
+template class EntityPoint<ModelPart::ConditionType>;
+template class EntityPoint<ModelPart::ElementType>;
+
+} // namespace Kratos

--- a/applications/OptimizationApplication/custom_utilities/mappers/entity_point.h
+++ b/applications/OptimizationApplication/custom_utilities/mappers/entity_point.h
@@ -1,0 +1,67 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   license: OptimizationApplication/license.txt
+//
+//  Main author:     Suneth Warnakulasuriya
+//
+
+#pragma once
+
+// System includes
+
+// Project includes
+#include "includes/define.h"
+#include "geometries/point.h"
+
+// Application includes
+
+namespace Kratos {
+
+///@name Kratos Classes
+///@{
+
+template<class TEntityType>
+class KRATOS_API(OPTIMIZATION_APPLICATION) EntityPoint : public Point
+{
+public:
+    ///@name Type definitions
+    ///@{
+
+    /// Pointer definition of ContainerData
+    KRATOS_CLASS_POINTER_DEFINITION(EntityPoint);
+
+    ///@}
+    ///@name Life cycle
+    ///@{
+
+    EntityPoint() = default;
+
+    EntityPoint(
+        const TEntityType& rEntity,
+        const IndexType Id);
+
+    IndexType Id() const;
+
+    ///@}
+private:
+    ///@name Private member variables
+    ///@{
+
+    const IndexType mId = 0;
+
+    ///@}
+    ///@name Private static methods
+    ///@{
+
+    static constexpr Point GetPoint(const TEntityType& rEntity);
+
+    ///@}
+};
+
+///@}
+} // namespace Kratos

--- a/applications/OptimizationApplication/custom_utilities/mappers/mapping_filter_functions.cpp
+++ b/applications/OptimizationApplication/custom_utilities/mappers/mapping_filter_functions.cpp
@@ -1,0 +1,83 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   license: OptimizationApplication/license.txt
+//
+//  Main authors:    Baumgaertner Daniel
+//                   Aditya Ghantasala
+//                   Suneth Warnakulasuriya
+//
+
+// System includes
+#include <string>
+
+// Project includes
+#include "mapping_filter_functions.h"
+
+namespace Kratos
+{
+
+MappingFilterFunction::MappingFilterFunction(const std::string& rFilterFunctionType)
+{
+    // Set type of weighting function
+
+    // Type 1: Gaussian function
+    if (rFilterFunctionType == "gaussian")
+        mMappingFilterFunctional =  [](double radius, double distance) {return std::max(0.0, exp(-(distance*distance) / (2 * radius * radius / 9.0)));};
+
+    // Type 2: Linear function
+    else if (rFilterFunctionType == "linear")
+        mMappingFilterFunctional =  [](double radius, double distance) {return std::max(0.0, (radius - distance) / radius);};
+
+    // Type 3: Constant function
+    else if (rFilterFunctionType == "constant")
+        mMappingFilterFunctional = [](double radius, double distance) {return 1.0;};
+
+    // Type 4: Cosine function
+    else if (rFilterFunctionType == "cosine")
+        mMappingFilterFunctional = [](double radius, double distance) {return std::max(0.0, 1-0.5*(1-std::cos(Globals::Pi/radius*distance)));};
+
+    // Type 5: Quartic function
+    else if (rFilterFunctionType == "quartic")
+        mMappingFilterFunctional = [](double radius, double distance) {return std::max(0.0, (pow(distance-radius,4.0)/pow(radius,4.0)));};
+
+    // Throw error message in case of wrong specification
+    else
+        KRATOS_ERROR << "Specified kernel function of type : "
+                     << rFilterFunctionType << " is not recognized. \n \t Options are:"
+                     << "\n\tconstant"
+                     << "\n\tlinear"
+                     << "\n\tgaussian"
+                     << "\n\tcosine"
+                     << "\n\tquartic.\n";
+}
+
+double MappingFilterFunction::GetDistance(
+    const Array3DType& ICoord,
+    const Array3DType& JCoord) const
+{
+    const Array3DType dist_vector = ICoord - JCoord;
+    return sqrt(dist_vector[0] * dist_vector[0] + dist_vector[1] * dist_vector[1] + dist_vector[2] * dist_vector[2]);
+}
+
+double MappingFilterFunction::ComputeWeight(
+    const Array3DType& ICoord,
+    const Array3DType& JCoord,
+    const double Radius) const
+{
+    KRATOS_TRY;
+
+    // Compute distance vector
+    const double distance = GetDistance(ICoord, JCoord);
+
+    // Depending on which weighting function is chosen, compute weight
+    return mMappingFilterFunctional(Radius, distance);
+
+    KRATOS_CATCH("");
+}
+
+} // namespace Kratos.

--- a/applications/OptimizationApplication/custom_utilities/mappers/mapping_filter_functions.h
+++ b/applications/OptimizationApplication/custom_utilities/mappers/mapping_filter_functions.h
@@ -1,0 +1,86 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   license: OptimizationApplication/license.txt
+//
+//  Main authors:    Baumgaertner Daniel
+//                   Aditya Ghantasala
+//                   Suneth Warnakulasuriya
+//
+
+#pragma once
+
+// System includes
+#include <string>
+#include <functional>
+
+// Project includes
+#include "includes/define.h"
+#include "spaces/ublas_space.h"
+
+namespace Kratos
+{
+
+///@name Kratos Classes
+///@{
+
+/// Short class definition.
+/**
+ * MappingFilterFunction implementations.
+*/
+
+class KRATOS_API(SHAPE_OPTIMIZATION_APPLICATION) MappingFilterFunction
+{
+  public:
+    ///@name Type Definitions
+    ///@{
+
+    using Array3DType = array_1d<double, 3>;
+
+    /// Pointer definition of MappingFilterFunction
+    KRATOS_CLASS_POINTER_DEFINITION(MappingFilterFunction);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Constructor.
+    MappingFilterFunction(const std::string& MappingFilterFunctionType);
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    double ComputeWeight(
+        const Array3DType& ICoord,
+        const Array3DType& JCoord,
+        const double Radius) const;
+
+    ///@}
+
+  private:
+    ///@name Member Variables
+    ///@{
+
+    std::function<double (const double, const double)> mMappingFilterFunctional;
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+    double inline GetDistance(
+        const Array3DType& ICoord,
+        const Array3DType& JCoord) const;
+
+    ///@}
+
+}; // Class MappingFilterFunction
+
+///@}
+
+} // namespace Kratos.
+

--- a/applications/OptimizationApplication/custom_utilities/mappers/vertex_morphing_container_variable_data_mapper.cpp
+++ b/applications/OptimizationApplication/custom_utilities/mappers/vertex_morphing_container_variable_data_mapper.cpp
@@ -1,0 +1,285 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   license: OptimizationApplication/license.txt
+//
+//  Main authors:    Baumgaertner Daniel
+//                   Aditya Ghantasala
+//                   Suneth Warnakulasuriya
+//
+
+// System includes
+#include <sstream>
+
+// Project includes
+#include "includes/define.h"
+#include "includes/model_part.h"
+#include "utilities/parallel_utilities.h"
+
+// Application includes
+#include "custom_utilities/container_variable_data_holder_utils.h"
+
+// Include base h
+#include "vertex_morphing_container_variable_data_mapper.h"
+
+namespace Kratos {
+
+namespace VertexMorphingContainerVariableDataMapperHelpers
+{
+template<class TContainerType>
+const TContainerType& GetContainer(const ModelPart& rModelPart);
+
+template <>
+const ModelPart::NodesContainerType& GetContainer<ModelPart::NodesContainerType>(const ModelPart& rModelPart)
+{
+    return rModelPart.GetCommunicator().LocalMesh().Nodes();
+}
+
+template <>
+const ModelPart::ConditionsContainerType& GetContainer<ModelPart::ConditionsContainerType>(const ModelPart& rModelPart)
+{
+    return rModelPart.GetCommunicator().LocalMesh().Conditions();
+}
+
+template <>
+const ModelPart::ElementsContainerType& GetContainer<ModelPart::ElementsContainerType>(const ModelPart& rModelPart)
+{
+    return rModelPart.GetCommunicator().LocalMesh().Elements();
+}
+}
+
+template<class TContainerType>
+VertexMorphingContainerVariableDataMapper<TContainerType>::VertexMorphingContainerVariableDataMapper(
+    const ModelPart& rOriginModelPart,
+    const ModelPart& rDestinationModelPart,
+    Parameters Params)
+    : mrOriginModelPart(rOriginModelPart),
+      mrDestinationModelPart(rDestinationModelPart)
+{
+    KRATOS_TRY
+
+    Parameters default_parameters = Parameters(R"(
+    {
+        "filter_function_type"         : "linear",
+        "filter_radius"                : 1.0,
+        "max_entities_in_filter_radius": 10000
+    })" );
+
+    Params.ValidateAndAssignDefaults(default_parameters);
+
+    mFilterFunctionType = Params["filter_function_type"].GetString();
+    mpMappingFilterFunction = Kratos::make_shared<MappingFilterFunction>(mFilterFunctionType);
+    mFilterRadius = Params["filter_radius"].GetDouble();
+    mMaxEntitiesInFilterRadius = Params["max_entities_in_filter_radius"].GetInt();
+    mIsConsistentMapping = (mrOriginModelPart.FullName() == mrDestinationModelPart.FullName());
+
+    KRATOS_CATCH("");
+}
+
+template<class TContainerType>
+void VertexMorphingContainerVariableDataMapper<TContainerType>::InitializeEntityPoints(
+    EntityPointVector& rEntityPointsVector,
+    const ModelPart& rModelPart) const
+{
+    auto& r_container = VertexMorphingContainerVariableDataMapperHelpers::GetContainer<TContainerType>(rModelPart);
+
+    if (rEntityPointsVector.size() != r_container.size()) {
+        rEntityPointsVector.resize(r_container.size());
+    }
+
+    IndexPartition<IndexType>(rEntityPointsVector.size()).for_each([&](const IndexType Index) {
+        rEntityPointsVector[Index] = Kratos::make_shared<EntityPointType>(*(r_container.begin() + Index), Index);
+    });
+}
+
+template<class TContainerType>
+void VertexMorphingContainerVariableDataMapper<TContainerType>::CreateSearchTreeWithAllNodesInOriginModelPart()
+{
+    mpSearchTree = Kratos::shared_ptr<KDTree>(new KDTree(mOriginEntityPointsVector.begin(), mOriginEntityPointsVector.end(), mBucketSize));
+}
+
+template<class TContainerType>
+void VertexMorphingContainerVariableDataMapper<TContainerType>::ComputeWeightForAllNeighbors(
+    double& rWieghtsSum,
+    std::vector<double>& rListOfWeights,
+    const IndexType NumberOfNeighbours,
+    const EntityPointType& rEntityPoint,
+    const EntityPointVector& rNeighbourEntityPoints) const
+{
+    for (IndexType neighbour_index = 0; neighbour_index < NumberOfNeighbours; ++neighbour_index) {
+        const auto& r_neighbour_entity = *(*(rNeighbourEntityPoints.begin() + neighbour_index));
+        const double weight = mpMappingFilterFunction->ComputeWeight(rEntityPoint.Coordinates(), r_neighbour_entity.Coordinates(), mFilterRadius);
+
+        rListOfWeights[neighbour_index] = weight;
+        rWieghtsSum += weight;
+    }
+}
+
+template<class TContainerType>
+void VertexMorphingContainerVariableDataMapper<TContainerType>::FillMappingMatrixWithWeights(
+    const EntityPointType& rEntityPoint,
+    const EntityPointVector& rNeighbourEntityPoints,
+    const std::vector<double>& rListOfWeights,
+    const double WeightSum,
+    const IndexType NumberOfNeighbours)
+{
+    const IndexType row_id = rEntityPoint.Id();
+    for (IndexType neighbour_index = 0; neighbour_index < NumberOfNeighbours; ++neighbour_index) {
+        const auto& r_neighbour_entity = *(rNeighbourEntityPoints.begin() + neighbour_index);
+        const IndexType column_id = r_neighbour_entity->Id();
+
+        double weight = rListOfWeights[neighbour_index] / WeightSum;
+        mMappingMatrix.insert_element(row_id, column_id, weight);
+    }
+}
+
+template<class TContainerType>
+void VertexMorphingContainerVariableDataMapper<TContainerType>::ComputeMappingMatrix(
+    const EntityPointVector& rDestinationEntityPointsVector)
+{
+    for(const auto& r_entity : rDestinationEntityPointsVector) {
+        EntityPointVector neighbor_entity_points(mMaxEntitiesInFilterRadius);
+        std::vector<double> resulting_squared_distances(mMaxEntitiesInFilterRadius);
+        unsigned int number_of_neighbors = mpSearchTree->SearchInRadius(*r_entity,
+                                                                        mFilterRadius,
+                                                                        neighbor_entity_points.begin(),
+                                                                        resulting_squared_distances.begin(),
+                                                                        mMaxEntitiesInFilterRadius);
+
+
+
+        std::vector<double> list_of_weights( number_of_neighbors, 0.0 );
+        double sum_of_weights = 0.0;
+
+        if(number_of_neighbors >= mMaxEntitiesInFilterRadius) {
+            KRATOS_WARNING("OptApp::VertexMorphingContainerDataMapper")
+                << "Reached maximum number of neighbor nodes for radius (="
+                << mMaxEntitiesInFilterRadius << "!" << std::endl;
+        }
+
+        ComputeWeightForAllNeighbors(sum_of_weights, list_of_weights, number_of_neighbors, *r_entity, neighbor_entity_points);
+        FillMappingMatrixWithWeights(*r_entity, neighbor_entity_points, list_of_weights, sum_of_weights, number_of_neighbors);
+    }
+}
+
+template<class TContainerType>
+void VertexMorphingContainerVariableDataMapper<TContainerType>::Update()
+{
+    KRATOS_TRY
+
+    if (!mIsConsistentMapping) {
+        // if we are mapping from/to different model parts
+        InitializeEntityPoints(mOriginEntityPointsVector, mrOriginModelPart);
+        InitializeEntityPoints(mDestinationEntityPointsVector, mrDestinationModelPart);
+        mMappingMatrix.resize(mDestinationEntityPointsVector.size(), mOriginEntityPointsVector.size(), false);
+
+        // search tree is always computed on the origin model part
+        CreateSearchTreeWithAllNodesInOriginModelPart();
+        ComputeMappingMatrix(mDestinationEntityPointsVector);
+    } else {
+        // if we are mapping from/to the same model part
+        InitializeEntityPoints(mOriginEntityPointsVector, mrOriginModelPart);
+        mMappingMatrix.resize(mOriginEntityPointsVector.size(), mOriginEntityPointsVector.size(), false);
+
+        CreateSearchTreeWithAllNodesInOriginModelPart();
+        ComputeMappingMatrix(mOriginEntityPointsVector);
+    }
+
+    KRATOS_CATCH("");
+}
+
+template<class TContainerType>
+void VertexMorphingContainerVariableDataMapper<TContainerType>::Map(
+    const ContainerVariableDataHolderType& rOriginDataContainer,
+    ContainerVariableDataHolderType& rDestinationDataContainer) const
+{
+    KRATOS_TRY
+
+    KRATOS_ERROR_IF_NOT(rOriginDataContainer.GetModelPart() == mrOriginModelPart)
+        << "Origin model part ["
+        << mrOriginModelPart.FullName() << "] of the mapper and model part of the origin data container are mismatching. "
+        << "Followings are the provided containers: "
+        << "\n\tDestination container = " << rDestinationDataContainer
+        << "\n\tOrigin container      = " << rOriginDataContainer << "\n";
+
+    KRATOS_ERROR_IF_NOT(rDestinationDataContainer.GetModelPart() == mrDestinationModelPart)
+        << "Destination model part ["
+        << mrDestinationModelPart.FullName() << "] of the mapper and model part of the destination data container are mismatching. "
+        << "Followings are the provided containers: "
+        << "\n\tDestination container = " << rDestinationDataContainer
+        << "\n\tOrigin container      = " << rDestinationDataContainer << "\n";
+
+    ContainerVariableDataHolderUtils::ProductWithEntityMatrix(rDestinationDataContainer, mMappingMatrix, rOriginDataContainer);
+
+    KRATOS_CATCH("");
+}
+
+template<class TContainerType>
+void VertexMorphingContainerVariableDataMapper<TContainerType>::InverseMap(
+    ContainerVariableDataHolderType& rOriginDataContainer,
+    const ContainerVariableDataHolderType& rDestinationDataContainer) const
+{
+    KRATOS_TRY
+
+    KRATOS_ERROR_IF_NOT(rOriginDataContainer.GetModelPart() == mrOriginModelPart)
+        << "Origin model part ["
+        << mrOriginModelPart.FullName() << "] of the mapper and model part of the origin data container are mismatching. "
+        << "Followings are the provided containers: "
+        << "\n\tDestination container = " << rDestinationDataContainer
+        << "\n\tOrigin container      = " << rOriginDataContainer << "\n";
+
+    KRATOS_ERROR_IF_NOT(rDestinationDataContainer.GetModelPart() == mrDestinationModelPart)
+        << "Destination model part ["
+        << mrDestinationModelPart.FullName() << "] of the mapper and model part of the destination data container are mismatching. "
+        << "Followings are the provided containers: "
+        << "\n\tDestination container = " << rDestinationDataContainer
+        << "\n\tOrigin container      = " << rDestinationDataContainer << "\n";
+
+    if(mIsConsistentMapping) {
+        ContainerVariableDataHolderUtils::ProductWithEntityMatrix(rOriginDataContainer, mMappingMatrix, rDestinationDataContainer);
+    }
+    else {
+        SparseMatrixType transpose;
+        ContainerVariableDataHolderUtils::Transpose(transpose, mMappingMatrix);
+        ContainerVariableDataHolderUtils::ProductWithEntityMatrix(rOriginDataContainer, transpose, rDestinationDataContainer);
+    }
+
+    KRATOS_CATCH("");
+}
+
+template<class TContainerType>
+std::string VertexMorphingContainerVariableDataMapper<TContainerType>::Info() const
+{
+    std::stringstream msg;
+
+    msg << "VertexMorphing";
+
+    if constexpr(std::is_same_v<TContainerType, ModelPart::NodesContainerType>) {
+        msg << "Nodal";
+    } else if constexpr(std::is_same_v<TContainerType, ModelPart::ConditionsContainerType>) {
+        msg << "Condition";
+    } else if constexpr(std::is_same_v<TContainerType, ModelPart::ElementsContainerType>) {
+        msg << "Element";
+    }
+
+    msg << "ContainerVariableDataMapper [ ";
+    msg << "Origin model part = " << mrOriginModelPart.FullName() << ", ";
+    msg << "Destination model part = " << mrDestinationModelPart.FullName() << ", ";
+    msg << "Is consistent mapping = " << (mIsConsistentMapping ? "yes" : "no") << ", ";
+    msg << "Filter function type = " << mFilterFunctionType << ", ";
+    msg << "Filter radius = " << mFilterRadius << ", ";
+    msg << "Max num. neighbours = " << mMaxEntitiesInFilterRadius << " ]" << std::endl;
+
+    return msg.str();
+}
+
+// template instantiations
+template class VertexMorphingContainerVariableDataMapper<ModelPart::NodesContainerType>;
+template class VertexMorphingContainerVariableDataMapper<ModelPart::ElementsContainerType>;
+template class VertexMorphingContainerVariableDataMapper<ModelPart::ConditionsContainerType>;
+
+} // namespace Kratos

--- a/applications/OptimizationApplication/custom_utilities/mappers/vertex_morphing_container_variable_data_mapper.h
+++ b/applications/OptimizationApplication/custom_utilities/mappers/vertex_morphing_container_variable_data_mapper.h
@@ -1,0 +1,169 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   license: OptimizationApplication/license.txt
+//
+//  Main authors:    Baumgaertner Daniel
+//                   Aditya Ghantasala
+//                   Suneth Warnakulasuriya
+//
+
+#pragma once
+
+// System includes
+#include <string>
+#include <functional>
+#include <vector>
+
+// Project includes
+#include "includes/define.h"
+#include "includes/model_part.h"
+#include "spatial_containers/spatial_containers.h"
+
+// Application includes
+#include "custom_utilities/mappers/container_variable_data_mapper.h"
+#include "custom_utilities/mappers/entity_point.h"
+#include "custom_utilities/mappers/mapping_filter_functions.h"
+
+namespace Kratos {
+
+///@name Kratos Classes
+///@{
+
+template<class TContainerType>
+class KRATOS_API(OPTIMIZATION_APPLICATION) VertexMorphingContainerVariableDataMapper : public ContainerVariableDataMapper<TContainerType>
+{
+public:
+    ///@name Type definitions
+    ///@{
+
+    using BaseType = ContainerVariableDataMapper<TContainerType>;
+
+    using ContainerVariableDataHolderType = ContainerVariableDataHolderBase<TContainerType>;
+
+    using TEntityType = typename TContainerType::data_type;
+
+    using EntityPointType = EntityPoint<TEntityType>;
+
+    using EntityPointTypePointer = typename EntityPointType::Pointer;
+
+    using EntityPointVector = std::vector<EntityPointTypePointer>;
+
+    using EntityPointIterator = typename std::vector<EntityPointTypePointer>::iterator;
+
+    using DoubleVectorIterator = std::vector<double>::iterator;
+
+    using BucketType = Bucket<3, EntityPointType, EntityPointVector, EntityPointTypePointer, EntityPointIterator, DoubleVectorIterator>;
+
+    using KDTree = Tree<KDTreePartition<BucketType>>;
+
+    using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;
+
+    using SparseMatrixType = SparseSpaceType::MatrixType;
+
+    /// Pointer definition of ContainerMapper
+    KRATOS_CLASS_POINTER_DEFINITION(VertexMorphingContainerVariableDataMapper);
+
+    ///@}
+    ///@name LifeCycle
+    ///@{
+
+    VertexMorphingContainerVariableDataMapper(
+        const ModelPart& rOriginModelPart,
+        const ModelPart& rDestinationModelPart,
+        Parameters Params);
+
+    ~VertexMorphingContainerVariableDataMapper() override = default;
+
+    ///@}
+    ///@name Public operations
+
+    void Update() override;
+
+    void Map(
+        const ContainerVariableDataHolderType& rOriginDataContainer,
+        ContainerVariableDataHolderType& rDestinationDataContainer) const override;
+
+    void InverseMap(
+        ContainerVariableDataHolderType& rOriginDataContainer,
+        const ContainerVariableDataHolderType& rDestinationDataContainer) const override;
+
+    std::string Info() const override;
+
+    ///@}
+private:
+    ///@name Private member variables
+    ///@{
+
+    const ModelPart& mrOriginModelPart;
+
+    const ModelPart& mrDestinationModelPart;
+
+    IndexType mMaxEntitiesInFilterRadius;
+
+    std::string mFilterFunctionType;
+
+    double mFilterRadius;
+
+    bool mIsConsistentMapping;
+
+    EntityPointVector mOriginEntityPointsVector;
+
+    EntityPointVector mDestinationEntityPointsVector;
+
+    MappingFilterFunction::Pointer mpMappingFilterFunction;
+
+    SparseMatrixType mMappingMatrix;
+
+    IndexType mBucketSize = 100;
+
+    typename KDTree::Pointer mpSearchTree;
+
+    ///@}
+    ///@name Private operations
+    ///@{
+
+    void InitializeEntityPoints(
+        EntityPointVector& rEntityPointsVector,
+        const ModelPart& rModelPart) const;
+
+    void CreateSearchTreeWithAllNodesInOriginModelPart();
+
+    void ComputeWeightForAllNeighbors(
+        double& rSumOfWeights,
+        std::vector<double>& rListOfWeights,
+        const IndexType NumberOfNeighbours,
+        const EntityPointType& rEntityPoint,
+        const EntityPointVector& rNeighbourEntityPoints) const;
+
+    void FillMappingMatrixWithWeights(
+        const EntityPointType& rEntityPoint,
+        const EntityPointVector& rNeighbourEntityPoints,
+        const std::vector<double>& rListOfWeights,
+        const double WeightSum,
+        const IndexType NumberOfNeighbours);
+
+    void ComputeMappingMatrix(const EntityPointVector& rDestinationEntityPointsVector);
+
+    ///@}
+};
+
+///@}
+///@name Input and output
+///@{
+
+/// output stream function
+template<class TContainerType>
+inline std::ostream& operator<<(
+    std::ostream& rOStream,
+    const VertexMorphingContainerVariableDataMapper<TContainerType>& rThis)
+{
+    return rOStream << rThis.Info();
+}
+
+///@}
+} // namespace Kratos

--- a/applications/OptimizationApplication/python_scripts/transformation_techniques/transformation_technique.py
+++ b/applications/OptimizationApplication/python_scripts/transformation_techniques/transformation_technique.py
@@ -1,0 +1,12 @@
+import KratosMultiphysics as Kratos
+from KratosMultiphysics.OptimizationApplication.utilities.helper_utilities import ContainerVariableDataHolderUnion
+
+class TransformationTechnique(Kratos.Process):
+    def __init__(self):
+        super().__init__()
+
+    def TransformSensitivity(self, container_variable_data_holder: ContainerVariableDataHolderUnion):
+        raise NotImplementedError("Calling base class TransformationTechnique::TransformSensitivity. Please implement it in the derrived class")
+
+    def TransformUpdate(self, container_variable_data_holder: ContainerVariableDataHolderUnion):
+        raise NotImplementedError("Calling base class TransformationTechnique::TransformUpdate. Please implement it in the derrived class")

--- a/applications/OptimizationApplication/python_scripts/transformation_techniques/transformation_technique.py
+++ b/applications/OptimizationApplication/python_scripts/transformation_techniques/transformation_technique.py
@@ -9,4 +9,4 @@ class TransformationTechnique(Kratos.Process):
         raise NotImplementedError("Calling base class TransformationTechnique::TransformSensitivity. Please implement it in the derrived class")
 
     def TransformUpdate(self, container_variable_data_holder: ContainerVariableDataHolderUnion):
-        raise NotImplementedError("Calling base class TransformationTechnique::TransformUpdate. Please implement it in the derrived class")
+        raise NotImplementedError("Calling base class TransformationTechnique::TransformUpdate. Please implement it in the derived class")

--- a/applications/OptimizationApplication/python_scripts/transformation_techniques/transformation_technique.py
+++ b/applications/OptimizationApplication/python_scripts/transformation_techniques/transformation_technique.py
@@ -6,7 +6,7 @@ class TransformationTechnique(Kratos.Process):
         super().__init__()
 
     def TransformSensitivity(self, container_variable_data_holder: ContainerVariableDataHolderUnion):
-        raise NotImplementedError("Calling base class TransformationTechnique::TransformSensitivity. Please implement it in the derrived class")
+        raise NotImplementedError("Calling base class TransformationTechnique::TransformSensitivity. Please implement it in the derived class")
 
     def TransformUpdate(self, container_variable_data_holder: ContainerVariableDataHolderUnion):
         raise NotImplementedError("Calling base class TransformationTechnique::TransformUpdate. Please implement it in the derived class")

--- a/applications/OptimizationApplication/python_scripts/transformation_techniques/vertex_morphing_transformation_technique.py
+++ b/applications/OptimizationApplication/python_scripts/transformation_techniques/vertex_morphing_transformation_technique.py
@@ -1,0 +1,45 @@
+from typing import Union
+
+import KratosMultiphysics as Kratos
+import KratosMultiphysics.OptimizationApplication as KratosOA
+from KratosMultiphysics.OptimizationApplication.transformation_techniques.transformation_technique import TransformationTechnique
+from KratosMultiphysics.OptimizationApplication.optimization_info import OptimizationInfo
+from KratosMultiphysics.OptimizationApplication.utilities.helper_utilities import ContainerVariableDataHolderUnion
+from KratosMultiphysics.OptimizationApplication.utilities.helper_utilities import ContainerTypes
+
+class VertexMorphingTransformationTechnique(TransformationTechnique):
+    __MapperTypes = Union[
+        KratosOA.Mappers.VertexMorphingNodalContainerVariableDataMapper,
+        KratosOA.Mappers.VertexMorphingConditionContainerVariableDataMapper,
+        KratosOA.Mappers.VertexMorphingElementContainerVariableDataMapper
+    ]
+
+    def __init__(self, _: Kratos.Model, parameters: Kratos.Parameters, __: OptimizationInfo):
+        super().__init__()
+
+        self.__parameters = parameters
+        self.__mappers: 'dict[ContainerTypes, VertexMorphingTransformationTechnique.__MapperTypes]' = {}
+
+    def ExecuteInitializeSolutionStep(self):
+        # update the mappers
+        for __mapper in self.__mappers.values():
+            __mapper.Update()
+
+    def TransformSensitivity(self, container_variable_data_holder: ContainerVariableDataHolderUnion):
+        self.__GetMapper(container_variable_data_holder).Map(container_variable_data_holder.Clone(), container_variable_data_holder)
+
+    def TransformUpdate(self, container_variable_data_holder: ContainerVariableDataHolderUnion):
+        self.__GetMapper(container_variable_data_holder).InverseMap(container_variable_data_holder, container_variable_data_holder.Clone())
+
+    def __GetMapper(self, container_variable_data_holder: ContainerVariableDataHolderUnion):
+        if container_variable_data_holder.GetContainer() not in self.__mappers.keys():
+            if isinstance(container_variable_data_holder.GetContainer(), Kratos.NodesArray):
+                self.__mappers[container_variable_data_holder.GetContainer()] = KratosOA.Mappers.VertexMorphingNodalContainerVariableDataMapper(container_variable_data_holder.GetModelPart(), container_variable_data_holder.GetModelPart(), self.__parameters.Clone())
+            elif isinstance(container_variable_data_holder.GetContainer(), Kratos.ConditionsArray):
+                self.__mappers[container_variable_data_holder.GetContainer()] = KratosOA.Mappers.VertexMorphingConditionContainerVariableDataMapper(container_variable_data_holder.GetModelPart(), container_variable_data_holder.GetModelPart(), self.__parameters.Clone())
+            elif isinstance(container_variable_data_holder.GetContainer(), Kratos.ElementsArray):
+                self.__mappers[container_variable_data_holder.GetContainer()] = KratosOA.Mappers.VertexMorphingElementContainerVariableDataMapper(container_variable_data_holder.GetModelPart(), container_variable_data_holder.GetModelPart(), self.__parameters.Clone())
+
+            self.__mappers[container_variable_data_holder.GetContainer()].Update()
+
+        return self.__mappers[container_variable_data_holder.GetContainer()]

--- a/applications/OptimizationApplication/tests/test_OptimizationApplication.py
+++ b/applications/OptimizationApplication/tests/test_OptimizationApplication.py
@@ -34,6 +34,9 @@ from test_model_part_controllers import TestMdpaModelPartController
 from test_container_variable_data_holder_utils import TestContainerVariableDataHolderUtils
 from test_material_properties_control import TestMaterialPropertiesControl
 from test_shape_control import TestShapeControl
+from test_vertex_morphing_mappers import TestVertexMorphingNodalContainerVariableDataMapper
+from test_vertex_morphing_mappers import TestVertexMorphingConditionContainerVariableDataMapper
+from test_vertex_morphing_mappers import TestVertexMorphingElementContainerVariableDataMapper
 
 # Nightly tests
 
@@ -80,6 +83,11 @@ def AssembleTestSuites():
 
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestMaterialPropertiesControl]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestShapeControl]))
+
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestVertexMorphingNodalContainerVariableDataMapper]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestVertexMorphingConditionContainerVariableDataMapper]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestVertexMorphingElementContainerVariableDataMapper]))
+
     # Adding nightly tests (tests that take < 10min)
     nightSuite = suites['nightly']
 

--- a/applications/OptimizationApplication/tests/test_vertex_morphing_mappers.py
+++ b/applications/OptimizationApplication/tests/test_vertex_morphing_mappers.py
@@ -1,0 +1,260 @@
+from typing import Union
+from abc import ABC
+from abc import abstractmethod
+
+import KratosMultiphysics as Kratos
+import KratosMultiphysics.KratosUnittest as kratos_unittest
+import KratosMultiphysics.OptimizationApplication as KratosOA
+from KratosMultiphysics.OptimizationApplication.utilities.helper_utilities import ContainerVariableDataHolderUnion
+
+class TestVertexMoprhingContainerVariableDataMapper(ABC):
+    @classmethod
+    def setUpClass(cls):
+        cls.KratosEntity = Union[Kratos.Node, Kratos.Condition, Kratos.Element]
+
+        cls.model = Kratos.Model()
+        cls.origin_model_part = cls.model.CreateModelPart("origin")
+        cls.destination_model_part = cls.model.CreateModelPart("destination")
+        cls.origin_model_part.ProcessInfo[Kratos.DOMAIN_SIZE] = 3
+        cls.destination_model_part.ProcessInfo[Kratos.DOMAIN_SIZE] = 3
+
+        cls.neighbour_entitys_map = {
+            1: [1, 2, 4, 5],
+            2: [2, 3, 5, 6],
+            3: [4, 5, 7, 8],
+            4: [5, 6, 8, 9]
+        }
+
+        cls.inverse_neighbour_map = {
+            1: [1],
+            2: [1, 2],
+            3: [2],
+            4: [1, 3],
+            5: [1, 2, 3, 4],
+            6: [2, 4],
+            7: [3],
+            8: [3, 4],
+            9: [4]
+        }
+        cls.origin_grid_size = 3
+        cls.destination_grid_size = 2
+        cls.number_of_origin_entities = 9
+        cls.number_of_destination_entities = 4
+
+        cls.mapper_parameters = Kratos.Parameters("""{
+            "filter_function_type"          : "linear",
+            "filter_radius"                 : 1.0,
+            "max_entities_in_filter_radius" : 100
+        }""")
+
+    @abstractmethod
+    def _GetMapper(self) -> Union[KratosOA.Mappers.VertexMorphingNodalContainerVariableDataMapper, KratosOA.Mappers.VertexMorphingConditionContainerVariableDataMapper, KratosOA.Mappers.VertexMorphingElementContainerVariableDataMapper]:
+        pass
+
+    @abstractmethod
+    def _GetContainerDataHolder(self, model_part: Kratos.ModelPart) -> ContainerVariableDataHolderUnion:
+        pass
+
+    @abstractmethod
+    def _GetEntity(self, model_part: Kratos.ModelPart, id: int) -> Union[Kratos.Node, Kratos.Condition, Kratos.Element]:
+        pass
+
+    @abstractmethod
+    def _GetValue(self, entity, variable) -> Union[float, Kratos.Array3]:
+        pass
+
+    def test_MapScalar(self):
+        mapper = self._GetMapper()
+        mapper.Update()
+
+        origin_data = self._GetContainerDataHolder(self.origin_model_part)
+        origin_data.ReadDataFromContainerVariable(Kratos.PRESSURE)
+
+        destination_data = self._GetContainerDataHolder(self.destination_model_part)
+        mapper.Map(origin_data, destination_data)
+        destination_data.AssignDataToContainerVariable(Kratos.PRESSURE)
+
+        for dest_id, orig_ids in self.neighbour_entitys_map.items():
+            dest_entity: self.KratosEntity = self._GetEntity(self.destination_model_part, dest_id)
+            v = 0.0
+            for orig_id in orig_ids:
+                orig_entity: self.KratosEntity = self._GetEntity(self.origin_model_part, orig_id)
+                v += self._GetValue(orig_entity, Kratos.PRESSURE) * 0.25
+            self.assertAlmostEqual(self._GetValue(dest_entity, Kratos.PRESSURE), v, 12)
+
+        inverse_origin_data = self._GetContainerDataHolder(self.origin_model_part)
+        mapper.InverseMap(inverse_origin_data, destination_data)
+        inverse_origin_data.AssignDataToContainerVariable(Kratos.DENSITY)
+
+        for orig_id, dest_ids in self.inverse_neighbour_map.items():
+            orig_entity: self.KratosEntity = self._GetEntity(self.origin_model_part, orig_id)
+            v = 0.0
+            for dest_id in dest_ids:
+                dest_entity: self.KratosEntity = self._GetEntity(self.destination_model_part, dest_id)
+                v += self._GetValue(dest_entity, Kratos.PRESSURE) * 0.25
+            self.assertAlmostEqual(self._GetValue(orig_entity, Kratos.DENSITY), v, 12)
+
+    def test_MapArray(self):
+        mapper = self._GetMapper()
+        mapper.Update()
+
+        origin_data = self._GetContainerDataHolder(self.origin_model_part)
+        origin_data.ReadDataFromContainerVariable(Kratos.VELOCITY)
+
+        destination_data = self._GetContainerDataHolder(self.destination_model_part)
+        mapper.Map(origin_data, destination_data)
+        destination_data.AssignDataToContainerVariable(Kratos.VELOCITY)
+
+        for dest_id, orig_ids in self.neighbour_entitys_map.items():
+            dest_entity: self.KratosEntity = self._GetEntity(self.destination_model_part, dest_id)
+            v = Kratos.Array3([0, 0, 0])
+            for orig_id in orig_ids:
+                orig_entity: self.KratosEntity = self._GetEntity(self.origin_model_part, orig_id)
+                v += self._GetValue(orig_entity, Kratos.VELOCITY) * 0.25
+            self.assertVectorAlmostEqual(self._GetValue(dest_entity, Kratos.VELOCITY), v, 12)
+
+        inverse_origin_data = self._GetContainerDataHolder(self.origin_model_part)
+        mapper.InverseMap(inverse_origin_data, destination_data)
+        inverse_origin_data.AssignDataToContainerVariable(Kratos.ACCELERATION)
+
+        for orig_id, dest_ids in self.inverse_neighbour_map.items():
+            orig_entity: self.KratosEntity = self._GetEntity(self.origin_model_part, orig_id)
+            v = Kratos.Array3([0, 0, 0])
+            for dest_id in dest_ids:
+                dest_entity: self.KratosEntity = self._GetEntity(self.destination_model_part, dest_id)
+                v += self._GetValue(dest_entity, Kratos.VELOCITY) * 0.25
+            self.assertVectorAlmostEqual(self._GetValue(orig_entity, Kratos.ACCELERATION), v, 12)
+
+class TestVertexMorphingNodalContainerVariableDataMapper(TestVertexMoprhingContainerVariableDataMapper, kratos_unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.origin_model_part.AddNodalSolutionStepVariable(Kratos.PRESSURE)
+        cls.origin_model_part.AddNodalSolutionStepVariable(Kratos.DENSITY)
+        cls.origin_model_part.AddNodalSolutionStepVariable(Kratos.VELOCITY)
+        cls.origin_model_part.AddNodalSolutionStepVariable(Kratos.ACCELERATION)
+
+        cls.destination_model_part.AddNodalSolutionStepVariable(Kratos.PRESSURE)
+        cls.destination_model_part.AddNodalSolutionStepVariable(Kratos.DENSITY)
+        cls.destination_model_part.AddNodalSolutionStepVariable(Kratos.VELOCITY)
+        cls.destination_model_part.AddNodalSolutionStepVariable(Kratos.ACCELERATION)
+
+        for i in range(cls.number_of_origin_entities):
+            cls.origin_model_part.CreateNewNode(i+1, i // cls.origin_grid_size, i % cls.origin_grid_size, 0)
+
+        for i in range(cls.number_of_destination_entities):
+            cls.destination_model_part.CreateNewNode(i+1, 1.0 / cls.destination_grid_size + (i // cls.destination_grid_size), 1.0 / cls.destination_grid_size + (i % cls.destination_grid_size), 0)
+
+        node: Kratos.Node
+        for node in cls.origin_model_part.Nodes:
+            node.SetSolutionStepValue(Kratos.PRESSURE, node.Id)
+            node.SetSolutionStepValue(Kratos.VELOCITY, Kratos.Array3([node.Id + 1, node.Id + 2, node.Id + 3]))
+
+    def _GetMapper(self):
+        return KratosOA.Mappers.VertexMorphingNodalContainerVariableDataMapper(self.origin_model_part, self.destination_model_part, self.mapper_parameters.Clone())
+
+    def _GetContainerDataHolder(self, model_part: Kratos.ModelPart):
+        return KratosOA.HistoricalContainerVariableDataHolder(model_part)
+
+    def _GetEntity(self, model_part: Kratos.ModelPart, id: int):
+        return model_part.GetNode(id)
+
+    def _GetValue(self, entity, variable):
+        return entity.GetSolutionStepValue(variable)
+
+class TestVertexMorphingConditionContainerVariableDataMapper(TestVertexMoprhingContainerVariableDataMapper, kratos_unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        for i in range(cls.number_of_origin_entities):
+            cls.__GenerateEntity(Kratos.Array3([i // cls.origin_grid_size, i % cls.origin_grid_size, 0]), cls.origin_model_part)
+
+        for i in range(cls.number_of_destination_entities):
+            cls.__GenerateEntity(Kratos.Array3([1.0 / cls.destination_grid_size + (i // cls.destination_grid_size), 1.0 / cls.destination_grid_size + (i % cls.destination_grid_size), 0]), cls.destination_model_part)
+
+        condition: Kratos.Condition
+        for condition in cls.origin_model_part.Conditions:
+            condition.SetValue(Kratos.PRESSURE, condition.Id)
+            condition.SetValue(Kratos.VELOCITY, Kratos.Array3([condition.Id + 1, condition.Id + 2, condition.Id + 3]))
+
+    def _GetMapper(self):
+        return KratosOA.Mappers.VertexMorphingConditionContainerVariableDataMapper(self.origin_model_part, self.destination_model_part, self.mapper_parameters.Clone())
+
+    def _GetContainerDataHolder(self, model_part: Kratos.ModelPart):
+        return KratosOA.ConditionContainerVariableDataHolder(model_part)
+
+    def _GetEntity(self, model_part: Kratos.ModelPart, id: int):
+        return model_part.GetCondition(id)
+
+    def _GetValue(self, entity, variable):
+        return entity.GetValue(variable)
+
+    @classmethod
+    def __GenerateEntity(cls, center: Kratos.Array3, model_part: Kratos.ModelPart):
+        def __get_index(position):
+            for node in model_part.Nodes:
+                distance = (position[0] - node.X)**2 + (position[1] - node.Y)**2 + (position[2] - node.Z)**2
+                if distance < 1e-8:
+                    return node.Id
+
+            node = model_part.CreateNewNode(model_part.NumberOfNodes(), position[0], position[1], position[2])
+            return node.Id
+
+        model_part.CreateNewCondition("SurfaceCondition3D4N", model_part.NumberOfConditions() + 1, [
+                __get_index(center + Kratos.Array3([-0.5, -0.5, 0.0])),
+                __get_index(center + Kratos.Array3([0.5, -0.5, 0.0])),
+                __get_index(center + Kratos.Array3([0.5, 0.5, 0.0])),
+                __get_index(center + Kratos.Array3([-0.5, 0.5, 0.0]))
+        ], model_part.GetProperties()[0])
+
+class TestVertexMorphingElementContainerVariableDataMapper(TestVertexMoprhingContainerVariableDataMapper, kratos_unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        for i in range(cls.number_of_origin_entities):
+            cls.__GenerateEntity(Kratos.Array3([i // cls.origin_grid_size, i % cls.origin_grid_size, 0]), cls.origin_model_part)
+
+        for i in range(cls.number_of_destination_entities):
+            cls.__GenerateEntity(Kratos.Array3([1.0 / cls.destination_grid_size + (i // cls.destination_grid_size), 1.0 / cls.destination_grid_size + (i % cls.destination_grid_size), 0]), cls.destination_model_part)
+
+        condition: Kratos.Element
+        for condition in cls.origin_model_part.Elements:
+            condition.SetValue(Kratos.PRESSURE, condition.Id)
+            condition.SetValue(Kratos.VELOCITY, Kratos.Array3([condition.Id + 1, condition.Id + 2, condition.Id + 3]))
+
+    def _GetMapper(self):
+        return KratosOA.Mappers.VertexMorphingElementContainerVariableDataMapper(self.origin_model_part, self.destination_model_part, self.mapper_parameters.Clone())
+
+    def _GetContainerDataHolder(self, model_part: Kratos.ModelPart):
+        return KratosOA.ElementContainerVariableDataHolder(model_part)
+
+    def _GetEntity(self, model_part: Kratos.ModelPart, id: int):
+        return model_part.GetElement(id)
+
+    def _GetValue(self, entity, variable):
+        return entity.GetValue(variable)
+
+    @classmethod
+    def __GenerateEntity(cls, center: Kratos.Array3, model_part: Kratos.ModelPart):
+        def __get_index(position):
+            for node in model_part.Nodes:
+                distance = (position[0] - node.X)**2 + (position[1] - node.Y)**2 + (position[2] - node.Z)**2
+                if distance < 1e-8:
+                    return node.Id
+
+            node = model_part.CreateNewNode(model_part.NumberOfNodes(), position[0], position[1], position[2])
+            return node.Id
+
+        model_part.CreateNewElement("Element2D4N", model_part.NumberOfElements() + 1, [
+                __get_index(center + Kratos.Array3([-0.5, -0.5, 0.0])),
+                __get_index(center + Kratos.Array3([0.5, -0.5, 0.0])),
+                __get_index(center + Kratos.Array3([0.5, 0.5, 0.0])),
+                __get_index(center + Kratos.Array3([-0.5, 0.5, 0.0]))
+        ], model_part.GetProperties()[0])
+
+if __name__ == "__main__":
+    Kratos.Tester.SetVerbosity(Kratos.Tester.Verbosity.PROGRESS)  # TESTS_OUTPUTS
+    kratos_unittest.main()

--- a/applications/OptimizationApplication/tests/test_vertex_morphing_mappers.py
+++ b/applications/OptimizationApplication/tests/test_vertex_morphing_mappers.py
@@ -7,7 +7,7 @@ import KratosMultiphysics.KratosUnittest as kratos_unittest
 import KratosMultiphysics.OptimizationApplication as KratosOA
 from KratosMultiphysics.OptimizationApplication.utilities.helper_utilities import ContainerVariableDataHolderUnion
 
-class TestVertexMoprhingContainerVariableDataMapper(ABC):
+class TestVertexMorphingContainerVariableDataMapper(ABC):
     @classmethod
     def setUpClass(cls):
         cls.KratosEntity = Union[Kratos.Node, Kratos.Condition, Kratos.Element]


### PR DESCRIPTION
**📝 Description**
This PR adds generic matrix based vertex morphing which can be used on variables following containers

1. Nodal historical variables
2. Nodal non historical variables
3. Elemental variables
4. Elemental properties variables
5. Condition variables
6. Condition properties variables

**🆕 Changelog**
- Added vertex morphing mappers
- Added tests
