### PR TITLE
[Core] Model part io add conditions to base model part

### DIFF
--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -1841,59 +1841,9 @@ void ModelPartIO::ReadElementsBlock(ModelPart& rModelPart)
 {
     KRATOS_TRY
 
-    SizeType id;
-    SizeType properties_id;
-    SizeType node_id;
-    SizeType number_of_read_elements = 0;
-
-
-    std::string word;
-    std::string element_name;
-
-    ReadWord(element_name);
-    KRATOS_INFO("ModelPartIO") << "  [Reading Elements : ";
-
-    if(!KratosComponents<Element>::Has(element_name))
-    {
-        std::stringstream buffer;
-        buffer << "Element " << element_name << " is not registered in Kratos.";
-        buffer << " Please check the spelling of the element name and see if the application which containing it, is registered correctly.";
-        buffer << " [Line " << mNumberOfLines << " ]";
-        KRATOS_ERROR << buffer.str() << std::endl;
-        return;
-    }
-
-    Element const& r_clone_element = KratosComponents<Element>::Get(element_name);
-    SizeType number_of_nodes = r_clone_element.GetGeometry().size();
-    Element::NodesArrayType temp_element_nodes;
-    ModelPart::ElementsContainerType aux_elements;
-
-    while(!mpStream->eof())
-    {
-        ReadWord(word); // Reading the element id or End
-        if(CheckEndBlock("Elements", word))
-            break;
-
-        ExtractValue(word,id);
-        ReadWord(word); // Reading the properties id;
-        ExtractValue(word, properties_id);
-        Properties::Pointer p_temp_properties = *(FindKey(rModelPart.rProperties(), properties_id, "Properties").base());
-        temp_element_nodes.clear();
-        for(SizeType i = 0 ; i < number_of_nodes ; i++)
-        {
-            ReadWord(word); // Reading the node id;
-            ExtractValue(word, node_id);
-            temp_element_nodes.push_back( *(FindKey(rModelPart.Nodes(), ReorderedNodeId(node_id), "Node").base()));
-        }
-
-        aux_elements.push_back(r_clone_element.Create(ReorderedElementId(id), temp_element_nodes, p_temp_properties));
-        number_of_read_elements++;
-
-    }
-    KRATOS_INFO("") << number_of_read_elements << " elements read] [Type: " <<element_name << "]" << std::endl;
-    aux_elements.Unique();
-
-    rModelPart.AddElements(aux_elements.begin(), aux_elements.end());
+    ModelPart::ElementsContainerType aux_elems;
+    ReadElementsBlock(rModelPart.Nodes(), rModelPart.rProperties(), aux_elems);
+    rModelPart.AddElements(aux_elems.begin(), aux_elems.end());
 
     KRATOS_CATCH("")
 }
@@ -1961,57 +1911,8 @@ void ModelPartIO::ReadConditionsBlock(ModelPart& rModelPart)
 {
     KRATOS_TRY
 
-    SizeType id;
-    SizeType properties_id;
-    SizeType node_id;
-    SizeType number_of_read_conditions = 0;
-
-
-    std::string word;
-    std::string condition_name;
-
-    ReadWord(condition_name);
-    KRATOS_INFO("ModelPartIO") << "  [Reading Conditions : ";
-
-    if(!KratosComponents<Condition>::Has(condition_name))
-    {
-        std::stringstream buffer;
-        buffer << "Condition " << condition_name << " is not registered in Kratos.";
-        buffer << " Please check the spelling of the condition name and see if the application containing it is registered correctly.";
-        buffer << " [Line " << mNumberOfLines << " ]";
-        KRATOS_ERROR << buffer.str() << std::endl;
-        return;
-    }
-
-    Condition const& r_clone_condition = KratosComponents<Condition>::Get(condition_name);
-    SizeType number_of_nodes = r_clone_condition.GetGeometry().size();
-    Condition::NodesArrayType temp_condition_nodes;
     ModelPart::ConditionsContainerType aux_conds;
-
-    while(!mpStream->eof())
-    {
-        ReadWord(word); // Reading the condition id or End
-        if(CheckEndBlock("Conditions", word))
-            break;
-
-        ExtractValue(word,id);
-        ReadWord(word); // Reading the properties id;
-        ExtractValue(word, properties_id);
-        Properties::Pointer p_temp_properties = *(FindKey(rModelPart.rProperties(), properties_id, "Properties").base());
-        temp_condition_nodes.clear();
-        for(SizeType i = 0 ; i < number_of_nodes ; i++)
-        {
-            ReadWord(word); // Reading the node id;
-            ExtractValue(word, node_id);
-            temp_condition_nodes.push_back( *(FindKey(rModelPart.Nodes(), ReorderedNodeId(node_id), "Node").base()));
-        }
-
-        aux_conds.push_back(r_clone_condition.Create(ReorderedConditionId(id), temp_condition_nodes, p_temp_properties));
-        number_of_read_conditions++;
-    }
-    KRATOS_INFO("") << number_of_read_conditions << " conditions read] [Type: " << condition_name << "]" << std::endl;
-    aux_conds.Unique();
-
+    ReadConditionsBlock(rModelPart.Nodes(), rModelPart.rProperties(), aux_conds);
     rModelPart.AddConditions(aux_conds.begin(), aux_conds.end());
 
     KRATOS_CATCH("")

--- a/kratos/tests/test_model_part_io.py
+++ b/kratos/tests/test_model_part_io.py
@@ -35,6 +35,28 @@ class TestModelPartIO(KratosUnittest.TestCase):
         with self.subTest("pathlib.Path"):
             self.execute_test_model_part_io_read_model_part(Path(input_mdpa))
 
+    def test_model_part_io_read_using_submodelpart(self):
+        current_model = KratosMultiphysics.Model()
+
+        main_model_part = current_model.CreateModelPart("Main")
+        model_part = main_model_part.CreateSubModelPart("submodelpart")
+        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
+        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VISCOSITY)
+        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
+
+        model_part_io = KratosMultiphysics.ModelPartIO(GetFilePath("auxiliar_files_for_python_unittest/mdpa_files/test_model_part_io_read"))
+        model_part_io.ReadModelPart(model_part)
+
+        self.assertEqual(model_part.NumberOfSubModelParts(), 2)
+        self.assertEqual(model_part.NumberOfTables(), 1)
+        self.assertEqual(model_part.NumberOfProperties(), 1)
+        self.assertEqual(model_part.NumberOfNodes(), 6)
+        self.assertEqual(model_part.NumberOfProperties(), 1)
+        self.assertEqual(model_part.NumberOfGeometries(), 9)
+        self.assertEqual(model_part.NumberOfElements(), 4)
+        self.assertEqual(model_part.NumberOfConditions(), 5)
+
+
     def execute_test_model_part_io_read_model_part(self, input_mdpa):
         current_model = KratosMultiphysics.Model()
 


### PR DESCRIPTION
I was trying to use model part io to read a model part directly into a submodelpart (so for example instead of reading the mdpa insde main_model_part, I put it inside main_model_part/structure. I am getting an error while reading mdpa submodel part conditions saying that "condition does not exist in root model part".
I was checking the code and it seems we are doing different things when reading elements and conditions. For elements , we are calling AddElements function, which push elements to all parent model parts.  However, in the case of conditions we directly push conditions to the ConditionsContainer instead and therefore they are not being added to the parent model part. This usually does not matter because most of the times the input model part is not a submodel part.
I saw that the change for the elements was done a long time ago by @rubenzorrilla , but it was done only for elements, not for the conditions. 
https://github.com/KratosMultiphysics/Kratos/commit/c43752d0e301aa369e7ef3d91790da58d1e42756
In this PR I modify the function for conditions so it does the same in both cases.