### PR TITLE
[Core] Minor refactor type of `number_of_entities` in `GlobalPointerUtilities`

### DIFF
--- a/kratos/utilities/global_pointer_utilities.h
+++ b/kratos/utilities/global_pointer_utilities.h
@@ -286,7 +286,7 @@ public:
         const int world_size = rDataCommunicator.Size();
 
         // Getting number of entities
-        const int number_of_entities = rContainer.size();
+        const std::size_t number_of_entities = rContainer.size();
 
         // Getting global number of points
         std::vector<int> number_of_entities_per_partition(world_size);
@@ -295,7 +295,7 @@ public:
 
         // Retrieve the ids
         std::vector<int> global_id_list, local_id_list;
-        local_id_list.reserve(rContainer.size());
+        local_id_list.reserve(number_of_entities);
         for (const auto& r_entity : rContainer) {
             local_id_list.push_back(r_entity.Id());
         }


### PR DESCRIPTION
**📝 Description**

In this commit, the type of `number_of_entities` variable in the `global_pointer_utilities.h` file is changed from `int` to `std::size_t`. This change likely improves type consistency and avoids potential overflow issues, as `std::size_t` is commonly used for object sizes and container indices in C++. This could potentially remove type mismatch warnings and ensure better cross-platform compatibility.

Moreover, the reservation size for the `local_id_list` vector now utilizes the newly defined `number_of_entities` variable, making the code cleaner and more maintainable by avoiding direct multiple calls to `rContainer.size()`. 

**🆕 Changelog**

- [Minor correction `GlobalPointerUtilities`](https://github.com/KratosMultiphysics/Kratos/commit/6a89c5aa1c8df8dc9ea42cbc9c31ef71d0164478)
