### PR TITLE
[Poro] Corrected linking error 

### DIFF
--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -2243,6 +2243,19 @@ template void UPwSmallStrainInterfaceElement<3,8>::CalculateShapeFunctionsGradie
                                                     const BoundedMatrix<double,3,3>& RotationMatrix,
                                                     const Matrix& DN_De,const Matrix& Ncontainer, const double& JointWidth,const unsigned int& GPoint );
 
+template void UPwSmallStrainInterfaceElement<2,4>::InterpolateOutputValues< array_1d<double,3> >
+                                                    ( std::vector<array_1d<double,3>>& rOutput, const std::vector<array_1d<double,3>>& GPValues );
+template void UPwSmallStrainInterfaceElement<2,4>::InterpolateOutputValues< Matrix >
+                                                    ( std::vector<Matrix>& rOutput, const std::vector<Matrix>& GPValues );
+template void UPwSmallStrainInterfaceElement<3,6>::InterpolateOutputValues< array_1d<double,3> >
+                                                    ( std::vector<array_1d<double,3>>& rOutput, const std::vector<array_1d<double,3>>& GPValues );
+template void UPwSmallStrainInterfaceElement<3,6>::InterpolateOutputValues< Matrix >
+                                                    ( std::vector<Matrix>& rOutput, const std::vector<Matrix>& GPValues );
+template void UPwSmallStrainInterfaceElement<3,8>::InterpolateOutputValues< array_1d<double,3> >
+                                                    ( std::vector<array_1d<double,3>>& rOutput, const std::vector<array_1d<double,3>>& GPValues );
+template void UPwSmallStrainInterfaceElement<3,8>::InterpolateOutputValues< Matrix >
+                                                    ( std::vector<Matrix>& rOutput, const std::vector<Matrix>& GPValues );
+
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 template class UPwSmallStrainInterfaceElement<2,4>;


### PR DESCRIPTION
**📝 Description**
A linking error was corrected. The explicit instantiation of some template methods was missing in the interface element.

**🆕 Changelog**
- Added explicit instantiation of the _InterpolateOutputValues_ method in _U_Pw_small_strain_interface_element.cpp_
