### PR TITLE
[Core] Adding KRATOS_WATCH_MPI

### DIFF
--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -803,7 +803,7 @@ namespace Kratos
 //Print Trace if defined
 #define KRATOS_WATCH(variable) std::cout << #variable << " : " << variable << std::endl;
 #define KRATOS_WATCH_CERR(variable) std::cerr << #variable << " : " << variable << std::endl;
-#define KRATOS_WATCH_MPI(variable, mpi_data_comm) std::cout << "RANK " << mpi_data_comm.Rank() << "/" << mpi_data_comm.Size() - 1 << "\t"; KRATOS_WATCH(variable);
+#define KRATOS_WATCH_MPI(variable, mpi_data_comm) std::cout << "RANK " << mpi_data_comm.Rank() << "/" << mpi_data_comm.Size()  << "    "; KRATOS_WATCH(variable);
 
 }  /* namespace Kratos.*/
 

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -803,6 +803,7 @@ namespace Kratos
 //Print Trace if defined
 #define KRATOS_WATCH(variable) std::cout << #variable << " : " << variable << std::endl;
 #define KRATOS_WATCH_CERR(variable) std::cerr << #variable << " : " << variable << std::endl;
+#define KRATOS_WATCH_MPI(variable, mpi_data_comm) std::cout << "RANK " << mpi_data_comm.Rank() + 1 << "/" << mpi_data_comm.Size() << "\t" << #variable << " : " << variable << std::endl;
 
 }  /* namespace Kratos.*/
 

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -803,7 +803,7 @@ namespace Kratos
 //Print Trace if defined
 #define KRATOS_WATCH(variable) std::cout << #variable << " : " << variable << std::endl;
 #define KRATOS_WATCH_CERR(variable) std::cerr << #variable << " : " << variable << std::endl;
-#define KRATOS_WATCH_MPI(variable, mpi_data_comm) std::cout << "RANK " << mpi_data_comm.Rank() + 1 << "/" << mpi_data_comm.Size() << "\t" << #variable << " : " << variable << std::endl;
+#define KRATOS_WATCH_MPI(variable, mpi_data_comm) std::cout << "RANK " << mpi_data_comm.Rank() << "/" << mpi_data_comm.Size() - 1 << "\t"; KRATOS_WATCH(variable);
 
 }  /* namespace Kratos.*/
 


### PR DESCRIPTION
**📝 Description**

Adding KRATOS_WATCH_MPI. Basically the same as KRATOS_WATCH, but you also pass the DataCommunicator, so you can see from which partition it comes each message.

Example output:

~~~cpp
const auto& r_comm = rModelPart.GetCommunicator().GetDataCommunicator();
KRATOS_WATCH_MPI(number_of_local_dofs, r_comm)
~~~

~~~sh
RANK 1/2      number_of_local_dofs : 4
RANK 0/2      number_of_local_dofs : 2
~~~

**🆕 Changelog**

- [Adding KRATOS_WATCH_MPI](https://github.com/KratosMultiphysics/Kratos/commit/2917b7429b897ca83e663d0e47710de79e344e33)