### PR TITLE
[Core] Fix unity build conflict in test

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_polynomial_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_polynomial_utilities.cpp
@@ -19,13 +19,13 @@
 #include "testing/testing.h"
 #include "utilities/polynomial_utilities.h"
 
-namespace Kratos::Testing {
+namespace Kratos::Testing::PolynomialUtilitiesTests {
 
 namespace {
     using Polynomial = PolynomialUtilities::PolynomialType;
     using Interval = PolynomialUtilities::IntervalType;
     using RootIntervals = std::vector<PolynomialUtilities::IntervalType>;
-    constexpr double POLYNOMIAL_TOLERANCE = 1e-9;
+    constexpr double TOLERANCE = 1e-9;
 
     void CheckExactlyOneIntervalContains(const RootIntervals& rIntervals, double Coordinate) {
         std::size_t containing = 0;
@@ -47,15 +47,15 @@ KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesDegree, KratosCoreFastSuite) {
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesEvaluate, KratosCoreFastSuite) {
     Polynomial p{1.0, 2.0, 3.0, 4.0}; // x^3 + 2x^2 + 3x + 4
 
-    KRATOS_CHECK_NEAR(PolynomialUtilities::Evaluate(p, 0.0), 4.0, POLYNOMIAL_TOLERANCE);
-    KRATOS_CHECK_NEAR(PolynomialUtilities::Evaluate(p, 0.5), 6.125, POLYNOMIAL_TOLERANCE);
+    KRATOS_CHECK_NEAR(PolynomialUtilities::Evaluate(p, 0.0), 4.0, TOLERANCE);
+    KRATOS_CHECK_NEAR(PolynomialUtilities::Evaluate(p, 0.5), 6.125, TOLERANCE);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesDifferentiate, KratosCoreFastSuite) {
     Polynomial p{1.0, 2.0, 3.0, 4.0}; // x^3 + 2x^2 + 3x + 4
     Polynomial d{3.0, 4.0, 3.0}; // 3x^2 + 4x + 3
 
-    KRATOS_CHECK_VECTOR_NEAR(PolynomialUtilities::Differentiate(p), d, POLYNOMIAL_TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(PolynomialUtilities::Differentiate(p), d, TOLERANCE);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesMultiply, KratosCoreFastSuite) {
@@ -63,7 +63,7 @@ KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesMultiply, KratosCoreFastSuite) {
     Polynomial b{4.0, 5.0}; // 4x + 5
     Polynomial c{4.0, 13.0, 22.0, 15.0}; // 4x^3 + 13x^2 + 22x + 15
 
-    KRATOS_CHECK_VECTOR_NEAR(PolynomialUtilities::Multiply(a, b), c, POLYNOMIAL_TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(PolynomialUtilities::Multiply(a, b), c, TOLERANCE);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesDivide, KratosCoreFastSuite) {
@@ -76,13 +76,13 @@ KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesDivide, KratosCoreFastSuite) {
     Polynomial expected_quotient{1.0/4.0, 3.0/16.0};
     Polynomial expected_remainder{33.0/16.0};
 
-    KRATOS_CHECK_VECTOR_NEAR(q, expected_quotient, POLYNOMIAL_TOLERANCE);
-    KRATOS_CHECK_VECTOR_NEAR(r, expected_remainder, POLYNOMIAL_TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(q, expected_quotient, TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(r, expected_remainder, TOLERANCE);
 
     Polynomial c{4.0, 13.0, 22.0, 15.0}; // a*b
     PolynomialUtilities::Divide(q, r, c, a);
-    KRATOS_CHECK_VECTOR_NEAR(q, b, POLYNOMIAL_TOLERANCE);
-    KRATOS_CHECK_VECTOR_NEAR(r, Polynomial{0.0}, POLYNOMIAL_TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(q, b, TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(r, Polynomial{0.0}, TOLERANCE);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesIsolateRoots, KratosCoreFastSuite) {
@@ -106,9 +106,9 @@ KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesIsolateRoots, KratosCoreFastSuite) 
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesFindRoot, KratosCoreFastSuite) {
     Polynomial a{1.06, 0.75, -0.26, -0.175}; // Has three roots in [-1, 1]
 
-    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{-1, -0.5}), -0.7360625845831237, POLYNOMIAL_TOLERANCE);
-    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{-0.5, 0}), -0.45955361708183773, POLYNOMIAL_TOLERANCE);
-    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{0, 1}), 0.4880690318514098, POLYNOMIAL_TOLERANCE);
+    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{-1, -0.5}), -0.7360625845831237, TOLERANCE);
+    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{-0.5, 0}), -0.45955361708183773, TOLERANCE);
+    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{0, 1}), 0.4880690318514098, TOLERANCE);
 }
 
 }

--- a/kratos/tests/cpp_tests/utilities/test_polynomial_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_polynomial_utilities.cpp
@@ -27,15 +27,14 @@ namespace {
     using RootIntervals = std::vector<PolynomialUtilities::IntervalType>;
     constexpr double TOLERANCE = 1e-9;
 
-    void CheckExactlyOneIntervalContains(const RootIntervals& rIntervals, double Coordinate) {
+    std::size_t CountIntervalsContaining(const RootIntervals& rIntervals, double Coordinate) {
         std::size_t containing = 0;
         for (const auto& range: rIntervals) {
             if (range[0] <= Coordinate && range[1] >= Coordinate) {
                 ++containing;
             }
         }
-        KRATOS_ERROR_IF(containing > 1) << "More than one interval contains coordinate " << Coordinate << std::endl;
-        KRATOS_ERROR_IF(containing == 0) << "No interval contains coordinate " << Coordinate << std::endl;
+        return containing;
     }
 }
 
@@ -91,13 +90,13 @@ KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesIsolateRoots, KratosCoreFastSuite) 
 
     PolynomialUtilities::IsolateRoots(intervals, a, Interval{-1, 1});
     KRATOS_CHECK_EQUAL(intervals.size(), 3);
-    CheckExactlyOneIntervalContains(intervals, -0.7360625845831237);
-    CheckExactlyOneIntervalContains(intervals, -0.45955361708183773);
-    CheckExactlyOneIntervalContains(intervals,  0.4880690318514098);
+    KRATOS_CHECK_EQUAL(CountIntervalsContaining(intervals, -0.7360625845831237), 1);
+    KRATOS_CHECK_EQUAL(CountIntervalsContaining(intervals, -0.45955361708183773), 1);
+    KRATOS_CHECK_EQUAL(CountIntervalsContaining(intervals,  0.4880690318514098), 1);
 
     PolynomialUtilities::IsolateRoots(intervals, a, Interval{0, 1});
     KRATOS_CHECK_EQUAL(intervals.size(), 1);
-    CheckExactlyOneIntervalContains(intervals, 0.4880690318514098);
+    KRATOS_CHECK_EQUAL(CountIntervalsContaining(intervals, 0.4880690318514098), 1);
 
     PolynomialUtilities::IsolateRoots(intervals, a, Interval{-2, -1});
     KRATOS_CHECK_EQUAL(intervals.size(), 0);

--- a/kratos/tests/cpp_tests/utilities/test_polynomial_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_polynomial_utilities.cpp
@@ -25,7 +25,7 @@ namespace {
     using Polynomial = PolynomialUtilities::PolynomialType;
     using Interval = PolynomialUtilities::IntervalType;
     using RootIntervals = std::vector<PolynomialUtilities::IntervalType>;
-    constexpr double TOLERANCE = 1e-9;
+    constexpr double POLYNOMIAL_TOLERANCE = 1e-9;
 
     void CheckExactlyOneIntervalContains(const RootIntervals& rIntervals, double Coordinate) {
         std::size_t containing = 0;
@@ -47,15 +47,15 @@ KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesDegree, KratosCoreFastSuite) {
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesEvaluate, KratosCoreFastSuite) {
     Polynomial p{1.0, 2.0, 3.0, 4.0}; // x^3 + 2x^2 + 3x + 4
 
-    KRATOS_CHECK_NEAR(PolynomialUtilities::Evaluate(p, 0.0), 4.0, TOLERANCE);
-    KRATOS_CHECK_NEAR(PolynomialUtilities::Evaluate(p, 0.5), 6.125, TOLERANCE);
+    KRATOS_CHECK_NEAR(PolynomialUtilities::Evaluate(p, 0.0), 4.0, POLYNOMIAL_TOLERANCE);
+    KRATOS_CHECK_NEAR(PolynomialUtilities::Evaluate(p, 0.5), 6.125, POLYNOMIAL_TOLERANCE);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesDifferentiate, KratosCoreFastSuite) {
     Polynomial p{1.0, 2.0, 3.0, 4.0}; // x^3 + 2x^2 + 3x + 4
     Polynomial d{3.0, 4.0, 3.0}; // 3x^2 + 4x + 3
 
-    KRATOS_CHECK_VECTOR_NEAR(PolynomialUtilities::Differentiate(p), d, TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(PolynomialUtilities::Differentiate(p), d, POLYNOMIAL_TOLERANCE);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesMultiply, KratosCoreFastSuite) {
@@ -63,7 +63,7 @@ KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesMultiply, KratosCoreFastSuite) {
     Polynomial b{4.0, 5.0}; // 4x + 5
     Polynomial c{4.0, 13.0, 22.0, 15.0}; // 4x^3 + 13x^2 + 22x + 15
 
-    KRATOS_CHECK_VECTOR_NEAR(PolynomialUtilities::Multiply(a, b), c, TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(PolynomialUtilities::Multiply(a, b), c, POLYNOMIAL_TOLERANCE);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesDivide, KratosCoreFastSuite) {
@@ -76,13 +76,13 @@ KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesDivide, KratosCoreFastSuite) {
     Polynomial expected_quotient{1.0/4.0, 3.0/16.0};
     Polynomial expected_remainder{33.0/16.0};
 
-    KRATOS_CHECK_VECTOR_NEAR(q, expected_quotient, TOLERANCE);
-    KRATOS_CHECK_VECTOR_NEAR(r, expected_remainder, TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(q, expected_quotient, POLYNOMIAL_TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(r, expected_remainder, POLYNOMIAL_TOLERANCE);
 
     Polynomial c{4.0, 13.0, 22.0, 15.0}; // a*b
     PolynomialUtilities::Divide(q, r, c, a);
-    KRATOS_CHECK_VECTOR_NEAR(q, b, TOLERANCE);
-    KRATOS_CHECK_VECTOR_NEAR(r, Polynomial{0.0}, TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(q, b, POLYNOMIAL_TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(r, Polynomial{0.0}, POLYNOMIAL_TOLERANCE);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesIsolateRoots, KratosCoreFastSuite) {
@@ -106,9 +106,9 @@ KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesIsolateRoots, KratosCoreFastSuite) 
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesFindRoot, KratosCoreFastSuite) {
     Polynomial a{1.06, 0.75, -0.26, -0.175}; // Has three roots in [-1, 1]
 
-    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{-1, -0.5}), -0.7360625845831237, TOLERANCE);
-    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{-0.5, 0}), -0.45955361708183773, TOLERANCE);
-    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{0, 1}), 0.4880690318514098, TOLERANCE);
+    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{-1, -0.5}), -0.7360625845831237, POLYNOMIAL_TOLERANCE);
+    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{-0.5, 0}), -0.45955361708183773, POLYNOMIAL_TOLERANCE);
+    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{0, 1}), 0.4880690318514098, POLYNOMIAL_TOLERANCE);
 }
 
 }


### PR DESCRIPTION
**📝 Description**

Overall, the changes in the PR include modifying the function name `CheckExactlyOneIntervalContains` to `CountIntervalsContaining` and updating its return type, as well as replacing the function calls in the test case with the modified function name. Also add a namespace to avoid conflicts with the definition `TOLERANCE`.

**🆕 Changelog**

- [Fix unity build conflict in test](https://github.com/KratosMultiphysics/Kratos/commit/816108204bfb3b9b9d281ee0b0184e328135fe6b)
