### PR TITLE
No longer create a symlink to the compilation database

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,10 +71,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${KRATOS_SOURCE_DIR}/cmake_modules")
 
 # Generate and copy configuration for language servers
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-EXECUTE_PROCESS(
-    COMMAND ${CMAKE_COMMAND} -E create_symlink
-    "${CMAKE_BINARY_DIR}/compile_commands.json"
-    "${CMAKE_SOURCE_DIR}/compile_commands.json")
 
 # Include cmake modules
 include(DownloadLib)


### PR DESCRIPTION
**📝 Description**
Creating a symlink on Windows requires elevated rights. As a result, the following error was raised by CMake when a regular user attempted to build Kratos on a Windows platform:
```
CMake Error: failed to create symbolic link
'C:/path/to/kratos/source/compile_commands.json': A required privilege
is not held by the client.
```
It was triggered by an attempt to create a symlink in the source directory that points to file `compile_commands.json` in the build directory.

**🆕 Changelog**
In consultation with the original author of the CMake code involved (@matekelemen) we have decided to remove the command that attempts to create the symlink, since it is no longer needed.