### PR TITLE
[Core] Extend AccumReduction to be used with std::set

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_parallel_utilities.cpp
@@ -317,6 +317,21 @@ KRATOS_TEST_CASE_IN_SUITE(AccumReductionVector, KratosCoreFastSuite)
     KRATOS_CHECK_VECTOR_EQUAL(assembled_vector, expct_data_vector);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(AccumReductionSet, KratosCoreFastSuite)
+{
+    int nsize = 1e3;
+    std::vector<int> input_data_vector(nsize);
+    std::iota(input_data_vector.begin(), input_data_vector.end(), 0);
+
+    const auto& assembled_vector = block_for_each<AccumReduction<int, std::set<int>>>(input_data_vector, [](const int rValue) -> int {
+        return rValue+1;
+    });
+
+    for (int i = 0; i < nsize; ++i) {
+        KRATOS_CHECK_NOT_EQUAL(assembled_vector.find(i+1), assembled_vector.end());
+    }
+}
+
 KRATOS_TEST_CASE_IN_SUITE(MapReduction, KratosCoreFastSuite)
 {
     using map_type = std::unordered_map<int, int>;

--- a/kratos/utilities/reduction_utilities.h
+++ b/kratos/utilities/reduction_utilities.h
@@ -267,14 +267,14 @@ public:
 
     /// NON-THREADSAFE (fast) value of reduction, to be used within a single thread
     void LocalReduce(const TDataType value){
-        mValue.push_back(value);
+        mValue.insert(mValue.end(), value);
     }
 
     /// THREADSAFE (needs some sort of lock guard) reduction, to be used to sync threads
     void ThreadSafeReduce(const AccumReduction<TDataType, TReturnType>& rOther)
     {
         KRATOS_CRITICAL_SECTION
-        mValue.insert(mValue.end(), rOther.mValue.begin(), rOther.mValue.end());
+        std::copy(rOther.mValue.begin(), rOther.mValue.end(), std::inserter(mValue, mValue.end()));
     }
 };
 


### PR DESCRIPTION
**📝 Description**
This PR extends existing `AccumReduction` to be used with `std::set` as well.

**🆕 Changelog**
- Extends `AccumReduction` to be used with `std::set`
