### PR TITLE
[GeoMechanicsApplication] Changed Sellmeijer Formulation to reflect heads

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
@@ -12,6 +12,7 @@
 
 // Application includes
 #include "custom_elements/steady_state_Pw_piping_element.hpp"
+#include "custom_utilities/element_utilities.hpp"
 #include <cmath>
 namespace Kratos
 {
@@ -262,20 +263,20 @@ void SteadyStatePwPipingElement<TDim,TNumNodes>::
 }
 
 template< >
-double SteadyStatePwPipingElement<2, 4>::CalculateWaterPressureGradient(const PropertiesType& Prop, const GeometryType& Geom, double dx)
+double SteadyStatePwPipingElement<2, 4>::CalculateHeadGradient(const PropertiesType& Prop, const GeometryType& Geom, double dx)
 {
-	return abs((Geom[3].FastGetSolutionStepValue(WATER_PRESSURE) + Geom[0].FastGetSolutionStepValue(WATER_PRESSURE))/2 
-        - (Geom[2].GetSolutionStepValue(WATER_PRESSURE)+ Geom[1].GetSolutionStepValue(WATER_PRESSURE))/2) / dx;
+    auto nodalHead = GeoElementUtilities::CalculateNodalHydraulicHeadFromWaterPressures<4>(Geom, Prop);
+	return abs((nodalHead[3] + nodalHead[0]) / 2 - (nodalHead[2] + nodalHead[1])/2) / dx;
 }
 template< >
-double SteadyStatePwPipingElement<3, 6>::CalculateWaterPressureGradient(const PropertiesType& Prop, const GeometryType& Geom, double dx)
+double SteadyStatePwPipingElement<3, 6>::CalculateHeadGradient(const PropertiesType& Prop, const GeometryType& Geom, double dx)
 {
-    KRATOS_ERROR << " pressure gradient calculation of SteadyStatePwPipingElement3D6N element is not implemented" << std::endl;
+    KRATOS_ERROR << " head gradient calculation of SteadyStatePwPipingElement3D6N element is not implemented" << std::endl;
 }
 template< >
-double SteadyStatePwPipingElement<3, 8>::CalculateWaterPressureGradient(const PropertiesType& Prop, const GeometryType& Geom, double dx)
+double SteadyStatePwPipingElement<3, 8>::CalculateHeadGradient(const PropertiesType& Prop, const GeometryType& Geom, double dx)
 {
-    KRATOS_ERROR << " pressure gradient calculation of SteadyStatePwPipingElement3D8N element is not implemented" << std::endl;
+    KRATOS_ERROR << " head gradient calculation of SteadyStatePwPipingElement3D8N element is not implemented" << std::endl;
 }
 
 /// <summary>
@@ -312,8 +313,8 @@ double SteadyStatePwPipingElement<TDim,TNumNodes>:: CalculateEquilibriumPipeHeig
     const double SolidDensity = Prop[DENSITY_SOLID];
     const double FluidDensity = Prop[DENSITY_WATER];
  
-    // calculate pressure gradient over element
-    double dpdx = CalculateWaterPressureGradient(Prop, Geom, pipe_length);
+    // calculate head gradient over element
+    double dhdx = CalculateHeadGradient(Prop, Geom, pipe_length);
 
     // calculate particle diameter
     double particle_d = CalculateParticleDiameter(Prop);
@@ -321,17 +322,13 @@ double SteadyStatePwPipingElement<TDim,TNumNodes>:: CalculateEquilibriumPipeHeig
     // todo calculate slope of pipe, currently pipe is assumed to be horizontal
     const double pipeSlope = 0;
 
-    // return infinite when dpdx is 0
-    if (dpdx < std::numeric_limits<double>::epsilon())
+    // return infinite when dhdx is 0
+    if (dhdx < std::numeric_limits<double>::epsilon())
     { 
         return 1e10;
     }
-
-    // gravity is taken from first node
-    array_1d<double, 3> gravity_array= Geom[0].FastGetSolutionStepValue(VOLUME_ACCELERATION);
-    const double gravity = norm_2(gravity_array);
 	
-    return modelFactor * M_PI / 3.0 * particle_d * (SolidDensity - FluidDensity) * gravity * eta  * sin((theta  + pipeSlope) * M_PI / 180.0) / cos(theta * M_PI / 180.0) / dpdx;
+    return modelFactor * M_PI / 3.0 * particle_d * (SolidDensity / FluidDensity - 1) * eta  * sin((theta  + pipeSlope) * M_PI / 180.0) / cos(theta * M_PI / 180.0) / dhdx;
 
 }
 

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.cpp
@@ -266,7 +266,7 @@ template< >
 double SteadyStatePwPipingElement<2, 4>::CalculateHeadGradient(const PropertiesType& Prop, const GeometryType& Geom, double dx)
 {
     auto nodalHead = GeoElementUtilities::CalculateNodalHydraulicHeadFromWaterPressures<4>(Geom, Prop);
-	return abs((nodalHead[3] + nodalHead[0]) / 2 - (nodalHead[2] + nodalHead[1])/2) / dx;
+	return std::abs((nodalHead[3] + nodalHead[0]) / 2 - (nodalHead[2] + nodalHead[1])/2) / dx;
 }
 template< >
 double SteadyStatePwPipingElement<3, 6>::CalculateHeadGradient(const PropertiesType& Prop, const GeometryType& Geom, double dx)

--- a/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/steady_state_Pw_piping_element.hpp
@@ -95,7 +95,7 @@ public:
 
     bool InEquilibrium(const PropertiesType& Prop, const GeometryType& Geom);
 
-    double CalculateWaterPressureGradient(const PropertiesType& Prop, const GeometryType& Geom, double pipe_length);
+    double CalculateHeadGradient(const PropertiesType& Prop, const GeometryType& Geom, double pipe_length);
 
     double CalculateEquilibriumPipeHeight(const PropertiesType& Prop, const GeometryType& Geom, double dx);
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_steady_state_Pw_piping_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_steady_state_Pw_piping_element.cpp
@@ -58,8 +58,8 @@ namespace Kratos
             p_elem_prop->SetValue(CONSTITUTIVE_LAW, r_clone_cl.Clone());
 
             // Create the test piping element nodes
-            auto p_node_1 = r_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-            auto p_node_2 = r_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+            auto p_node_1 = r_model_part.CreateNewNode(1, 0.0, -0.1, 0.0);
+            auto p_node_2 = r_model_part.CreateNewNode(2, 1.0, -0.1, 0.0);
             auto p_node_3 = r_model_part.CreateNewNode(3, 1.0, 0.1, 0.0);
             auto p_node_4 = r_model_part.CreateNewNode(4, 0.0, 0.1, 0.0);
 
@@ -112,7 +112,7 @@ namespace Kratos
                 1.0e-6);
         }
 
-        KRATOS_TEST_CASE_IN_SUITE(CalculateWaterPressureGradient, KratosGeoMechanicsFastSuite)
+        KRATOS_TEST_CASE_IN_SUITE(CalculateHeadGradient, KratosGeoMechanicsFastSuite)
         {
             // initialize modelpart
             Model current_model;
@@ -123,16 +123,22 @@ namespace Kratos
             // Set the element properties
             auto p_elem_prop = r_model_part.CreateNewProperties(0);
             p_elem_prop->SetValue(PIPE_ELEMENT_LENGTH, 1);
+            p_elem_prop->SetValue(DENSITY_WATER, 1000);
 
             // set constitutive law
             const auto &r_clone_cl = KratosComponents<ConstitutiveLaw>::Get("LinearElastic2DInterfaceLaw");
             p_elem_prop->SetValue(CONSTITUTIVE_LAW, r_clone_cl.Clone());
 
             // Create the test piping element nodes
-            auto p_node_1 = r_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-            auto p_node_2 = r_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+            auto p_node_1 = r_model_part.CreateNewNode(1, 0.0, -0.1, 0.0);
+            auto p_node_2 = r_model_part.CreateNewNode(2, 1.0, -0.1, 0.0);
             auto p_node_3 = r_model_part.CreateNewNode(3, 1.0, 0.1, 0.0);
             auto p_node_4 = r_model_part.CreateNewNode(4, 0.0, 0.1, 0.0);
+
+            array_1d<double, 3> gravity_array;
+            gravity_array[0] = 0;
+            gravity_array[1] = 10;
+            gravity_array[2] = 0;
 
             // set water pressure values to nodes
             p_node_1->SetLock();
@@ -141,9 +147,14 @@ namespace Kratos
             p_node_4->SetLock();
 
             p_node_1->FastGetSolutionStepValue(WATER_PRESSURE) = 0;
-            p_node_2->FastGetSolutionStepValue(WATER_PRESSURE) = 2;
-            p_node_3->FastGetSolutionStepValue(WATER_PRESSURE) = 2;
+            p_node_2->FastGetSolutionStepValue(WATER_PRESSURE) = 20000;
+            p_node_3->FastGetSolutionStepValue(WATER_PRESSURE) = 20000;
             p_node_4->FastGetSolutionStepValue(WATER_PRESSURE) = 0;
+
+            p_node_1->FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_array;
+            p_node_2->FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_array;
+            p_node_3->FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_array;
+            p_node_4->FastGetSolutionStepValue(VOLUME_ACCELERATION) = gravity_array;
 
             p_node_1->UnSetLock();
             p_node_2->UnSetLock();
@@ -165,7 +176,7 @@ namespace Kratos
             auto PipeEl = static_cast<SteadyStatePwPipingElement<2, 4> *>(p_element.get());
 
             // calculate water pressure gradient
-            double expected_gradient = PipeEl->CalculateWaterPressureGradient(*p_elem_prop, Geom, p_elem_prop->GetValue(PIPE_ELEMENT_LENGTH));
+            double expected_gradient = PipeEl->CalculateHeadGradient(*p_elem_prop, Geom, p_elem_prop->GetValue(PIPE_ELEMENT_LENGTH));
 
             // assert gradient
             // expected gradient should be 2. Test is failing on purpose to check CI

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_steady_state_Pw_piping_element.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_steady_state_Pw_piping_element.cpp
@@ -119,6 +119,7 @@ namespace Kratos
             auto &r_model_part = current_model.CreateModelPart("ModelPart", 1);
             r_model_part.GetProcessInfo().SetValue(DOMAIN_SIZE, 2);
             r_model_part.AddNodalSolutionStepVariable(WATER_PRESSURE);
+            r_model_part.AddNodalSolutionStepVariable(VOLUME_ACCELERATION);
 
             // Set the element properties
             auto p_elem_prop = r_model_part.CreateNewProperties(0);


### PR DESCRIPTION
**📝 Description**
Changed Sellmeijer Formulation to reflect heads, and not pressures. (closes #10941) 

A brief description of the PR.
- Changed Sellmeijer Formulation to reflect heads, and not water pressures.
- As requested by PO DGeoFlow
- This should have no fundemental change in the calculation or result of horizonal pipes.

**🆕 Changelog**
Please summarize the changes in one list to generate the changelog:
- Changed equilibrium pipe height calculation to reflect use of heads and not water pressure.
- All effected tests changed accordingly. Full integrations tests should not change.
