### PR TITLE
[StructuralMechanicsApplication] Clarify MPC B&S creation

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -337,8 +337,7 @@ class MechanicalSolver(PythonSolver):
         if not hasattr(self, '_builder_and_solver'):
             self._builder_and_solver = self._CreateBuilderAndSolver()
         elif not self.use_block_builder: # Block builder and solver are unified with MPC and without. In the case of the elimination this could be a problem
-            if self.settings["multi_point_constraints_used"].GetBool() is False and
-                self.GetComputingModelPart().NumberOfMasterSlaveConstraints() > 0 and not self.mpc_block_builder_initialized:
+            if self.settings["multi_point_constraints_used"].GetBool() is False and self.GetComputingModelPart().NumberOfMasterSlaveConstraints() > 0 and not self.mpc_block_builder_initialized:
                 self.settings["multi_point_constraints_used"].SetBool(True)
                 self._builder_and_solver = self._CreateBuilderAndSolver()
                 self.mpc_block_builder_initialized = True
@@ -348,8 +347,7 @@ class MechanicalSolver(PythonSolver):
         if not hasattr(self, '_mechanical_solution_strategy'):
             self._mechanical_solution_strategy = self._CreateSolutionStrategy()
         elif not self.use_block_builder: # Block builder and solver are unified with MPC and without. In the case of the elimination this could be a problem
-            if self.settings["multi_point_constraints_used"].GetBool() is False and
-                self.GetComputingModelPart().NumberOfMasterSlaveConstraints() > 0 and not self.mpc_block_builder_initialized:
+            if self.settings["multi_point_constraints_used"].GetBool() is False and self.GetComputingModelPart().NumberOfMasterSlaveConstraints() > 0 and not self.mpc_block_builder_initialized:
                 self._mechanical_solution_strategy = self._CreateSolutionStrategy()
         return self._mechanical_solution_strategy
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -336,7 +336,7 @@ class MechanicalSolver(PythonSolver):
     def _GetBuilderAndSolver(self):
         if not hasattr(self, '_builder_and_solver'):
             self._builder_and_solver = self._CreateBuilderAndSolver()
-        elif not self.use_block_builder: # Block builder and solver are unified with MPC and without. In the case of the elimination this could be a problem
+        elif not self.settings["builder_and_solver_settings"]["use_block_builder"].GetBool(): # Block builder and solver are unified with MPC and without. In the case of the elimination this could be a problem
             if self.settings["multi_point_constraints_used"].GetBool() is False and self.GetComputingModelPart().NumberOfMasterSlaveConstraints() > 0 and not self.mpc_block_builder_initialized:
                 self.settings["multi_point_constraints_used"].SetBool(True)
                 self._builder_and_solver = self._CreateBuilderAndSolver()
@@ -346,7 +346,7 @@ class MechanicalSolver(PythonSolver):
     def _GetSolutionStrategy(self):
         if not hasattr(self, '_mechanical_solution_strategy'):
             self._mechanical_solution_strategy = self._CreateSolutionStrategy()
-        elif not self.use_block_builder: # Block builder and solver are unified with MPC and without. In the case of the elimination this could be a problem
+        elif not self.settings["builder_and_solver_settings"]["use_block_builder"].GetBool(): # Block builder and solver are unified with MPC and without. In the case of the elimination this could be a problem
             if self.settings["multi_point_constraints_used"].GetBool() is False and self.GetComputingModelPart().NumberOfMasterSlaveConstraints() > 0 and not self.mpc_block_builder_initialized:
                 self._mechanical_solution_strategy = self._CreateSolutionStrategy()
         return self._mechanical_solution_strategy

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -93,6 +93,10 @@ class MechanicalSolver(PythonSolver):
                 raise Exception('Please specify a "domain_size" >= 0!')
             self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, domain_size)
 
+        # Some variables initialization
+        self.mpc_block_builder_initialized = False
+
+        # Printing message
         KratosMultiphysics.Logger.PrintInfo("::[MechanicalSolver]:: ", "Construction finished")
 
         # Set if the analysis is restarted
@@ -243,10 +247,6 @@ class MechanicalSolver(PythonSolver):
         mechanical_solution_strategy = self._GetSolutionStrategy()
         mechanical_solution_strategy.SetEchoLevel(self.settings["echo_level"].GetInt())
         mechanical_solution_strategy.Initialize()
-
-        # Some variables initialization
-        self.use_block_builder = self.settings["builder_and_solver_settings"]["use_block_builder"].GetBool()
-        self.mpc_block_builder_initialized = False
 
         # Printing that inialization is finished
         KratosMultiphysics.Logger.PrintInfo("::[MechanicalSolver]:: ", "Finished initialization.")
@@ -443,7 +443,7 @@ class MechanicalSolver(PythonSolver):
 
     def _CreateBuilderAndSolver(self):
         linear_solver = self._GetLinearSolver()
-        if self.use_block_builder:
+        self.settings["builder_and_solver_settings"]["use_block_builder"].GetBool():
             bs_params = self.settings["builder_and_solver_settings"]["advanced_settings"]
             if not self.settings["builder_and_solver_settings"]["use_lagrange_BS"].GetBool():
                 builder_and_solver = KratosMultiphysics.ResidualBasedBlockBuilderAndSolver(linear_solver, bs_params)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -337,7 +337,7 @@ class MechanicalSolver(PythonSolver):
         if not hasattr(self, '_builder_and_solver'):
             self._builder_and_solver = self._CreateBuilderAndSolver()
         elif not self.settings["builder_and_solver_settings"]["use_block_builder"].GetBool(): # Block builder and solver are unified with MPC and without. In the case of the elimination this could be a problem
-            if self.settings["multi_point_constraints_used"].GetBool() is False and self.GetComputingModelPart().NumberOfMasterSlaveConstraints() > 0 and not self.mpc_block_builder_initialized:
+            if self.GetComputingModelPart().NumberOfMasterSlaveConstraints() > 0 and not self.mpc_block_builder_initialized:
                 self.settings["multi_point_constraints_used"].SetBool(True)
                 self._builder_and_solver = self._CreateBuilderAndSolver()
                 self.mpc_block_builder_initialized = True
@@ -347,7 +347,7 @@ class MechanicalSolver(PythonSolver):
         if not hasattr(self, '_mechanical_solution_strategy'):
             self._mechanical_solution_strategy = self._CreateSolutionStrategy()
         elif not self.settings["builder_and_solver_settings"]["use_block_builder"].GetBool(): # Block builder and solver are unified with MPC and without. In the case of the elimination this could be a problem
-            if self.settings["multi_point_constraints_used"].GetBool() is False and self.GetComputingModelPart().NumberOfMasterSlaveConstraints() > 0 and not self.mpc_block_builder_initialized:
+            if self.GetComputingModelPart().NumberOfMasterSlaveConstraints() > 0 and not self.mpc_block_builder_initialized:
                 self._mechanical_solution_strategy = self._CreateSolutionStrategy()
         return self._mechanical_solution_strategy
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -443,7 +443,7 @@ class MechanicalSolver(PythonSolver):
 
     def _CreateBuilderAndSolver(self):
         linear_solver = self._GetLinearSolver()
-        self.settings["builder_and_solver_settings"]["use_block_builder"].GetBool():
+        if self.settings["builder_and_solver_settings"]["use_block_builder"].GetBool():
             bs_params = self.settings["builder_and_solver_settings"]["advanced_settings"]
             if not self.settings["builder_and_solver_settings"]["use_lagrange_BS"].GetBool():
                 builder_and_solver = KratosMultiphysics.ResidualBasedBlockBuilderAndSolver(linear_solver, bs_params)


### PR DESCRIPTION
**📝 Description**

@pablobecker found this https://github.com/KratosMultiphysics/Kratos/blob/ed73cf379f8523e1581092381f89394f28615844/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py#L339, and he asked me why doing this in a so inefficient manner. I did a research and a git blame and I found this was merged 5 years ago here: https://github.com/KratosMultiphysics/Kratos/pull/2567

I was explicitly asked why doing so at that time, and apparently I replied with a meme and not answering the question:

![image](https://user-images.githubusercontent.com/19991680/227950898-c032b4b4-4d01-47cf-be64-b4005dfbd012.png)

The thing is that this was done in order to avoid potential issues when using the elimination builder and solver, that in the case of using MPC is an independent B&S (not the same one as in the case of block builder and solver). This is because in the elimination the graph of the matrix is very dependent of the DoFs and its status. 

@philbucher and @RiccardoRossi sorry for not clarifying that at the time

**🆕 Changelog**

- [Clarify MPC B&S creation](https://github.com/KratosMultiphysics/Kratos/commit/2882f9856ea5cfc1f7d1b4628889ac5503410765)