### PR TITLE
[ConstitutiveLawsApp] Adding perturbation to coordinates of nodes

### DIFF
--- a/applications/ConstitutiveLawsApplication/python_scripts/add_texture_normal_distribution_process.py
+++ b/applications/ConstitutiveLawsApplication/python_scripts/add_texture_normal_distribution_process.py
@@ -49,7 +49,7 @@ class AddTextureNormalDistributionProcess(KM.Process):
         self.echo = settings["echo_level"].GetInt()
 
 
-    def ExecuteInitializeSolutionStep(self):
+    def ExecuteInitialize(self):
         """This method is executed in order to initialize the current step
 
         Keyword arguments:
@@ -58,5 +58,24 @@ class AddTextureNormalDistributionProcess(KM.Process):
         # Here we compute the normal field
         normal_calculation_utils = KM.NormalCalculationUtils()
         normal_calculation_utils.CalculateUnitNormalsNonHistorical(self.model_part, 3)
+        number_nodes = len(self.model_part.Nodes)
+        normal = KM.Array3([0,0,0])
+
+        # We generate a random normal distribution
+        norm_distr = np.random.normal(self.mu, self.sigma, number_nodes)
+        counter = 0
+
+        for node in self.model_part.Nodes:
+            normal = node.GetValue(KM.NORMAL)
+            node.X0 += norm_distr[counter] * normal[0]
+            node.Y0 += norm_distr[counter] * normal[1]
+            node.Z0 += norm_distr[counter] * normal[2]
+            node.X  += norm_distr[counter] * normal[0]
+            node.Y  += norm_distr[counter] * normal[1]
+            node.Z  += norm_distr[counter] * normal[2]
+            counter += 1
+        
+        # Now we print a backup of the nodes coordinates used in the simulation
+        
 
 

--- a/applications/ConstitutiveLawsApplication/python_scripts/add_texture_normal_distribution_process.py
+++ b/applications/ConstitutiveLawsApplication/python_scripts/add_texture_normal_distribution_process.py
@@ -93,6 +93,8 @@ class AddTextureNormalDistributionProcess(KM.Process):
             counter += 1
             if self.print_coords:
                 # Now we print a backup of the nodes coordinates used in the simulation
+                if counter == 1:
+                    self.ascii_writer.write("The applied distribution has a mean of " + "{0:.4e}".format(np.mean(norm_distr)).rjust(11) + " and a standard deviation of " + "{0:.4e}".format(np.std(norm_distr)).rjust(11) + "\n\n")
                 self.ascii_writer.write(str(node.Id)+ "\t\t")
                 self.ascii_writer.write("{0:.4e}".format(node.X0).rjust(11) + "\t")
                 self.ascii_writer.write("{0:.4e}".format(node.Y0).rjust(11) + "\t")

--- a/applications/ConstitutiveLawsApplication/python_scripts/add_texture_normal_distribution_process.py
+++ b/applications/ConstitutiveLawsApplication/python_scripts/add_texture_normal_distribution_process.py
@@ -10,7 +10,10 @@ def Factory(settings, Model):
 
 class AddTextureNormalDistributionProcess(KM.Process):
 
-    """This process perturbates the coordinates of the nodes of the designated submodelpart according to a normal distribution with [mu,sigma] by using numpy capabilities (https://numpy.org/doc/stable/reference/random/generated/numpy.random.normal.html)
+    """
+    This process perturbates the coordinates of the nodes of the designated submodelpart according to a normal distribution with [mu,sigma] by using numpy capabilities (https://numpy.org/doc/stable/reference/random/generated/numpy.random.normal.html)
+
+    Note: the process assumes that the submodelpart includes a set of conditions to be able to compute the normal field.
 
 
     Public member variables:
@@ -29,18 +32,14 @@ class AddTextureNormalDistributionProcess(KM.Process):
         KM.Process.__init__(self)
 
         # The value can be a double or a string (function)
-        default_settings = KM.Parameters(
-            """
-        {
+        default_settings = KM.Parameters("""{
             "help"                       : "This process perturbates the coordinates of the nodes according to a normal distribution",
             "model_part_name"            : "please_specify_model_part_name",
             "normal_mu"                  : 0.0,
             "normal_sigma"               : 0.1,
             "print_modified_coordinates" : true,
             "echo_level"                 : 1
-        }
-        """
-        )
+        }""")
         settings.ValidateAndAssignDefaults(default_settings)
 
         self.model_part = Model[settings["model_part_name"].GetString()]
@@ -56,6 +55,8 @@ class AddTextureNormalDistributionProcess(KM.Process):
         Keyword arguments:
         self -- It signifies an instance of a class.
         """
-
+        # Here we compute the normal field
+        normal_calculation_utils = KM.NormalCalculationUtils()
+        normal_calculation_utils.CalculateUnitNormalsNonHistorical(self.model_part, 3)
 
 

--- a/applications/ConstitutiveLawsApplication/python_scripts/add_texture_normal_distribution_process.py
+++ b/applications/ConstitutiveLawsApplication/python_scripts/add_texture_normal_distribution_process.py
@@ -1,5 +1,4 @@
 import KratosMultiphysics as KM
-import KratosMultiphysics.ConstitutiveLawsApplication as CLApp
 import numpy as np
 
 def Factory(settings, Model):
@@ -11,8 +10,7 @@ def Factory(settings, Model):
 
 class AddTextureNormalDistributionProcess(KM.Process):
 
-    """This process sets the pre-stressing imposed strain according to a load factor (can depend on time) inside a defined Interval.
-    This process should be called together with set_up_pre_stressed_oriented_composite_materials.py in order to work properly (it sets the initial value of imposed strain)
+    """This process perturbates the coordinates of the nodes of the designated submodelpart according to a normal distribution with [mu,sigma] by using numpy capabilities (https://numpy.org/doc/stable/reference/random/generated/numpy.random.normal.html)
 
 
     Public member variables:
@@ -36,22 +34,21 @@ class AddTextureNormalDistributionProcess(KM.Process):
         {
             "help"                       : "This process perturbates the coordinates of the nodes according to a normal distribution",
             "model_part_name"            : "please_specify_model_part_name",
-            "normal_mu"                  : "0.0",
+            "normal_mu"                  : 0.0,
             "normal_sigma"               : 0.1,
-            "print_modified_coordinates" : true
+            "print_modified_coordinates" : true,
+            "echo_level"                 : 1
         }
         """
         )
         settings.ValidateAndAssignDefaults(default_settings)
 
-        if not settings.Has("load_factor"):
-            raise RuntimeError("Please specify the value to set the vector to. Example:\n" + '{\n\t"load_factor" : 0.1*t*x\n}\n')
-
         self.model_part = Model[settings["model_part_name"].GetString()]
-        # self.interval = KM.IntervalUtility(settings)
-        # self.load_factor_function = self.CreateFunction(settings["load_factor"])
+        self.mu    = settings["normal_mu"].GetDouble()    # average
+        self.sigma = settings["normal_sigma"].GetDouble() # standard deviation
+        self.print_coords = settings["print_modified_coordinates"].GetBool()
         self.echo = settings["echo_level"].GetInt()
-        # self.old_load_factor = 1.0e30
+
 
     def ExecuteInitializeSolutionStep(self):
         """This method is executed in order to initialize the current step
@@ -59,20 +56,6 @@ class AddTextureNormalDistributionProcess(KM.Process):
         Keyword arguments:
         self -- It signifies an instance of a class.
         """
-        # current_time = self.model_part.ProcessInfo[KM.TIME]
-        # step = self.model_part.ProcessInfo[KM.STEP]
 
-        # if self.interval.IsInInterval(current_time):
-        #     current_load_factor = self.load_factor_function.CallFunction(0,0,0,current_time,0,0,0)
-        #     if self.echo > 0:
-        #         KM.Logger.PrintInfo("ApplyPreStressingImposedStrainProcess", "Applying a load factor of " + "{0:.4e}".format(current_load_factor).rjust(11) + ".")
-        #     for element in self.model_part.Elements:
-        #         if element.Has(CLApp.SERIAL_PARALLEL_IMPOSED_STRAIN): # With previous imposed strain
-        #             current_strain = element.GetValue(CLApp.SERIAL_PARALLEL_IMPOSED_STRAIN)
-        #             if step == 1:
-        #                 element.SetValue(CLApp.SERIAL_PARALLEL_IMPOSED_STRAIN, current_strain * current_load_factor)
-        #             else:
-        #                 element.SetValue(CLApp.SERIAL_PARALLEL_IMPOSED_STRAIN, current_strain * current_load_factor / self.old_load_factor)
-        #     self.old_load_factor = current_load_factor
 
 

--- a/applications/ConstitutiveLawsApplication/python_scripts/add_texture_normal_distribution_process.py
+++ b/applications/ConstitutiveLawsApplication/python_scripts/add_texture_normal_distribution_process.py
@@ -1,0 +1,78 @@
+import KratosMultiphysics as KM
+import KratosMultiphysics.ConstitutiveLawsApplication as CLApp
+import numpy as np
+
+def Factory(settings, Model):
+    if not isinstance(settings, KM.Parameters):
+        raise Exception(
+            "expected input shall be a Parameters object, encapsulating a json string"
+        )
+    return AddTextureNormalDistributionProcess(Model, settings["Parameters"])
+
+class AddTextureNormalDistributionProcess(KM.Process):
+
+    """This process sets the pre-stressing imposed strain according to a load factor (can depend on time) inside a defined Interval.
+    This process should be called together with set_up_pre_stressed_oriented_composite_materials.py in order to work properly (it sets the initial value of imposed strain)
+
+
+    Public member variables:
+    Model -- the container of the different model parts.
+    settings -- Kratos parameters containing solver settings.
+    """
+
+    def __init__(self, Model, settings):
+        """The default constructor of the class
+
+        Keyword arguments:
+        self -- It signifies an instance of a class.
+        Model -- the container of the different model parts.
+        settings -- Kratos parameters containing solver settings.
+        """
+        KM.Process.__init__(self)
+
+        # The value can be a double or a string (function)
+        default_settings = KM.Parameters(
+            """
+        {
+            "help"                       : "This process perturbates the coordinates of the nodes according to a normal distribution",
+            "model_part_name"            : "please_specify_model_part_name",
+            "normal_mu"                  : "0.0",
+            "normal_sigma"               : 0.1,
+            "print_modified_coordinates" : true
+        }
+        """
+        )
+        settings.ValidateAndAssignDefaults(default_settings)
+
+        if not settings.Has("load_factor"):
+            raise RuntimeError("Please specify the value to set the vector to. Example:\n" + '{\n\t"load_factor" : 0.1*t*x\n}\n')
+
+        self.model_part = Model[settings["model_part_name"].GetString()]
+        # self.interval = KM.IntervalUtility(settings)
+        # self.load_factor_function = self.CreateFunction(settings["load_factor"])
+        self.echo = settings["echo_level"].GetInt()
+        # self.old_load_factor = 1.0e30
+
+    def ExecuteInitializeSolutionStep(self):
+        """This method is executed in order to initialize the current step
+
+        Keyword arguments:
+        self -- It signifies an instance of a class.
+        """
+        # current_time = self.model_part.ProcessInfo[KM.TIME]
+        # step = self.model_part.ProcessInfo[KM.STEP]
+
+        # if self.interval.IsInInterval(current_time):
+        #     current_load_factor = self.load_factor_function.CallFunction(0,0,0,current_time,0,0,0)
+        #     if self.echo > 0:
+        #         KM.Logger.PrintInfo("ApplyPreStressingImposedStrainProcess", "Applying a load factor of " + "{0:.4e}".format(current_load_factor).rjust(11) + ".")
+        #     for element in self.model_part.Elements:
+        #         if element.Has(CLApp.SERIAL_PARALLEL_IMPOSED_STRAIN): # With previous imposed strain
+        #             current_strain = element.GetValue(CLApp.SERIAL_PARALLEL_IMPOSED_STRAIN)
+        #             if step == 1:
+        #                 element.SetValue(CLApp.SERIAL_PARALLEL_IMPOSED_STRAIN, current_strain * current_load_factor)
+        #             else:
+        #                 element.SetValue(CLApp.SERIAL_PARALLEL_IMPOSED_STRAIN, current_strain * current_load_factor / self.old_load_factor)
+        #     self.old_load_factor = current_load_factor
+
+

--- a/applications/ConstitutiveLawsApplication/python_scripts/add_texture_normal_distribution_process.py
+++ b/applications/ConstitutiveLawsApplication/python_scripts/add_texture_normal_distribution_process.py
@@ -61,6 +61,9 @@ class AddTextureNormalDistributionProcess(KM.Process):
         header = "# In this file we print the used perturbed coordinates of the nodes:" + "\n\n" + "Id		X            Y           Z\n"
         self.ascii_writer = AsciiWriter.TimeBasedAsciiFileWriterUtility(self.model_part, ascii_writer_params, header).file
 
+        if len(self.model_part.Conditions) == 0:
+            raise RuntimeError('The provided submodelpart does not include any condition...')
+
 
     def ExecuteInitialize(self):
         """This method is executed in order to initialize the current step


### PR DESCRIPTION
**📝 Description**
In this PR I am adding a new process for the CLApp in which we perturbate the initial coordinates of a submodelpart by a normal distribution of probability.

The coordinate perturbation is done according to a numpy.normal_distribution in the direction of the nodal normal. 

**Required:** the submodelpart passed to the process must include a set of conditions to be able to compute the nodal normal field.

Finally, it prints the used coordinates of the perturbed nodes since this information will be lost after running.

Input to the json:

~~~json
{
            "python_module" : "add_texture_normal_distribution_process",
            "kratos_module" : "KratosMultiphysics.ConstitutiveLawsApplication",
            "process_name"  : "AddTextureNormalDistributionProcess",
            "Parameters"    : {
                "model_part_name" : "Structure.SurfacePressure3D_Pressure_on_surfaces_Auto1",
                "normal_mu"                  : 0.0,
                "normal_sigma"               : 0.05,
                "print_modified_coordinates" : true,
                "echo_level"                 : 1
            }
    }
~~~

Example of the result:

Without perturbation:
![imagen](https://user-images.githubusercontent.com/26402605/221780917-351e3955-1e44-4fe0-93a0-55e807e198ab.png)

With perturbation:

![imagen](https://user-images.githubusercontent.com/26402605/221781009-11cce270-70ca-431d-9c4c-384495c9e497.png)




