### PR TITLE
[Poro] Fixed rotation matrix sign in 2D interface elements

### DIFF
--- a/applications/DamApplication/custom_elements/small_displacement_interface_element.cpp
+++ b/applications/DamApplication/custom_elements/small_displacement_interface_element.cpp
@@ -1114,10 +1114,14 @@ void SmallDisplacementInterfaceElement<2,4>::CalculateRotationMatrix(BoundedMatr
     rRotationMatrix(0,0) = Vx[0];
     rRotationMatrix(0,1) = Vx[1];
 
-    // NOTE. Assuming that the nodes in quadrilateral_interface_2d_4 are
-    // ordered clockwise (GiD does so), the rotation matrix is build like follows:
-    rRotationMatrix(1,0) = Vx[1];
-    rRotationMatrix(1,1) = -Vx[0];
+    // NOTE. Assuming that the nodes in quadrilateral_interface_2d_4 are 
+    // ordered counter-clockwise (GiD does so now), the rotation matrix is build like follows:
+    rRotationMatrix(1,0) = -Vx[1];
+    rRotationMatrix(1,1) = Vx[0];
+    // NOTE. Assuming that the nodes in quadrilateral_interface_2d_4 are 
+    // ordered clockwise, the rotation matrix is build like follows:
+    // rRotationMatrix(1,0) = Vx[1];
+    // rRotationMatrix(1,1) = -Vx[0];
 
     // NOTE. In zero-thickness quadrilateral_interface_2d_4 elements we are not able to know
     // whether the nodes are ordered clockwise or counter-clockwise.

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -1236,9 +1236,13 @@ void UPwSmallStrainInterfaceElement<2,4>::CalculateRotationMatrix(BoundedMatrix<
     rRotationMatrix(0,1) = Vx[1];
 
     // NOTE. Assuming that the nodes in quadrilateral_interface_2d_4 are 
-    // ordered clockwise (GiD does so), the rotation matrix is build like follows:
-    rRotationMatrix(1,0) = Vx[1];
-    rRotationMatrix(1,1) = -Vx[0];
+    // ordered counter-clockwise (GiD does so now), the rotation matrix is build like follows:
+    rRotationMatrix(1,0) = -Vx[1];
+    rRotationMatrix(1,1) = Vx[0];
+    // NOTE. Assuming that the nodes in quadrilateral_interface_2d_4 are 
+    // ordered clockwise, the rotation matrix is build like follows:
+    // rRotationMatrix(1,0) = Vx[1];
+    // rRotationMatrix(1,1) = -Vx[0];
 
     // NOTE. In zero-thickness quadrilateral_interface_2d_4 elements we are not able to know
     // whether the nodes are ordered clockwise or counter-clockwise.

--- a/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_2D_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_2D_utilities.hpp
@@ -1531,9 +1531,13 @@ private:
         rRotationMatrix(0,1) = Vx[1];
 
         // NOTE. Assuming that the nodes in quadrilateral_interface_2d_4 are 
-        // ordered clockwise (GiD does so), the rotation matrix is build like follows:
-        rRotationMatrix(1,0) = Vx[1];
-        rRotationMatrix(1,1) = -Vx[0];
+        // ordered counter-clockwise (GiD does so now), the rotation matrix is build like follows:
+        rRotationMatrix(1,0) = -Vx[1];
+        rRotationMatrix(1,1) = Vx[0];
+        // NOTE. Assuming that the nodes in quadrilateral_interface_2d_4 are 
+        // ordered clockwise, the rotation matrix is build like follows:
+        // rRotationMatrix(1,0) = Vx[1];
+        // rRotationMatrix(1,1) = -Vx[0];
 
         // NOTE. In zero-thickness quadrilateral_interface_2d_4 elements we are not able to know
         // whether the nodes are ordered clockwise or counter-clockwise.


### PR DESCRIPTION
**📝 Description**
Some months ago, we had to change the sign of the 2D interface element rotation matrix because GiD generated the 2D interface elements mesh with a clockwise numbering. Now the numbering in GiD is counter-clockwise. In this PR we reverse the previous change of sign to be consistent with respect to the GiD numbering.

**🆕 Changelog**
- The sign of the second row of the 2D interface element rotation matrix has been changed. This change has been applied in two methods in the Poromechanics Application and in another method in the Dam Application.
