### PR TITLE
[Core] Cleaning `bounding_box.h`

### DIFF
--- a/kratos/geometries/bounding_box.h
+++ b/kratos/geometries/bounding_box.h
@@ -51,10 +51,8 @@ public:
     /// Default constructor
     BoundingBox()
     {
-        for (unsigned int i = 0; i < Dimension; i++) {
-            GetMinPoint()[i] = 0.0;
-            GetMaxPoint()[i] = 0.0;
-        }
+        std::fill(GetMinPoint().begin(), GetMinPoint().end(), 0.0);
+        std::fill(GetMaxPoint().begin(), GetMaxPoint().end(), 0.0);
     };
 
     BoundingBox(TPointType const& MinPoint, TPointType const& MaxPoint) :
@@ -96,10 +94,8 @@ public:
     void Set(TIteratorType const& PointsBegin, TIteratorType const& PointsEnd)
     {
         if (PointsBegin == PointsEnd) {
-            for (unsigned int i = 0; i < Dimension; i++) {
-                GetMinPoint()[i] = 0.00;
-                GetMaxPoint()[i] = 0.00;
-            }
+            std::fill(GetMinPoint().begin(), GetMinPoint().end(), 0.0);
+            std::fill(GetMaxPoint().begin(), GetMaxPoint().end(), 0.0);
             return;
         }
 

--- a/kratos/geometries/bounding_box.h
+++ b/kratos/geometries/bounding_box.h
@@ -48,7 +48,7 @@ public:
     ///@name Life Cycle
     ///@{
 
-    /// Default constructor deleted.
+    /// Default constructor
     BoundingBox()
     {
         for (unsigned int i = 0; i < Dimension; i++) {

--- a/kratos/geometries/bounding_box.h
+++ b/kratos/geometries/bounding_box.h
@@ -4,28 +4,20 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                  
-//
 
-#if !defined(KRATOS_BOUNDING_BOX_H_INCLUDED )
-#define  KRATOS_BOUNDING_BOX_H_INCLUDED
-
+#pragma once
 
 // System includes
-#include <string>
-#include <iostream>
-
 
 // External includes
 
-
 // Project includes
 #include "includes/define.h"
-
 
 namespace Kratos
 {
@@ -35,14 +27,16 @@ namespace Kratos
 ///@name Kratos Classes
 ///@{
 
-/// Representing a bounding box by storing the min and max points
-/** It stores the min and max points and have constructor for it construction with any container of points.
+/**
+ * @brief Representing a bounding box by storing the min and max points
+ * @details It stores the min and max points and have constructor for it construction with any container of points.
  *  TPointType should provide access operator [] to its coordinate and deep copy operator=
-*/
+ * @tparam TPointType The type of point considered
+ * @author Pooyan Dadvand
+ */
 template <typename TPointType>
 class BoundingBox 
 {
-	static constexpr int Dimension = 3;
 public:
     ///@name Type Definitions
     ///@{
@@ -55,27 +49,28 @@ public:
     ///@{
 
     /// Default constructor deleted.
-    BoundingBox(){
-        for (int i = 0; i < Dimension; i++)
-        {
-            GetMinPoint()[i] = 0.00;
-            GetMaxPoint()[i] = 0.00;
+    BoundingBox()
+    {
+        for (unsigned int i = 0; i < Dimension; i++) {
+            GetMinPoint()[i] = 0.0;
+            GetMaxPoint()[i] = 0.0;
         }
     };
 
-	BoundingBox(TPointType const& MinPoint, TPointType const& MaxPoint) :
+    BoundingBox(TPointType const& MinPoint, TPointType const& MaxPoint) :
 		mMinMaxPoints{MinPoint,MaxPoint} {}
 
     /// Copy constructor
-	BoundingBox( const BoundingBox &Other) :
+    BoundingBox( const BoundingBox &Other) :
 		mMinMaxPoints(Other.mMinMaxPoints) {}
 
 
     /// Construction with container of points.
-	template<typename TIteratorType>
-	BoundingBox(TIteratorType const& PointsBegin, TIteratorType const& PointsEnd) {
+    template<typename TIteratorType>
+    BoundingBox(TIteratorType const& PointsBegin, TIteratorType const& PointsEnd) 
+    {
         Set(PointsBegin, PointsEnd);
-	}
+    }
 
     /// Destructor.
     virtual ~BoundingBox(){}
@@ -84,9 +79,9 @@ public:
     ///@name Operators
     ///@{
 
-
     /// Assignment operator.
-    BoundingBox& operator=(BoundingBox const& rOther){
+    BoundingBox& operator=(BoundingBox const& rOther)
+    {
         GetMinPoint() = rOther.GetMinPoint();
         GetMaxPoint() = rOther.GetMaxPoint();
 
@@ -98,16 +93,17 @@ public:
     ///@{
 
     template<typename TIteratorType>
-    void Set(TIteratorType const& PointsBegin, TIteratorType const& PointsEnd){
+    void Set(TIteratorType const& PointsBegin, TIteratorType const& PointsEnd)
+    {
         if (PointsBegin == PointsEnd) {
-            for (int i = 0; i < Dimension; i++) {
+            for (unsigned int i = 0; i < Dimension; i++) {
                 GetMinPoint()[i] = 0.00;
                 GetMaxPoint()[i] = 0.00;
             }
             return;
         }
 
-        for (int i = 0; i < Dimension; i++) {
+        for (unsigned int i = 0; i < Dimension; i++) {
             GetMinPoint()[i] = (*PointsBegin)[i];
             GetMaxPoint()[i] = (*PointsBegin)[i];
         }
@@ -116,41 +112,40 @@ public:
     }
 
     template<typename TIteratorType>
-    void Extend(TIteratorType const& PointsBegin, TIteratorType const& PointsEnd){
-
+    void Extend(TIteratorType const& PointsBegin, TIteratorType const& PointsEnd)
+    {
         for (TIteratorType i_point = PointsBegin; i_point != PointsEnd; i_point++){
-            for (int i = 0; i < Dimension; i++)
-            {
+            for (unsigned int i = 0; i < Dimension; i++) {
                 if ((*i_point)[i] < GetMinPoint()[i]) GetMinPoint()[i] = (*i_point)[i];
                 if ((*i_point)[i] > GetMaxPoint()[i]) GetMaxPoint()[i] = (*i_point)[i];
             }
         }
     }
 
-    void Extend(double Margin){
-        for (int i = 0; i < Dimension; i++){
+    void Extend(const double Margin)
+    {
+        for (unsigned int i = 0; i < Dimension; i++){
             GetMinPoint()[i] -= Margin;
             GetMaxPoint()[i] += Margin;
         }
 
     }
 
-
     ///@}
     ///@name Access
     ///@{
 
-	TPointType& GetMinPoint() { return mMinMaxPoints[0]; }
-	TPointType const& GetMinPoint() const { return mMinMaxPoints[0]; }
+    TPointType& GetMinPoint() { return mMinMaxPoints[0]; }
+    
+    TPointType const& GetMinPoint() const { return mMinMaxPoints[0]; }
 
-	TPointType& GetMaxPoint() { return mMinMaxPoints[1]; }
-	TPointType const& GetMaxPoint() const { return mMinMaxPoints[1]; }
-
+    TPointType& GetMaxPoint() { return mMinMaxPoints[1]; }
+    
+    TPointType const& GetMaxPoint() const { return mMinMaxPoints[1]; }
 
     ///@}
     ///@name Inquiry
     ///@{
-
 
     ///@}
     ///@name Input and output
@@ -177,34 +172,30 @@ public:
     ///@name Friends
     ///@{
 
-
     ///@}
-
 private:
     ///@name Static Member Variables
     ///@{
-
-
+    
+    static constexpr unsigned int Dimension = 3;
+    
     ///@}
     ///@name Member Variables
     ///@{
 
-        std::array<TPointType, 2> mMinMaxPoints;
+    std::array<TPointType, 2> mMinMaxPoints;  /// The min and max points 
 
     ///@}
 
 }; // Class BoundingBox
 
 ///@}
-
 ///@name Type Definitions
 ///@{
-
 
 ///@}
 ///@name Input and output
 ///@{
-
 
 /// input stream function
 template <typename TPointType>
@@ -229,7 +220,3 @@ inline std::ostream& operator << (std::ostream& rOStream,
 ///@} addtogroup block
 
 }  // namespace Kratos.
-
-#endif // KRATOS_BOUNDING_BOX_H_INCLUDED  defined
-
-


### PR DESCRIPTION
**📝 Description**

This PR updates the `kratos/geometries/bounding_box.h` file, making several changes to the `BoundingBox` class:

- The file's formatting and whitespace have been improved for better readability.
- The constructor now uses `#pragma once` instead of include guards.
- The class and its methods have been more thoroughly documented, with the addition of details, author, and template parameters.
- The `Dimension` constant has been changed from an `int` to an `unsigned int`, and its position has been moved to the private section.
- Some loops have been updated to use `unsigned int` instead of `int`.
- The `mMinMaxPoints` member variable has been briefly commented to describe its purpose.

**🆕 Changelog**

- [Cleaning bounding_box.h](https://github.com/KratosMultiphysics/Kratos/commit/dca1b609867ffdb7b6d2864277e346f1f9996651)
