### PR TITLE
[Core] STL Reader - pass new entity type by parameters

### DIFF
--- a/kratos/input_output/stl_io.cpp
+++ b/kratos/input_output/stl_io.cpp
@@ -91,7 +91,7 @@ void StlIO::ReadModelPart(ModelPart & rThisModelPart)
     std::function<void(ModelPart&, NodesArrayType&)> create_entity_func;
     const std::string new_entity_type = mParameters["new_entity_type"].GetString();
     if (new_entity_type == "geometry") {
-        create_entity_func = [this](
+        create_entity_func = [](
             ModelPart& rThisModelPart,
             NodesArrayType& rIndexes) {
                 rThisModelPart.CreateNewGeometry("Triangle3D3", rIndexes);

--- a/kratos/input_output/stl_io.h
+++ b/kratos/input_output/stl_io.h
@@ -95,10 +95,14 @@ public:
     ///@{
 
     /// Constructor with filename, and open option with default being read mode
-    StlIO(std::filesystem::path const& Filename, const Flags Options = IO::READ);
+    StlIO(
+        std::filesystem::path const& Filename,
+        Parameters ThisParameters = Parameters());
 
     /// Constructor with stream.
-    StlIO(Kratos::shared_ptr<std::iostream> pInputStream);
+    StlIO(
+        Kratos::shared_ptr<std::iostream> pInputStream,
+        Parameters ThisParameters = Parameters());
 
     /// Destructor.
     virtual ~StlIO(){}
@@ -110,6 +114,8 @@ public:
     ///@}
     ///@name Operations
     ///@{
+
+    static Parameters GetDefaultParameters();
 
     void ReadModelPart(ModelPart & rThisModelPart) override;
 
@@ -148,6 +154,12 @@ protected:
     ///@}
     ///@name Protected member Variables
     ///@{
+
+    Parameters mParameters;
+
+    std::size_t mNextNodeId = 0;
+    std::size_t mNextElementId = 0;
+    std::size_t mNextConditionId = 0;
 
     ///@}
     ///@name Protected Operators

--- a/kratos/input_output/stl_io.h
+++ b/kratos/input_output/stl_io.h
@@ -85,7 +85,8 @@ public:
     ///@name Type Definitions
     ///@{
 
-    typedef ModelPart::GeometriesMapType GeometriesMapType;
+    using GeometriesMapType = ModelPart::GeometriesMapType;
+    using NodesArrayType = Element::NodesArrayType;
 
     /// Pointer definition of StlIO
     KRATOS_CLASS_POINTER_DEFINITION(StlIO);
@@ -201,11 +202,17 @@ private:
     ///@name Private Operations
     ///@{
 
-    void ReadSolid(ModelPart & rThisModelPart);
-    
-    void ReadFacet(ModelPart & rThisModelPart);
+    void ReadSolid(
+        ModelPart & rThisModelPart,
+        const std::function<void(ModelPart&, NodesArrayType&)>& rCreateEntityFunctor );
 
-    void ReadLoop(ModelPart & rThisModelPart);
+    void ReadFacet(
+        ModelPart & rThisModelPart,
+        const std::function<void(ModelPart&, NodesArrayType&)>& rCreateEntityFunctor);
+
+    void ReadLoop(
+        ModelPart & rThisModelPart,
+        const std::function<void(ModelPart&, NodesArrayType&)>& rCreateEntityFunctor);
 
     Point ReadPoint();
 

--- a/kratos/python/add_io_to_python.cpp
+++ b/kratos/python/add_io_to_python.cpp
@@ -186,7 +186,7 @@ void  AddIOToPython(pybind11::module& m)
 
     py::class_<StlIO, StlIO::Pointer, IO>(m, "StlIO")
         .def(py::init<std::filesystem::path const& >())
-        .def(py::init<const std::filesystem::path&, const Flags>())
+        .def(py::init<std::filesystem::path const&, Parameters>())
         ;
 
 

--- a/kratos/tests/cpp_tests/input_output/test_stl_io.cpp
+++ b/kratos/tests/cpp_tests/input_output/test_stl_io.cpp
@@ -44,8 +44,6 @@ KRATOS_TEST_CASE_IN_SUITE(ReadTriangleFromSTL, KratosCoreFastSuite)
     StlIO stl_io(p_input);
     stl_io.ReadModelPart(r_model_part);
 
-    std::cout << r_model_part << std::endl;
-
     KRATOS_CHECK(r_model_part.HasSubModelPart("1 triangle"));
     KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("1 triangle").NumberOfNodes(), 3);
     KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("1 triangle").NumberOfGeometries(), 1);
@@ -73,8 +71,6 @@ KRATOS_TEST_CASE_IN_SUITE(ReadTriangleFromSTLAsElement, KratosCoreFastSuite)
     })");
     StlIO stl_io(p_input,settings);
     stl_io.ReadModelPart(r_model_part);
-
-    std::cout << r_model_part << std::endl;
 
     KRATOS_CHECK(r_model_part.HasSubModelPart("1 triangle"));
     KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("1 triangle").NumberOfNodes(), 3);
@@ -115,8 +111,6 @@ KRATOS_TEST_CASE_IN_SUITE(ReadMultipleTrianglesFromSTL, KratosCoreFastSuite)
 
     StlIO stl_io(p_input);
     stl_io.ReadModelPart(r_model_part);
-
-    std::cout << r_model_part << std::endl;
 
     KRATOS_CHECK(r_model_part.HasSubModelPart("3 triangles"));
     KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("3 triangles").NumberOfNodes(), 9);

--- a/kratos/tests/cpp_tests/input_output/test_stl_io.cpp
+++ b/kratos/tests/cpp_tests/input_output/test_stl_io.cpp
@@ -51,6 +51,37 @@ KRATOS_TEST_CASE_IN_SUITE(ReadTriangleFromSTL, KratosCoreFastSuite)
     KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("1 triangle").NumberOfGeometries(), 1);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(ReadTriangleFromSTLAsElement, KratosCoreFastSuite)
+{
+    Kratos::shared_ptr<std::stringstream> p_input = Kratos::make_shared<std::stringstream>(R"input(
+    solid 1 triangle
+        facet normal  1.000000 0.000000 0.000000 
+            outer loop 
+            vertex 0.1 -2.56114e-08 0.1
+            vertex 0.1 -0.499156 -0.0352136
+            vertex 0.1 -0.473406 -0.0446259
+            endloop 
+        endfacet 
+    endsolid 1 triangle
+    )input");  
+
+    Model current_model;
+    ModelPart& r_model_part = current_model.CreateModelPart("Main");
+
+    Parameters settings(R"({
+        "new_entity_type" : "element"
+    })");
+    StlIO stl_io(p_input,settings);
+    stl_io.ReadModelPart(r_model_part);
+
+    std::cout << r_model_part << std::endl;
+
+    KRATOS_CHECK(r_model_part.HasSubModelPart("1 triangle"));
+    KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("1 triangle").NumberOfNodes(), 3);
+    KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("1 triangle").NumberOfGeometries(), 0);
+    KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("1 triangle").NumberOfElements(), 1);
+}
+
 KRATOS_TEST_CASE_IN_SUITE(ReadMultipleTrianglesFromSTL, KratosCoreFastSuite)
 {
     Kratos::shared_ptr<std::stringstream> p_input = Kratos::make_shared<std::stringstream>(R"input(
@@ -109,10 +140,14 @@ KRATOS_TEST_CASE_IN_SUITE(WriteTriangleToSTL, KratosCoreFastSuite)
     //this element should be ignored as its area is zero.
     r_model_part.CreateNewElement("Element3D3N", 102, {1, 2, 4}, p_properties);
 
+    Parameters settings(R"({
+        "open_mode" : "write"
+    })");
+
     // write stl
     std::filesystem::path filename = "test_stl_write.stl";
     {
-        StlIO stl_write(filename, IO::WRITE);
+        StlIO stl_write(filename, settings);
         stl_write.WriteModelPart(r_model_part);
         // force to write to file
     }


### PR DESCRIPTION
I tried to use stl reader with geometries after https://github.com/KratosMultiphysics/Kratos/pull/10937 but the problem is that in many places we cannot directly use this, as many processes/utilities do not work with geometry containers, only with elements/conditions. @pooyan-dadvand proposed to pass this as an option, so by default we still read the new entities as geometries, but we can also create elements or conditions.

This class already received a Flags object in the constructor. I thought it'd be more clear to put everything together under Parameters.
