### PR TITLE
Small change, getting rid of .keys(). ROM.

### DIFF
--- a/applications/RomApplication/python_scripts/rom_solver.py
+++ b/applications/RomApplication/python_scripts/rom_solver.py
@@ -75,7 +75,7 @@ def CreateSolver(cls, model, custom_settings):
                     # Add the assembling strategy prefix to the projection strategy
                     projection_strategy = f"{assembling_strategy}_{projection_strategy}"
                 else:
-                    err_msg = f"'Assembling_strategy': '{assembling_strategy}' is not available. Please select one of the following: {list(available_assembling_strategies.keys())}."
+                    err_msg = f"'Assembling_strategy': '{assembling_strategy}' is not available. Please select one of the following: {list(available_assembling_strategies)}."
                     raise ValueError(err_msg)
             # Return the validated ROM parameters
             return self.settings["rom_settings"], projection_strategy


### PR DESCRIPTION
The pull request addresses an **AttributeError** exception that occurred when running a ROM solver for a fluid dynamics application. The error message indicates that the 'list' object has no attribute **'keys'.** The change made in the pull request was to remove the **.keys()** method call from the **err_msg** variable, which was causing the exception. This change should resolve the issue and allow the ROM solver to run successfully. The pull request is a **FASTPR.**
