### PR TITLE
[Core][MPI] Remove unnecessary argument so MPI C++ tests are run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
-        mpiexec -np 2 --hostfile ${GITHUB_WORKSPACE}/ci_hostfile python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --using-mpi
+        mpiexec -np 2 --hostfile ${GITHUB_WORKSPACE}/ci_hostfile python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py
 
     - name: Running MPICore C++ tests (3 Cores)
       shell: bash
@@ -100,7 +100,7 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
-        mpiexec -np 3 --hostfile ${GITHUB_WORKSPACE}/ci_hostfile python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --using-mpi
+        mpiexec -np 3 --hostfile ${GITHUB_WORKSPACE}/ci_hostfile python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py
 
     - name: Running MPICore C++ tests (4 Cores)
       shell: bash
@@ -109,7 +109,7 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
-        mpiexec -np 4 --hostfile ${GITHUB_WORKSPACE}/ci_hostfile python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --using-mpi
+        mpiexec -np 4 --hostfile ${GITHUB_WORKSPACE}/ci_hostfile python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py
 
     - name: Running Python MPI tests (2 Cores)
       shell: bash
@@ -283,7 +283,7 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
-        mpiexec -np 2 python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --using-mpi
+        mpiexec -np 2 python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py
 
     - name: Running MPICore C++ tests (3 Cores)
       shell: bash
@@ -292,7 +292,7 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
-        mpiexec -np 3 python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --using-mpi
+        mpiexec -np 3 python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py
 
     - name: Running MPICore C++ tests (4 Cores)
       shell: bash
@@ -301,7 +301,7 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
-        mpiexec -np 4 python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --using-mpi
+        mpiexec -np 4 python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py
 
     - name: Running Python MPI tests (2 Cores)
       shell: bash
@@ -438,7 +438,7 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
-        mpiexec -np 2 python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --using-mpi
+        mpiexec -np 2 python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py
 
     - name: Running MPICore C++ tests (3 Cores)
       shell: bash
@@ -447,7 +447,7 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
-        mpiexec -np 3 python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --using-mpi
+        mpiexec -np 3 python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py
 
     - name: Running MPICore C++ tests (4 Cores)
       shell: bash
@@ -456,7 +456,7 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
-        mpiexec -np 4 python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --using-mpi
+        mpiexec -np 4 python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py
 
     - name: Running Python MPI tests (2 Cores)
       shell: bash


### PR DESCRIPTION
**📝 Description**

Part of https://github.com/KratosMultiphysics/Kratos/pull/11148

The PR consists of changes in the continuous integration (CI) workflow file `ci.yml`. This file is typically responsible for setting up the environment and running tests automatically whenever changes are pushed to the repository. 

Until now `--using-mpi` was provoking that any test was run at all, due to the implementation of https://github.com/KratosMultiphysics/Kratos/blob/1f82bd8d96560ed962935f629fa61ed5e69bc126/kratos/python_scripts/testing/run_cpp_mpi_tests.py#L12

~~~sh
 |  /           |                  
 ' /   __| _` | __|  _ \   __|    
 . \  |   (   | |   (   |\__ \  
_|\_\_|  \__,_|\__|\___/ ____/
           Multi-Physics 9.3."1"--02ef2d1-Custom-x86_64
           Compiled for GNU/Linux and Python3.10 with GCC-12.1
Compiled with threading and MPI support.
Maximum number of threads: 1.
MPI world size:         2.
Process Id: 4523 
Ran 0 of 1544 test cases in 0.000481801s. OK
~~~

**🆕 Changelog**

- [Remove unnecessary argument](https://github.com/KratosMultiphysics/Kratos/commit/fe4298008639c83259071eceadb50999500e6e8a)
