### PR TITLE
[CLApp] Minor bug when printing doubles in Rule of Mixtures

### DIFF
--- a/applications/ConstitutiveLawsApplication/custom_constitutive/composites/rule_of_mixtures_law.cpp
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/composites/rule_of_mixtures_law.cpp
@@ -581,6 +581,7 @@ double& ParallelRuleOfMixturesLaw<TDim>::CalculateValue(
 
     // We combine the value of each layer
     rValue = 0.0;
+    double aux_value = 0.0;
     const auto it_prop_begin = r_material_properties.GetSubProperties().begin();
     for (IndexType i_layer = 0; i_layer < mCombinationFactors.size(); ++i_layer) {
         const double factor = mCombinationFactors[i_layer];
@@ -588,7 +589,7 @@ double& ParallelRuleOfMixturesLaw<TDim>::CalculateValue(
         Properties& r_prop = *(it_prop_begin + i_layer);
 
         rParameterValues.SetMaterialProperties(r_prop);
-        double aux_value = 0.0;
+        aux_value = 0.0;
         p_law->CalculateValue(rParameterValues,rThisVariable, aux_value);
         rValue += factor * aux_value;
     }

--- a/applications/ConstitutiveLawsApplication/custom_constitutive/composites/rule_of_mixtures_law.cpp
+++ b/applications/ConstitutiveLawsApplication/custom_constitutive/composites/rule_of_mixtures_law.cpp
@@ -588,7 +588,7 @@ double& ParallelRuleOfMixturesLaw<TDim>::CalculateValue(
         Properties& r_prop = *(it_prop_begin + i_layer);
 
         rParameterValues.SetMaterialProperties(r_prop);
-        double aux_value;
+        double aux_value = 0.0;
         p_law->CalculateValue(rParameterValues,rThisVariable, aux_value);
         rValue += factor * aux_value;
     }


### PR DESCRIPTION
**📝 Description**
If not equal to 0.0 it does not print properly when combining cl's that not calculate the variable.


