### PR TITLE
[Core] Missing `Pointer` definition for `TreeNode`

### DIFF
--- a/kratos/spatial_containers/tree.h
+++ b/kratos/spatial_containers/tree.h
@@ -59,6 +59,11 @@ class TreeNode
 {
 public:
 
+    ///@name Type Definitions
+
+    /// Pointer definition of TreeNode
+    KRATOS_CLASS_POINTER_DEFINITION(TreeNode);
+
     // Global definitions
     typedef std::size_t SizeType;
     typedef std::size_t IndexType;


### PR DESCRIPTION
**📝 Description**

In this PR, a pointer definition for the `TreeNode` class is added using the `KRATOS_CLASS_POINTER_DEFINITION` macro.

**🆕 Changelog**

- [Missing `Pointer` definition for `TreeNode`](https://github.com/KratosMultiphysics/Kratos/commit/e9690c5ee5dab2cd4701f2ab74a10290376fa90f)
