### PR TITLE
[GeoMechanics] Made some protected data members private

### DIFF
--- a/applications/GeoMechanicsApplication/custom_conditions/Pw_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/Pw_condition.hpp
@@ -43,22 +43,19 @@ public:
     
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    // Default constructor
-    PwCondition() : Condition() {}
+    PwCondition() : PwCondition(0, nullptr, nullptr) {}
 
-    // Constructor 1
-    PwCondition( IndexType NewId, GeometryType::Pointer pGeometry ) : Condition(NewId, pGeometry) {}
-    
-    // Constructor 2
-    PwCondition( IndexType NewId,
-                  GeometryType::Pointer pGeometry,
-                  PropertiesType::Pointer pProperties ) : Condition(NewId, pGeometry, pProperties)
-    {
-        mThisIntegrationMethod = this->GetIntegrationMethod();
-    }
+    PwCondition( IndexType NewId, GeometryType::Pointer pGeometry )
+        : PwCondition(NewId, pGeometry, nullptr)
+    {}
 
-    // Destructor
-    virtual ~PwCondition() {}
+    PwCondition( IndexType               NewId,
+                 GeometryType::Pointer   pGeometry,
+                 PropertiesType::Pointer pProperties )
+        : Condition(NewId, pGeometry, pProperties)
+    {}
+
+    ~PwCondition() override = default;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -87,13 +84,6 @@ public:
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 protected:
-
-    // Member Variables
-
-    GeometryData::IntegrationMethod mThisIntegrationMethod;
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
     virtual void CalculateAll(MatrixType& rLeftHandSideMatrix,
                               VectorType& rRightHandSideVector,
                               const ProcessInfo& rCurrentProcessInfo);

--- a/applications/GeoMechanicsApplication/custom_conditions/Pw_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/Pw_normal_flux_condition.cpp
@@ -35,16 +35,16 @@ void PwNormalFluxCondition<TDim,TNumNodes>::
 {        
     //Previous definitions
     const GeometryType& Geom = this->GetGeometry();
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = Geom.IntegrationPoints( mThisIntegrationMethod );
+    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = Geom.IntegrationPoints(this->GetIntegrationMethod());
     const unsigned int NumGPoints = IntegrationPoints.size();
     const unsigned int LocalDim = Geom.LocalSpaceDimension();
     
     //Containers of variables at all integration points
-    const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
+    const Matrix& NContainer = Geom.ShapeFunctionsValues(this->GetIntegrationMethod());
     GeometryType::JacobiansType JContainer(NumGPoints);
     for(unsigned int i = 0; i<NumGPoints; ++i)
         (JContainer[i]).resize(TDim,LocalDim,false);
-    Geom.Jacobian( JContainer, mThisIntegrationMethod );
+    Geom.Jacobian(JContainer, this->GetIntegrationMethod());
     
     //Condition variables
     array_1d<double,TNumNodes> NormalFluxVector;

--- a/applications/GeoMechanicsApplication/custom_conditions/Pw_normal_flux_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/Pw_normal_flux_condition.hpp
@@ -44,7 +44,6 @@ public:
     typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
     typedef Vector VectorType;
     typedef Matrix MatrixType;
-    using PwCondition<TDim,TNumNodes>::mThisIntegrationMethod;
     
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_condition.hpp
@@ -42,22 +42,20 @@ public:
     
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    // Default constructor
-    UPwCondition() : Condition() {}
+    UPwCondition() : UPwCondition(0, nullptr, nullptr){}
 
-    // Constructor 1
-    UPwCondition( IndexType NewId, GeometryType::Pointer pGeometry ) : Condition(NewId, pGeometry) {}
-    
-    // Constructor 2
-    UPwCondition( IndexType NewId,
-                  GeometryType::Pointer pGeometry,
-                  PropertiesType::Pointer pProperties ) : Condition(NewId, pGeometry, pProperties)
-    {
-        mThisIntegrationMethod = this->GetIntegrationMethod();
-    }
+    UPwCondition( IndexType               NewId,
+                  GeometryType::Pointer   pGeometry )
+        : UPwCondition(NewId, pGeometry, nullptr)
+    {}
 
-    // Destructor
-    virtual ~UPwCondition() {}
+    UPwCondition( IndexType               NewId,
+                  GeometryType::Pointer   pGeometry,
+                  PropertiesType::Pointer pProperties )
+        : Condition(NewId, pGeometry, pProperties)
+    {}
+
+    ~UPwCondition() override = default;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -67,6 +65,16 @@ public:
  
     void GetDofList(DofsVectorType& rConditionDofList,
                     const ProcessInfo& rCurrentProcessInfo) const override;
+
+    IntegrationMethod GetIntegrationMethod() const override
+    {
+        return mThisIntegrationMethod;
+    }
+
+    void SetIntegrationMethod(IntegrationMethod method)
+    {
+        mThisIntegrationMethod = method;
+    }
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -86,13 +94,6 @@ public:
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 protected:
-
-    // Member Variables
-
-    GeometryData::IntegrationMethod mThisIntegrationMethod;
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
     virtual void CalculateAll(MatrixType& rLeftHandSideMatrix,
                               VectorType& rRightHandSideVector,
                               const ProcessInfo& rCurrentProcessInfo);
@@ -103,6 +104,7 @@ protected:
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 private:
+    GeometryData::IntegrationMethod mThisIntegrationMethod{ Condition::GetIntegrationMethod() };
     
     // Serialization
     

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_condition.cpp
@@ -36,16 +36,16 @@ void UPwFaceLoadCondition<TDim,TNumNodes>::
 {        
     //Previous definitions
     const GeometryType& Geom = this->GetGeometry();
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = Geom.IntegrationPoints( mThisIntegrationMethod );
+    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = Geom.IntegrationPoints(this->GetIntegrationMethod());
     const unsigned int NumGPoints = IntegrationPoints.size();
     const unsigned int LocalDim = Geom.LocalSpaceDimension();
 
     //Containers of variables at all integration points
-    const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
+    const Matrix& NContainer = Geom.ShapeFunctionsValues(this->GetIntegrationMethod());
     GeometryType::JacobiansType JContainer(NumGPoints);
     for(unsigned int i = 0; i<NumGPoints; ++i)
         (JContainer[i]).resize(TDim, LocalDim, false);
-    Geom.Jacobian( JContainer, mThisIntegrationMethod );
+    Geom.Jacobian(JContainer, this->GetIntegrationMethod());
 
     //Condition variables
     array_1d<double,TNumNodes*TDim> FaceLoadVector;

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_condition.hpp
@@ -43,7 +43,6 @@ public:
     typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
     typedef Vector VectorType;
     typedef Matrix MatrixType;
-    using UPwCondition<TDim,TNumNodes>::mThisIntegrationMethod;
     
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.cpp
@@ -75,16 +75,16 @@ void UPwFaceLoadInterfaceCondition<TDim,TNumNodes>::
 {        
     //Previous definitions
     const GeometryType& Geom = this->GetGeometry();
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = Geom.IntegrationPoints( mThisIntegrationMethod );
+    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = Geom.IntegrationPoints(this->GetIntegrationMethod());
     const unsigned int NumGPoints = IntegrationPoints.size();
     const unsigned int LocalDim = Geom.LocalSpaceDimension();
     
     //Containers of variables at all integration points
-    const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
+    const Matrix& NContainer = Geom.ShapeFunctionsValues(this->GetIntegrationMethod());
     GeometryType::JacobiansType JContainer(NumGPoints);
     for (unsigned int i = 0; i<NumGPoints; i++)
         (JContainer[i]).resize(TDim,LocalDim,false);
-    Geom.Jacobian( JContainer, mThisIntegrationMethod );
+    Geom.Jacobian(JContainer, this->GetIntegrationMethod());
     
     //Condition variables
     array_1d<double,TNumNodes*TDim> DisplacementVector;

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.hpp
@@ -43,24 +43,25 @@ public:
     typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
     typedef Vector VectorType;
     typedef Matrix MatrixType;
-    using UPwCondition<TDim,TNumNodes>::mThisIntegrationMethod;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    // Default constructor
-    UPwFaceLoadInterfaceCondition() : UPwCondition<TDim,TNumNodes>() {}
+    UPwFaceLoadInterfaceCondition() : UPwFaceLoadInterfaceCondition(0, nullptr, nullptr) {}
 
-    // Constructor 1
-    UPwFaceLoadInterfaceCondition( IndexType NewId, GeometryType::Pointer pGeometry ) : UPwCondition<TDim,TNumNodes>(NewId, pGeometry) {}
+    UPwFaceLoadInterfaceCondition( IndexType               NewId,
+                                   GeometryType::Pointer   pGeometry )
+        : UPwFaceLoadInterfaceCondition(NewId, pGeometry, nullptr)
+    {}
 
-    // Constructor 2
-    UPwFaceLoadInterfaceCondition( IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties ) : UPwCondition<TDim,TNumNodes>(NewId, pGeometry, pProperties)
+    UPwFaceLoadInterfaceCondition( IndexType               NewId,
+                                   GeometryType::Pointer   pGeometry,
+                                   PropertiesType::Pointer pProperties )
+        : UPwCondition<TDim,TNumNodes>(NewId, pGeometry, pProperties)
     {
         // Lobatto integration method with the integration points located at the "mid plane nodes" of the interface
-        mThisIntegrationMethod = GeometryData::IntegrationMethod::GI_GAUSS_1;
+        this->SetIntegrationMethod(GeometryData::IntegrationMethod::GI_GAUSS_1);
     }
 
-    // Destructor
     ~UPwFaceLoadInterfaceCondition() override {}
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -72,13 +73,6 @@ public:
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 protected:
-
-    // Member Variables
-
-    Vector mInitialGap;
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
     void CalculateInitialGap(const GeometryType& Geom);
 
     void CalculateRHS(VectorType& rRightHandSideVector,
@@ -97,8 +91,7 @@ protected:
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 private:
-
-    // Member Variables
+    Vector mInitialGap;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_force_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_force_condition.hpp
@@ -41,7 +41,6 @@ public:
     typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
     typedef Vector VectorType;
     typedef Matrix MatrixType;
-    using UPwCondition<TDim,TNumNodes>::mThisIntegrationMethod;
     
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_face_load_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_face_load_condition.cpp
@@ -36,16 +36,16 @@ void UPwNormalFaceLoadCondition<TDim,TNumNodes>::
 {
     //Previous definitions
     const GeometryType& rGeom = this->GetGeometry();
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = rGeom.IntegrationPoints( mThisIntegrationMethod );
+    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = rGeom.IntegrationPoints(this->GetIntegrationMethod());
     const unsigned int NumGPoints = IntegrationPoints.size();
     const unsigned int LocalDim = rGeom.LocalSpaceDimension();
 
     //Containers of variables at all integration points
-    const Matrix& NContainer = rGeom.ShapeFunctionsValues( mThisIntegrationMethod );
+    const Matrix& NContainer = rGeom.ShapeFunctionsValues(this->GetIntegrationMethod());
     GeometryType::JacobiansType JContainer(NumGPoints);
     for (unsigned int i = 0; i<NumGPoints; ++i)
         (JContainer[i]).resize(TDim,LocalDim,false);
-    rGeom.Jacobian( JContainer, mThisIntegrationMethod );
+    rGeom.Jacobian(JContainer, this->GetIntegrationMethod());
 
     //Condition variables
     NormalFaceLoadVariables Variables;

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_face_load_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_face_load_condition.hpp
@@ -42,7 +42,6 @@ public:
     typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
     typedef Vector VectorType;
     typedef Matrix MatrixType;
-    using UPwCondition<TDim,TNumNodes>::mThisIntegrationMethod;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.cpp
@@ -44,16 +44,16 @@ void UPwNormalFluxFICCondition<TDim,TNumNodes>::
     //Previous definitions
     const PropertiesType& Prop = this->GetProperties();
     const GeometryType& Geom = this->GetGeometry();
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = Geom.IntegrationPoints( mThisIntegrationMethod );
+    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = Geom.IntegrationPoints(this->GetIntegrationMethod());
     const unsigned int NumGPoints = IntegrationPoints.size();
     const unsigned int LocalDim = Geom.LocalSpaceDimension();
 
     //Containers of variables at all integration points
-    const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
+    const Matrix& NContainer = Geom.ShapeFunctionsValues(this->GetIntegrationMethod());
     GeometryType::JacobiansType JContainer(NumGPoints);
     for(unsigned int i = 0; i<NumGPoints; ++i)
         (JContainer[i]).resize(TDim,LocalDim,false);
-    Geom.Jacobian( JContainer, mThisIntegrationMethod );
+    Geom.Jacobian(JContainer, this->GetIntegrationMethod());
 
     //Condition variables
     array_1d<double,TNumNodes> NormalFluxVector;
@@ -108,16 +108,16 @@ void UPwNormalFluxFICCondition<TDim,TNumNodes>::
     //Previous definitions
     const PropertiesType& Prop = this->GetProperties();
     const GeometryType& Geom = this->GetGeometry();
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = Geom.IntegrationPoints( mThisIntegrationMethod );
+    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = Geom.IntegrationPoints(this->GetIntegrationMethod());
     const unsigned int NumGPoints = IntegrationPoints.size();
     const unsigned int LocalDim = Geom.LocalSpaceDimension();
 
     //Containers of variables at all integration points
-    const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
+    const Matrix& NContainer = Geom.ShapeFunctionsValues(this->GetIntegrationMethod());
     GeometryType::JacobiansType JContainer(NumGPoints);
     for(unsigned int i = 0; i<NumGPoints; ++i)
         (JContainer[i]).resize(TDim,LocalDim,false);
-    Geom.Jacobian( JContainer, mThisIntegrationMethod );
+    Geom.Jacobian(JContainer, this->GetIntegrationMethod());
 
     //Condition variables
     array_1d<double,TNumNodes> NormalFluxVector;

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.hpp
@@ -45,24 +45,23 @@ public:
     typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
     typedef Vector VectorType;
     typedef Matrix MatrixType;
-    using UPwCondition<TDim,TNumNodes>::mThisIntegrationMethod;
     typedef typename UPwNormalFluxCondition<TDim,TNumNodes>::NormalFluxVariables NormalFluxVariables;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    // Default constructor
-    UPwNormalFluxFICCondition() : UPwNormalFluxCondition<TDim,TNumNodes>() {}
+    UPwNormalFluxFICCondition() : UPwNormalFluxFICCondition(0, nullptr, nullptr) {}
 
-    // Constructor 1
-    UPwNormalFluxFICCondition( IndexType NewId, GeometryType::Pointer pGeometry ) : UPwNormalFluxCondition<TDim,TNumNodes>(NewId, pGeometry) {}
+    UPwNormalFluxFICCondition(IndexType                NewId,
+                              GeometryType::Pointer    pGeometry )
+        : UPwNormalFluxFICCondition(NewId, pGeometry, nullptr)
+    {}
 
-    // Constructor 2
-    UPwNormalFluxFICCondition( IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties ) : UPwNormalFluxCondition<TDim,TNumNodes>(NewId, pGeometry, pProperties)
-    {
-        mThisIntegrationMethod = this->GetIntegrationMethod();
-    }
+    UPwNormalFluxFICCondition( IndexType               NewId,
+                               GeometryType::Pointer   pGeometry,
+                               PropertiesType::Pointer pProperties )
+        : UPwNormalFluxCondition<TDim,TNumNodes>(NewId, pGeometry, pProperties)
+    {}
 
-    // Destructor
     ~UPwNormalFluxFICCondition() override {}
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_condition.cpp
@@ -34,16 +34,16 @@ void UPwNormalFluxCondition<TDim,TNumNodes>::
 {        
     //Previous definitions
     const GeometryType& Geom = this->GetGeometry();
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = Geom.IntegrationPoints( mThisIntegrationMethod );
+    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = Geom.IntegrationPoints(this->GetIntegrationMethod());
     const unsigned int NumGPoints = IntegrationPoints.size();
     const unsigned int LocalDim = Geom.LocalSpaceDimension();
     
     //Containers of variables at all integration points
-    const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
+    const Matrix& NContainer = Geom.ShapeFunctionsValues(this->GetIntegrationMethod());
     GeometryType::JacobiansType JContainer(NumGPoints);
     for(unsigned int i = 0; i<NumGPoints; ++i)
         (JContainer[i]).resize(TDim,LocalDim,false);
-    Geom.Jacobian( JContainer, mThisIntegrationMethod );
+    Geom.Jacobian(JContainer, this->GetIntegrationMethod());
     
     //Condition variables
     array_1d<double,TNumNodes> NormalFluxVector;

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_condition.hpp
@@ -44,7 +44,6 @@ public:
     typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
     typedef Vector VectorType;
     typedef Matrix MatrixType;
-    using UPwCondition<TDim,TNumNodes>::mThisIntegrationMethod;
     
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_interface_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_interface_condition.cpp
@@ -34,16 +34,16 @@ void UPwNormalFluxInterfaceCondition<TDim,TNumNodes>::
 {        
     //Previous definitions
     const GeometryType& Geom = this->GetGeometry();
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = Geom.IntegrationPoints( mThisIntegrationMethod );
+    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = Geom.IntegrationPoints(this->GetIntegrationMethod());
     const unsigned int NumGPoints = IntegrationPoints.size();
     const unsigned int LocalDim = Geom.LocalSpaceDimension();
     
     //Containers of variables at all integration points
-    const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
+    const Matrix& NContainer = Geom.ShapeFunctionsValues(this->GetIntegrationMethod());
     GeometryType::JacobiansType JContainer(NumGPoints);
     for(unsigned int i = 0; i<NumGPoints; ++i)
         (JContainer[i]).resize(TDim,LocalDim,false);
-    Geom.Jacobian( JContainer, mThisIntegrationMethod );
+    Geom.Jacobian(JContainer, this->GetIntegrationMethod());
     
     //Condition variables
     array_1d<double,TNumNodes*TDim> DisplacementVector;

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_interface_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_interface_condition.hpp
@@ -45,7 +45,6 @@ public:
     typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
     typedef Vector VectorType;
     typedef Matrix MatrixType;
-    using UPwCondition<TDim,TNumNodes>::mThisIntegrationMethod;
     
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.cpp
@@ -44,7 +44,7 @@ void UPwLysmerAbsorbingCondition<TDim, TNumNodes>::CalculateConditionStiffnessMa
     //Previous definitions
     GeometryType& r_geom = this->GetGeometry();
 
-    GeometryData::IntegrationMethod integration_method = this->mThisIntegrationMethod;
+    GeometryData::IntegrationMethod integration_method = this->GetIntegrationMethod();
     const GeometryType::IntegrationPointsArrayType& r_integration_points = r_geom.IntegrationPoints(integration_method);
     const unsigned int num_g_points = r_integration_points.size();
     const unsigned int local_dim = r_geom.LocalSpaceDimension();
@@ -117,7 +117,7 @@ void UPwLysmerAbsorbingCondition<TDim, TNumNodes>::CalculateDampingMatrix(Matrix
     //Previous definitions
     GeometryType& r_geom = this->GetGeometry();
 
-    GeometryData::IntegrationMethod r_integration_method = this->mThisIntegrationMethod;
+    GeometryData::IntegrationMethod r_integration_method = this->GetIntegrationMethod();
     const GeometryType::IntegrationPointsArrayType& r_integration_points = r_geom.IntegrationPoints(r_integration_method);
     const unsigned int num_g_points = r_integration_points.size();
     const unsigned int local_dim = r_geom.LocalSpaceDimension();

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.hpp
@@ -43,7 +43,6 @@ public:
     typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
     typedef Vector VectorType;
     typedef Matrix MatrixType;
-    using UPwCondition<TDim,TNumNodes>::mThisIntegrationMethod;
     
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_U_Pw_normal_face_load_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_U_Pw_normal_face_load_condition.hpp
@@ -42,26 +42,22 @@ public:
     typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
     typedef Vector VectorType;
     typedef Matrix MatrixType;
-    using UPwNormalFaceLoadCondition<TDim,TNumNodes>::mThisIntegrationMethod;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    // Default constructor
-    AxisymmetricUPwNormalFaceLoadCondition() : UPwNormalFaceLoadCondition<TDim,TNumNodes>() {}
+    AxisymmetricUPwNormalFaceLoadCondition() : AxisymmetricUPwNormalFaceLoadCondition(0, nullptr, nullptr) {}
 
-    // Constructor 1
-    AxisymmetricUPwNormalFaceLoadCondition( IndexType NewId, GeometryType::Pointer pGeometry ) : UPwNormalFaceLoadCondition<TDim,TNumNodes>(NewId, pGeometry) {}
+    AxisymmetricUPwNormalFaceLoadCondition( IndexType               NewId,
+                                            GeometryType::Pointer   pGeometry )
+        : AxisymmetricUPwNormalFaceLoadCondition(NewId, pGeometry, nullptr)
+    {}
 
-    // Constructor 2
-    AxisymmetricUPwNormalFaceLoadCondition( IndexType NewId,
-                                            GeometryType::Pointer pGeometry,
+    AxisymmetricUPwNormalFaceLoadCondition( IndexType               NewId,
+                                            GeometryType::Pointer   pGeometry,
                                             PropertiesType::Pointer pProperties )
-                                            : UPwNormalFaceLoadCondition<TDim,TNumNodes>(NewId, pGeometry, pProperties)
-    {
-        mThisIntegrationMethod = this->GetIntegrationMethod();
-    }
+        : UPwNormalFaceLoadCondition<TDim,TNumNodes>(NewId, pGeometry, pProperties)
+    {}
 
-    // Destructor
     ~AxisymmetricUPwNormalFaceLoadCondition() override {}
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
@@ -23,31 +23,6 @@
 namespace Kratos
 {
 
-// Default Constructor
-GeneralUPwDiffOrderCondition::GeneralUPwDiffOrderCondition() : Condition() {}
-
-//----------------------------------------------------------------------------------------
-
-//Constructor 1
-GeneralUPwDiffOrderCondition::
-    GeneralUPwDiffOrderCondition(IndexType NewId,
-                                 GeometryType::Pointer pGeometry) :
-                                 Condition(NewId, pGeometry) {}
-
-//----------------------------------------------------------------------------------------
-
-//Constructor 2
-GeneralUPwDiffOrderCondition::
-    GeneralUPwDiffOrderCondition(IndexType NewId,
-                                 GeometryType::Pointer pGeometry,
-                                 PropertiesType::Pointer pProperties) :
-                                 Condition(NewId, pGeometry, pProperties)
-{
-    mThisIntegrationMethod = this->GetIntegrationMethod();
-}
-
-//----------------------------------------------------------------------------------------
-
 //Destructor
 GeneralUPwDiffOrderCondition::~GeneralUPwDiffOrderCondition() {}
 
@@ -255,7 +230,7 @@ void GeneralUPwDiffOrderCondition::
     this->InitializeConditionVariables(Variables,rCurrentProcessInfo);
 
     //Loop over integration points
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = GetGeometry().IntegrationPoints( mThisIntegrationMethod );
+    const GeometryType::IntegrationPointsArrayType& IntegrationPoints = GetGeometry().IntegrationPoints(this->GetIntegrationMethod());
 
     for ( unsigned int PointNumber = 0; PointNumber < IntegrationPoints.size(); PointNumber++ )
     {
@@ -291,15 +266,15 @@ void GeneralUPwDiffOrderCondition::
     const GeometryType& rGeom = GetGeometry();
     const SizeType NumUNodes = rGeom.PointsNumber();
     const SizeType NumPNodes = mpPressureGeometry->PointsNumber();
-    const SizeType NumGPoints = rGeom.IntegrationPointsNumber( mThisIntegrationMethod );
+    const SizeType NumGPoints = rGeom.IntegrationPointsNumber(this->GetIntegrationMethod());
     const SizeType WorkingDim = rGeom.WorkingSpaceDimension();
     const SizeType LocalDim = rGeom.LocalSpaceDimension();
 
     (rVariables.NuContainer).resize(NumGPoints,NumUNodes,false);
-    rVariables.NuContainer = rGeom.ShapeFunctionsValues( mThisIntegrationMethod );
+    rVariables.NuContainer = rGeom.ShapeFunctionsValues(this->GetIntegrationMethod());
 
     (rVariables.NpContainer).resize(NumGPoints,NumPNodes,false);
-    rVariables.NpContainer = mpPressureGeometry->ShapeFunctionsValues( mThisIntegrationMethod );
+    rVariables.NpContainer = mpPressureGeometry->ShapeFunctionsValues(this->GetIntegrationMethod());
 
     (rVariables.Nu).resize(NumUNodes,false);
     (rVariables.Np).resize(NumPNodes,false);
@@ -307,7 +282,7 @@ void GeneralUPwDiffOrderCondition::
     (rVariables.JContainer).resize(NumGPoints,false);
     for(SizeType i = 0; i<NumGPoints; ++i)
         ((rVariables.JContainer)[i]).resize(WorkingDim,LocalDim,false);
-    rGeom.Jacobian( rVariables.JContainer, mThisIntegrationMethod );
+    rGeom.Jacobian(rVariables.JContainer, this->GetIntegrationMethod());
 }
 
 //----------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.hpp
@@ -47,16 +47,18 @@ public:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    // Default constructor
-    GeneralUPwDiffOrderCondition();
+    GeneralUPwDiffOrderCondition() : GeneralUPwDiffOrderCondition(0, nullptr, nullptr) {};
 
-    // Constructor 1
-    GeneralUPwDiffOrderCondition( IndexType NewId, GeometryType::Pointer pGeometry );
+    GeneralUPwDiffOrderCondition( IndexType               NewId,
+                                  GeometryType::Pointer   pGeometry )
+        : GeneralUPwDiffOrderCondition(NewId, pGeometry, nullptr)
+    {}
 
-    // Constructor 2
-    GeneralUPwDiffOrderCondition( IndexType NewId,
-                                  GeometryType::Pointer pGeometry,
-                                  PropertiesType::Pointer pProperties );
+    GeneralUPwDiffOrderCondition( IndexType               NewId,
+                                  GeometryType::Pointer   pGeometry,
+                                  PropertiesType::Pointer pProperties )
+        : Condition(NewId, pGeometry, pProperties)
+    {}
 
     // Destructor
     virtual ~GeneralUPwDiffOrderCondition();
@@ -108,9 +110,6 @@ protected:
     };
 
     // Member Variables
-
-    IntegrationMethod mThisIntegrationMethod;
-
     Geometry< Node<3> >::Pointer mpPressureGeometry;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**📝 Description**
Resolved several issues related to protected data members as reported by SonarCloud ("Member variables should not be protected").

**🆕 Changelog**
- Whenever the integration method is needed, call the corresponding getter rather than accessing the corresponding data member directly. In this way, those data members no longer need to be protected.
- Avoid that the above data members may remain uninitialized by using in-class initialization.
- Use delegating constructors to avoid repeating the initialization of the base class part. Also, it makes clearer what the differences between the constructors are.
- Replaced some occurrences of `virtual` where `override` was intended.
- Removed some redundant comments.
