### PR TITLE
[Core] Ray Casting process - add option to set nodes on interface to zero

### DIFF
--- a/kratos/processes/apply_ray_casting_process.h
+++ b/kratos/processes/apply_ray_casting_process.h
@@ -80,7 +80,7 @@ public:
         ModelPart& rSkinPart,
         Parameters ThisParameters = Parameters());
 
-    /**
+        /**
      * @brief Construct a new ApplyRayCastingProcess object using volume and skin model parts
      *
      * @param rVolumePart model part containing the volume elements
@@ -104,7 +104,7 @@ public:
         FindIntersectedGeometricalObjectsProcess& TheFindIntersectedObjectsProcess,
         Parameters ThisParameters = Parameters());
 
-	/**
+    /**
      * @brief Construct a new Apply Ray Casting Process object using an already created search strucutre
      *
      * @param TheFindIntersectedObjectsProcess reference to the already created search structure
@@ -291,6 +291,12 @@ private:
      * This method sets the ray casting tolerances values according to the domain bounding box size
      */
     void SetRayCastingTolerances();
+
+    /**
+     * @brief This method returns the function that sets nodal distances after
+     * ray distances have been computed
+     */
+    std::function<void(const double,double&)> CreateSetNodalDistanceFunction();
 
     ///@}
     ///@name Private  Access


### PR DESCRIPTION
When computing ray distances we check if the distance to the intersection is lower than mEpsilon here
https://github.com/KratosMultiphysics/Kratos/blob/7a7e56d2259ddf2ad524884ee8f0d7b3c5ed8eeb/kratos/processes/apply_ray_casting_process.cpp#L172

However, this is not considered later when we set the nodal distance, we only change the sign there. Here I am adding the option to set the distance to zero on nodes that are close to the interface (closer than mEpsilon). This would be useful for me to recognize objects that are completely intersect with the skin. Current behaviour is kept though by default.
