### PR TITLE
[Core] Remove Dimension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,7 +597,7 @@ endforeach()
 message("\n***********************************************************************\n")
 
 message("\nList of upcoming API-breaking and behavior changes:")
-message("\t Geometry 'Dimension' deprecation: https://github.com/KratosMultiphysics/Kratos/pull/10977")
+message("\t Geometry 'Dimension' removed: https://github.com/KratosMultiphysics/Kratos/pull/10977")
 message("\t Geometry old projection methods deprecation: https://github.com/KratosMultiphysics/Kratos/pull/9024")
 message("\t Geometry old closest point methods deprecation: https://github.com/KratosMultiphysics/Kratos/pull/9243")
 message("\t Model 'CreateModelPart' behavior change (no error thrown if model part exists): https://github.com/KratosMultiphysics/Kratos/pull/9598")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -597,7 +597,7 @@ endforeach()
 message("\n***********************************************************************\n")
 
 message("\nList of upcoming API-breaking and behavior changes:")
-message("\t Geometry 'Dimension' deprecation: https://github.com/KratosMultiphysics/Kratos/pull/10445")
+message("\t Geometry 'Dimension' deprecation: https://github.com/KratosMultiphysics/Kratos/pull/10977")
 message("\t Geometry old projection methods deprecation: https://github.com/KratosMultiphysics/Kratos/pull/9024")
 message("\t Geometry old closest point methods deprecation: https://github.com/KratosMultiphysics/Kratos/pull/9243")
 message("\t Model 'CreateModelPart' behavior change (no error thrown if model part exists): https://github.com/KratosMultiphysics/Kratos/pull/9598")

--- a/applications/CableNetApplication/custom_geometries/line_3d_n.h
+++ b/applications/CableNetApplication/custom_geometries/line_3d_n.h
@@ -864,8 +864,8 @@ const GeometryData Line3DN<TPointType>::msGeometryData(
 
 
 template<class TPointType>
-const GeometryDimension Line3DN<TPointType>::msGeometryDimension(
-    3, 3, 1);
+const GeometryDimension Line3DN<TPointType>::msGeometryDimension(3, 1);
+
 }  // namespace Kratos.
 
 #endif // KRATOS_LINE_3D_3_H_INCLUDED  defined

--- a/applications/HDF5Application/custom_io/hdf5_connectivities_data.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_connectivities_data.cpp
@@ -52,19 +52,16 @@ void ConnectivitiesData::WriteData(File& rFile, const std::string& rPath, WriteI
     {
         const auto& r_geom = KratosComponents<ElementType>::Get(mName).GetGeometry();
         ws_dim = r_geom.WorkingSpaceDimension();
-        dim = r_geom.Dimension();
         num_nodes = r_geom.size();
     }
     else
     {
         const auto& r_geom = KratosComponents<ConditionType>::Get(mName).GetGeometry();
         ws_dim = r_geom.WorkingSpaceDimension();
-        dim = r_geom.Dimension();
         num_nodes = r_geom.size();
     }
     rFile.WriteAttribute(rPath, "Name", mName);
     rFile.WriteAttribute(rPath, "WorkingSpaceDimension", ws_dim);
-    rFile.WriteAttribute(rPath, "Dimension", dim);
     rFile.WriteAttribute(rPath, "NumberOfNodes", num_nodes);
     KRATOS_CATCH("");
 }

--- a/applications/HDF5Application/custom_io/hdf5_connectivities_data.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_connectivities_data.cpp
@@ -47,7 +47,7 @@ void ConnectivitiesData::WriteData(File& rFile, const std::string& rPath, WriteI
     rFile.WriteDataSet(rPath + "/Ids", mIds, rInfo);
     rFile.WriteDataSet(rPath + "/PropertiesIds", mPropertiesIds, rInfo);
     rFile.WriteDataSet(rPath + "/Connectivities", mConnectivities, rInfo);
-    int ws_dim, dim, num_nodes;
+    int ws_dim, num_nodes;
     if (KratosComponents<ElementType>::Has(mName))
     {
         const auto& r_geom = KratosComponents<ElementType>::Get(mName).GetGeometry();

--- a/applications/IgaApplication/custom_conditions/support_lagrange_condition.cpp
+++ b/applications/IgaApplication/custom_conditions/support_lagrange_condition.cpp
@@ -43,7 +43,7 @@ namespace Kratos
         // Integration
         const typename GeometryType::IntegrationPointsArrayType& integration_points = r_geometry.IntegrationPoints();
 
-        // Determinant of jacobian 
+        // Determinant of jacobian
         // Determine the integration: conservative -> initial; non-conservative -> current
         Vector determinant_jacobian_vector(integration_points.size());
         const bool integrate_conservative = GetProperties().Has(INTEGRATE_CONSERVATIVE)
@@ -61,7 +61,7 @@ namespace Kratos
         for (IndexType point_number = 0; point_number < integration_points.size(); point_number++)
         {
             // Differential area, being 1 for points.
-            const double integration = (r_geometry.Dimension() == 0)
+            const double integration = (r_geometry.LocalSpaceDimension() == 0)
                 ? 1
                 : integration_points[point_number].Weight() * determinant_jacobian_vector[point_number];
 

--- a/applications/IgaApplication/custom_modelers/iga_modeler.cpp
+++ b/applications/IgaApplication/custom_modelers/iga_modeler.cpp
@@ -4,7 +4,7 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:         BSD License 
+//  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
 
@@ -334,8 +334,8 @@ namespace Kratos
             auto p_background_geometry = geom.pGetGeometryPart(GeometryType::BACKGROUND_GEOMETRY_INDEX);
 
             if (rGeometryType == "GeometryCurveNodes") {
-                KRATOS_DEBUG_ERROR_IF(geom.Dimension() != 1) << "Geometry #" << geom.Id()
-                    << " needs to have a dimension of 1 for type GeometryCurveNodes. Dimension: " << geom.Dimension()
+                KRATOS_DEBUG_ERROR_IF(geom.LocalSpaceDimension() != 1) << "Geometry #" << geom.Id()
+                    << " needs to have a dimension of 1 for type GeometryCurveNodes. LocalSpaceDimension: " << geom.LocalSpaceDimension()
                     << ". Geometry" << geom << std::endl;
 
                 SizeType number_of_cps = p_background_geometry->size();
@@ -353,8 +353,8 @@ namespace Kratos
                 }
             }
             else if (rGeometryType == "GeometryCurveVariationNodes") {
-                KRATOS_DEBUG_ERROR_IF(geom.Dimension() != 1) << "Geometry #" << geom.Id()
-                    << " needs to have a dimension of 1 for type GeometryCurveVariationNodes. Dimension: " << geom.Dimension()
+                KRATOS_DEBUG_ERROR_IF(geom.LocalSpaceDimension() != 1) << "Geometry #" << geom.Id()
+                    << " needs to have a dimension of 1 for type GeometryCurveVariationNodes. LocalSpaceDimension: " << geom.LocalSpaceDimension()
                     << ". Geometry" << geom << std::endl;
 
                 SizeType number_of_cps = p_background_geometry->size();
@@ -376,9 +376,9 @@ namespace Kratos
             }
             else if (rGeometryType == "GeometrySurfaceNodes"
                 || rGeometryType == "GeometrySurfaceVariationNodes") {
-                KRATOS_DEBUG_ERROR_IF(geom.Dimension() != 2) << "Geometry #" << geom.Id()
-                    << " needs to have a dimension of 2 for type " << rGeometryType << ". Dimension: "
-                    << geom.Dimension() << ". Geometry" << geom << std::endl;
+                KRATOS_DEBUG_ERROR_IF(geom.LocalSpaceDimension() != 2) << "Geometry #" << geom.Id()
+                    << " needs to have a dimension of 2 for type " << rGeometryType << ". LocalSpaceDimension: "
+                    << geom.LocalSpaceDimension() << ". Geometry" << geom << std::endl;
 
                 SizeType number_of_cps_u = geom.PointsNumberInDirection(0);
                 SizeType number_of_cps_v = geom.PointsNumberInDirection(1);

--- a/applications/ParticleMechanicsApplication/custom_utilities/pqmpm_partition_utilities.cpp
+++ b/applications/ParticleMechanicsApplication/custom_utilities/pqmpm_partition_utilities.cpp
@@ -299,7 +299,7 @@ namespace Kratos
         // Check all points are in MPM grid geom bounding box
         Node<3> low, high;
         rReferenceGeom.BoundingBox(low, high);
-        const SizeType geom_dim = rReferenceGeom.Dimension();
+        const SizeType geom_dim = rReferenceGeom.WorkingSpaceDimension();
         for (size_t i = 0; i < rPoints.size(); ++i) {
             for (size_t dim = 0; dim < geom_dim; ++dim)
             {

--- a/applications/ShapeOptimizationApplication/custom_utilities/geometry_utilities.cpp
+++ b/applications/ShapeOptimizationApplication/custom_utilities/geometry_utilities.cpp
@@ -116,7 +116,7 @@ void GeometryUtilities::ExtractBoundaryNodes( std::string const& rBoundarySubMod
     // Fill map that counts number of faces for given set of nodes
     for (auto& elem_i : mrModelPart.Elements())
     {
-        KRATOS_ERROR_IF(elem_i.GetGeometry().Dimension() < domain_size) << "ExtractBoundaryNodes: This function does only work"
+        KRATOS_ERROR_IF(elem_i.GetGeometry().WorkingSpaceDimension() < domain_size) << "ExtractBoundaryNodes: This function does only work"
             <<" for solid elements in 3D and surface elements in 2D!" << std::endl;
 
         Element::GeometryType::GeometriesArrayType boundaries = elem_i.GetGeometry().GenerateBoundariesEntities();
@@ -294,7 +294,7 @@ void GeometryUtilities::ComputeVolumeShapeDerivatives(
     block_for_each(mrModelPart.Elements(), VolumeDerivativeMethodType(), [&](ModelPart::ElementType& rElement, VolumeDerivativeMethodType& rVolumeDerivativeMethodType){
         auto& r_geometry = rElement.GetGeometry();
         const auto& geometry_type = r_geometry.GetGeometryType();
-        const SizeType dimension = r_geometry.Dimension();
+        const SizeType dimension = r_geometry.WorkingSpaceDimension();
 
         switch (geometry_type) {
             case GeometryData::KratosGeometryType::Kratos_Triangle2D3:

--- a/applications/ShapeOptimizationApplication/custom_utilities/input_output/universal_file_io.cpp
+++ b/applications/ShapeOptimizationApplication/custom_utilities/input_output/universal_file_io.cpp
@@ -145,7 +145,7 @@ void UniversalFileIO::WriteAllElementsButNoConditions()
         ModelPart::ConditionType::GeometryType element_geometry = element_i.GetGeometry();
 
         // Write triangles
-        if( element_geometry.size()==3 && element_geometry.Dimension()==2 )
+        if( element_geometry.size()==3 && element_geometry.WorkingSpaceDimension()==2 )
         {
             const int feDescriptorId = 41; // Plane Stress Linear Triangle
             const int numberOfNodes = 3;
@@ -160,7 +160,7 @@ void UniversalFileIO::WriteAllElementsButNoConditions()
             outputFile << std::setw(10) << element_geometry[2].Id() << "\n";
         }
         // Write quads
-        else if( element_geometry.size()==4 && element_geometry.Dimension()==2 )
+        else if( element_geometry.size()==4 && element_geometry.WorkingSpaceDimension()==2 )
         {
             const int feDescriptorId = 44; // Plane Stress Linear Quadrilateral
             const int numberOfNodes = 4;
@@ -176,7 +176,7 @@ void UniversalFileIO::WriteAllElementsButNoConditions()
             outputFile << std::setw(10) << element_geometry[3].Id() << "\n";
         }
         // Write tetrahedras
-        else if( element_geometry.size()==4 && element_geometry.Dimension()==3 )
+        else if( element_geometry.size()==4 && element_geometry.WorkingSpaceDimension()==3 )
         {
             const int feDescriptorId = 111; // Solid linear tetrahedron
             const int numberOfNodes = 4;

--- a/kratos/geometries/brep_curve.h
+++ b/kratos/geometries/brep_curve.h
@@ -486,8 +486,7 @@ GeometryData BrepCurve<TContainerPointType, TContainerPointEmbeddedType>::msGeom
     {}, {}, {});
 
 template<class TContainerPointType, class TContainerPointEmbeddedType>
-const GeometryDimension BrepCurve<TContainerPointType, TContainerPointEmbeddedType>::msGeometryDimension(
-    1, 3, 1);
+const GeometryDimension BrepCurve<TContainerPointType, TContainerPointEmbeddedType>::msGeometryDimension(3, 1);
 
 ///@}
 }// namespace Kratos.

--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -700,8 +700,7 @@ GeometryData BrepCurveOnSurface<TContainerPointType, TContainerPointEmbeddedType
     {}, {}, {});
 
 template<class TContainerPointType, class TContainerPointEmbeddedType>
-const GeometryDimension BrepCurveOnSurface<TContainerPointType, TContainerPointEmbeddedType>::msGeometryDimension(
-    1, 3, 1);
+const GeometryDimension BrepCurveOnSurface<TContainerPointType, TContainerPointEmbeddedType>::msGeometryDimension(3, 1);
 
 ///@}
 }// namespace Kratos.

--- a/kratos/geometries/brep_surface.h
+++ b/kratos/geometries/brep_surface.h
@@ -631,8 +631,7 @@ GeometryData BrepSurface<TContainerPointType, TContainerPointEmbeddedType>::msGe
     {}, {}, {});
 
 template<class TContainerPointType, class TContainerPointEmbeddedType>
-const GeometryDimension BrepSurface<TContainerPointType, TContainerPointEmbeddedType>::msGeometryDimension(
-    2, 3, 2);
+const GeometryDimension BrepSurface<TContainerPointType, TContainerPointEmbeddedType>::msGeometryDimension(3, 2);
 
 ///@}
 }// namespace Kratos.

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -1277,19 +1277,6 @@ public:
     ///@name Informations
     ///@{
 
-    /** Dimension of the geometry for example a triangle2d is a 2
-    dimensional shape
-
-    @return SizeType, dimension of this geometry.
-    @see WorkingSpaceDimension()
-    @see LocalSpaceDimension()
-    */
-    KRATOS_DEPRECATED_MESSAGE("'Dimension' is deprecated. Use either 'WorkingSpaceDimension' or 'LocalSpaceDimension' instead.")
-    inline SizeType Dimension() const
-    {
-        return mpGeometryData->Dimension();
-    }
-
     /** Working space dimension. for example a triangle is a 2
     dimensional shape but can be used in 3 dimensional space.
 
@@ -1347,8 +1334,8 @@ public:
         return 0.0;
     }
 
-    /** 
-     * @brief This method calculate and return area or surface area of this geometry depending to it's dimension. 
+    /**
+     * @brief This method calculate and return area or surface area of this geometry depending to it's dimension.
      * @details For one dimensional geometry it returns length, for two dimensional it gives area and for three dimensional geometries it gives surface area.
      * @return double value contains area or surface area.
      * @see Length()
@@ -1360,8 +1347,8 @@ public:
         return 0.0;
     }
 
-    /** 
-     * @brief This method calculate and return volume of this geometry. 
+    /**
+     * @brief This method calculate and return volume of this geometry.
      * @details For one and two dimensional geometry it returns zero and for three dimensional it gives volume of geometry.
      * @return double value contains volume.
      * @see Length()
@@ -1373,8 +1360,8 @@ public:
         return 0.0;
     }
 
-    /** 
-     * @brief This method calculate and return length, area or volume of this geometry depending to it's dimension. 
+    /**
+     * @brief This method calculate and return length, area or volume of this geometry depending to it's dimension.
      * @details For one dimensional geometry it returns its length, for two dimensional it gives area and for three dimensional geometries it gives its volume.
      * @return double value contains length, area or volume.
      * @see Length()
@@ -4296,7 +4283,6 @@ inline std::ostream& operator << ( std::ostream& rOStream,
 ///@}
 
 template<class TPointType>
-const GeometryDimension Geometry<TPointType>::msGeometryDimension(
-    3, 3, 3);
+const GeometryDimension Geometry<TPointType>::msGeometryDimension(3, 3);
 
 }  // namespace Kratos.

--- a/kratos/geometries/geometry_data.h
+++ b/kratos/geometries/geometry_data.h
@@ -364,19 +364,6 @@ public:
     ///@name Informations
     ///@{
 
-    /** Dimension of the geometry for example a triangle2d is a 2
-    dimensional shape
-
-    @return SizeType, dimension of this geometry.
-    @see WorkingSpaceDimension()
-    @see LocalSpaceDimension()
-    */
-    KRATOS_DEPRECATED_MESSAGE("'Dimension' is deprecated. Use either 'WorkingSpaceDimension' or 'LocalSpaceDimension' instead.")
-    SizeType Dimension() const
-    {
-        return mpGeometryDimension->Dimension();
-    }
-
     /** Working space dimension. for example a triangle is a 2
     dimensional shape but can be used in 3 dimensional space.
 

--- a/kratos/geometries/geometry_dimension.h
+++ b/kratos/geometries/geometry_dimension.h
@@ -68,11 +68,10 @@ public:
     for example a triangle is a 2 dimensional shape but
     can have 3 dimensional area coordinates l1, l2, l3.
     */
-    GeometryDimension( SizeType ThisDimension,
-                  SizeType ThisWorkingSpaceDimension,
-                  SizeType ThisLocalSpaceDimension )
-        : mDimension( ThisDimension )
-        , mWorkingSpaceDimension( ThisWorkingSpaceDimension )
+    GeometryDimension(
+        SizeType ThisWorkingSpaceDimension,
+        SizeType ThisLocalSpaceDimension )
+        : mWorkingSpaceDimension( ThisWorkingSpaceDimension )
         , mLocalSpaceDimension( ThisLocalSpaceDimension )
     {
     }
@@ -81,8 +80,7 @@ public:
     Construct this geometry data as a copy of given geometry data.
     */
     GeometryDimension( const GeometryDimension& rOther )
-        : mDimension( rOther.mDimension )
-        , mWorkingSpaceDimension( rOther.mWorkingSpaceDimension )
+        : mWorkingSpaceDimension( rOther.mWorkingSpaceDimension )
         , mLocalSpaceDimension( rOther.mLocalSpaceDimension )
     {
     }
@@ -96,7 +94,6 @@ public:
 
     GeometryDimension& operator=( const GeometryDimension& rOther )
     {
-        mDimension = rOther.mDimension;
         mWorkingSpaceDimension = rOther.mWorkingSpaceDimension;
         mLocalSpaceDimension = rOther.mLocalSpaceDimension;
 
@@ -106,20 +103,6 @@ public:
     ///@}
     ///@name Informations
     ///@{
-
-    /** Dimension of the geometry for example a triangle2d is a 2
-    dimensional shape. A line is 1 dimensional shape and
-    a point 0 dimensional.
-
-    @return SizeType, dimension of this geometry.
-    @see WorkingSpaceDimension()
-    @see LocalSpaceDimension()
-    */
-    KRATOS_DEPRECATED_MESSAGE("'Dimension' is deprecated. Use either 'WorkingSpaceDimension' or 'LocalSpaceDimension' instead.")
-    inline SizeType Dimension() const
-    {
-        return mDimension;
-    }
 
     /** Working space dimension. for example a triangle as part
     of a surface is a 2 dimensional shape but can be used in
@@ -176,8 +159,6 @@ private:
     ///@name Member Variables
     ///@{
 
-    SizeType mDimension;
-
     SizeType mWorkingSpaceDimension;
 
     SizeType mLocalSpaceDimension;
@@ -190,14 +171,12 @@ private:
 
     virtual void save( Serializer& rSerializer ) const
     {
-        rSerializer.save( "Dimension", mDimension );
         rSerializer.save( "WorkingSpaceDimension", mWorkingSpaceDimension );
         rSerializer.save( "LocalSpaceDimension", mLocalSpaceDimension );
     }
 
     virtual void load( Serializer& rSerializer )
     {
-        rSerializer.load( "Dimension", mDimension );
         rSerializer.load( "WorkingSpaceDimension", mWorkingSpaceDimension );
         rSerializer.load( "LocalSpaceDimension", mLocalSpaceDimension );
     }

--- a/kratos/geometries/hexahedra_3d_20.h
+++ b/kratos/geometries/hexahedra_3d_20.h
@@ -441,8 +441,8 @@ public:
 
     }
 
-    /** 
-     * @brief This method calculate and return volume of this geometry. 
+    /**
+     * @brief This method calculate and return volume of this geometry.
      * @details For one and two dimensional geometry it returns zero and for three dimensional it gives volume of geometry.
      * @return double value contains volume.
      * @see Length()
@@ -1606,7 +1606,6 @@ GeometryData Hexahedra3D20<TPointType>::msGeometryData(
 );
 
 template<class TPointType> const
-GeometryDimension Hexahedra3D20<TPointType>::msGeometryDimension(
-    3, 3, 3);
+GeometryDimension Hexahedra3D20<TPointType>::msGeometryDimension(3, 3);
 
 }// namespace Kratos.

--- a/kratos/geometries/hexahedra_3d_27.h
+++ b/kratos/geometries/hexahedra_3d_27.h
@@ -14,7 +14,7 @@
 //                   Josep Maria Carbonell
 //
 
-#pragma once 
+#pragma once
 
 // System includes
 
@@ -465,8 +465,8 @@ public:
         return Volume();
     }
 
-    /** 
-     * @brief This method calculate and return volume of this geometry. 
+    /**
+     * @brief This method calculate and return volume of this geometry.
      * @details For one and two dimensional geometry it returns zero and for three dimensional it gives volume of geometry.
      * @return double value contains volume.
      * @see Length()
@@ -1478,7 +1478,6 @@ GeometryData Hexahedra3D27<TPointType>::msGeometryData(
 );
 
 template<class TPointType>
-const GeometryDimension Hexahedra3D27<TPointType>::msGeometryDimension(
-    3, 3, 3);
+const GeometryDimension Hexahedra3D27<TPointType>::msGeometryDimension(3, 3);
 
 }// namespace Kratos.

--- a/kratos/geometries/hexahedra_3d_8.h
+++ b/kratos/geometries/hexahedra_3d_8.h
@@ -409,8 +409,8 @@ public:
         return Volume();
     }
 
-    /** 
-     * @brief This method calculate and return volume of this geometry. 
+    /**
+     * @brief This method calculate and return volume of this geometry.
      * @details For one and two dimensional geometry it returns zero and for three dimensional it gives volume of geometry.
      * @return double value contains volume.
      * @see Length()
@@ -579,7 +579,7 @@ public:
     * @return double value with the average edge length
     *
     */
-    double AverageEdgeLength() const override 
+    double AverageEdgeLength() const override
     {
         const TPointType& p0 = this->GetPoint(0);
         const TPointType& p1 = this->GetPoint(1);
@@ -690,7 +690,7 @@ public:
         return false;
     }
 
-    /** 
+    /**
      * @brief Implements the calculus of the 8 solid angles of the hexa
      * @details Implements the calculus of the 8 solid angles of the hexa
      * @param rSolidAngles The solid angles of the geometry
@@ -712,7 +712,7 @@ public:
         }
     }
 
-    /** 
+    /**
      * @brief Implements the calculus of the 24 dihedral angles of the hexa
      * @details Implements the calculus of the 24 dihedral angles of the hexa.
      * Each edge has two different dihedral angles in each extreme.
@@ -746,7 +746,7 @@ public:
         }
     }
 
-    /** 
+    /**
      * @brief Calculates the min dihedral angle quality metric.
      * @details Calculates the min dihedral angle quality metric.
      * The min dihedral angle is min angle between two faces of the element
@@ -763,7 +763,7 @@ public:
       return min_dihedral_angle;
     }
 
-    /** 
+    /**
      * @brief Calculates the max dihedral angle quality metric.
      * @details Calculates the max dihedral angle quality metric.
      * The max dihedral angle is max angle between two faces of the element
@@ -804,7 +804,7 @@ public:
         return Volume() / std::pow(rms_edge, 3.0);
     }
 
-    /** 
+    /**
      * @brief Calculates the shortest to longest edge quality metric.
      * Calculates the shortest to longest edge quality metric.
      * This metric is bounded by the interval (0,1) being:
@@ -1441,7 +1441,6 @@ GeometryData Hexahedra3D8<TPointType>::msGeometryData(
 );
 
 template<class TPointType> const
-GeometryDimension Hexahedra3D8<TPointType>::msGeometryDimension(
-    3, 3, 3);
+GeometryDimension Hexahedra3D8<TPointType>::msGeometryDimension(3, 3);
 
 }// namespace Kratos.

--- a/kratos/geometries/hexahedra_interface_3d_8.h
+++ b/kratos/geometries/hexahedra_interface_3d_8.h
@@ -1837,8 +1837,7 @@ GeometryData HexahedraInterface3D8<TPointType>::msGeometryData(
 );
 
 template<class TPointType>
-const GeometryDimension HexahedraInterface3D8<TPointType>::msGeometryDimension(
-    3, 3, 3);
+const GeometryDimension HexahedraInterface3D8<TPointType>::msGeometryDimension(3, 3);
 
 }// namespace Kratos.
 

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -1402,7 +1402,6 @@ const GeometryData Line2D2<TPointType>::msGeometryData(
         AllShapeFunctionsLocalGradients() );
 
 template<class TPointType>
-const GeometryDimension Line2D2<TPointType>::msGeometryDimension(
-    2, 2, 1);
+const GeometryDimension Line2D2<TPointType>::msGeometryDimension(2, 1);
 
 }  // namespace Kratos.

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -1147,7 +1147,6 @@ const GeometryData Line2D3<TPointType>::msGeometryData(
         AllShapeFunctionsLocalGradients() );
 
 template<class TPointType>
-const GeometryDimension Line2D3<TPointType>::msGeometryDimension(
-    2, 2, 1);
+const GeometryDimension Line2D3<TPointType>::msGeometryDimension(2, 1);
 
 }  // namespace Kratos.

--- a/kratos/geometries/line_2d_4.h
+++ b/kratos/geometries/line_2d_4.h
@@ -8,10 +8,10 @@
 //                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Mohamed Nabi
-//                   
-//                   
-//  Contributors:    
-//                   
+//
+//
+//  Contributors:
+//
 //
 
 #pragma once
@@ -54,8 +54,8 @@ namespace Kratos
  * @details The node ordering corresponds with:
  *      0-----2----3----1
  * @author Mohamed Nabi
- * @author 
- * @author 
+ * @author
+ * @author
  */
 template<class TPointType>
 class Line2D4 : public Geometry<TPointType>
@@ -184,7 +184,7 @@ public:
     explicit Line2D4(const IndexType GeometryId, const PointsArrayType& rThisPoints)
         : BaseType(GeometryId, rThisPoints, &msGeometryData)
     {
-        KRATOS_ERROR_IF(this->PointsNumber() != 4) << "Invalid points number. Expected 4, given " 
+        KRATOS_ERROR_IF(this->PointsNumber() != 4) << "Invalid points number. Expected 4, given "
                                                    << this->PointsNumber() << std::endl;
     }
 
@@ -278,7 +278,7 @@ public:
      * @param rThisPoints the nodes of the new geometry
      * @return Pointer to the new geometry
      */
-    typename BaseType::Pointer Create(const IndexType NewGeometryId, PointsArrayType const& rThisPoints) 
+    typename BaseType::Pointer Create(const IndexType NewGeometryId, PointsArrayType const& rThisPoints)
         const override
     {
         return typename BaseType::Pointer(new Line2D4(NewGeometryId, rThisPoints));
@@ -306,7 +306,7 @@ public:
      *      - Evaluation of M using a quadrature involving only the nodal points and thus
      *        automatically yielding a diagonal matrix for standard element shape function
      */
-    Vector& LumpingFactors(Vector& rResult, const typename BaseType::LumpingMethods LumpingMethod 
+    Vector& LumpingFactors(Vector& rResult, const typename BaseType::LumpingMethods LumpingMethod
         = BaseType::LumpingMethods::ROW_SUM) const override
     {
         if (rResult.size() != 4) rResult.resize(4, false);
@@ -349,7 +349,7 @@ public:
      * this geometry depending to it's dimension. For one dimensional
      * geometry it returns length, for two dimensional it gives area
      * and for three dimensional geometries it gives surface area.
-     * 
+     *
      * @return double value contains area or surface area.
      * @see Length()
      * @see Volume()
@@ -364,7 +364,7 @@ public:
      * this geometry depending to it's dimension. For one dimensional
      * geometry it returns its length, for two dimensional it gives area
      * and for three dimensional geometries it gives its volume.
-     * 
+     *
      * @return double value contains length, area or volume.
      * @see Length()
      * @see Area()
@@ -481,7 +481,7 @@ public:
     JacobiansType& Jacobian(JacobiansType& rResult, IntegrationMethod ThisMethod) const override
     {
         // Getting derivatives of shape functions
-        const ShapeFunctionsGradientsType shape_functions_gradients 
+        const ShapeFunctionsGradientsType shape_functions_gradients
             = CalculateShapeFunctionsIntegrationPointsLocalGradients(ThisMethod);
         const std::size_t number_of_integration_points = this->IntegrationPointsNumber(ThisMethod);
         if (rResult.size() != number_of_integration_points) {
@@ -519,11 +519,11 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    JacobiansType& Jacobian(JacobiansType& rResult, IntegrationMethod ThisMethod, 
+    JacobiansType& Jacobian(JacobiansType& rResult, IntegrationMethod ThisMethod,
         Matrix& rDeltaPosition) const override
     {
         // Getting derivatives of shape functions
-        ShapeFunctionsGradientsType shape_functions_gradients 
+        ShapeFunctionsGradientsType shape_functions_gradients
             = CalculateShapeFunctionsIntegrationPointsLocalGradients(ThisMethod);
         const std::size_t number_of_integration_points = this->IntegrationPointsNumber(ThisMethod);
         // Getting values of shape functions
@@ -569,7 +569,7 @@ public:
         rResult.resize(2, 1, false);
         noalias(rResult) = ZeroMatrix(2, 1);
         // Derivatives of shape functions
-        ShapeFunctionsGradientsType shape_functions_gradients 
+        ShapeFunctionsGradientsType shape_functions_gradients
             = CalculateShapeFunctionsIntegrationPointsLocalGradients(ThisMethod);
         Matrix shape_function_gradient_in_integration_point = shape_functions_gradients(IntegrationPointIndex);
         // Values of shape functions in integration points
@@ -759,7 +759,7 @@ public:
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
     }
 
-    void ShapeFunctionsIntegrationPointsGradients(ShapeFunctionsGradientsType& rResult, 
+    void ShapeFunctionsIntegrationPointsGradients(ShapeFunctionsGradientsType& rResult,
                       Vector& rDeterminantsOfJacobian, IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
@@ -808,7 +808,7 @@ public:
      */
     virtual ShapeFunctionsGradientsType ShapeFunctionsLocalGradients(IntegrationMethod& ThisMethod)
     {
-        ShapeFunctionsGradientsType localGradients 
+        ShapeFunctionsGradientsType localGradients
             = CalculateShapeFunctionsIntegrationPointsLocalGradients(ThisMethod);
         const int integration_points_number = msGeometryData.IntegrationPointsNumber(ThisMethod);
         ShapeFunctionsGradientsType Result(integration_points_number);
@@ -826,7 +826,7 @@ public:
     virtual ShapeFunctionsGradientsType ShapeFunctionsLocalGradients()
     {
         IntegrationMethod ThisMethod = msGeometryData.DefaultIntegrationMethod();
-        ShapeFunctionsGradientsType localGradients 
+        ShapeFunctionsGradientsType localGradients
             = CalculateShapeFunctionsIntegrationPointsLocalGradients(ThisMethod);
         const int integration_points_number = msGeometryData.IntegrationPointsNumber(ThisMethod);
         ShapeFunctionsGradientsType Result(integration_points_number);
@@ -1135,6 +1135,6 @@ const GeometryData Line2D4<TPointType>::msGeometryData(
     AllShapeFunctionsLocalGradients());
 
 template<class TPointType>
-const GeometryDimension Line2D4<TPointType>::msGeometryDimension(2, 2, 1);
+const GeometryDimension Line2D4<TPointType>::msGeometryDimension(2, 1);
 
 }  // namespace Kratos.

--- a/kratos/geometries/line_2d_5.h
+++ b/kratos/geometries/line_2d_5.h
@@ -8,10 +8,10 @@
 //                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Mohamed Nabi
-//                   
-//                   
-//  Contributors:    
-//                   
+//
+//
+//  Contributors:
+//
 //
 
 #pragma once
@@ -54,8 +54,8 @@ namespace Kratos
      * @details The node ordering corresponds with:
      *      0-----2----3----4----1
      * @author Mohamed Nabi
-     * @author 
-     * @author 
+     * @author
+     * @author
      */
     template<class TPointType>
     class Line2D5 : public Geometry<TPointType>
@@ -156,7 +156,7 @@ namespace Kratos
         ///@{
 
         Line2D5(const PointType& Point01, const PointType& Point02, const PointType& Point03,
-                const PointType& Point04, const PointType& Point05) 
+                const PointType& Point04, const PointType& Point05)
                 : BaseType(PointsArrayType(), &msGeometryData)
         {
             BaseType::Points().push_back(typename PointType::Pointer(new PointType(Point01)));
@@ -184,7 +184,7 @@ namespace Kratos
         }
 
         /// Constructor with Geometry Id
-        explicit Line2D5(const IndexType GeometryId, const PointsArrayType& rThisPoints) 
+        explicit Line2D5(const IndexType GeometryId, const PointsArrayType& rThisPoints)
             : BaseType(GeometryId, rThisPoints, &msGeometryData)
         {
             KRATOS_ERROR_IF(this->PointsNumber() != 5) << "Invalid points number. Expected 5, given "
@@ -195,7 +195,7 @@ namespace Kratos
         explicit Line2D5(const std::string& rGeometryName, const PointsArrayType& rThisPoints)
             : BaseType(rGeometryName, rThisPoints, &msGeometryData)
         {
-            KRATOS_ERROR_IF(this->PointsNumber() != 5) << "Invalid points number. Expected 5, given " 
+            KRATOS_ERROR_IF(this->PointsNumber() != 5) << "Invalid points number. Expected 5, given "
                 << this->PointsNumber() << std::endl;
         }
 
@@ -241,7 +241,7 @@ namespace Kratos
         ///@}
         ///@name Operators
         ///@{
-        
+
         /** Assignment operator.
          * @note This operator don't copy the points and this
          * geometry shares points with given source geometry. It's
@@ -274,7 +274,7 @@ namespace Kratos
         ///@}
         ///@name Operations
         ///@{
-        
+
         /**
          * @brief Creates a new geometry pointer
          * @param NewGeometryId the ID of the new geometry
@@ -309,7 +309,7 @@ namespace Kratos
          *      - Evaluation of M using a quadrature involving only the nodal points and thus
          *        automatically yielding a diagonal matrix for standard element shape function
          */
-        Vector& LumpingFactors(Vector& rResult, const typename BaseType::LumpingMethods LumpingMethod 
+        Vector& LumpingFactors(Vector& rResult, const typename BaseType::LumpingMethods LumpingMethod
             = BaseType::LumpingMethods::ROW_SUM)  const override
         {
             if (rResult.size() != 5) rResult.resize(5, false);
@@ -324,11 +324,11 @@ namespace Kratos
         ///@}
         ///@name Informations
         ///@{
-        
-        /** This method calculate and return Length or charactereistic 
-         * length of this geometry depending to it's dimension. For one 
-         * dimensional geometry for example Line it returns length of it 
-         * and for the other geometries it gives Characteristic length 
+
+        /** This method calculate and return Length or charactereistic
+         * length of this geometry depending to it's dimension. For one
+         * dimensional geometry for example Line it returns length of it
+         * and for the other geometries it gives Characteristic length
          * otherwise.
          * @return double value contains length or Characteristic length.
          * @see Area()
@@ -354,7 +354,7 @@ namespace Kratos
          * this geometry depending to it's dimension. For one dimensional
          * geometry it returns length, for two dimensional it gives area
          * and for three dimensional geometries it gives surface area.
-         * 
+         *
          * @return double value contains area or surface area.
          * @see Length()
          * @see Volume()
@@ -369,7 +369,7 @@ namespace Kratos
          * this geometry depending to it's dimension. For one dimensional
          * geometry it returns its length, for two dimensional it gives area
          * and for three dimensional geometries it gives its volume.
-         * 
+         *
          * @return double value contains length, area or volume.
          * @see Length()
          * @see Area()
@@ -467,9 +467,9 @@ namespace Kratos
         ///@}
         ///@name Jacobian
         ///@{
-        
-        /** Jacobians for given method. This method 
-         * calculate jacobians matrices in all integrations points of 
+
+        /** Jacobians for given method. This method
+         * calculate jacobians matrices in all integrations points of
          * given integration method.
          *
          * @param ThisMethod integration method which jacobians has to
@@ -683,7 +683,7 @@ namespace Kratos
         ///@}
         ///@name Shape Function
         ///@{
-        
+
         /**
          * @brief This method gives all non-zero shape functions values evaluated at the rCoordinates provided
          * @note There is no control if the return vector is empty or not!
@@ -765,7 +765,7 @@ namespace Kratos
         ///@}
         ///@name Shape Function Integration Points Gradient
         ///@{
-        
+
         void ShapeFunctionsIntegrationPointsGradients(ShapeFunctionsGradientsType& rResult,
             IntegrationMethod ThisMethod) const override
         {
@@ -781,7 +781,7 @@ namespace Kratos
         ///@}
         ///@name Input and output
         ///@{
-        
+
         /** Turn back information as a string.
          *
          * @return String contains information about this geometry.
@@ -803,7 +803,7 @@ namespace Kratos
             rOStream << "1 dimensional line with 5 nodes in 2D space";
         }
 
-        /** Print geometry's data into given stream. Prints it's points 
+        /** Print geometry's data into given stream. Prints it's points
          * by the order they stored in the geometry and then center point of geometry.
          * @param rOStream Stream to print into it.
          * @see PrintInfo()
@@ -822,7 +822,7 @@ namespace Kratos
          */
         virtual ShapeFunctionsGradientsType ShapeFunctionsLocalGradients(IntegrationMethod& ThisMethod)
         {
-            ShapeFunctionsGradientsType localGradients 
+            ShapeFunctionsGradientsType localGradients
                 = CalculateShapeFunctionsIntegrationPointsLocalGradients(ThisMethod);
             const int integration_points_number = msGeometryData.IntegrationPointsNumber(ThisMethod);
             ShapeFunctionsGradientsType Result(integration_points_number);
@@ -1163,6 +1163,6 @@ namespace Kratos
         AllShapeFunctionsLocalGradients());
 
     template<class TPointType>
-    const GeometryDimension Line2D5<TPointType>::msGeometryDimension(2, 2, 1);
+    const GeometryDimension Line2D5<TPointType>::msGeometryDimension(2, 1);
 
 }  // namespace Kratos.

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -14,7 +14,7 @@
 //                   Josep Maria Carbonell
 //
 
-#pragma once 
+#pragma once
 
 // System includes
 
@@ -1157,7 +1157,6 @@ const GeometryData Line3D2<TPointType>::msGeometryData(
         AllShapeFunctionsLocalGradients() );
 
 template<class TPointType>
-const GeometryDimension Line3D2<TPointType>::msGeometryDimension(
-    3, 3, 1);
+const GeometryDimension Line3D2<TPointType>::msGeometryDimension(3, 1);
 
 }  // namespace Kratos.

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -898,7 +898,6 @@ const GeometryData Line3D3<TPointType>::msGeometryData(
         AllShapeFunctionsLocalGradients() );
 
 template<class TPointType>
-const GeometryDimension Line3D3<TPointType>::msGeometryDimension(
-    3, 3, 1);
+const GeometryDimension Line3D3<TPointType>::msGeometryDimension(3, 1);
 
 }  // namespace Kratos.

--- a/kratos/geometries/line_gauss_lobatto_3d_2.h
+++ b/kratos/geometries/line_gauss_lobatto_3d_2.h
@@ -922,8 +922,7 @@ const GeometryData LineGaussLobatto3D2<TPointType>::msGeometryData(
         AllShapeFunctionsLocalGradients() );
 
 template<class TPointType>
-const GeometryDimension LineGaussLobatto3D2<TPointType>::msGeometryDimension(
-    3, 3, 1);
+const GeometryDimension LineGaussLobatto3D2<TPointType>::msGeometryDimension(3, 1);
 
 }  // namespace Kratos.
 

--- a/kratos/geometries/nurbs_curve_geometry.h
+++ b/kratos/geometries/nurbs_curve_geometry.h
@@ -818,8 +818,7 @@ const GeometryData NurbsCurveGeometry<TWorkingSpaceDimension, TContainerPointTyp
     {}, {}, {});
 
 template<int TWorkingSpaceDimension, class TContainerPointType>
-const GeometryDimension NurbsCurveGeometry<TWorkingSpaceDimension, TContainerPointType>::msGeometryDimension(
-    1, TWorkingSpaceDimension, 1);
+const GeometryDimension NurbsCurveGeometry<TWorkingSpaceDimension, TContainerPointType>::msGeometryDimension(TWorkingSpaceDimension, 1);
 
 } // namespace Kratos
 

--- a/kratos/geometries/nurbs_curve_on_surface_geometry.h
+++ b/kratos/geometries/nurbs_curve_on_surface_geometry.h
@@ -663,8 +663,7 @@ const GeometryData NurbsCurveOnSurfaceGeometry<TWorkingSpaceDimension, TCurveCon
     {}, {}, {});
 
 template<int TWorkingSpaceDimension, class TCurveContainerPointType, class TSurfaceContainerPointType>
-const GeometryDimension NurbsCurveOnSurfaceGeometry<TWorkingSpaceDimension, TCurveContainerPointType, TSurfaceContainerPointType>::msGeometryDimension(
-    1, TWorkingSpaceDimension, 1);
+const GeometryDimension NurbsCurveOnSurfaceGeometry<TWorkingSpaceDimension, TCurveContainerPointType, TSurfaceContainerPointType>::msGeometryDimension(TWorkingSpaceDimension, 1);
 
 } // namespace Kratos
 

--- a/kratos/geometries/nurbs_surface_geometry.h
+++ b/kratos/geometries/nurbs_surface_geometry.h
@@ -969,8 +969,7 @@ const GeometryData NurbsSurfaceGeometry<TWorkingSpaceDimension, TPointType>::msG
     {}, {}, {});
 
 template<int TWorkingSpaceDimension, class TPointType>
-const GeometryDimension NurbsSurfaceGeometry<TWorkingSpaceDimension, TPointType>::msGeometryDimension(
-    2, TWorkingSpaceDimension, 2);
+const GeometryDimension NurbsSurfaceGeometry<TWorkingSpaceDimension, TPointType>::msGeometryDimension(TWorkingSpaceDimension, 2);
 
 } // namespace Kratos
 

--- a/kratos/geometries/nurbs_volume_geometry.h
+++ b/kratos/geometries/nurbs_volume_geometry.h
@@ -1130,8 +1130,7 @@ const GeometryData NurbsVolumeGeometry<TPointType>::msGeometryData(
     {}, {}, {});
 
 template<class TPointType>
-const GeometryDimension NurbsVolumeGeometry<TPointType>::msGeometryDimension(
-    3, 3, 3);
+const GeometryDimension NurbsVolumeGeometry<TPointType>::msGeometryDimension(3, 3);
 
 } // namespace Kratos
 

--- a/kratos/geometries/point_2d.h
+++ b/kratos/geometries/point_2d.h
@@ -772,8 +772,7 @@ const GeometryData Point2D<TPointType>::msGeometryData(
         AllShapeFunctionsLocalGradients());
 
 template<class TPointType>
-const GeometryDimension Point2D<TPointType>::msGeometryDimension(
-    2, 2, 0);
+const GeometryDimension Point2D<TPointType>::msGeometryDimension(2, 0);
 
 }  // namespace Kratos.
 

--- a/kratos/geometries/point_3d.h
+++ b/kratos/geometries/point_3d.h
@@ -796,8 +796,7 @@ const GeometryData Point3D<TPointType>::msGeometryData(
         AllShapeFunctionsLocalGradients());
 
 template<class TPointType>
-const GeometryDimension Point3D<TPointType>::msGeometryDimension(
-    3, 3, 0);
+const GeometryDimension Point3D<TPointType>::msGeometryDimension(3, 0);
 
 }  // namespace Kratos.
 

--- a/kratos/geometries/point_on_geometry.h
+++ b/kratos/geometries/point_on_geometry.h
@@ -402,8 +402,7 @@ GeometryData PointOnGeometry<TContainerPointType, TWorkingSpaceDimension, TLocal
     {}, {}, {});
 
 template<class TContainerPointType, int TWorkingSpaceDimension, int TLocalSpaceDimensionOfBackground>
-const GeometryDimension PointOnGeometry<TContainerPointType, TWorkingSpaceDimension, TLocalSpaceDimensionOfBackground>::msGeometryDimension(
-    0, TWorkingSpaceDimension, TLocalSpaceDimensionOfBackground);
+const GeometryDimension PointOnGeometry<TContainerPointType, TWorkingSpaceDimension, TLocalSpaceDimensionOfBackground>::msGeometryDimension(TWorkingSpaceDimension, TLocalSpaceDimensionOfBackground);
 
 ///@}
 }// namespace Kratos.

--- a/kratos/geometries/prism_3d_15.h
+++ b/kratos/geometries/prism_3d_15.h
@@ -380,8 +380,8 @@ public:
         return this->Volume();
     }
 
-    /** 
-     * @brief This method calculate and return volume of this geometry. 
+    /**
+     * @brief This method calculate and return volume of this geometry.
      * @details For one and two dimensional geometry it returns zero and for three dimensional it gives volume of geometry.
      * @return double value contains volume.
      * @see Length()
@@ -659,9 +659,9 @@ public:
      *
      * @return the value of the shape function at the given point
      */
-    double ShapeFunctionValue( 
+    double ShapeFunctionValue(
         IndexType ShapeFunctionIndex,
-        const CoordinatesArrayType& rPoint 
+        const CoordinatesArrayType& rPoint
         ) const override
     {
         return CalculateShapeFunctionValue(ShapeFunctionIndex, rPoint);
@@ -768,9 +768,9 @@ private:
      *
      * @return the value of the shape function at the given point
      */
-    static double CalculateShapeFunctionValue( 
+    static double CalculateShapeFunctionValue(
         const IndexType ShapeFunctionIndex,
-        const CoordinatesArrayType& rPoint 
+        const CoordinatesArrayType& rPoint
         )
     {
         const double x = rPoint[0];
@@ -830,7 +830,7 @@ private:
         rResult(  12  ) = x*z*(2*z - 1)*(-4.0*x - 4.0*y + 4.0) ;
         rResult(  13  ) = 4.0*x*y*z*(2*z - 1) ;
         rResult(  14  ) = 4.0*y*z*(2*z - 1)*(-x - y + 1.0) ;
-        
+
         return rResult;
     }
 
@@ -910,13 +910,13 @@ private:
     {
         IntegrationPointsContainerType all_integration_points = AllIntegrationPoints();
         IntegrationPointsArrayType integration_points = all_integration_points[static_cast<int>(ThisMethod)];
-        
+
         // Number of integration points
         const std::size_t integration_points_number = integration_points.size();
-        
+
         //Setting up return matrix
         Matrix shape_function_values( integration_points_number, 15 );
-        
+
         // Loop over all integration points
         double x, y, z;
         for ( std::size_t pnt = 0; pnt < integration_points_number; pnt++ ) {
@@ -962,7 +962,7 @@ private:
         // Number of integration points
         const std::size_t integration_points_number = integration_points.size();
         ShapeFunctionsGradientsType d_shape_f_values( integration_points_number );
-        
+
         // Initialising container
         Matrix result = ZeroMatrix( 15, 3 );
 
@@ -1109,7 +1109,6 @@ GeometryData Prism3D15<TPointType>::msGeometryData(
 );
 
 template<class TPointType> const
-GeometryDimension Prism3D15<TPointType>::msGeometryDimension(
-    3, 3, 3);
+GeometryDimension Prism3D15<TPointType>::msGeometryDimension(3, 3);
 
 }// namespace Kratos.

--- a/kratos/geometries/prism_3d_6.h
+++ b/kratos/geometries/prism_3d_6.h
@@ -14,7 +14,7 @@
 //                   Josep Maria Carbonell
 //
 
-#pragma once 
+#pragma once
 
 // System includes
 
@@ -406,8 +406,8 @@ public:
         return std::abs( this->DeterminantOfJacobian( PointType() ) ) * 0.5;
     }
 
-    /** 
-     * @brief This method calculate and return volume of this geometry. 
+    /**
+     * @brief This method calculate and return volume of this geometry.
      * @details For one and two dimensional geometry it returns zero and for three dimensional it gives volume of geometry.
      * @return double value contains volume.
      * @see Length()
@@ -1076,7 +1076,6 @@ GeometryData Prism3D6<TPointType>::msGeometryData(
 );
 
 template<class TPointType> const
-GeometryDimension Prism3D6<TPointType>::msGeometryDimension(
-    3, 3, 3);
+GeometryDimension Prism3D6<TPointType>::msGeometryDimension(3, 3);
 
 }// namespace Kratos.

--- a/kratos/geometries/prism_interface_3d_6.h
+++ b/kratos/geometries/prism_interface_3d_6.h
@@ -1555,8 +1555,7 @@ GeometryData PrismInterface3D6<TPointType>::msGeometryData(
 );
 
 template<class TPointType> const
-GeometryDimension PrismInterface3D6<TPointType>::msGeometryDimension(
-    3, 3, 3);
+GeometryDimension PrismInterface3D6<TPointType>::msGeometryDimension(3, 3);
 
 }// namespace Kratos.
 

--- a/kratos/geometries/pyramid_3d_13.h
+++ b/kratos/geometries/pyramid_3d_13.h
@@ -343,8 +343,8 @@ public:
         return 5;
     }
 
-    /** 
-     * @brief This method calculate and return volume of this geometry. 
+    /**
+     * @brief This method calculate and return volume of this geometry.
      * @details For one and two dimensional geometry it returns zero and for three dimensional it gives volume of geometry.
      * @return double value contains volume.
      * @see Length()
@@ -876,7 +876,6 @@ GeometryData Pyramid3D13<TPointType>::msGeometryData(
 );
 
 template<class TPointType> const
-GeometryDimension Pyramid3D13<TPointType>::msGeometryDimension(
-    3, 3, 3);
+GeometryDimension Pyramid3D13<TPointType>::msGeometryDimension(3, 3);
 
 }  // namespace Kratos.

--- a/kratos/geometries/pyramid_3d_5.h
+++ b/kratos/geometries/pyramid_3d_5.h
@@ -864,7 +864,6 @@ GeometryData Pyramid3D5<TPointType>::msGeometryData(
 );
 
 template<class TPointType> const
-GeometryDimension Pyramid3D5<TPointType>::msGeometryDimension(
-    3, 3, 3);
+GeometryDimension Pyramid3D5<TPointType>::msGeometryDimension(3, 3);
 
 }  // namespace Kratos.

--- a/kratos/geometries/quadrature_point_geometry.h
+++ b/kratos/geometries/quadrature_point_geometry.h
@@ -669,7 +669,6 @@ const GeometryDimension QuadraturePointGeometry<
     TWorkingSpaceDimension,
     TLocalSpaceDimension,
     TDimension>::msGeometryDimension(
-        TDimension,
         TWorkingSpaceDimension,
         TLocalSpaceDimension);
 

--- a/kratos/geometries/quadrilateral_2d_4.h
+++ b/kratos/geometries/quadrilateral_2d_4.h
@@ -436,8 +436,8 @@ public:
 
     }
 
-    /** 
-     * @brief This method calculates and returns area or surface area of this geometry depending to it's dimension. 
+    /**
+     * @brief This method calculates and returns area or surface area of this geometry depending to it's dimension.
      * @details For one dimensional geometry it returns zero, for two dimensional it gives area
      * and for three dimensional geometries it gives surface area.
      * @return double value contains area or surface area
@@ -463,12 +463,12 @@ public:
         KRATOS_WARNING("Quadrilateral2D4") << "Method not well defined. Replace with DomainSize() instead. This method preserves current behaviour but will be changed in June 2023 (returning error instead)" << std::endl;
         return Area();
         // TODO: Replace in June 2023
-        // KRATOS_ERROR << "Quadrilateral2D4:: Method not well defined. Replace with DomainSize() instead." << std::endl; 
+        // KRATOS_ERROR << "Quadrilateral2D4:: Method not well defined. Replace with DomainSize() instead." << std::endl;
         // return 0.0;
     }
 
-    /** 
-     * @brief This method calculates and returns length, area or volume of this geometry depending to it's dimension. 
+    /**
+     * @brief This method calculates and returns length, area or volume of this geometry depending to it's dimension.
      * @details For one dimensional geometry it returns its length, for two dimensional it gives area and for three dimensional geometries it gives its volume.
      * @return double value contains length, area or volume.
      * @see Length()
@@ -480,7 +480,7 @@ public:
     {
         return Area();
     }
-    
+
     /**
      * @brief Returns whether given arbitrary point is inside the Geometry and the respective
      * local point for the given global point
@@ -1154,7 +1154,6 @@ GeometryData Quadrilateral2D4<TPointType>::msGeometryData(
 );
 
 template<class TPointType> const
-GeometryDimension Quadrilateral2D4<TPointType>::msGeometryDimension(
-    2, 2, 2);
+GeometryDimension Quadrilateral2D4<TPointType>::msGeometryDimension(2, 2);
 
 }// namespace Kratos.

--- a/kratos/geometries/quadrilateral_2d_8.h
+++ b/kratos/geometries/quadrilateral_2d_8.h
@@ -14,7 +14,7 @@
 //                   Josep Maria Carbonell
 //
 
-#pragma once 
+#pragma once
 
 // System includes
 
@@ -434,7 +434,7 @@ public:
     //  */
     // double Volume() const override
     // {
-    //     KRATOS_ERROR << "Quadrilateral2D8:: Method not well defined. Replace with DomainSize() instead." << std::endl; 
+    //     KRATOS_ERROR << "Quadrilateral2D8:: Method not well defined. Replace with DomainSize() instead." << std::endl;
     //     return 0.0;
     // }
 
@@ -1752,7 +1752,6 @@ const GeometryData Quadrilateral2D8<TPointType>::msGeometryData(
 );
 
 template<class TPointType>
-const GeometryDimension Quadrilateral2D8<TPointType>::msGeometryDimension(
-    2, 2, 2);
+const GeometryDimension Quadrilateral2D8<TPointType>::msGeometryDimension(2, 2);
 
 }  // namespace Kratos.

--- a/kratos/geometries/quadrilateral_2d_9.h
+++ b/kratos/geometries/quadrilateral_2d_9.h
@@ -14,7 +14,7 @@
 //                   Josep Maria Carbonell
 //
 
-#pragma once 
+#pragma once
 
 // System includes
 
@@ -437,7 +437,7 @@ public:
         KRATOS_WARNING("Quadrilateral2D9") << "Method not well defined. Replace with DomainSize() instead. This method preserves current behaviour but will be changed in June 2023 (returning zero instead)" << std::endl;
         return Area();
         // TODO: Replace in June 2023
-        // KRATOS_ERROR << "Quadrilateral2D9:: Method not well defined. Replace with DomainSize() instead." << std::endl; 
+        // KRATOS_ERROR << "Quadrilateral2D9:: Method not well defined. Replace with DomainSize() instead." << std::endl;
         // return 0.0;
     }
 
@@ -456,7 +456,7 @@ public:
     {
         return Area();
     }
-    
+
     /**
      * Returns whether given arbitrary point is inside the Geometry and the respective
      * local point for the given global point
@@ -1311,7 +1311,6 @@ const GeometryData Quadrilateral2D9<TPointType>::msGeometryData(
 );
 
 template<class TPointType>
-const GeometryDimension Quadrilateral2D9<TPointType>::msGeometryDimension(
-    2, 2, 2);
+const GeometryDimension Quadrilateral2D9<TPointType>::msGeometryDimension(2, 2);
 
 }  // namespace Kratos.

--- a/kratos/geometries/quadrilateral_3d_4.h
+++ b/kratos/geometries/quadrilateral_3d_4.h
@@ -442,8 +442,8 @@ public:
         return std::sqrt( Area() );
     }
 
-    /** 
-     * @brief This method calculates and returns area or surface area of this geometry depending to it's dimension. 
+    /**
+     * @brief This method calculates and returns area or surface area of this geometry depending to it's dimension.
      * @details For one dimensional geometry it returns zero, for two dimensional it gives area
      * and for three dimensional geometries it gives surface area.
      * @return double value contains area or surface area
@@ -469,12 +469,12 @@ public:
         KRATOS_WARNING("Quadrilateral3D4") << "Method not well defined. Replace with DomainSize() instead. This method preserves current behaviour but will be changed in June 2023 (returning error instead)" << std::endl;
         return Area();
         // TODO: Replace in June 2023
-        // KRATOS_ERROR << "Quadrilateral3D4:: Method not well defined. Replace with DomainSize() instead." << std::endl; 
+        // KRATOS_ERROR << "Quadrilateral3D4:: Method not well defined. Replace with DomainSize() instead." << std::endl;
         // return 0.0;
     }
 
-    /** 
-     * @brief This method calculates and returns length, area or volume of this geometry depending to it's dimension. 
+    /**
+     * @brief This method calculates and returns length, area or volume of this geometry depending to it's dimension.
      * @details For one dimensional geometry it returns its length, for two dimensional it gives area and for three dimensional geometries it gives its volume.
      * @return double value contains length, area or volume.
      * @see Length()
@@ -485,7 +485,7 @@ public:
     {
         return Area();
     }
-    
+
 
     /**
      * Returns whether given arbitrary point is inside the Geometry and the respective
@@ -1810,7 +1810,6 @@ const GeometryData Quadrilateral3D4<TPointType>::msGeometryData(
 );
 
 template<class TPointType>
-const GeometryDimension Quadrilateral3D4<TPointType>::msGeometryDimension(
-    2, 3, 2);
+const GeometryDimension Quadrilateral3D4<TPointType>::msGeometryDimension(3, 2);
 
 }// namespace Kratos.

--- a/kratos/geometries/quadrilateral_3d_8.h
+++ b/kratos/geometries/quadrilateral_3d_8.h
@@ -428,7 +428,7 @@ public:
         KRATOS_WARNING("Quadrilateral3D8") << "Method not well defined. Replace with DomainSize() instead. This method preserves current behaviour but will be changed in June 2023 (returning error instead)" << std::endl;
         return Area();
         // TODO: Replace in June 2023
-        // KRATOS_ERROR << "Quadrilateral3D8:: Method not well defined. Replace with DomainSize() instead." << std::endl; 
+        // KRATOS_ERROR << "Quadrilateral3D8:: Method not well defined. Replace with DomainSize() instead." << std::endl;
         // return 0.0;
     }
 
@@ -1670,7 +1670,6 @@ const GeometryData Quadrilateral3D8<TPointType>::msGeometryData(
 );
 
 template<class TPointType>
-const GeometryDimension Quadrilateral3D8<TPointType>::msGeometryDimension(
-    2, 3, 2);
+const GeometryDimension Quadrilateral3D8<TPointType>::msGeometryDimension(3, 2);
 
 }  // namespace Kratos.

--- a/kratos/geometries/quadrilateral_3d_9.h
+++ b/kratos/geometries/quadrilateral_3d_9.h
@@ -437,7 +437,7 @@ public:
         KRATOS_WARNING("Quadrilateral3D9") << "Method not well defined. Replace with DomainSize() instead. This method preserves current behaviour but will be changed in June 2023 (returning error instead)" << std::endl;
         return Area();
         // TODO: Replace in June 2023
-        // KRATOS_ERROR << "Quadrilateral3D9:: Method not well defined. Replace with DomainSize() instead." << std::endl; 
+        // KRATOS_ERROR << "Quadrilateral3D9:: Method not well defined. Replace with DomainSize() instead." << std::endl;
         // return 0.0;
     }
 
@@ -1754,7 +1754,6 @@ const GeometryData Quadrilateral3D9<TPointType>::msGeometryData(
 );
 
 template<class TPointType>
-const GeometryDimension Quadrilateral3D9<TPointType>::msGeometryDimension(
-    2, 3, 2);
+const GeometryDimension Quadrilateral3D9<TPointType>::msGeometryDimension(3, 2);
 
 }  // namespace Kratos.

--- a/kratos/geometries/quadrilateral_interface_2d_4.h
+++ b/kratos/geometries/quadrilateral_interface_2d_4.h
@@ -1387,8 +1387,7 @@ GeometryData QuadrilateralInterface2D4<TPointType>::msGeometryData(
 );
 
 template<class TPointType>
-const GeometryDimension QuadrilateralInterface2D4<TPointType>::msGeometryDimension(
-    2, 2, 2);
+const GeometryDimension QuadrilateralInterface2D4<TPointType>::msGeometryDimension(2, 2);
 
 }// namespace Kratos.
 

--- a/kratos/geometries/quadrilateral_interface_3d_4.h
+++ b/kratos/geometries/quadrilateral_interface_3d_4.h
@@ -458,7 +458,7 @@ public:
         KRATOS_WARNING("QuadrilateralInterface3D4") << "Method not well defined. Replace with DomainSize() instead. This method preserves current behaviour but will be changed in June 2023 (returning error instead)" << std::endl;
         return Area();
         // TODO: Replace in June 2023
-        // KRATOS_ERROR << "QuadrilateralInterface3D4:: Method not well defined. Replace with DomainSize() instead." << std::endl; 
+        // KRATOS_ERROR << "QuadrilateralInterface3D4:: Method not well defined. Replace with DomainSize() instead." << std::endl;
         // return 0.0;
     }
 
@@ -1434,8 +1434,7 @@ GeometryData QuadrilateralInterface3D4<TPointType>::msGeometryData(
 );
 
 template<class TPointType>
-const GeometryDimension QuadrilateralInterface3D4<TPointType>::msGeometryDimension(
-    2, 3, 1);
+const GeometryDimension QuadrilateralInterface3D4<TPointType>::msGeometryDimension(3, 1);
 
 }// namespace Kratos.
 

--- a/kratos/geometries/sphere_3d_1.h
+++ b/kratos/geometries/sphere_3d_1.h
@@ -892,8 +892,7 @@ const GeometryData Sphere3D1<TPointType>::msGeometryData(
 );
 
 template<class TPointType>
-const GeometryDimension Sphere3D1<TPointType>::msGeometryDimension(
-    3, 3, 1);
+const GeometryDimension Sphere3D1<TPointType>::msGeometryDimension(3, 1);
 
 }  // namespace Kratos.
 

--- a/kratos/geometries/surface_in_nurbs_volume_geometry.h
+++ b/kratos/geometries/surface_in_nurbs_volume_geometry.h
@@ -506,8 +506,7 @@ const GeometryData SurfaceInNurbsVolumeGeometry<TWorkingSpaceDimension, TVolumeC
     {}, {}, {});
 
 template<int TWorkingSpaceDimension, class TVolumeContainerPointType>
-const GeometryDimension SurfaceInNurbsVolumeGeometry<TWorkingSpaceDimension, TVolumeContainerPointType>::msGeometryDimension(
-    2, TWorkingSpaceDimension, 3);
+const GeometryDimension SurfaceInNurbsVolumeGeometry<TWorkingSpaceDimension, TVolumeContainerPointType>::msGeometryDimension(TWorkingSpaceDimension, 3);
 
 } // namespace Kratos
 

--- a/kratos/geometries/tetrahedra_3d_10.h
+++ b/kratos/geometries/tetrahedra_3d_10.h
@@ -440,8 +440,8 @@ public:
         return Volume();
     }
 
-    /** 
-     * @brief This method calculate and return volume of this geometry. 
+    /**
+     * @brief This method calculate and return volume of this geometry.
      * @details For one and two dimensional geometry it returns zero and for three dimensional it gives volume of geometry.
      * @return double value contains volume.
      * @see Length()
@@ -1126,7 +1126,6 @@ GeometryData Tetrahedra3D10<TPointType>::msGeometryData(
 );
 
 template<class TPointType> const
-GeometryDimension Tetrahedra3D10<TPointType>::msGeometryDimension(
-    3, 3, 3);
+GeometryDimension Tetrahedra3D10<TPointType>::msGeometryDimension(3, 3);
 
 }// namespace Kratos.

--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -2001,8 +2001,7 @@ GeometryData Tetrahedra3D4<TPointType>::msGeometryData(
 );
 
 template<class TPointType>
-const GeometryDimension Tetrahedra3D4<TPointType>::msGeometryDimension(
-    3, 3, 3);
+const GeometryDimension Tetrahedra3D4<TPointType>::msGeometryDimension(3, 3);
 
 }// namespace Kratos.
 

--- a/kratos/geometries/triangle_2d_10.h
+++ b/kratos/geometries/triangle_2d_10.h
@@ -8,10 +8,10 @@
 //                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Mohamed Nabi
-//                   
-//                   
-//  Contributors:    
-//                   
+//
+//
+//  Contributors:
+//
 //
 
 #pragma once
@@ -59,8 +59,8 @@ namespace Kratos
  *          |        `\
  *          0---3--4---1
  * @author Mohamed Nabi
- * @author 
- * @author 
+ * @author
+ * @author
  */
 template<class TPointType>
 class Triangle2D10 : public Geometry<TPointType>
@@ -288,7 +288,7 @@ public:
      * obvious that any change to this new geometry's point affect
      * source geometry's points too.
      */
-    template<class TOtherPointType> Triangle2D10(Triangle2D10<TOtherPointType> const& rOther) 
+    template<class TOtherPointType> Triangle2D10(Triangle2D10<TOtherPointType> const& rOther)
         : BaseType(rOther)
     {
     }
@@ -367,7 +367,7 @@ public:
      * @param rThisPoints the nodes of the new geometry
      * @return Pointer to the new geometry
      */
-    typename BaseType::Pointer Create(const IndexType NewGeometryId, 
+    typename BaseType::Pointer Create(const IndexType NewGeometryId,
         PointsArrayType const& rThisPoints) const override
     {
         return typename BaseType::Pointer(new Triangle2D10(NewGeometryId, rThisPoints));
@@ -745,7 +745,7 @@ public:
      */
     virtual ShapeFunctionsGradientsType ShapeFunctionsLocalGradients(IntegrationMethod ThisMethod)
     {
-        ShapeFunctionsGradientsType localGradients 
+        ShapeFunctionsGradientsType localGradients
             = CalculateShapeFunctionsIntegrationPointsLocalGradients(ThisMethod);
         const int integration_points_number = msGeometryData.IntegrationPointsNumber(ThisMethod);
         ShapeFunctionsGradientsType Result(integration_points_number);
@@ -763,7 +763,7 @@ public:
     virtual ShapeFunctionsGradientsType ShapeFunctionsLocalGradients()
     {
         IntegrationMethod ThisMethod = msGeometryData.DefaultIntegrationMethod();
-        ShapeFunctionsGradientsType localGradients 
+        ShapeFunctionsGradientsType localGradients
             = CalculateShapeFunctionsIntegrationPointsLocalGradients(ThisMethod);
         const int integration_points_number = msGeometryData.IntegrationPointsNumber(ThisMethod);
         ShapeFunctionsGradientsType Result(integration_points_number);
@@ -1347,6 +1347,6 @@ GeometryData Triangle2D10<TPointType>::msGeometryData(
     AllShapeFunctionsLocalGradients());
 
 template<class TPointType>
-const GeometryDimension Triangle2D10<TPointType>::msGeometryDimension(2, 2, 2);
+const GeometryDimension Triangle2D10<TPointType>::msGeometryDimension(2, 2);
 
 }// namespace Kratos.

--- a/kratos/geometries/triangle_2d_15.h
+++ b/kratos/geometries/triangle_2d_15.h
@@ -9,10 +9,10 @@
 //                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Mohamed Nabi
-//                   
-//                   
-//  Contributors:    
-//                   
+//
+//
+//  Contributors:
+//
 //
 
 #pragma once
@@ -62,8 +62,8 @@ namespace Kratos
      *          |         `\
      *          0--3--4--5--1
      * @author Mohamed Nabi
-     * @author 
-     * @author 
+     * @author
+     * @author
      */
     template<class TPointType>
     class Triangle2D15 : public Geometry<TPointType>
@@ -202,7 +202,7 @@ namespace Kratos
         ///@}
         ///@name Life Cycle
         ///@{
-        
+
         Triangle2D15(const PointType& Point01, const PointType& Point02, const PointType& Point03,
             const PointType& Point04, const PointType& Point05, const PointType& Point06,
             const PointType& Point07, const PointType& Point08, const PointType& Point09,
@@ -275,12 +275,12 @@ namespace Kratos
         explicit Triangle2D15(const std::string& rGeometryName, const PointsArrayType& rThisPoints)
             : BaseType(rGeometryName, rThisPoints, &msGeometryData)
         {
-            KRATOS_ERROR_IF(this->PointsNumber() != 15) << "Invalid points number. Expected 15, given " 
+            KRATOS_ERROR_IF(this->PointsNumber() != 15) << "Invalid points number. Expected 15, given "
                 << this->PointsNumber() << std::endl;
         }
 
         /**
-         * Copy constructor. 
+         * Copy constructor.
          * Construct this geometry as a copy of given geometry.
          *
          * @note This copy constructor does not copy the points and new
@@ -293,10 +293,10 @@ namespace Kratos
         }
 
         /**
-         * Copy constructor from a geometry with other point type. 
-         * Construct this geometry as a copy of given geometry which 
-         * has different type of points. The given goemetry's 
-         * TOtherPointType* must be implicity convertible to this 
+         * Copy constructor from a geometry with other point type.
+         * Construct this geometry as a copy of given geometry which
+         * has different type of points. The given goemetry's
+         * TOtherPointType* must be implicity convertible to this
          * geometry PointType.
          *
          * @note This copy constructor does not copy the points and new
@@ -800,7 +800,7 @@ namespace Kratos
          */
         virtual ShapeFunctionsGradientsType ShapeFunctionsLocalGradients(IntegrationMethod ThisMethod)
         {
-            ShapeFunctionsGradientsType localGradients 
+            ShapeFunctionsGradientsType localGradients
                 = CalculateShapeFunctionsIntegrationPointsLocalGradients(ThisMethod);
             const int integration_points_number = msGeometryData.IntegrationPointsNumber(ThisMethod);
             ShapeFunctionsGradientsType Result(integration_points_number);
@@ -1600,6 +1600,6 @@ namespace Kratos
         );
 
     template<class TPointType>
-    const GeometryDimension Triangle2D15<TPointType>::msGeometryDimension(2, 2, 2);
+    const GeometryDimension Triangle2D15<TPointType>::msGeometryDimension(2, 2);
 
 }// namespace Kratos.

--- a/kratos/geometries/triangle_2d_3.h
+++ b/kratos/geometries/triangle_2d_3.h
@@ -520,7 +520,7 @@ public:
         if (rThisGeometry.LocalSpaceDimension() < this->LocalSpaceDimension()) {
             return IntersectionUtilities::TriangleLineIntersection2D(
                 *this, rThisGeometry[0], rThisGeometry[1]);
-        }  // Both geometries are 2D 
+        }  // Both geometries are 2D
         const BaseType& geom_1 = *this;
         const BaseType& geom_2 = rThisGeometry;
         return  NoDivTriTriIsect(geom_1[0], geom_1[1], geom_1[2], geom_2[0], geom_2[1], geom_2[2]);
@@ -2240,8 +2240,7 @@ GeometryData Triangle2D3<TPointType>::msGeometryData(
 );
 
 template<class TPointType> const
-GeometryDimension Triangle2D3<TPointType>::msGeometryDimension(
-    2, 2, 2);
+GeometryDimension Triangle2D3<TPointType>::msGeometryDimension(2, 2);
 
 }// namespace Kratos.
 

--- a/kratos/geometries/triangle_2d_6.h
+++ b/kratos/geometries/triangle_2d_6.h
@@ -459,8 +459,8 @@ public:
         return std::sqrt( std::abs( Area() ) );
     }
 
-    /** 
-     * @brief This method calculates and returns area or surface area of this geometry depending to it's dimension. 
+    /**
+     * @brief This method calculates and returns area or surface area of this geometry depending to it's dimension.
      * @details For one dimensional geometry it returns zero, for two dimensional it gives area
      * and for three dimensional geometries it gives surface area.
      * @return double value contains area or surface area
@@ -487,8 +487,8 @@ public:
     //     return 0.0;
     // }
 
-    /** 
-     * @brief This method calculates and returns length, area or volume of this geometry depending to it's dimension. 
+    /**
+     * @brief This method calculates and returns length, area or volume of this geometry depending to it's dimension.
      * @details For one dimensional geometry it returns its length, for two dimensional it gives area and for three dimensional geometries it gives its volume.
      * @return double value contains length, area or volume.
      * @see Length()
@@ -1187,7 +1187,6 @@ GeometryData Triangle2D6<TPointType>::msGeometryData(
 );
 
 template<class TPointType>
-const GeometryDimension Triangle2D6<TPointType>::msGeometryDimension(
-    2, 2, 2);
+const GeometryDimension Triangle2D6<TPointType>::msGeometryDimension(2, 2);
 
 }// namespace Kratos.

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -470,8 +470,8 @@ public:
         return std::sqrt(2.0 * Area());
     }
 
-    /** 
-     * @brief This method calculates and returns area or surface area of this geometry depending to it's dimension. 
+    /**
+     * @brief This method calculates and returns area or surface area of this geometry depending to it's dimension.
      * @details For one dimensional geometry it returns zero, for two dimensional it gives area
      * and for three dimensional geometries it gives surface area.
      * @return double value contains area or surface area
@@ -504,8 +504,8 @@ public:
     //     return 0.0;
     // }
 
-    /** 
-     * @brief This method calculates and returns length, area or volume of this geometry depending to it's dimension. 
+    /**
+     * @brief This method calculates and returns length, area or volume of this geometry depending to it's dimension.
      * @details For one dimensional geometry it returns its length, for two dimensional it gives area and for three dimensional geometries it gives its volume.
      * @return double value contains length, area or volume.
      * @see Length()
@@ -2483,8 +2483,7 @@ GeometryData Triangle3D3<TPointType>::msGeometryData(
 );
 
 template<class TPointType>
-const GeometryDimension Triangle3D3<TPointType>::msGeometryDimension(
-    2, 3, 2);
+const GeometryDimension Triangle3D3<TPointType>::msGeometryDimension(3, 2);
 
 }// namespace Kratos.
 

--- a/kratos/geometries/triangle_3d_6.h
+++ b/kratos/geometries/triangle_3d_6.h
@@ -452,8 +452,8 @@ public:
         return std::sqrt(std::abs(this->DeterminantOfJacobian( PointType() ) ) );
     }
 
-    /** 
-     * @brief This method calculates and returns area or surface area of this geometry depending to it's dimension. 
+    /**
+     * @brief This method calculates and returns area or surface area of this geometry depending to it's dimension.
      * @details For one dimensional geometry it returns zero, for two dimensional it gives area
      * and for three dimensional geometries it gives surface area.
      * @return double value contains area or surface area
@@ -481,8 +481,8 @@ public:
     //     return 0.0;
     // }
 
-    /** 
-     * @brief This method calculates and returns length, area or volume of this geometry depending to it's dimension. 
+    /**
+     * @brief This method calculates and returns length, area or volume of this geometry depending to it's dimension.
      * @details For one dimensional geometry it returns its length, for two dimensional it gives area and for three dimensional geometries it gives its volume.
      * @return double value contains length, area or volume.
      * @see Length()
@@ -1123,7 +1123,6 @@ GeometryData Triangle3D6<TPointType>::msGeometryData(
 );
 
 template<class TPointType> const
-GeometryDimension Triangle3D6<TPointType>::msGeometryDimension(
-    2, 3, 2);
+GeometryDimension Triangle3D6<TPointType>::msGeometryDimension(3, 2);
 
 }// namespace Kratos.

--- a/kratos/python/add_geometries_to_python.cpp
+++ b/kratos/python/add_geometries_to_python.cpp
@@ -138,7 +138,6 @@ void  AddGeometriesToPython(pybind11::module& m)
     // Dimension access
     .def("WorkingSpaceDimension", &GeometryType::WorkingSpaceDimension)
     .def("LocalSpaceDimension", &GeometryType::LocalSpaceDimension)
-    .def("Dimension", &GeometryType::Dimension)
     .def("DomainSize", &GeometryType::DomainSize)
     .def("EdgesNumber", &GeometryType::EdgesNumber)
     .def("PointsNumber", &GeometryType::PointsNumber)

--- a/kratos/tests/cpp_tests/geometries/test_nurbs_curve.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_nurbs_curve.cpp
@@ -169,7 +169,6 @@ typedef Node<3> NodeType;
         auto curve = GenerateReferenceCurve2d();
 
         // Check general information, input to ouput
-        KRATOS_CHECK_EQUAL(curve.Dimension(), 1);
         KRATOS_CHECK_EQUAL(curve.WorkingSpaceDimension(), 2);
         KRATOS_CHECK_EQUAL(curve.LocalSpaceDimension(), 1);
         KRATOS_CHECK_EQUAL(curve.IsRational(), false);
@@ -215,7 +214,6 @@ typedef Node<3> NodeType;
         auto curve = GenerateReferenceCurve3d();
 
         // Check general information, input to ouput
-        KRATOS_CHECK_EQUAL(curve.Dimension(), 1);
         KRATOS_CHECK_EQUAL(curve.WorkingSpaceDimension(), 3);
         KRATOS_CHECK_EQUAL(curve.LocalSpaceDimension(), 1);
         KRATOS_CHECK_EQUAL(curve.IsRational(), true);

--- a/kratos/tests/cpp_tests/geometries/test_nurbs_surface.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_nurbs_surface.cpp
@@ -274,7 +274,6 @@ namespace Testing {
         auto surface = GenerateReferencePointSurface();
 
         // Check general information, input to ouput
-        KRATOS_CHECK_EQUAL(surface.Dimension(), 2);
         KRATOS_CHECK_EQUAL(surface.WorkingSpaceDimension(), 3);
         KRATOS_CHECK_EQUAL(surface.LocalSpaceDimension(), 2);
         KRATOS_CHECK_EQUAL(surface.IsRational(), true);
@@ -305,7 +304,6 @@ namespace Testing {
         auto surface = GenerateReferencePieceOfCylinderNurbsSurface();
 
         // Check general information, input to ouput
-        KRATOS_CHECK_EQUAL(surface.Dimension(), 2);
         KRATOS_CHECK_EQUAL(surface.WorkingSpaceDimension(), 3);
         KRATOS_CHECK_EQUAL(surface.LocalSpaceDimension(), 2);
         KRATOS_CHECK_EQUAL(surface.IsRational(), true);
@@ -379,7 +377,6 @@ namespace Testing {
         auto surface = GenerateReferenceNodeSurface();
 
         // Check general information, input to ouput
-        KRATOS_CHECK_EQUAL(surface.Dimension(), 2);
         KRATOS_CHECK_EQUAL(surface.WorkingSpaceDimension(), 3);
         KRATOS_CHECK_EQUAL(surface.LocalSpaceDimension(), 2);
         KRATOS_CHECK_EQUAL(surface.IsRational(), false);
@@ -697,7 +694,6 @@ namespace Testing {
         auto surface = GenerateReferenceQuarterSphereGeometry();
 
         // Check general information, input to ouput
-        KRATOS_CHECK_EQUAL(surface.Dimension(), 2);
         KRATOS_CHECK_EQUAL(surface.WorkingSpaceDimension(), 3);
         KRATOS_CHECK_EQUAL(surface.LocalSpaceDimension(), 2);
         KRATOS_CHECK_EQUAL(surface.IsRational(), true);

--- a/kratos/tests/cpp_tests/geometries/test_nurbs_volume.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_nurbs_volume.cpp
@@ -169,7 +169,6 @@ namespace Testing {
     KRATOS_TEST_CASE_IN_SUITE(NurbsVolumeGeometryIntegrationPoints1, KratosCoreNurbsGeometriesFastSuite) {
             NurbsVolumeGeometry<PointerVector<NodeType>> TruncatedPyramid = GenerateTruncatedPyramid();
 
-            KRATOS_CHECK_EQUAL(TruncatedPyramid.Dimension(), 3);
             KRATOS_CHECK_EQUAL(TruncatedPyramid.WorkingSpaceDimension(), 3);
             KRATOS_CHECK_EQUAL(TruncatedPyramid.LocalSpaceDimension(), 3);
             KRATOS_CHECK_EQUAL(TruncatedPyramid.IsRational(), false);
@@ -345,7 +344,6 @@ namespace Testing {
         typename Geometry<Point>::IntegrationPointsArrayType integration_points;
         IntegrationInfo integration_info = DistortedCube.GetDefaultIntegrationInfo();
         DistortedCube.CreateIntegrationPoints(integration_points, integration_info);
-        KRATOS_CHECK_EQUAL(DistortedCube.Dimension(), 3);
         KRATOS_CHECK_EQUAL(DistortedCube.WorkingSpaceDimension(), 3);
         KRATOS_CHECK_EQUAL(DistortedCube.LocalSpaceDimension(), 3);
         KRATOS_CHECK_EQUAL(DistortedCube.IsRational(), false);

--- a/kratos/tests/cpp_tests/geometries/test_point_on_geometry.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_point_on_geometry.cpp
@@ -50,7 +50,6 @@ namespace Kratos {
 
             PointOnGeometry<PointerVector<Node<3>>, 3, 1> point(point_coordinates, p_nurbs_curve);
 
-            KRATOS_CHECK_EQUAL(point.Dimension(), 0);
             KRATOS_CHECK_EQUAL(point.LocalSpaceDimension(), 1);
             KRATOS_CHECK_EQUAL(point.WorkingSpaceDimension(), 3);
 
@@ -59,7 +58,6 @@ namespace Kratos {
             auto integration_info = point.GetDefaultIntegrationInfo();
             point.CreateQuadraturePointGeometries(geometry_vector, 2, integration_info);
 
-            KRATOS_CHECK_EQUAL(geometry_vector[0].Dimension(), 0);
             KRATOS_CHECK_EQUAL(geometry_vector[0].LocalSpaceDimension(), 1);
             KRATOS_CHECK_EQUAL(geometry_vector[0].WorkingSpaceDimension(), 3);
 

--- a/kratos/tests/cpp_tests/geometries/test_quadrature_point_geometry.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_quadrature_point_geometry.cpp
@@ -120,7 +120,6 @@ namespace Kratos {
             KRATOS_CHECK_EQUAL(quadrature_points[0]->size(), 3);
             KRATOS_CHECK_EQUAL(quadrature_points[0]->WorkingSpaceDimension(), 2);
             KRATOS_CHECK_EQUAL(quadrature_points[0]->LocalSpaceDimension(), 2);
-            KRATOS_CHECK_EQUAL(quadrature_points[0]->Dimension(), 2);
 
             KRATOS_CHECK_MATRIX_NEAR(quadrature_points[0]->ShapeFunctionsLocalGradients()[0], triangle->ShapeFunctionsLocalGradients(GeometryData::IntegrationMethod::GI_GAUSS_3)[0], 1e-6);
             KRATOS_CHECK_MATRIX_NEAR(quadrature_points[1]->ShapeFunctionsLocalGradients()[0], triangle->ShapeFunctionsLocalGradients(GeometryData::IntegrationMethod::GI_GAUSS_3)[1], 1e-6);
@@ -140,7 +139,6 @@ namespace Kratos {
             KRATOS_CHECK_EQUAL(p_this_quadrature_point->size(), 3);
             KRATOS_CHECK_EQUAL(p_this_quadrature_point->WorkingSpaceDimension(), 2);
             KRATOS_CHECK_EQUAL(p_this_quadrature_point->LocalSpaceDimension(), 2);
-            KRATOS_CHECK_EQUAL(p_this_quadrature_point->Dimension(), 2);
 
             KRATOS_CHECK_EQUAL(p_this_quadrature_point->ShapeFunctionsValues().size1(), 1);
             KRATOS_CHECK_EQUAL(p_this_quadrature_point->ShapeFunctionsValues().size2(), 3);
@@ -179,7 +177,6 @@ namespace Kratos {
             KRATOS_CHECK_EQUAL(p_this_quadrature_point->size(), 3);
             KRATOS_CHECK_EQUAL(p_this_quadrature_point->WorkingSpaceDimension(), 2);
             KRATOS_CHECK_EQUAL(p_this_quadrature_point->LocalSpaceDimension(), 2);
-            KRATOS_CHECK_EQUAL(p_this_quadrature_point->Dimension(), 2);
 
             KRATOS_CHECK_EQUAL((*p_this_quadrature_point)[0].Id(), 4);
             KRATOS_CHECK_EQUAL((*p_this_quadrature_point)[1].Id(), 5);
@@ -219,7 +216,6 @@ namespace Kratos {
             KRATOS_CHECK_EQUAL(p_this_quadrature_point->size(), 3);
             KRATOS_CHECK_EQUAL(p_this_quadrature_point->WorkingSpaceDimension(), 2);
             KRATOS_CHECK_EQUAL(p_this_quadrature_point->LocalSpaceDimension(), 2);
-            KRATOS_CHECK_EQUAL(p_this_quadrature_point->Dimension(), 2);
 
             KRATOS_CHECK_EQUAL((*p_this_quadrature_point)[0].Id(), 4);
             KRATOS_CHECK_EQUAL((*p_this_quadrature_point)[1].Id(), 5);
@@ -261,7 +257,6 @@ namespace Kratos {
             KRATOS_CHECK_EQUAL(geom.size(), 3);
             KRATOS_CHECK_EQUAL(geom.WorkingSpaceDimension(), 2);
             KRATOS_CHECK_EQUAL(geom.LocalSpaceDimension(), 2);
-            KRATOS_CHECK_EQUAL(geom.Dimension(), 2);
 
             KRATOS_CHECK_EQUAL(geom.ShapeFunctionsValues().size1(), 1);
             KRATOS_CHECK_EQUAL(geom.ShapeFunctionsValues().size2(), 3);
@@ -286,7 +281,6 @@ namespace Kratos {
             KRATOS_CHECK_EQUAL(geom.size(), 3);
             KRATOS_CHECK_EQUAL(geom.WorkingSpaceDimension(), 2);
             KRATOS_CHECK_EQUAL(geom.LocalSpaceDimension(), 2);
-            KRATOS_CHECK_EQUAL(geom.Dimension(), 2);
 
             KRATOS_CHECK_EQUAL(geom.ShapeFunctionsValues().size1(), 1);
             KRATOS_CHECK_EQUAL(geom.ShapeFunctionsValues().size2(), 3);

--- a/kratos/tests/cpp_tests/geometries/test_surface_in_nurbs_volume.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_surface_in_nurbs_volume.cpp
@@ -176,8 +176,6 @@ namespace Testing {
         KRATOS_CHECK_EQUAL( quad_geometries[0].LocalSpaceDimension(), 3 );
         KRATOS_CHECK_EQUAL( surface_in_volume.WorkingSpaceDimension(), 3 );
         KRATOS_CHECK_EQUAL( quad_geometries[0].WorkingSpaceDimension(), 3 );
-        KRATOS_CHECK_EQUAL( surface_in_volume.Dimension(), 2 );
-        KRATOS_CHECK_EQUAL( quad_geometries[0].Dimension(), 2 );
 
         // Check geometrical information
         double global_area_triangle =  surface_in_volume.Area();
@@ -254,9 +252,6 @@ namespace Testing {
         KRATOS_CHECK_EQUAL( quad_geometries[0].LocalSpaceDimension(), 3 );
         KRATOS_CHECK_EQUAL( surface_in_volume.WorkingSpaceDimension(), 3 );
         KRATOS_CHECK_EQUAL( quad_geometries[0].WorkingSpaceDimension(), 3 );
-        KRATOS_CHECK_EQUAL( surface_in_volume.Dimension(), 2 );
-        KRATOS_CHECK_EQUAL( quad_geometries[0].Dimension(), 2 );
-
 
         // Check geometrical information
         CoordinatesArrayType test_point; // Center in Dimension Space
@@ -379,9 +374,6 @@ namespace Testing {
         KRATOS_CHECK_EQUAL( quad_geometries[0].LocalSpaceDimension(), 3 );
         KRATOS_CHECK_EQUAL( surface_in_volume.WorkingSpaceDimension(), 3 );
         KRATOS_CHECK_EQUAL( quad_geometries[0].WorkingSpaceDimension(), 3 );
-        KRATOS_CHECK_EQUAL( surface_in_volume.Dimension(), 2 );
-        KRATOS_CHECK_EQUAL( quad_geometries[0].Dimension(), 2 );
-
 
         // Check geometrical information
         auto center = surface_in_volume.Center();

--- a/kratos/tests/cpp_tests/sources/test_serializer_geometry_data.cpp
+++ b/kratos/tests/cpp_tests/sources/test_serializer_geometry_data.cpp
@@ -189,7 +189,6 @@ namespace Kratos {
                                      quadrature_loaded->GetGeometryData().ShapeFunctionsLocalGradients()[0], 1e-6);
 
             // Check Dimensions of geometry data
-            KRATOS_CHECK_EQUAL(quadrature_saved->GetGeometryData().Dimension(), quadrature_loaded->GetGeometryData().Dimension());
             KRATOS_CHECK_EQUAL(quadrature_saved->GetGeometryData().WorkingSpaceDimension(), quadrature_loaded->GetGeometryData().WorkingSpaceDimension());
             KRATOS_CHECK_EQUAL(quadrature_saved->GetGeometryData().LocalSpaceDimension(), quadrature_loaded->GetGeometryData().LocalSpaceDimension());
         }

--- a/kratos/tests/test_geometries.py
+++ b/kratos/tests/test_geometries.py
@@ -163,7 +163,6 @@ class TestGeometry(KratosUnittest.TestCase):
         self.assertFalse(curve.IsRational())
 
         # check general information
-        self.assertEqual(curve.Dimension(), 1);
         self.assertEqual(curve.WorkingSpaceDimension(), 3);
         self.assertEqual(curve.LocalSpaceDimension(), 1);
 


### PR DESCRIPTION
**📝 Description**
As agreed before, this will finally remove the `Dimension` method from the geometry classes as well as the `GeometryData` and `GeometryDimension` ones.

Related to #10445.