### PR TITLE
[Core] Bugfix for ContainerExpression segfaulting in MPI when some ranks are empty.

### DIFF
--- a/kratos/expression/container_expression.cpp
+++ b/kratos/expression/container_expression.cpp
@@ -255,7 +255,7 @@ void ContainerExpression<TContainerType, TMeshType>::Evaluate(
         << NumberOfEntities
         << ", local container size = " << this->GetContainer().size() << " ].\n";
 
-    CArrayExpressionIO::Output(pBegin, NumberOfEntities * std::accumulate(pShapeBegin, pShapeBegin+ShapeSize, 1, [](const int V1, const int V2) { return V1 * V2; })).Execute(**this->mpExpression);
+    CArrayExpressionIO::Output(pBegin, NumberOfEntities * std::accumulate(pShapeBegin, pShapeBegin+ShapeSize, 1, [](const int V1, const int V2) { return V1 * V2; })).Execute(*this->mpExpression.value());
 
     KRATOS_CATCH("");
 }
@@ -289,14 +289,14 @@ bool ContainerExpression<TContainerType, TMeshType>::HasExpression() const
 template <class TContainerType, MeshType TMeshType>
 const Expression& ContainerExpression<TContainerType, TMeshType>::GetExpression() const
 {
-    return *(*mpExpression);
+    return *mpExpression.value();
 }
 
 
 template <class TContainerType, MeshType TMeshType>
 Expression::ConstPointer ContainerExpression<TContainerType, TMeshType>::pGetExpression() const
 {
-    return *mpExpression;
+    return mpExpression.value();
 }
 
 template <class TContainerType, MeshType TMeshType>
@@ -495,7 +495,7 @@ KRATOS_DEFINE_BINARY_CONTAINER_EXPRESSION_OPERATOR(Power)
     ContainerExpression<CONTAINER_TYPE, MESH_TYPE>& ContainerExpression<CONTAINER_TYPE, MESH_TYPE>::OPERATOR_NAME( \
         const double Value)                                                                                        \
     {                                                                                                              \
-        this->mpExpression = EXPRESSION_OPERATOR_NAME(*this->mpExpression, Value);                                 \
+        this->mpExpression = EXPRESSION_OPERATOR_NAME(this->mpExpression.value(), Value);                          \
         return *this;                                                                                              \
     }                                                                                                              \
     template <>                                                                                                    \
@@ -503,7 +503,7 @@ KRATOS_DEFINE_BINARY_CONTAINER_EXPRESSION_OPERATOR(Power)
         const ContainerExpression<CONTAINER_TYPE, MESH_TYPE>& Value)                                               \
     {                                                                                                              \
         this->mpExpression =                                                                                       \
-            EXPRESSION_OPERATOR_NAME(*this->mpExpression, Value.pGetExpression());                                 \
+            EXPRESSION_OPERATOR_NAME(this->mpExpression.value(), Value.pGetExpression());                          \
         return *this;                                                                                              \
     }
 
@@ -539,7 +539,7 @@ KRATOS_DEFINE_BINARY_CONTAINER_EXPRESSION_OPERATOR(Power)
         const ContainerExpression<CONTAINER_TYPE, MESH_TYPE>& rScaling)                                    \
     {                                                                                                      \
         this->mpExpression =                                                                               \
-            Kratos::Scale(*this->mpExpression, rScaling.pGetExpression());                                 \
+            Kratos::Scale(this->mpExpression.value(), rScaling.pGetExpression());                          \
         return *this;                                                                                      \
     }
 

--- a/kratos/expression/variable_expression_io.cpp
+++ b/kratos/expression/variable_expression_io.cpp
@@ -113,11 +113,7 @@ void VariableExpressionIO::Read(
                                 TMeshType)
             .Execute();
 
-    // p_expression is nullptr if there are no items in the ModelParts relevant container.
-    // such as in ghost containers or interface containers.
-    if (p_expression.get() != nullptr) {
-        rContainerExpression.SetExpression(p_expression);
-    }
+    rContainerExpression.SetExpression(p_expression);
 }
 
 template<class TContainerType, MeshType TMeshType>
@@ -137,11 +133,7 @@ void VariableExpressionIO::Read(
                                 TMeshType)
             .Execute();
 
-    // p_expression is nullptr if there are no items in the ModelParts relevant container.
-    // such as in ghost containers or interface containers.
-    if (p_expression.get() != nullptr) {
-        rContainerExpression.SetExpression(p_expression);
-    }
+    rContainerExpression.SetExpression(p_expression);
 }
 
 template<MeshType TMeshType>

--- a/kratos/expression/variable_expression_io.cpp
+++ b/kratos/expression/variable_expression_io.cpp
@@ -37,22 +37,23 @@ VariableExpressionIO::VariableExpressionInput::VariableExpressionInput(
 Expression::Pointer VariableExpressionIO::VariableExpressionInput::Execute() const
 {
     const auto& r_mesh = ExpressionIOUtils::GetMesh(mrModelPart.GetCommunicator(), mMeshType);
+    const auto& r_data_communicator = mrModelPart.GetCommunicator().GetDataCommunicator();
 
     switch (mContainerType) {
         case ContainerType::NodalHistorical: {
-                return ExpressionIOUtils::ReadToExpression<ModelPart::NodesContainerType, ContainerDataIO<ContainerDataIOTags::Historical>, const VariableType>(r_mesh.Nodes(), mpVariable);
+                return ExpressionIOUtils::ReadToExpression<ModelPart::NodesContainerType, ContainerDataIO<ContainerDataIOTags::Historical>, const VariableType>(r_mesh.Nodes(), mpVariable, r_data_communicator);
                 break;
             }
         case ContainerType::NodalNonHistorical: {
-                return ExpressionIOUtils::ReadToExpression<ModelPart::NodesContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Nodes(), mpVariable);
+                return ExpressionIOUtils::ReadToExpression<ModelPart::NodesContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Nodes(), mpVariable, r_data_communicator);
                 break;
             }
         case ContainerType::ConditionNonHistorical: {
-                return ExpressionIOUtils::ReadToExpression<ModelPart::ConditionsContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Conditions(), mpVariable);
+                return ExpressionIOUtils::ReadToExpression<ModelPart::ConditionsContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Conditions(), mpVariable, r_data_communicator);
                 break;
             }
         case ContainerType::ElementNonHistorical: {
-                return ExpressionIOUtils::ReadToExpression<ModelPart::ElementsContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Elements(), mpVariable);
+                return ExpressionIOUtils::ReadToExpression<ModelPart::ElementsContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Elements(), mpVariable, r_data_communicator);
                 break;
             }
         default: {

--- a/kratos/tests/test_container_expression.py
+++ b/kratos/tests/test_container_expression.py
@@ -650,8 +650,6 @@ class TestNodalContainerExpression(kratos_unittest.TestCase, TestContainerExpres
     def _Evaluate(self, container_expression, variable):
         Kratos.Expression.VariableExpressionIO.Write(container_expression, variable, False)
 
-#This test does not work when using more than 7 cores, because then some partitions do not have conditions
-@kratos_unittest.skipIf( Kratos.Testing.GetDefaultDataCommunicator().Size() > 7, "This test does not work for more than 7 cores.")
 class TestConditionContainerExpression(kratos_unittest.TestCase, TestContainerExpression):
     @classmethod
     def setUpClass(cls):

--- a/kratos/tests/test_container_expression.py
+++ b/kratos/tests/test_container_expression.py
@@ -580,6 +580,15 @@ class TestContainerExpression(ABC):
         a = self._GetContainerExpression()
         self.assertEqual(self._GetContainer(), a.GetContainer())
 
+    def test_EmptyContainer(self):
+        model_part = self.model.CreateModelPart("empty_model_part")
+        a = type(self._GetContainerExpression())(model_part)
+        self._Read(a, Kratos.VELOCITY)
+
+        a *= 3
+        self._Evaluate(a, Kratos.ACCELERATION)
+        self.assertEqual(a.Evaluate().shape, (0, ))
+
     @abstractmethod
     def _GetContainerExpression(self) -> Union[Kratos.Expression.NodalExpression, Kratos.Expression.ElementExpression, Kratos.Expression.ConditionExpression]:
         pass


### PR DESCRIPTION
**📝 Description**
This fixes #10983. 

The failure was happening due to some containers in some ranks not having any entities, hence could not deduce the shape information of the variable types of `Vector` and `Matrix` types. The fix properly communicates the sizes now.

@ddiezrod Could you also please check this?

**🆕 Changelog**
- Fixes #10983 .
