### PR TITLE
[Core] Replace attributte name `aux_msg` with `aux_message` in `KratosUnittest.py`

### DIFF
--- a/kratos/python_scripts/KratosUnittest.py
+++ b/kratos/python_scripts/KratosUnittest.py
@@ -110,7 +110,7 @@ class TestCase(TestCase):
             def __init__(self, idx_1, idx_2, aux_message=None):
                 self.idx_1 = idx_1
                 self.idx_2 = idx_2
-                self.aux_msg = aux_message
+                self.aux_message = aux_message
 
             def __str__(self):
                 err_msg  = '\nCheck failed because matrix arguments are not equal in component ({},{})'.format(self.idx_1, self.idx_2)


### PR DESCRIPTION
**📝 Description**
As in the title, this PR replace the attribute `aux_msg` with `aux_message` in the class `LazyValErrMsg` defined in function `assertMatrixAlmostEqual`