### PR TITLE
[MappingApplication] Minor clean up headers

### DIFF
--- a/applications/MappingApplication/custom_mappers/barycentric_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/barycentric_mapper.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher (https://github.com/philbucher)
 //

--- a/applications/MappingApplication/custom_mappers/barycentric_mapper.h
+++ b/applications/MappingApplication/custom_mappers/barycentric_mapper.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher (https://github.com/philbucher)
 //

--- a/applications/MappingApplication/custom_mappers/coupling_geometry_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/coupling_geometry_mapper.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher
 //                   Tobias Teschemachen

--- a/applications/MappingApplication/custom_mappers/coupling_geometry_mapper.h
+++ b/applications/MappingApplication/custom_mappers/coupling_geometry_mapper.h
@@ -4,15 +4,14 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher
 //                   Tobias Teschemachen
 //
 
-#if !defined(KRATOS_COUPLING_GEOMETRY_MAPPER_H_INCLUDED)
-#define  KRATOS_COUPLING_GEOMETRY_MAPPER_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -382,5 +381,3 @@ private:
 
 ///@} addtogroup block
 }  // namespace Kratos.
-
-#endif // KRATOS_COUPLING_GEOMETRY_MAPPER_H_INCLUDED defined

--- a/applications/MappingApplication/custom_mappers/nearest_element_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/nearest_element_mapper.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //

--- a/applications/MappingApplication/custom_mappers/nearest_element_mapper.h
+++ b/applications/MappingApplication/custom_mappers/nearest_element_mapper.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //

--- a/applications/MappingApplication/custom_mappers/nearest_neighbor_mapper.h
+++ b/applications/MappingApplication/custom_mappers/nearest_neighbor_mapper.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //

--- a/applications/MappingApplication/custom_modelers/mapping_geometries_modeler.cpp
+++ b/applications/MappingApplication/custom_modelers/mapping_geometries_modeler.cpp
@@ -7,11 +7,11 @@
 //  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
-
+//  Main authors:    Philipp Bucher
+//
 
 // Project includes
 #include "mapping_geometries_modeler.h"
-
 
 namespace Kratos
 {

--- a/applications/MappingApplication/custom_modelers/mapping_geometries_modeler.h
+++ b/applications/MappingApplication/custom_modelers/mapping_geometries_modeler.h
@@ -7,12 +7,10 @@
 //  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
+//  Main authors:    Philipp Bucher
 //
 
-
-#if !defined(KRATOS_MAPPING_GEOMETRIES_MODELER_H_INCLUDED )
-#define  KRATOS_MAPPING_GEOMETRIES_MODELER_H_INCLUDED
-
+#pragma once
 
 // System includes
 
@@ -21,7 +19,6 @@
 // Project includes
 #include "modeler/modeler.h"
 #include "custom_utilities/mapping_intersection_utilities.h"
-
 
 namespace Kratos
 {
@@ -154,5 +151,3 @@ inline std::ostream& operator << (
 ///@}
 
 }  // namespace Kratos.
-
-#endif // KRATOS_MAPPING_GEOMETRIES_MODELER_H_INCLUDED  defined

--- a/applications/MappingApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/MappingApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -5,8 +5,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //

--- a/applications/MappingApplication/custom_python/add_custom_utilities_to_python.h
+++ b/applications/MappingApplication/custom_python/add_custom_utilities_to_python.h
@@ -5,17 +5,16 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
-//  Main authors:    Philipp Bucher, Jordi Cotela
+//  Main authorse:    Philipp Bucher, Jordi Cotela
 //
 // See Master-Thesis P.Bucher
 // "Development and Implementation of a Parallel
 //  Framework for Non-Matching Grid Mapping"
 
-#if !defined(KRATOS_MAPPING_ADD_UTILITIES_TO_PYTHON_H_INCLUDED )
-#define  KRATOS_MAPPING_ADD_UTILITIES_TO_PYTHON_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -24,13 +23,8 @@
 
 // Project includes
 
-
-namespace Kratos {
-namespace Python {
+namespace Kratos::Python {
 
 void AddCustomUtilitiesToPython(pybind11::module& m);
 
-}  // namespace Python.
-}  // namespace Kratos.
-
-#endif // KRATOS_MAPPING_ADD_UTILITIES_TO_PYTHON_H_INCLUDED  defined
+}  // namespace Kratos::Python.

--- a/applications/MappingApplication/custom_python/mapping_python_application.cpp
+++ b/applications/MappingApplication/custom_python/mapping_python_application.cpp
@@ -23,8 +23,7 @@
 #include "mapping_application.h"
 #include "custom_python/add_custom_utilities_to_python.h"
 
-namespace Kratos {
-namespace Python {
+namespace Kratos::Python {
 
 
 PYBIND11_MODULE(KratosMappingApplication, m)
@@ -40,7 +39,6 @@ PYBIND11_MODULE(KratosMappingApplication, m)
     AddCustomUtilitiesToPython(m);
 }
 
-}  // namespace Python.
-}  // namespace Kratos.
+}  // namespace Kratos::Python.
 
 #endif // KRATOS_PYTHON defined

--- a/applications/MappingApplication/custom_searching/custom_configures/interface_object_configure.h
+++ b/applications/MappingApplication/custom_searching/custom_configures/interface_object_configure.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //
@@ -13,8 +13,7 @@
 // "Development and Implementation of a Parallel
 //  Framework for Non-Matching Grid Mapping"
 
-#if !defined(KRATOS_INTERFACE_OBJECT_CONFIGURE_H_INCLUDED)
-#define  KRATOS_INTERFACE_OBJECT_CONFIGURE_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -335,4 +334,3 @@ inline std::ostream& operator << (std::ostream& rOStream, const InterfaceObjectC
 ///@}
 
 } // namespace Kratos.
-#endif /* KRATOS_INTERFACE_OBJECT_CONFIGURE_H_INCLUDED */

--- a/applications/MappingApplication/custom_searching/interface_communicator.cpp
+++ b/applications/MappingApplication/custom_searching/interface_communicator.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //

--- a/applications/MappingApplication/custom_searching/interface_communicator.h
+++ b/applications/MappingApplication/custom_searching/interface_communicator.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //
@@ -13,8 +13,7 @@
 // "Development and Implementation of a Parallel
 //  Framework for Non-Matching Grid Mapping"
 
-#if !defined(KRATOS_INTERFACE_COMMUNICATOR_H_INCLUDED )
-#define  KRATOS_INTERFACE_COMMUNICATOR_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -181,5 +180,3 @@ private:
 ///@} addtogroup block
 
 }  // namespace Kratos.
-
-#endif // KRATOS_INTERFACE_COMMUNICATOR_H_INCLUDED  defined

--- a/applications/MappingApplication/custom_searching/interface_object.h
+++ b/applications/MappingApplication/custom_searching/interface_object.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //
@@ -13,21 +13,16 @@
 // "Development and Implementation of a Parallel
 //  Framework for Non-Matching Grid Mapping"
 
-#if !defined(KRATOS_INTERFACE_SEARCH_OBJECT_INCLUDED_H_INCLUDED )
-#define  KRATOS_INTERFACE_SEARCH_OBJECT_INCLUDED_H_INCLUDED
-
+#pragma once
 
 // System includes
 
-
 // External includes
-
 
 // Project includes
 #include "includes/define.h"
 #include "includes/node.h"
 #include "geometries/geometry.h"
-
 
 namespace Kratos
 {
@@ -225,7 +220,5 @@ private:
 };
 
 }  // namespace Kratos.
-
-#endif // KRATOS_INTERFACE_SEARCH_OBJECT_INCLUDED_H_INCLUDED  defined
 
 

--- a/applications/MappingApplication/custom_utilities/closest_points.cpp
+++ b/applications/MappingApplication/custom_utilities/closest_points.cpp
@@ -6,8 +6,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher (https://github.com/philbucher)
 //

--- a/applications/MappingApplication/custom_utilities/closest_points.h
+++ b/applications/MappingApplication/custom_utilities/closest_points.h
@@ -5,14 +5,13 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher (https://github.com/philbucher)
 //
 
-#if !defined(KRATOS_CLOSEST_POINTS_H_INCLUDED )
-#define  KRATOS_CLOSEST_POINTS_H_INCLUDED
+#pragma once
 
 // System includes
 #include <set>
@@ -25,7 +24,6 @@
 #include "includes/indexed_object.h"
 #include "includes/serializer.h"
 #include "geometries/point.h"
-
 
 namespace Kratos
 {
@@ -125,5 +123,3 @@ private:
 
 ///@} addtogroup block
 }  // namespace Kratos.
-
-#endif // KRATOS_CLOSEST_POINTS_H_INCLUDED  defined

--- a/applications/MappingApplication/custom_utilities/interface_vector_container.cpp
+++ b/applications/MappingApplication/custom_utilities/interface_vector_container.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //

--- a/applications/MappingApplication/custom_utilities/interface_vector_container.h
+++ b/applications/MappingApplication/custom_utilities/interface_vector_container.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //
@@ -13,20 +13,16 @@
 // "Development and Implementation of a Parallel
 //  Framework for Non-Matching Grid Mapping"
 
-#if !defined(KRATOS_INTERFACE_VECTOR_CONTAINER_H_INCLUDED )
-#define  KRATOS_INTERFACE_VECTOR_CONTAINER_H_INCLUDED
+#pragma once
 
 // System includes
 
-
 // External includes
-
 
 // Project includes
 #include "includes/define.h"
 #include "includes/model_part.h"
 #include "mapper_utilities.h"
-
 
 namespace Kratos
 {
@@ -126,5 +122,3 @@ private:
 ///@} addtogroup block
 
 }  // namespace Kratos.
-
-#endif // KRATOS_INTERFACE_VECTOR_CONTAINER_H_INCLUDED  defined

--- a/applications/MappingApplication/custom_utilities/mapper_backend.h
+++ b/applications/MappingApplication/custom_utilities/mapper_backend.h
@@ -10,8 +10,7 @@
 //  Main authors:    Philipp Bucher (https://github.com/philbucher)
 //
 
-#if !defined(KRATOS_MAPPER_BACKEND_H_INCLUDED)
-#define KRATOS_MAPPER_BACKEND_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -33,5 +32,3 @@ struct MapperBackend
 };
 
 }  // namespace Kratos.
-
-#endif // KRATOS_MAPPER_BACKEND_H_INCLUDED defined

--- a/applications/MappingApplication/custom_utilities/mapper_interface_info.h
+++ b/applications/MappingApplication/custom_utilities/mapper_interface_info.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //
@@ -13,8 +13,7 @@
 // "Development and Implementation of a Parallel
 //  Framework for Non-Matching Grid Mapping"
 
-#if !defined(KRATOS_MAPPER_INTERFACE_INFO_H_INCLUDED)
-#define  KRATOS_MAPPER_INTERFACE_INFO_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -23,7 +22,6 @@
 // Project includes
 #include "includes/define.h"
 #include "custom_searching/interface_object.h"
-
 
 namespace Kratos
 {
@@ -250,5 +248,3 @@ private:
 ///@} addtogroup block
 
 }  // namespace Kratos.
-
-#endif // KRATOS_MAPPER_INTERFACE_INFO_H_INCLUDED  defined

--- a/applications/MappingApplication/custom_utilities/mapper_local_system.h
+++ b/applications/MappingApplication/custom_utilities/mapper_local_system.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //
@@ -13,8 +13,7 @@
 // "Development and Implementation of a Parallel
 //  Framework for Non-Matching Grid Mapping"
 
-#if !defined(KRATOS_MAPPER_LOCAL_SYSTEM_H_INCLUDED )
-#define  KRATOS_MAPPER_LOCAL_SYSTEM_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -247,5 +246,3 @@ protected:
 ///@} addtogroup block
 
 }  // namespace Kratos.
-
-#endif // KRATOS_MAPPER_LOCAL_SYSTEM_H_INCLUDED  defined

--- a/applications/MappingApplication/custom_utilities/mapper_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/mapper_utilities.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //

--- a/applications/MappingApplication/custom_utilities/mapper_utilities.h
+++ b/applications/MappingApplication/custom_utilities/mapper_utilities.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //
@@ -13,8 +13,7 @@
 // "Development and Implementation of a Parallel
 //  Framework for Non-Matching Grid Mapping"
 
-#if !defined(KRATOS_MAPPER_UTILITIES_H_INCLUDED)
-#define  KRATOS_MAPPER_UTILITIES_H_INCLUDED
+#pragma once
 
 // System includes
 #include <array>
@@ -327,5 +326,3 @@ private:
 }  // namespace MapperUtilities.
 
 }  // namespace Kratos.
-
-#endif // KRATOS_MAPPER_UTILITIES_H_INCLUDED  defined

--- a/applications/MappingApplication/custom_utilities/mapping_intersection_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/mapping_intersection_utilities.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Peter Wilson
 //

--- a/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //

--- a/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.h
+++ b/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //
@@ -13,8 +13,7 @@
 // "Development and Implementation of a Parallel
 //  Framework for Non-Matching Grid Mapping"
 
-#if !defined(KRATOS_MAPPING_MATRIX_UTILITIES_H_INCLUDED)
-#define  KRATOS_MAPPING_MATRIX_UTILITIES_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -52,5 +51,3 @@ static void CheckRowSum(
 };
 
 }  // namespace Kratos.
-
-#endif // KRATOS_MAPPING_MATRIX_UTILITIES_H_INCLUDED  defined

--- a/applications/MappingApplication/custom_utilities/projection_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/projection_utilities.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //

--- a/applications/MappingApplication/custom_utilities/projection_utilities.h
+++ b/applications/MappingApplication/custom_utilities/projection_utilities.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //
@@ -13,8 +13,7 @@
 // "Development and Implementation of a Parallel
 //  Framework for Non-Matching Grid Mapping"
 
-#if !defined(KRATOS_PROJECTION_UTILITIES_H_INCLUDED)
-#define  KRATOS_PROJECTION_UTILITIES_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -82,5 +81,3 @@ bool KRATOS_API(MAPPING_APPLICATION) ComputeProjection(const GeometryType& rGeom
 }  // namespace ProjectionUtilities.
 
 }  // namespace Kratos.
-
-#endif // KRATOS_PROJECTION_UTILITIES_H_INCLUDED  defined

--- a/applications/MappingApplication/mapping_application.h
+++ b/applications/MappingApplication/mapping_application.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //
@@ -13,24 +13,17 @@
 // "Development and Implementation of a Parallel
 //  Framework for Non-Matching Grid Mapping"
 
-
-#if !defined(KRATOS_MAPPING_APPLICATION_H_INCLUDED )
-#define  KRATOS_MAPPING_APPLICATION_H_INCLUDED
-
+#pragma once
 
 // System includes
 
-
 // External includes
-
 
 // Project includes
 #include "includes/define.h"
 #include "includes/kratos_application.h"
-
 #include "custom_searching/interface_object.h"
 #include "custom_modelers/mapping_geometries_modeler.h"
-
 
 namespace Kratos
 {
@@ -230,11 +223,8 @@ private:
 }; // Class KratosMappingApplication
 
 ///@}
-
-
 ///@name Type Definitions
 ///@{
-
 
 ///@}
 ///@name Input and output
@@ -242,7 +232,4 @@ private:
 
 ///@}
 
-
 }  // namespace Kratos.
-
-#endif // KRATOS_MAPPING_APPLICATION_H_INCLUDED  defined

--- a/applications/MappingApplication/mapping_application_variables.cpp
+++ b/applications/MappingApplication/mapping_application_variables.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //

--- a/applications/MappingApplication/mapping_application_variables.h
+++ b/applications/MappingApplication/mapping_application_variables.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //
@@ -13,9 +13,7 @@
 // "Development and Implementation of a Parallel
 //  Framework for Non-Matching Grid Mapping"
 
-
-#if !defined(KRATOS_MAPPING_APPLICATION_VARIABLES_H_INCLUDED )
-#define  KRATOS_MAPPING_APPLICATION_VARIABLES_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -33,5 +31,3 @@ namespace Kratos
     KRATOS_DEFINE_APPLICATION_VARIABLE( MAPPING_APPLICATION, bool, IS_PROJECTED_LOCAL_SYSTEM)
     KRATOS_DEFINE_APPLICATION_VARIABLE(MAPPING_APPLICATION, bool, IS_DUAL_MORTAR)
 }
-
-#endif //KRATOS_MAPPING_APPLICATION_VARIABLES_H_INCLUDED

--- a/applications/MappingApplication/mpi_extension/cpp_tests/test_mapper_utilities_mpi.cpp
+++ b/applications/MappingApplication/mpi_extension/cpp_tests/test_mapper_utilities_mpi.cpp
@@ -4,7 +4,7 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
+//  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher (https://github.com/philbucher)
@@ -16,8 +16,7 @@
 #include "mpi/utilities/model_part_communicator_utilities.h"
 #include "custom_utilities/mapper_utilities.h"
 
-namespace Kratos {
-namespace Testing {
+namespace Kratos::Testing {
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MapperUtilities_ComputeGlobalBoundingBox_distributed, KratosMappingApplicationMPITestSuite)
 {
@@ -55,5 +54,4 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MapperUtilities_ComputeGlobalBoundingBox_d
     }
 }
 
-}  // namespace Testing
-}  // namespace Kratos
+}  // namespace Kratos::Testing

--- a/applications/MappingApplication/mpi_extension/custom_python/mapping_mpi_extension.cpp
+++ b/applications/MappingApplication/mpi_extension/custom_python/mapping_mpi_extension.cpp
@@ -26,8 +26,7 @@
 #include "factories/mapper_factory.h"
 #include "python/add_mapper_to_python.h"
 
-namespace Kratos {
-namespace Python {
+namespace Kratos::Python {
 
 PYBIND11_MODULE(KratosMappingMPIExtension,m)
 {
@@ -52,7 +51,6 @@ PYBIND11_MODULE(KratosMappingMPIExtension,m)
     KRATOS_REGISTER_MAPPER(Projection3D2DMapper,  "projection_3D_2D");
 }
 
-}
 }
 
 #endif // KRATOS_PYTHON defined

--- a/applications/MappingApplication/mpi_extension/custom_searching/interface_communicator_mpi.cpp
+++ b/applications/MappingApplication/mpi_extension/custom_searching/interface_communicator_mpi.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //

--- a/applications/MappingApplication/mpi_extension/custom_searching/interface_communicator_mpi.h
+++ b/applications/MappingApplication/mpi_extension/custom_searching/interface_communicator_mpi.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //
@@ -13,8 +13,7 @@
 // "Development and Implementation of a Parallel
 //  Framework for Non-Matching Grid Mapping"
 
-#if !defined(KRATOS_INTERFACE_COMMUNICATOR_MPI_H_INCLUDED )
-#define  KRATOS_INTERFACE_COMMUNICATOR_MPI_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -22,7 +21,6 @@
 
 // Project includes
 #include "custom_searching/interface_communicator.h"
-
 
 namespace Kratos
 {
@@ -143,5 +141,3 @@ private:
 ///@} addtogroup block
 
 }  // namespace Kratos.
-
-#endif // KRATOS_INTERFACE_COMMUNICATOR_MPI_H_INCLUDED  defined

--- a/applications/MappingApplication/mpi_extension/custom_utilities/interface_vector_container_mpi.cpp
+++ b/applications/MappingApplication/mpi_extension/custom_utilities/interface_vector_container_mpi.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //

--- a/applications/MappingApplication/mpi_extension/custom_utilities/mapper_mpi_backend.h
+++ b/applications/MappingApplication/mpi_extension/custom_utilities/mapper_mpi_backend.h
@@ -10,8 +10,7 @@
 //  Main authors:    Philipp Bucher (https://github.com/philbucher)
 //
 
-#if !defined(KRATOS_MAPPER_MPI_BACKEND_H_INCLUDED)
-#define KRATOS_MAPPER_MPI_BACKEND_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -33,5 +32,3 @@ struct MapperMPIBackend
 };
 
 }  // namespace Kratos.
-
-#endif // KRATOS_MAPPER_MPI_BACKEND_H_INCLUDED defined

--- a/applications/MappingApplication/mpi_extension/custom_utilities/mapper_mpi_define.h
+++ b/applications/MappingApplication/mpi_extension/custom_utilities/mapper_mpi_define.h
@@ -10,8 +10,7 @@
 //  Main authors:    Philipp Bucher (https://github.com/philbucher)
 //
 
-#if !defined(KRATOS_MAPPER_MPI_DEFINE_H_INCLUDED)
-#define KRATOS_MAPPER_MPI_DEFINE_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -34,5 +33,3 @@ namespace MPIMapperDefinitions {
 }  // namespace MPIMapperDefinitions.
 
 }  // namespace Kratos.
-
-#endif // KRATOS_MAPPER_MPI_DEFINE_H_INCLUDED defined

--- a/applications/MappingApplication/mpi_extension/custom_utilities/mapping_matrix_utilities_mpi.cpp
+++ b/applications/MappingApplication/mpi_extension/custom_utilities/mapping_matrix_utilities_mpi.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher, Jordi Cotela
 //

--- a/applications/MappingApplication/tests/cpp_tests/test_barycentric_mapper_aux_classes.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_barycentric_mapper_aux_classes.cpp
@@ -4,7 +4,7 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
+//  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher (https://github.com/philbucher)

--- a/applications/MappingApplication/tests/cpp_tests/test_barycentric_mapper_aux_classes.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_barycentric_mapper_aux_classes.cpp
@@ -23,8 +23,7 @@
 #include "custom_utilities/mapper_utilities.h"
 #include "mapping_application_variables.h"
 
-namespace Kratos {
-namespace Testing {
+namespace Kratos::Testing {
 
 typedef typename MapperLocalSystem::MatrixType MatrixType;
 typedef typename MapperLocalSystem::EquationIdVectorType EquationIdVectorType;
@@ -473,5 +472,4 @@ KRATOS_TEST_CASE_IN_SUITE(BarycentricInterfaceInfo_simple_tetra_interpolation, K
     KRATOS_CHECK_VECTOR_EQUAL(exp_results, neighbor_coords)
 }
 
-}  // namespace Testing
-}  // namespace Kratos
+}  // namespace Kratos::Testing

--- a/applications/MappingApplication/tests/cpp_tests/test_closest_points.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_closest_points.cpp
@@ -4,7 +4,7 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
+//  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher (https://github.com/philbucher)

--- a/applications/MappingApplication/tests/cpp_tests/test_closest_points.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_closest_points.cpp
@@ -17,8 +17,7 @@
 #include "includes/stream_serializer.h"
 #include "custom_utilities/closest_points.h"
 
-namespace Kratos {
-namespace Testing {
+namespace Kratos::Testing {
 
 KRATOS_TEST_CASE_IN_SUITE(PointWithIdBasics, KratosMappingApplicationSerialTestSuite)
 {
@@ -266,5 +265,4 @@ KRATOS_TEST_CASE_IN_SUITE(ClosestPointsContainerSerialization, KratosMappingAppl
     }
 }
 
-}  // namespace Testing
-}  // namespace Kratos
+}  // namespace Kratos::Testing

--- a/applications/MappingApplication/tests/cpp_tests/test_interface_object.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_interface_object.cpp
@@ -4,7 +4,7 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
+//  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher

--- a/applications/MappingApplication/tests/cpp_tests/test_interface_object.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_interface_object.cpp
@@ -15,9 +15,7 @@
 #include "geometries/quadrilateral_2d_4.h"
 #include "custom_searching/interface_object.h"
 
-namespace Kratos {
-namespace Testing {
-
+namespace Kratos::Testing {
 
 KRATOS_TEST_CASE_IN_SUITE(InterfaceGeometryObject, KratosMappingApplicationSerialTestSuite)
 {
@@ -89,5 +87,4 @@ KRATOS_TEST_CASE_IN_SUITE(InterfaceObject, KratosMappingApplicationSerialTestSui
     // KRATOS_CHECK_EQUAL(*(p_interface_obj->pGetBaseGeometry()), *p_quad); // does not compile ...
 }
 
-}  // namespace Testing
-}  // namespace Kratos
+}  // namespace Kratos::Testing

--- a/applications/MappingApplication/tests/cpp_tests/test_mapper_utilities.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_mapper_utilities.cpp
@@ -4,7 +4,7 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
+//  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher

--- a/applications/MappingApplication/tests/cpp_tests/test_mapper_utilities.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_mapper_utilities.cpp
@@ -23,8 +23,7 @@
 #include "custom_utilities/mapper_utilities.h"
 #include "custom_mappers/nearest_neighbor_mapper.h"
 
-namespace Kratos {
-namespace Testing {
+namespace Kratos::Testing {
 
 typedef std::size_t IndexType;
 typedef std::size_t SizeType;
@@ -693,5 +692,4 @@ KRATOS_TEST_CASE_IN_SUITE(MapperUtilities_PointsAreCollinear, KratosMappingAppli
     KRATOS_CHECK_IS_FALSE(MapperUtilities::PointsAreCollinear(p2,p3,p4));
 }
 
-}  // namespace Testing
-}  // namespace Kratos
+}  // namespace Kratos::Testing

--- a/applications/MappingApplication/tests/cpp_tests/test_nearest_element_aux_classes.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_nearest_element_aux_classes.cpp
@@ -4,7 +4,7 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
+//  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher

--- a/applications/MappingApplication/tests/cpp_tests/test_nearest_element_aux_classes.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_nearest_element_aux_classes.cpp
@@ -22,8 +22,7 @@
 #include "custom_utilities/mapper_utilities.h"
 #include "mapping_application_variables.h"
 
-namespace Kratos {
-namespace Testing {
+namespace Kratos::Testing {
 
 typedef typename MapperLocalSystem::MatrixType MatrixType;
 typedef typename MapperLocalSystem::EquationIdVectorType EquationIdVectorType;
@@ -520,5 +519,4 @@ KRATOS_TEST_CASE_IN_SUITE(NearestElementLocalSystem_ComputeLocalSystemWithApprox
     TestNearestElementLocalSystem(exp_loc_matrix, exp_origin_ids, p_geom);
 }
 
-}  // namespace Testing
-}  // namespace Kratos
+}  // namespace Kratos::Testing

--- a/applications/MappingApplication/tests/cpp_tests/test_nearest_neighbor_aux_classes.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_nearest_neighbor_aux_classes.cpp
@@ -18,8 +18,7 @@
 #include "custom_utilities/mapper_utilities.h"
 #include "mapping_application_variables.h"
 
-namespace Kratos {
-namespace Testing {
+namespace Kratos::Testing {
 
 typedef typename MapperLocalSystem::MatrixType MatrixType;
 typedef typename MapperLocalSystem::EquationIdVectorType EquationIdVectorType;
@@ -344,5 +343,4 @@ KRATOS_TEST_CASE_IN_SUITE(NearestNeighborLocalSystem_ComputeLocalSystem, KratosM
     KRATOS_CHECK_EQUAL(destination_ids2[0], dest_id);
 }
 
-}  // namespace Testing
-}  // namespace Kratos
+}  // namespace Kratos::Testing

--- a/applications/MappingApplication/tests/cpp_tests/test_nearest_neighbor_aux_classes.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_nearest_neighbor_aux_classes.cpp
@@ -4,7 +4,7 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
+//  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher

--- a/applications/MappingApplication/tests/cpp_tests/test_projection_utilities.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_projection_utilities.cpp
@@ -4,7 +4,7 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
+//  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher

--- a/applications/MappingApplication/tests/cpp_tests/test_projection_utilities.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_projection_utilities.cpp
@@ -20,8 +20,7 @@
 #include "custom_utilities/projection_utilities.h"
 #include "mapping_application_variables.h"
 
-namespace Kratos {
-namespace Testing {
+namespace Kratos::Testing {
 
 typedef Node<3> NodeType;
 typedef Geometry<NodeType> GeometryType;
@@ -390,5 +389,4 @@ KRATOS_TEST_CASE_IN_SUITE(ProjectionUtils_Hexahedra_Outside, KratosMappingApplic
     TestComputeProjection(*p_geom, point_to_project, local_coord_tol, exp_sf_values, exp_eq_ids, proj_dist, pairing_index, compute_approximation, full_projection);
 }
 
-}  // namespace Testing
-}  // namespace Kratos
+}  // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**

This uses `#pragma once` and corrects tabs in header 

**🆕 Changelog**

- Uses `#pragma once` 
- Corrects tabs in header 
- Unify python namespace
