### PR TITLE
[Structural][Hotfix] Integration order base solid element correction

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -64,7 +64,7 @@ void BaseSolidElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
             }
         }
 
-        const GeometryType::IntegrationPointsArrayType& integration_points = this->IntegrationPoints();
+        const auto& integration_points = this->IntegrationPoints(mThisIntegrationMethod);
 
         //Constitutive Law initialisation
         if ( mConstitutiveLawVector.size() != integration_points.size() )


### PR DESCRIPTION
**📝 Description**
This fixes the usage of non-default integration orders in the base solid element. As it is right now, the constitutive law vector has a wrong size, leading to a segmentation fault when evaluating the material response.
