### PR TITLE
Mpi/fix communicator test case

### DIFF
--- a/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
+++ b/kratos/mpi/tests/cpp_tests/sources/test_mpi_communicator.cpp
@@ -32,7 +32,11 @@ namespace Internals {
 
 void ModelPartForMPICommunicatorTests(ModelPart& rModelPart, const DataCommunicator& rComm)
 {
-    /* NOTE: the modelpart should at least have PARTITION_INDEX in the nodal solution step data */
+    /* Mesh one quarter of a circle with triangular slices (one triangle per rank)
+    * Nodes 1=(0,0) and 2=(1,0) always belong to rank 0
+    * Node n+2=(0,1) always belongs to the last rank
+    * Nodes 3...n+1 are shared between rank n-3 and rank n-2
+    * NOTE: the modelpart should at least have PARTITION_INDEX in the nodal solution step data */
     constexpr double total_angle = Globals::Pi/2.0;
     constexpr double side_length = 1.0;
 
@@ -54,13 +58,13 @@ void ModelPartForMPICommunicatorTests(ModelPart& rModelPart, const DataCommunica
     const double y2 = side_length * std::sin(angle_end);
 
     const unsigned int local_index = rank + 2;
-    const unsigned int ghost_index = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    const unsigned int ghost_index = rank + 3;
     auto p_node_1 = rModelPart.CreateNewNode(local_index, x1, y1, 0.0);
     auto p_node_2 = rModelPart.CreateNewNode(ghost_index, x2, y2, 0.0);
 
     p_node_1->FastGetSolutionStepValue(PARTITION_INDEX) = rank;
-    const int remote_rank = (rank != size-1) ? rank + 1 : 0;
-    p_node_2->FastGetSolutionStepValue(PARTITION_INDEX) = remote_rank;
+    const int other_rank = (rank != size-1) ? rank + 1 : rank;
+    p_node_2->FastGetSolutionStepValue(PARTITION_INDEX) = other_rank;
 
     std::vector<ModelPart::IndexType> element_nodes{1, local_index, ghost_index};
     rModelPart.CreateNewElement("Element2D3N", rank+1, element_nodes, p_properties);
@@ -250,30 +254,30 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableAs
     Node<3>& r_center = r_model_part.Nodes()[1];
     // local and ghost nodes are each known in two ranks
     const unsigned int local_id = rank + 2;
-    unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    unsigned int ghost_id = rank + 3;
     Node<3>& r_local = r_model_part.Nodes()[local_id];
     Node<3>& r_ghost = r_model_part.Nodes()[ghost_id];
 
     r_comm.AssembleCurrentData(DOMAIN_SIZE);
-    int expected_int = (size > 1) ? 2 : 1;
+    int expected_int_local = (size > 1) && (rank > 0) ? 2 : 1;
+    int expected_int_ghost = (size > 1) && (rank != size - 1) ? 2 : 1;
     KRATOS_CHECK_EQUAL(r_center.FastGetSolutionStepValue(DOMAIN_SIZE,0), size);
-    KRATOS_CHECK_EQUAL( r_local.FastGetSolutionStepValue(DOMAIN_SIZE,0), expected_int);
-    KRATOS_CHECK_EQUAL( r_ghost.FastGetSolutionStepValue(DOMAIN_SIZE,0), expected_int);
+    KRATOS_CHECK_EQUAL( r_local.FastGetSolutionStepValue(DOMAIN_SIZE,0), expected_int_local);
+    KRATOS_CHECK_EQUAL( r_ghost.FastGetSolutionStepValue(DOMAIN_SIZE,0), expected_int_ghost);
 
     r_comm.AssembleCurrentData(TEMPERATURE);
-    int expected_double = 2.0*expected_int;
     KRATOS_CHECK_EQUAL(r_center.FastGetSolutionStepValue(TEMPERATURE,0), 2.0*size);
-    KRATOS_CHECK_EQUAL( r_local.FastGetSolutionStepValue(TEMPERATURE,0), expected_double);
-    KRATOS_CHECK_EQUAL( r_ghost.FastGetSolutionStepValue(TEMPERATURE,0), expected_double);
+    KRATOS_CHECK_EQUAL( r_local.FastGetSolutionStepValue(TEMPERATURE,0), 2.0*expected_int_local);
+    KRATOS_CHECK_EQUAL( r_ghost.FastGetSolutionStepValue(TEMPERATURE,0), 2.0*expected_int_ghost);
 
     r_comm.AssembleCurrentData(VELOCITY);
     KRATOS_CHECK_EQUAL(r_center.FastGetSolutionStepValue(VELOCITY_X,0), 1.0*size);
-    KRATOS_CHECK_EQUAL( r_local.FastGetSolutionStepValue(VELOCITY_X,0), 1.0*expected_int);
-    KRATOS_CHECK_EQUAL( r_ghost.FastGetSolutionStepValue(VELOCITY_X,0), 1.0*expected_int);
+    KRATOS_CHECK_EQUAL( r_local.FastGetSolutionStepValue(VELOCITY_X,0), 1.0*expected_int_local);
+    KRATOS_CHECK_EQUAL( r_ghost.FastGetSolutionStepValue(VELOCITY_X,0), 1.0*expected_int_ghost);
 
     KRATOS_CHECK_EQUAL(r_center.FastGetSolutionStepValue(VELOCITY_Y,0), 2.0*size);
-    KRATOS_CHECK_EQUAL( r_local.FastGetSolutionStepValue(VELOCITY_Y,0), 2.0*expected_int);
-    KRATOS_CHECK_EQUAL( r_ghost.FastGetSolutionStepValue(VELOCITY_Y,0), 2.0*expected_int);
+    KRATOS_CHECK_EQUAL( r_local.FastGetSolutionStepValue(VELOCITY_Y,0), 2.0*expected_int_local);
+    KRATOS_CHECK_EQUAL( r_ghost.FastGetSolutionStepValue(VELOCITY_Y,0), 2.0*expected_int_ghost);
 
     KRATOS_CHECK_EQUAL(r_center.FastGetSolutionStepValue(VELOCITY_Z,0), 0.0);
     KRATOS_CHECK_EQUAL( r_local.FastGetSolutionStepValue(VELOCITY_Z,0), 0.0);
@@ -288,12 +292,12 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableAs
     const auto& r_assembled_local_vector = r_local.FastGetSolutionStepValue(CAUCHY_STRESS_VECTOR,0);
     KRATOS_CHECK_EQUAL(r_assembled_local_vector.size(), 2);
     KRATOS_CHECK_EQUAL(r_assembled_local_vector[0], 0.0);
-    KRATOS_CHECK_EQUAL(r_assembled_local_vector[1], 1.0*expected_int);
+    KRATOS_CHECK_EQUAL(r_assembled_local_vector[1], 1.0*expected_int_local);
 
     const auto& r_assembled_ghost_vector = r_ghost.FastGetSolutionStepValue(CAUCHY_STRESS_VECTOR,0);
     KRATOS_CHECK_EQUAL(r_assembled_ghost_vector.size(), 2);
     KRATOS_CHECK_EQUAL(r_assembled_ghost_vector[0], 0.0);
-    KRATOS_CHECK_EQUAL(r_assembled_ghost_vector[1], 1.0*expected_int);
+    KRATOS_CHECK_EQUAL(r_assembled_ghost_vector[1], 1.0*expected_int_ghost);
 
     r_comm.AssembleCurrentData(DEFORMATION_GRADIENT);
     const auto& r_assembled_center_matrix = r_center.FastGetSolutionStepValue(DEFORMATION_GRADIENT,0);
@@ -306,13 +310,13 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableAs
     KRATOS_CHECK_EQUAL(r_assembled_local_matrix.size1(), 3);
     KRATOS_CHECK_EQUAL(r_assembled_local_matrix.size2(), 2);
     KRATOS_CHECK_EQUAL(r_assembled_local_matrix(0,0), 0.0);
-    KRATOS_CHECK_EQUAL(r_assembled_local_matrix(2,0), 1.0*expected_int);
+    KRATOS_CHECK_EQUAL(r_assembled_local_matrix(2,0), 1.0*expected_int_local);
 
     const auto& r_assembled_ghost_matrix = r_ghost.FastGetSolutionStepValue(DEFORMATION_GRADIENT,0);
     KRATOS_CHECK_EQUAL(r_assembled_ghost_matrix.size1(), 3);
     KRATOS_CHECK_EQUAL(r_assembled_ghost_matrix.size2(), 2);
     KRATOS_CHECK_EQUAL(r_assembled_ghost_matrix(0,0), 0.0);
-    KRATOS_CHECK_EQUAL(r_assembled_ghost_matrix(2,0), 1.0*expected_int);
+    KRATOS_CHECK_EQUAL(r_assembled_ghost_matrix(2,0), 1.0*expected_int_ghost);
 }
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSynchronize, KratosMPICoreFastSuite)
@@ -439,30 +443,30 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataAssembly, KratosMP
     Node<3>& r_center = r_model_part.Nodes()[1];
     // local and ghost nodes are each known in two ranks
     const unsigned int local_id = rank + 2;
-    unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    unsigned int ghost_id = rank + 3;
     Node<3>& r_local = r_model_part.Nodes()[local_id];
     Node<3>& r_ghost = r_model_part.Nodes()[ghost_id];
 
     r_comm.AssembleNonHistoricalData(DOMAIN_SIZE);
-    int expected_int = (size > 1) ? 2 : 1;
+    int expected_int_local = (size > 1) && rank != 0 ? 2 : 1;
+    int expected_int_ghost = (size > 1) && rank != size - 1 ? 2 : 1;
     KRATOS_CHECK_EQUAL(r_center.GetValue(DOMAIN_SIZE), size);
-    KRATOS_CHECK_EQUAL( r_local.GetValue(DOMAIN_SIZE), expected_int);
-    KRATOS_CHECK_EQUAL( r_ghost.GetValue(DOMAIN_SIZE), expected_int);
+    KRATOS_CHECK_EQUAL( r_local.GetValue(DOMAIN_SIZE), expected_int_local);
+    KRATOS_CHECK_EQUAL( r_ghost.GetValue(DOMAIN_SIZE), expected_int_ghost);
 
     r_comm.AssembleNonHistoricalData(TEMPERATURE);
-    int expected_double = 2.0*expected_int;
     KRATOS_CHECK_EQUAL(r_center.GetValue(TEMPERATURE), 2.0*size);
-    KRATOS_CHECK_EQUAL( r_local.GetValue(TEMPERATURE), expected_double);
-    KRATOS_CHECK_EQUAL( r_ghost.GetValue(TEMPERATURE), expected_double);
+    KRATOS_CHECK_EQUAL( r_local.GetValue(TEMPERATURE), 2.0*expected_int_local);
+    KRATOS_CHECK_EQUAL( r_ghost.GetValue(TEMPERATURE), 2.0*expected_int_ghost);
 
     r_comm.AssembleNonHistoricalData(VELOCITY);
     KRATOS_CHECK_EQUAL(r_center.GetValue(VELOCITY_X), 1.0*size);
-    KRATOS_CHECK_EQUAL( r_local.GetValue(VELOCITY_X), 1.0*expected_int);
-    KRATOS_CHECK_EQUAL( r_ghost.GetValue(VELOCITY_X), 1.0*expected_int);
+    KRATOS_CHECK_EQUAL( r_local.GetValue(VELOCITY_X), 1.0*expected_int_local);
+    KRATOS_CHECK_EQUAL( r_ghost.GetValue(VELOCITY_X), 1.0*expected_int_ghost);
 
     KRATOS_CHECK_EQUAL(r_center.GetValue(VELOCITY_Y), 2.0*size);
-    KRATOS_CHECK_EQUAL( r_local.GetValue(VELOCITY_Y), 2.0*expected_int);
-    KRATOS_CHECK_EQUAL( r_ghost.GetValue(VELOCITY_Y), 2.0*expected_int);
+    KRATOS_CHECK_EQUAL( r_local.GetValue(VELOCITY_Y), 2.0*expected_int_local);
+    KRATOS_CHECK_EQUAL( r_ghost.GetValue(VELOCITY_Y), 2.0*expected_int_ghost);
 
     KRATOS_CHECK_EQUAL(r_center.GetValue(VELOCITY_Z), 0.0);
     KRATOS_CHECK_EQUAL( r_local.GetValue(VELOCITY_Z), 0.0);
@@ -477,12 +481,12 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataAssembly, KratosMP
     const auto& r_assembled_local_vector = r_local.GetValue(CAUCHY_STRESS_VECTOR);
     KRATOS_CHECK_EQUAL(r_assembled_local_vector.size(), 2);
     KRATOS_CHECK_EQUAL(r_assembled_local_vector[0], 0.0);
-    KRATOS_CHECK_EQUAL(r_assembled_local_vector[1], 1.0*expected_int);
+    KRATOS_CHECK_EQUAL(r_assembled_local_vector[1], 1.0*expected_int_local);
 
     const auto& r_assembled_ghost_vector = r_ghost.GetValue(CAUCHY_STRESS_VECTOR);
     KRATOS_CHECK_EQUAL(r_assembled_ghost_vector.size(), 2);
     KRATOS_CHECK_EQUAL(r_assembled_ghost_vector[0], 0.0);
-    KRATOS_CHECK_EQUAL(r_assembled_ghost_vector[1], 1.0*expected_int);
+    KRATOS_CHECK_EQUAL(r_assembled_ghost_vector[1], 1.0*expected_int_ghost);
 
     r_comm.AssembleNonHistoricalData(DEFORMATION_GRADIENT);
     const auto& r_assembled_center_matrix = r_center.GetValue(DEFORMATION_GRADIENT);
@@ -495,13 +499,13 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataAssembly, KratosMP
     KRATOS_CHECK_EQUAL(r_assembled_local_matrix.size1(), 3);
     KRATOS_CHECK_EQUAL(r_assembled_local_matrix.size2(), 2);
     KRATOS_CHECK_EQUAL(r_assembled_local_matrix(0,0), 0.0);
-    KRATOS_CHECK_EQUAL(r_assembled_local_matrix(2,0), 1.0*expected_int);
+    KRATOS_CHECK_EQUAL(r_assembled_local_matrix(2,0), 1.0*expected_int_local);
 
     const auto& r_assembled_ghost_matrix = r_ghost.GetValue(DEFORMATION_GRADIENT);
     KRATOS_CHECK_EQUAL(r_assembled_ghost_matrix.size1(), 3);
     KRATOS_CHECK_EQUAL(r_assembled_ghost_matrix.size2(), 2);
     KRATOS_CHECK_EQUAL(r_assembled_ghost_matrix(0,0), 0.0);
-    KRATOS_CHECK_EQUAL(r_assembled_ghost_matrix(2,0), 1.0*expected_int);
+    KRATOS_CHECK_EQUAL(r_assembled_ghost_matrix(2,0), 1.0*expected_int_ghost);
 }
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataSynchronize, KratosMPICoreFastSuite)
@@ -608,13 +612,13 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSy
 
     // center is local to rank 0 and ghost in all other ranks
     Node<3>& r_center = r_model_part.Nodes()[1];
-    // local and ghost nodes are each known in two ranks
+    // local and ghost nodes are each known in two ranks (except for first and last rank)
     const unsigned int local_id = rank + 2;
-    const unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    const unsigned int ghost_id = rank + 3;
     auto& r_local = r_model_part.Nodes()[local_id];
     auto& r_ghost = r_model_part.Nodes()[ghost_id];
 
-    const int expected_local = (rank == 0) ? 10.0*(size-1) : 10.0*rank;
+    const int expected_local = (rank == 0) ? 0.0 : 10.0*rank;
     const int expected_ghost = (rank + 1 < size) ? 10.0*(rank+1) : 10.0*(size-1);
 
     r_comm.SynchronizeCurrentDataToMax(TEMPERATURE);
@@ -629,7 +633,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToMax,
     ModelPart& r_model_part = model.CreateModelPart("TestModelPart");
     r_model_part.AddNodalSolutionStepVariable(PARTITION_INDEX);
 
-    MPIDataCommunicator comm_world(MPI_COMM_WORLD);  
+    MPIDataCommunicator comm_world(MPI_COMM_WORLD);
     Internals::ModelPartForMPICommunicatorTests(r_model_part, comm_world);
     const int rank = comm_world.Rank();
     const int size = comm_world.Size();
@@ -642,13 +646,13 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToMax,
 
     // center is local to rank 0 and ghost in all other ranks
     Node<3>& r_center = r_model_part.Nodes()[1];
-    // local and ghost nodes are each known in two ranks
+    // local and ghost nodes are each known in two ranks (except on first and last rank)
     const unsigned int local_id = rank + 2;
-    const unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    const unsigned int ghost_id = rank + 3;
     auto& r_local = r_model_part.Nodes()[local_id];
     auto& r_ghost = r_model_part.Nodes()[ghost_id];
 
-    const int expected_local = (rank == 0) ? 10.0*(size-1) : 10.0*rank;
+    const int expected_local = 10.0*rank;
     const int expected_ghost = (rank + 1 < size) ? 10.0*(rank+1) : 10.0*(size-1);
 
     r_comm.SynchronizeNonHistoricalDataToMax(TEMPERATURE);
@@ -679,11 +683,11 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSy
     Node<3>& r_center = r_model_part.Nodes()[1];
     // local and ghost nodes are each known in two ranks
     const unsigned int local_id = rank + 2;
-    const unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    const unsigned int ghost_id = rank + 3;
     auto& r_local = r_model_part.Nodes()[local_id];
     auto& r_ghost = r_model_part.Nodes()[ghost_id];
 
-    const int expected_local = (rank == 0) ? - 10.0*(size-1) : - 10.0*rank;
+    const int expected_local = (rank == 0) ? 0.0 : - 10.0*rank;
     const int expected_ghost = (rank + 1 < size) ? - 10.0*(rank+1) : - 10.0*(size-1);
 
     r_comm.SynchronizeCurrentDataToAbsMax(TEMPERATURE);
@@ -698,7 +702,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToAbsM
     ModelPart& r_model_part = model.CreateModelPart("TestModelPart");
     r_model_part.AddNodalSolutionStepVariable(PARTITION_INDEX);
 
-    MPIDataCommunicator comm_world(MPI_COMM_WORLD);  
+    MPIDataCommunicator comm_world(MPI_COMM_WORLD);
     Internals::ModelPartForMPICommunicatorTests(r_model_part, comm_world);
     const int rank = comm_world.Rank();
     const int size = comm_world.Size();
@@ -711,13 +715,13 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToAbsM
 
     // center is local to rank 0 and ghost in all other ranks
     Node<3>& r_center = r_model_part.Nodes()[1];
-    // local and ghost nodes are each known in two ranks
+    // local and ghost nodes are each known in two ranks (except on first and last rank)
     const unsigned int local_id = rank + 2;
-    const unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    const unsigned int ghost_id = rank + 3;
     auto& r_local = r_model_part.Nodes()[local_id];
     auto& r_ghost = r_model_part.Nodes()[ghost_id];
 
-    const int expected_local = (rank == 0) ? - 10.0*(size-1) : - 10.0*rank;
+    const int expected_local = - 10.0*rank;
     const int expected_ghost = (rank + 1 < size) ? - 10.0*(rank+1) : - 10.0*(size-1);
 
     r_comm.SynchronizeNonHistoricalDataToAbsMax(TEMPERATURE);
@@ -736,7 +740,6 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSy
     MPIDataCommunicator comm_world(MPI_COMM_WORLD);
     Internals::ModelPartForMPICommunicatorTests(r_model_part, comm_world);
     int rank = comm_world.Rank();
-    int size = comm_world.Size();
 
     for (auto& r_node : r_model_part.Nodes()) {
         r_node.FastGetSolutionStepValue(TEMPERATURE, 0) = 10.0*rank;
@@ -746,14 +749,14 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSy
 
     // center is local to rank 0 and ghost in all other ranks
     Node<3>& r_center = r_model_part.Nodes()[1];
-    // local and ghost nodes are each known in two ranks
+    // local and ghost nodes are each known in two ranks (except on first and last rank)
     const unsigned int local_id = rank + 2;
-    unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    unsigned int ghost_id = rank + 3;
     Node<3>& r_local = r_model_part.Nodes()[local_id];
     Node<3>& r_ghost = r_model_part.Nodes()[ghost_id];
 
     int expected_local = (rank > 0) ? 10.0*(rank-1) : 0.0;
-    int expected_ghost = (rank + 1 < size) ? 10.0*rank : 0.0;
+    int expected_ghost = 10.0*rank;
 
     r_comm.SynchronizeCurrentDataToMin(TEMPERATURE);
     KRATOS_CHECK_EQUAL(r_center.FastGetSolutionStepValue(TEMPERATURE,0), 0.0);
@@ -770,7 +773,6 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToMin,
     MPIDataCommunicator comm_world(MPI_COMM_WORLD);
     Internals::ModelPartForMPICommunicatorTests(r_model_part, comm_world);
     int rank = comm_world.Rank();
-    int size = comm_world.Size();
 
     for (auto& r_node : r_model_part.Nodes()) {
         r_node.SetValue(TEMPERATURE, 10.0*rank);
@@ -780,14 +782,14 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToMin,
 
     // center is local to rank 0 and ghost in all other ranks
     Node<3>& r_center = r_model_part.Nodes()[1];
-    // local and ghost nodes are each known in two ranks
+    // local and ghost nodes are each known in two ranks (except on first and last rank)
     const unsigned int local_id = rank + 2;
-    unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    unsigned int ghost_id = rank + 3;
     Node<3>& r_local = r_model_part.Nodes()[local_id];
     Node<3>& r_ghost = r_model_part.Nodes()[ghost_id];
 
     int expected_local = (rank > 0) ? 10.0*(rank-1) : 0.0;
-    int expected_ghost = (rank + 1 < size) ? 10.0*rank : 0.0;
+    int expected_ghost = 10.0*rank;
 
     r_comm.SynchronizeNonHistoricalDataToMin(TEMPERATURE);
     KRATOS_CHECK_EQUAL(r_center.GetValue(TEMPERATURE), 0.0);
@@ -805,7 +807,6 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSy
     MPIDataCommunicator comm_world(MPI_COMM_WORLD);
     Internals::ModelPartForMPICommunicatorTests(r_model_part, comm_world);
     int rank = comm_world.Rank();
-    int size = comm_world.Size();
 
     for (auto& r_node : r_model_part.Nodes()) {
         r_node.FastGetSolutionStepValue(TEMPERATURE, 0) = - 10.0*rank;
@@ -815,14 +816,14 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalSolutionStepVariableSy
 
     // center is local to rank 0 and ghost in all other ranks
     Node<3>& r_center = r_model_part.Nodes()[1];
-    // local and ghost nodes are each known in two ranks
+    // local and ghost nodes are each known in two ranks (except on first and last rank)
     const unsigned int local_id = rank + 2;
-    unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    unsigned int ghost_id = rank + 3;
     Node<3>& r_local = r_model_part.Nodes()[local_id];
     Node<3>& r_ghost = r_model_part.Nodes()[ghost_id];
 
     int expected_local = (rank > 0) ? - 10.0*(rank-1) : 0.0;
-    int expected_ghost = (rank + 1 < size) ? - 10.0*rank : 0.0;
+    int expected_ghost = - 10.0*rank;
 
     r_comm.SynchronizeCurrentDataToAbsMin(TEMPERATURE);
     KRATOS_CHECK_EQUAL(r_center.FastGetSolutionStepValue(TEMPERATURE,0), 0.0);
@@ -839,7 +840,6 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToAbsM
     MPIDataCommunicator comm_world(MPI_COMM_WORLD);
     Internals::ModelPartForMPICommunicatorTests(r_model_part, comm_world);
     int rank = comm_world.Rank();
-    int size = comm_world.Size();
 
     for (auto& r_node : r_model_part.Nodes()) {
         r_node.SetValue(TEMPERATURE, - 10.0*rank);
@@ -849,14 +849,14 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPICommunicatorNodalDataVariableSyncToAbsM
 
     // center is local to rank 0 and ghost in all other ranks
     Node<3>& r_center = r_model_part.Nodes()[1];
-    // local and ghost nodes are each known in two ranks
+    // local and ghost nodes are each known in two ranks (except on first and last rank)
     const unsigned int local_id = rank + 2;
-    unsigned int ghost_id = (size == 1) || (rank != size-1) ? rank + 3 : 2;
+    unsigned int ghost_id = rank + 3;
     Node<3>& r_local = r_model_part.Nodes()[local_id];
     Node<3>& r_ghost = r_model_part.Nodes()[ghost_id];
 
     int expected_local = (rank > 0) ? - 10.0*(rank-1) : 0.0;
-    int expected_ghost = (rank + 1 < size) ? - 10.0*rank : 0.0;
+    int expected_ghost = - 10.0*rank;
 
     r_comm.SynchronizeNonHistoricalDataToAbsMin(TEMPERATURE);
     KRATOS_CHECK_EQUAL(r_center.GetValue(TEMPERATURE), 0.0);
@@ -1026,7 +1026,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(CommunicatorGlobalNumMethods, KratosMPICor
 
     const unsigned int comm_size = r_mpi_comm.TotalProcesses();
 
-    KRATOS_CHECK_EQUAL(r_mpi_comm.GlobalNumberOfNodes(), comm_size+1);
+    KRATOS_CHECK_EQUAL(r_mpi_comm.GlobalNumberOfNodes(), comm_size+2);
     KRATOS_CHECK_EQUAL(r_mpi_comm.GlobalNumberOfElements(), comm_size);
 }
 

--- a/kratos/python_scripts/testing/run_cpp_mpi_tests.py
+++ b/kratos/python_scripts/testing/run_cpp_mpi_tests.py
@@ -1,10 +1,8 @@
 import sys
 
-from KratosMultiphysics import *
-from KratosMultiphysics import mpi
+from KratosMultiphysics import mpi, Tester
 
 if __name__ == '__main__':
-    import sys
     #Tester.SetVerbosity(Tester.Verbosity.TESTS_LIST)
     Tester.SetVerbosity(Tester.Verbosity.TESTS_OUTPUTS)
 

--- a/kratos/python_scripts/testing/run_cpp_mpi_tests.py
+++ b/kratos/python_scripts/testing/run_cpp_mpi_tests.py
@@ -1,7 +1,14 @@
+import sys
+
 from KratosMultiphysics import *
 from KratosMultiphysics import mpi
 
-#Tester.SetVerbosity(Tester.Verbosity.TESTS_LIST)
-Tester.SetVerbosity(Tester.Verbosity.TESTS_OUTPUTS)
+if __name__ == '__main__':
+    import sys
+    #Tester.SetVerbosity(Tester.Verbosity.TESTS_LIST)
+    Tester.SetVerbosity(Tester.Verbosity.TESTS_OUTPUTS)
 
-Tester.RunTestSuite("KratosMPICoreFastSuite")
+    if len(sys.argv) < 2:
+        Tester.RunTestSuite("KratosMPICoreFastSuite")
+    else:
+        Tester.RunTestCases(sys.argv[1])


### PR DESCRIPTION
**📝 Description**
The test model used in the mpi data communicator tests is currently overwriting one of the nodes, effectively creating an inverted element on the last rank. It is not a big deal, since the model is not used for computation, but I think it is confusing when trying to reason about the tests.

In this PR I am updating the model so that it is always a valid triangular mesh and updating some tests where this change in connectivity implies a change of the results.

I'm also including a minor update on the test script launcher so that one can select a subset of the tests from the command line, as it is done for most test scripts.

**🆕 Changelog**
- Fixed the test model used in mpi data communicator tests so that it is a valid triangular mesh.
- Enabled selecting a subset of the available tests from command line when calling run_cpp_mpi_tests.py 
