### PR TITLE
[Core][MPI] Refactor MPI Python bindings and update header guards

### DIFF
--- a/kratos/mpi/python/add_distributed_sparse_matrices_to_python.cpp
+++ b/kratos/mpi/python/add_distributed_sparse_matrices_to_python.cpp
@@ -25,8 +25,7 @@
 #include "add_distributed_sparse_matrices_to_python.h"
 #include "mpi/utilities/amgcl_distributed_csr_spmm_utilities.h"
 
-namespace Kratos {
-namespace Python {
+namespace Kratos::Python {
 
 void AddDistributedSparseMatricesToPython(pybind11::module& m)
 {
@@ -245,6 +244,5 @@ void AddDistributedSparseMatricesToPython(pybind11::module& m)
         .def("__str__", PrintObject<DistributedCsrMatrix<double,IndexType>>);
 }
 
-} // namespace Python
-} // namespace Kratos
+} // namespace Kratos::Python
 

--- a/kratos/mpi/python/add_distributed_sparse_matrices_to_python.h
+++ b/kratos/mpi/python/add_distributed_sparse_matrices_to_python.h
@@ -10,23 +10,19 @@
 //  Main author:     Riccardo Rossi
 //
 
-#ifndef KRATOS_ADD_DISTRIBUTED_SPARSE_MATRICES_TO_PYTHON_H_INCLUDED
-#define KRATOS_ADD_DISTRIBUTED_SPARSE_MATRICES_TO_PYTHON_H_INCLUDED
+#pragma once
 
 // System includes
 
 // External includes
-#include "includes/define_python.h"
+#include <pybind11/pybind11.h>
 
 // Project includes
+#include "includes/define_python.h"
 
-namespace Kratos {
-namespace Python {
+namespace Kratos::Python {
 
 void AddDistributedSparseMatricesToPython(pybind11::module& m);
 
-} // namespace Python
-} // namespace Kratos
-
-#endif // KRATOS_ADD_DISTRIBUTED_SPARSE_MATRICES_TO_PYTHON_H_INCLUDED
+} // namespace Kratos::Python
 

--- a/kratos/mpi/python/add_mpi_communicator_to_python.cpp
+++ b/kratos/mpi/python/add_mpi_communicator_to_python.cpp
@@ -20,8 +20,7 @@
 #include "add_mpi_communicator_to_python.h"
 #include "mpi/includes/mpi_communicator.h"
 
-namespace Kratos {
-namespace Python {
+namespace Kratos::Python {
 
 void AddMPICommunicatorToPython(pybind11::module& m)
 {
@@ -32,6 +31,5 @@ void AddMPICommunicatorToPython(pybind11::module& m)
     ;
 }
 
-} // namespace Python
-} // namespace Kratos
+} // namespace Kratos::Python
 

--- a/kratos/mpi/python/add_mpi_communicator_to_python.h
+++ b/kratos/mpi/python/add_mpi_communicator_to_python.h
@@ -10,8 +10,7 @@
 //  Main author:     Jordi Cotela
 //
 
-#ifndef KRATOS_ADD_MPI_COMMUNICATOR_TO_PYTHON_H_INCLUDED
-#define KRATOS_ADD_MPI_COMMUNICATOR_TO_PYTHON_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -20,12 +19,8 @@
 
 // Project includes
 
-namespace Kratos {
-namespace Python {
+namespace Kratos::Python {
 
 void AddMPICommunicatorToPython(pybind11::module& m);
 
-} // namespace Python
-} // namespace Kratos
-
-#endif // KRATOS_ADD_MPI_COMMUNICATOR_TO_PYTHON_H_INCLUDED
+} // namespace Kratos::Python

--- a/kratos/mpi/python/add_mpi_data_communicator_to_python.cpp
+++ b/kratos/mpi/python/add_mpi_data_communicator_to_python.cpp
@@ -19,9 +19,7 @@
 #include "includes/data_communicator.h"
 #include "mpi/includes/mpi_data_communicator.h"
 
-namespace Kratos {
-
-namespace Python {
+namespace Kratos::Python {
 
 void AddMPIDataCommunicatorToPython(pybind11::module &m)
 {
@@ -30,6 +28,4 @@ void AddMPIDataCommunicatorToPython(pybind11::module &m)
     py::class_<MPIDataCommunicator, MPIDataCommunicator::Pointer, DataCommunicator>(m,"MPIDataCommunicator");
 }
 
-} // namespace Python.
-
-} // Namespace Kratos
+} // namespace Kratos::Python.

--- a/kratos/mpi/python/add_mpi_data_communicator_to_python.h
+++ b/kratos/mpi/python/add_mpi_data_communicator_to_python.h
@@ -10,24 +10,17 @@
 //  Main author:     Jordi Cotela
 //
 
-#ifndef KRATOS_ADD_MPI_DATA_COMMUNICATOR_TO_PYTHON_H_INCLUDED
-#define KRATOS_ADD_MPI_DATA_COMMUNICATOR_TO_PYTHON_H_INCLUDED
+#pragma once
 
 // System includes
-#include <pybind11/pybind11.h>
 
 // External includes
+#include <pybind11/pybind11.h>
 
 // Project includes
 
-namespace Kratos {
-
-namespace Python {
+namespace Kratos::Python {
 
 void AddMPIDataCommunicatorToPython(pybind11::module &m);
 
-} // namespace Python.
-
-} // namespace Kratos.
-
-#endif // KRATOS_ADD_MPI_DATA_COMMUNICATOR_TO_PYTHON_H_INCLUDED  defined
+} // namespace Kratos::Python.

--- a/kratos/mpi/python/add_mpi_debug_utilities_to_python.h
+++ b/kratos/mpi/python/add_mpi_debug_utilities_to_python.h
@@ -10,8 +10,7 @@
 //  Main author:     Carlos A. Roig
 //
 
-#ifndef KRATOS_ADD_MPI_DEBUG_UTILITIES_TO_PYTHON_H_INCLUDED
-#define KRATOS_ADD_MPI_DEBUG_UTILITIES_TO_PYTHON_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -20,13 +19,9 @@
 
 // Project includes
 
-namespace Kratos {
-namespace Python {
+namespace Kratos::Python {
 
 void AddMPIDebugUtilitiesToPython(pybind11::module& m);
 
-} // namespace Python
-} // namespace Kratos
-
-#endif // KRATOS_ADD_MPI_DEBUG_UTILITIES_TO_PYTHON_H_INCLUDED
+} // namespace Kratos::Python
 

--- a/kratos/mpi/python/add_mpi_utilities_to_python.cpp
+++ b/kratos/mpi/python/add_mpi_utilities_to_python.cpp
@@ -25,8 +25,7 @@
 #include "mpi/utilities/mpi_normal_calculation_utilities.h"
 #include "mpi/utilities/distributed_model_part_initializer.h"
 
-namespace Kratos {
-namespace Python {
+namespace Kratos::Python {
 
 const DataCommunicator& CreateFromListOfRanks(
     const DataCommunicator& rReferenceComm,
@@ -99,6 +98,5 @@ void AddMPIUtilitiesToPython(pybind11::module& m)
 
 }
 
-} // namespace Python
-} // namespace Kratos
+} // namespace Kratos::Python
 

--- a/kratos/mpi/python/add_mpi_utilities_to_python.h
+++ b/kratos/mpi/python/add_mpi_utilities_to_python.h
@@ -10,8 +10,7 @@
 //  Main author:     Jordi Cotela
 //
 
-#ifndef KRATOS_ADD_MPI_UTILITIES_TO_PYTHON_H_INCLUDED
-#define KRATOS_ADD_MPI_UTILITIES_TO_PYTHON_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -20,13 +19,9 @@
 
 // Project includes
 
-namespace Kratos {
-namespace Python {
+namespace Kratos::Python {
 
 void AddMPIUtilitiesToPython(pybind11::module& m);
 
-} // namespace Python
-} // namespace Kratos
-
-#endif // KRATOS_ADD_MPI_UTILITIES_TO_PYTHON_H_INCLUDED
+} // namespace Kratos::Python
 

--- a/kratos/mpi/python/kratos_mpi_python.cpp
+++ b/kratos/mpi/python/kratos_mpi_python.cpp
@@ -26,8 +26,7 @@
 #include "add_distributed_sparse_matrices_to_python.h"
 #include "includes/parallel_environment.h"
 
-namespace Kratos {
-namespace Python {
+namespace Kratos::Python {
 
 void InitializeMPIParallelRun()
 {
@@ -74,5 +73,4 @@ PYBIND11_MODULE(KratosMPI, m)
     AddDistributedSparseMatricesToPython(m);
 }
 
-}
 }


### PR DESCRIPTION
**📝 Description**

This commit refactors the MPI Python bindings by changing the nested namespaces to the modern syntax (Kratos::Python), updating the header guards to use `#pragma once` instead of `#ifndef` and `#define`, and making minor changes to the include statements. The changes affect ten files related to the distributed sparse matrices, MPI communicators, MPI data communicators, MPI debug utilities, and MPI utilities.

**🆕 Changelog**

- [Clean up python bindings](https://github.com/KratosMultiphysics/Kratos/commit/415115e7b24c32d90d276559f6dcffe96b8c8f98)