### PR TITLE
[Core] Improved STL file parsing and formatting, fix issues with line ends and trailing spaces

### DIFF
--- a/kratos/input_output/stl_io.cpp
+++ b/kratos/input_output/stl_io.cpp
@@ -219,16 +219,19 @@ void StlIO::ReadSolid(
     std::getline(*mpInputStream, word); // Reading solid name to be the model part name
 
     // Remove Comments
-    std::size_t pos = word.find("COMMENT:");
-    if(pos!=std::string::npos){
-        word = word.substr(0,pos);
+for (const auto& symbol : {"COMMENT:", ";"}) {
+        const auto position = word.find(symbol);
+        if (position != word.npos) {
+            word.erase(position);
+        }
     }
-    pos = word.find(";");
-    if(pos!=std::string::npos){
-        word = word.substr(0,pos);
-    }
-    // Remove newline and spaces characters from string in C++
-    word = std::regex_replace( word, std::regex("\\r\\n|\\r|\\n| "), "");
+    word.erase(std::remove_if(
+        word.begin(),
+        word.end(),
+        [](auto character) -> bool {
+            return character == '\r' || character == '\n';
+        }
+    ), word.end());
 
     if(word == "") // empty solid name is valid in STL format
         word = "main";

--- a/kratos/input_output/stl_io.cpp
+++ b/kratos/input_output/stl_io.cpp
@@ -11,7 +11,7 @@
 //
 
 // System includes
-
+#include <regex>
 // External includes
 
 // Project includes
@@ -217,7 +217,17 @@ void StlIO::ReadSolid(
     KRATOS_ERROR_IF(word != "solid") << "Invalid stl file. Solid block should begin with \"solid\" keyword but \"" << word << "\" was found" << std::endl;
     std::getline(*mpInputStream, word); // Reading solid name to be the model part name
 
-    word.erase(word.begin(), std::find_if(word.begin(), word.end(), [](int ch) {return !std::isspace(ch);})); // Triming the leading spaces
+    // Remove Comments
+    std::size_t pos = word.find("COMMENT:");
+    if(pos!=std::string::npos){
+        word = word.substr(0,pos);
+    }
+        std::size_t pos = word.find(";");
+    if(pos!=std::string::npos){
+        word = word.substr(0,pos);
+    }
+    // Remove newline and spaces characters from string in C++
+    word = std::regex_replace( word, std::regex("\\r\\n|\\r|\\n| "), "");
 
     if(word == "") // empty solid name is valid in STL format
         word = "main";

--- a/kratos/input_output/stl_io.cpp
+++ b/kratos/input_output/stl_io.cpp
@@ -222,7 +222,7 @@ void StlIO::ReadSolid(
     if(pos!=std::string::npos){
         word = word.substr(0,pos);
     }
-        std::size_t pos = word.find(";");
+    std::size_t pos = word.find(";");
     if(pos!=std::string::npos){
         word = word.substr(0,pos);
     }

--- a/kratos/input_output/stl_io.cpp
+++ b/kratos/input_output/stl_io.cpp
@@ -12,6 +12,7 @@
 
 // System includes
 #include <regex>
+
 // External includes
 
 // Project includes

--- a/kratos/input_output/stl_io.cpp
+++ b/kratos/input_output/stl_io.cpp
@@ -223,7 +223,7 @@ void StlIO::ReadSolid(
     if(pos!=std::string::npos){
         word = word.substr(0,pos);
     }
-    std::size_t pos = word.find(";");
+    pos = word.find(";");
     if(pos!=std::string::npos){
         word = word.substr(0,pos);
     }

--- a/kratos/input_output/stl_io.cpp
+++ b/kratos/input_output/stl_io.cpp
@@ -11,7 +11,6 @@
 //
 
 // System includes
-#include <regex>
 
 // External includes
 
@@ -219,7 +218,7 @@ void StlIO::ReadSolid(
     std::getline(*mpInputStream, word); // Reading solid name to be the model part name
 
     // Remove Comments
-for (const auto& symbol : {"COMMENT:", ";"}) {
+    for (const auto& symbol : {"COMMENT:", ";"}) {
         const auto position = word.find(symbol);
         if (position != word.npos) {
             word.erase(position);
@@ -229,7 +228,7 @@ for (const auto& symbol : {"COMMENT:", ";"}) {
         word.begin(),
         word.end(),
         [](auto character) -> bool {
-            return character == '\r' || character == '\n';
+            return character == '\r' || character == '\n' || character == ' '; //remove eol's and white spaces
         }
     ), word.end());
 

--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -2092,7 +2092,7 @@ void ModelPart::RemoveSubModelPart(std::string const& ThisSubModelPartName)
                     << "\" in model part \"" << FullName() << "\" which does not exist.\n"
                     << "The the following sub model parts are available:";
             for (const auto& r_avail_smp_name : GetSubModelPartNames()) {
-                warning_msg << "\n\t" << r_avail_smp_name;
+                warning_msg << "\n\t" "\"" << r_avail_smp_name << "\"";
             }
             KRATOS_WARNING("ModelPart") << warning_msg.str() << std::endl;
         } else {
@@ -2393,7 +2393,7 @@ void ModelPart::ErrorNonExistingSubModelPart(const std::string& rSubModelPartNam
             << "\" in model part \"" << FullName() << "\"\n"
             << "The following sub model parts are available:";
     for (const auto& r_avail_smp_name : GetSubModelPartNames()) {
-        err_msg << "\n\t" << r_avail_smp_name;
+        err_msg << "\n\t" << "\""<<r_avail_smp_name << "\"";
     }
     KRATOS_ERROR << err_msg.str() << std::endl;
 }

--- a/kratos/tests/cpp_tests/input_output/test_stl_io.cpp
+++ b/kratos/tests/cpp_tests/input_output/test_stl_io.cpp
@@ -27,7 +27,7 @@ namespace Kratos::Testing {
 KRATOS_TEST_CASE_IN_SUITE(ReadTriangleFromSTL, KratosCoreFastSuite)
 {
     Kratos::shared_ptr<std::stringstream> p_input = Kratos::make_shared<std::stringstream>(R"input(
-    solid 1 triangle
+    solid 1_triangle
         facet normal  1.000000 0.000000 0.000000 
             outer loop 
             vertex 0.1 -2.56114e-08 0.1
@@ -35,7 +35,7 @@ KRATOS_TEST_CASE_IN_SUITE(ReadTriangleFromSTL, KratosCoreFastSuite)
             vertex 0.1 -0.473406 -0.0446259
             endloop 
         endfacet 
-    endsolid 1 triangle
+    endsolid 1_triangle
     )input");  
 
     Model current_model;
@@ -44,15 +44,15 @@ KRATOS_TEST_CASE_IN_SUITE(ReadTriangleFromSTL, KratosCoreFastSuite)
     StlIO stl_io(p_input);
     stl_io.ReadModelPart(r_model_part);
 
-    KRATOS_CHECK(r_model_part.HasSubModelPart("1 triangle"));
-    KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("1 triangle").NumberOfNodes(), 3);
-    KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("1 triangle").NumberOfGeometries(), 1);
+    KRATOS_CHECK(r_model_part.HasSubModelPart("1_triangle"));
+    KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("1_triangle").NumberOfNodes(), 3);
+    KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("1_triangle").NumberOfGeometries(), 1);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ReadTriangleFromSTLAsElement, KratosCoreFastSuite)
 {
     Kratos::shared_ptr<std::stringstream> p_input = Kratos::make_shared<std::stringstream>(R"input(
-    solid 1 triangle
+    solid 1_triangle
         facet normal  1.000000 0.000000 0.000000 
             outer loop 
             vertex 0.1 -2.56114e-08 0.1
@@ -60,7 +60,7 @@ KRATOS_TEST_CASE_IN_SUITE(ReadTriangleFromSTLAsElement, KratosCoreFastSuite)
             vertex 0.1 -0.473406 -0.0446259
             endloop 
         endfacet 
-    endsolid 1 triangle
+    endsolid 1_triangle
     )input");  
 
     Model current_model;
@@ -72,16 +72,90 @@ KRATOS_TEST_CASE_IN_SUITE(ReadTriangleFromSTLAsElement, KratosCoreFastSuite)
     StlIO stl_io(p_input,settings);
     stl_io.ReadModelPart(r_model_part);
 
-    KRATOS_CHECK(r_model_part.HasSubModelPart("1 triangle"));
-    KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("1 triangle").NumberOfNodes(), 3);
-    KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("1 triangle").NumberOfGeometries(), 0);
-    KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("1 triangle").NumberOfElements(), 1);
+    KRATOS_CHECK(r_model_part.HasSubModelPart("1_triangle"));
+    KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("1_triangle").NumberOfNodes(), 3);
+    KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("1_triangle").NumberOfGeometries(), 0);
+    KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("1_triangle").NumberOfElements(), 1);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ReadSolidNameWithComments, KratosCoreFastSuite)
+{
+
+    Model current_model;
+    ModelPart& r_model_part = current_model.CreateModelPart("Main");
+    Parameters settings(R"({
+        "new_entity_type" : "element"
+    })");
+
+    Kratos::shared_ptr<std::stringstream> p_input = Kratos::make_shared<std::stringstream>(R"input(
+    solid triangle_1 ;Do not read after this
+        facet normal  1.000000 0.000000 0.000000
+            outer loop
+            vertex 0.1 -2.56114e-08 0.1
+            vertex 0.1 -0.499156 -0.0352136
+            vertex 0.1 -0.473406 -0.0446259
+            endloop
+        endfacet
+    endsolid triangle_1
+    )input");
+
+    StlIO stl_io(p_input,settings);
+    stl_io.ReadModelPart(r_model_part);
+    KRATOS_CHECK(r_model_part.HasSubModelPart("triangle_1"));
+
+    Kratos::shared_ptr<std::stringstream> p_input2 = Kratos::make_shared<std::stringstream>(R"input(
+    solid triangle_2    COMMENT: This should be skipped
+        facet normal  1.000000 0.000000 0.000000
+            outer loop
+            vertex 0.1 -2.56114e-08 0.1
+            vertex 0.1 -0.499156 -0.0352136
+            vertex 0.1 -0.473406 -0.0446259
+            endloop
+        endfacet
+    endsolid triangle_2
+    )input");
+
+    StlIO stl_io2(p_input2,settings);
+    stl_io2.ReadModelPart(r_model_part);
+    KRATOS_CHECK(r_model_part.HasSubModelPart("triangle_2"));
+
+    Kratos::shared_ptr<std::stringstream> p_input3 = Kratos::make_shared<std::stringstream>(R"input(
+    solid triangle _ 3    COMMENT: This should be skipped
+        facet normal  1.000000 0.000000 0.000000
+            outer loop
+            vertex 0.1 -2.56114e-08 0.1
+            vertex 0.1 -0.499156 -0.0352136
+            vertex 0.1 -0.473406 -0.0446259
+            endloop
+        endfacet
+    endsolid triangle _ 3
+    )input");
+
+    StlIO stl_io3(p_input3,settings);
+    stl_io3.ReadModelPart(r_model_part);
+    KRATOS_CHECK(r_model_part.HasSubModelPart("triangle_3"));
+
+    Kratos::shared_ptr<std::stringstream> p_input4 = Kratos::make_shared<std::stringstream>(R"input(
+    solid core_851 COMMENT: Exported from Inspire HWVERSION_2023.0.0.21_Jun  6 2023_09:37:24 Build 4500, Altair Inc. Unit : mm
+    facet normal  0.999872 0.000003 -0.016028
+        outer loop
+           vertex 25.4997 58.7925 4.68075e-11
+           vertex 25.4961 58.7925 -0.226466
+           vertex 25.4959 135 -0.226461
+        endloop
+    endfacet
+    endsolid core_851
+    )input");
+
+    StlIO stl_io4(p_input4,settings);
+    stl_io4.ReadModelPart(r_model_part);
+    KRATOS_CHECK(r_model_part.HasSubModelPart("core_851"));
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ReadMultipleTrianglesFromSTL, KratosCoreFastSuite)
 {
     Kratos::shared_ptr<std::stringstream> p_input = Kratos::make_shared<std::stringstream>(R"input(
-    solid 3 triangles
+    solid 3_triangles
         facet normal  1.000000 0.000000 0.000000 
             outer loop 
             vertex 0.1 -2.56114e-08 0.1
@@ -103,7 +177,7 @@ KRATOS_TEST_CASE_IN_SUITE(ReadMultipleTrianglesFromSTL, KratosCoreFastSuite)
             vertex 0.1 -0.499156 -0.0352136
             endloop 
         endfacet 
-    endsolid 3 triangles
+    endsolid 3_triangles
     )input");  
 
     Model current_model;
@@ -112,9 +186,9 @@ KRATOS_TEST_CASE_IN_SUITE(ReadMultipleTrianglesFromSTL, KratosCoreFastSuite)
     StlIO stl_io(p_input);
     stl_io.ReadModelPart(r_model_part);
 
-    KRATOS_CHECK(r_model_part.HasSubModelPart("3 triangles"));
-    KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("3 triangles").NumberOfNodes(), 9);
-    KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("3 triangles").NumberOfGeometries(), 3);
+    KRATOS_CHECK(r_model_part.HasSubModelPart("3_triangles"));
+    KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("3_triangles").NumberOfNodes(), 9);
+    KRATOS_CHECK_EQUAL(r_model_part.GetSubModelPart("3_triangles").NumberOfGeometries(), 3);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(WriteTriangleToSTL, KratosCoreFastSuite)

--- a/kratos/tests/cpp_tests/sources/test_model_part.cpp
+++ b/kratos/tests/cpp_tests/sources/test_model_part.cpp
@@ -399,10 +399,10 @@ namespace Kratos {
         KRATOS_CHECK_EQUAL("sub_inlet", r_const_model_part.GetSubModelPart("Inlet1.sub_inlet").Name());
 
         KRATOS_CHECK_EXCEPTION_IS_THROWN(model_part.GetSubModelPart("Inlet1.random_sub_inlet"),
-            "Error: There is no sub model part with name \"random_sub_inlet\" in model part \"Main.Inlet1\"\nThe following sub model parts are available:\n\tsub_inlet");
+            "Error: There is no sub model part with name \"random_sub_inlet\" in model part \"Main.Inlet1\"\nThe following sub model parts are available:\n\t\"sub_inlet\"");
 
         KRATOS_CHECK_EXCEPTION_IS_THROWN(r_const_model_part.GetSubModelPart("Inlet1.random_sub_inlet"),
-            "Error: There is no sub model part with name \"random_sub_inlet\" in model part \"Main.Inlet1\"\nThe following sub model parts are available:\n\tsub_inlet");
+            "Error: There is no sub model part with name \"random_sub_inlet\" in model part \"Main.Inlet1\"\nThe following sub model parts are available:\n\t\"sub_inlet\"");
 
         // Checking SubSubSubModelPart
         ssmp.CreateSubModelPart("tiny_inlet");
@@ -414,10 +414,10 @@ namespace Kratos {
         KRATOS_CHECK_EQUAL("tiny_inlet", r_const_model_part.GetSubModelPart("Inlet1.sub_inlet.tiny_inlet").Name());
 
         KRATOS_CHECK_EXCEPTION_IS_THROWN(model_part.GetSubModelPart("Inlet1.sub_inlet.big_inlet"),
-            "Error: There is no sub model part with name \"big_inlet\" in model part \"Main.Inlet1.sub_inlet\"\nThe following sub model parts are available:\n\ttiny_inlet");
+            "Error: There is no sub model part with name \"big_inlet\" in model part \"Main.Inlet1.sub_inlet\"\nThe following sub model parts are available:\n\t\"tiny_inlet\"");
 
         KRATOS_CHECK_EXCEPTION_IS_THROWN(r_const_model_part.GetSubModelPart("Inlet1.sub_inlet.big_inlet"),
-            "Error: There is no sub model part with name \"big_inlet\" in model part \"Main.Inlet1.sub_inlet\"\nThe following sub model parts are available:\n\ttiny_inlet");
+            "Error: There is no sub model part with name \"big_inlet\" in model part \"Main.Inlet1.sub_inlet\"\nThe following sub model parts are available:\n\t\"tiny_inlet\"");
     }
 
     KRATOS_TEST_CASE_IN_SUITE(ModelPartHasSubModelPart, KratosCoreFastSuite)


### PR DESCRIPTION
**📝 Description**

This PR contains several improvements and fixes, particularly concerning STL file parsing and the formatting of error messages in the model part. This PR fixes an issue when reading STL solids with trailing whitespaces. It also adds encloses between quotation marks the output modelpart names when a submodelpart is not found.

Reopens https://github.com/KratosMultiphysics/Kratos/pull/11239, after the CI was not updated with the changes.

**🆕 Changelog**

- [Modify stl io](https://github.com/KratosMultiphysics/Kratos/commit/b3ad015c891fddc6027f6eb367e1eecc3772141b)
	1. In `stl_io.cpp`, the STL file parsing mechanism has been enhanced. The new code includes the use of the `regex` library. Also, a mechanism has been introduced to remove comments (lines starting with "COMMENT:") and semicolons (;) from the parsed words. Moreover, newline and space characters are also removed from the parsed string. 
	2. In `model_part.cpp`, formatting for error and warning messages has been updated. Sub-model part names are now enclosed in quotes ("") for better readability.
	3. The commit also includes a few smaller fixes like the correction of misaligned code, the addition of a missing space, and a compilation fix related to variable declaration in `stl_io.cpp`.
- [Fix compilation](https://github.com/KratosMultiphysics/Kratos/commit/817eb8418ce0b771a2debc12368669d715a9573f)
