### PR TITLE
[Structural] Remove UseGeometryIntegrationMethod from base solid

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -35,33 +35,31 @@ void BaseSolidElement::Initialize(const ProcessInfo& rCurrentProcessInfo)
 
     // Initialization should not be done again in a restart!
     if (!rCurrentProcessInfo[IS_RESTARTED]) {
-        if(this->UseGeometryIntegrationMethod()) {
-            if( GetProperties().Has(INTEGRATION_ORDER) ) {
-                const SizeType integration_order = GetProperties()[INTEGRATION_ORDER];
-                switch ( integration_order )
-                {
-                case 1:
-                    mThisIntegrationMethod = GeometryData::IntegrationMethod::GI_GAUSS_1;
-                    break;
-                case 2:
-                    mThisIntegrationMethod = GeometryData::IntegrationMethod::GI_GAUSS_2;
-                    break;
-                case 3:
-                    mThisIntegrationMethod = GeometryData::IntegrationMethod::GI_GAUSS_3;
-                    break;
-                case 4:
-                    mThisIntegrationMethod = GeometryData::IntegrationMethod::GI_GAUSS_4;
-                    break;
-                case 5:
-                    mThisIntegrationMethod = GeometryData::IntegrationMethod::GI_GAUSS_5;
-                    break;
-                default:
-                    KRATOS_WARNING("BaseSolidElement") << "Integration order " << integration_order << " is not available, using default integration order for the geometry" << std::endl;
-                    mThisIntegrationMethod = GetGeometry().GetDefaultIntegrationMethod();
-                }
-            } else {
+        if( GetProperties().Has(INTEGRATION_ORDER) ) {
+            const SizeType integration_order = GetProperties()[INTEGRATION_ORDER];
+            switch ( integration_order )
+            {
+            case 1:
+                mThisIntegrationMethod = GeometryData::IntegrationMethod::GI_GAUSS_1;
+                break;
+            case 2:
+                mThisIntegrationMethod = GeometryData::IntegrationMethod::GI_GAUSS_2;
+                break;
+            case 3:
+                mThisIntegrationMethod = GeometryData::IntegrationMethod::GI_GAUSS_3;
+                break;
+            case 4:
+                mThisIntegrationMethod = GeometryData::IntegrationMethod::GI_GAUSS_4;
+                break;
+            case 5:
+                mThisIntegrationMethod = GeometryData::IntegrationMethod::GI_GAUSS_5;
+                break;
+            default:
+                KRATOS_WARNING("BaseSolidElement") << "Integration order " << integration_order << " is not available, using default integration order for the geometry" << std::endl;
                 mThisIntegrationMethod = GetGeometry().GetDefaultIntegrationMethod();
             }
+        } else {
+            mThisIntegrationMethod = GetGeometry().GetDefaultIntegrationMethod();
         }
 
         const auto& integration_points = this->IntegrationPoints(mThisIntegrationMethod);
@@ -626,7 +624,7 @@ void BaseSolidElement::CalculateMassMatrix(
 
         Matrix J0(dimension, dimension);
 
-        IntegrationMethod integration_method = UseGeometryIntegrationMethod() ? IntegrationUtilities::GetIntegrationMethodForExactMassMatrixEvaluation(r_geom) : mThisIntegrationMethod ;
+        IntegrationMethod integration_method = IntegrationUtilities::GetIntegrationMethodForExactMassMatrixEvaluation(r_geom);
         const GeometryType::IntegrationPointsArrayType& integration_points = this->IntegrationPoints( integration_method );
         const Matrix& Ncontainer = this->ShapeFunctionsValues(integration_method);
 
@@ -823,13 +821,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
             // calculate the determinatn of the Jacobian in the current configuration
             Vector detJ(number_of_integration_points);
-            if (UseGeometryIntegrationMethod()){
-                detJ = r_geometry.DeterminantOfJacobian(detJ);
-            } else {
-                for (IndexType point_number = 0; point_number < number_of_integration_points; ++point_number) {
-                   detJ[point_number] = r_geometry.DeterminantOfJacobian(integration_points[point_number]);
-                }
-            }
+            detJ = r_geometry.DeterminantOfJacobian(detJ);
 
             // If strain has to be computed inside of the constitutive law with PK2
             Values.SetStrainVector(this_constitutive_variables.StrainVector); //this is the input  parameter
@@ -1140,7 +1132,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
         } else {
             CalculateOnConstitutiveLaw(rVariable, rOutput, rCurrentProcessInfo);
         }
-        
+
 
     }
 }
@@ -1489,7 +1481,7 @@ void BaseSolidElement::CalculateShapeGradientOfMassMatrix(MatrixType& rMassMatri
     const double density = StructuralMechanicsElementUtilities::GetDensityForMassMatrixComputation(*this);
     const double thickness = (dimension == 2 && r_prop.Has(THICKNESS)) ? r_prop[THICKNESS] : 1.0;
 
-    const IntegrationMethod integration_method = this->UseGeometryIntegrationMethod() ? IntegrationUtilities::GetIntegrationMethodForExactMassMatrixEvaluation(r_geom) : mThisIntegrationMethod;
+    const IntegrationMethod integration_method = IntegrationUtilities::GetIntegrationMethodForExactMassMatrixEvaluation(r_geom);
     const Matrix& Ncontainer = this->ShapeFunctionsValues(integration_method);
     Matrix J0(dimension, dimension), DN_DX0_deriv;
     const auto& integration_points = this->IntegrationPoints(integration_method);
@@ -1497,11 +1489,7 @@ void BaseSolidElement::CalculateShapeGradientOfMassMatrix(MatrixType& rMassMatri
         Matrix DN_De;
         GeometryUtils::JacobianOnInitialConfiguration(
             r_geom, integration_points[point_number], J0);
-        if(UseGeometryIntegrationMethod()) {
-            DN_De = r_geom.ShapeFunctionsLocalGradients(integration_method)[point_number];
-        } else {
-            r_geom.ShapeFunctionsLocalGradients(DN_De, integration_points[point_number]);
-        }
+        DN_De = r_geom.ShapeFunctionsLocalGradients(integration_method)[point_number];
         GeometricalSensitivityUtility geometrical_sensitivity(J0, DN_De);
         double detJ0_deriv;
         geometrical_sensitivity.CalculateSensitivity(Deriv, detJ0_deriv, DN_DX0_deriv);
@@ -1736,23 +1724,12 @@ double BaseSolidElement::CalculateDerivativesOnReferenceConfiguration(
 {
     const GeometryType& r_geom = GetGeometry();
     double detJ0;
-    if (UseGeometryIntegrationMethod()) {
-        GeometryUtils::JacobianOnInitialConfiguration(
-            r_geom,
-            this->IntegrationPoints(ThisIntegrationMethod)[PointNumber], rJ0);
-        MathUtils<double>::InvertMatrix(rJ0, rInvJ0, detJ0);
-        const Matrix& rDN_De =
-            GetGeometry().ShapeFunctionsLocalGradients(ThisIntegrationMethod)[PointNumber];
-        GeometryUtils::ShapeFunctionsGradients(rDN_De, rInvJ0, rDN_DX);
-    } else {
-        const auto& integration_points =  this->IntegrationPoints();
-        GeometryUtils::JacobianOnInitialConfiguration(
-            r_geom, integration_points[PointNumber],rJ0);
-        MathUtils<double>::InvertMatrix(rJ0, rInvJ0, detJ0);
-        Matrix DN_De;
-        GetGeometry().ShapeFunctionsLocalGradients(DN_De, integration_points[PointNumber]);
-        GeometryUtils::ShapeFunctionsGradients(DN_De, rInvJ0, rDN_DX);
-    }
+    GeometryUtils::JacobianOnInitialConfiguration(
+        r_geom,
+        this->IntegrationPoints(ThisIntegrationMethod)[PointNumber], rJ0);
+    MathUtils<double>::InvertMatrix(rJ0, rInvJ0, detJ0);
+    const Matrix& rDN_De = GetGeometry().ShapeFunctionsLocalGradients(ThisIntegrationMethod)[PointNumber];
+    GeometryUtils::ShapeFunctionsGradients(rDN_De, rInvJ0, rDN_DX);
     return detJ0;
 }
 
@@ -1768,19 +1745,10 @@ double BaseSolidElement::CalculateDerivativesOnCurrentConfiguration(
     ) const
 {
     double detJ;
-    if (UseGeometryIntegrationMethod()) {
-        rJ = GetGeometry().Jacobian( rJ, PointNumber, ThisIntegrationMethod );
-        const Matrix& DN_De = GetGeometry().ShapeFunctionsLocalGradients(ThisIntegrationMethod)[PointNumber];
-        MathUtils<double>::InvertMatrix( rJ, rInvJ, detJ );
-        GeometryUtils::ShapeFunctionsGradients(DN_De, rInvJ, rDN_DX);
-    } else{
-        const auto& integration_points =  this->IntegrationPoints();
-        rJ = GetGeometry().Jacobian( rJ, integration_points[PointNumber] );
-        Matrix DN_De;
-        GetGeometry().ShapeFunctionsLocalGradients(DN_De, integration_points[PointNumber]);
-        MathUtils<double>::InvertMatrix( rJ, rInvJ, detJ );
-        GeometryUtils::ShapeFunctionsGradients(DN_De, rInvJ, rDN_DX);
-    }
+    rJ = GetGeometry().Jacobian( rJ, PointNumber, ThisIntegrationMethod );
+    const Matrix& DN_De = GetGeometry().ShapeFunctionsLocalGradients(ThisIntegrationMethod)[PointNumber];
+    MathUtils<double>::InvertMatrix( rJ, rInvJ, detJ );
+    GeometryUtils::ShapeFunctionsGradients(DN_De, rInvJ, rDN_DX);
     return detJ;
 }
 
@@ -1891,10 +1859,6 @@ void BaseSolidElement::CalculateLumpedMassVector(
     ) const
 {
     KRATOS_TRY;
-
-    if(!UseGeometryIntegrationMethod())
-        KRATOS_ERROR << "CalculateLumpedMassVector not implemented for element-based integration in base class" << std::endl;
-
 
     const auto& r_geom = GetGeometry();
     const auto& r_prop = GetProperties();

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -274,17 +274,7 @@ public:
         return mThisIntegrationMethod;
     }
 
-    /**
-    * element can be integrated using the GP provided by the geometry or custom ones
-    * by default, the base element will use the standard integration provided by the geom
-    * @return bool to select if use/not use GPs given by the geometry
-    */
-    bool virtual UseGeometryIntegrationMethod() const
-    {
-        return true;
-    }
-
-    const virtual GeometryType::IntegrationPointsArrayType  IntegrationPoints() const 
+    const virtual GeometryType::IntegrationPointsArrayType  IntegrationPoints() const
     {
         return GetGeometry().IntegrationPoints();
     }
@@ -628,14 +618,14 @@ public:
     ///@}
     ///@name Input and output
     ///@{
-    
+
     /**
      * @brief This method provides the specifications/requirements of the element
      * @details This can be used to enhance solvers and analysis
      * @return specifications The required specifications/requirements
      */
     const Parameters GetSpecifications() const override;
-    
+
     /// Turn back information as a string.
     std::string Info() const override
     {


### PR DESCRIPTION
**📝 Description**
Remove the always  true `UseGeometryIntegrationMethod` from the `BaseSolidElement`. On top of the fact that it's not being used, resulting in a more cumbersome implementation, from current code I think that the case of switching it to false would have led to some missbehaviours.