### PR TITLE
[GeoMechanicsApplication] Moved writing of GiD output to a new class

### DIFF
--- a/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
@@ -21,6 +21,8 @@
 #include "input_output/logger_output.h"
 #include "input_output/logger_table_output.h"
 #include "includes/model_part_io.h"
+#include "write_output.h"
+
 
 class GeoFlowApplyConstantScalarValueProcess : public Kratos::ApplyConstantScalarValueProcess
 {
@@ -74,43 +76,6 @@ public:
     }
 };
 
-void NodeOperation::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part){};
-
-void NodeDISPLACEMENT::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) { gid_io.WriteNodalResults(Kratos::DISPLACEMENT, model_part.Nodes(), 0, 0); }
-
-void NodeTOTAL_DISPLACEMENT::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) { gid_io.WriteNodalResults(Kratos::TOTAL_DISPLACEMENT, model_part.Nodes(), 0, 0); }
-
-void NodeWATER_PRESSURE::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) { gid_io.WriteNodalResults(Kratos::WATER_PRESSURE, model_part.Nodes(), 0, 0); }
-
-void NodeNORMAL_FLUID_FLUX::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) { gid_io.WriteNodalResults(Kratos::NORMAL_FLUID_FLUX, model_part.Nodes(), 0, 0); }
-
-void NodeVOLUME_ACCELERATION::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) { gid_io.WriteNodalResults(Kratos::VOLUME_ACCELERATION, model_part.Nodes(), 0, 0); }
-
-void NodeHYDRAULIC_DISCHARGE::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) { gid_io.WriteNodalResults(Kratos::HYDRAULIC_DISCHARGE, model_part.Nodes(), 0, 0); }
-
-void NodeHYDRAULIC_HEAD::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) { gid_io.WriteNodalResults(Kratos::HYDRAULIC_HEAD, model_part.Nodes(), 0, 0); }
-
-void GaussOperation::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part){};
-
-void GaussFLUID_FLUX_VECTOR::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) { gid_io.PrintOnGaussPoints(Kratos::FLUID_FLUX_VECTOR, model_part, 0, 0); }
-
-void GaussHYDRAULIC_HEAD::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) { gid_io.PrintOnGaussPoints(Kratos::HYDRAULIC_HEAD, model_part, 0, 0); }
-
-void GaussLOCAL_FLUID_FLUX_VECTOR::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) { gid_io.PrintOnGaussPoints(Kratos::LOCAL_FLUID_FLUX_VECTOR, model_part, 0, 0); }
-
-void GaussLOCAL_PERMEABILITY_MATRIX::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) { gid_io.PrintOnGaussPoints(Kratos::LOCAL_PERMEABILITY_MATRIX, model_part, 0, 0); }
-
-void GaussPERMEABILITY_MATRIX::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) { gid_io.PrintOnGaussPoints(Kratos::PERMEABILITY_MATRIX, model_part, 0, 0); }
-
-void GaussDEGREE_OF_SATURATION::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) { gid_io.PrintOnGaussPoints(Kratos::DEGREE_OF_SATURATION, model_part, 0, 0); }
-
-void GaussDERIVATIVE_OF_SATURATION::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) { gid_io.PrintOnGaussPoints(Kratos::DERIVATIVE_OF_SATURATION, model_part, 0, 0); }
-
-void GaussRELATIVE_PERMEABILITY::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) { gid_io.PrintOnGaussPoints(Kratos::RELATIVE_PERMEABILITY, model_part, 0, 0); }
-
-void GaussPIPE_ACTIVE::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) { gid_io.PrintOnGaussPoints(Kratos::PIPE_ACTIVE, model_part, 0, 0); }
-
-void GaussPIPE_HEIGHT::write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) { gid_io.PrintOnGaussPoints(Kratos::PIPE_HEIGHT, model_part, 0, 0); }
 
 namespace Kratos
 {
@@ -288,105 +253,6 @@ namespace Kratos
         return processes;
     }
 
-    void KratosExecute::outputGiD(Model &model, ModelPart &model_part, Parameters parameters, std::string workingDirectory)
-    {
-        std::map<std::string, GiD_PostMode> PostMode;
-        PostMode["GiD_PostAscii"] = GiD_PostAscii;
-        PostMode["GiD_PostAsciiZipped"] = GiD_PostAsciiZipped;
-        PostMode["GiD_PostBinary"] = GiD_PostBinary;
-        PostMode["GiD_PostHDF5"] = GiD_PostHDF5;
-
-        std::map<std::string, MultiFileFlag> MultiFiles;
-        MultiFiles["SingleFile"] = SingleFile;
-        MultiFiles["MultipleFiles"] = MultipleFiles;
-
-        std::map<std::string, WriteDeformedMeshFlag> DeformedFlag;
-        DeformedFlag["WriteDeformed"] = WriteDeformed;
-        DeformedFlag["WriteUndeformed"] = WriteUndeformed;
-
-        std::map<std::string, WriteConditionsFlag> ConditionFlag;
-        ConditionFlag["WriteConditions"] = WriteConditions;
-        ConditionFlag["WriteElementsOnly"] = WriteElementsOnly;
-        ConditionFlag["WriteConditionsOnly"] = WriteConditionsOnly;
-
-        Parameters gid_out = parameters["output_processes"]["gid_output"].GetArrayItem(0);
-        Parameters outputParameters = gid_out["Parameters"];
-        std::string filename = outputParameters["output_name"].GetString();
-        GiD_PostMode gid_output_type = PostMode[outputParameters["postprocess_parameters"]["result_file_configuration"]["gidpost_flags"]["GiDPostMode"].GetString()];
-        MultiFileFlag multifiles_output = MultiFiles[outputParameters["postprocess_parameters"]["result_file_configuration"]["gidpost_flags"]["MultiFileFlag"].GetString()];
-        WriteDeformedMeshFlag deformed_output = DeformedFlag[outputParameters["postprocess_parameters"]["result_file_configuration"]["gidpost_flags"]["WriteDeformedMeshFlag"].GetString()];
-        WriteConditionsFlag condition_output = ConditionFlag[outputParameters["postprocess_parameters"]["result_file_configuration"]["gidpost_flags"]["WriteConditionsFlag"].GetString()];
-
-        filename = workingDirectory + "/" + filename;
-        GidIO<> gid_io(filename, gid_output_type, multifiles_output, deformed_output, condition_output);
-
-        gid_io.InitializeMesh(0.0);
-        gid_io.WriteMesh(model_part.GetMesh());
-        gid_io.FinalizeMesh();
-        gid_io.InitializeResults(0, model_part.GetMesh());
-
-        std::unordered_map<std::string, unique_ptr<NodeOperation>> NodeOutput;
-        NodeOutput["DISPLACEMENT"] = Kratos::make_unique<NodeDISPLACEMENT>();
-        NodeOutput["TOTAL_DISPLACEMENT"] = Kratos::make_unique<NodeTOTAL_DISPLACEMENT>();
-        NodeOutput["WATER_PRESSURE"] = Kratos::make_unique<NodeWATER_PRESSURE>();
-        NodeOutput["NORMAL_FLUID_FLUX"] = Kratos::make_unique<NodeNORMAL_FLUID_FLUX>();
-        NodeOutput["VOLUME_ACCELERATION"] = Kratos::make_unique<NodeVOLUME_ACCELERATION>();
-        NodeOutput["HYDRAULIC_DISCHARGE"] = Kratos::make_unique<NodeHYDRAULIC_DISCHARGE>();
-        NodeOutput["HYDRAULIC_HEAD"] = Kratos::make_unique<NodeHYDRAULIC_HEAD>();
-
-        // Calculate hydraulic head on the nodes
-        auto gauss_outputs = outputParameters["postprocess_parameters"]["result_file_configuration"]["gauss_point_results"].GetStringArray();
-        auto nodal_outputs = outputParameters["postprocess_parameters"]["result_file_configuration"]["nodal_results"].GetStringArray();
-
-        if (std::find(gauss_outputs.begin(), gauss_outputs.end(), "HYDRAULIC_HEAD") != gauss_outputs.end())
-        {
-            calculateNodalHydraulicHead(gid_io, model_part);
-        }
-
-        for (std::string var : nodal_outputs)
-        {
-            NodeOutput[var]->write(gid_io, model_part);
-        }
-
-        std::unordered_map<std::string, std::unique_ptr<GaussOperation>> GaussOutput;
-        GaussOutput["FLUID_FLUX_VECTOR"] = Kratos::make_unique<GaussFLUID_FLUX_VECTOR>();
-        GaussOutput["HYDRAULIC_HEAD"] = Kratos::make_unique<GaussHYDRAULIC_HEAD>();
-        GaussOutput["LOCAL_FLUID_FLUX_VECTOR"] = Kratos::make_unique<GaussLOCAL_FLUID_FLUX_VECTOR>();
-        GaussOutput["LOCAL_PERMEABILITY_MATRIX"] = Kratos::make_unique<GaussLOCAL_PERMEABILITY_MATRIX>();
-        GaussOutput["PERMEABILITY_MATRIX"] = Kratos::make_unique<GaussPERMEABILITY_MATRIX>();
-        GaussOutput["DEGREE_OF_SATURATION"] = Kratos::make_unique<GaussDEGREE_OF_SATURATION>();
-        GaussOutput["DERIVATIVE_OF_SATURATION"] = Kratos::make_unique<GaussDERIVATIVE_OF_SATURATION>();
-        GaussOutput["RELATIVE_PERMEABILITY"] = Kratos::make_unique<GaussRELATIVE_PERMEABILITY>();
-        GaussOutput["PIPE_ACTIVE"] = Kratos::make_unique<GaussPIPE_ACTIVE>();
-        GaussOutput["PIPE_HEIGHT"] = Kratos::make_unique<GaussPIPE_HEIGHT>();
-
-        // Now Output Gauss Point Results on Gauss Points
-        for (std::string var : gauss_outputs)
-        {
-            GaussOutput[var]->write(gid_io, model_part);
-        }
-
-        gid_io.FinalizeResults();
-    }
-
-    void KratosExecute::calculateNodalHydraulicHead(GidIO<> &gid_io, ModelPart &model_part) {
-            const auto& element_var = KratosComponents<Variable<double>>::Get("HYDRAULIC_HEAD");
-
-            for (Element element : model_part.Elements())
-            {
-                auto& rGeom = element.GetGeometry();
-                const auto& rProp = element.GetProperties();
-                
-                const auto NodalHydraulicHead = GeoElementUtilities::CalculateNodalHydraulicHeadFromWaterPressures<3>(rGeom, rProp);
-
-            	for (unsigned int node = 0; node < 3; ++node)
-                {
-                    rGeom[node].SetValue(element_var, NodalHydraulicHead[node]);
-                }
-            }
-            gid_io.WriteNodalResultsNonHistorical(element_var, model_part.Nodes(), 0);
-    }
-
     int KratosExecute::mainExecution(ModelPart &model_part,
                                      std::vector<std::shared_ptr<Process>> processes,
                                      GeoMechanicsNewtonRaphsonErosionProcessStrategyType::Pointer p_solving_strategy,
@@ -541,7 +407,7 @@ namespace Kratos
             if (!hasPiping)
             {
                 mainExecution(model_part, processes, p_solving_strategy, 0.0, 1.0, 1);
-                outputGiD(current_model, model_part, projectfile, workingDirectory);
+                GeoOutputWriter::WriteGiDOutput(model_part, projectfile, workingDirectory);
             }
             else
             {
@@ -626,7 +492,7 @@ namespace Kratos
                         break;
                     }
 
-                    outputGiD(current_model, model_part, projectfile, workingDirectory);
+                    GeoOutputWriter::WriteGiDOutput(model_part, projectfile, workingDirectory);
 
                     // Update boundary conditions for next search head.
                     if (RiverBoundary->Info() == "ApplyConstantScalarValueProcess")

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.h
@@ -35,8 +35,6 @@
 // The strategies to test
 #include <custom_processes/apply_component_table_process.hpp>
 #include <custom_processes/apply_constant_hydrostatic_pressure_process.hpp>
-//#include <ghc/filesystem.hpp>
-#include <includes/gid_io.h>
 #include <linear_solvers/skyline_lu_factorization_solver.h>
 
 #include <solving_strategies/convergencecriterias/mixed_generic_criteria.h>
@@ -45,105 +43,6 @@
 
 #include "custom_strategies/strategies/geo_mechanics_newton_raphson_erosion_process_strategy.hpp"
 
-class NodeOperation
-{
-public:
-    virtual ~NodeOperation() = default;
-    virtual void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part);
-};
-class NodeDISPLACEMENT : public NodeOperation
-{
-public:
-    void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) override;
-};
-class NodeTOTAL_DISPLACEMENT : public NodeOperation
-{
-public:
-    void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) override;
-};
-class NodeWATER_PRESSURE : public NodeOperation
-{
-public:
-    void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) override;
-};
-class NodeNORMAL_FLUID_FLUX : public NodeOperation
-{
-public:
-    void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) override;
-};
-class NodeVOLUME_ACCELERATION : public NodeOperation
-{
-public:
-    void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) override;
-};
-class NodeHYDRAULIC_DISCHARGE : public NodeOperation
-{
-public:
-    void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) override;
-};
-class NodeHYDRAULIC_HEAD : public NodeOperation
-{
-public:
-    void write(Kratos::GidIO<>& gid_io, Kratos::ModelPart& model_part) override;
-};
-
-class GaussOperation
-{
-public:
-    virtual ~GaussOperation() = default;
-    virtual void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part);
-};
-
-class GaussFLUID_FLUX_VECTOR : public GaussOperation
-{
-public:
-    void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) override;
-};
-class GaussHYDRAULIC_HEAD : public GaussOperation
-{
-public:
-    void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) override;
-};
-class GaussLOCAL_FLUID_FLUX_VECTOR : public GaussOperation
-{
-public:
-    void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) override;
-};
-class GaussLOCAL_PERMEABILITY_MATRIX : public GaussOperation
-{
-public:
-    void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) override;
-};
-class GaussPERMEABILITY_MATRIX : public GaussOperation
-{
-public:
-    void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) override;
-};
-class GaussDEGREE_OF_SATURATION : public GaussOperation
-{
-public:
-    void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) override;
-};
-class GaussDERIVATIVE_OF_SATURATION : public GaussOperation
-{
-public:
-    void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) override;
-};
-class GaussRELATIVE_PERMEABILITY : public GaussOperation
-{
-public:
-    void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) override;
-};
-class GaussPIPE_ACTIVE : public GaussOperation
-{
-public:
-    void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) override;
-};
-class GaussPIPE_HEIGHT : public GaussOperation
-{
-public:
-    void write(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part) override;
-};
 
 namespace Kratos
 {
@@ -206,7 +105,6 @@ namespace Kratos
 
         Parameters openProjectParamsFile(std::string filepath);
         std::vector<std::shared_ptr<Process>> parseProcess(ModelPart &model_part, Parameters projFile);
-        void outputGiD(Model &model, ModelPart &model_part, Parameters parameters, std::string workingDirectory);
 
     private:
         // Initial Setup
@@ -232,7 +130,5 @@ namespace Kratos
                           std::vector<std::shared_ptr<Process>> processes,
                           KratosExecute::GeoMechanicsNewtonRaphsonErosionProcessStrategyType::Pointer p_solving_strategy,
                           double time, double delta_time, double number_iterations);
-        
-        void calculateNodalHydraulicHead(Kratos::GidIO<> &gid_io, Kratos::ModelPart &model_part);
     };
 }

--- a/applications/GeoMechanicsApplication/custom_workflows/write_output.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/write_output.cpp
@@ -1,0 +1,330 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Anne van de Graaf
+//
+
+#include "write_output.h"
+#include "includes/model_part.h"
+#include "custom_utilities/element_utilities.hpp"
+
+
+namespace
+{
+
+class NodeOperation
+{
+  public:
+    virtual ~NodeOperation() = default;
+    virtual void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) = 0;
+};
+
+class NodeDISPLACEMENT : public NodeOperation
+{
+  public:
+    void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) override
+    {
+        rGidIO.WriteNodalResults(Kratos::DISPLACEMENT, rModelPart.Nodes(), 0, 0);
+    }
+};
+
+class NodeTOTAL_DISPLACEMENT : public NodeOperation
+{
+  public:
+    void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) override
+    {
+        rGidIO.WriteNodalResults(Kratos::TOTAL_DISPLACEMENT, rModelPart.Nodes(), 0, 0);
+    }
+};
+
+class NodeWATER_PRESSURE : public NodeOperation
+{
+  public:
+    void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) override
+    {
+        rGidIO.WriteNodalResults(Kratos::WATER_PRESSURE, rModelPart.Nodes(), 0, 0);
+    }
+};
+
+class NodeNORMAL_FLUID_FLUX : public NodeOperation
+{
+  public:
+    void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) override
+    {
+        rGidIO.WriteNodalResults(Kratos::NORMAL_FLUID_FLUX, rModelPart.Nodes(), 0, 0);
+    }
+};
+
+class NodeVOLUME_ACCELERATION : public NodeOperation
+{
+  public:
+    void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) override
+    {
+        rGidIO.WriteNodalResults(Kratos::VOLUME_ACCELERATION, rModelPart.Nodes(), 0, 0);
+    }
+};
+
+class NodeHYDRAULIC_DISCHARGE : public NodeOperation
+{
+  public:
+    void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) override
+    {
+        rGidIO.WriteNodalResults(Kratos::HYDRAULIC_DISCHARGE, rModelPart.Nodes(), 0, 0);
+    }
+};
+
+class NodeHYDRAULIC_HEAD : public NodeOperation
+{
+  public:
+    void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) override
+    {
+        rGidIO.WriteNodalResults(Kratos::HYDRAULIC_HEAD, rModelPart.Nodes(), 0, 0);
+    }
+};
+
+
+class GaussOperation
+{
+  public:
+    virtual ~GaussOperation() = default;
+    virtual void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) = 0;
+};
+
+class GaussFLUID_FLUX_VECTOR : public GaussOperation
+{
+  public:
+    void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) override
+    {
+        rGidIO.PrintOnGaussPoints(Kratos::FLUID_FLUX_VECTOR, rModelPart, 0, 0);
+    }
+};
+
+class GaussHYDRAULIC_HEAD : public GaussOperation
+{
+  public:
+    void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) override
+    {
+        rGidIO.PrintOnGaussPoints(Kratos::HYDRAULIC_HEAD, rModelPart, 0, 0);
+    }
+};
+
+class GaussLOCAL_FLUID_FLUX_VECTOR : public GaussOperation
+{
+  public:
+    void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) override
+    {
+        rGidIO.PrintOnGaussPoints(Kratos::LOCAL_FLUID_FLUX_VECTOR, rModelPart, 0, 0);
+    }
+};
+
+class GaussLOCAL_PERMEABILITY_MATRIX : public GaussOperation
+{
+  public:
+    void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) override
+    {
+        rGidIO.PrintOnGaussPoints(Kratos::LOCAL_PERMEABILITY_MATRIX, rModelPart, 0, 0);
+    }
+};
+
+class GaussPERMEABILITY_MATRIX : public GaussOperation
+{
+  public:
+    void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) override
+    {
+        rGidIO.PrintOnGaussPoints(Kratos::PERMEABILITY_MATRIX, rModelPart, 0, 0);
+    }
+};
+
+class GaussDEGREE_OF_SATURATION : public GaussOperation
+{
+  public:
+    void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) override
+    {
+        rGidIO.PrintOnGaussPoints(Kratos::DEGREE_OF_SATURATION, rModelPart, 0, 0);
+    }
+};
+
+class GaussDERIVATIVE_OF_SATURATION : public GaussOperation
+{
+  public:
+    void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) override
+    {
+        rGidIO.PrintOnGaussPoints(Kratos::DERIVATIVE_OF_SATURATION, rModelPart, 0, 0);
+    }
+};
+
+class GaussRELATIVE_PERMEABILITY : public GaussOperation
+{
+  public:
+    void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) override
+    {
+        rGidIO.PrintOnGaussPoints(Kratos::RELATIVE_PERMEABILITY, rModelPart, 0, 0);
+    }
+};
+
+class GaussPIPE_ACTIVE : public GaussOperation
+{
+  public:
+    void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) override
+    {
+        rGidIO.PrintOnGaussPoints(Kratos::PIPE_ACTIVE, rModelPart, 0, 0);
+    }
+};
+
+class GaussPIPE_HEIGHT : public GaussOperation
+{
+  public:
+    void write(Kratos::GidIO<>& rGidIO, Kratos::ModelPart& rModelPart) override
+    {
+        rGidIO.PrintOnGaussPoints(Kratos::PIPE_HEIGHT, rModelPart, 0, 0);
+    }
+};
+
+}
+
+
+namespace Kratos
+{
+
+void GeoOutputWriter::WriteGiDOutput(ModelPart&         rModelPart,
+                                     Parameters         Settings,
+                                     const std::string& rWorkingDirectory)
+{
+    auto output_parameters = Settings["output_processes"]["gid_output"].GetArrayItem(0)["Parameters"];
+    auto gid_post_flags = output_parameters["postprocess_parameters"]["result_file_configuration"]["gidpost_flags"];
+
+    GidIO<> gid_io{rWorkingDirectory + "/" + output_parameters["output_name"].GetString(),
+                   GetGiDPostModeFrom(gid_post_flags),
+                   GetMultiFileFlagFrom(gid_post_flags),
+                   GetWriteDeformedMeshFlagFrom(gid_post_flags),
+                   GetWriteConditionsFlagFrom(gid_post_flags)};
+
+    gid_io.InitializeMesh(0.0);
+    gid_io.WriteMesh(rModelPart.GetMesh());
+    gid_io.FinalizeMesh();
+
+    gid_io.InitializeResults(0, rModelPart.GetMesh());
+
+    // Calculate hydraulic head on the nodes
+    auto gauss_outputs = output_parameters["postprocess_parameters"]["result_file_configuration"]["gauss_point_results"].GetStringArray();
+    if (std::find(gauss_outputs.begin(), gauss_outputs.end(), "HYDRAULIC_HEAD") != gauss_outputs.end())
+    {
+        CalculateNodalHydraulicHead(gid_io, rModelPart);
+    }
+
+    const auto nodal_outputs = output_parameters["postprocess_parameters"]["result_file_configuration"]["nodal_results"].GetStringArray();
+    WriteNodalOutput(nodal_outputs, gid_io, rModelPart);
+    WriteIntegrationPointOutput(gauss_outputs, gid_io, rModelPart);
+
+    gid_io.FinalizeResults();
+}
+
+
+void GeoOutputWriter::WriteNodalOutput(const std::vector<std::string>& rOutputItemNames,
+                                       GidIO<>&                        rGidIO,
+                                       ModelPart&                      rModelPart)
+{
+    std::map<std::string, std::unique_ptr<NodeOperation>, std::less<>> output_writer_map;
+    output_writer_map["DISPLACEMENT"]        = std::make_unique<NodeDISPLACEMENT>();
+    output_writer_map["TOTAL_DISPLACEMENT"]  = std::make_unique<NodeTOTAL_DISPLACEMENT>();
+    output_writer_map["WATER_PRESSURE"]      = std::make_unique<NodeWATER_PRESSURE>();
+    output_writer_map["NORMAL_FLUID_FLUX"]   = std::make_unique<NodeNORMAL_FLUID_FLUX>();
+    output_writer_map["VOLUME_ACCELERATION"] = std::make_unique<NodeVOLUME_ACCELERATION>();
+    output_writer_map["HYDRAULIC_DISCHARGE"] = std::make_unique<NodeHYDRAULIC_DISCHARGE>();
+    output_writer_map["HYDRAULIC_HEAD"]      = std::make_unique<NodeHYDRAULIC_HEAD>();
+
+    for (const auto& name : rOutputItemNames)
+    {
+        output_writer_map.at(name)->write(rGidIO, rModelPart);
+    }
+}
+
+
+void GeoOutputWriter::WriteIntegrationPointOutput(const std::vector<std::string>& rOutputItemNames,
+                                                  GidIO<>&                        rGidIO,
+                                                  ModelPart&                      rModelPart)
+{
+    std::map<std::string, std::unique_ptr<GaussOperation>, std::less<>> output_writer_map;
+    output_writer_map["FLUID_FLUX_VECTOR"]         = std::make_unique<GaussFLUID_FLUX_VECTOR>();
+    output_writer_map["HYDRAULIC_HEAD"]            = std::make_unique<GaussHYDRAULIC_HEAD>();
+    output_writer_map["LOCAL_FLUID_FLUX_VECTOR"]   = std::make_unique<GaussLOCAL_FLUID_FLUX_VECTOR>();
+    output_writer_map["LOCAL_PERMEABILITY_MATRIX"] = std::make_unique<GaussLOCAL_PERMEABILITY_MATRIX>();
+    output_writer_map["PERMEABILITY_MATRIX"]       = std::make_unique<GaussPERMEABILITY_MATRIX>();
+    output_writer_map["DEGREE_OF_SATURATION"]      = std::make_unique<GaussDEGREE_OF_SATURATION>();
+    output_writer_map["DERIVATIVE_OF_SATURATION"]  = std::make_unique<GaussDERIVATIVE_OF_SATURATION>();
+    output_writer_map["RELATIVE_PERMEABILITY"]     = std::make_unique<GaussRELATIVE_PERMEABILITY>();
+    output_writer_map["PIPE_ACTIVE"]               = std::make_unique<GaussPIPE_ACTIVE>();
+    output_writer_map["PIPE_HEIGHT"]               = std::make_unique<GaussPIPE_HEIGHT>();
+
+    for (const auto& name : rOutputItemNames)
+    {
+        output_writer_map.at(name)->write(rGidIO, rModelPart);
+    }
+}
+
+
+void GeoOutputWriter::CalculateNodalHydraulicHead(GidIO<>& rGidIO, ModelPart& rModelPart)
+{
+    const auto& element_var = KratosComponents<Variable<double>>::Get("HYDRAULIC_HEAD");
+
+    for (Element element : rModelPart.Elements())
+    {
+        auto& rGeom = element.GetGeometry();
+        const auto& rProp = element.GetProperties();
+
+        const auto NodalHydraulicHead = GeoElementUtilities::CalculateNodalHydraulicHeadFromWaterPressures<3>(rGeom, rProp);
+
+        for (unsigned int node = 0; node < 3; ++node)
+        {
+            rGeom[node].SetValue(element_var, NodalHydraulicHead[node]);
+        }
+    }
+    rGidIO.WriteNodalResultsNonHistorical(element_var, rModelPart.Nodes(), 0);
+}
+
+GiD_PostMode GeoOutputWriter::GetGiDPostModeFrom(const Parameters& rGiDPostFlags)
+{
+    const std::map<std::string, GiD_PostMode, std::less<>> to_post_mode{
+        {"GiD_PostAscii",       GiD_PostAscii},
+        {"GiD_PostAsciiZipped", GiD_PostAsciiZipped},
+        {"GiD_PostBinary",      GiD_PostBinary},
+        {"GiD_PostHDF5",        GiD_PostHDF5}
+    };
+    return to_post_mode.at(rGiDPostFlags["GiDPostMode"].GetString());
+}
+
+MultiFileFlag GeoOutputWriter::GetMultiFileFlagFrom(const Parameters& rGiDPostFlags)
+{
+    const std::map<std::string, MultiFileFlag, std::less<>> to_multi_file_flag{
+        {"SingleFile",    SingleFile},
+        {"MultipleFiles", MultipleFiles}
+    };
+    return to_multi_file_flag.at(rGiDPostFlags["MultiFileFlag"].GetString());
+}
+
+WriteDeformedMeshFlag GeoOutputWriter::GetWriteDeformedMeshFlagFrom(const Parameters& rGiDPostFlags)
+{
+    const std::map<std::string, WriteDeformedMeshFlag, std::less<>> to_write_deformed_flag{
+        {"WriteDeformed",   WriteDeformed},
+        {"WriteUndeformed", WriteUndeformed}
+    };
+    return to_write_deformed_flag.at(rGiDPostFlags["WriteDeformedMeshFlag"].GetString());
+}
+
+WriteConditionsFlag GeoOutputWriter::GetWriteConditionsFlagFrom(const Parameters& rGiDPostFlags)
+{
+    const std::map<std::string, WriteConditionsFlag, std::less<>> to_write_conditions_flag{
+        {"WriteConditions",     WriteConditions},
+        {"WriteElementsOnly",   WriteElementsOnly},
+        {"WriteConditionsOnly", WriteConditionsOnly}
+    };
+    return to_write_conditions_flag.at(rGiDPostFlags["WriteConditionsFlag"].GetString());
+}
+
+}

--- a/applications/GeoMechanicsApplication/custom_workflows/write_output.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/write_output.h
@@ -1,0 +1,57 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Anne van de Graaf
+//
+
+#pragma once
+
+#include <string>
+
+#include "includes/kratos_parameters.h"
+#include "includes/gid_io.h"
+
+
+namespace Kratos
+{
+
+class Model;
+class ModelPart;
+
+// A collection of functions to write output to files. According to Kratos' coding style we should use static member
+// functions rather than nonmember (i.e. free) functions. See
+// https://github.com/KratosMultiphysics/Kratos/wiki/Namespaces-vs-Static-Classes for details.
+class GeoOutputWriter
+{
+public:
+    GeoOutputWriter() = delete;
+    ~GeoOutputWriter() = delete;
+    GeoOutputWriter(const GeoOutputWriter&) = delete;
+    GeoOutputWriter& operator=(const GeoOutputWriter&) = delete;
+
+    static void WriteGiDOutput(ModelPart&         rModelPart,
+                               Parameters         Settings,
+                               const std::string& rWorkingDirectory);
+
+private:
+    static void WriteNodalOutput(const std::vector<std::string>& rOutputItemNames,
+                                 GidIO<>&                        rGidIO,
+                                 ModelPart&                      rModelPart);
+    static void WriteIntegrationPointOutput(const std::vector<std::string>& rOutputItemNames,
+                                            GidIO<>&                        rGidIO,
+                                            ModelPart&                      rModelPart);
+    static void CalculateNodalHydraulicHead(GidIO<>& rGidIO, ModelPart &rModelPart);
+
+    static GiD_PostMode GetGiDPostModeFrom(const Parameters& rGiDPostFlags);
+    static MultiFileFlag GetMultiFileFlagFrom(const Parameters& rGiDPostFlags);
+    static WriteDeformedMeshFlag GetWriteDeformedMeshFlagFrom(const Parameters& rGiDPostFlags);
+    static WriteConditionsFlag GetWriteConditionsFlagFrom(const Parameters& rGiDPostFlags);
+};
+
+}


### PR DESCRIPTION
**📝 Description**
Moved writing of GiD output to a new class in order to reuse it for our settlement application.


**🆕 Changelog**
- Extracted some code to new functions to make it easier to read.
- Renamed a few things to make their meanings clearer and to comply with Kratos' Style Guide.
- Avoid making unnecessary copies of objects.
- Removed an unused member function parameter.
- Removed a commented-out `#include` as well as an unused one.
- Broke a few long lines down to shorter ones.
- Removed some redundant intermediate variables.
- Populate some (now immutable) maps on construction.
- Fixed a few code smells by using transparent comparators.
- Prefer member `at` when the intention is to look up items only.
- Be consistent when choosing C++ types.