### PR TITLE
[Core] Base64 encoder bugfix for data arrays of size 1 byte.

### DIFF
--- a/kratos/input_output/base_64_encoded_output.h
+++ b/kratos/input_output/base_64_encoded_output.h
@@ -24,7 +24,7 @@
 // Project includes
 #include "includes/define.h"
 
-namespace Kratos 
+namespace Kratos
 {
 ///@name Kratos Classes
 ///@{
@@ -67,8 +67,8 @@ public:
 
         using value_type = char;                               //// The value type representing a byte.
         using pointer = char*;                                 //// Pointer to a byte.
-        using reference = char&;                               //// Reference to a byte. 
-        using iterator_category = std::forward_iterator_tag;   //// Iterator category - forward iterator. 
+        using reference = char&;                               //// Reference to a byte.
+        using iterator_category = std::forward_iterator_tag;   //// Iterator category - forward iterator.
         using difference_type = std::ptrdiff_t;                //// Difference type between iterators.
 
         ///@}
@@ -201,9 +201,16 @@ public:
 
         const IndexType raw_bytes = N * sizeof(value_type);
 
+        // Following offset forces to write bytes to mByteTripliet array even
+        // if raw_bytes count is less than the mByteTripletIndex. This is important
+        // in the case if there are less number of raw_bytes (in case of UInt8 data type),
+        // then raw bytes may be less than mByteTripletIndex, hence avoiding
+        // reading data from the data stream.
+        const IndexType initial_byte_triplet_offset = raw_bytes + mByteTripletIndex;
+
         // first fill the existing mByteTriplet
         IndexType number_of_written_bytes = 0;
-        for (; mByteTripletIndex < std::min(raw_bytes, IndexType{3}); ++mByteTripletIndex) {
+        for (; mByteTripletIndex < std::min(initial_byte_triplet_offset, IndexType{3}); ++mByteTripletIndex) {
             mByteTriplet[mByteTripletIndex] = *itr_byte_triplet++;
             ++number_of_written_bytes;
         }

--- a/kratos/tests/cpp_tests/input_output/test_base_64_encoded_output.cpp
+++ b/kratos/tests/cpp_tests/input_output/test_base_64_encoded_output.cpp
@@ -89,4 +89,21 @@ KRATOS_TEST_CASE_IN_SUITE(Base64EcodedLargeInput, KratosCoreFastSuite)
     KRATOS_CHECK_EQUAL(output.str(), expected);
 }
 
+KRATOS_TEST_CASE_IN_SUITE(Base64EcodedSmallInput, KratosCoreFastSuite)
+{
+    std::stringstream output;
+
+    {
+        auto encoder = Base64EncodedOutput(output);
+
+        const unsigned int v1 = 1;
+        encoder.WriteData(&v1, 1);
+
+        const char v2 = 1;
+        encoder.WriteData(&v2, 1);
+    }
+
+    KRATOS_CHECK_EQUAL(output.str(), "AQAAAAE=");
+}
+
 } // namespace Kratos::Testing


### PR DESCRIPTION
**📝 Description**
The `Base4EncodedOutput` may omit writing data array of `char` with 1 element if the previous data set had 1 byte leftover writing the encoded byte triplet. So this data in the array is never written. Suggested fix always forces to write all the data in the stream. This does not affect existing tests since such small data sets were not tested (Such small data sets usually appear only in unit testing) . Hence a proper small data set unit test is also added.

**🆕 Changelog**
- Fixed base64 encoding for small data sets.
- Added a test.
