### PR TITLE
[Core][MPI] Adding required files for `AddMPISearchStrategiesToPython`

### DIFF
--- a/kratos/mpi/CMakeLists.txt
+++ b/kratos/mpi/CMakeLists.txt
@@ -8,6 +8,7 @@ include_directories( ${KRATOS_SOURCE_DIR}/kratos )
 ## Kratos MPI extension sources
 file(GLOB_RECURSE KRATOS_MPI_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/spatial_containers/*.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/*.cpp
 )
 

--- a/kratos/mpi/python/add_mpi_search_strategies_to_python.cpp
+++ b/kratos/mpi/python/add_mpi_search_strategies_to_python.cpp
@@ -1,0 +1,32 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define_python.h"
+#include "includes/model_part.h"
+#include "mpi/python/add_mpi_search_strategies_to_python.h"
+
+namespace Kratos::Python
+{
+
+void AddMPISearchStrategiesToPython(pybind11::module& m)
+{
+    namespace py = pybind11;
+
+
+}
+
+}  // namespace Kratos::Python

--- a/kratos/mpi/python/add_mpi_search_strategies_to_python.h
+++ b/kratos/mpi/python/add_mpi_search_strategies_to_python.h
@@ -1,0 +1,27 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+#include <pybind11/pybind11.h>
+
+// Project includes
+
+namespace Kratos::Python
+{
+
+void  AddMPISearchStrategiesToPython(pybind11::module& m);
+
+}  // namespace Kratos::Python.

--- a/kratos/mpi/python/kratos_mpi_python.cpp
+++ b/kratos/mpi/python/kratos_mpi_python.cpp
@@ -25,6 +25,7 @@
 #include "add_mpi_debug_utilities_to_python.h"
 #include "add_distributed_sparse_matrices_to_python.h"
 #include "includes/parallel_environment.h"
+#include "add_mpi_search_strategies_to_python.h"
 
 namespace Kratos::Python {
 
@@ -71,6 +72,7 @@ PYBIND11_MODULE(KratosMPI, m)
     AddMPIUtilitiesToPython(m);
     AddMPIDebugUtilitiesToPython(m);
     AddDistributedSparseMatricesToPython(m);
+    AddMPISearchStrategiesToPython(m);
 }
 
 }


### PR DESCRIPTION
**📝 Description**

This is a transition PR, adding the required files for `AddMPISearchStrategiesToPython`, considered in https://github.com/KratosMultiphysics/Kratos/pull/11224 and in a future PR that will be using this as well. So in order to create these two PRs in parallel, this transition PR is created.

A new C++ source file (`add_mpi_search_strategies_to_python.cpp`) and its corresponding header file (`add_mpi_search_strategies_to_python.h`) have been added to the project. These files contain a function named `AddMPISearchStrategiesToPython` which currently doesn't contain any implementation.  An import for `add_mpi_search_strategies_to_python.h` has been added in `kratos_mpi_python.cpp`, and the function `AddMPISearchStrategiesToPython` is now being called within the `PYBIND11_MODULE(KratosMPI, m)` function. This will allow the MPI Search Strategies to be accessible when the Kratos MPI Python module is imported. 

Moreover, the CMakeLists.txt file has been updated to include a new source file path in `KRATOS_MPI_SOURCES`. This new source file path points to the `spatial_containers` directory.

**🆕 Changelog**

- [Adding required files for `AddMPISearchStrategiesToPython`](https://github.com/KratosMultiphysics/Kratos/commit/797f5dad2cb2775efdf7c0cfc85a106a192696ac)
