### PR TITLE
Assign Neighbour Elements to Conditions - Convection Diffusion

### DIFF
--- a/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
@@ -326,7 +326,7 @@ class ConvectionDiffusionSolver(PythonSolver):
                 flags |= tmoc.ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS
             else:
                 flags |= (tmoc.ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS).AsFalse()
-            tmoc.(self.main_model_part,throw_errors, flags).Execute()
+            tmoc(self.main_model_part,throw_errors, flags).Execute()
 
             self._set_and_fill_buffer()
 

--- a/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
@@ -153,7 +153,7 @@ class ConvectionDiffusionSolver(PythonSolver):
             "problem_domain_sub_model_part_list": [""],
             "processes_sub_model_part_list": [""],
             "auxiliary_variables_list" : [],
-            "assign_neighbour_elements_to_conditions" : false
+            "assign_neighbour_elements_to_conditions" : true
         }
         """)
         default_settings.AddMissingParameters(super().GetDefaultParameters())

--- a/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
@@ -326,7 +326,7 @@ class ConvectionDiffusionSolver(PythonSolver):
                 flags |= tmoc.ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS
             else:
                 flags |= (tmoc.ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS).AsFalse()
-            KratosMultiphysics.TetrahedralMeshOrientationCheck(self.main_model_part,throw_errors, flags).Execute()
+            tmoc.(self.main_model_part,throw_errors, flags).Execute()
 
             self._set_and_fill_buffer()
 

--- a/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
@@ -152,7 +152,8 @@ class ConvectionDiffusionSolver(PythonSolver):
             },
             "problem_domain_sub_model_part_list": [""],
             "processes_sub_model_part_list": [""],
-            "auxiliary_variables_list" : []
+            "auxiliary_variables_list" : [],
+            "assign_neighbour_elements_to_conditions" : false
         }
         """)
         default_settings.AddMissingParameters(super().GetDefaultParameters())
@@ -307,6 +308,7 @@ class ConvectionDiffusionSolver(PythonSolver):
                 self.distributed_model_part_importer.ImportModelPart()
 
     def PrepareModelPart(self):
+        assign_neighbour_elements = self.settings["assign_neighbour_elements_to_conditions"].GetBool()
         if not self.is_restarted():
             # Import material properties
             materials_imported = self.import_materials()
@@ -315,10 +317,16 @@ class ConvectionDiffusionSolver(PythonSolver):
             else:
                 KratosMultiphysics.Logger.PrintInfo("::[ConvectionDiffusionSolver]:: ", "Materials were not imported.")
 
-            throw_errors = False
-            KratosMultiphysics.TetrahedralMeshOrientationCheck(self.main_model_part, throw_errors).Execute()
-
             KratosMultiphysics.ReplaceElementsAndConditionsProcess(self.main_model_part,self._get_element_condition_replace_settings()).Execute()
+
+            tmoc = KratosMultiphysics.TetrahedralMeshOrientationCheck
+            throw_errors = False
+            flags = (tmoc.COMPUTE_NODAL_NORMALS).AsFalse() | (tmoc.COMPUTE_CONDITION_NORMALS).AsFalse()
+            if assign_neighbour_elements:
+                flags |= tmoc.ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS
+            else:
+                flags |= (tmoc.ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS).AsFalse()
+            KratosMultiphysics.TetrahedralMeshOrientationCheck(self.main_model_part,throw_errors, flags).Execute()
 
             self._set_and_fill_buffer()
 


### PR DESCRIPTION
## Changes in this Pull Request

This pull request includes two changes to the `convection_diffusion_solver.py` file:

1. Added `assign_neighbour_elements_to_conditions` flag - This flag allows the solver to assign a parent element to each condition when performing the `TetrahedralMeshOrientationCheck`. 

2. Moved `ReplaceElementsAndConditionsProcess` before `TetrahedralMeshOrientationCheck` - This change moves the `ReplaceElementsAndConditionsProcess` to before the `TetrahedralMeshOrientationCheck`. By doing so, the solver no longer replaces the conditions or modifies the `TetrahedralMeshOrientationCheck`. 

Note that these changes only affect the `convection_diffusion_solver.py` file. The changes are not expected to modify or interfere with the solution of any simulation.

In addition, the `assign_neighbour_elements_to_conditions` flag will be helpful for Hyper-reduction, where one needs to store the parent elements if the hyper-reduction strategy selects one condition. 



