### PR TITLE
[ExternalLib][Clipper2] Add `#include <stdint.h>` to clipper.engine.h

### DIFF
--- a/external_libraries/clipper/include/clipper2/clipper.engine.h
+++ b/external_libraries/clipper/include/clipper2/clipper.engine.h
@@ -13,6 +13,7 @@
 #define CLIPPER2_VERSION "1.0.5"
 
 #include <cstdlib>
+#include <stdint.h>
 #include <queue>
 #include <stdexcept>
 #include <vector>


### PR DESCRIPTION
**📝 Description**

This PR introduces a new include statement into the `clipper.engine.h` header file of the Clipper2Lib in the CPP project. Specifically, it adds `#include <stdint.h>`, which is a header file in the C standard library that allows for the use of integer types with specified widths. 

The lack of this include induced compilation failing with GCC12.

Related with https://github.com/AngusJohnson/Clipper2/pull/541 (fix in main project)

**🆕 Changelog**

- [Add `#include <stdint.h>` to clipper.engine.h](https://github.com/KratosMultiphysics/Kratos/commit/efbbe996b53a078bda4778d6cec602d339bd5da0)