### PR TITLE
[Core] Adding test for `Hexahedra3D20` and cleaning tests for `Hexahedra3D8`

### DIFF
--- a/kratos/tests/cpp_tests/geometries/test_hexahedra_3d_20.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_hexahedra_3d_20.cpp
@@ -1,0 +1,145 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "testing/testing.h"
+#include "geometries/hexahedra_3d_20.h"
+#include "tests/cpp_tests/geometries/test_geometry.h"
+#include "tests/cpp_tests/geometries/test_shape_function_derivatives.h"
+#include "tests/cpp_tests/geometries/cross_check_shape_functions_values.h"
+
+namespace Kratos::Testing
+{
+using PointType = Node<3>;
+using PointPtrType = Node<3>::Pointer;
+using HexaGeometryType = Hexahedra3D20<PointType>;
+using HexaGeometryPtrType = HexaGeometryType::Pointer;
+
+/** Generates a sample Hexahedra3D20.
+ * Generates a hexahedra defined by eight random points in the space.
+ * @return  Pointer to a Hexahedra3D20
+ */
+HexaGeometryPtrType GenerateHexahedra3D20(
+    PointPtrType PointA = GeneratePoint<PointType>(),
+    PointPtrType PointB = GeneratePoint<PointType>(),
+    PointPtrType PointC = GeneratePoint<PointType>(),
+    PointPtrType PointD = GeneratePoint<PointType>(),
+    PointPtrType PointE = GeneratePoint<PointType>(),
+    PointPtrType PointF = GeneratePoint<PointType>(),
+    PointPtrType PointG = GeneratePoint<PointType>(),
+    PointPtrType PointH = GeneratePoint<PointType>(),
+    PointPtrType PointI = GeneratePoint<PointType>(),
+    PointPtrType PointJ = GeneratePoint<PointType>(),
+    PointPtrType PointK = GeneratePoint<PointType>(),
+    PointPtrType PointM = GeneratePoint<PointType>(),
+    PointPtrType PointN = GeneratePoint<PointType>(),
+    PointPtrType PointO = GeneratePoint<PointType>(),
+    PointPtrType PointP = GeneratePoint<PointType>(),
+    PointPtrType PointQ = GeneratePoint<PointType>(),
+    PointPtrType PointR = GeneratePoint<PointType>(),
+    PointPtrType PointS = GeneratePoint<PointType>(),
+    PointPtrType PointT = GeneratePoint<PointType>(),
+    PointPtrType PointU = GeneratePoint<PointType>()) {
+  return HexaGeometryPtrType(new HexaGeometryType(PointA, PointB, PointC, PointD, PointE, PointF, PointG, PointH, PointI, PointJ, PointK, PointM, PointN, PointO, PointP, PointQ, PointR, PointS, PointT, PointU));
+}
+
+/** Generates a sample Hexahedra3D20.
+ * Generates a hexahedra with center on the origin with positive volume and side 1.
+ * @return  Pointer to a Hexahedra3D20
+ */
+HexaGeometryPtrType GenerateCanonicalHexahedra3D20()
+{
+  auto p1 = GeneratePoint<PointType>(0.0,1.0,1.0);
+  auto p2 = GeneratePoint<PointType>(0.0,1.0,0.5);
+  auto p3 = GeneratePoint<PointType>(0.5,1.0,1.0);
+  auto p4 = GeneratePoint<PointType>(0.0,0.5,1.0);
+  auto p5 = GeneratePoint<PointType>(0.0,0.0,1.0);
+  auto p6 = GeneratePoint<PointType>(1.0,1.0,1.0);
+  auto p7 = GeneratePoint<PointType>(0.0,1.0,0.0);
+  auto p8 = GeneratePoint<PointType>(1.0,0.5,1.0);
+  auto p9 = GeneratePoint<PointType>(1.0,1.0,0.5);
+  auto p10 = GeneratePoint<PointType>(0.0,0.0,0.5);
+  auto p11 = GeneratePoint<PointType>(0.5,1.0,0.0);
+  auto p12 = GeneratePoint<PointType>(0.0,0.5,0.0);
+  auto p13 = GeneratePoint<PointType>(0.5,0.0,1.0);
+  auto p14 = GeneratePoint<PointType>(1.0,1.0,0.0);
+  auto p15 = GeneratePoint<PointType>(1.0,0.0,1.0);
+  auto p16 = GeneratePoint<PointType>(0.0,0.0,0.0);
+  auto p17 = GeneratePoint<PointType>(0.5,0.0,0.0);
+  auto p18 = GeneratePoint<PointType>(1.0,0.5,0.0);
+  auto p19 = GeneratePoint<PointType>(1.0,0.0,0.5);
+  auto p20 = GeneratePoint<PointType>(1.0,0.0,0.0);
+  return HexaGeometryPtrType(new HexaGeometryType(p6, p1, p7, p14, p15, p5, p16, p20, p3, p2, p11, p9, p8, p4, p12, p18, p13, p10, p17, p19));
+}
+
+/** Checks if the number of edges is correct.
+ * Checks if the number of edges is correct.
+ */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D20EdgesNumber, KratosCoreGeometriesFastSuite)
+{
+  auto geom = GenerateCanonicalHexahedra3D20();
+
+  KRATOS_CHECK_EQUAL(geom->EdgesNumber(), 12);
+}
+
+/** Checks if the number of faces is correct.
+ * Checks if the number of faces is correct.
+ */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D20FacesNumber, KratosCoreGeometriesFastSuite)
+{
+  auto geom = GenerateCanonicalHexahedra3D20();
+
+  KRATOS_CHECK_EQUAL(geom->FacesNumber(), 6);
+}
+
+/** Checks if the characteristic length of the hexahedra is calculated correctly.
+ * Checks if the characteristic length of the hexahedra is calculated correctly.
+ */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D20Length, KratosCoreGeometriesFastSuite)
+{
+  auto geom = GenerateCanonicalHexahedra3D20();
+
+  KRATOS_CHECK_NEAR(geom->Length(), 0.353553, TOLERANCE);
+}
+
+/** Checks if the area of the hexahedra is calculated correctly.
+ * Checks if the area of the hexahedra is calculated correctly.
+ */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D20Area, KratosCoreGeometriesFastSuite)
+{
+  auto geom = GenerateCanonicalHexahedra3D20();
+
+  KRATOS_CHECK_NEAR(geom->Area(), 1.0, TOLERANCE);
+}
+
+/** Checks if the volume of the hexahedra is calculated correctly.
+ * Checks if the volume of the hexahedra is calculated correctly.
+ * For hexahedra 3D8 'volume()' call defaults to 'area()'
+ */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D20Volume, KratosCoreGeometriesFastSuite)
+{
+  auto geom = GenerateCanonicalHexahedra3D20();
+
+  KRATOS_CHECK_NEAR(geom->Volume(), 1.0, TOLERANCE);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D20ShapeFunctionsLocalGradients, KratosCoreGeometriesFastSuite)
+{
+    auto geom = GenerateCanonicalHexahedra3D20();
+    TestAllShapeFunctionsLocalGradients(*geom);
+}
+
+}  // namespace Kratos::Testing.

--- a/kratos/tests/cpp_tests/geometries/test_hexahedra_3d_20.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_hexahedra_3d_20.cpp
@@ -25,14 +25,14 @@ namespace Kratos::Testing
 {
 using PointType = Node<3>;
 using PointPtrType = Node<3>::Pointer;
-using HexaGeometryType = Hexahedra3D20<PointType>;
-using HexaGeometryPtrType = HexaGeometryType::Pointer;
+using Hexa20GeometryType = Hexahedra3D20<PointType>;
+using Hexa20GeometryPtrType = Hexa20GeometryType::Pointer;
 
 /** Generates a sample Hexahedra3D20.
  * Generates a hexahedra defined by eight random points in the space.
  * @return  Pointer to a Hexahedra3D20
  */
-HexaGeometryPtrType GenerateHexahedra3D20(
+Hexa20GeometryPtrType GenerateHexahedra3D20(
     PointPtrType PointA = GeneratePoint<PointType>(),
     PointPtrType PointB = GeneratePoint<PointType>(),
     PointPtrType PointC = GeneratePoint<PointType>(),
@@ -53,14 +53,14 @@ HexaGeometryPtrType GenerateHexahedra3D20(
     PointPtrType PointS = GeneratePoint<PointType>(),
     PointPtrType PointT = GeneratePoint<PointType>(),
     PointPtrType PointU = GeneratePoint<PointType>()) {
-  return HexaGeometryPtrType(new HexaGeometryType(PointA, PointB, PointC, PointD, PointE, PointF, PointG, PointH, PointI, PointJ, PointK, PointM, PointN, PointO, PointP, PointQ, PointR, PointS, PointT, PointU));
+  return Hexa20GeometryPtrType(new Hexa20GeometryType(PointA, PointB, PointC, PointD, PointE, PointF, PointG, PointH, PointI, PointJ, PointK, PointM, PointN, PointO, PointP, PointQ, PointR, PointS, PointT, PointU));
 }
 
 /** Generates a sample Hexahedra3D20.
  * Generates a hexahedra with center on the origin with positive volume and side 1.
  * @return  Pointer to a Hexahedra3D20
  */
-HexaGeometryPtrType GenerateCanonicalHexahedra3D20()
+Hexa20GeometryPtrType GenerateCanonicalHexahedra3D20()
 {
   auto p1 = GeneratePoint<PointType>(0.0,1.0,1.0);
   auto p2 = GeneratePoint<PointType>(0.0,1.0,0.5);
@@ -82,7 +82,7 @@ HexaGeometryPtrType GenerateCanonicalHexahedra3D20()
   auto p18 = GeneratePoint<PointType>(1.0,0.5,0.0);
   auto p19 = GeneratePoint<PointType>(1.0,0.0,0.5);
   auto p20 = GeneratePoint<PointType>(1.0,0.0,0.0);
-  return HexaGeometryPtrType(new HexaGeometryType(p6, p1, p7, p14, p15, p5, p16, p20, p3, p2, p11, p9, p8, p4, p12, p18, p13, p10, p17, p19));
+  return Hexa20GeometryPtrType(new Hexa20GeometryType(p6, p1, p7, p14, p15, p5, p16, p20, p3, p2, p11, p9, p8, p4, p12, p18, p13, p10, p17, p19));
 }
 
 /** Checks if the number of edges is correct.

--- a/kratos/tests/cpp_tests/geometries/test_hexahedra_3d_8.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_hexahedra_3d_8.cpp
@@ -4,15 +4,13 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Bodhinanda Chandra
 //
-//
 
 // System includes
-#include <set>
 
 // External includes
 
@@ -23,338 +21,354 @@
 #include "tests/cpp_tests/geometries/test_shape_function_derivatives.h"
 #include "tests/cpp_tests/geometries/cross_check_shape_functions_values.h"
 
-namespace Kratos {
-	namespace Testing {
+namespace Kratos::Testing 
+{
+using PointType = Node<3>;
+using PointPtrType = Node<3>::Pointer;
+using HexaGeometryType = Hexahedra3D8<PointType>;
+using HexaGeometryPtrType = HexaGeometryType::Pointer;
 
-    typedef Node<3>                   PointType;
-    typedef Node<3>::Pointer          PointPtrType;
-    typedef Hexahedra3D8<PointType>   HexaGeometryType;
-    typedef HexaGeometryType::Pointer HexaGeometryPtrType;
+/** Generates a sample Hexahedra3D8.
+ * Generates a hexahedra defined by eight random points in the space.
+ * @return  Pointer to a Hexahedra3D8
+ */
+HexaGeometryPtrType GenerateHexahedra3D8(
+    PointPtrType PointA = GeneratePoint<PointType>(),
+    PointPtrType PointB = GeneratePoint<PointType>(),
+    PointPtrType PointC = GeneratePoint<PointType>(),
+    PointPtrType PointD = GeneratePoint<PointType>(),
+    PointPtrType PointE = GeneratePoint<PointType>(),
+    PointPtrType PointF = GeneratePoint<PointType>(),
+    PointPtrType PointG = GeneratePoint<PointType>(),
+    PointPtrType PointH = GeneratePoint<PointType>()) {
+    return HexaGeometryPtrType(new HexaGeometryType(PointA, PointB, PointC, PointD, PointE, PointF, PointG, PointH));
+}
 
-    /** Generates a sample Hexahedra3D8.
-     * Generates a hexahedra defined by eight random points in the space.
-     * @return  Pointer to a Hexahedra3D8
-     */
-    HexaGeometryPtrType GenerateHexahedra3D8(
-        PointPtrType PointA = GeneratePoint<PointType>(),
-        PointPtrType PointB = GeneratePoint<PointType>(),
-        PointPtrType PointC = GeneratePoint<PointType>(),
-        PointPtrType PointD = GeneratePoint<PointType>(),
-        PointPtrType PointE = GeneratePoint<PointType>(),
-        PointPtrType PointF = GeneratePoint<PointType>(),
-        PointPtrType PointG = GeneratePoint<PointType>(),
-        PointPtrType PointH = GeneratePoint<PointType>()) {
-      return HexaGeometryPtrType(new HexaGeometryType(PointA, PointB, PointC, PointD, PointE, PointF, PointG, PointH));
+/** Generates a sample Hexahedra3D8.
+ * Generates a hexahedra with center on the origin with positive volume and side 1.
+ * @return  Pointer to a Hexahedra3D8
+ */
+HexaGeometryPtrType GenerateOriginCenterLen1Hexahedra3D8()
+{
+    return HexaGeometryPtrType(new HexaGeometryType(
+      GeneratePoint<PointType>(-0.5, -0.5, -0.5),
+      GeneratePoint<PointType>( 0.5, -0.5, -0.5),
+      GeneratePoint<PointType>( 0.5,  0.5, -0.5),
+      GeneratePoint<PointType>(-0.5,  0.5, -0.5),
+      GeneratePoint<PointType>(-0.5, -0.5,  0.5),
+      GeneratePoint<PointType>( 0.5, -0.5,  0.5),
+      GeneratePoint<PointType>( 0.5,  0.5,  0.5),
+      GeneratePoint<PointType>(-0.5,  0.5,  0.5)
+    ));
+}
+
+/** Generates a sample Hexahedra3D8.
+ * Generates a hexahedra with center on the origin with positive volume and side 2.
+ * @return  Pointer to a Hexahedra3D8
+ */
+HexaGeometryPtrType GenerateOriginCenterLen2Hexahedra3D8()
+{
+    return HexaGeometryPtrType(new HexaGeometryType(
+      GeneratePoint<PointType>(-1.0, -1.0, -1.0),
+      GeneratePoint<PointType>( 1.0, -1.0, -1.0),
+      GeneratePoint<PointType>( 1.0,  1.0, -1.0),
+      GeneratePoint<PointType>(-1.0,  1.0, -1.0),
+      GeneratePoint<PointType>(-1.0, -1.0,  1.0),
+      GeneratePoint<PointType>( 1.0, -1.0,  1.0),
+      GeneratePoint<PointType>( 1.0,  1.0,  1.0),
+      GeneratePoint<PointType>(-1.0,  1.0,  1.0)
+    ));
+}
+
+/** Generates a sample Hexahedra3D8.
+ * Generates a hexahedra with side 1 where faces are not parallel to main planes.
+ * @return  Pointer to a Hexahedra3D8
+ */
+HexaGeometryPtrType GenerateDeformedCenterLen1Hexahedra3D8()
+{
+    return HexaGeometryPtrType(new HexaGeometryType(
+      GeneratePoint<PointType>(-0.5, -0.5, -0.5),
+      GeneratePoint<PointType>( 0.5, -0.5, -0.5),
+      GeneratePoint<PointType>( 0.5,  0.5, -0.5),
+      GeneratePoint<PointType>(-0.5,  0.5, -0.5),
+      GeneratePoint<PointType>( 0.5, -0.5,  0.5),
+      GeneratePoint<PointType>( 1.5, -0.5,  0.5),
+      GeneratePoint<PointType>( 1.5,  0.5,  0.5),
+      GeneratePoint<PointType>( 0.5,  0.5,  0.5)
+    ));
+}
+
+/** Checks if the number of edges is correct.
+ * Checks if the number of edges is correct.
+ */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8EdgesNumber, KratosCoreGeometriesFastSuite)
+{
+    auto geomRegLen1 = GenerateOriginCenterLen1Hexahedra3D8();
+    auto geomRegLen2 = GenerateOriginCenterLen2Hexahedra3D8();
+
+    KRATOS_CHECK_EQUAL(geomRegLen1->EdgesNumber(), 12);
+    KRATOS_CHECK_EQUAL(geomRegLen2->EdgesNumber(), 12);
+}
+
+/** Checks if the number of faces is correct.
+ * Checks if the number of faces is correct.
+ */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8FacesNumber, KratosCoreGeometriesFastSuite)
+{
+    auto geomRegLen1 = GenerateOriginCenterLen1Hexahedra3D8();
+    auto geomRegLen2 = GenerateOriginCenterLen2Hexahedra3D8();
+
+    KRATOS_CHECK_EQUAL(geomRegLen1->FacesNumber(), 6);
+    KRATOS_CHECK_EQUAL(geomRegLen2->FacesNumber(), 6);
+}
+
+/** Checks if the characteristic length of the hexahedra is calculated correctly.
+ * Checks if the characteristic length of the hexahedra is calculated correctly.
+ */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8Length, KratosCoreGeometriesFastSuite)
+{
+    auto geomRegLen1 = GenerateOriginCenterLen1Hexahedra3D8();
+    auto geomRegLen2 = GenerateOriginCenterLen2Hexahedra3D8();
+
+    KRATOS_CHECK_NEAR(geomRegLen1->Length(), 0.353553, TOLERANCE);
+    KRATOS_CHECK_NEAR(geomRegLen2->Length(), 1.000000, TOLERANCE);
+}
+
+/** Checks if the area of the hexahedra is calculated correctly.
+ * Checks if the area of the hexahedra is calculated correctly.
+ */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8Area, KratosCoreGeometriesFastSuite)
+{
+    auto geomRegLen1 = GenerateOriginCenterLen1Hexahedra3D8();
+    auto geomRegLen2 = GenerateOriginCenterLen2Hexahedra3D8();
+
+    KRATOS_CHECK_NEAR(geomRegLen1->Area(), 1.0, TOLERANCE);
+    KRATOS_CHECK_NEAR(geomRegLen2->Area(), 8.0, TOLERANCE);
+}
+
+/** Checks if the volume of the hexahedra is calculated correctly.
+ * Checks if the volume of the hexahedra is calculated correctly.
+ * For hexahedra 3D8 'volume()' call defaults to 'area()'
+ */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8Volume, KratosCoreGeometriesFastSuite)
+{
+    auto geomRegLen1 = GenerateOriginCenterLen1Hexahedra3D8();
+    auto geomRegLen2 = GenerateOriginCenterLen2Hexahedra3D8();
+
+    KRATOS_CHECK_NEAR(geomRegLen1->Volume(), 1.0, TOLERANCE);
+    KRATOS_CHECK_NEAR(geomRegLen2->Volume(), 8.0, TOLERANCE);
+}
+
+/**
+ * This test performs the check of the box intersection method
+ */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8BoxIntersection, KratosCoreGeometriesFastSuite)
+{
+    auto hexahedron = GenerateOriginCenterLen1Hexahedra3D8();
+
+    //hexahedron inside the box
+    KRATOS_CHECK(hexahedron->HasIntersection(Point(-0.6,-0.6,-0.6), Point(0.6,0.6,0.6)));
+
+    //hexahedron contains the box
+    KRATOS_CHECK(hexahedron->HasIntersection(Point(-.25,-.25,-.25), Point(.25,.25,.25)));
+
+    //hexahedron intersects the box
+    KRATOS_CHECK(hexahedron->HasIntersection(Point(.25,.25,.25), Point(1.0,1.0,1.0)));
+
+    //hexahedron not intersects the box
+    KRATOS_CHECK_IS_FALSE(hexahedron->HasIntersection(Point(.51,.51,.51), Point(1.1,1.1,1.1)));
+}
+
+/** Checks the inside test for a given point respect to the hexahedra
+* Checks the inside test for a given point respect to the hexahedra
+* It performs 4 tests:
+* A Point inside the hexahedra: Expected result TRUE
+* A Point outside the hexahedra: Expected result FALSE
+* A Point over a vertex of the hexahedra: Expected result TRUE
+* A Point over an edge of the hexahedra: Expected result TRUE
+*/
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8IsInside, KratosCoreGeometriesFastSuite) 
+{
+    auto geom = GenerateOriginCenterLen1Hexahedra3D8();
+
+    Point PointInside(0.4999, 0.4999, 0.4999);
+    Point PointOutside(0.5001, 0.5001, 0.5001);
+    Point PointInVertex(-0.5, -0.5, -0.5);
+    Point PointInEdge(0.5, 0.5, 0.0);
+
+    Point LocalCoords;
+
+    KRATOS_CHECK(geom->IsInside(PointInside, LocalCoords, EPSILON));
+    KRATOS_CHECK_IS_FALSE(geom->IsInside(PointOutside, LocalCoords, EPSILON));
+    KRATOS_CHECK(geom->IsInside(PointInVertex, LocalCoords, EPSILON));
+    KRATOS_CHECK(geom->IsInside(PointInEdge, LocalCoords, EPSILON));
+}
+
+/** Checks the point local coordinates for a given point respect to the
+* hexahedra. The baricentre of the hexahedra is selected due to its known
+* solution.
+*/
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8PointLocalCoordinates, KratosCoreGeometriesFastSuite)
+{
+    auto geom = GenerateOriginCenterLen2Hexahedra3D8();
+
+    // Compute the global coordinates of the baricentre
+    auto points = geom->Points();
+    auto baricentre = Point{points[0] + points[1] + points[2] + points[3] + points[4] + points[5] + points[6] + points[7]};
+    baricentre /= 8.0;
+
+    // Compute the baricentre local coordinates
+    array_1d<double, 3> baricentre_local_coords;
+    geom->PointLocalCoordinates(baricentre_local_coords, baricentre);
+
+    KRATOS_CHECK_NEAR(baricentre_local_coords(0), 0.0, TOLERANCE);
+    KRATOS_CHECK_NEAR(baricentre_local_coords(1), 0.0, TOLERANCE);
+    KRATOS_CHECK_NEAR(baricentre_local_coords(2), 0.0, TOLERANCE);
+
+    Point baricentre_face_1;
+    baricentre_face_1.Coordinates()[0] = 1.0;
+    baricentre_face_1.Coordinates()[1] = 0.0;
+    baricentre_face_1.Coordinates()[2] = 0.0;
+
+    // Compute the baricentre local coordinates
+    array_1d<double, 3> baricentre_local_coords_face_1;
+    geom->PointLocalCoordinates(baricentre_local_coords_face_1, baricentre_face_1);
+
+    KRATOS_CHECK_NEAR(baricentre_local_coords_face_1(0), 1.0, TOLERANCE);
+    KRATOS_CHECK_NEAR(baricentre_local_coords_face_1(1), 0.0, TOLERANCE);
+    KRATOS_CHECK_NEAR(baricentre_local_coords_face_1(2), 0.0, TOLERANCE);
+
+    Point baricentre_face_2;
+    baricentre_face_2.Coordinates()[0] =  0.0;
+    baricentre_face_2.Coordinates()[1] = -1.0;
+    baricentre_face_2.Coordinates()[2] =  0.0;
+
+    // Compute the baricentre local coordinates
+    array_1d<double, 3> baricentre_local_coords_face_2;
+    geom->PointLocalCoordinates(baricentre_local_coords_face_2, baricentre_face_2);
+
+    KRATOS_CHECK_NEAR(baricentre_local_coords_face_2(0), 0.0, TOLERANCE);
+    KRATOS_CHECK_NEAR(baricentre_local_coords_face_2(1),-1.0, TOLERANCE);
+    KRATOS_CHECK_NEAR(baricentre_local_coords_face_2(2), 0.0, TOLERANCE);
+
+    Point baricentre_face_3;
+    baricentre_face_3.Coordinates()[0] = 0.0;
+    baricentre_face_3.Coordinates()[1] = 0.3;
+    baricentre_face_3.Coordinates()[2] = 1.0;
+
+    // Compute the baricentre local coordinates
+    array_1d<double, 3> baricentre_local_coords_face_3;
+    geom->PointLocalCoordinates(baricentre_local_coords_face_3, baricentre_face_3);
+
+    KRATOS_CHECK_NEAR(baricentre_local_coords_face_3(0), 0.0, TOLERANCE);
+    KRATOS_CHECK_NEAR(baricentre_local_coords_face_3(1), 0.3, TOLERANCE);
+    KRATOS_CHECK_NEAR(baricentre_local_coords_face_3(2), 1.0, TOLERANCE);
+
+    Point outside_point;
+    outside_point.Coordinates()[0] = 1.0;
+    outside_point.Coordinates()[1] = 1.0;
+    outside_point.Coordinates()[2] = 1.0;
+
+    // Compute the baricentre local coordinates
+    array_1d<double, 3> local_coords_outside_point;
+    geom->PointLocalCoordinates(local_coords_outside_point, outside_point);
+
+    KRATOS_CHECK_NEAR(local_coords_outside_point(0), 1.0, TOLERANCE);
+    KRATOS_CHECK_NEAR(local_coords_outside_point(1), 1.0, TOLERANCE);
+    KRATOS_CHECK_NEAR(local_coords_outside_point(2), 1.0, TOLERANCE);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8ShapeFunctionsValues, KratosCoreGeometriesFastSuite)
+{
+    auto geom = GenerateOriginCenterLen2Hexahedra3D8();
+    array_1d<double, 3> coord(3);
+    coord[0] = 1.0 / 2.0;
+    coord[1] = 1.0 / 4.0;
+    coord[2] = 1.0 / 16.0;
+    KRATOS_CHECK_NEAR(geom->ShapeFunctionValue(0, coord), 0.0439453125, TOLERANCE);
+    KRATOS_CHECK_NEAR(geom->ShapeFunctionValue(1, coord), 0.1318359375, TOLERANCE);
+    KRATOS_CHECK_NEAR(geom->ShapeFunctionValue(2, coord), 0.2197265625, TOLERANCE);
+    KRATOS_CHECK_NEAR(geom->ShapeFunctionValue(3, coord), 0.0732421875, TOLERANCE);
+    KRATOS_CHECK_NEAR(geom->ShapeFunctionValue(4, coord), 0.0498046875, TOLERANCE);
+    KRATOS_CHECK_NEAR(geom->ShapeFunctionValue(5, coord), 0.1494140625, TOLERANCE);
+    KRATOS_CHECK_NEAR(geom->ShapeFunctionValue(6, coord), 0.2490234375, TOLERANCE);
+    KRATOS_CHECK_NEAR(geom->ShapeFunctionValue(7, coord), 0.0830078125, TOLERANCE);
+    CrossCheckShapeFunctionsValues(*geom);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8ShapeFunctionsLocalGradients, KratosCoreGeometriesFastSuite)
+{
+    auto geom = GenerateOriginCenterLen2Hexahedra3D8();
+    TestAllShapeFunctionsLocalGradients(*geom);
+}
+
+/** Checks the average edge length */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8AverageEdgeLength, KratosCoreGeometriesFastSuite)
+{
+    auto geom = GenerateOriginCenterLen2Hexahedra3D8();
+    KRATOS_CHECK_NEAR(geom->AverageEdgeLength(), 2.0, TOLERANCE);
+}
+
+/** Checks the solid angles */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8SolidAngles, KratosCoreGeometriesFastSuite)
+{
+    auto geom = GenerateOriginCenterLen2Hexahedra3D8();
+    Vector solid_angles;
+    geom->ComputeSolidAngles(solid_angles);
+    for (int i = 0; i < 8; i++) {
+      KRATOS_CHECK_NEAR(solid_angles[i], Globals::Pi/2.0, TOLERANCE);
     }
 
-    /** Generates a sample Hexahedra3D8.
-     * Generates a hexahedra with center on the origin with positive volume and side 1.
-     * @return  Pointer to a Hexahedra3D8
-     */
-    HexaGeometryPtrType GenerateOriginCenterLen1Hexahedra3D8() {
-      return HexaGeometryPtrType(new HexaGeometryType(
-        GeneratePoint<PointType>(-0.5, -0.5, -0.5),
-        GeneratePoint<PointType>( 0.5, -0.5, -0.5),
-        GeneratePoint<PointType>( 0.5,  0.5, -0.5),
-        GeneratePoint<PointType>(-0.5,  0.5, -0.5),
-        GeneratePoint<PointType>(-0.5, -0.5,  0.5),
-        GeneratePoint<PointType>( 0.5, -0.5,  0.5),
-        GeneratePoint<PointType>( 0.5,  0.5,  0.5),
-        GeneratePoint<PointType>(-0.5,  0.5,  0.5)
-      ));
-    }
+    auto geom2 = GenerateDeformedCenterLen1Hexahedra3D8();
+    geom2->ComputeSolidAngles(solid_angles);
+    constexpr double pi = Globals::Pi; 
+    std::vector<double> result_solid_angles = {
+      pi*0.25, pi*0.75, pi*0.75, pi*0.25,
+      pi*0.75, pi*0.25, pi*0.25, pi*0.75
+    };
+    KRATOS_CHECK_VECTOR_NEAR(solid_angles, result_solid_angles, TOLERANCE);
+}
 
-    /** Generates a sample Hexahedra3D8.
-     * Generates a hexahedra with center on the origin with positive volume and side 2.
-     * @return  Pointer to a Hexahedra3D8
-     */
-    HexaGeometryPtrType GenerateOriginCenterLen2Hexahedra3D8() {
-      return HexaGeometryPtrType(new HexaGeometryType(
-        GeneratePoint<PointType>(-1.0, -1.0, -1.0),
-        GeneratePoint<PointType>( 1.0, -1.0, -1.0),
-        GeneratePoint<PointType>( 1.0,  1.0, -1.0),
-        GeneratePoint<PointType>(-1.0,  1.0, -1.0),
-        GeneratePoint<PointType>(-1.0, -1.0,  1.0),
-        GeneratePoint<PointType>( 1.0, -1.0,  1.0),
-        GeneratePoint<PointType>( 1.0,  1.0,  1.0),
-        GeneratePoint<PointType>(-1.0,  1.0,  1.0)
-      ));
-    }
+/** Checks the diahedral angles */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8DihedralAngles, KratosCoreGeometriesFastSuite)
+{
+    auto geom = GenerateDeformedCenterLen1Hexahedra3D8();
+    Vector diahedral_angles;
+    geom->ComputeDihedralAngles(diahedral_angles);
+    constexpr double pi = Globals::Pi; 
+    std::vector<double> result_diahedral_angles = {
+      pi*0.5, pi*0.25, pi*0.5,
+      pi*0.5, pi*0.75, pi*0.5,
+      pi*0.5, pi*0.75, pi*0.5,
+      pi*0.5, pi*0.25, pi*0.5,
+      pi*0.5, pi*0.75, pi*0.5,
+      pi*0.5, pi*0.25, pi*0.5,
+      pi*0.5, pi*0.25, pi*0.5,
+      pi*0.5, pi*0.75, pi*0.5
+    };
+    KRATOS_CHECK_VECTOR_NEAR(diahedral_angles, result_diahedral_angles, TOLERANCE);
 
-    /** Generates a sample Hexahedra3D8.
-     * Generates a hexahedra with side 1 where faces are not parallel to main planes.
-     * @return  Pointer to a Hexahedra3D8
-     */
-    HexaGeometryPtrType GenerateDeformedCenterLen1Hexahedra3D8() {
-      return HexaGeometryPtrType(new HexaGeometryType(
-        GeneratePoint<PointType>(-0.5, -0.5, -0.5),
-        GeneratePoint<PointType>( 0.5, -0.5, -0.5),
-        GeneratePoint<PointType>( 0.5,  0.5, -0.5),
-        GeneratePoint<PointType>(-0.5,  0.5, -0.5),
-        GeneratePoint<PointType>( 0.5, -0.5,  0.5),
-        GeneratePoint<PointType>( 1.5, -0.5,  0.5),
-        GeneratePoint<PointType>( 1.5,  0.5,  0.5),
-        GeneratePoint<PointType>( 0.5,  0.5,  0.5)
-      ));
-    }
+    double min_dihedral = geom->MinDihedralAngle();
+    KRATOS_CHECK_NEAR(min_dihedral, 0.25*pi, TOLERANCE);
+    double max_dihedral = geom->MaxDihedralAngle();
+    KRATOS_CHECK_NEAR(max_dihedral, 0.75*pi, TOLERANCE);
+}
 
-    /** Checks if the number of edges is correct.
-     * Checks if the number of edges is correct.
-     */
-    KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8EdgesNumber, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateOriginCenterLen1Hexahedra3D8();
-      auto geomRegLen2 = GenerateOriginCenterLen2Hexahedra3D8();
+/** Checks the VolumeToRMSEdgeLength */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8VolumeToRMSEdgeLength, KratosCoreGeometriesFastSuite)
+{
+    auto geom = GenerateOriginCenterLen1Hexahedra3D8();
+    KRATOS_CHECK_NEAR(geom->VolumeToRMSEdgeLength(), 1.0, TOLERANCE);
+    auto geom_2 = GenerateDeformedCenterLen1Hexahedra3D8();
+    KRATOS_CHECK_NEAR(geom_2->VolumeToRMSEdgeLength(), 0.6495190528383, TOLERANCE);
+}
 
-      KRATOS_CHECK_EQUAL(geomRegLen1->EdgesNumber(), 12);
-      KRATOS_CHECK_EQUAL(geomRegLen2->EdgesNumber(), 12);
-    }
-
-    /** Checks if the number of faces is correct.
-     * Checks if the number of faces is correct.
-     */
-    KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8FacesNumber, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateOriginCenterLen1Hexahedra3D8();
-      auto geomRegLen2 = GenerateOriginCenterLen2Hexahedra3D8();
-
-      KRATOS_CHECK_EQUAL(geomRegLen1->FacesNumber(), 6);
-      KRATOS_CHECK_EQUAL(geomRegLen2->FacesNumber(), 6);
-    }
-
-    /** Checks if the characteristic length of the hexahedra is calculated correctly.
-     * Checks if the characteristic length of the hexahedra is calculated correctly.
-     */
-    KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8Length, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateOriginCenterLen1Hexahedra3D8();
-      auto geomRegLen2 = GenerateOriginCenterLen2Hexahedra3D8();
-
-      KRATOS_CHECK_NEAR(geomRegLen1->Length(), 0.353553, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen2->Length(), 1.000000, TOLERANCE);
-    }
-
-    /** Checks if the area of the hexahedra is calculated correctly.
-     * Checks if the area of the hexahedra is calculated correctly.
-     */
-    KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8Area, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateOriginCenterLen1Hexahedra3D8();
-      auto geomRegLen2 = GenerateOriginCenterLen2Hexahedra3D8();
-
-      KRATOS_CHECK_NEAR(geomRegLen1->Area(), 1.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen2->Area(), 8.0, TOLERANCE);
-    }
-
-    /** Checks if the volume of the hexahedra is calculated correctly.
-     * Checks if the volume of the hexahedra is calculated correctly.
-     * For hexahedra 3D8 'volume()' call defaults to 'area()'
-     */
-    KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8Volume, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateOriginCenterLen1Hexahedra3D8();
-      auto geomRegLen2 = GenerateOriginCenterLen2Hexahedra3D8();
-
-      KRATOS_CHECK_NEAR(geomRegLen1->Volume(), 1.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen2->Volume(), 8.0, TOLERANCE);
-  	}
-
-    /**
-     * This test performs the check of the box intersection method
-     */
-    KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8BoxIntersection, KratosCoreGeometriesFastSuite) {
-      auto hexahedron = GenerateOriginCenterLen1Hexahedra3D8();
-
-      //hexahedron inside the box
-      KRATOS_CHECK(hexahedron->HasIntersection(Point(-0.6,-0.6,-0.6), Point(0.6,0.6,0.6)));
-
-      //hexahedron contains the box
-      KRATOS_CHECK(hexahedron->HasIntersection(Point(-.25,-.25,-.25), Point(.25,.25,.25)));
-
-      //hexahedron intersects the box
-      KRATOS_CHECK(hexahedron->HasIntersection(Point(.25,.25,.25), Point(1.0,1.0,1.0)));
-
-      //hexahedron not intersects the box
-      KRATOS_CHECK_IS_FALSE(hexahedron->HasIntersection(Point(.51,.51,.51), Point(1.1,1.1,1.1)));
-    }
-
-    /** Checks the inside test for a given point respect to the hexahedra
-    * Checks the inside test for a given point respect to the hexahedra
-    * It performs 4 tests:
-    * A Point inside the hexahedra: Expected result TRUE
-    * A Point outside the hexahedra: Expected result FALSE
-    * A Point over a vertex of the hexahedra: Expected result TRUE
-    * A Point over an edge of the hexahedra: Expected result TRUE
-    */
-    KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8IsInside, KratosCoreGeometriesFastSuite) {
-        auto geom = GenerateOriginCenterLen1Hexahedra3D8();
-
-        Point PointInside(0.4999, 0.4999, 0.4999);
-        Point PointOutside(0.5001, 0.5001, 0.5001);
-        Point PointInVertex(-0.5, -0.5, -0.5);
-        Point PointInEdge(0.5, 0.5, 0.0);
-
-        Point LocalCoords;
-
-        KRATOS_CHECK(geom->IsInside(PointInside, LocalCoords, EPSILON));
-        KRATOS_CHECK_IS_FALSE(geom->IsInside(PointOutside, LocalCoords, EPSILON));
-        KRATOS_CHECK(geom->IsInside(PointInVertex, LocalCoords, EPSILON));
-        KRATOS_CHECK(geom->IsInside(PointInEdge, LocalCoords, EPSILON));
-    }
-
-    /** Checks the point local coordinates for a given point respect to the
-    * hexahedra. The baricentre of the hexahedra is selected due to its known
-    * solution.
-    */
-    KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8PointLocalCoordinates, KratosCoreGeometriesFastSuite) {
-        auto geom = GenerateOriginCenterLen2Hexahedra3D8();
-
-        // Compute the global coordinates of the baricentre
-        auto points = geom->Points();
-        auto baricentre = Point{points[0] + points[1] + points[2] + points[3] + points[4] + points[5] + points[6] + points[7]};
-        baricentre /= 8.0;
-
-        // Compute the baricentre local coordinates
-        array_1d<double, 3> baricentre_local_coords;
-        geom->PointLocalCoordinates(baricentre_local_coords, baricentre);
-
-        KRATOS_CHECK_NEAR(baricentre_local_coords(0), 0.0, TOLERANCE);
-        KRATOS_CHECK_NEAR(baricentre_local_coords(1), 0.0, TOLERANCE);
-        KRATOS_CHECK_NEAR(baricentre_local_coords(2), 0.0, TOLERANCE);
-
-        Point baricentre_face_1;
-        baricentre_face_1.Coordinates()[0] = 1.0;
-        baricentre_face_1.Coordinates()[1] = 0.0;
-        baricentre_face_1.Coordinates()[2] = 0.0;
-
-        // Compute the baricentre local coordinates
-        array_1d<double, 3> baricentre_local_coords_face_1;
-        geom->PointLocalCoordinates(baricentre_local_coords_face_1, baricentre_face_1);
-
-        KRATOS_CHECK_NEAR(baricentre_local_coords_face_1(0), 1.0, TOLERANCE);
-        KRATOS_CHECK_NEAR(baricentre_local_coords_face_1(1), 0.0, TOLERANCE);
-        KRATOS_CHECK_NEAR(baricentre_local_coords_face_1(2), 0.0, TOLERANCE);
-
-        Point baricentre_face_2;
-        baricentre_face_2.Coordinates()[0] =  0.0;
-        baricentre_face_2.Coordinates()[1] = -1.0;
-        baricentre_face_2.Coordinates()[2] =  0.0;
-
-        // Compute the baricentre local coordinates
-        array_1d<double, 3> baricentre_local_coords_face_2;
-        geom->PointLocalCoordinates(baricentre_local_coords_face_2, baricentre_face_2);
-
-        KRATOS_CHECK_NEAR(baricentre_local_coords_face_2(0), 0.0, TOLERANCE);
-        KRATOS_CHECK_NEAR(baricentre_local_coords_face_2(1),-1.0, TOLERANCE);
-        KRATOS_CHECK_NEAR(baricentre_local_coords_face_2(2), 0.0, TOLERANCE);
-
-        Point baricentre_face_3;
-        baricentre_face_3.Coordinates()[0] = 0.0;
-        baricentre_face_3.Coordinates()[1] = 0.3;
-        baricentre_face_3.Coordinates()[2] = 1.0;
-
-        // Compute the baricentre local coordinates
-        array_1d<double, 3> baricentre_local_coords_face_3;
-        geom->PointLocalCoordinates(baricentre_local_coords_face_3, baricentre_face_3);
-
-        KRATOS_CHECK_NEAR(baricentre_local_coords_face_3(0), 0.0, TOLERANCE);
-        KRATOS_CHECK_NEAR(baricentre_local_coords_face_3(1), 0.3, TOLERANCE);
-        KRATOS_CHECK_NEAR(baricentre_local_coords_face_3(2), 1.0, TOLERANCE);
-
-        Point outside_point;
-        outside_point.Coordinates()[0] = 1.0;
-        outside_point.Coordinates()[1] = 1.0;
-        outside_point.Coordinates()[2] = 1.0;
-
-        // Compute the baricentre local coordinates
-        array_1d<double, 3> local_coords_outside_point;
-        geom->PointLocalCoordinates(local_coords_outside_point, outside_point);
-
-        KRATOS_CHECK_NEAR(local_coords_outside_point(0), 1.0, TOLERANCE);
-        KRATOS_CHECK_NEAR(local_coords_outside_point(1), 1.0, TOLERANCE);
-        KRATOS_CHECK_NEAR(local_coords_outside_point(2), 1.0, TOLERANCE);
-    }
-
-  KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8ShapeFunctionsValues, KratosCoreGeometriesFastSuite) {
-      auto geom = GenerateOriginCenterLen2Hexahedra3D8();
-      array_1d<double, 3> coord(3);
-      coord[0] = 1.0 / 2.0;
-      coord[1] = 1.0 / 4.0;
-      coord[2] = 1.0 / 16.0;
-      KRATOS_CHECK_NEAR(geom->ShapeFunctionValue(0, coord), 0.0439453125, TOLERANCE);
-      KRATOS_CHECK_NEAR(geom->ShapeFunctionValue(1, coord), 0.1318359375, TOLERANCE);
-      KRATOS_CHECK_NEAR(geom->ShapeFunctionValue(2, coord), 0.2197265625, TOLERANCE);
-      KRATOS_CHECK_NEAR(geom->ShapeFunctionValue(3, coord), 0.0732421875, TOLERANCE);
-      KRATOS_CHECK_NEAR(geom->ShapeFunctionValue(4, coord), 0.0498046875, TOLERANCE);
-      KRATOS_CHECK_NEAR(geom->ShapeFunctionValue(5, coord), 0.1494140625, TOLERANCE);
-      KRATOS_CHECK_NEAR(geom->ShapeFunctionValue(6, coord), 0.2490234375, TOLERANCE);
-      KRATOS_CHECK_NEAR(geom->ShapeFunctionValue(7, coord), 0.0830078125, TOLERANCE);
-      CrossCheckShapeFunctionsValues(*geom);
-  }
-
-  KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8ShapeFunctionsLocalGradients, KratosCoreGeometriesFastSuite) {
-      auto geom = GenerateOriginCenterLen2Hexahedra3D8();
-      TestAllShapeFunctionsLocalGradients(*geom);
-  }
-
-    /** Checks the average edge length */
-    KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8AverageEdgeLength, KratosCoreGeometriesFastSuite) {
-        auto geom = GenerateOriginCenterLen2Hexahedra3D8();
-        KRATOS_CHECK_NEAR(geom->AverageEdgeLength(), 2.0, TOLERANCE);
-    }
-
-    /** Checks the solid angles */
-    KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8SolidAngles, KratosCoreGeometriesFastSuite) {
-        auto geom = GenerateOriginCenterLen2Hexahedra3D8();
-        Vector solid_angles;
-        geom->ComputeSolidAngles(solid_angles);
-        for (int i = 0; i < 8; i++) {
-          KRATOS_CHECK_NEAR(solid_angles[i], Globals::Pi/2.0, TOLERANCE);
-        }
-
-        auto geom2 = GenerateDeformedCenterLen1Hexahedra3D8();
-        geom2->ComputeSolidAngles(solid_angles);
-        constexpr double pi = Globals::Pi; 
-        std::vector<double> result_solid_angles = {
-          pi*0.25, pi*0.75, pi*0.75, pi*0.25,
-          pi*0.75, pi*0.25, pi*0.25, pi*0.75
-        };
-        KRATOS_CHECK_VECTOR_NEAR(solid_angles, result_solid_angles, TOLERANCE);
-    }
-
-    /** Checks the diahedral angles */
-    KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8DihedralAngles, KratosCoreGeometriesFastSuite) {
-        auto geom = GenerateDeformedCenterLen1Hexahedra3D8();
-        Vector diahedral_angles;
-        geom->ComputeDihedralAngles(diahedral_angles);
-        constexpr double pi = Globals::Pi; 
-        std::vector<double> result_diahedral_angles = {
-          pi*0.5, pi*0.25, pi*0.5,
-          pi*0.5, pi*0.75, pi*0.5,
-          pi*0.5, pi*0.75, pi*0.5,
-          pi*0.5, pi*0.25, pi*0.5,
-          pi*0.5, pi*0.75, pi*0.5,
-          pi*0.5, pi*0.25, pi*0.5,
-          pi*0.5, pi*0.25, pi*0.5,
-          pi*0.5, pi*0.75, pi*0.5
-        };
-        KRATOS_CHECK_VECTOR_NEAR(diahedral_angles, result_diahedral_angles, TOLERANCE);
-
-        double min_dihedral = geom->MinDihedralAngle();
-        KRATOS_CHECK_NEAR(min_dihedral, 0.25*pi, TOLERANCE);
-        double max_dihedral = geom->MaxDihedralAngle();
-        KRATOS_CHECK_NEAR(max_dihedral, 0.75*pi, TOLERANCE);
-    }
-
-    /** Checks the VolumeToRMSEdgeLength */
-    KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8VolumeToRMSEdgeLength, KratosCoreGeometriesFastSuite) {
-        auto geom = GenerateOriginCenterLen1Hexahedra3D8();
-        KRATOS_CHECK_NEAR(geom->VolumeToRMSEdgeLength(), 1.0, TOLERANCE);
-        auto geom_2 = GenerateDeformedCenterLen1Hexahedra3D8();
-        KRATOS_CHECK_NEAR(geom_2->VolumeToRMSEdgeLength(), 0.6495190528383, TOLERANCE);
-    }
-
-    /** Checks the VolumeToRMSEdgeLength */
-    KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8ShortestToLongestEdgeQuality, KratosCoreGeometriesFastSuite) {
-        auto geom = GenerateOriginCenterLen1Hexahedra3D8();
-        KRATOS_CHECK_NEAR(geom->ShortestToLongestEdgeQuality(), 1.0, TOLERANCE);
-        auto geom_2 = GenerateDeformedCenterLen1Hexahedra3D8();
-        KRATOS_CHECK_NEAR(geom_2->ShortestToLongestEdgeQuality(), 0.70710678118, TOLERANCE);
-    }
-	}
-}  // namespace Kratos.
+/** Checks the VolumeToRMSEdgeLength */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8ShortestToLongestEdgeQuality, KratosCoreGeometriesFastSuite)
+{
+    auto geom = GenerateOriginCenterLen1Hexahedra3D8();
+    KRATOS_CHECK_NEAR(geom->ShortestToLongestEdgeQuality(), 1.0, TOLERANCE);
+    auto geom_2 = GenerateDeformedCenterLen1Hexahedra3D8();
+    KRATOS_CHECK_NEAR(geom_2->ShortestToLongestEdgeQuality(), 0.70710678118, TOLERANCE);
+}
+}  // namespace Kratos::Testing.


### PR DESCRIPTION
**📝 Description**

This PR introduces tests for the `Hexahedra3D20` geometry and updates the existing tests for `Hexahedra3D8` geometry. The changes include the creation of a new test file for `Hexahedra3D20`. 

The tests cover various aspects of the geometries, such as volume calculation, face number, intersection, shape function values, and quality metrics like shortest to longest edge quality and volume to RMS edge length.

The existing test file for `Hexahedra3D8` has been cleaned up. 

**🆕 Changelog**

- [Adding test for Hexahedra3D20 and cleaning tests for `Hexahedra3D8`](https://github.com/KratosMultiphysics/Kratos/commit/fad71140315f359c27c2f3dbf35acc4dbf6cf5eb)
