### PR TITLE
[Mapping] optionally allow to not compute approximation

### DIFF
--- a/applications/MappingApplication/README.md
+++ b/applications/MappingApplication/README.md
@@ -243,7 +243,7 @@ Internally it constructs the mapping matrix, hence it offers the usage of the tr
 
 The _NearestElementMapper_ projects nodes to the elements( or conditions) on other side of the inteface. Mapping is then done by interpolating the values of the nodes of the elements by using the shape functions at the projected position.
 
-This mapper is best suited for problems where the _NearestNeighborMapper_ cannot be used, i.e. for cases where the discretization on the interfaces is different. Note that it is less robust than the _NearestNeighborMapper_ due to the projections it performs. In case a projection fails it uses an approximation that is similar to the approach of the _NearestNeighborMapper_.
+This mapper is best suited for problems where the _NearestNeighborMapper_ cannot be used, i.e. for cases where the discretization on the interfaces is different. Note that it is less robust than the _NearestNeighborMapper_ due to the projections it performs. In case a projection fails, it uses an approximation that is similar to the approach of the _NearestNeighborMapper_. This can be disabled by setting `use_approximation` to `false` in the mapper-settings.
 
 Internally it constructs the mapping matrix, hence it offers the usage of the transposed mapping matrix. When using this, for very inhomogenous interface discretizations it can come to oscillations in the mapped quantities.
 

--- a/applications/MappingApplication/custom_mappers/nearest_element_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/nearest_element_mapper.cpp
@@ -14,6 +14,7 @@
 //  Framework for Non-Matching Grid Mapping"
 
 // System includes
+#include <limits>
 
 // External includes
 
@@ -56,7 +57,7 @@ void NearestElementInterfaceInfo::SaveSearchResult(const InterfaceObject& rInter
     if (is_full_projection) {
         SetLocalSearchWasSuccessful();
     } else {
-        if (!ComputeApproximation || mLocalCoordTol < std::numeric_limits<double>::epsilon) {
+        if (!ComputeApproximation || mLocalCoordTol < std::numeric_limits<double>::epsilon()) {
             return;
         } else {
             SetIsApproximation();

--- a/applications/MappingApplication/custom_mappers/nearest_element_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/nearest_element_mapper.cpp
@@ -56,7 +56,7 @@ void NearestElementInterfaceInfo::SaveSearchResult(const InterfaceObject& rInter
     if (is_full_projection) {
         SetLocalSearchWasSuccessful();
     } else {
-        if (!ComputeApproximation) {
+        if (!ComputeApproximation || mLocalCoordTol < std::numeric_limits<double>::epsilon) {
             return;
         } else {
             SetIsApproximation();

--- a/applications/MappingApplication/custom_mappers/nearest_element_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/nearest_element_mapper.cpp
@@ -14,7 +14,6 @@
 //  Framework for Non-Matching Grid Mapping"
 
 // System includes
-#include <limits>
 
 // External includes
 
@@ -35,7 +34,10 @@ void NearestElementInterfaceInfo::ProcessSearchResult(const InterfaceObject& rIn
 
 void NearestElementInterfaceInfo::ProcessSearchResultForApproximation(const InterfaceObject& rInterfaceObject)
 {
-    SaveSearchResult(rInterfaceObject, true);
+    // setting the local coord tolerance to zero means to not compute an approximation
+    if (mLocalCoordTol > 0.0) {
+        SaveSearchResult(rInterfaceObject, true);
+    }
 }
 
 void NearestElementInterfaceInfo::SaveSearchResult(const InterfaceObject& rInterfaceObject,
@@ -57,7 +59,7 @@ void NearestElementInterfaceInfo::SaveSearchResult(const InterfaceObject& rInter
     if (is_full_projection) {
         SetLocalSearchWasSuccessful();
     } else {
-        if (!ComputeApproximation || mLocalCoordTol < std::numeric_limits<double>::epsilon()) {
+        if (!ComputeApproximation) {
             return;
         } else {
             SetIsApproximation();

--- a/applications/MappingApplication/custom_mappers/nearest_element_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/nearest_element_mapper.cpp
@@ -35,7 +35,7 @@ void NearestElementInterfaceInfo::ProcessSearchResult(const InterfaceObject& rIn
 void NearestElementInterfaceInfo::ProcessSearchResultForApproximation(const InterfaceObject& rInterfaceObject)
 {
     // setting the local coord tolerance to zero means to not compute an approximation
-    if (mLocalCoordTol > 0.0) {
+    if (mOptions.UseApproximation) {
         SaveSearchResult(rInterfaceObject, true);
     }
 }
@@ -54,7 +54,7 @@ void NearestElementInterfaceInfo::SaveSearchResult(const InterfaceObject& rInter
 
     ProjectionUtilities::PairingIndex pairing_index;
 
-    const bool is_full_projection = ProjectionUtilities::ComputeProjection(*p_geom, point_to_proj, mLocalCoordTol, shape_function_values, eq_ids, proj_dist, pairing_index, ComputeApproximation);
+    const bool is_full_projection = ProjectionUtilities::ComputeProjection(*p_geom, point_to_proj, mOptions.LocalCoordTol, shape_function_values, eq_ids, proj_dist, pairing_index, ComputeApproximation);
 
     if (is_full_projection) {
         SetLocalSearchWasSuccessful();

--- a/applications/MappingApplication/custom_mappers/nearest_element_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/nearest_element_mapper.cpp
@@ -34,7 +34,6 @@ void NearestElementInterfaceInfo::ProcessSearchResult(const InterfaceObject& rIn
 
 void NearestElementInterfaceInfo::ProcessSearchResultForApproximation(const InterfaceObject& rInterfaceObject)
 {
-    // setting the local coord tolerance to zero means to not compute an approximation
     if (mOptions.UseApproximation) {
         SaveSearchResult(rInterfaceObject, true);
     }

--- a/applications/MappingApplication/custom_mappers/nearest_element_mapper.h
+++ b/applications/MappingApplication/custom_mappers/nearest_element_mapper.h
@@ -28,22 +28,29 @@ namespace Kratos
 ///@name Kratos Classes
 ///@{
 
+/// @brief Options for configuring the behavior of the Mapper
+struct NearestElementOptions
+{
+    bool UseApproximation = true; // Whether or not an approximation should be computed, if the full projection fails
+    double LocalCoordTol = 0.25; // tolerance for the local coordinates, until which the projection is considered
+};
+
 class KRATOS_API(MAPPING_APPLICATION) NearestElementInterfaceInfo : public MapperInterfaceInfo
 {
 public:
 
     /// Default constructor.
-    explicit NearestElementInterfaceInfo(const double LocalCoordTol=0.0) : mLocalCoordTol(LocalCoordTol) {}
+    explicit NearestElementInterfaceInfo(const NearestElementOptions Options={}) : mOptions(Options) {}
 
     explicit NearestElementInterfaceInfo(const CoordinatesArrayType& rCoordinates,
                                 const IndexType SourceLocalSystemIndex,
                                 const IndexType SourceRank,
-                                         const double LocalCoordTol=0.0)
-        : MapperInterfaceInfo(rCoordinates, SourceLocalSystemIndex, SourceRank), mLocalCoordTol(LocalCoordTol) {}
+                                         const NearestElementOptions Options={})
+        : MapperInterfaceInfo(rCoordinates, SourceLocalSystemIndex, SourceRank), mOptions(Options) {}
 
     MapperInterfaceInfo::Pointer Create() const override
     {
-        return Kratos::make_shared<NearestElementInterfaceInfo>(mLocalCoordTol);
+        return Kratos::make_shared<NearestElementInterfaceInfo>(mOptions);
     }
 
     MapperInterfaceInfo::Pointer Create(const CoordinatesArrayType& rCoordinates,
@@ -54,7 +61,7 @@ public:
             rCoordinates,
             SourceLocalSystemIndex,
             SourceRank,
-            mLocalCoordTol);
+            mOptions);
     }
 
     InterfaceObject::ConstructionType GetInterfaceObjectType() const override
@@ -98,7 +105,7 @@ private:
     std::vector<double> mShapeFunctionValues;
     double mClosestProjectionDistance = std::numeric_limits<double>::max();
     ProjectionUtilities::PairingIndex mPairingIndex = ProjectionUtilities::PairingIndex::Unspecified;
-    double mLocalCoordTol; // this is not needed after searching, hence no need to serialize it
+    NearestElementOptions mOptions; // this is not needed after searching, hence no need to serialize it
     std::size_t mNumSearchResults = 0;
 
     void SaveSearchResult(const InterfaceObject& rInterfaceObject,
@@ -208,8 +215,11 @@ public:
 
         this->ValidateInput();
 
-        mLocalCoordTol = JsonParameters["local_coord_tolerance"].GetDouble();
-        KRATOS_ERROR_IF(mLocalCoordTol < 0.0) << "The local-coord-tolerance cannot be negative" << std::endl;
+        const bool use_approximation = JsonParameters["use_approximation"].GetBool();
+        const double local_coord_tol = JsonParameters["local_coord_tolerance"].GetDouble();
+        KRATOS_ERROR_IF(local_coord_tol < 0.0) << "The local-coord-tolerance cannot be negative" << std::endl;
+
+        mOptions = NearestElementOptions{use_approximation, local_coord_tol};
 
         this->Initialize();
 
@@ -267,7 +277,7 @@ private:
     ///@name Member Variables
     ///@{
 
-    double mLocalCoordTol;
+    NearestElementOptions mOptions;;
 
     ///@}
 
@@ -286,7 +296,7 @@ private:
 
     MapperInterfaceInfoUniquePointerType GetMapperInterfaceInfo() const override
     {
-        return Kratos::make_unique<NearestElementInterfaceInfo>(mLocalCoordTol);
+        return Kratos::make_unique<NearestElementInterfaceInfo>(mOptions);
     }
 
     Parameters GetMapperDefaultSettings() const override
@@ -294,6 +304,7 @@ private:
         return Parameters( R"({
             "search_settings"              : {},
             "local_coord_tolerance"        : 0.25,
+            "use_approximation"            : true,
             "use_initial_configuration"    : false,
             "echo_level"                   : 0,
             "print_pairing_status_to_file" : false,

--- a/applications/MappingApplication/tests/cpp_tests/test_nearest_element_aux_classes.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_nearest_element_aux_classes.cpp
@@ -177,6 +177,37 @@ KRATOS_TEST_CASE_IN_SUITE(NearestElementInterfaceInfo_ValidProjectionExists, Kra
     KRATOS_CHECK_DOUBLE_EQUAL(sf_values[2], 0.4);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(NearestElementInterfaceInfo_WithoutApproximation, KratosMappingApplicationSerialTestSuite)
+{
+    const double dist = 1.1;
+    Point coords(-0.01, -0.3, dist);
+
+    std::size_t source_local_sys_idx = 123;
+
+    NearestElementInterfaceInfo nearest_element_info(coords, source_local_sys_idx, 0);
+    NearestElementInterfaceInfo nearest_element_info_without_approx(coords, source_local_sys_idx, 0, {false});
+
+    auto node_1(Kratos::make_intrusive<NodeType>(1, 0.0, 0.0, 0.0));
+    auto node_2(Kratos::make_intrusive<NodeType>(2, 1.0, 0.0, 0.0));
+    auto node_3(Kratos::make_intrusive<NodeType>(3, 0.0, -1.0, 0.0));
+
+    const Geometry<NodeType>::Pointer tria(Kratos::make_shared<Triangle3D3<NodeType>>(node_3, node_2, node_1));
+
+    InterfaceObject::Pointer interface_geom_obj(Kratos::make_shared<InterfaceGeometryObject>(tria.get()));
+
+    node_1->SetValue(INTERFACE_EQUATION_ID, 35);
+    node_2->SetValue(INTERFACE_EQUATION_ID, 18);
+    node_3->SetValue(INTERFACE_EQUATION_ID, 61);
+
+    nearest_element_info.ProcessSearchResultForApproximation(*interface_geom_obj);
+    nearest_element_info_without_approx.ProcessSearchResultForApproximation(*interface_geom_obj);
+
+    KRATOS_CHECK(nearest_element_info.GetLocalSearchWasSuccessful());
+    KRATOS_CHECK(nearest_element_info.GetIsApproximation());
+
+    KRATOS_CHECK_IS_FALSE(nearest_element_info_without_approx.GetLocalSearchWasSuccessful());
+}
+
 // KRATOS_TEST_CASE_IN_SUITE(NearestElementInterfaceInfo_Approximation, KratosMappingApplicationSerialTestSuite)
 // {
 //     const double z_coord = 0.2;


### PR DESCRIPTION
This allows to disable the computation of an approximation with the nearest element mapper
This is actually how I thought it would work in the first place, but I implemented it wrong

@akhilkmat can you please test if this now works for you? (still with setting the local coord tolerance to zero)

