### PR TITLE
[Core] Extend definitions from `define_python`, adding `VectorToPyList` and `MatrixToPyList`

### DIFF
--- a/kratos/includes/define_python.h
+++ b/kratos/includes/define_python.h
@@ -16,15 +16,14 @@
 
 // External includes
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/stl/filesystem.h>
 
 // Project includes
 #include "intrusive_ptr/intrusive_ptr.hpp"
 
 // Always needed for custom holder types
 PYBIND11_DECLARE_HOLDER_TYPE(T, Kratos::intrusive_ptr<T>);
-
-#include <pybind11/stl.h>
-#include <pybind11/stl/filesystem.h>
 
 #include "includes/define.h"
 
@@ -103,15 +102,53 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, Kratos::intrusive_ptr<T>);
 #define KRATOS_REGISTER_IN_PYTHON_FLAG(module,flag) \
     KRATOS_REGISTER_IN_PYTHON_FLAG_IMPLEMENTATION(module,flag);
 
-// This function is used to print the ofstream-operator
-// i.e. printing an object will give the same result in Python as in C++
-// To be defined as the "__str__" function
-// e.g. ".def("__str__", PrintObject<ProcessInfo>)"
-// It replicates the function "self_ns::str(self))" of boost-python
+/** 
+ * @brief This function is used to print the ofstream-operator
+ * @details i.e. printing an object will give the same result in Python as in C++
+ * To be defined as the "__str__" function
+ * e.g. ".def("__str__", PrintObject<ProcessInfo>)"
+ * It replicates the function "self_ns::str(self))" of boost-python
+ */
 template< class T>
 std::string PrintObject(const T& rObject)
 {
     std::stringstream ss;
     ss << rObject;
     return ss.str();
+}
+
+/**
+ * @brief Converts a vector to a Python list using pybind11.
+ * @details This function is generic enough to be moved to a more general place.
+ * @tparam T The type of the vector.
+ * @param results The vector to convert.
+ * @return The converted Python list.
+ */
+template<typename T>
+pybind11::list VectorToPyList(const T& results) {
+    pybind11::list list_results;
+    for (auto& r_result : results) {
+        list_results.append(r_result);
+    }
+    return list_results;
+}
+
+/**
+ * @brief Converts a matrix to a nested Python list using pybind11.
+ * @details This function is generic enough to be moved to a more general place.
+ * @tparam T The type of the matrix.
+ * @param results The matrix to convert.
+ * @return The converted nested Python list.
+ */
+template<typename T>
+pybind11::list MatrixToPyList(const T& results) {
+    pybind11::list list_results;
+    for (auto& r_result : results) {
+        pybind11::list i_list_results;
+        for (auto& r_sub_result : r_result) {
+            i_list_results.append(r_sub_result);
+        }
+        list_results.append(i_list_results);
+    }
+    return list_results;
 }


### PR DESCRIPTION
**📝 Description**

This PR primarily introduces two new functions `VectorToPyList` and `MatrixToPyList` that provide conversion from C++ vectors and matrices to Python lists using pybind11. These functions aim to enhance the interoperability between Python and the Kratos codebase.

The changes made include:
1. Two additional includes for `pybind11/stl.h` and `pybind11/stl/filesystem.h` have been moved to the beginning of the file to adhere to the proper structure of including external libraries.
2. A detailed comment block has been added to describe the `PrintObject` function, improving readability and understanding of its purpose and usage. 
3. The creation of `VectorToPyList`, a template function that converts C++ vectors into Python lists. It iterates over the input vector, appending each element to a pybind11 list which is then returned.
4. The creation of `MatrixToPyList`, another template function that converts C++ matrices into nested Python lists (list of lists). It iterates over the input matrix and for each row, it creates a new pybind11 list, appends the elements of the row to this list and then appends the row list to the final result list.

These new conversion functions are significant as they facilitate data transfer between the C++ and Python parts of the codebase.

**🆕 Changelog**

- [Extend definitions from define_python, adding `VectorToPyList` and `MatrixToPyList`](https://github.com/KratosMultiphysics/Kratos/commit/13dee6782a6a4fce6db4f27eb9ba04436145b5fa)
