### PR TITLE
[Core] LevelSet_Convection_Process: Turning auxiliar mdpa check into an error

### DIFF
--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -514,9 +514,7 @@ protected:
 
         KRATOS_TRY
 
-        if (mrModel.HasModelPart(mAuxModelPartName)) {
-            mrModel.DeleteModelPart(mAuxModelPartName);
-        }
+        KRATOS_ERROR_IF(mrModel.HasModelPart(mAuxModelPartName)) << "A process or operation using an auxiliar model_part with the name '" << mAuxModelPartName << "' already exists. Please choose another." << std::endl;
 
         mpDistanceModelPart= &(mrModel.CreateModelPart(mAuxModelPartName));
 


### PR DESCRIPTION
**📝 Description**
This PR prevents the Levelset_convection_process from deleting model_parts if the name of the auxiliary `mpDistanceModelPart` already exists in the model.

This is related with #11025, but in general I consider it as an error. Specifically this causes problems if 2 of the same processes exists without setting different names for the mpda or if another process / mpda happens to have the same name for whatever reason

@ddiezrod This may affect you, so take a look. If @KratosMultiphysics/technical-committee agrees, we should do the same for any process that is having the same behavior. 

**🆕 Changelog**
- Turning the existing mpda check of the levelset_convection_process into an error.
