### PR TITLE
RomApp Get simulation residuals and store them as numpy files

### DIFF
--- a/applications/RomApplication/python_scripts/residual_output_analysis.py
+++ b/applications/RomApplication/python_scripts/residual_output_analysis.py
@@ -1,0 +1,50 @@
+import KratosMultiphysics
+
+def GetResidualOutputAnalysisClass(cls):
+    class ResidualOutputAnalysis(cls):
+
+        def __init__(self, model,project_parameters):
+            print('Inside_ResidualAnalysisStage')
+            super().__init__(model,project_parameters)
+
+            self.residuals_list = []
+
+        def ModifyInitialGeometry(self):
+            super().ModifyInitialGeometry()
+
+            self.main_model_part = self.model.GetModelPart("Structure")
+
+
+        def FinalizeSolutionStep(self):
+            super().FinalizeSolutionStep()
+
+            self.strategy = self._GetSolver()._GetSolutionStrategy()
+            self.buildsol = self._GetSolver()._GetBuilderAndSolver()
+            self.scheme = self._GetSolver()._GetScheme()
+
+            A = self.strategy.GetSystemMatrix()
+            b = self.strategy.GetSystemVector()
+
+            space = KratosMultiphysics.UblasSparseSpace()
+
+            space.SetToZeroMatrix(A)
+            space.SetToZeroVector(b)
+
+            # Create dummy vector
+            xD = space.CreateEmptyVectorPointer()
+            space.ResizeVector( xD, space.Size1(A) )
+            space.SetToZeroVector(xD)
+
+            self.buildsol.Build(self.scheme, self.main_model_part, A, b)
+
+            # Apply constraints
+            self.buildsol.ApplyConstraints(self.scheme, self.main_model_part, A, b)
+            # Apply boundary conditions
+            self.buildsol.ApplyDirichletConditions(self.scheme, self.main_model_part, A, xD, b)
+            
+            self.residuals_list.append(b)
+
+        def GetResiduals(self):
+            return self.residuals_list
+
+    return ResidualOutputAnalysis

--- a/applications/RomApplication/python_scripts/residual_output_analysis.py
+++ b/applications/RomApplication/python_scripts/residual_output_analysis.py
@@ -4,7 +4,6 @@ def GetResidualOutputAnalysisClass(cls):
     class ResidualOutputAnalysis(cls):
 
         def __init__(self, model,project_parameters):
-            print('Inside_ResidualAnalysisStage')
             super().__init__(model,project_parameters)
 
             self.residuals_list = []

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -1,5 +1,6 @@
 import KratosMultiphysics
 from KratosMultiphysics.RomApplication.rom_testing_utilities import SetUpSimulationInstance
+from KratosMultiphysics.RomApplication.residual_output_analysis import GetResidualOutputAnalysisClass
 from KratosMultiphysics.RomApplication.calculate_rom_basis_output_process import CalculateRomBasisOutputProcess
 from KratosMultiphysics.RomApplication.randomized_singular_value_decomposition import RandomizedSingularValueDecomposition
 import numpy as np
@@ -26,19 +27,18 @@ class RomManager(object):
         self.UpdateMaterialParametersFile = UpdateMaterialParametersFile
 
 
-
-    def Fit(self, mu_train=[None], store_all_snapshots=False, store_fom_snapshots=False, store_rom_snapshots=False, store_hrom_snapshots=False, store_residuals_projected = False):
+    def Fit(self, mu_train=[None], store_all_snapshots=False, store_fom_snapshots=False, store_rom_snapshots=False, store_hrom_snapshots=False, store_residuals=False, store_residuals_projected = False):
         chosen_projection_strategy = self.general_rom_manager_parameters["projection_strategy"].GetString()
         training_stages = self.general_rom_manager_parameters["rom_stages_to_train"].GetStringArray()
         #######################
         ######  Galerkin ######
         if chosen_projection_strategy == "galerkin":
             if any(item == "ROM" for item in training_stages):
-                fom_snapshots = self.__LaunchTrainROM(mu_train)
+                fom_snapshots = self.__LaunchTrainROM(mu_train, store_residuals)
                 if store_all_snapshots or store_fom_snapshots:
                     self._StoreSnapshotsMatrix('fom_snapshots', fom_snapshots)
                 self._ChangeRomFlags(simulation_to_run = "GalerkinROM")
-                rom_snapshots = self.__LaunchROM(mu_train)
+                rom_snapshots = self.__LaunchROM(mu_train, store_residuals)
                 if store_all_snapshots or store_rom_snapshots:
                     self._StoreSnapshotsMatrix('rom_snapshots', rom_snapshots)
                 self.ROMvsFOM_train = np.linalg.norm(fom_snapshots - rom_snapshots)/ np.linalg.norm(fom_snapshots)
@@ -48,7 +48,7 @@ class RomManager(object):
                 self._ChangeRomFlags(simulation_to_run = "trainHROMGalerkin")
                 self.__LaunchTrainHROM(mu_train, store_residuals_projected)
                 self._ChangeRomFlags(simulation_to_run = "runHROMGalerkin")
-                hrom_snapshots = self.__LaunchHROM(mu_train)
+                hrom_snapshots = self.__LaunchHROM(mu_train, store_residuals)
                 if store_all_snapshots or store_hrom_snapshots:
                     self._StoreSnapshotsMatrix('hrom_snapshots', hrom_snapshots)
                 self.ROMvsHROM_train = np.linalg.norm(rom_snapshots - hrom_snapshots) / np.linalg.norm(rom_snapshots)
@@ -58,11 +58,11 @@ class RomManager(object):
         ##  Least-Squares Petrov Galerkin   ###
         elif chosen_projection_strategy == "lspg":
             if any(item == "ROM" for item in training_stages):
-                fom_snapshots = self.__LaunchTrainROM(mu_train)
+                fom_snapshots = self.__LaunchTrainROM(mu_train, store_residuals)
                 if store_all_snapshots or store_fom_snapshots:
                     self._StoreSnapshotsMatrix('fom_snapshots', fom_snapshots)
                 self._ChangeRomFlags(simulation_to_run = "lspg")
-                rom_snapshots = self.__LaunchROM(mu_train)
+                rom_snapshots = self.__LaunchROM(mu_train, store_residuals)
                 if store_all_snapshots or store_rom_snapshots:
                     self._StoreSnapshotsMatrix('rom_snapshots', rom_snapshots)
                 self.ROMvsFOM_train = np.linalg.norm(fom_snapshots - rom_snapshots)/ np.linalg.norm(fom_snapshots)
@@ -74,13 +74,13 @@ class RomManager(object):
         ###  Petrov Galerkin   ###
         elif chosen_projection_strategy == "petrov_galerkin":
             if any(item == "ROM" for item in training_stages):
-                fom_snapshots = self.__LaunchTrainROM(mu_train)
+                fom_snapshots = self.__LaunchTrainROM(mu_train, store_residuals)
                 if store_all_snapshots or store_fom_snapshots:
                     self._StoreSnapshotsMatrix('fom_snapshots', fom_snapshots)
                 self._ChangeRomFlags(simulation_to_run = "TrainPG")
                 self.__LaunchTrainPG(mu_train)
                 self._ChangeRomFlags(simulation_to_run = "PG")
-                rom_snapshots = self.__LaunchROM(mu_train)
+                rom_snapshots = self.__LaunchROM(mu_train, store_residuals)
                 if store_all_snapshots or store_rom_snapshots:
                     self._StoreSnapshotsMatrix('rom_snapshots', rom_snapshots)
                 self.ROMvsFOM_train = np.linalg.norm(fom_snapshots - rom_snapshots)/ np.linalg.norm(fom_snapshots)
@@ -89,7 +89,7 @@ class RomManager(object):
                 self._ChangeRomFlags(simulation_to_run = "trainHROMPetrovGalerkin")
                 self.__LaunchTrainHROM(mu_train, store_residuals_projected)
                 self._ChangeRomFlags(simulation_to_run = "runHROMPetrovGalerkin")
-                hrom_snapshots = self.__LaunchHROM(mu_train)
+                hrom_snapshots = self.__LaunchHROM(mu_train, store_residuals)
                 if store_all_snapshots or store_hrom_snapshots:
                     self._StoreSnapshotsMatrix('hrom_snapshots', hrom_snapshots)
                 self.ROMvsHROM_train = np.linalg.norm(rom_snapshots - hrom_snapshots) / np.linalg.norm(rom_snapshots)
@@ -210,13 +210,14 @@ class RomManager(object):
             print("approximation error in test set ROM vs HROM: ",  self.ROMvsHROM_test)
 
 
-    def __LaunchTrainROM(self, mu_train):
+    def __LaunchTrainROM(self, mu_train, store_residuals=False):
         """
         This method should be parallel capable
         """
         with open(self.project_parameters_name,'r') as parameter_file:
             parameters = KratosMultiphysics.Parameters(parameter_file.read())
         SnapshotsMatrix = []
+        ResidualsMatrix = []
         for Id, mu in enumerate(mu_train):
             parameters = self.UpdateProjectParameters(parameters, mu)
             parameters = self._AddBasisCreationToProjectParameters(parameters) #TODO stop using the RomBasisOutputProcess to store the snapshots. Use instead the upcoming build-in function
@@ -225,19 +226,26 @@ class RomManager(object):
             self.UpdateMaterialParametersFile(materials_file_name, mu)
             model = KratosMultiphysics.Model()
             analysis_stage_class = self._GetAnalysisStageClass(parameters)
+            if store_residuals:
+                analysis_stage_class = GetResidualOutputAnalysisClass(analysis_stage_class)
             simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters)
             simulation.Run()
             for process in simulation._GetListOfOutputProcesses():
                 if isinstance(process, CalculateRomBasisOutputProcess):
                     BasisOutputProcess = process
             SnapshotsMatrix.append(BasisOutputProcess._GetSnapshotsMatrix()) #TODO add a CustomMethod() as a standard method in the Analysis Stage to retrive some solution
+            if store_residuals:
+                ResidualsMatrix.append(simulation.GetResiduals())
         SnapshotsMatrix = np.block(SnapshotsMatrix)
+        if store_residuals:
+            ResidualsMatrix = np.block(ResidualsMatrix)
+            self._StoreResidualsMatrix('fom_residuals', ResidualsMatrix)
         BasisOutputProcess._PrintRomBasis(SnapshotsMatrix) #Calling the RomOutput Process for creating the RomParameter.json
 
         return SnapshotsMatrix
 
 
-    def __LaunchROM(self, mu_train):
+    def __LaunchROM(self, mu_train, store_residuals=False):
         """
         This method should be parallel capable
         """
@@ -245,6 +253,7 @@ class RomManager(object):
             parameters = KratosMultiphysics.Parameters(parameter_file.read())
 
         SnapshotsMatrix = []
+        ResidualsMatrix = []
         for Id, mu in enumerate(mu_train):
             parameters = self.UpdateProjectParameters(parameters, mu)
             parameters = self._AddBasisCreationToProjectParameters(parameters)  #TODO stop using the RomBasisOutputProcess to store the snapshots. Use instead the upcoming build-in function
@@ -253,13 +262,20 @@ class RomManager(object):
             self.UpdateMaterialParametersFile(materials_file_name, mu)
             model = KratosMultiphysics.Model()
             analysis_stage_class = type(SetUpSimulationInstance(model, parameters))
+            if store_residuals:
+                analysis_stage_class = GetResidualOutputAnalysisClass(analysis_stage_class)
             simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters)
             simulation.Run()
             for process in simulation._GetListOfOutputProcesses():
                 if isinstance(process, CalculateRomBasisOutputProcess):
                     BasisOutputProcess = process
             SnapshotsMatrix.append(BasisOutputProcess._GetSnapshotsMatrix()) #TODO add a CustomMethod() as a standard method in the Analysis Stage to retrive some solution
+            if store_residuals:
+                ResidualsMatrix.append(simulation.GetResiduals())
         SnapshotsMatrix = np.block(SnapshotsMatrix)
+        if store_residuals:
+            ResidualsMatrix = np.block(ResidualsMatrix)
+            self._StoreResidualsMatrix('rom_residuals', ResidualsMatrix)
 
         return SnapshotsMatrix
 
@@ -314,7 +330,7 @@ class RomManager(object):
         simulation.GetHROM_utility().CreateHRomModelParts()
 
 
-    def __LaunchHROM(self, mu_train):
+    def __LaunchHROM(self, mu_train, store_residuals=False):
         """
         This method should be parallel capable
         """
@@ -322,6 +338,7 @@ class RomManager(object):
             parameters = KratosMultiphysics.Parameters(parameter_file.read())
 
         SnapshotsMatrix = []
+        ResidualsMatrix = []
         for Id, mu in enumerate(mu_train):
             parameters = self.UpdateProjectParameters(parameters, mu)
             parameters = self._AddBasisCreationToProjectParameters(parameters)
@@ -330,13 +347,20 @@ class RomManager(object):
             self.UpdateMaterialParametersFile(materials_file_name, mu)
             model = KratosMultiphysics.Model()
             analysis_stage_class = type(SetUpSimulationInstance(model, parameters))
+            if store_residuals:
+                analysis_stage_class = GetResidualOutputAnalysisClass(analysis_stage_class)
             simulation = self.CustomizeSimulation(analysis_stage_class,model,parameters)
             simulation.Run()
             for process in simulation._GetListOfOutputProcesses():
                 if isinstance(process, CalculateRomBasisOutputProcess):
                     BasisOutputProcess = process
             SnapshotsMatrix.append(BasisOutputProcess._GetSnapshotsMatrix()) #TODO add a CustomMethod() as a standard method in the Analysis Stage to retrive some solution
+            if store_residuals:
+                ResidualsMatrix.append(simulation.GetResiduals())
         SnapshotsMatrix = np.block(SnapshotsMatrix)
+        if store_residuals:
+            ResidualsMatrix = np.block(ResidualsMatrix)
+            self._StoreResidualsMatrix('hrom_residuals', ResidualsMatrix)
 
         return SnapshotsMatrix
 
@@ -652,6 +676,19 @@ class RomManager(object):
 
         # Define the directory and file path
         directory = './SnapshotsMatrices'
+        file_path = os.path.join(directory, f'{string_numpy_array_name}.npy')
+
+        # Create the directory if it doesn't exist
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+
+        #save the array inside the chosen directory
+        np.save(file_path, numpy_array)
+
+    def _StoreResidualsMatrix(self, string_numpy_array_name, numpy_array):
+
+        # Define the directory and file path
+        directory = './ResidualsMatrices'
         file_path = os.path.join(directory, f'{string_numpy_array_name}.npy')
 
         # Create the directory if it doesn't exist


### PR DESCRIPTION
**📝 Description**

This PR allows the user to obtain the residuals of the simulations at the FinalizeSolutionStep() of the analysis stage and to save them as .npy files.
It gets and stores the residuals from all simulations performed within the __LaunchTrainROM, __LaunchROM and __LaunchHROM methods of the RomManager To activate/deactivate this functionality, the user just needs to add the parameter "store_residuals=False/True" when calling the Fit() method of the RomManager.
The residuals are obtained by adding an intermediate analysis stage before the one defined in the user's own CustomizeSimulation method.
The residuals are stored in a folder named "./ResidualsMatrices/" in the current directory

**🆕 Changelog**

- Added file residual_output_analysis.py, which contains the new method GetResidualOutputAnalysisClass.
- Added parameter store_residuals with default value to the RomManager.Fit() method.
- Added method _StoreResidualsMatrix to the RomManager to store the residuals in .npy files.
- Modified RomManager.__LaunchTrainROM, RomManager.__LaunchROM and RomManager.__LaunchHROM to take the parameter store_residuals with default value and to apply the GetResidualOutputAnalysisClass and the RomManager._StoreResidualsMatrix methods if indicated.
