### PR TITLE
[OptApp] Add Neighbour utils

### DIFF
--- a/applications/OptimizationApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/OptimizationApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -20,6 +20,7 @@
 
 // Application includes
 #include "custom_utilities/geometrical/symmetry_utility.h"
+#include "custom_utilities/geometrical/neighbour_utils.h"
 #include "custom_utilities/optimization_utils.h"
 
 // Include base h
@@ -38,6 +39,11 @@ void  AddCustomUtilitiesToPython(pybind11::module& m)
         .def("Update", &SymmetryUtility::Update)
         .def("ApplyOnVectorField", &SymmetryUtility::ApplyOnVectorField)
         .def("ApplyOnScalarField", &SymmetryUtility::ApplyOnScalarField)
+        ;
+
+    py::class_<NeighbourUtils >(m, "NeighbourUtils")
+        .def_static("InitializeParentElementForConditions", &NeighbourUtils::InitializeParentElementForConditions)
+        .def_static("GetConditionIdAndParentElementIdMap", &NeighbourUtils::GetConditionIdAndParentElementIdMap)
         ;
 
     py::class_<OptimizationUtils >(m, "OptimizationUtils")

--- a/applications/OptimizationApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/OptimizationApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -42,8 +42,8 @@ void  AddCustomUtilitiesToPython(pybind11::module& m)
         ;
 
     py::class_<NeighbourUtils >(m, "NeighbourUtils")
-        .def_static("InitializeParentElementForConditions", &NeighbourUtils::InitializeParentElementForConditions)
-        .def_static("GetConditionIdAndParentElementIdMap", &NeighbourUtils::GetConditionIdAndParentElementIdMap)
+        .def_static("InitializeParentElementsForConditions", &NeighbourUtils::InitializeParentElementsForConditions)
+        .def_static("GetConditionIdAndParentElementIdsMap", &NeighbourUtils::GetConditionIdAndParentElementIdsMap)
         ;
 
     py::class_<OptimizationUtils >(m, "OptimizationUtils")

--- a/applications/OptimizationApplication/custom_utilities/geometrical/neighbour_utils.cpp
+++ b/applications/OptimizationApplication/custom_utilities/geometrical/neighbour_utils.cpp
@@ -1,0 +1,179 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   license: OptimizationApplication/license.txt
+//
+//  Main author:     Suneth Warnakulasuriya
+//
+
+// System includes
+#include <vector>
+#include <unordered_map>
+
+// Project includes
+#include "containers/global_pointers_vector.h"
+#include "utilities/parallel_utilities.h"
+
+// Application includes
+
+// Include base h
+#include "neighbour_utils.h"
+
+namespace Kratos {
+
+void NeighbourUtils::InitializeParentElementForConditions(ModelPart& rModelPart)
+{
+    KRATOS_TRY
+
+    using key_type = std::vector<IndexType>;
+
+    KRATOS_ERROR_IF(rModelPart.NumberOfElements() == 0)
+        << rModelPart.FullName() << " does not contain any elements which are required for initialize parent elements for conditions.";
+
+    KRATOS_ERROR_IF(rModelPart.NumberOfConditions() == 0)
+        << rModelPart.FullName() << " does not contain any conditions which are required for initialize parent elements for conditions.";
+
+    // first generate the map of condition and its node ids
+    const auto& map = block_for_each<HashMapReducer<key_type, Condition*, KeyHasherRange<key_type>, KeyComparorRange<key_type>>>(rModelPart.Conditions(), [&](auto& rCondition) {
+        key_type node_ids;
+        for (const auto& r_node : rCondition.GetGeometry()) {
+            node_ids.push_back(r_node.Id());
+        }
+        std::sort(node_ids.begin(), node_ids.end());
+
+        // we reset the NEIGHBOUR_ELEMENTS vector of the corresponding condition
+        GlobalPointersVector<Element> vector_of_neighbours;
+        rCondition.SetValue(NEIGHBOUR_ELEMENTS, vector_of_neighbours);
+
+        return std::make_pair<key_type, Condition*>(std::forward<key_type>(node_ids), &rCondition);
+    });
+
+    // now iterate through element faces, edges, nodes
+    block_for_each(rModelPart.Elements(), [&](auto& rElement) {
+        const auto& r_geometry = rElement.GetGeometry();
+        const IndexType dimension = r_geometry.LocalSpaceDimension();
+
+        if (dimension == 3) {
+            // 3 dimensional geometries can have conditions which can be either face, edge or point.
+            // hence faces, edges and points needs to be checked.
+
+            // check for faces.
+            const auto& r_boundary_faces = r_geometry.GenerateFaces();
+            for (const auto& r_boundary_face : r_boundary_faces) {
+                key_type node_ids;
+                for (const auto& r_boundary_node : r_boundary_face) {
+                    node_ids.push_back(r_boundary_node.Id());
+                }
+                std::sort(node_ids.begin(), node_ids.end());
+
+                const auto& p_found_it = map.find(node_ids);
+                if (p_found_it != map.end()) {
+                    // this is done without any critical section because, for each element, there can be only
+                    // one face shared among condition and element. So there won't be any race conditions.
+                    auto& r_neighbour_elements_vector = p_found_it->second->GetValue(NEIGHBOUR_ELEMENTS);
+                    r_neighbour_elements_vector.push_back(Element::WeakPointer(&rElement));
+                }
+            }
+
+            // check for edges.
+            const auto& r_boundary_edges = r_geometry.GenerateEdges();
+            for (const auto& r_boundary_edge : r_boundary_edges) {
+                key_type node_ids;
+                for (const auto& r_boundary_node : r_boundary_edge) {
+                    node_ids.push_back(r_boundary_node.Id());
+                }
+                std::sort(node_ids.begin(), node_ids.end());
+
+                const auto& p_found_it = map.find(node_ids);
+                if (p_found_it != map.end()) {
+                    KRATOS_CRITICAL_SECTION
+                    auto& r_neighbour_elements_vector = p_found_it->second->GetValue(NEIGHBOUR_ELEMENTS);
+                    r_neighbour_elements_vector.push_back(Element::WeakPointer(&rElement));
+                }
+            }
+
+            // check for points.
+            const auto& r_boundary_points = r_geometry.GeneratePoints();
+            for (const auto& r_boundary_point : r_boundary_points) {
+                key_type node_ids;
+                for (const auto& r_boundary_node : r_boundary_point) {
+                    node_ids.push_back(r_boundary_node.Id());
+                }
+                std::sort(node_ids.begin(), node_ids.end());
+
+                const auto& p_found_it = map.find(node_ids);
+                if (p_found_it != map.end()) {
+                    KRATOS_CRITICAL_SECTION
+                    auto& r_neighbour_elements_vector = p_found_it->second->GetValue(NEIGHBOUR_ELEMENTS);
+                    r_neighbour_elements_vector.push_back(Element::WeakPointer(&rElement));
+                }
+            }
+        } else if (dimension == 2) {
+            // 2 dimensional geometries can have conditions which can be either edge or point.
+            // hence edges and points needs to be checked.
+
+            // check for edges.
+            const auto& r_boundary_edges = r_geometry.GenerateEdges();
+            for (const auto& r_boundary_edge : r_boundary_edges) {
+                key_type node_ids;
+                for (const auto& r_boundary_node : r_boundary_edge) {
+                    node_ids.push_back(r_boundary_node.Id());
+                }
+                std::sort(node_ids.begin(), node_ids.end());
+
+                const auto& p_found_it = map.find(node_ids);
+                if (p_found_it != map.end()) {
+                    // this is done without any critical section because, for each element, there can be only
+                    // one edge shared among condition and element. So there won't be any race conditions.
+                    auto& r_neighbour_elements_vector = p_found_it->second->GetValue(NEIGHBOUR_ELEMENTS);
+                    r_neighbour_elements_vector.push_back(Element::WeakPointer(&rElement));
+                }
+            }
+
+            // check for points.
+            const auto& r_boundary_points = r_geometry.GeneratePoints();
+            for (const auto& r_boundary_point : r_boundary_points) {
+                key_type node_ids;
+                for (const auto& r_boundary_node : r_boundary_point) {
+                    node_ids.push_back(r_boundary_node.Id());
+                }
+                std::sort(node_ids.begin(), node_ids.end());
+
+                const auto& p_found_it = map.find(node_ids);
+                if (p_found_it != map.end()) {
+                    KRATOS_CRITICAL_SECTION
+                    auto& r_neighbour_elements_vector = p_found_it->second->GetValue(NEIGHBOUR_ELEMENTS);
+                    r_neighbour_elements_vector.push_back(Element::WeakPointer(&rElement));
+                }
+            }
+        } else {
+            KRATOS_ERROR << "Unsupported LocalSpaceDimension for element with id "
+                         << rElement.Id() << " found in " << rModelPart.FullName()
+                         << ". [ dimension = " << dimension << " ].\n";
+        }
+    });
+
+    KRATOS_CATCH("");
+}
+
+std::unordered_map<IndexType, std::vector<IndexType>> NeighbourUtils::GetConditionIdAndParentElementIdMap(const ModelPart& rModelPart)
+{
+    KRATOS_TRY
+
+    return block_for_each<HashMapReducer<IndexType, std::vector<IndexType>>>(rModelPart.Conditions(), [&](const auto& rCondition) {
+        std::vector<IndexType> ids;
+        for (const auto& p_element : rCondition.GetValue(NEIGHBOUR_ELEMENTS).GetContainer()) {
+            ids.push_back(p_element->Id());
+        }
+        std::sort(ids.begin(), ids.end());
+        return std::make_pair(rCondition.Id(), ids);
+    });
+
+    KRATOS_CATCH("");
+}
+
+} // namespace Kratos

--- a/applications/OptimizationApplication/custom_utilities/geometrical/neighbour_utils.cpp
+++ b/applications/OptimizationApplication/custom_utilities/geometrical/neighbour_utils.cpp
@@ -25,7 +25,7 @@
 
 namespace Kratos {
 
-void NeighbourUtils::InitializeParentElementForConditions(ModelPart& rModelPart)
+void NeighbourUtils::InitializeParentElementsForConditions(ModelPart& rModelPart)
 {
     KRATOS_TRY
 
@@ -137,7 +137,7 @@ void NeighbourUtils::InitializeParentElementForConditions(ModelPart& rModelPart)
     KRATOS_CATCH("");
 }
 
-std::unordered_map<IndexType, std::vector<IndexType>> NeighbourUtils::GetConditionIdAndParentElementIdMap(const ModelPart& rModelPart)
+std::unordered_map<IndexType, std::vector<IndexType>> NeighbourUtils::GetConditionIdAndParentElementIdsMap(const ModelPart& rModelPart)
 {
     KRATOS_TRY
 

--- a/applications/OptimizationApplication/custom_utilities/geometrical/neighbour_utils.cpp
+++ b/applications/OptimizationApplication/custom_utilities/geometrical/neighbour_utils.cpp
@@ -95,23 +95,6 @@ void NeighbourUtils::InitializeParentElementForConditions(ModelPart& rModelPart)
                     r_neighbour_elements_vector.push_back(Element::WeakPointer(&rElement));
                 }
             }
-
-            // check for points.
-            const auto& r_boundary_points = r_geometry.GeneratePoints();
-            for (const auto& r_boundary_point : r_boundary_points) {
-                key_type node_ids;
-                for (const auto& r_boundary_node : r_boundary_point) {
-                    node_ids.push_back(r_boundary_node.Id());
-                }
-                std::sort(node_ids.begin(), node_ids.end());
-
-                const auto& p_found_it = map.find(node_ids);
-                if (p_found_it != map.end()) {
-                    KRATOS_CRITICAL_SECTION
-                    auto& r_neighbour_elements_vector = p_found_it->second->GetValue(NEIGHBOUR_ELEMENTS);
-                    r_neighbour_elements_vector.push_back(Element::WeakPointer(&rElement));
-                }
-            }
         } else if (dimension == 2) {
             // 2 dimensional geometries can have conditions which can be either edge or point.
             // hence edges and points needs to be checked.
@@ -133,27 +116,21 @@ void NeighbourUtils::InitializeParentElementForConditions(ModelPart& rModelPart)
                     r_neighbour_elements_vector.push_back(Element::WeakPointer(&rElement));
                 }
             }
-
-            // check for points.
-            const auto& r_boundary_points = r_geometry.GeneratePoints();
-            for (const auto& r_boundary_point : r_boundary_points) {
-                key_type node_ids;
-                for (const auto& r_boundary_node : r_boundary_point) {
-                    node_ids.push_back(r_boundary_node.Id());
-                }
-                std::sort(node_ids.begin(), node_ids.end());
-
-                const auto& p_found_it = map.find(node_ids);
-                if (p_found_it != map.end()) {
-                    KRATOS_CRITICAL_SECTION
-                    auto& r_neighbour_elements_vector = p_found_it->second->GetValue(NEIGHBOUR_ELEMENTS);
-                    r_neighbour_elements_vector.push_back(Element::WeakPointer(&rElement));
-                }
-            }
         } else {
             KRATOS_ERROR << "Unsupported LocalSpaceDimension for element with id "
                          << rElement.Id() << " found in " << rModelPart.FullName()
                          << ". [ dimension = " << dimension << " ].\n";
+        }
+
+        // check for points.
+        const auto& r_boundary_points = r_geometry.GeneratePoints();
+        for (const auto& r_boundary_point : r_boundary_points) {
+            const auto& p_found_it = map.find({r_boundary_point[0].Id()});
+            if (p_found_it != map.end()) {
+                KRATOS_CRITICAL_SECTION
+                auto& r_neighbour_elements_vector = p_found_it->second->GetValue(NEIGHBOUR_ELEMENTS);
+                r_neighbour_elements_vector.push_back(Element::WeakPointer(&rElement));
+            }
         }
     });
 

--- a/applications/OptimizationApplication/custom_utilities/geometrical/neighbour_utils.cpp
+++ b/applications/OptimizationApplication/custom_utilities/geometrical/neighbour_utils.cpp
@@ -30,6 +30,7 @@ void NeighbourUtils::InitializeParentElementsForConditions(ModelPart& rModelPart
     KRATOS_TRY
 
     using key_type = std::vector<IndexType>;
+    using map_type = std::unordered_map<key_type, Condition*, KeyHasherRange<key_type>, KeyComparorRange<key_type>>;
 
     KRATOS_ERROR_IF(rModelPart.NumberOfElements() == 0)
         << rModelPart.FullName() << " does not contain any elements which are required for initialize parent elements for conditions.";
@@ -38,7 +39,7 @@ void NeighbourUtils::InitializeParentElementsForConditions(ModelPart& rModelPart
         << rModelPart.FullName() << " does not contain any conditions which are required for initialize parent elements for conditions.";
 
     // first generate the map of condition and its node ids
-    const auto& map = block_for_each<HashMapReducer<key_type, Condition*, KeyHasherRange<key_type>, KeyComparorRange<key_type>>>(rModelPart.Conditions(), [&](auto& rCondition) {
+    const auto& map = block_for_each<MapReduction<map_type>>(rModelPart.Conditions(), [&](auto& rCondition) {
         key_type node_ids;
         for (const auto& r_node : rCondition.GetGeometry()) {
             node_ids.push_back(r_node.Id());
@@ -141,7 +142,7 @@ std::unordered_map<IndexType, std::vector<IndexType>> NeighbourUtils::GetConditi
 {
     KRATOS_TRY
 
-    return block_for_each<HashMapReducer<IndexType, std::vector<IndexType>>>(rModelPart.Conditions(), [&](const auto& rCondition) {
+    return block_for_each<MapReduction<std::unordered_map<IndexType, std::vector<IndexType>>>>(rModelPart.Conditions(), [&](const auto& rCondition) {
         std::vector<IndexType> ids;
         for (const auto& p_element : rCondition.GetValue(NEIGHBOUR_ELEMENTS).GetContainer()) {
             ids.push_back(p_element->Id());

--- a/applications/OptimizationApplication/custom_utilities/geometrical/neighbour_utils.h
+++ b/applications/OptimizationApplication/custom_utilities/geometrical/neighbour_utils.h
@@ -85,12 +85,12 @@ private:
      * @tparam KeyType
      * @tparam ValueType
      */
-    template<class KeyType, class ValueType, class Hasher = std::hash<KeyType>, class Comparator = std::equal_to<KeyType>>
-    class HashMapReducer
+    template<class MapType>
+    class MapReduction
     {
     public:
-        using value_type = std::pair<KeyType, ValueType>;
-        using return_type = std::unordered_map<KeyType, ValueType, Hasher, Comparator>;
+        using value_type = typename MapType::value_type;
+        using return_type = MapType;
 
         return_type mValue;
 
@@ -101,12 +101,12 @@ private:
         }
 
         /// NON-THREADSAFE (fast) value of reduction, to be used within a single thread
-        void LocalReduce(value_type rValue){
+        void LocalReduce(const value_type rValue){
             mValue.emplace(rValue);
         }
 
         /// THREADSAFE (needs some sort of lock guard) reduction, to be used to sync threads
-        void ThreadSafeReduce(const HashMapReducer& rOther)
+        void ThreadSafeReduce(const MapReduction<MapType>& rOther)
         {
             KRATOS_CRITICAL_SECTION
             for (const auto& it : rOther.mValue) {

--- a/applications/OptimizationApplication/custom_utilities/geometrical/neighbour_utils.h
+++ b/applications/OptimizationApplication/custom_utilities/geometrical/neighbour_utils.h
@@ -1,0 +1,115 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   license: OptimizationApplication/license.txt
+//
+//  Main author:     Suneth Warnakulasuriya
+//
+
+#pragma once
+
+// System includes
+#include <unordered_map>
+#include <vector>
+
+// Project includes
+#include "includes/define.h"
+#include "includes/model_part.h"
+
+// Application includes
+
+namespace Kratos {
+
+///@name Kratos Classes
+///@{
+
+class KRATOS_API(OPTIMIZATION_APPLICATION) NeighbourUtils {
+public:
+    ///@name Type definitions
+    ///@{
+
+    using IndexType = std::size_t;
+
+    ///@}
+    ///@name Static operations
+    ///@{
+
+    /**
+     * @brief This method initializes NEIGHBOUR_ELEMENTS variable of conditions with its parent element
+     *
+     * This method initializes the NEIGHBOUR_ELEMENTS variable of each condition with one item, which
+     * is the parent element which a condition is sharing a face (in 3D), an edge (in 2D), point (in 1D).
+     *
+     * The input model part must contain both elements and conditions (including each conditions parents).
+     *
+     * This should work in MPI as well, because, MPI mesh partitioner always keeps conditions and their parents
+     * in the same partition (i.e. rank), hence the methodology does not differ if run in MPI or OpenMP.
+     *
+     * This is an expensive initialization, so number of calls to this method should be kept minimum.
+     *
+     * @param rModelPart Input model part which contains conditions and their parent elements.
+     */
+    static void InitializeParentElementForConditions(ModelPart& rModelPart);
+
+    /**
+     * @brief Get the Condition Id And Parent Element Ids Map using the initialized NEIGHBOUR_ELEMENTS varaible of conditions
+     *
+     * This method gives a map of condition id, condition parent element ids for the given rModelPart. This method
+     * should be only called once the NEIGHBOUR_ELEMENTS of the given model part conditions have been properly initialized.
+     *
+     * @see InitializeParentElementForConditions
+     * @param rModelPart
+     * @return std::unordered_map<IndexType, std::vector<IndexType>>
+     */
+    static std::unordered_map<IndexType, std::vector<IndexType>> GetConditionIdAndParentElementIdMap(const ModelPart& rModelPart);
+
+    ///@}
+private:
+    ///@name Classes
+    ///@{
+
+    /**
+     * @brief Unordered map reducer for shared memory parallelized loops.
+     *
+     * @tparam KeyType
+     * @tparam ValueType
+     */
+    template<class KeyType, class ValueType, class Hasher = std::hash<KeyType>, class Comparator = std::equal_to<KeyType>>
+    class HashMapReducer
+    {
+    public:
+        using value_type = std::pair<KeyType, ValueType>;
+        using return_type = std::unordered_map<KeyType, ValueType, Hasher, Comparator>;
+
+        return_type mValue;
+
+        /// access to reduced value
+        return_type GetValue() const
+        {
+            return mValue;
+        }
+
+        /// NON-THREADSAFE (fast) value of reduction, to be used within a single thread
+        void LocalReduce(value_type rValue){
+            mValue.emplace(rValue);
+        }
+
+        /// THREADSAFE (needs some sort of lock guard) reduction, to be used to sync threads
+        void ThreadSafeReduce(const HashMapReducer& rOther)
+        {
+            KRATOS_CRITICAL_SECTION
+            for (const auto& it : rOther.mValue) {
+                mValue.emplace(it);
+            }
+        }
+    };
+
+    ///@}
+};
+
+///@}
+} // namespace Kratos

--- a/applications/OptimizationApplication/custom_utilities/geometrical/neighbour_utils.h
+++ b/applications/OptimizationApplication/custom_utilities/geometrical/neighbour_utils.h
@@ -39,21 +39,28 @@ public:
     ///@{
 
     /**
-     * @brief This method initializes NEIGHBOUR_ELEMENTS variable of conditions with its parent element
+     * @brief This method initializes NEIGHBOUR_ELEMENTS variable of conditions with its parent elements
      *
-     * This method initializes the NEIGHBOUR_ELEMENTS variable of each condition with one item, which
-     * is the parent element which a condition is sharing a face (in 3D), an edge (in 2D), point (in 1D).
+     * This method initializes the NEIGHBOUR_ELEMENTS variable of each condition with their parent elements.
+     *
+     * In elements with LocalSpaceDimension == 3, this assign parent elements for surface conditions, line conditions
+     * and point conditions
+     *
+     * In elements with LocalSpaceDimension == 2, this assigns parent elements for line conditions and point conditions.
      *
      * The input model part must contain both elements and conditions (including each conditions parents).
      *
      * This should work in MPI as well, because, MPI mesh partitioner always keeps conditions and their parents
      * in the same partition (i.e. rank), hence the methodology does not differ if run in MPI or OpenMP.
      *
+     * In the case of Point conditions, this assigns only the local parents to the node (or ghost node). Hence,
+     * the computations done on to those nodes, should be assembled to have MPI compatibility.
+     *
      * This is an expensive initialization, so number of calls to this method should be kept minimum.
      *
      * @param rModelPart Input model part which contains conditions and their parent elements.
      */
-    static void InitializeParentElementForConditions(ModelPart& rModelPart);
+    static void InitializeParentElementsForConditions(ModelPart& rModelPart);
 
     /**
      * @brief Get the Condition Id And Parent Element Ids Map using the initialized NEIGHBOUR_ELEMENTS varaible of conditions
@@ -61,11 +68,11 @@ public:
      * This method gives a map of condition id, condition parent element ids for the given rModelPart. This method
      * should be only called once the NEIGHBOUR_ELEMENTS of the given model part conditions have been properly initialized.
      *
-     * @see InitializeParentElementForConditions
+     * @see InitializeParentElementsForConditions
      * @param rModelPart
      * @return std::unordered_map<IndexType, std::vector<IndexType>>
      */
-    static std::unordered_map<IndexType, std::vector<IndexType>> GetConditionIdAndParentElementIdMap(const ModelPart& rModelPart);
+    static std::unordered_map<IndexType, std::vector<IndexType>> GetConditionIdAndParentElementIdsMap(const ModelPart& rModelPart);
 
     ///@}
 private:

--- a/applications/OptimizationApplication/tests/test_neighbour_utils.py
+++ b/applications/OptimizationApplication/tests/test_neighbour_utils.py
@@ -8,7 +8,6 @@ import KratosMultiphysics.KratosUnittest as kratos_unittest
 from KratosMultiphysics.testing.utilities  import ReadModelPart
 from KratosMultiphysics.kratos_utilities import DeleteFileIfExisting
 
-@kratos_unittest.skipIfApplicationsNotAvailable("StructuralMechanicsApplication")
 class TestNeighbourUtils(kratos_unittest.TestCase):
     def test_InitializeParentElementForConditions(self):
         model = Kratos.Model()
@@ -25,8 +24,8 @@ class TestNeighbourUtils(kratos_unittest.TestCase):
        # create the primal analysis execution policy wrapper
         with kratos_unittest.WorkFolderScope("linear_strain_energy_test", __file__):
             ReadModelPart("Structure", model_part)
-            KratosOA.NeighbourUtils.InitializeParentElementForConditions(model_part)
-            computed_map = KratosOA.NeighbourUtils.GetConditionIdAndParentElementIdMap(model_part)
+            KratosOA.NeighbourUtils.InitializeParentElementsForConditions(model_part)
+            computed_map = KratosOA.NeighbourUtils.GetConditionIdAndParentElementIdsMap(model_part)
             for k, v in computed_map.items():
                 self.assertEqual(ref_map[k], v)
 

--- a/applications/OptimizationApplication/tests/test_neighbour_utils.py
+++ b/applications/OptimizationApplication/tests/test_neighbour_utils.py
@@ -1,0 +1,40 @@
+
+import KratosMultiphysics as Kratos
+import KratosMultiphysics.StructuralMechanicsApplication
+import KratosMultiphysics.OptimizationApplication as KratosOA
+
+# Import KratosUnittest
+import KratosMultiphysics.KratosUnittest as kratos_unittest
+from KratosMultiphysics.testing.utilities  import ReadModelPart
+from KratosMultiphysics.kratos_utilities import DeleteFileIfExisting
+
+@kratos_unittest.skipIfApplicationsNotAvailable("StructuralMechanicsApplication")
+class TestNeighbourUtils(kratos_unittest.TestCase):
+    def test_InitializeParentElementForConditions(self):
+        model = Kratos.Model()
+        model_part = model.CreateModelPart("Structure")
+        model_part.ProcessInfo[Kratos.DOMAIN_SIZE] = 3
+
+        ref_map = {
+            1: [1, 2],
+            2: [2, 3],
+            3: [2, 3],
+            4: [1, 2]
+        }
+
+       # create the primal analysis execution policy wrapper
+        with kratos_unittest.WorkFolderScope("linear_strain_energy_test", __file__):
+            ReadModelPart("Structure", model_part)
+            KratosOA.NeighbourUtils.InitializeParentElementForConditions(model_part)
+            computed_map = KratosOA.NeighbourUtils.GetConditionIdAndParentElementIdMap(model_part)
+            for k, v in computed_map.items():
+                self.assertEqual(ref_map[k], v)
+
+    @classmethod
+    def tearDownClass(cls):
+        with kratos_unittest.WorkFolderScope("linear_strain_energy_test", __file__):
+            DeleteFileIfExisting("Structure.time")
+
+if __name__ == "__main__":
+    Kratos.Tester.SetVerbosity(Kratos.Tester.Verbosity.PROGRESS)  # TESTS_OUTPUTS
+    kratos_unittest.main()


### PR DESCRIPTION
**📝 Description**
This PR adds a neighbour utils, which initializes `NEIGHBOUR_ELEMENTS` variable of conditions with their parents. It is done as follows.

1. If `LocalSpaceDimension` == 3, then first faces, edges, and points of elements are compared against surface conditions, line conditions and point conditions accordingly and `NEIGHBOUR_ELEMENTS` of each condition is populated with the respective parent element.
2. If `LocalSpaceDimension` == 2, then first edges, and points of elements are compared against line conditions and point conditions accordingly and `NEIGHBOUR_ELEMENTS` of each condition is populated with the respective parent element.

This is supposed to be used to compute sensitivities of model parts where, the sensitivity model part does not have all the elements of the analysis model part or evaluated model part but they have common interfaces.

A test is added.

**🆕 Changelog**
- Add `NeighbourUtils`
- Add tests
