### PR TITLE
[Core] PlaceholderPattern and ModelPartPattern

### DIFF
--- a/kratos/python/add_other_utilities_to_python.cpp
+++ b/kratos/python/add_other_utilities_to_python.cpp
@@ -186,6 +186,13 @@ void AddSubModelPartEntitiesBooleanOperationToPython(pybind11::module &m, std::s
         ;
 }
 
+/// @brief Collect globbed paths to an array of strings.
+std::vector<std::filesystem::path> Glob (const PlaceholderPattern& rInstance) {
+    std::vector<std::filesystem::path> output;
+    rInstance.Glob(std::back_inserter(output));
+    return output;
+}
+
 void AddOtherUtilitiesToPython(pybind11::module &m)
 {
 
@@ -803,7 +810,37 @@ void AddOtherUtilitiesToPython(pybind11::module &m)
              "snake_case to CamelCase conversion")
         ;
 
+    pybind11::class_<PlaceholderPattern, PlaceholderPattern::Pointer>(m, "PlaceholderPattern")
+        .def(pybind11::init<const std::string&,const PlaceholderPattern::PlaceholderMap&>())
+        .def("IsAMatch",
+             &PlaceholderPattern::IsAMatch,
+             "Check whether a string satisfies the pattern")
+        .def("Match",
+             &PlaceholderPattern::Match,
+             "Find all placeholders' values in the input string.")
+        .def("Apply",
+             &PlaceholderPattern::Apply,
+             "Substitute values from the input map into the stored pattern.")
+        .def("Glob",
+             &Glob,
+             "Collect all file/directory paths that match the pattern.")
+        .def("GetRegexString",
+             &PlaceholderPattern::GetRegexString,
+             "Get the string representation of the regex.")
+        .def("IsConst",
+             &PlaceholderPattern::IsConst,
+             "Return true if the input pattern contains no placeholders.")
+        ;
 
+    pybind11::class_<ModelPartPattern, ModelPartPattern::Pointer, PlaceholderPattern>(m, "ModelPartPattern")
+        .def(pybind11::init<const std::string&>())
+        .def("Apply",
+             static_cast<std::string(ModelPartPattern::*)(const ModelPartPattern::PlaceholderMap&)const>(&ModelPartPattern::Apply),
+             "Substitute values from the input map into the stored pattern.")
+        .def("Apply",
+             static_cast<std::string(ModelPartPattern::*)(const ModelPart&)const>(&ModelPartPattern::Apply),
+             "Substitute values from the model part into the stored pattern.")
+        ;
 }
 
 } // namespace Python.

--- a/kratos/tests/test_KratosCore.py
+++ b/kratos/tests/test_KratosCore.py
@@ -82,6 +82,7 @@ import test_combine_model_part_modeler
 import test_calculate_distance_to_path_process
 import test_check_same_modelpart_using_skin_distance
 import test_kratos_globals
+import test_string_utilities
 
 if sympy_available:
     import test_sympy_fe_utilities
@@ -181,6 +182,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_calculate_distance_to_path_process.TestCalculateDistanceToPathProcess]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_check_same_modelpart_using_skin_distance.TestCheckSameModelPartUsingSkinDistanceProcess]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_kratos_globals.TestKratosGlobals]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_string_utilities.TestModelPartPattern]))
 
     if sympy_available:
         smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_sympy_fe_utilities.TestSympyFEUtilities]))

--- a/kratos/tests/test_string_utilities.py
+++ b/kratos/tests/test_string_utilities.py
@@ -1,0 +1,247 @@
+# --- Core Imports ---
+import KratosMultiphysics
+import KratosMultiphysics.KratosUnittest as UnitTest
+
+# --- STD Imports ---
+import pathlib
+import itertools
+
+
+class TestModelPartPattern(UnitTest.TestCase):
+
+    def setUp(self) -> None:
+        """ @brief Create the following directory structure relative to the working directory:
+            @code
+            .
+            └── test_path_pattern
+                ├── valid_root
+                    └── mdpa name_step_1_time_0.0.h5
+                        └── mdpa name_step_1_time_10.h5
+                    └── mdpa name_step_1_time_1.0.h5
+                    └── mdpa name_step_1_time_1.h5
+                    └── mdpa name_step_1_time_1.1.h5
+                    └── mdpa name_step_2_time_1.0.h5
+                    └── mdpa name_step_3_time_0.5.h5
+                    └── mdpa name_step_3_time_2.h5
+                    └── mdpa name_step_3_time_03.h5
+                    └── mdpa name_step_3_time_004.0.h5
+                    └── mdpa_name_step_1_time_1.h5
+                    └── m_dpa_name_step_1_time_1.h5
+                    └── mdpa name_step_04_time_1.h5
+                    └── mdpa name_step_04_time_2.hdf5
+                    └── ir.relevant
+                └── invalid_root
+                    └── mdpa name_step_1_time_0.0.h5
+                        └── mdpa name_step_1_time_10.h5
+                    └── mdpa name_step_1_time_1.0.h5
+                    └── mdpa name_step_1_time_1.h5
+                    └── mdpa name_step_1_time_1.1.h5
+                    └── mdpa name_step_2_time_1.0.h5
+                    └── mdpa name_step_3_time_0.5.h5
+                    └── mdpa name_step_3_time_2.h5
+                    └── mdpa name_step_3_time_03.h5
+                    └── mdpa name_step_3_time_004.0.h5
+                    └── mdpa_name_step_1_time_1.h5
+                    └── m_dpa_name_step_1_time_1.h5
+                    └── mdpa name_step_04_time_1.h5
+                    └── mdpa name_step_04_time_2.hdf5
+                    └── ir.relevant
+                └── step_1
+                    └── mdpa name_time_1.h5
+                └── step_2
+                    └── mdpa name_time_0.h5
+                @endcode
+        """
+        KratosMultiphysics.kratos_utilities.DeleteDirectoryIfExisting("test_path_pattern")
+        mkdir_arguments = {"exist_ok" : False, "parents" : True}
+        self.test_root = pathlib.Path().cwd() / "test_path_pattern"
+        self.valid_root = self.test_root / "valid_root"
+        self.invalid_root = self.test_root / "invalid_root"
+
+        file_names = [
+            "mdpa name_step_1_time_1.0.h5",
+            "mdpa name_step_1_time_1.h5",
+            "mdpa name_step_1_time_1.1.h5",
+            "mdpa name_step_2_time_1.0.h5",
+            "mdpa name_step_3_time_0.5.h5",
+            "mdpa name_step_3_time_2.h5",
+            "mdpa name_step_3_time_03.h5",
+            "mdpa name_step_3_time_004.0.h5",
+            "mdpa_name_step_1_time_1.h5",
+            "m_dpa_name_step_1_time_1.h5",
+            "mdpa name_step_04_time_1.h5",
+            "mdpa name_step_04_time_2.hdf5",
+            "ir.relevant"
+        ]
+
+        for directory in (self.test_root, self.valid_root, self.invalid_root):
+            (directory / "mdpa name_step_1_time_0.0.h5").mkdir(**mkdir_arguments)
+            (directory / "mdpa name_step_1_time_0.0.h5" / "mdpa name_step_1_time_10.h5").touch(exist_ok=False)
+
+        for file_name in file_names:
+            (self.valid_root / file_name).touch(exist_ok=False)
+            (self.invalid_root / file_name).touch(exist_ok=False)
+
+        (self.test_root / "step_1").mkdir(**mkdir_arguments)
+        (self.test_root / "step_1" / "mdpa name_time_1.h5").touch(exist_ok=False)
+        (self.test_root / "step_2").mkdir(**mkdir_arguments)
+        (self.test_root / "step_2" / "mdpa name_time_0.h5").touch(exist_ok=False)
+
+    def tearDown(self) -> None:
+        """Remove ./test_path_pattern"""
+        KratosMultiphysics.kratos_utilities.DeleteDirectoryIfExisting("test_path_pattern")
+
+    def test_IsAMatch(self) -> None:
+        pattern_string = "mdpa_name_<model_part_name>_step_<step>_time_<time>_suffix"
+        pattern = KratosMultiphysics.ModelPartPattern(pattern_string)
+
+        valid_strings = [
+            "mdpa_name_NAME_step_1_time_1.0_suffix",
+            "mdpa_name_N_step_1_time_1.0_suffix",
+            "mdpa_name_NAME_step_123456789_time_1.0_suffix",
+            "mdpa_name_NAME_step_1_time_1_suffix",
+            "mdpa_name_NAME_step_1_time_-1.0_suffix",
+            "mdpa_name_NAME_step_1_time_-1_suffix",
+            "mdpa_name_NAME_step_1_time_0.123456789_suffix"
+        ]
+
+        invalid_strings = [
+            "mdpa_name_NAME_step_01_time_1.0_suffix",
+            "mdpa_name_NAME_step_0101_time_1.0_suffix",
+            "mdpa_name__step_1_time_1.0_suffix",
+            "mdpa_name_NAME_step__time_1.0_suffix",
+            "mdpa_name_NAME_step_1O_time_1.0_suffix",
+            "mdpa_name_NAME_step_1a1_time_1.0_suffix",
+            "mdpa_name_NAME_step_1_time__suffix",
+            "mdpa_name_NAME_step_1_time_1.O_suffix",
+            "mdpa_name_NAME_step_1_time_1.0_suffiy",
+            "Mdpa_name_NAME_step_1_time_1.0_suffix"
+        ]
+
+        for string in valid_strings:
+            self.assertTrue(pattern.IsAMatch(string), msg = "{} should match but it doesn't".format(string))
+
+        for string in invalid_strings:
+            self.assertFalse(pattern.IsAMatch(string), msg = "{} shouldn't match but it does".format(string))
+
+    def test_Match(self) -> None:
+        pattern_string = "<model_part_name>/name_<model_part_name>_step_<step>_time_<time>suffix"
+        pattern = KratosMultiphysics.ModelPartPattern(pattern_string)
+
+        placeholders = ("<model_part_name>", "<step>", "<time>")
+        values = [
+            dict(zip(placeholders, ("mdpa name", "1", "1.0"))),
+            dict(zip(placeholders, ("mdpa name", "10", "1"))),
+            dict(zip(placeholders, (r'()[]\\"-+_*' + "'", "90", "0.010")))
+        ]
+
+        for dictionary in values:
+            string = pattern_string
+            for key, value in dictionary.items():
+                string = string.replace(key, value)
+            matches = pattern.Match(string)
+
+            for key, value in dictionary.items():
+                self.assertIn(key, matches)
+                self.assertTrue(matches[key])
+                for match_value in matches[key]:
+                    self.assertEqual(match_value, value)
+
+            self.assertEqual(len(matches["<model_part_name>"]), 2)
+
+    def test_Apply(self) -> None:
+        pattern = "prefix/<step>_<model_part_name>_<time><not_a_placeholder>/<time>.suffix"
+        model_part_pattern = KratosMultiphysics.ModelPartPattern(pattern)
+        model_part_names = ("mdpa name", r"""\/=()@$&^""")
+        times = (-5.0, -5, 0.0, 1.0, 30, "10.0101E-1")
+        steps = (0, 1, 1009)
+
+        model_part = KratosMultiphysics.Model().CreateModelPart("_")
+
+        for model_part_name, time, step in itertools.product(model_part_names, times, steps):
+            placeholder_map = {
+                "<model_part_name>" : model_part_name,
+                "<time>" : str(time),
+                "<step>" : str(step)
+            }
+
+            reference = pattern
+            for placeholder, value in placeholder_map.items():
+                reference = reference.replace(placeholder, value)
+
+            # Test apply from a map
+            applied_string = model_part_pattern.Apply(placeholder_map)
+            self.assertEqual(applied_string,
+                             reference)
+
+            # Test apply from a model part
+            model_part.Name = model_part_name
+            model_part.ProcessInfo[KratosMultiphysics.TIME] = float(time)
+            model_part.ProcessInfo[KratosMultiphysics.STEP] = step
+            applied_string = model_part_pattern.Apply(model_part)
+            # Testing the output string directly doesn't make sense
+            # until formatting options are implemented.
+            #self.assertEqual(model_part_pattern.Apply(model_part),
+            #                 reference)
+
+    def test_Glob(self) -> None:
+        valid_paths = {
+            self.valid_root / "mdpa name_step_1_time_0.0.h5",
+            self.valid_root / "mdpa name_step_1_time_1.h5",
+            self.valid_root / "mdpa name_step_1_time_1.0.h5",
+            self.valid_root / "mdpa name_step_1_time_1.1.h5",
+            self.valid_root / "mdpa name_step_2_time_1.0.h5",
+            self.valid_root / "mdpa name_step_3_time_0.5.h5",
+            self.valid_root / "mdpa name_step_3_time_2.h5",
+        }
+
+        invalid_paths = {
+            self.valid_root / "mdpa name_step_3_time_03.h5",
+            self.valid_root / "mdpa name_step_3_time_004.0.h5",
+            self.valid_root / "mdpa name_step_04_time_1.h5",
+            self.valid_root / "mdpa_name_step_1_time_1.h5",
+            self.valid_root / "m_dpa_name_step_1_time_1.h5",
+            self.valid_root / "mdpa name_step_04_time_2.hdf5",
+            self.valid_root / "ir.relevant",
+            self.invalid_root / "mdpa name_step_1_time_1.0.h5",
+            self.invalid_root / "mdpa name_step_1_time_1.h5",
+            self.invalid_root / "mdpa name_step_1_time_1.1.h5",
+            self.invalid_root / "mdpa name_step_2_time_1.0.h5",
+            self.invalid_root / "mdpa name_step_3_time_0.5.h5",
+            self.invalid_root / "mdpa name_step_3_time_2.h5",
+            self.invalid_root / "mdpa name_step_3_time_03.h5",
+            self.invalid_root / "mdpa name_step_3_time_004.0.h5",
+            self.invalid_root / "ir.relevant",
+            self.test_root / "mdpa name_step_1_time_0.0.h5" / "mdpa name_step_1_time_0.0.h5"
+        }
+
+        pattern_string = "test_path_pattern/valid_root/<model_part_name>_step_<step>_time_<time>.h5"
+
+        # Base pattern (all placeholders)
+        pattern = KratosMultiphysics.ModelPartPattern(pattern_string)
+        paths = [pathlib.Path(path) for path in pattern.Glob()]
+        for path in valid_paths:
+            self.assertIn(path, paths, msg = path)
+
+        extra = {
+            self.valid_root / "mdpa_name_step_1_time_1.h5",
+            self.valid_root / "m_dpa_name_step_1_time_1.h5"
+        }
+        self.assertEqual(len(paths), len(valid_paths) + len(extra))
+        for path in valid_paths | extra:
+            self.assertIn(path, paths, msg = path)
+        for path in invalid_paths - extra:
+            self.assertNotIn(path, paths, msg = path)
+
+        # Partial pattern (<model_part_name> replaced)
+        pattern = KratosMultiphysics.ModelPartPattern(pattern_string.replace("<model_part_name>", "mdpa name"))
+        paths = [pathlib.Path(path) for path in pattern.Glob()]
+        self.assertEqual(len(paths), len(valid_paths))
+        for path in valid_paths:
+            self.assertIn(path, paths, msg = path)
+        for path in invalid_paths:
+            self.assertNotIn(path, paths, msg = path)
+
+
+if __name__ == "__main__":
+    UnitTest.main()

--- a/kratos/utilities/string_utilities.cpp
+++ b/kratos/utilities/string_utilities.cpp
@@ -417,17 +417,14 @@ const std::string& PlaceholderPattern::GetPatternString() const
 }
 
 
-const ModelPartPattern::PlaceholderMap& ModelPartPattern::GetPlaceholderMap()
+ModelPartPattern::PlaceholderMap ModelPartPattern::GetPlaceholderMap()
 {
-    if (mModelPartPlaceholderMap.empty()) {
-        mModelPartPlaceholderMap = PlaceholderMap {
-            {"<model_part_name>", ".+"},
-            {"<step>", RegexUtility::UnsignedInteger().first},
-            {"<time>", RegexUtility::FloatingPoint().first},
-            {"<rank>", RegexUtility::Integer().first}
-        };
-    }
-    return mModelPartPlaceholderMap;
+    return PlaceholderMap {
+        {"<model_part_name>", ".+"},
+        {"<step>", RegexUtility::UnsignedInteger().first},
+        {"<time>", RegexUtility::FloatingPoint().first},
+        {"<rank>", RegexUtility::Integer().first}
+    };
 }
 
 
@@ -465,9 +462,6 @@ std::string PlaceholderPattern::FormatRegexLiteral(const std::string& rLiteral)
 
     KRATOS_CATCH("");
 }
-
-
-ModelPartPattern::PlaceholderMap ModelPartPattern::mModelPartPlaceholderMap;
 
 
 ModelPartPattern::ModelPartPattern(const std::string& rPattern)

--- a/kratos/utilities/string_utilities.cpp
+++ b/kratos/utilities/string_utilities.cpp
@@ -8,6 +8,7 @@
 //                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Vicente Mataix Ferrandiz
+//                   Máté Kelemen
 //
 
 // System includes

--- a/kratos/utilities/string_utilities.cpp
+++ b/kratos/utilities/string_utilities.cpp
@@ -175,4 +175,347 @@ std::string ReplaceAllSubstrings(
     return output_string;
 }
 
+
 } // namespace Kratos::StringUtilities
+
+
+
+namespace Kratos {
+
+
+std::pair<std::string,std::regex> RegexUtility::Integer()
+{
+    std::pair<std::string,std::regex> output;
+
+    output.first = R"(0|(?:-?[1-9]+[0-9]*))";
+    output.second = std::regex(output.first);
+
+    return output;
+}
+
+
+std::pair<std::string,std::regex> RegexUtility::UnsignedInteger()
+{
+    std::pair<std::string,std::regex> output;
+
+    output.first = R"(0|(?:[1-9]+[0-9]*))";
+    output.second = std::regex(output.first);
+
+    return output;
+}
+
+
+std::pair<std::string,std::regex> RegexUtility::FloatingPoint()
+{
+    std::pair<std::string,std::regex> output;
+
+    // Clutter due to the many uncapturing groups
+    output.first = R"(-?(?:(?:(?:[1-9][0-9]*)(?:\.[0-9]*)?)|(?:0(?:\.[0-9]*)?))(?:[eE][\+-]?[0-9]+)?)";
+    output.second = std::regex(output.first);
+
+    return output;
+}
+
+
+PlaceholderPattern::PlaceholderPattern(const std::string& rPattern,
+                                       const PlaceholderMap& rPlaceholderMap)
+    : mPattern(rPattern),
+      mPlaceholderGroupMap(),
+      mRegexString(FormatRegexLiteral(rPattern)),
+      mRegex()
+{
+    KRATOS_TRY
+
+    using PositionPair = std::pair<std::size_t,PlaceholderMap::const_iterator>;
+    const auto number_of_placeholders = rPlaceholderMap.size();
+
+    // Array for tracking position-placeholder pairs for assigning
+    // regex groups to placeholders later.
+    // {position_in_pattern, it_placeholder_regex_pair}
+    std::vector<PositionPair> position_map;
+    position_map.reserve(number_of_placeholders);
+
+    // Replace placeholders with their corresponding regex strings
+    // and note their positions in the pattern
+    PlaceholderMap::const_iterator it_pair = rPlaceholderMap.begin();
+    const auto it_end = rPlaceholderMap.end();
+
+    for ( ; it_pair!=it_end; ++it_pair){
+        // Make sure that input pattern has no capturing groups of its own.
+        KRATOS_ERROR_IF(std::regex(it_pair->second).mark_count())
+            << "pattern " << it_pair->second
+            << " of placeholder '" << it_pair->first << "'"
+            << " has internal capturing group(s) (this is forbidden in PlaceholderPattern)";
+
+        // Wrap the regex in a group
+        std::string regex = "(" + it_pair->second + ")";
+
+        const auto placeholder_size = it_pair->first.size();
+        const auto regex_size = regex.size();
+        const int size_difference = regex_size - placeholder_size;
+
+        while (true) {
+            // Find the next instance of the current placeholder
+            const auto position_in_pattern = mRegexString.find(it_pair->first);
+
+            // Replace it with its regex (if found)
+            if (position_in_pattern != std::string::npos) {
+                mRegexString.replace(position_in_pattern, placeholder_size, regex);
+            } else {
+                break;
+            }
+
+            // Update positions
+            for (auto& r_pair : position_map) {
+                if (position_in_pattern < r_pair.first) r_pair.first += size_difference;
+            }
+
+            position_map.emplace_back(position_in_pattern, it_pair);
+        } // while placeholder in pattern
+    } // for placeholder in rPlaceHolderMap
+
+    // Replace positions with indices in ascending order (based on position)
+    // in lieu of std::transform_if
+    std::sort(
+        position_map.begin(),
+        position_map.end(),
+        [](const PositionPair& rLeft, const PositionPair& rRight) {return rLeft.first < rRight.first;});
+
+    std::size_t index = 0;
+    for (auto& r_pair : position_map) r_pair.first = index++;
+
+    // Populate the placeholder - group index map
+    for (auto it_pair=rPlaceholderMap.begin() ; it_pair!=it_end; ++it_pair) {
+        // Move the placeholder string and construct an associated empty index array
+        auto emplace_result = mPlaceholderGroupMap.emplace(it_pair->first, PlaceholderGroupMap::mapped_type(
+            PlaceholderGroupMap::mapped_type::value_type()
+        ));
+
+        // Fill the index array with the group indices
+        for (const auto& r_pair : position_map) {
+            if (r_pair.second == it_pair) emplace_result.first->second.value().push_back(r_pair.first);
+        }
+    }
+
+    // Disable placeholders that aren't in the pattern
+    for (auto& r_pair : mPlaceholderGroupMap) {
+        if (r_pair.second.value().empty()) {
+            r_pair.second = PlaceholderGroupMap::mapped_type();
+        } // if placeholder was not found in the pattern
+    } // for key, value in mPlaceholderGroupMap
+
+    // Construct the regex
+    mRegexString = "^" + mRegexString + "$";
+    mRegex = std::regex(mRegexString);
+
+    KRATOS_CATCH("");
+} // PlaceholderPattern::PlaceholderPattern
+
+
+bool PlaceholderPattern::IsAMatch(const std::string& rString) const
+{
+    KRATOS_TRY
+
+    return std::regex_match(rString, mRegex);
+
+    KRATOS_CATCH("");
+} // PlaceholderPattern::IsAMatch
+
+
+PlaceholderPattern::MatchType PlaceholderPattern::Match(const std::string& rString) const
+{
+    KRATOS_TRY
+
+    std::smatch results;
+    MatchType output;
+
+    // Perform regex search and extract matches
+    if (std::regex_match(rString, results, mRegex)) {
+        for (auto& r_pair : mPlaceholderGroupMap) {
+            if (r_pair.second.has_value()) {
+                // Construct empty group matches
+                auto emplace_result = output.emplace(r_pair.first, MatchType::value_type::second_type());
+
+                // Collect matches for the current placeholder
+                for (auto i_group : r_pair.second.value()) {
+                    // First match (index 0) is irrelevant because it's the entire pattern,
+                    // the rest is offset by 1
+                    const auto i_group_match = i_group + 1;
+
+                    if (!results.str(i_group_match).empty()) {
+                        emplace_result.first->second.push_back(results.str(i_group_match));
+                    }
+                } // for i_group
+            } // for placeholder, group_indices
+        } // if group_indices is not None
+    } /*if regex_match*/ else {
+        KRATOS_ERROR << "'" << rString << "' is not a match for '" << this->GetRegexString() << "'";
+    }
+
+    return output;
+
+    KRATOS_CATCH("");
+}
+
+
+std::string PlaceholderPattern::Apply(const PlaceholderMap& rPlaceholderValueMap) const
+{
+    KRATOS_TRY
+
+    auto output = mPattern;
+    const auto it_group_map_end = mPlaceholderGroupMap.end();
+
+    for (const auto& r_pair : rPlaceholderValueMap) {
+        auto it_pair = mPlaceholderGroupMap.find(r_pair.first);
+        if (it_pair != it_group_map_end) {
+            if (it_pair->second.has_value()) {
+                while (true) {
+                    auto position = output.find(r_pair.first);
+                    if (position != output.npos) {
+                        output.replace(position, r_pair.first.size(), r_pair.second);
+                    } else {
+                        break;
+                    }
+                } // while placeholder in output
+            } // if placeholder in pattern
+        } else {
+            KRATOS_ERROR << r_pair.first << " is not a registered placeholder in " << mPattern;
+        } // unrecognized placeholder
+    } // for placeholder, value in map
+
+    return output;
+
+    KRATOS_CATCH("");
+}
+
+
+bool PlaceholderPattern::IsConst() const
+{
+    return std::none_of(mPlaceholderGroupMap.begin(),
+                        mPlaceholderGroupMap.end(),
+                        [](const auto& rPair) {
+                            return rPair.second.has_value();
+                        });
+}
+
+
+const std::regex& PlaceholderPattern::GetRegex() const
+{
+    return mRegex;
+}
+
+
+const std::string& PlaceholderPattern::GetRegexString() const
+{
+    return mRegexString;
+}
+
+
+const std::string& PlaceholderPattern::GetPatternString() const
+{
+    return mPattern;
+}
+
+
+const ModelPartPattern::PlaceholderMap& ModelPartPattern::GetPlaceholderMap()
+{
+    if (mModelPartPlaceholderMap.empty()) {
+        mModelPartPlaceholderMap = PlaceholderMap {
+            {"<model_part_name>", ".+"},
+            {"<step>", RegexUtility::UnsignedInteger().first},
+            {"<time>", RegexUtility::FloatingPoint().first},
+            {"<rank>", RegexUtility::Integer().first}
+        };
+    }
+    return mModelPartPlaceholderMap;
+}
+
+
+std::string PlaceholderPattern::FormatRegexLiteral(const std::string& rLiteral)
+{
+    KRATOS_TRY
+
+    auto output = rLiteral;
+
+    for (char char_to_escape : R"(!$()*+-?[\]^)") {
+        std::size_t position = 0;
+
+        std::string escaped;
+        escaped.reserve(2);
+        escaped.push_back('\\');
+        escaped.push_back(char_to_escape);
+
+        while (true) {
+            if (output.size() <= position) break;
+
+            position = output.find(char_to_escape, position);
+            if (position == output.npos) {
+                break;
+            } else {
+                // Escape the sensitive character
+                if (!position || output[position-1] != '\\') {
+                    output.replace(position, 1, escaped);
+                    position += 2;
+                }
+            } // if char_to_escape in output
+        } // while True
+    } // for char_to_escape
+
+    return output;
+
+    KRATOS_CATCH("");
+}
+
+
+ModelPartPattern::PlaceholderMap ModelPartPattern::mModelPartPlaceholderMap;
+
+
+ModelPartPattern::ModelPartPattern(const std::string& rPattern)
+    : PlaceholderPattern(rPattern, ModelPartPattern::GetPlaceholderMap())
+{
+}
+
+
+std::string ModelPartPattern::Apply(const ModelPart& rModelPart) const
+{
+    KRATOS_TRY
+    ModelPartPattern::PlaceholderMap map;
+    this->PopulatePlaceholderMap(map, rModelPart);
+    return this->Apply(map);
+    KRATOS_CATCH("");
+}
+
+
+void ModelPartPattern::PopulatePlaceholderMap(PlaceholderMap& rMap, const ModelPart& rModelPart) const
+{
+    // TODO: implement formatting, see the documentation in the header. @matekelemen
+    const auto& r_pattern = this->GetPatternString();
+
+    if (r_pattern.find("<model_part_name>") != r_pattern.npos) {
+        rMap.emplace("<model_part_name>", rModelPart.Name());
+    }
+
+    if (r_pattern.find("<step>") != r_pattern.npos) {
+        rMap.emplace("<step>", std::to_string(rModelPart.GetProcessInfo().GetValue(STEP)));
+    }
+
+    if (r_pattern.find("<time>") != r_pattern.npos) {
+        // Hardcoded formatting - to be changed later
+        std::stringstream stream;
+        stream << std::scientific << std::setprecision(4) << rModelPart.GetProcessInfo().GetValue(TIME);
+        rMap.emplace("<time>", stream.str());
+    }
+
+    if (r_pattern.find("<rank>") != r_pattern.npos) {
+        rMap.emplace("<rank>", std::to_string(rModelPart.GetCommunicator().MyPID()));
+    }
+}
+
+
+ModelPartPattern::ModelPartPattern(const std::string& rPattern, const PlaceholderMap& rPlaceholderMap)
+    : PlaceholderPattern(rPattern, rPlaceholderMap)
+{
+}
+
+
+} // namespace Kratos

--- a/kratos/utilities/string_utilities.h
+++ b/kratos/utilities/string_utilities.h
@@ -369,7 +369,7 @@ private:
  *           placeholders can be added at compile time by tweaking the construction
  *           of the static member @ref ModelPartPattern::mModelpartPlaceholderMap.
  */
-class KRATOS_API(WR_APPLICATION) ModelPartPattern : public PlaceholderPattern
+class KRATOS_API(KRATOS_CORE) ModelPartPattern : public PlaceholderPattern
 {
 public:
     ///@name Type Definitions

--- a/kratos/utilities/string_utilities.h
+++ b/kratos/utilities/string_utilities.h
@@ -425,15 +425,7 @@ protected:
     /// @brief Populate a key-value map of registered placeholders from a @ref ModelPart.
     virtual void PopulatePlaceholderMap(PlaceholderMap& rMap, const ModelPart& rModelPart) const;
 
-    static const PlaceholderMap& GetPlaceholderMap();
-
-    ///@}
-
-private:
-    ///@name Static Member Variables
-    ///@{
-
-    static PlaceholderMap mModelPartPlaceholderMap;
+    static PlaceholderMap GetPlaceholderMap();
 
     ///@}
 }; // class ModelPartPattern

--- a/kratos/utilities/string_utilities.h
+++ b/kratos/utilities/string_utilities.h
@@ -8,13 +8,22 @@
 //                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Vicente Mataix Ferrandiz
+//                   Máté Kelemen
 //
 
 #pragma once
 
+// Core includes
+#include "includes/kratos_export_api.h"
+#include "includes/model_part.h"
+
 // System includes
 #include <string>
 #include <vector>
+#include <regex>
+#include <map>
+#include <filesystem>
+#include <optional>
 
 // External includes
 
@@ -120,4 +129,319 @@ namespace StringUtilities
         );
 
 }; // namespace StringUtilities
+
+
+/// @addtogroup KratosCore
+/// @{
+
+
+/** @brief Static-only utility class for common regexes.
+ *
+ *  @details Static access to pairs of regex patterns (as @c std::string)
+ *           and their associated regexes (as @c std::regex).
+ *  @note No instances are allowed to be constructed from this class.
+ */
+class RegexUtility
+{
+public:
+    ///@name Inquiry
+    ///@{
+
+    /** @brief Get a string-regex pair representing an integer.
+     *
+     *  @details Matches the following pattern:
+     *           - optional leading '-'
+     *           - 0 or [1-9]+[0-9]*
+     *
+     *  @return A pair of
+     *          - @c std::string of a regex pattern representing an @a integer.
+     *          - @c std::regex of that string.
+     *  @note This function can be called safely from other static functions.
+     */
+    static std::pair<std::string,std::regex> Integer();
+
+    /** @brief Get a string-regex pair representing an unsigned integer.
+     *
+     *  @details Matches the following pattern:
+     *           - 0 or [1-9]+[0-9]*
+     *
+     *  @return A pair of
+     *          - @c std::string of a regex pattern representing an <em>unsigned integer</em>.
+     *          - @c std::regex of that string.
+     *  @note This function can be called safely from other static functions.
+     */
+    static std::pair<std::string,std::regex> UnsignedInteger();
+
+    /** @brief Get a string-regex pair representing an integer.
+     *
+     *  @details Matches the following pattern:
+     *           - optional leading '-'
+     *           - whole part identical to @ref RegexUtility::Integer
+     *           - optional decimal point, optionally followed by the fractional part [0-9]*
+     *           - optional scientific notation suffix [eE][\+-][0-9]+
+     *
+     *  @return A pair of
+     *          - @c std::string of a regex pattern representing a <em>floating point</em>
+     *            number in decimal or scientific notation.
+     *          - @c std::regex of that string.
+     *
+     *  @note This function can be called safely from other static functions.
+     */
+    static std::pair<std::string,std::regex> FloatingPoint();
+
+    ///@}
+
+private:
+    ///@name Life Cycle
+    ///@{
+
+    /// @brief Deleted default constructor (no instances of this class are allowed).
+    RegexUtility() = delete;
+
+    /// @brief Deleted move constructor (no instances of this class are allowed).
+    RegexUtility(RegexUtility&& rOther) = delete;
+
+    /// @brief Deleted copy constructor (no instances of this class are allowed).
+    RegexUtility(const RegexUtility& rOther) = delete;
+
+    ///@}
+}; // class RegexUtility
+
+
+/** @brief A class for interfacing placeholders and regular expressions.
+ *
+ *  @note placeholders should be separated by literals, otherwise
+ *        regex will probably not capture them as you'd expect.
+ *        <b>BAD</b> example:
+ *            @code
+ *            pattern:    "<placeholder_1><placeholder_2>"
+ *            string:     "abcdefg"
+ *            result:
+ *                "<placeholder_1>" : "abcdef"
+ *                "<placeholder_2>" : "g"
+ *            @endcode
+ *        <b>CORRECT</b> example:
+ *            @code
+ *            pattern:    "<placeholder_1>d<placeholder_2>"
+ *            string:     "abcdefg"
+ *            result:
+ *                "<placeholder_1>" : "abc"
+ *                "<placeholder_2>" : "efg"
+ *            @endcode
+ */
+class KRATOS_API(WR_APPLICATION) PlaceholderPattern
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    using PlaceholderMap = std::map<std::string,std::string>;
+
+    using PlaceholderGroupMap = std::map<std::string,std::optional<std::vector<std::size_t>>>;
+
+    using MatchType = std::map<std::string,std::vector<std::string>>;
+
+    using PathType = std::filesystem::path;
+
+    KRATOS_CLASS_POINTER_DEFINITION(PlaceholderPattern);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor
+    PlaceholderPattern() = default;
+
+    /** @brief Construct from a placeholder pattern and its associated map.
+     *  @param rPattern Pattern string with placeholders.
+     *  @param rPlaceholderMap Pairs of placeholders and their corresponding regex strings.
+     *                         Example: @code {{"<name>", ".+"}, {"<identifier>", "[0-9]+"}} @endcode
+     *
+     *  @warning The corresponding regexes must be bare, not containing groups (checked)
+     *           or position constraints such as line begin or end modifiers (not checked).
+     */
+    PlaceholderPattern(const std::string& rPattern,
+                       const PlaceholderMap& rPlaceholderMap);
+
+    /// Move constructor
+    PlaceholderPattern(PlaceholderPattern&& rOther) = default;
+
+    /// Copy constructor
+    PlaceholderPattern(const PlaceholderPattern& rOther) = default;
+
+    virtual ~PlaceholderPattern() = default;
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /// @brief Move assignment operator
+    PlaceholderPattern& operator=(PlaceholderPattern&& rOther) = default;
+
+    /// @brief Copy assignment operator
+    PlaceholderPattern& operator=(const PlaceholderPattern& rOther) = default;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /// @brief Check whether a string satisfies the pattern
+    bool IsAMatch(const std::string& rString) const;
+
+    /** @brief Find all placeholders' values in the input string.
+     *
+     *  @param rString String matching the input pattern.
+     *  @return Map associating a vector of strings, i.e. the values
+     *          of placeholders in the input string, to the placeholders.
+     *
+     *  @note The returned placeholder values appear in the same order
+     *        they do in the input pattern.
+     */
+    MatchType Match(const std::string& rString) const;
+
+    /** @brief Substitute values in the stored pattern.
+     *
+     *  @details Return a copy of the pattern that has its placeholders replaced
+     *           with the corresponding values specified in the input map.
+     *  @param rPlaceholderValueMap string - string map associating values to placeholders
+     *                              @code {"palceholder" : "placeholder_value"} @endcode
+     */
+    std::string Apply(const PlaceholderMap& rPlaceholderValueMap) const;
+
+    /** @brief Collect all file/directory paths that match the pattern.
+     *  @tparam TOutputIterator: output iterator with value type constructible from @ref PathType.
+     *  @note the search begins from the filesystem root if the pattern is an absolute path,
+     *        otherwise it begins from @c cwd.
+     */
+    template <class TOutputIterator>
+    void Glob(TOutputIterator it) const;
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    /// @brief Return true if the input pattern contains no placeholders.
+    bool IsConst() const;
+
+    /// @brief Get the regex for the input pattern.
+    const std::regex& GetRegex() const;
+
+    /// @brief Get the string representation of the regex.
+    const std::string& GetRegexString() const;
+
+    /// @brief Get the pattern with placeholders.
+    const std::string& GetPatternString() const;
+
+    ///@}
+
+private:
+    ///@name Member Variables
+    ///@{
+
+    std::string mPattern;
+
+    // Placeholders and their assigned group indices in the pattern
+    PlaceholderGroupMap mPlaceholderGroupMap;
+
+    std::string mRegexString;
+
+    std::regex mRegex;
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+    /// @brief Escape characters in the input that interfere with regex syntax.
+    static std::string FormatRegexLiteral(const std::string& rLiteral);
+
+    ///@}
+}; // class PlaceholderPattern
+
+
+/** @brief A class for working with formatted strings related to @ref ModelParts.
+ *
+ *  @details Operations on strings with the following placeholders are supported:
+ *           - <model_part_name>
+ *           - <step>
+ *           - <time>
+ *           - <rank>
+ *           See @ref PlaceholderPattern for supported functionalities. Other
+ *           placeholders can be added at compile time by tweaking the construction
+ *           of the static member @ref ModelPartPattern::mModelpartPlaceholderMap.
+ */
+class KRATOS_API(WR_APPLICATION) ModelPartPattern : public PlaceholderPattern
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    KRATOS_CLASS_POINTER_DEFINITION(ModelPartPattern);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    ModelPartPattern() = default;
+
+    ModelPartPattern(const std::string& rPattern);
+
+    ModelPartPattern(ModelPartPattern&& rOther) = default;
+
+    ModelPartPattern(const ModelPartPattern& rOther) = default;
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    using PlaceholderPattern::operator=;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    using PlaceholderPattern::Apply;
+
+    /** @brief Substitute values from the specified @ref ModelPart in the stored pattern.
+     *
+     *  @param rModelPart: Model part to extract the values of placeholders from.
+     *  @note @p rModelPart must store @ref STEP and @ref TIME.
+     *  @todo Add support for string formatting. Options are:
+     *        - @c snprintf from the C STL (security issues due to allowing the user to freely specify the format)
+     *        - @c fmt::format (requires fmtlib)
+     *        - @c std::format (==fmtlib adopted in the standard, requires C++20)
+     *        - @c boost::format (requires boost)
+     */
+    std::string Apply(const ModelPart& rModelPart) const;
+
+    ///@}
+
+protected:
+    ///@name Protected Methods
+    ///@{
+
+    /// @brief Forwarding constructor for derived classes.
+    ModelPartPattern(const std::string& rPattern, const PlaceholderMap& rPlaceholderMap);
+
+    /// @brief Populate a key-value map of registered placeholders from a @ref ModelPart.
+    virtual void PopulatePlaceholderMap(PlaceholderMap& rMap, const ModelPart& rModelPart) const;
+
+    static const PlaceholderMap& GetPlaceholderMap();
+
+    ///@}
+
+private:
+    ///@name Static Member Variables
+    ///@{
+
+    static PlaceholderMap mModelPartPlaceholderMap;
+
+    ///@}
+}; // class ModelPartPattern
+
+
+///@}
+
+
 }  // namespace Kratos
+
+#include "utilities/string_utilities_impl.h"

--- a/kratos/utilities/string_utilities.h
+++ b/kratos/utilities/string_utilities.h
@@ -229,7 +229,7 @@ private:
  *                "<placeholder_2>" : "efg"
  *            @endcode
  */
-class KRATOS_API(WR_APPLICATION) PlaceholderPattern
+class KRATOS_API(KRATOS_CORE) PlaceholderPattern
 {
 public:
     ///@name Type Definitions

--- a/kratos/utilities/string_utilities_impl.h
+++ b/kratos/utilities/string_utilities_impl.h
@@ -1,0 +1,70 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Máté Kelemen
+//
+
+#pragma once
+
+// --- Core Includes ---
+#include "utilities/string_utilities.h"
+
+
+namespace Kratos {
+
+
+template <class TOutputIterator>
+void PlaceholderPattern::Glob(TOutputIterator it) const
+{
+    KRATOS_TRY
+
+    // Create a path from the regex string omitting the leading '^' and trailing '$\0'
+    PathType pattern(this->GetRegexString().substr(1, this->GetRegexString().size()-2));
+
+    auto it_pattern_part = pattern.begin();
+    std::vector<PathType> paths;
+
+    // Decide where to begin globbing
+    if (pattern.is_absolute()) { // the pattern is absolute => begin globbing at the filesystem root
+        paths.emplace_back(pattern.root_path());
+        ++it_pattern_part;
+    } else { // the pattern is relative => begin globbing at the current working directory
+        paths.emplace_back(std::filesystem::current_path());
+    }
+
+    // Compare the pattern parts to the globbed files'/directories' parts
+    for ( ; it_pattern_part!=pattern.end(); ++it_pattern_part) {
+        if (paths.empty()) break;
+
+        std::regex pattern_part_regex(it_pattern_part->string());
+        std::vector<PathType> tmp_paths;
+
+        for (const auto& r_path : paths) {
+            if (std::filesystem::is_directory(r_path)) {
+                for (auto item : std::filesystem::directory_iterator(r_path)) {
+                    if (std::regex_match(item.path().filename().string(), pattern_part_regex)) {
+                        tmp_paths.emplace_back(item);
+                    }
+                } // for r_item in r_path.glob(*)
+            } // if r_path.is_directory()
+        } // for r_path in paths
+
+        paths = tmp_paths;
+    } // for pattern_part in pattern.parts
+
+    // Output
+    for (auto& r_path : paths) {
+        *it++ = std::move(r_path);
+    }
+
+    KRATOS_CATCH("");
+}
+
+
+} // namespace Kratos


### PR DESCRIPTION
## Description

- add a utility class `PlaceholderPattern` for string and filesystem related tasks involving basic string patterns
- add a convenience class `ModelPartPattern` that uses predefined placeholders `<model_part_name>`, `<step>`, `<time>` and `<rank>` (+ an interface for fetching the related values from a `ModelPart`)

Requested from #10778 by @sunethwarna.

## Features

- check whether an input string matches the pattern
- extract placeholders' values from an input string (even if the pattern contains duplicate placeholders but the input string has different values for them)
- substitute placeholders for given values
- collect all directories/files matching the pattern

## Example

A simple example with `ModelPartPattern`:
```py
import KratosMultiphysics

pattern = KratosMultiphysics.ModelPartPattern("<model_part_name>_<step>/output_<step>_<rank>.log")
pattern.IsAMatch("a_1/output_1_0.log") # <== true
pattern.IsAMatch("a_1/output_1_zero.log") # <== false
pattern.Match("a_1/output_2_0.log") # <== {"<model_part_name>" : ["a"], "<rank>" : ["0"], "<step>" : ["1", "2"]}
pattern.Glob() # <== depends on your filesystem, but most likely []

model_part = KratosMultiphysics.Model().CreateModelPart("whatever")
model_part.ProcessInfo[KratosMultiphysics.STEP] = 5
pattern.Apply(model_part) # <== "whatever_5/output_5_0.log"
```

`PlaceholderPattern` is a generalization of `ModelPartPattern`. You need to define it via a placeholder-regex map that specifies what expression to associate with each placeholder. Otherwise it works identically to `ModelPartPattern`.