### PR TITLE
RomApp Bug Fix HROM Modelpart creation

### DIFF
--- a/applications/RomApplication/python_scripts/hrom_training_utility.py
+++ b/applications/RomApplication/python_scripts/hrom_training_utility.py
@@ -87,7 +87,11 @@ class HRomTrainingUtility(object):
         model_part_name = self.solver.settings["model_part_name"].GetString()
         model_part_output_name = self.solver.settings["model_import_settings"]["input_filename"].GetString()
         # computing_model_part = self.solver.GetComputingModelPart()
-        computing_model_part = self.solver.GetComputingModelPart().GetRootModelPart() #TODO: DECIDE WHICH ONE WE SHOULD USE?¿?¿ MOST PROBABLY THE ROOT FOR THOSE CASES IN WHICH THE COMPUTING IS CUSTOM (e.g. CFD)
+        #computing_model_part = self.solver.GetComputingModelPart().GetRootModelPart() #TODO: DECIDE WHICH ONE WE SHOULD USE?¿?¿ MOST PROBABLY THE ROOT FOR THOSE CASES IN WHICH THE COMPUTING IS CUSTOM (e.g. CFD)
+        aux_model = KratosMultiphysics.Model()
+        computing_model_part = aux_model.CreateModelPart("main")
+        model_part_io = KratosMultiphysics.ModelPartIO(model_part_output_name)
+        model_part_io.ReadModelPart(computing_model_part)
 
         # Create a new model with the HROM main model part
         # This is intentionally done in order to completely emulate the origin model part


### PR DESCRIPTION
**📝 Description**
This PR tackles a bug we have identified in the creation of the HROM modelpart.

What was being done before was creating the HROM mdpa from the currently loaded modelpart object. The problem is that, since either the computing_model_part or the root_model_part are used to create the hrom modelpart, the created HROM mdpa contains data that should not be there. For example, for some simulations the HROM mdpa contains properties that cause issues during the initialization of the HROM simulations. 

A more robust way of creating the HROM mdpa is to be devised, since in cases where more than 1 HROM mdpa is to be created (so-simulation), the path should be provided. 

**🆕 Changelog**
- Changed the way the computing_model_part is defined inside the hrom_training_utility.py
 self.solver.GetComputingModelPart().GetRootModelPart()  --> model_part_io.ReadModelPart(computing_model_part)
