### PR TITLE
[Core] include ext libraries as SYSTEM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,7 +541,7 @@ endif( FORCE_LOCAL_ZLIB_COMPILATION MATCHES ON )
 message("\n-- CMAKE_BUILD_TYPE ........ ${CMAKE_BUILD_TYPE}\n")
 
 # Include dir for external libraries
-include_directories( ${KRATOS_SOURCE_DIR}/external_libraries )
+include_directories( SYSTEM ${KRATOS_SOURCE_DIR}/external_libraries )
 
 # defines needed
 add_definitions( -DKRATOS_PYTHON )


### PR DESCRIPTION
Same as we do for MPI, Trilinos, eigen etc ...
Not sure why we forgot about this one

Basically allows to ignore compiler warnings from the ext libs that we use, which would conflict with our rather strict CI
