### PR TITLE
[MPM] Kinematic update of particles

### DIFF
--- a/applications/ParticleMechanicsApplication/custom_elements/mpm_updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/mpm_updated_lagrangian.cpp
@@ -963,6 +963,7 @@ void MPMUpdatedLagrangian::UpdateGaussPoint( GeneralVariables & rVariables, cons
     const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
 
     const array_1d<double,3> & MP_PreviousVelocity = mMP.velocity;
+    const array_1d<double,3> & MP_PreviousAcceleration = mMP.acceleration;
 
     array_1d<double,3> delta_xg = ZeroVector(3);
     array_1d<double,3> MP_acceleration = ZeroVector(3);
@@ -999,12 +1000,14 @@ void MPMUpdatedLagrangian::UpdateGaussPoint( GeneralVariables & rVariables, cons
     /* NOTE:
     Update velocity with Newmark integration rule 
     This assumes newmark (since n.gamma=0.5 and beta=0.25) rule of integration*/
-    mMP.velocity = 2.0/delta_time* delta_xg -  MP_PreviousVelocity;
+    if (std::abs(std::sqrt(MP_PreviousAcceleration[0]*MP_PreviousAcceleration[0]+MP_PreviousAcceleration[1]*MP_PreviousAcceleration[1]+MP_PreviousAcceleration[2]*MP_PreviousAcceleration[2]))<std::numeric_limits<double>::epsilon())
+        mMP.velocity = 2.0/delta_time* delta_xg -  MP_PreviousVelocity;
+    else
+        mMP.velocity = MP_PreviousVelocity + 0.5 * delta_time * (MP_acceleration + MP_PreviousAcceleration);
 
     /* NOTE: The following interpolation techniques have been tried:
         MP_acceleration = 4/(delta_time * delta_time) * delta_xg - 4/delta_time * MP_PreviousVelocity;
         MP_velocity = 2.0/delta_time * delta_xg - MP_PreviousVelocity;
-        mMP.velocity = mMP.velocity + 0.5 * delta_time * (MP_acceleration + mMP.acceleration);
     */
 
     // Update the MP Position

--- a/applications/ParticleMechanicsApplication/custom_elements/mpm_updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/mpm_updated_lagrangian.cpp
@@ -1000,7 +1000,7 @@ void MPMUpdatedLagrangian::UpdateGaussPoint( GeneralVariables & rVariables, cons
     /* NOTE:
     Update velocity with Newmark integration rule 
     This assumes newmark (since n.gamma=0.5 and beta=0.25) rule of integration*/
-    if (std::abs(std::sqrt(MP_PreviousAcceleration[0]*MP_PreviousAcceleration[0]+MP_PreviousAcceleration[1]*MP_PreviousAcceleration[1]+MP_PreviousAcceleration[2]*MP_PreviousAcceleration[2]))<std::numeric_limits<double>::epsilon())
+    if (std::sqrt(MP_PreviousAcceleration[0]*MP_PreviousAcceleration[0]+MP_PreviousAcceleration[1]*MP_PreviousAcceleration[1]+MP_PreviousAcceleration[2]*MP_PreviousAcceleration[2])<std::numeric_limits<double>::epsilon())
         mMP.velocity = 2.0/delta_time* delta_xg -  MP_PreviousVelocity;
     else
         mMP.velocity = MP_PreviousVelocity + 0.5 * delta_time * (MP_acceleration + MP_PreviousAcceleration);

--- a/applications/ParticleMechanicsApplication/custom_elements/mpm_updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/mpm_updated_lagrangian.cpp
@@ -962,7 +962,6 @@ void MPMUpdatedLagrangian::UpdateGaussPoint( GeneralVariables & rVariables, cons
     const unsigned int number_of_nodes = GetGeometry().PointsNumber();
     const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
 
-    const array_1d<double,3> & MP_PreviousAcceleration = mMP.acceleration;
     const array_1d<double,3> & MP_PreviousVelocity = mMP.velocity;
 
     array_1d<double,3> delta_xg = ZeroVector(3);

--- a/applications/ParticleMechanicsApplication/custom_elements/mpm_updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/mpm_updated_lagrangian.cpp
@@ -998,13 +998,14 @@ void MPMUpdatedLagrangian::UpdateGaussPoint( GeneralVariables & rVariables, cons
     }
 
     /* NOTE:
-    Another way to update the MP velocity (see paper Guilkey and Weiss, 2003).
-    This assume newmark (or trapezoidal, since n.gamma=0.5) rule of integration*/
-    mMP.velocity = MP_PreviousVelocity + 0.5 * delta_time * (MP_acceleration + MP_PreviousAcceleration);
+    Update velocity with Newmark integration rule 
+    This assumes newmark (since n.gamma=0.5 and beta=0.25) rule of integration*/
+    mMP.velocity = 2.0/delta_time* delta_xg -  MP_PreviousVelocity;
 
     /* NOTE: The following interpolation techniques have been tried:
         MP_acceleration = 4/(delta_time * delta_time) * delta_xg - 4/delta_time * MP_PreviousVelocity;
         MP_velocity = 2.0/delta_time * delta_xg - MP_PreviousVelocity;
+        mMP.velocity = mMP.velocity + 0.5 * delta_time * (MP_acceleration + mMP.acceleration);
     */
 
     // Update the MP Position

--- a/applications/ParticleMechanicsApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
@@ -174,6 +174,8 @@ void MPMUpdatedLagrangianUP::UpdateGaussPoint( GeneralVariables & rVariables, co
     const unsigned int number_of_nodes = r_geometry.PointsNumber();
     unsigned int dimension = r_geometry.WorkingSpaceDimension();
 
+    const array_1d<double,3> & MP_PreviousVelocity = mMP.velocity;
+
     array_1d<double,3> delta_xg = ZeroVector(3);
     array_1d<double,3> MP_acceleration = ZeroVector(3);
     array_1d<double,3> MP_velocity = ZeroVector(3);
@@ -210,14 +212,16 @@ void MPMUpdatedLagrangianUP::UpdateGaussPoint( GeneralVariables & rVariables, co
 
     }
 
+    
     /* NOTE:
-    Another way to update the MP velocity (see paper Guilkey and Weiss, 2003).
-    This assume newmark (or trapezoidal, since n.gamma=0.5) rule of integration*/
-    mMP.velocity = mMP.velocity + 0.5 * delta_time * (MP_acceleration + mMP.acceleration);
+    Update velocity with Newmark integration rule 
+    This assumes newmark (since n.gamma=0.5 and beta=0.25) rule of integration*/
+    mMP.velocity = 2.0/delta_time* delta_xg -  MP_PreviousVelocity;
 
     /* NOTE: The following interpolation techniques have been tried:
         MP_acceleration = 4/(delta_time * delta_time) * delta_xg - 4/delta_time * MP_PreviousVelocity;
         MP_velocity = 2.0/delta_time * delta_xg - MP_PreviousVelocity;
+        mMP.velocity = mMP.velocity + 0.5 * delta_time * (MP_acceleration + mMP.acceleration); 
     */
 
     // Update the MP Pressure

--- a/applications/ParticleMechanicsApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
@@ -217,7 +217,7 @@ void MPMUpdatedLagrangianUP::UpdateGaussPoint( GeneralVariables & rVariables, co
     /* NOTE:
     Update velocity with Newmark integration rule 
     This assumes newmark (since n.gamma=0.5 and beta=0.25) rule of integration*/
-    if (std::abs(std::sqrt(MP_PreviousAcceleration[0]*MP_PreviousAcceleration[0]+MP_PreviousAcceleration[1]*MP_PreviousAcceleration[1]+MP_PreviousAcceleration[2]*MP_PreviousAcceleration[2]))<std::numeric_limits<double>::epsilon())
+    if (std::sqrt(MP_PreviousAcceleration[0]*MP_PreviousAcceleration[0]+MP_PreviousAcceleration[1]*MP_PreviousAcceleration[1]+MP_PreviousAcceleration[2]*MP_PreviousAcceleration[2])<std::numeric_limits<double>::epsilon())
         mMP.velocity = 2.0/delta_time* delta_xg -  MP_PreviousVelocity;
     else
         mMP.velocity = MP_PreviousVelocity + 0.5 * delta_time * (MP_acceleration + MP_PreviousAcceleration);

--- a/applications/ParticleMechanicsApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/mpm_updated_lagrangian_UP.cpp
@@ -175,6 +175,7 @@ void MPMUpdatedLagrangianUP::UpdateGaussPoint( GeneralVariables & rVariables, co
     unsigned int dimension = r_geometry.WorkingSpaceDimension();
 
     const array_1d<double,3> & MP_PreviousVelocity = mMP.velocity;
+    const array_1d<double,3> & MP_PreviousAcceleration = mMP.acceleration;
 
     array_1d<double,3> delta_xg = ZeroVector(3);
     array_1d<double,3> MP_acceleration = ZeroVector(3);
@@ -216,12 +217,14 @@ void MPMUpdatedLagrangianUP::UpdateGaussPoint( GeneralVariables & rVariables, co
     /* NOTE:
     Update velocity with Newmark integration rule 
     This assumes newmark (since n.gamma=0.5 and beta=0.25) rule of integration*/
-    mMP.velocity = 2.0/delta_time* delta_xg -  MP_PreviousVelocity;
+    if (std::abs(std::sqrt(MP_PreviousAcceleration[0]*MP_PreviousAcceleration[0]+MP_PreviousAcceleration[1]*MP_PreviousAcceleration[1]+MP_PreviousAcceleration[2]*MP_PreviousAcceleration[2]))<std::numeric_limits<double>::epsilon())
+        mMP.velocity = 2.0/delta_time* delta_xg -  MP_PreviousVelocity;
+    else
+        mMP.velocity = MP_PreviousVelocity + 0.5 * delta_time * (MP_acceleration + MP_PreviousAcceleration);
 
     /* NOTE: The following interpolation techniques have been tried:
         MP_acceleration = 4/(delta_time * delta_time) * delta_xg - 4/delta_time * MP_PreviousVelocity;
         MP_velocity = 2.0/delta_time * delta_xg - MP_PreviousVelocity;
-        mMP.velocity = mMP.velocity + 0.5 * delta_time * (MP_acceleration + mMP.acceleration); 
     */
 
     // Update the MP Pressure


### PR DESCRIPTION
Hey all,

the Newmark integration is used to update the velocity of the particles. The previous approach which updates the velocity using the accelerations is wrong for the first time step unless the particle acceleration is not set explicitly before the solution loop (which was done for gravity)


