### PR TITLE
[Core] Missing include in `GeometricalObject`

### DIFF
--- a/kratos/includes/geometrical_object.h
+++ b/kratos/includes/geometrical_object.h
@@ -4,16 +4,14 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                   Riccardo Rossi
 //
-//
 
-#if !defined(KRATOS_GEOMETRICAL_OBJECT_H_INCLUDED )
-#define  KRATOS_GEOMETRICAL_OBJECT_H_INCLUDED
+#pragma once
 
 // System includes
 #include <atomic>
@@ -25,6 +23,7 @@
 #include "includes/node.h"
 #include "containers/flags.h"
 #include "geometries/geometry.h"
+#include "includes/indexed_object.h"
 
 namespace Kratos
 {
@@ -500,7 +499,5 @@ inline std::ostream& operator << (std::ostream& rOStream,
 
 
 }  // namespace Kratos.
-
-#endif // KRATOS_GEOMETRICAL_OBJECT_H_INCLUDED  defined
 
 


### PR DESCRIPTION
**📝 Description**

- There's a formatting correction in the license comment section where some spaces were added to improve readability.
- The traditional include guard, which was previously `#if !defined(KRATOS_GEOMETRICAL_OBJECT_H_INCLUDED )` and `#endif // KRATOS_GEOMETRICAL_OBJECT_H_INCLUDED  defined`, has been replaced with the more modern `#pragma once` directive. 
- The `indexed_object.h` include file has been added, as the class derives from `IndexedObject`.

**🆕 Changelog**

- [Missing include in `GeometricalObject`](https://github.com/KratosMultiphysics/Kratos/commit/67acb8fe03f38d01230c80e863d020d2b8d40620)
