### PR TITLE
[Core] Container Expression - Skip Expression::Evaluate vtable if possible

### DIFF
--- a/kratos/containers/container_expression/container_expression.cpp
+++ b/kratos/containers/container_expression/container_expression.cpp
@@ -272,13 +272,33 @@ void ContainerExpression<TContainerType, TMeshType>::Evaluate(
 
     const IndexType flattened_size = r_expression.GetItemComponentCount();
 
-    IndexPartition<IndexType>(number_of_entities).for_each([pBegin, flattened_size, &r_expression](const IndexType EntityIndex) {
-        const IndexType entity_data_begin_index = EntityIndex * flattened_size;
-        double* p_input_data_begin = pBegin + entity_data_begin_index;
-        for (IndexType i = 0; i < flattened_size; ++i) {
-            *(p_input_data_begin+i) = r_expression.Evaluate(EntityIndex, entity_data_begin_index, i);
-        }
-    });
+    if (dynamic_cast<const LiteralFlatExpression<char>*>(&r_expression)) {
+        const auto& r_transformed_expression = *dynamic_cast<const LiteralFlatExpression<char>*>(&r_expression);
+        const auto p_expression_begin = r_transformed_expression.cbegin();
+        IndexPartition<IndexType>(number_of_entities * flattened_size).for_each([pBegin, p_expression_begin](const IndexType Index) {
+                pBegin[Index] = static_cast<double>(p_expression_begin[Index]);
+        });
+    } else if (dynamic_cast<const LiteralFlatExpression<int>*>(&r_expression)) {
+        const auto& r_transformed_expression = *dynamic_cast<const LiteralFlatExpression<int>*>(&r_expression);
+        const auto p_expression_begin = r_transformed_expression.cbegin();
+        IndexPartition<IndexType>(number_of_entities * flattened_size).for_each([pBegin, p_expression_begin](const IndexType Index) {
+                pBegin[Index] = static_cast<double>(p_expression_begin[Index]);
+        });
+    } else if (dynamic_cast<const LiteralFlatExpression<double>*>(&r_expression)) {
+        const auto& r_transformed_expression = *dynamic_cast<const LiteralFlatExpression<double>*>(&r_expression);
+        const auto p_expression_begin = r_transformed_expression.cbegin();
+        IndexPartition<IndexType>(number_of_entities * flattened_size).for_each([pBegin, p_expression_begin](const IndexType Index) {
+                pBegin[Index] = p_expression_begin[Index];
+        });
+    } else {
+        IndexPartition<IndexType>(number_of_entities).for_each([pBegin, flattened_size, &r_expression](const IndexType EntityIndex) {
+            const IndexType entity_data_begin_index = EntityIndex * flattened_size;
+            double* p_input_data_begin = pBegin + entity_data_begin_index;
+            for (IndexType i = 0; i < flattened_size; ++i) {
+                *(p_input_data_begin+i) = r_expression.Evaluate(EntityIndex, entity_data_begin_index, i);
+            }
+        });
+    }
 
     KRATOS_CATCH("");
 }

--- a/kratos/containers/container_expression/specialized_container_expression_impl.h
+++ b/kratos/containers/container_expression/specialized_container_expression_impl.h
@@ -119,10 +119,30 @@ void SpecializedContainerExpression<TContainerType, TContainerDataIO, TMeshType>
             }
         }
 
-        IndexPartition<IndexType>(number_of_entities).for_each(TDataType{}, [&r_container, &rVariable, &r_expression, &variable_flatten_data_io](const IndexType Index, TDataType& rValue){
-            variable_flatten_data_io.Assign(rValue, r_expression, Index);
-            TContainerDataIO::SetValue(*(r_container.begin() + Index), rVariable, rValue);
-        });
+        if (dynamic_cast<const LiteralFlatExpression<char>*>(&r_expression)) {
+            auto& r_transformed_expression = *dynamic_cast<const LiteralFlatExpression<char>*>(&r_expression);
+            IndexPartition<IndexType>(number_of_entities).for_each(TDataType{}, [&r_container, &rVariable, &r_transformed_expression, &variable_flatten_data_io](const IndexType Index, TDataType& rValue){
+                variable_flatten_data_io.Assign(rValue, r_transformed_expression, Index);
+                TContainerDataIO::SetValue(*(r_container.begin() + Index), rVariable, rValue);
+            });
+        } else if (dynamic_cast<const LiteralFlatExpression<int>*>(&r_expression)) {
+            auto& r_transformed_expression = *dynamic_cast<const LiteralFlatExpression<int>*>(&r_expression);
+            IndexPartition<IndexType>(number_of_entities).for_each(TDataType{}, [&r_container, &rVariable, &r_transformed_expression, &variable_flatten_data_io](const IndexType Index, TDataType& rValue){
+                variable_flatten_data_io.Assign(rValue, r_transformed_expression, Index);
+                TContainerDataIO::SetValue(*(r_container.begin() + Index), rVariable, rValue);
+            });
+        } else if (dynamic_cast<const LiteralFlatExpression<double>*>(&r_expression)) {
+            auto& r_transformed_expression = *dynamic_cast<const LiteralFlatExpression<double>*>(&r_expression);
+            IndexPartition<IndexType>(number_of_entities).for_each(TDataType{}, [&r_container, &rVariable, &r_transformed_expression, &variable_flatten_data_io](const IndexType Index, TDataType& rValue){
+                variable_flatten_data_io.Assign(rValue, r_transformed_expression, Index);
+                TContainerDataIO::SetValue(*(r_container.begin() + Index), rVariable, rValue);
+            });
+        } else {
+            IndexPartition<IndexType>(number_of_entities).for_each(TDataType{}, [&r_container, &rVariable, &r_expression, &variable_flatten_data_io](const IndexType Index, TDataType& rValue){
+                variable_flatten_data_io.Assign(rValue, r_expression, Index);
+                TContainerDataIO::SetValue(*(r_container.begin() + Index), rVariable, rValue);
+            });
+        }
 
         if constexpr(std::is_same_v<TContainerType, ModelPart::NodesContainerType>) {
             // synchronize nodal values

--- a/kratos/containers/container_expression/variable_expression_data_io.h
+++ b/kratos/containers/container_expression/variable_expression_data_io.h
@@ -58,9 +58,10 @@ public:
 
     static Pointer Create(const std::vector<IndexType>& rShape);
 
+    template<class TExpressionType>
     void Assign(
         TDataType& rOutput,
-        const Expression& rExpression,
+        const TExpressionType& rExpression,
         const IndexType EntityIndex) const;
 
     void Read(


### PR DESCRIPTION
**📝 Description**
This PR checks whether the underlying expressions is of type `LiteralFlatExpression<T>` which has an underlying T contiguous array, if so, skips the `Expression::Evaluate` method  call and directly iterate through the contiguous array when `Evaluate` is called on the Container.

**🆕 Changelog**
- Skips `Expression::Evaluate` call which goes through the vtable if possible.
