### PR TITLE
[Core] Define `CalculateDistance` for `Triangle3D3` and `Line3D2`

### DIFF
--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -25,7 +25,7 @@
 #include "integration/line_gauss_legendre_integration_points.h"
 #include "integration/line_collocation_integration_points.h"
 #include "utilities/intersection_utilities.h"
-
+#include "utilities/geometry_utilities.h"
 namespace Kratos
 {
 
@@ -423,11 +423,34 @@ public:
         return IntersectionUtilities::ComputeLineLineIntersection(r_geom, rThisGeometry[0], rThisGeometry[1], intersection_point);
     }
 
+    ///@}
+    ///@name Spatial Operations
+    ///@{
+
+    /**
+    * @brief Computes the distance between an point in
+    *        global coordinates and the closest point
+    *        of this geometry.
+    *        If projection fails, double::max will be returned.
+    * @param rPointGlobalCoordinates the point to which the
+    *        closest point has to be found.
+    * @param Tolerance accepted orthogonal error.
+    * @return Distance to geometry.
+    *         positive -> outside of to the geometry (for 2D and solids)
+    *         0        -> on/ in the geometry.
+    */
+    double CalculateDistance(
+        const CoordinatesArrayType& rPointGlobalCoordinates,
+        const double Tolerance = std::numeric_limits<double>::epsilon()
+        ) const override
+    {
+        const Point point(rPointGlobalCoordinates);
+        return GeometryUtils::PointDistanceToLineSegment3D(this->GetPoint(0), this->GetPoint(1), point);
+    }
 
     ///@}
     ///@name Jacobian
     ///@{
-
 
     /** Jacobians for given  method. This method
     calculate jacobians matrices in all integrations points of

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -15,8 +15,7 @@
 //                   Vicente Mataix Ferrandiz
 //
 
-#if !defined(KRATOS_TRIANGLE_3D_3_H_INCLUDED )
-#define  KRATOS_TRIANGLE_3D_3_H_INCLUDED
+#pragma once
 
 // System includes
 #include <iomanip>
@@ -28,6 +27,7 @@
 #include "geometries/line_3d_2.h"
 #include "integration/triangle_gauss_legendre_integration_points.h"
 #include "integration/triangle_collocation_integration_points.h"
+#include "utilities/geometry_utilities.h"
 #include "utilities/geometrical_projection_utilities.h"
 #include "utilities/intersection_utilities.h"
 
@@ -968,6 +968,31 @@ public:
         rResult(1) = eta;
 
         return rResult;
+    }
+
+    ///@}
+    ///@name Spatial Operations
+    ///@{
+
+    /**
+    * @brief Computes the distance between an point in
+    *        global coordinates and the closest point
+    *        of this geometry.
+    *        If projection fails, double::max will be returned.
+    * @param rPointGlobalCoordinates the point to which the
+    *        closest point has to be found.
+    * @param Tolerance accepted orthogonal error.
+    * @return Distance to geometry.
+    *         positive -> outside of to the geometry (for 2D and solids)
+    *         0        -> on/ in the geometry.
+    */
+    double CalculateDistance(
+        const CoordinatesArrayType& rPointGlobalCoordinates,
+        const double Tolerance = std::numeric_limits<double>::epsilon()
+        ) const override
+    {
+        const Point point(rPointGlobalCoordinates);
+        return GeometryUtils::PointDistanceToTriangle3D(this->GetPoint(0), this->GetPoint(1), this->GetPoint(2), point);
     }
 
     ///@}
@@ -2486,5 +2511,3 @@ template<class TPointType>
 const GeometryDimension Triangle3D3<TPointType>::msGeometryDimension(3, 2);
 
 }// namespace Kratos.
-
-#endif // KRATOS_QUADRILATERAL_3D_4_H_INCLUDED  defined


### PR DESCRIPTION
**📝 Description**

This PR modifies two files, `triangle_3d_3.h` and `line_3d_2.h`. In both files, the `CalculateDistance` method has been added to the respective geometry classes, `Triangle3D3` and `Line3D2`. This method computes the distance between a point in global coordinates and the closest point on the geometry. The implementation relies on `GeometryUtils` for distance calculations. In addition, the `triangle_3d_3.h` file has been refactored to use `#pragma once` instead of include guards.

**🆕 Changelog**

- [Define CalculateDistance for Triangle3D3](https://github.com/KratosMultiphysics/Kratos/commit/586f90670e91625fab3ab4b1748e4e8760fe4216)
- [Adding CalculateDistance to Line3D2](https://github.com/KratosMultiphysics/Kratos/commit/4d29b6ae5c597d435f176df1f8e1bbd9a6af0a90)
