### PR TITLE
Removing MLMC from CI

### DIFF
--- a/.github/workflows/configure.sh
+++ b/.github/workflows/configure.sh
@@ -43,7 +43,6 @@ add_app ${KRATOS_APP_DIR}/ContactStructuralMechanicsApplication;
 add_app ${KRATOS_APP_DIR}/IgaApplication;
 add_app ${KRATOS_APP_DIR}/ParticleMechanicsApplication;
 add_app ${KRATOS_APP_DIR}/ChimeraApplication;
-add_app ${KRATOS_APP_DIR}/MultilevelMonteCarloApplication;
 add_app ${KRATOS_APP_DIR}/StatisticsApplication;
 add_app ${KRATOS_APP_DIR}/SwimmingDEMApplication;
 add_app ${KRATOS_APP_DIR}/ConstitutiveLawsApplication;


### PR DESCRIPTION
**📝 Description**
See #11212. 

If someone is willing to maintain the application I will re-enable it. If it remains without activity for a month I will move MLMC to legacy apps.

**🆕 Changelog**
- Disabling MLMC from CI
