### PR TITLE
[Core] Fixed interval recurring event utility

### DIFF
--- a/kratos/python/add_other_utilities_to_python.cpp
+++ b/kratos/python/add_other_utilities_to_python.cpp
@@ -69,6 +69,7 @@
 #include "utilities/particles_utilities.h"
 #include "utilities/string_utilities.h"
 #include "utilities/model_part_operation_utilities.h"
+#include "utilities/fixed_interval_recurring_event_utility.h"
 
 namespace Kratos {
 namespace Python {
@@ -811,6 +812,20 @@ void AddOtherUtilitiesToPython(pybind11::module &m)
         .def("Intersect", &ModelPartOperationUtilities::CreateModelPartWithOperation<ModelPartIntersectionOperator>, py::arg("output_model_part_name"), py::arg("main_model_part"), py::arg("model_parts_to_intersect"), py::arg("add_neighbours"), py::return_value_policy::reference_internal)
         .def("HasIntersection", &ModelPartOperationUtilities::HasIntersection, py::arg("model_parts_to_intersect"))
     ;
+
+    py::class_<FixedIntervalRecurringEventUtility<int>, FixedIntervalRecurringEventUtility<int>::Pointer>(m,"IntegerFixedIntervalRecurringEventUtility")
+        .def(py::init<const int, const int>(), py::arg("initial_value"), py::arg("interval"))
+        .def("IsEventExpected", &FixedIntervalRecurringEventUtility<int>::IsEventExpected, py::arg("current_value"))
+        .def("ScheduleNextEvent", &FixedIntervalRecurringEventUtility<int>::ScheduleNextEvent, py::arg("current_value"))
+        .def("__str__", &FixedIntervalRecurringEventUtility<int>::Info)
+    ;
+
+    py::class_<FixedIntervalRecurringEventUtility<double>, FixedIntervalRecurringEventUtility<double>::Pointer>(m,"DoubleFixedIntervalRecurringEventUtility")
+        .def(py::init<const double, const double>(), py::arg("initial_value"), py::arg("interval"))
+        .def("IsEventExpected", &FixedIntervalRecurringEventUtility<double>::IsEventExpected, py::arg("current_value"))
+        .def("ScheduleNextEvent", &FixedIntervalRecurringEventUtility<double>::ScheduleNextEvent, py::arg("current_value"))
+        .def("__str__", &FixedIntervalRecurringEventUtility<double>::Info)
+    ;    
 
 }
 

--- a/kratos/python_scripts/unv_output_process.py
+++ b/kratos/python_scripts/unv_output_process.py
@@ -2,14 +2,16 @@ import KratosMultiphysics
 from KratosMultiphysics import kratos_utilities
 from  KratosMultiphysics.deprecation_management import DeprecationManager
 
-def Factory(settings, model):
-    if(type(settings) != KratosMultiphysics.Parameters):
+def Factory(settings: KratosMultiphysics.Parameters, model: KratosMultiphysics.Model):
+    if(isinstance(settings, KratosMultiphysics.Parameters)):
         raise Exception("expected input shall be a Parameters object, encapsulating a json string")
+    if(isinstance(model, KratosMultiphysics.Model)):
+        raise Exception("expected input shall be a Model object")
+
     return UnvOutputProcess(model, settings["Parameters"])
 
-
 class UnvOutputProcess(KratosMultiphysics.Process):
-    def __init__(self, model, settings ):
+    def __init__(self, model: KratosMultiphysics.Model, settings: KratosMultiphysics.Parameters ):
         KratosMultiphysics.Process.__init__(self)
 
         # IMPORTANT: when "output_control_type" is "time",
@@ -46,10 +48,15 @@ class UnvOutputProcess(KratosMultiphysics.Process):
         self.unv_io.InitializeMesh()
         self.unv_io.WriteMesh()
 
-        self.output_interval = self.settings["output_interval"].GetDouble()
-        self.output_control = self.settings["output_control_type"].GetString()
-        self.next_output = 0.0
-        self.step_count = 0
+        output_control_type = settings["output_control_type"].GetString()
+        if output_control_type == "time":
+            self.output_control_variable = KratosMultiphysics.TIME
+            self.output_control_utility = KratosMultiphysics.DoubleFixedIntervalRecurringEventUtility(self.model_part.ProcessInfo[self.output_control_variable], settings["output_interval"].GetDouble())
+        elif output_control_type == "step":
+            self.output_control_variable = KratosMultiphysics.STEP
+            self.output_control_utility = KratosMultiphysics.IntegerFixedIntervalRecurringEventUtility(self.model_part.ProcessInfo[self.output_control_variable], settings["output_interval"].GetInt())
+        else:
+            raise RuntimeError(f"Unsupported output control type = \"{output_control_type}\" requested. Supported control types are:\n\ttime\n\tstep")
 
     # This function can be extended with new deprecated variables as they are generated
     def TranslateLegacyVariablesAccordingToCurrentStandard(self, settings):
@@ -63,39 +70,13 @@ class UnvOutputProcess(KratosMultiphysics.Process):
             DeprecationManager.ReplaceDeprecatedVariableName(settings, old_name, new_name)
 
     def ExecuteInitialize(self):
-        if self.output_control == "time":
-            self.next_output = self.model_part.ProcessInfo[KratosMultiphysics.TIME]
-        else:
-            self.next_output = self.model_part.ProcessInfo[KratosMultiphysics.STEP]
-
         self.nodal_variables = kratos_utilities.GenerateVariableListFromInput(self.settings["nodal_results"])
 
-    def ExecuteInitializeSolutionStep(self):
-        self.step_count += 1
-
     def PrintOutput(self):
+        current_control_value = self.model_part.ProcessInfo[self.output_control_variable]
         for variable in self.nodal_variables:
-            self.unv_io.PrintOutput(variable, self.next_output)
-
-        # Schedule next output
-        time = GetPrettyTime(self.model_part.ProcessInfo[KratosMultiphysics.TIME])
-        if self.output_interval > 0.0: # Note: if == 0, we'll just always print
-            if self.output_control == "time":
-                while GetPrettyTime(self.next_output) <= time:
-                    self.next_output += self.output_interval
-            else:
-                while self.next_output <= self.step_count:
-                    self.next_output += self.output_interval
+            self.unv_io.PrintOutput(variable, current_control_value)
+        self.output_control_utility.ScheduleNextEvent(current_control_value)
 
     def IsOutputStep(self):
-        if self.output_control == "time":
-            time = GetPrettyTime(self.model_part.ProcessInfo[KratosMultiphysics.TIME])
-            return (time >= GetPrettyTime(self.next_output))
-        else:
-            return ( self.step_count >= self.next_output )
-
-
-def GetPrettyTime(time):
-    pretty_time = "{0:.12g}".format(time)
-    pretty_time = float(pretty_time)
-    return pretty_time
+        return self.output_control_utility.IsEventExpected(self.model_part.ProcessInfo[self.output_control_variable])

--- a/kratos/python_scripts/unv_output_process.py
+++ b/kratos/python_scripts/unv_output_process.py
@@ -3,9 +3,9 @@ from KratosMultiphysics import kratos_utilities
 from  KratosMultiphysics.deprecation_management import DeprecationManager
 
 def Factory(settings: KratosMultiphysics.Parameters, model: KratosMultiphysics.Model):
-    if(isinstance(settings, KratosMultiphysics.Parameters)):
+    if not isinstance(settings, KratosMultiphysics.Parameters):
         raise Exception("expected input shall be a Parameters object, encapsulating a json string")
-    if(isinstance(model, KratosMultiphysics.Model)):
+    if not isinstance(model, KratosMultiphysics.Model):
         raise Exception("expected input shall be a Model object")
 
     return UnvOutputProcess(model, settings["Parameters"])

--- a/kratos/python_scripts/vtk_output_process.py
+++ b/kratos/python_scripts/vtk_output_process.py
@@ -3,9 +3,9 @@ import KratosMultiphysics.kratos_utilities as kratos_utils
 from  KratosMultiphysics.deprecation_management import DeprecationManager
 
 def Factory(settings: KratosMultiphysics.Parameters, model: KratosMultiphysics.Model):
-    if(isinstance(settings, KratosMultiphysics.Parameters)):
+    if not isinstance(settings, KratosMultiphysics.Parameters):
         raise Exception("expected input shall be a Parameters object, encapsulating a json string")
-    if(isinstance(model, KratosMultiphysics.Model)):
+    if not isinstance(model, KratosMultiphysics.Model):
         raise Exception("expected input shall be a Model object")
 
     return VtkOutputProcess(model, settings["Parameters"])

--- a/kratos/python_scripts/vtk_output_process.py
+++ b/kratos/python_scripts/vtk_output_process.py
@@ -2,14 +2,16 @@ import KratosMultiphysics
 import KratosMultiphysics.kratos_utilities as kratos_utils
 from  KratosMultiphysics.deprecation_management import DeprecationManager
 
-def Factory(settings, model):
-    if not isinstance(settings, KratosMultiphysics.Parameters):
+def Factory(settings: KratosMultiphysics.Parameters, model: KratosMultiphysics.Model):
+    if(isinstance(settings, KratosMultiphysics.Parameters)):
         raise Exception("expected input shall be a Parameters object, encapsulating a json string")
+    if(isinstance(model, KratosMultiphysics.Model)):
+        raise Exception("expected input shall be a Model object")
+
     return VtkOutputProcess(model, settings["Parameters"])
 
-
 class VtkOutputProcess(KratosMultiphysics.OutputProcess):
-    def __init__(self, model, settings):
+    def __init__(self, model: KratosMultiphysics.Model, settings: KratosMultiphysics.Parameters):
         super().__init__()
 
         model_part_name = settings["model_part_name"].GetString()
@@ -33,11 +35,15 @@ class VtkOutputProcess(KratosMultiphysics.OutputProcess):
                     kratos_utils.DeleteDirectoryIfExisting(output_path)
             self.model_part.GetCommunicator().GetDataCommunicator().Barrier()
 
-        self.output_interval = settings["output_interval"].GetDouble()
-        self.output_control = settings["output_control_type"].GetString()
-        self.next_output = 0.0
-
-        self.__ScheduleNextOutput() # required here esp for restart
+        output_control_type = settings["output_control_type"].GetString()
+        if output_control_type == "time":
+            self.output_control_variable = KratosMultiphysics.TIME
+            self.output_control_utility = KratosMultiphysics.DoubleFixedIntervalRecurringEventUtility(self.model_part.ProcessInfo[self.output_control_variable], settings["output_interval"].GetDouble())
+        elif output_control_type == "step":
+            self.output_control_variable = KratosMultiphysics.STEP
+            self.output_control_utility = KratosMultiphysics.IntegerFixedIntervalRecurringEventUtility(self.model_part.ProcessInfo[self.output_control_variable], settings["output_interval"].GetInt())
+        else:
+            raise RuntimeError(f"Unsupported output control type = \"{output_control_type}\" requested. Supported control types are:\n\ttime\n\tstep")
 
     # This function can be extended with new deprecated variables as they are generated
     def TranslateLegacyVariablesAccordingToCurrentStandard(self, settings):
@@ -64,25 +70,8 @@ class VtkOutputProcess(KratosMultiphysics.OutputProcess):
 
     def PrintOutput(self):
         self.vtk_io.PrintOutput()
-
-        self.__ScheduleNextOutput()
+        self.output_control_utility.ScheduleNextEvent(self.model_part.ProcessInfo[self.output_control_variable])
 
     def IsOutputStep(self):
-        if self.output_control == "time":
-            return self.__GetTime() >= self.next_output
-        else:
-            return self.model_part.ProcessInfo[KratosMultiphysics.STEP] >= self.next_output
+        return self.output_control_utility.IsEventExpected(self.model_part.ProcessInfo[self.output_control_variable])
 
-    def __ScheduleNextOutput(self):
-        if self.output_interval > 0.0: # Note: if == 0, we'll just always print
-            if self.output_control == "time":
-                while self.next_output <= self.__GetTime():
-                    self.next_output += self.output_interval
-            else:
-                while self.next_output <= self.model_part.ProcessInfo[KratosMultiphysics.STEP]:
-                    self.next_output += self.output_interval
-
-    def __GetTime(self):
-        # remove rounding errors that mess with the comparison
-        # e.g. 1.99999999999999999 => 2.0
-        return float("{0:.12g}".format(self.model_part.ProcessInfo[KratosMultiphysics.TIME]))

--- a/kratos/utilities/fixed_interval_recurring_event_utility.cpp
+++ b/kratos/utilities/fixed_interval_recurring_event_utility.cpp
@@ -1,0 +1,65 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ \.
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Suneth Warnakulasuriya
+//
+
+// System includes
+#include <sstream>
+
+// Project includes
+
+// Include base h
+#include "fixed_interval_recurring_event_utility.h"
+
+namespace Kratos {
+
+template <class TDataType>
+FixedIntervalRecurringEventUtility<TDataType>::FixedIntervalRecurringEventUtility(
+    const TDataType InitialValue,
+    const TDataType Interval)
+    : mInterval(Interval),
+      mNextEventValue(TDataType{})
+{
+    ScheduleNextEvent(InitialValue);
+}
+
+template <class TDataType>
+bool FixedIntervalRecurringEventUtility<TDataType>::IsEventExpected(const TDataType CurrentValue) const
+{
+    return CurrentValue >= mNextEventValue;
+}
+
+template <class TDataType>
+void FixedIntervalRecurringEventUtility<TDataType>::ScheduleNextEvent(const TDataType CurrentValue)
+{
+    if (mInterval > TDataType{}) {
+        while (mNextEventValue <= CurrentValue) {
+            mNextEventValue += mInterval;
+        }
+    }
+}
+
+template <class TDataType>
+std::string FixedIntervalRecurringEventUtility<TDataType>::Info() const
+{
+    std::stringstream msg;
+
+    msg << "FixedIntervalRecurringEventUtility [ Interval = "
+        << mInterval << ", Next event expected at = "
+        << mNextEventValue << " ]\n";
+
+    return msg.str();
+}
+
+// template instantiations
+template class FixedIntervalRecurringEventUtility<int>;
+template class FixedIntervalRecurringEventUtility<double>;
+
+} // namespace Kratos

--- a/kratos/utilities/fixed_interval_recurring_event_utility.h
+++ b/kratos/utilities/fixed_interval_recurring_event_utility.h
@@ -1,0 +1,77 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ \.
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Suneth Warnakulasuriya
+//
+
+#pragma once
+
+// System includes
+
+// Project includes
+#include "includes/define.h"
+
+namespace Kratos {
+
+template <class TDataType>
+class KRATOS_API(KRATOS_CORE) FixedIntervalRecurringEventUtility
+{
+public:
+    ///@name Type definitions
+    ///@{
+
+    KRATOS_CLASS_POINTER_DEFINITION(FixedIntervalRecurringEventUtility);
+
+    ///@}
+    ///@name Life cycle
+    ///@{
+
+    FixedIntervalRecurringEventUtility(
+        const TDataType InitialValue,
+        const TDataType Interval);
+
+    ///@}
+    ///@name Public operations
+    ///@{
+
+    bool IsEventExpected(const TDataType CurrentValue) const;
+
+    void ScheduleNextEvent(const TDataType CurrentValue);
+
+    ///@}
+    ///@name Public input output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const;
+
+    ///@}
+
+private:
+    ///@name Private member variables
+    ///@{
+
+    const TDataType mInterval;
+
+    TDataType mNextEventValue;
+
+    ///@}
+};
+
+/// output stream function
+template <class TDataType>
+inline std::ostream& operator<<(
+    std::ostream& rOStream,
+    const FixedIntervalRecurringEventUtility<TDataType>& rThis)
+{
+    rOStream << rThis.Info();
+    return rOStream;
+}
+
+} // namespace Kratos

--- a/kratos/utilities/fixed_interval_recurring_event_utility.h
+++ b/kratos/utilities/fixed_interval_recurring_event_utility.h
@@ -19,6 +19,12 @@
 
 namespace Kratos {
 
+/**
+ * @class FixedIntervalRecurringEventUtility
+ * @ingroup KratosCore
+ * @brief Utility class to handle fixed interval recurring events.
+ * @tparam TDataType The data type used for event values.
+ */
 template <class TDataType>
 class KRATOS_API(KRATOS_CORE) FixedIntervalRecurringEventUtility
 {
@@ -32,6 +38,11 @@ public:
     ///@name Life cycle
     ///@{
 
+    /**
+     * @brief Constructor.
+     * @param InitialValue The initial value of the event.
+     * @param Interval The time interval between events.
+     */
     FixedIntervalRecurringEventUtility(
         const TDataType InitialValue,
         const TDataType Interval);
@@ -40,15 +51,27 @@ public:
     ///@name Public operations
     ///@{
 
+    /**
+     * @brief Checks if an event is expected based on the current value.
+     * @param CurrentValue The current value.
+     * @return true if an event is expected, false otherwise.
+     */
     bool IsEventExpected(const TDataType CurrentValue) const;
 
+    /**
+     * @brief Schedules the next event based on the current value.
+     * @param CurrentValue The current value.
+     */
     void ScheduleNextEvent(const TDataType CurrentValue);
 
     ///@}
     ///@name Public input output
     ///@{
 
-    /// Turn back information as a string.
+    /**
+     * @brief Returns the information of the utility as a string.
+     * @return The utility information as a string.
+     */
     std::string Info() const;
 
     ///@}
@@ -57,9 +80,8 @@ private:
     ///@name Private member variables
     ///@{
 
-    const TDataType mInterval;
-
-    TDataType mNextEventValue;
+    const TDataType mInterval; /// The time interval between events.
+    TDataType mNextEventValue; /// The value of the next event.
 
     ///@}
 };


### PR DESCRIPTION
**📝 Description**
This PR introduces the `FixedIntervalRecurringEventUtility` which has the same mechanism which was copy pasted in some of the output processes such as `unv_output_process.py`, `vtk_output_process.py` and `vtu_output_process.py`.

One behaviour change:
The existing implementations assumes output control type as "step" if the `output_control_type` is not `time`. This is changed, and now only supports `time` and `step` as the output control type, if any other is given an error is thrown.

**🆕 Changelog**
- Added `FixedIntervalRecurringEventUtility`
- Updated `unv_output_process.py`, `vtk_output_process.py`, and `vtu_output_process.py`.
