### PR TITLE
[Hotfix][KratosCore] ComputeNodalGradientProces DOMAIN_SIZE check.

### DIFF
--- a/kratos/processes/compute_nodal_gradient_process.cpp
+++ b/kratos/processes/compute_nodal_gradient_process.cpp
@@ -62,6 +62,7 @@ void ComputeNodalGradientProcess<THistorical>::ComputeElementalContributionsAndV
     const auto it_element_begin = mrModelPart.ElementsBegin();
 
     // Current domain size
+    KRATOS_ERROR_IF_NOT(mrModelPart.GetProcessInfo().Has(DOMAIN_SIZE)) << "'DOMAIN_SIZE' is not found in '" << mrModelPart.FullName() << "' ProcessInfo container." << std::endl;
     const std::size_t dimension = mrModelPart.GetProcessInfo()[DOMAIN_SIZE];
 
     // Initial resize


### PR DESCRIPTION
**📝 Description**
@uxuech discovered that no check is done in the `ComputeNodalGradientProcess` `DOMAIN_SIZE` retrieve from the `ProcessInfo`. If not provided, a weird misbehavior occurs without any notification to the user. This PR amends this.
