### PR TITLE
[Core] Add branch name to Kratos version information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,9 +151,20 @@ if(GIT_FOUND)
     message("Git did not find the SHA1 number. It will be set to 0.")
     set (KratosMultiphysics_SHA1_NUMBER 0)
   endif(SHA1_NOT_FOUND)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} branch --show-current
+    OUTPUT_VARIABLE KratosMultiphysics_BRANCH_NAME
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_VARIABLE BRANCH_NAME_NOT_FOUND
+  )
+  if(BRANCH_NAME_NOT_FOUND)
+    message("Git did not find the branch name. It will be set to empty.")
+    set (KratosMultiphysics_BRANCH_NAME "")
+  endif(BRANCH_NAME_NOT_FOUND)
 else(GIT_FOUND)
-  message("Git was not found on your system. SHA1 number will be set to 0.")
+  message(STATUS "Git was not found on your system. SHA1 number will be set to 0. Branch name to empty.")
   set (KratosMultiphysics_SHA1_NUMBER 0)
+  set (KratosMultiphysics_BRANCH_NAME "")
 endif(GIT_FOUND)
 
 # Configure files depending on the build type

--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -72,6 +72,7 @@ target_compile_definitions(KratosVersion PRIVATE
     KRATOS_MINOR_VERSION=${KratosMultiphysics_MINOR_VERSION}
     KRATOS_PATCH_VERSION="${KratosMultiphysics_PATCH_VERSION}"
     KRATOS_SHA1_NUMBER="${KratosMultiphysics_SHA1_NUMBER}"
+    KRATOS_BRANCH_NAME="${KratosMultiphysics_BRANCH_NAME}"
     KRATOS_BUILD_TYPE="${CMAKE_BUILD_TYPE}"
 )
 

--- a/kratos/includes/kratos_version.h
+++ b/kratos/includes/kratos_version.h
@@ -57,6 +57,7 @@ constexpr int GetMinorVersion() {
 
 KRATOS_API_EXPORT std::string GetPatchVersion();
 KRATOS_API_EXPORT std::string GetCommit();
+KRATOS_API_EXPORT std::string GetBranchName();
 KRATOS_API_EXPORT std::string GetBuildType();
 KRATOS_API_EXPORT std::string GetVersionString();
 KRATOS_API_EXPORT std::string GetOSName();

--- a/kratos/sources/kratos_version.cpp
+++ b/kratos/sources/kratos_version.cpp
@@ -30,6 +30,11 @@ namespace Kratos {
 #define KRATOS_SHA1_NUMBER "0"
 #endif
 
+// GiT branch name at configure
+#ifndef KRATOS_BRANCH_NAME
+#define KRATOS_BRANCH_NAME ""
+#endif
+
 // Build type
 #ifndef KRATOS_BUILD_TYPE
 #define KRATOS_BUILD_TYPE "Release"
@@ -59,6 +64,7 @@ namespace Kratos {
 KRATOS_TO_STRING(KRATOS_MAJOR_VERSION) "." \
 KRATOS_TO_STRING(KRATOS_MINOR_VERSION) "." \
 KRATOS_TO_STRING(KRATOS_PATCH_VERSION) "-" \
+KRATOS_BRANCH_NAME "-" \
 KRATOS_SHA1_NUMBER "-" \
 KRATOS_BUILD_TYPE  "-" \
 KRATOS_ARCH_TYPE
@@ -96,8 +102,12 @@ std::string GetPatchVersion() {
     return KRATOS_PATCH_VERSION;
 }
 
-std::string GetCommitVersion() {
+std::string GetCommit() {
     return KRATOS_SHA1_NUMBER;
+}
+
+std::string GetBranchName() {
+    return KRATOS_BRANCH_NAME;
 }
 
 std::string GetBuildType() {


### PR DESCRIPTION
**📝 Description**

This PR adds the branch name to the Kratos version information. It updates the `CMakeLists.txt` files to retrieve the branch name using `Git` and include it in the build configuration. The `kratos_version.h` header file is updated to include a new function `GetBranchName()`, and the `kratos_version.cpp` source file is updated to define the new function, returning the branch name.

**🆕 Changelog**

- [Adding branch name to loading header](https://github.com/KratosMultiphysics/Kratos/commit/a37bea518e7f72a9e8ab44c28478aa081ea5c327)
- Fix `GetCommit()` inconsistent definition
