### PR TITLE
[CoSim] Restrict internal interfaces

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
@@ -118,7 +118,7 @@ class CoSimulationSolverWrapper:
     def IsDefinedOnThisRank(self):
         return self.data_communicator.IsDefinedOnThisRank()
 
-    def GetInterfaceData(self, data_name):
+    def GetInterfaceData(self, data_name) -> CouplingInterfaceData:
         try:
             return self.data_dict[data_name]
         except KeyError:

--- a/applications/CoSimulationApplication/python_scripts/convergence_accelerators/convergence_accelerator_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/convergence_accelerators/convergence_accelerator_wrapper.py
@@ -1,5 +1,9 @@
+# Core imports
+import KratosMultiphysics
+
 # CoSimulation imports
 from KratosMultiphysics.CoSimulationApplication.factories.convergence_accelerator_factory import CreateConvergenceAccelerator
+from ..coupling_interface_data import CouplingInterfaceData
 
 # Other imports
 import numpy as np
@@ -12,13 +16,17 @@ class ConvergenceAcceleratorWrapper:
     In case of distributed data, it is checked whether the convergence accelerator supports it.
     If not, the data is gathered / scattered and the accelerator is executed on only one rank
     """
-    def __init__(self, settings, solver_wrapper, parent_coupled_solver_data_communicator):
-        self.interface_data = solver_wrapper.GetInterfaceData(settings["data_name"].GetString())
-        self.residual_computation = CreateResidualComputation(settings, solver_wrapper)
+    def __init__(self,
+                 settings: KratosMultiphysics.Parameters,
+                 interface_data_dict: "dict[str,CouplingInterfaceData]",
+                 parent_coupled_solver_data_communicator: KratosMultiphysics.DataCommunicator):
+        self.interface_data = interface_data_dict[settings["data_name"].GetString()]
+        self.residual_computation = CreateResidualComputation(settings, interface_data_dict)
 
-        settings.RemoveValue("data_name")
-        settings.RemoveValue("solver")
-        settings.RemoveValue("residual_computation")
+        # Remove extra entries from accelerator parameters
+        for key in ("data_name", "solver", "residual_computation"):
+            if settings.Has(key):
+                settings.RemoveValue(key)
 
         self.conv_acc = CreateConvergenceAccelerator(settings)
         self.data_communicator = parent_coupled_solver_data_communicator
@@ -88,29 +96,34 @@ class ConvergenceAcceleratorResidual(metaclass=ABCMeta):
     def ComputeResidual(self, input_data): pass
 
 class DataDifferenceResidual(ConvergenceAcceleratorResidual):
-    def __init__(self, settings, solver_wrapper):
-        self.interface_data = solver_wrapper.GetInterfaceData(settings["data_name"].GetString())
+    def __init__(self,
+                 settings: KratosMultiphysics.Parameters,
+                 interface_data_dict: "dict[str,CouplingInterfaceData]"):
+        self.interface_data = interface_data_dict[settings["data_name"].GetString()]
 
     def ComputeResidual(self, input_data):
         return self.interface_data.GetData() - input_data
 
 class DifferentDataDifferenceResidual(ConvergenceAcceleratorResidual):
-    def __init__(self, settings, solver_wrapper):
-        self.interface_data = solver_wrapper.GetInterfaceData(settings["data_name"].GetString())
-        self.interface_data1 = solver_wrapper.GetInterfaceData(settings["residual_computation"]["data_name1"].GetString())
-        self.interface_data2 = solver_wrapper.GetInterfaceData(settings["residual_computation"]["data_name2"].GetString())
+    def __init__(self,
+                 settings: KratosMultiphysics.Parameters,
+                 interface_data_dict: "dict[str,CouplingInterfaceData]"):
+        self.interface_data =  interface_data_dict[settings["data_name"].GetString()]
+        self.interface_data1 = interface_data_dict[settings["residual_computation"]["data_name1"].GetString()]
+        self.interface_data2 = interface_data_dict[settings["residual_computation"]["data_name2"].GetString()]
 
     def ComputeResidual(self, input_data):
         return self.interface_data1.GetData() - self.interface_data2.GetData()
 
-def CreateResidualComputation(settings, solver_wrapper):
+def CreateResidualComputation(settings: KratosMultiphysics.Parameters,
+                              interface_data_dict: "dict[str,CouplingInterfaceData]"):
     residual_computation_type = "data_difference"
     if settings.Has("residual_computation"):
         residual_computation_type = settings["residual_computation"]["type"].GetString()
 
     if residual_computation_type == "data_difference":
-        return DataDifferenceResidual(settings, solver_wrapper)
+        return DataDifferenceResidual(settings, interface_data_dict)
     elif residual_computation_type == "different_data_difference":
-        return DifferentDataDifferenceResidual(settings, solver_wrapper)
+        return DifferentDataDifferenceResidual(settings, interface_data_dict)
     else:
         raise Exception('The specified residual computation "{}" is not available!'.format(residual_computation_type))

--- a/applications/CoSimulationApplication/python_scripts/convergence_criteria/convergence_criteria_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/convergence_criteria/convergence_criteria_wrapper.py
@@ -1,20 +1,30 @@
+# Core imports
+import KratosMultiphysics
+
 # CoSimulation imports
 from KratosMultiphysics.CoSimulationApplication.factories.convergence_criterion_factory import CreateConvergenceCriterion
+from KratosMultiphysics.CoSimulationApplication.coupling_interface_data import CouplingInterfaceData
 import KratosMultiphysics.CoSimulationApplication.colors as colors
 
 # Other imports
 import numpy as np
 
 class ConvergenceCriteriaWrapper:
-    """This class wraps the convergence criteria such that they can be used "automized"
-    => this class stores the residual and updates the solutions, such that the
-    convergence criteria can be configured through json
-    In case of distributed data, the data is gathered on one rank, the convergence checked and the result broadcasted to the other ranks
+    """ @brief This class wraps the convergence criteria such that they can be used "automated".
+        @details This class stores the residual and updates the solutions, such that the
+                 convergence criteria can be configured through JSON.
+                 In case of distributed data, the data is gathered on one rank, the convergence
+                 checked and the result broadcast to the other ranks.
     """
-    def __init__(self, settings, solver_wrapper, parent_coupled_solver_data_communicator):
-        self.interface_data = solver_wrapper.GetInterfaceData(settings["data_name"].GetString())
-        settings.RemoveValue("data_name")
-        settings.RemoveValue("solver")
+    def __init__(self,
+                 settings: KratosMultiphysics.Parameters,
+                 interface_data: CouplingInterfaceData,
+                 parent_coupled_solver_data_communicator: KratosMultiphysics.DataCommunicator):
+        self.interface_data = interface_data
+
+        for key in ("data_name", "solver"):
+            if settings.Has(key):
+                settings.RemoveValue(key)
 
         if not settings.Has("label"):
             settings.AddEmptyValue("label").SetString(colors.bold('{}.{}'.format(self.interface_data.solver_name, self.interface_data.name)))

--- a/applications/CoSimulationApplication/python_scripts/coupling_interface_data.py
+++ b/applications/CoSimulationApplication/python_scripts/coupling_interface_data.py
@@ -7,6 +7,9 @@ import KratosMultiphysics.CoSimulationApplication.co_simulation_tools as cs_tool
 # Other imports
 import numpy as np
 
+# STD imports
+import typing
+
 class BaseCouplingInterfaceData:
     """This class serves as interface to the data structure (Model and ModelPart)
     that holds the data used during CoSimulation
@@ -155,7 +158,7 @@ class CouplingInterfaceData(BaseCouplingInterfaceData):
         else:
             return {}
 
-    def GetData(self, solution_step_index=0):
+    def GetData(self, solution_step_index=0) -> "np.ndarray[typing.Union[bool,np.intc,np.uintc,np.double]]":
         self.__CheckBufferSize(solution_step_index)
 
         if self.location == "node_historical":

--- a/applications/CoSimulationApplication/python_scripts/factories/helpers.py
+++ b/applications/CoSimulationApplication/python_scripts/factories/helpers.py
@@ -28,12 +28,18 @@ def CreatePredictors(predictor_settings_list, solvers, parent_echo_level):
         predictors.append(CreatePredictor(predictor_settings, solver))
     return predictors
 
-def CreateConvergenceAccelerators(convergence_accelerator_settings_list, solvers, parent_data_communicator, parent_echo_level):
+def CreateConvergenceAccelerators(convergence_accelerator_settings_list: KM.Parameters,
+                                  solvers: "collections.OrderedDict[str,CoSimulationSolverWrapper]",
+                                  parent_data_communicator: KM.DataCommunicator,
+                                  parent_echo_level: int):
     convergence_accelerators = []
     for conv_acc_settings in convergence_accelerator_settings_list:
         solver = solvers[conv_acc_settings["solver"].GetString()]
+        interface_data_dict = solver.data_dict
         AddEchoLevelToSettings(conv_acc_settings, parent_echo_level)
-        convergence_accelerators.append(ConvergenceAcceleratorWrapper(conv_acc_settings, solver, parent_data_communicator))
+        convergence_accelerators.append(ConvergenceAcceleratorWrapper(conv_acc_settings,
+                                                                      interface_data_dict,
+                                                                      parent_data_communicator))
 
     return convergence_accelerators
 

--- a/applications/CoSimulationApplication/python_scripts/factories/helpers.py
+++ b/applications/CoSimulationApplication/python_scripts/factories/helpers.py
@@ -8,7 +8,10 @@ from KratosMultiphysics.CoSimulationApplication.convergence_accelerators.converg
 from KratosMultiphysics.CoSimulationApplication.convergence_criteria.convergence_criteria_wrapper import ConvergenceCriteriaWrapper
 from KratosMultiphysics.CoSimulationApplication.factories.convergence_criterion_factory import CreateConvergenceCriterion
 from KratosMultiphysics.CoSimulationApplication.factories.predictor_factory import CreatePredictor
+from ..base_classes.co_simulation_solver_wrapper import CoSimulationSolverWrapper
 
+# STD Imports
+import collections
 
 def AddEchoLevelToSettings(settings, echo_level):
     echo_level_params = KM.Parameters("""{
@@ -34,7 +37,10 @@ def CreateConvergenceAccelerators(convergence_accelerator_settings_list, solvers
 
     return convergence_accelerators
 
-def CreateConvergenceCriteria(convergence_criterion_settings_list, solvers, parent_data_communicator, parent_echo_level):
+def CreateConvergenceCriteria(convergence_criterion_settings_list: KM.Parameters,
+                              solvers: "collections.OrderedDict[str,CoSimulationSolverWrapper]",
+                              parent_data_communicator: KM.DataCommunicator,
+                              parent_echo_level: int):
     convergence_criteria = []
     for conv_crit_settings in convergence_criterion_settings_list:
         AddEchoLevelToSettings(conv_crit_settings, parent_echo_level)
@@ -42,7 +48,10 @@ def CreateConvergenceCriteria(convergence_criterion_settings_list, solvers, pare
             convergence_criteria.append(CreateConvergenceCriterion(conv_crit_settings, solvers))
         else:
             solver = solvers[conv_crit_settings["solver"].GetString()]
-            convergence_criteria.append(ConvergenceCriteriaWrapper(conv_crit_settings, solver, parent_data_communicator))
+            interface_data = solver.GetInterfaceData(conv_crit_settings["data_name"].GetString())
+            convergence_criteria.append(ConvergenceCriteriaWrapper(conv_crit_settings,
+                                                                   interface_data,
+                                                                   parent_data_communicator))
 
     return convergence_criteria
 

--- a/applications/CoSimulationApplication/tests/test_convergence_accelerators.py
+++ b/applications/CoSimulationApplication/tests/test_convergence_accelerators.py
@@ -65,7 +65,7 @@ class TestConvergenceAcceleratorWrapper(KratosUnittest.TestCase):
 
         with patch('KratosMultiphysics.CoSimulationApplication.convergence_accelerators.convergence_accelerator_wrapper.CreateConvergenceAccelerator') as p:
             p.return_value = conv_acc_mock
-            conv_acc_wrapper = ConvergenceAcceleratorWrapper(conv_acc_settings, self.dummy_solver_wrapper, KM.Testing.GetDefaultDataCommunicator())
+            conv_acc_wrapper = ConvergenceAcceleratorWrapper(conv_acc_settings, self.dummy_solver_wrapper.interface_data_dict, KM.Testing.GetDefaultDataCommunicator())
 
         conv_acc_wrapper.InitializeSolutionStep()
 
@@ -111,7 +111,7 @@ class TestConvergenceAcceleratorWrapper(KratosUnittest.TestCase):
 
         with patch('KratosMultiphysics.CoSimulationApplication.convergence_accelerators.convergence_accelerator_wrapper.CreateConvergenceAccelerator') as p:
             p.return_value = conv_acc_mock
-            conv_acc_wrapper = ConvergenceAcceleratorWrapper(conv_acc_settings, self.dummy_solver_wrapper, KM.Testing.GetDefaultDataCommunicator())
+            conv_acc_wrapper = ConvergenceAcceleratorWrapper(conv_acc_settings, self.dummy_solver_wrapper.interface_data_dict, KM.Testing.GetDefaultDataCommunicator())
 
         exp_inp = self.interface_data.GetData()
 

--- a/applications/CoSimulationApplication/tests/test_convergence_criteria.py
+++ b/applications/CoSimulationApplication/tests/test_convergence_criteria.py
@@ -62,7 +62,7 @@ class TestConvergenceCriteriaWrapper(KratosUnittest.TestCase):
 
         with patch('KratosMultiphysics.CoSimulationApplication.convergence_criteria.convergence_criteria_wrapper.CreateConvergenceCriterion') as p:
             p.return_value = conv_crit_mock
-            conv_crit_wrapper = ConvergenceCriteriaWrapper(conv_crit_settings, self.dummy_solver_wrapper, KM.Testing.GetDefaultDataCommunicator())
+            conv_crit_wrapper = ConvergenceCriteriaWrapper(conv_crit_settings, self.interface_data, KM.Testing.GetDefaultDataCommunicator())
 
         self.assertEqual(conv_crit_wrapper.executing_rank, self.my_pid == 0) # only rank zero is the executing one
 
@@ -116,7 +116,7 @@ class TestConvergenceCriteria(KratosUnittest.TestCase):
             "rel_tolerance"  : 1e-12,
             "echo_level"     : 0
         }""")
-        conv_crit = ConvergenceCriteriaWrapper(conv_crit_settings, self.dummy_solver_wrapper, KM.Testing.GetDefaultDataCommunicator())
+        conv_crit = ConvergenceCriteriaWrapper(conv_crit_settings, self.interface_data, KM.Testing.GetDefaultDataCommunicator())
 
         sol_values = [
             (2e-1, False),
@@ -140,7 +140,7 @@ class TestConvergenceCriteria(KratosUnittest.TestCase):
             "rel_tolerance"  : 1e-5,
             "echo_level"     : 0
         }""")
-        conv_crit = ConvergenceCriteriaWrapper(conv_crit_settings, self.dummy_solver_wrapper, KM.Testing.GetDefaultDataCommunicator())
+        conv_crit = ConvergenceCriteriaWrapper(conv_crit_settings, self.interface_data, KM.Testing.GetDefaultDataCommunicator())
 
         sol_values = [
             (2e-1, False),
@@ -166,7 +166,7 @@ class TestConvergenceCriteria(KratosUnittest.TestCase):
             "rel_tolerance"  : 1e-12,
             "echo_level"     : 0
         }""")
-        conv_crit = ConvergenceCriteriaWrapper(conv_crit_settings, self.dummy_solver_wrapper, KM.Testing.GetDefaultDataCommunicator())
+        conv_crit = ConvergenceCriteriaWrapper(conv_crit_settings, self.interface_data, KM.Testing.GetDefaultDataCommunicator())
 
         sol_values = [
             (2e-1, False),
@@ -190,7 +190,7 @@ class TestConvergenceCriteria(KratosUnittest.TestCase):
             "rel_tolerance"  : 1e-5,
             "echo_level"     : 0
         }""")
-        conv_crit = ConvergenceCriteriaWrapper(conv_crit_settings, self.dummy_solver_wrapper, KM.Testing.GetDefaultDataCommunicator())
+        conv_crit = ConvergenceCriteriaWrapper(conv_crit_settings, self.interface_data, KM.Testing.GetDefaultDataCommunicator())
 
         sol_values = [
             (2e-1, False),


### PR DESCRIPTION
## Description
Restrict arguments passed to the constructors of `ConvergenceAcceleratorWrapper` and `ConvergenceCriteriaWrapper` to the objects they actually require, instead of passing entire `CoSimulationSolverWrapper`s.

This PR is an experiment to see how much opposition I'm gonna run into if I touch the `CoSimulationApplication`. 

## Motivation
I'm working on multiscale time integration, which would have a very similar abstraction system to the one implemented by `CoSimulationApplication`. The only issue is that solvers and the coupling logic share a common interface (`CoSimulationSolverWrapper`), which would need to be separated in my case. These commits represent the shy first steps in that direction.

## Changelog
- pass `CouplingInterfaceData` to `ConvergenceAcceleratorWrapper` and `ConvergenceCriteriaWrapper` instead of `CoSimulationSolverWrapper`
- factory signatures aren't changed, but they extract the necessary objects to pass on as arguments to the corresponding constructors
- update tests accordingly