### PR TITLE
[GeoMechanicsApplication] Replaced redundant Voigt indices

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/elastic_isotropic_K0_3d_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/elastic_isotropic_K0_3d_law.cpp
@@ -291,11 +291,11 @@ void ElasticIsotropicK03DLaw::CalculateElasticMatrix(Matrix& rConstitutiveMatrix
 
     double K0 = 0.0;
     const int &K0MainDirection = r_material_properties[K0_MAIN_DIRECTION];
-    if (K0MainDirection == VOIGT_INDEX_XX) {
+    if (K0MainDirection == INDEX_3D_XX) {
         K0 = 0.5*(K0ValueYY + K0ValueZZ);
-    } else if (K0MainDirection == VOIGT_INDEX_YY) {
+    } else if (K0MainDirection == INDEX_3D_YY) {
         K0 = 0.5*(K0ValueXX + K0ValueZZ);
-    } else if (K0MainDirection == VOIGT_INDEX_ZZ) {
+    } else if (K0MainDirection == INDEX_3D_ZZ) {
         K0 = 0.5*(K0ValueXX + K0ValueYY);
     } else {
          KRATOS_ERROR << "undefined K0_MAIN_DIRECTION in LinearElasticK03DLaw: " << K0MainDirection << std::endl;
@@ -345,15 +345,15 @@ void ElasticIsotropicK03DLaw::CalculatePK2Stress(const Vector& rStrainVector,
     const double& K0ValueZZ = r_material_properties[K0_VALUE_ZZ];
 
     const int& K0MainDirection = r_material_properties[K0_MAIN_DIRECTION];
-    if (K0MainDirection == VOIGT_INDEX_XX) {
-        rStressVector[VOIGT_INDEX_YY] = K0ValueYY * rStressVector[VOIGT_INDEX_XX];
-        rStressVector[VOIGT_INDEX_ZZ] = K0ValueZZ * rStressVector[VOIGT_INDEX_XX];
-    } else if (K0MainDirection == VOIGT_INDEX_YY) {
-        rStressVector[VOIGT_INDEX_XX] = K0ValueXX * rStressVector[VOIGT_INDEX_YY];
-        rStressVector[VOIGT_INDEX_ZZ] = K0ValueZZ * rStressVector[VOIGT_INDEX_YY];
-    } else if (K0MainDirection == VOIGT_INDEX_ZZ) {
-        rStressVector[VOIGT_INDEX_XX] = K0ValueXX * rStressVector[VOIGT_INDEX_ZZ];
-        rStressVector[VOIGT_INDEX_YY] = K0ValueYY * rStressVector[VOIGT_INDEX_ZZ];
+    if (K0MainDirection == INDEX_3D_XX) {
+        rStressVector[INDEX_3D_YY] = K0ValueYY * rStressVector[INDEX_3D_XX];
+        rStressVector[INDEX_3D_ZZ] = K0ValueZZ * rStressVector[INDEX_3D_XX];
+    } else if (K0MainDirection == INDEX_3D_YY) {
+        rStressVector[INDEX_3D_XX] = K0ValueXX * rStressVector[INDEX_3D_YY];
+        rStressVector[INDEX_3D_ZZ] = K0ValueZZ * rStressVector[INDEX_3D_YY];
+    } else if (K0MainDirection == INDEX_3D_ZZ) {
+        rStressVector[INDEX_3D_XX] = K0ValueXX * rStressVector[INDEX_3D_ZZ];
+        rStressVector[INDEX_3D_YY] = K0ValueYY * rStressVector[INDEX_3D_ZZ];
     } else {
          KRATOS_ERROR << "undefined K0_MAIN_DIRECTION in LinearElasticK03DLaw: " << K0MainDirection << std::endl;
     }

--- a/applications/GeoMechanicsApplication/custom_constitutive/elastic_isotropic_K0_3d_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/elastic_isotropic_K0_3d_law.h
@@ -352,12 +352,6 @@ private:
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, ConstitutiveLaw)
     }
-
-    // stress vector indices
-    const int VOIGT_INDEX_XX = 0;
-    const int VOIGT_INDEX_YY = 1;
-    const int VOIGT_INDEX_ZZ = 2;
-
 }; // Class ElasticIsotropicK03DLaw
 }  // namespace Kratos.
 #endif // KRATOS_ELASTIC_ISOTROPIC_K0_3D_LAW_H_INCLUDED  defined

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_beam_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_beam_law.h
@@ -208,11 +208,6 @@ private:
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, GeoLinearElasticPlaneStrain2DLaw)
     }
-
-    // stress vector indices
-    // const int VOIGT_INDEX_XX = 0;
-    // const int VOIGT_INDEX_YY = 1;
-
 }; // Class GeoLinearElasticPlaneStrain2DLaw
 }  // namespace Kratos.
 #endif // KRATOS_LINEAR_PLANE_STRAIN_K0_LAW_H_INCLUDED  defined

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_interface_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_interface_law.h
@@ -232,11 +232,6 @@ private:
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, GeoLinearElasticPlaneStrain2DLaw)
     }
-
-    // stress vector indices
-    // const int VOIGT_INDEX_XX = 0;
-    // const int VOIGT_INDEX_YY = 1;
-
 }; // Class GeoLinearElasticPlaneStrain2DLaw
 }  // namespace Kratos.
 #endif // KRATOS_LINEAR_PLANE_STRAIN_K0_LAW_H_INCLUDED  defined

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_3D_interface_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_3D_interface_law.h
@@ -232,11 +232,6 @@ private:
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, LinearElastic2DInterfaceLaw)
     }
-
-    // stress vector indices
-    // const int VOIGT_INDEX_XX = 0;
-    // const int VOIGT_INDEX_YY = 1;
-
 }; // Class LinearElastic2DInterfaceLaw
 }  // namespace Kratos.
 #endif // KRATOS_LINEAR_PLANE_STRAIN_K0_LAW_H_INCLUDED  defined

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_2D_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_2D_law.h
@@ -236,11 +236,6 @@ private:
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, LinearPlaneStrainK0Law)
     }
-
-    // stress vector indices
-    // const int VOIGT_INDEX_XX = 0;
-    // const int VOIGT_INDEX_YY = 1;
-
 }; // Class LinearPlaneStrainK0Law
 }  // namespace Kratos.
 #endif // KRATOS_LINEAR_PLANE_STRAIN_K0_LAW_H_INCLUDED  defined

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_K0_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_K0_law.cpp
@@ -107,9 +107,9 @@ void LinearPlaneStrainK0Law::
 
     double K0 = 0.0;
     const int &K0MainDirection = r_material_properties[K0_MAIN_DIRECTION];
-    if (K0MainDirection == VOIGT_INDEX_XX) {
+    if (K0MainDirection == INDEX_2D_PLANE_STRAIN_XX) {
         K0 = 0.5*(K0ValueYY + K0ValueZZ);
-    } else if (K0MainDirection == VOIGT_INDEX_YY) {
+    } else if (K0MainDirection == INDEX_2D_PLANE_STRAIN_YY) {
         K0 = 0.5*(K0ValueXX + K0ValueZZ);
     } else {
          KRATOS_ERROR << "undefined K0_MAIN_DIRECTION in LinearElasticPlaneStrainK02DLaw: " << K0MainDirection << std::endl;
@@ -165,10 +165,10 @@ void LinearPlaneStrainK0Law::CalculatePK2Stress(const Vector& rStrainVector,
     const double& K0ValueZZ = r_material_properties[K0_VALUE_ZZ];
 
     const int& K0MainDirection = r_material_properties[K0_MAIN_DIRECTION];
-    if (K0MainDirection == VOIGT_INDEX_XX) {
+    if (K0MainDirection == INDEX_2D_PLANE_STRAIN_XX) {
         rStressVector[INDEX_2D_PLANE_STRAIN_YY] = K0ValueYY * rStressVector[INDEX_2D_PLANE_STRAIN_XX];
         rStressVector[INDEX_2D_PLANE_STRAIN_ZZ] = K0ValueZZ * rStressVector[INDEX_2D_PLANE_STRAIN_XX];
-    } else if (K0MainDirection == VOIGT_INDEX_YY) {
+    } else if (K0MainDirection == INDEX_2D_PLANE_STRAIN_YY) {
         rStressVector[INDEX_2D_PLANE_STRAIN_XX] = K0ValueXX * rStressVector[INDEX_2D_PLANE_STRAIN_YY];
         rStressVector[INDEX_2D_PLANE_STRAIN_ZZ] = K0ValueZZ * rStressVector[INDEX_2D_PLANE_STRAIN_YY];
     } else {

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_K0_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_K0_law.h
@@ -236,11 +236,6 @@ private:
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, ElasticIsotropicK03DLaw)
     }
-
-    // stress vector indices
-    const int VOIGT_INDEX_XX = 0;
-    const int VOIGT_INDEX_YY = 1;
-
 }; // Class LinearPlaneStrainK0Law
 }  // namespace Kratos.
 #endif // KRATOS_LINEAR_PLANE_STRAIN_K0_LAW_H_INCLUDED  defined


### PR DESCRIPTION
**📝 Description**
Replaced some locally defined Voigt indices by globally defined indices. Also removed several Voigt indices that had been commented out.

**🆕 Changelog**
- Replaced indices `VOIGT_INDEX_XX` and `VOIGT_INDEX_YY` defined in class `LinearPlaneStrainK0Law` by their global counterparts `INDEX_2D_PLANE_STRAIN_XX` and `INDEX_2D_PLANE_STRAIN_YY`, respectively.
- Replaced indices `VOIGT_INDEX_XX`, `VOIGT_INDEX_YY`, and `VOIGT_INDEX_ZZ` defined in class `ElasticIsotropicK03DLaw` by their global counterparts `INDEX_3D_XX`, `INDEX_3D_YY`, and `INDEX_3D_ZZ`, respectively.
- Removed commented-out definitions of Voigt indices from classes `GeoLinearElasticPlaneStrain2DLaw`, `LinearElastic2DInterfaceLaw`, `LinearElastic3DInterfaceLaw`, and `LinearElastic2DBeamLaw`.
