### PR TITLE
[Core] Activate check after recent merge in `== operator` in `SpatialSearchResult`

### DIFF
--- a/kratos/tests/cpp_tests/spatial_containers/test_spatial_search_result.cpp
+++ b/kratos/tests/cpp_tests/spatial_containers/test_spatial_search_result.cpp
@@ -28,7 +28,7 @@ KRATOS_TEST_CASE_IN_SUITE(SpatialSearchResultDefaultConstruction, KratosCoreFast
     auto result = SpatialSearchResult<GeometricalObject>();
     KRATOS_CHECK_EQUAL(result.IsObjectFound(), false);
     KRATOS_CHECK_EQUAL(result.IsDistanceCalculated(), false);
-    //KRATOS_CHECK_EQUAL(result.Get(), nullptr); // operator== does not work with GlobalPointer nullptr
+    KRATOS_CHECK_EQUAL(result.Get(), nullptr);
     KRATOS_CHECK_EQUAL(result.GetDistance(), 0.0);
 }
 


### PR DESCRIPTION
**📝 Description**

This PR modifies a test case in the spatial container testing module, In the 'SpatialSearchResultDefaultConstruction' test suite, a commented-out line that previously caused a failure due to an issue with comparing against nullptr has been re-enabled. The line checks if the `Get` method of a `SpatialSearchResult<GeometricalObject>` object returns `nullptr` when it hasn't found any object. This suggests that the issue with the comparison against `nullptr` has been resolved, either within the `SpatialSearchResult` class itself or in the `GlobalPointer` class that it works with. Therefore, this commit improves the robustness of the testing suite by enabling a previously commented-out assertion.

**🆕 Changelog**

- [Activate check after recent merge in == operator](https://github.com/KratosMultiphysics/Kratos/commit/a1cb143bdf220d1175f78a4d523a15d13cb163b6)
