### PR TITLE
[Core] TestConditionContainerExpression - skip test with more than 7 cores

### DIFF
--- a/kratos/tests/test_container_expression.py
+++ b/kratos/tests/test_container_expression.py
@@ -650,6 +650,8 @@ class TestNodalContainerExpression(kratos_unittest.TestCase, TestContainerExpres
     def _Evaluate(self, container_expression, variable):
         Kratos.Expression.VariableExpressionIO.Write(container_expression, variable, False)
 
+#This test does not work when using more than 7 cores, because then some partitions do not have conditions
+@kratos_unittest.skipIf( Kratos.Testing.GetDefaultDataCommunicator().Size() > 7, "This test does not work for more than 7 cores.")
 class TestConditionContainerExpression(kratos_unittest.TestCase, TestContainerExpression):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
This test fails with more than 7 cores as mentioned here https://github.com/KratosMultiphysics/Kratos/issues/10983 because the condition container is empty, I'm skipping the test with more than 7 cores until a proper fix is done.
