### PR TITLE
[GeoMechanicsApplcation] Add toggle in to select experimental mode

### DIFF
--- a/applications/GeoMechanicsApplication/GeoMechanicsApplication.py
+++ b/applications/GeoMechanicsApplication/GeoMechanicsApplication.py
@@ -1,8 +1,14 @@
+import os
+
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
 import KratosMultiphysics.StructuralMechanicsApplication
 from KratosGeoMechanicsApplication import *
 application = KratosGeoMechanicsApplication()
 application_name = "KratosGeoMechanicsApplication"
+
+geo_experimental = os.getenv('GEO_EXPERIMENTAL')
+if geo_experimental:
+    application.SetExperimental()
 
 _ImportApplication(application, application_name)

--- a/applications/GeoMechanicsApplication/custom_python/geo_mechanics_python_application.cpp
+++ b/applications/GeoMechanicsApplication/custom_python/geo_mechanics_python_application.cpp
@@ -42,7 +42,8 @@ PYBIND11_MODULE(KratosGeoMechanicsApplication,m)
     py::class_<KratosGeoMechanicsApplication,
             KratosGeoMechanicsApplication::Pointer,
             KratosApplication>(m, "KratosGeoMechanicsApplication")
-            .def(py::init<>());
+            .def(py::init<>())
+            .def("SetExperimental",&KratosGeoMechanicsApplication::SetExperimental);
 
     AddCustomStrategiesToPython(m);
     AddCustomUtilitiesToPython(m);

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
@@ -29,6 +29,11 @@ using NodeType = Node<3>;
 KratosGeoMechanicsApplication::KratosGeoMechanicsApplication() :
     KratosApplication("GeoMechanicsApplication") {}
 
+void KratosGeoMechanicsApplication::SetExperimental()
+{
+    mExperimental = true;
+}
+
 void KratosGeoMechanicsApplication::Register() {
     KRATOS_INFO("") << " KRATOS___                             \n"
                     << "     //   ) )                          \n"
@@ -37,8 +42,10 @@ void KratosGeoMechanicsApplication::Register() {
                     << "  //    / / //       //   / /          \n"
                     << " ((____/ / ((____   ((___/ /  MECHANICS\n"
                     << " Initializing KratosGeoMechanicsApplication..." << std::endl;
-
-
+    if(mExperimental)
+    {
+      KRATOS_INFO("") << " Use experimental components\n" << std::endl;
+    }
 
     //Register Elements
     // transient one-phase flow elements:
@@ -477,13 +484,17 @@ void KratosGeoMechanicsApplication::Register() {
     KRATOS_REGISTER_VARIABLE( STATE_VARIABLE_41 )
     KRATOS_REGISTER_VARIABLE( STATE_VARIABLE_42 )
     KRATOS_REGISTER_VARIABLE( STATE_VARIABLE_43 )
-    KRATOS_REGISTER_VARIABLE( STATE_VARIABLE_44 )
-    KRATOS_REGISTER_VARIABLE( STATE_VARIABLE_45 )
-    KRATOS_REGISTER_VARIABLE( STATE_VARIABLE_46 )
-    KRATOS_REGISTER_VARIABLE( STATE_VARIABLE_47 )
-    KRATOS_REGISTER_VARIABLE( STATE_VARIABLE_48 )
-    KRATOS_REGISTER_VARIABLE( STATE_VARIABLE_49 )
-    KRATOS_REGISTER_VARIABLE( STATE_VARIABLE_50 )
+
+    if (mExperimental)
+    {
+      KRATOS_REGISTER_VARIABLE( STATE_VARIABLE_44 )
+      KRATOS_REGISTER_VARIABLE( STATE_VARIABLE_45 )
+      KRATOS_REGISTER_VARIABLE( STATE_VARIABLE_46 )
+      KRATOS_REGISTER_VARIABLE( STATE_VARIABLE_47 )
+      KRATOS_REGISTER_VARIABLE( STATE_VARIABLE_48 )
+      KRATOS_REGISTER_VARIABLE( STATE_VARIABLE_49 )  
+      KRATOS_REGISTER_VARIABLE( STATE_VARIABLE_50 )
+    }
 
    }
 }  // namespace Kratos.

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.h
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.h
@@ -188,6 +188,9 @@ public:
     ///@name Operations
     ///@{
 
+        
+    void SetExperimental();
+
     virtual void Register() override;
 
 
@@ -316,6 +319,8 @@ private:
     ///@}
     ///@name Un accessible methods
     ///@{
+
+    bool mExperimental = false;
 
     // elements
     // transient one-phase flow elements:


### PR DESCRIPTION
**📝 Description**
Add a toggle to select experimental mode from the Python interface.
The registration of the application happens in the python `__init__.py` file. Which limits control over the code flow.
Selection based on an environmental variable is not ideal but the least ugly variation I could think of. Python does not like global variable sharing over module boundaries. This creation keeps it local to the GeoMechanicsApplication. 
Any suggestions on how to improve are welcome.

Note: Which elements, conditions, or laws are experimental is not decided. This PR is just the mechanism.



