### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -205,6 +205,8 @@ Then, these scripts can be launched through the system terminal.
 sh /path_to_kratos/scripts/configure.sh
 ```
 
+**NOTE**: In case the compiler runs out of memory, try increasing the swap size to at least 16 GB and re-starting the compilation process.
+
 *Windows*
 
 ```Shell


### PR DESCRIPTION
I have noticed that the installer may run out of memory on Linux. Was able to solve this by temporarily increasing swap size. I believe this is useful information to have in the instructions.

**📝 Description**
Added note to INSTALL.md

Please mark the PR with appropriate tags: 
- Documentation

**🆕 Changelog**
- Added note to INSTALL.md
