### PR TITLE
[Core][VTKOutput] make type of entity selectable

### DIFF
--- a/kratos/input_output/vtk_output.cpp
+++ b/kratos/input_output/vtk_output.cpp
@@ -164,9 +164,13 @@ VtkOutput::EntityType VtkOutput::GetEntityType(const ModelPart& rModelPart) cons
         return mEntityType;
     }
 
-    return (rModelPart.GetCommunicator().GlobalNumberOfElements() > 0) ?
-        EntityType::ELEMENT :
-        EntityType::CONDITION;
+    if (rModelPart.GetCommunicator().GlobalNumberOfElements() > 0) {
+        return EntityType::ELEMENT;
+    } else if(rModelPart.GetCommunicator().GlobalNumberOfConditions() > 0) {
+        return EntityType::CONDITION;
+    } else {
+        return EntityType::NONE;
+    }
 }
 
 /***********************************************************************************/

--- a/kratos/input_output/vtk_output.h
+++ b/kratos/input_output/vtk_output.h
@@ -107,20 +107,25 @@ public:
         VTK_BINARY
     };
 
+protected:
+    ///@name  Enum's
+    ///@{
+
     enum class EntityType {
         ELEMENT,
         CONDITION,
-        NONE // used internally to skip some writing checks
+        AUTOMATIC,
+        NONE
         // GEOMETRY // TODO PBucher
     };
 
-protected:
+    ///@}
+
     ///@name Member Variables
     ///@{
 
     ModelPart& mrModelPart;                        /// The main model part to post process
     VtkOutput::FileFormat mFileFormat;             /// The file format considered
-    VtkOutput::EntityType mEntityType;             /// The entities to be written
 
     Parameters mOutputSettings;                    /// The configuration parameters
     unsigned int mDefaultPrecision;                /// The default precision
@@ -133,6 +138,12 @@ protected:
     ///@}
     ///@name Operations
     ///@{
+
+    /**
+     * @brief Helper to determine which entities to write
+     * @param rModelPart The ModelPart that is currently outputted (can be a SubModelPart)
+     */
+    EntityType GetEntityType(const ModelPart& rModelPart) const;
 
     /**
      * @brief Interpolates the gauss point results on to the node using IntegrationValuesExtrapolationToNodesProcess
@@ -465,6 +476,10 @@ protected:
     ///@}
 
 private:
+    ///@name Member Variables
+    ///@{
+    VtkOutput::EntityType mEntityType;             /// The entities to be written
+
     ///@name Operations
     ///@{
 

--- a/kratos/input_output/vtk_output.h
+++ b/kratos/input_output/vtk_output.h
@@ -7,7 +7,8 @@
 //  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
-//  Main authors:    Aditya Ghantasala, Philipp Bucher
+//  Main authors:    Aditya Ghantasala
+//                   Philipp Bucher (https://github.com/philbucher)
 //  Collaborator:    Vicente Mataix Ferrandiz
 //
 //
@@ -106,17 +107,25 @@ public:
         VTK_BINARY
     };
 
+    enum class EntityType {
+        ELEMENT,
+        CONDITION,
+        NONE // used internally to skip some writing checks
+        // GEOMETRY // TODO PBucher
+    };
+
 protected:
     ///@name Member Variables
     ///@{
 
     ModelPart& mrModelPart;                        /// The main model part to post process
     VtkOutput::FileFormat mFileFormat;             /// The file format considered
+    VtkOutput::EntityType mEntityType;             /// The entities to be written
 
     Parameters mOutputSettings;                    /// The configuration parameters
     unsigned int mDefaultPrecision;                /// The default precision
     std::unordered_map<int, int> mKratosIdToVtkId; /// The map storing the relationship between the Kratos ID and VTK ID
-    bool mShouldSwap = false;                      /// If it should swap
+    bool mShouldSwap = false;                      /// If the bytes need to be swapped (endianness)
 
     // pointer to object of the extrapolation from gauss point to nodes process
     IntegrationValuesExtrapolationToNodesProcess::UniquePointer mpGaussToNodesProcess;
@@ -175,7 +184,7 @@ protected:
      * @param rModelPart modelpart which is beging output
      * @param rFileStream the file stream to which data is to be written.
      */
-    void WriteNodesToFile(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
+    virtual void WriteNodesToFile(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
 
     /**
      * @brief Write the elements and conditions in rModelPart.


### PR DESCRIPTION
This PR makes the selection of entities written by the VtkOutput selectable, which was previously hardcoded
The behavior has not changed, still by default elements have a higher prio than conditions
Also the MPI-performance is slightly increased by removing some collective communication operations

This change is necessary for
- Preparation for #11140
- Preparation for Output of geometries

FYI @ncrescenzio