### PR TITLE
[GeoMechanicsApplication] Fixed warnings related to "GeometryType::Pointer"

### DIFF
--- a/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
@@ -74,22 +74,22 @@ void GeneralUPwDiffOrderCondition::Initialize(const ProcessInfo& rCurrentProcess
 
     switch(NumUNodes) {
         case 3: //2D L3P2
-            mpPressureGeometry = GeometryType::Pointer( new Line2D2< Node<3> >(rGeom(0), rGeom(1)) );
+            mpPressureGeometry = make_shared<Line2D2<Node<3>>>(rGeom(0), rGeom(1));
             break;
         case 4: //2D L4P3
-            mpPressureGeometry = GeometryType::Pointer( new Line2D3< Node<3> >(rGeom(0), rGeom(1), rGeom(2)));
+            mpPressureGeometry = make_shared<Line2D3<Node<3>>>(rGeom(0), rGeom(1), rGeom(2));
             break;
         case 5: //2D L5P4
-            mpPressureGeometry = GeometryType::Pointer( new Line2D4< Node<3> >(rGeom(0), rGeom(1), rGeom(2), rGeom(3)));
+            mpPressureGeometry = make_shared<Line2D4<Node<3>>>(rGeom(0), rGeom(1), rGeom(2), rGeom(3));
             break;
         case 6: //3D T6P3
-            mpPressureGeometry = GeometryType::Pointer( new Triangle3D3< Node<3> >(rGeom(0), rGeom(1), rGeom(2)) );
+            mpPressureGeometry = make_shared<Triangle3D3<Node<3>>>(rGeom(0), rGeom(1), rGeom(2));
             break;
         case 8: //3D Q8P4
-            mpPressureGeometry = GeometryType::Pointer( new Quadrilateral3D4< Node<3> >(rGeom(0), rGeom(1), rGeom(2), rGeom(3)) );
+            mpPressureGeometry = make_shared<Quadrilateral3D4<Node<3>>>(rGeom(0), rGeom(1), rGeom(2), rGeom(3));
             break;
         case 9: //3D Q9P4
-            mpPressureGeometry = GeometryType::Pointer( new Quadrilateral3D4< Node<3> >(rGeom(0), rGeom(1), rGeom(2), rGeom(3)) );
+            mpPressureGeometry = make_shared<Quadrilateral3D4<Node<3>>>(rGeom(0), rGeom(1), rGeom(2), rGeom(3));
             break;
         default:
             KRATOS_ERROR << "Unexpected geometry type for different order interpolation element" << std::endl;

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -204,28 +204,28 @@ void SmallStrainUPwDiffOrderElement::Initialize(const ProcessInfo& rCurrentProce
     switch(NumUNodes)
     {
         case 6: //2D T6P3
-            mpPressureGeometry = GeometryType::Pointer( new Triangle2D3< Node<3> >(rGeom(0), rGeom(1), rGeom(2)) );
+            mpPressureGeometry = make_shared<Triangle2D3<Node<3>>>(rGeom(0), rGeom(1), rGeom(2));
             break;
         case 8: //2D Q8P4
-            mpPressureGeometry = GeometryType::Pointer( new Quadrilateral2D4< Node<3> >(rGeom(0), rGeom(1), rGeom(2), rGeom(3)) );
+            mpPressureGeometry = make_shared<Quadrilateral2D4<Node<3>>>(rGeom(0), rGeom(1), rGeom(2), rGeom(3));
             break;
         case 9: //2D Q9P4
-            mpPressureGeometry = GeometryType::Pointer( new Quadrilateral2D4< Node<3> >(rGeom(0), rGeom(1), rGeom(2), rGeom(3)) );
+            mpPressureGeometry = make_shared<Quadrilateral2D4<Node<3>>>(rGeom(0), rGeom(1), rGeom(2), rGeom(3));
             break;
         case 10: //3D T10P4  //2D T10P6
             if (NumDim == 3)
-                mpPressureGeometry = GeometryType::Pointer(new Tetrahedra3D4< Node<3> >(rGeom(0), rGeom(1), rGeom(2), rGeom(3)));
+                mpPressureGeometry = make_shared<Tetrahedra3D4<Node<3>>>(rGeom(0), rGeom(1), rGeom(2), rGeom(3));
             else if (NumDim == 2)
-                mpPressureGeometry = GeometryType::Pointer(new Triangle2D6< Node<3> >(rGeom(0), rGeom(1), rGeom(2), rGeom(3), rGeom(4), rGeom(5)));
+                mpPressureGeometry = make_shared<Triangle2D6<Node<3>>>(rGeom(0), rGeom(1), rGeom(2), rGeom(3), rGeom(4), rGeom(5));
             break;
         case 15: //2D T15P10
-            mpPressureGeometry = GeometryType::Pointer(new Triangle2D10< Node<3> >(rGeom(0), rGeom(1), rGeom(2), rGeom(3), rGeom(4), rGeom(5), rGeom(6), rGeom(7), rGeom(8), rGeom(9)));
+            mpPressureGeometry = make_shared<Triangle2D10<Node<3>>>(rGeom(0), rGeom(1), rGeom(2), rGeom(3), rGeom(4), rGeom(5), rGeom(6), rGeom(7), rGeom(8), rGeom(9));
             break;
         case 20: //3D H20P8
-            mpPressureGeometry = GeometryType::Pointer( new Hexahedra3D8< Node<3> >(rGeom(0), rGeom(1), rGeom(2), rGeom(3), rGeom(4), rGeom(5), rGeom(6), rGeom(7)) );
+            mpPressureGeometry = make_shared<Hexahedra3D8<Node<3>>>(rGeom(0), rGeom(1), rGeom(2), rGeom(3), rGeom(4), rGeom(5), rGeom(6), rGeom(7));
             break;
         case 27: //3D H27P8
-            mpPressureGeometry = GeometryType::Pointer( new Hexahedra3D8< Node<3> >(rGeom(0), rGeom(1), rGeom(2), rGeom(3), rGeom(4), rGeom(5), rGeom(6), rGeom(7)) );
+            mpPressureGeometry = make_shared<Hexahedra3D8<Node<3>>>(rGeom(0), rGeom(1), rGeom(2), rGeom(3), rGeom(4), rGeom(5), rGeom(6), rGeom(7));
             break;
         default:
             KRATOS_ERROR << "Unexpected geometry type for different order interpolation element" << this->Id() << std::endl;


### PR DESCRIPTION
**📝 Description**
Warning type:
Use "std::make_shared" to construct "std::shared_ptr".

**🆕 Changelog**
Change "GeometryType::Pointer" to make_shared