### PR TITLE
Fixing some tests that fail when mpi size is 1.

### DIFF
--- a/kratos/mpi/tests/cpp_tests/sources/test_debug_utilities.cpp
+++ b/kratos/mpi/tests/cpp_tests/sources/test_debug_utilities.cpp
@@ -61,6 +61,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableFix
 {
     const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
     const int world_size = r_comm.Size();
+    KRATOS_SKIP_TEST_IF(world_size == 1);
 
     Model model;
     ModelPart& model_part = model.CreateModelPart("ConsistentModelPart");
@@ -92,6 +93,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableVal
     const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
     const int world_rank = r_comm.Rank();
     const int world_size = r_comm.Size();
+    KRATOS_SKIP_TEST_IF(world_size == 1);
 
     Model model;
     ModelPart& model_part = model.CreateModelPart("ConsistentModelPart");
@@ -125,6 +127,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableFix
     const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
     const int world_rank = r_comm.Rank();
     const int world_size = r_comm.Size();
+    KRATOS_SKIP_TEST_IF(world_size == 1);
 
     Model model;
     ModelPart& model_part = model.CreateModelPart("ConsistentModelPart");
@@ -161,6 +164,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleHistoricalVariableCom
     const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
     const int world_rank = r_comm.Rank();
     const int world_size = r_comm.Size();
+    KRATOS_SKIP_TEST_IF(world_size == 1);
 
     Model model;
     ModelPart& model_part = model.CreateModelPart("ConsistentModelPart");
@@ -224,6 +228,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(DebugToolsCheckSingleNonHistoricalVariable
     const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
     const int world_rank = r_comm.Rank();
     const int world_size = r_comm.Size();
+    KRATOS_SKIP_TEST_IF(world_size == 1);
 
     Model model;
     ModelPart& model_part = model.CreateModelPart("ConsistentModelPart");

--- a/kratos/mpi/tests/cpp_tests/sources/test_mpi_assign_unique_model_part_collection_tag_utility.cpp
+++ b/kratos/mpi/tests/cpp_tests/sources/test_mpi_assign_unique_model_part_collection_tag_utility.cpp
@@ -63,7 +63,7 @@ namespace Kratos
             r_sub_modelpart_4.AddNode(r_model_part.pGetNode(6));
 
             // Adding nodes to random submodelparts
-            if (r_data_communicator.IsDistributed()) {
+            if (r_data_communicator.IsDistributed() && size > 1) {
                 if (rank == 0) {
                     r_sub_modelpart_3.AddNode(r_model_part.pGetNode(4));
                 }


### PR DESCRIPTION
**📝 Description**
Some MPI tests are currently failing when run with `mpirun -np 1` and I understand that it is just because these tests are not designed to work that way. I tried to skip or adjust them as appropriate.

**🆕 Changelog**
- Fixed some tests MPI that were failing when run on a single process
