### PR TITLE
[StructuralMechanicsApplication] Fix distributed load and added parallel utilities in the `distribute_load_on_surface_process`

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_processes/distribute_load_on_surface_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/distribute_load_on_surface_process.cpp
@@ -16,30 +16,32 @@
 // Project includes
 #include "distribute_load_on_surface_process.h"
 #include "utilities/interval_utility.h"
+#include "utilities/parallel_utilities.h"
+#include "utilities/reduction_utilities.h"
 #include "structural_mechanics_application_variables.h"
 
 namespace Kratos
 {
 
-DistributeLoadOnSurfaceProcess::DistributeLoadOnSurfaceProcess(ModelPart& rModelPart,
-                                                                Parameters Settings)
-                                                                : mrModelPart(rModelPart),
-                                                                mParameters(Settings)
+DistributeLoadOnSurfaceProcess::DistributeLoadOnSurfaceProcess(
+    ModelPart& rModelPart,
+    Parameters Settings)
+    : mrModelPart(rModelPart),
+      mParameters(Settings)
 {
     Parameters default_parameters(R"(
         {
             "help"            : "This process distributes a load on surface load conditions belonging to a modelpart. The load is distributed according to the surface area.",
             "model_part_name" : "please_specify_model_part_name",
             "interval"        : [0.0, 1e30],
-            "load"           : [1.0, 0.0, 0.0]
+            "load"            : [1.0, 0.0, 0.0]
         }  )"
     );
 
     IntervalUtility interval_utility(mParameters);
 
     mParameters.RecursivelyValidateAndAssignDefaults(default_parameters);
-    KRATOS_ERROR_IF(mParameters["load"].GetVector().size() != 3) <<
-        "'load' has to be a vector of doubles with size 3!" << std::endl;
+    KRATOS_ERROR_IF(mParameters["load"].GetVector().size() != 3) << "'load' has to be a vector of doubles with size 3!" << std::endl;
 }
 
 void DistributeLoadOnSurfaceProcess::ExecuteInitializeSolutionStep()
@@ -48,18 +50,23 @@ void DistributeLoadOnSurfaceProcess::ExecuteInitializeSolutionStep()
 
     IntervalUtility interval_utility(mParameters);
     if (interval_utility.IsInInterval(current_time)) {
-        double total_area = 0.0;
+        // Calculate the total area
+        const auto& r_communicator = mrModelPart.GetCommunicator();
+        const auto& r_local_mesh = r_communicator.LocalMesh();
+        const auto& r_conditions_array = r_local_mesh.Conditions();
+        const double total_area = block_for_each<SumReduction<double>>(r_conditions_array, [&](Condition& rCond) {
+            return rCond.GetGeometry().Area();
+        });
+
+        // Compute the total area
+        const double global_total_area = r_communicator.GetDataCommunicator().SumAll(total_area);
+
+        // Getting force by area
+        const Vector force_by_area = mParameters["load"].GetVector() / global_total_area;
+
+        // Assign on conditions
         for (auto& r_cond : mrModelPart.Conditions()) {
-            total_area += r_cond.GetGeometry().Area();
-        }
-
-        const double global_total_area = mrModelPart.GetCommunicator().GetDataCommunicator().SumAll(total_area);
-
-        Vector force_by_area = mParameters["load"].GetVector() / global_total_area;
-
-        for (auto& r_cond : mrModelPart.Conditions()) {
-            const double area = r_cond.GetGeometry().Area();
-            r_cond.SetValue(SURFACE_LOAD, force_by_area * area);
+            r_cond.SetValue(SURFACE_LOAD, force_by_area);
         }
     }
 }

--- a/applications/StructuralMechanicsApplication/custom_processes/distribute_load_on_surface_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/distribute_load_on_surface_process.h
@@ -29,11 +29,14 @@ namespace Kratos {
 ///@name Kratos Classes
 ///@{
 
-/// Process to create the animated Eigenvectors
-/** This process distributes a load on surface load conditions belonging to a modelpart.
- *  The load is distributed according to the surface area.
+/** 
+ * @class DistributeLoadOnSurfaceProcess
+ * @brief This process distributes a load on surface load conditions belonging to a modelpart
+ * @details The load is distributed according to the surface area.
+ * @author Armin Geiser
  */
-class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) DistributeLoadOnSurfaceProcess : public Process
+class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) DistributeLoadOnSurfaceProcess 
+    : public Process
 {
 public:
     ///@name Type Definitions
@@ -83,8 +86,8 @@ private:
     ///@name Member Variables
     ///@{
 
-    ModelPart& mrModelPart;
-    Parameters mParameters;
+    ModelPart& mrModelPart; /// The model part
+    Parameters mParameters; /// The parameters
 
     ///@}
     ///@name Private Operations

--- a/applications/StructuralMechanicsApplication/tests/test_distribute_load_on_surface_process.py
+++ b/applications/StructuralMechanicsApplication/tests/test_distribute_load_on_surface_process.py
@@ -4,7 +4,6 @@ import KratosMultiphysics.StructuralMechanicsApplication as KSM
 from KratosMultiphysics.StructuralMechanicsApplication.distribute_load_on_surface_process import Factory
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 
-
 class TestDistributeLoadOnSurfaceProcess(KratosUnittest.TestCase):
 
     def test_load_on_surface_distribution(self):
@@ -13,7 +12,7 @@ class TestDistributeLoadOnSurfaceProcess(KratosUnittest.TestCase):
         current_model = KM.Model()
         mp = current_model.CreateModelPart("main")
 
-        #create nodes
+        # Create nodes
         mp.CreateNewNode(1, 0.0, 0.0, 0.0)
         mp.CreateNewNode(2, 1.0, 0.0, 0.0)
         mp.CreateNewNode(3, 1.0, 1.0, 0.0)
@@ -21,41 +20,55 @@ class TestDistributeLoadOnSurfaceProcess(KratosUnittest.TestCase):
         mp.CreateNewNode(5, 1.0, 1.0, 1.0)
         mp.CreateNewNode(6, 1.0, 0.0, 1.0)
 
-        #ensure that the property 1 is created
+        # Ensure that the property 1 is created
         prop = mp.GetProperties()[1]
 
+        # Create conditions
         cond1 = mp.CreateNewCondition("SurfaceLoadCondition3D3N", 1, [1,2,3], prop)
         cond2 = mp.CreateNewCondition("SurfaceLoadCondition3D3N", 2, [1,3,4], prop)
         cond3 = mp.CreateNewCondition("SurfaceLoadCondition3D4N", 3, [2,6,5,3], prop)
 
+        # Generate process
         settings = KM.Parameters("""{
             "Parameters" : {
-                "model_part_name": "main",
-                "load": [1.0, 2.0, 3.0]
+                "model_part_name" : "main",
+                "load"            : [1.0, 2.0, 3.0]
             }
         }""")
 
         process = Factory(settings, current_model)
 
+        # Initial calls of process
         process.ExecuteInitialize()
         process.ExecuteBeforeSolutionLoop()
         process.ExecuteInitializeSolutionStep()
 
+        # Getting loads
         surface_load_1 = cond1.GetValue(KSM.SURFACE_LOAD)
         surface_load_2 = cond2.GetValue(KSM.SURFACE_LOAD)
         surface_load_3 = cond3.GetValue(KSM.SURFACE_LOAD)
         total_load = KM.Vector([1.0, 2.0, 3.0])
 
-        self.assertVectorAlmostEqual(surface_load_1, total_load / 2.0 * 0.5)
-        self.assertVectorAlmostEqual(surface_load_2, total_load / 2.0 * 0.5)
-        self.assertVectorAlmostEqual(surface_load_3, total_load / 2.0 * 1.0)
-        self.assertVectorAlmostEqual(surface_load_1 + surface_load_2 + surface_load_3, total_load)
+        # Get total area
+        area1 = cond1.GetGeometry().Area()
+        area2 = cond2.GetGeometry().Area()
+        area3 = cond3.GetGeometry().Area()
+        total_area = area1 + area2 + area3
+        self.assertAlmostEqual(total_area, 2.0)
 
+        # Compute distributed load
+        distributed_load = total_load / total_area
+        self.assertVectorAlmostEqual(surface_load_1, distributed_load)
+        self.assertVectorAlmostEqual(surface_load_2, distributed_load)
+        self.assertVectorAlmostEqual(surface_load_3, distributed_load)
+        self.assertVectorAlmostEqual(surface_load_1 * area1 + surface_load_2 * area2 + surface_load_3 * area3, total_load)
+
+        # More calls (does nothing, but checks that it does not break the process)
         process.ExecuteFinalizeSolutionStep()
         process.ExecuteBeforeOutputStep()
         process.ExecuteAfterOutputStep()
         process.ExecuteFinalize()
 
-
 if __name__ == '__main__':
+    KM.Logger.GetDefaultOutput().SetSeverity(KM.Logger.Severity.WARNING)
     KratosUnittest.main()


### PR DESCRIPTION
**📝 Description**

Fixes https://github.com/KratosMultiphysics/Kratos/issues/11109

In this PR, the `distribute_load_on_surface_process` in the StructuralMechanicsApplication bugfrom https://github.com/KratosMultiphysics/Kratos/issues/11109 has been fixed, and part of the code now uses the parallel utilities.

**🆕 Changelog**

- [Fix distributed load process](https://github.com/KratosMultiphysics/Kratos/commit/9cf5b9d3cd8ee11658f74611a2c1233c100aa848)
	- `SURFACE_LOAD` now is a distributed load, instead of a total load, fixing the bug from https://github.com/KratosMultiphysics/Kratos/issues/11109
	- `parallel_utilities` and `reduction_utilities`, are included in the `distribute_load_on_surface_process.cpp`. These utilities allow for parallel computation. The calculation of total surface area has been improved, likely for better performance and parallel computation. Instead of a simple loop, `block_for_each<SumReduction<double>>` function is used, which is likely a parallel operation for summing all elements of a container.
	- The documentation and class definition in the `distribute_load_on_surface_process.h` file have been improved for better readability and understanding.

- [Update test](https://github.com/KratosMultiphysics/Kratos/commit/4623f8b4cb96ca71a97d46acab0cb1cbad730067)
	-  The test file, `test_distribute_load_on_surface_process.py`, is also updated to reflect these changes.
