### PR TITLE
[Core] Check Container Template Arguments

### DIFF
--- a/kratos/utilities/parallel_utilities.h
+++ b/kratos/utilities/parallel_utilities.h
@@ -354,42 +354,82 @@ template <class TReduction,
 }
 
 /** @brief simplified version of the basic loop (without reduction) to enable template type deduction
- * @param v - containers to be looped upon
- * @param func - must be a unary function accepting as input TContainerType::value_type&
+ *  @tparam TContainerType A standard-conforming container type.
+ *  @tparam TFunctionType Functor operating on @a TContainerType::value_type.
+ *  @param v - containers to be looped upon
+ *  @param func - must be a unary function accepting as input TContainerType::value_type&
  */
-template <class TContainerType, class TFunctionType>
+template <class TContainerType,
+          class TFunctionType,
+          std::enable_if_t<!std::is_same_v<
+            std::iterator_traits<typename decltype(std::declval<std::remove_cv_t<TContainerType>>().begin())::value_type>,
+            void
+          >, bool> = true
+         >
 void block_for_each(TContainerType &&v, TFunctionType &&func)
 {
     block_for_each(v.begin(), v.end(), std::forward<TFunctionType>(func));
 }
 
 /** @brief simplified version of the basic loop with reduction to enable template type deduction
- * @param v - containers to be looped upon
- * @param func - must be a unary function accepting as input TContainerType::value_type&
+ *  @tparam TReducer Reduction type to apply. See @ref SumReduction as an example.
+ *  @tparam TContainerType A standard-conforming container type.
+ *  @tparam TFunctionType Functor operating on @a TContainerType::value_type.
+ *  @param v - containers to be looped upon
+ *  @param func - must be a unary function accepting as input TContainerType::value_type&
  */
-template <class TReducer, class TContainerType, class TFunctionType>
+template <class TReducer,
+          class TContainerType,
+          class TFunctionType,
+          std::enable_if_t<!std::is_same_v<
+            std::iterator_traits<typename decltype(std::declval<std::remove_cv_t<TContainerType>>().begin())::value_type>,
+            void
+          >, bool> = true
+         >
 [[nodiscard]] typename TReducer::return_type block_for_each(TContainerType &&v, TFunctionType &&func)
 {
     return block_for_each<TReducer>(v.begin(), v.end(), std::forward<TFunctionType>(func));
 }
 
 /** @brief simplified version of the basic loop with thread local storage (TLS) to enable template type deduction
- * @param v - containers to be looped upon
- * @param tls - thread local storage
- * @param func - must be a function accepting as input TContainerType::value_type& and the thread local storage
+ *  @tparam TContainerType A standard-conforming container type.
+ *  @tparam TThreadLocalStorage Copy constructible thread-local type.
+ *  @tparam TFunctionType Functor operating on @a TContainerType::value_type.
+ *  @param v - containers to be looped upon
+ *  @param tls - thread local storage
+ *  @param func - must be a function accepting as input TContainerType::value_type& and the thread local storage
  */
-template <class TContainerType, class TThreadLocalStorage, class TFunctionType>
+template <class TContainerType,
+          class TThreadLocalStorage,
+          class TFunctionType,
+          std::enable_if_t<!std::is_same_v<
+            std::iterator_traits<typename decltype(std::declval<std::remove_cv_t<TContainerType>>().begin())::value_type>,
+            void
+          >, bool> = true
+         >
 void block_for_each(TContainerType &&v, const TThreadLocalStorage& tls, TFunctionType &&func)
 {
     block_for_each(v.begin(), v.end(), tls, std::forward<TFunctionType>(func));
 }
 
 /** @brief simplified version of the basic loop with reduction and thread local storage (TLS) to enable template type deduction
- * @param v - containers to be looped upon
- * @param tls - thread local storage
- * @param func - must be a function accepting as input TContainerType::value_type& and the thread local storage
+ *  @tparam TReducer Reduction type to apply. See @ref SumReduction as an example.
+ *  @tparam TContainerType A standard-conforming container type.
+ *  @tparam TThreadLocalStorage Copy constructible thread-local type.
+ *  @tparam TFunctionType Functor operating on @a TContainerType::value_type.
+ *  @param v - containers to be looped upon
+ *  @param tls - thread local storage
+ *  @param func - must be a function accepting as input TContainerType::value_type& and the thread local storage
  */
-template <class TReducer, class TContainerType, class TThreadLocalStorage, class TFunctionType>
+template <class TReducer,
+          class TContainerType,
+          class TThreadLocalStorage,
+          class TFunctionType,
+          std::enable_if_t<!std::is_same_v<
+            std::iterator_traits<typename decltype(std::declval<std::remove_cv_t<TContainerType>>().begin())::value_type>,
+            void
+          >, bool> = true
+         >
 [[nodiscard]] typename TReducer::return_type block_for_each(TContainerType &&v, const TThreadLocalStorage& tls, TFunctionType &&func)
 {
     return block_for_each<TReducer>(v.begin(), v.end(), tls, std::forward<TFunctionType>(func));

--- a/kratos/utilities/parallel_utilities.h
+++ b/kratos/utilities/parallel_utilities.h
@@ -149,7 +149,10 @@ public:
                    TIterator it_end,
                    int Nchunks = ParallelUtilities::GetNumThreads())
     {
-        static_assert(std::is_same_v<typename std::iterator_traits<TIterator>::iterator_category, std::random_access_iterator_tag>);
+        static_assert(
+            std::is_same_v<typename std::iterator_traits<TIterator>::iterator_category, std::random_access_iterator_tag>,
+            "BlockPartition requires random access iterators to divide the input range into partitions"
+        );
         KRATOS_ERROR_IF(Nchunks < 1) << "Number of chunks must be > 0 (and not " << Nchunks << ")" << std::endl;
 
         const std::ptrdiff_t size_container = it_end-it_begin;
@@ -292,7 +295,7 @@ private:
  */
 template <class TIterator,
           class TFunction,
-          std::enable_if_t<std::is_same_v<typename std::iterator_traits<TIterator>::iterator_category,std::random_access_iterator_tag>,bool> = true>
+          std::enable_if_t<std::is_base_of_v<std::input_iterator_tag, typename std::iterator_traits<TIterator>::iterator_category>,bool> = true>
 void block_for_each(TIterator itBegin, TIterator itEnd, TFunction&& rFunction)
 {
     BlockPartition<TIterator>(itBegin, itEnd).for_each(std::forward<TFunction>(rFunction));
@@ -309,7 +312,7 @@ void block_for_each(TIterator itBegin, TIterator itEnd, TFunction&& rFunction)
 template <class TReduction,
           class TIterator,
           class TFunction,
-          std::enable_if_t<std::is_same_v<typename std::iterator_traits<TIterator>::iterator_category,std::random_access_iterator_tag>,bool> = true>
+          std::enable_if_t<std::is_base_of_v<std::input_iterator_tag, typename std::iterator_traits<TIterator>::iterator_category>,bool> = true>
 [[nodiscard]] typename TReduction::return_type block_for_each(TIterator itBegin, TIterator itEnd, TFunction&& rFunction)
 {
     return  BlockPartition<TIterator>(itBegin, itEnd).template for_each<TReduction>(std::forward<TFunction>(std::forward<TFunction>(rFunction)));
@@ -327,7 +330,7 @@ template <class TReduction,
 template <class TIterator,
           class TTLS,
           class TFunction,
-          std::enable_if_t<std::is_same_v<typename std::iterator_traits<TIterator>::iterator_category,std::random_access_iterator_tag>,bool> = true>
+          std::enable_if_t<std::is_base_of_v<std::input_iterator_tag, typename std::iterator_traits<TIterator>::iterator_category>,bool> = true>
 void block_for_each(TIterator itBegin, TIterator itEnd, const TTLS& rTLS, TFunction &&rFunction)
 {
      BlockPartition<TIterator>(itBegin, itEnd).for_each(rTLS, std::forward<TFunction>(rFunction));
@@ -347,7 +350,7 @@ template <class TReduction,
           class TIterator,
           class TTLS,
           class TFunction,
-          std::enable_if_t<std::is_same_v<typename std::iterator_traits<TIterator>::iterator_category,std::random_access_iterator_tag>,bool> = true>
+          std::enable_if_t<std::is_base_of_v<std::input_iterator_tag, typename std::iterator_traits<TIterator>::iterator_category>,bool> = true>
 [[nodiscard]] typename TReduction::return_type block_for_each(TIterator itBegin, TIterator itEnd, const TTLS& tls, TFunction&& rFunction)
 {
     return BlockPartition<TIterator>(itBegin, itEnd).template for_each<TReduction>(tls, std::forward<TFunction>(std::forward<TFunction>(rFunction)));


### PR DESCRIPTION
## Description

Check whether `block_for_each` overloads expecting containers really do get a valid container type as template argument.

## Why?

### In a nutshell

If someone tries using `block_for_each` with iterators other than random access iterators, failed overload resolutions result in a cryptic error message. This PR adds compile-time checks to previously unchecked overloads, effectively disabling `block_for_each` if invalid template arguments are provided.

### Details

The current call hierarchy looks like this:
1) `block_for_each` on containers
2) `block_for_each` on iterators
3) `BlockPartition`

Each of the above steps can be invoked individually as well. In step 2, the iterator type is checked and if it's not a random access iterator, the overload is disabled. If the user wants to call this overload but provides an iterator of some other category (e.g.: a bidirectional iterator), the overload is still dropped and overload resolution will try invoking functions in step 1. Since there aren't any checks in step 1, the function isn't discarded but template instantiation fails because the function expects a container-like object but gets an iterator. The resulting error message misleads the user about where the problem truly lies.

This PR adds compile-time checks in step 1 that check whether the expected container-like object satisfied the requirements. Now if someone passes the wrong iterator type, these functions also get discarded and the compiler won't find a suitable overload. The error message correctly informs the user that no suitable overload was found for the provided arguments.

## Implementation

The check itself just tests whether `TContainerType` has a member function `begin` and whether it returns a valid iterator. This doesn't properly check whether `TContainerType` is a standard-conforming container, but it's better than nothing and doesn't pollute the template argument list that much.

Another reason why C++20 concepts would be nice to have.
