### PR TITLE
[Core] Extend ContainerExpression to Ghost/Interface meshes

### DIFF
--- a/kratos/containers/container_expression/container_expression.cpp
+++ b/kratos/containers/container_expression/container_expression.cpp
@@ -255,6 +255,12 @@ void ContainerExpression<TContainerType, TMeshType>::SetExpression(Expression::P
 }
 
 template <class TContainerType, class TMeshType>
+const bool ContainerExpression<TContainerType, TMeshType>::HasExpression() const
+{
+    return mpExpression.has_value();
+}
+
+template <class TContainerType, class TMeshType>
 const Expression& ContainerExpression<TContainerType, TMeshType>::GetExpression() const
 {
     return *(*mpExpression);

--- a/kratos/containers/container_expression/container_expression.cpp
+++ b/kratos/containers/container_expression/container_expression.cpp
@@ -255,7 +255,7 @@ void ContainerExpression<TContainerType, TMeshType>::SetExpression(Expression::P
 }
 
 template <class TContainerType, class TMeshType>
-const bool ContainerExpression<TContainerType, TMeshType>::HasExpression() const
+bool ContainerExpression<TContainerType, TMeshType>::HasExpression() const
 {
     return mpExpression.has_value();
 }

--- a/kratos/containers/container_expression/container_expression.cpp
+++ b/kratos/containers/container_expression/container_expression.cpp
@@ -25,23 +25,110 @@
 
 namespace Kratos {
 
+namespace ContainerExpressionHelperUtilities
+{
+template <class TMeshType>
+ModelPart::MeshType& GetMesh(ModelPart& rModelPart);
+
+template<>
+ModelPart::MeshType& GetMesh<MeshType::Local>(ModelPart& rModelPart)
+{
+    return rModelPart.GetCommunicator().LocalMesh();
+}
+
+template<>
+ModelPart::MeshType& GetMesh<MeshType::Ghost>(ModelPart& rModelPart)
+{
+    return rModelPart.GetCommunicator().GhostMesh();
+}
+
+template<>
+ModelPart::MeshType& GetMesh<MeshType::Interface>(ModelPart& rModelPart)
+{
+    return rModelPart.GetCommunicator().InterfaceMesh();
+}
+
+template <class TMeshType>
+const ModelPart::MeshType& GetMesh(const ModelPart& rModelPart);
+
+template<>
+const ModelPart::MeshType& GetMesh<MeshType::Local>(const ModelPart& rModelPart)
+{
+    return rModelPart.GetCommunicator().LocalMesh();
+}
+
+template<>
+const ModelPart::MeshType& GetMesh<MeshType::Ghost>(const ModelPart& rModelPart)
+{
+    return rModelPart.GetCommunicator().GhostMesh();
+}
+
+template<>
+const ModelPart::MeshType& GetMesh<MeshType::Interface>(const ModelPart& rModelPart)
+{
+    return rModelPart.GetCommunicator().InterfaceMesh();
+}
+
 template <class TContainerType>
-ContainerExpression<TContainerType>::ContainerExpression(ModelPart& rModelPart)
+TContainerType& GetContainer(ModelPart::MeshType &rMesh);
+
+template<>
+ModelPart::NodesContainerType& GetContainer<ModelPart::NodesContainerType>(ModelPart::MeshType& rMesh)
+{
+    return rMesh.Nodes();
+}
+
+template<>
+ModelPart::ConditionsContainerType& GetContainer<ModelPart::ConditionsContainerType>(ModelPart::MeshType& rMesh)
+{
+    return rMesh.Conditions();
+}
+
+template<>
+ModelPart::ElementsContainerType& GetContainer<ModelPart::ElementsContainerType>(ModelPart::MeshType& rMesh)
+{
+    return rMesh.Elements();
+}
+
+template <class TContainerType>
+const TContainerType& GetContainer(const ModelPart::MeshType &rMesh);
+
+template<>
+const ModelPart::NodesContainerType& GetContainer<ModelPart::NodesContainerType>(const ModelPart::MeshType& rMesh)
+{
+    return rMesh.Nodes();
+}
+
+template<>
+const ModelPart::ConditionsContainerType& GetContainer<ModelPart::ConditionsContainerType>(const ModelPart::MeshType& rMesh)
+{
+    return rMesh.Conditions();
+}
+
+template<>
+const ModelPart::ElementsContainerType& GetContainer<ModelPart::ElementsContainerType>(const ModelPart::MeshType& rMesh){
+    return rMesh.Elements();
+}
+
+} // namespace ContainerExpressionHelperUtilities
+
+template <class TContainerType, class TMeshType>
+ContainerExpression<TContainerType, TMeshType>::ContainerExpression(ModelPart& rModelPart)
     : mpExpression(),
       mpModelPart(&rModelPart)
 {
 }
 
-template <class TContainerType>
-ContainerExpression<TContainerType>::ContainerExpression(
+template <class TContainerType, class TMeshType>
+ContainerExpression<TContainerType, TMeshType>::ContainerExpression(
     const ContainerExpression& rOther)
     : mpExpression(rOther.mpExpression),
       mpModelPart(rOther.mpModelPart)
 {
 }
-template <class TContainerType>
-void ContainerExpression<TContainerType>::CopyFrom(
-    const ContainerExpression<TContainerType>& rOther)
+template <class TContainerType, class TMeshType>
+void ContainerExpression<TContainerType, TMeshType>::CopyFrom(
+    const ContainerExpression<TContainerType, TMeshType>& rOther)
 {
     KRATOS_ERROR_IF(this->GetContainer().size() != rOther.GetContainer().size())
         << "Mismatching model parts found with different number of entities in CopyFrom operation.\n"
@@ -51,8 +138,8 @@ void ContainerExpression<TContainerType>::CopyFrom(
     mpExpression = rOther.mpExpression;
 }
 
-template <class TContainerType>
-void ContainerExpression<TContainerType>::Read(
+template <class TContainerType, class TMeshType>
+void ContainerExpression<TContainerType, TMeshType>::Read(
     double const* pBegin,
     const int NumberOfEntities,
     int const* pShapeBegin,
@@ -90,8 +177,8 @@ void ContainerExpression<TContainerType>::Read(
     KRATOS_CATCH("");
 }
 
-template <class TContainerType>
-void ContainerExpression<TContainerType>::MoveFrom(
+template <class TContainerType, class TMeshType>
+void ContainerExpression<TContainerType, TMeshType>::MoveFrom(
     double* pBegin,
     const int NumberOfEntities,
     int const* pShapeBegin,
@@ -116,8 +203,8 @@ void ContainerExpression<TContainerType>::MoveFrom(
     KRATOS_CATCH("");
 }
 
-template <class TContainerType>
-void ContainerExpression<TContainerType>::Evaluate(
+template <class TContainerType, class TMeshType>
+void ContainerExpression<TContainerType, TMeshType>::Evaluate(
     double* pBegin,
     const int NumberOfEntities,
     int const* pShapeBegin,
@@ -155,93 +242,69 @@ void ContainerExpression<TContainerType>::Evaluate(
     KRATOS_CATCH("");
 }
 
-template <class TContainerType>
-void ContainerExpression<TContainerType>::SetDataToZero()
+template <class TContainerType, class TMeshType>
+void ContainerExpression<TContainerType, TMeshType>::SetDataToZero()
 {
     mpExpression = LiteralExpression<double>::Create(0.0);
 }
 
-template <class TContainerType>
-void ContainerExpression<TContainerType>::SetExpression(Expression::Pointer pExpression)
+template <class TContainerType, class TMeshType>
+void ContainerExpression<TContainerType, TMeshType>::SetExpression(Expression::Pointer pExpression)
 {
     this->mpExpression = pExpression;
 }
 
-template <class TContainerType>
-const Expression& ContainerExpression<TContainerType>::GetExpression() const
+template <class TContainerType, class TMeshType>
+const Expression& ContainerExpression<TContainerType, TMeshType>::GetExpression() const
 {
     return *(*mpExpression);
 }
 
 
-template <class TContainerType>
-const Expression::Pointer ContainerExpression<TContainerType>::pGetExpression() const
+template <class TContainerType, class TMeshType>
+const Expression::Pointer ContainerExpression<TContainerType, TMeshType>::pGetExpression() const
 {
     return *mpExpression;
 }
 
-template <class TContainerType>
-const std::vector<std::size_t> ContainerExpression<TContainerType>::GetShape() const
+template <class TContainerType, class TMeshType>
+const std::vector<std::size_t> ContainerExpression<TContainerType, TMeshType>::GetShape() const
 {
     return this->GetExpression().GetShape();
 }
 
-template <class TContainerType>
-std::size_t ContainerExpression<TContainerType>::GetFlattenedSize() const
+template <class TContainerType, class TMeshType>
+std::size_t ContainerExpression<TContainerType, TMeshType>::GetFlattenedSize() const
 {
     return this->GetExpression().GetFlattenedSize();
 }
 
-template <class TContainerType>
-ModelPart& ContainerExpression<TContainerType>::GetModelPart()
+template <class TContainerType, class TMeshType>
+ModelPart& ContainerExpression<TContainerType, TMeshType>::GetModelPart()
 {
     return *mpModelPart;
 }
 
-template <class TContainerType>
-const ModelPart& ContainerExpression<TContainerType>::GetModelPart() const
+template <class TContainerType, class TMeshType>
+const ModelPart& ContainerExpression<TContainerType, TMeshType>::GetModelPart() const
 {
     return *mpModelPart;
 }
 
-template <>
-ModelPart::NodesContainerType& ContainerExpression<ModelPart::NodesContainerType>::GetContainer()
+template <class TContainerType, class TMeshType>
+TContainerType& ContainerExpression<TContainerType, TMeshType>::GetContainer()
 {
-    return mpModelPart->GetCommunicator().LocalMesh().Nodes();
+    return ContainerExpressionHelperUtilities::GetContainer<TContainerType>(ContainerExpressionHelperUtilities::GetMesh<TMeshType>(*mpModelPart));
 }
 
-template <>
-ModelPart::ConditionsContainerType& ContainerExpression<ModelPart::ConditionsContainerType>::GetContainer()
+template <class TContainerType, class TMeshType>
+const TContainerType& ContainerExpression<TContainerType, TMeshType>::GetContainer() const
 {
-    return mpModelPart->GetCommunicator().LocalMesh().Conditions();
+    return ContainerExpressionHelperUtilities::GetContainer<TContainerType>(ContainerExpressionHelperUtilities::GetMesh<TMeshType>(*mpModelPart));
 }
 
-template <>
-ModelPart::ElementsContainerType& ContainerExpression<ModelPart::ElementsContainerType>::GetContainer()
-{
-    return mpModelPart->GetCommunicator().LocalMesh().Elements();
-}
-
-template <>
-const ModelPart::NodesContainerType& ContainerExpression<ModelPart::NodesContainerType>::GetContainer() const
-{
-    return mpModelPart->GetCommunicator().LocalMesh().Nodes();
-}
-
-template <>
-const ModelPart::ConditionsContainerType& ContainerExpression<ModelPart::ConditionsContainerType>::GetContainer() const
-{
-    return mpModelPart->GetCommunicator().LocalMesh().Conditions();
-}
-
-template <>
-const ModelPart::ElementsContainerType& ContainerExpression<ModelPart::ElementsContainerType>::GetContainer() const
-{
-    return mpModelPart->GetCommunicator().LocalMesh().Elements();
-}
-
-template <class TContainerType>
-std::string ContainerExpression<TContainerType>::Info() const
+template <class TContainerType, class TMeshType>
+std::string ContainerExpression<TContainerType, TMeshType>::Info() const
 {
     std::stringstream msg;
 
@@ -261,8 +324,8 @@ std::string ContainerExpression<TContainerType>::Info() const
     return msg.str();
 }
 
-template <class TContainerType>
-std::string ContainerExpression<TContainerType>::PrintData() const
+template <class TContainerType, class TMeshType>
+std::string ContainerExpression<TContainerType, TMeshType>::PrintData() const
 {
     std::stringstream msg;
     msg << this->Info();
@@ -270,8 +333,16 @@ std::string ContainerExpression<TContainerType>::PrintData() const
 }
 
 // template instantiations
-template class ContainerExpression<ModelPart::NodesContainerType>;
-template class ContainerExpression<ModelPart::ConditionsContainerType>;
-template class ContainerExpression<ModelPart::ElementsContainerType>;
+template class ContainerExpression<ModelPart::NodesContainerType, MeshType::Local>;
+template class ContainerExpression<ModelPart::ConditionsContainerType, MeshType::Local>;
+template class ContainerExpression<ModelPart::ElementsContainerType, MeshType::Local>;
+
+template class ContainerExpression<ModelPart::NodesContainerType, MeshType::Ghost>;
+template class ContainerExpression<ModelPart::ConditionsContainerType, MeshType::Ghost>;
+template class ContainerExpression<ModelPart::ElementsContainerType, MeshType::Ghost>;
+
+template class ContainerExpression<ModelPart::NodesContainerType, MeshType::Interface>;
+template class ContainerExpression<ModelPart::ConditionsContainerType, MeshType::Interface>;
+template class ContainerExpression<ModelPart::ElementsContainerType, MeshType::Interface>;
 
 } // namespace Kratos

--- a/kratos/containers/container_expression/container_expression.h
+++ b/kratos/containers/container_expression/container_expression.h
@@ -29,6 +29,12 @@ namespace Kratos {
 ///@name Kratos Classes
 ///@{
 
+namespace MeshType {
+    struct Local     {};
+    struct Ghost     {};
+    struct Interface {};
+} // namespace MeshTypes
+
 /**
  * @brief Container variable data holder
  *
@@ -72,9 +78,10 @@ namespace Kratos {
  *
  * This class is optimized and compatible with OpenMP and MPI.
  *
- * @tparam TContainerType
+ * @tparam TContainerType       Container type, should be nodal, condition or elemental.
+ * @tparam TMeshType            Mesh type, should be Local, Ghost or Interface
  */
-template <class TContainerType>
+template <class TContainerType, class TMeshType = MeshType::Local>
 class KRATOS_API(KRATOS_CORE) ContainerExpression {
 public:
     ///@name Type definitions
@@ -104,7 +111,7 @@ public:
      *
      * @param rOther        Other container variable data
      */
-    void CopyFrom(const ContainerExpression<TContainerType>& rOther);
+    void CopyFrom(const ContainerExpression<TContainerType, TMeshType>& rOther);
 
     /**
      * @brief Reads data from c like interface
@@ -140,9 +147,9 @@ public:
     /**
      * @brief Move data from pBegin array to internal structure.
      *
-     * @warning This instance does not take the ownership of the passed array. 
+     * @warning This instance does not take the ownership of the passed array.
      *  The life time of the passed array is not managed by this instance
-     * @warning Seg faults if this is used when passed @ref pBegin was destroyed. 
+     * @warning Seg faults if this is used when passed @ref pBegin was destroyed.
      *
      * @param pBegin            Starting pointer to the data.
      * @param NumberOfEntities  Number of entities present in data.
@@ -206,6 +213,14 @@ public:
      * @param pExpression       Expression to be used in this container variable data
      */
     void SetExpression(Expression::Pointer pExpression);
+
+    /**
+     * @brief Checks whether an expression has been initialized.
+     *
+     * @return true             If an expression is initialized.
+     * @return false            If an expression is not initialized.
+     */
+    const bool HasExpression() const;
 
     /**
      * @brief Get the Expression

--- a/kratos/containers/container_expression/container_expression.h
+++ b/kratos/containers/container_expression/container_expression.h
@@ -220,7 +220,7 @@ public:
      * @return true             If an expression is initialized.
      * @return false            If an expression is not initialized.
      */
-    const bool HasExpression() const;
+    bool HasExpression() const;
 
     /**
      * @brief Get the Expression

--- a/kratos/containers/container_expression/specialized_container_expression.h
+++ b/kratos/containers/container_expression/specialized_container_expression.h
@@ -47,16 +47,17 @@ namespace Kratos {
  *
  * This class can take advantage of OpenMP and MPI.
  *
- * @tparam TContainerType           Container type
- * @tparam TContainerDataIO         Container entity input/output type
+ * @tparam TContainerType           Container type.
+ * @tparam TContainerDataIO         Container entity input/output type.
+ * @tparam TMeshType                Mesh type, should be Local, Ghost or Interface.
  */
-template <class TContainerType, class TContainerDataIO>
-class SpecializedContainerExpression : public ContainerExpression<TContainerType> {
+template <class TContainerType, class TContainerDataIO, class TMeshType = MeshType::Local>
+class SpecializedContainerExpression : public ContainerExpression<TContainerType, TMeshType> {
 public:
     ///@name Type definitions
     ///@{
 
-    using BaseType = ContainerExpression<TContainerType>;
+    using BaseType = ContainerExpression<TContainerType, TMeshType>;
 
     using IndexType = std::size_t;
 
@@ -214,10 +215,10 @@ public:
 
 ///@}
 /// output stream function
-template<class TContainerType, class TContainerDataIO>
+template <class TContainerType, class TContainerDataIO, class TMeshType>
 inline std::ostream& operator<<(
     std::ostream& rOStream,
-    const SpecializedContainerExpression<TContainerType, TContainerDataIO>& rThis)
+    const SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& rThis)
 {
     return rOStream << rThis.Info();
 }

--- a/kratos/containers/container_expression/specialized_container_expression_impl.h
+++ b/kratos/containers/container_expression/specialized_container_expression_impl.h
@@ -27,8 +27,8 @@
 
 namespace Kratos {
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO>& SpecializedContainerExpression<TContainerType, TContainerDataIO>::operator=(const SpecializedContainerExpression& rOther)
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::operator=(const SpecializedContainerExpression& rOther)
 {
     KRATOS_ERROR_IF(this->GetContainer().size() != rOther.GetContainer().size())
         << "Mismatching model parts found with different number of entities in assignment operation.\n"
@@ -39,15 +39,15 @@ SpecializedContainerExpression<TContainerType, TContainerDataIO>& SpecializedCon
     return *this;
 }
 
-template <class TContainerType, class TContainerDataIO>
-typename SpecializedContainerExpression<TContainerType, TContainerDataIO>::Pointer SpecializedContainerExpression<TContainerType, TContainerDataIO>::Clone() const
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+typename SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::Pointer SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::Clone() const
 {
-    return Kratos::make_shared<SpecializedContainerExpression<TContainerType, TContainerDataIO>>(*this);
+    return Kratos::make_shared<SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>>(*this);
 }
 
-template <class TContainerType, class TContainerDataIO>
+template <class TContainerType, class TContainerDataIO, class TMeshType>
 template<class TDataType>
-void SpecializedContainerExpression<TContainerType, TContainerDataIO>::Read(const Variable<TDataType>& rVariable)
+void SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::Read(const Variable<TDataType>& rVariable)
 {
     KRATOS_TRY
 
@@ -71,9 +71,9 @@ void SpecializedContainerExpression<TContainerType, TContainerDataIO>::Read(cons
     KRATOS_CATCH("")
 }
 
-template <class TContainerType, class TContainerDataIO>
+template <class TContainerType, class TContainerDataIO, class TMeshType>
 template<class TDataType>
-void SpecializedContainerExpression<TContainerType, TContainerDataIO>::Evaluate(const Variable<TDataType>& rVariable)
+void SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::Evaluate(const Variable<TDataType>& rVariable)
 {
     KRATOS_TRY
 
@@ -131,35 +131,35 @@ void SpecializedContainerExpression<TContainerType, TContainerDataIO>::Evaluate(
     KRATOS_CATCH("");
 }
 
-template <class TContainerType, class TContainerDataIO>
+template <class TContainerType, class TContainerDataIO, class TMeshType>
 template<class TDataType>
-void SpecializedContainerExpression<TContainerType, TContainerDataIO>::SetData(const TDataType& rValue)
+void SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::SetData(const TDataType& rValue)
 {
     this->mpExpression = LiteralExpression<TDataType>::Create(rValue);
 }
 
-template <class TContainerType, class TContainerDataIO>
+template <class TContainerType, class TContainerDataIO, class TMeshType>
 template<class TDataType>
-void SpecializedContainerExpression<TContainerType, TContainerDataIO>::SetZero(const Variable<TDataType>& rVariable)
+void SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::SetZero(const Variable<TDataType>& rVariable)
 {
     this->SetData(rVariable.Zero());
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO> SpecializedContainerExpression<TContainerType, TContainerDataIO>::operator+(const SpecializedContainerExpression<TContainerType, TContainerDataIO>& rOther) const
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::operator+(const SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& rOther) const
 {
     KRATOS_ERROR_IF(this->GetContainer().size() != rOther.GetContainer().size())
         << "Mismatching model parts found with different number of entities in addition operation.\n"
         << "      Left operand data : " << *this << "\n"
         << "      Right operand data: " << rOther << "\n";
 
-    SpecializedContainerExpression<TContainerType, TContainerDataIO> result(*(this->mpModelPart));
+    SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> result(*(this->mpModelPart));
     result.mpExpression = BinaryExpression<BinaryOperations::Addition>::Create(*this->mpExpression, *rOther.mpExpression);
     return result;
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO>& SpecializedContainerExpression<TContainerType, TContainerDataIO>::operator+=(const SpecializedContainerExpression<TContainerType, TContainerDataIO>& rOther)
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::operator+=(const SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& rOther)
 {
     KRATOS_ERROR_IF(this->GetContainer().size() != rOther.GetContainer().size())
         << "Mismatching model parts found with different number of entities in addition operation.\n"
@@ -170,37 +170,37 @@ SpecializedContainerExpression<TContainerType, TContainerDataIO>& SpecializedCon
     return *this;
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO> SpecializedContainerExpression<TContainerType, TContainerDataIO>::operator+(const double Value) const
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::operator+(const double Value) const
 {
 
-    SpecializedContainerExpression<TContainerType, TContainerDataIO> result(*(this->mpModelPart));
+    SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> result(*(this->mpModelPart));
     result.mpExpression = BinaryExpression<BinaryOperations::Addition>::Create(*this->mpExpression, LiteralExpression<double>::Create(Value));
     return result;
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO>& SpecializedContainerExpression<TContainerType, TContainerDataIO>::operator+=(const double Value)
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::operator+=(const double Value)
 {
     this->mpExpression = BinaryExpression<BinaryOperations::Addition>::Create(*this->mpExpression, LiteralExpression<double>::Create(Value));
     return *this;
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO> SpecializedContainerExpression<TContainerType, TContainerDataIO>::operator-(const SpecializedContainerExpression<TContainerType, TContainerDataIO>& rOther) const
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::operator-(const SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& rOther) const
 {
     KRATOS_ERROR_IF(this->GetContainer().size() != rOther.GetContainer().size())
         << "Mismatching model parts found with different number of entities in substraction operation.\n"
         << "      Left operand data : " << *this << "\n"
         << "      Right operand data: " << rOther << "\n";
 
-    SpecializedContainerExpression<TContainerType, TContainerDataIO> result(*(this->mpModelPart));
+    SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> result(*(this->mpModelPart));
     result.mpExpression = BinaryExpression<BinaryOperations::Substraction>::Create(*this->mpExpression, *rOther.mpExpression);
     return result;
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO>& SpecializedContainerExpression<TContainerType, TContainerDataIO>::operator-=(const SpecializedContainerExpression<TContainerType, TContainerDataIO>& rOther)
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::operator-=(const SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& rOther)
 {
     KRATOS_ERROR_IF(this->GetContainer().size() != rOther.GetContainer().size())
         << "Mismatching model parts found with different number of entities in substraction operation.\n"
@@ -211,36 +211,36 @@ SpecializedContainerExpression<TContainerType, TContainerDataIO>& SpecializedCon
     return *this;
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO> SpecializedContainerExpression<TContainerType, TContainerDataIO>::operator-(const double Value) const
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::operator-(const double Value) const
 {
-    SpecializedContainerExpression<TContainerType, TContainerDataIO> result(*(this->mpModelPart));
+    SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> result(*(this->mpModelPart));
     result.mpExpression = BinaryExpression<BinaryOperations::Substraction>::Create(*this->mpExpression, LiteralExpression<double>::Create(Value));
     return result;
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO>& SpecializedContainerExpression<TContainerType, TContainerDataIO>::operator-=(const double Value)
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::operator-=(const double Value)
 {
     this->mpExpression = BinaryExpression<BinaryOperations::Substraction>::Create(*this->mpExpression, LiteralExpression<double>::Create(Value));
     return *this;
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO> SpecializedContainerExpression<TContainerType, TContainerDataIO>::operator*(const SpecializedContainerExpression<TContainerType, TContainerDataIO>& rOther) const
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::operator*(const SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& rOther) const
 {
     KRATOS_ERROR_IF(this->GetContainer().size() != rOther.GetContainer().size())
         << "Mismatching model parts found with different number of entities in substraction operation.\n"
         << "      Left operand data : " << *this << "\n"
         << "      Right operand data: " << rOther << "\n";
 
-    SpecializedContainerExpression<TContainerType, TContainerDataIO> result(*(this->mpModelPart));
+    SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> result(*(this->mpModelPart));
     result.mpExpression = BinaryExpression<BinaryOperations::Multiplication>::Create(*this->mpExpression, *rOther.mpExpression);
     return result;
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO>& SpecializedContainerExpression<TContainerType, TContainerDataIO>::operator*=(const SpecializedContainerExpression<TContainerType, TContainerDataIO>& rOther)
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::operator*=(const SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& rOther)
 {
     KRATOS_ERROR_IF(this->GetContainer().size() != rOther.GetContainer().size())
         << "Mismatching model parts found with different number of entities in substraction operation.\n"
@@ -251,36 +251,36 @@ SpecializedContainerExpression<TContainerType, TContainerDataIO>& SpecializedCon
     return *this;
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO> SpecializedContainerExpression<TContainerType, TContainerDataIO>::operator*(const double Value) const
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::operator*(const double Value) const
 {
-    SpecializedContainerExpression<TContainerType, TContainerDataIO> result(*(this->mpModelPart));
+    SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> result(*(this->mpModelPart));
     result.mpExpression = BinaryExpression<BinaryOperations::Multiplication>::Create(*this->mpExpression, LiteralExpression<double>::Create(Value));
     return result;
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO>& SpecializedContainerExpression<TContainerType, TContainerDataIO>::operator*=(const double Value)
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::operator*=(const double Value)
 {
     this->mpExpression = BinaryExpression<BinaryOperations::Multiplication>::Create(*this->mpExpression, LiteralExpression<double>::Create(Value));
     return *this;
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO> SpecializedContainerExpression<TContainerType, TContainerDataIO>::operator/(const SpecializedContainerExpression<TContainerType, TContainerDataIO>& rOther) const
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::operator/(const SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& rOther) const
 {
     KRATOS_ERROR_IF(this->GetContainer().size() != rOther.GetContainer().size())
         << "Mismatching model parts found with different number of entities in substraction operation.\n"
         << "      Left operand data : " << *this << "\n"
         << "      Right operand data: " << rOther << "\n";
 
-    SpecializedContainerExpression<TContainerType, TContainerDataIO> result(*(this->mpModelPart));
+    SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> result(*(this->mpModelPart));
     result.mpExpression = BinaryExpression<BinaryOperations::Division>::Create(*this->mpExpression, *rOther.mpExpression);
     return result;
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO>& SpecializedContainerExpression<TContainerType, TContainerDataIO>::operator/=(const SpecializedContainerExpression<TContainerType, TContainerDataIO>& rOther)
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::operator/=(const SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& rOther)
 {
     KRATOS_ERROR_IF(this->GetContainer().size() != rOther.GetContainer().size())
         << "Mismatching model parts found with different number of entities in substraction operation.\n"
@@ -291,21 +291,21 @@ SpecializedContainerExpression<TContainerType, TContainerDataIO>& SpecializedCon
     return *this;
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO> SpecializedContainerExpression<TContainerType, TContainerDataIO>::operator/(const double Value) const
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::operator/(const double Value) const
 {
     KRATOS_ERROR_IF(std::abs(Value) < std::numeric_limits<double>::epsilon())
         << "Division by zero.\n"
         << "      Left operand data : " << *this << "\n"
         << "      Divisor           : " << Value << "\n";
 
-    SpecializedContainerExpression<TContainerType, TContainerDataIO> result(*(this->mpModelPart));
+    SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> result(*(this->mpModelPart));
     result.mpExpression = BinaryExpression<BinaryOperations::Multiplication>::Create(*this->mpExpression, LiteralExpression<double>::Create(1.0 / Value));
     return result;
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO>& SpecializedContainerExpression<TContainerType, TContainerDataIO>::operator/=(const double Value)
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::operator/=(const double Value)
 {
     KRATOS_ERROR_IF(std::abs(Value) < std::numeric_limits<double>::epsilon())
         << "Division by zero.\n"
@@ -316,29 +316,29 @@ SpecializedContainerExpression<TContainerType, TContainerDataIO>& SpecializedCon
     return *this;
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO> SpecializedContainerExpression<TContainerType, TContainerDataIO>::Pow(const SpecializedContainerExpression<TContainerType, TContainerDataIO>& rOther) const
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::Pow(const SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>& rOther) const
 {
     KRATOS_ERROR_IF(this->GetContainer().size() != rOther.GetContainer().size())
         << "Mismatching model parts found with different number of entities in substraction operation.\n"
         << "      Left operand data : " << *this << "\n"
         << "      Right operand data: " << rOther << "\n";
 
-    SpecializedContainerExpression<TContainerType, TContainerDataIO> result(*(this->mpModelPart));
+    SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> result(*(this->mpModelPart));
     result.mpExpression = BinaryExpression<BinaryOperations::Power>::Create(*this->mpExpression, *rOther.mpExpression);
     return result;
 }
 
-template <class TContainerType, class TContainerDataIO>
-SpecializedContainerExpression<TContainerType, TContainerDataIO> SpecializedContainerExpression<TContainerType, TContainerDataIO>::Pow(const double Value) const
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::Pow(const double Value) const
 {
-    SpecializedContainerExpression<TContainerType, TContainerDataIO> result(*(this->mpModelPart));
+    SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType> result(*(this->mpModelPart));
     result.mpExpression = BinaryExpression<BinaryOperations::Power>::Create(*this->mpExpression, LiteralExpression<double>::Create(Value));
     return result;
 }
 
-template <class TContainerType, class TContainerDataIO>
-std::string SpecializedContainerExpression<TContainerType, TContainerDataIO>::Info() const
+template <class TContainerType, class TContainerDataIO, class TMeshType>
+std::string SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>::Info() const
 {
     std::stringstream msg;
 

--- a/kratos/python/add_container_expression_to_python_utils.h
+++ b/kratos/python/add_container_expression_to_python_utils.h
@@ -107,6 +107,7 @@ void AddContainerExpressionToPython(pybind11::module& m, const std::string& rNam
                            shape.data(),
                            shape.size());
         }, py::arg("numpy_array").noconvert())
+        .def("HasExpression", &container_expression_holder_base::HasExpression)
         .def("Read", &container_expression_holder_base::Read, py::arg("starting_value"), py::arg("number_of_entities"), py::arg("starting_value_of_shape"), py::arg("shape_size"))
         .def("GetModelPart", py::overload_cast<>(&container_expression_holder_base::GetModelPart), py::return_value_policy::reference)
         .def("GetContainer", py::overload_cast<>(&container_expression_holder_base::GetContainer), py::return_value_policy::reference)


### PR DESCRIPTION
**📝 Description**
As in the title, this extends `ContainerExpression` and `CollectiveContainerExpression` to ghost and interface meshes. These ghost and interface mesh extension is not exposed to python, because it is not intended to be used in python. Local mesh param is used as default in all.

Apart from this, I added `HasExpression` to return whether the `ContainerExpression` is initialized with an `Expression`.

**🆕 Changelog**
- Extends `ContainerExpression` to `ContainerExpression::MeshTypes::Local`, `ContainerExpression::MeshTypes::Ghost`, `ContainerExpression::MeshTypes::Interface`.
- Extends `SpecializedContainerExpression` to `ContainerExpression::MeshTypes::Local`, `ContainerExpression::MeshTypes::Ghost`, `ContainerExpression::MeshTypes::Interface`.
- Added `ContainerExpression::HasExpression`