### PR TITLE
[GeoMechanicsApplication] Inheritance for geomechanics solvers are changed

### DIFF
--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_Pw_solver.py
@@ -14,15 +14,11 @@ def CreateSolver(model, custom_settings):
 class PwSolver(GeoSolver):
     '''Solver for the solution of displacement-pore pressure coupled problems.'''
 
-    # =============================================================================================
-    # =============================================================================================
     def __init__(self, model, custom_settings):
         super().__init__(model, custom_settings)
 
         KratosMultiphysics.Logger.PrintInfo("GeoMechanics_Pw_Solver", "Construction of Solver finished.")
 
-    # =============================================================================================
-    # =============================================================================================
     @classmethod
     def GetDefaultParameters(cls):
         this_defaults = KratosMultiphysics.Parameters("""{
@@ -102,22 +98,16 @@ class PwSolver(GeoSolver):
         this_defaults.AddMissingParameters(super().GetDefaultParameters())
         return this_defaults
 
-    # =============================================================================================
-    # =============================================================================================
     def PrepareModelPart(self):
         super().PrepareModelPart()
         KratosMultiphysics.Logger.PrintInfo("GeoMechanics_Pw_Solver", "Model reading finished.")
 
-    # =============================================================================================
-    # =============================================================================================
     def AddDofs(self):
         ## Fluid dofs
         KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.WATER_PRESSURE, KratosMultiphysics.REACTION_WATER_PRESSURE,self.main_model_part)
 
         KratosMultiphysics.Logger.PrintInfo("GeoMechanics_Pw_Solver", "DOFs added correctly.")
 
-    # =============================================================================================
-    # =============================================================================================
     def Initialize(self):
         KratosMultiphysics.Logger.PrintInfo("::[GeoMechanics_Pw_Solver]:: ", "Initialisation ...")
         
@@ -136,11 +126,9 @@ class PwSolver(GeoSolver):
 
         KratosMultiphysics.Logger.PrintInfo("GeoMechanics_Pw_Solver", "Solver initialization finished.")
 
-
     #### Specific internal functions ####
 
-    # =============================================================================================
-    # =============================================================================================
+
     def _ConstructScheme(self, scheme_type, solution_type):
 
         self.main_model_part.ProcessInfo.SetValue(KratosGeo.VELOCITY_COEFFICIENT, 1.0)
@@ -174,8 +162,6 @@ class PwSolver(GeoSolver):
 
         return scheme
 
-    # =============================================================================================
-    # =============================================================================================
     def _ConstructConvergenceCriterion(self, convergence_criterion):
 
         D_RT = self.settings["water_pressure_relative_tolerance"].GetDouble()

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_Pw_solver.py
@@ -6,19 +6,23 @@ import KratosMultiphysics.GeoMechanicsApplication as KratosGeo
 import KratosMultiphysics.StructuralMechanicsApplication as KratosStructure
 
 # Import base class file
-from KratosMultiphysics.GeoMechanicsApplication.geomechanics_U_Pw_solver import UPwSolver
+from KratosMultiphysics.GeoMechanicsApplication.geomechanics_solver import GeoMechanicalSolver as GeoSolver
 
 def CreateSolver(model, custom_settings):
     return PwSolver(model, custom_settings)
 
-class PwSolver(UPwSolver):
+class PwSolver(GeoSolver):
     '''Solver for the solution of displacement-pore pressure coupled problems.'''
 
+    # =============================================================================================
+    # =============================================================================================
     def __init__(self, model, custom_settings):
         super().__init__(model, custom_settings)
 
         KratosMultiphysics.Logger.PrintInfo("GeoMechanics_Pw_Solver", "Construction of Solver finished.")
 
+    # =============================================================================================
+    # =============================================================================================
     @classmethod
     def GetDefaultParameters(cls):
         this_defaults = KratosMultiphysics.Parameters("""{
@@ -98,15 +102,25 @@ class PwSolver(UPwSolver):
         this_defaults.AddMissingParameters(super().GetDefaultParameters())
         return this_defaults
 
+    # =============================================================================================
+    # =============================================================================================
+    def PrepareModelPart(self):
+        super().PrepareModelPart()
+        KratosMultiphysics.Logger.PrintInfo("GeoMechanics_Pw_Solver", "Model reading finished.")
+
+    # =============================================================================================
+    # =============================================================================================
     def AddDofs(self):
         ## Fluid dofs
         KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.WATER_PRESSURE, KratosMultiphysics.REACTION_WATER_PRESSURE,self.main_model_part)
 
         KratosMultiphysics.Logger.PrintInfo("GeoMechanics_Pw_Solver", "DOFs added correctly.")
 
-
+    # =============================================================================================
+    # =============================================================================================
     def Initialize(self):
         KratosMultiphysics.Logger.PrintInfo("::[GeoMechanics_Pw_Solver]:: ", "Initialisation ...")
+        
         super().Initialize()
 
         self.find_neighbour_elements_of_conditions_process = KratosGeo.FindNeighbourElementsOfConditionsProcess(self.computing_model_part)
@@ -122,9 +136,11 @@ class PwSolver(UPwSolver):
 
         KratosMultiphysics.Logger.PrintInfo("GeoMechanics_Pw_Solver", "Solver initialization finished.")
 
+
     #### Specific internal functions ####
 
-
+    # =============================================================================================
+    # =============================================================================================
     def _ConstructScheme(self, scheme_type, solution_type):
 
         self.main_model_part.ProcessInfo.SetValue(KratosGeo.VELOCITY_COEFFICIENT, 1.0)
@@ -158,6 +174,8 @@ class PwSolver(UPwSolver):
 
         return scheme
 
+    # =============================================================================================
+    # =============================================================================================
     def _ConstructConvergenceCriterion(self, convergence_criterion):
 
         D_RT = self.settings["water_pressure_relative_tolerance"].GetDouble()
@@ -190,4 +208,3 @@ class PwSolver(UPwSolver):
             raise Exception(err_msg)
 
         return convergence_criterion
-

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
@@ -7,19 +7,23 @@ import KratosMultiphysics.GeoMechanicsApplication as KratosGeo
 import KratosMultiphysics.StructuralMechanicsApplication as KratosStructure
 
 # Import base class file
-import KratosMultiphysics.GeoMechanicsApplication.geomechanics_solver as GeoSolver
+from KratosMultiphysics.GeoMechanicsApplication.geomechanics_solver import GeoMechanicalSolver as GeoSolver
 
 def CreateSolver(model, custom_settings):
     return UPwSolver(model, custom_settings)
 
-class UPwSolver(GeoSolver.GeoMechanicalSolver):
+class UPwSolver(GeoSolver):
     '''Solver for the solution of displacement-pore pressure coupled problems.'''
 
+    # =============================================================================================
+    # =============================================================================================
     def __init__(self, model, custom_settings):
         super().__init__(model, custom_settings)
 
         KratosMultiphysics.Logger.PrintInfo("GeoMechanics_U_Pw_Solver", "Construction of Solver finished.")
-
+        
+    # =============================================================================================
+    # =============================================================================================
     @classmethod
     def GetDefaultParameters(cls):
         this_defaults = KratosMultiphysics.Parameters("""{
@@ -81,7 +85,6 @@ class UPwSolver(GeoSolver.GeoMechanicalSolver):
             "line_search_tolerance"      : 0.5,
             "rotation_dofs"              : false,
             "block_builder"              : true,
-            "prebuild_dynamics"          : false,
             "search_neighbours_step"     : false,
             "linear_solver_settings":{
                 "solver_type": "AMGCL",
@@ -104,31 +107,14 @@ class UPwSolver(GeoSolver.GeoMechanicalSolver):
         this_defaults.AddMissingParameters(super().GetDefaultParameters())
         return this_defaults
 
+    # =============================================================================================
+    # =============================================================================================
     def PrepareModelPart(self):
-
-        # Set ProcessInfo variables
-        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.TIME,
-                                                  self.settings["start_time"].GetDouble())
-        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DELTA_TIME,
-                                                  self.settings["time_stepping"]["time_step"].GetDouble())
-        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.STEP, 0)
-
-        self.main_model_part.ProcessInfo.SetValue(KratosGeo.TIME_UNIT_CONVERTER, 1.0)
-
-        self.main_model_part.ProcessInfo.SetValue(KratosGeo.NODAL_SMOOTHING,
-                                                  self.settings["nodal_smoothing"].GetBool())
-
-        if not self.main_model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED]:
-            ## Executes the check and prepare model process (Create computing_model_part and set constitutive law)
-            self._ExecuteCheckAndPrepare()
-            ## Set buffer size
-            self._SetBufferSize()
-
-        if not self.model.HasModelPart(self.settings["model_part_name"].GetString()):
-            self.model.AddModelPart(self.main_model_part)
-
+        super().PrepareModelPart()
         KratosMultiphysics.Logger.PrintInfo("GeoMechanics_U_Pw_Solver", "Model reading finished.")
 
+    # =============================================================================================
+    # =============================================================================================
     def AddDofs(self):
         ## displacement dofs
         KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.DISPLACEMENT_X, KratosMultiphysics.REACTION_X,self.main_model_part)
@@ -173,41 +159,12 @@ class UPwSolver(GeoSolver.GeoMechanicalSolver):
 
         KratosMultiphysics.Logger.PrintInfo("GeoMechanics_U_Pw_Solver", "DOFs added correctly.")
 
-
+    # =============================================================================================
+    # =============================================================================================
     def Initialize(self):
         KratosMultiphysics.Logger.PrintInfo("::[GeoMechanics_U_Pw_Solver]:: ", "Initialisation ...")
 
-        self.computing_model_part = self.GetComputingModelPart()
-
-        # Fill the previous steps of the buffer with the initial conditions
-        self._FillBuffer()
-
-        # Construct the linear solver
-        self.linear_solver = self._ConstructLinearSolver()
-
-        # Builder and solver creation
-        self.builder_and_solver = self._ConstructBuilderAndSolver(self.settings["block_builder"].GetBool(),
-                                                                  self.settings["prebuild_dynamics"].GetBool())
-
-        # Solution scheme creation
-        self.scheme = self._ConstructScheme(self.settings["scheme_type"].GetString(),
-                                            self.settings["solution_type"].GetString())
-
-        # Get the convergence criterion
-        self.convergence_criterion = self._ConstructConvergenceCriterion(self.settings["convergence_criterion"].GetString())
-
-        # Solver creation
-        self.solver = self._ConstructSolver(self.builder_and_solver,
-                                            self.settings["strategy_type"].GetString())
-
-        # Set echo_level
-        self.SetEchoLevel(self.settings["echo_level"].GetInt())
-
-        # Initialize Strategy
-        if self.settings["clear_storage"].GetBool():
-            self.Clear()
-
-        self.solver.Initialize()
+        super().Initialize()
 
         self.find_neighbour_elements_of_conditions_process = KratosGeo.FindNeighbourElementsOfConditionsProcess(self.computing_model_part)
         self.find_neighbour_elements_of_conditions_process.Execute()
@@ -222,104 +179,11 @@ class UPwSolver(GeoSolver.GeoMechanicalSolver):
 
         KratosMultiphysics.Logger.PrintInfo("GeoMechanics_U_Pw_Solver", "Solver initialization finished.")
 
-    def InitializeSolutionStep(self):
-        self.solver.InitializeSolutionStep()
-
-    def Predict(self):
-        self.solver.Predict()
-
-    def SolveSolutionStep(self):
-        is_converged = self.solver.SolveSolutionStep()
-        return is_converged
-
-    def FinalizeSolutionStep(self):
-        self.solver.FinalizeSolutionStep()
 
     #### Specific internal functions ####
-
-    def _ExecuteCheckAndPrepare(self):
-
-        self.computing_model_part_name = "porous_computational_model_part"
-
-        # Create list of sub sub model parts (it is a copy of the standard lists with a different name)
-        import json
-
-        self.body_domain_sub_sub_model_part_list = []
-        for i in range(self.settings["body_domain_sub_model_part_list"].size()):
-            self.body_domain_sub_sub_model_part_list.append("sub_"+self.settings["body_domain_sub_model_part_list"][i].GetString())
-        self.body_domain_sub_sub_model_part_list = KratosMultiphysics.Parameters(json.dumps(self.body_domain_sub_sub_model_part_list))
-
-        self.loads_sub_sub_model_part_list = []
-        for i in range(self.settings["loads_sub_model_part_list"].size()):
-            self.loads_sub_sub_model_part_list.append("sub_"+self.settings["loads_sub_model_part_list"][i].GetString())
-        self.loads_sub_sub_model_part_list = KratosMultiphysics.Parameters(json.dumps(self.loads_sub_sub_model_part_list))
-
-        # Auxiliary parameters object for the CheckAndPepareModelProcess
-        params = KratosMultiphysics.Parameters("{}")
-        params.AddEmptyValue("computing_model_part_name").SetString(self.computing_model_part_name)
-        params.AddValue("problem_domain_sub_model_part_list",self.settings["problem_domain_sub_model_part_list"])
-        params.AddValue("processes_sub_model_part_list",self.settings["processes_sub_model_part_list"])
-        params.AddValue("body_domain_sub_model_part_list",self.settings["body_domain_sub_model_part_list"])
-        params.AddValue("body_domain_sub_sub_model_part_list",self.body_domain_sub_sub_model_part_list)
-        params.AddValue("loads_sub_model_part_list",self.settings["loads_sub_model_part_list"])
-        params.AddValue("loads_sub_sub_model_part_list",self.loads_sub_sub_model_part_list)
-        # CheckAndPrepareModelProcess creates the porous_computational_model_part
-        from KratosMultiphysics.GeoMechanicsApplication import check_and_prepare_model_process_geo
-        check_and_prepare_model_process_geo.CheckAndPrepareModelProcess(self.main_model_part, params).Execute()
-
-        # NOTE: We do this here in case the model is empty, so the properties can be assigned
-        if not self.model.HasModelPart(self.main_model_part.Name):
-            self.model.AddModelPart(self.main_model_part)
-
-        # Import constitutive laws.
-        materials_imported = self.import_constitutive_laws()
-        if materials_imported:
-            KratosMultiphysics.Logger.PrintInfo("::[GeoMechanicalSolver]:: ", "Constitutive law was successfully imported.")
-        else:
-            # KratosMultiphysics.Logger.PrintInfo("::[GeoMechanicalSolver]:: ", "Constitutive law was not imported.")
-            raise Exception("::[GeoMechanicalSolver]:: ", "Constitutive law was not imported.")
-
-    def _SetBufferSize(self):
-        required_buffer_size = self.settings["buffer_size"].GetInt()
-        if required_buffer_size < self.GetMinimumBufferSize():
-            required_buffer_size = self.GetMinimumBufferSize()
-        current_buffer_size = self.main_model_part.GetBufferSize()
-        buffer_size = max(current_buffer_size, required_buffer_size)
-        self.main_model_part.SetBufferSize(buffer_size)
-
-    def _FillBuffer(self):
-        buffer_size = self.main_model_part.GetBufferSize()
-        time = self.main_model_part.ProcessInfo[KratosMultiphysics.TIME]
-        delta_time = self.main_model_part.ProcessInfo[KratosMultiphysics.DELTA_TIME]
-        step = self.main_model_part.ProcessInfo[KratosMultiphysics.STEP]
-
-        step = step - (buffer_size-1)*1
-        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.STEP, step)
-        time = time - (buffer_size-1)*delta_time
-        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.TIME, time)
-        for i in range(buffer_size-1):
-            step = step + 1
-            self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.STEP, step)
-            time = time + delta_time
-            self.main_model_part.CloneTimeStep(time)
-
-    def _ConstructLinearSolver(self):
-        import KratosMultiphysics.python_linear_solver_factory as linear_solver_factory
-        return linear_solver_factory.ConstructSolver(self.settings["linear_solver_settings"])
-
-    def _ConstructBuilderAndSolver(self, block_builder, prebuild_dynamics):
-
-        # Creating the builder and solver
-        if (block_builder):
-            if prebuild_dynamics:
-                builder_and_solver = KratosGeo.ResidualBasedBlockBuilderAndSolverWithMassAndDamping(self.linear_solver)
-            else:
-                builder_and_solver = KratosMultiphysics.ResidualBasedBlockBuilderAndSolver(self.linear_solver)
-        else:
-            builder_and_solver = KratosMultiphysics.ResidualBasedEliminationBuilderAndSolver(self.linear_solver)
-
-        return builder_and_solver
-
+    
+    # =============================================================================================
+    # =============================================================================================
     def _ConstructScheme(self, scheme_type, solution_type):
 
         self.main_model_part.ProcessInfo.SetValue(KratosGeo.VELOCITY_COEFFICIENT, 1.0)
@@ -366,7 +230,9 @@ class UPwSolver(GeoSolver.GeoMechanicalSolver):
             raise Exception("Apart from Newmark, other scheme_type are not available.")
 
         return scheme
-
+        
+    # =============================================================================================
+    # =============================================================================================
     def _ConstructConvergenceCriterion(self, convergence_criterion):
 
         D_RT = self.settings["displacement_relative_tolerance"].GetDouble()
@@ -412,97 +278,13 @@ class UPwSolver(GeoSolver.GeoMechanicalSolver):
 
         return convergence_criterion
 
-    def _ConstructSolver(self, builder_and_solver, strategy_type):
-
-        self.main_model_part.ProcessInfo.SetValue(KratosGeo.IS_CONVERGED, True)
-        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.NL_ITERATION_NUMBER, 1)
-
-        max_iters = self.settings["max_iterations"].GetInt()
-        compute_reactions = self.settings["compute_reactions"].GetBool()
-        reform_step_dofs = self.settings["reform_dofs_at_each_step"].GetBool()
-        move_mesh_flag = self.settings["move_mesh_flag"].GetBool()
-
-        if strategy_type.lower() == "newton_raphson":
-            self.strategy_params = KratosMultiphysics.Parameters("{}")
-            self.strategy_params.AddValue("loads_sub_model_part_list",self.loads_sub_sub_model_part_list)
-            self.strategy_params.AddValue("loads_variable_list",self.settings["loads_variable_list"])
-            solving_strategy = KratosGeo.GeoMechanicsNewtonRaphsonStrategy(self.computing_model_part,
-                                                                           self.scheme,
-                                                                           self.linear_solver,
-                                                                           self.convergence_criterion,
-                                                                           builder_and_solver,
-                                                                           self.strategy_params,
-                                                                           max_iters,
-                                                                           compute_reactions,
-                                                                           reform_step_dofs,
-                                                                           move_mesh_flag)
-        elif strategy_type.lower() == "newton_raphson_with_piping":
-            self.strategy_params = KratosMultiphysics.Parameters("{}")
-            self.strategy_params.AddValue("loads_sub_model_part_list",self.loads_sub_sub_model_part_list)
-            self.strategy_params.AddValue("loads_variable_list",self.settings["loads_variable_list"])
-            self.strategy_params.AddValue("max_piping_iterations", self.settings["max_piping_iterations"])
-            solving_strategy = KratosGeo.GeoMechanicsNewtonRaphsonErosionProcessStrategy(self.computing_model_part,
-                                                                                             self.scheme,
-                                                                                             self.linear_solver,
-                                                                                             self.convergence_criterion,
-                                                                                             builder_and_solver,
-                                                                                             self.strategy_params,
-                                                                                             max_iters,
-                                                                                             compute_reactions,
-                                                                                             reform_step_dofs,
-                                                                                             move_mesh_flag)
-
-        elif strategy_type.lower() == "line_search":
-            self.strategy_params = KratosMultiphysics.Parameters("{}")
-            self.strategy_params.AddValue("max_iteration",              self.settings["max_iterations"])
-            self.strategy_params.AddValue("compute_reactions",          self.settings["compute_reactions"])
-            self.strategy_params.AddValue("max_line_search_iterations", self.settings["max_line_search_iterations"])
-            self.strategy_params.AddValue("first_alpha_value",          self.settings["first_alpha_value"])
-            self.strategy_params.AddValue("second_alpha_value",         self.settings["second_alpha_value"])
-            self.strategy_params.AddValue("min_alpha",                  self.settings["min_alpha"])
-            self.strategy_params.AddValue("max_alpha",                  self.settings["max_alpha"])
-            self.strategy_params.AddValue("line_search_tolerance",      self.settings["line_search_tolerance"])
-            self.strategy_params.AddValue("move_mesh_flag",             self.settings["move_mesh_flag"])
-            self.strategy_params.AddValue("reform_dofs_at_each_step",   self.settings["reform_dofs_at_each_step"])
-            self.strategy_params.AddValue("echo_level",                 self.settings["echo_level"])
-
-            solving_strategy = KratosMultiphysics.LineSearchStrategy(self.computing_model_part,
-                                                                     self.scheme,
-                                                                     self.linear_solver,
-                                                                     self.convergence_criterion,
-                                                                     self.strategy_params)
-
-        elif strategy_type.lower() == "arc_length":
-            # Arc-Length strategy
-            self.main_model_part.ProcessInfo.SetValue(KratosGeo.ARC_LENGTH_LAMBDA,        1.0)
-            self.main_model_part.ProcessInfo.SetValue(KratosGeo.ARC_LENGTH_RADIUS_FACTOR, 1.0)
-            self.strategy_params = KratosMultiphysics.Parameters("{}")
-            self.strategy_params.AddValue("desired_iterations",self.settings["desired_iterations"])
-            self.strategy_params.AddValue("max_radius_factor",self.settings["max_radius_factor"])
-            self.strategy_params.AddValue("min_radius_factor",self.settings["min_radius_factor"])
-            self.strategy_params.AddValue("loads_sub_model_part_list",self.loads_sub_sub_model_part_list)
-            self.strategy_params.AddValue("loads_variable_list",self.settings["loads_variable_list"])
-            solving_strategy = KratosGeo.GeoMechanicsRammArcLengthStrategy(self.computing_model_part,
-                                                                           self.scheme,
-                                                                           self.linear_solver,
-                                                                           self.convergence_criterion,
-                                                                           builder_and_solver,
-                                                                           self.strategy_params,
-                                                                           max_iters,
-                                                                           compute_reactions,
-                                                                           reform_step_dofs,
-                                                                           move_mesh_flag)
-        else:
-            raise Exception("Undefined strategy type", strategy_type)
-
-        return solving_strategy
-
+    # =============================================================================================
+    # =============================================================================================
     def _CheckConvergence(self):
-
         IsConverged = self.solver.IsConverged()
-
         return IsConverged
 
+    # =============================================================================================
+    # =============================================================================================
     def _UpdateLoads(self):
-
         self.solver.UpdateLoads()

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
@@ -85,6 +85,7 @@ class UPwSolver(GeoSolver):
             "line_search_tolerance"      : 0.5,
             "rotation_dofs"              : false,
             "block_builder"              : true,
+            "prebuild_dynamics"          : false,
             "search_neighbours_step"     : false,
             "linear_solver_settings":{
                 "solver_type": "AMGCL",

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
@@ -15,15 +15,11 @@ def CreateSolver(model, custom_settings):
 class UPwSolver(GeoSolver):
     '''Solver for the solution of displacement-pore pressure coupled problems.'''
 
-    # =============================================================================================
-    # =============================================================================================
     def __init__(self, model, custom_settings):
         super().__init__(model, custom_settings)
 
         KratosMultiphysics.Logger.PrintInfo("GeoMechanics_U_Pw_Solver", "Construction of Solver finished.")
-        
-    # =============================================================================================
-    # =============================================================================================
+
     @classmethod
     def GetDefaultParameters(cls):
         this_defaults = KratosMultiphysics.Parameters("""{
@@ -108,14 +104,10 @@ class UPwSolver(GeoSolver):
         this_defaults.AddMissingParameters(super().GetDefaultParameters())
         return this_defaults
 
-    # =============================================================================================
-    # =============================================================================================
     def PrepareModelPart(self):
         super().PrepareModelPart()
         KratosMultiphysics.Logger.PrintInfo("GeoMechanics_U_Pw_Solver", "Model reading finished.")
 
-    # =============================================================================================
-    # =============================================================================================
     def AddDofs(self):
         ## displacement dofs
         KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.DISPLACEMENT_X, KratosMultiphysics.REACTION_X,self.main_model_part)
@@ -160,8 +152,6 @@ class UPwSolver(GeoSolver):
 
         KratosMultiphysics.Logger.PrintInfo("GeoMechanics_U_Pw_Solver", "DOFs added correctly.")
 
-    # =============================================================================================
-    # =============================================================================================
     def Initialize(self):
         KratosMultiphysics.Logger.PrintInfo("::[GeoMechanics_U_Pw_Solver]:: ", "Initialisation ...")
 
@@ -180,11 +170,8 @@ class UPwSolver(GeoSolver):
 
         KratosMultiphysics.Logger.PrintInfo("GeoMechanics_U_Pw_Solver", "Solver initialization finished.")
 
-
     #### Specific internal functions ####
-    
-    # =============================================================================================
-    # =============================================================================================
+
     def _ConstructScheme(self, scheme_type, solution_type):
 
         self.main_model_part.ProcessInfo.SetValue(KratosGeo.VELOCITY_COEFFICIENT, 1.0)
@@ -231,9 +218,7 @@ class UPwSolver(GeoSolver):
             raise Exception("Apart from Newmark, other scheme_type are not available.")
 
         return scheme
-        
-    # =============================================================================================
-    # =============================================================================================
+
     def _ConstructConvergenceCriterion(self, convergence_criterion):
 
         D_RT = self.settings["displacement_relative_tolerance"].GetDouble()
@@ -279,13 +264,9 @@ class UPwSolver(GeoSolver):
 
         return convergence_criterion
 
-    # =============================================================================================
-    # =============================================================================================
     def _CheckConvergence(self):
         IsConverged = self.solver.IsConverged()
         return IsConverged
 
-    # =============================================================================================
-    # =============================================================================================
     def _UpdateLoads(self):
         self.solver.UpdateLoads()

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
@@ -120,6 +120,7 @@ class GeoMechanicalSolver(PythonSolver):
             "line_search_tolerance"      : 0.5,
             "rotation_dofs"              : false,
             "block_builder"              : true,
+            "prebuild_dynamics"          : false,
             "search_neighbours_step"     : false,
             "linear_solver_settings":{
                 "solver_type": "AMGCL",

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
@@ -17,9 +17,6 @@ class GeoMechanicalSolver(PythonSolver):
 
     Derived classes can override the functions
     """
-    
-    # =============================================================================================
-    # =============================================================================================
     def __init__(self, model, custom_settings):
 
         super().__init__(model, custom_settings)
@@ -56,9 +53,7 @@ class GeoMechanicalSolver(PythonSolver):
         else:
             KratosMultiphysics.Logger.PrintInfo("geomechanics_solver", "is not a restarted model")
             self.main_model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED] = False
-            
-    # =============================================================================================
-    # =============================================================================================
+
     @classmethod
     def GetDefaultParameters(cls):
         this_defaults = KratosMultiphysics.Parameters("""{
@@ -142,9 +137,7 @@ class GeoMechanicalSolver(PythonSolver):
 
         this_defaults.AddMissingParameters(super().GetDefaultParameters())
         return this_defaults
-            
-    # =============================================================================================
-    # =============================================================================================
+
     def AddVariables(self):
         # this can safely be called also for restarts, it is internally checked if the variables exist already
         # Variables for 1-phase types of calculations:
@@ -173,26 +166,18 @@ class GeoMechanicalSolver(PythonSolver):
 
         KratosMultiphysics.Logger.PrintInfo("::[GeoMechanicalSolver]:: ", "Variables ADDED")
 
-    # =============================================================================================
-    # =============================================================================================
     def AddDofs(self):
         pass
 
-    # =============================================================================================
-    # =============================================================================================
     def GetMinimumBufferSize(self):
         return self.min_buffer_size
 
-    # =============================================================================================
-    # =============================================================================================
     def ImportModelPart(self):
         """This function imports the ModelPart
         """
         if self.solver_imports_model_part:
             self._ImportModelPart(self.main_model_part, self.settings["model_import_settings"])
 
-    # =============================================================================================
-    # =============================================================================================
     def PrepareModelPart(self):
         """This function prepares the ModelPart for being used by the PythonSolver
         """
@@ -217,14 +202,10 @@ class GeoMechanicalSolver(PythonSolver):
         if not self.model.HasModelPart(self.settings["model_part_name"].GetString()):
             self.model.AddModelPart(self.main_model_part)
 
-    # =============================================================================================
-    # =============================================================================================
     def KeepAdvancingSolutionLoop(self, end_time):
         current_time_corrected = self.main_model_part.ProcessInfo[KratosMultiphysics.TIME]
         return current_time_corrected < end_time
 
-    # =============================================================================================
-    # =============================================================================================
     def Initialize(self):
         """Perform initialization after adding nodal variables and dofs to the main model part. """
         self.computing_model_part = self.GetComputingModelPart()
@@ -258,29 +239,19 @@ class GeoMechanicalSolver(PythonSolver):
 
         self.solver.Initialize()
 
-    # =============================================================================================
-    # =============================================================================================
     def InitializeSolutionStep(self):
         self.solver.InitializeSolutionStep()
 
-    # =============================================================================================
-    # =============================================================================================
     def Predict(self):
         self.solver.Predict()
 
-    # =============================================================================================
-    # =============================================================================================
     def SolveSolutionStep(self):
         is_converged = self.solver.SolveSolutionStep()
         return is_converged
 
-    # =============================================================================================
-    # =============================================================================================
     def FinalizeSolutionStep(self):
         self.solver.FinalizeSolutionStep()
 
-    # =============================================================================================
-    # =============================================================================================
     def AdvanceInTime(self, current_time):
         dt = self.ComputeDeltaTime()
         current_time_corrected = self.main_model_part.ProcessInfo[KratosMultiphysics.TIME]
@@ -290,44 +261,30 @@ class GeoMechanicalSolver(PythonSolver):
 
         return new_time
 
-    # =============================================================================================
-    # =============================================================================================
     def ComputeDeltaTime(self):
         return self.main_model_part.ProcessInfo[KratosMultiphysics.DELTA_TIME]
 
-    # =============================================================================================
-    # =============================================================================================
     def GetComputingModelPart(self):
         return self.main_model_part.GetSubModelPart(self.computing_model_part_name)
 
-    # =============================================================================================
-    # =============================================================================================
     def ExportModelPart(self):
         name_out_file = self.settings["model_import_settings"]["input_filename"].GetString()+".out"
         file = open(name_out_file + ".mdpa","w")
         file.close()
         KratosMultiphysics.ModelPartIO(name_out_file, KratosMultiphysics.IO.WRITE).WriteModelPart(self.main_model_part)
 
-    # =============================================================================================
-    # =============================================================================================
     def SetEchoLevel(self, level):
         self.solver.SetEchoLevel(level)
 
-    # =============================================================================================
-    # =============================================================================================
     def Clear(self):
         self.solver.Clear()
 
-    # =============================================================================================
-    # =============================================================================================
     def Check(self):
         self.solver.Check()
 
 
     #### Specific internal functions ####
 
-    # =============================================================================================
-    # =============================================================================================
     def import_constitutive_laws(self):
         materials_filename = self.settings["material_import_settings"]["materials_filename"].GetString()
         KratosMultiphysics.Logger.PrintInfo("::[GeoMechanicalSolver]:: importing constitutive law", materials_filename)
@@ -342,16 +299,12 @@ class GeoMechanicalSolver(PythonSolver):
         return materials_imported
 
     #### Private functions ####
-    
-    # =============================================================================================
-    # =============================================================================================
+
     def _add_dynamic_variables(self):
         # For being consistent for Serial and Trilinos
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ACCELERATION)
 
-    # =============================================================================================
-    # =============================================================================================
     def _add_displacement_variables(self):
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
         self.main_model_part.AddNodalSolutionStepVariable(GeoMechanicsApplication.TOTAL_DISPLACEMENT)
@@ -363,8 +316,6 @@ class GeoMechanicalSolver(PythonSolver):
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.NORMAL_CONTACT_STRESS)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.TANGENTIAL_CONTACT_STRESS)
 
-    # =============================================================================================
-    # =============================================================================================
     def _add_rotational_variables(self):
         if (self.settings.Has("rotation_dofs")):
             if self.settings["rotation_dofs"].GetBool():
@@ -375,8 +326,6 @@ class GeoMechanicalSolver(PythonSolver):
                 self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ANGULAR_VELOCITY)
                 self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ANGULAR_ACCELERATION)
 
-    # =============================================================================================
-    # =============================================================================================
     def _add_water_variables(self):
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.WATER_PRESSURE)
         # Add reactions for the water pressure
@@ -388,8 +337,6 @@ class GeoMechanicalSolver(PythonSolver):
         # Add variables for the water conditions
         self.main_model_part.AddNodalSolutionStepVariable(GeoMechanicsApplication.HYDRAULIC_DISCHARGE)
 
-    # =============================================================================================
-    # =============================================================================================
     def _add_smoothing_variables(self):
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.NODAL_AREA)
         self.main_model_part.AddNodalSolutionStepVariable(GeoMechanicsApplication.NODAL_CAUCHY_STRESS_TENSOR)
@@ -398,8 +345,6 @@ class GeoMechanicalSolver(PythonSolver):
         self.main_model_part.AddNodalSolutionStepVariable(GeoMechanicsApplication.NODAL_JOINT_WIDTH)
         self.main_model_part.AddNodalSolutionStepVariable(GeoMechanicsApplication.NODAL_JOINT_DAMAGE)
 
-    # =============================================================================================
-    # =============================================================================================
     def _add_dynamic_dofs(self):
         # For being consistent for Serial and Trilinos
         KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.VELOCITY_X,self.main_model_part)
@@ -416,8 +361,6 @@ class GeoMechanicalSolver(PythonSolver):
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_Y,self.main_model_part)
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_Z,self.main_model_part)
 
-    # =============================================================================================
-    # =============================================================================================
     def _ExecuteCheckAndPrepare(self):
 
         self.computing_model_part_name = "porous_computational_model_part"
@@ -460,8 +403,6 @@ class GeoMechanicalSolver(PythonSolver):
             # KratosMultiphysics.Logger.PrintInfo("::[GeoMechanicalSolver]:: ", "Constitutive law was not imported.")
             raise Exception("::[GeoMechanicalSolver]:: ", "Constitutive law was not imported.")
 
-    # =============================================================================================
-    # =============================================================================================
     def _SetBufferSize(self):
         required_buffer_size = self.settings["buffer_size"].GetInt()
         if required_buffer_size < self.GetMinimumBufferSize():
@@ -470,8 +411,6 @@ class GeoMechanicalSolver(PythonSolver):
         buffer_size = max(current_buffer_size, required_buffer_size)
         self.main_model_part.SetBufferSize(buffer_size)
 
-    # =============================================================================================
-    # =============================================================================================
     def _FillBuffer(self):
         buffer_size = self.main_model_part.GetBufferSize()
         time = self.main_model_part.ProcessInfo[KratosMultiphysics.TIME]
@@ -488,14 +427,10 @@ class GeoMechanicalSolver(PythonSolver):
             time = time + delta_time
             self.main_model_part.CloneTimeStep(time)
 
-    # =============================================================================================
-    # =============================================================================================
     def _ConstructLinearSolver(self):
         import KratosMultiphysics.python_linear_solver_factory as linear_solver_factory
         return linear_solver_factory.ConstructSolver(self.settings["linear_solver_settings"])
-        
-    # =============================================================================================
-    # =============================================================================================
+
     def _ConstructBuilderAndSolver(self, block_builder):
 
         # Creating the builder and solver
@@ -505,9 +440,7 @@ class GeoMechanicalSolver(PythonSolver):
             builder_and_solver = KratosMultiphysics.ResidualBasedEliminationBuilderAndSolver(self.linear_solver)
 
         return builder_and_solver
-        
-    # =============================================================================================
-    # =============================================================================================
+
     def _ConstructSolver(self, builder_and_solver, strategy_type):
 
         self.main_model_part.ProcessInfo.SetValue(GeoMechanicsApplication.IS_CONVERGED, True)

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
@@ -17,6 +17,9 @@ class GeoMechanicalSolver(PythonSolver):
 
     Derived classes can override the functions
     """
+    
+    # =============================================================================================
+    # =============================================================================================
     def __init__(self, model, custom_settings):
 
         super().__init__(model, custom_settings)
@@ -53,7 +56,94 @@ class GeoMechanicalSolver(PythonSolver):
         else:
             KratosMultiphysics.Logger.PrintInfo("geomechanics_solver", "is not a restarted model")
             self.main_model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED] = False
+            
+    # =============================================================================================
+    # =============================================================================================
+    @classmethod
+    def GetDefaultParameters(cls):
+        this_defaults = KratosMultiphysics.Parameters("""{
+            "solver_type": "geomechanics_U_Pw_solver",
+            "model_part_name": "PorousDomain",
+            "domain_size": 2,
+            "start_time": 0.0,
+            "model_import_settings":{
+                "input_type": "mdpa",
+                "input_filename": "unknown_name"
+            },
+            "material_import_settings" :{
+                "materials_filename": ""
+            },
+            "time_stepping": {
+                "end_time" : 1.0,
+                "time_step": 0.1
+            },
+            "buffer_size": 2,
+            "echo_level": 0,
+            "rebuild_level": 2,
+            "reform_dofs_at_each_step": false,
+            "clear_storage": false,
+            "compute_reactions": false,
+            "move_mesh_flag": false,
+            "nodal_smoothing": false,
+            "reset_displacements":  false,
+            "solution_type": "quasi_static",
+            "scheme_type": "Newmark",
+            "newmark_beta": 0.25,
+            "newmark_gamma": 0.5,
+            "newmark_theta": 0.5,
+            "rayleigh_m": 0.0,
+            "rayleigh_k": 0.0,
+            "strategy_type": "newton_raphson",
+            "max_piping_iterations": 50,
+            "convergence_criterion": "Displacement_criterion",
+            "water_pressure_relative_tolerance": 1.0e-4,
+            "water_pressure_absolute_tolerance": 1.0e-9,
+            "displacement_relative_tolerance": 1.0e-4,
+            "displacement_absolute_tolerance": 1.0e-9,
+            "residual_relative_tolerance": 1.0e-4,
+            "residual_absolute_tolerance": 1.0e-9,
+            "desired_iterations"         : 4,
+            "max_radius_factor"          : 20.0,
+            "min_radius_factor"          : 0.5,
+            "max_iterations"             : 15,
+            "min_iterations"             : 6,
+            "number_cycles"              : 5,
+            "increase_factor"            : 2.0,
+            "reduction_factor"           : 0.5,
+            "realised_factor"            : 1.0,
+            "calculate_reactions"        : true,
+            "max_line_search_iterations" : 5,
+            "first_alpha_value"          : 0.5,
+            "second_alpha_value"         : 1.0,
+            "min_alpha"                  : 0.1,
+            "max_alpha"                  : 2.0,
+            "line_search_tolerance"      : 0.5,
+            "rotation_dofs"              : false,
+            "block_builder"              : true,
+            "search_neighbours_step"     : false,
+            "linear_solver_settings":{
+                "solver_type": "AMGCL",
+                "tolerance": 1.0e-6,
+                "max_iteration": 100,
+                "scaling": false,
+                "verbosity": 0,
+                "preconditioner_type": "ILU0Preconditioner",
+                "smoother_type": "ilu0",
+                "krylov_type": "gmres",
+                "coarsening_type": "aggregation"
+            },
+            "problem_domain_sub_model_part_list": [""],
+            "processes_sub_model_part_list": [""],
+            "body_domain_sub_model_part_list": [""],
+            "loads_sub_model_part_list": [],
+            "loads_variable_list": []
+        }""")
 
+        this_defaults.AddMissingParameters(super().GetDefaultParameters())
+        return this_defaults
+            
+    # =============================================================================================
+    # =============================================================================================
     def AddVariables(self):
         # this can safely be called also for restarts, it is internally checked if the variables exist already
         # Variables for 1-phase types of calculations:
@@ -82,43 +172,114 @@ class GeoMechanicalSolver(PythonSolver):
 
         KratosMultiphysics.Logger.PrintInfo("::[GeoMechanicalSolver]:: ", "Variables ADDED")
 
+    # =============================================================================================
+    # =============================================================================================
     def AddDofs(self):
         pass
 
+    # =============================================================================================
+    # =============================================================================================
     def GetMinimumBufferSize(self):
         return self.min_buffer_size
 
+    # =============================================================================================
+    # =============================================================================================
     def ImportModelPart(self):
         """This function imports the ModelPart
         """
         if self.solver_imports_model_part:
             self._ImportModelPart(self.main_model_part, self.settings["model_import_settings"])
 
+    # =============================================================================================
+    # =============================================================================================
     def PrepareModelPart(self):
         """This function prepares the ModelPart for being used by the PythonSolver
         """
-        pass
+        # Set ProcessInfo variables
+        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.TIME,
+                                                  self.settings["start_time"].GetDouble())
+        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DELTA_TIME,
+                                                  self.settings["time_stepping"]["time_step"].GetDouble())
+        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.STEP, 0)
 
+        self.main_model_part.ProcessInfo.SetValue(GeoMechanicsApplication.TIME_UNIT_CONVERTER, 1.0)
+
+        self.main_model_part.ProcessInfo.SetValue(GeoMechanicsApplication.NODAL_SMOOTHING,
+                                                  self.settings["nodal_smoothing"].GetBool())
+
+        if not self.main_model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED]:
+            ## Executes the check and prepare model process (Create computing_model_part and set constitutive law)
+            self._ExecuteCheckAndPrepare()
+            ## Set buffer size
+            self._SetBufferSize()
+
+        if not self.model.HasModelPart(self.settings["model_part_name"].GetString()):
+            self.model.AddModelPart(self.main_model_part)
+
+    # =============================================================================================
+    # =============================================================================================
     def KeepAdvancingSolutionLoop(self, end_time):
         current_time_corrected = self.main_model_part.ProcessInfo[KratosMultiphysics.TIME]
         return current_time_corrected < end_time
 
+    # =============================================================================================
+    # =============================================================================================
     def Initialize(self):
         """Perform initialization after adding nodal variables and dofs to the main model part. """
-        pass
+        self.computing_model_part = self.GetComputingModelPart()
 
+        # Fill the previous steps of the buffer with the initial conditions
+        self._FillBuffer()
+
+        # Construct the linear solver
+        self.linear_solver = self._ConstructLinearSolver()
+
+        # Builder and solver creation
+        builder_and_solver = self._ConstructBuilderAndSolver(self.settings["block_builder"].GetBool())
+
+        # Solution scheme creation
+        self.scheme = self._ConstructScheme(self.settings["scheme_type"].GetString(),
+                                            self.settings["solution_type"].GetString())
+
+        # Get the convergence criterion
+        self.convergence_criterion = self._ConstructConvergenceCriterion(self.settings["convergence_criterion"].GetString())
+
+        # Solver creation
+        self.solver = self._ConstructSolver(builder_and_solver,
+                                            self.settings["strategy_type"].GetString())
+
+        # Set echo_level
+        self.SetEchoLevel(self.settings["echo_level"].GetInt())
+
+        # Initialize Strategy
+        if self.settings["clear_storage"].GetBool():
+            self.Clear()
+
+        self.solver.Initialize()
+
+    # =============================================================================================
+    # =============================================================================================
     def InitializeSolutionStep(self):
-        pass
+        self.solver.InitializeSolutionStep()
 
+    # =============================================================================================
+    # =============================================================================================
     def Predict(self):
-        pass
+        self.solver.Predict()
 
+    # =============================================================================================
+    # =============================================================================================
     def SolveSolutionStep(self):
-        pass
+        is_converged = self.solver.SolveSolutionStep()
+        return is_converged
 
+    # =============================================================================================
+    # =============================================================================================
     def FinalizeSolutionStep(self):
-        pass
+        self.solver.FinalizeSolutionStep()
 
+    # =============================================================================================
+    # =============================================================================================
     def AdvanceInTime(self, current_time):
         dt = self.ComputeDeltaTime()
         current_time_corrected = self.main_model_part.ProcessInfo[KratosMultiphysics.TIME]
@@ -128,30 +289,44 @@ class GeoMechanicalSolver(PythonSolver):
 
         return new_time
 
+    # =============================================================================================
+    # =============================================================================================
     def ComputeDeltaTime(self):
         return self.main_model_part.ProcessInfo[KratosMultiphysics.DELTA_TIME]
 
+    # =============================================================================================
+    # =============================================================================================
     def GetComputingModelPart(self):
         return self.main_model_part.GetSubModelPart(self.computing_model_part_name)
 
+    # =============================================================================================
+    # =============================================================================================
     def ExportModelPart(self):
         name_out_file = self.settings["model_import_settings"]["input_filename"].GetString()+".out"
         file = open(name_out_file + ".mdpa","w")
         file.close()
         KratosMultiphysics.ModelPartIO(name_out_file, KratosMultiphysics.IO.WRITE).WriteModelPart(self.main_model_part)
 
+    # =============================================================================================
+    # =============================================================================================
     def SetEchoLevel(self, level):
         self.solver.SetEchoLevel(level)
 
+    # =============================================================================================
+    # =============================================================================================
     def Clear(self):
         self.solver.Clear()
 
+    # =============================================================================================
+    # =============================================================================================
     def Check(self):
         self.solver.Check()
 
 
     #### Specific internal functions ####
 
+    # =============================================================================================
+    # =============================================================================================
     def import_constitutive_laws(self):
         materials_filename = self.settings["material_import_settings"]["materials_filename"].GetString()
         KratosMultiphysics.Logger.PrintInfo("::[GeoMechanicalSolver]:: importing constitutive law", materials_filename)
@@ -166,12 +341,16 @@ class GeoMechanicalSolver(PythonSolver):
         return materials_imported
 
     #### Private functions ####
-
+    
+    # =============================================================================================
+    # =============================================================================================
     def _add_dynamic_variables(self):
         # For being consistent for Serial and Trilinos
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ACCELERATION)
 
+    # =============================================================================================
+    # =============================================================================================
     def _add_displacement_variables(self):
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
         self.main_model_part.AddNodalSolutionStepVariable(GeoMechanicsApplication.TOTAL_DISPLACEMENT)
@@ -183,6 +362,8 @@ class GeoMechanicalSolver(PythonSolver):
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.NORMAL_CONTACT_STRESS)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.TANGENTIAL_CONTACT_STRESS)
 
+    # =============================================================================================
+    # =============================================================================================
     def _add_rotational_variables(self):
         if (self.settings.Has("rotation_dofs")):
             if self.settings["rotation_dofs"].GetBool():
@@ -193,6 +374,8 @@ class GeoMechanicalSolver(PythonSolver):
                 self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ANGULAR_VELOCITY)
                 self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ANGULAR_ACCELERATION)
 
+    # =============================================================================================
+    # =============================================================================================
     def _add_water_variables(self):
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.WATER_PRESSURE)
         # Add reactions for the water pressure
@@ -204,6 +387,8 @@ class GeoMechanicalSolver(PythonSolver):
         # Add variables for the water conditions
         self.main_model_part.AddNodalSolutionStepVariable(GeoMechanicsApplication.HYDRAULIC_DISCHARGE)
 
+    # =============================================================================================
+    # =============================================================================================
     def _add_smoothing_variables(self):
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.NODAL_AREA)
         self.main_model_part.AddNodalSolutionStepVariable(GeoMechanicsApplication.NODAL_CAUCHY_STRESS_TENSOR)
@@ -212,6 +397,8 @@ class GeoMechanicalSolver(PythonSolver):
         self.main_model_part.AddNodalSolutionStepVariable(GeoMechanicsApplication.NODAL_JOINT_WIDTH)
         self.main_model_part.AddNodalSolutionStepVariable(GeoMechanicsApplication.NODAL_JOINT_DAMAGE)
 
+    # =============================================================================================
+    # =============================================================================================
     def _add_dynamic_dofs(self):
         # For being consistent for Serial and Trilinos
         KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.VELOCITY_X,self.main_model_part)
@@ -228,3 +415,180 @@ class GeoMechanicalSolver(PythonSolver):
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_Y,self.main_model_part)
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_Z,self.main_model_part)
 
+    # =============================================================================================
+    # =============================================================================================
+    def _ExecuteCheckAndPrepare(self):
+
+        self.computing_model_part_name = "porous_computational_model_part"
+
+        # Create list of sub sub model parts (it is a copy of the standard lists with a different name)
+        import json
+
+        self.body_domain_sub_sub_model_part_list = []
+        for i in range(self.settings["body_domain_sub_model_part_list"].size()):
+            self.body_domain_sub_sub_model_part_list.append("sub_"+self.settings["body_domain_sub_model_part_list"][i].GetString())
+        self.body_domain_sub_sub_model_part_list = KratosMultiphysics.Parameters(json.dumps(self.body_domain_sub_sub_model_part_list))
+
+        self.loads_sub_sub_model_part_list = []
+        for i in range(self.settings["loads_sub_model_part_list"].size()):
+            self.loads_sub_sub_model_part_list.append("sub_"+self.settings["loads_sub_model_part_list"][i].GetString())
+        self.loads_sub_sub_model_part_list = KratosMultiphysics.Parameters(json.dumps(self.loads_sub_sub_model_part_list))
+
+        # Auxiliary parameters object for the CheckAndPepareModelProcess
+        params = KratosMultiphysics.Parameters("{}")
+        params.AddEmptyValue("computing_model_part_name").SetString(self.computing_model_part_name)
+        params.AddValue("problem_domain_sub_model_part_list",self.settings["problem_domain_sub_model_part_list"])
+        params.AddValue("processes_sub_model_part_list",self.settings["processes_sub_model_part_list"])
+        params.AddValue("body_domain_sub_model_part_list",self.settings["body_domain_sub_model_part_list"])
+        params.AddValue("body_domain_sub_sub_model_part_list",self.body_domain_sub_sub_model_part_list)
+        params.AddValue("loads_sub_model_part_list",self.settings["loads_sub_model_part_list"])
+        params.AddValue("loads_sub_sub_model_part_list",self.loads_sub_sub_model_part_list)
+        # CheckAndPrepareModelProcess creates the porous_computational_model_part
+        from KratosMultiphysics.GeoMechanicsApplication import check_and_prepare_model_process_geo
+        check_and_prepare_model_process_geo.CheckAndPrepareModelProcess(self.main_model_part, params).Execute()
+
+        # NOTE: We do this here in case the model is empty, so the properties can be assigned
+        if not self.model.HasModelPart(self.main_model_part.Name):
+            self.model.AddModelPart(self.main_model_part)
+
+        # Import constitutive laws.
+        materials_imported = self.import_constitutive_laws()
+        if materials_imported:
+            KratosMultiphysics.Logger.PrintInfo("::[GeoMechanicalSolver]:: ", "Constitutive law was successfully imported.")
+        else:
+            # KratosMultiphysics.Logger.PrintInfo("::[GeoMechanicalSolver]:: ", "Constitutive law was not imported.")
+            raise Exception("::[GeoMechanicalSolver]:: ", "Constitutive law was not imported.")
+
+    # =============================================================================================
+    # =============================================================================================
+    def _SetBufferSize(self):
+        required_buffer_size = self.settings["buffer_size"].GetInt()
+        if required_buffer_size < self.GetMinimumBufferSize():
+            required_buffer_size = self.GetMinimumBufferSize()
+        current_buffer_size = self.main_model_part.GetBufferSize()
+        buffer_size = max(current_buffer_size, required_buffer_size)
+        self.main_model_part.SetBufferSize(buffer_size)
+
+    # =============================================================================================
+    # =============================================================================================
+    def _FillBuffer(self):
+        buffer_size = self.main_model_part.GetBufferSize()
+        time = self.main_model_part.ProcessInfo[KratosMultiphysics.TIME]
+        delta_time = self.main_model_part.ProcessInfo[KratosMultiphysics.DELTA_TIME]
+        step = self.main_model_part.ProcessInfo[KratosMultiphysics.STEP]
+
+        step = step - (buffer_size-1)*1
+        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.STEP, step)
+        time = time - (buffer_size-1)*delta_time
+        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.TIME, time)
+        for i in range(buffer_size-1):
+            step = step + 1
+            self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.STEP, step)
+            time = time + delta_time
+            self.main_model_part.CloneTimeStep(time)
+
+    # =============================================================================================
+    # =============================================================================================
+    def _ConstructLinearSolver(self):
+        import KratosMultiphysics.python_linear_solver_factory as linear_solver_factory
+        return linear_solver_factory.ConstructSolver(self.settings["linear_solver_settings"])
+        
+    # =============================================================================================
+    # =============================================================================================
+    def _ConstructBuilderAndSolver(self, block_builder):
+
+        # Creating the builder and solver
+        if (block_builder):
+            builder_and_solver = KratosMultiphysics.ResidualBasedBlockBuilderAndSolver(self.linear_solver)
+        else:
+            builder_and_solver = KratosMultiphysics.ResidualBasedEliminationBuilderAndSolver(self.linear_solver)
+
+        return builder_and_solver
+        
+    # =============================================================================================
+    # =============================================================================================
+    def _ConstructSolver(self, builder_and_solver, strategy_type):
+
+        self.main_model_part.ProcessInfo.SetValue(GeoMechanicsApplication.IS_CONVERGED, True)
+        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.NL_ITERATION_NUMBER, 1)
+
+        max_iters = self.settings["max_iterations"].GetInt()
+        compute_reactions = self.settings["compute_reactions"].GetBool()
+        reform_step_dofs = self.settings["reform_dofs_at_each_step"].GetBool()
+        move_mesh_flag = self.settings["move_mesh_flag"].GetBool()
+
+        if strategy_type.lower() == "newton_raphson":
+            self.strategy_params = KratosMultiphysics.Parameters("{}")
+            self.strategy_params.AddValue("loads_sub_model_part_list",self.loads_sub_sub_model_part_list)
+            self.strategy_params.AddValue("loads_variable_list",self.settings["loads_variable_list"])
+            solving_strategy = GeoMechanicsApplication.GeoMechanicsNewtonRaphsonStrategy(self.computing_model_part,
+                                                                           self.scheme,
+                                                                           self.linear_solver,
+                                                                           self.convergence_criterion,
+                                                                           builder_and_solver,
+                                                                           self.strategy_params,
+                                                                           max_iters,
+                                                                           compute_reactions,
+                                                                           reform_step_dofs,
+                                                                           move_mesh_flag)
+        elif strategy_type.lower() == "newton_raphson_with_piping":
+            self.strategy_params = KratosMultiphysics.Parameters("{}")
+            self.strategy_params.AddValue("loads_sub_model_part_list",self.loads_sub_sub_model_part_list)
+            self.strategy_params.AddValue("loads_variable_list",self.settings["loads_variable_list"])
+            self.strategy_params.AddValue("max_piping_iterations", self.settings["max_piping_iterations"])
+            solving_strategy = GeoMechanicsApplication.GeoMechanicsNewtonRaphsonErosionProcessStrategy(self.computing_model_part,
+                                                                                             self.scheme,
+                                                                                             self.linear_solver,
+                                                                                             self.convergence_criterion,
+                                                                                             builder_and_solver,
+                                                                                             self.strategy_params,
+                                                                                             max_iters,
+                                                                                             compute_reactions,
+                                                                                             reform_step_dofs,
+                                                                                             move_mesh_flag)
+
+        elif strategy_type.lower() == "line_search":
+            self.strategy_params = KratosMultiphysics.Parameters("{}")
+            self.strategy_params.AddValue("max_iteration",              self.settings["max_iterations"])
+            self.strategy_params.AddValue("compute_reactions",          self.settings["compute_reactions"])
+            self.strategy_params.AddValue("max_line_search_iterations", self.settings["max_line_search_iterations"])
+            self.strategy_params.AddValue("first_alpha_value",          self.settings["first_alpha_value"])
+            self.strategy_params.AddValue("second_alpha_value",         self.settings["second_alpha_value"])
+            self.strategy_params.AddValue("min_alpha",                  self.settings["min_alpha"])
+            self.strategy_params.AddValue("max_alpha",                  self.settings["max_alpha"])
+            self.strategy_params.AddValue("line_search_tolerance",      self.settings["line_search_tolerance"])
+            self.strategy_params.AddValue("move_mesh_flag",             self.settings["move_mesh_flag"])
+            self.strategy_params.AddValue("move_mesh_flag",             self.settings["move_mesh_flag"])
+            self.strategy_params.AddValue("reform_dofs_at_each_step",   self.settings["reform_dofs_at_each_step"])
+            self.strategy_params.AddValue("echo_level",                 self.settings["echo_level"])
+
+            solving_strategy = KratosMultiphysics.LineSearchStrategy(self.computing_model_part,
+                                                                     self.scheme,
+                                                                     self.linear_solver,
+                                                                     self.convergence_criterion,
+                                                                     self.strategy_params)
+
+        elif strategy_type.lower() == "arc_length":
+            # Arc-Length strategy
+            self.main_model_part.ProcessInfo.SetValue(KratosGeo.ARC_LENGTH_LAMBDA,        1.0)
+            self.main_model_part.ProcessInfo.SetValue(KratosGeo.ARC_LENGTH_RADIUS_FACTOR, 1.0)
+            self.strategy_params = KratosMultiphysics.Parameters("{}")
+            self.strategy_params.AddValue("desired_iterations",self.settings["desired_iterations"])
+            self.strategy_params.AddValue("max_radius_factor",self.settings["max_radius_factor"])
+            self.strategy_params.AddValue("min_radius_factor",self.settings["min_radius_factor"])
+            self.strategy_params.AddValue("loads_sub_model_part_list",self.loads_sub_sub_model_part_list)
+            self.strategy_params.AddValue("loads_variable_list",self.settings["loads_variable_list"])
+            solving_strategy = GeoMechanicsApplication.GeoMechanicsRammArcLengthStrategy(self.computing_model_part,
+                                                                           self.scheme,
+                                                                           self.linear_solver,
+                                                                           self.convergence_criterion,
+                                                                           builder_and_solver,
+                                                                           self.strategy_params,
+                                                                           max_iters,
+                                                                           compute_reactions,
+                                                                           reform_step_dofs,
+                                                                           move_mesh_flag)
+        else:
+            raise Exception("Undefined strategy type", strategy_type)
+
+        return solving_strategy


### PR DESCRIPTION
**📝 Description**
The code structure for Python solvers are as follow:

_geomechanics_solver -> geomechanics_U_Pw_solver -> geomechanics_Pw_solver_

However, it is not a preffered way of inheretence for us, and we would like to break the dependency of Pw and U-Pw solvers. By doing as above, in order to solve Pw, the solver U-Pw gets initialized (which is redundant).
We would like to change it to:

_geomechanics_solver -> geomechanics_U_Pw_solver 
geomechanics_solver -> geomechanics_Pw_solver_.

**🆕 Changelog**
- Inheritances of Pw and U-Pw based of geomechanics_solver are changed
- the shared functions are added to the Geo solver 