### PR TITLE
[Meshing] Fix error in father nodes in fulldebug

### DIFF
--- a/applications/MeshingApplication/custom_utilities/local_refine_geometry_mesh.cpp
+++ b/applications/MeshingApplication/custom_utilities/local_refine_geometry_mesh.cpp
@@ -444,7 +444,9 @@ void LocalRefineGeometryMesh::UpdateSubModelPartNodes(ModelPart &rModelPart)
 void LocalRefineGeometryMesh::ResetFatherNodes(ModelPart &rModelPart)
 {
     block_for_each(mModelPart.Nodes(), [&](Node<3>& rNode) {
-        (rNode.GetValue(FATHER_NODES)).clear();
+        if (rNode.Has(FATHER_NODES)) {
+            (rNode.GetValue(FATHER_NODES)).clear();
+        }
     });
 }
 


### PR DESCRIPTION
This was throwing an error in FullDebug, because if FATHER_NODES were not assigned before calling this method, you are doing a GetValue in a parallel section, allocating new memory.
