### PR TITLE
Kratos global galerkin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,12 @@ if(POLICY CMP0057)
   cmake_policy(SET CMP0057 NEW)
 endif(POLICY CMP0057)
 
+# Allow target dependeices built in other directories to be used in other subprojects.
+# This is a fix to be able to use mkl and feast4 in the LinearSolver and Rom Applications
+if(POLICY CMP0079 )
+  cmake_policy(SET CMP0079 NEW)
+endif()
+
 # Set here the version number **** only update upon tagging a release!
 set (KratosMultiphysics_MAJOR_VERSION 9)
 set (KratosMultiphysics_MINOR_VERSION 3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,12 +25,6 @@ if(POLICY CMP0057)
   cmake_policy(SET CMP0057 NEW)
 endif(POLICY CMP0057)
 
-# Allow target dependeices built in other directories to be used in other subprojects.
-# This is a fix to be able to use mkl and feast4 in the LinearSolver and Rom Applications
-if(POLICY CMP0079 )
-  cmake_policy(SET CMP0079 NEW)
-endif()
-
 # Set here the version number **** only update upon tagging a release!
 set (KratosMultiphysics_MAJOR_VERSION 9)
 set (KratosMultiphysics_MINOR_VERSION 3)

--- a/applications/LinearSolversApplication/CMakeLists.txt
+++ b/applications/LinearSolversApplication/CMakeLists.txt
@@ -18,17 +18,15 @@ include(pybind11Tools)
 
 add_definitions( -DEIGEN_MPL2_ONLY)
 
-include_directories(
-    ${KRATOS_SOURCE_DIR}/kratos
-    SYSTEM external_libraries/eigen3 # Including as System to suppress compile-warnings from it
-    SYSTEM external_libraries/spectra1/include # Including as System to suppress compile-warnings from it
-)
+include_directories(${KRATOS_SOURCE_DIR}/kratos)
+
+set(KRATOS_LINEAR_SOLVERS_APPLICATION_LIB_INC "external_libraries/eigen3" "external_libraries/spectra1/include")
 
 if( USE_EIGEN_MKL MATCHES ON )
     if( DEFINED ENV{MKLROOT} )
         message( "-- MKLROOT = $ENV{MKLROOT}" )
 
-        include_directories( SYSTEM $ENV{MKLROOT}/include )
+        set(KRATOS_LINEAR_SOLVERS_APPLICATION_LIB_INC ${KRATOS_LINEAR_SOLVERS_APPLICATION_LIB_INC} $ENV{MKLROOT}/include)
 
         link_directories("$ENV{MKLROOT}/lib")
 
@@ -39,10 +37,10 @@ if( USE_EIGEN_MKL MATCHES ON )
         message("-- Found Conda environment: $ENV{CONDA_PREFIX}")
 
         if( WIN32 )
-            include_directories(SYSTEM $ENV{CONDA_PREFIX}/Library/include)
+            set(KRATOS_LINEAR_SOLVERS_APPLICATION_LIB_INC ${KRATOS_LINEAR_SOLVERS_APPLICATION_LIB_INC} $ENV{CONDA_PREFIX}/Library/include)
             link_directories("$ENV{CONDA_PREFIX}/Library/lib")
         else()
-            include_directories(SYSTEM $ENV{CONDA_PREFIX}/include)
+            set(KRATOS_LINEAR_SOLVERS_APPLICATION_LIB_INC ${KRATOS_LINEAR_SOLVERS_APPLICATION_LIB_INC} $ENV{CONDA_PREFIX}/include)
             link_directories("$ENV{CONDA_PREFIX}/lib")
         endif()
     else()
@@ -62,7 +60,7 @@ if( USE_EIGEN_FEAST MATCHES ON )
     include(CMakeAddFortranSubdirectory)
     cmake_add_fortran_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/external_libraries/FEAST NO_EXTERNAL_INSTALL )
     set(FEAST_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/external_libraries/FEAST/4.0 )
-    include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/external_libraries/FEAST/4.0/include )
+    set(KRATOS_LINEAR_SOLVERS_APPLICATION_LIB_INC ${KRATOS_LINEAR_SOLVERS_APPLICATION_LIB_INC} ${CMAKE_CURRENT_SOURCE_DIR}/external_libraries/FEAST/4.0/include)
     add_definitions(-DUSE_EIGEN_FEAST)
     # MKL implements some of FEAST's function. This definition excludes the definitions of MKL's FEAST
     # functions in mkl/include/mkl_solvers_ee.h. Otherwise, some functions are defined multiple times
@@ -89,6 +87,8 @@ file(
 add_library( KratosLinearSolversCore SHARED ${KRATOS_LINEARSOLVERS_APPLICATION_CORE_SOURCES} )
 target_link_libraries( KratosLinearSolversCore PUBLIC KratosCore )
 set_target_properties( KratosLinearSolversCore PROPERTIES COMPILE_DEFINITIONS "LINEARSOLVERS_APPLICATION=EXPORT,API")
+
+target_include_directories(KratosLinearSolversCore SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${KRATOS_LINEAR_SOLVERS_APPLICATION_LIB_INC})
 
 ## LinearSolversApplication python module
 pybind11_add_module( KratosLinearSolversApplication MODULE THIN_LTO ${KRATOS_LINEARSOLVERS_APPLICATION_PYTHON_INTERFACE} )

--- a/applications/RomApplication/CMakeLists.txt
+++ b/applications/RomApplication/CMakeLists.txt
@@ -5,7 +5,41 @@ message("**** configuring KratosRomApplication ****")
 ################### PYBIND11
 include(pybind11Tools)
 
-include_directories( ${KRATOS_SOURCE_DIR}/kratos )
+add_definitions( -DEIGEN_MPL2_ONLY)
+
+include_directories(
+    ${KRATOS_SOURCE_DIR}/kratos
+    SYSTEM ${KRATOS_SOURCE_DIR}/applications/LinearSolversApplication/external_libraries/eigen3
+    SYSTEM ${KRATOS_SOURCE_DIR}/applications/LinearSolversApplication/
+)
+
+if( USE_EIGEN_MKL MATCHES ON )
+    if( DEFINED ENV{MKLROOT} )
+        message( "-- MKLROOT = $ENV{MKLROOT}" )
+
+        include_directories( SYSTEM $ENV{MKLROOT}/include )
+
+        link_directories("$ENV{MKLROOT}/lib")
+
+        if( NOT MSVC )
+            set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -L$ENV{MKLROOT}/lib/intel64 -Wl,--no-as-needed -lpthread -lm -ldl" )
+        endif()
+    elseif( DEFINED ENV{CONDA_PREFIX} )
+        message("-- Found Conda environment: $ENV{CONDA_PREFIX}")
+
+        if( WIN32 )
+            include_directories(SYSTEM $ENV{CONDA_PREFIX}/Library/include)
+            link_directories("$ENV{CONDA_PREFIX}/Library/lib")
+        else()
+            include_directories(SYSTEM $ENV{CONDA_PREFIX}/include)
+            link_directories("$ENV{CONDA_PREFIX}/lib")
+        endif()
+    else()
+        message( FATAL_ERROR "MKLROOT not defined" )
+    endif()
+
+    add_definitions( -DUSE_EIGEN_MKL -DEIGEN_USE_MKL_ALL )
+endif()
 
 ## RomApplication Core sources
 file(GLOB_RECURSE KRATOS_ROM_APPLICATION_CORE
@@ -41,6 +75,25 @@ IF(CMAKE_UNITY_BUILD MATCHES ON)
     set_target_properties(KratosRomApplicationCore PROPERTIES UNITY_BUILD_BATCH_SIZE ${KRATOS_UNITY_BUILD_BATCH_SIZE})
     set_target_properties(KratosRomApplication PROPERTIES UNITY_BUILD_BATCH_SIZE ${KRATOS_UNITY_BUILD_BATCH_SIZE})
 ENDIF(CMAKE_UNITY_BUILD MATCHES ON)
+
+if( USE_EIGEN_MKL MATCHES ON )
+    if( MSVC )
+        find_library(MKL_RT_LIB mkl_rt)
+        if(NOT MKL_RT_LIB)
+            message( FATAL_ERROR "mkl_rt.lib not found")
+        else(NOT MKL_RT_LIB)
+            message( "mkl_rt.lib found at: ${MKL_RT_LIB}")
+            target_link_libraries( KratosLinearSolversCore PUBLIC ${MKL_RT_LIB} )
+        endif(NOT MKL_RT_LIB)
+    elseif( ${CMAKE_CXX_COMPILER_ID} MATCHES Clang )
+        message( FATAL_ERROR "Clang does not yet support MKL" )
+    else( MSVC )
+        target_link_libraries( KratosLinearSolversCore PUBLIC mkl_rt )
+        if( USE_EIGEN_FEAST MATCHES ON )
+            target_link_libraries(KratosLinearSolversCore PUBLIC feast4 gfortran m)
+        endif()
+    endif( MSVC )
+endif()
 
 # changing the .dll suffix to .pyd (Windows)
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")

--- a/applications/RomApplication/CMakeLists.txt
+++ b/applications/RomApplication/CMakeLists.txt
@@ -5,41 +5,9 @@ message("**** configuring KratosRomApplication ****")
 ################### PYBIND11
 include(pybind11Tools)
 
-add_definitions( -DEIGEN_MPL2_ONLY)
+kratos_add_dependency(${KRATOS_SOURCE_DIR}/applications/LinearSolversApplication)
 
-include_directories(
-    ${KRATOS_SOURCE_DIR}/kratos
-    SYSTEM ${KRATOS_SOURCE_DIR}/applications/LinearSolversApplication/external_libraries/eigen3
-    SYSTEM ${KRATOS_SOURCE_DIR}/applications/LinearSolversApplication/
-)
-
-if( USE_EIGEN_MKL MATCHES ON )
-    if( DEFINED ENV{MKLROOT} )
-        message( "-- MKLROOT = $ENV{MKLROOT}" )
-
-        include_directories( SYSTEM $ENV{MKLROOT}/include )
-
-        link_directories("$ENV{MKLROOT}/lib")
-
-        if( NOT MSVC )
-            set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -L$ENV{MKLROOT}/lib/intel64 -Wl,--no-as-needed -lpthread -lm -ldl" )
-        endif()
-    elseif( DEFINED ENV{CONDA_PREFIX} )
-        message("-- Found Conda environment: $ENV{CONDA_PREFIX}")
-
-        if( WIN32 )
-            include_directories(SYSTEM $ENV{CONDA_PREFIX}/Library/include)
-            link_directories("$ENV{CONDA_PREFIX}/Library/lib")
-        else()
-            include_directories(SYSTEM $ENV{CONDA_PREFIX}/include)
-            link_directories("$ENV{CONDA_PREFIX}/lib")
-        endif()
-    else()
-        message( FATAL_ERROR "MKLROOT not defined" )
-    endif()
-
-    add_definitions( -DUSE_EIGEN_MKL -DEIGEN_USE_MKL_ALL )
-endif()
+include_directories( ${KRATOS_SOURCE_DIR}/kratos )
 
 ## RomApplication Core sources
 file(GLOB_RECURSE KRATOS_ROM_APPLICATION_CORE
@@ -61,7 +29,7 @@ endif(${KRATOS_BUILD_TESTING} MATCHES ON)
 file(GLOB_RECURSE KRATOS_ROM_APPLICATION_PYTHON_INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/*.cpp)
 
 add_library(KratosRomApplicationCore SHARED ${KRATOS_ROM_APPLICATION_CORE} ${KRATOS_ROM_APPLICATION_TESTING_SOURCES})
-target_link_libraries(KratosRomApplicationCore PUBLIC KratosCore)
+target_link_libraries(KratosRomApplicationCore PUBLIC KratosCore KratosLinearSolversCore)
 set_target_properties(KratosRomApplicationCore PROPERTIES COMPILE_DEFINITIONS "ROM_APPLICATION=EXPORT,API")
 
 ###############################################################
@@ -75,25 +43,6 @@ IF(CMAKE_UNITY_BUILD MATCHES ON)
     set_target_properties(KratosRomApplicationCore PROPERTIES UNITY_BUILD_BATCH_SIZE ${KRATOS_UNITY_BUILD_BATCH_SIZE})
     set_target_properties(KratosRomApplication PROPERTIES UNITY_BUILD_BATCH_SIZE ${KRATOS_UNITY_BUILD_BATCH_SIZE})
 ENDIF(CMAKE_UNITY_BUILD MATCHES ON)
-
-if( USE_EIGEN_MKL MATCHES ON )
-    if( MSVC )
-        find_library(MKL_RT_LIB mkl_rt)
-        if(NOT MKL_RT_LIB)
-            message( FATAL_ERROR "mkl_rt.lib not found")
-        else(NOT MKL_RT_LIB)
-            message( "mkl_rt.lib found at: ${MKL_RT_LIB}")
-            target_link_libraries( KratosLinearSolversCore PUBLIC ${MKL_RT_LIB} )
-        endif(NOT MKL_RT_LIB)
-    elseif( ${CMAKE_CXX_COMPILER_ID} MATCHES Clang )
-        message( FATAL_ERROR "Clang does not yet support MKL" )
-    else( MSVC )
-        target_link_libraries( KratosLinearSolversCore PUBLIC mkl_rt )
-        if( USE_EIGEN_FEAST MATCHES ON )
-            target_link_libraries(KratosLinearSolversCore PUBLIC feast4 gfortran m)
-        endif()
-    endif( MSVC )
-endif()
 
 # changing the .dll suffix to .pyd (Windows)
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")

--- a/applications/RomApplication/RomApplication.py
+++ b/applications/RomApplication/RomApplication.py
@@ -1,7 +1,8 @@
-
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
+import KratosMultiphysics.LinearSolversApplication
 from KratosRomApplication import *
+
 application = KratosRomApplication()
 application_name = "KratosRomApplication"
 

--- a/applications/RomApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/RomApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -31,7 +31,7 @@
 #include "custom_strategies/rom_builder_and_solver.h"
 #include "custom_strategies/lspg_rom_builder_and_solver.h"
 #include "custom_strategies/petrov_galerkin_rom_builder_and_solver.h"
-
+#include "custom_strategies/global_rom_builder_and_solver.h"
 
 //linear solvers
 #include "linear_solvers/linear_solver.h"
@@ -68,6 +68,13 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
     typedef PetrovGalerkinROMBuilderAndSolver<SparseSpaceType, LocalSpaceType, LinearSolverType> PetrovGalerkinROMBuilderAndSolverType;
 
      py::class_<PetrovGalerkinROMBuilderAndSolverType, typename PetrovGalerkinROMBuilderAndSolverType::Pointer, ROMBuilderAndSolverType, BuilderAndSolverType>(m, "PetrovGalerkinROMBuilderAndSolver")
+        .def(py::init< LinearSolverType::Pointer, Parameters>() )
+        ;
+
+    typedef GlobalROMBuilderAndSolver<SparseSpaceType, LocalSpaceType, LinearSolverType> GlobalROMBuilderAndSolverType;
+    typedef ResidualBasedBlockBuilderAndSolver<SparseSpaceType, LocalSpaceType, LinearSolverType> ResidualBasedBlockBuilderAndSolverType;
+    
+    py::class_<GlobalROMBuilderAndSolverType, typename GlobalROMBuilderAndSolverType::Pointer, ResidualBasedBlockBuilderAndSolverType>(m, "GlobalROMBuilderAndSolver")
         .def(py::init< LinearSolverType::Pointer, Parameters>() )
         ;
 

--- a/applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h
@@ -83,42 +83,42 @@ public:
     KRATOS_CLASS_POINTER_DEFINITION(GlobalROMBuilderAndSolver);
 
     // The size_t types
-    typedef std::size_t SizeType;
-    typedef std::size_t IndexType;
+    using SizeType = std::size_t;
+    using IndexType = std::size_t;
 
     /// The definition of the current class
-    typedef GlobalROMBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver> ClassType;
+    using ClassType = GlobalROMBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>;
 
     /// Definition of the classes from the base class
-    typedef BuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>   BaseBuilderAndSolverType;
-    typedef ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver> BaseType;
-    typedef typename BaseBuilderAndSolverType::TSchemeType TSchemeType;
-    typedef typename BaseBuilderAndSolverType::DofsArrayType DofsArrayType;
-    typedef typename BaseBuilderAndSolverType::TSystemMatrixType TSystemMatrixType;
-    typedef typename BaseBuilderAndSolverType::TSystemVectorType TSystemVectorType;
-    typedef typename BaseBuilderAndSolverType::LocalSystemVectorType LocalSystemVectorType;
-    typedef typename BaseBuilderAndSolverType::LocalSystemMatrixType LocalSystemMatrixType;
-    typedef typename BaseBuilderAndSolverType::TSystemMatrixPointerType TSystemMatrixPointerType;
-    typedef typename BaseBuilderAndSolverType::TSystemVectorPointerType TSystemVectorPointerType;
-    typedef typename BaseBuilderAndSolverType::ElementsArrayType ElementsArrayType;
-    typedef typename BaseBuilderAndSolverType::ConditionsArrayType ConditionsArrayType;
+    using BaseBuilderAndSolverType = BuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>;
+    using BaseType = ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>;
+    using TSchemeType = typename BaseBuilderAndSolverType::TSchemeType;
+    using DofsArrayType = typename BaseBuilderAndSolverType::DofsArrayType;
+    using TSystemMatrixType = typename BaseBuilderAndSolverType::TSystemMatrixType;
+    using TSystemVectorType = typename BaseBuilderAndSolverType::TSystemVectorType;
+    using LocalSystemVectorType = typename BaseBuilderAndSolverType::LocalSystemVectorType;
+    using LocalSystemMatrixType = typename BaseBuilderAndSolverType::LocalSystemMatrixType;
+    using TSystemMatrixPointerType = typename BaseBuilderAndSolverType::TSystemMatrixPointerType;
+    using TSystemVectorPointerType = typename BaseBuilderAndSolverType::TSystemVectorPointerType;
+    using ElementsArrayType = typename BaseBuilderAndSolverType::ElementsArrayType;
+    using ConditionsArrayType = typename BaseBuilderAndSolverType::ConditionsArrayType;
 
     /// Additional definitions
-    typedef typename ModelPart::MasterSlaveConstraintContainerType MasterSlaveConstraintContainerType;
-    typedef Element::EquationIdVectorType EquationIdVectorType;
-    typedef Element::DofsVectorType DofsVectorType;
-    typedef boost::numeric::ublas::compressed_matrix<double> CompressedMatrixType;
-    typedef LocalSystemMatrixType RomSystemMatrixType;
-    typedef LocalSystemVectorType RomSystemVectorType;
+    using MasterSlaveConstraintContainerType = typename ModelPart::MasterSlaveConstraintContainerType;
+    using EquationIdVectorType = typename Element::EquationIdVectorType;
+    using DofsVectorType = typename Element::DofsVectorType;
+    using CompressedMatrixType = boost::numeric::ublas::compressed_matrix<double>;
+    using RomSystemMatrixType = LocalSystemMatrixType;
+    using RomSystemVectorType = LocalSystemVectorType;
     using EigenDynamicMatrix = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
     using EigenDynamicVector = Eigen::Matrix<double, Eigen::Dynamic, 1>;
     using EigenSparseMatrix = Eigen::SparseMatrix<double, Eigen::RowMajor, int>;
 
     /// DoF types definition
-    typedef Node<3> NodeType;
-    typedef typename NodeType::DofType DofType;
-    typedef typename DofType::Pointer DofPointerType;
-    typedef moodycamel::ConcurrentQueue<DofType::Pointer> DofQueue;
+    using NodeType = Node<3>;
+    using DofType = typename NodeType::DofType;
+    using DofPointerType = typename DofType::Pointer;
+    using DofQueue = moodycamel::ConcurrentQueue<DofType::Pointer>;
 
     ///@}
     ///@name Life cycle

--- a/applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h
@@ -1,0 +1,800 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:        BSD License
+//                  Kratos default license: kratos/license.txt
+//
+//  Main authors:   Sebastian Ares de Parga
+//                  
+//
+
+#if !defined(KRATOS_GLOBAL_ROM_BUILDER_AND_SOLVER)
+#define KRATOS_GLOBAL_ROM_BUILDER_AND_SOLVER
+
+/* System includes */
+
+/* External includes */
+#include "concurrentqueue/concurrentqueue.h"
+#include <Eigen/Core>
+#include <Eigen/Dense>
+#include <Eigen/Sparse>
+
+/* Project includes */
+#include "includes/define.h"
+#include "includes/model_part.h"
+#include "solving_strategies/schemes/scheme.h"
+#include "solving_strategies/builder_and_solvers/builder_and_solver.h"
+#include "solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h"
+#include "utilities/builtin_timer.h"
+#include "utilities/reduction_utilities.h"
+#include "custom_utilities/ublas_wrapper.h"
+
+/* Application includes */
+#include "rom_application_variables.h"
+#include "custom_utilities/rom_auxiliary_utilities.h"
+
+namespace Kratos
+{
+
+///@name Kratos Globals
+///@{
+
+
+///@}
+///@name Type Definitions
+///@{
+
+
+///@}GlobalROMBuilderAndSolver
+///@name  Enum's
+///@{
+
+
+///@}
+///@name  Functions
+///@{
+
+
+///@}
+///@name Kratos Classes
+///@{
+
+template <class TSparseSpace, class TDenseSpace, class TLinearSolver>
+class GlobalROMBuilderAndSolver : public ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>
+{
+public:
+
+    //TODO: UPDATE THIS
+    /**
+     * This struct is used in the component wise calculation only
+     * is defined here and is used to declare a member variable in the component wise builder and solver
+     * private pointers can only be accessed by means of set and get functions
+     * this allows to set and not copy the Element_Variables and Condition_Variables
+     * which will be asked and set by another strategy object
+     */
+
+    ///@name Type Definitions
+    ///@{
+
+    // Class pointer definition
+    KRATOS_CLASS_POINTER_DEFINITION(GlobalROMBuilderAndSolver);
+
+    // The size_t types
+    typedef std::size_t SizeType;
+    typedef std::size_t IndexType;
+
+    /// The definition of the current class
+    typedef GlobalROMBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver> ClassType;
+
+    /// Definition of the classes from the base class
+    typedef BuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>   BaseBuilderAndSolverType;
+    typedef ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver> BaseType;
+    typedef typename BaseBuilderAndSolverType::TSchemeType TSchemeType;
+    typedef typename BaseBuilderAndSolverType::DofsArrayType DofsArrayType;
+    typedef typename BaseBuilderAndSolverType::TSystemMatrixType TSystemMatrixType;
+    typedef typename BaseBuilderAndSolverType::TSystemVectorType TSystemVectorType;
+    typedef typename BaseBuilderAndSolverType::LocalSystemVectorType LocalSystemVectorType;
+    typedef typename BaseBuilderAndSolverType::LocalSystemMatrixType LocalSystemMatrixType;
+    typedef typename BaseBuilderAndSolverType::TSystemMatrixPointerType TSystemMatrixPointerType;
+    typedef typename BaseBuilderAndSolverType::TSystemVectorPointerType TSystemVectorPointerType;
+    typedef typename BaseBuilderAndSolverType::ElementsArrayType ElementsArrayType;
+    typedef typename BaseBuilderAndSolverType::ConditionsArrayType ConditionsArrayType;
+
+    /// Additional definitions
+    typedef typename ModelPart::MasterSlaveConstraintContainerType MasterSlaveConstraintContainerType;
+    typedef Element::EquationIdVectorType EquationIdVectorType;
+    typedef Element::DofsVectorType DofsVectorType;
+    typedef boost::numeric::ublas::compressed_matrix<double> CompressedMatrixType;
+    typedef LocalSystemMatrixType RomSystemMatrixType;
+    typedef LocalSystemVectorType RomSystemVectorType;
+    using EigenDynamicMatrix = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+    using EigenDynamicVector = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+    using EigenSparseMatrix = Eigen::SparseMatrix<double, Eigen::RowMajor, int>;
+
+    /// DoF types definition
+    typedef Node<3> NodeType;
+    typedef typename NodeType::DofType DofType;
+    typedef typename DofType::Pointer DofPointerType;
+    typedef moodycamel::ConcurrentQueue<DofType::Pointer> DofQueue;
+
+    ///@}
+    ///@name Life cycle
+    ///@{
+
+    explicit GlobalROMBuilderAndSolver(
+        typename TLinearSolver::Pointer pNewLinearSystemSolver,
+        Parameters ThisParameters): BaseType(pNewLinearSystemSolver)
+    {
+        // Validate and assign defaults
+        Parameters this_parameters_copy = ThisParameters.Clone();
+        this_parameters_copy = this->ValidateAndAssignParameters(this_parameters_copy, this->GetDefaultParameters());
+        this->AssignSettings(this_parameters_copy);
+    }
+
+    explicit GlobalROMBuilderAndSolver(
+        typename TLinearSolver::Pointer pNewLinearSystemSolver)
+        : ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>(pNewLinearSystemSolver)
+    {
+    }
+
+    ~GlobalROMBuilderAndSolver() = default;
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    typename BaseBuilderAndSolverType::Pointer Create(
+        typename TLinearSolver::Pointer pNewLinearSystemSolver,
+        Parameters ThisParameters) const override
+    {
+        return Kratos::make_shared<ClassType>(pNewLinearSystemSolver,ThisParameters);
+    }
+
+    void SetUpDofSet(
+        typename TSchemeType::Pointer pScheme,
+        ModelPart &rModelPart) override
+    {
+        KRATOS_TRY;
+
+        KRATOS_INFO_IF("GlobalROMBuilderAndSolver", (this->GetEchoLevel() > 1)) << "Setting up the dofs" << std::endl;
+        KRATOS_INFO_IF("GlobalROMBuilderAndSolver", (this->GetEchoLevel() > 2)) << "Number of threads" << ParallelUtilities::GetNumThreads() << "\n" << std::endl;
+        KRATOS_INFO_IF("GlobalROMBuilderAndSolver", (this->GetEchoLevel() > 2)) << "Initializing element loop" << std::endl;
+
+        // Get model part data
+        if (mHromWeightsInitialized == false) {
+            InitializeHROMWeights(rModelPart);
+        }
+
+        auto dof_queue = ExtractDofSet(pScheme, rModelPart);
+
+        // Fill a sorted auxiliary array of with the DOFs set
+        KRATOS_INFO_IF("GlobalROMBuilderAndSolver", (this->GetEchoLevel() > 2)) << "Initializing ordered array filling\n" << std::endl;
+        auto dof_array = SortAndRemoveDuplicateDofs(dof_queue);
+
+        // Update base builder and solver DOFs array and set corresponding flag
+        BaseBuilderAndSolverType::GetDofSet().swap(dof_array);
+        BaseBuilderAndSolverType::SetDofSetIsInitializedFlag(true);
+
+        // Throw an exception if there are no DOFs involved in the analysis
+        KRATOS_ERROR_IF(BaseBuilderAndSolverType::GetDofSet().size() == 0) << "No degrees of freedom!" << std::endl;
+        KRATOS_INFO_IF("GlobalROMBuilderAndSolver", (this->GetEchoLevel() > 2)) << "Number of degrees of freedom:" << BaseBuilderAndSolverType::GetDofSet().size() << std::endl;
+        KRATOS_INFO_IF("GlobalROMBuilderAndSolver", (this->GetEchoLevel() > 2)) << "Finished setting up the dofs" << std::endl;
+
+#ifdef KRATOS_DEBUG
+        // If reactions are to be calculated, we check if all the dofs have reactions defined
+        if (BaseBuilderAndSolverType::GetCalculateReactionsFlag())
+        {
+            for (const auto& r_dof: BaseBuilderAndSolverType::GetDofSet())
+            {
+                KRATOS_ERROR_IF_NOT(r_dof.HasReaction())
+                    << "Reaction variable not set for the following :\n"
+                    << "Node : " << r_dof.Id() << '\n'
+                    << "Dof  : " << r_dof      << '\n'
+                    << "Not possible to calculate reactions." << std::endl;
+            }
+        }
+#endif
+        KRATOS_CATCH("");
+    }
+
+    void SetUpSystem(ModelPart &rModelPart) override
+    {
+        auto& r_dof_set = BaseBuilderAndSolverType::GetDofSet();
+        BaseBuilderAndSolverType::mEquationSystemSize = r_dof_set.size();
+        IndexPartition<IndexType>(r_dof_set.size()).for_each([&](IndexType Index)
+        {
+            auto dof_iterator = r_dof_set.begin() + Index;
+            dof_iterator->SetEquationId(Index);
+        });
+    }
+
+    // Vector ProjectToReducedBasis(
+	// 	const TSystemVectorType& rX,
+	// 	ModelPart::NodesContainerType& rNodes
+	// )
+    // {
+    //     Vector rom_unknowns = ZeroVector(GetNumberOfROMModes());
+    //     for(const auto& node : rNodes)
+    //     {
+    //         unsigned int node_aux_id = node.GetValue(AUX_ID);
+    //         const auto& nodal_rom_basis = node.GetValue(ROM_BASIS);
+	// 			for (int i = 0; i < GetNumberOfROMModes(); ++i) {
+	// 				for (int j = 0; j < mNodalDofs; ++j) {
+	// 					rom_unknowns[i] += nodal_rom_basis(j, i)*rX(node_aux_id*mNodalDofs + j);
+	// 				}
+	// 			}
+    //     }
+    //     return rom_unknowns;
+	// }
+
+    SizeType GetNumberOfROMModes() const noexcept
+    {
+        return mNumberOfRomModes;
+    } 
+
+    void ProjectToFineBasis(
+        const TSystemVectorType& rRomUnkowns,
+        const ModelPart& rModelPart,
+        TSystemVectorType& rDx) const
+    {
+        const auto& r_dof_set = BaseBuilderAndSolverType::GetDofSet();
+        block_for_each(r_dof_set, [&](const DofType& r_dof)
+        {
+            const auto& r_node = rModelPart.GetNode(r_dof.Id());
+            const Matrix& r_rom_nodal_basis = r_node.GetValue(ROM_BASIS);
+            const Matrix::size_type row_id = mMapPhi.at(r_dof.GetVariable().Key());
+            rDx[r_dof.EquationId()] = inner_prod(row(r_rom_nodal_basis, row_id), rRomUnkowns);
+        });
+    }
+
+    void BuildRightROMBasis(
+        const ModelPart& rModelPart) 
+    {
+        const auto& r_dof_set = BaseBuilderAndSolverType::GetDofSet();
+        block_for_each(r_dof_set, [&](const DofType& r_dof)
+        {
+            const auto& r_node = rModelPart.GetNode(r_dof.Id());
+            const Matrix& r_rom_nodal_basis = r_node.GetValue(ROM_BASIS);
+            const Matrix::size_type row_id = mMapPhi.at(r_dof.GetVariable().Key());
+            if (r_dof.IsFixed())
+            {
+                noalias(row(mPhiGlobal, r_dof.EquationId())) = ZeroVector(r_rom_nodal_basis.size2());
+            }
+            else{
+                noalias(row(mPhiGlobal, r_dof.EquationId())) = row(r_rom_nodal_basis, row_id);
+            }
+        });
+    }
+
+    virtual void InitializeSolutionStep(
+        ModelPart& rModelPart,
+        TSystemMatrixType& rA,
+        TSystemVectorType& rDx,
+        TSystemVectorType& rb) override
+    {
+        // Call the base B&S InitializeSolutionStep
+        BaseBuilderAndSolverType::InitializeSolutionStep(rModelPart, rA, rDx, rb);
+
+        // Reset the ROM solution increment in the root modelpart database
+        auto& r_root_mp = rModelPart.GetRootModelPart();
+        r_root_mp.GetValue(ROM_SOLUTION_INCREMENT) = ZeroVector(GetNumberOfROMModes());
+    }
+
+    
+    void BuildAndSolve(
+        typename TSchemeType::Pointer pScheme,
+        ModelPart &rModelPart,
+        TSystemMatrixType &A,
+        TSystemVectorType &Dx,
+        TSystemVectorType &b) override
+    {
+        KRATOS_TRY
+
+        BuildAndProjectROM(pScheme, rModelPart, A, b);
+        
+        SolveROM(rModelPart, A, b, Dx);
+
+        KRATOS_CATCH("")
+    }
+
+    void ResizeAndInitializeVectors(
+        typename TSchemeType::Pointer pScheme,
+        TSystemMatrixPointerType &pA,
+        TSystemVectorPointerType &pDx,
+        TSystemVectorPointerType &pb,
+        ModelPart &rModelPart) override
+    {
+        KRATOS_TRY
+
+        // If not initialized, initalize the system arrays to an empty vector/matrix
+        if (!pA) {
+            TSystemMatrixPointerType p_new_A = Kratos::make_shared<TSystemMatrixType>(0, 0);
+            pA.swap(p_new_A);
+        }
+        if (!pDx) {
+            TSystemVectorPointerType p_new_Dx = Kratos::make_shared<TSystemVectorType>(0);
+            pDx.swap(p_new_Dx);
+        }
+        if (!pb) {
+            TSystemVectorPointerType p_new_b = Kratos::make_shared<TSystemVectorType>(0);
+            pb.swap(p_new_b);
+        }
+
+        TSystemVectorType& r_Dx = *pDx;
+        if (r_Dx.size() != BaseBuilderAndSolverType::GetEquationSystemSize()) {
+            r_Dx.resize(BaseBuilderAndSolverType::GetEquationSystemSize(), false);
+        }
+
+        TSystemVectorType& r_b = *pb;
+        if (r_b.size() != BaseBuilderAndSolverType::GetEquationSystemSize()) {
+            r_b.resize(BaseBuilderAndSolverType::GetEquationSystemSize(), false);
+        }
+
+        KRATOS_CATCH("")
+    }
+
+    Parameters GetDefaultParameters() const override
+    {
+        Parameters default_parameters = Parameters(R"(
+        {
+            "name" : "global_rom_builder_and_solver",
+            "nodal_unknowns" : [],
+            "number_of_rom_dofs" : 10
+        })");
+        default_parameters.AddMissingParameters(BaseBuilderAndSolverType::GetDefaultParameters());
+
+        return default_parameters;
+    }
+
+    static std::string Name()
+    {
+        return "global_rom_builder_and_solver";
+    }
+
+    ///@}
+    ///@name Access
+    ///@{
+
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    virtual std::string Info() const override
+    {
+        return "GlobalROMBuilderAndSolver";
+    }
+
+    /// Print information about this object.
+    virtual void PrintInfo(std::ostream &rOStream) const override
+    {
+        rOStream << Info();
+    }
+
+    /// Print object's data.
+    virtual void PrintData(std::ostream &rOStream) const override
+    {
+        rOStream << Info();
+    }
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+protected:
+    ///@}
+    ///@name Protected static member variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected member variables
+    ///@{
+
+    SizeType mNodalDofs;
+    std::unordered_map<Kratos::VariableData::KeyType, Matrix::size_type> mMapPhi;
+
+    ElementsArrayType mSelectedElements;
+    ConditionsArrayType mSelectedConditions;
+
+    bool mHromSimulation = false;
+    bool mHromWeightsInitialized = false;
+
+    bool mRightRomBasisInitialized = false;
+
+    ///@}
+    ///@name Protected operators
+    ///@{
+
+
+    ///@}
+    ///@name Protected operations
+    ///@{
+
+    void AssignSettings(const Parameters ThisParameters) override
+    {
+        BaseBuilderAndSolverType::AssignSettings(ThisParameters);
+
+        // Set member variables
+        mNodalDofs = ThisParameters["nodal_unknowns"].size();
+        mNumberOfRomModes = ThisParameters["number_of_rom_dofs"].GetInt();
+
+        // Set up a map with key the variable key and value the correct row in ROM basis
+        IndexType k = 0;
+        for (const auto& r_var_name : ThisParameters["nodal_unknowns"].GetStringArray()) {
+            if(KratosComponents<Variable<double>>::Has(r_var_name)) {
+                const auto& var = KratosComponents<Variable<double>>::Get(r_var_name);
+                mMapPhi[var.Key()] = k++;
+            } else {
+                KRATOS_ERROR << "Variable \""<< r_var_name << "\" not valid" << std::endl;
+            }
+        }
+    }
+
+
+    void InitializeHROMWeights(ModelPart& rModelPart)
+    {
+        KRATOS_TRY
+
+        using ElementQueue = moodycamel::ConcurrentQueue<Element::Pointer>;
+        using ConditionQueue = moodycamel::ConcurrentQueue<Condition::Pointer>;
+
+        // Inspecting elements
+        ElementQueue element_queue;
+        block_for_each(rModelPart.Elements().GetContainer(),
+            [&](Element::Pointer p_element)
+        {
+            if (p_element->Has(HROM_WEIGHT)) {
+                element_queue.enqueue(std::move(p_element));
+            } else {
+                p_element->SetValue(HROM_WEIGHT, 1.0);
+            }
+        });
+
+        // Inspecting conditions
+        ConditionQueue condition_queue;
+        block_for_each(rModelPart.Conditions().GetContainer(),
+            [&](Condition::Pointer p_condition)
+        {
+            if (p_condition->Has(HROM_WEIGHT)) {
+                condition_queue.enqueue(std::move(p_condition));
+            } else {
+                p_condition->SetValue(HROM_WEIGHT, 1.0);
+            }
+        });
+
+        // Dequeueing elements
+        std::size_t err_id;
+        mSelectedElements.reserve(element_queue.size_approx());
+        Element::Pointer p_element;
+        while ( (err_id = element_queue.try_dequeue(p_element)) != 0) {
+            mSelectedElements.push_back(std::move(p_element));
+        }
+
+        // Dequeueing conditions
+        mSelectedConditions.reserve(condition_queue.size_approx());
+        Condition::Pointer p_condition;
+        while ( (err_id = condition_queue.try_dequeue(p_condition)) != 0) {
+            mSelectedConditions.push_back(std::move(p_condition));
+        }
+
+        // Wrap-up
+        mHromSimulation = !(mSelectedElements.empty() && mSelectedConditions.empty());
+        mHromWeightsInitialized = true;
+
+        KRATOS_CATCH("")
+    }
+    
+    static DofQueue ExtractDofSet(
+        typename TSchemeType::Pointer pScheme,
+        ModelPart& rModelPart)
+    {
+        KRATOS_TRY
+
+        DofQueue dof_queue;
+
+        // Emulates ConcurrentQueue::enqueue_bulk adding move semantics to avoid atomic ops
+        const auto enqueue_bulk_move = [](DofQueue& r_queue, DofsVectorType& r_dof_list) {
+            for(auto& p_dof: r_dof_list) {
+                r_queue.enqueue(std::move(p_dof));
+            }
+            r_dof_list.clear();
+        };
+
+        // Inspecting elements
+        DofsVectorType tls_dof_list; // Preallocation
+        block_for_each(rModelPart.Elements(), tls_dof_list,
+            [&](const Element& r_element, DofsVectorType& r_dof_list)
+        {
+            pScheme->GetDofList(r_element, r_dof_list, rModelPart.GetProcessInfo());
+            enqueue_bulk_move(dof_queue, r_dof_list);
+        });
+
+        // Inspecting conditions
+        block_for_each(rModelPart.Conditions(), tls_dof_list,
+            [&](const Condition& r_condition, DofsVectorType& r_dof_list)
+        {
+            pScheme->GetDofList(r_condition, r_dof_list, rModelPart.GetProcessInfo());
+            enqueue_bulk_move(dof_queue, r_dof_list);
+        });
+
+        // Inspecting master-slave constraints
+        std::pair<DofsVectorType, DofsVectorType> tls_ms_dof_lists; // Preallocation
+        block_for_each(rModelPart.MasterSlaveConstraints(), tls_ms_dof_lists,
+            [&](const MasterSlaveConstraint& r_constraint, std::pair<DofsVectorType, DofsVectorType>& r_dof_lists)
+        {
+            r_constraint.GetDofList(r_dof_lists.first, r_dof_lists.second, rModelPart.GetProcessInfo());
+
+            enqueue_bulk_move(dof_queue, r_dof_lists.first);
+            enqueue_bulk_move(dof_queue, r_dof_lists.second);
+        });
+
+        return dof_queue;
+
+        KRATOS_CATCH("")
+    }
+
+    static DofsArrayType SortAndRemoveDuplicateDofs(DofQueue& rDofQueue)
+    {
+        KRATOS_TRY
+
+        DofsArrayType dof_array;
+        dof_array.reserve(rDofQueue.size_approx());
+        DofType::Pointer p_dof;
+        std::size_t err_id;
+        while ( (err_id = rDofQueue.try_dequeue(p_dof)) != 0) {
+            dof_array.push_back(std::move(p_dof));
+        }
+
+        dof_array.Unique(); // Sorts internally
+
+        return dof_array;
+
+        KRATOS_CATCH("")
+    }
+
+    /**
+     * Resizes a Matrix if it's not the right size
+     */
+    template<typename TMatrix>
+    static void ResizeIfNeeded(TMatrix& mat, const SizeType rows, const SizeType cols)
+    {
+        if(mat.size1() != rows || mat.size2() != cols) {
+            mat.resize(rows, cols, false);
+        }
+    }
+
+    /**
+     * Builds and projects the reduced system of equations 
+     */
+    virtual void BuildAndProjectROM(
+        typename TSchemeType::Pointer pScheme,
+        ModelPart &rModelPart,
+        TSystemMatrixType &rA,
+        TSystemVectorType &rb)
+    {
+        KRATOS_TRY
+
+        KRATOS_ERROR_IF(!pScheme) << "No scheme provided!" << std::endl;
+
+        const auto assembling_timer = BuiltinTimer();
+
+        if (rA.size1() != BaseType::mEquationSystemSize || rA.size2() != BaseType::mEquationSystemSize) {
+            rA.resize(BaseType::mEquationSystemSize, BaseType::mEquationSystemSize, false);
+            BaseType::ConstructMatrixStructure(pScheme, rA, rModelPart);
+        }
+
+        Build(pScheme, rModelPart, rA, rb);
+
+        ProjectROM(rModelPart, rA, rb);
+
+        double time = assembling_timer.ElapsedSeconds();
+        KRATOS_INFO_IF("GlobalROMBuilderAndSolver", (this->GetEchoLevel() > 0)) << "Build and project time: " << time << std::endl;
+
+        KRATOS_CATCH("")
+    }
+
+    /**
+     * @brief Function to perform the build of the LHS and RHS multiplied by its corresponding hrom weight. 
+     * @param pScheme The integration scheme considered
+     * @param rModelPart The model part of the problem to solve
+     * @param A The LHS matrix
+     * @param b The RHS vector
+     */
+    void Build(
+        typename TSchemeType::Pointer pScheme,
+        ModelPart& rModelPart,
+        TSystemMatrixType& A,
+        TSystemVectorType& b) override
+    {
+        KRATOS_TRY
+
+        KRATOS_ERROR_IF(!pScheme) << "No scheme provided!" << std::endl;
+
+        // // Getting the elements from the model
+        const int nelements = mHromSimulation ? mSelectedElements.size() : rModelPart.Elements().size();
+
+        // // Getting the array of the conditions
+        const int nconditions = mHromSimulation ? mSelectedConditions.size() : rModelPart.Conditions().size();
+
+        const ProcessInfo& CurrentProcessInfo = rModelPart.GetProcessInfo();
+        ModelPart::ElementsContainerType::iterator el_begin = mHromSimulation ? mSelectedElements.begin() : rModelPart.Elements().begin();
+        ModelPart::ConditionsContainerType::iterator cond_begin = mHromSimulation ? mSelectedConditions.begin() : rModelPart.Conditions().begin();
+
+        //contributions to the system
+        LocalSystemMatrixType LHS_Contribution = LocalSystemMatrixType(0, 0);
+        LocalSystemVectorType RHS_Contribution = LocalSystemVectorType(0);
+
+        //vector containing the localization in the system of the different
+        //terms
+        Element::EquationIdVectorType EquationId;
+
+        // Assemble all elements
+        const auto timer = BuiltinTimer();
+
+        #pragma omp parallel firstprivate(nelements,nconditions, LHS_Contribution, RHS_Contribution, EquationId )
+        {
+            # pragma omp for  schedule(guided, 512) nowait
+            for (int k = 0; k < nelements; k++) {
+                auto it_elem = el_begin + k;
+
+                if (it_elem->IsActive()) {
+                    // Calculate elemental contribution
+                    pScheme->CalculateSystemContributions(*it_elem, LHS_Contribution, RHS_Contribution, EquationId, CurrentProcessInfo);
+
+                    //Get HROM weight and multiply it by its contribution
+                    const double h_rom_weight = mHromSimulation ? it_elem->GetValue(HROM_WEIGHT) : 1.0;
+                    LHS_Contribution *= h_rom_weight;
+                    RHS_Contribution *= h_rom_weight;
+
+                    // Assemble the elemental contribution
+                    BaseType::Assemble(A, b, LHS_Contribution, RHS_Contribution, EquationId);
+                }
+
+            }
+
+            #pragma omp for  schedule(guided, 512)
+            for (int k = 0; k < nconditions; k++) {
+                auto it_cond = cond_begin + k;
+
+                if (it_cond->IsActive()) {
+                    // Calculate elemental contribution
+                    pScheme->CalculateSystemContributions(*it_cond, LHS_Contribution, RHS_Contribution, EquationId, CurrentProcessInfo);
+
+                    //Get HROM weight and multiply it by its contribution
+                    const double h_rom_weight = mHromSimulation ? it_cond->GetValue(HROM_WEIGHT) : 1.0;
+                    LHS_Contribution *= h_rom_weight;
+                    RHS_Contribution *= h_rom_weight;
+
+                    // Assemble the elemental contribution
+                    BaseType::Assemble(A, b, LHS_Contribution, RHS_Contribution, EquationId);
+                }
+            }
+        }
+
+        KRATOS_INFO_IF("GlobalROMResidualBasedBlockBuilderAndSolver", this->GetEchoLevel() >= 1) << "Build time: " << timer.ElapsedSeconds() << std::endl;
+
+        KRATOS_INFO_IF("GlobalROMResidualBasedBlockBuilderAndSolver", (this->GetEchoLevel() > 2 && rModelPart.GetCommunicator().MyPID() == 0)) << "Finished parallel building" << std::endl;
+
+        KRATOS_CATCH("")
+    }
+
+    /**
+     * Projects the reduced system of equations 
+     */
+    virtual void ProjectROM(
+        ModelPart &rModelPart,
+        TSystemMatrixType &rA,
+        TSystemVectorType &rb)
+    {
+        KRATOS_TRY
+
+        if (mRightRomBasisInitialized==false){
+            mPhiGlobal = ZeroMatrix(BaseBuilderAndSolverType::GetEquationSystemSize(), GetNumberOfROMModes());
+            mRightRomBasisInitialized = true;
+        }
+
+        BuildRightROMBasis(rModelPart);
+
+        auto a_wrapper = UblasWrapper<double>(rA);
+        const auto& eigen_rA = a_wrapper.matrix();
+        Eigen::Map<EigenDynamicVector> eigen_rb(rb.data().begin(), rb.size());
+        Eigen::Map<EigenDynamicMatrix> eigen_mPhiGlobal(mPhiGlobal.data().begin(), mPhiGlobal.size1(), mPhiGlobal.size2());
+        
+        EigenDynamicMatrix eigen_rA_times_mPhiGlobal = eigen_rA * eigen_mPhiGlobal; //TODO: Make it in parallel.
+
+        // Compute the matrix multiplication
+        meigen_romA = eigen_mPhiGlobal.transpose() * eigen_rA_times_mPhiGlobal; //TODO: Make it in parallel.
+        meigen_romb = eigen_mPhiGlobal.transpose() * eigen_rb; //TODO: Make it in parallel.
+        
+        KRATOS_CATCH("")
+    }
+
+    /**
+     * Solves reduced system of equations and broadcasts it
+     */
+    virtual void SolveROM(
+        ModelPart &rModelPart,
+        TSystemMatrixType &rA,
+        TSystemVectorType &rb,
+        TSystemVectorType &rDx)
+    {
+        KRATOS_TRY
+
+        RomSystemVectorType dxrom(GetNumberOfROMModes());
+        
+        const auto solving_timer = BuiltinTimer();
+
+        using EigenDynamicVector = Eigen::Matrix<double, Eigen::Dynamic, 1>;
+        Eigen::Map<EigenDynamicVector> dxrom_eigen(dxrom.data().begin(), dxrom.size());
+        dxrom_eigen = meigen_romA.colPivHouseholderQr().solve(meigen_romb);
+        
+        double time = solving_timer.ElapsedSeconds();
+        KRATOS_INFO_IF("GlobalROMBuilderAndSolver", (this->GetEchoLevel() > 0)) << "Solve reduced system time: " << time << std::endl;
+
+        // Save the ROM solution increment in the root modelpart database
+        auto& r_root_mp = rModelPart.GetRootModelPart();
+        noalias(r_root_mp.GetValue(ROM_SOLUTION_INCREMENT)) += dxrom;
+
+        // project reduced solution back to full order model
+        const auto backward_projection_timer = BuiltinTimer();
+        ProjectToFineBasis(dxrom, rModelPart, rDx);
+        KRATOS_INFO_IF("GlobalROMBuilderAndSolver", (this->GetEchoLevel() > 0)) << "Project to fine basis time: " << backward_projection_timer.ElapsedSeconds() << std::endl;
+
+        KRATOS_CATCH("")
+    }
+
+    ///@}
+    ///@name Protected access
+    ///@{
+
+
+    ///@}
+    ///@name Protected inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Protected life cycle
+    ///@{
+
+private:
+
+    SizeType mNumberOfRomModes;
+    EigenDynamicMatrix meigen_romA;
+    EigenDynamicVector meigen_romb;
+    Matrix mPhiGlobal;
+
+    ///@}
+    ///@name Private operations 
+    ///@{
+
+    ///@}
+}; /* Class GlobalROMBuilderAndSolver */
+
+///@}
+///@name Type Definitions
+///@{
+
+
+///@}
+
+} /* namespace Kratos.*/
+
+#endif /* KRATOS_GLOBAL_ROM_BUILDER_AND_SOLVER  defined */

--- a/applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h
@@ -711,8 +711,8 @@ protected:
         EigenDynamicMatrix eigen_rA_times_mPhiGlobal = eigen_rA * eigen_mPhiGlobal; //TODO: Make it in parallel.
 
         // Compute the matrix multiplication
-        meigen_romA = eigen_mPhiGlobal.transpose() * eigen_rA_times_mPhiGlobal; //TODO: Make it in parallel.
-        meigen_romb = eigen_mPhiGlobal.transpose() * eigen_rb; //TODO: Make it in parallel.
+        mEigenRomA = eigen_mPhiGlobal.transpose() * eigen_rA_times_mPhiGlobal; //TODO: Make it in parallel.
+        mEigenRomB = eigen_mPhiGlobal.transpose() * eigen_rb; //TODO: Make it in parallel.
         
         KRATOS_CATCH("")
     }
@@ -734,7 +734,7 @@ protected:
 
         using EigenDynamicVector = Eigen::Matrix<double, Eigen::Dynamic, 1>;
         Eigen::Map<EigenDynamicVector> dxrom_eigen(dxrom.data().begin(), dxrom.size());
-        dxrom_eigen = meigen_romA.colPivHouseholderQr().solve(meigen_romb);
+        dxrom_eigen = mEigenRomA.colPivHouseholderQr().solve(mEigenRomB);
         
         double time = solving_timer.ElapsedSeconds();
         KRATOS_INFO_IF("GlobalROMBuilderAndSolver", (this->GetEchoLevel() > 0)) << "Solve reduced system time: " << time << std::endl;
@@ -767,8 +767,8 @@ private:
     ///@{
         
     SizeType mNumberOfRomModes;
-    EigenDynamicMatrix meigen_romA;
-    EigenDynamicVector meigen_romb;
+    EigenDynamicMatrix mEigenRomA;
+    EigenDynamicVector mEigenRomB;
     Matrix mPhiGlobal;
 
     ///@}

--- a/applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h
+++ b/applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h
@@ -11,18 +11,17 @@
 //                  
 //
 
-#if !defined(KRATOS_GLOBAL_ROM_BUILDER_AND_SOLVER)
-#define KRATOS_GLOBAL_ROM_BUILDER_AND_SOLVER
+#pragma once
 
-/* System includes */
+// System includes
 
-/* External includes */
+// External includes
 #include "concurrentqueue/concurrentqueue.h"
 #include <Eigen/Core>
 #include <Eigen/Dense>
 #include <Eigen/Sparse>
 
-/* Project includes */
+// Project includes
 #include "includes/define.h"
 #include "includes/model_part.h"
 #include "solving_strategies/schemes/scheme.h"
@@ -38,30 +37,28 @@
 
 namespace Kratos
 {
-
 ///@name Kratos Globals
 ///@{
-
 
 ///@}
 ///@name Type Definitions
 ///@{
 
-
-///@}GlobalROMBuilderAndSolver
+///@}
 ///@name  Enum's
 ///@{
-
 
 ///@}
 ///@name  Functions
 ///@{
 
-
 ///@}
 ///@name Kratos Classes
 ///@{
 
+/**
+ * @class GlobalROMBuilderAndSolver
+ */
 template <class TSparseSpace, class TDenseSpace, class TLinearSolver>
 class GlobalROMBuilderAndSolver : public ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>
 {
@@ -145,7 +142,6 @@ public:
     ///@}
     ///@name Operators
     ///@{
-
 
     ///@}
     ///@name Operations
@@ -363,11 +359,9 @@ public:
     ///@name Access
     ///@{
 
-
     ///@}
     ///@name Inquiry
     ///@{
-
 
     ///@}
     ///@name Input and output
@@ -395,13 +389,11 @@ public:
     ///@name Friends
     ///@{
 
-
     ///@}
 protected:
     ///@}
     ///@name Protected static member variables
     ///@{
-
 
     ///@}
     ///@name Protected member variables
@@ -421,7 +413,6 @@ protected:
     ///@}
     ///@name Protected operators
     ///@{
-
 
     ///@}
     ///@name Protected operations
@@ -764,18 +755,17 @@ protected:
     ///@name Protected access
     ///@{
 
-
     ///@}
     ///@name Protected inquiry
     ///@{
 
-
     ///@}
     ///@name Protected life cycle
     ///@{
-
 private:
-
+    ///@name Private member variables 
+    ///@{
+        
     SizeType mNumberOfRomModes;
     EigenDynamicMatrix meigen_romA;
     EigenDynamicVector meigen_romb;
@@ -796,5 +786,3 @@ private:
 ///@}
 
 } /* namespace Kratos.*/
-
-#endif /* KRATOS_GLOBAL_ROM_BUILDER_AND_SOLVER  defined */

--- a/applications/RomApplication/python_scripts/calculate_rom_basis_output_process.py
+++ b/applications/RomApplication/python_scripts/calculate_rom_basis_output_process.py
@@ -138,6 +138,7 @@ class CalculateRomBasisOutputProcess(KratosMultiphysics.OutputProcess):
             "train_hrom": False,
             "run_hrom": False,
             "projection_strategy": "galerkin",
+            "assembling_strategy": "global",
             "rom_format": "numpy",
             "train_petrov_galerkin": {
                 "train": False,
@@ -164,6 +165,7 @@ class CalculateRomBasisOutputProcess(KratosMultiphysics.OutputProcess):
         rom_basis_dict["rom_settings"]["nodal_unknowns"] = [var.Name() for var in self.snapshot_variables_list]
         rom_basis_dict["rom_settings"]["number_of_rom_dofs"] = numpy.shape(u)[1] #TODO: This is way misleading. I'd call it number_of_basis_modes or number_of_rom_modes
         rom_basis_dict["projection_strategy"] = "galerkin" # Galerkin: (Phi.T@K@Phi dq= Phi.T@b), LSPG = (K@Phi dq= b), Petrov-Galerkin = (Psi.T@K@Phi dq = Psi.T@b)
+        rom_basis_dict["assembling_strategy"] = "global" # Assemble the ROM globally or element by element: "global" (Phi_g @ J_g @ Phi_g), "element by element" sum(Phi_e^T @ K_e @ Phi_e)
         rom_basis_dict["rom_format"] = self.rom_basis_output_format
         rom_basis_dict["rom_settings"]["petrov_galerkin_number_of_rom_dofs"] = 0
         #NOTE "petrov_galerkin_number_of_rom_dofs" is not used unless a Petrov-Galerkin simulation is called, in which case it shall be modified either manually or from the RomManager

--- a/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
+++ b/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
@@ -52,6 +52,7 @@ def CreateSolverByParameters(model, solver_settings, parallelism, analysis_stage
     aux_solver_settings = solver_settings.Clone()
     aux_solver_settings.RemoveValue("rom_settings")
     aux_solver_settings.RemoveValue("projection_strategy")
+    aux_solver_settings.RemoveValue("assembling_strategy")
     aux_base_solver_instance = solvers_wrapper_module.CreateSolverByParameters(KratosMultiphysics.Model(), aux_solver_settings, parallelism)
 
     # Create the ROM solver from the base solver

--- a/applications/RomApplication/python_scripts/rom_analysis.py
+++ b/applications/RomApplication/python_scripts/rom_analysis.py
@@ -61,6 +61,10 @@ def CreateRomAnalysisInstance(cls, global_model, parameters):
             else:
                 self.project_parameters["solver_settings"]["rom_settings"].RemoveValue("petrov_galerkin_number_of_rom_dofs")
 
+            # ROM assembling strategy
+            self.assembling_strategy = self.rom_parameters["assembling_strategy"].GetString() if self.rom_parameters.Has("assembling_strategy") else "global"
+            self.project_parameters["solver_settings"].AddString("assembling_strategy",self.assembling_strategy)
+
             # Create the ROM solver
             return new_python_solvers_wrapper_rom.CreateSolver(
                 self.model,

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -358,6 +358,7 @@ class RomManager(object):
         parameters_file_name = './RomParameters.json'
         with open(parameters_file_name, 'r+') as parameter_file:
             f=json.load(parameter_file)
+            f['assembling_strategy'] = self.general_rom_manager_parameters['assembling_strategy'].GetString() if self.general_rom_manager_parameters.Has('assembling_strategy') else 'global'
             if simulation_to_run=='GalerkinROM':
                 f['projection_strategy']="galerkin"
                 f['train_hrom']=False
@@ -513,12 +514,6 @@ class RomManager(object):
                 "create_hrom_visualization_model_part" : true
             }""")
         return hrom_training_parameters
-
-
-
-
-
-
 
 
 

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -242,6 +242,7 @@ class RomManager(object):
         simulation.GetHROM_utility().hyper_reduction_element_selector.SetUp(u)
         simulation.GetHROM_utility().hyper_reduction_element_selector.Run()
         simulation.GetHROM_utility().AppendHRomWeightsToRomParameters()
+        simulation.GetHROM_utility().CreateHRomModelParts()
 
 
     def LaunchHROM(self, mu_train):
@@ -512,7 +513,6 @@ class RomManager(object):
                 "create_hrom_visualization_model_part" : true
             }""")
         return hrom_training_parameters
-
 
 
 

--- a/applications/RomApplication/python_scripts/rom_solver.py
+++ b/applications/RomApplication/python_scripts/rom_solver.py
@@ -21,6 +21,7 @@ def CreateSolver(cls, model, custom_settings):
         def GetDefaultParameters(cls):
             default_settings = KratosMultiphysics.Parameters("""{
                 "projection_strategy" : "galerkin",
+                "assembling_strategy" : "global",
                 "rom_settings": {
                     "nodal_unknowns": [],
                     "number_of_rom_dofs": 0
@@ -33,7 +34,8 @@ def CreateSolver(cls, model, custom_settings):
             linear_solver = self._GetLinearSolver()
             rom_parameters, solving_strategy = self._ValidateAndReturnRomParameters()
             available_solving_strategies = {
-                "galerkin": KratosROM.ROMBuilderAndSolver, 
+                "elemental_galerkin": KratosROM.ROMBuilderAndSolver, 
+                "global_galerkin": KratosROM.GlobalROMBuilderAndSolver, 
                 "lspg": KratosROM.LeastSquaresPetrovGalerkinROMBuilderAndSolver,
                 "petrov_galerkin": KratosROM.PetrovGalerkinROMBuilderAndSolver
             }
@@ -62,7 +64,19 @@ def CreateSolver(cls, model, custom_settings):
                     err_msg += " Please manually set \'nodal_unknowns\' in \'rom_settings\'."
                     raise Exception(err_msg)
             projection_strategy = self.settings["projection_strategy"].GetString()
-
+            assembling_strategy = self.settings["assembling_strategy"].GetString()
+            # For now, only Galerkin projection has the elemental or global approach option
+            if projection_strategy=="galerkin": #TODO: Possibility of doing elemental lspg and petrov_galerkin
+                available_assembling_strategies = {
+                    "global",
+                    "elemental"
+                }
+                if assembling_strategy in available_assembling_strategies:
+                    # Add the assembling strategy prefix to the projection strategy
+                    projection_strategy = f"{assembling_strategy}_{projection_strategy}"
+                else:
+                    err_msg = f"'Assembling_strategy': '{assembling_strategy}' is not available. Please select one of the following: {list(available_assembling_strategies.keys())}."
+                    raise ValueError(err_msg)
             # Return the validated ROM parameters
             return self.settings["rom_settings"], projection_strategy
 

--- a/applications/RomApplication/tests/compressible_potential_test_files/RomParameters.json
+++ b/applications/RomApplication/tests/compressible_potential_test_files/RomParameters.json
@@ -2,6 +2,7 @@
     "rom_manager": false,
     "train_hrom": false,
     "run_hrom": false,
+    "assembling_strategy": "elemental",
     "rom_format":"numpy",
     "rom_settings": {
         "nodal_unknowns": [

--- a/applications/RomApplication/tests/thermal_dynamic_test_files/ROM/RomParameters.json
+++ b/applications/RomApplication/tests/thermal_dynamic_test_files/ROM/RomParameters.json
@@ -4,6 +4,7 @@
     "run_hrom": false,
     "rom_format":"numpy",
     "projection_strategy": "galerkin",
+    "assembling_strategy": "elemental",
     "train_petrov_galerkin": {
         "train": false,
         "basis_strategy": "residuals",

--- a/applications/RomApplication/tests/thermal_static_test_files/ROM/RomParameters.json
+++ b/applications/RomApplication/tests/thermal_static_test_files/ROM/RomParameters.json
@@ -4,6 +4,7 @@
     "run_hrom": false,
     "rom_format":"numpy",
     "projection_strategy": "galerkin",
+    "assembling_strategy": "elemental",
     "train_petrov_galerkin": {
         "train": false,
         "basis_strategy": "residuals",


### PR DESCRIPTION
### Description

This pull request addresses the time-consuming ROMs in the application, which took longer as the number of modes used increased. We identified two main issues causing this: the use of Ublas instead of Eigen library, and building the reduced order model element by element. #11031

### Changes
To resolve this, we have made the following changes:

Instead of building the ROM element by element ($\sum_e \mathbf{\Phi}^{eT} \mathbf{J}^e \mathbf{\Phi}^{e}$), we now build it globally. This involves creating the Global Jacobian $\mathbf{J}$ and Global Basis $\mathbf{\Phi}$, performing a Sparse to Dense product $\mathbf{Aux}=\mathbf{J} \mathbf{\Phi}$, and then a Dense to Dense product $\mathbf{\Phi}^T\mathbf{Aux}$. This approach is more efficient, especially when building the ROM reduced system for a basis $\mathbf{\Phi}$ with a large number of modes.

We have also replaced Ublas with Eigen library to improve performance.

The following files have been modified as part of this change:

- `applications/RomApplication/CMakeLists.txt`: Importing eigen library to rom application, which introduces a dependency with the linear solvers application.
- `applications/RomApplication/custom_python/add_custom_strategies_to_python.cpp`: Added the global builder and solver for the Galerkin case.
- `applications/RomApplication/custom_strategies/global_rom_builder_and_solver.h`: Introduced the global builder and solver. Note that the elemental builder and solver still exists. This is just a new option.
- `applications/RomApplication/python_scripts/calculate_rom_basis_output_process.py`: Added the assembling strategy flag, setting the global as the default.
- `applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py`: Removed the assembling strategy flag to create the solver.
- `applications/RomApplication/python_scripts/rom_analysis.py`: Set the default assembling strategy when not provided.
- `applications/RomApplication/python_scripts/rom_manager.py`: Added the assembling strategy to the manager. Also fixed a bug related to the creation of the HROM model part by adding a missing line.
- `applications/RomApplication/python_scripts/rom_solver.py`: Added the "assembling_strategy" prefix to the solving strategy for the Galerkin projection only. We plan to do this for all solving strategies soon.

The following tests were preserved with the elemental assembling:

- `applications/RomApplication/tests/compressible_potential_test_files/RomParameters.json`
- `applications/RomApplication/tests/thermal_dynamic_test_files/ROM/RomParameters.json`
- `applications/RomApplication/tests/thermal_static_test_files/ROM/RomParameters.json`

We have multiple pull requests in the pipeline, so let's merge them carefully but quickly as many projects are using the ROM application.