### PR TITLE
[Core] Test XML Utilities - fix test in MVSC 2019

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_xml_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_xml_utilities.cpp
@@ -183,12 +183,12 @@ KRATOS_TEST_CASE_IN_SUITE(XmlOStreamWriterWriteDataElementAsciiDouble, KratosCor
     element.AddAttribute("attribute1", "value1");
 
     std::stringstream ss;
-    XmlOStreamAsciiWriter writer(ss, 0);
+    XmlOStreamAsciiWriter writer(ss, 1);
     writer.WriteElement(element, 1);
 
     KRATOS_CHECK_EQUAL(ss.str(),
             "   <DataArray type=\"Float64\" Name=\"data_1\" NumberOfComponents=\"3\" attribute1=\"value1\" format=\"ascii\">\n"
-            "     0e+00  1e+00  2e+00  3e+00  4e+00  5e+00  0e+00  1e+00  2e+00  3e+00  4e+00  5e+00  6e+00  7e+00  8e+00\n"
+            "     0.0e+00  1.0e+00  2.0e+00  3.0e+00  4.0e+00  5.0e+00  0.0e+00  1.0e+00  2.0e+00  3.0e+00  4.0e+00  5.0e+00  6.0e+00  7.0e+00  8.0e+00\n"
             "   </DataArray>\n");
 }
 
@@ -211,12 +211,12 @@ KRATOS_TEST_CASE_IN_SUITE(XmlOStreamWriterWriteDataElementAsciiMixed, KratosCore
     element.AddAttribute("attribute1", "value1");
 
     std::stringstream ss;
-    XmlOStreamAsciiWriter writer(ss, 0);
+    XmlOStreamAsciiWriter writer(ss, 1);
     writer.WriteElement(element, 1);
 
     KRATOS_CHECK_EQUAL(ss.str(),
             "   <DataArray type=\"Float64\" Name=\"data_1\" NumberOfComponents=\"3\" attribute1=\"value1\" format=\"ascii\">\n"
-            "     0e+00  1e+00  2e+00  3e+00  4e+00  5e+00  0e+00  1e+00  2e+00  3e+00  4e+00  5e+00  6e+00  7e+00  8e+00\n"
+            "     0.0e+00  1.0e+00  2.0e+00  3.0e+00  4.0e+00  5.0e+00  0.0e+00  1.0e+00  2.0e+00  3.0e+00  4.0e+00  5.0e+00  6.0e+00  7.0e+00  8.0e+00\n"
             "   </DataArray>\n");
 }
 


### PR DESCRIPTION
For some reason. std::setprecision(0) is not working with MSVC 2019 (at least it did not work properly in the two machines I tried with this compiler). Instead of setting number of printing the number without decimal values, it uses the default settings (5 decimals if I remember correctly).
If I use any other value it works correctly. As we do not have license for 2022 version in @KratosMultiphysics/altair I changed the test to use setprecision(1). I hope this is ok with you @sunethwarna 
