### PR TITLE
[TrilinosApplication] Adding `SetValue` methods and corresponding tests for `TrilinosAssemblingUtilities`

### DIFF
--- a/applications/TrilinosApplication/custom_utilities/trilinos_assembling_utilities.h
+++ b/applications/TrilinosApplication/custom_utilities/trilinos_assembling_utilities.h
@@ -184,6 +184,105 @@ public:
         }
     }
 
+    /**
+     * @brief Sets a value in a vector
+     * @param rX The vector considered
+     * @param i The index of the value considered
+     * @param Value The value considered
+     * @tparam TGlobalAssemble If considering a global assembling
+     */
+    template<bool TGlobalIndex = true, bool TGlobalAssemble = true>
+    static inline void SetValue(
+        VectorType& rX,
+        IndexType i,
+        const double Value
+        )
+    {
+        int ierr = 0;
+        if constexpr (TGlobalIndex) {
+            Epetra_IntSerialDenseVector indices(1);
+            Epetra_SerialDenseVector values(1);
+            indices[0] = i;
+            values[0] = Value;
+            ierr = rX.ReplaceGlobalValues(indices, values);
+        } else {
+            ierr = rX.ReplaceMyValue(static_cast<int>(i), 0, Value);
+        }
+        KRATOS_ERROR_IF(ierr != 0) << "Epetra failure found" << std::endl;
+
+        if constexpr (TGlobalAssemble) {
+            ierr = rX.GlobalAssemble(Insert,true); //Epetra_CombineMode mode=Add);
+            KRATOS_ERROR_IF(ierr < 0) << "Epetra failure when attempting to insert value in function SetValue" << std::endl;
+        }
+    }
+
+    /**
+     * @brief Sets a value in a vector without global assembly
+     * @param rX The vector considered
+     * @param i The index of the value considered
+     * @param Value The value considered
+     */
+    template<bool TGlobalIndex = true>
+    static inline void SetValueWithoutGlobalAssembly(
+        VectorType& rX,
+        IndexType i,
+        const double Value
+        )
+    {
+        SetValue<TGlobalIndex, false>(rX, i, Value);
+    }
+
+    /**
+     * @brief Sets a value in a matrix
+     * @param rX The vector considered
+     * @param i The first index of the value considered
+     * @param j The second index of the value considered
+     * @param Value The value considered
+     * @tparam TGlobalAssemble If considering a global assembling
+     */
+    template<bool TGlobalIndex = true, bool TGlobalAssemble = true>
+    static inline void SetValue(
+        MatrixType& rA,
+        IndexType i,
+        IndexType j,
+        const double Value
+        )
+    {
+        std::vector<double> values(1, Value);
+        std::vector<int> indices(1, j);
+
+        int ierr = 0;
+        if constexpr (TGlobalIndex) {
+            ierr = rA.ReplaceGlobalValues(static_cast<int>(i), 1, values.data(), indices.data());
+        } else {
+            ierr = rA.ReplaceMyValues(static_cast<int>(i), 1, values.data(), indices.data());
+        }
+        KRATOS_ERROR_IF(ierr != 0) << "Epetra failure found" << std::endl;
+
+        if constexpr (TGlobalAssemble) {
+            ierr = rA.GlobalAssemble();
+            KRATOS_ERROR_IF(ierr < 0) << "Epetra failure when attempting to insert value in function SetValue" << std::endl;
+        }
+    }
+
+    /**
+     * @brief Sets a value in a matrix
+     * @param rX The vector considered
+     * @param i The first index of the value considered
+     * @param j The second index of the value considered
+     * @param Value The value considered
+     */
+    template<bool TGlobalIndex = true>
+    static inline void SetValueWithoutGlobalAssembly(
+        MatrixType& rA,
+        IndexType i,
+        IndexType j,
+        const double Value
+        )
+    {
+        SetValue<TGlobalIndex, false>(rA, i, j, Value);
+    }
+
     ///@}
     ///@name Access
     ///@{

--- a/applications/TrilinosApplication/custom_utilities/trilinos_assembling_utilities.h
+++ b/applications/TrilinosApplication/custom_utilities/trilinos_assembling_utilities.h
@@ -189,47 +189,76 @@ public:
      * @param rX The vector considered
      * @param i The index of the value considered
      * @param Value The value considered
-     * @tparam TGlobalAssemble If considering a global assembling
      */
-    template<bool TGlobalIndex = true, bool TGlobalAssemble = true>
-    static inline void SetValue(
+    static inline void SetGlobalValue(
         VectorType& rX,
         IndexType i,
         const double Value
         )
     {
-        int ierr = 0;
-        if constexpr (TGlobalIndex) {
-            Epetra_IntSerialDenseVector indices(1);
-            Epetra_SerialDenseVector values(1);
-            indices[0] = i;
-            values[0] = Value;
-            ierr = rX.ReplaceGlobalValues(indices, values);
-        } else {
-            ierr = rX.ReplaceMyValue(static_cast<int>(i), 0, Value);
-        }
+        Epetra_IntSerialDenseVector indices(1);
+        Epetra_SerialDenseVector values(1);
+        indices[0] = i;
+        values[0] = Value;
+        int ierr = rX.ReplaceGlobalValues(indices, values);
         KRATOS_ERROR_IF(ierr != 0) << "Epetra failure found" << std::endl;
 
-        if constexpr (TGlobalAssemble) {
-            ierr = rX.GlobalAssemble(Insert,true); //Epetra_CombineMode mode=Add);
-            KRATOS_ERROR_IF(ierr < 0) << "Epetra failure when attempting to insert value in function SetValue" << std::endl;
-        }
+        ierr = rX.GlobalAssemble(Insert,true); //Epetra_CombineMode mode=Add);
+        KRATOS_ERROR_IF(ierr < 0) << "Epetra failure when attempting to insert value in function SetValue" << std::endl;
     }
 
     /**
-     * @brief Sets a value in a vector without global assembly
+     * @brief Sets a value in a vector
      * @param rX The vector considered
      * @param i The index of the value considered
      * @param Value The value considered
      */
-    template<bool TGlobalIndex = true>
-    static inline void SetValueWithoutGlobalAssembly(
+    static inline void SetGlobalValueWithoutGlobalAssembly(
         VectorType& rX,
         IndexType i,
         const double Value
         )
     {
-        SetValue<TGlobalIndex, false>(rX, i, Value);
+        Epetra_IntSerialDenseVector indices(1);
+        Epetra_SerialDenseVector values(1);
+        indices[0] = i;
+        values[0] = Value;
+        const int ierr = rX.ReplaceGlobalValues(indices, values);
+        KRATOS_ERROR_IF(ierr != 0) << "Epetra failure found" << std::endl;
+    }
+
+    /**
+     * @brief Sets a value in a vector (local)
+     * @param rX The vector considered
+     * @param i The index of the value considered
+     * @param Value The value considered
+     */
+    static inline void SetLocalValue(
+        VectorType& rX,
+        IndexType i,
+        const double Value
+        )
+    {
+        int ierr = rX.ReplaceMyValue(static_cast<int>(i), 0, Value);
+        KRATOS_ERROR_IF(ierr != 0) << "Epetra failure found" << std::endl;
+        ierr = rX.GlobalAssemble(Insert,true); //Epetra_CombineMode mode=Add);
+        KRATOS_ERROR_IF(ierr < 0) << "Epetra failure when attempting to insert value in function SetValue" << std::endl;
+    }
+
+    /**
+     * @brief Sets a value in a vector (local without global assembly)
+     * @param rX The vector considered
+     * @param i The index of the value considered
+     * @param Value The value considered
+     */
+    static inline void SetLocalValueWithoutGlobalAssembly(
+        VectorType& rX,
+        IndexType i,
+        const double Value
+        )
+    {
+        const int ierr = rX.ReplaceMyValue(static_cast<int>(i), 0, Value);
+        KRATOS_ERROR_IF(ierr != 0) << "Epetra failure found" << std::endl;
     }
 
     /**
@@ -238,10 +267,8 @@ public:
      * @param i The first index of the value considered
      * @param j The second index of the value considered
      * @param Value The value considered
-     * @tparam TGlobalAssemble If considering a global assembling
      */
-    template<bool TGlobalIndex = true, bool TGlobalAssemble = true>
-    static inline void SetValue(
+    static inline void SetGlobalValue(
         MatrixType& rA,
         IndexType i,
         IndexType j,
@@ -251,18 +278,11 @@ public:
         std::vector<double> values(1, Value);
         std::vector<int> indices(1, j);
 
-        int ierr = 0;
-        if constexpr (TGlobalIndex) {
-            ierr = rA.ReplaceGlobalValues(static_cast<int>(i), 1, values.data(), indices.data());
-        } else {
-            ierr = rA.ReplaceMyValues(static_cast<int>(i), 1, values.data(), indices.data());
-        }
+        int ierr = rA.ReplaceGlobalValues(static_cast<int>(i), 1, values.data(), indices.data());
         KRATOS_ERROR_IF(ierr != 0) << "Epetra failure found" << std::endl;
 
-        if constexpr (TGlobalAssemble) {
-            ierr = rA.GlobalAssemble();
-            KRATOS_ERROR_IF(ierr < 0) << "Epetra failure when attempting to insert value in function SetValue" << std::endl;
-        }
+        ierr = rA.GlobalAssemble();
+        KRATOS_ERROR_IF(ierr < 0) << "Epetra failure when attempting to insert value in function SetValue" << std::endl;
     }
 
     /**
@@ -272,15 +292,63 @@ public:
      * @param j The second index of the value considered
      * @param Value The value considered
      */
-    template<bool TGlobalIndex = true>
-    static inline void SetValueWithoutGlobalAssembly(
+    static inline void SetGlobalValueWithoutGlobalAssembly(
         MatrixType& rA,
         IndexType i,
         IndexType j,
         const double Value
         )
     {
-        SetValue<TGlobalIndex, false>(rA, i, j, Value);
+        std::vector<double> values(1, Value);
+        std::vector<int> indices(1, j);
+
+        const int ierr = rA.ReplaceGlobalValues(static_cast<int>(i), 1, values.data(), indices.data());
+        KRATOS_ERROR_IF(ierr != 0) << "Epetra failure found" << std::endl;
+    }
+
+    /**
+     * @brief Sets a value in a matrix
+     * @param rX The vector considered
+     * @param i The first index of the value considered
+     * @param j The second index of the value considered
+     * @param Value The value considered
+     */
+    static inline void SetLocalValue(
+        MatrixType& rA,
+        IndexType i,
+        IndexType j,
+        const double Value
+        )
+    {
+        std::vector<double> values(1, Value);
+        std::vector<int> indices(1, j);
+
+        int ierr = rA.ReplaceMyValues(static_cast<int>(i), 1, values.data(), indices.data());
+        KRATOS_ERROR_IF(ierr != 0) << "Epetra failure found" << std::endl;
+
+        ierr = rA.GlobalAssemble();
+        KRATOS_ERROR_IF(ierr < 0) << "Epetra failure when attempting to insert value in function SetValue" << std::endl;
+    }
+
+    /**
+     * @brief Sets a value in a matrix
+     * @param rX The vector considered
+     * @param i The first index of the value considered
+     * @param j The second index of the value considered
+     * @param Value The value considered
+     */
+    static inline void SetLocalValueWithoutGlobalAssembly(
+        MatrixType& rA,
+        IndexType i,
+        IndexType j,
+        const double Value
+        )
+    {
+        std::vector<double> values(1, Value);
+        std::vector<int> indices(1, j);
+
+        const int ierr = rA.ReplaceMyValues(static_cast<int>(i), 1, values.data(), indices.data());
+        KRATOS_ERROR_IF(ierr != 0) << "Epetra failure found" << std::endl;
     }
 
     ///@}

--- a/applications/TrilinosApplication/tests/cpp_tests/test_trilinos_assembling_utilities.cpp
+++ b/applications/TrilinosApplication/tests/cpp_tests/test_trilinos_assembling_utilities.cpp
@@ -50,7 +50,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosVectorSetValue, KratosTrilinosAppl
     // Solution global
     TrilinosSparseSpaceType::SetToZero(vector);
     for (int i = 0; i < 2; ++i) {
-        TrilinosAssemblingUtilities::SetValue(vector, rank * 2 + i, 1.0);
+        TrilinosAssemblingUtilities::SetGlobalValue(vector, rank * 2 + i, 1.0);
     }
 
     // Check global
@@ -59,14 +59,14 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosVectorSetValue, KratosTrilinosAppl
     // Solution local
     TrilinosSparseSpaceType::SetToZero(vector);
     for (int i = 0; i < 2; ++i) {
-        TrilinosAssemblingUtilities::SetValue<false>(vector, i, 1.0);
+        TrilinosAssemblingUtilities::SetLocalValue(vector, i, 1.0);
     }
 
     // Check local
     TrilinosCPPTestUtilities::CheckSparseVectorFromLocalVector(vector, local_vector);
 }
 
-KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosVectorSetValueWithoutGlobalAssembly, KratosTrilinosApplicationMPITestSuite)
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosVectorSetGlobalValueWithoutGlobalAssembly, KratosTrilinosApplicationMPITestSuite)
 {
     // The data communicator
     const auto& r_comm = Testing::GetDefaultDataCommunicator();
@@ -83,7 +83,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosVectorSetValueWithoutGlobalAssembl
     // Solution global
     TrilinosSparseSpaceType::SetToZero(vector);
     for (int i = 0; i < 2; ++i) {
-        TrilinosAssemblingUtilities::SetValueWithoutGlobalAssembly(vector, rank * 2 + i, 1.0);
+        TrilinosAssemblingUtilities::SetGlobalValueWithoutGlobalAssembly(vector, rank * 2 + i, 1.0);
     }
     vector.GlobalAssemble();
 
@@ -93,7 +93,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosVectorSetValueWithoutGlobalAssembl
     // Solution local
     TrilinosSparseSpaceType::SetToZero(vector);
     for (int i = 0; i < 2; ++i) {
-        TrilinosAssemblingUtilities::SetValueWithoutGlobalAssembly<false>(vector, i, 1.0);
+        TrilinosAssemblingUtilities::SetLocalValueWithoutGlobalAssembly(vector, i, 1.0);
     }
     vector.GlobalAssemble();
 
@@ -117,7 +117,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosMatrixSetValue, KratosTrilinosAppl
 
     // Solution global
     for (int i = 0; i < 2; ++i) {
-        TrilinosAssemblingUtilities::SetValue(matrix, rank * 2 + i, rank * 2 + i, 1.0);
+        TrilinosAssemblingUtilities::SetGlobalValue(matrix, rank * 2 + i, rank * 2 + i, 1.0);
     }
 
     // Check global
@@ -126,14 +126,14 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosMatrixSetValue, KratosTrilinosAppl
     // Solution local
     TrilinosSparseSpaceType::SetToZero(matrix);
     for (int i = 0; i < 2; ++i) {
-        TrilinosAssemblingUtilities::SetValue<false>(matrix, i, i, 1.0);
+        TrilinosAssemblingUtilities::SetLocalValue(matrix, i, i, 1.0);
     }
 
     // Check local
     TrilinosCPPTestUtilities::CheckSparseMatrixFromLocalMatrix(matrix, local_matrix);
 }
 
-KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosMatrixSetValueWithoutGlobalAssembly, KratosTrilinosApplicationMPITestSuite)
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosMatrixSetGlobalValueWithoutGlobalAssembly, KratosTrilinosApplicationMPITestSuite)
 {
     // The data communicator
     const auto& r_comm = Testing::GetDefaultDataCommunicator();
@@ -149,7 +149,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosMatrixSetValueWithoutGlobalAssembl
 
     // Solution global
     for (int i = 0; i < 2; ++i) {
-        TrilinosAssemblingUtilities::SetValueWithoutGlobalAssembly(matrix, rank * 2 + i, rank * 2 + i, 1.0);
+        TrilinosAssemblingUtilities::SetGlobalValueWithoutGlobalAssembly(matrix, rank * 2 + i, rank * 2 + i, 1.0);
     }
     matrix.GlobalAssemble();
 
@@ -159,7 +159,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosMatrixSetValueWithoutGlobalAssembl
     // Solution local
     TrilinosSparseSpaceType::SetToZero(matrix);
     for (int i = 0; i < 2; ++i) {
-        TrilinosAssemblingUtilities::SetValueWithoutGlobalAssembly<false>(matrix, i, i, 1.0);
+        TrilinosAssemblingUtilities::SetLocalValueWithoutGlobalAssembly(matrix, i, i, 1.0);
     }
     matrix.GlobalAssemble();
 

--- a/applications/TrilinosApplication/tests/cpp_tests/test_trilinos_assembling_utilities.cpp
+++ b/applications/TrilinosApplication/tests/cpp_tests/test_trilinos_assembling_utilities.cpp
@@ -1,0 +1,170 @@
+//  KRATOS  _____     _ _ _
+//         |_   _| __(_) (_)_ __   ___  ___
+//           | || '__| | | | '_ \ / _ \/ __|
+//           | || |  | | | | | | | (_) \__
+//           |_||_|  |_|_|_|_| |_|\___/|___/ APPLICATION
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "testing/testing.h"
+#include "mpi/includes/mpi_data_communicator.h"
+#include "trilinos_cpp_test_utilities.h"
+#include "custom_utilities/trilinos_assembling_utilities.h"
+
+namespace Kratos::Testing
+{
+/// Basic definitions
+using TrilinosSparseSpaceType = TrilinosSpace<Epetra_FECrsMatrix, Epetra_FEVector>;
+using TrilinosLocalSpaceType = UblasSpace<double, Matrix, Vector>;
+
+using TrilinosSparseMatrixType = TrilinosSparseSpaceType::MatrixType;
+using TrilinosVectorType = TrilinosSparseSpaceType::VectorType;
+
+using TrilinosLocalMatrixType = TrilinosLocalSpaceType::MatrixType;
+using TrilinosLocalVectorType = TrilinosLocalSpaceType::VectorType;
+
+
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosVectorSetValue, KratosTrilinosApplicationMPITestSuite)
+{
+    // The data communicator
+    const auto& r_comm = Testing::GetDefaultDataCommunicator();
+
+    // The dummy vector
+    const int size = 2 * r_comm.Size();
+    const int rank = r_comm.Rank();
+    auto vector = TrilinosCPPTestUtilities::GenerateDummySparseVector(r_comm, size);
+    TrilinosLocalVectorType local_vector = ZeroVector(size);
+    for (int i = 0; i < size; ++i) {
+        local_vector[i] = 1.0;
+    }
+
+    // Solution global
+    TrilinosSparseSpaceType::SetToZero(vector);
+    for (int i = 0; i < 2; ++i) {
+        TrilinosAssemblingUtilities::SetValue(vector, rank * 2 + i, 1.0);
+    }
+
+    // Check global
+    TrilinosCPPTestUtilities::CheckSparseVectorFromLocalVector(vector, local_vector);
+
+    // Solution local
+    TrilinosSparseSpaceType::SetToZero(vector);
+    for (int i = 0; i < 2; ++i) {
+        TrilinosAssemblingUtilities::SetValue<false>(vector, i, 1.0);
+    }
+
+    // Check local
+    TrilinosCPPTestUtilities::CheckSparseVectorFromLocalVector(vector, local_vector);
+}
+
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosVectorSetValueWithoutGlobalAssembly, KratosTrilinosApplicationMPITestSuite)
+{
+    // The data communicator
+    const auto& r_comm = Testing::GetDefaultDataCommunicator();
+
+    // The dummy vector
+    const int size = 2 * r_comm.Size();
+    const int rank = r_comm.Rank();
+    auto vector = TrilinosCPPTestUtilities::GenerateDummySparseVector(r_comm, size);
+    TrilinosLocalVectorType local_vector = ZeroVector(size);
+    for (int i = 0; i < size; ++i) {
+        local_vector[i] = 1.0;
+    }
+
+    // Solution global
+    TrilinosSparseSpaceType::SetToZero(vector);
+    for (int i = 0; i < 2; ++i) {
+        TrilinosAssemblingUtilities::SetValueWithoutGlobalAssembly(vector, rank * 2 + i, 1.0);
+    }
+    vector.GlobalAssemble();
+
+    // Check global
+    TrilinosCPPTestUtilities::CheckSparseVectorFromLocalVector(vector, local_vector);
+
+    // Solution local
+    TrilinosSparseSpaceType::SetToZero(vector);
+    for (int i = 0; i < 2; ++i) {
+        TrilinosAssemblingUtilities::SetValueWithoutGlobalAssembly<false>(vector, i, 1.0);
+    }
+    vector.GlobalAssemble();
+
+    // Check local
+    TrilinosCPPTestUtilities::CheckSparseVectorFromLocalVector(vector, local_vector);
+}
+
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosMatrixSetValue, KratosTrilinosApplicationMPITestSuite)
+{
+    // The data communicator
+    const auto& r_comm = Testing::GetDefaultDataCommunicator();
+
+    // The dummy vector
+    const int size = 2 * r_comm.Size();
+    const int rank = r_comm.Rank();
+    auto matrix = TrilinosCPPTestUtilities::GenerateDummySparseMatrix(r_comm, size);
+    TrilinosLocalMatrixType local_matrix = ZeroMatrix(size, size);
+    for (int i = 0; i < size; ++i) {
+        local_matrix(i, i) = 1.0;
+    }
+
+    // Solution global
+    for (int i = 0; i < 2; ++i) {
+        TrilinosAssemblingUtilities::SetValue(matrix, rank * 2 + i, rank * 2 + i, 1.0);
+    }
+
+    // Check global
+    TrilinosCPPTestUtilities::CheckSparseMatrixFromLocalMatrix(matrix, local_matrix);
+
+    // Solution local
+    TrilinosSparseSpaceType::SetToZero(matrix);
+    for (int i = 0; i < 2; ++i) {
+        TrilinosAssemblingUtilities::SetValue<false>(matrix, i, i, 1.0);
+    }
+
+    // Check local
+    TrilinosCPPTestUtilities::CheckSparseMatrixFromLocalMatrix(matrix, local_matrix);
+}
+
+KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosMatrixSetValueWithoutGlobalAssembly, KratosTrilinosApplicationMPITestSuite)
+{
+    // The data communicator
+    const auto& r_comm = Testing::GetDefaultDataCommunicator();
+
+    // The dummy vector
+    const int size = 2 * r_comm.Size();
+    const int rank = r_comm.Rank();
+    auto matrix = TrilinosCPPTestUtilities::GenerateDummySparseMatrix(r_comm, size);
+    TrilinosLocalMatrixType local_matrix = ZeroMatrix(size, size);
+    for (int i = 0; i < size; ++i) {
+        local_matrix(i, i) = 1.0;
+    }
+
+    // Solution global
+    for (int i = 0; i < 2; ++i) {
+        TrilinosAssemblingUtilities::SetValueWithoutGlobalAssembly(matrix, rank * 2 + i, rank * 2 + i, 1.0);
+    }
+    matrix.GlobalAssemble();
+
+    // Check global
+    TrilinosCPPTestUtilities::CheckSparseMatrixFromLocalMatrix(matrix, local_matrix);
+
+    // Solution local
+    TrilinosSparseSpaceType::SetToZero(matrix);
+    for (int i = 0; i < 2; ++i) {
+        TrilinosAssemblingUtilities::SetValueWithoutGlobalAssembly<false>(matrix, i, i, 1.0);
+    }
+    matrix.GlobalAssemble();
+
+    // Check local
+    TrilinosCPPTestUtilities::CheckSparseMatrixFromLocalMatrix(matrix, local_matrix);
+}
+
+} // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**

This commit introduces new functionality to the `TrilinosAssemblingUtilities` class by adding `SetValue` methods for both vectors and matrices. The methods include options for global and local indexing, as well as global and local assembling.

The changes involve the `trilinos_assembling_utilities.h file, which define the new `SetValue` methods. Furthermore, the PR includes a new test file, `test_trilinos_assembling_utilities.cpp`, with distributed test cases to check the correct functionality of the newly added methods.

In summary, this commit adds new `SetValue` methods to the `TrilinosAssemblingUtilities` class and corresponding tests to verify their functionality.

**🆕 Changelog**

- [Adding `SetValue` methods to `TrilinosAssemblingUtilities`](https://github.com/KratosMultiphysics/Kratos/commit/2142bd50b262f86d10724d648d1afc81b0909725)
- [Adding tests for `TrilinosAssemblingUtilities`](https://github.com/KratosMultiphysics/Kratos/commit/a1133cc039c108e55a4ae1cf7aaa9d222600db4b)
