### PR TITLE
[PFEMFluid] Minor API update in PFEM elements

### DIFF
--- a/applications/PfemFluidDynamicsApplication/custom_elements/three_step_second_order_pspg_updated_lagrangian_element.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/three_step_second_order_pspg_updated_lagrangian_element.cpp
@@ -93,7 +93,6 @@ namespace Kratos
 
     double Viscosity = 0;
     double Density = 0;
-    double totalVolume = 0;
 
     MatrixType DynamicStabilizationMatrix = ZeroMatrix(NumNodes, NumNodes);
 
@@ -104,7 +103,6 @@ namespace Kratos
     for (unsigned int g = 0; g < NumGauss; ++g)
     {
       const double GaussWeight = GaussWeights[g];
-      totalVolume += GaussWeight;
       const ShapeFunctionsType &rN = row(NContainer, g);
       const ShapeFunctionDerivativesType &rDN_DX = DN_DX[g];
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/three_step_updated_lagrangian_element.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/three_step_updated_lagrangian_element.cpp
@@ -369,7 +369,6 @@ namespace Kratos
 
     double Viscosity = 0;
     double Density = 0;
-    double totalVolume = 0;
 
     MatrixType DynamicStabilizationMatrix = ZeroMatrix(NumNodes, NumNodes);
 
@@ -380,7 +379,6 @@ namespace Kratos
     for (unsigned int g = 0; g < NumGauss; ++g)
     {
       const double GaussWeight = GaussWeights[g];
-      totalVolume += GaussWeight;
       const ShapeFunctionsType &rN = row(NContainer, g);
       const ShapeFunctionDerivativesType &rDN_DX = DN_DX[g];
 
@@ -450,114 +448,6 @@ namespace Kratos
     }
   }
 
-  // template <unsigned int TDim>
-  // void ThreeStepUpdatedLagrangianElement<TDim>::CalculateFICPressureSystem(MatrixType &rLeftHandSideMatrix,
-  //                                                                          VectorType &rRightHandSideVector,
-  //                                                                          const ProcessInfo &rCurrentProcessInfo)
-  // {
-
-  //   GeometryType &rGeom = this->GetGeometry();
-  //   const unsigned int NumNodes = rGeom.PointsNumber();
-
-  //   // Check sizes and initialize
-  //   if (rLeftHandSideMatrix.size1() != NumNodes)
-  //     rLeftHandSideMatrix.resize(NumNodes, NumNodes, false);
-
-  //   noalias(rLeftHandSideMatrix) = ZeroMatrix(NumNodes, NumNodes);
-  //   MatrixType LaplacianMatrix = ZeroMatrix(NumNodes, NumNodes);
-
-  //   if (rRightHandSideVector.size() != NumNodes)
-  //     rRightHandSideVector.resize(NumNodes, false);
-
-  //   noalias(rRightHandSideVector) = ZeroVector(NumNodes);
-
-  //   // Shape functions and integration points
-  //   ShapeFunctionDerivativesArrayType DN_DX;
-  //   Matrix NContainer;
-  //   VectorType GaussWeights;
-  //   this->CalculateGeometryData(DN_DX, NContainer, GaussWeights);
-  //   const unsigned int NumGauss = GaussWeights.size();
-
-  //   double TimeStep = rCurrentProcessInfo[DELTA_TIME];
-  //   double ElemSize = this->ElementSize();
-
-  //   double Viscosity = 0;
-  //   double Density = 0;
-  //   double totalVolume = 0;
-
-  //   double maxViscousValueForStabilization = 0.001;
-
-  //   ElementalVariables rElementalVariables;
-  //   this->InitializeElementalVariables(rElementalVariables);
-
-  //   VectorType NewRhsLaplacian = ZeroVector(NumNodes);
-
-  //   // Loop on integration points
-  //   for (unsigned int g = 0; g < NumGauss; ++g)
-  //   {
-  //     const double GaussWeight = GaussWeights[g];
-  //     totalVolume += GaussWeight;
-  //     const ShapeFunctionsType &rN = row(NContainer, g);
-  //     const ShapeFunctionDerivativesType &rDN_DX = DN_DX[g];
-
-  //     this->EvaluateInPoint(Viscosity, DYNAMIC_VISCOSITY, rN);
-  //     this->EvaluateInPoint(Density, DENSITY, rN);
-
-  //     if (Viscosity > maxViscousValueForStabilization)
-  //     {
-  //       Viscosity = maxViscousValueForStabilization;
-  //     }
-
-  //     double Tau = 0;
-  //     this->CalculateTauFIC(Tau, ElemSize, Density, Viscosity, rCurrentProcessInfo);
-
-  //     double StabLaplacianWeight = Tau * GaussWeight;
-
-  //     array_1d<double, TDim> OldPressureGradient = ZeroVector(TDim);
-  //     this->EvaluateGradientInPoint(OldPressureGradient, PRESSURE, rDN_DX, 0);
-
-  //     double DivU = 0;
-  //     this->EvaluateDivergenceInPoint(DivU, VELOCITY, rDN_DX);
-
-  //     bool computeElement = this->CalcCompleteStrainRate(rElementalVariables, rCurrentProcessInfo, rDN_DX, 1.0);
-
-  //     double BoundLHSCoeff = 4.0 * StabLaplacianWeight / (ElemSize * ElemSize);
-  //     this->ComputeBoundLHSMatrix(rLeftHandSideMatrix, rN, BoundLHSCoeff);
-
-  //     double BoundRHSCoeffAcc = -2.0 * StabLaplacianWeight * Density / ElemSize;
-  //     double BoundRHSCoeffDev = -8.0 * StabLaplacianWeight * Viscosity / (ElemSize * ElemSize);
-
-  //     this->ComputeBoundRHSVectorComplete(rRightHandSideVector, TimeStep, BoundRHSCoeffAcc, BoundRHSCoeffDev, rElementalVariables.SpatialDefRate);
-
-  //     this->ComputeStabLaplacianMatrix(LaplacianMatrix, rDN_DX, StabLaplacianWeight);
-
-  //     for (SizeType i = 0; i < NumNodes; ++i)
-  //     {
-  //       // RHS contribution
-  //       // Velocity divergence
-  //       rRightHandSideVector[i] += -GaussWeight * rN[i] * DivU;
-
-  //       double laplacianRHSi = 0;
-  //       double bodyForceStabilizedRHSi = 0;
-  //       array_1d<double, 3> VolumeAcceleration = this->GetGeometry()[i].FastGetSolutionStepValue(VOLUME_ACCELERATION);
-
-  //       for (SizeType d = 0; d < TDim; ++d)
-  //       {
-  //         laplacianRHSi += -StabLaplacianWeight * rDN_DX(i, d) * OldPressureGradient[d];
-
-  //         bodyForceStabilizedRHSi += StabLaplacianWeight * rDN_DX(i, d) * (Density * VolumeAcceleration[d]);
-  //       }
-  //       rRightHandSideVector[i] += laplacianRHSi + bodyForceStabilizedRHSi;
-  //     }
-  //   }
-
-  //   VectorType PressureValues = ZeroVector(NumNodes);
-  //   VectorType PressureValuesForRHS = ZeroVector(NumNodes);
-  //   this->GetPressureValues(PressureValuesForRHS, 0);
-  //   //the LHS matrix up to now just contains the laplacian term and the bound term
-  //   noalias(rRightHandSideVector) -= prod(rLeftHandSideMatrix, PressureValuesForRHS);
-  //   noalias(rLeftHandSideMatrix) += LaplacianMatrix;
-  // }
 
   template <>
   void ThreeStepUpdatedLagrangianElement<2>::ComputeBoundRHSVectorComplete(VectorType &BoundRHSVector,

--- a/applications/PfemFluidDynamicsApplication/custom_elements/three_step_updated_lagrangian_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/three_step_updated_lagrangian_element.h
@@ -401,9 +401,15 @@ namespace Kratos
                            const ShapeFunctionsType &rN,
                            const double Weight) override;
 
-    virtual void CalcElasticPlasticCauchySplitted(ElementalVariables &rElementalVariables, double TimeStep,
-                                                  unsigned int g, const ProcessInfo &rCurrentProcessInfo, double &Density,
-                                                  double &DeviatoricCoeff, double &VolumetricCoeff) override{};
+    virtual void CalcElasticPlasticCauchySplitted(
+        ElementalVariables &rElementalVariables,
+        const unsigned int g,
+        const Vector& rN,
+        const ProcessInfo &rCurrentProcessInfo,
+        double &Density,
+        double &DeviatoricCoeff,
+        double &VolumetricCoeff) override
+    {};
 
     ///@}
     ///@name Protected  Access

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_element.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_element.cpp
@@ -120,7 +120,7 @@ namespace Kratos
 
       computeElement = this->CalcMechanicsUpdated(rElementalVariables, rCurrentProcessInfo, rDN_DX);
 
-      this->CalcElasticPlasticCauchySplitted(rElementalVariables, TimeStep, g, rCurrentProcessInfo, Density, DeviatoricCoeff, VolumetricCoeff);
+      this->CalcElasticPlasticCauchySplitted(rElementalVariables, g, N, rCurrentProcessInfo, Density, DeviatoricCoeff, VolumetricCoeff);
 
       if (computeElement == true && this->IsNot(BLOCKED) && this->IsNot(ISOLATED))
       {
@@ -140,6 +140,7 @@ namespace Kratos
     }
 
     double lumpedDynamicWeight = totalVolume * Density;
+    //FIXME: This has to be computed with the corresponding shape functions...
     this->ComputeLumpedMassMatrix(MassMatrix, lumpedDynamicWeight, MeanValueMass);
     if (computeElement == true && this->IsNot(BLOCKED) && this->IsNot(ISOLATED))
     {

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_element.h
@@ -386,9 +386,15 @@ namespace Kratos
                                             const ShapeFunctionDerivativesType &rShapeDeriv,
                                             const double Weight){};
 
-    void CalcElasticPlasticCauchySplitted(ElementalVariables &rElementalVariables, double TimeStep, unsigned int g,
-                                          const ProcessInfo &rCurrentProcessInfo, double &Density,
-                                          double &DeviatoricCoeff, double &VolumetricCoeff) override{};
+    void CalcElasticPlasticCauchySplitted(
+        ElementalVariables &rElementalVariables,
+        const unsigned int g,
+        const Vector& rN,
+        const ProcessInfo &rCurrentProcessInfo,
+        double &Density,
+        double &DeviatoricCoeff,
+        double &VolumetricCoeff) override
+    {};
 
     virtual void CalculateTauFIC(double &TauOne,
                                  double ElemSize,

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_fluid_element.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_fluid_element.cpp
@@ -561,8 +561,13 @@ namespace Kratos
 
   template <>
   void TwoStepUpdatedLagrangianVPImplicitFluidElement<2>::CalcElasticPlasticCauchySplitted(
-      ElementalVariables &rElementalVariables, double TimeStep, unsigned int g, const ProcessInfo &rCurrentProcessInfo,
-      double &Density, double &DeviatoricCoeff, double &VolumetricCoeff)
+      ElementalVariables &rElementalVariables,
+      const unsigned int g,
+      const Vector& rN,
+      const ProcessInfo &rCurrentProcessInfo,
+      double &Density,
+      double &DeviatoricCoeff,
+      double &VolumetricCoeff)
   {
 
     mpConstitutiveLaw = this->GetProperties().GetValue(CONSTITUTIVE_LAW);
@@ -573,8 +578,7 @@ namespace Kratos
     constitutive_law_options.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
     constitutive_law_options.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
 
-    const Vector &r_shape_functions = row((this->GetGeometry()).ShapeFunctionsValues(), g);
-    constitutive_law_values.SetShapeFunctionsValues(r_shape_functions);
+    constitutive_law_values.SetShapeFunctionsValues(rN);
     constitutive_law_values.SetStrainVector(rElementalVariables.SpatialDefRate);
     constitutive_law_values.SetStressVector(rElementalVariables.UpdatedDeviatoricCauchyStress);
     constitutive_law_values.SetConstitutiveMatrix(rElementalVariables.ConstitutiveMatrix);
@@ -602,8 +606,13 @@ namespace Kratos
 
   template <>
   void TwoStepUpdatedLagrangianVPImplicitFluidElement<3>::CalcElasticPlasticCauchySplitted(
-      ElementalVariables &rElementalVariables, double TimeStep, unsigned int g, const ProcessInfo &rCurrentProcessInfo,
-      double &Density, double &DeviatoricCoeff, double &VolumetricCoeff)
+      ElementalVariables &rElementalVariables, 
+      const unsigned int g,
+      const Vector& rN,
+      const ProcessInfo &rCurrentProcessInfo,
+      double &Density,
+      double &DeviatoricCoeff,
+      double &VolumetricCoeff)
   {
 
     mpConstitutiveLaw = this->GetProperties().GetValue(CONSTITUTIVE_LAW);
@@ -614,8 +623,7 @@ namespace Kratos
     constitutive_law_options.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
     constitutive_law_options.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
 
-    const Vector &r_shape_functions = row((this->GetGeometry()).ShapeFunctionsValues(), g);
-    constitutive_law_values.SetShapeFunctionsValues(r_shape_functions);
+    constitutive_law_values.SetShapeFunctionsValues(rN);
     constitutive_law_values.SetStrainVector(rElementalVariables.SpatialDefRate);
     constitutive_law_values.SetStressVector(rElementalVariables.UpdatedDeviatoricCauchyStress);
     constitutive_law_values.SetConstitutiveMatrix(rElementalVariables.ConstitutiveMatrix);

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_fluid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_fluid_element.h
@@ -326,9 +326,14 @@ namespace Kratos
     void ComputeBulkMatrixLump(MatrixType &BulkMatrix,
                                const double Weight) override;
 
-    void CalcElasticPlasticCauchySplitted(ElementalVariables &rElementalVariables, double TimeStep, unsigned int g,
-                                          const ProcessInfo &rCurrentProcessInfo, double &Density,
-                                          double &DeviatoricCoeff, double &VolumetricCoeff) override;
+    void CalcElasticPlasticCauchySplitted(
+        ElementalVariables &rElementalVariables,
+        const unsigned int g,
+        const Vector& rN,
+        const ProcessInfo &rCurrentProcessInfo,
+        double &Density,
+        double &DeviatoricCoeff,
+        double &VolumetricCoeff) override;
 
     double GetThetaMomentum() override { return 0.5; };
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_solid_element.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_solid_element.cpp
@@ -117,15 +117,14 @@ namespace Kratos
     const ShapeFunctionDerivativesType &rDN_DX = DN_DX[g];
     // bool computeElement=this->CalcStrainRate(rElementalVariables,rCurrentProcessInfo,rDN_DX,theta);
     bool computeElement = this->CalcCompleteStrainRate(rElementalVariables, rCurrentProcessInfo, rDN_DX, theta);
-    const double TimeStep = rCurrentProcessInfo[DELTA_TIME];
 
     if (computeElement == true)
     {
       double Density = 0;
       double DeviatoricCoeff = 0;
       double VolumetricCoeff = 0;
-      CalcElasticPlasticCauchySplitted(rElementalVariables, TimeStep, g, rCurrentProcessInfo, Density,
-                                       DeviatoricCoeff, VolumetricCoeff);
+      const auto& r_N = row(NContainer, g);
+      CalcElasticPlasticCauchySplitted(rElementalVariables, g, r_N, rCurrentProcessInfo, Density, DeviatoricCoeff, VolumetricCoeff);
     }
 
     this->mCurrentTotalCauchyStress[g] = this->mUpdatedTotalCauchyStress[g];
@@ -271,13 +270,11 @@ namespace Kratos
     VectorType GaussWeights;
     this->CalculateGeometryData(DN_DX, NContainer, GaussWeights);
     const unsigned int NumGauss = GaussWeights.size();
-    const double TimeStep = rCurrentProcessInfo[DELTA_TIME];
 
     double theta = 1.0;
     ElementalVariables rElementalVariables;
     this->InitializeElementalVariables(rElementalVariables);
 
-    double totalVolume = 0;
     double Density = 0.0;
     double DeviatoricCoeff = 0;
     double VolumetricCoeff = 0;
@@ -286,7 +283,6 @@ namespace Kratos
     for (unsigned int g = 0; g < NumGauss; ++g)
     {
       const double GaussWeight = GaussWeights[g];
-      totalVolume += GaussWeight;
       const ShapeFunctionsType &N = row(NContainer, g);
       const ShapeFunctionDerivativesType &rDN_DX = DN_DX[g];
 
@@ -301,7 +297,7 @@ namespace Kratos
 
       bool computeElement = this->CalcCompleteStrainRate(rElementalVariables, rCurrentProcessInfo, rDN_DX, theta);
 
-      CalcElasticPlasticCauchySplitted(rElementalVariables, TimeStep, g, rCurrentProcessInfo, Density, DeviatoricCoeff, VolumetricCoeff);
+      CalcElasticPlasticCauchySplitted(rElementalVariables, g, N, rCurrentProcessInfo, Density, DeviatoricCoeff, VolumetricCoeff);
 
       if (computeElement == true)
       {
@@ -323,8 +319,13 @@ namespace Kratos
 
   template <>
   void TwoStepUpdatedLagrangianVPImplicitNodallyIntegratedSolidElement<2>::CalcElasticPlasticCauchySplitted(
-      ElementalVariables &rElementalVariables, double TimeStep, unsigned int g, const ProcessInfo &rCurrentProcessInfo,
-      double &Density, double &DeviatoricCoeff, double &VolumetricCoeff)
+      ElementalVariables &rElementalVariables,
+      const unsigned int g,
+      const Vector& rN,
+      const ProcessInfo &rCurrentProcessInfo,
+      double &Density,
+      double &DeviatoricCoeff,
+      double &VolumetricCoeff)
   {
 
     mpConstitutiveLaw = this->GetProperties().GetValue(CONSTITUTIVE_LAW);
@@ -338,8 +339,7 @@ namespace Kratos
     rElementalVariables.CurrentTotalCauchyStress = this->mCurrentTotalCauchyStress[g];
     rElementalVariables.CurrentDeviatoricCauchyStress = this->mCurrentDeviatoricCauchyStress[g];
 
-    const Vector &r_shape_functions = row((this->GetGeometry()).ShapeFunctionsValues(), g);
-    constitutive_law_values.SetShapeFunctionsValues(r_shape_functions);
+    constitutive_law_values.SetShapeFunctionsValues(rN);
     constitutive_law_values.SetStrainVector(rElementalVariables.SpatialDefRate);
     constitutive_law_values.SetStressVector(rElementalVariables.CurrentDeviatoricCauchyStress);
 
@@ -382,8 +382,13 @@ namespace Kratos
 
   template <>
   void TwoStepUpdatedLagrangianVPImplicitNodallyIntegratedSolidElement<3>::CalcElasticPlasticCauchySplitted(
-      ElementalVariables &rElementalVariables, double TimeStep, unsigned int g, const ProcessInfo &rCurrentProcessInfo,
-      double &Density, double &DeviatoricCoeff, double &VolumetricCoeff)
+      ElementalVariables &rElementalVariables,
+      unsigned int g,
+      const Vector& rN,
+      const ProcessInfo &rCurrentProcessInfo,
+      double &Density,
+      double &DeviatoricCoeff,
+      double &VolumetricCoeff)
   {
 
     mpConstitutiveLaw = this->GetProperties().GetValue(CONSTITUTIVE_LAW);
@@ -397,8 +402,7 @@ namespace Kratos
     rElementalVariables.CurrentTotalCauchyStress = this->mCurrentTotalCauchyStress[g];
     rElementalVariables.CurrentDeviatoricCauchyStress = this->mCurrentDeviatoricCauchyStress[g];
 
-    const Vector &r_shape_functions = row((this->GetGeometry()).ShapeFunctionsValues(), g);
-    constitutive_law_values.SetShapeFunctionsValues(r_shape_functions);
+    constitutive_law_values.SetShapeFunctionsValues(rN);
     constitutive_law_values.SetStrainVector(rElementalVariables.SpatialDefRate);
     constitutive_law_values.SetStressVector(rElementalVariables.CurrentDeviatoricCauchyStress);
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_solid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_solid_element.h
@@ -202,13 +202,14 @@ namespace Kratos
                                          VectorType &rRightHandSideVector,
                                          const ProcessInfo &rCurrentProcessInfo) override;
 
-    void CalcElasticPlasticCauchySplitted(ElementalVariables &rElementalVariables,
-                                          double TimeStep,
-                                          unsigned int g,
-                                          const ProcessInfo &rCurrentProcessInfo,
-                                          double &Density,
-                                          double &DeviatoricCoeff,
-                                          double &VolumetricCoeff) override;
+    void CalcElasticPlasticCauchySplitted(
+        ElementalVariables &rElementalVariables,
+        const unsigned int g,
+        const Vector& rN,
+        const ProcessInfo &rCurrentProcessInfo,
+        double &Density,
+        double &DeviatoricCoeff,
+        double &VolumetricCoeff) override;
 
     // The following methods have different implementations depending on TDim
     /// Provides the global indices for each one of this element's local rows

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_solid_element.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_solid_element.cpp
@@ -375,8 +375,13 @@ namespace Kratos
   }
   template <>
   void TwoStepUpdatedLagrangianVPImplicitSolidElement<2>::CalcElasticPlasticCauchySplitted(
-      ElementalVariables &rElementalVariables, double TimeStep, unsigned int g, const ProcessInfo &rCurrentProcessInfo,
-      double &Density, double &DeviatoricCoeff, double &VolumetricCoeff)
+        ElementalVariables &rElementalVariables,
+        const unsigned int g,
+        const Vector &rN,
+        const ProcessInfo &rCurrentProcessInfo,
+        double &Density,
+        double &DeviatoricCoeff,
+        double &VolumetricCoeff)
   {
 
     rElementalVariables.CurrentTotalCauchyStress = this->mCurrentTotalCauchyStress[g];
@@ -390,8 +395,7 @@ namespace Kratos
     constitutive_law_options.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
     constitutive_law_options.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
 
-    const Vector &r_shape_functions = row((this->GetGeometry()).ShapeFunctionsValues(), g);
-    constitutive_law_values.SetShapeFunctionsValues(r_shape_functions);
+    constitutive_law_values.SetShapeFunctionsValues(rN);
     constitutive_law_values.SetStrainVector(rElementalVariables.SpatialDefRate);
     constitutive_law_values.SetStressVector(rElementalVariables.CurrentDeviatoricCauchyStress);
 
@@ -421,8 +425,13 @@ namespace Kratos
 
   template <>
   void TwoStepUpdatedLagrangianVPImplicitSolidElement<3>::CalcElasticPlasticCauchySplitted(
-      ElementalVariables &rElementalVariables, double TimeStep, unsigned int g, const ProcessInfo &rCurrentProcessInfo,
-      double &Density, double &DeviatoricCoeff, double &VolumetricCoeff)
+        ElementalVariables &rElementalVariables,
+        const unsigned int g,
+        const Vector &rN,
+        const ProcessInfo &rCurrentProcessInfo,
+        double &Density,
+        double &DeviatoricCoeff,
+        double &VolumetricCoeff)
   {
 
     rElementalVariables.CurrentTotalCauchyStress = this->mCurrentTotalCauchyStress[g];
@@ -436,8 +445,7 @@ namespace Kratos
     constitutive_law_options.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
     constitutive_law_options.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
 
-    const Vector &r_shape_functions = row((this->GetGeometry()).ShapeFunctionsValues(), g);
-    constitutive_law_values.SetShapeFunctionsValues(r_shape_functions);
+    constitutive_law_values.SetShapeFunctionsValues(rN);
     constitutive_law_values.SetStrainVector(rElementalVariables.SpatialDefRate);
     constitutive_law_values.SetStressVector(rElementalVariables.CurrentDeviatoricCauchyStress);
 
@@ -486,8 +494,8 @@ namespace Kratos
       double Density = 0;
       double DeviatoricCoeff = 0;
       double VolumetricCoeff = 0;
-      this->CalcElasticPlasticCauchySplitted(rElementalVariables, TimeStep, g, rCurrentProcessInfo, Density,
-                                             DeviatoricCoeff, VolumetricCoeff);
+      const auto& r_N = row(NContainer, g);
+      this->CalcElasticPlasticCauchySplitted(rElementalVariables, g, r_N, rCurrentProcessInfo, Density, DeviatoricCoeff, VolumetricCoeff);
     }
 
     this->mCurrentTotalCauchyStress[g] = this->mUpdatedTotalCauchyStress[g];

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_solid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_solid_element.h
@@ -343,9 +343,14 @@ namespace Kratos
                                const double BoundRHSCoeffAcc,
                                const double BoundRHSCoeffDev) override{};
 
-    void CalcElasticPlasticCauchySplitted(ElementalVariables &rElementalVariables, double TimeStep, unsigned int g,
-                                          const ProcessInfo &rCurrentProcessInfo, double &Density,
-                                          double &DeviatoricCoeff, double &VolumetricCoeff) override;
+    void CalcElasticPlasticCauchySplitted(
+        ElementalVariables &rElementalVariables,
+        const unsigned int g,
+        const Vector& rN,
+        const ProcessInfo &rCurrentProcessInfo,
+        double &Density,
+        double &DeviatoricCoeff,
+        double &VolumetricCoeff) override;
 
     void CalculateLocalContinuityEqForPressure(MatrixType &rLeftHandSideMatrix,
                                                VectorType &rRightHandSideVector,

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_element.h
@@ -354,9 +354,15 @@ namespace Kratos
     virtual void ComputeBulkMatrixRHS(MatrixType &BulkMatrix,
                                       const double Weight) override{};
 
-    virtual void CalcElasticPlasticCauchySplitted(ElementalVariables &rElementalVariables, double TimeStep,
-                                                  unsigned int g, const ProcessInfo &rCurrentProcessInfo, double &Density,
-                                                  double &DeviatoricCoeff, double &VolumetricCoeff) override{};
+    virtual void CalcElasticPlasticCauchySplitted(
+        ElementalVariables &rElementalVariables,
+        const unsigned int g,
+        const Vector& rN,
+        const ProcessInfo &rCurrentProcessInfo,
+        double &Density,
+        double &DeviatoricCoeff,
+        double &VolumetricCoeff) override
+    {};
 
     ///@}
     ///@name Protected  Access

--- a/applications/PfemFluidDynamicsApplication/custom_elements/updated_lagrangian_V_implicit_solid_element.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/updated_lagrangian_V_implicit_solid_element.cpp
@@ -67,8 +67,14 @@ Element::Pointer UpdatedLagrangianVImplicitSolidElement<TDim>::Clone(IndexType N
 
 template <>
 void UpdatedLagrangianVImplicitSolidElement<2>::CalcElasticPlasticCauchySplitted(
-    ElementalVariables &rElementalVariables, double TimeStep, unsigned int g, const ProcessInfo &rCurrentProcessInfo,
-    double &Density, double &DeviatoricCoeff, double &VolumetricCoeff) {
+    ElementalVariables &rElementalVariables,
+    const unsigned int g,
+    const Vector& rN,
+    const ProcessInfo &rCurrentProcessInfo,
+    double &Density,
+    double &DeviatoricCoeff,
+    double &VolumetricCoeff)
+{
 
     mpConstitutiveLaw = this->GetProperties().GetValue(CONSTITUTIVE_LAW);
     auto constitutive_law_values =
@@ -81,8 +87,7 @@ void UpdatedLagrangianVImplicitSolidElement<2>::CalcElasticPlasticCauchySplitted
     rElementalVariables.CurrentTotalCauchyStress = this->mCurrentTotalCauchyStress[g];
     rElementalVariables.CurrentDeviatoricCauchyStress = this->mCurrentDeviatoricCauchyStress[g];
 
-    const Vector &r_shape_functions = row((this->GetGeometry()).ShapeFunctionsValues(), g);
-    constitutive_law_values.SetShapeFunctionsValues(r_shape_functions);
+    constitutive_law_values.SetShapeFunctionsValues(rN);
     constitutive_law_values.SetStrainVector(rElementalVariables.SpatialDefRate);
     constitutive_law_values.SetStressVector(rElementalVariables.CurrentDeviatoricCauchyStress);
 
@@ -127,8 +132,14 @@ void UpdatedLagrangianVImplicitSolidElement<2>::CalcElasticPlasticCauchySplitted
 
 template <>
 void UpdatedLagrangianVImplicitSolidElement<3>::CalcElasticPlasticCauchySplitted(
-    ElementalVariables &rElementalVariables, double TimeStep, unsigned int g, const ProcessInfo &rCurrentProcessInfo,
-    double &Density, double &DeviatoricCoeff, double &VolumetricCoeff) {
+    ElementalVariables &rElementalVariables,
+    const unsigned int g,
+    const Vector& rN,
+    const ProcessInfo &rCurrentProcessInfo,
+    double &Density,
+    double &DeviatoricCoeff,
+    double &VolumetricCoeff)
+{
 
     mpConstitutiveLaw = this->GetProperties().GetValue(CONSTITUTIVE_LAW);
     auto constitutive_law_values =
@@ -141,8 +152,7 @@ void UpdatedLagrangianVImplicitSolidElement<3>::CalcElasticPlasticCauchySplitted
     rElementalVariables.CurrentTotalCauchyStress = this->mCurrentTotalCauchyStress[g];
     rElementalVariables.CurrentDeviatoricCauchyStress = this->mCurrentDeviatoricCauchyStress[g];
 
-    const Vector &r_shape_functions = row((this->GetGeometry()).ShapeFunctionsValues(), g);
-    constitutive_law_values.SetShapeFunctionsValues(r_shape_functions);
+    constitutive_law_values.SetShapeFunctionsValues(rN);
     constitutive_law_values.SetStrainVector(rElementalVariables.SpatialDefRate);
     constitutive_law_values.SetStressVector(rElementalVariables.CurrentDeviatoricCauchyStress);
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/updated_lagrangian_V_implicit_solid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/updated_lagrangian_V_implicit_solid_element.h
@@ -292,9 +292,14 @@ namespace Kratos
        * @param Weight Multiplication coefficient for the matrix, typically Density times integration point weight.
        */
 
-    void CalcElasticPlasticCauchySplitted(ElementalVariables &rElementalVariables, double TimeStep, unsigned int g,
-                                          const ProcessInfo &rCurrentProcessInfo, double &Density,
-                                          double &DeviatoricCoeff, double &VolumetricCoeff) override;
+    void CalcElasticPlasticCauchySplitted(
+        ElementalVariables &rElementalVariables,
+        const unsigned int g,
+        const Vector& rN,
+        const ProcessInfo &rCurrentProcessInfo,
+        double &Density,
+        double &DeviatoricCoeff,
+        double &VolumetricCoeff) override;
 
     double GetThetaMomentum() override { return 1.0; };
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/updated_lagrangian_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/updated_lagrangian_element.h
@@ -255,16 +255,20 @@ namespace Kratos
        * @param rResult A vector containing the global Id of each row
        * @param rCurrentProcessInfo the current process info object (unused)
        */
-    virtual void EquationIdVector(EquationIdVectorType &rResult,
-                                  const ProcessInfo &rCurrentProcessInfo){};
+    void EquationIdVector(
+        EquationIdVectorType &rResult,
+        const ProcessInfo &rCurrentProcessInfo) const override
+    {};
 
     /// Returns a list of the element's Dofs
     /**
        * @param ElementalDofList the list of DOFs
        * @param rCurrentProcessInfo the current process info instance
        */
-    virtual void GetDofList(DofsVectorType &rElementalDofList,
-                            const ProcessInfo &rCurrentProcessInfo){};
+    void GetDofList(
+        DofsVectorType &rElementalDofList,
+        const ProcessInfo &rCurrentProcessInfo) const override
+    {};
 
     GeometryData::IntegrationMethod GetIntegrationMethod() const override;
 
@@ -536,9 +540,15 @@ namespace Kratos
     bool CheckStrain3(VectorType &SpatialDefRate,
                       MatrixType &SpatialVelocityGrad);
 
-    virtual void CalcElasticPlasticCauchySplitted(ElementalVariables &rElementalVariables, double TimeStep,
-                                                  unsigned int g, const ProcessInfo &rCurrentProcessInfo, double &Density,
-                                                  double &DeviatoricCoeff, double &VolumetricCoeff){};
+    virtual void CalcElasticPlasticCauchySplitted(
+        ElementalVariables &rElementalVariables,
+        const unsigned int g,
+        const Vector& rN,
+        const ProcessInfo &rCurrentProcessInfo,
+        double &Density,
+        double &DeviatoricCoeff,
+        double &VolumetricCoeff)
+    {};
 
     void ComputeMechanicalDissipation(ElementalVariables &rElementalVariables);
 


### PR DESCRIPTION
Update in the `CalcElasticPlasticCauchySplitted` method API. I removed the time step argument as it is passed within the `ProcessInfo` and added the shape functions vector. On top of being required for the subintegration, this avoids calculating twice the shape functions.

I also took the chance to remove some compilation warnings.
