### PR TITLE
[ContactStructuralMechanicsApplication] Remove `MathUtils` template, replace `MathUtils<double>::` with `MathUtils::`

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mortar_contact_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mortar_contact_condition.cpp
@@ -500,8 +500,8 @@ bool MortarContactCondition<TDim,TNumNodes,TFrictional, TNormalVariation,TNumNod
 //     const array_1d<double, 3> normal_slave = this->GetValue(NORMAL);
 //     const array_1d<double, 3>& r_normal_master = this->GetPairedNormal();
 //
-//     const double angle_slave = MathUtils<double>::VectorsAngle(delta_disp_vect_slave, normal_slave);
-//     const double angle_master = MathUtils<double>::VectorsAngle(delta_disp_vect_master, normal_master);
+//     const double angle_slave = MathUtils::VectorsAngle(delta_disp_vect_slave, normal_slave);
+//     const double angle_master = MathUtils::VectorsAngle(delta_disp_vect_master, normal_master);
 //
 //     // In case the both angles are in absolute value minor to angle threshold is active
 //     const double angle_threshold = 1.025 * Globals::Pi/2; // We add some tolerance to the angle

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mpc_mortar_contact_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mpc_mortar_contact_condition.cpp
@@ -625,7 +625,7 @@ void MPCMortarContactCondition<TDim,TNumNodes,TNumNodesMaster>::UpdateConstraint
         }
     } else { // Otherwise regular inverse
         double det;
-        MathUtils<double>::InvertMatrix(r_DOperator, inverse_DOperator, det, -1.0);
+        MathUtils::InvertMatrix(r_DOperator, inverse_DOperator, det, -1.0);
     }
 
     // Multiplying in order to obtain the proper relation matrix
@@ -750,7 +750,7 @@ void MPCMortarContactCondition<TDim,TNumNodes,TNumNodesMaster>::UpdateConstraint
         }
     } else { // Otherwise regular inverse
         double det;
-        MathUtils<double>::InvertMatrix(r_DOperator, inverse_DOperator, det, -1.0);
+        MathUtils::InvertMatrix(r_DOperator, inverse_DOperator, det, -1.0);
     }
 
     // Multiplying in order to obtain the proper relation matrix
@@ -868,7 +868,7 @@ void MPCMortarContactCondition<TDim,TNumNodes,TNumNodesMaster>::UpdateConstraint
         }
     } else { // Otherwise regular inverse
         double det;
-        MathUtils<double>::InvertMatrix(r_DOperator, inverse_DOperator, det, -1.0);
+        MathUtils::InvertMatrix(r_DOperator, inverse_DOperator, det, -1.0);
     }
 
     // Multiplying in order to obtain the proper relation matrix

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
@@ -258,7 +258,7 @@ void ContactSPRErrorProcess<TDim>::CalculatePatch(
 
         Vector coeff(SigmaSize * (TDim+1));
         const Vector& r_b_vector = column(b, 0);
-        MathUtils<double>::Solve(A, coeff, r_b_vector);
+        MathUtils::Solve(A, coeff, r_b_vector);
 
         for (IndexType j = 0; j < SigmaSize;++j){
             p_k(j,j*(TDim + 1) + 1) = r_coordinates[0] - r_coordinates_patch_node[0];

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_contact_strategy.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_contact_strategy.h
@@ -930,7 +930,7 @@ protected:
             it_elem->CalculateOnIntegrationPoints( DEFORMATION_GRADIENT, deformation_gradient_matrices, r_process_info);
 
             for (IndexType i_gp = 0; i_gp  < deformation_gradient_matrices.size(); ++i_gp) {
-                const double det_f = MathUtils<double>::Det(deformation_gradient_matrices[i_gp]);
+                const double det_f = MathUtils::Det(deformation_gradient_matrices[i_gp]);
                 if (det_f < 0.0) {
                     if (mConvergenceCriteriaEchoLevel > 0) {
                         KRATOS_WATCH(it_elem->Id())

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/contact_utilities.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/contact_utilities.h
@@ -228,7 +228,7 @@ public:
             } else { // We consider the tangent direction as auxiliary
                 const array_1d<double, 3>& r_normal = rGeometry[i_node].FastGetSolutionStepValue(NORMAL);
                 array_1d<double, 3> tangent_xi, tangent_eta;
-                MathUtils<double>::OrthonormalBasis(r_normal, tangent_xi, tangent_eta);
+                MathUtils::OrthonormalBasis(r_normal, tangent_xi, tangent_eta);
                 if constexpr (TDim == 3) {
                     for (std::size_t i_dof = 0; i_dof < 3; ++i_dof)
                         tangent_matrix(i_node, i_dof) = tangent_xi[i_dof];

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.cpp
@@ -46,7 +46,7 @@ void DerivativesUtilities<TDim, TNumNodes, TFrictional, TNormalVariation, TNumNo
         const array_1d<double, 3> x31cell = x3cell - x1cell;
 
         array_1d<double, 3> aux_cross_product;
-        MathUtils<double>::CrossProduct(aux_cross_product, x21cell, x31cell);
+        MathUtils::CrossProduct(aux_cross_product, x21cell, x31cell);
         aux_cross_product /= rVariables.DetjSlave;
 //             aux_cross_product /= norm_2(aux_cross_product);
 
@@ -55,8 +55,8 @@ void DerivativesUtilities<TDim, TNumNodes, TFrictional, TNormalVariation, TNumNo
             for (IndexType i_dof = 0; i_dof < TDim; ++i_dof) {
                 const auto& r_local_delta_vertex = rDerivativeData.DeltaCellVertex[i_node * TDim + i_dof];
 
-                MathUtils<double>::CrossProduct(aux_delta_cross_product1, row(r_local_delta_vertex, 1) - row(r_local_delta_vertex, 0), x31cell);
-                MathUtils<double>::CrossProduct(aux_delta_cross_product2, x21cell, row(r_local_delta_vertex, 2) - row(r_local_delta_vertex, 0));
+                MathUtils::CrossProduct(aux_delta_cross_product1, row(r_local_delta_vertex, 1) - row(r_local_delta_vertex, 0), x31cell);
+                MathUtils::CrossProduct(aux_delta_cross_product2, x21cell, row(r_local_delta_vertex, 2) - row(r_local_delta_vertex, 0));
 
                 rDerivativeData.DeltaDetjSlave[i_node * TDim + i_dof] = inner_prod(aux_cross_product, aux_delta_cross_product1) + inner_prod(aux_cross_product, aux_delta_cross_product2);
             }
@@ -93,7 +93,7 @@ inline array_1d<array_1d<double, 3>, TDim * TNumNodes> DerivativesUtilities<TDim
     }
 
     array_1d<double, 3> normal;;
-    MathUtils<double>::CrossProduct(normal, j0, j1);
+    MathUtils::CrossProduct(normal, j0, j1);
     const double area_normal_norm = norm_2(normal);
 
     KRATOS_DEBUG_ERROR_IF(area_normal_norm < ZeroTolerance) << "ZERO NORMAL: " << area_normal_norm << std::endl;
@@ -115,8 +115,8 @@ inline array_1d<array_1d<double, 3>, TDim * TNumNodes> DerivativesUtilities<TDim
             if constexpr (TDim == 3)
                 delta_j1[i_dim] += rDNDe(i_node, 1);
 
-            MathUtils<double>::CrossProduct(aux_delta_normal0, j0, delta_j1);
-            MathUtils<double>::CrossProduct(aux_delta_normal1, delta_j0, j1);
+            MathUtils::CrossProduct(aux_delta_normal0, j0, delta_j1);
+            MathUtils::CrossProduct(aux_delta_normal1, delta_j0, j1);
             const array_1d<double, 3> r_aux_delta_normal = aux_delta_normal0 + aux_delta_normal1;
             const double delta_norm = inner_prod(r_aux_delta_normal, normal);
 
@@ -156,7 +156,7 @@ inline array_1d<array_1d<double, 3>, TDim * TNumNodesMaster> DerivativesUtilitie
     }
 
     array_1d<double, 3> normal;;
-    MathUtils<double>::CrossProduct(normal, j0, j1);
+    MathUtils::CrossProduct(normal, j0, j1);
     const double area_normal_norm = norm_2(normal);
 
     KRATOS_DEBUG_ERROR_IF(area_normal_norm < ZeroTolerance) << "ZERO NORMAL: " << area_normal_norm << std::endl;
@@ -178,8 +178,8 @@ inline array_1d<array_1d<double, 3>, TDim * TNumNodesMaster> DerivativesUtilitie
             if constexpr (TDim == 3)
                 delta_j1[i_dim] += rDNDe(i_node, 1);
 
-            MathUtils<double>::CrossProduct(aux_delta_normal0, j0, delta_j1);
-            MathUtils<double>::CrossProduct(aux_delta_normal1, delta_j0, j1);
+            MathUtils::CrossProduct(aux_delta_normal0, j0, delta_j1);
+            MathUtils::CrossProduct(aux_delta_normal1, delta_j0, j1);
             noalias(r_aux_delta_normal) = aux_delta_normal0 + aux_delta_normal1;
             const double delta_norm = inner_prod(r_aux_delta_normal, normal);
 
@@ -459,8 +459,8 @@ void DerivativesUtilities<TDim, TNumNodes, TFrictional, TNormalVariation, TNumNo
             noalias(diff3) = xe1 - xs1;
 
             // We compute the denominator and numerator of the clipping
-            MathUtils<double>::CrossProduct(aux_num,   diff1, diff2);
-            MathUtils<double>::CrossProduct(aux_denom, diff3, diff2);
+            MathUtils::CrossProduct(aux_num,   diff1, diff2);
+            MathUtils::CrossProduct(aux_denom, diff3, diff2);
             const double num   = inner_prod(aux_num,   rNormal);
             const double denom = inner_prod(aux_denom, rNormal);
 
@@ -500,14 +500,14 @@ void DerivativesUtilities<TDim, TNumNodes, TFrictional, TNormalVariation, TNumNo
                     noalias(delta_diff3) = (i_belong == 1) ? LocalDeltaVertex(rNormal, delta_normal, i_dof, belong_index, ConsiderNormalVariation, rSlaveGeometry, rMasterGeometry, 1.0) : (i_belong == 0) ? LocalDeltaVertex(rNormal, delta_normal, i_dof, belong_index, ConsiderNormalVariation, rSlaveGeometry, rMasterGeometry, - 1.0) : zero_array;
 
                     // We compute now the delta num and denom
-                    MathUtils<double>::CrossProduct(aux_cross_product, delta_diff1, diff2);
+                    MathUtils::CrossProduct(aux_cross_product, delta_diff1, diff2);
                     double delta_num = inner_prod(aux_cross_product, rNormal);
-                    MathUtils<double>::CrossProduct(aux_cross_product, diff1, delta_diff2);
+                    MathUtils::CrossProduct(aux_cross_product, diff1, delta_diff2);
                     delta_num += inner_prod(aux_cross_product, rNormal);
 
-                    MathUtils<double>::CrossProduct(aux_cross_product, delta_diff3, diff2);
+                    MathUtils::CrossProduct(aux_cross_product, delta_diff3, diff2);
                     double delta_denom = inner_prod(aux_cross_product, rNormal);
-                    MathUtils<double>::CrossProduct(aux_cross_product, diff3, delta_diff2);
+                    MathUtils::CrossProduct(aux_cross_product, diff3, delta_diff2);
                     delta_denom += inner_prod(aux_cross_product, rNormal);
 
                     // Finally we add the contributions of delta num and denom
@@ -1164,7 +1164,7 @@ inline array_1d<double, 3> DerivativesUtilities<TDim, TNumNodes, TFrictional, TN
     }
 
     array_1d<double, 3> previous_normal;
-    MathUtils<double>::CrossProduct(previous_normal, tangent_xi, tangent_eta);
+    MathUtils::CrossProduct(previous_normal, tangent_xi, tangent_eta);
     const double norm_normal = norm_2(previous_normal);
     previous_normal /= norm_normal;
     KRATOS_ERROR_IF(norm_normal < ZeroTolerance) << "ERROR: The normal norm is zero or almost zero. Norm. normal: " << norm_normal << std::endl;
@@ -1227,8 +1227,8 @@ inline void DerivativesUtilities<TDim, TNumNodes, TFrictional, TNormalVariation,
     const BoundedMatrix<double, 2, 2> J = prod(trans(DN),DN);
     double det_j;
     BoundedMatrix<double, 2, 2> invJ;
-    MathUtils<double>::InvertMatrix(J, invJ, det_j, -1.0);
-    const bool good_condition_number = MathUtils<double>::CheckConditionNumber(J, invJ, std::numeric_limits<double>::epsilon(), false);
+    MathUtils::InvertMatrix(J, invJ, det_j, -1.0);
+    const bool good_condition_number = MathUtils::CheckConditionNumber(J, invJ, std::numeric_limits<double>::epsilon(), false);
     if (!good_condition_number) // Reset in case of bad condition number
         noalias(invJ) = ZeroMatrix(2,2);
 
@@ -1248,8 +1248,8 @@ inline void DerivativesUtilities<TDim, TNumNodes, TFrictional, TNormalVariation,
 //
 //     double det_L;
 //     BoundedMatrix<double, 3, 3> invL;
-//     MathUtils<double>::InvertMatrix(L, invL, det_L, -1.0);
-//     const bool good_condition_number = MathUtils<double>::CheckConditionNumber(L, invL, std::numeric_limits<double>::epsilon(), false);
+//     MathUtils::InvertMatrix(L, invL, det_L, -1.0);
+//     const bool good_condition_number = MathUtils::CheckConditionNumber(L, invL, std::numeric_limits<double>::epsilon(), false);
 //     if (!good_condition_number) // Reset in case of bad condition number
 //         noalias(invL) = ZeroMatrix(3,3);
 //     array_1d<double, 3> aux = prod(invL, DeltaPoint);
@@ -1288,8 +1288,8 @@ inline void DerivativesUtilities<TDim, TNumNodes, TFrictional, TNormalVariation,
     const BoundedMatrix<double, 2, 2> J = prod(trans(DN),DN);
     double det_j;
     BoundedMatrix<double, 2, 2> invJ;
-    MathUtils<double>::InvertMatrix(J, invJ, det_j, -1.0);
-    const bool good_condition_number = MathUtils<double>::CheckConditionNumber(J, invJ, std::numeric_limits<double>::epsilon(), false);
+    MathUtils::InvertMatrix(J, invJ, det_j, -1.0);
+    const bool good_condition_number = MathUtils::CheckConditionNumber(J, invJ, std::numeric_limits<double>::epsilon(), false);
     if (!good_condition_number) // Reset in case of bad condition number
         noalias(invJ) = ZeroMatrix(2,2);
 

--- a/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/test_integration.cpp
+++ b/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/test_integration.cpp
@@ -490,7 +490,7 @@ KRATOS_TEST_CASE_IN_SUITE(TestCheckRotation, KratosContactStructuralMechanicsFas
     triangle_0.PointLocalCoordinates(aux_coords, triangle_0.Center());
     const array_1d<double, 3> normal = triangle_0.UnitNormal(aux_coords);
     array_1d<double, 3> slave_tangent_eta;
-    MathUtils<double>::CrossProduct(slave_tangent_eta, normal, slave_tangent_xi);
+    MathUtils::CrossProduct(slave_tangent_eta, normal, slave_tangent_xi);
     
     // We define the auxiliary geometry
     std::vector<PointType::Pointer> points_array  (3);


### PR DESCRIPTION
**📝 Description**

This PR refactors and cleans up code in the `ContactStructuralMechanicsApplication`. The key change across all affected files is the replacement of `MathUtils<double>::` with `MathUtils::`, which streamlines the syntax and avoids unnecessary template specification.

The changes are spread across several files, with a focus on replacing mathematical operations such as `InvertMatrix`, `VectorsAngle`, `OrthonormalBasis`, `CrossProduct`, `CheckConditionNumber`, `Det`, and `norm_2` functions. Besides, there are also some minor updates to vector and matrix manipulations.

These changes are primarily refactoring and should not alter the functionality of the code but rather improve its readability and maintainability. 

**🆕 Changelog**

- [Remove MathUtils template](https://github.com/KratosMultiphysics/Kratos/commit/084e44d0b3bef95ba2227c67cb0b14e3cca54a95)
