### PR TITLE
[TrilinosApplication] Cleaning trailing whitespaces

### DIFF
--- a/applications/TrilinosApplication/tests/cpp_tests/trilinos_cpp_test_utilities.h
+++ b/applications/TrilinosApplication/tests/cpp_tests/trilinos_cpp_test_utilities.h
@@ -197,7 +197,7 @@ public:
         const bool PrintValues = false,
         const double ThresholdIncludeHardZeros = -1
         );
-        
+
     /**
     * @brief This method generates a sparse matrix from a set of row, columns and values
     * @param rDataCommunicator The data communicator considered
@@ -216,7 +216,7 @@ public:
         const std::vector<double>& rValues,
         const Epetra_Map* pMap =  nullptr
         );
-        
+
     ///@}
 
 }; /// class TrilinosCPPTestUtilities


### PR DESCRIPTION
**📝 Description**

This PR contains a minor change to the `TrilinosCPPTestUtilities` (`applications/TrilinosApplication/tests/cpp_tests/trilinos_cpp_test_utilities.h`) header file, where two lines with trailing whitespaces have been cleaned up. The affected lines are 197 and 216. No functional changes have been made to the code.

**🆕 Changelog**

- [Cleaning trailing whitespaces](https://github.com/KratosMultiphysics/Kratos/commit/3e660ea6292ef3051d8b1665b152f06e0f691b4d)
