### PR TITLE
[Core] Added equality operator overload to `GlobalPointer` class in global_pointer.h

### DIFF
--- a/kratos/includes/global_pointer.h
+++ b/kratos/includes/global_pointer.h
@@ -196,6 +196,17 @@ public:
     return mDataPointer;
   }
 
+  /**
+   * @brief Overloads the '==' operator to compare two GlobalPointer objects of the
+   * same template type. Returns true if the underlying pointers are equal.
+   * @param rOther The GlobalPointer object to be compared.
+   * @return true if the underlying pointers are equal, false otherwise.
+   */
+  bool operator==(const GlobalPointer& rOther)
+  {
+      return this->get() == rOther.get();
+  }
+
   /** Fills buffer with the GlobalPoiter data
    * Fills buffer with the GlobalPoiter data
    * @param buffer Object data buffer
@@ -227,8 +238,6 @@ public:
   private:
 
   friend class Serializer;
-
-
 
   void save(Serializer& rSerializer) const
   {

--- a/kratos/includes/global_pointer.h
+++ b/kratos/includes/global_pointer.h
@@ -204,7 +204,11 @@ public:
    */
   bool operator==(const GlobalPointer& rOther)
   {
-      return this->get() == rOther.get();
+#ifdef KRATOS_USING_MPI
+    return this->get() == rOther.get() && this->GetRank() == rOther.GetRank();
+#else 
+    return this->get() == rOther.get();
+#endif
   }
 
   /** Fills buffer with the GlobalPoiter data


### PR DESCRIPTION
**📝 Description**

This PR it adds an overload of the '==' operator, allowing for direct comparison of two `GlobalPointer` objects of the same type. The overloaded '==' operator returns true if the underlying pointers of the two `GlobalPointer` objects are equal, and false otherwise.

The implementation of this operator is done in a new member function of the `GlobalPointer` class. This new function uses the `get()` member function to access the underlying pointers of the `GlobalPointer` objects.

**🆕 Changelog**

- [Adding missing == operator](https://github.com/KratosMultiphysics/Kratos/commit/38d9642528c44c42e1adaa5a63eeb27606b951a8)
