### PR TITLE
[Core] Adding test for spatial search result

### DIFF
--- a/kratos/spatial_containers/spatial_search_result.h
+++ b/kratos/spatial_containers/spatial_search_result.h
@@ -136,18 +136,38 @@ public:
         mIsDistanceCalculated = true;
     }
 
+    /// Getting if the object is found
+    bool GetIsObjectFound() const {
+        return mIsObjectFound;
+    }
+
+    /// Getting if the ibject is found
+    void SetIsObjectFound(const bool IsObjectFound) {
+        mIsObjectFound = IsObjectFound;
+    }
+
+    /// Getting if the distance is calculated
+    bool GetIsDistanceCalculated() const {
+        return mIsDistanceCalculated;
+    }
+
+    /// Setting if the distance is calculated
+    void SetIsDistanceCalculated(const bool IsDistanceCalculated) {
+        mIsDistanceCalculated = IsDistanceCalculated;
+    }
+
     ///@}
     ///@name Inquiry
     ///@{
 
-    /// Returns true if the object is set 
-	bool IsObjectFound() const { 
-        return mIsObjectFound; 
+    /// Returns true if the object is set
+    bool IsObjectFound() const {
+        return mIsObjectFound;
     }
 
     /// Returns true if the distance is set
-	bool IsDistanceCalculated() const { 
-        return mIsDistanceCalculated; 
+    bool IsDistanceCalculated() const {
+        return mIsDistanceCalculated;
     }
 
     ///@}

--- a/kratos/tests/cpp_tests/spatial_containers/test_spatial_search_result.cpp
+++ b/kratos/tests/cpp_tests/spatial_containers/test_spatial_search_result.cpp
@@ -1,0 +1,64 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "testing/testing.h"
+#include "includes/element.h"
+#include "spatial_containers/spatial_search_result_container.h"
+
+namespace Kratos::Testing 
+{
+
+KRATOS_TEST_CASE_IN_SUITE(TestDefaultConstruction, KratosCoreFastSuite)
+{
+    auto result = SpatialSearchResult<GeometricalObject>();
+    KRATOS_CHECK_EQUAL(result.IsObjectFound(), false);
+    KRATOS_CHECK_EQUAL(result.IsDistanceCalculated(), false);
+    //KRATOS_CHECK_EQUAL(result.Get(), nullptr); // operator== does not work with GlobalPointer nullptr
+    KRATOS_CHECK_EQUAL(result.GetDistance(), 0.0);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TestObjectFound, KratosCoreFastSuite)
+{
+    auto result = SpatialSearchResult<GeometricalObject>();
+    result.SetIsObjectFound(true);
+    KRATOS_CHECK_EQUAL(result.IsObjectFound(), true);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TestDistanceCalculated, KratosCoreFastSuite)
+{
+    auto result = SpatialSearchResult<GeometricalObject>();
+    result.SetIsDistanceCalculated(true);
+    KRATOS_CHECK_EQUAL(result.IsDistanceCalculated(), true);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TestPointer, KratosCoreFastSuite)
+{
+    Element element = Element();
+    auto result = SpatialSearchResult<GeometricalObject>(&element);
+    GeometricalObject* ptr = &element;
+    KRATOS_CHECK_EQUAL(result.Get().get(), ptr);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(TestDistance, KratosCoreFastSuite)
+{
+    auto result = SpatialSearchResult<GeometricalObject>();
+    result.SetDistance(3.14);
+    KRATOS_CHECK_EQUAL(result.GetDistance(), 3.14);
+}
+
+}  // namespace Kratos::Testing

--- a/kratos/tests/cpp_tests/spatial_containers/test_spatial_search_result.cpp
+++ b/kratos/tests/cpp_tests/spatial_containers/test_spatial_search_result.cpp
@@ -18,7 +18,7 @@
 // Project includes
 #include "testing/testing.h"
 #include "includes/element.h"
-#include "spatial_containers/spatial_search_result_container.h"
+#include "spatial_containers/spatial_search_result.h"
 
 namespace Kratos::Testing 
 {

--- a/kratos/tests/cpp_tests/spatial_containers/test_spatial_search_result.cpp
+++ b/kratos/tests/cpp_tests/spatial_containers/test_spatial_search_result.cpp
@@ -23,7 +23,7 @@
 namespace Kratos::Testing 
 {
 
-KRATOS_TEST_CASE_IN_SUITE(TestDefaultConstruction, KratosCoreFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(SpatialSearchResultDefaultConstruction, KratosCoreFastSuite)
 {
     auto result = SpatialSearchResult<GeometricalObject>();
     KRATOS_CHECK_EQUAL(result.IsObjectFound(), false);
@@ -32,21 +32,21 @@ KRATOS_TEST_CASE_IN_SUITE(TestDefaultConstruction, KratosCoreFastSuite)
     KRATOS_CHECK_EQUAL(result.GetDistance(), 0.0);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(TestObjectFound, KratosCoreFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(SpatialSearchResultObjectFound, KratosCoreFastSuite)
 {
     auto result = SpatialSearchResult<GeometricalObject>();
     result.SetIsObjectFound(true);
     KRATOS_CHECK_EQUAL(result.IsObjectFound(), true);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(TestDistanceCalculated, KratosCoreFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(SpatialSearchResultDistanceCalculated, KratosCoreFastSuite)
 {
     auto result = SpatialSearchResult<GeometricalObject>();
     result.SetIsDistanceCalculated(true);
     KRATOS_CHECK_EQUAL(result.IsDistanceCalculated(), true);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(TestPointer, KratosCoreFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(SpatialSearchResultPointer, KratosCoreFastSuite)
 {
     Element element = Element();
     auto result = SpatialSearchResult<GeometricalObject>(&element);
@@ -54,7 +54,7 @@ KRATOS_TEST_CASE_IN_SUITE(TestPointer, KratosCoreFastSuite)
     KRATOS_CHECK_EQUAL(result.Get().get(), ptr);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(TestDistance, KratosCoreFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(SpatialSearchResultDistance, KratosCoreFastSuite)
 {
     auto result = SpatialSearchResult<GeometricalObject>();
     result.SetDistance(3.14);


### PR DESCRIPTION
**📝 Description**

This PR introduces a new file `test_spatial_search_result.cpp` within the `kratos/tests/cpp_tests/spatial_containers` directory. It includes unit tests for a class named `SpatialSearchResult`. 

The added tests are as follows:
1. `SpatialSearchResultDefaultConstruction`: This test checks the default constructor of the `SpatialSearchResult` class. It asserts that initially, no object is found, no distance is calculated, and the object pointer is null.
2. `SpatialSearchResultObjectFound`: This test verifies the functionality of the `SetIsObjectFound` method by checking if the `IsObjectFound` method correctly reports an object as found after it has been set so.
3. `SpatialSearchResultDistanceCalculated`: Similar to `SpatialSearchResultObjectFound`, this test checks the functionality of `SetIsDistanceCalculated` method.
4. `SpatialSearchResultPointer`: This test constructs a `SpatialSearchResult` object with a `GeometricalObject` element and checks if the object returned by the `Get` method is the same as the one initialized.
5. `SpatialSearchResultDistance`: This test checks if the `SetDistance` method correctly sets the distance that can be retrieved by the `GetDistance` method.

This suite of tests are designed to ensure that the `SpatialSearchResult` class behaves as expected and that all of its methods function properly.

**🆕 Changelog**

- [Adding test for spatial search result](https://github.com/KratosMultiphysics/Kratos/commit/e1e42beaa38d560ffdf7a8781ab1148ca0318411)
