### PR TITLE
[Core] Added `KRATOS_FORCE_INLINE` macro for function inlining across different compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,12 @@ endif(NOT DEFINED ENV{KRATOS_INSTALL_PYTHON_USING_LINKS})
 # Setting the libs folder for the shared objects built in kratos
 set(CMAKE_INSTALL_RPATH "$ORIGIN/../libs")
 
+# If no inlining policy disable by default
+option(KRATOS_FORCE_INLINING "KRATOS_FORCE_INLINING defines if the compiler enforces the inlining. Default setting is OFF" OFF)
+if(${KRATOS_FORCE_INLINING})
+   add_definitions( -DKRATOS_FORCE_INLINING )
+endif(${KRATOS_FORCE_INLINING})
+
 # If no test policy enable by default
 option(KRATOS_BUILD_TESTING "KRATOS_BUILD_TESTING defines if the C++ tests are compiled. These increase compilation time, but if not set only python tests can be executed. Default setting is ON" ON)
 

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -774,6 +774,20 @@ __pragma(warning(pop))
 #define KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING // not implemented for other compilers, hence does nothing
 #endif
 
+// Defining macros to force inlining
+#ifdef _MSC_VER
+    #define KRATOS_FORCE_INLINE __forceinline
+#elif defined(__GNUC__)
+    #define KRATOS_FORCE_INLINE inline __attribute__((__always_inline__))
+#elif defined(__CLANG__)
+    #if __has_attribute(__always_inline__)
+        #define KRATOS_FORCE_INLINE inline __attribute__((__always_inline__))
+    #else
+        #define KRATOS_FORCE_INLINE inline
+    #endif
+#else
+    #define KRATOS_FORCE_INLINE inline
+#endif
 
 namespace Kratos
 {

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -785,6 +785,12 @@ __pragma(warning(pop))
     #else
         #define KRATOS_FORCE_INLINE inline
     #endif
+#elif defined(__INTEL_COMPILER)
+    #if __has_attribute(__always_inline__)
+        #define KRATOS_FORCE_INLINE inline __attribute__((__always_inline__))
+    #else
+        #define KRATOS_FORCE_INLINE inline
+    #endif
 #else
     #define KRATOS_FORCE_INLINE inline
 #endif

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -775,19 +775,23 @@ __pragma(warning(pop))
 #endif
 
 // Defining macros to force inlining
-#ifdef _MSC_VER
-    #define KRATOS_FORCE_INLINE __forceinline
-#elif defined(__GNUC__)
-    #define KRATOS_FORCE_INLINE inline __attribute__((__always_inline__))
-#elif defined(__CLANG__)
-    #if __has_attribute(__always_inline__)
+#ifdef KRATOS_FORCE_INLINING
+    #ifdef _MSC_VER
+        #define KRATOS_FORCE_INLINE __forceinline
+    #elif defined(__GNUC__)
         #define KRATOS_FORCE_INLINE inline __attribute__((__always_inline__))
-    #else
-        #define KRATOS_FORCE_INLINE inline
-    #endif
-#elif defined(__INTEL_COMPILER)
-    #if __has_attribute(__always_inline__)
-        #define KRATOS_FORCE_INLINE inline __attribute__((__always_inline__))
+    #elif defined(__CLANG__)
+        #if __has_attribute(__always_inline__)
+            #define KRATOS_FORCE_INLINE inline __attribute__((__always_inline__))
+        #else
+            #define KRATOS_FORCE_INLINE inline
+        #endif
+    #elif defined(__INTEL_COMPILER)
+        #if __has_attribute(__always_inline__)
+            #define KRATOS_FORCE_INLINE inline __attribute__((__always_inline__))
+        #else
+            #define KRATOS_FORCE_INLINE inline
+        #endif
     #else
         #define KRATOS_FORCE_INLINE inline
     #endif


### PR DESCRIPTION
**📝 Description**

Mentioned in https://github.com/KratosMultiphysics/Kratos/pull/11086

This commit introduces the `KRATOS_FORCE_INLINE` macro to the `kratos/includes/define.h` file in order to force inline function behavior across different compilers. The macro's definition changes based on the detected compiler:

1. If the compiler is Microsoft's MSVC, it uses `__forceinline`.
2. If the compiler is GNU GCC, it uses `inline` with the `__always_inline__` attribute.
3. If the compiler is Clang and supports the `__always_inline__` attribute, it uses `inline` with the `__always_inline__` attribute. If the attribute is not supported, it defaults to `inline`.
4. For any other compilers, it defaults to `inline`. 

The introduction of this macro allows the Kratos codebase to optimize function inlining and enhance performance across different compilers.

**🆕 Changelog**

- [Adding macros to force inlining](https://github.com/KratosMultiphysics/Kratos/commit/148ae879b73840c5260c95a80009e66484ea582d)