### PR TITLE
[GeoMechanicsApplication] Fixed a slicing issue

### DIFF
--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_lysmer_absorbing_condition.cpp
@@ -639,7 +639,7 @@ void UPwLysmerAbsorbingCondition<3, 4>::CalculateRotationMatrix( BoundedMatrix<d
     //Quadrilateral_3d_4
     array_1d<double, 3> p_mid_0;
     array_1d<double, 3> p_mid_1;
-    const auto& r_p_2 = array_1d<double, 3>(rGeom.GetPoint(2));
+    const array_1d<double, 3>& r_p_2 = rGeom.GetPoint(2);
     noalias(p_mid_0) = 0.5 * (rGeom.GetPoint(0) + rGeom.GetPoint(3));
     noalias(p_mid_1) = 0.5 * (rGeom.GetPoint(1) + r_p_2);
 


### PR DESCRIPTION
**📝 Description**
Avoid constructing a (temporary) object, which slices off a part of the original object. Use a reference-to-const instead.

This fixes issue #10898.