### PR TITLE
Adding an option to evaluate the stabilization tau at nodes for the level set convection process. 

### DIFF
--- a/kratos/elements/levelset_convection_element_simplex.h
+++ b/kratos/elements/levelset_convection_element_simplex.h
@@ -110,6 +110,21 @@ public:
         KRATOS_CATCH("");
     }
 
+    void Initialize(const ProcessInfo& rProcessInfo) override
+    {
+        std::size_t count = 0;
+        for (const auto& r_node : GetGeometry()) {
+            if(r_node.Has(TAU)){
+                count++;
+            }
+        }
+        if (count == TNumNodes) {
+            mElementTauNodal = true;
+        } else {
+            mElementTauNodal = false;
+        }
+    }
+    
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
@@ -189,9 +204,20 @@ public:
             }
             const double norm_vel = norm_2(vel_gauss);
             array_1d<double, TNumNodes > a_dot_grad = prod(DN_DX, vel_gauss);
+            double tau = 0.0;
 
-            const double tau_denom = std::max(dyn_st_beta *dt_inv + 2.0 * norm_vel / h + std::abs(/*beta**/div_v),  1e-2); //the term std::abs(div_v) is added following Pablo Becker's suggestion
-            const double tau = 1.0 / (tau_denom);
+            if (mElementTauNodal){
+                
+                for (unsigned int i = 0; i < TNumNodes; i++)
+                {
+                    tau += N[i] * GetGeometry()[i].GetValue(TAU);
+                }
+            }
+            else{
+                const double tau_denom = std::max(dyn_st_beta * dt_inv + 2.0 * norm_vel / h + std::abs(/*beta**/ div_v), 1e-2); // the term std::abs(div_v) is added following Pablo Becker's suggestion
+                tau = 1.0 / (tau_denom);
+            }
+
 
             //terms multiplying dphi/dt (aux1)
             noalias(aux1) += (1.0+tau*beta*div_v)*outer_prod(N, N);
@@ -408,6 +434,8 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
+
+    bool mElementTauNodal; // Flag to indicate if the stabilization tau is evaluated at each Gauss point or interpolated
 
     ///@}
     ///@name Serialization

--- a/kratos/elements/levelset_convection_element_simplex.h
+++ b/kratos/elements/levelset_convection_element_simplex.h
@@ -112,17 +112,12 @@ public:
 
     void Initialize(const ProcessInfo& rProcessInfo) override
     {
-        std::size_t count = 0;
-        for (const auto& r_node : GetGeometry()) {
-            if(r_node.Has(TAU)){
-                count++;
-            }
-        }
-        if (count == TNumNodes) {
-            mElementTauNodal = true;
-        } else {
-            mElementTauNodal = false;
-        }
+        const auto& r_geometry = GetGeometry();
+        mElementTauNodal = std::all_of(r_geometry.begin(),
+                                       r_geometry.end(),
+                                       [](const auto& rNode) {
+                                           rNode.Has(TAU)
+                                       });
     }
     
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override

--- a/kratos/elements/levelset_convection_element_simplex.h
+++ b/kratos/elements/levelset_convection_element_simplex.h
@@ -116,7 +116,7 @@ public:
         mElementTauNodal = std::all_of(r_geometry.begin(),
                                        r_geometry.end(),
                                        [](const auto& rNode) {
-                                           rNode.Has(TAU)
+                                           return rNode.Has(TAU);
                                        });
     }
     

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -177,10 +177,10 @@ public:
         // Save the variables to be employed so that they can be restored after the solution
         const auto& r_previous_var = rCurrentProcessInfo.GetValue(CONVECTION_DIFFUSION_SETTINGS)->GetUnknownVariable();
         const double previous_delta_time = rCurrentProcessInfo.GetValue(DELTA_TIME);
-        if (mElementTauNodal || mHIsCalculated)
+        if (mElementTauNodal || mCalculateNodalH)
         {
             ComputeNodalH();
-            mHIsCalculated = false;
+            mCalculateNodalH = false;
         }
         const double dynamic_tau = rCurrentProcessInfo.GetValue(DYNAMIC_TAU);
         // Save current level set value and current and previous step velocity values
@@ -371,9 +371,9 @@ protected:
 
     bool mElementRequiresLimiter;
 
-    bool mElementTauNodal; 
+    bool mElementTauNodal;
 
-    bool mHIsCalculated = true;
+    bool mCalculateNodalH = true;
 
     bool mElementRequiresLevelSetGradient;
 
@@ -559,6 +559,9 @@ protected:
 
         if (mElementRequiresLimiter){
                 block_for_each(mpDistanceModelPart->Nodes(), [&](Node<3>& rNode){rNode.SetValue(LIMITER_COEFFICIENT, 0.0);});
+        }
+        if(mElementTauNodal){
+                block_for_each(mpDistanceModelPart->Nodes(), [&](Node<3>& rNode){rNode.SetValue(TAU, 0.0);});
         }
     }
 

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -373,7 +373,7 @@ protected:
 
     bool mElementTauNodal; 
 
-    bool mHIsCalculated = true;
+    bool mCalculateNodalH = true;
 
     bool mElementRequiresLevelSetGradient;
 

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -177,8 +177,10 @@ public:
         // Save the variables to be employed so that they can be restored after the solution
         const auto& r_previous_var = rCurrentProcessInfo.GetValue(CONVECTION_DIFFUSION_SETTINGS)->GetUnknownVariable();
         const double previous_delta_time = rCurrentProcessInfo.GetValue(DELTA_TIME);
-        if (mElementTauNodal){
-            ComputeNodalH();    
+        if (mElementTauNodal || mHIsCalculated)
+        {
+            ComputeNodalH();
+            mHIsCalculated = false;
         }
         const double dynamic_tau = rCurrentProcessInfo.GetValue(DYNAMIC_TAU);
         // Save current level set value and current and previous step velocity values
@@ -370,6 +372,8 @@ protected:
     bool mElementRequiresLimiter;
 
     bool mElementTauNodal; 
+
+    bool mHIsCalculated = true;
 
     bool mElementRequiresLevelSetGradient;
 

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -38,6 +38,7 @@
 #include "utilities/parallel_utilities.h"
 #include "utilities/pointer_communicator.h"
 #include "utilities/pointer_map_communicator.h"
+#include "processes/find_nodal_h_process.h"
 
 namespace Kratos
 {
@@ -176,7 +177,10 @@ public:
         // Save the variables to be employed so that they can be restored after the solution
         const auto& r_previous_var = rCurrentProcessInfo.GetValue(CONVECTION_DIFFUSION_SETTINGS)->GetUnknownVariable();
         const double previous_delta_time = rCurrentProcessInfo.GetValue(DELTA_TIME);
-
+        if (mElementTauNodal){
+            ComputeNodalH();    
+        }
+        const double dynamic_tau = rCurrentProcessInfo.GetValue(DYNAMIC_TAU);
         // Save current level set value and current and previous step velocity values
         IndexPartition<int>(mpDistanceModelPart->NumberOfNodes()).for_each(
         [&](int i_node){
@@ -184,6 +188,14 @@ public:
             mVelocity[i_node] = it_node->FastGetSolutionStepValue(*mpConvectVar);
             mVelocityOld[i_node] = it_node->FastGetSolutionStepValue(*mpConvectVar,1);
             mOldDistance[i_node] = it_node->FastGetSolutionStepValue(*mpLevelSetVar,1);
+            double velocity_norm = norm_2(mVelocity[i_node]);
+            double nodal_h = it_node-> GetValue(NODAL_H);
+
+            if (mElementTauNodal)
+            {
+                double tau = 1.0 / (dynamic_tau / previous_delta_time + velocity_norm / std::pow(nodal_h,2));
+                it_node->GetValue(TAU) = tau;
+            }
             }
         );
 
@@ -356,6 +368,8 @@ protected:
     bool mIsBfecc;
 
     bool mElementRequiresLimiter;
+
+    bool mElementTauNodal; 
 
     bool mElementRequiresLevelSetGradient;
 
@@ -760,6 +774,16 @@ protected:
         mpSolvingStrategy->SolveSolutionStep(); // forward convection to obtain the corrected phi_n+1
         mpSolvingStrategy->FinalizeSolutionStep();
     }
+ 
+    /**
+     * @brief Nodal H calculation
+     * This function calculates the nodal h  by executing a process where the nodal h calculaiton is implemented. 
+     */
+    void ComputeNodalH()
+    {
+        auto nodal_h_process = FindNodalHProcess<FindNodalHSettings::SaveAsNonHistoricalVariable>(mrBaseModelPart);
+        nodal_h_process.Execute();
+    }
 
     ///@}
     ///@name Protected  Access
@@ -803,7 +827,8 @@ private:
 
         mpConvectionFactoryElement = &KratosComponents<Element>::Get(element_register_name);
         mElementRequiresLimiter =  ThisParameters["element_settings"].Has("include_anti_diffusivity_terms") ? ThisParameters["element_settings"]["include_anti_diffusivity_terms"].GetBool() : false;
-
+        mElementTauNodal = ThisParameters["element_settings"].Has("tau_nodal") ? ThisParameters["element_settings"]["tau_nodal"].GetBool() : false;
+        
         if (ThisParameters["element_settings"].Has("elemental_limiter_acuteness") && mElementRequiresLimiter) {
             mPowerElementalLimiter = ThisParameters["element_settings"]["elemental_limiter_acuteness"].GetDouble();
         }
@@ -899,7 +924,8 @@ private:
                 "dynamic_tau" : 0.0,
                 "cross_wind_stabilization_factor" : 0.7,
                 "requires_distance_gradient" : false,
-                "time_integration_theta" : 0.5
+                "time_integration_theta" : 0.5,
+                "tau_nodal": false
             })");
         } else if (ElementType == "levelset_convection_algebraic_stabilization") {
             default_parameters = Parameters(R"({

--- a/kratos/tests/test_levelset_convection.py
+++ b/kratos/tests/test_levelset_convection.py
@@ -286,8 +286,8 @@ class TestLevelSetConvection(KratosUnittest.TestCase):
             max_distance = max(max_distance, d)
             min_distance = min(min_distance, d)
 
-        self.assertAlmostEqual(max_distance, 0.8209084289826344)
-        self.assertAlmostEqual(min_distance,-0.049613825219342975)
+        self.assertAlmostEqual(max_distance,0.7868643986367427)
+        self.assertAlmostEqual(min_distance,-0.057482590870069024)
 
 
 

--- a/kratos/tests/test_levelset_convection.py
+++ b/kratos/tests/test_levelset_convection.py
@@ -243,6 +243,53 @@ class TestLevelSetConvection(KratosUnittest.TestCase):
         self.assertAlmostEqual(max_distance, 1.0001547969705757)
         self.assertAlmostEqual(min_distance, -0.00022682772863112904)
 
+    def test_levelset_convection_tau_nodal(self):
+        current_model = KratosMultiphysics.Model()
+        model_part = current_model.CreateModelPart("Main")
+        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
+        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
+        KratosMultiphysics.ModelPartIO(GetFilePath("auxiliar_files_for_python_unittest/mdpa_files/levelset_convection_process_mesh")).ReadModelPart(model_part)
+        model_part.SetBufferSize(2)
+
+        for node in model_part.Nodes:
+            node.SetSolutionStepValue(KratosMultiphysics.DISTANCE, 0, BaseDistance(node.X,node.Y,node.Z))
+            node.SetSolutionStepValue(KratosMultiphysics.VELOCITY, 0, ConvectionVelocity(node.X,node.Y,node.Z))
+
+        for node in model_part.Nodes:
+            if node.X < 0.001:
+                node.Fix(KratosMultiphysics.DISTANCE)
+
+        from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory
+        linear_solver = linear_solver_factory.ConstructSolver(
+            KratosMultiphysics.Parameters("""{"solver_type" : "skyline_lu_factorization"}"""))
+
+        model_part.CloneTimeStep(20.0)
+
+        levelset_convection_settings = KratosMultiphysics.Parameters("""{
+            "max_CFL" : 1.0,
+            "max_substeps" : 0,
+            "eulerian_error_compensation" : false,
+            "element_type" : "levelset_convection_supg",
+            "element_settings" :{
+                "tau_nodal": true
+            }
+        }""")
+        KratosMultiphysics.LevelSetConvectionProcess2D(
+            model_part,
+            linear_solver,
+            levelset_convection_settings).Execute()
+
+        max_distance = -1.0
+        min_distance = +1.0
+        for node in model_part.Nodes:
+            d =  node.GetSolutionStepValue(KratosMultiphysics.DISTANCE)
+            max_distance = max(max_distance, d)
+            min_distance = min(min_distance, d)
+
+        self.assertAlmostEqual(max_distance, 0.8209084289826344)
+        self.assertAlmostEqual(min_distance,-0.049613825219342975)
+
+
 
 if __name__ == '__main__':
     KratosUnittest.main()


### PR DESCRIPTION
**📝 Description**

With this PR, it is now possible for the SUPG element in the level set convection process to evaluate the stabilization coefficient tau at nodes. By evaluating the stabilization coefficient at nodes the  jump of its value between elements decreases.  The purpose of this is to avoid artificial bumbles for the two fluid simulations .

**🆕 Changelog**

 The modified files are: 

- _test_levelset_convection.py._ 
         A test has been added where the nodal tau option is activated. 
- _levelset_convection_process.h_
         The nodal tau is calculated for each node. 
- _levelset_convection_element_simplex.h_ 
         For each gauss point the calculated nodal tau is interpolated. 
