### PR TITLE
[Core] Fix issues in stl reader with line ends and trailing spaces

### DIFF
--- a/kratos/input_output/stl_io.cpp
+++ b/kratos/input_output/stl_io.cpp
@@ -11,7 +11,7 @@
 //
 
 // System includes
-
+#include <regex>
 // External includes
 
 // Project includes
@@ -217,7 +217,17 @@ void StlIO::ReadSolid(
     KRATOS_ERROR_IF(word != "solid") << "Invalid stl file. Solid block should begin with \"solid\" keyword but \"" << word << "\" was found" << std::endl;
     std::getline(*mpInputStream, word); // Reading solid name to be the model part name
 
-    word.erase(word.begin(), std::find_if(word.begin(), word.end(), [](int ch) {return !std::isspace(ch);})); // Triming the leading spaces
+    // Remove Comments
+    std::size_t pos = word.find("COMMENT:");
+    if(pos!=std::string::npos){
+        word = word.substr(0,pos);
+    }
+        std::size_t pos = word.find(";");
+    if(pos!=std::string::npos){
+        word = word.substr(0,pos);
+    }
+    // Remove newline and spaces characters from string in C++
+    word = std::regex_replace( word, std::regex("\\r\\n|\\r|\\n| "), "");
 
     if(word == "") // empty solid name is valid in STL format
         word = "main";

--- a/kratos/input_output/stl_io.cpp
+++ b/kratos/input_output/stl_io.cpp
@@ -222,7 +222,7 @@ void StlIO::ReadSolid(
     if(pos!=std::string::npos){
         word = word.substr(0,pos);
     }
-        std::size_t pos = word.find(";");
+    std::size_t pos = word.find(";");
     if(pos!=std::string::npos){
         word = word.substr(0,pos);
     }

--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -2092,7 +2092,7 @@ void ModelPart::RemoveSubModelPart(std::string const& ThisSubModelPartName)
                     << "\" in model part \"" << FullName() << "\" which does not exist.\n"
                     << "The the following sub model parts are available:";
             for (const auto& r_avail_smp_name : GetSubModelPartNames()) {
-                warning_msg << "\n\t" << r_avail_smp_name;
+                warning_msg << "\n\t" "\"" << r_avail_smp_name << "\"";
             }
             KRATOS_WARNING("ModelPart") << warning_msg.str() << std::endl;
         } else {
@@ -2393,7 +2393,7 @@ void ModelPart::ErrorNonExistingSubModelPart(const std::string& rSubModelPartNam
             << "\" in model part \"" << FullName() << "\"\n"
             << "The following sub model parts are available:";
     for (const auto& r_avail_smp_name : GetSubModelPartNames()) {
-        err_msg << "\n\t" << r_avail_smp_name;
+        err_msg << "\n\t" << "\""<<r_avail_smp_name << "\"";
     }
     KRATOS_ERROR << err_msg.str() << std::endl;
 }


### PR DESCRIPTION
**📝 Description**
This PR fixes an issue when reading STL solids with trailing whitespaces. It also adds encloses between quotation marks the output modelpart names when a submodelpart is not found.