### PR TITLE
[Core] Fixed typo in error message in `Geometry` class.

### DIFF
--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -2676,7 +2676,7 @@ public:
         const double Tolerance = std::numeric_limits<double>::epsilon()
     ) const
     {
-        KRATOS_ERROR << "Calling ProjectionPoinGlobalToLocalSpace within geometry base class."
+        KRATOS_ERROR << "Calling ProjectionPointGlobalToLocalSpace within geometry base class."
             << " Please check the definition within derived class. "
             << *this << std::endl;
     }


### PR DESCRIPTION
**📝 Description**

This PR corrects a typographical error in the error message of the `ProjectionPointGlobalToLocalSpace` method in the `Geometry` class within the `kratos/geometries/geometry.h` file. The previous error message referenced a non-existent method `ProjectionPoinGlobalToLocalSpace`, which has been corrected to `ProjectionPointGlobalToLocalSpace`.  This is a minor text fix that improves the readability and accuracy of the error messages, but does not modify the functionality of the code.


**🆕 Changelog**

- [Typo in `Geometry`](https://github.com/KratosMultiphysics/Kratos/commit/868642650a50a253004c741e782b085d0bf76141)
