### PR TITLE
[Core] Added GetThreadId function to ParallelUtilities for thread ID retrieval

### DIFF
--- a/kratos/utilities/parallel_utilities.cpp
+++ b/kratos/utilities/parallel_utilities.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //                   Denis Demidov
@@ -30,6 +30,18 @@ namespace {
     std::once_flag flag_once;
 }
 
+int ParallelUtilities::GetThreadId()
+{
+#ifdef KRATOS_SMP_OPENMP
+    const int ithreads = omp_get_thread_num();
+    return ithreads;
+#elif defined(KRATOS_SMP_CXX11)
+    KRATOS_ERROR << "No equivalent definition of GetThreadId in C++11. Replace current implementation to something that fits the C++ STL requirements" << std::endl;
+    return -1;
+#else
+    return 0;
+#endif
+}
 
 int ParallelUtilities::GetNumThreads()
 {

--- a/kratos/utilities/parallel_utilities.h
+++ b/kratos/utilities/parallel_utilities.h
@@ -74,6 +74,11 @@ public:
     ///@name Operations
     ///@{
 
+    /**
+     @return The thread number for this thread, 0 if scalar run.
+     */
+    [[nodiscard]] static int GetThreadId();
+
     /** @brief Returns the current number of threads
      * @return number of threads
      */


### PR DESCRIPTION
**📝 Description**

This commit mainly focuses on the addition of the `GetThreadId` function in the `ParallelUtilities` class. This function is implemented to provide the thread number for the current thread, and returns 0 if it is a scalar run. The implementation is done considering different scenarios such as `KRATOS_SMP_OPENMP` and `KRATOS_SMP_CXX11`.

For `KRATOS_SMP_OPENMP`, it retrieves the thread number using `omp_get_thread_num()`. For `KRATOS_SMP_CXX11`, an error message is returned, indicating the lack of an equivalent definition for `GetThreadId` in C++11. If neither of these macros are defined, the function defaults to return 0.

In addition to this main change, the indentation of the license comments in parallel_utilities.cpp file has been corrected for better readability.

https://github.com/KratosMultiphysics/Kratos/pull/9985 will be the proper solution for this, not requiring the `GetThreadId` at all, but it will require to refactor the classes currently using `GetThreadId` and `ThisThread` (`OMPUtils`)

**🆕 Changelog**

- [Adding method to reduce dependency in Legacy OMPUtils](https://github.com/KratosMultiphysics/Kratos/commit/9438f45d02766ea5ec1089dc3712a17d6e7ff624)
