### PR TITLE
Prevent double deprecated warning

### DIFF
--- a/kratos/geometries/geometry_data.h
+++ b/kratos/geometries/geometry_data.h
@@ -374,7 +374,10 @@ public:
     KRATOS_DEPRECATED_MESSAGE("'Dimension' is deprecated. Use either 'WorkingSpaceDimension' or 'LocalSpaceDimension' instead.")
     SizeType Dimension() const
     {
+        #pragma GCC diagnostic push
+        #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         return mpGeometryDimension->Dimension();
+        #pragma GCC diagnostic pop
     }
 
     /** Working space dimension. for example a triangle is a 2


### PR DESCRIPTION
**📝 Description**
This is starting to drive me insane. Since nobody is getting ride of the `Dimension()` warning and we cannot remove the function I added a pragma that prevents the warning from triggering from every file that includes `geometry_data.h` (quite a few)

The problem is that `GeometryData::Dimension()` (deprecated) calls `GeometryDimension::Dimension()` (also deprecated). When compiling the body of the first, we always calling a deprecated code.