### PR TITLE
[StructuralMechanicsApplication] Remove `MathUtils`template, replace `MathUtils<double>` with `MathUtils`

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_conditions/line_load_condition.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/line_load_condition.cpp
@@ -132,7 +132,7 @@ void LineLoadCondition<TDim>::CalculateOnIntegrationPoints(
             GetLocalAxis1(tangent_xi, J);
 
             // Computing normal
-            MathUtils<double>::UnitCrossProduct(rOutput[point_number], tangent_xi, tangent_eta);
+            MathUtils::UnitCrossProduct(rOutput[point_number], tangent_xi, tangent_eta);
         }
     } else {
         for (IndexType point_number = 0; point_number < r_integration_points.size(); ++point_number) {
@@ -256,7 +256,7 @@ void LineLoadCondition<TDim>::CalculateAll(
                 GetLocalAxis2(tangent_eta);
 
                 // Computing normal
-                MathUtils<double>::UnitCrossProduct(normal, tangent_xi, tangent_eta);
+                MathUtils::UnitCrossProduct(normal, tangent_xi, tangent_eta);
 
                 CalculateAndAddPressureForce( rRightHandSideVector, row( rNcontainer, point_number ), normal, gauss_pressure, integration_weight );
             }
@@ -320,7 +320,7 @@ void LineLoadCondition<TDim>::CalculateAndSubKp(
             const double coeff = Pressure * rN[i] * rDN_De( j, 0 ) * IntegrationWeight;
             noalias(Kij) = coeff * cross_tangent_xi;
 
-            MathUtils<double>::AddMatrix( rK, Kij, row_index, col_index );
+            MathUtils::AddMatrix( rK, Kij, row_index, col_index );
         }
     }
 

--- a/applications/StructuralMechanicsApplication/custom_conditions/moving_load_condition.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/moving_load_condition.cpp
@@ -313,10 +313,10 @@ void MovingLoadCondition< TDim, TNumNodes>::CalculateRotationMatrix(BoundedMatri
 
     // Unitary vector in local y direction
     if (std::fabs(vx[0]) < tolerance && std::fabs(vx[1]) < tolerance) {
-        MathUtils<double>::CrossProduct(vy, vy_tmp, vx);
+        MathUtils::CrossProduct(vy, vy_tmp, vx);
     }
     else {
-        MathUtils<double>::CrossProduct(vy, vz_tmp, vx);
+        MathUtils::CrossProduct(vy, vz_tmp, vx);
     }
 
     // set 3d part of Rotation Matrix
@@ -330,7 +330,7 @@ void MovingLoadCondition< TDim, TNumNodes>::CalculateRotationMatrix(BoundedMatri
         vy[2] *= inv_norm_y;
 
         // Unitary vector in local z direction
-        MathUtils<double>::CrossProduct(vz, vx, vy);
+        MathUtils::CrossProduct(vz, vx, vy);
         const double inv_norm_z = 1.0 / norm_2(vz);
         if (inv_norm_z > tolerance) {
             vz[0] *= inv_norm_z;

--- a/applications/StructuralMechanicsApplication/custom_conditions/small_displacement_line_load_condition.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/small_displacement_line_load_condition.cpp
@@ -180,7 +180,7 @@ void SmallDisplacementLineLoadCondition<TDim>::CalculateAll(
     // Iterate over the Gauss points
     for ( IndexType point_number = 0; point_number < integration_points.size(); point_number++ ) {
         GeometryUtils::JacobianOnInitialConfiguration(r_geometry, integration_points[point_number], J0);
-        const double detJ0 = MathUtils<double>::GeneralizedDet(J0);
+        const double detJ0 = MathUtils::GeneralizedDet(J0);
         const double integration_weight = this->GetIntegrationWeight(integration_points, point_number, detJ0);
 
         // Calculating the pressure on the gauss point
@@ -204,7 +204,7 @@ void SmallDisplacementLineLoadCondition<TDim>::CalculateAll(
                 this->GetLocalAxis2(tangent_eta);
 
                 // Computing normal
-                MathUtils<double>::UnitCrossProduct(normal, tangent_xi, tangent_eta);
+                MathUtils::UnitCrossProduct(normal, tangent_xi, tangent_eta);
 
                 this->CalculateAndAddPressureForce( rRightHandSideVector, row( rNcontainer, point_number ), normal, gauss_pressure, integration_weight );
             }

--- a/applications/StructuralMechanicsApplication/custom_conditions/small_displacement_surface_load_condition_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/small_displacement_surface_load_condition_3d.cpp
@@ -175,7 +175,7 @@ void SmallDisplacementSurfaceLoadCondition3D::CalculateAll(
     Matrix J0(3, 2);
     for (std::size_t point_number = 0; point_number < integration_points.size(); ++point_number) {
         GeometryUtils::JacobianOnInitialConfiguration(r_geometry, integration_points[point_number], J0);
-        const double detJ0 = MathUtils<double>::GeneralizedDet(J0);
+        const double detJ0 = MathUtils::GeneralizedDet(J0);
         const double integration_weight = GetIntegrationWeight(integration_points, point_number, detJ0);
         const auto& rN = row(Ncontainer, point_number);
 
@@ -187,7 +187,7 @@ void SmallDisplacementSurfaceLoadCondition3D::CalculateAll(
         tangent_eta[2] = J0(2, 1);
 
         array_1d<double, 3 > normal;
-        MathUtils<double>::UnitCrossProduct(normal, tangent_eta, tangent_xi);
+        MathUtils::UnitCrossProduct(normal, tangent_eta, tangent_xi);
 
         // Calculating the pressure on the gauss point
         double pressure = 0.0;

--- a/applications/StructuralMechanicsApplication/custom_conditions/surface_load_condition_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/surface_load_condition_3d.cpp
@@ -167,7 +167,7 @@ void SurfaceLoadCondition3D::CalculateAndSubKp(
             coeff = Pressure * rN[i] * rDN_De(j, 1) * Weight;
             noalias(Kij) -= coeff * cross_tangent_xi;
 
-            MathUtils<double>::AddMatrix(rK, Kij, row_index, column_index);
+            MathUtils::AddMatrix(rK, Kij, row_index, column_index);
         }
     }
 
@@ -276,7 +276,7 @@ void SurfaceLoadCondition3D::CalculateAll(
     Matrix J(3, 2);
     for (std::size_t point_number = 0; point_number < integration_points.size(); ++point_number) {
         r_geometry.Jacobian(J, point_number, integration_method);
-        const double detJ = MathUtils<double>::GeneralizedDet(J);
+        const double detJ = MathUtils::GeneralizedDet(J);
         const double integration_weight = GetIntegrationWeight(integration_points, point_number, detJ);
         const auto& rN = row(Ncontainer, point_number);
 
@@ -288,7 +288,7 @@ void SurfaceLoadCondition3D::CalculateAll(
         tangent_eta[2] = J(2, 1);
 
         array_1d<double, 3 > normal;
-        MathUtils<double>::UnitCrossProduct(normal, tangent_eta, tangent_xi);
+        MathUtils::UnitCrossProduct(normal, tangent_eta, tangent_xi);
 
         // Calculating the pressure on the gauss point
         double pressure = 0.0;

--- a/applications/StructuralMechanicsApplication/custom_constitutive/elastic_isotropic_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/elastic_isotropic_3d.cpp
@@ -397,7 +397,7 @@ void ElasticIsotropic3D::CalculateCauchyGreenStrain(
       E_tensor(i,i) -= 1.0;
     E_tensor *= 0.5;
 
-    noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
+    noalias(rStrainVector) = MathUtils::StrainTensorToVector(E_tensor);
 }
 
 } // Namespace Kratos

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_plane_strain.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_plane_strain.cpp
@@ -162,7 +162,7 @@ void LinearPlaneStrain::CalculateCauchyGreenStrain(Parameters& rValues, Constitu
 
     E_tensor *= 0.5;
 
-    noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
+    noalias(rStrainVector) = MathUtils::StrainTensorToVector(E_tensor);
 }
 
 } // Namespace Kratos

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_plane_stress.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_plane_stress.cpp
@@ -138,7 +138,7 @@ void LinearPlaneStress::CalculateCauchyGreenStrain(Parameters& rValues, Vector& 
 
     E_tensor *= 0.5;
 
-    noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
+    noalias(rStrainVector) = MathUtils::StrainTensorToVector(E_tensor);
 }
 
 } // Namespace Kratos

--- a/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.cpp
@@ -243,7 +243,7 @@ void BaseShellElement<TCoordinateTransformation>::Initialize(const ProcessInfo& 
 
             const array_1d<double, 3> prescribed_direcition = GetValue(LOCAL_MATERIAL_AXIS_1);
 
-            double mat_orientation_angle = MathUtils<double>::VectorsAngle(local_axes_1[0], prescribed_direcition);
+            double mat_orientation_angle = MathUtils::VectorsAngle(local_axes_1[0], prescribed_direcition);
 
             // make sure the angle is positively defined according to right hand rule
             if (inner_prod(local_axes_2[0], prescribed_direcition) < 0.0) {
@@ -672,7 +672,7 @@ void BaseShellElement<TCoordinateTransformation>::SetupOrientationAngles()
         dZ(2) = 1.0; // for the moment let's take this. But the user can specify its own triad! TODO
 
         Vector3Type dirX;
-        MathUtils<double>::CrossProduct(dirX, dZ, normal);
+        MathUtils::CrossProduct(dirX, dZ, normal);
 
         // try to normalize the x vector. if it is near zero it means that we need
         // to choose a default one.

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -631,7 +631,7 @@ void BaseSolidElement::CalculateMassMatrix(
         for ( IndexType point_number = 0; point_number < integration_points.size(); ++point_number ) {
             GeometryUtils::JacobianOnInitialConfiguration(
                 r_geom, integration_points[point_number], J0);
-            const double detJ0 = MathUtils<double>::Det(J0);
+            const double detJ0 = MathUtils::Det(J0);
             const double integration_weight =
                 GetIntegrationWeight(integration_points, point_number, detJ0) * thickness;
             const Vector& rN = row(Ncontainer,point_number);
@@ -862,7 +862,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                     // Calculate inverse of material matrix
                     Matrix invD(strain_size,strain_size);
                     double detD;
-                    MathUtils<double>::InvertMatrix(this_constitutive_variables.D, invD,detD);
+                    MathUtils::InvertMatrix(this_constitutive_variables.D, invD,detD);
 
                     // Calculate error_energy
                     rOutput[point_number] = integration_weight * inner_prod(error_sigma, prod(invD, error_sigma));
@@ -956,7 +956,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 const array_1d<double, 3> r_local_axis_1 = this->GetValue(LOCAL_AXIS_1);
                 const array_1d<double, 3> local_axis_2 = this->GetValue(LOCAL_AXIS_2);
                 for (IndexType point_number = 0; point_number < number_of_integration_points; ++point_number)
-                    noalias(rOutput[point_number]) = MathUtils<double>::CrossProduct(r_local_axis_1, local_axis_2);
+                    noalias(rOutput[point_number]) = MathUtils::CrossProduct(r_local_axis_1, local_axis_2);
             }
         } else {
             CalculateOnConstitutiveLaw(rVariable, rOutput, rCurrentProcessInfo);
@@ -1169,7 +1169,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 if ( rOutput[point_number].size2() != dimension )
                     rOutput[point_number].resize( dimension, dimension, false );
 
-                noalias(rOutput[point_number]) = MathUtils<double>::StressVectorToTensor(stress_vector[point_number]);
+                noalias(rOutput[point_number]) = MathUtils::StressVectorToTensor(stress_vector[point_number]);
             }
         }
         else if ( rVariable == GREEN_LAGRANGE_STRAIN_TENSOR  || rVariable == ALMANSI_STRAIN_TENSOR) {
@@ -1184,7 +1184,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                 if ( rOutput[point_number].size2() != dimension )
                     rOutput[point_number].resize( dimension, dimension, false );
 
-                noalias(rOutput[point_number]) = MathUtils<double>::StrainVectorToTensor(strain_vector[point_number]);
+                noalias(rOutput[point_number]) = MathUtils::StrainVectorToTensor(strain_vector[point_number]);
             }
         } else if ( rVariable == CONSTITUTIVE_MATRIX ) {
             const bool is_rotated = IsElementRotated();
@@ -1567,7 +1567,7 @@ void BaseSolidElement::BuildRotationSystem(
 
     if (StrainSize == 6) {
         noalias(local_axis_2) = this->GetValue(LOCAL_AXIS_2);
-        noalias(local_axis_3) = MathUtils<double>::CrossProduct(r_local_axis_1, local_axis_2);
+        noalias(local_axis_3) = MathUtils::CrossProduct(r_local_axis_1, local_axis_2);
     } else if (StrainSize == 3) { // we assume xy plane
         local_axis_2[0] = r_local_axis_1[1];
         local_axis_2[1] = -r_local_axis_1[0];
@@ -1606,7 +1606,7 @@ void BaseSolidElement::RotateToLocalAxes(
     } else { // Rotate F
         BoundedMatrix<double, 3, 3> inv_rotation_matrix;
         double aux_det;
-        MathUtils<double>::InvertMatrix3(rotation_matrix, inv_rotation_matrix, aux_det);
+        MathUtils::InvertMatrix3(rotation_matrix, inv_rotation_matrix, aux_det);
         rThisKinematicVariables.F = prod(rotation_matrix, rThisKinematicVariables.F);
         rThisKinematicVariables.F = prod(rThisKinematicVariables.F, inv_rotation_matrix);
         rValues.SetDeformationGradientF(rThisKinematicVariables.F);
@@ -1658,7 +1658,7 @@ void BaseSolidElement::RotateToGlobalAxes(
     if (!UseElementProvidedStrain()) {
         BoundedMatrix<double, 3, 3> inv_rotation_matrix;
         double aux_det;
-        MathUtils<double>::InvertMatrix3(rotation_matrix, inv_rotation_matrix, aux_det);
+        MathUtils::InvertMatrix3(rotation_matrix, inv_rotation_matrix, aux_det);
         rThisKinematicVariables.F = prod(inv_rotation_matrix, rThisKinematicVariables.F);
         rThisKinematicVariables.F = prod(rThisKinematicVariables.F, rotation_matrix);
         rValues.SetDeformationGradientF(rThisKinematicVariables.F);
@@ -1727,7 +1727,7 @@ double BaseSolidElement::CalculateDerivativesOnReferenceConfiguration(
     GeometryUtils::JacobianOnInitialConfiguration(
         r_geom,
         this->IntegrationPoints(ThisIntegrationMethod)[PointNumber], rJ0);
-    MathUtils<double>::InvertMatrix(rJ0, rInvJ0, detJ0);
+    MathUtils::InvertMatrix(rJ0, rInvJ0, detJ0);
     const Matrix& rDN_De = GetGeometry().ShapeFunctionsLocalGradients(ThisIntegrationMethod)[PointNumber];
     GeometryUtils::ShapeFunctionsGradients(rDN_De, rInvJ0, rDN_DX);
     return detJ0;
@@ -1747,7 +1747,7 @@ double BaseSolidElement::CalculateDerivativesOnCurrentConfiguration(
     double detJ;
     rJ = GetGeometry().Jacobian( rJ, PointNumber, ThisIntegrationMethod );
     const Matrix& DN_De = GetGeometry().ShapeFunctionsLocalGradients(ThisIntegrationMethod)[PointNumber];
-    MathUtils<double>::InvertMatrix( rJ, rInvJ, detJ );
+    MathUtils::InvertMatrix( rJ, rInvJ, detJ );
     GeometryUtils::ShapeFunctionsGradients(DN_De, rInvJ, rDN_DX);
     return detJ;
 }
@@ -1793,10 +1793,10 @@ void BaseSolidElement::CalculateAndAddKg(
     KRATOS_TRY
 
     const SizeType dimension = GetGeometry().WorkingSpaceDimension();
-    const Matrix stress_tensor_x_weigth = IntegrationWeight * MathUtils<double>::StressVectorToTensor( StressVector );
+    const Matrix stress_tensor_x_weigth = IntegrationWeight * MathUtils::StressVectorToTensor( StressVector );
     Matrix reduced_Kg(DN_DX.size1(), DN_DX.size1());
-    MathUtils<double>::BDBtProductOperation(reduced_Kg, stress_tensor_x_weigth, DN_DX);
-    MathUtils<double>::ExpandAndAddReducedMatrix( rLeftHandSideMatrix, reduced_Kg, dimension );
+    MathUtils::BDBtProductOperation(reduced_Kg, stress_tensor_x_weigth, DN_DX);
+    MathUtils::ExpandAndAddReducedMatrix( rLeftHandSideMatrix, reduced_Kg, dimension );
 
     KRATOS_CATCH( "" )
 }

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
@@ -345,7 +345,7 @@ void CrBeamElement2D2N::CalculateAndAddWorkEquivalentNodalForcesLineLoad(
         GetGeometry()[1].Y() - GetGeometry()[0].Y();
     geometric_orientation[2] = 0.000;
 
-    const double vector_norm_a = MathUtils<double>::Norm(geometric_orientation);
+    const double vector_norm_a = MathUtils::Norm(geometric_orientation);
     if (vector_norm_a > numerical_limit) {
         geometric_orientation /= vector_norm_a;
     }
@@ -355,7 +355,7 @@ void CrBeamElement2D2N::CalculateAndAddWorkEquivalentNodalForcesLineLoad(
         line_load_direction[i] = ForceInput[i];
     }
 
-    const double vector_norm_b = MathUtils<double>::Norm(line_load_direction);
+    const double vector_norm_b = MathUtils::Norm(line_load_direction);
     if (vector_norm_b > numerical_limit) {
         line_load_direction /= vector_norm_b;
     }
@@ -382,7 +382,7 @@ void CrBeamElement2D2N::CalculateAndAddWorkEquivalentNodalForcesLineLoad(
     Vector load_orthogonal_direction = ZeroVector(3);
     load_orthogonal_direction = node_b - node_c;
     const double vector_norm_c =
-        MathUtils<double>::Norm(load_orthogonal_direction);
+        MathUtils::Norm(load_orthogonal_direction);
     if (vector_norm_c > numerical_limit) {
         load_orthogonal_direction /= vector_norm_c;
     }
@@ -393,7 +393,7 @@ void CrBeamElement2D2N::CalculateAndAddWorkEquivalentNodalForcesLineLoad(
         norm_force_vector_orthogonal * GeometryLength * GeometryLength / 12.00;
 
     Vector moment_node_a = ZeroVector(3);
-    moment_node_a = MathUtils<double>::CrossProduct(geometric_orientation,
+    moment_node_a = MathUtils::CrossProduct(geometric_orientation,
                     load_orthogonal_direction);
     moment_node_a *= custom_moment;
 

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
@@ -241,7 +241,7 @@ void CrBeamElement3D2N::CalculateAndAddWorkEquivalentNodalForcesLineLoad(
             GetGeometry()[1].Z() - GetGeometry()[0].Z();
     }
 
-    const double vector_norm_a = MathUtils<double>::Norm(geometric_orientation);
+    const double vector_norm_a = MathUtils::Norm(geometric_orientation);
     if (vector_norm_a > numerical_limit) {
         geometric_orientation /= vector_norm_a;
     }
@@ -251,7 +251,7 @@ void CrBeamElement3D2N::CalculateAndAddWorkEquivalentNodalForcesLineLoad(
         line_load_direction[i] = ForceInput[i];
     }
 
-    const double vector_norm_b = MathUtils<double>::Norm(line_load_direction);
+    const double vector_norm_b = MathUtils::Norm(line_load_direction);
     if (vector_norm_b > numerical_limit) {
         line_load_direction /= vector_norm_b;
     }
@@ -280,7 +280,7 @@ void CrBeamElement3D2N::CalculateAndAddWorkEquivalentNodalForcesLineLoad(
     Vector load_orthogonal_direction = ZeroVector(msDimension);
     load_orthogonal_direction = node_b - node_c;
     const double vector_norm_c =
-        MathUtils<double>::Norm(load_orthogonal_direction);
+        MathUtils::Norm(load_orthogonal_direction);
     if (vector_norm_c > numerical_limit) {
         load_orthogonal_direction /= vector_norm_c;
     }
@@ -291,7 +291,7 @@ void CrBeamElement3D2N::CalculateAndAddWorkEquivalentNodalForcesLineLoad(
         norm_force_vector_orthogonal * GeometryLength * GeometryLength / 12.00;
 
     Vector moment_a = ZeroVector(msDimension);
-    moment_a = MathUtils<double>::CrossProduct(geometric_orientation,
+    moment_a = MathUtils::CrossProduct(geometric_orientation,
                load_orthogonal_direction);
     moment_a *= custom_moment;
 
@@ -614,7 +614,7 @@ CrBeamElement3D2N::CalculateInitialLocalCS() const
 
     // take user defined local axis 2 from GID input
     if (Has(LOCAL_AXIS_2)) {
-        double vector_norm = MathUtils<double>::Norm(direction_vector_x);
+        double vector_norm = MathUtils::Norm(direction_vector_x);
         if (vector_norm > numerical_limit) {
             direction_vector_x /= vector_norm;
         }
@@ -628,7 +628,7 @@ CrBeamElement3D2N::CalculateInitialLocalCS() const
         direction_vector_z[2] = direction_vector_x[0] * direction_vector_y[1] -
                                 direction_vector_x[1] * direction_vector_y[0];
 
-        vector_norm = MathUtils<double>::Norm(direction_vector_z);
+        vector_norm = MathUtils::Norm(direction_vector_z);
         if (vector_norm > numerical_limit) {
             direction_vector_z /= vector_norm;
         } else
@@ -658,7 +658,7 @@ CrBeamElement3D2N::CalculateInitialLocalCS() const
         arraydim v3 = ZeroVector(msDimension);
 
         double vector_norm;
-        vector_norm = MathUtils<double>::Norm(direction_vector_x);
+        vector_norm = MathUtils::Norm(direction_vector_x);
         if (vector_norm > numerical_limit) {
             direction_vector_x /= vector_norm;
         }
@@ -670,8 +670,8 @@ CrBeamElement3D2N::CalculateInitialLocalCS() const
             v2[1] = 1.0;
             v3[0] = 1.0;
         } else {
-            MathUtils<double>::UnitCrossProduct(v2, global_z, direction_vector_x);
-            MathUtils<double>::UnitCrossProduct(v3, direction_vector_x, v2);
+            MathUtils::UnitCrossProduct(v2, global_z, direction_vector_x);
+            MathUtils::UnitCrossProduct(v3, direction_vector_x, v2);
         }
 
         // manual rotation around the beam axis
@@ -682,13 +682,13 @@ CrBeamElement3D2N::CalculateInitialLocalCS() const
             const double sin_theta = std::sin(theta_custom);
 
             v2 = ny_temp * cos_theta + nz_temp * sin_theta;
-            vector_norm = MathUtils<double>::Norm(v2);
+            vector_norm = MathUtils::Norm(v2);
             if (vector_norm > numerical_limit) {
                 v2 /= vector_norm;
             }
 
             v3 = nz_temp * cos_theta - ny_temp * sin_theta;
-            vector_norm = MathUtils<double>::Norm(v3);
+            vector_norm = MathUtils::Norm(v3);
             if (vector_norm > numerical_limit) {
                 v3 /= vector_norm;
             }
@@ -766,7 +766,7 @@ void CrBeamElement3D2N::UpdateQuaternionParameters(
 
     rVecNodeA = drA_sca * temp_vector;
     rVecNodeA += temp_scalar * drA_vec;
-    rVecNodeA += MathUtils<double>::CrossProduct(drA_vec, temp_vector);
+    rVecNodeA += MathUtils::CrossProduct(drA_vec, temp_vector);
 
     // Node B
     temp_vector = mQuaternionVEC_B;
@@ -779,7 +779,7 @@ void CrBeamElement3D2N::UpdateQuaternionParameters(
 
     rVecNodeB = drB_sca * temp_vector;
     rVecNodeB += temp_scalar * drB_vec;
-    rVecNodeB += MathUtils<double>::CrossProduct(drB_vec, temp_vector);
+    rVecNodeB += MathUtils::CrossProduct(drB_vec, temp_vector);
     KRATOS_CATCH("");
 }
 
@@ -824,8 +824,8 @@ CrBeamElement3D2N::UpdateRotationMatrixLocal(Vector& Bisectrix,
                          (quaternion_sca_a + quaternion_sca_b);
 
     temp_vector = quaternion_vec_a + quaternion_vec_b;
-    scalar_diff += MathUtils<double>::Norm(temp_vector) *
-                   MathUtils<double>::Norm(temp_vector);
+    scalar_diff += MathUtils::Norm(temp_vector) *
+                   MathUtils::Norm(temp_vector);
 
     scalar_diff = 0.50 * std::sqrt(scalar_diff);
 
@@ -840,7 +840,7 @@ CrBeamElement3D2N::UpdateRotationMatrixLocal(Vector& Bisectrix,
     VectorDifference = ZeroVector(msDimension);
     VectorDifference = quaternion_sca_a * quaternion_vec_b;
     VectorDifference -= quaternion_sca_b * quaternion_vec_a;
-    VectorDifference += MathUtils<double>::CrossProduct(quaternion_vec_a,
+    VectorDifference += MathUtils::CrossProduct(quaternion_vec_a,
                         quaternion_vec_b);
 
     VectorDifference = 0.50 * VectorDifference / scalar_diff;
@@ -885,13 +885,13 @@ CrBeamElement3D2N::UpdateRotationMatrixLocal(Vector& Bisectrix,
         delta_x[i] =
             current_nodal_position[msDimension + i] - current_nodal_position[i];
 
-    vector_norm = MathUtils<double>::Norm(delta_x);
+    vector_norm = MathUtils::Norm(delta_x);
     if (vector_norm > numerical_limit) {
         delta_x /= vector_norm;
     }
 
     Bisectrix = rotated_nx0 + delta_x;
-    vector_norm = MathUtils<double>::Norm(Bisectrix);
+    vector_norm = MathUtils::Norm(Bisectrix);
     if (vector_norm > numerical_limit) {
         Bisectrix /= vector_norm;
     }
@@ -941,7 +941,7 @@ Vector CrBeamElement3D2N::CalculateAntiSymmetricDeformationMode() const
         rotated_nx0[i] = rotation_matrix(i, 0);
     }
     Vector temp_vector = ZeroVector(msDimension);
-    MathUtils<double>::CrossProduct(temp_vector, rotated_nx0, bisectrix);
+    MathUtils::CrossProduct(temp_vector, rotated_nx0, bisectrix);
     phi_a = prod(Matrix(trans(rotation_matrix)), temp_vector);
     phi_a *= 4.00;
 
@@ -1701,18 +1701,18 @@ int CrBeamElement3D2N::Check(const ProcessInfo& rCurrentProcessInfo) const
             direction_vector_x[i] = (reference_coordinates[i + msDimension] - reference_coordinates[i]);
         }
 
-        const double vector_norm = MathUtils<double>::Norm(direction_vector_x);
+        const double vector_norm = MathUtils::Norm(direction_vector_x);
         if (vector_norm > numerical_limit) {
             direction_vector_x /= vector_norm;
         }
 
         direction_vector_y = GetValue(LOCAL_AXIS_2);
-        const double norm_dir_y = MathUtils<double>::Norm(direction_vector_y);
+        const double norm_dir_y = MathUtils::Norm(direction_vector_y);
 
         KRATOS_ERROR_IF(norm_dir_y<numerical_limit) << "Given LOCAL_AXIS_2 has length 0 for element " << Id() << std::endl;
 
         // a tolerance of 1e-3 allows for a rough deviation of 0.06 degrees from 90.0 degrees
-        const double dot_prod = MathUtils<double>::Dot(direction_vector_x, direction_vector_y);
+        const double dot_prod = MathUtils::Dot(direction_vector_x, direction_vector_y);
         if (std::abs(dot_prod)>1e-3) {
             const double angle = (180.0 / Globals::Pi) * std::acos(dot_prod / (vector_norm*norm_dir_y));
             KRATOS_ERROR << "LOCAL_AXIS_1 is not perpendicular to LOCAL_AXIS_2 for element " << Id() << ", angle is " << angle << " degree" << std::endl;

--- a/applications/StructuralMechanicsApplication/custom_elements/isotropic_shell_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/isotropic_shell_element.cpp
@@ -104,7 +104,7 @@ void IsotropicShellElement::CalculateLocalGlobalTransformation(
     temp[0]=GetGeometry()[2].X()-GetGeometry()[0].X();
     temp[1]=GetGeometry()[2].Y()-GetGeometry()[0].Y();
     temp[2]=GetGeometry()[2].Z()-GetGeometry()[0].Z();
-    MathUtils<double>::CrossProduct(v3,v1,temp);
+    MathUtils::CrossProduct(v3,v1,temp);
     area = 0.5 * norm_2(v3);
 
     //normalizing base vectors
@@ -112,7 +112,7 @@ void IsotropicShellElement::CalculateLocalGlobalTransformation(
     v3 /= (2.0*area);
 
     //forming the "second" base vector - it is already normalized
-    MathUtils<double>::CrossProduct(v2,v3,v1);
+    MathUtils::CrossProduct(v2,v3,v1);
     x31 = inner_prod(temp,v1);
     y31 = inner_prod(temp,v2);
 
@@ -1035,7 +1035,7 @@ void IsotropicShellElement::CalculateOnIntegrationPoints(const Variable<Matrix >
 
             for(unsigned int ii = 0; ii<rotated_stress.size(); ii++)
             	Output[0](0,ii) = rotated_stress[ii];*/
-            Output[0] = MathUtils<double>::StressVectorToTensor(rotated_stress);
+            Output[0] = MathUtils::StressVectorToTensor(rotated_stress);
         }
 
     }
@@ -1898,7 +1898,7 @@ void IsotropicShellElement::SetupOrientationAngles()
     dZ(2) = 1.0; // for the moment let's take this. But the user can specify its own triad! TODO
 
     array_1d<double,3> dirX;
-    MathUtils<double>::CrossProduct(dirX,   dZ, normal);
+    MathUtils::CrossProduct(dirX,   dZ, normal);
 
     // try to normalize the local x direction, otherwise chose the default one( global X )
     double dirX_norm( dirX(0)*dirX(0) + dirX(1)*dirX(1) + dirX(2)*dirX(2) );

--- a/applications/StructuralMechanicsApplication/custom_elements/membrane_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/membrane_element.cpp
@@ -307,8 +307,8 @@ void MembraneElement::AddPreStressPk2(Vector& rStress, const array_1d<Vector,2>&
         if (Has(LOCAL_PRESTRESS_AXIS_1) && Has(LOCAL_PRESTRESS_AXIS_2)){
 
             array_1d<array_1d<double,3>,2> local_prestress_axis;
-            local_prestress_axis[0] = GetValue(LOCAL_PRESTRESS_AXIS_1)/MathUtils<double>::Norm(GetValue(LOCAL_PRESTRESS_AXIS_1));
-            local_prestress_axis[1] = GetValue(LOCAL_PRESTRESS_AXIS_2)/MathUtils<double>::Norm(GetValue(LOCAL_PRESTRESS_AXIS_2));
+            local_prestress_axis[0] = GetValue(LOCAL_PRESTRESS_AXIS_1)/MathUtils::Norm(GetValue(LOCAL_PRESTRESS_AXIS_1));
+            local_prestress_axis[1] = GetValue(LOCAL_PRESTRESS_AXIS_2)/MathUtils::Norm(GetValue(LOCAL_PRESTRESS_AXIS_2));
 
             Matrix transformation_matrix = ZeroMatrix(3);
             InPlaneTransformationMatrix(transformation_matrix,rTransformedBaseVectors,local_prestress_axis);
@@ -317,12 +317,12 @@ void MembraneElement::AddPreStressPk2(Vector& rStress, const array_1d<Vector,2>&
         } else if (Has(LOCAL_PRESTRESS_AXIS_1)) {
 
             Vector base_3 = ZeroVector(3);
-            MathUtils<double>::UnitCrossProduct(base_3, rTransformedBaseVectors[0], rTransformedBaseVectors[1]);
+            MathUtils::UnitCrossProduct(base_3, rTransformedBaseVectors[0], rTransformedBaseVectors[1]);
 
             array_1d<array_1d<double,3>,2> local_prestress_axis;
-            local_prestress_axis[0] = GetValue(LOCAL_PRESTRESS_AXIS_1)/MathUtils<double>::Norm(GetValue(LOCAL_PRESTRESS_AXIS_1));
+            local_prestress_axis[0] = GetValue(LOCAL_PRESTRESS_AXIS_1)/MathUtils::Norm(GetValue(LOCAL_PRESTRESS_AXIS_1));
 
-            MathUtils<double>::UnitCrossProduct(local_prestress_axis[1], base_3, local_prestress_axis[0]);
+            MathUtils::UnitCrossProduct(local_prestress_axis[1], base_3, local_prestress_axis[0]);
 
             Matrix transformation_matrix = ZeroMatrix(3);
             InPlaneTransformationMatrix(transformation_matrix,rTransformedBaseVectors,local_prestress_axis);
@@ -370,7 +370,7 @@ void MembraneElement::StrainGreenLagrange(Vector& rStrain, const Matrix& rRefere
     const Matrix& rTransformationMatrix)
 {
     Matrix strain_matrix = 0.50 * (rCurrentCoVariantMetric-rReferenceCoVariantMetric);
-    Vector reference_strain = MathUtils<double>::StrainTensorToVector(strain_matrix,3);
+    Vector reference_strain = MathUtils::StrainTensorToVector(strain_matrix,3);
     TransformStrains(rStrain,reference_strain,rTransformationMatrix);
 }
 
@@ -380,7 +380,7 @@ void MembraneElement::DerivativeStrainGreenLagrange(Vector& rStrain, const Matri
     Matrix current_covariant_metric_derivative = ZeroMatrix(2);
     DerivativeCurrentCovariantMetric(current_covariant_metric_derivative,rShapeFunctionGradientValues,DofR,rCurrentCovariantBaseVectors);
     Matrix strain_matrix_derivative = 0.50 * current_covariant_metric_derivative;
-    Vector reference_strain = MathUtils<double>::StrainTensorToVector(strain_matrix_derivative,3);
+    Vector reference_strain = MathUtils::StrainTensorToVector(strain_matrix_derivative,3);
     TransformStrains(rStrain,reference_strain,rTransformationMatrix);
 }
 
@@ -393,15 +393,15 @@ void MembraneElement::Derivative2StrainGreenLagrange(Vector& rStrain,
 
     Matrix strain_matrix_derivative = 0.50 * current_covariant_metric_derivative;
 
-    Vector reference_strain = MathUtils<double>::StrainTensorToVector(strain_matrix_derivative,3);
+    Vector reference_strain = MathUtils::StrainTensorToVector(strain_matrix_derivative,3);
     TransformStrains(rStrain,reference_strain,rTransformationMatrix);
 }
 
 void MembraneElement::JacobiDeterminante(double& rDetJacobi, const array_1d<Vector,2>& rReferenceBaseVectors) const
 {
     Vector3 g3 = ZeroVector(3);
-    MathUtils<double>::CrossProduct(g3, rReferenceBaseVectors[0], rReferenceBaseVectors[1]);
-    rDetJacobi = MathUtils<double>::Norm(g3);
+    MathUtils::CrossProduct(g3, rReferenceBaseVectors[0], rReferenceBaseVectors[1]);
+    rDetJacobi = MathUtils::Norm(g3);
     KRATOS_ERROR_IF(rDetJacobi<std::numeric_limits<double>::epsilon()) << "det of Jacobi smaller 0 for element with id" << Id() << std::endl;
 }
 
@@ -717,22 +717,22 @@ void MembraneElement::TransformBaseVectors(array_1d<Vector,2>& rBaseVectors,
 
     // create local cartesian coordinate system aligned to global material vectors (orthotropic)
     if (Has(LOCAL_MATERIAL_AXIS_1) && Has(LOCAL_MATERIAL_AXIS_2)){
-        rBaseVectors[0] = GetValue(LOCAL_MATERIAL_AXIS_1)/MathUtils<double>::Norm(GetValue(LOCAL_MATERIAL_AXIS_1));
-        rBaseVectors[1] = GetValue(LOCAL_MATERIAL_AXIS_2)/MathUtils<double>::Norm(GetValue(LOCAL_MATERIAL_AXIS_2));
+        rBaseVectors[0] = GetValue(LOCAL_MATERIAL_AXIS_1)/MathUtils::Norm(GetValue(LOCAL_MATERIAL_AXIS_1));
+        rBaseVectors[1] = GetValue(LOCAL_MATERIAL_AXIS_2)/MathUtils::Norm(GetValue(LOCAL_MATERIAL_AXIS_2));
     } else if (Has(LOCAL_MATERIAL_AXIS_1)) {
         Vector base_3 = ZeroVector(3);
-        MathUtils<double>::UnitCrossProduct(base_3, rLocalBaseVectors[0], rLocalBaseVectors[1]);
+        MathUtils::UnitCrossProduct(base_3, rLocalBaseVectors[0], rLocalBaseVectors[1]);
 
-        rBaseVectors[0] = GetValue(LOCAL_MATERIAL_AXIS_1)/MathUtils<double>::Norm(GetValue(LOCAL_MATERIAL_AXIS_1));
-        MathUtils<double>::UnitCrossProduct(rBaseVectors[1], base_3, rBaseVectors[0]);
+        rBaseVectors[0] = GetValue(LOCAL_MATERIAL_AXIS_1)/MathUtils::Norm(GetValue(LOCAL_MATERIAL_AXIS_1));
+        MathUtils::UnitCrossProduct(rBaseVectors[1], base_3, rBaseVectors[0]);
 
     } else {
         // create local cartesian coordinate system
         rBaseVectors[0] = ZeroVector(3);
         rBaseVectors[1] = ZeroVector(3);
-        rBaseVectors[0] = rLocalBaseVectors[0] / MathUtils<double>::Norm(rLocalBaseVectors[0]);
+        rBaseVectors[0] = rLocalBaseVectors[0] / MathUtils::Norm(rLocalBaseVectors[0]);
         rBaseVectors[1] = rLocalBaseVectors[1] - (inner_prod(rLocalBaseVectors[1],rBaseVectors[0]) * rBaseVectors[0]);
-        rBaseVectors[1] /= MathUtils<double>::Norm(rBaseVectors[1]);
+        rBaseVectors[1] /= MathUtils::Norm(rBaseVectors[1]);
     }
 }
 
@@ -875,7 +875,7 @@ void MembraneElement::CalculateOnIntegrationPoints(const Variable<Vector >& rVar
             DeformationGradient(deformation_gradient,det_deformation_gradient,current_covariant_base_vectors,reference_contravariant_base_vectors);
 
 
-            Matrix stress_matrix_local_cs = MathUtils<double>::StressVectorToTensor(stress);
+            Matrix stress_matrix_local_cs = MathUtils::StressVectorToTensor(stress);
 
             // transform stresses to original bases
             Matrix stress_matrix = ZeroMatrix(3);
@@ -899,7 +899,7 @@ void MembraneElement::CalculateOnIntegrationPoints(const Variable<Vector >& rVar
                     local_stress(i,j) = inner_prod(transformed_base_vectors[i],prod(cauchy_stress_matrix,transformed_base_vectors[j]));
                 }
             }
-            stress = MathUtils<double>::StressTensorToVector(local_stress,3);
+            stress = MathUtils::StressTensorToVector(local_stress,3);
 
 
             if (rVariable==PRINCIPAL_CAUCHY_STRESS_VECTOR){
@@ -926,10 +926,10 @@ void MembraneElement::DeformationGradient(Matrix& rDeformationGradient, double& 
 
     // calculate out of plane local vectors (membrane has no thickness change so g3 and G3 are normalized)
     Vector current_cov_3 = ZeroVector(3);
-    MathUtils<double>::UnitCrossProduct(current_cov_3,rCurrentCovariantBase[0],rCurrentCovariantBase[1]);
+    MathUtils::UnitCrossProduct(current_cov_3,rCurrentCovariantBase[0],rCurrentCovariantBase[1]);
 
     Vector reference_contra_3 = ZeroVector(3);
-    MathUtils<double>::UnitCrossProduct(reference_contra_3,rReferenceContraVariantBase[0],rReferenceContraVariantBase[1]);
+    MathUtils::UnitCrossProduct(reference_contra_3,rReferenceContraVariantBase[0],rReferenceContraVariantBase[1]);
 
     // calculate deformation gradient
     rDeformationGradient = ZeroMatrix(3);
@@ -942,7 +942,7 @@ void MembraneElement::DeformationGradient(Matrix& rDeformationGradient, double& 
 
 
     // calculate det(F)
-    rDetDeformationGradient = MathUtils<double>::Det(rDeformationGradient);
+    rDetDeformationGradient = MathUtils::Det(rDeformationGradient);
 }
 
 void MembraneElement::CalculateOnIntegrationPoints(
@@ -991,7 +991,7 @@ void MembraneElement::CalculateOnIntegrationPoints(
 
             if (rVariable == LOCAL_AXIS_3){
                 Vector base_vec_3 = ZeroVector(3);
-                MathUtils<double>::UnitCrossProduct(base_vec_3,transformed_base_vectors[0],transformed_base_vectors[1]);
+                MathUtils::UnitCrossProduct(base_vec_3,transformed_base_vectors[0],transformed_base_vectors[1]);
 
                 for (SizeType i =0; i<3; ++i) {
                     rOutput[point_number][i] = base_vec_3[i];
@@ -1029,7 +1029,7 @@ void MembraneElement::Calculate(const Variable<Matrix>& rVariable, Matrix& rOutp
             base_2 += base_vectors_current_cov[1]*integration_weight_i;
         }
 
-        MathUtils<double>::UnitCrossProduct(base_3, base_1, base_2);
+        MathUtils::UnitCrossProduct(base_3, base_1, base_2);
 
         column(rOutput,0) = base_1;
         column(rOutput,1) = base_2;

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.cpp
@@ -232,7 +232,7 @@ ShellThickElement3D4N<TKinematics>::EASOperator::EASOperator(const ShellQ4_Local
     F0(2,2) = j11*j22 + j12*j21;
 
     double dummyDet;
-    MathUtils<double>::InvertMatrix3(F0, mF0inv, dummyDet);
+    MathUtils::InvertMatrix3(F0, mF0inv, dummyDet);
 
     // initialize these data to zero because they will
     // be integrated during the gauss loop

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.cpp
@@ -1074,8 +1074,8 @@ void ShellThinElement3D3N<TKinematics>::ApplyCorrectionToRHS(CalculationData& da
         z(1) = 0.0;
         z(2) = 1.0;
         Vector3Type n;
-        MathUtils<double>::CrossProduct(n,  t,z);
-        n /= MathUtils<double>::Norm3(n);
+        MathUtils::CrossProduct(n,  t,z);
+        n /= MathUtils::Norm3(n);
 
         double sx, sy;
         sx = s1(0)*n(0) + s1(2)*n(1);

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.cpp
@@ -965,11 +965,11 @@ void ShellThinElement3D4N<TKinematics>::InitializeCalculationData(CalculationDat
 
         for (int i = 0; i < 4; i++) {
             //eqn 5.2.29
-            const Vector vec1 = MathUtils<double>::CrossProduct(data.r_cartesian[i], s_xi);
+            const Vector vec1 = MathUtils::CrossProduct(data.r_cartesian[i], s_xi);
             d_xi_i[i] = std::sqrt(inner_prod(vec1, vec1));
             chi_xi_i[i] = d_xi_i[i] / l_xi;
 
-            const Vector vec2 = MathUtils<double>::CrossProduct(data.r_cartesian[i], s_eta);
+            const Vector vec2 = MathUtils::CrossProduct(data.r_cartesian[i], s_eta);
             d_eta_i[i] = std::sqrt(inner_prod(vec2, vec2));
             chi_eta_i[i] = d_eta_i[i] / l_eta;
         }
@@ -980,7 +980,7 @@ void ShellThinElement3D4N<TKinematics>::InitializeCalculationData(CalculationDat
         double l_13 = std::sqrt(inner_prod(r_13, r_13));
 
         Vector e_24 = Vector(r_24 / l_24);
-        const Vector vec1 = Vector(MathUtils<double>::CrossProduct(r_13, e_24));
+        const Vector vec1 = Vector(MathUtils::CrossProduct(r_13, e_24));
 
         const double d_24 = std::sqrt(inner_prod(vec1, vec1));
         const double d_13 = d_24;
@@ -1144,10 +1144,10 @@ void ShellThinElement3D4N<TKinematics>::InitializeCalculationData(CalculationDat
 
         Matrix T_13 = Matrix(3, 3, 0.0);
         Matrix T_24 = Matrix(3, 3, 0.0);
-        double t13invdet = MathUtils<double>::Det(T_13_inv);
-        MathUtils<double>::InvertMatrix(T_13_inv, T_13, t13invdet);
-        double t24invdet = MathUtils<double>::Det(T_24_inv);
-        MathUtils<double>::InvertMatrix(T_24_inv, T_24, t24invdet);
+        double t13invdet = MathUtils::Det(T_13_inv);
+        MathUtils::InvertMatrix(T_13_inv, T_13, t13invdet);
+        double t24invdet = MathUtils::Det(T_24_inv);
+        MathUtils::InvertMatrix(T_24_inv, T_24, t24invdet);
 
         data.B_h_1 = prod(T_13, Q1);
         data.B_h_2 = prod(T_24, Q2);
@@ -1273,7 +1273,7 @@ void ShellThinElement3D4N<TKinematics>::InitializeCalculationData(CalculationDat
         DKQ_temp(1, 0) = x32 + x41 + xi*(x12 + x34);
         DKQ_temp(1, 1) = y32 + y41 + xi*(y12 + y34);
         DKQ_temp = DKQ_temp / 4;
-        double det = MathUtils<double>::Det(DKQ_temp);
+        double det = MathUtils::Det(DKQ_temp);
         Matrix DKQ_temp_inv = Matrix(2, 2, 0.0);
         DKQ_temp_inv(0, 0) = DKQ_temp(1, 1);
         DKQ_temp_inv(1, 1) = DKQ_temp(0, 0);

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
@@ -215,7 +215,7 @@ void SmallDisplacement::CalculateKinematicVariables(
     Vector strain_vector(mConstitutiveLawVector[0]->GetStrainSize());
     noalias(strain_vector) = prod(rThisKinematicVariables.B, rThisKinematicVariables.Displacements);
     ComputeEquivalentF(rThisKinematicVariables.F, strain_vector);
-    rThisKinematicVariables.detF = MathUtils<double>::Det(rThisKinematicVariables.F);
+    rThisKinematicVariables.detF = MathUtils::Det(rThisKinematicVariables.F);
 }
 
 /***********************************************************************************/

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
@@ -213,7 +213,7 @@ void SmallDisplacementBbar::CalculateKinematicVariables(
     GetValuesVector(displacements);
     Vector strain_vector = prod(rThisKinematicVariables.B, displacements);
     rThisKinematicVariables.F = ComputeEquivalentF(strain_vector);
-    rThisKinematicVariables.detF = MathUtils<double>::Det(rThisKinematicVariables.F);
+    rThisKinematicVariables.detF = MathUtils::Det(rThisKinematicVariables.F);
 }
 
 //************************************************************************************
@@ -254,7 +254,7 @@ void SmallDisplacementBbar::CalculateKinematicVariablesBbar(
     GetValuesVector(displacements);
     Vector strain_vector = prod(rThisKinematicVariables.B, displacements);
     rThisKinematicVariables.F = ComputeEquivalentF(strain_vector);
-    rThisKinematicVariables.detF = MathUtils<double>::Det(rThisKinematicVariables.F);
+    rThisKinematicVariables.detF = MathUtils::Det(rThisKinematicVariables.F);
 }
 
 //************************************************************************************
@@ -279,7 +279,7 @@ void SmallDisplacementBbar::SetConstitutiveVariables(
     rThisKinematicVariables.F = ComputeEquivalentF(rThisConstitutiveVariables.StrainVector);
 
     // Here we essentially set the input parameters
-    rThisKinematicVariables.detF = MathUtils<double>::Det(rThisKinematicVariables.F);
+    rThisKinematicVariables.detF = MathUtils::Det(rThisKinematicVariables.F);
     rValues.SetShapeFunctionsValues(rThisKinematicVariables.N); // shape functions
     rValues.SetDeterminantF(rThisKinematicVariables.detF); //assuming the determinant is computed somewhere else
     rValues.SetDeformationGradientF(rThisKinematicVariables.F); //F computed somewhere else
@@ -588,7 +588,7 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
                                            Values, point_number, integration_points,
                                            GetStressMeasure(), false);
 
-            const Matrix stress_tensor = MathUtils<double>::StressVectorToTensor( this_constitutive_variables.StressVector );
+            const Matrix stress_tensor = MathUtils::StressVectorToTensor( this_constitutive_variables.StressVector );
 
             double sigma_equivalent = 0.0;
 
@@ -762,7 +762,7 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
             if ( rOutput[point_number].size2() != dimension )
                 rOutput[point_number].resize( dimension, dimension, false );
 
-            noalias(rOutput[point_number]) = MathUtils<double>::StressVectorToTensor(stress_vector[point_number]);
+            noalias(rOutput[point_number]) = MathUtils::StressVectorToTensor(stress_vector[point_number]);
         }
     }
     else if ( rVariable == GREEN_LAGRANGE_STRAIN_TENSOR  || rVariable == ALMANSI_STRAIN_TENSOR) {
@@ -777,7 +777,7 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
             if ( rOutput[point_number].size2() != dimension )
                 rOutput[point_number].resize( dimension, dimension, false );
 
-            noalias(rOutput[point_number]) = MathUtils<double>::StrainVectorToTensor(strain_vector[point_number]);
+            noalias(rOutput[point_number]) = MathUtils::StrainVectorToTensor(strain_vector[point_number]);
         }
     }
     else if (rVariable == CONSTITUTIVE_MATRIX) {

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_mixed_volumetric_strain_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_mixed_volumetric_strain_element.cpp
@@ -359,8 +359,8 @@ void SmallDisplacementMixedVolumetricStrainElement::CalculateLocalSystem(
         }
         double det;
         Matrix tau_1_mat(dim, dim);
-        MathUtils<double>::InvertMatrix(aux, tau_1_mat, det);
-        const Vector tau_1_vect = MathUtils<double>::SymmetricTensorToVector(tau_1_mat);
+        MathUtils::InvertMatrix(aux, tau_1_mat, det);
+        const Vector tau_1_vect = MathUtils::SymmetricTensorToVector(tau_1_mat);
         double m_T_tau_1 = inner_prod(m_T, tau_1_vect);
 
         // Calculate tau_2 stabilization constant
@@ -529,8 +529,8 @@ void SmallDisplacementMixedVolumetricStrainElement::CalculateLeftHandSide(
         }
         double det;
         Matrix tau_1_mat(dim, dim);
-        MathUtils<double>::InvertMatrix(aux, tau_1_mat, det);
-        const Vector tau_1_vect = MathUtils<double>::SymmetricTensorToVector(tau_1_mat);
+        MathUtils::InvertMatrix(aux, tau_1_mat, det);
+        const Vector tau_1_vect = MathUtils::SymmetricTensorToVector(tau_1_mat);
         double m_T_tau_1 = inner_prod(m_T, tau_1_vect);
 
         // Calculate tau_2 stabilization constant
@@ -665,8 +665,8 @@ void SmallDisplacementMixedVolumetricStrainElement::CalculateRightHandSide(
         }
         double det;
         Matrix tau_1_mat(dim, dim);
-        MathUtils<double>::InvertMatrix(aux, tau_1_mat, det);
-        const Vector tau_1_vect = MathUtils<double>::SymmetricTensorToVector(tau_1_mat);
+        MathUtils::InvertMatrix(aux, tau_1_mat, det);
+        const Vector tau_1_vect = MathUtils::SymmetricTensorToVector(tau_1_mat);
         double m_T_tau_1 = inner_prod(m_T, tau_1_vect);
 
         // Calculate tau_2 stabilization constant
@@ -839,7 +839,7 @@ void SmallDisplacementMixedVolumetricStrainElement::CalculateKinematicVariables(
         r_geometry,
         r_integration_points[PointNumber],
         rThisKinematicVariables.J0);
-    MathUtils<double>::InvertMatrix(
+    MathUtils::InvertMatrix(
         rThisKinematicVariables.J0,
         rThisKinematicVariables.InvJ0,
         rThisKinematicVariables.detJ0);
@@ -860,7 +860,7 @@ void SmallDisplacementMixedVolumetricStrainElement::CalculateKinematicVariables(
 
     // Compute equivalent F
     ComputeEquivalentF(rThisKinematicVariables.F, rThisKinematicVariables.EquivalentStrain);
-    rThisKinematicVariables.detF = MathUtils<double>::Det(rThisKinematicVariables.F);
+    rThisKinematicVariables.detF = MathUtils::Det(rThisKinematicVariables.F);
 }
 
 /***********************************************************************************/
@@ -962,15 +962,15 @@ void SmallDisplacementMixedVolumetricStrainElement::CalculateAnisotropyTensor(co
     Matrix b;
     const double tolerance = 1.0e-12;
     const unsigned int max_iterations = 100;
-    const bool is_converged_a = MathUtils<double>::MatrixSquareRoot(rC, a, tolerance, max_iterations);
+    const bool is_converged_a = MathUtils::MatrixSquareRoot(rC, a, tolerance, max_iterations);
     KRATOS_WARNING_IF("SmallDisplacementMixedVolumetricStrainElement", !is_converged_a) << "Element " << Id() << " anisotropic tensor square root did not converge.";
-    const bool is_converged_b = MathUtils<double>::MatrixSquareRoot(C_iso, b, tolerance, max_iterations);
+    const bool is_converged_b = MathUtils::MatrixSquareRoot(C_iso, b, tolerance, max_iterations);
     KRATOS_WARNING_IF("SmallDisplacementMixedVolumetricStrainElement", !is_converged_b) << "Element " << Id() << " isotropic tensor square root did not converge.";
 
     // Calculate the anisotropy tensor T as inv(b)*a
     Matrix inv_b;
     double det_b;
-    MathUtils<double>::InvertMatrix(b, inv_b, det_b);
+    MathUtils::InvertMatrix(b, inv_b, det_b);
     mAnisotropyTensor = prod(inv_b, a);
 }
 
@@ -982,7 +982,7 @@ void SmallDisplacementMixedVolumetricStrainElement::CalculateInverseAnisotropyTe
     const SizeType strain_size = GetProperties().GetValue(CONSTITUTIVE_LAW)->GetStrainSize();
     double aux_det;
     mInverseAnisotropyTensor = ZeroMatrix(strain_size, strain_size);
-    MathUtils<double>::InvertMatrix(mAnisotropyTensor, mInverseAnisotropyTensor, aux_det);
+    MathUtils::InvertMatrix(mAnisotropyTensor, mInverseAnisotropyTensor, aux_det);
 }
 
 /***********************************************************************************/

--- a/applications/StructuralMechanicsApplication/custom_elements/solid_shell_element_sprism_3D6N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/solid_shell_element_sprism_3D6N.cpp
@@ -717,7 +717,7 @@ void SolidShellElementSprism3D6N::CalculateOnIntegrationPoints(
             // Call the constitutive law to update material variables
             mConstitutiveLawVector[point_number]->CalculateMaterialResponseCauchy (Values);
 
-            const Matrix& stress_tensor = MathUtils<double>::StressVectorToTensor(general_variables.StressVector); //reduced dimension stress tensor
+            const Matrix& stress_tensor = MathUtils::StressVectorToTensor(general_variables.StressVector); //reduced dimension stress tensor
 
 
             // In general coordinates:
@@ -779,7 +779,7 @@ void SolidShellElementSprism3D6N::CalculateOnIntegrationPoints(
             // Call the constitutive law to update material variables
             mConstitutiveLawVector[point_number]->CalculateMaterialResponseCauchy (Values);
 
-            const Matrix& stress_tensor  = MathUtils<double>::StressVectorToTensor(general_variables.StressVector); //reduced dimension stress tensor
+            const Matrix& stress_tensor  = MathUtils::StressVectorToTensor(general_variables.StressVector); //reduced dimension stress tensor
 
             double stress_norm =  ((stress_tensor(0,0)*stress_tensor(0,0))+(stress_tensor(1,1)*stress_tensor(1,1))+(stress_tensor(2,2)*stress_tensor(2,2))+
                                    (stress_tensor(0,1)*stress_tensor(0,1))+(stress_tensor(0,2)*stress_tensor(0,2))+(stress_tensor(1,2)*stress_tensor(1,2))+
@@ -1131,7 +1131,7 @@ void SolidShellElementSprism3D6N::CalculateOnIntegrationPoints(
         for ( IndexType point_number = 0; point_number < rOutput.size(); ++point_number ) {
             if (rOutput[point_number].size2() != 3)
                 rOutput[point_number].resize(3, 3, false);
-            rOutput[point_number] = MathUtils<double>::StressVectorToTensor(stress_vector[point_number]);
+            rOutput[point_number] = MathUtils::StressVectorToTensor(stress_vector[point_number]);
         }
     }
     else if ( rVariable == GREEN_LAGRANGE_STRAIN_TENSOR  || rVariable == ALMANSI_STRAIN_TENSOR || rVariable == HENCKY_STRAIN_TENSOR) {
@@ -1151,7 +1151,7 @@ void SolidShellElementSprism3D6N::CalculateOnIntegrationPoints(
             if (rOutput[point_number].size2() != 3)
                 rOutput[point_number].resize(3, 3, false);
 
-            rOutput[point_number] = MathUtils<double>::StrainVectorToTensor(StrainVector[point_number]);
+            rOutput[point_number] = MathUtils::StrainVectorToTensor(StrainVector[point_number]);
         }
     } else if ( rVariable == CONSTITUTIVE_MATRIX ) {
         // Create and initialize element variables:
@@ -1629,7 +1629,7 @@ void SolidShellElementSprism3D6N::Initialize(const ProcessInfo& rCurrentProcessI
             for ( IndexType point_number = 0; point_number < integration_points.size(); ++point_number ) {
                 // Calculating and storing inverse of the jacobian and the parameters needed
                 double aux_detJ;
-                MathUtils<double>::InvertMatrix( J0[point_number], mAuxContainer[point_number], aux_detJ );
+                MathUtils::InvertMatrix( J0[point_number], mAuxContainer[point_number], aux_detJ );
             }
         } else { // Historic deformation gradient
             for ( IndexType point_number = 0; point_number < integration_points.size(); ++point_number ) {
@@ -2108,7 +2108,7 @@ void SolidShellElementSprism3D6N::CalculateLocalCoordinateSystem(
         vye[2] = 0.5 * ((GetGeometry()[0].Z() + GetGeometry()[3].Z()) - (GetGeometry()[2].Z() + GetGeometry()[5].Z()));
     }
 
-    MathUtils<double>::CrossProduct(ThisOrthogonalBase.Vzeta, vxe, vye);
+    MathUtils::CrossProduct(ThisOrthogonalBase.Vzeta, vxe, vye);
     norm = norm_2(ThisOrthogonalBase.Vzeta);
     ThisOrthogonalBase.Vzeta /= norm;
 
@@ -2129,7 +2129,7 @@ void SolidShellElementSprism3D6N::CalculateLocalCoordinateSystem(
 
             norm = norm_2(ThisOrthogonalBase.Vxi);
             ThisOrthogonalBase.Vxi /= norm;
-            MathUtils<double>::CrossProduct(ThisOrthogonalBase.Vxi, ThisOrthogonalBase.Veta, ThisOrthogonalBase.Vzeta);
+            MathUtils::CrossProduct(ThisOrthogonalBase.Vxi, ThisOrthogonalBase.Veta, ThisOrthogonalBase.Vzeta);
         } else { // SELECT local y=ThisOrthogonalBase.Vxi in the global YZ plane
             ThisOrthogonalBase.Vxi[0] = 0.0;
             ThisOrthogonalBase.Vxi[1] = ThisOrthogonalBase.Vzeta[2];
@@ -2154,7 +2154,7 @@ void SolidShellElementSprism3D6N::CalculateLocalCoordinateSystem(
 
             norm = norm_2(ThisOrthogonalBase.Veta);
             ThisOrthogonalBase.Veta /= norm;
-            MathUtils<double>::CrossProduct(ThisOrthogonalBase.Vxi, ThisOrthogonalBase.Veta, ThisOrthogonalBase.Vzeta);
+            MathUtils::CrossProduct(ThisOrthogonalBase.Vxi, ThisOrthogonalBase.Veta, ThisOrthogonalBase.Vzeta);
         } else { // SELECT local z=ThisOrthogonalBase.Vxi in the global ZX plane
             ThisOrthogonalBase.Vxi[0] = - ThisOrthogonalBase.Vzeta[2]; // Choose ThisOrthogonalBase.Vxi orthogonal to global Y direction
             ThisOrthogonalBase.Vxi[1] = 0.0;
@@ -2179,7 +2179,7 @@ void SolidShellElementSprism3D6N::CalculateLocalCoordinateSystem(
 
             norm = norm_2(ThisOrthogonalBase.Veta);
             ThisOrthogonalBase.Veta /= norm;
-            MathUtils<double>::CrossProduct(ThisOrthogonalBase.Vxi, ThisOrthogonalBase.Veta, ThisOrthogonalBase.Vzeta);
+            MathUtils::CrossProduct(ThisOrthogonalBase.Vxi, ThisOrthogonalBase.Veta, ThisOrthogonalBase.Vzeta);
         } else { // SELECT local x=ThisOrthogonalBase.Vxi in the global XY plane
             ThisOrthogonalBase.Vxi[0] = - ThisOrthogonalBase.Vzeta[1];
             ThisOrthogonalBase.Vxi[1] = ThisOrthogonalBase.Vzeta[0];
@@ -2369,7 +2369,7 @@ void SolidShellElementSprism3D6N::CalculateJacobianCenterGauss(
     noalias(J[rPointNumber]) = prod(nodes_coord, LocalDerivativePatch);
 
     /* Compute inverse of the Jaccobian */
-    MathUtils<double>::InvertMatrix( J[rPointNumber], Jinv[rPointNumber], detJ[rPointNumber] );
+    MathUtils::InvertMatrix( J[rPointNumber], Jinv[rPointNumber], detJ[rPointNumber] );
 }
 
 /***********************************************************************************/
@@ -2397,7 +2397,7 @@ void SolidShellElementSprism3D6N::CalculateJacobian(
     noalias(J) = prod(nodes_coord_aux, LocalDerivativePatch);
 
     /* Compute determinant */
-    detJ = MathUtils<double>::Det3(J);
+    detJ = MathUtils::Det3(J);
 }
 
 /***********************************************************************************/
@@ -2419,7 +2419,7 @@ void SolidShellElementSprism3D6N::CalculateJacobianAndInv(
 
     /* Compute inverse of the Jaccobian */
     double detJ;
-    MathUtils<double>::InvertMatrix(J, Jinv, detJ);
+    MathUtils::InvertMatrix(J, Jinv, detJ);
 }
 
 /***********************************************************************************/
@@ -2441,7 +2441,7 @@ void SolidShellElementSprism3D6N::CalculateJacobianAndInv(
 
     /* Compute inverse of the Jaccobian */
     double detJ;
-    MathUtils<double>::InvertMatrix(J, Jinv, detJ);
+    MathUtils::InvertMatrix(J, Jinv, detJ);
 }
 
 /***********************************************************************************/
@@ -2476,15 +2476,15 @@ void SolidShellElementSprism3D6N::CalculateCartesianDerivativesOnCenterPlane(
     }
 
     array_1d<double, 3 > t1g, t2g, t3g;
-    MathUtils<double>::CrossProduct(t3g, vxe, vye);
+    MathUtils::CrossProduct(t3g, vxe, vye);
     norm0 = norm_2(t3g);
     t3g /= norm0;
 
-    MathUtils<double>::CrossProduct(t2g, t3g, ThisOrthogonalBase.Vxi);
+    MathUtils::CrossProduct(t2g, t3g, ThisOrthogonalBase.Vxi);
     norm = norm_2(t2g);
     t2g /= norm;
 
-    MathUtils<double>::CrossProduct(t1g, t2g, t3g);
+    MathUtils::CrossProduct(t1g, t2g, t3g);
     norm = norm_2(t1g);
     t1g /= norm;
 
@@ -2559,7 +2559,7 @@ void SolidShellElementSprism3D6N::CalculateCartesianDerOnGaussPlane(
     /* Compute the inverse of the Jacobian */
     double aux_det;
     BoundedMatrix<double, 2, 2 > JinvPlane;
-    MathUtils<double>::InvertMatrix(jac, JinvPlane, aux_det);
+    MathUtils::InvertMatrix(jac, JinvPlane, aux_det);
 
     /* Compute the Cartesian derivatives */
     noalias(InPlaneCartesianDerivativesGauss) = prod(JinvPlane, trans(local_derivative_patch));
@@ -3753,13 +3753,13 @@ void SolidShellElementSprism3D6N::CalculateKinematics(
         // Jacobian Determinant for the isoparametric and numerical integration
         Matrix J0;
         GeometryUtils::JacobianOnInitialConfiguration(GetGeometry(), rIntegrationPoints[rPointNumber], J0);
-        rVariables.detJ = MathUtils<double>::Det(J0);
+        rVariables.detJ = MathUtils::Det(J0);
     } else {
         // Cauchy stress measure
         rVariables.StressMeasure = ConstitutiveLaw::StressMeasure_Cauchy;
 
         //Determinant of the Deformation Gradient F0
-        rVariables.detF0 = MathUtils<double>::Det3(mAuxContainer[rPointNumber]);
+        rVariables.detF0 = MathUtils::Det3(mAuxContainer[rPointNumber]);
         rVariables.F0    = mAuxContainer[rPointNumber];
     }
 
@@ -3806,11 +3806,11 @@ void SolidShellElementSprism3D6N::CbartoFbar(
     /* We perform a polar decomposition of the CBar and F(regular) to obtain F_bar */
 
     // Assemble matrix C_bar
-    const Matrix C_bar = MathUtils<double>::VectorToSymmetricTensor(rVariables.C);
+    const Matrix C_bar = MathUtils::VectorToSymmetricTensor(rVariables.C);
 
     // Decompose matrix C_bar, get U_bar
     Matrix U_bar;
-    MathUtils<double>::MatrixSquareRoot(C_bar, U_bar, 1e-24, 100);
+    MathUtils::MatrixSquareRoot(C_bar, U_bar, 1e-24, 100);
 
     /* Decompose F */
     Matrix F = ZeroMatrix(3, 3);
@@ -3820,7 +3820,7 @@ void SolidShellElementSprism3D6N::CbartoFbar(
     } else {
         // Calculating the inverse of the jacobian and the parameters needed [d£/dx_n]
         Matrix InvJ(3, 3);
-        MathUtils<double>::InvertMatrix( rVariables.J[rPointNumber], InvJ, rVariables.detJ);
+        MathUtils::InvertMatrix( rVariables.J[rPointNumber], InvJ, rVariables.detJ);
 
         // Deformation Gradient F [dx_n+1/dx_n]
         noalias(F) = prod( rVariables.j[rPointNumber], InvJ );
@@ -3950,7 +3950,7 @@ void SolidShellElementSprism3D6N::InitializeGeneralVariables(GeneralVariables& r
     double detJ;
     Matrix inv_j;
     for (IndexType i_point = 0; i_point < integration_point_number; ++i_point) {
-        MathUtils<double>::InvertMatrix( rVariables.j[i_point], inv_j, detJ );
+        MathUtils::InvertMatrix( rVariables.j[i_point], inv_j, detJ );
         noalias(DN_DX[i_point]) = prod(DN_De[i_point], inv_j);
     }
     rVariables.SetShapeFunctionsGradients(DN_DX);

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
@@ -60,7 +60,7 @@ private:
         // Calculate mInvJ0 and mDetJ0.
         GeometryUtils::JacobianOnInitialConfiguration(
             mrGeom, mrGeom.IntegrationPoints(mThisIntegrationMethod)[IntegrationPoint], mJ);
-        MathUtils<double>::InvertMatrix(mJ, mInvJ0, mDetJ0);
+        MathUtils::InvertMatrix(mJ, mInvJ0, mDetJ0);
         // Calculate mJ.
         mrGeom.Jacobian(mJ, IntegrationPoint, mThisIntegrationMethod);
         // Update current integration point.
@@ -275,7 +275,7 @@ void TotalLagrangian::CalculateKinematicVariables(
                    rThisKinematicVariables.DN_DX);
     }
 
-    rThisKinematicVariables.detF = MathUtils<double>::Det(rThisKinematicVariables.F);
+    rThisKinematicVariables.detF = MathUtils::Det(rThisKinematicVariables.F);
 }
 
 /***********************************************************************************/
@@ -551,7 +551,7 @@ void TotalLagrangian::CalculateSensitivityMatrix(
                 CalculateShapeSensitivity(deriv, DN_DX0, DN_DX0_deriv, F_deriv, detJ0_deriv, g);
                 CalculateGreenLagrangeStrainSensitivity(F, F_deriv, strain_tensor_deriv);
                 noalias(strain_vector_deriv) =
-                    MathUtils<double>::StrainTensorToVector(strain_tensor_deriv);
+                    MathUtils::StrainTensorToVector(strain_tensor_deriv);
                 CalculateStress(strain_vector_deriv, g, stress_vector_deriv, rCurrentProcessInfo);
                 CalculateBSensitivity(DN_DX0, F, DN_DX0_deriv, F_deriv, B_deriv);
                 const double weight_deriv =

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian_mixed_volumetric_strain_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian_mixed_volumetric_strain_element.cpp
@@ -6575,7 +6575,7 @@ void TotalLagrangianMixedVolumetricStrainElement<TDim>::CalculateKinematicVariab
         r_geometry,
         r_integration_points[PointNumber],
         rThisKinematicVariables.J0);
-    MathUtils<double>::InvertMatrix(
+    MathUtils::InvertMatrix(
         rThisKinematicVariables.J0,
         rThisKinematicVariables.InvJ0,
         rThisKinematicVariables.detJ0);
@@ -7135,7 +7135,7 @@ void TotalLagrangianMixedVolumetricStrainElement<TDim>::CalculateOnIntegrationPo
                 // If asked for Almansi, calculate the transformation
                 double det_F;
                 BoundedMatrix<double, TDim, TDim> inv_F;
-                MathUtils<double>::InvertMatrix(kinematic_variables.F, inv_F, det_F);
+                MathUtils::InvertMatrix(kinematic_variables.F, inv_F, det_F);
                 auto& r_e_strain = rOutput[i_gauss];
                 const auto& r_E_strain_voigt = kinematic_variables.EquivalentStrain;
                 if constexpr (TDim == 2) {

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian_q1p0_mixed_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian_q1p0_mixed_element.cpp
@@ -183,8 +183,8 @@ void TotalLagrangianQ1P0MixedElement::CalculateAll(
         this->CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, this->GetStressMeasure(), false);
 
         const Matrix& r_C = prod(trans(this_kinematic_variables.F), this_kinematic_variables.F);
-        MathUtils<double>::InvertMatrix3(r_C, inv_C, det);
-        noalias(inv_c_voigt) = MathUtils<double>::StrainTensorToVector(inv_C, strain_size);
+        MathUtils::InvertMatrix3(r_C, inv_C, det);
+        noalias(inv_c_voigt) = MathUtils::StrainTensorToVector(inv_C, strain_size);
         if (dimension == 2) {
             inv_c_voigt[2] /= 2.0;
         } else {
@@ -268,8 +268,8 @@ void TotalLagrangianQ1P0MixedElement::FinalizeNonLinearIteration(
         this->CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
 
         const Matrix& r_C = prod(trans(this_kinematic_variables.F), this_kinematic_variables.F);
-        MathUtils<double>::InvertMatrix3(r_C, inv_C, det);
-        noalias(inv_c_voigt) = MathUtils<double>::StrainTensorToVector(inv_C, strain_size);
+        MathUtils::InvertMatrix3(r_C, inv_C, det);
+        noalias(inv_c_voigt) = MathUtils::StrainTensorToVector(inv_C, strain_size);
         if (dimension == 2) {
             inv_c_voigt[2] /= 2.0;
         } else {

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
@@ -628,7 +628,7 @@ void TrussElement3D2N::CreateTransformationMatrix(
     }
     // local x-axis (e1_local) is the beam axis  (in GID is e3_local)
     double VectorNorm;
-    VectorNorm = MathUtils<double>::Norm(direction_vector_x);
+    VectorNorm = MathUtils::Norm(direction_vector_x);
     if (VectorNorm > numeric_limit) {
         direction_vector_x /= VectorNorm;
     }
@@ -648,9 +648,9 @@ void TrussElement3D2N::CreateTransformationMatrix(
     }
 
     else {
-        MathUtils<double>::UnitCrossProduct(direction_vector_y, direction_vector_x,
+        MathUtils::UnitCrossProduct(direction_vector_y, direction_vector_x,
                                             global_z_vector);
-        MathUtils<double>::UnitCrossProduct(direction_vector_z, direction_vector_y,
+        MathUtils::UnitCrossProduct(direction_vector_z, direction_vector_y,
                                             direction_vector_x);
     }
 

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -328,7 +328,7 @@ void UpdatedLagrangian::CalculateKinematicVariables(
         DF(2, 2) = current_radius/initial_radius;
     }
 
-    const double detDF = MathUtils<double>::Det(DF);
+    const double detDF = MathUtils::Det(DF);
     rThisKinematicVariables.detF = detDF * this->ReferenceConfigurationDeformationGradientDeterminant(PointNumber);
     noalias(rThisKinematicVariables.F) = prod(DF, this->ReferenceConfigurationDeformationGradient(PointNumber));
 
@@ -358,7 +358,7 @@ double UpdatedLagrangian::CalculateDerivativesOnReferenceConfiguration(
 
     const Matrix& DN_De = this->GetGeometry().ShapeFunctionsLocalGradients(ThisIntegrationMethod)[PointNumber];
 
-    MathUtils<double>::InvertMatrix( J0, InvJ0, detJ0 );
+    MathUtils::InvertMatrix( J0, InvJ0, detJ0 );
 
     noalias( DN_DX ) = prod( DN_De, InvJ0);
 

--- a/applications/StructuralMechanicsApplication/custom_processes/compute_mass_moment_of_inertia_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/compute_mass_moment_of_inertia_process.cpp
@@ -41,7 +41,7 @@ void ComputeMassMomentOfInertiaProcess::Execute()
         const double elem_mass = TotalStructuralMassProcess::CalculateElementMass(elem_i, domain_size);
         Vector3 ACrossB;
         Vector3 B_vec = elem_i.GetGeometry().Center() - mrPoint1;
-        MathUtils<double>::CrossProduct(ACrossB, axis_of_rotation,  B_vec);
+        MathUtils::CrossProduct(ACrossB, axis_of_rotation,  B_vec);
         const double distance_from_axis = std::sqrt(inner_prod(ACrossB, ACrossB)) / axis_length ;
         moment_of_inertia += elem_mass * (distance_from_axis*distance_from_axis) ;
     }

--- a/applications/StructuralMechanicsApplication/custom_processes/set_automated_initial_variable_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_automated_initial_variable_process.cpp
@@ -41,7 +41,7 @@ void SetAutomatedInitialVariableProcess::ExecuteInitialize()
     KRATOS_TRY
 
     const array_1d<double, 3> hole_generatrix_axis = mThisParameters["hole_generatrix_axis"].GetVector();
-    KRATOS_ERROR_IF(MathUtils<double>::Norm3(hole_generatrix_axis) < machine_tolerance) << "The hole generatrix axis has norm zero" << std::endl;
+    KRATOS_ERROR_IF(MathUtils::Norm3(hole_generatrix_axis) < machine_tolerance) << "The hole generatrix axis has norm zero" << std::endl;
     
     const array_1d<double, 3> hole_generatrix_point = mThisParameters["hole_generatrix_point"].GetVector();  
 
@@ -60,13 +60,13 @@ void SetAutomatedInitialVariableProcess::ExecuteInitialize()
         array_1d<double, 3> relative_position_vector;
         relative_position_vector = r_element_centroid - hole_generatrix_point;
 
-        double vector_scaler = MathUtils<double>::Dot3(relative_position_vector, normalized_generatrix_vector);
+        double vector_scaler = MathUtils::Dot3(relative_position_vector, normalized_generatrix_vector);
         
         const array_1d<double, 3> intersection_point = hole_generatrix_point + vector_scaler * normalized_generatrix_vector;
 
         const array_1d<double, 3> radial_position_vector = r_element_centroid - intersection_point;
 
-        double centroid_relative_distance = MathUtils<double>::Norm3(radial_position_vector) - hole_radius_offset;
+        double centroid_relative_distance = MathUtils::Norm3(radial_position_vector) - hole_radius_offset;
 
         if (centroid_relative_distance < 0.0){
             if (std::abs(centroid_relative_distance) <= tolerance) {

--- a/applications/StructuralMechanicsApplication/custom_processes/set_cylindrical_local_axes_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_cylindrical_local_axes_process.cpp
@@ -36,7 +36,7 @@ void SetCylindricalLocalAxesProcess::ExecuteInitialize()
     const array_1d<double, 3>& r_generatrix_axis  = mThisParameters["cylindrical_generatrix_axis"].GetVector();
     const array_1d<double, 3>& r_generatrix_point = mThisParameters["cylindrical_generatrix_point"].GetVector();
 
-    KRATOS_ERROR_IF(MathUtils<double>::Norm3(r_generatrix_axis) < std::numeric_limits<double>::epsilon()) << "The r_generatrix_axis has norm zero" << std::endl;
+    KRATOS_ERROR_IF(MathUtils::Norm3(r_generatrix_axis) < std::numeric_limits<double>::epsilon()) << "The r_generatrix_axis has norm zero" << std::endl;
 
     block_for_each(mrThisModelPart.Elements(), [&](Element &rElement) {
         array_1d<double, 3> local_axis_1;

--- a/applications/StructuralMechanicsApplication/custom_processes/set_spherical_local_axes_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_spherical_local_axes_process.cpp
@@ -42,7 +42,7 @@ void SetSphericalLocalAxesProcess::ExecuteInitialize()
     const array_1d<double, 3>& spherical_central_point   = mThisParameters["spherical_central_point"].GetVector();
     const double tolerance = std::numeric_limits<double>::epsilon();
 
-    KRATOS_ERROR_IF(MathUtils<double>::Norm3(spherical_reference_axis) < tolerance) << "The spherical_reference_axis has norm zero" << std::endl;
+    KRATOS_ERROR_IF(MathUtils::Norm3(spherical_reference_axis) < tolerance) << "The spherical_reference_axis has norm zero" << std::endl;
 
     block_for_each(mrThisModelPart.Elements(), [&](Element &rElement) {
         array_1d<double, 3> local_axis_1;

--- a/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.cpp
@@ -249,7 +249,7 @@ void SPRErrorProcess<TDim>::CalculatePatch(
 
     double det;
     BoundedMatrix<double, TDim + 1, TDim + 1> invA;
-    MathUtils<double>::InvertMatrix(A, invA, det, -1.0); // We consider a negative tolerance in order to avoid error
+    MathUtils::InvertMatrix(A, invA, det, -1.0); // We consider a negative tolerance in order to avoid error
 
     KRATOS_INFO_IF("SPRErrorProcess", mEchoLevel > 3) << A << std::endl << invA << std::endl << det<< std::endl;
 
@@ -261,7 +261,7 @@ void SPRErrorProcess<TDim>::CalculatePatch(
             for( IndexType j = 0; j < TDim + 1; j++)
                 A(i,j) += 0.001;
         }
-        MathUtils<double>::InvertMatrix(A, invA, det);
+        MathUtils::InvertMatrix(A, invA, det);
         KRATOS_WARNING_IF("SPRErrorProcess", mEchoLevel > 0) << "det: " << det << std::endl;
     }
 

--- a/applications/StructuralMechanicsApplication/custom_utilities/constitutive_law_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/constitutive_law_utilities.cpp
@@ -48,7 +48,7 @@ void ConstitutiveLawUtilities<TVoigtSize>::CalculateGreenLagrangianStrain(
     const BoundedMatrixType E_matrix = 0.5 * (rCauchyTensor - identity_matrix);
 
     // Green-Lagrangian Strain Calculation
-    rStrainVector = MathUtils<double>::StrainTensorToVector(E_matrix, TVoigtSize);
+    rStrainVector = MathUtils::StrainTensorToVector(E_matrix, TVoigtSize);
 }
 
 /***********************************************************************************/
@@ -72,7 +72,7 @@ void ConstitutiveLawUtilities<TVoigtSize>::PolarDecomposition(
 
     // Decompose matrix C
     BoundedMatrix<double, Dimension, Dimension> eigen_vector_matrix, eigen_values_matrix;
-    MathUtils<double>::GaussSeidelEigenSystem(C, eigen_vector_matrix, eigen_values_matrix, 1.0e-16, 200);
+    MathUtils::GaussSeidelEigenSystem(C, eigen_vector_matrix, eigen_values_matrix, 1.0e-16, 200);
 
     for (IndexType i = 0; i < Dimension; ++i)
         eigen_values_matrix(i, i) = std::sqrt(eigen_values_matrix(i, i));
@@ -81,7 +81,7 @@ void ConstitutiveLawUtilities<TVoigtSize>::PolarDecomposition(
 
     double aux_det;
     MatrixType invU(Dimension, Dimension);
-    MathUtils<double>::InvertMatrix(rUMatrix, invU, aux_det);
+    MathUtils::InvertMatrix(rUMatrix, invU, aux_det);
     noalias(rRMatrix) = prod(rFDeformationGradient, invU);
 }
 
@@ -95,11 +95,11 @@ void ConstitutiveLawUtilities<6>::CalculateProjectionOperator(
     )
 {
     BoundedMatrix<double, Dimension, Dimension> strain_tensor;
-    strain_tensor = MathUtils<double>::StrainVectorToTensor(rStrainVector);
+    strain_tensor = MathUtils::StrainVectorToTensor(rStrainVector);
     BoundedMatrix<double, Dimension, Dimension> eigen_vectors_matrix;
     BoundedMatrix<double, Dimension, Dimension> eigen_values_matrix;
 
-    MathUtils<double>::GaussSeidelEigenSystem(strain_tensor, eigen_vectors_matrix, eigen_values_matrix, 1.0e-16, 20);
+    MathUtils::GaussSeidelEigenSystem(strain_tensor, eigen_vectors_matrix, eigen_values_matrix, 1.0e-16, 20);
 
     std::vector<Vector> eigen_vectors_container;
 
@@ -116,7 +116,7 @@ void ConstitutiveLawUtilities<6>::CalculateProjectionOperator(
     for (IndexType i = 0; i < Dimension; ++i) {
         if (eigen_values_matrix(i, i) > 0.0) {
             sigma_tension_tensor = outer_prod(eigen_vectors_container[i], eigen_vectors_container[i]); // p_i x p_i
-            sigma_tension_vector = MathUtils<double>::StressTensorToVector(sigma_tension_tensor);
+            sigma_tension_vector = MathUtils::StressTensorToVector(sigma_tension_tensor);
             rProjectionOperatorTensor += outer_prod(sigma_tension_vector, sigma_tension_vector);
         }
     }
@@ -146,7 +146,7 @@ void ConstitutiveLawUtilities<6>::CalculateProjectionOperator(
 
         cross_p_ij_tensor = 0.5 * (outer_prod(eigen_vectors_container[i], eigen_vectors_container[j]) +
                                    outer_prod(eigen_vectors_container[j], eigen_vectors_container[i]));
-        cross_p_ij_vector = MathUtils<double>::StressTensorToVector(cross_p_ij_tensor);
+        cross_p_ij_vector = MathUtils::StressTensorToVector(cross_p_ij_tensor);
         rProjectionOperatorTensor += (h_i + h_j) * (outer_prod(cross_p_ij_vector, cross_p_ij_vector));
 
         h_i = 0.0;
@@ -164,11 +164,11 @@ void ConstitutiveLawUtilities<3>::CalculateProjectionOperator(
     )
 {
     BoundedMatrix<double, Dimension, Dimension> strain_tensor;
-    strain_tensor = MathUtils<double>::StrainVectorToTensor(rStrainVector);
+    strain_tensor = MathUtils::StrainVectorToTensor(rStrainVector);
     BoundedMatrix<double, Dimension, Dimension> eigen_vectors_matrix;
     BoundedMatrix<double, Dimension, Dimension> eigen_values_matrix;
 
-    MathUtils<double>::GaussSeidelEigenSystem(strain_tensor, eigen_vectors_matrix, eigen_values_matrix, 1.0e-16, 20);
+    MathUtils::GaussSeidelEigenSystem(strain_tensor, eigen_vectors_matrix, eigen_values_matrix, 1.0e-16, 20);
 
     std::vector<Vector> eigen_vectors_container;
 
@@ -184,7 +184,7 @@ void ConstitutiveLawUtilities<3>::CalculateProjectionOperator(
     for (IndexType i = 0; i < Dimension; ++i) {
         if (eigen_values_matrix(i, i) > 0.0) {
             sigma_tension_tensor = outer_prod(eigen_vectors_container[i], eigen_vectors_container[i]); // p_i x p_i
-            sigma_tension_vector = MathUtils<double>::StressTensorToVector(sigma_tension_tensor);
+            sigma_tension_vector = MathUtils::StressTensorToVector(sigma_tension_tensor);
             rProjectionOperatorTensor += outer_prod(sigma_tension_vector, sigma_tension_vector);
         }
     }
@@ -200,7 +200,7 @@ void ConstitutiveLawUtilities<3>::CalculateProjectionOperator(
 
     cross_p_ij_tensor = 0.5 * (outer_prod(eigen_vectors_container[0], eigen_vectors_container[1]) +
                                outer_prod(eigen_vectors_container[1], eigen_vectors_container[0]));
-    cross_p_ij_vector = MathUtils<double>::StressTensorToVector(cross_p_ij_tensor);
+    cross_p_ij_vector = MathUtils::StressTensorToVector(cross_p_ij_tensor);
 
     rProjectionOperatorTensor += (h_i + h_j) * (outer_prod(cross_p_ij_vector, cross_p_ij_vector));
 }

--- a/applications/StructuralMechanicsApplication/custom_utilities/constitutive_law_utilities.h
+++ b/applications/StructuralMechanicsApplication/custom_utilities/constitutive_law_utilities.h
@@ -235,7 +235,7 @@ class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) ConstitutiveLawUtilities
         TVector& rVector
         )
     {
-        const double norm = MathUtils<double>::Norm3(rVector);
+        const double norm = MathUtils::Norm3(rVector);
         if (norm > std::numeric_limits<double>::epsilon()) {
             rVector /= norm;
         } else {

--- a/applications/StructuralMechanicsApplication/custom_utilities/project_vector_on_surface_utility.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/project_vector_on_surface_utility.cpp
@@ -168,10 +168,10 @@ void ProjectVectorOnSurfaceUtility::PlanarProjection(
             Vector a_cross_b = ZeroVector(3);
             Vector projected_result = ZeroVector(3);
 
-            MathUtils<double>::CrossProduct(a_cross_b, vec_a, vec_b);
-            MathUtils<double>::CrossProduct(projected_result, vec_b, a_cross_b);
+            MathUtils::CrossProduct(a_cross_b, vec_a, vec_b);
+            MathUtils::CrossProduct(projected_result, vec_b, a_cross_b);
             //noramlize projected result
-            projected_result /= MathUtils<double>::Norm(projected_result);
+            projected_result /= MathUtils::Norm(projected_result);
 
             element.SetValue(rVariable, projected_result);
         }
@@ -228,10 +228,10 @@ void ProjectVectorOnSurfaceUtility::RadialProjection(
         } else {
             Vector projected_result = ZeroVector(3);
 
-            MathUtils<double>::CrossProduct(projected_result, rGlobalDirection, local_axis_3);
+            MathUtils::CrossProduct(projected_result, rGlobalDirection, local_axis_3);
 
             //noramlize projected result
-            projected_result /= MathUtils<double>::Norm(projected_result);
+            projected_result /= MathUtils::Norm(projected_result);
 
             element.SetValue(rVariable, projected_result);
         }

--- a/applications/StructuralMechanicsApplication/custom_utilities/rayleigh_damping_coefficients_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/rayleigh_damping_coefficients_utilities.cpp
@@ -70,7 +70,7 @@ Vector ComputeDampingCoefficients(Parameters ThisParameters)
             // We compute the inverse
             double det;
             BoundedMatrix<double, 2, 2> inverse_frequencies_matrix;
-            MathUtils<double>::InvertMatrix(frequencies_matrix, inverse_frequencies_matrix, det);
+            MathUtils::InvertMatrix(frequencies_matrix, inverse_frequencies_matrix, det);
 
             // We can compute now
             const array_1d<double, 2> aux_solution = prod(inverse_frequencies_matrix, damping_ratios);

--- a/applications/StructuralMechanicsApplication/custom_utilities/shell_cross_section.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/shell_cross_section.cpp
@@ -576,7 +576,7 @@ void ShellCrossSection::CalculateSectionResponse(SectionParameters& rValues, con
             Hinv(0, 0) = 1.0 / H(0, 0);
         } else {
             double dummy_det;
-            MathUtils<double>::InvertMatrix3(H, Hinv, dummy_det);
+            MathUtils::InvertMatrix3(H, Hinv, dummy_det);
         }
 
         // check convergence
@@ -1002,7 +1002,7 @@ void ShellCrossSection::CalculateIntegrationPointResponse(const IntegrationPoint
         F(0, 0) = materialStrainVector(0) + 1.0;
         F(1, 1) = materialStrainVector(1) + 1.0;
         F(0, 1) = F(1, 0) = materialStrainVector(2) * 0.5;
-        rVariables.DeterminantF = MathUtils<double>::Det2(F);
+        rVariables.DeterminantF = MathUtils::Det2(F);
     } else { // 6
         Matrix& F = rVariables.DeformationGradientF_3D;
         F(0, 0) = materialStrainVector(0) + 1.0; // xx
@@ -1011,7 +1011,7 @@ void ShellCrossSection::CalculateIntegrationPointResponse(const IntegrationPoint
         F(0, 1) = F(1, 0) = materialStrainVector(3) * 0.5; // xy - yx
         F(0, 2) = F(2, 0) = materialStrainVector(5) * 0.5; // xz - zx
         F(1, 2) = F(2, 1) = materialStrainVector(4) * 0.5; // yz - zy
-        rVariables.DeterminantF = MathUtils<double>::Det3(F);
+        rVariables.DeterminantF = MathUtils::Det3(F);
     }
     rVariables.DeterminantF0 = 1.0;
 

--- a/applications/StructuralMechanicsApplication/custom_utilities/static_condensation_utility.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/static_condensation_utility.cpp
@@ -36,7 +36,7 @@ namespace Kratos
             //1.) inverse K22
             MatrixType K_temp = ZeroMatrix(sub_matrices[3].size1());
             double detK22 = 0.00;
-            MathUtils<double>::InvertMatrix(sub_matrices[3],K_temp,detK22);
+            MathUtils::InvertMatrix(sub_matrices[3],K_temp,detK22);
             KRATOS_ERROR_IF(std::abs(detK22) < numerical_limit) << "Element " << rTheElement.Id()
                                                                 << " is singular !" << std::endl;
 
@@ -177,7 +177,7 @@ namespace Kratos
             //2.) inverse K22
             MatrixType K22_inv = ZeroMatrix(sub_matrices[3].size1());
             double detK22 = 0.00;
-            MathUtils<double>::InvertMatrix(sub_matrices[3], K22_inv, detK22);
+            MathUtils::InvertMatrix(sub_matrices[3], K22_inv, detK22);
 
             KRATOS_ERROR_IF(std::abs(detK22) < numerical_limit) << "Element " << rTheElement.Id() << " is singular !" << std::endl;
 

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
@@ -281,7 +281,7 @@ double CalculateReferenceLength3D2N(const Element& rElement)
         rElement.GetGeometry()[1].GetInitialPosition().Coordinates() -
         rElement.GetGeometry()[0].GetInitialPosition().Coordinates();
 
-    return MathUtils<double>::Norm3(delta_pos);
+    return MathUtils::Norm3(delta_pos);
 
     KRATOS_CATCH("")
 }
@@ -299,7 +299,7 @@ double CalculateCurrentLength3D2N(const Element& rElement)
         rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT) -
         rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT);
 
-    const double l = MathUtils<double>::Norm3(delta_pos);
+    const double l = MathUtils::Norm3(delta_pos);
 
     KRATOS_ERROR_IF(l <= std::numeric_limits<double>::epsilon())
             << "Element #" << rElement.Id() << " has a current length of zero!" << std::endl;
@@ -319,9 +319,9 @@ void InitialCheckLocalAxes(
     const double Tolerance
     )
 {
-    if (MathUtils<double>::Norm3(rv1) > 1.0 + Tolerance ||
-        MathUtils<double>::Norm3(rv2) > 1.0 + Tolerance ||
-        MathUtils<double>::Norm3(rv3) > 1.0 + Tolerance) {
+    if (MathUtils::Norm3(rv1) > 1.0 + Tolerance ||
+        MathUtils::Norm3(rv2) > 1.0 + Tolerance ||
+        MathUtils::Norm3(rv3) > 1.0 + Tolerance) {
             KRATOS_ERROR << "The norm of one of the LOCAL_AXIS is greater than 1.0!" << std::endl;
     }
 }

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_math_utilities.hpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_math_utilities.hpp
@@ -62,15 +62,15 @@ public:
     {
         double n;
 
-        MathUtils<double>::CrossProduct(t3g, vxe, vye);
+        MathUtils::CrossProduct(t3g, vxe, vye);
         n = norm_2(t3g);
         t3g /= n;
 
-        MathUtils<double>::CrossProduct(t2g, t3g, vxe);
+        MathUtils::CrossProduct(t2g, t3g, vxe);
         n = norm_2(t2g);
         t2g /= n;
 
-        MathUtils<double>::CrossProduct(t1g, t2g, t3g);
+        MathUtils::CrossProduct(t1g, t2g, t3g);
         n = norm_2(t1g);
         t1g /= n;
     }
@@ -92,15 +92,15 @@ public:
     {
         double n;
 
-        MathUtils<double>::CrossProduct(t3g, Xdxi, Xdeta);
+        MathUtils::CrossProduct(t3g, Xdxi, Xdeta);
         n = norm_2(t3g);
         t3g /= n;
 
-        MathUtils<double>::CrossProduct(t2g, t3g, vxe);
+        MathUtils::CrossProduct(t2g, t3g, vxe);
         n = norm_2(t2g);
         t2g /= n;
 
-        MathUtils<double>::CrossProduct(t1g, t2g, t3g);
+        MathUtils::CrossProduct(t1g, t2g, t3g);
         n = norm_2(t1g);
         t1g /= n;
     }
@@ -116,16 +116,16 @@ public:
 
         array_1d<double, 3 > t1g, t2g, t3g;
 
-        MathUtils<double>::CrossProduct(t3g, Xdxi, Xdeta);
+        MathUtils::CrossProduct(t3g, Xdxi, Xdeta);
 
         n = norm_2(t3g);
         t3g /= n;
 
-        MathUtils<double>::CrossProduct(t2g, t3g, vxe);
+        MathUtils::CrossProduct(t2g, t3g, vxe);
         n = norm_2(t2g);
         t2g /= n;
 
-        MathUtils<double>::CrossProduct(t1g, t2g, t3g);
+        MathUtils::CrossProduct(t1g, t2g, t3g);
         n = norm_2(t1g);
         t1g /= n;
 
@@ -403,8 +403,8 @@ public:
         double det;
         Matrix inv_metric_left = Matrix(TDim,TDim);
         Matrix inv_metric_right = Matrix(TDim,TDim);
-        MathUtils<double>::InvertMatrix(Matrix(metric_left),inv_metric_left,det);
-        MathUtils<double>::InvertMatrix(metric_right,inv_metric_right,det);
+        MathUtils::InvertMatrix(Matrix(metric_left),inv_metric_left,det);
+        MathUtils::InvertMatrix(metric_right,inv_metric_right,det);
 
         // Compute dual target base vectors
         BoundedMatrix<double,TDim,TDim> target_left_dual = ZeroMatrix(TDim,TDim); // Anna noalias?


### PR DESCRIPTION
**📝 Description**

This PR refactors and cleans up code in the `StructuralMechanicsApplication`. The key change across all affected files is the replacement of `MathUtils<double>::` with `MathUtils::`, which streamlines the syntax and avoids unnecessary template specification.

These changes are primarily refactoring and should not alter the functionality of the code, but rather improve its readability and maintainability. 

**🆕 Changelog**

- [Remove MathUtils template](https://github.com/KratosMultiphysics/Kratos/commit/42dbb80e35762194751861a6ab2a1f42bb43b2a7)
