### PR TITLE
[Core] Template BlockPartition on Iterators Instead of Containers

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
@@ -56,8 +56,9 @@ KRATOS_TEST_CASE_IN_SUITE(BlockPartitioner, KratosCoreFastSuite)
     std::vector<double> data_vector(nsize, 5.0);
 
     //here we raise every entry of a vector to the power 0.1
-    BlockPartition<std::vector<double>>(data_vector).for_each(
-                                         [](double& item)
+    BlockPartition<std::vector<double>::iterator>(data_vector.begin(),
+                                                  data_vector.end()).for_each(
+        [](double& item)
     {
         item = std::pow(item, 0.1);
     });
@@ -80,7 +81,8 @@ KRATOS_TEST_CASE_IN_SUITE(BlockPartitioner, KratosCoreFastSuite)
     }
 
     //here we check for a reduction (computing the sum of all the entries)
-    auto final_sum = BlockPartition<std::vector<double>>(data_vector).for_each<SumReduction<double>>(
+    auto final_sum = BlockPartition<std::vector<double>::iterator>(data_vector.begin(),
+                                                                   data_vector.end()).for_each<SumReduction<double>>(
         [](double& item)
         {
             return item;
@@ -98,7 +100,8 @@ KRATOS_TEST_CASE_IN_SUITE(BlockPartitionerConstContainer, KratosCoreFastSuite)
     const std::vector<double> data_vector(nsize, 5.0);
 
     //here we check for a reduction (computing the sum of all the entries)
-    auto final_sum = BlockPartition<decltype(data_vector)>(data_vector).for_each<SumReduction<double>>(
+    auto final_sum = BlockPartition<std::vector<double>::const_iterator>(data_vector.begin(),
+                                                                         data_vector.end()).for_each<SumReduction<double>>(
         [](const double item)
         {
             return item;
@@ -172,7 +175,8 @@ KRATOS_TEST_CASE_IN_SUITE(BlockPartitionerThreadLocalStorage, KratosCoreFastSuit
     // Manual Reduction, long form
     // here the TLS is constructed on the fly. This is the "private" approach of OpenMP
     // the result is checked with a "manual reduction"
-    BlockPartition<std::vector<RHSElementType>>(elements).for_each(std::vector<double>(), tls_lambda_manual_reduction);
+    BlockPartition<std::vector<RHSElementType>::iterator>(elements.begin(),
+                                                          elements.end()).for_each(std::vector<double>(), tls_lambda_manual_reduction);
 
     const double sum_elem_rhs_vals = std::accumulate(elements.begin(), elements.end(), 0.0, [](double acc, RHSElementType& rElem){
         return acc + rElem.GetAccumRHSValue();
@@ -197,7 +201,8 @@ KRATOS_TEST_CASE_IN_SUITE(BlockPartitionerThreadLocalStorage, KratosCoreFastSuit
     // here the TLS is constructed beforehand. This is the "firstprivate" approach of OpenMP
     // checking the results using reduction
     std::vector<double> tls(6);
-    const double final_sum = BlockPartition<std::vector<RHSElementType>>(elements).for_each<SumReduction<double>>(tls, tls_lambda_reduction);
+    const double final_sum = BlockPartition<std::vector<RHSElementType>::iterator>(elements.begin(),
+                                                                                   elements.end()).for_each<SumReduction<double>>(tls, tls_lambda_reduction);
 
     KRATOS_CHECK_NEAR(final_sum, exp_sum, tol);
 

--- a/kratos/utilities/normal_calculation_utils.cpp
+++ b/kratos/utilities/normal_calculation_utils.cpp
@@ -70,7 +70,7 @@ void NormalCalculationUtils::InitializeNormals(
         // If Parallel make sure normals are reset in all partitions
         VariableUtils().SetFlag(VISITED, false, rModelPart.Nodes());
 
-        BlockPartition<TContainerType>(r_entity_array).for_each([](typename TContainerType::value_type& rEntity) {
+        block_for_each(r_entity_array, [](typename TContainerType::value_type& rEntity) {
             for (auto& r_node : rEntity.GetGeometry()) {
                 r_node.SetLock();
                 r_node.Set(VISITED, true);
@@ -86,14 +86,13 @@ void NormalCalculationUtils::InitializeNormals(
         }
     } else {
         // In serial iterate normally over the condition nodes
-        BlockPartition<TContainerType>(r_entity_array)
-            .for_each([zero, &rNormalVariable, this](typename TContainerType::value_type& rEntity) {
+        block_for_each(r_entity_array, [zero, &rNormalVariable, this](typename TContainerType::value_type& rEntity) {
                 for (auto& r_node : rEntity.GetGeometry()) {
                     r_node.SetLock();
                     SetNormalValue<TIsHistorical>(r_node, rNormalVariable, zero);
                     r_node.UnSetLock();
                 }
-            });
+        });
     }
 }
 
@@ -229,7 +228,7 @@ void NormalCalculationUtils::CalculateNormalShapeDerivativesOnSimplex(
                                                  ZeroMatrix(4, 2), rConditions);
 
         // calculate condition normal shape derivatives
-        BlockPartition<ConditionsArrayType>(rConditions).for_each([](ConditionType& rCondition) {
+        block_for_each(rConditions, [](ConditionType& rCondition) {
             if (rCondition.GetGeometry().GetGeometryType() ==
                 GeometryData::KratosGeometryType::Kratos_Line2D2) {
                 CalculateNormalShapeDerivative2D(rCondition);
@@ -241,7 +240,7 @@ void NormalCalculationUtils::CalculateNormalShapeDerivativesOnSimplex(
                                                  ZeroMatrix(9, 3), rConditions);
 
         // calculate condition normal shape derivatives
-        BlockPartition<ConditionsArrayType>(rConditions).for_each([](ConditionType& rCondition) {
+        block_for_each(rConditions, [](ConditionType& rCondition) {
             if (rCondition.GetGeometry().GetGeometryType() ==
                 GeometryData::KratosGeometryType::Kratos_Triangle3D3) {
                 CalculateNormalShapeDerivative3D(rCondition);

--- a/kratos/utilities/parallel_utilities.h
+++ b/kratos/utilities/parallel_utilities.h
@@ -17,6 +17,7 @@
 // System includes
 #include <iostream>
 #include <array>
+#include <iterator>
 #include <vector>
 #include <tuple>
 #include <cmath>
@@ -132,16 +133,11 @@ private:
 //***********************************************************************************
 //***********************************************************************************
 //***********************************************************************************
-/** @param TContainerType - the type of the container used in the loop (must provide random access iterators)
- *  @param TIteratorType - type of iterator (by default as provided by the TContainerType)
- *  @param TMaxThreads - maximum number of threads allowed in the partitioning.
+/** @param TIterator - type of iterator (must be a random access iterator)
+ *  @param MaxThreads - maximum number of threads allowed in the partitioning.
  *                       must be known at compile time to avoid heap allocations in the partitioning
  */
-template<
-        class TContainerType,
-        class TIteratorType=decltype(std::declval<TContainerType>().begin()),
-        int TMaxThreads=Globals::MaxAllowedThreads
-        >
+template<class TIterator, int MaxThreads=Globals::MaxAllowedThreads>
 class BlockPartition
 {
 public:
@@ -149,10 +145,11 @@ public:
      *  @param it_end - iterator pointing to the end of the container
      *  @param Nchunks - number of threads to be used in the loop (must be lower than TMaxThreads)
      */
-    BlockPartition(TIteratorType it_begin,
-                   TIteratorType it_end,
+    BlockPartition(TIterator it_begin,
+                   TIterator it_end,
                    int Nchunks = ParallelUtilities::GetNumThreads())
     {
+        static_assert(std::is_same_v<typename std::iterator_traits<TIterator>::iterator_category, std::random_access_iterator_tag>);
         KRATOS_ERROR_IF(Nchunks < 1) << "Number of chunks must be > 0 (and not " << Nchunks << ")" << std::endl;
 
         const std::ptrdiff_t size_container = it_end-it_begin;
@@ -170,16 +167,6 @@ public:
             mBlockPartition[i] = mBlockPartition[i-1] + block_partition_size;
         }
     }
-
-    /** @param rData - the continer to be iterated upon
-     *  @param Nchunks - number of threads to be used in the loop (must be lower than TMaxThreads)
-     */
-    template <class TData>
-    BlockPartition(TData &&rData, int Nchunks = ParallelUtilities::GetNumThreads())
-        : BlockPartition(rData.begin(), rData.end(), Nchunks)
-    {}
-
-    virtual ~BlockPartition() = default;
 
     /** @brief simple iteration loop. f called on every entry in rData
      * @param f - must be a unary function accepting as input TContainerType::value_type&
@@ -293,8 +280,78 @@ public:
 
 private:
     int mNchunks;
-    std::array<TIteratorType, TMaxThreads> mBlockPartition;
+    std::array<TIterator, MaxThreads> mBlockPartition;
 };
+
+/** @brief Execute a functor on all items of a range in parallel.
+ *  @tparam TIterator: random access iterator.
+ *  @tparam TFunction: functor taking the dereferenced type of @a TIterator.
+ *  @param itBegin: iterator to the first item in the container to loop on.
+ *  @param itEnd: iterator past the last item in the container.
+ *  @param rFunction: function to execute on each item.
+ */
+template <class TIterator,
+          class TFunction,
+          std::enable_if_t<std::is_same_v<typename std::iterator_traits<TIterator>::iterator_category,std::random_access_iterator_tag>,bool> = true>
+void block_for_each(TIterator itBegin, TIterator itEnd, TFunction&& rFunction)
+{
+    BlockPartition<TIterator>(itBegin, itEnd).for_each(std::forward<TFunction>(rFunction));
+}
+
+/** @brief Execute a functor on all items of a range in parallel, and perform a reduction.
+ *  @tparam TReduction: type of reduction to apply. See @ref SumReduction for an example.
+ *  @tparam TIterator: random access iterator.
+ *  @tparam TFunction: functor taking the dereferenced type of @a TIterator.
+ *  @param itBegin: iterator to the first item in the container to loop on.
+ *  @param itEnd: iterator past the last item in the container.
+ *  @param rFunction: function to execute on each item.
+ */
+template <class TReduction,
+          class TIterator,
+          class TFunction,
+          std::enable_if_t<std::is_same_v<typename std::iterator_traits<TIterator>::iterator_category,std::random_access_iterator_tag>,bool> = true>
+[[nodiscard]] typename TReduction::return_type block_for_each(TIterator itBegin, TIterator itEnd, TFunction&& rFunction)
+{
+    return  BlockPartition<TIterator>(itBegin, itEnd).template for_each<TReduction>(std::forward<TFunction>(std::forward<TFunction>(rFunction)));
+}
+
+/** @brief Execute a functor with thread local storage on all items of a range in parallel.
+ *  @tparam TIterator:  random access iterator.
+ *  @tparam TTLS: copy constructible thread-local type.
+ *  @tparam TFunction: functor taking the dereferenced type of @a TIterator.
+ *  @param itBegin: iterator to the first item in the container to loop on.
+ *  @param itEnd: iterator past the last item in the container.
+ *  @param rTLS: thread local storage
+ *  @param rFunction: function to execute on each item.
+ */
+template <class TIterator,
+          class TTLS,
+          class TFunction,
+          std::enable_if_t<std::is_same_v<typename std::iterator_traits<TIterator>::iterator_category,std::random_access_iterator_tag>,bool> = true>
+void block_for_each(TIterator itBegin, TIterator itEnd, const TTLS& rTLS, TFunction &&rFunction)
+{
+     BlockPartition<TIterator>(itBegin, itEnd).for_each(rTLS, std::forward<TFunction>(rFunction));
+}
+
+/** @brief Execute a functor with thread local storage on all items of a range in parallel, and perform a reduction.
+ *  @tparam TReduction: type of reduction to apply. See @ref SumReduction for an example.
+ *  @tparam TIterator: random access iterator.
+ *  @tparam TTLS: copy constructible thread-local type.
+ *  @tparam TFunction: functor taking the dereferenced type of @a TIterator.
+ *  @param itBegin: iterator to the first item in the container to loop on.
+ *  @param itEnd: iterator past the last item in the container.
+ *  @param rTLS: thread local storage
+ *  @param rFunction: function to execute on each item.
+ */
+template <class TReduction,
+          class TIterator,
+          class TTLS,
+          class TFunction,
+          std::enable_if_t<std::is_same_v<typename std::iterator_traits<TIterator>::iterator_category,std::random_access_iterator_tag>,bool> = true>
+[[nodiscard]] typename TReduction::return_type block_for_each(TIterator itBegin, TIterator itEnd, const TTLS& tls, TFunction&& rFunction)
+{
+    return BlockPartition<TIterator>(itBegin, itEnd).template for_each<TReduction>(tls, std::forward<TFunction>(std::forward<TFunction>(rFunction)));
+}
 
 /** @brief simplified version of the basic loop (without reduction) to enable template type deduction
  * @param v - containers to be looped upon
@@ -303,7 +360,7 @@ private:
 template <class TContainerType, class TFunctionType>
 void block_for_each(TContainerType &&v, TFunctionType &&func)
 {
-    BlockPartition<TContainerType>(v.begin(), v.end()).for_each(std::forward<TFunctionType>(func));
+    block_for_each(v.begin(), v.end(), std::forward<TFunctionType>(func));
 }
 
 /** @brief simplified version of the basic loop with reduction to enable template type deduction
@@ -313,7 +370,7 @@ void block_for_each(TContainerType &&v, TFunctionType &&func)
 template <class TReducer, class TContainerType, class TFunctionType>
 [[nodiscard]] typename TReducer::return_type block_for_each(TContainerType &&v, TFunctionType &&func)
 {
-    return  BlockPartition<TContainerType>(v.begin(), v.end()).template for_each<TReducer>(std::forward<TFunctionType>(func));
+    return block_for_each<TReducer>(v.begin(), v.end(), std::forward<TFunctionType>(func));
 }
 
 /** @brief simplified version of the basic loop with thread local storage (TLS) to enable template type deduction
@@ -324,7 +381,7 @@ template <class TReducer, class TContainerType, class TFunctionType>
 template <class TContainerType, class TThreadLocalStorage, class TFunctionType>
 void block_for_each(TContainerType &&v, const TThreadLocalStorage& tls, TFunctionType &&func)
 {
-     BlockPartition<TContainerType>(v.begin(), v.end()).for_each(tls, std::forward<TFunctionType>(func));
+    block_for_each(v.begin(), v.end(), tls, std::forward<TFunctionType>(func));
 }
 
 /** @brief simplified version of the basic loop with reduction and thread local storage (TLS) to enable template type deduction
@@ -335,7 +392,7 @@ void block_for_each(TContainerType &&v, const TThreadLocalStorage& tls, TFunctio
 template <class TReducer, class TContainerType, class TThreadLocalStorage, class TFunctionType>
 [[nodiscard]] typename TReducer::return_type block_for_each(TContainerType &&v, const TThreadLocalStorage& tls, TFunctionType &&func)
 {
-    return BlockPartition<TContainerType>(v.begin(), v.end()).template for_each<TReducer>(tls, std::forward<TFunctionType>(func));
+    return block_for_each<TReducer>(v.begin(), v.end(), tls, std::forward<TFunctionType>(func));
 }
 
 //***********************************************************************************
@@ -375,8 +432,6 @@ public:
         }
 
     }
-
-    virtual ~IndexPartition() = default;
 
     //NOT COMMENTING IN DOXYGEN - THIS SHOULD BE SORT OF HIDDEN UNTIL GIVEN PRIME TIME
     //pure c++11 version (can handle exceptions)

--- a/kratos/utilities/pointer_map_communicator.h
+++ b/kratos/utilities/pointer_map_communicator.h
@@ -387,7 +387,7 @@ public:
                     }
 
                     // running this in parallel assuming rApplyProxy.mrApplyFunctor is thread safe
-                    BlockPartition<std::vector<GlobalPointerValueVectorPair>>(gp_value_pair_list).for_each([&](GlobalPointerValueVectorPair& rItem) {
+                    block_for_each(gp_value_pair_list, [&](GlobalPointerValueVectorPair& rItem) {
                         auto& r_pointer_data_type_entity = *(rItem.first);
                         for (IndexType i = 0; i < rItem.second.size(); ++i) {
                             // it is safer to call the serial update method here

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -1119,20 +1119,18 @@ public:
             CheckVariableExists(rVariable, rNodes);
 
             if (IsFixed) {
-                BlockPartition<NodesContainerType>(rNodes).for_each(
-                    [&rVariable, &rFlag, CheckValue](NodeType& rNode) {
-                        if (rNode.Is(rFlag) == CheckValue) {
-                            rNode.pGetDof(rVariable)->FixDof();
-                        }
-                    });
+                block_for_each(rNodes, [&rVariable, &rFlag, CheckValue](NodeType& rNode) {
+                    if (rNode.Is(rFlag) == CheckValue) {
+                        rNode.pGetDof(rVariable)->FixDof();
+                    }
+                });
             }
             else {
-                BlockPartition<NodesContainerType>(rNodes).for_each(
-                    [&rVariable, &rFlag, CheckValue](NodeType& rNode) {
-                        if (rNode.Is(rFlag) == CheckValue) {
-                            rNode.pGetDof(rVariable)->FreeDof();
-                        }
-                    });
+                block_for_each(rNodes, [&rVariable, &rFlag, CheckValue](NodeType& rNode) {
+                    if (rNode.Is(rFlag) == CheckValue) {
+                        rNode.pGetDof(rVariable)->FreeDof();
+                    }
+                });
             }
         }
 


### PR DESCRIPTION
## Description

https://github.com/KratosMultiphysics/Kratos/blob/02d27883c115c5f5508e2349cd1cea162468c45b/kratos/utilities/parallel_utilities.h#L140-L145

`BlockPartition` is templated on the container type even though it doesn't use it anywhere within the class. Furthermore, it restricts the types of iterators it acts on to the one returned by `TContainerType::begin` by default. This PR makes `BlockPartition` template directly on the iterator type.

## Motivation

1) Kratos has some containers that  have multiple iterator types (eg.: pointer containers that have iterators returning dereferenced pointers, or ones returning the pointers themselves), and choosing between them requires explicitly specifying them in `BlockPartition`'s template argument list, which results in a lot more and unreadable code than a simple `block_for_each` call.
2) There's no way of creating a `BlockPartition` on a subset of a container's items, because it automatically creates a partitioning of **all** items within the container (hard-coded to `TContainerType::begin` and `TContainerType::end` in `block_for_each`).

Removing the container type from the template argument list solves both problems. Now there shouldn't be any reason to use `BlockPartition` directly (unless `MaxThreads` needs to be set manually); `block_for_each` can handle all cases.

## Changelog
- Remove `TContainerType` from `BlockPartition`'s template argument list.
- Remove the default type of `BlockPartition::TIteratorType`.
- add overloads to `block_for_each` taking iterator pairs.
- reroute `block_for_each` calls taking containers to ones taking iterator pairs.
- update tests directly using `BlockPartition`.
- replace direct uses of `BlockPartition` with `block_for_each`