### PR TITLE
[Core] BugFix - ModelPartOperationUtilities - Sorting based on ids

### DIFF
--- a/kratos/tests/test_model_part_operation_utilities.py
+++ b/kratos/tests/test_model_part_operation_utilities.py
@@ -76,13 +76,13 @@ class TestModelPartOperationUtilities(KratosUnittest.TestCase):
     def test_Order(self):
         merged_model_part = Kratos.ModelPartOperationUtilities.Union("merge_order", self.model_part, self.model_part, False)
 
-        origin_node_ids_list = [entiy.Id for entity in self.model_part.Nodes]
-        origin_condition_ids_list = [entiy.Id for entity in self.model_part.Conditions]
-        origin_element_ids_list = [entiy.Id for entity in self.model_part.Elements]
+        origin_node_ids_list = [entity.Id for entity in self.model_part.Nodes]
+        origin_condition_ids_list = [entity.Id for entity in self.model_part.Conditions]
+        origin_element_ids_list = [entity.Id for entity in self.model_part.Elements]
 
-        merged_node_ids_list = [entiy.Id for entity in merged_model_part.Nodes]
-        merged_condition_ids_list = [entiy.Id for entity in merged_model_part.Conditions]
-        merged_element_ids_list = [entiy.Id for entity in merged_model_part.Elements]
+        merged_node_ids_list = [entity.Id for entity in merged_model_part.Nodes]
+        merged_condition_ids_list = [entity.Id for entity in merged_model_part.Conditions]
+        merged_element_ids_list = [entity.Id for entity in merged_model_part.Elements]
 
         self.assertEqual(origin_node_ids_list, merged_node_ids_list)
         self.assertEqual(origin_condition_ids_list, merged_condition_ids_list)

--- a/kratos/tests/test_model_part_operation_utilities.py
+++ b/kratos/tests/test_model_part_operation_utilities.py
@@ -73,6 +73,22 @@ class TestModelPartOperationUtilities(KratosUnittest.TestCase):
         self.assertTrue(Kratos.ModelPartOperationUtilities.CheckValidityOfModelPartsForOperations(temp_model_part, self.model_parts_list, True))
 
     @KratosUnittest.skipIf(Kratos.IsDistributedRun(), "only the test does not support MPI")
+    def test_Order(self):
+        merged_model_part = Kratos.ModelPartOperationUtilities.Union("merge_1", self.model_part, self.model_part, False)
+
+        origin_node_ids_list = [entiy.Id for entity in self.model_part.Nodes]
+        origin_condition_ids_list = [entiy.Id for entity in self.model_part.Conditions]
+        origin_element_ids_list = [entiy.Id for entity in self.model_part.Elements]
+
+        merged_node_ids_list = [entiy.Id for entity in merged_model_part.Nodes]
+        merged_condition_ids_list = [entiy.Id for entity in merged_model_part.Conditions]
+        merged_element_ids_list = [entiy.Id for entity in merged_model_part.Elements]
+
+        self.assertEqual(origin_node_ids_list, merged_node_ids_list)
+        self.assertEqual(origin_condition_ids_list, merged_condition_ids_list)
+        self.assertEqual(origin_element_ids_list, merged_element_ids_list)
+
+    @KratosUnittest.skipIf(Kratos.IsDistributedRun(), "only the test does not support MPI")
     def test_Union(self):
         merged_model_part = Kratos.ModelPartOperationUtilities.Union("merge_1", self.model_part, self.model_parts_list, False)
 

--- a/kratos/tests/test_model_part_operation_utilities.py
+++ b/kratos/tests/test_model_part_operation_utilities.py
@@ -74,7 +74,7 @@ class TestModelPartOperationUtilities(KratosUnittest.TestCase):
 
     @KratosUnittest.skipIf(Kratos.IsDistributedRun(), "only the test does not support MPI")
     def test_Order(self):
-        merged_model_part = Kratos.ModelPartOperationUtilities.Union("merge_order", self.model_part, self.model_part, False)
+        merged_model_part = Kratos.ModelPartOperationUtilities.Union("merge_order", self.model_part, [self.model_part], False)
 
         origin_node_ids_list = [entity.Id for entity in self.model_part.Nodes]
         origin_condition_ids_list = [entity.Id for entity in self.model_part.Conditions]

--- a/kratos/tests/test_model_part_operation_utilities.py
+++ b/kratos/tests/test_model_part_operation_utilities.py
@@ -74,7 +74,7 @@ class TestModelPartOperationUtilities(KratosUnittest.TestCase):
 
     @KratosUnittest.skipIf(Kratos.IsDistributedRun(), "only the test does not support MPI")
     def test_Order(self):
-        merged_model_part = Kratos.ModelPartOperationUtilities.Union("merge_1", self.model_part, self.model_part, False)
+        merged_model_part = Kratos.ModelPartOperationUtilities.Union("merge_order", self.model_part, self.model_part, False)
 
         origin_node_ids_list = [entiy.Id for entity in self.model_part.Nodes]
         origin_condition_ids_list = [entiy.Id for entity in self.model_part.Conditions]

--- a/kratos/utilities/model_part_operation_utilities.cpp
+++ b/kratos/utilities/model_part_operation_utilities.cpp
@@ -216,6 +216,19 @@ ModelPart& ModelPartOperationUtilities::CreateOutputModelPart(
     // sets the communicator info.
     SetCommunicator(r_output_model_part, rMainModelPart);
 
+    // until now everything is sorted based on the memory location ptrs.
+    // sorting them based on the ids.
+    const auto& sort_mesh = [](ModelPart::MeshType& rMesh) {
+        rMesh.Nodes().Sort();
+        rMesh.Conditions().Sort();
+        rMesh.Elements().Sort();
+    };
+
+    sort_mesh(r_output_model_part.GetMesh());
+    sort_mesh(r_output_model_part.GetCommunicator().LocalMesh());
+    sort_mesh(r_output_model_part.GetCommunicator().GhostMesh());
+    sort_mesh(r_output_model_part.GetCommunicator().InterfaceMesh());
+
     return r_output_model_part;
 }
 


### PR DESCRIPTION
**📝 Description**
Untill now the model parts created with the operations are sorted according to their memory locations which may not be in the same order as the ids. Hence, the resulting model part will have a different entity order than the input model part entities. This fixes it by sorting everything in `PointerVectorSet` after creating the model parts.


**🆕 Changelog**
- Sorts entities according to ids in `ModelPartOperationUtilities`
