### PR TITLE
Including quadratic elements support

### DIFF
--- a/kratos/geometries/hexahedra_3d_27.h
+++ b/kratos/geometries/hexahedra_3d_27.h
@@ -1389,7 +1389,6 @@ private:
         for ( unsigned int i = 0; i < this->PointsNumber(); i++ )
         {
             rResult[i].resize( 3, 3, false );
-            noalias( rResult[i] ) = ZeroMatrix( 3, 3 );
         }
 
         const double fx1 = 0.5 * ( rPoint[0] - 1 ) * rPoint[0];

--- a/kratos/geometries/hexahedra_3d_27.h
+++ b/kratos/geometries/hexahedra_3d_27.h
@@ -158,6 +158,14 @@ public:
     typedef typename BaseType::ShapeFunctionsGradientsType ShapeFunctionsGradientsType;
 
     /**
+     * A third order tensor to hold shape functions' local second derivatives.
+     * ShapefunctionsLocalGradients function return this
+     * type as its result.
+     */
+    typedef typename BaseType::ShapeFunctionsSecondDerivativesType
+    ShapeFunctionsSecondDerivativesType;
+
+    /**
      * Type of the normal vector used for normal to edges in geomety.
      */
     typedef typename BaseType::NormalType NormalType;
@@ -1365,6 +1373,331 @@ private:
 
         return d_shape_f_values;
     }
+
+       /**
+     * returns the second order derivatives of all shape functions
+     * in given arbitrary points
+     * @param rResult a third order tensor which contains the second derivatives
+     * @param rPoint the given point the second order derivatives are calculated in
+     */
+    ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    {
+        if ( rResult.size() != this->PointsNumber() )
+        {
+            // KLUDGE: While there is a bug in ublas vector resize, I have to put this beside resizing!!
+            ShapeFunctionsGradientsType temp( this->PointsNumber() );
+            rResult.swap( temp );
+        }
+
+        for ( unsigned int i = 0; i < this->PointsNumber(); i++ )
+        {
+            rResult[i].resize( 3, 3, false );
+            noalias( rResult[i] ) = ZeroMatrix( 3, 3 );
+        }
+
+        double fx1 = 0.5 * ( rPoint[0] - 1 ) * rPoint[0];
+        double fx2 = 0.5 * ( rPoint[0] + 1 ) * rPoint[0];
+        double fx3 = 1 - rPoint[0] * rPoint[0];
+        double fy1 = 0.5 * ( rPoint[1] - 1 ) * rPoint[1];
+        double fy2 = 0.5 * ( rPoint[1] + 1 ) * rPoint[1];
+        double fy3 = 1 - rPoint[1] * rPoint[1];
+        double fz1 = 0.5 * ( rPoint[2] - 1 ) * rPoint[2];
+        double fz2 = 0.5 * ( rPoint[2] + 1 ) * rPoint[2];
+        double fz3 = 1 - rPoint[2] * rPoint[2];
+
+        double gx1 = 0.5 * ( 2 * rPoint[0] - 1 );
+        double gx2 = 0.5 * ( 2 * rPoint[0] + 1 );
+        double gx3 = -2.0 * rPoint[0];
+        double gy1 = 0.5 * ( 2 * rPoint[1] - 1 );
+        double gy2 = 0.5 * ( 2 * rPoint[1] + 1 );
+        double gy3 = -2.0 * rPoint[1];
+        double gz1 = 0.5 * ( 2 * rPoint[2] - 1 );
+        double gz2 = 0.5 * ( 2 * rPoint[2] + 1 );
+        double gz3 = -2.0 * rPoint[2];
+
+        double hx1 = 1.0;
+        double hx2 = 1.0;
+        double hx3 = -2.0;
+        double hy1 = 1.0;
+        double hy2 = 1.0;
+        double hy3 = -2.0;
+        double hz1 = 1.0;
+        double hz2 = 1.0;
+        double hz3 = -2.0;
+
+        rResult[0]( 0, 0 ) = hx1 * fy1 * fz1;
+        rResult[0]( 0, 1 ) = gx1 * gy1 * fz1;
+        rResult[0]( 0, 2 ) = gx1 * fy1 * gz1;
+        rResult[0]( 1, 0 ) = gx1 * gy1 * fz1;
+        rResult[0]( 1, 1 ) = fx1 * hy1 * fz1;
+        rResult[0]( 1, 2 ) = fx1 * gy1 * gz1;
+        rResult[0]( 2, 0 ) = gx1 * fy1 * gz1;
+        rResult[0]( 2, 1 ) = fx1 * gy1 * gz1;
+        rResult[0]( 2, 2 ) = fx1 * fy1 * hz1;
+
+        rResult[1]( 0, 0 ) = hx2 * fy1 * fz1;
+        rResult[1]( 0, 1 ) = gx2 * gy1 * fz1;
+        rResult[1]( 0, 2 ) = gx2 * fy1 * gz1;
+        rResult[1]( 1, 0 ) = gx2 * gy1 * fz1;
+        rResult[1]( 1, 1 ) = fx2 * hy1 * fz1;
+        rResult[1]( 1, 2 ) = fx2 * gy1 * gz1;
+        rResult[1]( 2, 0 ) = gx2 * fy1 * gz1;
+        rResult[1]( 2, 1 ) = fx2 * gy1 * gz1;
+        rResult[1]( 2, 2 ) = fx2 * fy1 * hz1;
+
+        rResult[2]( 0, 0 ) = hx2 * fy2 * fz1;
+        rResult[2]( 0, 1 ) = gx2 * gy2 * fz1;
+        rResult[2]( 0, 2 ) = gx2 * fy2 * gz1;
+        rResult[2]( 1, 0 ) = gx2 * gy2 * fz1;
+        rResult[2]( 1, 1 ) = fx2 * hy2 * fz1;
+        rResult[2]( 1, 2 ) = fx2 * gy2 * gz1;
+        rResult[2]( 2, 0 ) = gx2 * fy2 * gz1;
+        rResult[2]( 2, 1 ) = fx2 * gy2 * gz1;
+        rResult[2]( 2, 2 ) = fx2 * fy2 * hz1;
+
+        rResult[3]( 0, 0 ) = hx1 * fy2 * fz1;
+        rResult[3]( 0, 1 ) = gx1 * gy2 * fz1;
+        rResult[3]( 0, 2 ) = gx1 * fy2 * gz1;
+        rResult[3]( 1, 0 ) = gx1 * gy2 * fz1;
+        rResult[3]( 1, 1 ) = fx1 * hy2 * fz1;
+        rResult[3]( 1, 2 ) = fx1 * gy2 * gz1;
+        rResult[3]( 2, 0 ) = gx1 * fy2 * gz1;
+        rResult[3]( 2, 1 ) = fx1 * gy2 * gz1;
+        rResult[3]( 2, 2 ) = fx1 * fy2 * hz1;
+
+        rResult[4]( 0, 0 ) = hx1 * fy1 * fz2;
+        rResult[4]( 0, 1 ) = gx1 * gy1 * fz2;
+        rResult[4]( 0, 2 ) = gx1 * fy1 * gz2;
+        rResult[4]( 1, 0 ) = gx1 * gy1 * fz2;
+        rResult[4]( 1, 1 ) = fx1 * hy1 * fz2;
+        rResult[4]( 1, 2 ) = fx1 * gy1 * gz2;
+        rResult[4]( 2, 0 ) = gx1 * fy1 * gz2;
+        rResult[4]( 2, 1 ) = fx1 * gy1 * gz2;
+        rResult[4]( 2, 2 ) = fx1 * fy1 * hz2;
+
+        rResult[5]( 0, 0 ) = hx2 * fy1 * fz2;
+        rResult[5]( 0, 1 ) = gx2 * gy1 * fz2;
+        rResult[5]( 0, 2 ) = gx2 * fy1 * gz2;
+        rResult[5]( 1, 0 ) = gx2 * gy1 * fz2;
+        rResult[5]( 1, 1 ) = fx2 * hy1 * fz2;
+        rResult[5]( 1, 2 ) = fx2 * gy1 * gz2;
+        rResult[5]( 2, 0 ) = gx2 * fy1 * gz2;
+        rResult[5]( 2, 1 ) = fx2 * gy1 * gz2;
+        rResult[5]( 2, 2 ) = fx2 * fy1 * hz2;
+
+        rResult[6]( 0, 0 ) = hx2 * fy2 * fz2;
+        rResult[6]( 0, 1 ) = gx2 * gy2 * fz2;
+        rResult[6]( 0, 2 ) = gx2 * fy2 * gz2;
+        rResult[6]( 1, 0 ) = gx2 * gy2 * fz2;
+        rResult[6]( 1, 1 ) = fx2 * hy2 * fz2;
+        rResult[6]( 1, 2 ) = fx2 * gy2 * gz2;
+        rResult[6]( 2, 0 ) = gx2 * fy2 * gz2;
+        rResult[6]( 2, 1 ) = fx2 * gy2 * gz2;
+        rResult[6]( 2, 2 ) = fx2 * fy2 * hz2;
+
+        rResult[7]( 0, 0 ) = hx1 * fy2 * fz2;
+        rResult[7]( 0, 1 ) = gx1 * gy2 * fz2;
+        rResult[7]( 0, 2 ) = gx1 * fy2 * gz2;
+        rResult[7]( 1, 0 ) = gx1 * gy2 * fz2;
+        rResult[7]( 1, 1 ) = fx1 * hy2 * fz2;
+        rResult[7]( 1, 2 ) = fx1 * gy2 * gz2;
+        rResult[7]( 2, 0 ) = gx1 * fy2 * gz2;
+        rResult[7]( 2, 1 ) = fx1 * gy2 * gz2;
+        rResult[7]( 2, 2 ) = fx1 * fy2 * hz2;
+
+        rResult[8]( 0, 0 ) = hx3 * fy1 * fz1;
+        rResult[8]( 0, 1 ) = gx3 * gy1 * fz1;
+        rResult[8]( 0, 2 ) = gx3 * fy1 * gz1;
+        rResult[8]( 1, 0 ) = gx3 * gy1 * fz1;
+        rResult[8]( 1, 1 ) = fx3 * hy1 * fz1;
+        rResult[8]( 1, 2 ) = fx3 * gy1 * gz1;
+        rResult[8]( 2, 0 ) = gx3 * fy1 * gz1;
+        rResult[8]( 2, 1 ) = fx3 * gy1 * gz1;
+        rResult[8]( 2, 2 ) = fx3 * fy1 * hz1;
+
+        rResult[9]( 0, 0 ) = hx2 * fy3 * fz1;
+        rResult[9]( 0, 1 ) = gx2 * gy3 * fz1;
+        rResult[9]( 0, 2 ) = gx2 * fy3 * gz1;
+        rResult[9]( 1, 0 ) = gx2 * gy3 * fz1;
+        rResult[9]( 1, 1 ) = fx2 * hy3 * fz1;
+        rResult[9]( 1, 2 ) = fx2 * gy3 * gz1;
+        rResult[9]( 2, 0 ) = gx2 * fy3 * gz1;
+        rResult[9]( 2, 1 ) = fx2 * gy3 * gz1;
+        rResult[9]( 2, 2 ) = fx2 * fy3 * hz1;
+
+        rResult[10]( 0, 0 ) = hx3 * fy2 * fz1;
+        rResult[10]( 0, 1 ) = gx3 * gy2 * fz1;
+        rResult[10]( 0, 2 ) = gx3 * fy2 * gz1;
+        rResult[10]( 1, 0 ) = gx3 * gy2 * fz1;
+        rResult[10]( 1, 1 ) = fx3 * hy2 * fz1;
+        rResult[10]( 1, 2 ) = fx3 * gy2 * gz1;
+        rResult[10]( 2, 0 ) = gx3 * fy2 * gz1;
+        rResult[10]( 2, 1 ) = fx3 * gy2 * gz1;
+        rResult[10]( 2, 2 ) = fx3 * fy2 * hz1;
+
+        rResult[11]( 0, 0 ) = hx1 * fy3 * fz1;
+        rResult[11]( 0, 1 ) = gx1 * gy3 * fz1;
+        rResult[11]( 0, 2 ) = gx1 * fy3 * gz1;
+        rResult[11]( 1, 0 ) = gx1 * gy3 * fz1;
+        rResult[11]( 1, 1 ) = fx1 * hy3 * fz1;
+        rResult[11]( 1, 2 ) = fx1 * gy3 * gz1;
+        rResult[11]( 2, 0 ) = gx1 * fy3 * gz1;
+        rResult[11]( 2, 1 ) = fx1 * gy3 * gz1;
+        rResult[11]( 2, 2 ) = fx1 * fy3 * hz1;
+
+        rResult[12]( 0, 0 ) = hx1 * fy1 * fz3;
+        rResult[12]( 0, 1 ) = gx1 * gy1 * fz3;
+        rResult[12]( 0, 2 ) = gx1 * fy1 * gz3;
+        rResult[12]( 1, 0 ) = gx1 * gy1 * fz3;
+        rResult[12]( 1, 1 ) = fx1 * hy1 * fz3;
+        rResult[12]( 1, 2 ) = fx1 * gy1 * gz3;
+        rResult[12]( 2, 0 ) = gx1 * fy1 * gz3;
+        rResult[12]( 2, 1 ) = fx1 * gy1 * gz3;
+        rResult[12]( 2, 2 ) = fx1 * fy1 * hz3;
+
+        rResult[13]( 0, 0 ) = hx2 * fy1 * fz3;
+        rResult[13]( 0, 1 ) = gx2 * gy1 * fz3;
+        rResult[13]( 0, 2 ) = gx2 * fy1 * gz3;
+        rResult[13]( 1, 0 ) = gx2 * gy1 * fz3;
+        rResult[13]( 1, 1 ) = fx2 * hy1 * fz3;
+        rResult[13]( 1, 2 ) = fx2 * gy1 * gz3;
+        rResult[13]( 2, 0 ) = gx2 * fy1 * gz3;
+        rResult[13]( 2, 1 ) = fx2 * gy1 * gz3;
+        rResult[13]( 2, 2 ) = fx2 * fy1 * hz3;
+
+        rResult[14]( 0, 0 ) = hx2 * fy2 * fz3;
+        rResult[14]( 0, 1 ) = gx2 * gy2 * fz3;
+        rResult[14]( 0, 2 ) = gx2 * fy2 * gz3;
+        rResult[14]( 1, 0 ) = gx2 * gy2 * fz3;
+        rResult[14]( 1, 1 ) = fx2 * hy2 * fz3;
+        rResult[14]( 1, 2 ) = fx2 * gy2 * gz3;
+        rResult[14]( 2, 0 ) = gx2 * fy2 * gz3;
+        rResult[14]( 2, 1 ) = fx2 * gy2 * gz3;
+        rResult[14]( 2, 2 ) = fx2 * fy2 * hz3;
+
+        rResult[15]( 0, 0 ) = hx1 * fy2 * fz3;
+        rResult[15]( 0, 1 ) = gx1 * gy2 * fz3;
+        rResult[15]( 0, 2 ) = gx1 * fy2 * gz3;
+        rResult[15]( 1, 0 ) = gx1 * gy2 * fz3;
+        rResult[15]( 1, 1 ) = fx1 * hy2 * fz3;
+        rResult[15]( 1, 2 ) = fx1 * gy2 * gz3;
+        rResult[15]( 2, 0 ) = gx1 * fy2 * gz3;
+        rResult[15]( 2, 1 ) = fx1 * gy2 * gz3;
+        rResult[15]( 2, 2 ) = fx1 * fy2 * hz3;
+
+        rResult[16]( 0, 0 ) = hx3 * fy1 * fz2;
+        rResult[16]( 0, 1 ) = gx3 * gy1 * fz2;
+        rResult[16]( 0, 2 ) = gx3 * fy1 * gz2;
+        rResult[16]( 1, 0 ) = gx3 * gy1 * fz2;
+        rResult[16]( 1, 1 ) = fx3 * hy1 * fz2;
+        rResult[16]( 1, 2 ) = fx3 * gy1 * gz2;
+        rResult[16]( 2, 0 ) = gx3 * fy1 * gz2;
+        rResult[16]( 2, 1 ) = fx3 * gy1 * gz2;
+        rResult[16]( 2, 2 ) = fx3 * fy1 * hz2;
+
+        rResult[17]( 0, 0 ) = hx2 * fy3 * fz2;
+        rResult[17]( 0, 1 ) = gx2 * gy3 * fz2;
+        rResult[17]( 0, 2 ) = gx2 * fy3 * gz2;
+        rResult[17]( 1, 0 ) = gx2 * gy3 * fz2;
+        rResult[17]( 1, 1 ) = fx2 * hy3 * fz2;
+        rResult[17]( 1, 2 ) = fx2 * gy3 * gz2;
+        rResult[17]( 2, 0 ) = gx2 * fy3 * gz2;
+        rResult[17]( 2, 1 ) = fx2 * gy3 * gz2;
+        rResult[17]( 2, 2 ) = fx2 * fy3 * hz2;
+
+        rResult[18]( 0, 0 ) = hx3 * fy2 * fz2;
+        rResult[18]( 0, 1 ) = gx3 * gy2 * fz2;
+        rResult[18]( 0, 2 ) = gx3 * fy2 * gz2;
+        rResult[18]( 1, 0 ) = gx3 * gy2 * fz2;
+        rResult[18]( 1, 1 ) = fx3 * hy2 * fz2;
+        rResult[18]( 1, 2 ) = fx3 * gy2 * gz2;
+        rResult[18]( 2, 0 ) = gx3 * fy2 * gz2;
+        rResult[18]( 2, 1 ) = fx3 * gy2 * gz2;
+        rResult[18]( 2, 2 ) = fx3 * fy2 * hz2;
+
+        rResult[19]( 0, 0 ) = hx1 * fy3 * fz2;
+        rResult[19]( 0, 1 ) = gx1 * gy3 * fz2;
+        rResult[19]( 0, 2 ) = gx1 * fy3 * gz2;
+        rResult[19]( 1, 0 ) = gx1 * gy3 * fz2;
+        rResult[19]( 1, 1 ) = fx1 * hy3 * fz2;
+        rResult[19]( 1, 2 ) = fx1 * gy3 * gz2;
+        rResult[19]( 2, 0 ) = gx1 * fy3 * gz2;
+        rResult[19]( 2, 1 ) = fx1 * gy3 * gz2;
+        rResult[19]( 2, 2 ) = fx1 * fy3 * hz2;
+
+        rResult[20]( 0, 0 ) = hx3 * fy3 * fz1;
+        rResult[20]( 0, 1 ) = gx3 * gy3 * fz1;
+        rResult[20]( 0, 2 ) = gx3 * fy3 * gz1;
+        rResult[20]( 1, 0 ) = gx3 * gy3 * fz1;
+        rResult[20]( 1, 1 ) = fx3 * hy3 * fz1;
+        rResult[20]( 1, 2 ) = fx3 * gy3 * gz1;
+        rResult[20]( 2, 0 ) = gx3 * fy3 * gz1;
+        rResult[20]( 2, 1 ) = fx3 * gy3 * gz1;
+        rResult[20]( 2, 2 ) = fx3 * fy3 * hz1;
+
+        rResult[21]( 0, 0 ) = hx3 * fy1 * fz3;
+        rResult[21]( 0, 1 ) = gx3 * gy1 * fz3;
+        rResult[21]( 0, 2 ) = gx3 * fy1 * gz3;
+        rResult[21]( 1, 0 ) = gx3 * gy1 * fz3;
+        rResult[21]( 1, 1 ) = fx3 * hy1 * fz3;
+        rResult[21]( 1, 2 ) = fx3 * gy1 * gz3;
+        rResult[21]( 2, 0 ) = gx3 * fy1 * gz3;
+        rResult[21]( 2, 1 ) = fx3 * gy1 * gz3;
+        rResult[21]( 2, 2 ) = fx3 * fy1 * hz3;
+
+        rResult[22]( 0, 0 ) = hx2 * fy3 * fz3;
+        rResult[22]( 0, 1 ) = gx2 * gy3 * fz3;
+        rResult[22]( 0, 2 ) = gx2 * fy3 * gz3;
+        rResult[22]( 1, 0 ) = gx2 * gy3 * fz3;
+        rResult[22]( 1, 1 ) = fx2 * hy3 * fz3;
+        rResult[22]( 1, 2 ) = fx2 * gy3 * gz3;
+        rResult[22]( 2, 0 ) = gx2 * fy3 * gz3;
+        rResult[22]( 2, 1 ) = fx2 * gy3 * gz3;
+        rResult[22]( 2, 2 ) = fx2 * fy3 * hz3;
+
+        rResult[23]( 0, 0 ) = hx3 * fy2 * fz3;
+        rResult[23]( 0, 1 ) = gx3 * gy2 * fz3;
+        rResult[23]( 0, 2 ) = gx3 * fy2 * gz3;
+        rResult[23]( 1, 0 ) = gx3 * gy2 * fz3;
+        rResult[23]( 1, 1 ) = fx3 * hy2 * fz3;
+        rResult[23]( 1, 2 ) = fx3 * gy2 * gz3;
+        rResult[23]( 2, 0 ) = gx3 * fy2 * gz3;
+        rResult[23]( 2, 1 ) = fx3 * gy2 * gz3;
+        rResult[23]( 2, 2 ) = fx3 * fy2 * hz3;
+
+        rResult[24]( 0, 0 ) = hx1 * fy3 * fz3;
+        rResult[24]( 0, 1 ) = gx1 * gy3 * fz3;
+        rResult[24]( 0, 2 ) = gx1 * fy3 * gz3;
+        rResult[24]( 1, 0 ) = gx1 * gy3 * fz3;
+        rResult[24]( 1, 1 ) = fx1 * hy3 * fz3;
+        rResult[24]( 1, 2 ) = fx1 * gy3 * gz3;
+        rResult[24]( 2, 0 ) = gx1 * fy3 * gz3;
+        rResult[24]( 2, 1 ) = fx1 * gy3 * gz3;
+        rResult[24]( 2, 2 ) = fx1 * fy3 * hz3;
+
+        rResult[25]( 0, 0 ) = hx3 * fy3 * fz2;
+        rResult[25]( 0, 1 ) = gx3 * gy3 * fz2;
+        rResult[25]( 0, 2 ) = gx3 * fy3 * gz2;
+        rResult[25]( 1, 0 ) = gx3 * gy3 * fz2;
+        rResult[25]( 1, 1 ) = fx3 * hy3 * fz2;
+        rResult[25]( 1, 2 ) = fx3 * gy3 * gz2;
+        rResult[25]( 2, 0 ) = gx3 * fy3 * gz2;
+        rResult[25]( 2, 1 ) = fx3 * gy3 * gz2;
+        rResult[25]( 2, 2 ) = fx3 * fy3 * hz2;
+
+        rResult[26]( 0, 0 ) = hx3 * fy3 * fz3;
+        rResult[26]( 0, 1 ) = gx3 * gy3 * fz3;
+        rResult[26]( 0, 2 ) = gx3 * fy3 * gz3;
+        rResult[26]( 1, 0 ) = gx3 * gy3 * fz3;
+        rResult[26]( 1, 1 ) = fx3 * hy3 * fz3;
+        rResult[26]( 1, 2 ) = fx3 * gy3 * gz3;
+        rResult[26]( 2, 0 ) = gx3 * fy3 * gz3;
+        rResult[26]( 2, 1 ) = fx3 * gy3 * gz3;
+        rResult[26]( 2, 2 ) = fx3 * fy3 * hz3;
+
+        return rResult;
+    }
+
 
     /**
      * TODO: TO BE VERIFIED

--- a/kratos/geometries/hexahedra_3d_27.h
+++ b/kratos/geometries/hexahedra_3d_27.h
@@ -1382,11 +1382,8 @@ private:
      */
     ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
-        if ( rResult.size() != this->PointsNumber() )
-        {
-            // KLUDGE: While there is a bug in ublas vector resize, I have to put this beside resizing!!
-            ShapeFunctionsGradientsType temp( this->PointsNumber() );
-            rResult.swap( temp );
+        if ( rResult.size() != this->PointsNumber() ) {
+            rResult.resize(this->PointsNumber());
         }
 
         for ( unsigned int i = 0; i < this->PointsNumber(); i++ )
@@ -1395,35 +1392,35 @@ private:
             noalias( rResult[i] ) = ZeroMatrix( 3, 3 );
         }
 
-        double fx1 = 0.5 * ( rPoint[0] - 1 ) * rPoint[0];
-        double fx2 = 0.5 * ( rPoint[0] + 1 ) * rPoint[0];
-        double fx3 = 1 - rPoint[0] * rPoint[0];
-        double fy1 = 0.5 * ( rPoint[1] - 1 ) * rPoint[1];
-        double fy2 = 0.5 * ( rPoint[1] + 1 ) * rPoint[1];
-        double fy3 = 1 - rPoint[1] * rPoint[1];
-        double fz1 = 0.5 * ( rPoint[2] - 1 ) * rPoint[2];
-        double fz2 = 0.5 * ( rPoint[2] + 1 ) * rPoint[2];
-        double fz3 = 1 - rPoint[2] * rPoint[2];
+        const double fx1 = 0.5 * ( rPoint[0] - 1 ) * rPoint[0];
+        const double fx2 = 0.5 * ( rPoint[0] + 1 ) * rPoint[0];
+        const double fx3 = 1 - rPoint[0] * rPoint[0];
+        const double fy1 = 0.5 * ( rPoint[1] - 1 ) * rPoint[1];
+        const double fy2 = 0.5 * ( rPoint[1] + 1 ) * rPoint[1];
+        const double fy3 = 1 - rPoint[1] * rPoint[1];
+        const double fz1 = 0.5 * ( rPoint[2] - 1 ) * rPoint[2];
+        const double fz2 = 0.5 * ( rPoint[2] + 1 ) * rPoint[2];
+        const double fz3 = 1 - rPoint[2] * rPoint[2];
 
-        double gx1 = 0.5 * ( 2 * rPoint[0] - 1 );
-        double gx2 = 0.5 * ( 2 * rPoint[0] + 1 );
-        double gx3 = -2.0 * rPoint[0];
-        double gy1 = 0.5 * ( 2 * rPoint[1] - 1 );
-        double gy2 = 0.5 * ( 2 * rPoint[1] + 1 );
-        double gy3 = -2.0 * rPoint[1];
-        double gz1 = 0.5 * ( 2 * rPoint[2] - 1 );
-        double gz2 = 0.5 * ( 2 * rPoint[2] + 1 );
-        double gz3 = -2.0 * rPoint[2];
+        const double gx1 = 0.5 * ( 2 * rPoint[0] - 1 );
+        const double gx2 = 0.5 * ( 2 * rPoint[0] + 1 );
+        const double gx3 = -2.0 * rPoint[0];
+        const double gy1 = 0.5 * ( 2 * rPoint[1] - 1 );
+        const double gy2 = 0.5 * ( 2 * rPoint[1] + 1 );
+        const double gy3 = -2.0 * rPoint[1];
+        const double gz1 = 0.5 * ( 2 * rPoint[2] - 1 );
+        const double gz2 = 0.5 * ( 2 * rPoint[2] + 1 );
+        const double gz3 = -2.0 * rPoint[2];
 
-        double hx1 = 1.0;
-        double hx2 = 1.0;
-        double hx3 = -2.0;
-        double hy1 = 1.0;
-        double hy2 = 1.0;
-        double hy3 = -2.0;
-        double hz1 = 1.0;
-        double hz2 = 1.0;
-        double hz3 = -2.0;
+        const double hx1 = 1.0;
+        const double hx2 = 1.0;
+        const double hx3 = -2.0;
+        const double hy1 = 1.0;
+        const double hy2 = 1.0;
+        const double hy3 = -2.0;
+        const double hz1 = 1.0;
+        const double hz2 = 1.0;
+        const double hz3 = -2.0;
 
         rResult[0]( 0, 0 ) = hx1 * fy1 * fz1;
         rResult[0]( 0, 1 ) = gx1 * gy1 * fz1;

--- a/kratos/geometries/quadrilateral_2d_9.h
+++ b/kratos/geometries/quadrilateral_2d_9.h
@@ -1221,6 +1221,8 @@ private:
                 Quadrature < QuadrilateralGaussLegendreIntegrationPoints3,
                 2, IntegrationPoint<3> >::GenerateIntegrationPoints(),
                 Quadrature < QuadrilateralGaussLegendreIntegrationPoints4,
+                2, IntegrationPoint<3> >::GenerateIntegrationPoints(),
+                Quadrature < QuadrilateralGaussLegendreIntegrationPoints5,
                 2, IntegrationPoint<3> >::GenerateIntegrationPoints()
             }
         };
@@ -1243,6 +1245,8 @@ private:
                     GeometryData::IntegrationMethod::GI_GAUSS_3 ),
                 Quadrilateral2D9<TPointType>::CalculateShapeFunctionsIntegrationPointsValues(
                     GeometryData::IntegrationMethod::GI_GAUSS_4 ),
+                Quadrilateral2D9<TPointType>::CalculateShapeFunctionsIntegrationPointsValues(
+                    GeometryData::IntegrationMethod::GI_GAUSS_5 ),
             }
         };
         return shape_functions_values;
@@ -1264,6 +1268,8 @@ private:
                 ( GeometryData::IntegrationMethod::GI_GAUSS_3 ),
                 Quadrilateral2D9<TPointType>::CalculateShapeFunctionsIntegrationPointsLocalGradients
                 ( GeometryData::IntegrationMethod::GI_GAUSS_4 ),
+                Quadrilateral2D9<TPointType>::CalculateShapeFunctionsIntegrationPointsLocalGradients
+                ( GeometryData::IntegrationMethod::GI_GAUSS_5 ),
             }
         };
         return shape_functions_local_gradients;

--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -166,6 +166,14 @@ public:
     typedef typename BaseType::ShapeFunctionsGradientsType ShapeFunctionsGradientsType;
 
     /**
+     * A third order tensor to hold shape functions' local second derivatives.
+     * ShapefunctionsLocalGradients function return this
+     * type as its result.
+     */
+    typedef typename BaseType::ShapeFunctionsSecondDerivativesType
+    ShapeFunctionsSecondDerivativesType;
+
+    /**
      * Type of the normal vector used for normal to edges in geomety.
      */
     typedef typename BaseType::NormalType NormalType;
@@ -1410,6 +1418,70 @@ public:
                 rResult[i] = DN_DX;
     }
 
+    /**
+     * returns the second order derivatives of all shape functions
+     * in given arbitrary points
+     * @param rResult a third order tensor which contains the second derivatives
+     * @param rPoint the given point the second order derivatives are calculated in
+     */
+    ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    {
+        if ( rResult.size() != this->PointsNumber() )
+        {
+            // KLUDGE: While there is a bug in ublas vector resize, I have to put this beside resizing!!
+            ShapeFunctionsGradientsType temp( this->PointsNumber() );
+            rResult.swap( temp );
+        }
+
+        for ( unsigned int i = 0; i < this->PointsNumber(); i++ )
+        {
+            rResult[i].resize( 3, 3, false );
+            noalias( rResult[i] ) = ZeroMatrix( 3, 3 );
+        }
+
+        rResult[0]( 0, 0 ) = 0.0;
+        rResult[0]( 0, 1 ) = 0.0;
+        rResult[0]( 0, 2 ) = 0.0;
+        rResult[0]( 1, 0 ) = 0.0;
+        rResult[0]( 1, 1 ) = 0.0;
+        rResult[0]( 1, 2 ) = 0.0;
+        rResult[0]( 2, 0 ) = 0.0;
+        rResult[0]( 2, 1 ) = 0.0;
+        rResult[0]( 2, 2 ) = 0.0;
+
+
+        rResult[1]( 0, 0 ) = 0.0;
+        rResult[1]( 0, 1 ) = 0.0;
+        rResult[1]( 0, 2 ) = 0.0;
+        rResult[1]( 1, 0 ) = 0.0;
+        rResult[1]( 1, 1 ) = 0.0;
+        rResult[1]( 1, 2 ) = 0.0;
+        rResult[1]( 2, 0 ) = 0.0;
+        rResult[1]( 2, 1 ) = 0.0;
+        rResult[1]( 2, 2 ) = 0.0;
+
+        rResult[2]( 0, 0 ) = 0.0;
+        rResult[2]( 0, 1 ) = 0.0;
+        rResult[2]( 0, 2 ) = 0.0;
+        rResult[2]( 1, 0 ) = 0.0;
+        rResult[2]( 1, 1 ) = 0.0;
+        rResult[2]( 1, 2 ) = 0.0;
+        rResult[2]( 2, 0 ) = 0.0;
+        rResult[2]( 2, 1 ) = 0.0;
+        rResult[2]( 2, 2 ) = 0.0;
+
+        rResult[3]( 0, 0 ) = 0.0;
+        rResult[3]( 0, 1 ) = 0.0;
+        rResult[3]( 0, 2 ) = 0.0;
+        rResult[3]( 1, 0 ) = 0.0;
+        rResult[3]( 1, 1 ) = 0.0;
+        rResult[3]( 1, 2 ) = 0.0;
+        rResult[3]( 2, 0 ) = 0.0;
+        rResult[3]( 2, 1 ) = 0.0;
+        rResult[3]( 2, 2 ) = 0.0;
+
+        return rResult;
+    }
 
     /**
      * @brief Test if this geometry intersects with other geometry

--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -1435,49 +1435,8 @@ public:
 
         for ( unsigned int i = 0; i < this->PointsNumber(); i++ )
         {
-            rResult[i].resize( 3, 3, false );
+            rResult[i] = ZeroMatrix(3,3);
         }
-
-        rResult[0]( 0, 0 ) = 0.0;
-        rResult[0]( 0, 1 ) = 0.0;
-        rResult[0]( 0, 2 ) = 0.0;
-        rResult[0]( 1, 0 ) = 0.0;
-        rResult[0]( 1, 1 ) = 0.0;
-        rResult[0]( 1, 2 ) = 0.0;
-        rResult[0]( 2, 0 ) = 0.0;
-        rResult[0]( 2, 1 ) = 0.0;
-        rResult[0]( 2, 2 ) = 0.0;
-
-
-        rResult[1]( 0, 0 ) = 0.0;
-        rResult[1]( 0, 1 ) = 0.0;
-        rResult[1]( 0, 2 ) = 0.0;
-        rResult[1]( 1, 0 ) = 0.0;
-        rResult[1]( 1, 1 ) = 0.0;
-        rResult[1]( 1, 2 ) = 0.0;
-        rResult[1]( 2, 0 ) = 0.0;
-        rResult[1]( 2, 1 ) = 0.0;
-        rResult[1]( 2, 2 ) = 0.0;
-
-        rResult[2]( 0, 0 ) = 0.0;
-        rResult[2]( 0, 1 ) = 0.0;
-        rResult[2]( 0, 2 ) = 0.0;
-        rResult[2]( 1, 0 ) = 0.0;
-        rResult[2]( 1, 1 ) = 0.0;
-        rResult[2]( 1, 2 ) = 0.0;
-        rResult[2]( 2, 0 ) = 0.0;
-        rResult[2]( 2, 1 ) = 0.0;
-        rResult[2]( 2, 2 ) = 0.0;
-
-        rResult[3]( 0, 0 ) = 0.0;
-        rResult[3]( 0, 1 ) = 0.0;
-        rResult[3]( 0, 2 ) = 0.0;
-        rResult[3]( 1, 0 ) = 0.0;
-        rResult[3]( 1, 1 ) = 0.0;
-        rResult[3]( 1, 2 ) = 0.0;
-        rResult[3]( 2, 0 ) = 0.0;
-        rResult[3]( 2, 1 ) = 0.0;
-        rResult[3]( 2, 2 ) = 0.0;
 
         return rResult;
     }

--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -1436,7 +1436,6 @@ public:
         for ( unsigned int i = 0; i < this->PointsNumber(); i++ )
         {
             rResult[i].resize( 3, 3, false );
-            noalias( rResult[i] ) = ZeroMatrix( 3, 3 );
         }
 
         rResult[0]( 0, 0 ) = 0.0;

--- a/kratos/utilities/geometry_tester.cpp
+++ b/kratos/utilities/geometry_tester.cpp
@@ -129,6 +129,8 @@ bool GeometryTesterUtility::StreamTestTetrahedra3D4N(
     VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_4, rErrorMessage);
     VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_GAUSS_5, rErrorMessage);
 
+    array_1d<double,3> point_in(3,1.0/3.0);
+    if( !VerifyShapeFunctionsSecondDerivativesValues(geometry,point_in,rErrorMessage) ) successful = false;
     rErrorMessage << std::endl;
 
     return successful;
@@ -515,6 +517,9 @@ bool GeometryTesterUtility::StreamTestHexahedra3D27N(
 //         VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_EXTENDED_GAUSS_3, rErrorMessage);
 //         VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_EXTENDED_GAUSS_4, rErrorMessage);
 //         VerifyStrainExactness( geometry, GeometryData::IntegrationMethod::GI_EXTENDED_GAUSS_5, rErrorMessage);
+
+    array_1d<double,3> point_in(3,1.0/3.0);
+    if( !VerifyShapeFunctionsSecondDerivativesValues(geometry,point_in,rErrorMessage) ) successful = false;
 
     rErrorMessage << std::endl;
 


### PR DESCRIPTION
**📝 Description**
Including second derivatives and higher order gauss quadrature to triangle, quadrilateral, tetrahedra, hexahedra. This PR is a part of the extend_viscous_resistance_term branch.

Please mark the PR with appropriate tags: 
- KratosCore

**🆕 Changelog**
- Including test of shape function second derivatives in `geometry_tester.cpp`.
- Including second derivatives in `tetrahedra_3d_4.h` and `hexahedra_3d_27.h`.
- Including `GI_GAUSS_5` in `quadrilateral_2d_9.h`
