### PR TITLE
[Core] Remove unused includes in DoF

### DIFF
--- a/kratos/includes/dof.h
+++ b/kratos/includes/dof.h
@@ -4,15 +4,14 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //
 //
 
-#if !defined(KRATOS_DOF_H_INCLUDED )
-#define  KRATOS_DOF_H_INCLUDED
+#pragma once
 
 // System includes
 #include <string>
@@ -23,10 +22,8 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "containers/data_value_container.h"
 #include "containers/nodal_data.h"
-#include "containers/array_1d.h"
 
 namespace Kratos
 {
@@ -630,9 +627,6 @@ inline bool operator == ( Dof<TDataType> const& First,
 
 }  // namespace Kratos.
 
-
 #undef KRATOS_DOF_TRAITS
 #undef KRATOS_MAKE_DOF_TRAIT
 #undef KRATOS_END_DOF_TRAIT
-
-#endif // KRATOS_DOF_H_INCLUDED  defined

--- a/kratos/includes/dof.h
+++ b/kratos/includes/dof.h
@@ -22,6 +22,7 @@
 // External includes
 
 // Project includes
+#include "includes/define.h"
 #include "containers/data_value_container.h"
 #include "containers/nodal_data.h"
 


### PR DESCRIPTION
**📝 Description**

1. It replaces the traditional include guard `#if !defined(KRATOS_DOF_H_INCLUDED)` with a `#pragma once` directive, which is a cleaner and more modern way of preventing multiple inclusions of the same header file. 
2. Some unnecessary includes are removed ("containers/array_1d.h"`), potentially reducing dependencies and improving compilation time. 

**🆕 Changelog**

- [Remove unused includes in DoF](https://github.com/KratosMultiphysics/Kratos/commit/e5e556f689677abd8988ee4bf14f3145b68e7600)