### PR TITLE
[Core] Bugfix - leave one empty mesh when calling clear Model Part

### DIFF
--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -82,6 +82,7 @@ void ModelPart::Clear()
 
     // Clear meshes list
     mMeshes.clear();
+    mMeshes.emplace_back(Kratos::make_shared<MeshType>());
 
     // Clear geometries
     mGeometries.Clear();


### PR DESCRIPTION
**📝 Description**
As described in https://github.com/KratosMultiphysics/Kratos/issues/10880, calling model part Clear leads to error as we should always have one default mesh. This PR add the fix proposed by @matekelemen there.
