### PR TITLE
[Core] Using `VariableData` for sake of consistency instead of `Variable<TDataType>`

### DIFF
--- a/kratos/containers/variables_list_data_value_container.h
+++ b/kratos/containers/variables_list_data_value_container.h
@@ -14,6 +14,10 @@
 #pragma once
 
 // System includes
+#include <string>
+#include <iostream>
+#include <cstddef>
+#include <cstring>
 
 // External includes
 
@@ -21,7 +25,6 @@
 #include "includes/define.h"
 #include "containers/variable.h"
 #include "containers/variables_list.h"
-#include "includes/global_variables.h"
 
 namespace Kratos
 {

--- a/kratos/containers/variables_list_data_value_container.h
+++ b/kratos/containers/variables_list_data_value_container.h
@@ -4,21 +4,16 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //
 //
 
-#if !defined(KRATOS_VARIABLES_LIST_DATA_VALUE_CONTAINER_H_INCLUDED )
-#define KRATOS_VARIABLES_LIST_DATA_VALUE_CONTAINER_H_INCLUDED
+#pragma once
 
 // System includes
-#include <string>
-#include <iostream>
-#include <cstddef>
-#include <cstring>
 
 // External includes
 
@@ -68,14 +63,17 @@ public:
     /// Pointer definition of VariablesListDataValueContainer
     KRATOS_CLASS_POINTER_DEFINITION(VariablesListDataValueContainer);
 
-    typedef VariablesList::BlockType BlockType;
+    /// The block type definition
+    using BlockType = VariablesList::BlockType;
 
     /// Type of the container used for variables
-    typedef BlockType* ContainerType;
+    using ContainerType= BlockType*;
 
-    typedef std::size_t IndexType;
+    /// The index type definition
+    using IndexType = std::size_t;
 
-    typedef std::size_t SizeType;
+    /// The size type definition
+    using SizeType = std::size_t;
 
     ///@}
     ///@name Life Cycle
@@ -695,7 +693,12 @@ public:
     ///@name Inquiry
     ///@{
 
-    template<class TDataType> bool Has(const Variable<TDataType>& rThisVariable) const
+    /**
+     * @brief This method returns if a certain variable is stored in the data value container
+     * @param rThisVariable The variable to be checked
+     * @return True if the variable is stored, false otherwise
+     */
+    bool Has(const VariableData& rThisVariable) const
     {
         if(!mpVariablesList)
             return false;
@@ -993,5 +996,3 @@ inline std::ostream& operator << (std::ostream& rOStream,
 
 
 }  // namespace Kratos.
-
-#endif // KRATOS_VARIABLES_LIST_DATA_VALUE_CONTAINER_H_INCLUDED  defined

--- a/kratos/includes/node.h
+++ b/kratos/includes/node.h
@@ -451,7 +451,7 @@ public:
     }
 
 
-    template<class TDataType> bool SolutionStepsDataHas(const Variable<TDataType>& rThisVariable) const
+    bool SolutionStepsDataHas(const VariableData& rThisVariable) const
     {
         return SolutionStepData().Has(rThisVariable);
     }


### PR DESCRIPTION
**📝 Description**

This is more consistent with base definitions, where only `VariableData` is considered, additionally removed unnecessary template arguments

**🆕 Changelog**

- [Using `VariableData` for sake of consistency instead of Variable](https://github.com/KratosMultiphysics/Kratos/commit/8ac69ca28e1d5222df6a5683c359e60c747a02d8)
- `pragma once`
- Header clean up
- Remove unused includes
