### PR TITLE
[Core] Remove methods duplicate STL methods from `MathUtils`

### DIFF
--- a/applications/DEMApplication/custom_strategies/strategies/explicit_solver_strategy.cpp
+++ b/applications/DEMApplication/custom_strategies/strategies/explicit_solver_strategy.cpp
@@ -885,7 +885,7 @@ namespace Kratos {
                 }
                 //node_area += 0.333333333333333 * Element_Area; //TODO: ONLY FOR TRIANGLE... Generalize for 3 or 4 nodes.
                 //node_pressure actually refers to normal force. Pressure is actually computed later in function Calculate_Nodal_Pressures_and_Stresses()
-                node_pressure += MathUtils<double>::Abs(GeometryFunctions::DotProduct(rhs_cond_comp, Normal_to_Element));
+                node_pressure += std::abs(GeometryFunctions::DotProduct(rhs_cond_comp, Normal_to_Element));
                 noalias(node_rhs_tang) += rhs_cond_comp - GeometryFunctions::DotProduct(rhs_cond_comp, Normal_to_Element) * Normal_to_Element;
 
                 geom[i].UnSetLock();

--- a/applications/ExaquteSandboxApplication/custom_processes/metrics_divergencefree_process.cpp
+++ b/applications/ExaquteSandboxApplication/custom_processes/metrics_divergencefree_process.cpp
@@ -360,7 +360,7 @@ void MetricDivergenceFreeProcess<TDim>::CalculateMetric()
             double factor = mGlobalErrorStrategyMeshConstant*std::abs(divergencefree_interp_value)/mGlobalErrorStrategyGlobalTolerance;
 
             // Check with max and min size
-            aux_element_size = MathUtils<double>::Min(MathUtils<double>::Max(factor, max_ratio), min_ratio);
+            aux_element_size = std::min(std::max(factor, max_ratio), min_ratio);
 
             // Set metric
             BoundedMatrix<double, TDim, TDim> metric_matrix = ZeroMatrix(TDim, TDim);

--- a/applications/MeshingApplication/custom_processes/metrics_hessian_process.cpp
+++ b/applications/MeshingApplication/custom_processes/metrics_hessian_process.cpp
@@ -120,7 +120,7 @@ array_1d<double, 3 * (TDim - 1)> ComputeHessianSolMetricProcess::ComputeHessianM
     // Calculating Metric parameters (using equation from remark 4.2.2 on Metric-Based Anisotropic Mesh Adaptation)
     double interpolation_error = rAuxiliarHessianComputationVariables.mInterpolationError;
     if (rAuxiliarHessianComputationVariables.mEstimateInterpolationError) {
-        interpolation_error = rAuxiliarHessianComputationVariables.mMeshDependentConstant * MathUtils<double>::Max(rAuxiliarHessianComputationVariables.mNodalH, rAuxiliarHessianComputationVariables.mNodalH * norm_frobenius(hessian_matrix)); // NOTE: To compute it properly instead of iterating over the nodes you should iterate over the elements and instead of ElementMaxSize you should iterate over the edges, this is equivalent when using nodes and computing NodalH previously
+        interpolation_error = rAuxiliarHessianComputationVariables.mMeshDependentConstant * std::max(rAuxiliarHessianComputationVariables.mNodalH, rAuxiliarHessianComputationVariables.mNodalH * norm_frobenius(hessian_matrix)); // NOTE: To compute it properly instead of iterating over the nodes you should iterate over the elements and instead of ElementMaxSize you should iterate over the edges, this is equivalent when using nodes and computing NodalH previously
     }
 
     // Declaring the eigen system
@@ -142,7 +142,7 @@ array_1d<double, 3 * (TDim - 1)> ComputeHessianSolMetricProcess::ComputeHessianM
 
         // Recalculate the Metric eigen values
         for (IndexType i = 0; i < TDim; ++i) {
-            eigen_values_matrix(i, i) = MathUtils<double>::Min(MathUtils<double>::Max(c_epsilon * std::abs(eigen_values_matrix(i, i)), max_ratio), min_ratio);
+            eigen_values_matrix(i, i) = std::min(std::max(c_epsilon * std::abs(eigen_values_matrix(i, i)), max_ratio), min_ratio);
         }
     }
 
@@ -152,20 +152,20 @@ array_1d<double, 3 * (TDim - 1)> ComputeHessianSolMetricProcess::ComputeHessianM
             double eigen_max = eigen_values_matrix(0, 0);
             double eigen_min = eigen_values_matrix(0, 0);
             for (IndexType i = 1; i < TDim; ++i) {
-                eigen_max = MathUtils<double>::Max(eigen_max, eigen_values_matrix(i, i));
-                eigen_min = MathUtils<double>::Min(eigen_min, eigen_values_matrix(i, i));
+                eigen_max = std::max(eigen_max, eigen_values_matrix(i, i));
+                eigen_min = std::min(eigen_min, eigen_values_matrix(i, i));
             }
 
             const double eigen_radius = std::abs(eigen_max - eigen_min) * (1.0 - rAuxiliarHessianComputationVariables.mAnisotropicRatio);
             const double relative_eigen_radius = std::abs(eigen_max - eigen_radius);
 
             for (IndexType i = 0; i < TDim; ++i)
-                eigen_values_matrix(i, i) = MathUtils<double>::Max(MathUtils<double>::Min(eigen_values_matrix(i, i), eigen_max), relative_eigen_radius);
+                eigen_values_matrix(i, i) = std::max(std::min(eigen_values_matrix(i, i), eigen_max), relative_eigen_radius);
         }
     } else { // NOTE: For isotropic we should consider the maximum of the eigenvalues
         double eigen_max = eigen_values_matrix(0, 0);
         for (IndexType i = 1; i < TDim; ++i)
-            eigen_max = MathUtils<double>::Max(eigen_max, eigen_values_matrix(i, i));
+            eigen_max = std::max(eigen_max, eigen_values_matrix(i, i));
         for (IndexType i = 0; i < TDim; ++i)
             eigen_values_matrix(i, i) = eigen_max;
         eigen_vector_matrix = IdentityMatrix(TDim, TDim);

--- a/applications/MeshingApplication/custom_utilities/metrics_math_utils.h
+++ b/applications/MeshingApplication/custom_utilities/metrics_math_utils.h
@@ -100,7 +100,7 @@ public:
         MathUtils<double>::BDBtProductOperation(mumat, metric2_matrix, emat);
 
         for (std::size_t i = 0; i < TDim; ++i) {
-            auxmat(i, i) = MathUtils<double>::Max(lambdamat(i, i), mumat(i, i));
+            auxmat(i, i) = std::max(lambdamat(i, i), mumat(i, i));
         }
 
         MatrixType invemat;

--- a/applications/PoromechanicsApplication/custom_utilities/solid_mechanics_math_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/solid_mechanics_math_utilities.hpp
@@ -908,9 +908,9 @@ public:
                 for( int j=i+1; j<n; j++ )
                 {
                     double theta = 0.0;
-                    if( MathUtilsType::Abs( A(i,j) ) >= zero_tolerance )
+                    if( std::abs( A(i,j) ) >= zero_tolerance )
                     {
-                        if( MathUtilsType::Abs( A(i,i)-A(j,j) ) > 0.0 )
+                        if( std::abs( A(i,i)-A(j,j) ) > 0.0 )
                         {
                             theta = 0.5*atan(2*A(i,j)/(A(i,i)-A(j,j)));
                         }
@@ -936,9 +936,9 @@ public:
             {
                 for( unsigned int j=0; j<A.size2(); j++ )
                 {
-                    sTot += MathUtilsType::Abs(A(i,j));
+                    sTot += std::abs(A(i,j));
                 }
-                sDiag+= MathUtilsType::Abs(A(i,i));
+                sDiag+= std::abs(A(i,i));
             }
             error=(sTot-sDiag)/sDiag;
         }

--- a/applications/SolidMechanicsApplication/custom_utilities/solid_mechanics_math_utilities.hpp
+++ b/applications/SolidMechanicsApplication/custom_utilities/solid_mechanics_math_utilities.hpp
@@ -909,9 +909,9 @@ public:
                 for( int j=i+1; j<n; j++ )
                 {
                     double theta = 0.0;
-                    if( MathUtilsType::Abs( A(i,j) ) >= zero_tolerance )
+                    if( std::abs( A(i,j) ) >= zero_tolerance )
                     {
-                        if( MathUtilsType::Abs( A(i,i)-A(j,j) ) > 0.0 )
+                        if( std::abs( A(i,i)-A(j,j) ) > 0.0 )
                         {
                             theta = 0.5*atan(2*A(i,j)/(A(i,i)-A(j,j)));
                         }
@@ -937,9 +937,9 @@ public:
             {
                 for( unsigned int j=0; j<A.size2(); j++ )
                 {
-                    sTot += MathUtilsType::Abs(A(i,j));
+                    sTot += std::abs(A(i,j));
                 }
-                sDiag+= MathUtilsType::Abs(A(i,i));
+                sDiag+= std::abs(A(i,i));
             }
             error=(sTot-sDiag)/sDiag;
         }

--- a/docs/pages/Kratos/For_Developers/General/How-to-create-unitary-tests.md
+++ b/docs/pages/Kratos/For_Developers/General/How-to-create-unitary-tests.md
@@ -855,28 +855,6 @@ namespace Kratos
 
             KRATOS_CHECK_NEAR(area, 0.5, TOLERANCE);
         }
-        
-        /** Checks if it gives you the absolute value of a given value
-         * Checks if It gives you the absolute value of a given value
-         */
-        
-        KRATOS_TEST_CASE_IN_SUITE(MathUtilsAbsTest, KratosCoreMathUtilsFastSuite) 
-        {
-            const double absolute = MathUtils<double>::Abs(-1.0);
-
-            KRATOS_CHECK_EQUAL(absolute, 1.0);
-        }
-        
-        /** Checks if it gives you the minimum value of a given value
-         * Checks if It gives you the minimum value of a given value
-         */
-        
-        KRATOS_TEST_CASE_IN_SUITE(MathUtilsMinTest, KratosCoreMathUtilsFastSuite) 
-        {
-            const double min = MathUtils<double>::Min(0.0,1.0);
-
-            KRATOS_CHECK_EQUAL(min, 0.0);
-        }
     } // namespace Testing
 }  // namespace Kratos.
 ```

--- a/kratos/tests/cpp_tests/utilities/test_math_utils.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_math_utils.cpp
@@ -42,39 +42,6 @@ namespace Kratos
             KRATOS_CHECK_NEAR(area, 0.5, tolerance);
         }
 
-        /** Checks if it gives you the absolute value of a given value
-         * Checks if It gives you the absolute value of a given value
-         */
-
-        KRATOS_TEST_CASE_IN_SUITE(MathUtilsAbs, KratosCoreFastSuite)
-        {
-            const double absolute = MathUtils<double>::Abs(-1.0);
-
-            KRATOS_CHECK_EQUAL(absolute, 1.0);
-        }
-
-        /** Checks if it gives you the minimum value of a given value
-         * Checks if It gives you the minimum value of a given value
-         */
-
-        KRATOS_TEST_CASE_IN_SUITE(MathUtilsMin, KratosCoreFastSuite)
-        {
-            const double min = MathUtils<double>::Min(0.0,1.0);
-
-            KRATOS_CHECK_EQUAL(min, 0.0);
-        }
-
-        /** Checks if it gives you the maximum value of a given value
-         * Checks if It gives you the maximum value of a given value
-         */
-
-        KRATOS_TEST_CASE_IN_SUITE(MathUtilsMax, KratosCoreFastSuite)
-        {
-            const double max = MathUtils<double>::Max(0.0,1.0);
-
-            KRATOS_CHECK_EQUAL(max, 1.0);
-        }
-
         /** Checks if it calculates the determinant of a 1x1, 2x2, 3x3 and 4x4 matrix
          * Checks if it calculates the determinant of a 1x1, 2x2, 3x3 and 4x4 matrix
          */

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -131,44 +131,6 @@ public:
     }
 
     /**
-     * @brief It gives you the absolute value of a given value
-     * @param rData The value to compute the absolute value
-     * @return The absolute value of rData
-     */
-    static TDataType Abs(const TDataType& rData)
-    {
-        return rData > TDataType(0) ? rData : -rData;
-    }
-
-    /**
-     * @brief It gives you the minimum value between two values
-     * @param rValue1 The first value
-     * @param rValue2 The second value
-     * @return The minimum value
-     */
-    static TDataType Min(
-        const TDataType& rValue1,
-        const TDataType& rValue2
-        )
-    {
-        return rValue1 > rValue2 ? rValue2 : rValue1;
-    }
-
-    /**
-     * @brief It gives you the maximum value between two values
-     * @param rValue1 The first value
-     * @param rValue2 The second value
-     * @return The maximum value
-     */
-    static TDataType Max(
-        const TDataType& rValue1,
-        const TDataType& rValue2
-        )
-    {
-        return rValue1 > rValue2 ? rValue1 : rValue2;
-    }
-
-    /**
      * @brief Calculates the cofactor
      * @param rMat The matrix to calculate
      * @param i The index i


### PR DESCRIPTION
**📝 Description**

Part of #11130

This commit removes three functions (`Abs`, `Min`, and `Max`) from the `MathUtils` class. The removal of these functions may indicate that they were either unnecessary or their functionalities are being replaced by standard library functions or methods.

**🆕 Changelog**

- [Remove methods duplicate STL methods](https://github.com/KratosMultiphysics/Kratos/commit/973e3dae38e2be5742f89c135285a176335646d1)
- [Remove abs, min, max](https://github.com/KratosMultiphysics/Kratos/commit/245aecdd3e8127d0e780ffd697d87f39d9e810f7)
- [More replacement](https://github.com/KratosMultiphysics/Kratos/commit/54ba831a719da7a4468496b9e3e8e3faeb505136)