### PR TITLE
Remove debug output.

### DIFF
--- a/kratos/tests/cpp_tests/geometries/test_prism_3d_15.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_prism_3d_15.cpp
@@ -223,7 +223,6 @@ void ShapeFunctionSanityCheck(
         for (unsigned int i = 0; i < numPoints; i++) {
             shapeFuncSum += shapeFunctions(g, i);
         }
-        std::cerr << "GPPT g " << g << " sum " << shapeFuncSum << std::endl;
         KRATOS_CHECK_NEAR(shapeFuncSum, 1.0, TOLERANCE);
     }
 


### PR DESCRIPTION
**📝 Description**

Removing debug output from a test recently added to kratos core.

**🆕 Changelog**

- Removing debug output from Prism3D15 tests.
