### PR TITLE
[HDF5] Replace Dimension in XDMF Generation

### DIFF
--- a/applications/HDF5Application/custom_processes/hdf5_xdmf_connectivities_writer_process.cpp
+++ b/applications/HDF5Application/custom_processes/hdf5_xdmf_connectivities_writer_process.cpp
@@ -101,14 +101,13 @@ void XdmfConnectivitiesWriterProcess::CreateXdmfConnectivities(const std::string
     int tmp;
     mpFile->ReadAttribute(rKratosConnectivitiesPath, "WorkingSpaceDimension", tmp);
     mpFile->WriteAttribute(rXdmfConnectivitiesPath, "WorkingSpaceDimension", tmp);
-    mpFile->ReadAttribute(rKratosConnectivitiesPath, "Dimension", tmp);
     mpFile->WriteAttribute(rXdmfConnectivitiesPath, "Dimension", tmp);
     mpFile->ReadAttribute(rKratosConnectivitiesPath, "NumberOfNodes", tmp);
     mpFile->WriteAttribute(rXdmfConnectivitiesPath, "NumberOfNodes", tmp);
 
     KRATOS_CATCH("");
 }
-    
+
 void XdmfConnectivitiesWriterProcess::CreateXdmfPoints(
     const std::string& rKratosNodeIdsPath,
     const std::string& rXdmfNodeIdsPath) const

--- a/applications/HDF5Application/python_scripts/xdmf_utils.py
+++ b/applications/HDF5Application/python_scripts/xdmf_utils.py
@@ -150,7 +150,7 @@ def CreateXdmfSpatialGrid(h5_model_part):
         else:
             for name, value in current_h5_item.items():
                 cell_type = TopologyCellType(
-                    value.attrs["Dimension"], value.attrs["NumberOfNodes"])
+                    value.attrs["WorkingSpaceDimension"], value.attrs["NumberOfNodes"])
                 connectivities = HDF5UniformDataItem(value["Connectivities"])
                 topology = UniformMeshTopology(cell_type, connectivities)
                 sgrid.add_grid(UniformGrid(spatial_grid_name + "." + name, geom, topology))
@@ -631,4 +631,4 @@ def WriteSinglefileTemporalAnalysisToXdmf(h5_file_name, h5path_pattern_to_mesh, 
     domain = Domain(temporal_grid)
     xdmf = Xdmf(domain)
     # Write the XML tree containing the XDMF metadata to the file.
-    ET.ElementTree(xdmf.create_xml_element()).write(h5_file_name[:h5_file_name.rfind(".")] + ".xdmf")    
+    ET.ElementTree(xdmf.create_xml_element()).write(h5_file_name[:h5_file_name.rfind(".")] + ".xdmf")

--- a/applications/HDF5Application/tests/test_hdf5_xdmf.py
+++ b/applications/HDF5Application/tests/test_hdf5_xdmf.py
@@ -57,7 +57,7 @@ class TestCreateXdmfSpatialGrid(KratosUnittest.TestCase):
             f.create_dataset(
                 "/ModelPart/Nodes/Local/Coordinates", (15, 3), "float64")
             elem2d4n = f.create_group("/ModelPart/Xdmf/Elements/Element2D4N")
-            elem2d4n.attrs["Dimension"] = 2
+            elem2d4n.attrs["WorkingSpaceDimension"] = 2
             elem2d4n.attrs["NumberOfNodes"] = 4
             elem2d4n.create_dataset("Connectivities", (10, 4), "int32")
             sgrid = CreateXdmfSpatialGrid(f["/ModelPart"])
@@ -264,7 +264,7 @@ class TestCreateXdmfTemporalGridFromMultifile(KratosUnittest.TestCase):
             f0.create_dataset(
             "/ModelPart/Nodes/Local/Coordinates", (15, 3), "float64")
             elem2d4n = f0.create_group("/ModelPart/Xdmf/Elements/Element2D4N")
-            elem2d4n.attrs["Dimension"] = 2
+            elem2d4n.attrs["WorkingSpaceDimension"] = 2
             elem2d4n.attrs["NumberOfNodes"] = 4
             elem2d4n.create_dataset("Connectivities", (10, 4), "int32")
         with h5py.File("kratos-1.0.h5", "w") as f1:
@@ -302,7 +302,7 @@ class TestCreateXdmfTemporalGridFromMultifile(KratosUnittest.TestCase):
             f.create_dataset(
             "/ModelPart/Nodes/Local/Coordinates", (20, 3), "float64")
             elem2d4n = f.create_group("/ModelPart/Xdmf/Elements/Element3D3N")
-            elem2d4n.attrs["Dimension"] = 3
+            elem2d4n.attrs["WorkingSpaceDimension"] = 3
             elem2d4n.attrs["NumberOfNodes"] = 3
             elem2d4n.create_dataset("Connectivities", (8, 3), "int32")
             f.create_dataset(


### PR DESCRIPTION
## Description
`Dimension` got replaced with `LocalSpaceDimension` and `WorkingSpaceDimension` and as a result, XDMF generation has been crashing because it didn't get updated (there aren't any tests for it in the CI). I've replaced `Dimension` with `WorkingSpaceDimension` in `XdmfConnectivitiesWriterProcess` though I'm not a 100% sure it's the right way to go.

## ToDo
Write XDMF generation tests and include them in the CI (requires `h5py`).
