### PR TITLE
Correctly parse --using-mpi if given

### DIFF
--- a/kratos/python_scripts/testing/run_cpp_mpi_tests.py
+++ b/kratos/python_scripts/testing/run_cpp_mpi_tests.py
@@ -1,12 +1,29 @@
-import sys
+import argparse
 
 from KratosMultiphysics import mpi, Tester
 
-if __name__ == '__main__':
-    #Tester.SetVerbosity(Tester.Verbosity.TESTS_LIST)
-    Tester.SetVerbosity(Tester.Verbosity.TESTS_OUTPUTS)
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--using-mpi',
+        action='store_true',
+        help="Force MPI mode if auto-detection fails")
+    parser.add_argument(
+        'match_string',
+        metavar='MATCH-STRING',
+        nargs='?',
+        help="run cases with names matching MATCH-STRING")
 
-    if len(sys.argv) < 2:
-        Tester.RunTestSuite("KratosMPICoreFastSuite")
+    args = parser.parse_args()
+
+    Tester.SetVerbosity(Tester.Verbosity.TESTS_OUTPUTS)
+    #Tester.SetVerbosity(Tester.Verbosity.TESTS_LIST)
+    if args.match_string:
+        Tester.RunTestCases(args.match_string)
     else:
-        Tester.RunTestCases(sys.argv[1])
+        Tester.RunTestSuite("KratosMPICoreFastSuite")
+
+
+
+if __name__ == '__main__':
+    main()

--- a/kratos/python_scripts/testing/run_cpp_mpi_tests.py
+++ b/kratos/python_scripts/testing/run_cpp_mpi_tests.py
@@ -16,14 +16,12 @@ def main():
 
     args = parser.parse_args()
 
-    Tester.SetVerbosity(Tester.Verbosity.TESTS_OUTPUTS)
-    #Tester.SetVerbosity(Tester.Verbosity.TESTS_LIST)
     if args.match_string:
+        Tester.SetVerbosity(Tester.Verbosity.TESTS_OUTPUTS)
         Tester.RunTestCases(args.match_string)
     else:
+        Tester.SetVerbosity(Tester.Verbosity.TESTS_LIST)
         Tester.RunTestSuite("KratosMPICoreFastSuite")
-
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
**📝 Description**
Add proper command-line argument parsing to run_cpp_mpi_tests.py to prevent the `--using-mpi` command-line option from being incorrectly interpreted as a test name.

This fixes a bug introduced in #11055 which was causing the CI to not run the MPI tests. #11157 addresses the same issue.

**🆕 Changelog**
- Add command-line argument parsing to run_cpp_mpi_tests.py
