### PR TITLE
[Core[ Add maximimum and minimum edge calculation to hex3d8n geometry

### DIFF
--- a/kratos/geometries/hexahedra_3d_8.h
+++ b/kratos/geometries/hexahedra_3d_8.h
@@ -613,7 +613,7 @@ public:
      */
     double MaxEdgeLength() const override {
         const auto edges = GenerateEdges();
-        double max_edge_length = -std::numeric_limits<double>::max();
+        double max_edge_length = 0.0;
         for (const auto& r_edge: edges) {
             max_edge_length = std::max(max_edge_length, r_edge.Length());
         }

--- a/kratos/geometries/hexahedra_3d_8.h
+++ b/kratos/geometries/hexahedra_3d_8.h
@@ -603,6 +603,40 @@ public:
             MathUtils<double>::Norm3(p3-p7)) /12.0;
     }
 
+    /** This method calculates and returns the maximum edge
+     * length of the geometry
+     *
+     * @return double value with the maximum edge length
+     *
+     * @see MinEdgeLength()
+     * @see AverageEdgeLength()
+     */
+    double MaxEdgeLength() const override {
+        const auto edges = GenerateEdges();
+        double max_edge_length = -std::numeric_limits<double>::max();
+        for (const auto& r_edge: edges) {
+            max_edge_length = std::max(max_edge_length, r_edge.Length());
+        }
+        return max_edge_length;
+    }
+
+    /** This method calculates and returns the minimum edge
+     * length of the geometry
+     *
+     * @return double value with the maximum edge length
+     *
+     * @see MaxEdgeLength()
+     * @see AverageEdgeLength()
+     */
+    double MinEdgeLength() const override {
+        const auto edges = GenerateEdges();
+        double min_edge_length = std::numeric_limits<double>::max();
+        for (const auto& r_edge: edges) {
+            min_edge_length = std::min(min_edge_length, r_edge.Length());
+        }
+        return min_edge_length;
+    }
+
     ///@}
     ///@name Face
     ///@{

--- a/kratos/tests/cpp_tests/geometries/test_hexahedra_3d_8.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_hexahedra_3d_8.cpp
@@ -309,6 +309,20 @@ KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8AverageEdgeLength, KratosCoreGeometriesFas
     KRATOS_CHECK_NEAR(geom->AverageEdgeLength(), 2.0, TOLERANCE);
 }
 
+/** Checks the min edge length */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8MinEdgeLength, KratosCoreGeometriesFastSuite)
+{
+    auto geom = GenerateDeformedCenterLen1Hexahedra3D8();
+    KRATOS_CHECK_NEAR(geom->MinEdgeLength(), 1.0, TOLERANCE);
+}
+
+/** Checks the max edge length */
+KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8MaxEdgeLength, KratosCoreGeometriesFastSuite)
+{
+    auto geom = GenerateDeformedCenterLen1Hexahedra3D8();
+    KRATOS_CHECK_NEAR(geom->MaxEdgeLength(), sqrt(2.0), TOLERANCE);
+}
+
 /** Checks the solid angles */
 KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8SolidAngles, KratosCoreGeometriesFastSuite)
 {


### PR DESCRIPTION
**📝 Description**
This PR contains adds the MaxedgeLength and MinEdgeLenght methods to the hex3d8n geometry

**🆕 Changelog**
In `hexahedra_3d_8n.h` both methods are added looping through all the edges. Two new tests have been added to `test_hexahedra_3d_8.cpp`
