### PR TITLE
[Fluid-Compressible-Navier-Stokes] Potential to compressible navier stokes operation

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/CMakeLists.txt
+++ b/applications/CompressiblePotentialFlowApplication/CMakeLists.txt
@@ -18,6 +18,7 @@ file( GLOB_RECURSE KRATOS_COMPRESSIBLE_POTENTIAL_APPLICATION_CORE
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_conditions/*.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/*.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_operations/*.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_response_functions/*.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/*.cpp
 )

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
@@ -99,7 +99,7 @@ void PotentialToCompressibleNavierStokesOperation::Execute()
         const auto &r_velocity = it_orig_node->GetValue(VELOCITY);
         
         // Calculate the conservative variables
-        const double& velocity_norm_2 = velocity[0] * velocity[0] + velocity[1] * velocity[1];
+        const double velocity_norm_2 = velocity[0] * velocity[0] + velocity[1] * velocity[1];
         const double velocity_norm = std::sqrt(velocity_norm_2);
         const double mach = velocity_norm / sound_velocity;
         const double num = 1.0 + 0.5 * (gamma - 1.0) * std::pow(free_stream_mach,2);

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
@@ -29,8 +29,6 @@ namespace Kratos
 PotentialToCompressibleNavierStokesOperation::PotentialToCompressibleNavierStokesOperation(
     Model& rModel,
     Parameters ModelParameters)
-        : mpModel(&rModel)
-        , mParameters(ModelParameters)
 {
     mParameters.ValidateAndAssignDefaults(this->GetDefaultParameters());
 }

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
@@ -96,7 +96,7 @@ void PotentialToCompressibleNavierStokesOperation::Execute()
         const auto it_orig_node = mOriginModelPart.NodesBegin() + index;
 
         // Getting potential flow velocities
-        const auto &velocity = it_orig_node->GetValue(VELOCITY);
+        const auto &r_velocity = it_orig_node->GetValue(VELOCITY);
         
         // Calculate the conservative variables
         const double& velocity_norm_2 = velocity[0] * velocity[0] + velocity[1] * velocity[1];

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
@@ -108,9 +108,10 @@ void PotentialToCompressibleNavierStokesOperation::Execute()
         const double energy = specific_heat * reference_temperature + 0.5 * velocity_norm_2;
         
         // Setting the Navier Stokes initial condition
-        it_dest_node->FastGetSolutionStepValue(DENSITY, 0) = density; 
-        it_dest_node->FastGetSolutionStepValue(MOMENTUM, 0) = density*velocity;
-        it_dest_node->FastGetSolutionStepValue(TOTAL_ENERGY, 0) = density*energy; });
+        it_dest_node->FastGetSolutionStepValue(DENSITY) = density; 
+        it_dest_node->FastGetSolutionStepValue(MOMENTUM) = density*velocity;
+        it_dest_node->FastGetSolutionStepValue(TOTAL_ENERGY) = density*energy;
+    });
 
     KRATOS_CATCH("")
 }

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
@@ -57,8 +57,8 @@ void PotentialToCompressibleNavierStokesOperation::Execute()
 
     const std::string origin_model_part_name = mParameters["origin_model_part"].GetString();
     const std::string destination_model_part_name = mParameters["destination_model_part"].GetString();
-    const double& reference_temperature = mParameters["reference_temperature"].GetDouble();
-    const double& compute_nodal_velocities = mParameters["compute_nodal_velocities"].GetBool();
+    const double reference_temperature = mParameters["reference_temperature"].GetDouble();
+    const bool compute_nodal_velocities = mParameters["compute_nodal_velocities"].GetBool();
     
     // Saving the modelparts
     auto& mOriginModelPart = mpModel->GetModelPart(origin_model_part_name);

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
@@ -1,0 +1,117 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Marco Antonio Zuñiga Perez
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "utilities/parallel_utilities.h"
+#include "potential_to_compressible_navier_stokes_operation.h"
+#include "fluid_dynamics_application_variables.h"
+#include "compressible_potential_flow_application_variables.h"
+#include "custom_processes/compute_nodal_value_process.h"
+
+namespace Kratos
+{
+
+PotentialToCompressibleNavierStokesOperation::PotentialToCompressibleNavierStokesOperation(
+    Model& rModel,
+    Parameters ModelParameters)
+        : mpModel(&rModel)
+        , mParameters(ModelParameters)
+{
+    mParameters.ValidateAndAssignDefaults(this->GetDefaultParameters());
+}
+
+Operation::Pointer PotentialToCompressibleNavierStokesOperation::Create(Model &rModel,
+    Parameters Parameters) const
+{
+    return Kratos::make_shared<PotentialToCompressibleNavierStokesOperation>(rModel, Parameters);
+}
+
+const Parameters PotentialToCompressibleNavierStokesOperation::GetDefaultParameters() const
+{
+    const Parameters default_parameters = Parameters(R"({
+        "origin_model_part"       : "",
+        "destination_model_part"  : "",
+        "reference_temperature"   : 273,
+        "compute_nodal_velocities": true
+    })");
+    return default_parameters;}
+
+void PotentialToCompressibleNavierStokesOperation::Execute()
+{
+    KRATOS_TRY;
+
+    const std::string origin_model_part_name = mParameters["origin_model_part"].GetString();
+    const std::string destination_model_part_name = mParameters["destination_model_part"].GetString();
+    const double& reference_temperature = mParameters["reference_temperature"].GetDouble();
+    const double& compute_nodal_velocities = mParameters["compute_nodal_velocities"].GetBool();
+    
+    // Saving the modelparts
+    auto& mOriginModelPart = mpModel->GetModelPart(origin_model_part_name);
+    auto& mDestinationModelPart = mpModel->GetModelPart(destination_model_part_name);
+
+    const int n_orig_nodes = mOriginModelPart.NumberOfNodes();
+    const int n_dest_nodes = mDestinationModelPart.NumberOfNodes();
+
+    // Check number of nodes
+    KRATOS_ERROR_IF_NOT(n_orig_nodes == n_dest_nodes)
+        << "Origin and destination model parts have different number of nodes."
+        << "\n\t- Number of origin nodes: " << n_orig_nodes
+        << "\n\t- Number of destination nodes: " << n_dest_nodes << std::endl;
+
+    // Getting the required variables
+    const double& gamma = mOriginModelPart.GetProcessInfo().GetValue(HEAT_CAPACITY_RATIO);
+    const double& sound_velocity = mOriginModelPart.GetProcessInfo().GetValue(SOUND_VELOCITY);
+    const double& free_stream_rho = mOriginModelPart.GetProcessInfo().GetValue(FREE_STREAM_DENSITY);
+    const double& free_stream_mach = mOriginModelPart.GetProcessInfo().GetValue(FREE_STREAM_MACH);
+    const double& specific_heat = (std::pow(sound_velocity,2) / (gamma * reference_temperature)) / (gamma - 1.0);
+    
+    // Calculate de nodal velocities
+    if (compute_nodal_velocities){
+        // Construct the ComputeNodalPotentialFlowVelocityProcess
+        const std::vector<std::string> variable_array = {"VELOCITY"};
+        ComputeNodalValueProcess ComputeNodalValueProcess(mOriginModelPart, variable_array);
+
+        // Execute the ComputeNodalPotentialFlowVelocityProcess
+        ComputeNodalValueProcess.Execute();}
+
+    // Transfer the potential flow values as initial condition for the compressible problem
+    IndexPartition<std::size_t>(n_orig_nodes).for_each([&](std::size_t index)
+                                                       {
+        auto it_dest_node = mDestinationModelPart.NodesBegin() + index;
+        const auto it_orig_node = mOriginModelPart.NodesBegin() + index;
+
+        // Getting potential flow velocities
+        const auto &velocity = it_orig_node->GetValue(VELOCITY);
+        
+        // Calculate the conservative variables
+        const double& velocity_norm_2 = velocity[0] * velocity[0] + velocity[1] * velocity[1];
+        const double& velocity_norm = std::pow(velocity_norm_2,0.5);
+        const double& mach = velocity_norm / sound_velocity;
+        const double& num = 1.0 + 0.5 * (gamma - 1.0) * std::pow(free_stream_mach,2);
+        const double& den = 1.0 + 0.5 * (gamma - 1.0) * std::pow(mach,2);
+        const double& density = free_stream_rho * std::pow((num / den),(1.0 / (gamma - 1.0)));
+        const double& energy = specific_heat * reference_temperature + 0.5 * velocity_norm_2;
+        
+        // Setting the Navier Stokes initial condition
+        it_dest_node->FastGetSolutionStepValue(DENSITY, 0) = density; 
+        it_dest_node->FastGetSolutionStepValue(MOMENTUM, 0) = density*velocity;
+        it_dest_node->FastGetSolutionStepValue(TOTAL_ENERGY, 0) = density*energy; });
+
+    KRATOS_CATCH("")
+}
+
+}

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
@@ -61,8 +61,8 @@ void PotentialToCompressibleNavierStokesOperation::Execute()
     const bool compute_nodal_velocities = mParameters["compute_nodal_velocities"].GetBool();
     
     // Saving the modelparts
-    auto& mOriginModelPart = mpModel->GetModelPart(origin_model_part_name);
-    auto& mDestinationModelPart = mpModel->GetModelPart(destination_model_part_name);
+    auto& r_origin_model_part = mpModel->GetModelPart(origin_model_part_name);
+    auto& r_destination_model_part = mpModel->GetModelPart(destination_model_part_name);
 
     const int n_orig_nodes = mOriginModelPart.NumberOfNodes();
     const int n_dest_nodes = mDestinationModelPart.NumberOfNodes();

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
@@ -29,6 +29,8 @@ namespace Kratos
 PotentialToCompressibleNavierStokesOperation::PotentialToCompressibleNavierStokesOperation(
     Model& rModel,
     Parameters ModelParameters)
+        : mpModel(&rModel)
+        , mParameters(ModelParameters)
 {
     mParameters.ValidateAndAssignDefaults(this->GetDefaultParameters());
 }

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
@@ -101,11 +101,11 @@ void PotentialToCompressibleNavierStokesOperation::Execute()
         // Calculate the conservative variables
         const double& velocity_norm_2 = velocity[0] * velocity[0] + velocity[1] * velocity[1];
         const double velocity_norm = std::sqrt(velocity_norm_2);
-        const double& mach = velocity_norm / sound_velocity;
-        const double& num = 1.0 + 0.5 * (gamma - 1.0) * std::pow(free_stream_mach,2);
-        const double& den = 1.0 + 0.5 * (gamma - 1.0) * std::pow(mach,2);
-        const double& density = free_stream_rho * std::pow((num / den),(1.0 / (gamma - 1.0)));
-        const double& energy = specific_heat * reference_temperature + 0.5 * velocity_norm_2;
+        const double mach = velocity_norm / sound_velocity;
+        const double num = 1.0 + 0.5 * (gamma - 1.0) * std::pow(free_stream_mach,2);
+        const double den = 1.0 + 0.5 * (gamma - 1.0) * std::pow(mach,2);
+        const double density = free_stream_rho * std::pow((num / den),(1.0 / (gamma - 1.0)));
+        const double energy = specific_heat * reference_temperature + 0.5 * velocity_norm_2;
         
         // Setting the Navier Stokes initial condition
         it_dest_node->FastGetSolutionStepValue(DENSITY, 0) = density; 

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
@@ -34,7 +34,8 @@ PotentialToCompressibleNavierStokesOperation::PotentialToCompressibleNavierStoke
     mParameters.ValidateAndAssignDefaults(this->GetDefaultParameters());
 }
 
-Operation::Pointer PotentialToCompressibleNavierStokesOperation::Create(Model &rModel,
+Operation::Pointer PotentialToCompressibleNavierStokesOperation::Create(
+    Model &rModel,
     Parameters Parameters) const
 {
     return Kratos::make_shared<PotentialToCompressibleNavierStokesOperation>(rModel, Parameters);

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
@@ -100,7 +100,7 @@ void PotentialToCompressibleNavierStokesOperation::Execute()
         
         // Calculate the conservative variables
         const double& velocity_norm_2 = velocity[0] * velocity[0] + velocity[1] * velocity[1];
-        const double& velocity_norm = std::pow(velocity_norm_2,0.5);
+        const double velocity_norm = std::sqrt(velocity_norm_2);
         const double& mach = velocity_norm / sound_velocity;
         const double& num = 1.0 + 0.5 * (gamma - 1.0) * std::pow(free_stream_mach,2);
         const double& den = 1.0 + 0.5 * (gamma - 1.0) * std::pow(mach,2);

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
@@ -16,6 +16,7 @@
 // External includes
 
 // Project includes
+
 #include "utilities/parallel_utilities.h"
 #include "potential_to_compressible_navier_stokes_operation.h"
 #include "fluid_dynamics_application_variables.h"
@@ -64,8 +65,8 @@ void PotentialToCompressibleNavierStokesOperation::Execute()
     auto& r_origin_model_part = mpModel->GetModelPart(origin_model_part_name);
     auto& r_destination_model_part = mpModel->GetModelPart(destination_model_part_name);
 
-    const int n_orig_nodes = mOriginModelPart.NumberOfNodes();
-    const int n_dest_nodes = mDestinationModelPart.NumberOfNodes();
+    const int n_orig_nodes = r_origin_model_part.NumberOfNodes();
+    const int n_dest_nodes = r_destination_model_part.NumberOfNodes();
 
     // Check number of nodes
     KRATOS_ERROR_IF_NOT(n_orig_nodes == n_dest_nodes)
@@ -74,43 +75,43 @@ void PotentialToCompressibleNavierStokesOperation::Execute()
         << "\n\t- Number of destination nodes: " << n_dest_nodes << std::endl;
 
     // Getting the required variables
-    const double gamma = mOriginModelPart.GetProcessInfo().GetValue(HEAT_CAPACITY_RATIO);
-    const double sound_velocity = mOriginModelPart.GetProcessInfo().GetValue(SOUND_VELOCITY);
-    const double free_stream_rho = mOriginModelPart.GetProcessInfo().GetValue(FREE_STREAM_DENSITY);
-    const double free_stream_mach = mOriginModelPart.GetProcessInfo().GetValue(FREE_STREAM_MACH);
-    const double specific_heat = (std::pow(sound_velocity,2) / (gamma * reference_temperature)) / (gamma - 1.0);
+    const double heat_capacity_ratio = r_origin_model_part.GetProcessInfo().GetValue(HEAT_CAPACITY_RATIO);
+    const double sound_velocity = r_origin_model_part.GetProcessInfo().GetValue(SOUND_VELOCITY);
+    const double free_stream_density = r_origin_model_part.GetProcessInfo().GetValue(FREE_STREAM_DENSITY);
+    const double free_stream_mach = r_origin_model_part.GetProcessInfo().GetValue(FREE_STREAM_MACH);
+    const double specific_heat = (std::pow(sound_velocity,2) / (heat_capacity_ratio * reference_temperature)) / (heat_capacity_ratio - 1.0);
     
     // Calculate de nodal velocities
     if (compute_nodal_velocities){
         // Construct the ComputeNodalPotentialFlowVelocityProcess
         const std::vector<std::string> variable_array = {"VELOCITY"};
-        ComputeNodalValueProcess ComputeNodalValueProcess(mOriginModelPart, variable_array);
+        ComputeNodalValueProcess ComputeNodalValueProcess(r_origin_model_part, variable_array);
 
         // Execute the ComputeNodalPotentialFlowVelocityProcess
         ComputeNodalValueProcess.Execute();}
 
     // Transfer the potential flow values as initial condition for the compressible problem
     IndexPartition<std::size_t>(n_orig_nodes).for_each([&](std::size_t index)
-                                                       {
-        auto it_dest_node = mDestinationModelPart.NodesBegin() + index;
-        const auto it_orig_node = mOriginModelPart.NodesBegin() + index;
+    {
+        auto it_dest_node = r_destination_model_part.NodesBegin() + index;
+        const auto it_orig_node = r_origin_model_part.NodesBegin() + index;
 
         // Getting potential flow velocities
         const auto &r_velocity = it_orig_node->GetValue(VELOCITY);
         
         // Calculate the conservative variables
-        const double velocity_norm_2 = velocity[0] * velocity[0] + velocity[1] * velocity[1];
+        const double velocity_norm_2 = r_velocity[0] * r_velocity[0] + r_velocity[1] * r_velocity[1] + r_velocity[2] * r_velocity[2];
         const double velocity_norm = std::sqrt(velocity_norm_2);
         const double mach = velocity_norm / sound_velocity;
-        const double num = 1.0 + 0.5 * (gamma - 1.0) * std::pow(free_stream_mach,2);
-        const double den = 1.0 + 0.5 * (gamma - 1.0) * std::pow(mach,2);
-        const double density = free_stream_rho * std::pow((num / den),(1.0 / (gamma - 1.0)));
+        const double num = 1.0 + 0.5 * (heat_capacity_ratio - 1.0) * std::pow(free_stream_mach,2);
+        const double den = 1.0 + 0.5 * (heat_capacity_ratio - 1.0) * std::pow(mach,2);
+        const double density = free_stream_density * std::pow((num / den),(1.0 / (heat_capacity_ratio - 1.0)));
         const double energy = specific_heat * reference_temperature + 0.5 * velocity_norm_2;
         
         // Setting the Navier Stokes initial condition
         it_dest_node->FastGetSolutionStepValue(DENSITY) = density; 
-        it_dest_node->FastGetSolutionStepValue(MOMENTUM) = density*velocity;
-        it_dest_node->FastGetSolutionStepValue(TOTAL_ENERGY) = density*energy;
+        it_dest_node->FastGetSolutionStepValue(MOMENTUM) = density * r_velocity;
+        it_dest_node->FastGetSolutionStepValue(TOTAL_ENERGY) = density * energy;
     });
 
     KRATOS_CATCH("")

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.cpp
@@ -74,11 +74,11 @@ void PotentialToCompressibleNavierStokesOperation::Execute()
         << "\n\t- Number of destination nodes: " << n_dest_nodes << std::endl;
 
     // Getting the required variables
-    const double& gamma = mOriginModelPart.GetProcessInfo().GetValue(HEAT_CAPACITY_RATIO);
-    const double& sound_velocity = mOriginModelPart.GetProcessInfo().GetValue(SOUND_VELOCITY);
-    const double& free_stream_rho = mOriginModelPart.GetProcessInfo().GetValue(FREE_STREAM_DENSITY);
-    const double& free_stream_mach = mOriginModelPart.GetProcessInfo().GetValue(FREE_STREAM_MACH);
-    const double& specific_heat = (std::pow(sound_velocity,2) / (gamma * reference_temperature)) / (gamma - 1.0);
+    const double gamma = mOriginModelPart.GetProcessInfo().GetValue(HEAT_CAPACITY_RATIO);
+    const double sound_velocity = mOriginModelPart.GetProcessInfo().GetValue(SOUND_VELOCITY);
+    const double free_stream_rho = mOriginModelPart.GetProcessInfo().GetValue(FREE_STREAM_DENSITY);
+    const double free_stream_mach = mOriginModelPart.GetProcessInfo().GetValue(FREE_STREAM_MACH);
+    const double specific_heat = (std::pow(sound_velocity,2) / (gamma * reference_temperature)) / (gamma - 1.0);
     
     // Calculate de nodal velocities
     if (compute_nodal_velocities){

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.h
@@ -1,0 +1,121 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Marco Antonio Zuñiga Perez
+//                   
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "operations/operation.h"
+
+namespace Kratos
+{
+  ///@addtogroup CompressiblePotentialFlowApplication
+  ///@{
+
+///@name Kratos Classes
+///@{
+
+/**
+ * @author Marco Antonio Zuñiga Perez
+ * @class PotentialToCompressibleNavierStokesOperation
+ * @ingroup CompressiblePotentialFlowApplication
+ * @brief This operation pass the nodal velocities from Potential model part as initial condition of a compressible 
+ * Navier Stokes model part in conservative variables form.
+*/
+class KRATOS_API(KRATOS_COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION) PotentialToCompressibleNavierStokesOperation : public Operation
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of Operation
+    KRATOS_CLASS_POINTER_DEFINITION(PotentialToCompressibleNavierStokesOperation);
+
+    /// Registry current operation
+    KRATOS_REGISTRY_ADD_PROTOTYPE("Operations.KratosMultiphysics.CompressiblePotentialFlowApplication", PotentialToCompressibleNavierStokesOperation)
+    KRATOS_REGISTRY_ADD_PROTOTYPE("Operations.All", PotentialToCompressibleNavierStokesOperation)
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+    PotentialToCompressibleNavierStokesOperation() : Operation() {}
+
+    PotentialToCompressibleNavierStokesOperation(
+        Model& rModel,
+        Parameters OperationParameters);
+
+    /// Destructor.
+    ~PotentialToCompressibleNavierStokesOperation() override = default;
+    /// Copy constructor.
+    //TODO: Check. It is required by the registry
+    PotentialToCompressibleNavierStokesOperation(PotentialToCompressibleNavierStokesOperation const& rOther)  = delete;
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /// Assignment operator.
+    PotentialToCompressibleNavierStokesOperation& operator=(PotentialToCompressibleNavierStokesOperation const& rOther) = delete;
+
+    /// This operator is provided to call the process as a function and simply calls the Execute method.
+    void operator()()
+    {
+        Execute();
+    }
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief This method creates an pointer of the operation
+     * @details We consider as input a Mmodel and a set of Parameters for the sake of generality
+     * @param rModel The model to be consider
+     * @param ThisParameters The configuration parameters
+     */
+    Operation::Pointer Create(
+        Model& rModel,
+        Parameters ThisParameters) const override;
+
+    /**
+     * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
+     */
+    const Parameters GetDefaultParameters() const override;
+
+    /**
+     * @brief Execute method is used to execute the Operation algorithms.
+     */
+    void Execute() override;
+
+    ///@}
+private:
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+    std::vector<const Variable<array_1d<double, 3>>*>    mArrayVariablesList;
+    std::vector<const Variable<double>*>                 mDoubleVariablesList;
+    Model* mpModel = nullptr;
+    Parameters mParameters;
+
+    ///@}
+}; // Class PotentialToCompressibleNavierStokesOperation
+
+    ///@} addtogroup block
+
+}  // namespace Kratos.

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.h
@@ -72,11 +72,6 @@ public:
     /// Assignment operator.
     PotentialToCompressibleNavierStokesOperation& operator=(PotentialToCompressibleNavierStokesOperation const& rOther) = delete;
 
-    /// This operator is provided to call the process as a function and simply calls the Execute method.
-    void operator()()
-    {
-        Execute();
-    }
 
     ///@}
     ///@name Operations

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.h
@@ -61,9 +61,9 @@ public:
 
     /// Destructor.
     ~PotentialToCompressibleNavierStokesOperation() override = default;
+
     /// Copy constructor.
-    //TODO: Check. It is required by the registry
-    PotentialToCompressibleNavierStokesOperation(PotentialToCompressibleNavierStokesOperation const& rOther)  = delete;
+    PotentialToCompressibleNavierStokesOperation(PotentialToCompressibleNavierStokesOperation const& rOther);
 
     ///@}
     ///@name Operators

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.h
@@ -108,8 +108,6 @@ private:
     ///@name Member Variables
     ///@{
 
-    std::vector<const Variable<array_1d<double, 3>>*>    mArrayVariablesList;
-    std::vector<const Variable<double>*>                 mDoubleVariablesList;
     Model* mpModel = nullptr;
     Parameters mParameters;
 

--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.h
@@ -35,7 +35,7 @@ namespace Kratos
  * @brief This operation pass the nodal velocities from Potential model part as initial condition of a compressible 
  * Navier Stokes model part in conservative variables form.
 */
-class KRATOS_API(KRATOS_COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION) PotentialToCompressibleNavierStokesOperation : public Operation
+class KRATOS_API(COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION) PotentialToCompressibleNavierStokesOperation : public Operation
 {
 public:
     ///@name Type Definitions

--- a/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_operations_to_python.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_operations_to_python.cpp
@@ -1,0 +1,37 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ \.
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Carlos Roig
+//                   Ruben Zorrilla
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define_python.h"
+#include "operations/operation.h"
+#include "custom_python/add_custom_operations_to_python.h"
+#include "custom_operations/potential_to_compressible_navier_stokes_operation.h"
+
+namespace Kratos::Python
+{
+
+void AddCustomOperationsToPython(pybind11::module& m)
+{
+    namespace py = pybind11;
+
+    py::class_<PotentialToCompressibleNavierStokesOperation, PotentialToCompressibleNavierStokesOperation::Pointer, Operation >
+        (m,"PotentialToCompressibleNavierStokesOperation")
+    .def(py::init<Model&, Parameters>())
+    ;
+}
+
+} // Namespace Kratos::Python

--- a/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_operations_to_python.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_operations_to_python.cpp
@@ -7,8 +7,7 @@
 //  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
-//  Main authors:    Carlos Roig
-//                   Ruben Zorrilla
+//  Main authors:    Marco Antonio Zuñiga Perez
 //
 
 // System includes

--- a/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_operations_to_python.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_operations_to_python.cpp
@@ -27,8 +27,7 @@ void AddCustomOperationsToPython(pybind11::module& m)
 {
     namespace py = pybind11;
 
-    py::class_<PotentialToCompressibleNavierStokesOperation, PotentialToCompressibleNavierStokesOperation::Pointer, Operation >
-        (m,"PotentialToCompressibleNavierStokesOperation")
+    py::class_<PotentialToCompressibleNavierStokesOperation, PotentialToCompressibleNavierStokesOperation::Pointer, Operation > (m,"PotentialToCompressibleNavierStokesOperation")
     .def(py::init<Model&, Parameters>())
     ;
 }

--- a/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_operations_to_python.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_operations_to_python.h
@@ -1,0 +1,28 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ \.
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Carlos Roig
+//                   Ruben Zorrilla
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+#include <pybind11/pybind11.h>
+
+// Project includes
+
+namespace Kratos::Python
+{
+
+void  AddCustomOperationsToPython(pybind11::module& m);
+
+}  // namespace Kratos::Python

--- a/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_operations_to_python.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_operations_to_python.h
@@ -7,8 +7,7 @@
 //  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
-//  Main authors:    Carlos Roig
-//                   Ruben Zorrilla
+//  Main authors:    Marco Antonio Zuñiga Perez
 //
 
 #pragma once

--- a/applications/CompressiblePotentialFlowApplication/custom_python/compressible_potential_flow_python_application.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_python/compressible_potential_flow_python_application.cpp
@@ -21,6 +21,7 @@
 #include "compressible_potential_flow_application.h"
 #include "compressible_potential_flow_application_variables.h"
 #include "custom_python/add_custom_processes_to_python.h"
+#include "custom_python/add_custom_operations_to_python.h"
 #include "custom_python/add_custom_response_functions_to_python.h"
 #include "custom_python/add_custom_utilities_to_python.h"
 
@@ -40,6 +41,7 @@ PYBIND11_MODULE(KratosCompressiblePotentialFlowApplication, m)
 
     AddCustomResponseFunctionUtilitiesToPython(m);
     AddCustomProcessesToPython(m);
+    AddCustomOperationsToPython(m);
     AddCustomUtilitiesToPython(m);
 
     //registering variables in python

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
@@ -31,7 +31,7 @@ KRATOS_TEST_CASE_IN_SUITE(PotentialToCompressibleNavierStokesOperation, Compress
     Model this_model;
     
     // Create potential_model_part
-    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+    auto& r_model_part = this_model.CreateModelPart("Main", 3);
     model_part.GetProcessInfo()[DOMAIN_SIZE] = 2;
     
     // Set potential_model_part properties

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
@@ -61,8 +61,7 @@ KRATOS_TEST_CASE_IN_SUITE(PotentialToCompressibleNavierStokesOperation, Compress
     model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
     model_part.CreateNewNode(3, 1.0, 1.0, 0.0);
     std::vector<ModelPart::IndexType> elemNodes_1{ 1, 2, 3 };
-    model_part.CreateNewElement("IncompressiblePotentialFlowElement2D3N", 1, elemNodes_1, pElemProp);
-    auto& r_element = model_part.GetElement(1);
+    auto p_element = model_part.CreateNewElement("IncompressiblePotentialFlowElement2D3N", 1, elemNodes_1, pElemProp);
     r_element.GetValue(WAKE) = 1;
     Vector wake_elemental_distances(3);
     wake_elemental_distances(0) = 1.0;

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
@@ -38,11 +38,11 @@ KRATOS_TEST_CASE_IN_SUITE(PotentialToCompressibleNavierStokesOperation, Compress
     // Set potential_model_part properties
     BoundedVector<double, 3> free_stream_velocity = ZeroVector(3);
     free_stream_velocity(0) = 10.0;      
-    const double& gamma = 1.4;
-    const double& sound_velocity = 340;
-    const double& free_stream_density = 1.0;
-    const double& free_stream_mach = 0.2;
-    const double& reference_temperature = 273;
+    const double gamma = 1.4;
+    const double sound_velocity = 340;
+    const double free_stream_density = 1.0;
+    const double free_stream_mach = 0.2;
+    const double reference_temperature = 273;
     model_part.GetProcessInfo()[FREE_STREAM_VELOCITY] = free_stream_velocity;
     model_part.GetProcessInfo()[HEAT_CAPACITY_RATIO] = gamma;
     model_part.GetProcessInfo()[SOUND_VELOCITY] = sound_velocity;

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
@@ -142,11 +142,11 @@ KRATOS_TEST_CASE_IN_SUITE(PotentialToCompressibleNavierStokesOperation, Compress
       // Explicit calculate of local nodal values
       const double& velocity_norm_2 = velocity[0] * velocity[0] + velocity[1] * velocity[1];
       const double& velocity_norm = std::pow(velocity_norm_2,0.5);
-      const double& mach = velocity_norm / sound_velocity;
-      const double& num = 1.0 + 0.5 * (gamma - 1.0) * std::pow(free_stream_mach,2);
-      const double& den = 1.0 + 0.5 * (gamma - 1.0) * std::pow(mach,2);
-      const double& density = free_stream_density * std::pow((num / den),(1.0 / (gamma - 1.0)));
-      const double& energy = specific_heat * reference_temperature + 0.5 * velocity_norm_2;
+      const double mach = velocity_norm / sound_velocity;
+      const double num = 1.0 + 0.5 * (gamma - 1.0) * std::pow(free_stream_mach,2);
+      const double den = 1.0 + 0.5 * (gamma - 1.0) * std::pow(mach,2);
+      const double density = free_stream_density * std::pow((num / den),(1.0 / (gamma - 1.0)));
+      const double energy = specific_heat * reference_temperature + 0.5 * velocity_norm_2;
 
       // Check nodal values
       auto nodal_density = r_node->FastGetSolutionStepValue(DENSITY);

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
@@ -161,5 +161,4 @@ KRATOS_TEST_CASE_IN_SUITE(PotentialToCompressibleNavierStokesOperation, Compress
       KRATOS_CHECK_NEAR(nodal_total_energy, density * energy, 1e-6);
     }
 }
-} // namespace Testing
-}  // namespace Kratos.
+} // namespace Kratos::Testing

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
@@ -105,7 +105,7 @@ KRATOS_TEST_CASE_IN_SUITE(PotentialToCompressibleNavierStokesOperation, Compress
     compressible_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
     compressible_model_part.CreateNewNode(3, 1.0, 1.0, 0.0);
     std::vector<ModelPart::IndexType> elemNodes_2{ 1, 2, 3 };
-    compressible_model_part.CreateNewElement("IncompressiblePotentialFlowElement2D3N", 1, elemNodes_2, compressible_pElemProp);
+    compressible_model_part.CreateNewElement("Element2D3N", 1, elemNodes_2, compressible_pElemProp);
     
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
@@ -141,7 +141,7 @@ KRATOS_TEST_CASE_IN_SUITE(PotentialToCompressibleNavierStokesOperation, Compress
 
       // Explicit calculate of local nodal values
       const double& velocity_norm_2 = velocity[0] * velocity[0] + velocity[1] * velocity[1];
-      const double& velocity_norm = std::pow(velocity_norm_2,0.5);
+      const double velocity_norm = std::sqrt(velocity_norm_2);
       const double mach = velocity_norm / sound_velocity;
       const double num = 1.0 + 0.5 * (gamma - 1.0) * std::pow(free_stream_mach,2);
       const double den = 1.0 + 0.5 * (gamma - 1.0) * std::pow(mach,2);

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
@@ -1,0 +1,166 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Marco Antonio Zuñiga Perez
+//
+//
+
+// Project includes
+#include "containers/model.h"
+#include "testing/testing.h"
+#include "fluid_dynamics_application_variables.h"
+#include "compressible_potential_flow_application_variables.h"
+#include "custom_operations/potential_to_compressible_navier_stokes_operation.h"
+
+namespace Kratos {
+namespace Testing {
+
+/**
+* @brief This method creates a potential_model_part and a "fake" compressible_model_part. 
+* The potential nodal values are setting and the nodal velocities are passed with 
+* the PotentialToCompressibleNavierStokesOperation to the compressible_model_part.
+* The values are check with the explicit local calculate for each node.
+*/
+KRATOS_TEST_CASE_IN_SUITE(PotentialToCompressibleNavierStokesOperation, CompressiblePotentialApplicationFastSuite)
+{
+    Model this_model;
+    
+    // Create potential_model_part
+    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+    model_part.GetProcessInfo()[DOMAIN_SIZE] = 2;
+    
+    // Set potential_model_part properties
+    BoundedVector<double, 3> free_stream_velocity = ZeroVector(3);
+    free_stream_velocity(0) = 10.0;      
+    const double& gamma = 1.4;
+    const double& sound_velocity = 340;
+    const double& free_stream_density = 1.0;
+    const double& free_stream_mach = 0.2;
+    const double& reference_temperature = 273;
+    model_part.GetProcessInfo()[FREE_STREAM_VELOCITY] = free_stream_velocity;
+    model_part.GetProcessInfo()[HEAT_CAPACITY_RATIO] = gamma;
+    model_part.GetProcessInfo()[SOUND_VELOCITY] = sound_velocity;
+    model_part.GetProcessInfo()[FREE_STREAM_DENSITY] = free_stream_density;
+    model_part.GetProcessInfo()[FREE_STREAM_MACH] = free_stream_mach;
+    const double& specific_heat = (std::pow(sound_velocity,2) / (gamma * reference_temperature)) / (gamma - 1.0);
+    
+    // Variables addition
+    model_part.AddNodalSolutionStepVariable(VELOCITY_POTENTIAL);
+    model_part.AddNodalSolutionStepVariable(AUXILIARY_VELOCITY_POTENTIAL);
+    
+    // Set the element properties
+    model_part.CreateNewProperties(0);
+    Properties::Pointer pElemProp = model_part.pGetProperties(0);
+   
+    // Geometry creation
+    model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    model_part.CreateNewNode(3, 1.0, 1.0, 0.0);
+    std::vector<ModelPart::IndexType> elemNodes_1{ 1, 2, 3 };
+    model_part.CreateNewElement("IncompressiblePotentialFlowElement2D3N", 1, elemNodes_1, pElemProp);
+    auto& r_element = model_part.GetElement(1);
+    r_element.GetValue(WAKE) = 1;
+    Vector wake_elemental_distances(3);
+    wake_elemental_distances(0) = 1.0;
+    wake_elemental_distances(1) = 1.0;
+    wake_elemental_distances(2) = -1.0;
+    r_element.GetValue(WAKE_ELEMENTAL_DISTANCES) = wake_elemental_distances;
+    
+    // Define the nodal values
+    Vector potential(3);
+    potential(0) = 1.0;
+    potential(1) = 2.0;
+    potential(2) = 3.0;
+    for (unsigned int i = 0; i < 3; i++){
+      if (wake_elemental_distances(i) > 0.0)
+        r_element.GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL) = potential(i);
+      else
+        r_element.GetGeometry()[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL) = potential(i);
+    }
+    for (unsigned int i = 0; i < 3; i++){
+      if (wake_elemental_distances(i) < 0.0)
+        r_element.GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL) = potential(i)+1;
+      else
+        r_element.GetGeometry()[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL) = potential(i)+1;
+    }      
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    
+    // Create fake compressible_model_part
+    ModelPart& compressible_model_part = this_model.CreateModelPart("Compressible", 3);
+    compressible_model_part.GetProcessInfo()[DOMAIN_SIZE] = 2;
+    
+    // Variables addition
+    compressible_model_part.AddNodalSolutionStepVariable(DENSITY);
+    compressible_model_part.AddNodalSolutionStepVariable(MOMENTUM);
+    compressible_model_part.AddNodalSolutionStepVariable(TOTAL_ENERGY);
+    
+    // Set the element properties
+    compressible_model_part.CreateNewProperties(0);
+    Properties::Pointer compressible_pElemProp = compressible_model_part.pGetProperties(0);
+    
+    // Geometry creation
+    compressible_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    compressible_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    compressible_model_part.CreateNewNode(3, 1.0, 1.0, 0.0);
+    std::vector<ModelPart::IndexType> elemNodes_2{ 1, 2, 3 };
+    compressible_model_part.CreateNewElement("IncompressiblePotentialFlowElement2D3N", 1, elemNodes_2, compressible_pElemProp);
+    
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    
+    // Operation parameters
+    Parameters operation_parameters = Parameters(R"(
+      {
+      "origin_model_part"       : "Main",
+      "destination_model_part"  : "Compressible",
+      "reference_temperature"   : 273,
+      "compute_nodal_velocities": true
+      })" );
+    
+    // Execute PotentialToCompressibleNavierStokesOperation
+    PotentialToCompressibleNavierStokesOperation PotentialToCompressibleNavierStokesOperation(this_model, operation_parameters);
+    PotentialToCompressibleNavierStokesOperation.Execute();
+    
+    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+   
+    for(unsigned int index = 0; index < model_part.NumberOfNodes(); ++index)
+    {  
+      auto r_node = compressible_model_part.NodesBegin() + index;
+      const auto potential_node = model_part.NodesBegin() + index;
+
+      // Getting potential flow velocities
+      const auto &velocity = potential_node->GetValue(VELOCITY);
+
+      // Check potential velocities and nodal areas
+      auto nodal_area = potential_node->GetValue(NODAL_AREA);
+      KRATOS_CHECK_NEAR(nodal_area, 0.166667, 1e-6);
+      KRATOS_CHECK_NEAR(velocity[0], 1, 1e-6);
+      KRATOS_CHECK_NEAR(velocity[1], 1, 1e-6);
+      KRATOS_CHECK_NEAR(velocity[2], 0, 1e-6);
+
+      // Explicit calculate of local nodal values
+      const double& velocity_norm_2 = velocity[0] * velocity[0] + velocity[1] * velocity[1];
+      const double& velocity_norm = std::pow(velocity_norm_2,0.5);
+      const double& mach = velocity_norm / sound_velocity;
+      const double& num = 1.0 + 0.5 * (gamma - 1.0) * std::pow(free_stream_mach,2);
+      const double& den = 1.0 + 0.5 * (gamma - 1.0) * std::pow(mach,2);
+      const double& density = free_stream_density * std::pow((num / den),(1.0 / (gamma - 1.0)));
+      const double& energy = specific_heat * reference_temperature + 0.5 * velocity_norm_2;
+
+      // Check nodal values
+      auto nodal_density = r_node->FastGetSolutionStepValue(DENSITY);
+      KRATOS_CHECK_NEAR(nodal_density, density, 1e-6);
+      auto nodal_momentum = r_node->FastGetSolutionStepValue(MOMENTUM);
+      KRATOS_CHECK_NEAR(nodal_momentum[0], density * velocity[0], 1e-6);
+      KRATOS_CHECK_NEAR(nodal_momentum[1], density * velocity[1], 1e-6);
+      auto nodal_total_energy = r_node->FastGetSolutionStepValue(TOTAL_ENERGY);
+      KRATOS_CHECK_NEAR(nodal_total_energy, density * energy, 1e-6);
+    }
+}
+} // namespace Testing
+}  // namespace Kratos.

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
@@ -48,7 +48,7 @@ KRATOS_TEST_CASE_IN_SUITE(PotentialToCompressibleNavierStokesOperation, Compress
     model_part.GetProcessInfo()[SOUND_VELOCITY] = sound_velocity;
     model_part.GetProcessInfo()[FREE_STREAM_DENSITY] = free_stream_density;
     model_part.GetProcessInfo()[FREE_STREAM_MACH] = free_stream_mach;
-    const double& specific_heat = (std::pow(sound_velocity,2) / (gamma * reference_temperature)) / (gamma - 1.0);
+    const double specific_heat = (std::pow(sound_velocity,2) / (gamma * reference_temperature)) / (gamma - 1.0);
     
     // Variables addition
     model_part.AddNodalSolutionStepVariable(VELOCITY_POTENTIAL);

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
@@ -126,8 +126,8 @@ KRATOS_TEST_CASE_IN_SUITE(PotentialToCompressibleNavierStokesOperation, Compress
    
     for(unsigned int index = 0; index < model_part.NumberOfNodes(); ++index)
     {  
-      auto r_node = compressible_model_part.NodesBegin() + index;
-      const auto potential_node = model_part.NodesBegin() + index;
+      auto it_node = compressible_model_part.NodesBegin() + index;
+      const auto it_potential_node = model_part.NodesBegin() + index;
 
       // Getting potential flow velocities
       const auto &velocity = potential_node->GetValue(VELOCITY);

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
@@ -98,8 +98,7 @@ KRATOS_TEST_CASE_IN_SUITE(PotentialToCompressibleNavierStokesOperation, Compress
     compressible_model_part.AddNodalSolutionStepVariable(TOTAL_ENERGY);
     
     // Set the element properties
-    compressible_model_part.CreateNewProperties(0);
-    Properties::Pointer compressible_pElemProp = compressible_model_part.pGetProperties(0);
+    auto p_compressible_elem_prop = compressible_model_part.CreateNewProperties(0);
     
     // Geometry creation
     compressible_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
@@ -18,8 +18,7 @@
 #include "compressible_potential_flow_application_variables.h"
 #include "custom_operations/potential_to_compressible_navier_stokes_operation.h"
 
-namespace Kratos {
-namespace Testing {
+namespace Kratos::Testing {
 
 /**
 * @brief This method creates a potential_model_part and a "fake" compressible_model_part. 

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
@@ -54,8 +54,7 @@ KRATOS_TEST_CASE_IN_SUITE(PotentialToCompressibleNavierStokesOperation, Compress
     model_part.AddNodalSolutionStepVariable(AUXILIARY_VELOCITY_POTENTIAL);
     
     // Set the element properties
-    model_part.CreateNewProperties(0);
-    Properties::Pointer pElemProp = model_part.pGetProperties(0);
+    auto p_elem_prop = model_part.CreateNewProperties(0);
    
     // Geometry creation
     model_part.CreateNewNode(1, 0.0, 0.0, 0.0);

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
@@ -140,7 +140,7 @@ KRATOS_TEST_CASE_IN_SUITE(PotentialToCompressibleNavierStokesOperation, Compress
       KRATOS_CHECK_NEAR(velocity[2], 0, 1e-6);
 
       // Explicit calculate of local nodal values
-      const double& velocity_norm_2 = velocity[0] * velocity[0] + velocity[1] * velocity[1];
+      const double velocity_norm_2 = velocity[0] * velocity[0] + velocity[1] * velocity[1];
       const double velocity_norm = std::sqrt(velocity_norm_2);
       const double mach = velocity_norm / sound_velocity;
       const double num = 1.0 + 0.5 * (gamma - 1.0) * std::pow(free_stream_mach,2);

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_operations.cpp
@@ -151,7 +151,7 @@ KRATOS_TEST_CASE_IN_SUITE(PotentialToCompressibleNavierStokesOperation, Compress
       // Check nodal values
       auto nodal_density = r_node->FastGetSolutionStepValue(DENSITY);
       KRATOS_CHECK_NEAR(nodal_density, density, 1e-6);
-      auto nodal_momentum = r_node->FastGetSolutionStepValue(MOMENTUM);
+      auto& r_nodal_momentum = r_node->FastGetSolutionStepValue(MOMENTUM);
       KRATOS_CHECK_NEAR(nodal_momentum[0], density * velocity[0], 1e-6);
       KRATOS_CHECK_NEAR(nodal_momentum[1], density * velocity[1], 1e-6);
       auto nodal_total_energy = r_node->FastGetSolutionStepValue(TOTAL_ENERGY);


### PR DESCRIPTION
**📝 Description**
The same operation as the PR #10945 but implemented as a c++ operation using the register.

**🆕 Changelog**
- Added "custom_operations" to Application Settings:
           - CMakeLists.txt
           - compressible_potential_flow_python_application.cpp
           - add_custom_operations_to_python.cpp
           - add_custom_operations_to_python.h
- Added custom_operations/potential_to_compressible_navier_stokes_operation.cpp
- Added custom_operations/potential_to_compressible_navier_stokes_operation.h
- Added cpp_test of the operation
