### PR TITLE
[StructuralMechanicsApplication] Adding test for quadratic triangles

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_small_strain.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_small_strain.py
@@ -23,7 +23,6 @@ class TestPatchTestSmallStrain(KratosUnittest.TestCase):
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.REACTION)
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.VOLUME_ACCELERATION)
 
-
     def _apply_BCs(self,mp,A,b):
         for node in mp.Nodes:
             node.Fix(KratosMultiphysics.DISPLACEMENT_X)
@@ -291,6 +290,43 @@ class TestPatchTestSmallStrain(KratosUnittest.TestCase):
                     self.assertAlmostEqual(M[i*dim+k,j*dim+k],coeff)
 
         #self.__post_process(mp)
+
+    def test_SmallDisplacementElement_2D_triangle_quadratic(self):
+        dim = 2
+        current_model = KratosMultiphysics.Model()
+        mp = current_model.CreateModelPart("solid_part")
+        self._add_variables(mp)
+        self._apply_material_properties(mp,dim)
+
+        # Create nodes
+        mp.CreateNewNode(1,1.0,0.0,0.0)
+        mp.CreateNewNode(2,0.5,0.0,0.0)
+        mp.CreateNewNode(3,1.0,0.5,0.0)
+        mp.CreateNewNode(4,0.5,0.5,0.0)
+        mp.CreateNewNode(5,0.0,0.0,0.0)
+        mp.CreateNewNode(6,1.0,1.0,0.0)
+        mp.CreateNewNode(7,0.5,1.0,0.0)
+        mp.CreateNewNode(8,0.0,0.5,0.0)
+        mp.CreateNewNode(9,0.0,1.0,0.0)
+
+        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.DISPLACEMENT_X, KratosMultiphysics.REACTION_X,mp)
+        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.DISPLACEMENT_Y, KratosMultiphysics.REACTION_Y,mp)
+        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.DISPLACEMENT_Z, KratosMultiphysics.REACTION_Z,mp)
+
+        #create a submodelpart for boundary conditions
+        bcs = mp.CreateSubModelPart("BoundaryCondtions")
+        bcs.AddNodes([1,2,3,5,6,7,8,9])
+
+        # Create Element
+        mp.CreateNewElement("SmallDisplacementElement2D6N", 1, [5,1,9,2,4,8], mp.GetProperties()[1])
+        mp.CreateNewElement("SmallDisplacementElement2D6N", 2, [1,6,9,3,7,4], mp.GetProperties()[1]) 
+
+        A,b = self._define_movement(dim)
+
+        self._apply_BCs(bcs,A,b)
+        self._solve(mp)
+        self._check_results(mp,A,b)
+        self._check_outputs(mp,A,dim)
 
     def test_SmallDisplacementElement_2D_quadrilateral(self):
         dim = 2


### PR DESCRIPTION
**📝 Description**

This PR adds a new test function `test_SmallDisplacementElement_2D_triangle_quadratic` in the `test_patch_test_small_strain.py` file. The test function creates a model part with quadratic 2D triangle elements (`SmallDisplacementElement2D6N`) and sets up the necessary boundary conditions. The test function then applies the movements, solves the system, and checks the results and outputs.

**🆕 Changelog**

- [Tests for quadratic triangles](https://github.com/KratosMultiphysics/Kratos/commit/37d5225c10cf32fcdc0056a5efab2441d7d39bfe)
