### PR TITLE
Adding Run() methods to RomManager

### DIFF
--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -33,11 +33,11 @@ class RomManager(object):
         ######  Galerkin ######
         if chosen_projection_strategy == "galerkin":
             if any(item == "ROM" for item in training_stages):
-                fom_snapshots = self.LaunchTrainROM(mu_train)
+                fom_snapshots = self.__LaunchTrainROM(mu_train)
                 if store_all_snapshots or store_fom_snapshots:
                     self._StoreSnapshotsMatrix('fom_snapshots', fom_snapshots)
                 self._ChangeRomFlags(simulation_to_run = "GalerkinROM")
-                rom_snapshots = self.LaunchROM(mu_train)
+                rom_snapshots = self.__LaunchROM(mu_train)
                 if store_all_snapshots or store_rom_snapshots:
                     self._StoreSnapshotsMatrix('rom_snapshots', rom_snapshots)
                 self.ROMvsFOM_train = np.linalg.norm(fom_snapshots - rom_snapshots)/ np.linalg.norm(fom_snapshots)
@@ -45,24 +45,23 @@ class RomManager(object):
             if any(item == "HROM" for item in training_stages):
                 #FIXME there will be an error if we only train HROM, but not ROM
                 self._ChangeRomFlags(simulation_to_run = "trainHROMGalerkin")
-                self.LaunchTrainHROM(mu_train, store_residuals_projected)
+                self.__LaunchTrainHROM(mu_train, store_residuals_projected)
                 self._ChangeRomFlags(simulation_to_run = "runHROMGalerkin")
-                hrom_snapshots = self.LaunchHROM(mu_train)
+                hrom_snapshots = self.__LaunchHROM(mu_train)
                 if store_all_snapshots or store_hrom_snapshots:
                     self._StoreSnapshotsMatrix('hrom_snapshots', hrom_snapshots)
                 self.ROMvsHROM_train = np.linalg.norm(rom_snapshots - hrom_snapshots) / np.linalg.norm(rom_snapshots)
         #######################
 
-
         #######################################
         ##  Least-Squares Petrov Galerkin   ###
         elif chosen_projection_strategy == "lspg":
             if any(item == "ROM" for item in training_stages):
-                fom_snapshots = self.LaunchTrainROM(mu_train)
+                fom_snapshots = self.__LaunchTrainROM(mu_train)
                 if store_all_snapshots or store_fom_snapshots:
                     self._StoreSnapshotsMatrix('fom_snapshots', fom_snapshots)
                 self._ChangeRomFlags(simulation_to_run = "lspg")
-                rom_snapshots = self.LaunchROM(mu_train)
+                rom_snapshots = self.__LaunchROM(mu_train)
                 if store_all_snapshots or store_rom_snapshots:
                     self._StoreSnapshotsMatrix('rom_snapshots', rom_snapshots)
                 self.ROMvsFOM_train = np.linalg.norm(fom_snapshots - rom_snapshots)/ np.linalg.norm(fom_snapshots)
@@ -74,22 +73,22 @@ class RomManager(object):
         ###  Petrov Galerkin   ###
         elif chosen_projection_strategy == "petrov_galerkin":
             if any(item == "ROM" for item in training_stages):
-                fom_snapshots = self.LaunchTrainROM(mu_train)
+                fom_snapshots = self.__LaunchTrainROM(mu_train)
                 if store_all_snapshots or store_fom_snapshots:
                     self._StoreSnapshotsMatrix('fom_snapshots', fom_snapshots)
                 self._ChangeRomFlags(simulation_to_run = "TrainPG")
-                self.TrainPG(mu_train)
+                self.__LaunchTrainPG(mu_train)
                 self._ChangeRomFlags(simulation_to_run = "PG")
-                rom_snapshots = self.LaunchROM(mu_train)
+                rom_snapshots = self.__LaunchROM(mu_train)
                 if store_all_snapshots or store_rom_snapshots:
                     self._StoreSnapshotsMatrix('rom_snapshots', rom_snapshots)
                 self.ROMvsFOM_train = np.linalg.norm(fom_snapshots - rom_snapshots)/ np.linalg.norm(fom_snapshots)
             if any(item == "HROM" for item in training_stages):
                 #FIXME there will be an error if we only train HROM, but not ROM
                 self._ChangeRomFlags(simulation_to_run = "trainHROMPetrovGalerkin")
-                self.LaunchTrainHROM(mu_train, store_residuals_projected)
+                self.__LaunchTrainHROM(mu_train, store_residuals_projected)
                 self._ChangeRomFlags(simulation_to_run = "runHROMPetrovGalerkin")
-                hrom_snapshots = self.LaunchHROM(mu_train)
+                hrom_snapshots = self.__LaunchHROM(mu_train)
                 if store_all_snapshots or store_hrom_snapshots:
                     self._StoreSnapshotsMatrix('hrom_snapshots', hrom_snapshots)
                 self.ROMvsHROM_train = np.linalg.norm(rom_snapshots - hrom_snapshots) / np.linalg.norm(rom_snapshots)
@@ -104,15 +103,15 @@ class RomManager(object):
         ######  Galerkin ######
         if chosen_projection_strategy == "galerkin":
             if any(item == "ROM" for item in testing_stages):
-                fom_snapshots = self.LaunchTestFOM(mu_test)
+                fom_snapshots = self.__LaunchTestFOM(mu_test)
                 self._ChangeRomFlags(simulation_to_run = "GalerkinROM")
-                rom_snapshots = self.LaunchTestROM(mu_test)
+                rom_snapshots = self.__LaunchTestROM(mu_test)
                 self.ROMvsFOM_test = np.linalg.norm(fom_snapshots - rom_snapshots)/ np.linalg.norm(fom_snapshots)
 
             if any(item == "HROM" for item in testing_stages):
                 #FIXME there will be an error if we only test HROM, but not ROM
                 self._ChangeRomFlags(simulation_to_run = "runHROMGalerkin")
-                hrom_snapshots = self.LaunchTestHROM(mu_test)
+                hrom_snapshots = self.__LaunchTestHROM(mu_test)
                 self.ROMvsHROM_test = np.linalg.norm(rom_snapshots - hrom_snapshots) / np.linalg.norm(rom_snapshots)
 
 
@@ -120,9 +119,9 @@ class RomManager(object):
         ##  Least-Squares Petrov Galerkin   ###
         elif chosen_projection_strategy == "lspg":
             if any(item == "ROM" for item in testing_stages):
-                fom_snapshots = self.LaunchTestFOM(mu_test)
+                fom_snapshots = self.__LaunchTestFOM(mu_test)
                 self._ChangeRomFlags(simulation_to_run = "lspg")
-                rom_snapshots = self.LaunchTestROM(mu_test)
+                rom_snapshots = self.__LaunchTestROM(mu_test)
                 self.ROMvsFOM_test = np.linalg.norm(fom_snapshots - rom_snapshots)/ np.linalg.norm(fom_snapshots)
             if any(item == "HROM" for item in testing_stages):
                 raise Exception('Sorry, Hyper Reduction not yet implemented for lspg')
@@ -133,14 +132,14 @@ class RomManager(object):
         ###  Petrov Galerkin   ###
         elif chosen_projection_strategy == "petrov_galerkin":
             if any(item == "ROM" for item in testing_stages):
-                fom_snapshots = self.LaunchTestFOM(mu_test)
+                fom_snapshots = self.__LaunchTestFOM(mu_test)
                 self._ChangeRomFlags(simulation_to_run = "PG")
-                rom_snapshots = self.LaunchTestROM(mu_test)
+                rom_snapshots = self.__LaunchTestROM(mu_test)
                 self.ROMvsFOM_test = np.linalg.norm(fom_snapshots - rom_snapshots)/ np.linalg.norm(fom_snapshots)
             if any(item == "HROM" for item in testing_stages):
                 #FIXME there will be an error if we only train HROM, but not ROM
                 self._ChangeRomFlags(simulation_to_run = "runHROMPetrovGalerkin")
-                hrom_snapshots = self.LaunchTestHROM(mu_test)
+                hrom_snapshots = self.__LaunchTestHROM(mu_test)
                 self.ROMvsHROM_test = np.linalg.norm(rom_snapshots - hrom_snapshots) / np.linalg.norm(rom_snapshots)
         ##########################
 
@@ -167,7 +166,7 @@ class RomManager(object):
         else:
             err_msg = f"Provided projection strategy '{self.general_rom_manager_parameters["projection_strategy"].GetString()}' is not supported. Available options are 'galerkin', 'lspg' and 'petrov_galerkin'."
             raise Exception(err_msg)
-        self.LaunchRunROM(mu_run)
+        self.__LaunchRunROM(mu_run)
 
     def RunHROM(self, mu_run=[None]):
         chosen_projection_strategy = self.general_rom_manager_parameters["projection_strategy"].GetString()
@@ -183,7 +182,7 @@ class RomManager(object):
         ###  Petrov Galerkin   ###
         elif self.general_rom_manager_parameters["projection_strategy"].GetString() == "petrov_galerkin":
             self._ChangeRomFlags(simulation_to_run = "runHROMPetrovGalerkin")
-        self.LaunchRunHROM(mu_run)
+        self.__LaunchRunHROM(mu_run)
 
 
 
@@ -201,7 +200,7 @@ class RomManager(object):
             print("approximation error in test set ROM vs HROM: ",  self.ROMvsHROM_test)
 
 
-    def LaunchTrainROM(self, mu_train):
+    def __LaunchTrainROM(self, mu_train):
         """
         This method should be parallel capable
         """

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -153,13 +153,13 @@ class RomManager(object):
 
 
 
-    def RunFOM(self, mu_run):
+    def RunFOM(self, mu_run=None):
         if mu_run is None:
             mu_run = ['single case with parameters already contained in the ProjectParameters.json and CustomSimulation']
         self.LaunchRunFOM(mu_run)
 
 
-    def RunROM(self, mu_run):
+    def RunROM(self, mu_run=None):
         if mu_run is None:
             mu_run = ['single case with parameters already contained in the ProjectParameters.json and CustomSimulation']
         #######################
@@ -176,7 +176,7 @@ class RomManager(object):
             self._ChangeRomFlags(simulation_to_run = "PG")
         self.LaunchRunROM(mu_run)
 
-    def RunHROM(self, mu_run):
+    def RunHROM(self, mu_run=None):
         if mu_run is None:
             mu_run = ['single case with parameters already contained in the ProjectParameters.json and CustomSimulation']
         #######################

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -225,7 +225,7 @@ class RomManager(object):
         return SnapshotsMatrix
 
 
-    def LaunchROM(self, mu_train):
+    def __LaunchROM(self, mu_train):
         """
         This method should be parallel capable
         """
@@ -250,7 +250,7 @@ class RomManager(object):
         return SnapshotsMatrix
 
 
-    def TrainPG(self, mu_train):
+    def __LaunchTrainPG(self, mu_train):
         """
         This method should be parallel capable
         """
@@ -269,7 +269,7 @@ class RomManager(object):
         simulation.GetPetrovGalerkinTrainUtility().CalculateAndSaveBasis(np.block(PetrovGalerkinTrainMatrix))
 
 
-    def LaunchTrainHROM(self, mu_train, store_residuals_projected=False):
+    def __LaunchTrainHROM(self, mu_train, store_residuals_projected=False):
         """
         This method should be parallel capable
         """
@@ -296,7 +296,7 @@ class RomManager(object):
         simulation.GetHROM_utility().CreateHRomModelParts()
 
 
-    def LaunchHROM(self, mu_train):
+    def __LaunchHROM(self, mu_train):
         """
         This method should be parallel capable
         """
@@ -321,7 +321,7 @@ class RomManager(object):
         return SnapshotsMatrix
 
 
-    def LaunchTestFOM(self, mu_test):
+    def __LaunchTestFOM(self, mu_test):
         """
         This method should be parallel capable
         """
@@ -347,7 +347,7 @@ class RomManager(object):
         return SnapshotsMatrix
 
 
-    def LaunchTestROM(self, mu_test):
+    def __LaunchTestROM(self, mu_test):
         """
         This method should be parallel capable
         """
@@ -373,7 +373,7 @@ class RomManager(object):
 
 
 
-    def LaunchTestHROM(self, mu_test):
+    def __LaunchTestHROM(self, mu_test):
         """
         This method should be parallel capable
         """

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -179,8 +179,6 @@ class RomManager(object):
             self._ChangeRomFlags(simulation_to_run = "PG")
         self.LaunchRunROM(mu_run)
 
-
-
     def RunHROM(self, mu_run=None):
         if mu_run is None:
             mu_run = ['single case with parameters already contained in the ProjectParameters.json and CustomSimulation']

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -153,10 +153,13 @@ class RomManager(object):
 
 
 
+
     def RunFOM(self, mu_run=None):
         if mu_run is None:
             mu_run = ['single case with parameters already contained in the ProjectParameters.json and CustomSimulation']
         self.LaunchRunFOM(mu_run)
+
+
 
 
     def RunROM(self, mu_run=None):
@@ -175,6 +178,8 @@ class RomManager(object):
         elif self.general_rom_manager_parameters["projection_strategy"].GetString() == "petrov_galerkin":
             self._ChangeRomFlags(simulation_to_run = "PG")
         self.LaunchRunROM(mu_run)
+
+
 
     def RunHROM(self, mu_run=None):
         if mu_run is None:
@@ -208,6 +213,7 @@ class RomManager(object):
             print("approximation error in test set ROM vs HROM: ",  self.ROMvsHROM_test)
 
 
+
     def LaunchTrainROM(self, mu_train):
         """
         This method should be parallel capable
@@ -231,6 +237,7 @@ class RomManager(object):
         BasisOutputProcess._PrintRomBasis(SnapshotsMatrix) #Calling the RomOutput Process for creating the RomParameter.json
 
         return SnapshotsMatrix
+
 
 
     def LaunchROM(self, mu_train):

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -177,6 +177,9 @@ class RomManager(object):
         ###  Petrov Galerkin   ###
         elif self.general_rom_manager_parameters["projection_strategy"].GetString() == "petrov_galerkin":
             self._ChangeRomFlags(simulation_to_run = "PG")
+        else:
+            err_msg = f"Provided projection strategy '{self.general_rom_manager_parameters["projection_strategy"].GetString()}' is not supported. Available options are 'galerkin', 'lspg' and 'petrov_galerkin'."
+            raise Exception(err_msg)
         self.LaunchRunROM(mu_run)
 
     def RunHROM(self, mu_run=None):

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -93,6 +93,9 @@ class RomManager(object):
                     self._StoreSnapshotsMatrix('hrom_snapshots', hrom_snapshots)
                 self.ROMvsHROM_train = np.linalg.norm(rom_snapshots - hrom_snapshots) / np.linalg.norm(rom_snapshots)
         ##########################
+        else:
+            err_msg = f'Provided projection strategy {chosen_projection_strategy} is not supported. Available options are \'galerkin\', \'lspg\' and \'petrov_galerkin\'.'
+            raise Exception(err_msg)
 
 
 
@@ -142,6 +145,9 @@ class RomManager(object):
                 hrom_snapshots = self.__LaunchTestHROM(mu_test)
                 self.ROMvsHROM_test = np.linalg.norm(rom_snapshots - hrom_snapshots) / np.linalg.norm(rom_snapshots)
         ##########################
+        else:
+            err_msg = f'Provided projection strategy {chosen_projection_strategy} is not supported. Available options are \'galerkin\', \'lspg\' and \'petrov_galerkin\'.'
+            raise Exception(err_msg)
 
 
 
@@ -182,6 +188,9 @@ class RomManager(object):
         ###  Petrov Galerkin   ###
         elif chosen_projection_strategy == "petrov_galerkin":
             self._ChangeRomFlags(simulation_to_run = "runHROMPetrovGalerkin")
+        else:
+            err_msg = f'Provided projection strategy {chosen_projection_strategy} is not supported. Available options are \'galerkin\', \'lspg\' and \'petrov_galerkin\'.'
+            raise Exception(err_msg)
         self.__LaunchRunHROM(mu_run)
 
 

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -413,7 +413,7 @@ class RomManager(object):
         return SnapshotsMatrix
 
 
-    def LaunchRunFOM(self, mu_run):
+    def __LaunchRunFOM(self, mu_run):
         """
         This method should be parallel capable
         """

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -238,7 +238,6 @@ class RomManager(object):
         return SnapshotsMatrix
 
 
-
     def LaunchROM(self, mu_train):
         """
         This method should be parallel capable

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -153,15 +153,15 @@ class RomManager(object):
         chosen_projection_strategy = self.general_rom_manager_parameters["projection_strategy"].GetString()
         #######################
         ######  Galerkin ######
-        if self.general_rom_manager_parameters["projection_strategy"].GetString() == "galerkin":
+        if chosen_projection_strategy == "galerkin":
             self._ChangeRomFlags(simulation_to_run = "GalerkinROM")
         #######################################
         ##  Least-Squares Petrov Galerkin   ###
-        elif self.general_rom_manager_parameters["projection_strategy"].GetString() == "lspg":
+        elif chosen_projection_strategy == "lspg":
             self._ChangeRomFlags(simulation_to_run = "lspg")
         ##########################
         ###  Petrov Galerkin   ###
-        elif self.general_rom_manager_parameters["projection_strategy"].GetString() == "petrov_galerkin":
+        elif chosen_projection_strategy == "petrov_galerkin":
             self._ChangeRomFlags(simulation_to_run = "PG")
         else:
             err_msg = f"Provided projection strategy '{self.general_rom_manager_parameters["projection_strategy"].GetString()}' is not supported. Available options are 'galerkin', 'lspg' and 'petrov_galerkin'."
@@ -172,15 +172,15 @@ class RomManager(object):
         chosen_projection_strategy = self.general_rom_manager_parameters["projection_strategy"].GetString()
         #######################
         ######  Galerkin ######
-        if self.general_rom_manager_parameters["projection_strategy"].GetString() == "galerkin":
+        if chosen_projection_strategy == "galerkin":
             self._ChangeRomFlags(simulation_to_run = "runHROMGalerkin")
         #######################################
         ##  Least-Squares Petrov Galerkin   ###
-        elif self.general_rom_manager_parameters["projection_strategy"].GetString() == "lspg":
+        elif chosen_projection_strategy == "lspg":
             raise Exception('Sorry, Hyper Reduction not yet implemented for lspg')
         ##########################
         ###  Petrov Galerkin   ###
-        elif self.general_rom_manager_parameters["projection_strategy"].GetString() == "petrov_galerkin":
+        elif chosen_projection_strategy == "petrov_galerkin":
             self._ChangeRomFlags(simulation_to_run = "runHROMPetrovGalerkin")
         self.__LaunchRunHROM(mu_run)
 

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -406,6 +406,54 @@ class RomManager(object):
         return SnapshotsMatrix
 
 
+    def LaunchRunFOM(self, mu_run):
+        """
+        This method should be parallel capable
+        """
+        with open(self.project_parameters_name,'r') as parameter_file:
+            parameters = KratosMultiphysics.Parameters(parameter_file.read())
+
+        for Id, mu in enumerate(mu_run):
+            parameters = self.UpdateProjectParameters(parameters, mu)
+            parameters = self._StoreResultsByName(parameters,'FOM_Run',mu,Id)
+            model = KratosMultiphysics.Model()
+            analysis_stage_class = self._GetAnalysisStageClass(parameters)
+            simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters)
+            simulation.Run()
+
+
+    def LaunchRunROM(self, mu_run):
+        """
+        This method should be parallel capable
+        """
+        with open(self.project_parameters_name,'r') as parameter_file:
+            parameters = KratosMultiphysics.Parameters(parameter_file.read())
+
+        for Id, mu in enumerate(mu_run):
+            parameters = self.UpdateProjectParameters(parameters, mu)
+            parameters = self._StoreResultsByName(parameters,'ROM_Run',mu,Id)
+            model = KratosMultiphysics.Model()
+            analysis_stage_class = type(SetUpSimulationInstance(model, parameters))
+            simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters)
+            simulation.Run()
+
+
+    def LaunchRunHROM(self, mu_run):
+        """
+        This method should be parallel capable
+        """
+        with open(self.project_parameters_name,'r') as parameter_file:
+            parameters = KratosMultiphysics.Parameters(parameter_file.read())
+
+        for Id, mu in enumerate(mu_run):
+            parameters = self.UpdateProjectParameters(parameters, mu)
+            parameters = self._StoreResultsByName(parameters,'HROM_Run',mu,Id)
+            model = KratosMultiphysics.Model()
+            analysis_stage_class = type(SetUpSimulationInstance(model, parameters))
+            simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters)
+            simulation.Run()
+
+
 
     def _ChangeRomFlags(self, simulation_to_run = 'ROM'):
         """

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -213,7 +213,6 @@ class RomManager(object):
             print("approximation error in test set ROM vs HROM: ",  self.ROMvsHROM_test)
 
 
-
     def LaunchTrainROM(self, mu_train):
         """
         This method should be parallel capable

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -153,6 +153,47 @@ class RomManager(object):
 
 
 
+    def RunFOM(self, mu_run):
+        if mu_run is None:
+            mu_run = ['single case with parameters already contained in the ProjectParameters.json and CustomSimulation']
+        self.LaunchRunFOM(mu_run)
+
+
+    def RunROM(self, mu_run):
+        if mu_run is None:
+            mu_run = ['single case with parameters already contained in the ProjectParameters.json and CustomSimulation']
+        #######################
+        ######  Galerkin ######
+        if self.general_rom_manager_parameters["projection_strategy"].GetString() == "galerkin":
+            self._ChangeRomFlags(simulation_to_run = "GalerkinROM")
+        #######################################
+        ##  Least-Squares Petrov Galerkin   ###
+        elif self.general_rom_manager_parameters["projection_strategy"].GetString() == "lspg":
+            self._ChangeRomFlags(simulation_to_run = "lspg")
+        ##########################
+        ###  Petrov Galerkin   ###
+        elif self.general_rom_manager_parameters["projection_strategy"].GetString() == "petrov_galerkin":
+            self._ChangeRomFlags(simulation_to_run = "PG")
+        self.LaunchRunROM(mu_run)
+
+    def RunHROM(self, mu_run):
+        if mu_run is None:
+            mu_run = ['single case with parameters already contained in the ProjectParameters.json and CustomSimulation']
+        #######################
+        ######  Galerkin ######
+        if self.general_rom_manager_parameters["projection_strategy"].GetString() == "galerkin":
+            self._ChangeRomFlags(simulation_to_run = "runHROMGalerkin")
+        #######################################
+        ##  Least-Squares Petrov Galerkin   ###
+        elif self.general_rom_manager_parameters["projection_strategy"].GetString() == "lspg":
+            raise Exception('Sorry, Hyper Reduction not yet implemented for lspg')
+        ##########################
+        ###  Petrov Galerkin   ###
+        elif self.general_rom_manager_parameters["projection_strategy"].GetString() == "petrov_galerkin":
+            self._ChangeRomFlags(simulation_to_run = "runHROMPetrovGalerkin")
+        self.LaunchRunHROM(mu_run)
+
+
 
     def PrintErrors(self):
         training_stages = self.general_rom_manager_parameters["rom_stages_to_train"].GetStringArray()

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -164,7 +164,7 @@ class RomManager(object):
         elif chosen_projection_strategy == "petrov_galerkin":
             self._ChangeRomFlags(simulation_to_run = "PG")
         else:
-            err_msg = f"Provided projection strategy '{self.general_rom_manager_parameters["projection_strategy"].GetString()}' is not supported. Available options are 'galerkin', 'lspg' and 'petrov_galerkin'."
+            err_msg = f'Provided projection strategy {chosen_projection_strategy} is not supported. Available options are \'galerkin\', \'lspg\' and \'petrov_galerkin\'.'
             raise Exception(err_msg)
         self.__LaunchRunROM(mu_run)
 

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -445,7 +445,7 @@ class RomManager(object):
             simulation.Run()
 
 
-    def LaunchRunHROM(self, mu_run):
+    def __LaunchRunHROM(self, mu_run):
         """
         This method should be parallel capable
         """

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -210,7 +210,7 @@ class RomManager(object):
         for Id, mu in enumerate(mu_train):
             parameters = self.UpdateProjectParameters(parameters, mu)
             parameters = self._AddBasisCreationToProjectParameters(parameters) #TODO stop using the RomBasisOutputProcess to store the snapshots. Use instead the upcoming build-in function
-            parameters = self._StoreResultsByName(parameters,'FOM',mu,Id)
+            parameters = self._StoreResultsByName(parameters,'FOM_Fit',mu,Id)
             model = KratosMultiphysics.Model()
             analysis_stage_class = self._GetAnalysisStageClass(parameters)
             simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters)
@@ -236,7 +236,7 @@ class RomManager(object):
         for Id, mu in enumerate(mu_train):
             parameters = self.UpdateProjectParameters(parameters, mu)
             parameters = self._AddBasisCreationToProjectParameters(parameters)  #TODO stop using the RomBasisOutputProcess to store the snapshots. Use instead the upcoming build-in function
-            parameters = self._StoreResultsByName(parameters,'ROM',mu,Id)
+            parameters = self._StoreResultsByName(parameters,'ROM_Fit',mu,Id)
             model = KratosMultiphysics.Model()
             analysis_stage_class = type(SetUpSimulationInstance(model, parameters))
             simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters)
@@ -260,7 +260,7 @@ class RomManager(object):
         PetrovGalerkinTrainMatrix = []
         for Id, mu in enumerate(mu_train):
             parameters = self.UpdateProjectParameters(parameters, mu)
-            parameters = self._StoreResultsByName(parameters,'ROM',mu,Id)
+            parameters = self._StoreNoResults(parameters)
             model = KratosMultiphysics.Model()
             analysis_stage_class = type(SetUpSimulationInstance(model, parameters))
             simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters)
@@ -307,7 +307,7 @@ class RomManager(object):
         for Id, mu in enumerate(mu_train):
             parameters = self.UpdateProjectParameters(parameters, mu)
             parameters = self._AddBasisCreationToProjectParameters(parameters)
-            parameters = self._StoreResultsByName(parameters,'HROM',mu,Id)
+            parameters = self._StoreResultsByName(parameters,'HROM_Fit',mu,Id)
             model = KratosMultiphysics.Model()
             analysis_stage_class = type(SetUpSimulationInstance(model, parameters))
             simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters)

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -159,9 +159,6 @@ class RomManager(object):
             mu_run = ['single case with parameters already contained in the ProjectParameters.json and CustomSimulation']
         self.LaunchRunFOM(mu_run)
 
-
-
-
     def RunROM(self, mu_run=None):
         if mu_run is None:
             mu_run = ['single case with parameters already contained in the ProjectParameters.json and CustomSimulation']

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -429,7 +429,7 @@ class RomManager(object):
             simulation.Run()
 
 
-    def LaunchRunROM(self, mu_run):
+    def __LaunchRunROM(self, mu_run):
         """
         This method should be parallel capable
         """


### PR DESCRIPTION
**📝 Description**
So far, the RomManager allowed to **train** and **test** a reduced order model. However, we were missing a method in the RomManager for cheaply launching the generated models.
 
This PR adds the methods in the RomManager for running a set of simulations using either of the models. Clearly, if any of the required files for launching them is missing, the simulations will fail, as no training or snapshots matrices storage is considered. 

In order not to generate any conflict with currently open PRs, this PR is not tackling known shortcomings of the current approach, for example if a user wants to launch a ROM using a different amount of modes each time, she would have to modify the RomParameters.json directly. That is, not all of the ROM simulation parameters are controlled from the RomManager and a few are still relying on the RomParameters.json. A possible solution would necessarily involve modifying the RomAnalysis class to pass the RomParameters object instead of reading it from disk. This or other solutions will be deffered to future PRs.


**🆕 Changelog**
Added six methods to the RomManager.

Methods to be called from the instantiated RomManager 
- RunFOM(self, mu_run=None)
- RunROM(self, mu_run=None)
- RunHROM(self, mu_run=None)

Auxiliary methods inside the RomManager class:
- LaunchRunFOM(self, mu_run)
- LaunchRunROM(self, mu_run)
- LaunchRunHROM(self, mu_run)

The branch is compatible with the RomManager example in the Examples repo [here](https://github.com/KratosMultiphysics/Examples/tree/master/rom_application/RomManager)

