### PR TITLE
[Core][MPI] Add exit code to run_cpp_mpi_tests for use in CI

### DIFF
--- a/kratos/mpi/tests/cpp_tests/sources/test_mpi_data_communicator.cpp
+++ b/kratos/mpi/tests/cpp_tests/sources/test_mpi_data_communicator.cpp
@@ -1246,7 +1246,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorScanSumVectorDouble, Kr
 // SendRecv ///////////////////////////////////////////////////////////////////
 
 namespace {
-template<typename T> 
+template<typename T>
 void MPIDataCommunicatorSendRecvIntegralTypeTest()
 {
     MPIDataCommunicator mpi_world_communicator(MPI_COMM_WORLD);
@@ -1287,7 +1287,7 @@ void MPIDataCommunicatorSendRecvIntegralTypeTest()
     }
 }
 
-template<typename T> 
+template<typename T>
 void MPIDataCommunicatorSendAndRecvIntegralTypeTest()
 {
     MPIDataCommunicator mpi_world_communicator(MPI_COMM_WORLD);
@@ -2574,6 +2574,7 @@ template<typename T> void MPIDataCommunicatorAllGathervIntegralTypeVectorTest()
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorAllGathervInt, KratosMPICoreFastSuite)
 {
+    KRATOS_CHECK_IS_FALSE(true) // Forcing a failure
     MPIDataCommunicatorAllGathervIntegralTypeVectorTest<int>();
 }
 

--- a/kratos/mpi/tests/cpp_tests/sources/test_mpi_data_communicator.cpp
+++ b/kratos/mpi/tests/cpp_tests/sources/test_mpi_data_communicator.cpp
@@ -1246,7 +1246,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorScanSumVectorDouble, Kr
 // SendRecv ///////////////////////////////////////////////////////////////////
 
 namespace {
-template<typename T>
+template<typename T> 
 void MPIDataCommunicatorSendRecvIntegralTypeTest()
 {
     MPIDataCommunicator mpi_world_communicator(MPI_COMM_WORLD);
@@ -1287,7 +1287,7 @@ void MPIDataCommunicatorSendRecvIntegralTypeTest()
     }
 }
 
-template<typename T>
+template<typename T> 
 void MPIDataCommunicatorSendAndRecvIntegralTypeTest()
 {
     MPIDataCommunicator mpi_world_communicator(MPI_COMM_WORLD);
@@ -2574,7 +2574,6 @@ template<typename T> void MPIDataCommunicatorAllGathervIntegralTypeVectorTest()
 
 KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorAllGathervInt, KratosMPICoreFastSuite)
 {
-    KRATOS_CHECK_IS_FALSE(true) // Forcing a failure
     MPIDataCommunicatorAllGathervIntegralTypeVectorTest<int>();
 }
 

--- a/kratos/python_scripts/testing/run_cpp_mpi_tests.py
+++ b/kratos/python_scripts/testing/run_cpp_mpi_tests.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 from KratosMultiphysics import mpi, Tester
 
@@ -18,10 +19,16 @@ def main():
 
     if args.match_string:
         Tester.SetVerbosity(Tester.Verbosity.TESTS_OUTPUTS)
-        Tester.RunTestCases(args.match_string)
+        return Tester.RunTestCases(args.match_string)
     else:
         Tester.SetVerbosity(Tester.Verbosity.TESTS_LIST)
-        Tester.RunTestSuite("KratosMPICoreFastSuite")
+        return Tester.RunTestSuite("KratosMPICoreFastSuite")
 
 if __name__ == '__main__':
-    main()
+    try:
+        exit_code = main()
+    except Exception as e:
+        print('[Error]:', e, file=sys.stderr)
+        exit_code = 1
+
+    sys.exit(exit_code)


### PR DESCRIPTION
**📝 Description**
As @loumalouomega noticed in #11148, the MPI cpp tests are always reported as a success in CI, even if some of them fail. It seems to me that this is due to the fact that `run_cpp_mpi_tests.py` does not set the exit code (unlike other test scripts used in CI), so I'm creating a draft PR to test it.

**🆕 Changelog**
- add exit code to run_cpp_mpi_tests for use in CI
