### PR TITLE
[MPM] Element classes renamed

### DIFF
--- a/applications/CoSimulationApplication/tests/mpm_dem/beam_Body.mdpa
+++ b/applications/CoSimulationApplication/tests/mpm_dem/beam_Body.mdpa
@@ -93,7 +93,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian2D3N// GUI group identifier: Solid Auto1
+Begin Elements MPMUpdatedLagrangian2D3N// GUI group identifier: Solid Auto1
         1          0    87    97    68 
         2          0   347   342   336 
         3          0    47    37    53 

--- a/applications/CoSimulationApplication/tests/mpm_fem_beam/particle_Body.mdpa
+++ b/applications/CoSimulationApplication/tests/mpm_fem_beam/particle_Body.mdpa
@@ -459,7 +459,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian2D4N// GUI group identifier: particle
+Begin Elements MPMUpdatedLagrangian2D4N// GUI group identifier: particle
         1          0        428        429        440        439 
         2          0        417        418        429        428 
         3          0        406        407        418        417 

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -34,15 +34,15 @@ namespace Kratos
 /**
  * Flags related to the element computation
  */
-KRATOS_CREATE_LOCAL_FLAG( UpdatedLagrangian, COMPUTE_RHS_VECTOR,                 0 );
-KRATOS_CREATE_LOCAL_FLAG( UpdatedLagrangian, COMPUTE_LHS_MATRIX,                 1 );
-KRATOS_CREATE_LOCAL_FLAG( UpdatedLagrangian, COMPUTE_RHS_VECTOR_WITH_COMPONENTS, 2 );
-KRATOS_CREATE_LOCAL_FLAG( UpdatedLagrangian, COMPUTE_LHS_MATRIX_WITH_COMPONENTS, 3 );
+KRATOS_CREATE_LOCAL_FLAG( MPMUpdatedLagrangian, COMPUTE_RHS_VECTOR,                 0 );
+KRATOS_CREATE_LOCAL_FLAG( MPMUpdatedLagrangian, COMPUTE_LHS_MATRIX,                 1 );
+KRATOS_CREATE_LOCAL_FLAG( MPMUpdatedLagrangian, COMPUTE_RHS_VECTOR_WITH_COMPONENTS, 2 );
+KRATOS_CREATE_LOCAL_FLAG( MPMUpdatedLagrangian, COMPUTE_LHS_MATRIX_WITH_COMPONENTS, 3 );
 
 //******************************CONSTRUCTOR*******************************************
 //************************************************************************************
 
-UpdatedLagrangian::UpdatedLagrangian( )
+MPMUpdatedLagrangian::MPMUpdatedLagrangian( )
     : Element( )
     , mMP()
 {
@@ -50,7 +50,7 @@ UpdatedLagrangian::UpdatedLagrangian( )
 }
 //******************************CONSTRUCTOR*******************************************
 //************************************************************************************
-UpdatedLagrangian::UpdatedLagrangian( IndexType NewId, GeometryType::Pointer pGeometry )
+MPMUpdatedLagrangian::MPMUpdatedLagrangian( IndexType NewId, GeometryType::Pointer pGeometry )
     : Element( NewId, pGeometry )
     , mMP()
 {
@@ -60,7 +60,7 @@ UpdatedLagrangian::UpdatedLagrangian( IndexType NewId, GeometryType::Pointer pGe
 //******************************CONSTRUCTOR*******************************************
 //************************************************************************************
 
-UpdatedLagrangian::UpdatedLagrangian( IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties )
+MPMUpdatedLagrangian::MPMUpdatedLagrangian( IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties )
     : Element( NewId, pGeometry, pProperties )
     , mMP()
 {
@@ -71,7 +71,7 @@ UpdatedLagrangian::UpdatedLagrangian( IndexType NewId, GeometryType::Pointer pGe
 //******************************COPY CONSTRUCTOR**************************************
 //************************************************************************************
 
-UpdatedLagrangian::UpdatedLagrangian( UpdatedLagrangian const& rOther)
+MPMUpdatedLagrangian::MPMUpdatedLagrangian( MPMUpdatedLagrangian const& rOther)
     :Element(rOther)
     ,mMP(rOther.mMP)
     ,mDeformationGradientF0(rOther.mDeformationGradientF0)
@@ -84,7 +84,7 @@ UpdatedLagrangian::UpdatedLagrangian( UpdatedLagrangian const& rOther)
 //*******************************ASSIGMENT OPERATOR***********************************
 //************************************************************************************
 
-UpdatedLagrangian&  UpdatedLagrangian::operator=(UpdatedLagrangian const& rOther)
+MPMUpdatedLagrangian&  MPMUpdatedLagrangian::operator=(MPMUpdatedLagrangian const& rOther)
 {
     Element::operator=(rOther);
 
@@ -102,22 +102,22 @@ UpdatedLagrangian&  UpdatedLagrangian::operator=(UpdatedLagrangian const& rOther
 //*********************************OPERATIONS*****************************************
 //************************************************************************************
 
-Element::Pointer UpdatedLagrangian::Create( IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties ) const
+Element::Pointer MPMUpdatedLagrangian::Create( IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties ) const
 {
-    return Element::Pointer( new UpdatedLagrangian( NewId, GetGeometry().Create( ThisNodes ), pProperties ) );
+    return Element::Pointer( new MPMUpdatedLagrangian( NewId, GetGeometry().Create( ThisNodes ), pProperties ) );
 }
 
-Element::Pointer UpdatedLagrangian::Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const
+Element::Pointer MPMUpdatedLagrangian::Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const
 {
-    return Kratos::make_intrusive< UpdatedLagrangian >(NewId, pGeom, pProperties);
+    return Kratos::make_intrusive< MPMUpdatedLagrangian >(NewId, pGeom, pProperties);
 }
 
 //************************************CLONE*******************************************
 //************************************************************************************
 
-Element::Pointer UpdatedLagrangian::Clone( IndexType NewId, NodesArrayType const& rThisNodes ) const
+Element::Pointer MPMUpdatedLagrangian::Clone( IndexType NewId, NodesArrayType const& rThisNodes ) const
 {
-    UpdatedLagrangian NewElement (NewId, GetGeometry().Create( rThisNodes ), pGetProperties() );
+    MPMUpdatedLagrangian NewElement (NewId, GetGeometry().Create( rThisNodes ), pGetProperties() );
 
     NewElement.mMP = mMP;
 
@@ -127,12 +127,12 @@ Element::Pointer UpdatedLagrangian::Clone( IndexType NewId, NodesArrayType const
 
     NewElement.mDeterminantF0 = mDeterminantF0;
 
-    return Element::Pointer( new UpdatedLagrangian(NewElement) );
+    return Element::Pointer( new MPMUpdatedLagrangian(NewElement) );
 }
 
 //*******************************DESTRUCTOR*******************************************
 //************************************************************************************
-UpdatedLagrangian::~UpdatedLagrangian()
+MPMUpdatedLagrangian::~MPMUpdatedLagrangian()
 {
 }
 
@@ -140,7 +140,7 @@ UpdatedLagrangian::~UpdatedLagrangian()
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangian::Initialize(const ProcessInfo& rCurrentProcessInfo)
+void MPMUpdatedLagrangian::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -161,7 +161,7 @@ void UpdatedLagrangian::Initialize(const ProcessInfo& rCurrentProcessInfo)
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangian::InitializeGeneralVariables (GeneralVariables& rVariables, const ProcessInfo& rCurrentProcessInfo)
+void MPMUpdatedLagrangian::InitializeGeneralVariables (GeneralVariables& rVariables, const ProcessInfo& rCurrentProcessInfo)
 {
     const SizeType number_of_nodes = GetGeometry().size();
     const SizeType dimension = GetGeometry().WorkingSpaceDimension();
@@ -201,7 +201,7 @@ void UpdatedLagrangian::InitializeGeneralVariables (GeneralVariables& rVariables
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangian::SetGeneralVariables(GeneralVariables& rVariables,
+void MPMUpdatedLagrangian::SetGeneralVariables(GeneralVariables& rVariables,
         ConstitutiveLaw::Parameters& rValues, const Vector& rN)
 {
     GeometryType& r_geometry = GetGeometry();
@@ -212,14 +212,14 @@ void UpdatedLagrangian::SetGeneralVariables(GeneralVariables& rVariables,
     // Check if detF is negative (element is inverted)
     if(rVariables.detF<0)
     {
-        KRATOS_INFO("UpdatedLagrangian")<<" Element: "<<this->Id()<<std::endl;
-        KRATOS_INFO("UpdatedLagrangian")<<" Element position: "<< mMP.xg <<std::endl;
-        KRATOS_INFO("UpdatedLagrangian")<<" Element velocity: "<< mMP.velocity <<std::endl;
+        KRATOS_INFO("MPMUpdatedLagrangian")<<" Element: "<<this->Id()<<std::endl;
+        KRATOS_INFO("MPMUpdatedLagrangian")<<" Element position: "<< mMP.xg <<std::endl;
+        KRATOS_INFO("MPMUpdatedLagrangian")<<" Element velocity: "<< mMP.velocity <<std::endl;
         const unsigned int number_of_nodes = r_geometry.PointsNumber();
-        KRATOS_INFO("UpdatedLagrangian") << " Shape functions: " << r_geometry.ShapeFunctionsValues() << std::endl;
-        KRATOS_INFO("UpdatedLagrangian") << " Quadrature points: " << r_geometry.IntegrationPointsNumber() << std::endl;
-        KRATOS_INFO("UpdatedLagrangian") << " Parent geometry ID: " << r_geometry.GetGeometryParent(0).Id() << std::endl;
-        KRATOS_INFO("UpdatedLagrangian") << " Parent geometry number of points: " << r_geometry.GetGeometryParent(0).PointsNumber() << std::endl;
+        KRATOS_INFO("MPMUpdatedLagrangian") << " Shape functions: " << r_geometry.ShapeFunctionsValues() << std::endl;
+        KRATOS_INFO("MPMUpdatedLagrangian") << " Quadrature points: " << r_geometry.IntegrationPointsNumber() << std::endl;
+        KRATOS_INFO("MPMUpdatedLagrangian") << " Parent geometry ID: " << r_geometry.GetGeometryParent(0).Id() << std::endl;
+        KRATOS_INFO("MPMUpdatedLagrangian") << " Parent geometry number of points: " << r_geometry.GetGeometryParent(0).PointsNumber() << std::endl;
 
         for ( unsigned int i = 0; i < number_of_nodes; i++ )
         {
@@ -227,8 +227,8 @@ void UpdatedLagrangian::SetGeneralVariables(GeneralVariables& rVariables,
             const array_1d<double, 3> & current_displacement  = r_geometry[i].FastGetSolutionStepValue(DISPLACEMENT);
             const array_1d<double, 3> & previous_displacement = r_geometry[i].FastGetSolutionStepValue(DISPLACEMENT,1);
 
-            KRATOS_INFO("UpdatedLagrangian")<<" NODE ["<<r_geometry[i].Id()<<"]: (Current position: "<<current_position<<") "<<std::endl;
-            KRATOS_INFO("UpdatedLagrangian")<<" ---Current Disp: "<<current_displacement<<" (Previour Disp: "<<previous_displacement<<")"<<std::endl;
+            KRATOS_INFO("MPMUpdatedLagrangian")<<" NODE ["<<r_geometry[i].Id()<<"]: (Current position: "<<current_position<<") "<<std::endl;
+            KRATOS_INFO("MPMUpdatedLagrangian")<<" ---Current Disp: "<<current_displacement<<" (Previour Disp: "<<previous_displacement<<")"<<std::endl;
         }
 
         for ( unsigned int i = 0; i < number_of_nodes; i++ )
@@ -237,11 +237,11 @@ void UpdatedLagrangian::SetGeneralVariables(GeneralVariables& rVariables,
             {
                 const array_1d<double, 3 > & PreContactForce = r_geometry[i].FastGetSolutionStepValue(CONTACT_FORCE,1);
                 const array_1d<double, 3 > & ContactForce = r_geometry[i].FastGetSolutionStepValue(CONTACT_FORCE);
-                KRATOS_INFO("UpdatedLagrangian")<<" ---Contact_Force: (Pre:"<<PreContactForce<<", Current:"<<ContactForce<<") "<<std::endl;
+                KRATOS_INFO("MPMUpdatedLagrangian")<<" ---Contact_Force: (Pre:"<<PreContactForce<<", Current:"<<ContactForce<<") "<<std::endl;
             }
             else
             {
-                KRATOS_INFO("UpdatedLagrangian")<<" ---Contact_Force: NULL "<<std::endl;
+                KRATOS_INFO("MPMUpdatedLagrangian")<<" ---Contact_Force: NULL "<<std::endl;
             }
         }
 
@@ -263,7 +263,7 @@ void UpdatedLagrangian::SetGeneralVariables(GeneralVariables& rVariables,
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangian::CalculateElementalSystem(
+void MPMUpdatedLagrangian::CalculateElementalSystem(
     MatrixType& rLeftHandSideMatrix,
     VectorType& rRightHandSideVector,
     const ProcessInfo& rCurrentProcessInfo,
@@ -342,7 +342,7 @@ void UpdatedLagrangian::CalculateElementalSystem(
 //************************************************************************************
 
 
-void UpdatedLagrangian::CalculateKinematics(GeneralVariables& rVariables, const ProcessInfo& rCurrentProcessInfo)
+void MPMUpdatedLagrangian::CalculateKinematics(GeneralVariables& rVariables, const ProcessInfo& rCurrentProcessInfo)
 
 {
     KRATOS_TRY
@@ -396,7 +396,7 @@ void UpdatedLagrangian::CalculateKinematics(GeneralVariables& rVariables, const 
 }
 //************************************************************************************
 
-void UpdatedLagrangian::CalculateDeformationMatrix(Matrix& rB,
+void MPMUpdatedLagrangian::CalculateDeformationMatrix(Matrix& rB,
         const Matrix& rDN_DX, const Matrix& rN, const bool IsAxisymmetric)
 {
     KRATOS_TRY
@@ -462,7 +462,7 @@ void UpdatedLagrangian::CalculateDeformationMatrix(Matrix& rB,
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangian::CalculateAndAddRHS(
+void MPMUpdatedLagrangian::CalculateAndAddRHS(
     VectorType& rRightHandSideVector,
     GeneralVariables& rVariables,
     Vector& rVolumeForce,
@@ -491,7 +491,7 @@ void UpdatedLagrangian::CalculateAndAddRHS(
 //************************************************************************************
 //*********************Calculate the contribution of external force*******************
 
-void UpdatedLagrangian::CalculateAndAddExternalForces(
+void MPMUpdatedLagrangian::CalculateAndAddExternalForces(
     VectorType& rRightHandSideVector,
         GeneralVariables& rVariables,
         Vector& rVolumeForce,
@@ -519,7 +519,7 @@ void UpdatedLagrangian::CalculateAndAddExternalForces(
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangian::CalculateAndAddInternalForces(VectorType& rRightHandSideVector,
+void MPMUpdatedLagrangian::CalculateAndAddInternalForces(VectorType& rRightHandSideVector,
         GeneralVariables & rVariables,
         const double& rIntegrationWeight)
 {
@@ -533,7 +533,7 @@ void UpdatedLagrangian::CalculateAndAddInternalForces(VectorType& rRightHandSide
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangian::CalculateExplicitStresses(const ProcessInfo& rCurrentProcessInfo,
+void MPMUpdatedLagrangian::CalculateExplicitStresses(const ProcessInfo& rCurrentProcessInfo,
     GeneralVariables& rVariables)
 {
     KRATOS_TRY
@@ -601,7 +601,7 @@ void UpdatedLagrangian::CalculateExplicitStresses(const ProcessInfo& rCurrentPro
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangian::CalculateAndAddLHS(
+void MPMUpdatedLagrangian::CalculateAndAddLHS(
     MatrixType& rLeftHandSideMatrix,
     GeneralVariables& rVariables,
     const double& rIntegrationWeight,
@@ -626,7 +626,7 @@ void UpdatedLagrangian::CalculateAndAddLHS(
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangian::CalculateAndAddKuum(
+void MPMUpdatedLagrangian::CalculateAndAddKuum(
     MatrixType& rLeftHandSideMatrix,
     GeneralVariables& rVariables,
     const double& rIntegrationWeight)
@@ -641,7 +641,7 @@ void UpdatedLagrangian::CalculateAndAddKuum(
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangian::CalculateAndAddKuug(MatrixType& rLeftHandSideMatrix,
+void MPMUpdatedLagrangian::CalculateAndAddKuug(MatrixType& rLeftHandSideMatrix,
         GeneralVariables& rVariables,
         const double& rIntegrationWeight, const bool IsAxisymmetric)
 {
@@ -692,7 +692,7 @@ void UpdatedLagrangian::CalculateAndAddKuug(MatrixType& rLeftHandSideMatrix,
 //************************************CALCULATE VOLUME CHANGE*************************
 //************************************************************************************
 
-double& UpdatedLagrangian::CalculateVolumeChange( double& rVolumeChange, GeneralVariables& rVariables )
+double& MPMUpdatedLagrangian::CalculateVolumeChange( double& rVolumeChange, GeneralVariables& rVariables )
 {
     KRATOS_TRY
 
@@ -703,7 +703,7 @@ double& UpdatedLagrangian::CalculateVolumeChange( double& rVolumeChange, General
     KRATOS_CATCH( "" )
 }
 
-void UpdatedLagrangian::CalculateDeformationGradient(const Matrix& rDN_DX, Matrix& rF, Matrix& rDisplacement,
+void MPMUpdatedLagrangian::CalculateDeformationGradient(const Matrix& rDN_DX, Matrix& rF, Matrix& rDisplacement,
     const bool IsAxisymmetric)
 {
     KRATOS_TRY
@@ -758,7 +758,7 @@ void UpdatedLagrangian::CalculateDeformationGradient(const Matrix& rDN_DX, Matri
 
 //************************************************************************************
 //************************************************************************************
-void UpdatedLagrangian::CalculateRightHandSide(
+void MPMUpdatedLagrangian::CalculateRightHandSide(
     VectorType& rRightHandSideVector,
     const ProcessInfo& rCurrentProcessInfo)
 {
@@ -778,7 +778,7 @@ void UpdatedLagrangian::CalculateRightHandSide(
 //************************************************************************************
 
 
-void UpdatedLagrangian::CalculateLeftHandSide(
+void MPMUpdatedLagrangian::CalculateLeftHandSide(
     MatrixType& rLeftHandSideMatrix,
     const ProcessInfo& rCurrentProcessInfo)
 {
@@ -798,7 +798,7 @@ void UpdatedLagrangian::CalculateLeftHandSide(
 //************************************************************************************
 
 
-void UpdatedLagrangian::CalculateLocalSystem(
+void MPMUpdatedLagrangian::CalculateLocalSystem(
     MatrixType& rLeftHandSideMatrix,
     VectorType& rRightHandSideVector,
     const ProcessInfo& rCurrentProcessInfo)
@@ -821,7 +821,7 @@ void UpdatedLagrangian::CalculateLocalSystem(
 
 //*******************************************************************************************
 //*******************************************************************************************
-void UpdatedLagrangian::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo )
+void MPMUpdatedLagrangian::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo )
 {
     /* NOTE:
     In the InitializeSolutionStep of each time step the nodal initial conditions are evaluated.
@@ -871,7 +871,7 @@ void UpdatedLagrangian::InitializeSolutionStep(const ProcessInfo& rCurrentProces
 ////************************************************************************************
 ////************************************************************************************
 
-void UpdatedLagrangian::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo )
+void MPMUpdatedLagrangian::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -917,7 +917,7 @@ void UpdatedLagrangian::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessI
 ////************************************************************************************
 ////************************************************************************************
 
-void UpdatedLagrangian::FinalizeStepVariables( GeneralVariables & rVariables, const ProcessInfo& rCurrentProcessInfo)
+void MPMUpdatedLagrangian::FinalizeStepVariables( GeneralVariables & rVariables, const ProcessInfo& rCurrentProcessInfo)
 {
     // Update internal (historical) variables
     mDeterminantF0         = rVariables.detF* rVariables.detF0;
@@ -954,7 +954,7 @@ void UpdatedLagrangian::FinalizeStepVariables( GeneralVariables & rVariables, co
  * The position of the Gauss points/Material points is updated
  */
 
-void UpdatedLagrangian::UpdateGaussPoint( GeneralVariables & rVariables, const ProcessInfo& rCurrentProcessInfo)
+void MPMUpdatedLagrangian::UpdateGaussPoint( GeneralVariables & rVariables, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -1021,7 +1021,7 @@ void UpdatedLagrangian::UpdateGaussPoint( GeneralVariables & rVariables, const P
 }
 
 
-void UpdatedLagrangian::InitializeMaterial(const ProcessInfo& rCurrentProcessInfo)
+void MPMUpdatedLagrangian::InitializeMaterial(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
     GeneralVariables Variables;
@@ -1049,7 +1049,7 @@ void UpdatedLagrangian::InitializeMaterial(const ProcessInfo& rCurrentProcessInf
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangian::ResetConstitutiveLaw()
+void MPMUpdatedLagrangian::ResetConstitutiveLaw()
 {
     KRATOS_TRY
     GeneralVariables Variables;
@@ -1071,7 +1071,7 @@ void UpdatedLagrangian::ResetConstitutiveLaw()
 /*
 This function convert the computed nodal displacement into matrix of (number_of_nodes, dimension)
 */
-Matrix& UpdatedLagrangian::CalculateCurrentDisp(Matrix & rCurrentDisp, const ProcessInfo& rCurrentProcessInfo)
+Matrix& MPMUpdatedLagrangian::CalculateCurrentDisp(Matrix & rCurrentDisp, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -1100,7 +1100,7 @@ Matrix& UpdatedLagrangian::CalculateCurrentDisp(Matrix & rCurrentDisp, const Pro
 //*************************COMPUTE ALMANSI STRAIN*************************************
 //************************************************************************************
 // Almansi Strain: E = 0.5 (I - U^(-2))
-void UpdatedLagrangian::CalculateAlmansiStrain(const Matrix& rF,
+void MPMUpdatedLagrangian::CalculateAlmansiStrain(const Matrix& rF,
         Vector& rStrainVector )
 {
     KRATOS_TRY
@@ -1144,7 +1144,7 @@ void UpdatedLagrangian::CalculateAlmansiStrain(const Matrix& rF,
 //*************************COMPUTE GREEN-LAGRANGE STRAIN*************************************
 //************************************************************************************
 // Green-Lagrange Strain: E = 0.5 * (U^2 - I) = 0.5 * (C - I)
-void UpdatedLagrangian::CalculateGreenLagrangeStrain(
+void MPMUpdatedLagrangian::CalculateGreenLagrangeStrain(
     const Matrix& rF,
     Vector& rStrainVector)
 {
@@ -1188,7 +1188,7 @@ void UpdatedLagrangian::CalculateGreenLagrangeStrain(
 //************************************************************************************
 //************************************************************************************
 
-double& UpdatedLagrangian::CalculateIntegrationWeight(double& rIntegrationWeight)
+double& MPMUpdatedLagrangian::CalculateIntegrationWeight(double& rIntegrationWeight)
 {
     const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
 
@@ -1202,7 +1202,7 @@ double& UpdatedLagrangian::CalculateIntegrationWeight(double& rIntegrationWeight
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangian::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo ) const
+void MPMUpdatedLagrangian::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo ) const
 {
     const GeometryType& r_geometry = GetGeometry();
     int number_of_nodes = r_geometry.size();
@@ -1227,7 +1227,7 @@ void UpdatedLagrangian::EquationIdVector( EquationIdVectorType& rResult, const P
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangian::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& CurrentProcessInfo ) const
+void MPMUpdatedLagrangian::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& CurrentProcessInfo ) const
 {
     const GeometryType& r_geometry = GetGeometry();
     rElementalDofList.resize( 0 );
@@ -1249,7 +1249,7 @@ void UpdatedLagrangian::GetDofList( DofsVectorType& rElementalDofList, const Pro
 //************************************************************************************
 //*******************DAMPING MATRIX***************************************************
 
-void UpdatedLagrangian::CalculateDampingMatrix( MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo )
+void MPMUpdatedLagrangian::CalculateDampingMatrix( MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1313,7 +1313,7 @@ void UpdatedLagrangian::CalculateDampingMatrix( MatrixType& rDampingMatrix, cons
 
     KRATOS_CATCH( "" )
 }
-void UpdatedLagrangian::AddExplicitContribution(const VectorType& rRHSVector, const Variable<VectorType>& rRHSVariable, const Variable<array_1d<double, 3>>& rDestinationVariable, const ProcessInfo& rCurrentProcessInfo)
+void MPMUpdatedLagrangian::AddExplicitContribution(const VectorType& rRHSVector, const Variable<VectorType>& rRHSVariable, const Variable<array_1d<double, 3>>& rDestinationVariable, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY;
 
@@ -1337,7 +1337,7 @@ void UpdatedLagrangian::AddExplicitContribution(const VectorType& rRHSVector, co
 //************************************************************************************
 //****************MASS MATRIX*********************************************************
 
-void UpdatedLagrangian::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo )
+void MPMUpdatedLagrangian::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1383,7 +1383,7 @@ void UpdatedLagrangian::CalculateMassMatrix( MatrixType& rMassMatrix, const Proc
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangian::GetValuesVector( Vector& values, int Step ) const
+void MPMUpdatedLagrangian::GetValuesVector( Vector& values, int Step ) const
 {
     const GeometryType& r_geometry = GetGeometry();
     const unsigned int number_of_nodes = r_geometry.size();
@@ -1406,7 +1406,7 @@ void UpdatedLagrangian::GetValuesVector( Vector& values, int Step ) const
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangian::GetFirstDerivativesVector( Vector& values, int Step ) const
+void MPMUpdatedLagrangian::GetFirstDerivativesVector( Vector& values, int Step ) const
 {
     const GeometryType& r_geometry = GetGeometry();
     const unsigned int number_of_nodes = r_geometry.size();
@@ -1429,7 +1429,7 @@ void UpdatedLagrangian::GetFirstDerivativesVector( Vector& values, int Step ) co
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangian::GetSecondDerivativesVector( Vector& values, int Step ) const
+void MPMUpdatedLagrangian::GetSecondDerivativesVector( Vector& values, int Step ) const
 {
     const GeometryType& r_geometry = GetGeometry();
     const unsigned int number_of_nodes = r_geometry.size();
@@ -1451,7 +1451,7 @@ void UpdatedLagrangian::GetSecondDerivativesVector( Vector& values, int Step ) c
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangian::GetHistoricalVariables( GeneralVariables& rVariables )
+void MPMUpdatedLagrangian::GetHistoricalVariables( GeneralVariables& rVariables )
 {
     //Deformation Gradient F ( set to identity )
     unsigned int size =  rVariables.F.size1();
@@ -1466,7 +1466,7 @@ void UpdatedLagrangian::GetHistoricalVariables( GeneralVariables& rVariables )
 //*************************DECIMAL CORRECTION OF STRAINS******************************
 //************************************************************************************
 
-void UpdatedLagrangian::DecimalCorrection(Vector& rVector)
+void MPMUpdatedLagrangian::DecimalCorrection(Vector& rVector)
 {
     KRATOS_TRY
 
@@ -1486,7 +1486,7 @@ void UpdatedLagrangian::DecimalCorrection(Vector& rVector)
 ///@name Access Get Values
 ///@{
 
-void UpdatedLagrangian::CalculateOnIntegrationPoints(const Variable<bool>& rVariable,
+void MPMUpdatedLagrangian::CalculateOnIntegrationPoints(const Variable<bool>& rVariable,
     std::vector<bool>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
@@ -1517,7 +1517,7 @@ void UpdatedLagrangian::CalculateOnIntegrationPoints(const Variable<bool>& rVari
     }
 }
 
-void UpdatedLagrangian::CalculateOnIntegrationPoints(const Variable<int>& rVariable,
+void MPMUpdatedLagrangian::CalculateOnIntegrationPoints(const Variable<int>& rVariable,
     std::vector<int>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
@@ -1533,7 +1533,7 @@ void UpdatedLagrangian::CalculateOnIntegrationPoints(const Variable<int>& rVaria
     }
 }
 
-void UpdatedLagrangian::CalculateOnIntegrationPoints(const Variable<double>& rVariable,
+void MPMUpdatedLagrangian::CalculateOnIntegrationPoints(const Variable<double>& rVariable,
     std::vector<double>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
@@ -1572,7 +1572,7 @@ void UpdatedLagrangian::CalculateOnIntegrationPoints(const Variable<double>& rVa
     }
 }
 
-void UpdatedLagrangian::CalculateOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+void MPMUpdatedLagrangian::CalculateOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
     std::vector<array_1d<double, 3 > >& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
@@ -1600,7 +1600,7 @@ void UpdatedLagrangian::CalculateOnIntegrationPoints(const Variable<array_1d<dou
     }
 }
 
-void UpdatedLagrangian::CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
+void MPMUpdatedLagrangian::CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
     std::vector<Vector>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
@@ -1623,13 +1623,13 @@ void UpdatedLagrangian::CalculateOnIntegrationPoints(const Variable<Vector>& rVa
 ///@name Access Set Values
 ///@{
 
-void UpdatedLagrangian::SetValuesOnIntegrationPoints(const Variable<int>& rVariable,
+void MPMUpdatedLagrangian::SetValuesOnIntegrationPoints(const Variable<int>& rVariable,
     const std::vector<int>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
 }
 
-void UpdatedLagrangian::SetValuesOnIntegrationPoints(const Variable<double>& rVariable,
+void MPMUpdatedLagrangian::SetValuesOnIntegrationPoints(const Variable<double>& rVariable,
     const std::vector<double>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
@@ -1652,7 +1652,7 @@ void UpdatedLagrangian::SetValuesOnIntegrationPoints(const Variable<double>& rVa
     }
 }
 
-void UpdatedLagrangian::SetValuesOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+void MPMUpdatedLagrangian::SetValuesOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
     const std::vector<array_1d<double, 3 > >& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
@@ -1681,7 +1681,7 @@ void UpdatedLagrangian::SetValuesOnIntegrationPoints(const Variable<array_1d<dou
     }
 }
 
-void UpdatedLagrangian::SetValuesOnIntegrationPoints(const Variable<Vector>& rVariable,
+void MPMUpdatedLagrangian::SetValuesOnIntegrationPoints(const Variable<Vector>& rVariable,
     const std::vector<Vector>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
@@ -1710,7 +1710,7 @@ void UpdatedLagrangian::SetValuesOnIntegrationPoints(const Variable<Vector>& rVa
  * or that no common error is found.
  * @param rCurrentProcessInfo
  */
-int  UpdatedLagrangian::Check( const ProcessInfo& rCurrentProcessInfo ) const
+int  MPMUpdatedLagrangian::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
@@ -1778,7 +1778,7 @@ int  UpdatedLagrangian::Check( const ProcessInfo& rCurrentProcessInfo ) const
     KRATOS_CATCH( "" );
 }
 
-void UpdatedLagrangian::save( Serializer& rSerializer ) const
+void MPMUpdatedLagrangian::save( Serializer& rSerializer ) const
 {
     KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, Element )
 
@@ -1788,7 +1788,7 @@ void UpdatedLagrangian::save( Serializer& rSerializer ) const
     rSerializer.save("MP",mMP);
 }
 
-void UpdatedLagrangian::load( Serializer& rSerializer )
+void MPMUpdatedLagrangian::load( Serializer& rSerializer )
 {
     KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, Element )
     rSerializer.load("ConstitutiveLawVector",mConstitutiveLawVector);

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.hpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.hpp
@@ -50,7 +50,7 @@ namespace Kratos
  * This works for arbitrary geometries in 3D and 2D (base class)
  */
 
-class UpdatedLagrangian
+class MPMUpdatedLagrangian
     : public Element
 {
 public:
@@ -69,7 +69,7 @@ public:
     typedef typename GeometryType::CoordinatesArrayType CoordinatesArrayType;
 
     /// Counted pointer of LargeDisplacementElement
-    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UpdatedLagrangian );
+    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( MPMUpdatedLagrangian );
     ///@}
 
 protected:
@@ -233,26 +233,26 @@ public:
     ///@{
 
     /// Empty constructor needed for serialization
-    UpdatedLagrangian();
+    MPMUpdatedLagrangian();
 
 
     /// Default constructors
-    UpdatedLagrangian(IndexType NewId, GeometryType::Pointer pGeometry);
+    MPMUpdatedLagrangian(IndexType NewId, GeometryType::Pointer pGeometry);
 
-    UpdatedLagrangian(IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties);
+    MPMUpdatedLagrangian(IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties);
 
     ///Copy constructor
-    UpdatedLagrangian(UpdatedLagrangian const& rOther);
+    MPMUpdatedLagrangian(MPMUpdatedLagrangian const& rOther);
 
     /// Destructor.
-    ~UpdatedLagrangian() override;
+    ~MPMUpdatedLagrangian() override;
 
     ///@}
     ///@name Operators
     ///@{
 
     /// Assignment operator.
-    UpdatedLagrangian& operator=(UpdatedLagrangian const& rOther);
+    MPMUpdatedLagrangian& operator=(MPMUpdatedLagrangian const& rOther);
 
     ///@}
     ///@name Operations
@@ -733,7 +733,7 @@ private:
     ///@{
     ///@}
 
-}; // Class UpdatedLagrangian
+}; // Class MPMUpdatedLagrangian
 
 ///@}
 ///@name Type Definitions

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_PQ.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_PQ.cpp
@@ -34,44 +34,44 @@
 namespace Kratos
 {
 
-UpdatedLagrangianPQ::UpdatedLagrangianPQ( )
-    : UpdatedLagrangian( )
+MPMUpdatedLagrangianPQ::MPMUpdatedLagrangianPQ( )
+    : MPMUpdatedLagrangian( )
 { }//DO NOT CALL IT: only needed for Register and Serialization!!!
 
-UpdatedLagrangianPQ::UpdatedLagrangianPQ( IndexType NewId, GeometryType::Pointer pGeometry )
-    : UpdatedLagrangian( NewId, pGeometry )
+MPMUpdatedLagrangianPQ::MPMUpdatedLagrangianPQ( IndexType NewId, GeometryType::Pointer pGeometry )
+    : MPMUpdatedLagrangian( NewId, pGeometry )
 { }//DO NOT ADD DOFS HERE!!!
 
-UpdatedLagrangianPQ::UpdatedLagrangianPQ( IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties )
-    : UpdatedLagrangian( NewId, pGeometry, pProperties )
+MPMUpdatedLagrangianPQ::MPMUpdatedLagrangianPQ( IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties )
+    : MPMUpdatedLagrangian( NewId, pGeometry, pProperties )
 { mFinalizedStep = true; }
 
-UpdatedLagrangianPQ::UpdatedLagrangianPQ(UpdatedLagrangianPQ const& rOther)
-    :UpdatedLagrangian(rOther)
+MPMUpdatedLagrangianPQ::MPMUpdatedLagrangianPQ(MPMUpdatedLagrangianPQ const& rOther)
+    :MPMUpdatedLagrangian(rOther)
 { }
 
-UpdatedLagrangianPQ& UpdatedLagrangianPQ::operator=(UpdatedLagrangianPQ const& rOther)
+MPMUpdatedLagrangianPQ& MPMUpdatedLagrangianPQ::operator=(MPMUpdatedLagrangianPQ const& rOther)
 {
-    UpdatedLagrangian::operator=(rOther);
+    MPMUpdatedLagrangian::operator=(rOther);
     return *this;
 }
 
-Element::Pointer UpdatedLagrangianPQ::Create( IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties ) const
-{ return Element::Pointer( new UpdatedLagrangianPQ( NewId, GetGeometry().Create( ThisNodes ), pProperties ) ); }
+Element::Pointer MPMUpdatedLagrangianPQ::Create( IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties ) const
+{ return Element::Pointer( new MPMUpdatedLagrangianPQ( NewId, GetGeometry().Create( ThisNodes ), pProperties ) ); }
 
-Element::Pointer UpdatedLagrangianPQ::Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const
-{ return Kratos::make_intrusive< UpdatedLagrangianPQ >(NewId, pGeom, pProperties); }
+Element::Pointer MPMUpdatedLagrangianPQ::Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const
+{ return Kratos::make_intrusive< MPMUpdatedLagrangianPQ >(NewId, pGeom, pProperties); }
 
-Element::Pointer UpdatedLagrangianPQ::Clone( IndexType NewId, NodesArrayType const& rThisNodes ) const
+Element::Pointer MPMUpdatedLagrangianPQ::Clone( IndexType NewId, NodesArrayType const& rThisNodes ) const
 {
-    UpdatedLagrangianPQ NewElement (NewId, GetGeometry().Create( rThisNodes ), pGetProperties() );
-    return Element::Pointer( new UpdatedLagrangianPQ(NewElement) );
+    MPMUpdatedLagrangianPQ NewElement (NewId, GetGeometry().Create( rThisNodes ), pGetProperties() );
+    return Element::Pointer( new MPMUpdatedLagrangianPQ(NewElement) );
 }
 
-UpdatedLagrangianPQ::~UpdatedLagrangianPQ()
+MPMUpdatedLagrangianPQ::~MPMUpdatedLagrangianPQ()
 { }
 
-void UpdatedLagrangianPQ::CalculateAndAddExternalForces(
+void MPMUpdatedLagrangianPQ::CalculateAndAddExternalForces(
     VectorType& rRightHandSideVector,
         GeneralVariables& rVariables,
         Vector& rVolumeForce,
@@ -100,7 +100,7 @@ void UpdatedLagrangianPQ::CalculateAndAddExternalForces(
     KRATOS_CATCH( "" )
 }
 
-void UpdatedLagrangianPQ::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo )
+void MPMUpdatedLagrangianPQ::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo )
 {
     GeometryType& r_geometry = GetGeometry();
     const unsigned int dimension = r_geometry.WorkingSpaceDimension();
@@ -152,7 +152,7 @@ void UpdatedLagrangianPQ::InitializeSolutionStep(const ProcessInfo& rCurrentProc
 }
 
 
-void UpdatedLagrangianPQ::InitializeMaterial(const ProcessInfo& rCurrentProcessInfo)
+void MPMUpdatedLagrangianPQ::InitializeMaterial(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
     GeneralVariables Variables;
@@ -178,24 +178,24 @@ void UpdatedLagrangianPQ::InitializeMaterial(const ProcessInfo& rCurrentProcessI
 }
 
 
-void UpdatedLagrangianPQ::CalculateOnIntegrationPoints(const Variable<int>& rVariable,
+void MPMUpdatedLagrangianPQ::CalculateOnIntegrationPoints(const Variable<int>& rVariable,
     std::vector<int>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
     if (rValues.size() != 1) rValues.resize(1);
     if (rVariable == MP_SUB_POINTS) rValues[0] = GetGeometry().IntegrationPointsNumber();
-    else UpdatedLagrangian::CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
+    else MPMUpdatedLagrangian::CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
 }
 
 
-void UpdatedLagrangianPQ::save( Serializer& rSerializer ) const
+void MPMUpdatedLagrangianPQ::save( Serializer& rSerializer ) const
 {
-    KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, UpdatedLagrangian )
+    KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, MPMUpdatedLagrangian )
 }
 
-void UpdatedLagrangianPQ::load( Serializer& rSerializer )
+void MPMUpdatedLagrangianPQ::load( Serializer& rSerializer )
 {
-    KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, UpdatedLagrangian )
+    KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, MPMUpdatedLagrangian )
 }
 } // Namespace Kratos
 

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_PQ.hpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_PQ.hpp
@@ -31,8 +31,8 @@ namespace Kratos
  * This works for arbitrary geometries in 3D and 2D (base class)
  */
 
-class UpdatedLagrangianPQ
-    : public UpdatedLagrangian
+class MPMUpdatedLagrangianPQ
+    : public MPMUpdatedLagrangian
 {
 public:
 
@@ -50,7 +50,7 @@ public:
     typedef typename GeometryType::CoordinatesArrayType CoordinatesArrayType;
 
     /// Counted pointer of LargeDisplacementElement
-    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UpdatedLagrangianPQ );
+    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( MPMUpdatedLagrangianPQ );
     ///@}
 
 public:
@@ -59,26 +59,26 @@ public:
     ///@{
 
     /// Empty constructor needed for serialization
-    UpdatedLagrangianPQ();
+    MPMUpdatedLagrangianPQ();
 
 
     /// Default constructors
-    UpdatedLagrangianPQ(IndexType NewId, GeometryType::Pointer pGeometry);
+    MPMUpdatedLagrangianPQ(IndexType NewId, GeometryType::Pointer pGeometry);
 
-    UpdatedLagrangianPQ(IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties);
+    MPMUpdatedLagrangianPQ(IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties);
 
     ///Copy constructor
-    UpdatedLagrangianPQ(UpdatedLagrangianPQ const& rOther);
+    MPMUpdatedLagrangianPQ(MPMUpdatedLagrangianPQ const& rOther);
 
     /// Destructor.
-    ~UpdatedLagrangianPQ() override;
+    ~MPMUpdatedLagrangianPQ() override;
 
     ///@}
     ///@name Operators
     ///@{
 
     /// Assignment operator.
-    UpdatedLagrangianPQ& operator=(UpdatedLagrangianPQ const& rOther);
+    MPMUpdatedLagrangianPQ& operator=(MPMUpdatedLagrangianPQ const& rOther);
 
     ///@}
     ///@name Operations
@@ -143,6 +143,6 @@ private:
 
     void load(Serializer& rSerializer) override;
 
-}; // Class UpdatedLagrangianPQ
+}; // Class MPMUpdatedLagrangianPQ
 } // namespace Kratos.
 #endif // KRATOS_UPDATED_LAGRANGIAN_PQ_H_INCLUDED  defined

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_UP.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_UP.cpp
@@ -31,24 +31,24 @@ namespace Kratos
 ///**
 //* Flags related to the element computation
 //*/
-//KRATOS_CREATE_LOCAL_FLAG( UpdatedLagrangian, COMPUTE_RHS_VECTOR,                 0 );
-//KRATOS_CREATE_LOCAL_FLAG( UpdatedLagrangian, COMPUTE_LHS_MATRIX,                 1 );
-//KRATOS_CREATE_LOCAL_FLAG( UpdatedLagrangian, COMPUTE_RHS_VECTOR_WITH_COMPONENTS, 2 );
-//KRATOS_CREATE_LOCAL_FLAG( UpdatedLagrangian, COMPUTE_LHS_MATRIX_WITH_COMPONENTS, 3 );
+//KRATOS_CREATE_LOCAL_FLAG( MPMUpdatedLagrangian, COMPUTE_RHS_VECTOR,                 0 );
+//KRATOS_CREATE_LOCAL_FLAG( MPMUpdatedLagrangian, COMPUTE_LHS_MATRIX,                 1 );
+//KRATOS_CREATE_LOCAL_FLAG( MPMUpdatedLagrangian, COMPUTE_RHS_VECTOR_WITH_COMPONENTS, 2 );
+//KRATOS_CREATE_LOCAL_FLAG( MPMUpdatedLagrangian, COMPUTE_LHS_MATRIX_WITH_COMPONENTS, 3 );
 
 //******************************CONSTRUCTOR*******************************************
 //************************************************************************************
 
-UpdatedLagrangianUP::UpdatedLagrangianUP()
-    : UpdatedLagrangian()
+MPMUpdatedLagrangianUP::MPMUpdatedLagrangianUP()
+    : MPMUpdatedLagrangian()
     , m_mp_pressure(1.0)
 {
     //DO NOT CALL IT: only needed for Register and Serialization!!!
 }
 //******************************CONSTRUCTOR*******************************************
 //************************************************************************************
-UpdatedLagrangianUP::UpdatedLagrangianUP( IndexType NewId, GeometryType::Pointer pGeometry )
-    : UpdatedLagrangian( NewId, pGeometry )
+MPMUpdatedLagrangianUP::MPMUpdatedLagrangianUP( IndexType NewId, GeometryType::Pointer pGeometry )
+    : MPMUpdatedLagrangian( NewId, pGeometry )
     , m_mp_pressure(1.0)
 {
     //DO NOT ADD DOFS HERE!!!
@@ -57,8 +57,8 @@ UpdatedLagrangianUP::UpdatedLagrangianUP( IndexType NewId, GeometryType::Pointer
 //******************************CONSTRUCTOR*******************************************
 //************************************************************************************
 
-UpdatedLagrangianUP::UpdatedLagrangianUP( IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties )
-    : UpdatedLagrangian( NewId, pGeometry, pProperties )
+MPMUpdatedLagrangianUP::MPMUpdatedLagrangianUP( IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties )
+    : MPMUpdatedLagrangian( NewId, pGeometry, pProperties )
     , m_mp_pressure(1.0)
 {
     mFinalizedStep = true;
@@ -68,8 +68,8 @@ UpdatedLagrangianUP::UpdatedLagrangianUP( IndexType NewId, GeometryType::Pointer
 //******************************COPY CONSTRUCTOR**************************************
 //************************************************************************************
 
-UpdatedLagrangianUP::UpdatedLagrangianUP( UpdatedLagrangianUP const& rOther)
-    :UpdatedLagrangian(rOther)
+MPMUpdatedLagrangianUP::MPMUpdatedLagrangianUP( MPMUpdatedLagrangianUP const& rOther)
+    :MPMUpdatedLagrangian(rOther)
     , m_mp_pressure(rOther.m_mp_pressure)
      //,mDeformationGradientF0(rOther.mDeformationGradientF0)
      //,mDeterminantF0(rOther.mDeterminantF0)
@@ -79,9 +79,9 @@ UpdatedLagrangianUP::UpdatedLagrangianUP( UpdatedLagrangianUP const& rOther)
 //*******************************ASSIGMENT OPERATOR***********************************
 //************************************************************************************
 
-UpdatedLagrangianUP&  UpdatedLagrangianUP::operator=(UpdatedLagrangianUP const& rOther)
+MPMUpdatedLagrangianUP&  MPMUpdatedLagrangianUP::operator=(MPMUpdatedLagrangianUP const& rOther)
 {
-    UpdatedLagrangian::operator=(rOther);
+    MPMUpdatedLagrangian::operator=(rOther);
 
     m_mp_pressure = rOther.m_mp_pressure;
 
@@ -90,23 +90,23 @@ UpdatedLagrangianUP&  UpdatedLagrangianUP::operator=(UpdatedLagrangianUP const& 
 //*********************************OPERATIONS*****************************************
 //************************************************************************************
 
-Element::Pointer UpdatedLagrangianUP::Create( IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties ) const
+Element::Pointer MPMUpdatedLagrangianUP::Create( IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties ) const
 {
-    return Element::Pointer( new UpdatedLagrangianUP( NewId, GetGeometry().Create( ThisNodes ), pProperties ) );
+    return Element::Pointer( new MPMUpdatedLagrangianUP( NewId, GetGeometry().Create( ThisNodes ), pProperties ) );
 }
 
-Element::Pointer UpdatedLagrangianUP::Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const
+Element::Pointer MPMUpdatedLagrangianUP::Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const
 {
-    return Kratos::make_intrusive< UpdatedLagrangianUP >(NewId, pGeom, pProperties);
+    return Kratos::make_intrusive< MPMUpdatedLagrangianUP >(NewId, pGeom, pProperties);
 }
 
 //************************************CLONE*******************************************
 //************************************************************************************
 
-Element::Pointer UpdatedLagrangianUP::Clone( IndexType NewId, NodesArrayType const& rThisNodes ) const
+Element::Pointer MPMUpdatedLagrangianUP::Clone( IndexType NewId, NodesArrayType const& rThisNodes ) const
 {
 
-    UpdatedLagrangianUP NewElement (NewId, GetGeometry().Create( rThisNodes ), pGetProperties() );
+    MPMUpdatedLagrangianUP NewElement (NewId, GetGeometry().Create( rThisNodes ), pGetProperties() );
 
     NewElement.m_mp_pressure = m_mp_pressure;
 
@@ -116,11 +116,11 @@ Element::Pointer UpdatedLagrangianUP::Clone( IndexType NewId, NodesArrayType con
 
     NewElement.mDeterminantF0 = mDeterminantF0;
 
-    return Element::Pointer( new UpdatedLagrangianUP(NewElement) );
+    return Element::Pointer( new MPMUpdatedLagrangianUP(NewElement) );
 }
 //*******************************DESTRUCTOR*******************************************
 //************************************************************************************
-UpdatedLagrangianUP::~UpdatedLagrangianUP()
+MPMUpdatedLagrangianUP::~MPMUpdatedLagrangianUP()
 {
 }
 
@@ -128,7 +128,7 @@ UpdatedLagrangianUP::~UpdatedLagrangianUP()
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::Initialize(const ProcessInfo& rCurrentProcessInfo)
+void MPMUpdatedLagrangianUP::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -149,11 +149,11 @@ void UpdatedLagrangianUP::Initialize(const ProcessInfo& rCurrentProcessInfo)
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::InitializeGeneralVariables (GeneralVariables& rVariables, const ProcessInfo& rCurrentProcessInfo)
+void MPMUpdatedLagrangianUP::InitializeGeneralVariables (GeneralVariables& rVariables, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
-    UpdatedLagrangian::InitializeGeneralVariables(rVariables,rCurrentProcessInfo);
+    MPMUpdatedLagrangian::InitializeGeneralVariables(rVariables,rCurrentProcessInfo);
 
     KRATOS_CATCH( "" )
 
@@ -165,7 +165,7 @@ void UpdatedLagrangianUP::InitializeGeneralVariables (GeneralVariables& rVariabl
  * The position of the Gauss points/Material points is updated
  */
 
-void UpdatedLagrangianUP::UpdateGaussPoint( GeneralVariables & rVariables, const ProcessInfo& rCurrentProcessInfo)
+void MPMUpdatedLagrangianUP::UpdateGaussPoint( GeneralVariables & rVariables, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -239,7 +239,7 @@ void UpdatedLagrangianUP::UpdateGaussPoint( GeneralVariables & rVariables, const
 //************************************************************************************
 
 
-void UpdatedLagrangianUP::CalculateKinematics(GeneralVariables& rVariables, const ProcessInfo& rCurrentProcessInfo)
+void MPMUpdatedLagrangianUP::CalculateKinematics(GeneralVariables& rVariables, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -290,7 +290,7 @@ void UpdatedLagrangianUP::CalculateKinematics(GeneralVariables& rVariables, cons
 }
 //************************************************************************************
 
-void UpdatedLagrangianUP::CalculateDeformationMatrix(Matrix& rB,
+void MPMUpdatedLagrangianUP::CalculateDeformationMatrix(Matrix& rB,
         Matrix& rF,
         Matrix& rDN_DX)
 {
@@ -343,7 +343,7 @@ void UpdatedLagrangianUP::CalculateDeformationMatrix(Matrix& rB,
 ////************************************************************************************
 ////************************************************************************************
 
-void UpdatedLagrangianUP::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo )
+void MPMUpdatedLagrangianUP::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo )
 {
     /* NOTE:
     In the InitializeSolutionStep of each time step the nodal initial conditions are evaluated.
@@ -411,7 +411,7 @@ void UpdatedLagrangianUP::InitializeSolutionStep(const ProcessInfo& rCurrentProc
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::CalculateAndAddRHS(
+void MPMUpdatedLagrangianUP::CalculateAndAddRHS(
     VectorType& rRightHandSideVector,
     GeneralVariables& rVariables,
     Vector& rVolumeForce,
@@ -442,7 +442,7 @@ void UpdatedLagrangianUP::CalculateAndAddRHS(
 //************************************************************************************
 //*********************Calculate the contribution of external force*******************
 
-void UpdatedLagrangianUP::CalculateAndAddExternalForces(VectorType& rRightHandSideVector,
+void MPMUpdatedLagrangianUP::CalculateAndAddExternalForces(VectorType& rRightHandSideVector,
         GeneralVariables& rVariables,
         Vector& rVolumeForce,
         const double& rIntegrationWeight)
@@ -468,7 +468,7 @@ void UpdatedLagrangianUP::CalculateAndAddExternalForces(VectorType& rRightHandSi
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::CalculateAndAddInternalForces(VectorType& rRightHandSideVector,
+void MPMUpdatedLagrangianUP::CalculateAndAddInternalForces(VectorType& rRightHandSideVector,
         GeneralVariables & rVariables,
         const double& rIntegrationWeight)
 {
@@ -495,7 +495,7 @@ void UpdatedLagrangianUP::CalculateAndAddInternalForces(VectorType& rRightHandSi
 
 //******************************************************************************************************************
 //******************************************************************************************************************
-double& UpdatedLagrangianUP::CalculatePUCoefficient(double& rCoefficient, GeneralVariables & rVariables)
+double& MPMUpdatedLagrangianUP::CalculatePUCoefficient(double& rCoefficient, GeneralVariables & rVariables)
 {
     KRATOS_TRY
 
@@ -511,7 +511,7 @@ double& UpdatedLagrangianUP::CalculatePUCoefficient(double& rCoefficient, Genera
 //************************************************************************************
 //************************************************************************************
 
-double& UpdatedLagrangianUP::CalculatePUDeltaCoefficient(double &rDeltaCoefficient, GeneralVariables & rVariables)
+double& MPMUpdatedLagrangianUP::CalculatePUDeltaCoefficient(double &rDeltaCoefficient, GeneralVariables & rVariables)
 {
 
     KRATOS_TRY
@@ -528,7 +528,7 @@ double& UpdatedLagrangianUP::CalculatePUDeltaCoefficient(double &rDeltaCoefficie
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::CalculateAndAddPressureForces(VectorType& rRightHandSideVector,
+void MPMUpdatedLagrangianUP::CalculateAndAddPressureForces(VectorType& rRightHandSideVector,
         GeneralVariables & rVariables,
         const double& rIntegrationWeight)
 {
@@ -573,7 +573,7 @@ void UpdatedLagrangianUP::CalculateAndAddPressureForces(VectorType& rRightHandSi
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::CalculateAndAddStabilizedPressure(VectorType& rRightHandSideVector,
+void MPMUpdatedLagrangianUP::CalculateAndAddStabilizedPressure(VectorType& rRightHandSideVector,
         GeneralVariables & rVariables,
         const double& rIntegrationWeight)
 {
@@ -636,7 +636,7 @@ void UpdatedLagrangianUP::CalculateAndAddStabilizedPressure(VectorType& rRightHa
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::CalculateAndAddLHS(
+void MPMUpdatedLagrangianUP::CalculateAndAddLHS(
     MatrixType& rLeftHandSideMatrix,
     GeneralVariables& rVariables,
     const double& rIntegrationWeight,
@@ -675,7 +675,7 @@ void UpdatedLagrangianUP::CalculateAndAddLHS(
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::CalculateAndAddKuum(MatrixType& rLeftHandSideMatrix,
+void MPMUpdatedLagrangianUP::CalculateAndAddKuum(MatrixType& rLeftHandSideMatrix,
         GeneralVariables& rVariables,
         const double& rIntegrationWeight
                                              )
@@ -714,7 +714,7 @@ void UpdatedLagrangianUP::CalculateAndAddKuum(MatrixType& rLeftHandSideMatrix,
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::CalculateAndAddKuugUP(MatrixType& rLeftHandSideMatrix,
+void MPMUpdatedLagrangianUP::CalculateAndAddKuugUP(MatrixType& rLeftHandSideMatrix,
         GeneralVariables& rVariables,
         const double& rIntegrationWeight)
 
@@ -756,7 +756,7 @@ void UpdatedLagrangianUP::CalculateAndAddKuugUP(MatrixType& rLeftHandSideMatrix,
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::CalculateAndAddKup (MatrixType& rLeftHandSideMatrix,
+void MPMUpdatedLagrangianUP::CalculateAndAddKup (MatrixType& rLeftHandSideMatrix,
         GeneralVariables& rVariables,
         const double& rIntegrationWeight)
 {
@@ -787,7 +787,7 @@ void UpdatedLagrangianUP::CalculateAndAddKup (MatrixType& rLeftHandSideMatrix,
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::CalculateAndAddKpu (MatrixType& rLeftHandSideMatrix,
+void MPMUpdatedLagrangianUP::CalculateAndAddKpu (MatrixType& rLeftHandSideMatrix,
         GeneralVariables& rVariables,
         const double& rIntegrationWeight)
 
@@ -818,7 +818,7 @@ void UpdatedLagrangianUP::CalculateAndAddKpu (MatrixType& rLeftHandSideMatrix,
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::CalculateAndAddKpp (MatrixType& rLeftHandSideMatrix,
+void MPMUpdatedLagrangianUP::CalculateAndAddKpp (MatrixType& rLeftHandSideMatrix,
         GeneralVariables& rVariables,
         const double& rIntegrationWeight)
 {
@@ -862,7 +862,7 @@ void UpdatedLagrangianUP::CalculateAndAddKpp (MatrixType& rLeftHandSideMatrix,
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::CalculateAndAddKppStab (MatrixType& rLeftHandSideMatrix,
+void MPMUpdatedLagrangianUP::CalculateAndAddKppStab (MatrixType& rLeftHandSideMatrix,
         GeneralVariables & rVariables,
         const double& rIntegrationWeight)
 {
@@ -926,7 +926,7 @@ void UpdatedLagrangianUP::CalculateAndAddKppStab (MatrixType& rLeftHandSideMatri
 //************************************CALCULATE VOLUME CHANGE*************************
 //************************************************************************************
 
-double& UpdatedLagrangianUP::CalculateVolumeChange( double& rVolumeChange, GeneralVariables& rVariables )
+double& MPMUpdatedLagrangianUP::CalculateVolumeChange( double& rVolumeChange, GeneralVariables& rVariables )
 {
     KRATOS_TRY
 
@@ -940,7 +940,7 @@ double& UpdatedLagrangianUP::CalculateVolumeChange( double& rVolumeChange, Gener
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo ) const
+void MPMUpdatedLagrangianUP::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo ) const
 {
     const GeometryType& r_geometry = GetGeometry();
     const unsigned int number_of_nodes = r_geometry.size();
@@ -971,7 +971,7 @@ void UpdatedLagrangianUP::EquationIdVector( EquationIdVectorType& rResult, const
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& CurrentProcessInfo ) const
+void MPMUpdatedLagrangianUP::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& CurrentProcessInfo ) const
 {
     rElementalDofList.resize( 0 );
 
@@ -994,7 +994,7 @@ void UpdatedLagrangianUP::GetDofList( DofsVectorType& rElementalDofList, const P
 //************************************************************************************
 //****************MASS MATRIX*********************************************************
 
-void UpdatedLagrangianUP::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo )
+void MPMUpdatedLagrangianUP::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -1040,7 +1040,7 @@ void UpdatedLagrangianUP::CalculateMassMatrix( MatrixType& rMassMatrix, const Pr
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::GetValuesVector( Vector& values, int Step ) const
+void MPMUpdatedLagrangianUP::GetValuesVector( Vector& values, int Step ) const
 {
     const GeometryType& r_geometry = GetGeometry();
     const unsigned int number_of_nodes = r_geometry.size();
@@ -1072,7 +1072,7 @@ void UpdatedLagrangianUP::GetValuesVector( Vector& values, int Step ) const
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::GetFirstDerivativesVector( Vector& values, int Step ) const
+void MPMUpdatedLagrangianUP::GetFirstDerivativesVector( Vector& values, int Step ) const
 {
     const GeometryType& r_geometry = GetGeometry();
     const unsigned int number_of_nodes = r_geometry.size();
@@ -1101,7 +1101,7 @@ void UpdatedLagrangianUP::GetFirstDerivativesVector( Vector& values, int Step ) 
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::GetSecondDerivativesVector( Vector& values, int Step ) const
+void MPMUpdatedLagrangianUP::GetSecondDerivativesVector( Vector& values, int Step ) const
 {
     const GeometryType& r_geometry = GetGeometry();
     const unsigned int number_of_nodes = r_geometry.size();
@@ -1132,16 +1132,16 @@ void UpdatedLagrangianUP::GetSecondDerivativesVector( Vector& values, int Step )
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::GetHistoricalVariables( GeneralVariables& rVariables )
+void MPMUpdatedLagrangianUP::GetHistoricalVariables( GeneralVariables& rVariables )
 {
     //Deformation Gradient F ( set to identity )
-    UpdatedLagrangian::GetHistoricalVariables(rVariables);
+    MPMUpdatedLagrangian::GetHistoricalVariables(rVariables);
 }
 
 //************************************************************************************
 //************************************************************************************
 
-void UpdatedLagrangianUP::FinalizeStepVariables( GeneralVariables & rVariables, const ProcessInfo& rCurrentProcessInfo)
+void MPMUpdatedLagrangianUP::FinalizeStepVariables( GeneralVariables & rVariables, const ProcessInfo& rCurrentProcessInfo)
 {
     GeometryType& r_geometry = GetGeometry();
     const unsigned int number_of_nodes = r_geometry.PointsNumber();
@@ -1152,7 +1152,7 @@ void UpdatedLagrangianUP::FinalizeStepVariables( GeneralVariables & rVariables, 
     if ( dimension == 3)
         voigtsize = 6;
 
-    UpdatedLagrangian::FinalizeStepVariables( rVariables, rCurrentProcessInfo);
+    MPMUpdatedLagrangian::FinalizeStepVariables( rVariables, rCurrentProcessInfo);
 
     // Evaluation of the pressure on the material point
     double nodal_mean_stress = 0.0;
@@ -1174,7 +1174,7 @@ void UpdatedLagrangianUP::FinalizeStepVariables( GeneralVariables & rVariables, 
 
 }
 
-void UpdatedLagrangianUP::CalculateOnIntegrationPoints(const Variable<double>& rVariable,
+void MPMUpdatedLagrangianUP::CalculateOnIntegrationPoints(const Variable<double>& rVariable,
     std::vector<double>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
@@ -1185,12 +1185,12 @@ void UpdatedLagrangianUP::CalculateOnIntegrationPoints(const Variable<double>& r
         rValues[0] = m_mp_pressure;
     }
     else {
-        UpdatedLagrangian::CalculateOnIntegrationPoints(
+        MPMUpdatedLagrangian::CalculateOnIntegrationPoints(
             rVariable, rValues, rCurrentProcessInfo);
     }
 }
 
-void UpdatedLagrangianUP::SetValuesOnIntegrationPoints(
+void MPMUpdatedLagrangianUP::SetValuesOnIntegrationPoints(
     const Variable<double>& rVariable,
     const std::vector<double>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
@@ -1203,7 +1203,7 @@ void UpdatedLagrangianUP::SetValuesOnIntegrationPoints(
         m_mp_pressure = rValues[0];
     }
     else {
-        UpdatedLagrangian::SetValuesOnIntegrationPoints(
+        MPMUpdatedLagrangian::SetValuesOnIntegrationPoints(
             rVariable, rValues, rCurrentProcessInfo);
     }
 }
@@ -1217,7 +1217,7 @@ void UpdatedLagrangianUP::SetValuesOnIntegrationPoints(
  * or that no common error is found.
  * @param rCurrentProcessInfo
  */
-int UpdatedLagrangianUP::Check( const ProcessInfo& rCurrentProcessInfo ) const
+int MPMUpdatedLagrangianUP::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
@@ -1228,7 +1228,7 @@ int UpdatedLagrangianUP::Check( const ProcessInfo& rCurrentProcessInfo ) const
     << "Explicit time integration not implemented for Updated Lagrangian UP MPM Element";
 
     int correct = 0;
-    correct = UpdatedLagrangian::Check(rCurrentProcessInfo);
+    correct = MPMUpdatedLagrangian::Check(rCurrentProcessInfo);
 
     // Verify compatibility with the constitutive law
     ConstitutiveLaw::Features LawFeatures;
@@ -1241,15 +1241,15 @@ int UpdatedLagrangianUP::Check( const ProcessInfo& rCurrentProcessInfo ) const
     KRATOS_CATCH( "" );
 }
 
-void UpdatedLagrangianUP::save( Serializer& rSerializer ) const
+void MPMUpdatedLagrangianUP::save( Serializer& rSerializer ) const
 {
-    KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, UpdatedLagrangian )
+    KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, MPMUpdatedLagrangian )
     rSerializer.save("Pressure",m_mp_pressure);
 }
 
-void UpdatedLagrangianUP::load( Serializer& rSerializer )
+void MPMUpdatedLagrangianUP::load( Serializer& rSerializer )
 {
-    KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, UpdatedLagrangian )
+    KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, MPMUpdatedLagrangian )
     rSerializer.load("Pressure",m_mp_pressure);
 }
 

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_UP.hpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_UP.hpp
@@ -45,8 +45,8 @@ namespace Kratos
  * This works for arbitrary geometries in 3D and 2D (base class)
  */
 
-class UpdatedLagrangianUP
-    : public UpdatedLagrangian
+class MPMUpdatedLagrangianUP
+    : public MPMUpdatedLagrangian
 {
 public:
 
@@ -62,7 +62,7 @@ public:
     typedef GeometryData::IntegrationMethod IntegrationMethod;
 
     /// Counted pointer of LargeDisplacementElement
-    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UpdatedLagrangianUP );
+    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( MPMUpdatedLagrangianUP );
     ///@}
 
 
@@ -75,26 +75,26 @@ public:
     ///@{
 
     /// Empty constructor needed for serialization
-    UpdatedLagrangianUP();
+    MPMUpdatedLagrangianUP();
 
 
     /// Default constructors
-    UpdatedLagrangianUP(IndexType NewId, GeometryType::Pointer pGeometry);
+    MPMUpdatedLagrangianUP(IndexType NewId, GeometryType::Pointer pGeometry);
 
-    UpdatedLagrangianUP(IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties);
+    MPMUpdatedLagrangianUP(IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties);
 
     ///Copy constructor
-    UpdatedLagrangianUP(UpdatedLagrangianUP const& rOther);
+    MPMUpdatedLagrangianUP(MPMUpdatedLagrangianUP const& rOther);
 
     /// Destructor.
-    ~UpdatedLagrangianUP() override;
+    ~MPMUpdatedLagrangianUP() override;
 
     ///@}
     ///@name Operators
     ///@{
 
     /// Assignment operator.
-    UpdatedLagrangianUP& operator=(UpdatedLagrangianUP const& rOther);
+    MPMUpdatedLagrangianUP& operator=(MPMUpdatedLagrangianUP const& rOther);
 
     ///@}
     ///@name Operations
@@ -386,7 +386,7 @@ protected:
     /**
      * Calculation of the Deformation Matrix  BL
      */
-    using UpdatedLagrangian::CalculateDeformationMatrix;
+    using MPMUpdatedLagrangian::CalculateDeformationMatrix;
     void CalculateDeformationMatrix(Matrix& rB,
                                     Matrix& rF,
                                     Matrix& rDN_DX);
@@ -451,7 +451,7 @@ private:
     ///@{
     ///@}
 
-}; // Class UpdatedLagrangian
+}; // Class MPMUpdatedLagrangian
 
 ///@}
 ///@name Type Definitions

--- a/applications/ParticleMechanicsApplication/custom_utilities/mpm_particle_generator_utility.cpp
+++ b/applications/ParticleMechanicsApplication/custom_utilities/mpm_particle_generator_utility.cpp
@@ -108,15 +108,15 @@ namespace MPMParticleGeneratorUtility
                     }
 
                     // Set element type
-                    std::string element_type_name = "UpdatedLagrangian";
+                    std::string element_type_name = "MPMUpdatedLagrangian";
                     if (IsMixedFormulation) {
-                        if (background_geo_type == GeometryData::KratosGeometryType::Kratos_Triangle2D3) element_type_name = "UpdatedLagrangianUP";
+                        if (background_geo_type == GeometryData::KratosGeometryType::Kratos_Triangle2D3) element_type_name = "MPMUpdatedLagrangianUP";
                         else KRATOS_ERROR << "Element for mixed U-P formulation is only implemented for 2D Triangle Elements." << std::endl;
                     }
                     else if (IsAxisSymmetry && domain_size == 3) KRATOS_ERROR << "Axisymmetric elements must be used in a 2D domain. You specified a 3D domain." << std::endl;
                     else if (rBackgroundGridModelPart.GetProcessInfo().Has(IS_PQMPM)) {
                         if (rBackgroundGridModelPart.GetProcessInfo().GetValue(IS_PQMPM)) {
-                            element_type_name = "UpdatedLagrangianPQ";
+                            element_type_name = "MPMUpdatedLagrangianPQ";
                             KRATOS_ERROR_IF(IsAxisSymmetry) << "PQMPM is not implemented for axisymmetric elements yet." << std::endl;
                         }
                     }

--- a/applications/ParticleMechanicsApplication/particle_mechanics_application.cpp
+++ b/applications/ParticleMechanicsApplication/particle_mechanics_application.cpp
@@ -115,20 +115,20 @@ namespace Kratos
                         << "Initializing KratosParticleMechanicsApplication..." << std::endl;
 
         // Registering elements
-        KRATOS_REGISTER_ELEMENT("UpdatedLagrangian", mMPMUpdatedLagrangian)
-        KRATOS_REGISTER_ELEMENT("UpdatedLagrangianUP", mMPMUpdatedLagrangianUP)
-        KRATOS_REGISTER_ELEMENT("UpdatedLagrangianPQ", mMPMUpdatedLagrangianPQ)
+        KRATOS_REGISTER_ELEMENT("MPMUpdatedLagrangian", mMPMUpdatedLagrangian)
+        KRATOS_REGISTER_ELEMENT("MPMUpdatedLagrangianUP", mMPMUpdatedLagrangianUP)
+        KRATOS_REGISTER_ELEMENT("MPMUpdatedLagrangianPQ", mMPMUpdatedLagrangianPQ)
 
         // Deprecated elements
-        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangian2D3N", mMPMUpdatedLagrangian2D3N )
-        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangian3D4N", mMPMUpdatedLagrangian3D4N )
-        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangianUP2D3N", mMPMUpdatedLagrangianUP2D3N )
+        KRATOS_REGISTER_ELEMENT( "MPMUpdatedLagrangian2D3N", mMPMUpdatedLagrangian2D3N )
+        KRATOS_REGISTER_ELEMENT( "MPMUpdatedLagrangian3D4N", mMPMUpdatedLagrangian3D4N )
+        KRATOS_REGISTER_ELEMENT( "MPMUpdatedLagrangianUP2D3N", mMPMUpdatedLagrangianUP2D3N )
         //KRATOS_REGISTER_ELEMENT( "MPMUpdatedLagrangianUP3D4N", mMPMUpdatedLagrangianUP3D4N )
-        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangian2D4N", mMPMUpdatedLagrangian2D4N )
-        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangian3D8N", mMPMUpdatedLagrangian3D8N )
+        KRATOS_REGISTER_ELEMENT( "MPMUpdatedLagrangian2D4N", mMPMUpdatedLagrangian2D4N )
+        KRATOS_REGISTER_ELEMENT( "MPMUpdatedLagrangian3D8N", mMPMUpdatedLagrangian3D8N )
         //KRATOS_REGISTER_ELEMENT( "MPMUpdatedLagrangianUP2D4N", mMPMUpdatedLagrangianUP2D4N )
-        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangianAxisymmetry2D3N", mMPMUpdatedLagrangianAxisymmetry2D3N )
-        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangianAxisymmetry2D4N", mMPMUpdatedLagrangianAxisymmetry2D4N )
+        KRATOS_REGISTER_ELEMENT( "MPMUpdatedLagrangianAxisymmetry2D3N", mMPMUpdatedLagrangianAxisymmetry2D3N )
+        KRATOS_REGISTER_ELEMENT( "MPMUpdatedLagrangianAxisymmetry2D4N", mMPMUpdatedLagrangianAxisymmetry2D4N )
 
         // Registering conditions
         // Grid Conditions

--- a/applications/ParticleMechanicsApplication/particle_mechanics_application.cpp
+++ b/applications/ParticleMechanicsApplication/particle_mechanics_application.cpp
@@ -60,22 +60,22 @@ namespace Kratos
     KratosParticleMechanicsApplication::KratosParticleMechanicsApplication():
         KratosApplication("ParticleMechanicsApplication"),
         /// Elements, using QuadraturePointGeometries:
-        mUpdatedLagrangian(0, Element::GeometryType::Pointer(new GeometryType(Element::GeometryType::PointsArrayType(0)))),
-        mUpdatedLagrangianUP(0, Element::GeometryType::Pointer(new GeometryType(Element::GeometryType::PointsArrayType(0)))),
-        mUpdatedLagrangianPQ(0, Element::GeometryType::Pointer(new GeometryType(Element::GeometryType::PointsArrayType(0)))),
+        mMPMUpdatedLagrangian(0, Element::GeometryType::Pointer(new GeometryType(Element::GeometryType::PointsArrayType(0)))),
+        mMPMUpdatedLagrangianUP(0, Element::GeometryType::Pointer(new GeometryType(Element::GeometryType::PointsArrayType(0)))),
+        mMPMUpdatedLagrangianPQ(0, Element::GeometryType::Pointer(new GeometryType(Element::GeometryType::PointsArrayType(0)))),
 
         /// Deprecated Elements
-        mUpdatedLagrangian2D3N( 0, Element::GeometryType::Pointer( new Triangle2D3 <Node<3> >( Element::GeometryType::PointsArrayType( 3 ) ) ) ),
-        mUpdatedLagrangian3D4N( 0, Element::GeometryType::Pointer( new Tetrahedra3D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) ),
-        mUpdatedLagrangianUP2D3N( 0, Element::GeometryType::Pointer( new Triangle2D3 <Node<3> >( Element::GeometryType::PointsArrayType( 3 ) ) ) ),
-        //mUpdatedLagrangianUP3D4N( 0, Element::GeometryType::Pointer( new Tetrahedra3D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) ),
-        mUpdatedLagrangian2D4N( 0, Element::GeometryType::Pointer( new Quadrilateral2D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) ),
-        mUpdatedLagrangian3D8N( 0, Element::GeometryType::Pointer( new Hexahedra3D8 <Node<3> >( Element::GeometryType::PointsArrayType( 8 ) ) ) ),
-        //mUpdatedLagrangianUP2D4N( 0, Element::GeometryType::Pointer( new Quadrilateral2D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) )
+        mMPMUpdatedLagrangian2D3N( 0, Element::GeometryType::Pointer( new Triangle2D3 <Node<3> >( Element::GeometryType::PointsArrayType( 3 ) ) ) ),
+        mMPMUpdatedLagrangian3D4N( 0, Element::GeometryType::Pointer( new Tetrahedra3D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) ),
+        mMPMUpdatedLagrangianUP2D3N( 0, Element::GeometryType::Pointer( new Triangle2D3 <Node<3> >( Element::GeometryType::PointsArrayType( 3 ) ) ) ),
+        //mMPMUpdatedLagrangianUP3D4N( 0, Element::GeometryType::Pointer( new Tetrahedra3D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) ),
+        mMPMUpdatedLagrangian2D4N( 0, Element::GeometryType::Pointer( new Quadrilateral2D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) ),
+        mMPMUpdatedLagrangian3D8N( 0, Element::GeometryType::Pointer( new Hexahedra3D8 <Node<3> >( Element::GeometryType::PointsArrayType( 8 ) ) ) ),
+        //mMPMUpdatedLagrangianUP2D4N( 0, Element::GeometryType::Pointer( new Quadrilateral2D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) )
         //mTotalLagrangian2D3N( 0, Element::GeometryType::Pointer( new Triangle2D3 <Node<3> >( Element::GeometryType::PointsArrayType( 3, Node<3>() ) ) ) ),
         //mTotalLagrangian3D4N( 0, Element::GeometryType::Pointer( new Tetrahedra3D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4, Node<3>() ) ) ) )
-        mUpdatedLagrangianAxisymmetry2D3N( 0, Element::GeometryType::Pointer( new Triangle2D3 <Node<3> >( Element::GeometryType::PointsArrayType( 3 ) ) ) ),
-        mUpdatedLagrangianAxisymmetry2D4N( 0, Element::GeometryType::Pointer( new Quadrilateral2D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) ),
+        mMPMUpdatedLagrangianAxisymmetry2D3N( 0, Element::GeometryType::Pointer( new Triangle2D3 <Node<3> >( Element::GeometryType::PointsArrayType( 3 ) ) ) ),
+        mMPMUpdatedLagrangianAxisymmetry2D4N( 0, Element::GeometryType::Pointer( new Quadrilateral2D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) ),
         //// CONDITIONS:
         // Grid Conditions
         mMPMGridPointLoadCondition2D1N(0, Condition::GeometryType::Pointer(new Point2D<Node<3>>(Condition::GeometryType::PointsArrayType(1)))),
@@ -115,20 +115,20 @@ namespace Kratos
                         << "Initializing KratosParticleMechanicsApplication..." << std::endl;
 
         // Registering elements
-        KRATOS_REGISTER_ELEMENT("UpdatedLagrangian", mUpdatedLagrangian)
-        KRATOS_REGISTER_ELEMENT("UpdatedLagrangianUP", mUpdatedLagrangianUP)
-        KRATOS_REGISTER_ELEMENT("UpdatedLagrangianPQ", mUpdatedLagrangianPQ)
+        KRATOS_REGISTER_ELEMENT("UpdatedLagrangian", mMPMUpdatedLagrangian)
+        KRATOS_REGISTER_ELEMENT("UpdatedLagrangianUP", mMPMUpdatedLagrangianUP)
+        KRATOS_REGISTER_ELEMENT("UpdatedLagrangianPQ", mMPMUpdatedLagrangianPQ)
 
         // Deprecated elements
-        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangian2D3N", mUpdatedLagrangian2D3N )
-        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangian3D4N", mUpdatedLagrangian3D4N )
-        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangianUP2D3N", mUpdatedLagrangianUP2D3N )
-        //KRATOS_REGISTER_ELEMENT( "UpdatedLagrangianUP3D4N", mUpdatedLagrangianUP3D4N )
-        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangian2D4N", mUpdatedLagrangian2D4N )
-        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangian3D8N", mUpdatedLagrangian3D8N )
-        //KRATOS_REGISTER_ELEMENT( "UpdatedLagrangianUP2D4N", mUpdatedLagrangianUP2D4N )
-        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangianAxisymmetry2D3N", mUpdatedLagrangianAxisymmetry2D3N )
-        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangianAxisymmetry2D4N", mUpdatedLagrangianAxisymmetry2D4N )
+        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangian2D3N", mMPMUpdatedLagrangian2D3N )
+        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangian3D4N", mMPMUpdatedLagrangian3D4N )
+        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangianUP2D3N", mMPMUpdatedLagrangianUP2D3N )
+        //KRATOS_REGISTER_ELEMENT( "MPMUpdatedLagrangianUP3D4N", mMPMUpdatedLagrangianUP3D4N )
+        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangian2D4N", mMPMUpdatedLagrangian2D4N )
+        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangian3D8N", mMPMUpdatedLagrangian3D8N )
+        //KRATOS_REGISTER_ELEMENT( "MPMUpdatedLagrangianUP2D4N", mMPMUpdatedLagrangianUP2D4N )
+        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangianAxisymmetry2D3N", mMPMUpdatedLagrangianAxisymmetry2D3N )
+        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangianAxisymmetry2D4N", mMPMUpdatedLagrangianAxisymmetry2D4N )
 
         // Registering conditions
         // Grid Conditions

--- a/applications/ParticleMechanicsApplication/particle_mechanics_application.h
+++ b/applications/ParticleMechanicsApplication/particle_mechanics_application.h
@@ -231,18 +231,18 @@ private:
     ///@{
 
     // Elements
-    const UpdatedLagrangian mUpdatedLagrangian;
-    const UpdatedLagrangianUP mUpdatedLagrangianUP;
-    const UpdatedLagrangianPQ mUpdatedLagrangianPQ;
+    const MPMUpdatedLagrangian mMPMUpdatedLagrangian;
+    const MPMUpdatedLagrangianUP mMPMUpdatedLagrangianUP;
+    const MPMUpdatedLagrangianPQ mMPMUpdatedLagrangianPQ;
 
     // Deprecated Elements
-    const UpdatedLagrangian mUpdatedLagrangian2D3N;
-    const UpdatedLagrangian mUpdatedLagrangian3D4N;
-    const UpdatedLagrangian mUpdatedLagrangianUP2D3N;
-    const UpdatedLagrangian mUpdatedLagrangian2D4N;
-    const UpdatedLagrangian mUpdatedLagrangian3D8N;
-    const UpdatedLagrangian mUpdatedLagrangianAxisymmetry2D3N;
-    const UpdatedLagrangian mUpdatedLagrangianAxisymmetry2D4N;
+    const MPMUpdatedLagrangian mMPMUpdatedLagrangian2D3N;
+    const MPMUpdatedLagrangian mMPMUpdatedLagrangian3D4N;
+    const MPMUpdatedLagrangian mMPMUpdatedLagrangianUP2D3N;
+    const MPMUpdatedLagrangian mMPMUpdatedLagrangian2D4N;
+    const MPMUpdatedLagrangian mMPMUpdatedLagrangian3D8N;
+    const MPMUpdatedLagrangian mMPMUpdatedLagrangianAxisymmetry2D3N;
+    const MPMUpdatedLagrangian mMPMUpdatedLagrangianAxisymmetry2D4N;
 
     // Conditions
     // Grid Conditions:

--- a/applications/ParticleMechanicsApplication/tests/axisym_tests/circular_plate_axisym_test_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/axisym_tests/circular_plate_axisym_test_Body.mdpa
@@ -416,7 +416,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangianAxisymmetry2D3N// GUI group identifier: Parts Auto1
+Begin Elements MPMUpdatedLagrangianAxisymmetry2D3N// GUI group identifier: Parts Auto1
         1          0        408        407        400
         2          0        404        403        397
         3          0          6         11          9

--- a/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_line_load_2D_quad_test_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_line_load_2D_quad_test_Body.mdpa
@@ -899,7 +899,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian2D4N// GUI group identifier: Parts Auto1
+Begin Elements MPMUpdatedLagrangian2D4N// GUI group identifier: Parts Auto1
         1          0         91         75         73         87 
         2          0         93         78         75         91 
         3          0         98         82         78         93 

--- a/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_point_load_2D_tri_test_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_point_load_2D_tri_test_Body.mdpa
@@ -963,7 +963,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian2D3N// GUI group identifier: Parts Auto1
+Begin Elements MPMUpdatedLagrangian2D3N// GUI group identifier: Parts Auto1
         1          0        955        944        954 
         2          0        216        207        204 
         3          0        450        462        457 

--- a/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_surface_load_3D_hexa_test_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_surface_load_3D_hexa_test_Body.mdpa
@@ -1484,7 +1484,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian3D8N// GUI group identifier: Parts Auto1
+Begin Elements MPMUpdatedLagrangian3D8N// GUI group identifier: Parts Auto1
         1          0        141        136        178        187        188        180        210        220 
         2          0        161        141        187        199        200        188        220        231 
         3          0        181        161        199        213        215        200        231        243 

--- a/applications/ParticleMechanicsApplication/tests/beam_tests/dynamic_UP_hyperelastic_cantilever_test/cantilever_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/dynamic_UP_hyperelastic_cantilever_test/cantilever_Body.mdpa
@@ -70,7 +70,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangianUP2D3N// GUI group identifier: Material_domain Auto3
+Begin Elements MPMUpdatedLagrangianUP2D3N// GUI group identifier: Material_domain Auto3
         1          0   406   396   409 
         2          0   132   116   140 
         3          0   261   277   260 

--- a/applications/ParticleMechanicsApplication/tests/beam_tests/dynamic_cantilever/dynamic_cantilever_consistent_mass_test_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/dynamic_cantilever/dynamic_cantilever_consistent_mass_test_Body.mdpa
@@ -30,7 +30,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian2D4N// GUI group identifier: beam
+Begin Elements MPMUpdatedLagrangian2D4N// GUI group identifier: beam
         1          0         13         11          5         10 
         2          0         21         16         11         13 
         3          0         26         23         16         21 

--- a/applications/ParticleMechanicsApplication/tests/beam_tests/hyperelastic_cantilever_beam/self_weight_load_2D_quad_test_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/hyperelastic_cantilever_beam/self_weight_load_2D_quad_test_Body.mdpa
@@ -921,7 +921,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian2D4N// GUI group identifier: Parts Auto1
+Begin Elements MPMUpdatedLagrangian2D4N// GUI group identifier: Parts Auto1
         1          0          2          1          3          4 
         2          0         74         93         95         76 
         3          0        902        913        912        901 

--- a/applications/ParticleMechanicsApplication/tests/cl_tests/fluid_cl/newtonian_fluid_test_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/cl_tests/fluid_cl/newtonian_fluid_test_Body.mdpa
@@ -133,7 +133,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian2D3N// GUI group identifier: Solid Auto1
+Begin Elements MPMUpdatedLagrangian2D3N// GUI group identifier: Solid Auto1
        21          0     3     6     4 
        22          0   126   130   122 
        23          0    60    47    53 

--- a/applications/ParticleMechanicsApplication/tests/cl_tests/solid_cl/linear_elastic_3D_hexa_test_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/cl_tests/solid_cl/linear_elastic_3D_hexa_test_Body.mdpa
@@ -16,7 +16,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian3D8N// GUI group identifier: Parts Auto1
+Begin Elements MPMUpdatedLagrangian3D8N// GUI group identifier: Parts Auto1
         1          0          4          1          2          6          7          3          5          8
 End Elements
 

--- a/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/cook_membrane_2D_test_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/cook_membrane_2D_test_Body.mdpa
@@ -1728,7 +1728,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian2D3N// GUI group identifier: Parts Auto1
+Begin Elements MPMUpdatedLagrangian2D3N// GUI group identifier: Parts Auto1
         1          0       1720       1718       1719 
         2          0       1574       1557       1553 
         3          0       1278       1258       1251 

--- a/applications/ParticleMechanicsApplication/tests/cpp_tests/test_energy_calculation_utility.cpp
+++ b/applications/ParticleMechanicsApplication/tests/cpp_tests/test_energy_calculation_utility.cpp
@@ -37,7 +37,7 @@ namespace Testing
         Properties::Pointer p_elem_prop = rModelPart.CreateNewProperties(0);
 
         // Elements
-        auto pElement = rModelPart.CreateNewElement("UpdatedLagrangian3D4N", 1, {{1, 2, 3, 4}}, p_elem_prop);
+        auto pElement = rModelPart.CreateNewElement("MPMUpdatedLagrangian3D4N", 1, {{1, 2, 3, 4}}, p_elem_prop);
 
         // For potential energy
         array_1d<double, 3> mp_coordinate;

--- a/applications/ParticleMechanicsApplication/tests/cpp_tests/test_search_element_utility.cpp
+++ b/applications/ParticleMechanicsApplication/tests/cpp_tests/test_search_element_utility.cpp
@@ -41,7 +41,7 @@ namespace Testing
         auto p_quad = CreateQuadraturePointsUtility<Node<3>>::CreateFromCoordinates(
             rBackgroundModelPart.GetElement(1).pGetGeometry(), rMPCoords, IntWeight);
 
-        const Element& new_element = KratosComponents<Element>::Get("UpdatedLagrangian2D4N");
+        const Element& new_element = KratosComponents<Element>::Get("MPMUpdatedLagrangian2D4N");
         Element::Pointer p_element = new_element.Create(
             2, p_quad, p_elem_prop);
 

--- a/applications/ParticleMechanicsApplication/tests/explicit_tests/axisymmetric_disk/quad_compressible_explicit_axisym_disk_test_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/explicit_tests/axisymmetric_disk/quad_compressible_explicit_axisym_disk_test_Body.mdpa
@@ -26,7 +26,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangianAxisymmetry2D4N// GUI group identifier: disk
+Begin Elements MPMUpdatedLagrangianAxisymmetry2D4N// GUI group identifier: disk
         1          0         44         41         49         52 
         2          0         36         33         41         44 
         3          0         29         22         33         36 

--- a/applications/ParticleMechanicsApplication/tests/explicit_tests/axisymmetric_disk/tri_compressible_explicit_axisym_disk_test_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/explicit_tests/axisymmetric_disk/tri_compressible_explicit_axisym_disk_test_Body.mdpa
@@ -26,7 +26,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangianAxisymmetry2D3N// GUI group identifier: disk
+Begin Elements MPMUpdatedLagrangianAxisymmetry2D3N// GUI group identifier: disk
         1          0         44         41         52 
         2          0         41         49         52 
         3          0         36         33         44 

--- a/applications/ParticleMechanicsApplication/tests/explicit_tests/oscillating_point/explicit_oscillating_point_test_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/explicit_tests/oscillating_point/explicit_oscillating_point_test_Body.mdpa
@@ -12,7 +12,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian2D4N// GUI group identifier: bar
+Begin Elements MPMUpdatedLagrangian2D4N// GUI group identifier: bar
        31          0         45         43         49         50 
 End Elements
 

--- a/applications/ParticleMechanicsApplication/tests/explicit_tests/oscillating_point/tri_explicit_oscillating_point_test_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/explicit_tests/oscillating_point/tri_explicit_oscillating_point_test_Body.mdpa
@@ -12,7 +12,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian2D3N// GUI group identifier: bar
+Begin Elements MPMUpdatedLagrangian2D3N// GUI group identifier: bar
         5          0          6          3         10 
         6          0          3          7         10 
 End Elements

--- a/applications/ParticleMechanicsApplication/tests/explicit_tests/oscillating_point_3d/3dhex_compressible_explicit_oscillating_point_test_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/explicit_tests/oscillating_point_3d/3dhex_compressible_explicit_oscillating_point_test_Body.mdpa
@@ -16,7 +16,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian3D8N// GUI group identifier: bar
+Begin Elements MPMUpdatedLagrangian3D8N// GUI group identifier: bar
         3          0         14         18         10          3         16         20         12          9 
 End Elements
 

--- a/applications/ParticleMechanicsApplication/tests/explicit_tests/oscillating_point_3d/3dtet_compressible_explicit_oscillating_point_test_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/explicit_tests/oscillating_point_3d/3dtet_compressible_explicit_oscillating_point_test_Body.mdpa
@@ -16,7 +16,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian3D4N// GUI group identifier: bar
+Begin Elements MPMUpdatedLagrangian3D4N// GUI group identifier: bar
        13          0          9          3         10         14 
        14          0         14         18         10          9 
        15          0         12         10         18          9 

--- a/applications/ParticleMechanicsApplication/tests/gravity_tests/dynamic_gravity_application_test_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/gravity_tests/dynamic_gravity_application_test_Body.mdpa
@@ -12,7 +12,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian2D4N// GUI group identifier: Parts Auto1
+Begin Elements MPMUpdatedLagrangian2D4N// GUI group identifier: Parts Auto1
        11          0         19         23         25         21 
 End Elements
 

--- a/applications/ParticleMechanicsApplication/tests/pqmpm_tests/pqmpm_explicit_2D_test_body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/pqmpm_tests/pqmpm_explicit_2D_test_body.mdpa
@@ -41,7 +41,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian2D4N// GUI group identifier: bar
+Begin Elements MPMUpdatedLagrangian2D4N// GUI group identifier: bar
         1          0        257        249        269        276 
         2          0        237        231        249        257 
         3          0        223        207        231        237 

--- a/applications/ParticleMechanicsApplication/tests/pqmpm_tests/pqmpm_explicit_3D_test_body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/pqmpm_tests/pqmpm_explicit_3D_test_body.mdpa
@@ -16,7 +16,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian3D8N// GUI group identifier: point
+Begin Elements MPMUpdatedLagrangian3D8N// GUI group identifier: point
        28          0         26         20         41         58         43         27         55         62 
 End Elements
 

--- a/applications/ParticleMechanicsApplication/tests/slip_tests/slip_boundary_test_Body.mdpa
+++ b/applications/ParticleMechanicsApplication/tests/slip_tests/slip_boundary_test_Body.mdpa
@@ -12,7 +12,7 @@ Begin Nodes
 End Nodes
 
 
-Begin Elements UpdatedLagrangian2D3N// GUI group identifier: Parts Auto1
+Begin Elements MPMUpdatedLagrangian2D3N// GUI group identifier: Parts Auto1
        21          0         25         23         21 
        22          0         23         20         21 
 End Elements

--- a/applications/ParticleMechanicsApplication/tests/test_generate_mpm_particle_condition.py
+++ b/applications/ParticleMechanicsApplication/tests/test_generate_mpm_particle_condition.py
@@ -56,9 +56,9 @@ class TestGenerateMPMParticleCondition(KratosUnittest.TestCase):
 
     def _create_elements(self, initial_mp, dimension, geometry_element):
         if (dimension == 2):
-            initial_mp.CreateNewElement("UpdatedLagrangian2D4N", 1, [1,2,3,4], initial_mp.GetProperties()[1])
+            initial_mp.CreateNewElement("MPMUpdatedLagrangian2D4N", 1, [1,2,3,4], initial_mp.GetProperties()[1])
         else:
-            initial_mp.CreateNewElement("UpdatedLagrangian3D8N", 1, [1,2,3,4,5,6,7,8], initial_mp.GetProperties()[1])
+            initial_mp.CreateNewElement("MPMUpdatedLagrangian3D8N", 1, [1,2,3,4,5,6,7,8], initial_mp.GetProperties()[1])
 
         KratosMultiphysics.VariableUtils().SetFlag(KratosMultiphysics.ACTIVE, True, initial_mp.Elements)
 

--- a/applications/ParticleMechanicsApplication/tests/test_particle_erase_process.py
+++ b/applications/ParticleMechanicsApplication/tests/test_particle_erase_process.py
@@ -53,7 +53,7 @@ class TestParticleEraseProcess(KratosUnittest.TestCase):
         initial_mp.CreateNewNode(8, -0.5,  0.5, 1.0)
 
     def _create_elements(self, initial_mp):
-        initial_mp.CreateNewElement("UpdatedLagrangian3D8N", 1, [1,2,3,4,5,6,7,8], initial_mp.GetProperties()[1])
+        initial_mp.CreateNewElement("MPMUpdatedLagrangian3D8N", 1, [1,2,3,4,5,6,7,8], initial_mp.GetProperties()[1])
         KratosMultiphysics.VariableUtils().SetFlag(KratosMultiphysics.ACTIVE, True, initial_mp.Elements)
 
     def _create_conditions(self, initial_mp):


### PR DESCRIPTION
**📝 Description**
The Updated Lagrangian Element Class name causes confusion when running a simulation with the Co-Simulation Application. For this reason, the MPM Classes were renamed using a unique name to avoid wrong serialization.

Implemented in combination with KratosMultiphysics/GiDInterface#929 .
