### PR TITLE
[Core] Add Octree tests for KratosCoreFastSuite

### DIFF
--- a/kratos/spatial_containers/octree.h
+++ b/kratos/spatial_containers/octree.h
@@ -215,7 +215,7 @@ public:
 
     }
 
-    virtual void PrintData(std::ostream& rOStream, std::string const& Perfix = std::string()) const
+    virtual void PrintData(std::ostream& rOStream, std::string const& Perfix = std::string()) const override
     {
         rOStream << Perfix << "Partition at point (" << mPosition[0];
         for(IndexType j = 0 ; j < Dimension - 1 ; j++)
@@ -239,7 +239,7 @@ public:
     ///@name Operations
     ///@{
 
-    void SearchNearestPoint(PointType const& ThisPoint, PointerType& Result, CoordinateType& rResultDistance)
+    void SearchNearestPoint(PointType const& ThisPoint, PointerType& Result, CoordinateType& rResultDistance) override
     {
         CoordinateType distances_to_partitions[number_of_childs];
 
@@ -256,7 +256,7 @@ public:
     }
 
     void SearchInRadius(PointType const& ThisPoint, CoordinateType const& Radius, CoordinateType const& Radius2, IteratorType& Results,
-                        DistanceIteratorType& ResultsDistances, SizeType& NumberOfResults, SizeType const& MaxNumberOfResults)
+                        DistanceIteratorType& ResultsDistances, SizeType& NumberOfResults, SizeType const& MaxNumberOfResults) override
     {
         SizeType child_index = GetChildIndex(ThisPoint);
 
@@ -273,7 +273,7 @@ public:
     }
 
     void SearchInRadius(PointType const& ThisPoint, CoordinateType const& Radius, CoordinateType const& Radius2, IteratorType& Results,
-                        SizeType& NumberOfResults, SizeType const& MaxNumberOfResults)
+                        SizeType& NumberOfResults, SizeType const& MaxNumberOfResults) override
     {
         SizeType child_index = GetChildIndex(ThisPoint);
 

--- a/kratos/spatial_containers/octree.h
+++ b/kratos/spatial_containers/octree.h
@@ -215,7 +215,7 @@ public:
 
     }
 
-    virtual void PrintData(std::ostream& rOStream, std::string const& Perfix = std::string()) const override
+    void PrintData(std::ostream& rOStream, std::string const& Perfix = std::string()) const override
     {
         rOStream << Perfix << "Partition at point (" << mPosition[0];
         for(IndexType j = 0 ; j < Dimension - 1 ; j++)

--- a/kratos/tests/cpp_tests/spatial_containers/test_kd_tree.cpp
+++ b/kratos/tests/cpp_tests/spatial_containers/test_kd_tree.cpp
@@ -24,14 +24,14 @@
 namespace Kratos::Testing {
 
 using PointType = Node<3>;
-using PointTypePointerType = typename PointType::Pointer;
+using PointPointerType = typename PointType::Pointer;
 using PointVectorType = std::vector<PointType::Pointer>;
 using PointIteratorType = std::vector<PointType::Pointer>::iterator;
 using DistanceVectorType = std::vector<double>;
 using DistanceIteratorType = std::vector<double>::iterator;
 
 /// KDtree definitions
-using BucketType = Bucket< 3ul, PointType, PointVectorType, PointTypePointerType, PointIteratorType, DistanceIteratorType>;
+using BucketType = Bucket< 3ul, PointType, PointVectorType, PointPointerType, PointIteratorType, DistanceIteratorType>;
 using KDTree = Tree<KDTreePartition<BucketType>>;
 
 /**
@@ -42,13 +42,13 @@ KRATOS_TEST_CASE_IN_SUITE(KDTreeExistPoint, KratosCoreFastSuite)
     PointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(PointTypePointerType(new PointType(i, i, i, i)));
+        points.push_back(PointPointerType(new PointType(i, i, i, i)));
     }
 
     KDTree testKDTree(points.begin(), points.end(), 100);
 
-    KRATOS_CHECK_EQUAL(testKDTree.ExistPoint(PointTypePointerType(new PointType(10, 10.0, 10.0, 10.0))), nullptr);
-    KRATOS_CHECK_EQUAL(testKDTree.ExistPoint(PointTypePointerType(new PointType(9, 9.0, 9.0, 9.0))), points[9]);
+    KRATOS_CHECK_EQUAL(testKDTree.ExistPoint(PointPointerType(new PointType(10, 10.0, 10.0, 10.0))), nullptr);
+    KRATOS_CHECK_EQUAL(testKDTree.ExistPoint(PointPointerType(new PointType(9, 9.0, 9.0, 9.0))), points[9]);
 }
 
 /**
@@ -59,7 +59,7 @@ KRATOS_TEST_CASE_IN_SUITE(KDTreeSearchNearestPoint, KratosCoreFastSuite)
     PointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(PointTypePointerType(new PointType(i, i, i, i)));
+        points.push_back(PointPointerType(new PointType(i, i, i, i)));
     }
 
     KDTree testKDTree(points.begin(), points.end(), 100);
@@ -79,7 +79,7 @@ KRATOS_TEST_CASE_IN_SUITE(KDTreeSearchInRadius, KratosCoreFastSuite)
     PointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(PointTypePointerType(new PointType(i, i, i, i)));
+        points.push_back(PointPointerType(new PointType(i, i, i, i)));
     }
 
     KDTree testKDTree(points.begin(), points.end(), 100);
@@ -106,7 +106,7 @@ KRATOS_TEST_CASE_IN_SUITE(KDTreeSearchInBox, KratosCoreFastSuite)
     PointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(PointTypePointerType(new PointType(i, i, i, i)));
+        points.push_back(PointPointerType(new PointType(i, i, i, i)));
     }
 
     KDTree testKDTree(points.begin(), points.end(), 100);
@@ -130,7 +130,7 @@ KRATOS_TEST_CASE_IN_SUITE(KDTreeBB, KratosCoreFastSuite)
     PointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(PointTypePointerType(new PointType(i, i, i, i)));
+        points.push_back(PointPointerType(new PointType(i, i, i, i)));
     }
 
     KDTree testKDTree(points.begin(), points.end(), 100);

--- a/kratos/tests/cpp_tests/spatial_containers/test_kd_tree.cpp
+++ b/kratos/tests/cpp_tests/spatial_containers/test_kd_tree.cpp
@@ -24,35 +24,31 @@
 namespace Kratos::Testing {
 
 using PointType = Node<3>;
-using PointTypePointer = Node<3>::Pointer;
-using PointVector = std::vector<PointType::Pointer>;
-using PointIterator = std::vector<PointType::Pointer>::iterator;
-using DistanceVector = std::vector<double>;
-using DistanceIterator = std::vector<double>::iterator;
+using PointTypePointerType = typename PointType::Pointer;
+using PointVectorType = std::vector<PointType::Pointer>;
+using PointIteratorType = std::vector<PointType::Pointer>::iterator;
+using DistanceVectorType = std::vector<double>;
+using DistanceIteratorType = std::vector<double>::iterator;
 
 /// KDtree definitions
-using BucketType = Bucket< 3ul, PointType, PointVector, PointTypePointer, PointIterator, DistanceIterator>;
+using BucketType = Bucket< 3ul, PointType, PointVectorType, PointTypePointerType, PointIteratorType, DistanceIteratorType>;
 using KDTree = Tree<KDTreePartition<BucketType>>;
-
-using CoordinateType = KDTree::CoordinateType;
-using PointerType = KDTree::PointerType;
-using SearchStructureType = KDTree::SearchStructureType;
 
 /**
  * @brief Test that ExistPoint works correctly
  */
 KRATOS_TEST_CASE_IN_SUITE(KDTreeExistPoint, KratosCoreFastSuite)
 {
-    PointVector points;
+    PointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(PointTypePointer(new PointType(i, i, i, i)));
+        points.push_back(PointTypePointerType(new PointType(i, i, i, i)));
     }
 
     KDTree testKDTree(points.begin(), points.end(), 100);
 
-    KRATOS_CHECK_EQUAL(testKDTree.ExistPoint(PointTypePointer(new PointType(10, 10.0, 10.0, 10.0))), nullptr);
-    KRATOS_CHECK_EQUAL(testKDTree.ExistPoint(PointTypePointer(new PointType(9, 9.0, 9.0, 9.0))), points[9]);
+    KRATOS_CHECK_EQUAL(testKDTree.ExistPoint(PointTypePointerType(new PointType(10, 10.0, 10.0, 10.0))), nullptr);
+    KRATOS_CHECK_EQUAL(testKDTree.ExistPoint(PointTypePointerType(new PointType(9, 9.0, 9.0, 9.0))), points[9]);
 }
 
 /**
@@ -60,10 +56,10 @@ KRATOS_TEST_CASE_IN_SUITE(KDTreeExistPoint, KratosCoreFastSuite)
  */
 KRATOS_TEST_CASE_IN_SUITE(KDTreeSearchNearestPoint, KratosCoreFastSuite)
 {
-    PointVector points;
+    PointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(PointTypePointer(new PointType(i, i, i, i)));
+        points.push_back(PointTypePointerType(new PointType(i, i, i, i)));
     }
 
     KDTree testKDTree(points.begin(), points.end(), 100);
@@ -80,17 +76,17 @@ KRATOS_TEST_CASE_IN_SUITE(KDTreeSearchNearestPoint, KratosCoreFastSuite)
  */
 KRATOS_TEST_CASE_IN_SUITE(KDTreeSearchInRadius, KratosCoreFastSuite)
 {
-    PointVector points;
+    PointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(PointTypePointer(new PointType(i, i, i, i)));
+        points.push_back(PointTypePointerType(new PointType(i, i, i, i)));
     }
 
     KDTree testKDTree(points.begin(), points.end(), 100);
 
     const std::size_t max_number_results = 10;
-    PointVector result_points(max_number_results);
-    DistanceVector distances(max_number_results);
+    PointVectorType result_points(max_number_results);
+    DistanceVectorType distances(max_number_results);
     auto point_10 = PointType(10, 10.0, 10.0, 10.0);
     KRATOS_CHECK_EQUAL(testKDTree.SearchInRadius(point_10, 1.0, result_points.begin(), distances.begin(), max_number_results), 0);
 
@@ -107,17 +103,17 @@ KRATOS_TEST_CASE_IN_SUITE(KDTreeSearchInRadius, KratosCoreFastSuite)
  */
 KRATOS_TEST_CASE_IN_SUITE(KDTreeSearchInBox, KratosCoreFastSuite)
 {
-    PointVector points;
+    PointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(PointTypePointer(new PointType(i, i, i, i)));
+        points.push_back(PointTypePointerType(new PointType(i, i, i, i)));
     }
 
     KDTree testKDTree(points.begin(), points.end(), 100);
 
     const std::size_t max_number_results = 10;
-    PointVector result_points(max_number_results);
-    DistanceVector distances(max_number_results);
+    PointVectorType result_points(max_number_results);
+    DistanceVectorType distances(max_number_results);
     auto point_10 = PointType(10, 10.0, 10.0, 10.0);
     auto point_11 = PointType(11, 9.1, 9.1, 9.1);
     KRATOS_CHECK_EQUAL(testKDTree.SearchInBox(point_11, point_10, result_points.begin(), max_number_results), 0);
@@ -131,10 +127,10 @@ KRATOS_TEST_CASE_IN_SUITE(KDTreeSearchInBox, KratosCoreFastSuite)
  */
 KRATOS_TEST_CASE_IN_SUITE(KDTreeBB, KratosCoreFastSuite)
 {
-    PointVector points;
+    PointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(PointTypePointer(new PointType(i, i, i, i)));
+        points.push_back(PointTypePointerType(new PointType(i, i, i, i)));
     }
 
     KDTree testKDTree(points.begin(), points.end(), 100);

--- a/kratos/tests/cpp_tests/spatial_containers/test_octree.cpp
+++ b/kratos/tests/cpp_tests/spatial_containers/test_octree.cpp
@@ -24,14 +24,14 @@
 namespace Kratos::Testing {
 
 using OTPointType = Point;
-using OTPointTypePointer = typename OTPointType::Pointer;
+using OTPointPointerType = typename OTPointType::Pointer;
 using OTPointVectorType = std::vector<OTPointType::Pointer>;
 using OTPointIteratorType = std::vector<OTPointType::Pointer>::iterator;
 using OTDistanceVectorType = std::vector<double>;
 using OTDistanceIteratorType = std::vector<double>::iterator;
 
 /// Octree definitions
-using OTBucketType = Bucket< 3ul, OTPointType, OTPointVectorType, OTPointTypePointer, OTPointIteratorType, OTDistanceIteratorType>;
+using OTBucketType = Bucket< 3ul, OTPointType, OTPointVectorType, OTPointPointerType, OTPointIteratorType, OTDistanceIteratorType>;
 using Octree = Tree<OCTreePartition<OTBucketType>>;
 
 /**
@@ -42,13 +42,13 @@ KRATOS_TEST_CASE_IN_SUITE(OctreeExistPoint, KratosCoreFastSuite)
     OTPointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(OTPointTypePointer(new OTPointType(i, i, i)));
+        points.push_back(OTPointPointerType(new OTPointType(i, i, i)));
     }
 
     Octree testOctree(points.begin(), points.end(), 100);
 
-    KRATOS_CHECK_EQUAL(testOctree.ExistPoint(OTPointTypePointer(new OTPointType(10.0, 10.0, 10.0))), nullptr);
-    KRATOS_CHECK_EQUAL(testOctree.ExistPoint(OTPointTypePointer(new OTPointType(9.0, 9.0, 9.0))), points[9]);
+    KRATOS_CHECK_EQUAL(testOctree.ExistPoint(OTPointPointerType(new OTPointType(10.0, 10.0, 10.0))), nullptr);
+    KRATOS_CHECK_EQUAL(testOctree.ExistPoint(OTPointPointerType(new OTPointType(9.0, 9.0, 9.0))), points[9]);
 }
 
 /**
@@ -59,7 +59,7 @@ KRATOS_TEST_CASE_IN_SUITE(OctreeSearchNearestPoint, KratosCoreFastSuite)
     OTPointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(OTPointTypePointer(new OTPointType(i, i, i)));
+        points.push_back(OTPointPointerType(new OTPointType(i, i, i)));
     }
 
     Octree testOctree(points.begin(), points.end(), 100);
@@ -79,7 +79,7 @@ KRATOS_TEST_CASE_IN_SUITE(OctreeSearchInRadius, KratosCoreFastSuite)
     OTPointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(OTPointTypePointer(new OTPointType(i, i, i)));
+        points.push_back(OTPointPointerType(new OTPointType(i, i, i)));
     }
 
     Octree testOctree(points.begin(), points.end(), 100);
@@ -106,7 +106,7 @@ KRATOS_TEST_CASE_IN_SUITE(OctreeSearchInBox, KratosCoreFastSuite)
     OTPointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(OTPointTypePointer(new OTPointType(i, i, i)));
+        points.push_back(OTPointPointerType(new OTPointType(i, i, i)));
     }
 
     Octree testOctree(points.begin(), points.end(), 100);
@@ -130,7 +130,7 @@ KRATOS_TEST_CASE_IN_SUITE(OctreeBB, KratosCoreFastSuite)
     OTPointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(OTPointTypePointer(new OTPointType(i, i, i)));
+        points.push_back(OTPointPointerType(new OTPointType(i, i, i)));
     }
 
     Octree testOctree(points.begin(), points.end(), 100);

--- a/kratos/tests/cpp_tests/spatial_containers/test_octree.cpp
+++ b/kratos/tests/cpp_tests/spatial_containers/test_octree.cpp
@@ -23,36 +23,32 @@
 
 namespace Kratos::Testing {
 
-using PointType = Point;
-using PointTypePointer = Point::Pointer;
-using PointVector = std::vector<PointType::Pointer>;
-using PointIterator = std::vector<PointType::Pointer>::iterator;
-using DistanceVector = std::vector<double>;
-using DistanceIterator = std::vector<double>::iterator;
+using OTPointType = Point;
+using OTPointTypePointer = typename OTPointType::Pointer;
+using OTPointVectorType = std::vector<OTPointType::Pointer>;
+using OTPointIteratorType = std::vector<OTPointType::Pointer>::iterator;
+using OTDistanceVectorType = std::vector<double>;
+using OTDistanceIteratorType = std::vector<double>::iterator;
 
-/// KDtree definitions
-using BucketType = Bucket< 3ul, PointType, PointVector, PointTypePointer, PointIterator, DistanceIterator>;
-using Octree = Tree<OCTreePartition<BucketType>>;
-
-using CoordinateType = Octree::CoordinateType;
-using PointerType = Octree::PointerType;
-using SearchStructureType = Octree::SearchStructureType;
+/// Octree definitions
+using OTBucketType = Bucket< 3ul, OTPointType, OTPointVectorType, OTPointTypePointer, OTPointIteratorType, OTDistanceIteratorType>;
+using Octree = Tree<OCTreePartition<OTBucketType>>;
 
 /**
  * @brief Test that ExistPoint works correctly
  */
 KRATOS_TEST_CASE_IN_SUITE(OctreeExistPoint, KratosCoreFastSuite)
 {
-    PointVector points;
+    OTPointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(PointTypePointer(new PointType(i, i, i)));
+        points.push_back(OTPointTypePointer(new OTPointType(i, i, i)));
     }
 
     Octree testOctree(points.begin(), points.end(), 100);
 
-    KRATOS_CHECK_EQUAL(testOctree.ExistPoint(PointTypePointer(new PointType(10.0, 10.0, 10.0))), nullptr);
-    KRATOS_CHECK_EQUAL(testOctree.ExistPoint(PointTypePointer(new PointType(9.0, 9.0, 9.0))), points[9]);
+    KRATOS_CHECK_EQUAL(testOctree.ExistPoint(OTPointTypePointer(new OTPointType(10.0, 10.0, 10.0))), nullptr);
+    KRATOS_CHECK_EQUAL(testOctree.ExistPoint(OTPointTypePointer(new OTPointType(9.0, 9.0, 9.0))), points[9]);
 }
 
 /**
@@ -60,15 +56,15 @@ KRATOS_TEST_CASE_IN_SUITE(OctreeExistPoint, KratosCoreFastSuite)
  */
 KRATOS_TEST_CASE_IN_SUITE(OctreeSearchNearestPoint, KratosCoreFastSuite)
 {
-    PointVector points;
+    OTPointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(PointTypePointer(new PointType(i, i, i)));
+        points.push_back(OTPointTypePointer(new OTPointType(i, i, i)));
     }
 
     Octree testOctree(points.begin(), points.end(), 100);
 
-    auto point_10 = PointType(10.0, 10.0, 10.0);
+    auto point_10 = OTPointType(10.0, 10.0, 10.0);
     KRATOS_CHECK_EQUAL(testOctree.SearchNearestPoint(point_10), points[9]);
     double distance;
     KRATOS_CHECK_EQUAL(testOctree.SearchNearestPoint(point_10, distance), points[9]);
@@ -80,18 +76,18 @@ KRATOS_TEST_CASE_IN_SUITE(OctreeSearchNearestPoint, KratosCoreFastSuite)
  */
 KRATOS_TEST_CASE_IN_SUITE(OctreeSearchInRadius, KratosCoreFastSuite)
 {
-    PointVector points;
+    OTPointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(PointTypePointer(new PointType(i, i, i)));
+        points.push_back(OTPointTypePointer(new OTPointType(i, i, i)));
     }
 
     Octree testOctree(points.begin(), points.end(), 100);
 
     const std::size_t max_number_results = 10;
-    PointVector result_points(max_number_results);
-    DistanceVector distances(max_number_results);
-    auto point_10 = PointType(10.0, 10.0, 10.0);
+    OTPointVectorType result_points(max_number_results);
+    OTDistanceVectorType distances(max_number_results);
+    auto point_10 = OTPointType(10.0, 10.0, 10.0);
     KRATOS_CHECK_EQUAL(testOctree.SearchInRadius(point_10, 1.0, result_points.begin(), distances.begin(), max_number_results), 0);
 
     KRATOS_CHECK_EQUAL(testOctree.SearchInRadius(point_10, 3.0, result_points.begin(), distances.begin(), max_number_results), 1);
@@ -107,22 +103,22 @@ KRATOS_TEST_CASE_IN_SUITE(OctreeSearchInRadius, KratosCoreFastSuite)
  */
 KRATOS_TEST_CASE_IN_SUITE(OctreeSearchInBox, KratosCoreFastSuite)
 {
-    PointVector points;
+    OTPointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(PointTypePointer(new PointType(i, i, i)));
+        points.push_back(OTPointTypePointer(new OTPointType(i, i, i)));
     }
 
     Octree testOctree(points.begin(), points.end(), 100);
 
     const std::size_t max_number_results = 10;
-    PointVector result_points(max_number_results);
-    DistanceVector distances(max_number_results);
-    auto point_10 = PointType(10.0, 10.0, 10.0);
-    auto point_11 = PointType(9.1, 9.1, 9.1);
+    OTPointVectorType result_points(max_number_results);
+    OTDistanceVectorType distances(max_number_results);
+    auto point_10 = OTPointType(10.0, 10.0, 10.0);
+    auto point_11 = OTPointType(9.1, 9.1, 9.1);
     KRATOS_CHECK_EQUAL(testOctree.SearchInBox(point_11, point_10, result_points.begin(), max_number_results), 0);
 
-    auto point_12 = PointType(9.0, 9.0, 9.0);
+    auto point_12 = OTPointType(9.0, 9.0, 9.0);
     KRATOS_CHECK_EQUAL(testOctree.SearchInBox(point_12, point_10, result_points.begin(), max_number_results), 1);
 }
 
@@ -131,10 +127,10 @@ KRATOS_TEST_CASE_IN_SUITE(OctreeSearchInBox, KratosCoreFastSuite)
  */
 KRATOS_TEST_CASE_IN_SUITE(OctreeBB, KratosCoreFastSuite)
 {
-    PointVector points;
+    OTPointVectorType points;
 
     for(std::size_t i = 0; i < 10; i++) {
-        points.push_back(PointTypePointer(new PointType(i, i, i)));
+        points.push_back(OTPointTypePointer(new OTPointType(i, i, i)));
     }
 
     Octree testOctree(points.begin(), points.end(), 100);

--- a/kratos/tests/cpp_tests/spatial_containers/test_octree.cpp
+++ b/kratos/tests/cpp_tests/spatial_containers/test_octree.cpp
@@ -1,0 +1,146 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/node.h"
+#include "testing/testing.h"
+#include "spatial_containers/bucket.h"
+#include "spatial_containers/octree.h"
+
+namespace Kratos::Testing {
+
+using PointType = Point;
+using PointTypePointer = Point::Pointer;
+using PointVector = std::vector<PointType::Pointer>;
+using PointIterator = std::vector<PointType::Pointer>::iterator;
+using DistanceVector = std::vector<double>;
+using DistanceIterator = std::vector<double>::iterator;
+
+/// KDtree definitions
+using BucketType = Bucket< 3ul, PointType, PointVector, PointTypePointer, PointIterator, DistanceIterator>;
+using Octree = Tree<OCTreePartition<BucketType>>;
+
+using CoordinateType = Octree::CoordinateType;
+using PointerType = Octree::PointerType;
+using SearchStructureType = Octree::SearchStructureType;
+
+/**
+ * @brief Test that ExistPoint works correctly
+ */
+KRATOS_TEST_CASE_IN_SUITE(OctreeExistPoint, KratosCoreFastSuite)
+{
+    PointVector points;
+
+    for(std::size_t i = 0; i < 10; i++) {
+        points.push_back(PointTypePointer(new PointType(i, i, i)));
+    }
+
+    Octree testOctree(points.begin(), points.end(), 100);
+
+    KRATOS_CHECK_EQUAL(testOctree.ExistPoint(PointTypePointer(new PointType(10.0, 10.0, 10.0))), nullptr);
+    KRATOS_CHECK_EQUAL(testOctree.ExistPoint(PointTypePointer(new PointType(9.0, 9.0, 9.0))), points[9]);
+}
+
+/**
+ * @brief Test that SearchNearestPoint works correctly
+ */
+KRATOS_TEST_CASE_IN_SUITE(OctreeSearchNearestPoint, KratosCoreFastSuite)
+{
+    PointVector points;
+
+    for(std::size_t i = 0; i < 10; i++) {
+        points.push_back(PointTypePointer(new PointType(i, i, i)));
+    }
+
+    Octree testOctree(points.begin(), points.end(), 100);
+
+    auto point_10 = PointType(10.0, 10.0, 10.0);
+    KRATOS_CHECK_EQUAL(testOctree.SearchNearestPoint(point_10), points[9]);
+    double distance;
+    KRATOS_CHECK_EQUAL(testOctree.SearchNearestPoint(point_10, distance), points[9]);
+    KRATOS_CHECK_DOUBLE_EQUAL(distance, 3.0); // NOTE: Should be sqrt of 3, may require to check that
+}
+
+/**
+ * @brief Test that SearchInRadius works correctly
+ */
+KRATOS_TEST_CASE_IN_SUITE(OctreeSearchInRadius, KratosCoreFastSuite)
+{
+    PointVector points;
+
+    for(std::size_t i = 0; i < 10; i++) {
+        points.push_back(PointTypePointer(new PointType(i, i, i)));
+    }
+
+    Octree testOctree(points.begin(), points.end(), 100);
+
+    const std::size_t max_number_results = 10;
+    PointVector result_points(max_number_results);
+    DistanceVector distances(max_number_results);
+    auto point_10 = PointType(10.0, 10.0, 10.0);
+    KRATOS_CHECK_EQUAL(testOctree.SearchInRadius(point_10, 1.0, result_points.begin(), distances.begin(), max_number_results), 0);
+
+    KRATOS_CHECK_EQUAL(testOctree.SearchInRadius(point_10, 3.0, result_points.begin(), distances.begin(), max_number_results), 1);
+    KRATOS_CHECK_DOUBLE_EQUAL(distances[0], 3.0); // NOTE: Should be sqrt of 3, it is always the quare for performance reasons
+
+    KRATOS_CHECK_EQUAL(testOctree.SearchInRadius(point_10, 4.0, result_points.begin(), max_number_results), 2);
+    KRATOS_CHECK_EQUAL(testOctree.SearchInRadius(point_10, 4.0, result_points.begin(), distances.begin(), max_number_results), 2);
+    KRATOS_CHECK_DOUBLE_EQUAL(distances[0] + distances[1], 15.0); // NOTE: Should be sqrt of 3 + sqrt of 12, it is always the quare for performance reasons
+}
+
+/**
+ * @brief Test that SearchInBox works correctly
+ */
+KRATOS_TEST_CASE_IN_SUITE(OctreeSearchInBox, KratosCoreFastSuite)
+{
+    PointVector points;
+
+    for(std::size_t i = 0; i < 10; i++) {
+        points.push_back(PointTypePointer(new PointType(i, i, i)));
+    }
+
+    Octree testOctree(points.begin(), points.end(), 100);
+
+    const std::size_t max_number_results = 10;
+    PointVector result_points(max_number_results);
+    DistanceVector distances(max_number_results);
+    auto point_10 = PointType(10.0, 10.0, 10.0);
+    auto point_11 = PointType(9.1, 9.1, 9.1);
+    KRATOS_CHECK_EQUAL(testOctree.SearchInBox(point_11, point_10, result_points.begin(), max_number_results), 0);
+
+    auto point_12 = PointType(9.0, 9.0, 9.0);
+    KRATOS_CHECK_EQUAL(testOctree.SearchInBox(point_12, point_10, result_points.begin(), max_number_results), 1);
+}
+
+/**
+ * @brief Test that Bounding box points works well works correctly
+ */
+KRATOS_TEST_CASE_IN_SUITE(OctreeBB, KratosCoreFastSuite)
+{
+    PointVector points;
+
+    for(std::size_t i = 0; i < 10; i++) {
+        points.push_back(PointTypePointer(new PointType(i, i, i)));
+    }
+
+    Octree testOctree(points.begin(), points.end(), 100);
+
+    KRATOS_CHECK_VECTOR_EQUAL(testOctree.BoundingBoxLowPoint().Coordinates(), points[0]->Coordinates());
+    KRATOS_CHECK_VECTOR_EQUAL(testOctree.BoundingBoxHighPoint().Coordinates(), points[9]->Coordinates());
+}
+
+} // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**

This commit introduces a new test file, `test_octree.cpp`, which contains tests for various `Octree` functionalities. The file is added to the `kratos/tests/cpp_tests/spatial_containers` directory. The tests cover the following functions:

- `ExistPoint` - checks if a point exists in the `Octree`.
- `SearchNearestPoint` - searches for the nearest point in the `Octree`.
- `SearchInRadius` - searches for points within a given radius in the `Octree`.
- `SearchInBox` - searches for points inside a bounding box in the `Octree`.
- `BoundingBoxLowPoint` and `BoundingBoxHighPoint` - checks the bounding box points.

The tests are added to the `KratosCoreFastSuite`, ensuring that the `Octree` implementation is functioning correctly.

Also adding missing `override` to `octree.h`.

**🆕 Changelog**

- [Adding Octree test](https://github.com/KratosMultiphysics/Kratos/commit/52ee07fd09a524346378b7ef90d9b3561bfa4e40)
- [Minor clean up](https://github.com/KratosMultiphysics/Kratos/pull/10987/commits/562ebaf354f9c5dd3be0ab8987f6a554c85be77d)
- [Missing override](https://github.com/KratosMultiphysics/Kratos/pull/10987/commits/67d2532c081d285908789dfd079c2623fad82d30)
