### PR TITLE
[Core] Missing `Rank` in constructor of `SpatialSearchResult`, required by `GlobalPointer`

### DIFF
--- a/kratos/spatial_containers/spatial_search_result.h
+++ b/kratos/spatial_containers/spatial_search_result.h
@@ -54,10 +54,23 @@ public:
     ///@{
 
     /// Default constructor.
-   	SpatialSearchResult() : mpObject(nullptr), mDistance(0.00), mIsObjectFound(false), mIsDistanceCalculated(false) {}
+   	SpatialSearchResult()
+        : mpObject(nullptr),
+          mDistance(0.0),
+          mIsObjectFound(false),
+          mIsDistanceCalculated(false)
+    {
+    }
 
-    /// Constructor with the resulted object   
-	SpatialSearchResult(TObjectType* pObject) : mpObject(pObject), mDistance(0.00), mIsObjectFound(false), mIsDistanceCalculated(false) {
+    /// Constructor with the resulted object
+	SpatialSearchResult(
+        TObjectType* pObject,
+        const int Rank = 0
+        ) : mpObject(pObject, Rank),
+            mDistance(0.0),
+            mIsObjectFound(false),
+            mIsDistanceCalculated(false)
+    {
 		if (mpObject.get() != nullptr)
 			mIsObjectFound = true;
 	}

--- a/kratos/spatial_containers/spatial_search_result.h
+++ b/kratos/spatial_containers/spatial_search_result.h
@@ -54,16 +54,16 @@ public:
     ///@{
 
     /// Default constructor.
-   	SpatialSearchResult()
-        : mpObject(nullptr),
-          mDistance(0.0),
-          mIsObjectFound(false),
-          mIsDistanceCalculated(false)
+    SpatialSearchResult()
+    : mpObject(nullptr),
+        mDistance(0.0),
+        mIsObjectFound(false),
+        mIsDistanceCalculated(false)
     {
     }
 
     /// Constructor with the resulted object
-	SpatialSearchResult(
+    SpatialSearchResult(
         TObjectType* pObject,
         const int Rank = 0
         ) : mpObject(pObject, Rank),
@@ -71,15 +71,15 @@ public:
             mIsObjectFound(false),
             mIsDistanceCalculated(false)
     {
-		if (mpObject.get() != nullptr)
-			mIsObjectFound = true;
-	}
+        if (mpObject.get() != nullptr)
+            mIsObjectFound = true;
+    }
 
     /// Copy constructor.
-	SpatialSearchResult(SpatialSearchResult const& /* Other */) = default;
+    SpatialSearchResult(SpatialSearchResult const& /* Other */) = default;
 
     /// Move constructor.
-	SpatialSearchResult(SpatialSearchResult&& /* Other */) = default;
+    SpatialSearchResult(SpatialSearchResult&& /* Other */) = default;
 
     /// Destructor.
     virtual ~SpatialSearchResult(){}
@@ -97,44 +97,44 @@ public:
     ///@{
 
     /// Reset the result
-	void Reset()
+    void Reset()
     {
-		mpObject = nullptr;
-		mDistance = 0.0;
-		mIsObjectFound = false;
-		mIsDistanceCalculated = false;
-	}
+        mpObject = nullptr;
+        mDistance = 0.0;
+        mIsObjectFound = false;
+        mIsDistanceCalculated = false;
+    }
 
     ///@}
     ///@name Access
     ///@{
 
     /// Returns the global pointer to the object
-	TPointerType Get() {
+    TPointerType Get() {
         return mpObject;
     }
 
     /// Returns a const global pointer to the object
-	TPointerType const Get() const {
+    TPointerType const Get() const {
         return mpObject;
     }
 
     /// Set the object to be pointed
-	void Set(TObjectType* pObject) {
-		mpObject = pObject;
-		mIsObjectFound = true;
-	}
+    void Set(TObjectType* pObject) {
+        mpObject = pObject;
+        mIsObjectFound = true;
+    }
 
     /// Getting the result distance
-	double GetDistance() const {
+    double GetDistance() const {
         return mDistance;
     }
 
     /// Setting the result distance
-	void SetDistance(const double TheDistance) {
-		mDistance = TheDistance;
-		mIsDistanceCalculated = true;
-	}
+    void SetDistance(const double TheDistance) {
+        mDistance = TheDistance;
+        mIsDistanceCalculated = true;
+    }
 
     ///@}
     ///@name Inquiry
@@ -174,10 +174,10 @@ private:
     ///@name Member Variables
     ///@{
 
-	TPointerType mpObject;      /// The object found
-	double mDistance;           /// The distance to the object
-	bool mIsObjectFound;        /// If the object is found
-	bool mIsDistanceCalculated; /// If the distance is calculated
+    TPointerType mpObject;      /// The object found
+    double mDistance;           /// The distance to the object
+    bool mIsObjectFound;        /// If the object is found
+    bool mIsDistanceCalculated; /// If the distance is calculated
 
     ///@}
     ///@name Private Operations


### PR DESCRIPTION
**📝 Description**

The constructor of `SpatialSearchResult` that accepts an object as a parameter was also restructured in the same way and had an additional parameter "Rank" added to it. This Rank value is now passed along when initializing the "mpObject" member variable, which is `GlobalPointer` and requires a rank. 

Also replace tabs indentation by 4 spaces changes, it corrects the inconsistent indentation levels throughout the code, making it adhere to a uniform code style for better readability and maintainability. 

**🆕 Changelog**

- [Missing `Rank` in constructor of `SpatialSearchResult`, required by `GlobalPointer`](https://github.com/KratosMultiphysics/Kratos/commit/39cb7bc005d386658bcab068f22003a21e5c2ce8)
- [Replace tabs by 4 spaces](https://github.com/KratosMultiphysics/Kratos/pull/11163/commits/2ec9dc2f41e8a4091f6fbd93ce66eaeca3cdee9d)
