### PR TITLE
RomApp Bugfix HROM Modelpart Part Creation

### DIFF
--- a/applications/RomApplication/python_scripts/hrom_training_utility.py
+++ b/applications/RomApplication/python_scripts/hrom_training_utility.py
@@ -244,12 +244,12 @@ class HRomTrainingUtility(object):
 
     def __CreateDictionaryWithRomElementsAndWeights(self, weights = None, indexes=None, number_of_elements = None):
 
+        if number_of_elements is None:
+            number_of_elements = self.solver.GetComputingModelPart().NumberOfElements()
         if weights is None:
             weights = np.r_[np.load('HROM_ElementWeights.npy'),np.load('HROM_ConditionWeights.npy')]
         if indexes is None:
-            indexes = np.r_[np.load('HROM_ElementIds.npy'),np.load('HROM_ConditionIds.npy')]
-        if number_of_elements is None:
-            number_of_elements = self.solver.GetComputingModelPart().NumberOfElements()
+            indexes = np.r_[np.load('HROM_ElementIds.npy'),np.load('HROM_ConditionIds.npy')+number_of_elements]
 
         hrom_weights = {}
         hrom_weights["Elements"] = {}


### PR DESCRIPTION
**📝 Description**
This PR adresses a bug in the current implementation of the workflow when using either the RomManager or when runing the workflow by hand inputting the correct flags to the RomParameters.json

The bug was not detected before because it is only present if the basis format selected is Numpy and if the simulation contains CONDITIONS which are selected by the HROM selection algorithm.

In future PRs, we will add more comprehensive tests including tests for the RomManager. And we shall also update the tests of the HROM model part creation with a simulation that does select ELEMENTS + CONDITIONS. I will update the TODOs in the RomApp project accodingly.


**🆕 Changelog**
Changed the placement of 3 lines in a single file: hrom_training_utility.py