### PR TITLE
Class name change: FluidDynamicsAnalysisRVE ==> FluidDynamicsAnalysisRve

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/fluid_dynamics_analysis_rve.py
+++ b/applications/FluidDynamicsApplication/python_scripts/fluid_dynamics_analysis_rve.py
@@ -5,7 +5,7 @@ from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis import 
 # Importing other libraries
 import math
 
-class FluidDynamicsAnalysisRVE(FluidDynamicsAnalysis):
+class FluidDynamicsAnalysisRve(FluidDynamicsAnalysis):
     def __init__(self, model, project_parameters):
         # Validate RVE settings
         input_rve_settings = project_parameters["rve_settings"]

--- a/applications/FluidDynamicsApplication/python_scripts/fluid_dynamics_analysis_rve.py
+++ b/applications/FluidDynamicsApplication/python_scripts/fluid_dynamics_analysis_rve.py
@@ -5,6 +5,10 @@ from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis import 
 # Importing other libraries
 import math
 
+class FluidDynamicsAnalysisRVE(FluidDynamicsAnalysisRve):
+    def __init__(self, model, project_parameters):
+        KratosMultiphysics.Logger.PrintWarning("'FluidDynamicsAnalysisRVE' is deprecated. Use 'FluidDynamicsAnalysisRve' instead.")
+        super().__init__(model, project_parameters)
 class FluidDynamicsAnalysisRve(FluidDynamicsAnalysis):
     def __init__(self, model, project_parameters):
         # Validate RVE settings

--- a/applications/FluidDynamicsApplication/python_scripts/fluid_dynamics_analysis_rve.py
+++ b/applications/FluidDynamicsApplication/python_scripts/fluid_dynamics_analysis_rve.py
@@ -5,10 +5,6 @@ from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis import 
 # Importing other libraries
 import math
 
-class FluidDynamicsAnalysisRVE(FluidDynamicsAnalysisRve):
-    def __init__(self, model, project_parameters):
-        KratosMultiphysics.Logger.PrintWarning("'FluidDynamicsAnalysisRVE' is deprecated. Use 'FluidDynamicsAnalysisRve' instead.")
-        super().__init__(model, project_parameters)
 class FluidDynamicsAnalysisRve(FluidDynamicsAnalysis):
     def __init__(self, model, project_parameters):
         # Validate RVE settings
@@ -250,3 +246,8 @@ class FluidDynamicsAnalysisRve(FluidDynamicsAnalysis):
         for node in self.averaging_mp.Nodes:
             v_new = node.GetSolutionStepValue(KratosMultiphysics.VELOCITY) - v_avg
             node.SetSolutionStepValue(KratosMultiphysics.VELOCITY, v_new)
+
+class FluidDynamicsAnalysisRVE(FluidDynamicsAnalysisRve):
+    def __init__(self, model, project_parameters):
+        KratosMultiphysics.Logger.PrintWarning("'FluidDynamicsAnalysisRVE' is deprecated. Use 'FluidDynamicsAnalysisRve' instead.")
+        super().__init__(model, project_parameters)

--- a/applications/FluidDynamicsApplication/tests/fluid_rve_test.py
+++ b/applications/FluidDynamicsApplication/tests/fluid_rve_test.py
@@ -1,6 +1,6 @@
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
-from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis_rve import FluidDynamicsAnalysisRVE
+from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis_rve import FluidDynamicsAnalysisRve
 
 class TestFluidRVETest(KratosUnittest.TestCase):
 
@@ -59,7 +59,7 @@ class TestFluidRVETest(KratosUnittest.TestCase):
 
         # Run RVE simulation
         model = KratosMultiphysics.Model()
-        self.simulation = FluidDynamicsAnalysisRVE(model, self.parameters)
+        self.simulation = FluidDynamicsAnalysisRve(model, self.parameters)
         self.simulation.Run()
 
     def _AddOutput(self):


### PR DESCRIPTION
**📝 Description**
While attempting a Reduced Order Model of the fluid RVE using the automatic processes implemented in the RomApplication, Kratos complaint that the RVE stage name is not in Pascal case. 

**🆕 Changelog**
Changing the name of the class in the two places where it appeared:
- the python script: fluid_dynamics_analysis_rve.py
- the test: fluid_rve_test.py
