### PR TITLE
Fix error importing missing registry

### DIFF
--- a/kratos/templates/template_application/CMakeLists.txt.in
+++ b/kratos/templates/template_application/CMakeLists.txt.in
@@ -47,7 +47,7 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 # Add to the KratosMultiphisics Python module
 kratos_python_install(${INSTALL_PYTHON_USING_LINKS} ${CMAKE_CURRENT_SOURCE_DIR}/@{APP_NAME_CAMEL}Application.py KratosMultiphysics/@{APP_NAME_CAMEL}Application/__init__.py )
-kratos_python_install(${INSTALL_PYTHON_USING_LINKS} ${CMAKE_CURRENT_SOURCE_DIR}/python_registry_lists.py KratosMultiphysics/@{APP_NAME_CAMEL}python_registry_lists.py )
+kratos_python_install(${INSTALL_PYTHON_USING_LINKS} ${CMAKE_CURRENT_SOURCE_DIR}/python_registry_lists.py KratosMultiphysics/@{APP_NAME_CAMEL}Application/python_registry_lists.py )
 
 # Install python files
 get_filename_component (CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)

--- a/kratos/templates/template_application/CMakeLists.txt.in
+++ b/kratos/templates/template_application/CMakeLists.txt.in
@@ -47,6 +47,7 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 # Add to the KratosMultiphisics Python module
 kratos_python_install(${INSTALL_PYTHON_USING_LINKS} ${CMAKE_CURRENT_SOURCE_DIR}/@{APP_NAME_CAMEL}Application.py KratosMultiphysics/@{APP_NAME_CAMEL}Application/__init__.py )
+kratos_python_install(${INSTALL_PYTHON_USING_LINKS} ${CMAKE_CURRENT_SOURCE_DIR}/python_registry_lists.py KratosMultiphysics/@{APP_NAME_CAMEL}python_registry_lists.py )
 
 # Install python files
 get_filename_component (CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)


### PR DESCRIPTION
**📝 Description**
python_registry_lists.py was not being copied by the templated cmake which caused a circular import while trying to import the one from the core.

**🆕 Changelog**
- Added line to automatically install the `python_registry_lists.py` for templated applications
