### PR TITLE
[Core] pass settings to apply ray casting process

### DIFF
--- a/kratos/processes/apply_ray_casting_process.cpp
+++ b/kratos/processes/apply_ray_casting_process.cpp
@@ -86,7 +86,7 @@ namespace Kratos
         } else if (database == "nodal_non_historical") {
             node_distance_getter = [](NodeType& rNode, const Variable<double>& rDistanceVariable)->double&{return rNode.GetValue(rDistanceVariable);};
         } else {
-            KRATOS_ERROR << "Unrecognized database " <<  database << std::endl;
+            KRATOS_ERROR << "Provided 'distance_database' is '" << database << "'. Available options are 'nodal_historical' and 'nodal_non_historical'." <<  std::endl;
         }
 
         const Variable<double>* mpDistanceVariable = &KratosComponents<Variable<double>>::Get(mSettings["distance_variable"].GetString());

--- a/kratos/processes/apply_ray_casting_process.cpp
+++ b/kratos/processes/apply_ray_casting_process.cpp
@@ -24,102 +24,98 @@
 namespace Kratos
 {
 
-	template<std::size_t TDim>
-	ApplyRayCastingProcess<TDim>::ApplyRayCastingProcess(
-		ModelPart& rVolumePart,
-		ModelPart& rSkinPart)
-		: mpFindIntersectedObjectsProcess(new FindIntersectedGeometricalObjectsProcess(rVolumePart, rSkinPart)),
-		  mIsSearchStructureAllocated(true)
-	{
-	}
+    template<std::size_t TDim>
+    ApplyRayCastingProcess<TDim>::ApplyRayCastingProcess(
+        ModelPart& rVolumePart,
+        ModelPart& rSkinPart,
+        Parameters ThisParameters)
+        : mSettings(ThisParameters),
+          mpFindIntersectedObjectsProcess(new FindIntersectedGeometricalObjectsProcess(rVolumePart, rSkinPart)),
+          mIsSearchStructureAllocated(true)
+    {
+        mSettings.ValidateAndAssignDefaults(GetDefaultParameters());
+        mRelativeTolerance = mSettings["relative_tolerance"].GetDouble();
+    }
 
-	template <std::size_t TDim>
-	ApplyRayCastingProcess<TDim>::ApplyRayCastingProcess(
-		ModelPart &rVolumePart,
-		ModelPart &rSkinPart,
-		const double RelativeTolerance)
-		: mRelativeTolerance(RelativeTolerance),
-		  mpFindIntersectedObjectsProcess(new FindIntersectedGeometricalObjectsProcess(rVolumePart, rSkinPart)),
-		  mIsSearchStructureAllocated(true)
-	{
-	}
+    template <std::size_t TDim>
+    ApplyRayCastingProcess<TDim>::ApplyRayCastingProcess(
+        FindIntersectedGeometricalObjectsProcess &TheFindIntersectedObjectsProcess,
+        Parameters ThisParameters)
+        : mSettings(ThisParameters),
+          mpFindIntersectedObjectsProcess(&TheFindIntersectedObjectsProcess),
+          mIsSearchStructureAllocated(false)
+    {
+        mSettings.ValidateAndAssignDefaults(GetDefaultParameters());
+        mRelativeTolerance = mSettings["relative_tolerance"].GetDouble();
+    }
 
-	template <std::size_t TDim>
-	ApplyRayCastingProcess<TDim>::ApplyRayCastingProcess(
-		FindIntersectedGeometricalObjectsProcess &TheFindIntersectedObjectsProcess,
-		const double RelativeTolerance)
-		: mRelativeTolerance(RelativeTolerance),
-		  mpFindIntersectedObjectsProcess(&TheFindIntersectedObjectsProcess),
-		  mIsSearchStructureAllocated(false)
-	{
-	}
-
-	template <std::size_t TDim>
-	ApplyRayCastingProcess<TDim>::ApplyRayCastingProcess(
-		FindIntersectedGeometricalObjectsProcess &TheFindIntersectedObjectsProcess,
-		const double RelativeTolerance,
-		const Variable<double>* pDistanceVariable,
-		const DistanceDatabase& rDistanceDatabase)
-		: mRelativeTolerance(RelativeTolerance),
-		  mpFindIntersectedObjectsProcess(&TheFindIntersectedObjectsProcess),
-		  mIsSearchStructureAllocated(false),
-		  mpDistanceVariable(pDistanceVariable)
-		, mDistanceDatabase(rDistanceDatabase)
-	{
-	}
-
-	template<std::size_t TDim>
-	ApplyRayCastingProcess<TDim>::~ApplyRayCastingProcess()
-	{
+    template<std::size_t TDim>
+    ApplyRayCastingProcess<TDim>::~ApplyRayCastingProcess()
+    {
         if(mIsSearchStructureAllocated)
             delete mpFindIntersectedObjectsProcess;
-	}
+    }
 
-	template<std::size_t TDim>
-	void ApplyRayCastingProcess<TDim>::Execute()
-	{
+
+    template<std::size_t TDim>
+    const Parameters ApplyRayCastingProcess<TDim>::GetDefaultParameters() const
+    {
+        return Parameters(R"({
+            "distance_database" : "nodal_historical",
+            "distance_variable" : "DISTANCE",
+            "relative_tolerance" : 1e-12
+        })");
+
+    }
+
+    template<std::size_t TDim>
+    void ApplyRayCastingProcess<TDim>::Execute()
+    {
         if(mIsSearchStructureAllocated) // we have not initialized it yet
             mpFindIntersectedObjectsProcess->ExecuteInitialize();
 
-		this->SetRayCastingTolerances();
+        this->SetRayCastingTolerances();
 
-		ModelPart& ModelPart1 = mpFindIntersectedObjectsProcess->GetModelPart1();
+        ModelPart& ModelPart1 = mpFindIntersectedObjectsProcess->GetModelPart1();
 
-		// Set the getter function according to the database to be used
-		NodeScalarGetFunctionType node_distance_getter;
-		if (mDistanceDatabase == DistanceDatabase::NodeHistorical) {
-			node_distance_getter = [](NodeType& rNode, const Variable<double>& rDistanceVariable)->double&{return rNode.FastGetSolutionStepValue(rDistanceVariable);};
-		} else {
-			node_distance_getter = [](NodeType& rNode, const Variable<double>& rDistanceVariable)->double&{return rNode.GetValue(rDistanceVariable);};
-		}
+        // Set the getter function according to the database to be used
+        NodeScalarGetFunctionType node_distance_getter;
+        const std::string database = mSettings["distance_database"].GetString();
+        if (database == "nodal_historical") {
+            node_distance_getter = [](NodeType& rNode, const Variable<double>& rDistanceVariable)->double&{return rNode.FastGetSolutionStepValue(rDistanceVariable);};
+        } else if (database == "nodal_non_historical") {
+            node_distance_getter = [](NodeType& rNode, const Variable<double>& rDistanceVariable)->double&{return rNode.GetValue(rDistanceVariable);};
+        } else {
+            KRATOS_ERROR << "Unrecognized database " <<  database << std::endl;
+        }
 
-		block_for_each(ModelPart1.Nodes(), [&](Node<3>& rNode){
-			double& r_node_distance = node_distance_getter(rNode, *mpDistanceVariable);
-			const double ray_distance = this->DistancePositionInSpace(rNode);
-			if (ray_distance * r_node_distance < 0.0) {
-				r_node_distance = -r_node_distance;
-			}
-		});
-	}
+        block_for_each(ModelPart1.Nodes(), [&](Node<3>& rNode){
+            double& r_node_distance = node_distance_getter(rNode, *mpDistanceVariable);
+            const double ray_distance = this->DistancePositionInSpace(rNode);
+            if (ray_distance * r_node_distance < 0.0) {
+                r_node_distance = -r_node_distance;
+            }
+        });
+    }
 
-	template<std::size_t TDim>
-	double ApplyRayCastingProcess<TDim>::DistancePositionInSpace(const Node<3> &rNode)
-	{
-		array_1d<double,TDim> distances;
-		unsigned int n_ray_pos(0), n_ray_neg(0);
+    template<std::size_t TDim>
+    double ApplyRayCastingProcess<TDim>::DistancePositionInSpace(const Node<3> &rNode)
+    {
+        array_1d<double,TDim> distances;
+        unsigned int n_ray_pos(0), n_ray_neg(0);
         IntersectionsContainerType intersections;
-		const auto &r_coords = rNode.Coordinates();
+        const auto &r_coords = rNode.Coordinates();
 
-		// Loop the x,y and z (3D) ray directions
+        // Loop the x,y and z (3D) ray directions
         for (unsigned int i_direction = 0; i_direction < TDim; i_direction++){
-			// Initialize the current direction distance
-			distances[i_direction] = 1.0;
+            // Initialize the current direction distance
+            distances[i_direction] = 1.0;
 
             // Creating the ray
             double ray[3] = {r_coords[0], r_coords[1], r_coords[2]};
-			auto &rp_octree = mpFindIntersectedObjectsProcess->GetOctreePointer();
-			rp_octree->NormalizeCoordinates(ray);
-			ray[i_direction] = 0; // Starting from the lower extreme
+            auto &rp_octree = mpFindIntersectedObjectsProcess->GetOctreePointer();
+            rp_octree->NormalizeCoordinates(ray);
+            ray[i_direction] = 0; // Starting from the lower extreme
 
             this->GetRayIntersections(ray, i_direction, intersections);
 
@@ -136,7 +132,7 @@ namespace Kratos
                 } else {
                     if (distances[i_direction] > -int_d) {
                         distances[i_direction] = -int_d;
-					}
+                    }
                     break;
                 }
 
@@ -144,184 +140,184 @@ namespace Kratos
             }
 
             distances[i_direction] *= ray_color;
-			if (ray_color == -1) {
-				n_ray_neg++;
-			} else {
-				n_ray_pos++;
-			}
+            if (ray_color == -1) {
+                n_ray_neg++;
+            } else {
+                n_ray_pos++;
+            }
         }
 
-		// Check the obtained cartesian ray colors
-		// If this situation happens, do the "evolved Predator" raycasting to vote
-		if (n_ray_neg != 0 && n_ray_pos != 0) {
-			this->ComputeExtraRayColors(r_coords, distances);
-		}
+        // Check the obtained cartesian ray colors
+        // If this situation happens, do the "evolved Predator" raycasting to vote
+        if (n_ray_neg != 0 && n_ray_pos != 0) {
+            this->ComputeExtraRayColors(r_coords, distances);
+        }
 
         double distance = (std::abs(distances[0]) > std::abs(distances[1])) ? distances[1] : distances[0];
-		if constexpr (TDim == 3){
-        	distance = (std::abs(distance) > std::abs(distances[2])) ? distances[2] : distance;
-		}
+        if constexpr (TDim == 3){
+            distance = (std::abs(distance) > std::abs(distances[2])) ? distances[2] : distance;
+        }
 
         return distance;
-	}
+    }
 
-	template<std::size_t TDim>
-	void ApplyRayCastingProcess<TDim>::ComputeExtraRayColors(
-		const array_1d<double,3> &rCoords,
+    template<std::size_t TDim>
+    void ApplyRayCastingProcess<TDim>::ComputeExtraRayColors(
+        const array_1d<double,3> &rCoords,
         array_1d<double,TDim> &rDistances)
-	{
-		// Set the extra ray origins
-		array_1d<array_1d<double,3>, (TDim == 3) ? 9 : 5> extra_ray_origs;
-		this->GetExtraRayOrigins(rCoords, extra_ray_origs);
+    {
+        // Set the extra ray origins
+        array_1d<array_1d<double,3>, (TDim == 3) ? 9 : 5> extra_ray_origs;
+        this->GetExtraRayOrigins(rCoords, extra_ray_origs);
 
-		// Get the pointer to the base Octree binary
-		auto &rp_octree = mpFindIntersectedObjectsProcess->GetOctreePointer();
+        // Get the pointer to the base Octree binary
+        auto &rp_octree = mpFindIntersectedObjectsProcess->GetOctreePointer();
 
-		// Loop the extra rays to compute its color
-		unsigned int n_ray_pos = 0; // Positive rays counter
-		unsigned int n_ray_neg = 0; // Negative rays counter
-		IntersectionsContainerType intersections; // Ray intersections container initialization
-		for (unsigned int i_direction = 0; i_direction < TDim; ++i_direction) {
-			for (unsigned int i_ray = 0; i_ray < extra_ray_origs.size(); ++i_ray) {
-				// Creating the ray
-				const auto aux_ray = extra_ray_origs[i_ray];
-				double ray[3] = {aux_ray[0], aux_ray[1], aux_ray[2]};
-				rp_octree->NormalizeCoordinates(ray);
-				ray[i_direction] = 0; // Starting from the lower extreme
-				this->CorrectExtraRayOrigin(ray); // Avoid extra ray normalized coordinates to be larger than 1 or 0
-				this->GetRayIntersections(ray, i_direction, intersections);
+        // Loop the extra rays to compute its color
+        unsigned int n_ray_pos = 0; // Positive rays counter
+        unsigned int n_ray_neg = 0; // Negative rays counter
+        IntersectionsContainerType intersections; // Ray intersections container initialization
+        for (unsigned int i_direction = 0; i_direction < TDim; ++i_direction) {
+            for (unsigned int i_ray = 0; i_ray < extra_ray_origs.size(); ++i_ray) {
+                // Creating the ray
+                const auto aux_ray = extra_ray_origs[i_ray];
+                double ray[3] = {aux_ray[0], aux_ray[1], aux_ray[2]};
+                rp_octree->NormalizeCoordinates(ray);
+                ray[i_direction] = 0; // Starting from the lower extreme
+                this->CorrectExtraRayOrigin(ray); // Avoid extra ray normalized coordinates to be larger than 1 or 0
+                this->GetRayIntersections(ray, i_direction, intersections);
 
-				// Compute the extra rays intersections
-				int ray_color = 1;
-				auto i_intersection = intersections.begin();
-				while (i_intersection != intersections.end()) {
-					const double int_d = extra_ray_origs[i_ray][i_direction] - i_intersection->first; // Octree ray intersection distance
-					if (int_d > mEpsilon) {
-						ray_color = -ray_color;
-					} else if (int_d > - mEpsilon) {
-						break;
-					} else {
-						break;
-					}
-					i_intersection++;
-				}
+                // Compute the extra rays intersections
+                int ray_color = 1;
+                auto i_intersection = intersections.begin();
+                while (i_intersection != intersections.end()) {
+                    const double int_d = extra_ray_origs[i_ray][i_direction] - i_intersection->first; // Octree ray intersection distance
+                    if (int_d > mEpsilon) {
+                        ray_color = -ray_color;
+                    } else if (int_d > - mEpsilon) {
+                        break;
+                    } else {
+                        break;
+                    }
+                    i_intersection++;
+                }
 
-				// Update the extra rays color counters
-				if (ray_color == -1) {
-					n_ray_neg++;
-				} else {
-					n_ray_pos++;
-				}
-			}
+                // Update the extra rays color counters
+                if (ray_color == -1) {
+                    n_ray_neg++;
+                } else {
+                    n_ray_pos++;
+                }
+            }
 
-		}
+        }
 
-		// Do the extra rays voting
-		int ray_color = n_ray_neg > n_ray_pos ? -1 : 1;
-		for (unsigned int i_direction = 0; i_direction < TDim; ++i_direction) {
-			rDistances[i_direction] = std::abs(rDistances[i_direction]) * ray_color;
-		}
-	}
+        // Do the extra rays voting
+        int ray_color = n_ray_neg > n_ray_pos ? -1 : 1;
+        for (unsigned int i_direction = 0; i_direction < TDim; ++i_direction) {
+            rDistances[i_direction] = std::abs(rDistances[i_direction]) * ray_color;
+        }
+    }
 
-	template<>
-	void ApplyRayCastingProcess<2>::GetExtraRayOrigins(
+    template<>
+    void ApplyRayCastingProcess<2>::GetExtraRayOrigins(
         const array_1d<double,3> &rCoords,
-		array_1d<array_1d<double,3>, 5> &rExtraRayOrigs)
-	{
-		if (rExtraRayOrigs.size() != 5) {
-			rExtraRayOrigs.resize(5);
-		}
+        array_1d<array_1d<double,3>, 5> &rExtraRayOrigs)
+    {
+        if (rExtraRayOrigs.size() != 5) {
+            rExtraRayOrigs.resize(5);
+        }
 
-		array_1d<double,3> aux_1; aux_1[0] = rCoords[0]; aux_1[1] = rCoords[1]; aux_1[2] = rCoords[2];
-		array_1d<double,3> aux_2; aux_2[0] = rCoords[0] + 2*mExtraRayOffset; aux_2[1] = rCoords[1] + mExtraRayOffset; aux_2[2] = rCoords[2];
-		array_1d<double,3> aux_3; aux_3[0] = rCoords[0] + mExtraRayOffset; aux_3[1] = rCoords[1] + 2*mExtraRayOffset; aux_3[2] = rCoords[2];
-		array_1d<double,3> aux_4; aux_4[0] = rCoords[0] - 2*mExtraRayOffset; aux_4[1] = rCoords[1] - mExtraRayOffset; aux_4[2] = rCoords[2];
-		array_1d<double,3> aux_5; aux_5[0] = rCoords[0] - mExtraRayOffset; aux_5[1] = rCoords[1] - 2*mExtraRayOffset; aux_5[2] = rCoords[2];
+        array_1d<double,3> aux_1; aux_1[0] = rCoords[0]; aux_1[1] = rCoords[1]; aux_1[2] = rCoords[2];
+        array_1d<double,3> aux_2; aux_2[0] = rCoords[0] + 2*mExtraRayOffset; aux_2[1] = rCoords[1] + mExtraRayOffset; aux_2[2] = rCoords[2];
+        array_1d<double,3> aux_3; aux_3[0] = rCoords[0] + mExtraRayOffset; aux_3[1] = rCoords[1] + 2*mExtraRayOffset; aux_3[2] = rCoords[2];
+        array_1d<double,3> aux_4; aux_4[0] = rCoords[0] - 2*mExtraRayOffset; aux_4[1] = rCoords[1] - mExtraRayOffset; aux_4[2] = rCoords[2];
+        array_1d<double,3> aux_5; aux_5[0] = rCoords[0] - mExtraRayOffset; aux_5[1] = rCoords[1] - 2*mExtraRayOffset; aux_5[2] = rCoords[2];
 
-		rExtraRayOrigs[0] = aux_1;
-		rExtraRayOrigs[1] = aux_2;
-		rExtraRayOrigs[2] = aux_3;
-		rExtraRayOrigs[3] = aux_4;
-		rExtraRayOrigs[4] = aux_5;
-	}
+        rExtraRayOrigs[0] = aux_1;
+        rExtraRayOrigs[1] = aux_2;
+        rExtraRayOrigs[2] = aux_3;
+        rExtraRayOrigs[3] = aux_4;
+        rExtraRayOrigs[4] = aux_5;
+    }
 
-	template<>
-	void ApplyRayCastingProcess<3>::GetExtraRayOrigins(
+    template<>
+    void ApplyRayCastingProcess<3>::GetExtraRayOrigins(
         const array_1d<double,3> &rCoords,
-		array_1d<array_1d<double,3>,9> &rExtraRayOrigs)
-	{
-		if (rExtraRayOrigs.size() != 9) {
-			rExtraRayOrigs.resize(9);
-		}
+        array_1d<array_1d<double,3>,9> &rExtraRayOrigs)
+    {
+        if (rExtraRayOrigs.size() != 9) {
+            rExtraRayOrigs.resize(9);
+        }
 
-		array_1d<double,3> aux_1; aux_1[0] = rCoords[0]; aux_1[1] = rCoords[1]; aux_1[2] = rCoords[2];
-		array_1d<double,3> aux_2; aux_2[0] = rCoords[0] + 2*mExtraRayOffset; aux_2[1] = rCoords[1] + mExtraRayOffset; aux_2[2] = rCoords[2] - mExtraRayOffset;
-		array_1d<double,3> aux_3; aux_3[0] = rCoords[0] + mExtraRayOffset; aux_3[1] = rCoords[1] + 2*mExtraRayOffset; aux_3[2] = rCoords[2] - mExtraRayOffset;
-		array_1d<double,3> aux_4; aux_4[0] = rCoords[0] - 2*mExtraRayOffset; aux_4[1] = rCoords[1] - mExtraRayOffset; aux_4[2] = rCoords[2] - mExtraRayOffset;
-		array_1d<double,3> aux_5; aux_5[0] = rCoords[0] - mExtraRayOffset; aux_5[1] = rCoords[1] - 2*mExtraRayOffset; aux_5[2] = rCoords[2] - mExtraRayOffset;
-		array_1d<double,3> aux_6; aux_6[0] = rCoords[0] + 2*mExtraRayOffset; aux_6[1] = rCoords[1] + mExtraRayOffset; aux_6[2] = rCoords[2] + mExtraRayOffset;
-		array_1d<double,3> aux_7; aux_7[0] = rCoords[0] + mExtraRayOffset; aux_7[1] = rCoords[1] + 2*mExtraRayOffset; aux_7[2] = rCoords[2] + mExtraRayOffset;
-		array_1d<double,3> aux_8; aux_8[0] = rCoords[0] - 2*mExtraRayOffset; aux_8[1] = rCoords[1] - mExtraRayOffset; aux_8[2] = rCoords[2] + mExtraRayOffset;
-		array_1d<double,3> aux_9; aux_9[0] = rCoords[0] - mExtraRayOffset; aux_9[1] = rCoords[1] - 2*mExtraRayOffset; aux_9[2] = rCoords[2] + mExtraRayOffset;
+        array_1d<double,3> aux_1; aux_1[0] = rCoords[0]; aux_1[1] = rCoords[1]; aux_1[2] = rCoords[2];
+        array_1d<double,3> aux_2; aux_2[0] = rCoords[0] + 2*mExtraRayOffset; aux_2[1] = rCoords[1] + mExtraRayOffset; aux_2[2] = rCoords[2] - mExtraRayOffset;
+        array_1d<double,3> aux_3; aux_3[0] = rCoords[0] + mExtraRayOffset; aux_3[1] = rCoords[1] + 2*mExtraRayOffset; aux_3[2] = rCoords[2] - mExtraRayOffset;
+        array_1d<double,3> aux_4; aux_4[0] = rCoords[0] - 2*mExtraRayOffset; aux_4[1] = rCoords[1] - mExtraRayOffset; aux_4[2] = rCoords[2] - mExtraRayOffset;
+        array_1d<double,3> aux_5; aux_5[0] = rCoords[0] - mExtraRayOffset; aux_5[1] = rCoords[1] - 2*mExtraRayOffset; aux_5[2] = rCoords[2] - mExtraRayOffset;
+        array_1d<double,3> aux_6; aux_6[0] = rCoords[0] + 2*mExtraRayOffset; aux_6[1] = rCoords[1] + mExtraRayOffset; aux_6[2] = rCoords[2] + mExtraRayOffset;
+        array_1d<double,3> aux_7; aux_7[0] = rCoords[0] + mExtraRayOffset; aux_7[1] = rCoords[1] + 2*mExtraRayOffset; aux_7[2] = rCoords[2] + mExtraRayOffset;
+        array_1d<double,3> aux_8; aux_8[0] = rCoords[0] - 2*mExtraRayOffset; aux_8[1] = rCoords[1] - mExtraRayOffset; aux_8[2] = rCoords[2] + mExtraRayOffset;
+        array_1d<double,3> aux_9; aux_9[0] = rCoords[0] - mExtraRayOffset; aux_9[1] = rCoords[1] - 2*mExtraRayOffset; aux_9[2] = rCoords[2] + mExtraRayOffset;
 
-		rExtraRayOrigs[0] = aux_1;
-		rExtraRayOrigs[1] = aux_2;
-		rExtraRayOrigs[2] = aux_3;
-		rExtraRayOrigs[3] = aux_4;
-		rExtraRayOrigs[4] = aux_5;
-		rExtraRayOrigs[5] = aux_6;
-		rExtraRayOrigs[6] = aux_7;
-		rExtraRayOrigs[7] = aux_8;
-		rExtraRayOrigs[8] = aux_9;
-	}
+        rExtraRayOrigs[0] = aux_1;
+        rExtraRayOrigs[1] = aux_2;
+        rExtraRayOrigs[2] = aux_3;
+        rExtraRayOrigs[3] = aux_4;
+        rExtraRayOrigs[4] = aux_5;
+        rExtraRayOrigs[5] = aux_6;
+        rExtraRayOrigs[6] = aux_7;
+        rExtraRayOrigs[7] = aux_8;
+        rExtraRayOrigs[8] = aux_9;
+    }
 
-	template<std::size_t TDim>
-	void ApplyRayCastingProcess<TDim>::CorrectExtraRayOrigin(double* ExtraRayCoords)
-	{
-		for (unsigned int d = 0; d < 3; ++d) {
-			if (ExtraRayCoords[d] > 1.0) {
-				ExtraRayCoords[d] = 1.0;
-			} else if (ExtraRayCoords[d] < 0.0) {
-				ExtraRayCoords[d] = 0.0;
-			}
-		}
-	}
+    template<std::size_t TDim>
+    void ApplyRayCastingProcess<TDim>::CorrectExtraRayOrigin(double* ExtraRayCoords)
+    {
+        for (unsigned int d = 0; d < 3; ++d) {
+            if (ExtraRayCoords[d] > 1.0) {
+                ExtraRayCoords[d] = 1.0;
+            } else if (ExtraRayCoords[d] < 0.0) {
+                ExtraRayCoords[d] = 0.0;
+            }
+        }
+    }
 
-	template<std::size_t TDim>
-	void ApplyRayCastingProcess<TDim>::GetRayIntersections(
-		const double* ray,
-		const unsigned int direction,
-		std::vector<std::pair<double,Element::GeometryType*> >& rIntersections)
-	{
-		// This function passes the ray through the model and gives the hit point to all objects in its way
+    template<std::size_t TDim>
+    void ApplyRayCastingProcess<TDim>::GetRayIntersections(
+        const double* ray,
+        const unsigned int direction,
+        std::vector<std::pair<double,Element::GeometryType*> >& rIntersections)
+    {
+        // This function passes the ray through the model and gives the hit point to all objects in its way
         // Ray is of dimension (3) normalized in (0,1)^3 space
         // Direction can be 0,1,2 which are x,y and z respectively
 
         // First clearing the intersections points vector
         rIntersections.clear();
 
-		// Get the octree from the parent discontinuous distance process
+        // Get the octree from the parent discontinuous distance process
         auto &rp_octree = mpFindIntersectedObjectsProcess->GetOctreePointer();
 
-		// Compute the normalized ray key
-		OctreeType::key_type ray_key[3] = {rp_octree->CalcKeyNormalized(ray[0]), rp_octree->CalcKeyNormalized(ray[1]), rp_octree->CalcKeyNormalized(ray[2])};
+        // Compute the normalized ray key
+        OctreeType::key_type ray_key[3] = {rp_octree->CalcKeyNormalized(ray[0]), rp_octree->CalcKeyNormalized(ray[1]), rp_octree->CalcKeyNormalized(ray[2])};
 
-		// Getting the entrance cell from lower extreme
+        // Getting the entrance cell from lower extreme
         OctreeType::key_type cell_key[3];
         auto cell = rp_octree->pGetCell(ray_key);
         while (cell) {
-			// Get the current cell intersections
+            // Get the current cell intersections
             const int cell_int = this->GetCellIntersections(cell, ray, ray_key, direction, rIntersections);
-			KRATOS_ERROR_IF(cell_int != 0)
-				<< "Error in GetCellIntersections for ray [" << ray[0] << "," << ray[1] << "," << ray[2] << "] with direction " << direction << std::endl;
-			// And if it exists, go to the next cell
+            KRATOS_ERROR_IF(cell_int != 0)
+                << "Error in GetCellIntersections for ray [" << ray[0] << "," << ray[1] << "," << ray[2] << "] with direction " << direction << std::endl;
+            // And if it exists, go to the next cell
             if (cell->GetNeighbourKey(1 + direction * 2, cell_key)) {
                 ray_key[direction] = cell_key[direction];
                 cell = rp_octree->pGetCell(ray_key);
                 ray_key[direction] -= 1 ; // The key returned by GetNeighbourKey is inside the cell (minkey +1), to ensure that the corresponding cell get in pGetCell is the right one.
             } else {
                 cell = NULL;
-			}
+            }
         }
 
         // Eliminate the repeated intersecting objects
@@ -338,146 +334,146 @@ namespace Kratos
             }
             rIntersections.resize((++i_intersection) - rIntersections.begin());
         }
-	}
+    }
 
-	template<std::size_t TDim>
-	int  ApplyRayCastingProcess<TDim>::GetCellIntersections(
-		OctreeType::cell_type* cell,
-		const double* ray,
-		OctreeType::key_type* ray_key,
-		const unsigned int direction,
-		std::vector<std::pair<double, Element::GeometryType*> > &rIntersections)
-	{
-		//This function passes the ray through the cell and gives the hit point to all objects in its way
-		//ray is of dimension (3) normalized in (0,1)^3 space
-		// direction can be 0,1,2 which are x,y and z respectively
-		typedef OctreeType::cell_type::object_container_type object_container_type;
-		auto objects = (cell->pGetObjects());
+    template<std::size_t TDim>
+    int  ApplyRayCastingProcess<TDim>::GetCellIntersections(
+        OctreeType::cell_type* cell,
+        const double* ray,
+        OctreeType::key_type* ray_key,
+        const unsigned int direction,
+        std::vector<std::pair<double, Element::GeometryType*> > &rIntersections)
+    {
+        //This function passes the ray through the cell and gives the hit point to all objects in its way
+        //ray is of dimension (3) normalized in (0,1)^3 space
+        // direction can be 0,1,2 which are x,y and z respectively
+        typedef OctreeType::cell_type::object_container_type object_container_type;
+        auto objects = (cell->pGetObjects());
 
-		// There are no intersection in empty cells
-		if (objects->empty()){
-			return 0;
-		}
+        // There are no intersection in empty cells
+        if (objects->empty()){
+            return 0;
+        }
 
-		// Calculating the two extreme of the ray segment inside the cell
-		double ray_point1[3] = {ray[0], ray[1], ray[2]};
-		double ray_point2[3] = {ray[0], ray[1], ray[2]};
-		double normalized_coordinate;
+        // Calculating the two extreme of the ray segment inside the cell
+        double ray_point1[3] = {ray[0], ray[1], ray[2]};
+        double ray_point2[3] = {ray[0], ray[1], ray[2]};
+        double normalized_coordinate;
 
-		auto &rp_octree = mpFindIntersectedObjectsProcess->GetOctreePointer();
-		rp_octree->CalculateCoordinateNormalized(ray_key[direction], normalized_coordinate);
-		ray_point1[direction] = normalized_coordinate;
-		ray_point2[direction] = ray_point1[direction] + rp_octree->CalcSizeNormalized(cell);
-		rp_octree->ScaleBackToOriginalCoordinate(ray_point1);
-		rp_octree->ScaleBackToOriginalCoordinate(ray_point2);
+        auto &rp_octree = mpFindIntersectedObjectsProcess->GetOctreePointer();
+        rp_octree->CalculateCoordinateNormalized(ray_key[direction], normalized_coordinate);
+        ray_point1[direction] = normalized_coordinate;
+        ray_point2[direction] = ray_point1[direction] + rp_octree->CalcSizeNormalized(cell);
+        rp_octree->ScaleBackToOriginalCoordinate(ray_point1);
+        rp_octree->ScaleBackToOriginalCoordinate(ray_point2);
 
-		// This is a workaround to avoid the z-component in 2D
-		if constexpr (TDim == 2){
-			ray_point1[2] = 0.0;
-			ray_point2[2] = 0.0;
-		}
+        // This is a workaround to avoid the z-component in 2D
+        if constexpr (TDim == 2){
+            ray_point1[2] = 0.0;
+            ray_point2[2] = 0.0;
+        }
 
-		for (object_container_type::iterator i_object = objects->begin(); i_object != objects->end(); ++i_object){
-			double intersection[3]={0.0, 0.0, 0.0};
-			const int is_intersected = ComputeRayIntersection((*i_object)->GetGeometry(), ray_point1, ray_point2, intersection);
-			if (is_intersected == 1){ // There is an intersection but not coplanar
-				rIntersections.push_back(std::pair<double, Element::GeometryType*>(intersection[direction], &((*i_object)->GetGeometry())));
-			}
-		}
+        for (object_container_type::iterator i_object = objects->begin(); i_object != objects->end(); ++i_object){
+            double intersection[3]={0.0, 0.0, 0.0};
+            const int is_intersected = ComputeRayIntersection((*i_object)->GetGeometry(), ray_point1, ray_point2, intersection);
+            if (is_intersected == 1){ // There is an intersection but not coplanar
+                rIntersections.push_back(std::pair<double, Element::GeometryType*>(intersection[direction], &((*i_object)->GetGeometry())));
+            }
+        }
 
-		return 0;
-	}
+        return 0;
+    }
 
-	template<>
-	int ApplyRayCastingProcess<2>::ComputeRayIntersection(
-		Element::GeometryType& rGeometry,
+    template<>
+    int ApplyRayCastingProcess<2>::ComputeRayIntersection(
+        Element::GeometryType& rGeometry,
         const double* pRayPoint1,
         const double* pRayPoint2,
         double* pIntersectionPoint)
-	{
-		// Auxiliar arrays
-		array_1d<double,3> ray_pt_1;
-		array_1d<double,3> ray_pt_2;
-		for (unsigned int i = 0; i < 3; ++i){
-			ray_pt_1[i] = pRayPoint1[i];
-			ray_pt_2[i] = pRayPoint2[i];
-		}
+    {
+        // Auxiliar arrays
+        array_1d<double,3> ray_pt_1;
+        array_1d<double,3> ray_pt_2;
+        for (unsigned int i = 0; i < 3; ++i){
+            ray_pt_1[i] = pRayPoint1[i];
+            ray_pt_2[i] = pRayPoint2[i];
+        }
 
-		// Call the line - line intersection util
-		array_1d<double,3> int_pt = ZeroVector(3);
-		const double tolerance = mEpsilon;
-		const int is_intersected =  IntersectionUtilities::ComputeLineLineIntersection(
-			rGeometry,
-			ray_pt_1,
-			ray_pt_2,
-			int_pt,
-			tolerance);
+        // Call the line - line intersection util
+        array_1d<double,3> int_pt = ZeroVector(3);
+        const double tolerance = mEpsilon;
+        const int is_intersected =  IntersectionUtilities::ComputeLineLineIntersection(
+            rGeometry,
+            ray_pt_1,
+            ray_pt_2,
+            int_pt,
+            tolerance);
 
-		// Convert the auxiliar intersection point to the original type
-		for (unsigned int i = 0; i < 3; ++i){
-			pIntersectionPoint[i] = int_pt[i];
-		}
+        // Convert the auxiliar intersection point to the original type
+        for (unsigned int i = 0; i < 3; ++i){
+            pIntersectionPoint[i] = int_pt[i];
+        }
 
-		return is_intersected;
-	}
+        return is_intersected;
+    }
 
-	template<>
-	int ApplyRayCastingProcess<3>::ComputeRayIntersection(
-		Element::GeometryType& rGeometry,
+    template<>
+    int ApplyRayCastingProcess<3>::ComputeRayIntersection(
+        Element::GeometryType& rGeometry,
         const double* pRayPoint1,
         const double* pRayPoint2,
         double* pIntersectionPoint)
-	{
-		// Auxiliar arrays
-		array_1d<double,3> ray_pt_1;
-		array_1d<double,3> ray_pt_2;
-		for (unsigned int i = 0; i < 3; ++i){
-			ray_pt_1[i] = pRayPoint1[i];
-			ray_pt_2[i] = pRayPoint2[i];
-		}
+    {
+        // Auxiliar arrays
+        array_1d<double,3> ray_pt_1;
+        array_1d<double,3> ray_pt_2;
+        for (unsigned int i = 0; i < 3; ++i){
+            ray_pt_1[i] = pRayPoint1[i];
+            ray_pt_2[i] = pRayPoint2[i];
+        }
 
-		// Call the line - triangle intersection util
-		array_1d<double,3> int_pt = ZeroVector(3);
-		const double tolerance = mEpsilon;
-		const int is_intersected = IntersectionUtilities::ComputeTriangleLineIntersection(
-			rGeometry,
-			ray_pt_1,
-			ray_pt_2,
-			int_pt,
-			tolerance);
+        // Call the line - triangle intersection util
+        array_1d<double,3> int_pt = ZeroVector(3);
+        const double tolerance = mEpsilon;
+        const int is_intersected = IntersectionUtilities::ComputeTriangleLineIntersection(
+            rGeometry,
+            ray_pt_1,
+            ray_pt_2,
+            int_pt,
+            tolerance);
 
-		// Convert the auxiliar intersection point to the original type
-		for (unsigned int i = 0; i < 3; ++i){
-			pIntersectionPoint[i] = int_pt[i];
-		}
+        // Convert the auxiliar intersection point to the original type
+        for (unsigned int i = 0; i < 3; ++i){
+            pIntersectionPoint[i] = int_pt[i];
+        }
 
-		return is_intersected;
-	}
+        return is_intersected;
+    }
 
-	/// Turn back information as a string.
-	template<std::size_t TDim>
-	std::string ApplyRayCastingProcess<TDim>::Info() const
-	{
-		return "ApplyRayCastingProcess";
-	}
+    /// Turn back information as a string.
+    template<std::size_t TDim>
+    std::string ApplyRayCastingProcess<TDim>::Info() const
+    {
+        return "ApplyRayCastingProcess";
+    }
 
-	/// Print information about this object.
-	template<std::size_t TDim>
-	void ApplyRayCastingProcess<TDim>::PrintInfo(std::ostream& rOStream) const
-	{
-		rOStream << Info();
-	}
+    /// Print information about this object.
+    template<std::size_t TDim>
+    void ApplyRayCastingProcess<TDim>::PrintInfo(std::ostream& rOStream) const
+    {
+        rOStream << Info();
+    }
 
-	/// Print object's data.
-	template<std::size_t TDim>
-	void ApplyRayCastingProcess<TDim>::PrintData(std::ostream& rOStream) const
-	{
-	}
+    /// Print object's data.
+    template<std::size_t TDim>
+    void ApplyRayCastingProcess<TDim>::PrintData(std::ostream& rOStream) const
+    {
+    }
 
-	template<std::size_t TDim>
-	void ApplyRayCastingProcess<TDim>::CalculateCharacteristicLength()
-	{
-		ModelPart& model_part1 = mpFindIntersectedObjectsProcess->GetModelPart1();
+    template<std::size_t TDim>
+    void ApplyRayCastingProcess<TDim>::CalculateCharacteristicLength()
+    {
+        ModelPart& model_part1 = mpFindIntersectedObjectsProcess->GetModelPart1();
         Point min_point(0.00, 0.00, 0.00);
         Point max_point(0.00, 0.00, 0.00);
 
@@ -488,21 +484,21 @@ namespace Kratos
             }
         }
 
-		mCharacteristicLength = norm_2(max_point - min_point);
-		KRATOS_ERROR_IF(mCharacteristicLength < std::numeric_limits<double>::epsilon()) << "Domain characteristic length is close to zero. Check if there is any node in the model part." << std::endl;
-	}
+        mCharacteristicLength = norm_2(max_point - min_point);
+        KRATOS_ERROR_IF(mCharacteristicLength < std::numeric_limits<double>::epsilon()) << "Domain characteristic length is close to zero. Check if there is any node in the model part." << std::endl;
+    }
 
-	template <std::size_t TDim>
-	void ApplyRayCastingProcess<TDim>::SetRayCastingTolerances()
-	{
-		this->CalculateCharacteristicLength();
-		mEpsilon = mRelativeTolerance * mCharacteristicLength;
-		mExtraRayOffset = 2.0 * mRelativeTolerance * mCharacteristicLength;
-	}
+    template <std::size_t TDim>
+    void ApplyRayCastingProcess<TDim>::SetRayCastingTolerances()
+    {
+        this->CalculateCharacteristicLength();
+        mEpsilon = mRelativeTolerance * mCharacteristicLength;
+        mExtraRayOffset = 2.0 * mRelativeTolerance * mCharacteristicLength;
+    }
 
 
 
-	template class Kratos::ApplyRayCastingProcess<2>;
-	template class Kratos::ApplyRayCastingProcess<3>;
+    template class Kratos::ApplyRayCastingProcess<2>;
+    template class Kratos::ApplyRayCastingProcess<3>;
 
 }  // namespace Kratos.

--- a/kratos/processes/apply_ray_casting_process.cpp
+++ b/kratos/processes/apply_ray_casting_process.cpp
@@ -37,6 +37,19 @@ namespace Kratos
         mRelativeTolerance = mSettings["relative_tolerance"].GetDouble();
     }
 
+    template<std::size_t TDim>
+    ApplyRayCastingProcess<TDim>::ApplyRayCastingProcess(
+        ModelPart& rVolumePart,
+        ModelPart& rSkinPart,
+		const double RelativeTolerance)
+		: mRelativeTolerance(RelativeTolerance),
+          mpFindIntersectedObjectsProcess(new FindIntersectedGeometricalObjectsProcess(rVolumePart, rSkinPart)),
+          mIsSearchStructureAllocated(true)
+    {
+        mSettings.ValidateAndAssignDefaults(GetDefaultParameters());
+        mSettings["relative_tolerance"].SetDouble(mRelativeTolerance);
+    }
+
     template <std::size_t TDim>
     ApplyRayCastingProcess<TDim>::ApplyRayCastingProcess(
         FindIntersectedGeometricalObjectsProcess &TheFindIntersectedObjectsProcess,
@@ -47,6 +60,31 @@ namespace Kratos
     {
         mSettings.ValidateAndAssignDefaults(GetDefaultParameters());
         mRelativeTolerance = mSettings["relative_tolerance"].GetDouble();
+    }
+
+    template<std::size_t TDim>
+	ApplyRayCastingProcess<TDim>::ApplyRayCastingProcess(
+		FindIntersectedGeometricalObjectsProcess &TheFindIntersectedObjectsProcess,
+		const double RelativeTolerance,
+		const Variable<double>* pDistanceVariable,
+		const DistanceDatabase& rDistanceDatabase)
+		: mRelativeTolerance(RelativeTolerance),
+		  mpFindIntersectedObjectsProcess(&TheFindIntersectedObjectsProcess),
+		  mIsSearchStructureAllocated(false)
+    {
+        mSettings.ValidateAndAssignDefaults(GetDefaultParameters());
+        mSettings["relative_tolerance"].SetDouble(mRelativeTolerance);
+        std::string distance_database;
+        if (rDistanceDatabase == DistanceDatabase::NodeHistorical) {
+            distance_database = "nodal_historical";
+        } else if (rDistanceDatabase == DistanceDatabase::NodeNonHistorical) {
+            distance_database = "nodal_non_historical";
+        } else {
+            KRATOS_ERROR << "Provided 'distance_database' is '" << distance_database <<
+             "'. Available options are 'nodal_historical' and 'nodal_non_historical'." <<  std::endl;
+        }
+        mSettings["distance_database"].SetString(distance_database);
+        mSettings["distance_database"].SetString(pDistanceVariable->Name());
     }
 
     template<std::size_t TDim>

--- a/kratos/processes/apply_ray_casting_process.cpp
+++ b/kratos/processes/apply_ray_casting_process.cpp
@@ -46,6 +46,7 @@ namespace Kratos
           mpFindIntersectedObjectsProcess(new FindIntersectedGeometricalObjectsProcess(rVolumePart, rSkinPart)),
           mIsSearchStructureAllocated(true)
     {
+        KRATOS_WARNING("ApplyRayCastingProcess") << "Using deprecated constructor. Please use the one with Parameters.\n";
         mSettings.ValidateAndAssignDefaults(GetDefaultParameters());
         mSettings["relative_tolerance"].SetDouble(mRelativeTolerance);
     }
@@ -72,6 +73,7 @@ namespace Kratos
 		  mpFindIntersectedObjectsProcess(&TheFindIntersectedObjectsProcess),
 		  mIsSearchStructureAllocated(false)
     {
+        KRATOS_WARNING("ApplyRayCastingProcess") << "Using deprecated constructor. Please use the one with Parameters.\n";
         mSettings.ValidateAndAssignDefaults(GetDefaultParameters());
         mSettings["relative_tolerance"].SetDouble(mRelativeTolerance);
         std::string distance_database;

--- a/kratos/processes/apply_ray_casting_process.cpp
+++ b/kratos/processes/apply_ray_casting_process.cpp
@@ -89,6 +89,8 @@ namespace Kratos
             KRATOS_ERROR << "Unrecognized database " <<  database << std::endl;
         }
 
+        const Variable<double>* mpDistanceVariable = &KratosComponents<Variable<double>>::Get(mSettings["distance_variable"].GetString());
+
         block_for_each(ModelPart1.Nodes(), [&](Node<3>& rNode){
             double& r_node_distance = node_distance_getter(rNode, *mpDistanceVariable);
             const double ray_distance = this->DistancePositionInSpace(rNode);

--- a/kratos/processes/apply_ray_casting_process.h
+++ b/kratos/processes/apply_ray_casting_process.h
@@ -41,12 +41,6 @@ public:
     ///@name Type Definitions
     ///@{
 
-    /// Nodal databases auxiliary enum
-    enum class DistanceDatabase {
-        NodeHistorical,
-        NodeNonHistorical
-    };
-
     /// Pointer definition of ApplyRayCastingProcess
     KRATOS_CLASS_POINTER_DEFINITION(ApplyRayCastingProcess);
 
@@ -76,20 +70,8 @@ public:
      */
     ApplyRayCastingProcess(
         ModelPart& rVolumePart,
-        ModelPart& rSkinPart);
-
-    /**
-     * @brief Construct a new ApplyRayCastingProcess object using volume and skin model parts
-     *
-     * @param rVolumePart model part containing the volume elements
-     * @param rSkinPart model part containing the skin to compute
-     * the distance to as conditions
-     * @param RelativeTolerance user-defined relative tolerance to be multiplied by the domain bounding box size
-     */
-    ApplyRayCastingProcess(
-        ModelPart& rVolumePart,
         ModelPart& rSkinPart,
-        const double RelativeTolerance);
+        Parameters ThisParameters = Parameters());
 
     /**
      * @brief Construct a new Apply Ray Casting Process object using an already created search strucutre
@@ -99,21 +81,7 @@ public:
      */
     ApplyRayCastingProcess(
         FindIntersectedGeometricalObjectsProcess& TheFindIntersectedObjectsProcess,
-        const double RelativeTolerance);
-
-    /**
-     * @brief Construct a new Apply Ray Casting Process object using an already created search strucutre
-     *
-     * @param TheFindIntersectedObjectsProcess reference to the already created search structure
-     * @param RelativeTolerance user-defined relative tolerance to be multiplied by the domain bounding box size
-     * @param pDistanceVariable user-defined variabe to be used to read and store the distance to the skin
-     * @param rDistanceDatabase enum value specifying the database from which the distance variable is retrieved (see DistanceDatabase)
-     */
-    ApplyRayCastingProcess(
-        FindIntersectedGeometricalObjectsProcess& TheFindIntersectedObjectsProcess,
-        const double RelativeTolerance,
-        const Variable<double>* pDistanceVariable,
-        const DistanceDatabase& rDistanceDatabase);
+        Parameters ThisParameters = Parameters());
 
     /// Destructor.
     ~ApplyRayCastingProcess() override;
@@ -134,6 +102,8 @@ public:
     ///@}
     ///@name Operations
     ///@{
+
+    const Parameters GetDefaultParameters() const override;
 
     /**
      * @brief Computes the raycasting distance for a node
@@ -209,6 +179,7 @@ private:
     ///@name Member Variables
     ///@{
 
+    Parameters mSettings;
     double mEpsilon = 1.0e-12;
     double mExtraRayOffset = 1.0e-8;
     double mRelativeTolerance = 1.0e-12;
@@ -218,7 +189,6 @@ private:
 
     const Variable<double>* mpDistanceVariable = &DISTANCE;
 
-    const DistanceDatabase mDistanceDatabase = DistanceDatabase::NodeHistorical;
 
     ///@}
     ///@name Private Operators

--- a/kratos/processes/apply_ray_casting_process.h
+++ b/kratos/processes/apply_ray_casting_process.h
@@ -187,8 +187,6 @@ private:
     bool mIsSearchStructureAllocated;
     double mCharacteristicLength = 1.0;
 
-    const Variable<double>* mpDistanceVariable = &DISTANCE;
-
 
     ///@}
     ///@name Private Operators

--- a/kratos/processes/apply_ray_casting_process.h
+++ b/kratos/processes/apply_ray_casting_process.h
@@ -41,6 +41,13 @@ public:
     ///@name Type Definitions
     ///@{
 
+    //TODO: delete after deprecated constructor are removed.
+    /// Nodal databases auxiliary enum
+    enum class DistanceDatabase {
+        NodeHistorical,
+        NodeNonHistorical
+    };
+
     /// Pointer definition of ApplyRayCastingProcess
     KRATOS_CLASS_POINTER_DEFINITION(ApplyRayCastingProcess);
 
@@ -74,6 +81,20 @@ public:
         Parameters ThisParameters = Parameters());
 
     /**
+     * @brief Construct a new ApplyRayCastingProcess object using volume and skin model parts
+     *
+     * @param rVolumePart model part containing the volume elements
+     * @param rSkinPart model part containing the skin to compute
+     * the distance to as conditions
+     * @param RelativeTolerance user-defined relative tolerance to be multiplied by the domain bounding box size
+     */
+    KRATOS_DEPRECATED_MESSAGE("Deprecated constructor, please use the one with Parameters.")
+    ApplyRayCastingProcess(
+        ModelPart& rVolumePart,
+        ModelPart& rSkinPart,
+        const double RelativeTolerance);
+
+    /**
      * @brief Construct a new Apply Ray Casting Process object using an already created search strucutre
      *
      * @param TheFindIntersectedObjectsProcess reference to the already created search structure
@@ -82,6 +103,21 @@ public:
     ApplyRayCastingProcess(
         FindIntersectedGeometricalObjectsProcess& TheFindIntersectedObjectsProcess,
         Parameters ThisParameters = Parameters());
+
+	/**
+     * @brief Construct a new Apply Ray Casting Process object using an already created search strucutre
+     *
+     * @param TheFindIntersectedObjectsProcess reference to the already created search structure
+     * @param RelativeTolerance user-defined relative tolerance to be multiplied by the domain bounding box size
+     * @param pDistanceVariable user-defined variabe to be used to read and store the distance to the skin
+     * @param rDistanceDatabase enum value specifying the database from which the distance variable is retrieved (see DistanceDatabase)
+     */
+    KRATOS_DEPRECATED_MESSAGE("Deprecated constructor, please use the one with Parameters.")
+    ApplyRayCastingProcess(
+        FindIntersectedGeometricalObjectsProcess& TheFindIntersectedObjectsProcess,
+        const double RelativeTolerance,
+        const Variable<double>* pDistanceVariable,
+        const DistanceDatabase& rDistanceDatabase);
 
     /// Destructor.
     ~ApplyRayCastingProcess() override;

--- a/kratos/processes/apply_ray_casting_process.h
+++ b/kratos/processes/apply_ray_casting_process.h
@@ -180,12 +180,12 @@ private:
     ///@{
 
     Parameters mSettings;
-    double mEpsilon = 1.0e-12;
-    double mExtraRayOffset = 1.0e-8;
-    double mRelativeTolerance = 1.0e-12;
+    double mEpsilon;
+    double mExtraRayOffset;
+    double mRelativeTolerance;
     FindIntersectedGeometricalObjectsProcess* mpFindIntersectedObjectsProcess;
     bool mIsSearchStructureAllocated;
-    double mCharacteristicLength = 1.0;
+    double mCharacteristicLength;
 
 
     ///@}

--- a/kratos/processes/calculate_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_distance_to_skin_process.cpp
@@ -24,278 +24,285 @@
 namespace Kratos
 {
 
-	template<std::size_t TDim>
-	CalculateDistanceToSkinProcess<TDim>::CalculateDistanceToSkinProcess(
-		ModelPart& rVolumePart,
-		ModelPart& rSkinPart)
-		: CalculateDiscontinuousDistanceToSkinProcess<TDim>(rVolumePart, rSkinPart)
-	{
-	}
+    template<std::size_t TDim>
+    CalculateDistanceToSkinProcess<TDim>::CalculateDistanceToSkinProcess(
+        ModelPart& rVolumePart,
+        ModelPart& rSkinPart)
+        : CalculateDiscontinuousDistanceToSkinProcess<TDim>(rVolumePart, rSkinPart)
+    {
+        mSettings.ValidateAndAssignDefaults(GetDefaultParameters());
+    }
 
-	template<std::size_t TDim>
-	CalculateDistanceToSkinProcess<TDim>::CalculateDistanceToSkinProcess(
-		ModelPart& rVolumePart,
-		ModelPart& rSkinPart,
-		const double RayCastingRelativeTolerance)
-		: CalculateDiscontinuousDistanceToSkinProcess<TDim>(rVolumePart, rSkinPart),
-		mRayCastingRelativeTolerance(RayCastingRelativeTolerance)
-	{
-	}
+    template<std::size_t TDim>
+    CalculateDistanceToSkinProcess<TDim>::CalculateDistanceToSkinProcess(
+        ModelPart& rVolumePart,
+        ModelPart& rSkinPart,
+        const double RayCastingRelativeTolerance)
+        : CalculateDiscontinuousDistanceToSkinProcess<TDim>(rVolumePart, rSkinPart),
+        mRayCastingRelativeTolerance(RayCastingRelativeTolerance)
+    {
+        mSettings.ValidateAndAssignDefaults(GetDefaultParameters());
+    }
 
-	template<std::size_t TDim>
-	CalculateDistanceToSkinProcess<TDim>::CalculateDistanceToSkinProcess(
-		ModelPart& rVolumePart,
-		ModelPart& rSkinPart,
-		Parameters rParameters)
-		: CalculateDiscontinuousDistanceToSkinProcess<TDim>(rVolumePart, rSkinPart)
-	{
-		rParameters.RecursivelyValidateAndAssignDefaults(GetDefaultParameters());
-		mRayCastingRelativeTolerance = rParameters["ray_casting_relative_tolerance"].GetDouble();
-        CalculateDiscontinuousDistanceToSkinProcess<TDim>::mpElementalDistancesVariable = &KratosComponents<Variable<Vector>>::Get(rParameters["elemental_distances_variable"].GetString());;
-        mpDistanceVariable = &KratosComponents<Variable<double>>::Get(rParameters["distance_variable"].GetString());;
-		const std::string distance_database = rParameters["distance_database"].GetString();
-		if (distance_database == "nodal_historical") {
-			mDistanceDatabase = DistanceDatabase::NodeHistorical;
-		} else if (distance_database == "nodal_non_historical") {
-			mDistanceDatabase = DistanceDatabase::NodeNonHistorical;
-		} else {
-			KRATOS_ERROR << "Provided 'distance_database' is '" << distance_database << "'. Available options are 'nodal_historical' and 'nodal_non_historical'." <<  std::endl;
-		}
-	}
+    template<std::size_t TDim>
+    CalculateDistanceToSkinProcess<TDim>::CalculateDistanceToSkinProcess(
+        ModelPart& rVolumePart,
+        ModelPart& rSkinPart,
+        Parameters ThisParameters)
+        : CalculateDiscontinuousDistanceToSkinProcess<TDim>(rVolumePart, rSkinPart),
+          mSettings(ThisParameters)
+    {
+        mSettings.ValidateAndAssignDefaults(GetDefaultParameters());
+        mRayCastingRelativeTolerance = mSettings["ray_casting_relative_tolerance"].GetDouble();
+        CalculateDiscontinuousDistanceToSkinProcess<TDim>::mpElementalDistancesVariable = &KratosComponents<Variable<Vector>>::Get(mSettings["elemental_distances_variable"].GetString());;
+        mpDistanceVariable = &KratosComponents<Variable<double>>::Get(mSettings["distance_variable"].GetString());;
+    }
 
-	template<std::size_t TDim>
-	const Parameters CalculateDistanceToSkinProcess<TDim>::GetDefaultParameters() const
-	{
-		Parameters default_parameters = Parameters(R"(
-		{
-			"distance_variable"                     : "DISTANCE",
-			"distance_database"                     : "nodal_historical",
-			"ray_casting_relative_tolerance"        : 1.0e-8
-		})" );
+    template<std::size_t TDim>
+    const Parameters CalculateDistanceToSkinProcess<TDim>::GetDefaultParameters() const
+    {
+        Parameters default_parameters = Parameters(R"(
+        {
+            "distance_variable"                     : "DISTANCE",
+            "distance_database"                     : "nodal_historical",
+            "ray_casting_relative_tolerance"        : 1.0e-8
+        })" );
 
-		// Getting base class default parameters
-		const Parameters base_default_parameters = CalculateDiscontinuousDistanceToSkinProcess<TDim>::GetDefaultParameters();
-		default_parameters.RecursivelyAddMissingParameters(base_default_parameters);
+        // Getting base class default parameters
+        const Parameters base_default_parameters = CalculateDiscontinuousDistanceToSkinProcess<TDim>::GetDefaultParameters();
+        default_parameters.RecursivelyAddMissingParameters(base_default_parameters);
 
-		return default_parameters;
-	}
+        return default_parameters;
+    }
 
-	template<std::size_t TDim>
-	CalculateDistanceToSkinProcess<TDim>::~CalculateDistanceToSkinProcess()
-	{
-	}
+    template<std::size_t TDim>
+    CalculateDistanceToSkinProcess<TDim>::~CalculateDistanceToSkinProcess()
+    {
+    }
 
-	template<std::size_t TDim>
-	void CalculateDistanceToSkinProcess<TDim>::Initialize()
-	{
-		CalculateDiscontinuousDistanceToSkinProcess<TDim>::Initialize();
-		this->InitializeNodalDistances();
-	}
+    template<std::size_t TDim>
+    void CalculateDistanceToSkinProcess<TDim>::Initialize()
+    {
+        CalculateDiscontinuousDistanceToSkinProcess<TDim>::Initialize();
+        this->InitializeNodalDistances();
+    }
 
-	template<std::size_t TDim>
-	void CalculateDistanceToSkinProcess<TDim>::InitializeNodalDistances()
-	{
-		// Get the volume model part from the base discontinuous distance process
-		ModelPart& ModelPart1 = (CalculateDiscontinuousDistanceToSkinProcess<TDim>::mFindIntersectedObjectsProcess).GetModelPart1();
+    template<std::size_t TDim>
+    void CalculateDistanceToSkinProcess<TDim>::InitializeNodalDistances()
+    {
+        // Get the volume model part from the base discontinuous distance process
+        ModelPart& ModelPart1 = (CalculateDiscontinuousDistanceToSkinProcess<TDim>::mFindIntersectedObjectsProcess).GetModelPart1();
 
-		// Calculate the domain characteristic length
-		const double char_length = this->CalculateCharacteristicLength();
+        // Calculate the domain characteristic length
+        const double char_length = this->CalculateCharacteristicLength();
 
-		// Initialize the nodal distance values to a maximum positive value
-		if (mDistanceDatabase == DistanceDatabase::NodeHistorical) {
-			VariableUtils().SetVariable(*mpDistanceVariable, char_length, ModelPart1.Nodes());
-		} else {
-			VariableUtils().SetNonHistoricalVariable(*mpDistanceVariable, char_length, ModelPart1.Nodes());
-		}
-	}
+        // Initialize the nodal distance values to a maximum positive value
+        const std::string database = mSettings["distance_database"].GetString();
+        if (database == "nodal_historical") {
+            VariableUtils().SetVariable(*mpDistanceVariable, char_length, ModelPart1.Nodes());
+        } else if (database == "nodal_non_historical"){
+            VariableUtils().SetNonHistoricalVariable(*mpDistanceVariable, char_length, ModelPart1.Nodes());
+        } else {
+            KRATOS_ERROR << "Provided 'distance_database' is '" << database << "'. Available options are 'nodal_historical' and 'nodal_non_historical'." <<  std::endl;
+        }
+    }
 
-	template<std::size_t TDim>
-	void CalculateDistanceToSkinProcess<TDim>::CalculateDistances(
-		std::vector<PointerVector<GeometricalObject>>& rIntersectedObjects)
-	{
-		// Compute the discontinuous (elemental) distance field
-		const bool use_base_elemental_distance = false;
-		if (use_base_elemental_distance) {
-			// Use the base class elemental distance computation (includes plane optimization)
-			CalculateDiscontinuousDistanceToSkinProcess<TDim>::CalculateDistances(rIntersectedObjects);
-		} else {
-			// Use a naive elemental distance computation (without plane optimization)
-			this->CalculateElementalDistances(rIntersectedObjects);
-		}
+    template<std::size_t TDim>
+    void CalculateDistanceToSkinProcess<TDim>::CalculateDistances(
+        std::vector<PointerVector<GeometricalObject>>& rIntersectedObjects)
+    {
+        // Compute the discontinuous (elemental) distance field
+        const bool use_base_elemental_distance = false;
+        if (use_base_elemental_distance) {
+            // Use the base class elemental distance computation (includes plane optimization)
+            CalculateDiscontinuousDistanceToSkinProcess<TDim>::CalculateDistances(rIntersectedObjects);
+        } else {
+            // Use a naive elemental distance computation (without plane optimization)
+            this->CalculateElementalDistances(rIntersectedObjects);
+        }
 
-		// Set the getter function according to the database to be used
-		NodeScalarGetFunctionType node_distance_getter;
-		if (mDistanceDatabase == DistanceDatabase::NodeHistorical) {
-			node_distance_getter = [](NodeType& rNode, const Variable<double>& rDistanceVariable)->double&{return rNode.FastGetSolutionStepValue(rDistanceVariable);};
-		} else {
-			node_distance_getter = [](NodeType& rNode, const Variable<double>& rDistanceVariable)->double&{return rNode.GetValue(rDistanceVariable);};
-		}
+        // Set the getter function according to the database to be used
+        NodeScalarGetFunctionType node_distance_getter;
+        const std::string database = mSettings["distance_database"].GetString();
+        if (database == "nodal_historical") {
+            node_distance_getter = [](NodeType& rNode, const Variable<double>& rDistanceVariable)->double&{return rNode.FastGetSolutionStepValue(rDistanceVariable);};
+        } else if (database == "nodal_non_historical"){
+            node_distance_getter = [](NodeType& rNode, const Variable<double>& rDistanceVariable)->double&{return rNode.GetValue(rDistanceVariable);};
+        } else {
+            KRATOS_ERROR << "Provided 'distance_database' is '" << database << "'. Available options are 'nodal_historical' and 'nodal_non_historical'." <<  std::endl;
+        }
 
-		// Get the minimum elemental distance value for each node
-		this->CalculateNodalDistances(node_distance_getter);
+        // Get the minimum elemental distance value for each node
+        this->CalculateNodalDistances(node_distance_getter);
 
-		// Perform raycasting to sign the previous distance field
-		this->CalculateRayDistances();
-	}
+        // Perform raycasting to sign the previous distance field
+        this->CalculateRayDistances();
+    }
 
-	template<std::size_t TDim>
-	void CalculateDistanceToSkinProcess<TDim>::CalculateElementalDistances(std::vector<PointerVector<GeometricalObject>>& rIntersectedObjects)
-	{
-		const int number_of_elements = (CalculateDiscontinuousDistanceToSkinProcess<TDim>::mFindIntersectedObjectsProcess.GetModelPart1()).NumberOfElements();
-		auto& r_elements = (CalculateDiscontinuousDistanceToSkinProcess<TDim>::mFindIntersectedObjectsProcess.GetModelPart1()).ElementsArray();
-		auto& r_elemental_dist_variable = *CalculateDiscontinuousDistanceToSkinProcess<TDim>::mpElementalDistancesVariable;
+    template<std::size_t TDim>
+    void CalculateDistanceToSkinProcess<TDim>::CalculateElementalDistances(std::vector<PointerVector<GeometricalObject>>& rIntersectedObjects)
+    {
+        const int number_of_elements = (CalculateDiscontinuousDistanceToSkinProcess<TDim>::mFindIntersectedObjectsProcess.GetModelPart1()).NumberOfElements();
+        auto& r_elements = (CalculateDiscontinuousDistanceToSkinProcess<TDim>::mFindIntersectedObjectsProcess.GetModelPart1()).ElementsArray();
+        auto& r_elemental_dist_variable = *CalculateDiscontinuousDistanceToSkinProcess<TDim>::mpElementalDistancesVariable;
 
-		#pragma omp parallel for schedule(dynamic)
-		for (int i = 0; i < number_of_elements; ++i) {
-			Element &r_element = *(r_elements[i]);
-			PointerVector<GeometricalObject>& r_element_intersections = rIntersectedObjects[i];
+        #pragma omp parallel for schedule(dynamic)
+        for (int i = 0; i < number_of_elements; ++i) {
+            Element &r_element = *(r_elements[i]);
+            PointerVector<GeometricalObject>& r_element_intersections = rIntersectedObjects[i];
 
-			// Check if the element has intersections
-			if (r_element_intersections.empty()) {
-				r_element.Set(TO_SPLIT, false);
-			} else {
-				// This function assumes tetrahedra element and triangle intersected object as input at this moment
-				constexpr int number_of_tetrahedra_points = TDim + 1;
-				constexpr double epsilon = std::numeric_limits<double>::epsilon();
-				Vector &elemental_distances = r_element.GetValue(r_elemental_dist_variable);
+            // Check if the element has intersections
+            if (r_element_intersections.empty()) {
+                r_element.Set(TO_SPLIT, false);
+            } else {
+                // This function assumes tetrahedra element and triangle intersected object as input at this moment
+                constexpr int number_of_tetrahedra_points = TDim + 1;
+                constexpr double epsilon = std::numeric_limits<double>::epsilon();
+                Vector &elemental_distances = r_element.GetValue(r_elemental_dist_variable);
 
-				if (elemental_distances.size() != number_of_tetrahedra_points){
-					elemental_distances.resize(number_of_tetrahedra_points, false);
-				}
+                if (elemental_distances.size() != number_of_tetrahedra_points){
+                    elemental_distances.resize(number_of_tetrahedra_points, false);
+                }
 
-				for (int i = 0; i < number_of_tetrahedra_points; i++) {
-					elemental_distances[i] = this->CalculateDistanceToNode(r_element.GetGeometry()[i], r_element_intersections, epsilon);
-				}
+                for (int i = 0; i < number_of_tetrahedra_points; i++) {
+                    elemental_distances[i] = this->CalculateDistanceToNode(r_element.GetGeometry()[i], r_element_intersections, epsilon);
+                }
 
-				bool has_positive_distance = false;
-				bool has_negative_distance = false;
-				for (int i = 0; i < number_of_tetrahedra_points; i++){
-					if (elemental_distances[i] > epsilon) {
-						has_positive_distance = true;
-					} else {
-						has_negative_distance = true;
-					}
-				}
+                bool has_positive_distance = false;
+                bool has_negative_distance = false;
+                for (int i = 0; i < number_of_tetrahedra_points; i++){
+                    if (elemental_distances[i] > epsilon) {
+                        has_positive_distance = true;
+                    } else {
+                        has_negative_distance = true;
+                    }
+                }
 
-				r_element.Set(TO_SPLIT, has_positive_distance && has_negative_distance);
-			}
-		}
-	}
+                r_element.Set(TO_SPLIT, has_positive_distance && has_negative_distance);
+            }
+        }
+    }
 
-	template<std::size_t TDim>
-	double CalculateDistanceToSkinProcess<TDim>::CalculateDistanceToNode(
-		Node<3> &rNode,
-		PointerVector<GeometricalObject>& rIntersectedObjects,
-		const double Epsilon)
-	{
-		// Initialize result distance value
-		double result_distance = std::numeric_limits<double>::max();
+    template<std::size_t TDim>
+    double CalculateDistanceToSkinProcess<TDim>::CalculateDistanceToNode(
+        Node<3> &rNode,
+        PointerVector<GeometricalObject>& rIntersectedObjects,
+        const double Epsilon)
+    {
+        // Initialize result distance value
+        double result_distance = std::numeric_limits<double>::max();
 
-		// For each intersecting object of the element, compute its nodal distance
-		for (const auto& it_int_obj : rIntersectedObjects.GetContainer()) {
-			// Compute the intersecting object distance to the current element node
-			const auto &r_int_obj_geom = it_int_obj->GetGeometry();
-			const double distance = this->CalculatePointDistance(r_int_obj_geom, rNode);
+        // For each intersecting object of the element, compute its nodal distance
+        for (const auto& it_int_obj : rIntersectedObjects.GetContainer()) {
+            // Compute the intersecting object distance to the current element node
+            const auto &r_int_obj_geom = it_int_obj->GetGeometry();
+            const double distance = this->CalculatePointDistance(r_int_obj_geom, rNode);
 
-			// Check that the computed distance is the minimum obtained one
-			if (std::abs(result_distance) > distance) {
-				if (distance < Epsilon) {
-					result_distance = -Epsilon; // Avoid values near to 0.0
-				} else {
-					result_distance = distance;
-					std::vector<array_1d<double,3>> plane_pts;
-					for (unsigned int i_node = 0; i_node < r_int_obj_geom.PointsNumber(); ++i_node){
-						plane_pts.push_back(r_int_obj_geom[i_node]);
-					}
-					Plane3D plane = this->SetIntersectionPlane(plane_pts);
+            // Check that the computed distance is the minimum obtained one
+            if (std::abs(result_distance) > distance) {
+                if (distance < Epsilon) {
+                    result_distance = -Epsilon; // Avoid values near to 0.0
+                } else {
+                    result_distance = distance;
+                    std::vector<array_1d<double,3>> plane_pts;
+                    for (unsigned int i_node = 0; i_node < r_int_obj_geom.PointsNumber(); ++i_node){
+                        plane_pts.push_back(r_int_obj_geom[i_node]);
+                    }
+                    Plane3D plane = this->SetIntersectionPlane(plane_pts);
 
-					// Check the distance sign using the distance to the intersection plane
-					if (plane.CalculateSignedDistance(rNode) < 0.0){
-						result_distance = -result_distance;
-					}
-				}
-			}
-		}
+                    // Check the distance sign using the distance to the intersection plane
+                    if (plane.CalculateSignedDistance(rNode) < 0.0){
+                        result_distance = -result_distance;
+                    }
+                }
+            }
+        }
 
-		return result_distance;
-	}
+        return result_distance;
+    }
 
-	template<std::size_t TDim>
-	void CalculateDistanceToSkinProcess<TDim>::CalculateNodalDistances(NodeScalarGetFunctionType& rGetDistanceFunction)
-	{
-		ModelPart& ModelPart1 = (CalculateDiscontinuousDistanceToSkinProcess<TDim>::mFindIntersectedObjectsProcess).GetModelPart1();
+    template<std::size_t TDim>
+    void CalculateDistanceToSkinProcess<TDim>::CalculateNodalDistances(NodeScalarGetFunctionType& rGetDistanceFunction)
+    {
+        ModelPart& ModelPart1 = (CalculateDiscontinuousDistanceToSkinProcess<TDim>::mFindIntersectedObjectsProcess).GetModelPart1();
 
-		constexpr int number_of_tetrahedra_points = TDim + 1;
-		auto& r_elemental_dist_variable = *CalculateDiscontinuousDistanceToSkinProcess<TDim>::mpElementalDistancesVariable;
-		for (auto& element : ModelPart1.Elements()) {
-			if (element.Is(TO_SPLIT)) {
-				const auto& r_elemental_distances = element.GetValue(r_elemental_dist_variable);
-				for (int i = 0; i < number_of_tetrahedra_points; i++) {
-					Node<3>& r_node = element.GetGeometry()[i];
-					double& r_distance = rGetDistanceFunction(r_node, *mpDistanceVariable);
-					if (std::abs(r_distance) > std::abs(r_elemental_distances[i])){
-						r_distance = r_elemental_distances[i];
-					}
-				}
-			}
-		}
-	}
+        constexpr int number_of_tetrahedra_points = TDim + 1;
+        auto& r_elemental_dist_variable = *CalculateDiscontinuousDistanceToSkinProcess<TDim>::mpElementalDistancesVariable;
+        for (auto& element : ModelPart1.Elements()) {
+            if (element.Is(TO_SPLIT)) {
+                const auto& r_elemental_distances = element.GetValue(r_elemental_dist_variable);
+                for (int i = 0; i < number_of_tetrahedra_points; i++) {
+                    Node<3>& r_node = element.GetGeometry()[i];
+                    double& r_distance = rGetDistanceFunction(r_node, *mpDistanceVariable);
+                    if (std::abs(r_distance) > std::abs(r_elemental_distances[i])){
+                        r_distance = r_elemental_distances[i];
+                    }
+                }
+            }
+        }
+    }
 
-	template<std::size_t TDim>
-	void CalculateDistanceToSkinProcess<TDim>::CalculateRayDistances()
-	{
-		ApplyRayCastingProcess<TDim> ray_casting_process(
-			CalculateDiscontinuousDistanceToSkinProcess<TDim>::mFindIntersectedObjectsProcess,
-			mRayCastingRelativeTolerance,
-			mpDistanceVariable,
-			mDistanceDatabase);
-		ray_casting_process.Execute();
-	}
+    template<std::size_t TDim>
+    void CalculateDistanceToSkinProcess<TDim>::CalculateRayDistances()
+    {
+        Parameters apply_ray_casting_settings(R"({
+            "distance_database" : "",
+            "distance_variable" : "",
+            "relative_tolerance" : 1e-12
+        })");
+        apply_ray_casting_settings["distance_variable"].SetString(mSettings["distance_variable"].GetString());
+        apply_ray_casting_settings["distance_database"].SetString(mSettings["distance_database"].GetString());
+        apply_ray_casting_settings["relative_tolerance"].SetDouble(mRayCastingRelativeTolerance);
+        ApplyRayCastingProcess<TDim> ray_casting_process(
+            CalculateDiscontinuousDistanceToSkinProcess<TDim>::mFindIntersectedObjectsProcess,
+            apply_ray_casting_settings);
+        ray_casting_process.Execute();
+    }
 
-	template<>
-	double inline CalculateDistanceToSkinProcess<2>::CalculatePointDistance(
-		const Element::GeometryType &rIntObjGeom,
-		const Point &rDistancePoint)
-	{
-		return GeometryUtils::PointDistanceToLineSegment3D(
-			rIntObjGeom[0],
-			rIntObjGeom[1],
-			rDistancePoint);
-	}
+    template<>
+    double inline CalculateDistanceToSkinProcess<2>::CalculatePointDistance(
+        const Element::GeometryType &rIntObjGeom,
+        const Point &rDistancePoint)
+    {
+        return GeometryUtils::PointDistanceToLineSegment3D(
+            rIntObjGeom[0],
+            rIntObjGeom[1],
+            rDistancePoint);
+    }
 
-	template<>
-	double inline CalculateDistanceToSkinProcess<3>::CalculatePointDistance(
-		const Element::GeometryType &rIntObjGeom,
-		const Point &rDistancePoint)
-	{
-		return GeometryUtils::PointDistanceToTriangle3D(
-			rIntObjGeom[0],
-			rIntObjGeom[1],
-			rIntObjGeom[2],
-			rDistancePoint);
-	}
+    template<>
+    double inline CalculateDistanceToSkinProcess<3>::CalculatePointDistance(
+        const Element::GeometryType &rIntObjGeom,
+        const Point &rDistancePoint)
+    {
+        return GeometryUtils::PointDistanceToTriangle3D(
+            rIntObjGeom[0],
+            rIntObjGeom[1],
+            rIntObjGeom[2],
+            rDistancePoint);
+    }
 
-	/// Turn back information as a string.
-	template<std::size_t TDim>
-	std::string CalculateDistanceToSkinProcess<TDim>::Info() const
-	{
-		return "CalculateDistanceToSkinProcess";
-	}
+    /// Turn back information as a string.
+    template<std::size_t TDim>
+    std::string CalculateDistanceToSkinProcess<TDim>::Info() const
+    {
+        return "CalculateDistanceToSkinProcess";
+    }
 
-	/// Print information about this object.
-	template<std::size_t TDim>
-	void CalculateDistanceToSkinProcess<TDim>::PrintInfo(std::ostream& rOStream) const
-	{
-		rOStream << Info();
-	}
+    /// Print information about this object.
+    template<std::size_t TDim>
+    void CalculateDistanceToSkinProcess<TDim>::PrintInfo(std::ostream& rOStream) const
+    {
+        rOStream << Info();
+    }
 
-	/// Print object's data.
-	template<std::size_t TDim>
-	void CalculateDistanceToSkinProcess<TDim>::PrintData(std::ostream& rOStream) const
-	{
-	}
+    /// Print object's data.
+    template<std::size_t TDim>
+    void CalculateDistanceToSkinProcess<TDim>::PrintData(std::ostream& rOStream) const
+    {
+    }
 
-	template class Kratos::CalculateDistanceToSkinProcess<2>;
-	template class Kratos::CalculateDistanceToSkinProcess<3>;
+    template class Kratos::CalculateDistanceToSkinProcess<2>;
+    template class Kratos::CalculateDistanceToSkinProcess<3>;
 
 }  // namespace Kratos.

--- a/kratos/processes/calculate_distance_to_skin_process.h
+++ b/kratos/processes/calculate_distance_to_skin_process.h
@@ -55,7 +55,6 @@ public:
     using NodeType = ModelPart::NodeType;
 
     /// Types from the ApplyRayCastingProcess
-    using DistanceDatabase = typename ApplyRayCastingProcess<TDim>::DistanceDatabase;
     using IntersectionGeometryType = typename ApplyRayCastingProcess<TDim>::IntersectionGeometryType;
     using IntersectionsContainerType = typename ApplyRayCastingProcess<TDim>::IntersectionsContainerType;
     using NodeScalarGetFunctionType = typename ApplyRayCastingProcess<TDim>::NodeScalarGetFunctionType;
@@ -218,11 +217,11 @@ private:
     ///@name Member Variables
     ///@{
 
+    Parameters mSettings;
+
     double mRayCastingRelativeTolerance = 1.0e-8;
 
     const Variable<double>* mpDistanceVariable = &DISTANCE;
-
-    DistanceDatabase mDistanceDatabase = DistanceDatabase::NodeHistorical;
 
     ///@}
     ///@name Private Operators

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -462,12 +462,12 @@ void  AddProcessesToPython(pybind11::module& m)
     // Continuous distance computation methods
     py::class_<ApplyRayCastingProcess<2>, ApplyRayCastingProcess<2>::Pointer, Process>(m,"ApplyRayCastingProcess2D")
         .def(py::init<ModelPart&, ModelPart&>())
-        .def(py::init<ModelPart&, ModelPart&, double>())
+        .def(py::init<ModelPart&, ModelPart&, Parameters>())
     ;
 
     py::class_<ApplyRayCastingProcess<3>, ApplyRayCastingProcess<3>::Pointer, Process>(m,"ApplyRayCastingProcess3D")
         .def(py::init<ModelPart&, ModelPart&>())
-        .def(py::init<ModelPart&, ModelPart&, double>())
+        .def(py::init<ModelPart&, ModelPart&, Parameters>())
     ;
 
 //     // Calculate embedded variable from skin processes

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -462,11 +462,13 @@ void  AddProcessesToPython(pybind11::module& m)
     // Continuous distance computation methods
     py::class_<ApplyRayCastingProcess<2>, ApplyRayCastingProcess<2>::Pointer, Process>(m,"ApplyRayCastingProcess2D")
         .def(py::init<ModelPart&, ModelPart&>())
+        .def(py::init<ModelPart&, ModelPart&, double>())
         .def(py::init<ModelPart&, ModelPart&, Parameters>())
     ;
 
     py::class_<ApplyRayCastingProcess<3>, ApplyRayCastingProcess<3>::Pointer, Process>(m,"ApplyRayCastingProcess3D")
         .def(py::init<ModelPart&, ModelPart&>())
+        .def(py::init<ModelPart&, ModelPart&, double>())
         .def(py::init<ModelPart&, ModelPart&, Parameters>())
     ;
 


### PR DESCRIPTION
This PR modifies apply ray casting class so settings can be passed by Parameters object instead of passing each setting as an argument. The default behavior stays the same. 

(I recommend to hide whitespace changes as indentation was using tabs in these classes)