### PR TITLE
[StructuralMechanicsApplication] Removed redefinition of `mParameters` in constructor set_moving_load_process

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_processes/set_moving_load_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_moving_load_process.cpp
@@ -44,7 +44,7 @@ SetMovingLoadProcess::SetMovingLoadProcess(ModelPart& rModelPart,
         }  )"
     );
     
-    // set default velocity as a string, if the input velocity is a string
+    // Set default velocity as a string, if the input velocity is a string
     if (mParameters.Has("velocity")){
         if (mParameters["velocity"].IsString()){
             default_parameters["velocity"].SetString("1");

--- a/applications/StructuralMechanicsApplication/custom_processes/set_moving_load_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_moving_load_process.cpp
@@ -43,7 +43,13 @@ SetMovingLoadProcess::SetMovingLoadProcess(ModelPart& rModelPart,
             "origin"          : [0.0, 0.0, 0.0]
         }  )"
     );
-    Parameters mParameters;
+    
+    // set default velocity as a string, if the input velocity is a string
+    if (mParameters.Has("velocity")){
+        if (mParameters["velocity"].IsString()){
+            default_parameters["velocity"].SetString("1");
+        }
+    }
 
     mParameters.RecursivelyValidateAndAssignDefaults(default_parameters);
 


### PR DESCRIPTION
- removed redefinition of mParameters in constructor

- default value for velocity is set to string if required by input