### PR TITLE
Replace "typedef" by "using"

### DIFF
--- a/applications/GeoMechanicsApplication/custom_conditions/Pw_normal_flux_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/Pw_normal_flux_condition.hpp
@@ -37,13 +37,13 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( PwNormalFluxCondition );
     
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
     
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_condition.hpp
@@ -36,13 +36,13 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwFaceLoadCondition );
     
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
     
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.hpp
@@ -36,13 +36,13 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwFaceLoadInterfaceCondition );
 
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_force_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_force_condition.hpp
@@ -34,13 +34,13 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwForceCondition );
     
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
     
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_face_load_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_face_load_condition.hpp
@@ -35,13 +35,13 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwNormalFaceLoadCondition );
 
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.hpp
@@ -38,14 +38,14 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwNormalFluxFICCondition );
 
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
-    typedef typename UPwNormalFluxCondition<TDim,TNumNodes>::NormalFluxVariables NormalFluxVariables;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
+    using NormalFluxVariables = typename UPwNormalFluxCondition<TDim, TNumNodes>::NormalFluxVariables;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_condition.hpp
@@ -37,13 +37,13 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwNormalFluxCondition );
     
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
     
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_interface_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_interface_condition.hpp
@@ -38,13 +38,13 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwNormalFluxInterfaceCondition );
     
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
     
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.hpp
@@ -36,13 +36,13 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(UPwLysmerAbsorbingCondition);
     
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
     
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -192,7 +192,7 @@ protected:
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 private:
-    typedef std::unordered_multimap<DenseVector<int>, std::vector<Condition::Pointer>, KeyHasherRange<DenseVector<int>>, KeyComparorRange<DenseVector<int>> > hashmap;
+    using hashmap = std::unordered_multimap<DenseVector<int>, std::vector<Condition::Pointer>, KeyHasherRange<DenseVector<int>>, KeyComparorRange<DenseVector<int>>>;
 
     // Member Variables
 

--- a/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_U_Pw_normal_face_load_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_U_Pw_normal_face_load_condition.hpp
@@ -35,13 +35,13 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( AxisymmetricUPwNormalFaceLoadCondition );
 
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_fluid_flux_2D_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_fluid_flux_2D_diff_order_condition.hpp
@@ -30,13 +30,13 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION)
 
 public:
 
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( AxisymmetricLineNormalFluidFlux2DDiffOrderCondition );
 

--- a/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_load_2D_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/axisymmetric_line_normal_load_2D_diff_order_condition.hpp
@@ -30,13 +30,13 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION)
 
 public:
 
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( AxisymmetricLineNormalLoad2DDiffOrderCondition );
 

--- a/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.hpp
@@ -35,13 +35,13 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) GeneralUPwDiffOrderCondition : publi
 
 public:
 
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( GeneralUPwDiffOrderCondition );
 

--- a/applications/GeoMechanicsApplication/custom_conditions/line_load_2D_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_load_2D_diff_order_condition.hpp
@@ -31,13 +31,13 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION)
 
 public:
 
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( LineLoad2DDiffOrderCondition );
 

--- a/applications/GeoMechanicsApplication/custom_conditions/line_normal_fluid_flux_2D_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_normal_fluid_flux_2D_diff_order_condition.hpp
@@ -31,13 +31,13 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION)
 
 public:
 
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( LineNormalFluidFlux2DDiffOrderCondition );
 

--- a/applications/GeoMechanicsApplication/custom_conditions/line_normal_load_2D_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/line_normal_load_2D_diff_order_condition.hpp
@@ -31,13 +31,13 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION)
 
 public:
 
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( LineNormalLoad2DDiffOrderCondition );
 

--- a/applications/GeoMechanicsApplication/custom_conditions/surface_load_3D_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/surface_load_3D_diff_order_condition.hpp
@@ -31,13 +31,13 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION)
 
 public:
 
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( SurfaceLoad3DDiffOrderCondition );
     

--- a/applications/GeoMechanicsApplication/custom_conditions/surface_normal_fluid_flux_3D_diff_order_condition.hpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/surface_normal_fluid_flux_3D_diff_order_condition.hpp
@@ -31,13 +31,13 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION)
 
 public:
 
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( SurfaceNormalFluidFlux3DDiffOrderCondition );
     

--- a/applications/GeoMechanicsApplication/custom_constitutive/elastic_isotropic_K0_3d_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/elastic_isotropic_K0_3d_law.h
@@ -61,10 +61,10 @@ public:
     ///@{
 
     /// The base class ConstitutiveLaw type definition
-    typedef ConstitutiveLaw         BaseType;
+    using BaseType = ConstitutiveLaw;
 
     /// The size type definition
-    typedef std::size_t             SizeType;
+    using SizeType = std::size_t;
 
     /// Static definition of the dimension
     static constexpr SizeType Dimension = N_DIM_3D;

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_beam_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_beam_law.h
@@ -56,13 +56,13 @@ public:
     ///@{
 
     /// The base class ConstitutiveLaw type definition
-    typedef ConstitutiveLaw                  CLBaseType;
+    using CLBaseType = ConstitutiveLaw;
 
     /// The base class ElasticIsotropicK03DLaw type definition
-    typedef GeoLinearElasticPlaneStrain2DLaw BaseType;
+    using BaseType = GeoLinearElasticPlaneStrain2DLaw;
 
     /// The size type definition
-    typedef std::size_t                      SizeType;
+    using SizeType = std::size_t;
 
     /// Counted pointer of GeoLinearElasticPlaneStrain2DLaw
     KRATOS_CLASS_POINTER_DEFINITION( LinearElastic2DBeamLaw );

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_interface_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_interface_law.h
@@ -56,13 +56,13 @@ public:
     ///@{
 
     /// The base class ConstitutiveLaw type definition
-    typedef ConstitutiveLaw       CLBaseType;
+    using CLBaseType = ConstitutiveLaw;
 
     /// The base class ElasticIsotropicK03DLaw type definition
-    typedef GeoLinearElasticPlaneStrain2DLaw      BaseType;
+    using BaseType = GeoLinearElasticPlaneStrain2DLaw;
 
     /// The size type definition
-    typedef std::size_t             SizeType;
+    using SizeType = std::size_t;
 
     /// Static definition of the dimension
     static constexpr SizeType Dimension = N_DIM_2D;

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_3D_interface_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_3D_interface_law.h
@@ -56,13 +56,13 @@ public:
     ///@{
 
     /// The base class ConstitutiveLaw type definition
-    typedef ConstitutiveLaw       CLBaseType;
+    using CLBaseType = ConstitutiveLaw;
 
     /// The base class ElasticIsotropicK03DLaw type definition
-    typedef LinearElastic2DInterfaceLaw      BaseType;
+    using BaseType = LinearElastic2DInterfaceLaw;
 
     /// The size type definition
-    typedef std::size_t             SizeType;
+    using SizeType = std::size_t;
 
     /// Static definition of the dimension
     static constexpr SizeType Dimension = N_DIM_3D;

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_2D_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_2D_law.h
@@ -56,13 +56,13 @@ public:
     ///@{
 
     /// The base class ConstitutiveLaw type definition
-    typedef ConstitutiveLaw       CLBaseType;
+    using CLBaseType = ConstitutiveLaw;
 
     /// The base class ElasticIsotropicK03DLaw type definition
-    typedef LinearPlaneStrainK0Law      BaseType;
+    using BaseType = LinearPlaneStrainK0Law;
 
     /// The size type definition
-    typedef std::size_t             SizeType;
+    using SizeType = std::size_t;
 
     /// Static definition of the dimension
     static constexpr SizeType Dimension = N_DIM_2D;

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_K0_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_K0_law.h
@@ -56,13 +56,13 @@ public:
     ///@{
 
     /// The base class ConstitutiveLaw type definition
-    typedef ConstitutiveLaw       CLBaseType;
+    using CLBaseType = ConstitutiveLaw;
 
     /// The base class ElasticIsotropicK03DLaw type definition
-    typedef ElasticIsotropicK03DLaw      BaseType;
+    using BaseType = ElasticIsotropicK03DLaw;
 
     /// The size type definition
-    typedef std::size_t             SizeType;
+    using SizeType = std::size_t;
 
     /// Static definition of the dimension
     static constexpr SizeType Dimension = N_DIM_2D;

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_stress_2D_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_stress_2D_law.h
@@ -55,17 +55,17 @@ public:
     ///@{
 
     /// The base class ConstitutiveLaw type definition
-    typedef ConstitutiveLaw       CLBaseType;
+    using CLBaseType = ConstitutiveLaw;
 
     /// The base class ElasticIsotropicK03DLaw type definition
-    typedef ElasticIsotropicK03DLaw      BaseType;
+    using BaseType = ElasticIsotropicK03DLaw;
 
     // Adding the respective using to avoid overload conflicts
     using BaseType::Has;
     using BaseType::GetValue;
 
     /// The size type definition
-    typedef std::size_t             SizeType;
+    using SizeType = std::size_t;
 
     /// Static definition of the dimension
     static constexpr SizeType Dimension = 2;

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.hpp
@@ -53,10 +53,10 @@ namespace Kratos
    public:
 
       // The base class ConstitutiveLaw type definition
-      typedef ConstitutiveLaw        BaseType;
+      using BaseType = ConstitutiveLaw;
 
       /// The size type definition
-      typedef std::size_t            SizeType;
+      using SizeType = std::size_t;
 
       /// Static definition of the dimension
       static constexpr SizeType Dimension = N_DIM_2D;

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.hpp
@@ -52,10 +52,10 @@ namespace Kratos
    {
    public:
       // The base class ConstitutiveLaw type definition
-      typedef ConstitutiveLaw        BaseType;
+      using BaseType = ConstitutiveLaw;
 
       /// The size type definition
-      typedef std::size_t            SizeType;
+      using SizeType = std::size_t;
 
       /// Static definition of the dimension
       static constexpr SizeType Dimension = N_DIM_2D;

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.hpp
@@ -52,10 +52,10 @@ namespace Kratos
    {
    public:
       // The base class ConstitutiveLaw type definition
-      typedef ConstitutiveLaw        BaseType;
+      using BaseType = ConstitutiveLaw;
 
       /// The size type definition
-      typedef std::size_t            SizeType;
+      using SizeType = std::size_t;
 
       /// Static definition of the dimension
       static constexpr SizeType Dimension = N_DIM_3D;

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_interface_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_interface_law.hpp
@@ -52,10 +52,10 @@ namespace Kratos
    {
    public:
       // The base class ConstitutiveLaw type definition
-      typedef ConstitutiveLaw        BaseType;
+      using BaseType = ConstitutiveLaw;
 
       /// The size type definition
-      typedef std::size_t            SizeType;
+      using SizeType = std::size_t;
 
       /// Static definition of the dimension
       static constexpr SizeType Dimension = N_DIM_2D;

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_plane_strain_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_plane_strain_law.hpp
@@ -52,10 +52,10 @@ namespace Kratos
    {
    public:
       // The base class ConstitutiveLaw type definition
-      typedef ConstitutiveLaw        BaseType;
+       using BaseType = ConstitutiveLaw;
 
       /// The size type definition
-      typedef std::size_t            SizeType;
+       using SizeType = std::size_t;
 
       /// Static definition of the dimension
       static constexpr SizeType Dimension = N_DIM_2D;

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_interface_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_interface_law.hpp
@@ -52,13 +52,13 @@ namespace Kratos
    {
    public:
       // The process info type definition
-      typedef ProcessInfo            ProcessInfoType;
+      using ProcessInfoType = ProcessInfo;
 
       // The base class ConstitutiveLaw type definition
-      typedef ConstitutiveLaw        BaseType;
+      using BaseType = ConstitutiveLaw;
 
       /// The size type definition
-      typedef std::size_t            SizeType;
+      using SizeType = std::size_t;
 
       /// Static definition of the dimension
       static constexpr SizeType Dimension = N_DIM_3D;

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_law.hpp
@@ -82,13 +82,13 @@ typedef void(*pF_UMATMod) (double* STRESS, double* STATEV, double** DDSDDE, doub
    {
    public:
       // The process info type definition
-      typedef ProcessInfo            ProcessInfoType;
+      using ProcessInfoType = ProcessInfo;
 
       // The base class ConstitutiveLaw type definition
-      typedef ConstitutiveLaw        BaseType;
+      using BaseType = ConstitutiveLaw;
 
       /// The size type definition
-      typedef std::size_t             SizeType;
+      using SizeType = std::size_t;
 
       /// Static definition of the dimension
       static constexpr SizeType Dimension = N_DIM_3D;

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
@@ -39,7 +39,7 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) UPwBaseElement : public Element
 public:
 
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwBaseElement );
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.hpp
@@ -37,13 +37,13 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwSmallStrainFICElement );
 
-    typedef std::size_t IndexType;
-	typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
     using UPwBaseElement<TDim,TNumNodes>::mConstitutiveLawVector;
     using UPwBaseElement<TDim,TNumNodes>::mStressVector;
     using UPwBaseElement<TDim,TNumNodes>::mStateVariablesFinalized;
@@ -52,7 +52,7 @@ public:
     using UPwSmallStrainElement<TDim,TNumNodes>::CalculateBulkModulus;
     using UPwSmallStrainElement<TDim,TNumNodes>::VoigtSize;
 
-    typedef typename UPwSmallStrainElement<TDim,TNumNodes>::ElementVariables ElementVariables;
+    using ElementVariables = typename UPwSmallStrainElement<TDim, TNumNodes>::ElementVariables;
 
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_axisymmetric_FIC_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_axisymmetric_FIC_element.hpp
@@ -34,15 +34,15 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwSmallStrainAxisymmetricFICElement );
 
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node<3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using  GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
     using UPwBaseElement<TDim,TNumNodes>::mConstitutiveLawVector;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_axisymmetric_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_axisymmetric_element.hpp
@@ -34,15 +34,15 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwSmallStrainAxisymmetricElement );
 
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
     using UPwBaseElement<TDim,TNumNodes>::mConstitutiveLawVector;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -35,15 +35,15 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwSmallStrainElement );
 
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
     using UPwBaseElement<TDim,TNumNodes>::mConstitutiveLawVector;
     using UPwBaseElement<TDim,TNumNodes>::mRetentionLawVector;
     using UPwBaseElement<TDim,TNumNodes>::mStressVector;

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
@@ -34,13 +34,13 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwSmallStrainInterfaceElement );
 
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
     using UPwBaseElement<TDim,TNumNodes>::mConstitutiveLawVector;
     using UPwBaseElement<TDim,TNumNodes>::mRetentionLawVector;
     using UPwBaseElement<TDim,TNumNodes>::mStressVector;

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.hpp
@@ -36,20 +36,20 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwSmallStrainLinkInterfaceElement );
 
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
     using UPwBaseElement<TDim,TNumNodes>::mConstitutiveLawVector;
     using UPwBaseElement<TDim,TNumNodes>::mRetentionLawVector;
     using UPwBaseElement<TDim,TNumNodes>::mStressVector;
     using UPwBaseElement<TDim,TNumNodes>::mThisIntegrationMethod;
 
-    typedef typename UPwSmallStrainInterfaceElement<TDim,TNumNodes>::SFGradAuxVariables SFGradAuxVariables;
-    typedef typename UPwSmallStrainInterfaceElement<TDim,TNumNodes>::InterfaceElementVariables InterfaceElementVariables;
+    using SFGradAuxVariables = typename UPwSmallStrainInterfaceElement<TDim, TNumNodes>::SFGradAuxVariables;
+    using InterfaceElementVariables = typename UPwSmallStrainInterfaceElement<TDim, TNumNodes>::InterfaceElementVariables;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_FIC_element.hpp
@@ -61,19 +61,19 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) UPwUpdatedLagrangianFICElement
 public:
     ///@name Type Definitions
     ///@{
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
 
     /// Type definition for integration methods
-    typedef GeometryData::IntegrationMethod IntegrationMethod;
+    using IntegrationMethod = GeometryData::IntegrationMethod;
 
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
     using UPwBaseElement<TDim,TNumNodes>::mConstitutiveLawVector;
     using UPwBaseElement<TDim,TNumNodes>::mStressVector;
     using UPwBaseElement<TDim,TNumNodes>::mStateVariablesFinalized;
@@ -82,8 +82,8 @@ public:
     using UPwSmallStrainFICElement<TDim,TNumNodes>::CalculateShearModulus;
     using UPwSmallStrainElement<TDim,TNumNodes>::CalculateBulkModulus;
 
-    typedef typename UPwSmallStrainElement<TDim,TNumNodes>::ElementVariables ElementVariables;
-    typedef typename UPwSmallStrainFICElement<TDim,TNumNodes>::FICElementVariables FICElementVariables;
+    using ElementVariables = typename UPwSmallStrainElement<TDim, TNumNodes>::ElementVariables;
+    using FICElementVariables = typename UPwSmallStrainFICElement<TDim, TNumNodes>::FICElementVariables;
 
     /// Counted pointer of UPwUpdatedLagrangianFICElement
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(UPwUpdatedLagrangianFICElement);

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_updated_lagrangian_element.hpp
@@ -61,19 +61,19 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) UPwUpdatedLagrangianElement
 public:
     ///@name Type Definitions
     ///@{
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
 
     /// Type definition for integration methods
-    typedef GeometryData::IntegrationMethod IntegrationMethod;
+    using IntegrationMethod = GeometryData::IntegrationMethod;
 
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
     using UPwBaseElement<TDim,TNumNodes>::mConstitutiveLawVector;
     using UPwBaseElement<TDim,TNumNodes>::mRetentionLawVector;
     using UPwBaseElement<TDim,TNumNodes>::mStressVector;
@@ -81,7 +81,7 @@ public:
     using UPwBaseElement<TDim,TNumNodes>::CalculateDerivativesOnInitialConfiguration;
     using UPwBaseElement<TDim,TNumNodes>::mThisIntegrationMethod;
 
-    typedef typename UPwSmallStrainElement<TDim,TNumNodes>::ElementVariables ElementVariables;
+    using ElementVariables = typename UPwSmallStrainElement<TDim, TNumNodes>::ElementVariables;
     using UPwSmallStrainElement<TDim,TNumNodes>::CalculateBulkModulus;
 
     /// Counted pointer of UPwUpdatedLagrangianElement

--- a/applications/GeoMechanicsApplication/custom_elements/drained_U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/drained_U_Pw_small_strain_element.hpp
@@ -34,21 +34,21 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( DrainedUPwSmallStrainElement );
 
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
     using UPwSmallStrainElement<TDim,TNumNodes>::mConstitutiveLawVector;
     using UPwSmallStrainElement<TDim,TNumNodes>::mStressVector;
     using UPwSmallStrainElement<TDim,TNumNodes>::mStateVariablesFinalized;
-    typedef typename UPwSmallStrainElement<TDim,TNumNodes>::ElementVariables ElementVariables;
-    typedef Element::EquationIdVectorType EquationIdVectorType;
-    typedef Element::DofsVectorType DofsVectorType;
+    using ElementVariables = typename UPwSmallStrainElement<TDim, TNumNodes>::ElementVariables;
+    using EquationIdVectorType = Element::EquationIdVectorType;
+    using DofsVectorType = Element::DofsVectorType;
 
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/geo_cable_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_cable_element.hpp
@@ -40,18 +40,18 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) GeoCableElement
 public:
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(GeoCableElement);
 
-    typedef GeoTrussElement<TDim,TNumNodes> BaseType;
+    using BaseType = GeoTrussElement<TDim, TNumNodes>;
 
-    typedef Element::GeometryType GeometryType;
-    typedef Element::NodesArrayType NodesArrayType;
-    typedef Element::PropertiesType PropertiesType;
-    typedef Element::IndexType IndexType;
-    typedef Element::SizeType SizeType;
-    typedef Element::MatrixType MatrixType;
-    typedef Element::VectorType VectorType;
+    using GeometryType = Element::GeometryType;
+    using NodesArrayType = Element::NodesArrayType;
+    using PropertiesType = Element::PropertiesType;
+    using IndexType = Element::IndexType;
+    using SizeType = Element::SizeType;
+    using MatrixType = Element::MatrixType;
+    using VectorType = Element::VectorType;
 
-    typedef typename GeoTrussElementBase<TDim,TNumNodes>::FullDofMatrixType FullDofMatrixType;
-    typedef typename GeoTrussElementBase<TDim,TNumNodes>::FullDofVectorType FullDofVectorType;
+    using FullDofMatrixType  = typename GeoTrussElementBase<TDim,TNumNodes>::FullDofMatrixType ;
+    using FullDofVectorType  = typename GeoTrussElementBase<TDim,TNumNodes>::FullDofVectorType ;
 
     using GeoTrussElementBase<TDim,TNumNodes>::mpConstitutiveLaw;
     using GeoTrussElement<TDim,TNumNodes>::mInternalStressesFinalizedPrevious;

--- a/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_2D2N.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_2D2N.hpp
@@ -41,17 +41,16 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) GeoCrBeamElement2D2N : public CrBeam
 public:
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(GeoCrBeamElement2D2N);
 
-
-    typedef CrBeamElement2D2N BaseType;
-    typedef BaseType::GeometryType GeometryType;
-    typedef BaseType::NodesArrayType NodesArrayType;
-    typedef BaseType::PropertiesType PropertiesType;
-    typedef BaseType::IndexType IndexType;
-    typedef BaseType::SizeType SizeType;
-    typedef BaseType::MatrixType MatrixType;
-    typedef BaseType::VectorType VectorType;
-    typedef BaseType::EquationIdVectorType EquationIdVectorType;
-    typedef BaseType::DofsVectorType DofsVectorType;
+    using BaseType = CrBeamElement2D2N;
+    using GeometryType = BaseType::GeometryType;
+    using NodesArrayType = BaseType::NodesArrayType;
+    using PropertiesType = BaseType::PropertiesType;
+    using IndexType = BaseType::IndexType;
+    using SizeType = BaseType::SizeType;
+    using MatrixType = BaseType::MatrixType;
+    using VectorType = BaseType::VectorType;
+    using EquationIdVectorType = BaseType::EquationIdVectorType;
+    using DofsVectorType = BaseType::DofsVectorType;
 
     GeoCrBeamElement2D2N() {};
     GeoCrBeamElement2D2N(IndexType NewId, GeometryType::Pointer pGeometry);

--- a/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_3D2N.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_3D2N.hpp
@@ -41,16 +41,16 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) GeoCrBeamElement3D2N : public CrBeam
 public:
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(GeoCrBeamElement3D2N);
 
-    typedef CrBeamElement3D2N BaseType;
-    typedef BaseType::GeometryType GeometryType;
-    typedef BaseType::NodesArrayType NodesArrayType;
-    typedef BaseType::PropertiesType PropertiesType;
-    typedef BaseType::IndexType IndexType;
-    typedef BaseType::SizeType SizeType;
-    typedef BaseType::MatrixType MatrixType;
-    typedef BaseType::VectorType VectorType;
-    typedef BaseType::EquationIdVectorType EquationIdVectorType;
-    typedef BaseType::DofsVectorType DofsVectorType;
+    using BaseType = CrBeamElement3D2N;
+    using GeometryType = BaseType::GeometryType;
+    using NodesArrayType = BaseType::NodesArrayType;
+    using PropertiesType = BaseType::PropertiesType;
+    using IndexType = BaseType::IndexType;
+    using SizeType = BaseType::SizeType;
+    using MatrixType = BaseType::MatrixType;
+    using VectorType = BaseType::VectorType;
+    using EquationIdVectorType = BaseType::EquationIdVectorType;
+    using DofsVectorType = BaseType::DofsVectorType;
 
     GeoCrBeamElement3D2N() {};
     GeoCrBeamElement3D2N(IndexType NewId, GeometryType::Pointer pGeometry);

--- a/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_linear_2D2N.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_linear_2D2N.hpp
@@ -39,16 +39,16 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) GeoCrBeamElementLinear2D2N : public 
 public:
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(GeoCrBeamElementLinear2D2N);
 
-    typedef CrBeamElementLinear2D2N BaseType;
-    typedef BaseType::GeometryType GeometryType;
-    typedef BaseType::NodesArrayType NodesArrayType;
-    typedef BaseType::PropertiesType PropertiesType;
-    typedef BaseType::IndexType IndexType;
-    typedef BaseType::SizeType SizeType;
-    typedef BaseType::MatrixType MatrixType;
-    typedef BaseType::VectorType VectorType;
-    typedef BaseType::EquationIdVectorType EquationIdVectorType;
-    typedef BaseType::DofsVectorType DofsVectorType;
+    using BaseType = CrBeamElementLinear2D2N;
+    using GeometryType = BaseType::GeometryType;
+    using NodesArrayType = BaseType::NodesArrayType;
+    using PropertiesType = BaseType::PropertiesType;
+    using IndexType = BaseType::IndexType;
+    using SizeType = BaseType::SizeType;
+    using MatrixType = BaseType::MatrixType;
+    using VectorType = BaseType::VectorType;
+    using EquationIdVectorType = BaseType::EquationIdVectorType;
+    using DofsVectorType = BaseType::DofsVectorType;
 
 
     GeoCrBeamElementLinear2D2N(IndexType NewId, GeometryType::Pointer pGeometry);

--- a/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_linear_3D2N.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_cr_beam_element_linear_3D2N.hpp
@@ -39,16 +39,16 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) GeoCrBeamElementLinear3D2N : public 
 public:
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(GeoCrBeamElementLinear3D2N);
 
-    typedef CrBeamElement3D2N BaseType;
-    typedef BaseType::GeometryType GeometryType;
-    typedef BaseType::NodesArrayType NodesArrayType;
-    typedef BaseType::PropertiesType PropertiesType;
-    typedef BaseType::IndexType IndexType;
-    typedef BaseType::SizeType SizeType;
-    typedef BaseType::MatrixType MatrixType;
-    typedef BaseType::VectorType VectorType;
-    typedef BaseType::EquationIdVectorType EquationIdVectorType;
-    typedef BaseType::DofsVectorType DofsVectorType;
+    using BaseType = CrBeamElement3D2N;
+    using GeometryType = BaseType::GeometryType;
+    using NodesArrayType = BaseType::NodesArrayType;
+    using PropertiesType = BaseType::PropertiesType;
+    using IndexType = BaseType::IndexType;
+    using SizeType = BaseType::SizeType;
+    using MatrixType = BaseType::MatrixType;
+    using VectorType = BaseType::VectorType;
+    using EquationIdVectorType = BaseType::EquationIdVectorType;
+    using DofsVectorType = BaseType::DofsVectorType;
 
     GeoCrBeamElementLinear3D2N() {};
     GeoCrBeamElementLinear3D2N(IndexType NewId, GeometryType::Pointer pGeometry);

--- a/applications/GeoMechanicsApplication/custom_elements/geo_curved_beam_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_curved_beam_element.hpp
@@ -41,17 +41,17 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) GeoCurvedBeamElement :
 
 public:
 
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
-    typedef GeometryData::ShapeFunctionsGradientsType ShapeFunctionsGradientsType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
+    using ShapeFunctionsGradientsType = GeometryData::ShapeFunctionsGradientsType;
 
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
 
     using GeoStructuralBaseElement<TDim,TNumNodes>::mThisIntegrationMethod;
     using GeoStructuralBaseElement<TDim,TNumNodes>::mConstitutiveLawVector;
@@ -59,7 +59,7 @@ public:
     using GeoStructuralBaseElement<TDim,TNumNodes>::N_DOF_ELEMENT;
     using GeoStructuralBaseElement<TDim,TNumNodes>::VoigtSize;
     using GeoStructuralBaseElement<TDim,TNumNodes>::GetNodalDofValuesVector;
-    typedef typename GeoStructuralBaseElement<TDim,TNumNodes>::ElementVariables ElementVariables;
+    using ElementVariables = typename GeoStructuralBaseElement<TDim, TNumNodes>::ElementVariables;
 
     KRATOS_CLASS_POINTER_DEFINITION( GeoCurvedBeamElement );
 

--- a/applications/GeoMechanicsApplication/custom_elements/geo_linear_truss_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_linear_truss_element.hpp
@@ -44,16 +44,16 @@ protected:
 public:
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(GeoLinearTrussElement);
 
-    typedef GeoTrussElementLinearBase<TDim,TNumNodes> BaseType;
-    typedef Element::GeometryType GeometryType;
-    typedef Element::NodesArrayType NodesArrayType;
-    typedef Element::PropertiesType PropertiesType;
-    typedef Element::IndexType IndexType;
-    typedef Element::SizeType SizeType;
-    typedef Element::MatrixType MatrixType;
-    typedef Element::VectorType VectorType;
-    typedef typename GeoTrussElementBase<TDim,TNumNodes>::FullDofMatrixType FullDofMatrixType;
-    typedef typename GeoTrussElementBase<TDim,TNumNodes>::FullDofVectorType FullDofVectorType;
+    using BaseType = GeoTrussElementLinearBase<TDim, TNumNodes>;
+    using GeometryType = Element::GeometryType;
+    using NodesArrayType = Element::NodesArrayType;
+    using PropertiesType = Element::PropertiesType;
+    using IndexType = Element::IndexType;
+    using SizeType = Element::SizeType;
+    using MatrixType = Element::MatrixType;
+    using VectorType = Element::VectorType;
+    using FullDofMatrixType = typename GeoTrussElementBase<TDim, TNumNodes>::FullDofMatrixType;
+    using FullDofVectorType = typename GeoTrussElementBase<TDim, TNumNodes>::FullDofVectorType;
 
     using GeoTrussElementBase<TDim,TNumNodes>::mpConstitutiveLaw;
 

--- a/applications/GeoMechanicsApplication/custom_elements/geo_linear_truss_element_base.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_linear_truss_element_base.hpp
@@ -40,16 +40,16 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) GeoTrussElementLinearBase
 public:
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(GeoTrussElementLinearBase);
 
-    typedef GeoTrussElementBase<TDim,TNumNodes> BaseType;
-    typedef Element::GeometryType GeometryType;
-    typedef Element::NodesArrayType NodesArrayType;
-    typedef Element::PropertiesType PropertiesType;
-    typedef Element::IndexType IndexType;
-    typedef Element::SizeType SizeType;
-    typedef Element::MatrixType MatrixType;
-    typedef Element::VectorType VectorType;
-    typedef typename GeoTrussElementBase<TDim,TNumNodes>::FullDofMatrixType FullDofMatrixType;
-    typedef typename GeoTrussElementBase<TDim,TNumNodes>::FullDofVectorType FullDofVectorType;
+    using BaseType = GeoTrussElementBase<TDim, TNumNodes>;
+    using GeometryType = Element::GeometryType;
+    using NodesArrayType = Element::NodesArrayType;
+    using PropertiesType = Element::PropertiesType;
+    using IndexType = Element::IndexType;
+    using SizeType = Element::SizeType;
+    using MatrixType = Element::MatrixType;
+    using VectorType = Element::VectorType;
+    using FullDofMatrixType = typename GeoTrussElementBase<TDim, TNumNodes>::FullDofMatrixType;
+    using FullDofVectorType = typename GeoTrussElementBase<TDim, TNumNodes>::FullDofVectorType;
 
     using GeoTrussElementBase<TDim,TNumNodes>::mpConstitutiveLaw;
 

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element_base.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element_base.cpp
@@ -741,7 +741,7 @@ void GeoTrussElementBase<3,2>::
     KRATOS_TRY
 
     // 1st calculate transformation matrix
-    typedef BoundedVector<double, DIM> arraydim;
+    using arraydim = BoundedVector<double, DIM>;
     arraydim direction_vector_x = ZeroVector(DIM);
     arraydim direction_vector_y = ZeroVector(DIM);
     arraydim direction_vector_z = ZeroVector(DIM);

--- a/applications/GeoMechanicsApplication/custom_elements/geo_truss_element_base.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_truss_element_base.hpp
@@ -47,18 +47,18 @@ protected:
 public:
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(GeoTrussElementBase);
 
-    typedef Element BaseType;
-    typedef BaseType::GeometryType GeometryType;
-    typedef BaseType::NodesArrayType NodesArrayType;
-    typedef BaseType::PropertiesType PropertiesType;
-    typedef BaseType::IndexType IndexType;
-    typedef BaseType::SizeType SizeType;
-    typedef BaseType::MatrixType MatrixType;
-    typedef BaseType::VectorType VectorType;
-    typedef BaseType::EquationIdVectorType EquationIdVectorType;
-    typedef BaseType::DofsVectorType DofsVectorType;
-    typedef BoundedMatrix<double, TDim*TNumNodes, TDim*TNumNodes> FullDofMatrixType;
-    typedef BoundedVector<double, TDim*TNumNodes> FullDofVectorType;
+    using BaseType = Element;
+    using GeometryType = BaseType::GeometryType;
+    using NodesArrayType = BaseType::NodesArrayType;
+    using PropertiesType = BaseType::PropertiesType;
+    using IndexType = BaseType::IndexType;
+    using SizeType = BaseType::SizeType;
+    using MatrixType = BaseType::MatrixType;
+    using VectorType = BaseType::VectorType;
+    using EquationIdVectorType = BaseType::EquationIdVectorType;
+    using DofsVectorType = BaseType::DofsVectorType;
+    using FullDofMatrixType = BoundedMatrix<double, TDim*TNumNodes, TDim*TNumNodes>;
+    using FullDofVectorType = BoundedVector<double, TDim*TNumNodes>;
 
 
     GeoTrussElementBase() {};

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_element.hpp
@@ -34,26 +34,26 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( SteadyStatePwElement );
 
-    typedef TransientPwElement<TDim, TNumNodes> BaseType;
+    using BaseType = TransientPwElement<TDim, TNumNodes>;
 
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
-    typedef Element::DofsVectorType DofsVectorType;
-    typedef Element::EquationIdVectorType EquationIdVectorType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
+    using DofsVectorType = Element::DofsVectorType;
+    using EquationIdVectorType = Element::EquationIdVectorType;
 
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
     using BaseType::mRetentionLawVector;
     using BaseType::mConstitutiveLawVector;
     using BaseType::mIsInitialised;
     using BaseType::CalculateRetentionResponse;
 
-    typedef typename BaseType::ElementVariables ElementVariables;
+    using ElementVariables = typename BaseType::ElementVariables;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_interface_element.hpp
@@ -33,28 +33,28 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( SteadyStatePwInterfaceElement );
 
-    typedef TransientPwInterfaceElement<TDim, TNumNodes> BaseType;
+    using BaseType = TransientPwInterfaceElement<TDim, TNumNodes>;
 
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
 
-    typedef Element::DofsVectorType DofsVectorType;
-    typedef Element::EquationIdVectorType EquationIdVectorType;
+    using DofsVectorType = Element::DofsVectorType;
+    using EquationIdVectorType = Element::EquationIdVectorType;
 
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
 
     using BaseType::mRetentionLawVector;
     using BaseType::mThisIntegrationMethod;
     using BaseType::CalculateRetentionResponse;
 
-    typedef typename BaseType::InterfaceElementVariables InterfaceElementVariables;
-    typedef typename BaseType::SFGradAuxVariables SFGradAuxVariables;
+    using InterfaceElementVariables = typename BaseType::InterfaceElementVariables;
+    using SFGradAuxVariables = typename BaseType::SFGradAuxVariables;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.hpp
@@ -33,28 +33,28 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( SteadyStatePwPipingElement );
 
-    typedef SteadyStatePwInterfaceElement<TDim, TNumNodes> BaseType;
+    using BaseType = SteadyStatePwInterfaceElement<TDim, TNumNodes>;
 
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
 
-    typedef Element::DofsVectorType DofsVectorType;
-    typedef Element::EquationIdVectorType EquationIdVectorType;
+    using DofsVectorType = Element::DofsVectorType;
+    using EquationIdVectorType = Element::EquationIdVectorType;
 
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
 
     using BaseType::mRetentionLawVector;
     using BaseType::mThisIntegrationMethod;
     using BaseType::CalculateRetentionResponse;
 
-    typedef typename BaseType::InterfaceElementVariables InterfaceElementVariables;
-    typedef typename BaseType::SFGradAuxVariables SFGradAuxVariables;
+    using InterfaceElementVariables = typename BaseType::InterfaceElementVariables;
+    using SFGradAuxVariables = typename BaseType::SFGradAuxVariables;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_element.hpp
@@ -34,26 +34,26 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( TransientPwElement );
 
-    typedef UPwSmallStrainElement<TDim, TNumNodes> BaseType;
+    using BaseType = UPwSmallStrainElement<TDim, TNumNodes>;
 
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
-    typedef Element::DofsVectorType DofsVectorType;
-    typedef Element::EquationIdVectorType EquationIdVectorType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
+    using DofsVectorType = Element::DofsVectorType;
+    using EquationIdVectorType = Element::EquationIdVectorType;
 
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
     using BaseType::mRetentionLawVector;
     using BaseType::mConstitutiveLawVector;
     using BaseType::mIsInitialised;
     using BaseType::CalculateRetentionResponse;
 
-    typedef typename BaseType::ElementVariables ElementVariables;
+    using ElementVariables = typename BaseType::ElementVariables;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/transient_Pw_interface_element.hpp
@@ -31,28 +31,28 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( TransientPwInterfaceElement );
 
-    typedef UPwSmallStrainInterfaceElement<TDim, TNumNodes> BaseType;
+    using BaseType = UPwSmallStrainInterfaceElement<TDim, TNumNodes>;
 
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
 
-    typedef Element::DofsVectorType DofsVectorType;
-    typedef Element::EquationIdVectorType EquationIdVectorType;
+    using DofsVectorType = Element::DofsVectorType;
+    using EquationIdVectorType = Element::EquationIdVectorType;
 
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
 
     using BaseType::mRetentionLawVector;
     using BaseType::mThisIntegrationMethod;
     using BaseType::CalculateRetentionResponse;
 
-    typedef typename BaseType::InterfaceElementVariables InterfaceElementVariables;
-    typedef typename BaseType::SFGradAuxVariables SFGradAuxVariables;
+    using InterfaceElementVariables = typename BaseType::InterfaceElementVariables;
+    using SFGradAuxVariables = typename BaseType::SFGradAuxVariables;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_elements/undrained_U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/undrained_U_Pw_small_strain_element.hpp
@@ -34,22 +34,22 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UndrainedUPwSmallStrainElement );
 
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
     using UPwSmallStrainElement<TDim,TNumNodes>::mConstitutiveLawVector;
     using UPwSmallStrainElement<TDim,TNumNodes>::mRetentionLawVector;
     using UPwSmallStrainElement<TDim,TNumNodes>::mStressVector;
     using UPwSmallStrainElement<TDim,TNumNodes>::mStateVariablesFinalized;
-    typedef typename UPwSmallStrainElement<TDim,TNumNodes>::ElementVariables ElementVariables;
-    typedef Element::EquationIdVectorType EquationIdVectorType;
-    typedef Element::DofsVectorType DofsVectorType;
+    using ElementVariables = typename UPwSmallStrainElement<TDim, TNumNodes>::ElementVariables;
+    using EquationIdVectorType = Element::EquationIdVectorType;
+    using DofsVectorType = Element::DofsVectorType;
 
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_axisymmetric_FIC_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_axisymmetric_FIC_element.hpp
@@ -34,15 +34,15 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwUpdatedLagrangianAxisymmetricFICElement );
 
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node<3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
     using UPwBaseElement<TDim,TNumNodes>::mConstitutiveLawVector;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_axisymmetric_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_axisymmetric_element.hpp
@@ -34,15 +34,15 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwUpdatedLagrangianAxisymmetricElement );
 
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
     using UPwBaseElement<TDim,TNumNodes>::mConstitutiveLawVector;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_axisymmetric_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_axisymmetric_element.hpp
@@ -33,15 +33,15 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UpdatedLagrangianUPwDiffOrderAxisymmetricElement );
 
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
     using UpdatedLagrangianUPwDiffOrderElement::mConstitutiveLawVector;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/updated_lagrangian_U_Pw_diff_order_element.hpp
@@ -58,19 +58,19 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) UpdatedLagrangianUPwDiffOrderElement
 public:
     ///@name Type Definitions
     ///@{
-    typedef std::size_t IndexType;
-    typedef Properties PropertiesType;
-    typedef Node <3> NodeType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
-    typedef Vector VectorType;
-    typedef Matrix MatrixType;
+    using IndexType = std::size_t;
+    using PropertiesType = Properties;
+    using NodeType = Node<3>;
+    using GeometryType = Geometry<NodeType>;
+    using NodesArrayType = GeometryType::PointsArrayType;
+    using VectorType = Vector;
+    using MatrixType = Matrix;
 
     /// Type definition for integration methods
-    typedef GeometryData::IntegrationMethod IntegrationMethod;
+    using IntegrationMethod = GeometryData::IntegrationMethod;
 
     /// The definition of the sizetype
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
     using SmallStrainUPwDiffOrderElement::mConstitutiveLawVector;
     using SmallStrainUPwDiffOrderElement::mStressVector;
     using SmallStrainUPwDiffOrderElement::mStateVariablesFinalized;
@@ -80,7 +80,7 @@ public:
     using SmallStrainUPwDiffOrderElement::CalculateCauchyStrain;
     using SmallStrainUPwDiffOrderElement::CalculateDerivativesOnInitialConfiguration;
 
-    typedef typename SmallStrainUPwDiffOrderElement::ElementVariables ElementVariables;
+    using ElementVariables = typename SmallStrainUPwDiffOrderElement::ElementVariables;
 
     /// Counted pointer of UpdatedLagrangianUPwDiffOrderElement
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(UpdatedLagrangianUPwDiffOrderElement);

--- a/applications/GeoMechanicsApplication/custom_processes/find_neighbour_elements_of_conditions_process.hpp
+++ b/applications/GeoMechanicsApplication/custom_processes/find_neighbour_elements_of_conditions_process.hpp
@@ -28,7 +28,7 @@ namespace Kratos
 {
 ///@name Type Definitions
 ///@{
-    typedef std::unordered_multimap<DenseVector<int>, std::vector<Condition::Pointer>, KeyHasherRange<DenseVector<int>>, KeyComparorRange<DenseVector<int>> > hashmap;
+    using hashmap = std::unordered_multimap<DenseVector<int>, std::vector<Condition::Pointer>, KeyHasherRange<DenseVector<int>>, KeyComparorRange<DenseVector<int>>>;
 
 ///@}
 ///@name Kratos Classes

--- a/applications/GeoMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/GeoMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -44,26 +44,25 @@ void AddCustomStrategiesToPython(pybind11::module& m)
 {
     namespace py = pybind11;
 
-    typedef UblasSpace<double, CompressedMatrix, Vector> SparseSpaceType;
-    typedef UblasSpace<double, Matrix, Vector>           LocalSpaceType;
+    using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;
+    using LocalSpaceType = UblasSpace<double, Matrix, Vector>;
 
-    typedef LinearSolver<SparseSpaceType, LocalSpaceType >                        LinearSolverType;
-    typedef ImplicitSolvingStrategy< SparseSpaceType, LocalSpaceType, LinearSolverType >  BaseSolvingStrategyType;
-    typedef Scheme< SparseSpaceType, LocalSpaceType >                             BaseSchemeType;
-    typedef BuilderAndSolver< SparseSpaceType, LocalSpaceType, LinearSolverType > BuilderAndSolverType;
-    typedef ConvergenceCriteria< SparseSpaceType, LocalSpaceType >                ConvergenceCriteriaType;
+    using LinearSolverType = LinearSolver<SparseSpaceType, LocalSpaceType >;
+    using BaseSolvingStrategyType = ImplicitSolvingStrategy< SparseSpaceType, LocalSpaceType, LinearSolverType >;
+    using BaseSchemeType = Scheme< SparseSpaceType, LocalSpaceType >;
+    using BuilderAndSolverType = BuilderAndSolver< SparseSpaceType, LocalSpaceType, LinearSolverType >;
+    using ConvergenceCriteriaType = ConvergenceCriteria< SparseSpaceType, LocalSpaceType >;
 
-    typedef NewmarkQuasistaticUPwScheme< SparseSpaceType, LocalSpaceType >        NewmarkQuasistaticUPwSchemeType;
-    typedef NewmarkQuasistaticDampedUPwScheme< SparseSpaceType, LocalSpaceType >  NewmarkQuasistaticDampedUPwSchemeType;
-    typedef NewmarkDynamicUPwScheme< SparseSpaceType, LocalSpaceType >            NewmarkDynamicUPwSchemeType;
-    typedef NewmarkQuasistaticPwScheme< SparseSpaceType, LocalSpaceType >         NewmarkQuasistaticPwSchemeType;
-    typedef BackwardEulerQuasistaticUPwScheme< SparseSpaceType, LocalSpaceType >  BackwardEulerQuasistaticUPwSchemeType;
-    typedef BackwardEulerQuasistaticPwScheme< SparseSpaceType, LocalSpaceType >   BackwardEulerQuasistaticPwSchemeType;
-    
+    using NewmarkQuasistaticUPwSchemeType = NewmarkQuasistaticUPwScheme< SparseSpaceType, LocalSpaceType >;
+    using NewmarkQuasistaticDampedUPwSchemeType = NewmarkQuasistaticDampedUPwScheme< SparseSpaceType, LocalSpaceType >;
+    using NewmarkDynamicUPwSchemeType = NewmarkDynamicUPwScheme< SparseSpaceType, LocalSpaceType >;
+    using NewmarkQuasistaticPwSchemeType = NewmarkQuasistaticPwScheme< SparseSpaceType, LocalSpaceType >;
+    using BackwardEulerQuasistaticUPwSchemeType = BackwardEulerQuasistaticUPwScheme< SparseSpaceType, LocalSpaceType >;
+    using BackwardEulerQuasistaticPwSchemeType = BackwardEulerQuasistaticPwScheme< SparseSpaceType, LocalSpaceType >;
 
-    typedef GeoMechanicsNewtonRaphsonStrategy< SparseSpaceType, LocalSpaceType, LinearSolverType > GeoMechanicsNewtonRaphsonStrategyType;
-    typedef GeoMechanicsRammArcLengthStrategy< SparseSpaceType, LocalSpaceType, LinearSolverType > GeoMechanicsRammArcLengthStrategyType;
-    typedef GeoMechanicsNewtonRaphsonErosionProcessStrategy< SparseSpaceType, LocalSpaceType, LinearSolverType > GeoMechanicsNewtonRaphsonErosionProcessStrategyType;
+    using GeoMechanicsNewtonRaphsonStrategyType = GeoMechanicsNewtonRaphsonStrategy< SparseSpaceType, LocalSpaceType, LinearSolverType >;
+    using GeoMechanicsRammArcLengthStrategyType = GeoMechanicsRammArcLengthStrategy< SparseSpaceType, LocalSpaceType, LinearSolverType >;
+    using GeoMechanicsNewtonRaphsonErosionProcessStrategyType = GeoMechanicsNewtonRaphsonErosionProcessStrategy< SparseSpaceType, LocalSpaceType, LinearSolverType >;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/GeoMechanicsApplication/custom_retention/retention_law.h
+++ b/applications/GeoMechanicsApplication/custom_retention/retention_law.h
@@ -36,9 +36,9 @@ public:
      * Type definitions
      * NOTE: geometries are assumed to be of type Node<3> for all problems
      */
-    typedef ProcessInfo ProcessInfoType;
-    typedef std::size_t SizeType;
-    typedef Geometry<Node<3>> GeometryType;
+    using ProcessInfoType = ProcessInfo;
+    using SizeType = std::size_t;
+    using GeometryType = Geometry<Node<3>>;
 
     /**
      * Counted pointer of RetentionLaw

--- a/applications/GeoMechanicsApplication/custom_retention/saturated_below_phreatic_level_law.h
+++ b/applications/GeoMechanicsApplication/custom_retention/saturated_below_phreatic_level_law.h
@@ -40,12 +40,12 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) SaturatedBelowPhreaticLevelLaw
 {
 public:
     /// The base class RetentionLaw type definition
-    typedef RetentionLaw         BaseType;
+    using BaseType = RetentionLaw;
 
-    typedef Geometry<Node<3>> GeometryType;
+    using GeometryType = Geometry<Node<3>>;
 
     /// The size type definition
-    typedef std::size_t             SizeType;
+    using SizeType = std::size_t;
 
     /// Counted pointer of SaturatedBelowPhreaticLevelLaw
     KRATOS_CLASS_POINTER_DEFINITION( SaturatedBelowPhreaticLevelLaw );

--- a/applications/GeoMechanicsApplication/custom_retention/saturated_law.h
+++ b/applications/GeoMechanicsApplication/custom_retention/saturated_law.h
@@ -41,12 +41,12 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) SaturatedLaw
 public:
 
     /// The base class RetentionLaw type definition
-    typedef RetentionLaw         BaseType;
+    using BaseType = RetentionLaw;
 
-    typedef Geometry<Node<3>> GeometryType;
+    using GeometryType = Geometry<Node<3>>;
 
     /// The size type definition
-    typedef std::size_t             SizeType;
+    using SizeType = std::size_t;
 
     /// Counted pointer of SaturatedLaw
     KRATOS_CLASS_POINTER_DEFINITION( SaturatedLaw );

--- a/applications/GeoMechanicsApplication/custom_retention/van_genuchten_law.h
+++ b/applications/GeoMechanicsApplication/custom_retention/van_genuchten_law.h
@@ -40,12 +40,12 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) VanGenuchtenLaw
 {
 public:
     /// The base class RetentionLaw type definition
-    typedef RetentionLaw         BaseType;
+    using BaseType = RetentionLaw;
 
-    typedef Geometry<Node<3>> GeometryType;
+    using GeometryType = Geometry<Node<3>>;
 
     /// The size type definition
-    typedef std::size_t             SizeType;
+    using SizeType = std::size_t;
 
     /// Counted pointer of VanGenuchtenLaw
     KRATOS_CLASS_POINTER_DEFINITION( VanGenuchtenLaw );

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
@@ -24,7 +24,7 @@
 
 namespace Kratos {
 // We define the node type
-typedef Node<3> NodeType;
+using NodeType = Node<3>;
 
 KratosGeoMechanicsApplication::KratosGeoMechanicsApplication() :
     KratosApplication("GeoMechanicsApplication") {}


### PR DESCRIPTION
**📝 Description**
"using" is preffered on "typedef" based on C++ guidelines.
SonarCloud also suggests replacing "typedef" by "using".

**🆕 Changelog**
Changed for Pw_normal_flux_condition.hpp
