### PR TITLE
[GeoMechanicsApplication] Cleaned up class `ApplyExcavationProcess`

### DIFF
--- a/applications/GeoMechanicsApplication/custom_processes/apply_excavation_process.hpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_excavation_process.hpp
@@ -11,30 +11,18 @@
 //                   Aron Noordam,
 //                   Vahid Galavi
 //
-//
-
-
-// System includes
-#include <cmath>
-#include <iostream>
-#include<string>
+#pragma once
 
 // Project includes
 #include "includes/model_part.h"
-#include "utilities/openmp_utils.h"
-#include "utilities/math_utils.h"
 #include "includes/element.h"
+#include "utilities/variable_utils.h"
 
 // Application includes
-
-#if !defined(KRATOS_GEO_APPLY_EXCAVATION_PROCESS )
-#define  KRATOS_GEO_APPLY_EXCAVATION_PROCESS
-
 #include "includes/kratos_flags.h"
 #include "includes/kratos_parameters.h"
 #include "processes/process.h"
 
-#include "geo_mechanics_application_variables.h"
 
 namespace Kratos
 {
@@ -42,87 +30,44 @@ namespace Kratos
 class ApplyExcavationProcess : public Process
 {
   public:
-
-    typedef std::size_t IndexType;
-    typedef Table<double, double> TableType;
-
     KRATOS_CLASS_POINTER_DEFINITION(ApplyExcavationProcess);
 
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    /// Constructor
-    ApplyExcavationProcess(ModelPart&  model_part,
-                           Parameters& rParameters) : Process(Flags()), mrModelPart(model_part)
+    ApplyExcavationProcess(ModelPart& model_part,
+                           Parameters Settings) : Process(Flags()), mrModelPart(model_part)
     {
         KRATOS_TRY
-
-        mDeactivateSoilPart =  rParameters["deactivate_soil_part"].GetBool();
-
+        mDeactivateSoilPart = Settings["deactivate_soil_part"].GetBool();
         KRATOS_CATCH("")
     }
 
-    ///------------------------------------------------------------------------------------
 
-    /// Destructor
-    ~ApplyExcavationProcess() override{}
+    ~ApplyExcavationProcess() override = default;
 
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     void ExecuteInitialize() override
     {
         KRATOS_TRY
 
-        if (mrModelPart.NumberOfElements() > 0) {
-            if (mDeactivateSoilPart) {
-                // Deactivation of the existing parts:
-                block_for_each(mrModelPart.Elements(), [&](Element& rElement) {
-                    rElement.Set(ACTIVE, false);
-                    rElement.ResetConstitutiveLaw();
-                });
-            } else {
-                // Activation of the existing parts:
-                block_for_each(mrModelPart.Elements(), [&](Element& rElement) {
-                    rElement.Set(ACTIVE, true);
-                });
+        VariableUtils{}.SetFlag(ACTIVE, !mDeactivateSoilPart, mrModelPart.Elements());
 
-                // Same nodes for both computing model part
-                if (mrModelPart.NumberOfNodes() > 0) {
-                    block_for_each(mrModelPart.Nodes(), [&](Node& rNode) {
-                        rNode.Set(ACTIVE, true);
-                    });
-                }
-            }
+        if (mDeactivateSoilPart) {
+            block_for_each(mrModelPart.Elements(), [](Element& rElement) {
+                rElement.ResetConstitutiveLaw();
+            });
+        } else {
+            VariableUtils{}.SetFlag(ACTIVE, true, mrModelPart.Nodes());
         }
 
-        // Conditions
-        if (mrModelPart.NumberOfConditions() > 0) {
-            if (mDeactivateSoilPart) {
-                block_for_each(mrModelPart.Conditions(), [&](Condition& rCondition) {
-                    rCondition.Set(ACTIVE, false);
-                });
-            } else {
-                block_for_each(mrModelPart.Conditions(), [&](Condition& rCondition) {
-                    rCondition.Set(ACTIVE, true);
-                });
-            }
-        }
+        VariableUtils{}.SetFlag(ACTIVE, !mDeactivateSoilPart, mrModelPart.Conditions());
 
         KRATOS_CATCH("")
     }
 
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-  protected:
-    /// Member Variables
-
+  private:
     ModelPart& mrModelPart;
     bool mDeactivateSoilPart;
+};
 
-}; //Class
-
-} /* namespace Kratos.*/
-
-#endif /* KRATOS_CONSTRUCTION_UTILITIES defined */
+}


### PR DESCRIPTION
**📝 Description**
Cleaned up and simplified class `ApplyExcavationProcess`.


**🆕 Changelog**
Most changes are due to review comments from PR #11201:
- The checks whether some sequence is non-empty were redundant. They have been removed.
- When activating or deactivating parts of the model, directly pass the value of flag `mDeactivateSoilPart` rather than splitting it out explicitly.
- Avoid `protected` data members. Rather use `private` ones.
- Removed comments that had no additional value.
- Replaced (incorrectly positioned) inclusion guard by `#pragma once`.
- Removed some redundant blank lines and whitespace.
- Removed some unused type aliases.
- Don't provide an empty function body for the destructor, but use `= default` instead.
- Removed several redundant `#include`s.
- Replaced some occurrences of `block_for_each` by `VariableUtils::SetFlag`.