### PR TITLE
Kratos rom reactions

### DIFF
--- a/applications/RomApplication/custom_strategies/rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/rom_builder_and_solver.h
@@ -448,10 +448,8 @@ protected:
                 r_condition.CalculateRightHandSide(r_rhs_cond, r_current_process_info);
                 r_condition.GetDofList(dofs, r_current_process_info);
                 for (IndexType i = 0; i < dofs.size(); ++i){
-                    if (dofs[i]->IsFixed()){
-                        double& r_bi = rb[dofs[i]->EquationId()];
-                        AtomicAdd(r_bi, r_rhs_cond[i]); // Building RHS.
-                    }
+                    double& r_bi = rb[dofs[i]->EquationId()];
+                    AtomicAdd(r_bi, r_rhs_cond[i]); // Building RHS.
                 }
             });
         }   

--- a/applications/RomApplication/custom_strategies/rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/rom_builder_and_solver.h
@@ -433,10 +433,8 @@ protected:
                 r_element.CalculateRightHandSide(r_rhs_elem, r_current_process_info);
                 r_element.GetDofList(dofs, r_current_process_info);
                 for (IndexType i = 0; i < dofs.size(); ++i){
-                    if (dofs[i]->IsFixed()){
-                        double& r_bi = rb[dofs[i]->EquationId()];
-                        AtomicAdd(r_bi, r_rhs_elem[i]); // Building RHS.
-                    }
+                    double& r_bi = rb[dofs[i]->EquationId()];
+                    AtomicAdd(r_bi, r_rhs_elem[i]); // Building RHS.
                 }
             });
         }

--- a/applications/RomApplication/custom_strategies/rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/rom_builder_and_solver.h
@@ -428,7 +428,8 @@ protected:
         {
             block_for_each(r_elements, Kratos::Vector(), [&](Element& r_element, Kratos::Vector& rhs_elem)
             {
-                DofsVectorType dofs = {};
+                DofsVectorType dofs;
+
                 r_element.CalculateRightHandSide(rhs_elem, r_current_process_info);
                 r_element.GetDofList(dofs, r_current_process_info);
                 for (IndexType i = 0; i < dofs.size(); ++i){

--- a/applications/RomApplication/custom_strategies/rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/rom_builder_and_solver.h
@@ -426,16 +426,16 @@ protected:
         auto& r_elements = mHromSimulation ? mSelectedElements : rModelPart.Elements();
         if(!r_elements.empty())
         {
-            block_for_each(r_elements, Kratos::Vector(), [&](Element& r_element, Kratos::Vector& rhs_elem)
+            block_for_each(r_elements, Kratos::Vector(), [&](Element& r_element, Kratos::Vector& r_rhs_elem)
             {
                 DofsVectorType dofs;
 
-                r_element.CalculateRightHandSide(rhs_elem, r_current_process_info);
+                r_element.CalculateRightHandSide(r_rhs_elem, r_current_process_info);
                 r_element.GetDofList(dofs, r_current_process_info);
                 for (IndexType i = 0; i < dofs.size(); ++i){
                     if (dofs[i]->IsFixed()){
                         double& r_bi = rb[dofs[i]->EquationId()];
-                        AtomicAdd(r_bi, rhs_elem[i]); // Building RHS.
+                        AtomicAdd(r_bi, r_rhs_elem[i]); // Building RHS.
                     }
                 }
             });
@@ -444,15 +444,15 @@ protected:
         auto& r_conditions = mHromSimulation ? mSelectedConditions : rModelPart.Conditions();
         if(!r_conditions.empty())
         {
-            block_for_each(r_conditions, Kratos::Vector(), [&](Condition& r_condition, Kratos::Vector& rhs_cond)
+            block_for_each(r_conditions, Kratos::Vector(), [&](Condition& r_condition, Kratos::Vector& r_rhs_cond)
             {
                 DofsVectorType dofs = {};
-                r_condition.CalculateRightHandSide(rhs_cond, r_current_process_info);
+                r_condition.CalculateRightHandSide(r_rhs_cond, r_current_process_info);
                 r_condition.GetDofList(dofs, r_current_process_info);
                 for (IndexType i = 0; i < dofs.size(); ++i){
                     if (dofs[i]->IsFixed()){
                         double& r_bi = rb[dofs[i]->EquationId()];
-                        AtomicAdd(r_bi, rhs_cond[i]); // Building RHS.
+                        AtomicAdd(r_bi, r_rhs_cond[i]); // Building RHS.
                     }
                 }
             });

--- a/applications/RomApplication/custom_strategies/rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/rom_builder_and_solver.h
@@ -205,10 +205,10 @@ public:
     {
         TSparseSpace::SetToZero(rb);
 
-        //refresh RHS to have the correct reactions
+        //refresh RHS to have the correct reactions (with contributions on Dirichlet BCs)
         BuildRHSNoDirichlet(rModelPart, rb);
 
-        //NOTE: dofs are assumed to be numbered consecutively in the BlockBuilderAndSolver
+        //NOTE: dofs are assumed to be numbered consecutively in the BuilderAndSolver
         block_for_each(BaseType::mDofSet, [&](Dof<double>& rDof){
             const std::size_t i = rDof.EquationId();
 
@@ -442,7 +442,7 @@ protected:
         }
 
         auto& r_conditions = mHromSimulation ? mSelectedConditions : rModelPart.Conditions();
-        if(!r_elements.empty())
+        if(!r_conditions.empty())
         {
             block_for_each(r_conditions, Kratos::Vector(), [&](Condition& r_condition, Kratos::Vector& rhs_cond)
             {

--- a/applications/RomApplication/custom_strategies/rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/rom_builder_and_solver.h
@@ -196,6 +196,26 @@ public:
         KRATOS_CATCH("");
     }
 
+    void CalculateReactions(
+        typename TSchemeType::Pointer pScheme,
+        ModelPart& rModelPart,
+        TSystemMatrixType& rA,
+        TSystemVectorType& rDx,
+        TSystemVectorType& rb) override
+    {
+        TSparseSpace::SetToZero(rb);
+
+        //refresh RHS to have the correct reactions
+        BuildRHSNoDirichlet(rModelPart, rb);
+
+        //NOTE: dofs are assumed to be numbered consecutively in the BlockBuilderAndSolver
+        block_for_each(BaseType::mDofSet, [&](Dof<double>& rDof){
+            const std::size_t i = rDof.EquationId();
+
+            rDof.GetSolutionStepReactionValue() = -rb[i];
+        });
+    }
+
     void SetUpSystem(ModelPart &rModelPart) override
     {
         auto& r_dof_set = BaseType::GetDofSet();
@@ -393,7 +413,53 @@ protected:
     ///@}
     ///@name Protected operators
     ///@{
+    
+    void BuildRHSNoDirichlet(
+        ModelPart& rModelPart,
+        TSystemVectorType& rb)
+    {
+        KRATOS_TRY
 
+        // Get ProcessInfo from main model part
+        const auto& r_current_process_info = rModelPart.GetProcessInfo();
+
+        auto& r_elements = mHromSimulation ? mSelectedElements : rModelPart.Elements();
+        if(!r_elements.empty())
+        {
+            block_for_each(r_elements, Kratos::Vector(), [&](Element& r_element, Kratos::Vector& rhs_elem)
+            {
+                DofsVectorType dofs = {};
+                r_element.CalculateRightHandSide(rhs_elem, r_current_process_info);
+                r_element.GetDofList(dofs, r_current_process_info);
+                for (IndexType i = 0; i < dofs.size(); ++i){
+                    if (dofs[i]->IsFixed()){
+                        rb[dofs[i]->EquationId()] += rhs_elem[i]; // Building RHS.
+                    }
+                }
+
+            });
+        }
+
+        auto& r_conditions = mHromSimulation ? mSelectedConditions : rModelPart.Conditions();
+        if(!r_elements.empty())
+        {
+            block_for_each(r_conditions, Kratos::Vector(), [&](Condition& r_condition, Kratos::Vector& rhs_cond)
+            {
+                DofsVectorType dofs = {};
+                r_condition.CalculateRightHandSide(rhs_cond, r_current_process_info);
+                r_condition.GetDofList(dofs, r_current_process_info);
+                for (IndexType i = 0; i < dofs.size(); ++i){
+                    if (dofs[i]->IsFixed()){
+                        rb[dofs[i]->EquationId()] += rhs_cond[i]; // Building RHS.
+                    }
+                }
+
+            });
+        }   
+
+        KRATOS_CATCH("")
+
+    }
 
     ///@}
     ///@name Protected operations

--- a/applications/RomApplication/custom_strategies/rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/rom_builder_and_solver.h
@@ -433,7 +433,8 @@ protected:
                 r_element.GetDofList(dofs, r_current_process_info);
                 for (IndexType i = 0; i < dofs.size(); ++i){
                     if (dofs[i]->IsFixed()){
-                        rb[dofs[i]->EquationId()] += rhs_elem[i]; // Building RHS.
+                        double& r_bi = rb[dofs[i]->EquationId()];
+                        AtomicAdd(r_bi, rhs_elem[i]); // Building RHS.
                     }
                 }
 
@@ -450,7 +451,8 @@ protected:
                 r_condition.GetDofList(dofs, r_current_process_info);
                 for (IndexType i = 0; i < dofs.size(); ++i){
                     if (dofs[i]->IsFixed()){
-                        rb[dofs[i]->EquationId()] += rhs_cond[i]; // Building RHS.
+                        double& r_bi = rb[dofs[i]->EquationId()];
+                        AtomicAdd(r_bi, rhs_cond[i]); // Building RHS.
                     }
                 }
 

--- a/applications/RomApplication/custom_strategies/rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/rom_builder_and_solver.h
@@ -437,7 +437,6 @@ protected:
                         AtomicAdd(r_bi, rhs_elem[i]); // Building RHS.
                     }
                 }
-
             });
         }
 
@@ -455,7 +454,6 @@ protected:
                         AtomicAdd(r_bi, rhs_cond[i]); // Building RHS.
                     }
                 }
-
             });
         }   
 


### PR DESCRIPTION
**Description**
This pull request enables users to obtain reactions in a reduced order model (ROM) by following the traditional way it is done in Kratos.

The changes involve building the right-hand side (RHS) with the function `BuildRHSNoDirichlet(rModelPart, rb)`, and then setting the ReactionValue on the degrees of freedom (DOFs) using `rDof.GetSolutionStepReactionValue()`.

This ensures that the code is safer and more straightforward to maintain and understand. 

It was separated from PR #10972.

**Changes Made**
Modified the ROM B&S to build the RHS first and then assign reactions to DOFs separately, following the typical way it is done in Kratos.
Tested the code to ensure that it works as expected.
