### PR TITLE
[MPM] Fix wrong computation local coordinates in search utility

### DIFF
--- a/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h
+++ b/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h
@@ -332,16 +332,9 @@ namespace MPMSearchElementUtility
                     }
                     else
                     {
-                        if (rMPMModelPart.GetProcessInfo()[IS_RESTARTED]) {
-                            (*element_itr).GetGeometry().SetGeometryParent((pelem->pGetGeometry().get()));
-                        }
                         auto p_quadrature_point_geometry = element_itr->pGetGeometry();
                         array_1d<double, 3> local_coordinates;
-                        if (!rMPMModelPart.GetProcessInfo()[IS_RESTARTED]) {
-                            p_quadrature_point_geometry->PointLocalCoordinates(local_coordinates, xg[0]);
-                        } else {
-                            pelem->pGetGeometry()->PointLocalCoordinates(local_coordinates, xg[0]);
-                        }
+                        pelem->pGetGeometry()->PointLocalCoordinates(local_coordinates, xg[0]);
                         CreateQuadraturePointsUtility<Node<3>>::UpdateFromLocalCoordinates(
                             p_quadrature_point_geometry, local_coordinates,
                             p_quadrature_point_geometry->IntegrationPoints()[0].Weight(), pelem->GetGeometry());
@@ -380,11 +373,7 @@ namespace MPMSearchElementUtility
                     if (is_found == true) {
                         auto p_quadrature_point_geometry = condition_itr->pGetGeometry();
                         array_1d<double, 3> local_coordinates;
-                        if (!rMPMModelPart.GetProcessInfo()[IS_RESTARTED]) {
-                            p_quadrature_point_geometry->PointLocalCoordinates(local_coordinates, xg[0]);
-                        } else {
-                            pelem->pGetGeometry()->PointLocalCoordinates(local_coordinates, xg[0]);
-                        }
+                        pelem->pGetGeometry()->PointLocalCoordinates(local_coordinates, xg[0]);
                         CreateQuadraturePointsUtility<Node<3>>::UpdateFromLocalCoordinates(
                             p_quadrature_point_geometry, local_coordinates,
                             p_quadrature_point_geometry->IntegrationPoints()[0].Weight(), pelem->GetGeometry());

--- a/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h
+++ b/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h
@@ -11,8 +11,7 @@
 //
 
 
-#ifndef KRATOS_MPM_SEARCH_ELEMENT_UTILITY
-#define KRATOS_MPM_SEARCH_ELEMENT_UTILITY
+#pragma once
 
 // System includes
 
@@ -22,17 +21,12 @@
 #include "includes/define.h"
 #include "utilities/binbased_fast_point_locator.h"
 #include "utilities/quadrature_points_utility.h"
-
 #include "particle_mechanics_application_variables.h"
-
 #include "geometries/geometry.h"
 #include "includes/model_part.h"
-
 #include "pqmpm_partition_utilities.h"
 
-namespace Kratos
-{
-namespace MPMSearchElementUtility
+namespace Kratos::MPMSearchElementUtility
 {
     // Standard types
     typedef std::size_t IndexType;
@@ -40,20 +34,32 @@ namespace MPMSearchElementUtility
     typedef Node<3> NodeType;
     typedef typename ModelPart::GeometryType GeometryType;
 
-    inline double CrossProductDet2D(array_1d<double, 3> VectorA, array_1d<double, 3> VectorB)
+
+    inline double CrossProductDet2D(
+        array_1d<double, 3> VectorA,
+        array_1d<double, 3> VectorB
+        )
     {
         return (VectorA[0] * VectorB[1] - VectorB[0] * VectorA[1]);
     }
 
-    inline bool CheckIsInside(const GeometryType& rGeom, array_1d<double, 3>& LocalCoords, const array_1d<double, 3>& Coords, const double Tolerance, const bool IsCalcLocalCoords = true)
+
+    inline bool CheckIsInside(
+        const GeometryType& rGeom,
+        array_1d<double, 3>& LocalCoords,
+        const array_1d<double, 3>& Coords,
+        const double Tolerance
+        )
     {
-
         // TODO some optimisation for simple 2D shapes.
-
         return rGeom.IsInside(Coords, LocalCoords, Tolerance);
     }
 
-    inline void ConstructNeighbourRelations(GeometryType& rGeom, const ModelPart& rBackgroundGridModelPart)
+
+    inline void ConstructNeighbourRelations(
+        GeometryType& rGeom,
+        const ModelPart& rBackgroundGridModelPart
+        )
     {
         std::vector<typename Geometry<Node<3>>::Pointer> geometry_neighbours;
         for (IndexType j = 0; j < rBackgroundGridModelPart.NumberOfElements(); j++)
@@ -76,8 +82,7 @@ namespace MPMSearchElementUtility
                                     break;
                                 }
                             }
-                            if (add_entry)
-                            {
+                            if (add_entry) {
                                 geometry_neighbours.push_back(p_geometry_neighbour);
                             }
                             break;
@@ -85,49 +90,49 @@ namespace MPMSearchElementUtility
                     }
                 }
             }
-
         }
         #pragma omp critical
         rGeom.SetValue(GEOMETRY_NEIGHBOURS, geometry_neighbours);
     }
 
 
-    inline bool IsExplicitAndNeedsCorrection(GeometryType::Pointer pQuadraturePoint, const ProcessInfo& rProcessInfo)
+    inline bool IsExplicitAndNeedsCorrection(
+        GeometryType::Pointer pQuadraturePoint,
+        const ProcessInfo& rProcessInfo
+        )
     {
         if (rProcessInfo.Has(IS_FIX_EXPLICIT_MP_ON_GRID_EDGE)) {
             if (rProcessInfo.GetValue(IS_FIX_EXPLICIT_MP_ON_GRID_EDGE)) {
-                if (pQuadraturePoint->IntegrationPointsNumber() == 1)
-                {
-                    for (size_t i = 0; i < pQuadraturePoint->ShapeFunctionsValues().size2(); ++i)
-                    {
-                        if (pQuadraturePoint->ShapeFunctionsValues()(0, i) < std::numeric_limits<double>::epsilon()) return true;
+                if (pQuadraturePoint->IntegrationPointsNumber() == 1) {
+                    for (size_t i = 0; i < pQuadraturePoint->ShapeFunctionsValues().size2(); ++i) {
+                        if (pQuadraturePoint->ShapeFunctionsValues()(0, i) < std::numeric_limits<double>::epsilon()) {
+                            return true;
+                        }
                     }
                 }
             }
         }
-
         return false;
     }
 
-    inline GeometryType& FindGridGeom(GeometryType& rParentGeom,
+    inline GeometryType& FindGridGeom(
+        GeometryType& rParentGeom,
         const ModelPart& rBackgroundGridModelPart,
         const double Tolerance,
         const array_1d<double, 3>& xg,
         array_1d<double, 3>& rLocalCoords,
         const ProcessInfo& rProcessInfo,
-        bool& IsFound)
+        bool& IsFound
+        )
     {
         IsFound = false;
-
         if (CheckIsInside(rParentGeom, rLocalCoords, xg, Tolerance)) {
             IsFound = true;
             return rParentGeom;
-        }
-        else
-        {
-            if (!rParentGeom.Has(GEOMETRY_NEIGHBOURS))
+        } else {
+            if (!rParentGeom.Has(GEOMETRY_NEIGHBOURS)) {
                 ConstructNeighbourRelations(rParentGeom, rBackgroundGridModelPart);
-
+            }
             auto& geometry_neighbours = rParentGeom.GetValue(GEOMETRY_NEIGHBOURS);
             for (IndexType k = 0; k < geometry_neighbours.size(); ++k) {
                 if (CheckIsInside(*geometry_neighbours[k], rLocalCoords, xg, Tolerance)) {
@@ -136,16 +141,17 @@ namespace MPMSearchElementUtility
                 }
             }
         }
-
         return rParentGeom;
     }
 
 
-    inline void UpdatePartitionedQuadraturePoint(const ModelPart& rBackgroundGridModelPart,
+    inline void UpdatePartitionedQuadraturePoint(
+        const ModelPart& rBackgroundGridModelPart,
         const array_1d<double, 3>& rCoordinates,
         Element& rMasterMaterialPoint,
         typename GeometryType::Pointer pQuadraturePointGeometry,
-        const double Tolerance)
+        const double Tolerance
+        )
     {
         KRATOS_TRY;
 
@@ -158,10 +164,12 @@ namespace MPMSearchElementUtility
     }
 
 
-    inline void NeighbourSearchElements(const ModelPart& rMPMModelPart,
+    inline void NeighbourSearchElements(
+        const ModelPart& rMPMModelPart,
         const ModelPart& rBackgroundGridModelPart,
         std::vector<typename Element::Pointer>& rMissingElements,
-        const double Tolerance)
+        const double Tolerance
+        )
     {
         #pragma omp parallel for
         for (int i = 0; i < static_cast<int>(rMPMModelPart.Elements().size()); ++i) {
@@ -175,33 +183,27 @@ namespace MPMSearchElementUtility
                 rBackgroundGridModelPart, Tolerance, xg[0], local_coordinates,
                 rMPMModelPart.GetProcessInfo(), is_found);
 
-            if (is_found)
-            {
+            if (is_found) {
                 const bool is_pqmpm = (rBackgroundGridModelPart.GetProcessInfo().Has(IS_PQMPM))
                     ? rBackgroundGridModelPart.GetProcessInfo().GetValue(IS_PQMPM) : false;
-                if (is_pqmpm)
-                {
+                if (is_pqmpm) {
                     // Updates the quadrature point geometry.
                     (*element_itr).GetGeometry().SetGeometryParent(&r_found_geom);
                     PQMPMPartitionUtilities::PartitionMasterMaterialPointsIntoSubPoints(rBackgroundGridModelPart, xg[0],
                         local_coordinates, *element_itr, element_itr->pGetGeometry(), Tolerance);
-                }
-                else
-                {
+                } else {
                     CreateQuadraturePointsUtility<Node<3>>::UpdateFromLocalCoordinates(
                         element_itr->pGetGeometry(), local_coordinates,
                         element_itr->GetGeometry().IntegrationPoints()[0].Weight(), r_found_geom);
                 }
-
-                if (IsExplicitAndNeedsCorrection(element_itr->pGetGeometry(), rBackgroundGridModelPart.GetProcessInfo()))
+                if (IsExplicitAndNeedsCorrection(element_itr->pGetGeometry(), rBackgroundGridModelPart.GetProcessInfo())) {
                     is_found = false;
-                else {
-                    for (IndexType j = 0; j < r_found_geom.PointsNumber(); ++j)
+                } else {
+                    for (IndexType j = 0; j < r_found_geom.PointsNumber(); ++j) {
                         r_found_geom.Points()[j].Set(ACTIVE);
+                    }
                 }
-            }
-            if(!is_found)
-            {
+            } else {
                 #pragma omp critical
                 rMissingElements.push_back(&*element_itr);
             }
@@ -209,23 +211,20 @@ namespace MPMSearchElementUtility
     }
 
 
-    //
-
-
-    inline void NeighbourSearchConditions(const ModelPart& rMPMModelPart,
+    inline void NeighbourSearchConditions(
+        const ModelPart& rMPMModelPart,
         const ModelPart& rBackgroundGridModelPart,
         std::vector<typename Condition::Pointer>& rMissingConditions,
-        const double Tolerance)
+        const double Tolerance
+        )
     {
         #pragma omp parallel for
         for (int i = 0; i < static_cast<int>(rMPMModelPart.Conditions().size()); ++i) {
             auto condition_itr = rMPMModelPart.Conditions().begin() + i;
-
             std::vector<array_1d<double, 3>> xg;
             condition_itr->CalculateOnIntegrationPoints(MPC_COORD, xg, rMPMModelPart.GetProcessInfo());
 
-            if (xg.size() > 0 && condition_itr->Is(BOUNDARY))
-            {
+            if (xg.size() > 0 && condition_itr->Is(BOUNDARY)) {
                 array_1d<double, 3> local_coordinates;
                 bool is_found = false;
 
@@ -233,17 +232,15 @@ namespace MPMSearchElementUtility
                     rBackgroundGridModelPart, Tolerance, xg[0], local_coordinates,
                     rMPMModelPart.GetProcessInfo(), is_found);
 
-                if (is_found)
-                {
+                if (is_found) {
                     CreateQuadraturePointsUtility<Node<3>>::UpdateFromLocalCoordinates(
                         condition_itr->pGetGeometry(), local_coordinates,
                         condition_itr->GetGeometry().IntegrationPoints()[0].Weight(), r_found_geom);
-                        
-                    for (IndexType j = 0; j < r_found_geom.PointsNumber(); ++j)
+
+                    for (IndexType j = 0; j < r_found_geom.PointsNumber(); ++j) {
                         r_found_geom[j].Set(ACTIVE);
-                }
-                else
-                {
+                    }
+                } else {
                     #pragma omp critical
                     rMissingConditions.push_back(&*condition_itr);
                 }
@@ -252,7 +249,10 @@ namespace MPMSearchElementUtility
     }
 
 
-    inline bool IsFixExplicitAndOnElementEdge(const Vector& N, const ProcessInfo& rProcessInfo)
+    inline bool IsFixExplicitAndOnElementEdge(
+        const Vector& N,
+        const ProcessInfo& rProcessInfo
+        )
     {
         if (rProcessInfo.Has(IS_FIX_EXPLICIT_MP_ON_GRID_EDGE)) {
             if (rProcessInfo.GetValue(IS_FIX_EXPLICIT_MP_ON_GRID_EDGE)) {
@@ -264,17 +264,19 @@ namespace MPMSearchElementUtility
                 }
             }
         }
-
         return false;
     }
 
 
     template <std::size_t TDimension>
-    void BinBasedSearchElementsAndConditions(ModelPart& rMPMModelPart,
+    void BinBasedSearchElementsAndConditions(
+        ModelPart& rMPMModelPart,
         ModelPart& rBackgroundGridModelPart,
         std::vector<typename Element::Pointer>& rMissingElements,
         std::vector<typename Condition::Pointer>& rMissingConditions,
-        const std::size_t MaxNumberOfResults, const double Tolerance)
+        const std::size_t MaxNumberOfResults,
+        const double Tolerance
+        )
     {
         const ProcessInfo& r_process_info = rBackgroundGridModelPart.GetProcessInfo();
         bool is_pqmpm = (r_process_info.Has(IS_PQMPM))
@@ -302,7 +304,9 @@ namespace MPMSearchElementUtility
                 // FindPointOnMesh find the background element in which a given point falls and the relative shape functions
                 bool is_found = SearchStructure.FindPointOnMesh(xg[0], N, pelem, result_begin, MaxNumberOfResults, Tolerance);
 
-                if (is_found == true) {
+                if (is_found) {
+                    pelem->Set(ACTIVE);
+
                     if (IsFixExplicitAndOnElementEdge(N, r_process_info) && !is_pqmpm) {
                         // MP is exactly on the edge. Now we give it a little 'nudge'
                         array_1d<double, 3> xg_nudged = array_1d<double, 3>(xg[0]);
@@ -319,19 +323,12 @@ namespace MPMSearchElementUtility
                                 << " lies exactly on an element edge and may give spurious results." << std::endl;
                         }
                     }
-                    pelem->Set(ACTIVE);
-
-                    const bool is_pqmpm = (rBackgroundGridModelPart.GetProcessInfo().Has(IS_PQMPM))
-                        ? rBackgroundGridModelPart.GetProcessInfo().GetValue(IS_PQMPM) : false;
-                    if (is_pqmpm)
-                    {
+                    if (is_pqmpm) {
                         // Updates the quadrature point geometry.
                         (*element_itr).GetGeometry().SetGeometryParent((pelem->pGetGeometry().get()));
                         UpdatePartitionedQuadraturePoint(rBackgroundGridModelPart, xg[0],
                             *element_itr, pelem->pGetGeometry(), Tolerance);
-                    }
-                    else
-                    {
+                    } else {
                         auto p_quadrature_point_geometry = element_itr->pGetGeometry();
                         array_1d<double, 3> local_coordinates;
                         pelem->pGetGeometry()->PointLocalCoordinates(local_coordinates, xg[0]);
@@ -339,15 +336,13 @@ namespace MPMSearchElementUtility
                             p_quadrature_point_geometry, local_coordinates,
                             p_quadrature_point_geometry->IntegrationPoints()[0].Weight(), pelem->GetGeometry());
                     }
-
                     auto& r_geometry = element_itr->GetGeometry();
-                    for (IndexType j = 0; j < r_geometry.PointsNumber(); ++j)
+                    for (IndexType j = 0; j < r_geometry.PointsNumber(); ++j) {
                         r_geometry[j].Set(ACTIVE);
-                }
-                else {
-                    KRATOS_INFO("MPMSearchElementUtility") << "WARNING: Search Element for Material Point: " << element_itr->Id()
-                        << " is failed. Geometry is cleared." << std::endl;
-
+                    }
+                } else {
+                    KRATOS_INFO("MPMSearchElementUtility") << "WARNING: Search Element for Material Point: "
+                        << element_itr->Id() << " is failed. Geometry is cleared." << std::endl;
                     element_itr->GetGeometry().clear();
                     element_itr->Reset(ACTIVE);
                     element_itr->Set(TO_ERASE);
@@ -370,22 +365,22 @@ namespace MPMSearchElementUtility
                     // FindPointOnMesh find the background element in which a given point falls and the relative shape functions
                     bool is_found = SearchStructure.FindPointOnMesh(xg[0], N, pelem, result_begin, MaxNumberOfResults, Tolerance);
 
-                    if (is_found == true) {
+                    if (is_found) {
                         auto p_quadrature_point_geometry = condition_itr->pGetGeometry();
                         array_1d<double, 3> local_coordinates;
                         pelem->pGetGeometry()->PointLocalCoordinates(local_coordinates, xg[0]);
                         CreateQuadraturePointsUtility<Node<3>>::UpdateFromLocalCoordinates(
                             p_quadrature_point_geometry, local_coordinates,
                             p_quadrature_point_geometry->IntegrationPoints()[0].Weight(), pelem->GetGeometry());
-                        
+
                         auto& r_geometry = condition_itr->GetGeometry();
 
-                        for (IndexType j = 0; j < r_geometry.PointsNumber(); ++j)
+                        for (IndexType j = 0; j < r_geometry.PointsNumber(); ++j) {
                             r_geometry[j].Set(ACTIVE);
+                        }
                     } else {
                         KRATOS_INFO("MPMSearchElementUtility") << "WARNING: Search Element for Material Point Condition: " << condition_itr->Id()
                             << " is failed. Geometry is cleared." << std::endl;
-
                         condition_itr->GetGeometry().clear();
                         condition_itr->Reset(ACTIVE);
                         condition_itr->Set(TO_ERASE);
@@ -395,19 +390,20 @@ namespace MPMSearchElementUtility
         }
     }
 
+
     inline void ResetElementsAndNodes(ModelPart& rBackgroundGridModelPart)
     {
         #pragma omp parallel for
         for (int i = 0; i < static_cast<int>(rBackgroundGridModelPart.Elements().size()); ++i) {
             auto element_itr = rBackgroundGridModelPart.Elements().begin() + i;
-            auto& r_geometry = element_itr->GetGeometry();
             element_itr->Reset(ACTIVE);
-
-            for (IndexType j = 0; j < r_geometry.PointsNumber(); ++j)
+            auto& r_geometry = element_itr->GetGeometry();
+            for (IndexType j = 0; j < r_geometry.PointsNumber(); ++j) {
                 r_geometry[j].Reset(ACTIVE);
-
+            }
         }
     }
+
 
     /**
      * @brief Search element connectivity for each particle
@@ -418,11 +414,14 @@ namespace MPMSearchElementUtility
      * STEPS:
      * 1) All the elements are set to be INACTIVE
      * 2) A searching is performed and the grid elements which contain at least a MP are set to be ACTIVE
-     *
      */
     template<std::size_t TDimension>
-    void SearchElement(ModelPart& rBackgroundGridModelPart, ModelPart& rMPMModelPart, const std::size_t MaxNumberOfResults,
-        const double Tolerance)
+    void SearchElement(
+        ModelPart& rBackgroundGridModelPart,
+        ModelPart& rMPMModelPart,
+        const std::size_t MaxNumberOfResults,
+        const double Tolerance
+        )
     {
         ResetElementsAndNodes(rBackgroundGridModelPart);
 
@@ -444,14 +443,10 @@ namespace MPMSearchElementUtility
             });
         }
 
-        if (missing_conditions.size() > 0 || missing_elements.size() > 0)
+        if (missing_conditions.size() > 0 || missing_elements.size() > 0) {
             BinBasedSearchElementsAndConditions<TDimension>(rMPMModelPart,
                 rBackgroundGridModelPart, missing_elements, missing_conditions,
                 MaxNumberOfResults, Tolerance);
+        }
     }
-} // end namespace MPMSearchElementUtility
-
-} // end namespace Kratos
-
-#endif // KRATOS_MPM_SEARCH_ELEMENT_UTILITY
-
+} // end namespace Kratos::MPMSearchElementUtility

--- a/applications/ParticleMechanicsApplication/tests/cpp_tests/test_search_element_utility.cpp
+++ b/applications/ParticleMechanicsApplication/tests/cpp_tests/test_search_element_utility.cpp
@@ -189,7 +189,7 @@ namespace Testing
     }
 
     ///// Check if search function works properly
-    KRATOS_TEST_CASE_IN_SUITE(MPMSearchElement, KratosParticleMechanicsFastSuite)
+    KRATOS_TEST_CASE_IN_SUITE(MPMSearchElementQuad2D, KratosParticleMechanicsFastSuite)
     {
         // First Coordinates of Material Point
         array_1d<double, 3> mp_coordinate;
@@ -238,6 +238,126 @@ namespace Testing
         KRATOS_CHECK_EQUAL(r_mpm_model_part.GetElement(2).GetGeometry()[1].Id(), 9);
         KRATOS_CHECK_EQUAL(r_mpm_model_part.GetElement(2).GetGeometry()[2].Id(), 10);
         KRATOS_CHECK_EQUAL(r_mpm_model_part.GetElement(2).GetGeometry()[3].Id(), 3);
+    }
+
+    ///// Check if search function works properly
+    KRATOS_TEST_CASE_IN_SUITE(MPMSearchElementTri2D, KratosParticleMechanicsFastSuite)
+    {
+        // First Coordinates of Material Point: (0.0, 0.2, 0.0)
+        array_1d<double, 3> mp_coordinate;
+        mp_coordinate[0] = 0.0;
+        mp_coordinate[1] = 0.2;
+        mp_coordinate[2] = 0.0;
+        const double int_weight = 1.5;
+
+        const IndexType grid_case = 10;
+
+        Model current_model;
+        ModelPart& r_mpm_model_part = current_model.CreateModelPart("MPMModelPart");
+
+        ModelPart& r_background_model_part = current_model.CreateModelPart("MPMBackgroundModelPart");
+        PrepareGeneralBackgroundModelPart(r_background_model_part, grid_case);
+        PrepareModelPart(r_mpm_model_part, r_background_model_part, mp_coordinate, int_weight);
+
+        const ProcessInfo& r_current_process_info = r_mpm_model_part.GetProcessInfo();
+        const double search_tolerance = 1e-7;
+        const double check_tolerance = 1e-10;
+
+        r_mpm_model_part.GetElement(2).SetValuesOnIntegrationPoints(
+            MP_COORD, { mp_coordinate }, r_current_process_info);
+
+        MPMSearchElementUtility::SearchElement<2>(
+            r_background_model_part, r_mpm_model_part, 1000, search_tolerance);
+
+        std::vector<array_1d<double, 3>> coords;
+        r_mpm_model_part.GetElement(2).CalculateOnIntegrationPoints(
+            MP_COORD, coords, r_current_process_info);
+        KRATOS_CHECK_VECTOR_NEAR(coords[0], mp_coordinate, 1e-6)
+
+        // Check nodes
+        KRATOS_CHECK_EQUAL(r_mpm_model_part.GetElement(2).GetGeometry()[0].Id(), 1);
+        KRATOS_CHECK_EQUAL(r_mpm_model_part.GetElement(2).GetGeometry()[1].Id(), 6);
+        KRATOS_CHECK_EQUAL(r_mpm_model_part.GetElement(2).GetGeometry()[2].Id(), 5);
+
+        Matrix shape_functions_values = r_mpm_model_part.GetElement(2).GetGeometry().ShapeFunctionsValues();
+        KRATOS_CHECK_NEAR(shape_functions_values(0,0), 0.8, check_tolerance);
+        KRATOS_CHECK_NEAR(shape_functions_values(0,1), 0.0, check_tolerance);
+        KRATOS_CHECK_NEAR(shape_functions_values(0,2), 0.2, check_tolerance);
+
+        // New Coordinates of Material Point
+        mp_coordinate[0] = 1.2;
+        mp_coordinate[1] = 0.0;
+        mp_coordinate[2] = 0.0;
+
+        r_mpm_model_part.GetElement(2).SetValuesOnIntegrationPoints(
+            MP_COORD, { mp_coordinate }, r_current_process_info);
+
+        MPMSearchElementUtility::SearchElement<2>(
+            r_background_model_part, r_mpm_model_part, 1000, search_tolerance);
+
+        r_mpm_model_part.GetElement(2).CalculateOnIntegrationPoints(
+            MP_COORD, coords, r_current_process_info);
+        KRATOS_CHECK_VECTOR_NEAR(coords[0], mp_coordinate, 1e-6)
+
+        // Check nodes
+        KRATOS_CHECK_EQUAL(r_mpm_model_part.GetElement(2).GetGeometry()[0].Id(), 2);
+        KRATOS_CHECK_EQUAL(r_mpm_model_part.GetElement(2).GetGeometry()[1].Id(), 3);
+        KRATOS_CHECK_EQUAL(r_mpm_model_part.GetElement(2).GetGeometry()[2].Id(), 7);
+
+        shape_functions_values = r_mpm_model_part.GetElement(2).GetGeometry().ShapeFunctionsValues();
+        KRATOS_CHECK_NEAR(shape_functions_values(0,0), 0.8, check_tolerance);
+        KRATOS_CHECK_NEAR(shape_functions_values(0,1), 0.2, check_tolerance);
+        KRATOS_CHECK_NEAR(shape_functions_values(0,2), 0.0, check_tolerance);
+
+        // New Coordinates of Material Point
+        mp_coordinate[0] = 2.6;
+        mp_coordinate[1] = 2.1;
+        mp_coordinate[2] = 0.0;
+
+        r_mpm_model_part.GetElement(2).SetValuesOnIntegrationPoints(
+            MP_COORD, { mp_coordinate }, r_current_process_info);
+
+        MPMSearchElementUtility::SearchElement<2>(
+            r_background_model_part, r_mpm_model_part, 1000, search_tolerance);
+
+        r_mpm_model_part.GetElement(2).CalculateOnIntegrationPoints(
+            MP_COORD, coords, r_current_process_info);
+        KRATOS_CHECK_VECTOR_NEAR(coords[0], mp_coordinate, 1e-6)
+
+        // Check nodes
+        KRATOS_CHECK_EQUAL(r_mpm_model_part.GetElement(2).GetGeometry()[0].Id(), 11);
+        KRATOS_CHECK_EQUAL(r_mpm_model_part.GetElement(2).GetGeometry()[1].Id(), 12);
+        KRATOS_CHECK_EQUAL(r_mpm_model_part.GetElement(2).GetGeometry()[2].Id(), 16);
+
+        shape_functions_values = r_mpm_model_part.GetElement(2).GetGeometry().ShapeFunctionsValues();
+        KRATOS_CHECK_NEAR(shape_functions_values(0,0), 0.4, check_tolerance);
+        KRATOS_CHECK_NEAR(shape_functions_values(0,1), 0.5, check_tolerance);
+        KRATOS_CHECK_NEAR(shape_functions_values(0,2), 0.1, check_tolerance);
+
+        // New Coordinates of Material Point
+        mp_coordinate[0] = 0.2349;
+        mp_coordinate[1] = 2.7238;
+        mp_coordinate[2] = 0.0;
+
+        r_mpm_model_part.GetElement(2).SetValuesOnIntegrationPoints(
+            MP_COORD, { mp_coordinate }, r_current_process_info);
+
+        MPMSearchElementUtility::SearchElement<2>(
+            r_background_model_part, r_mpm_model_part, 1000, search_tolerance);
+
+        r_mpm_model_part.GetElement(2).CalculateOnIntegrationPoints(
+            MP_COORD, coords, r_current_process_info);
+        KRATOS_CHECK_VECTOR_NEAR(coords[0], mp_coordinate, 1e-6)
+
+        // Check nodes
+        KRATOS_CHECK_EQUAL(r_mpm_model_part.GetElement(2).GetGeometry()[0].Id(), 9);
+        KRATOS_CHECK_EQUAL(r_mpm_model_part.GetElement(2).GetGeometry()[1].Id(), 14);
+        KRATOS_CHECK_EQUAL(r_mpm_model_part.GetElement(2).GetGeometry()[2].Id(), 13);
+
+        shape_functions_values = r_mpm_model_part.GetElement(2).GetGeometry().ShapeFunctionsValues();
+        KRATOS_CHECK_NEAR(shape_functions_values(0,0), 0.2762, check_tolerance);
+        KRATOS_CHECK_NEAR(shape_functions_values(0,1), 0.2349, check_tolerance);
+        KRATOS_CHECK_NEAR(shape_functions_values(0,2), 0.4889, check_tolerance);
     }
 
     /// PQMPM test 1 - MP domain is entirely within cell and should only make 1 mp


### PR DESCRIPTION
**📝 Description**
In `BinBasedSearchElementsAndConditions` local coordinates of material point elements and conditions are computed using old background geometry. This PR fixes the issue and adds a new cpp test to check shape functions values.

**🆕 Changelog**
- [Compute local coordinates using new background geometry](https://github.com/KratosMultiphysics/Kratos/commit/5b87c66fbd07ec74c3509881a3cebefa5ab34ee8)
- [Add cpp test](https://github.com/KratosMultiphysics/Kratos/commit/955c27e25d6675f7f3c21c723472ccb90d24cc42)
- [Clean up search utility file](https://github.com/KratosMultiphysics/Kratos/commit/936340f4a1257a9a213173b3841bafa4e41c6c0c)