### PR TITLE
[Core] Change the signature of model part operation utilities

### DIFF
--- a/applications/OptimizationApplication/python_scripts/utilities/model_part_utilities.py
+++ b/applications/OptimizationApplication/python_scripts/utilities/model_part_utilities.py
@@ -15,7 +15,9 @@ class ModelPartUtilities:
         if main_model_part.HasSubModelPart(unique_name):
             return False, main_model_part.GetSubModelPart(unique_name)
         else:
-            return True, Kratos.ModelPartOperationUtilities.Union(unique_name, main_model_part, union_model_parts, add_neighbours)
+            unique_model_part = main_model_part.CreateSubModelPart(unique_name)
+            Kratos.ModelPartOperationUtilities.Union(unique_model_part, main_model_part, union_model_parts, add_neighbours)
+            return True, unique_model_part
 
     @staticmethod
     def IntersectModelParts(main_model_part: Kratos.ModelPart, intersecting_model_parts: 'list[Kratos.ModelPart]', add_neighbours: bool) -> 'tuple[bool, Kratos.ModelPart]':
@@ -23,7 +25,9 @@ class ModelPartUtilities:
         if main_model_part.HasSubModelPart(unique_name):
             return False, main_model_part.GetSubModelPart(unique_name)
         else:
-            return True, Kratos.ModelPartOperationUtilities.Intersect(unique_name, main_model_part, intersecting_model_parts, add_neighbours)
+            unique_model_part = main_model_part.CreateSubModelPart(unique_name)
+            Kratos.ModelPartOperationUtilities.Intersect(unique_model_part, main_model_part, intersecting_model_parts, add_neighbours)
+            return True, unique_model_part
 
     @staticmethod
     def SubstractModelParts(main_model_part: Kratos.ModelPart, substracting_model_parts: 'list[Kratos.ModelPart]', add_neighbours: bool) -> 'tuple[bool, Kratos.ModelPart]':
@@ -31,7 +35,9 @@ class ModelPartUtilities:
         if main_model_part.HasSubModelPart(unique_name):
             return False, main_model_part.GetSubModelPart(unique_name)
         else:
-            return True, Kratos.ModelPartOperationUtilities.Substract(unique_name, main_model_part, substracting_model_parts, add_neighbours)
+            unique_model_part = main_model_part.CreateSubModelPart(unique_name)
+            Kratos.ModelPartOperationUtilities.Substract(unique_model_part, main_model_part, substracting_model_parts, add_neighbours)
+            return True, unique_model_part
 
     @staticmethod
     def GetMergedMap(main_model_part: Kratos.ModelPart, input_dict: 'dict[Any, KratosOA.CollectiveExpression]', add_neghbours: bool) -> 'dict[Any, Kratos.ModelPart]':

--- a/kratos/python/add_other_utilities_to_python.cpp
+++ b/kratos/python/add_other_utilities_to_python.cpp
@@ -806,9 +806,9 @@ void AddOtherUtilitiesToPython(pybind11::module &m)
 
     m.def_submodule("ModelPartOperationUtilities", "Free-floating utility functions for model part operations.")
         .def("CheckValidityOfModelPartsForOperations", &ModelPartOperationUtilities::CheckValidityOfModelPartsForOperations, py::arg("main_model_part"), py::arg("list_of_checking_model_parts"), py::arg("thow_error"))
-        .def("Union", &ModelPartOperationUtilities::FillSubModelPartWithOperation<ModelPartUnionOperator>, py::arg("output_sub_model_part"), py::arg("main_model_part"), py::arg("model_parts_to_merge"), py::arg("add_neighbours"))
-        .def("Substract", &ModelPartOperationUtilities::FillSubModelPartWithOperation<ModelPartSubstractionOperator>, py::arg("output_sub_model_part"), py::arg("main_model_part"), py::arg("model_parts_to_substract"), py::arg("add_neighbours"))
-        .def("Intersect", &ModelPartOperationUtilities::FillSubModelPartWithOperation<ModelPartIntersectionOperator>, py::arg("output_sub_model_part"), py::arg("main_model_part"), py::arg("model_parts_to_intersect"), py::arg("add_neighbours"))
+        .def("Union", &ModelPartOperationUtilities::FillSubModelPart<ModelPartUnionOperator>, py::arg("output_sub_model_part"), py::arg("main_model_part"), py::arg("model_parts_to_merge"), py::arg("add_neighbours"))
+        .def("Substract", &ModelPartOperationUtilities::FillSubModelPart<ModelPartSubstractionOperator>, py::arg("output_sub_model_part"), py::arg("main_model_part"), py::arg("model_parts_to_substract"), py::arg("add_neighbours"))
+        .def("Intersect", &ModelPartOperationUtilities::FillSubModelPart<ModelPartIntersectionOperator>, py::arg("output_sub_model_part"), py::arg("main_model_part"), py::arg("model_parts_to_intersect"), py::arg("add_neighbours"))
         .def("HasIntersection", &ModelPartOperationUtilities::HasIntersection, py::arg("model_parts_to_intersect"))
     ;
 

--- a/kratos/python/add_other_utilities_to_python.cpp
+++ b/kratos/python/add_other_utilities_to_python.cpp
@@ -806,9 +806,9 @@ void AddOtherUtilitiesToPython(pybind11::module &m)
 
     m.def_submodule("ModelPartOperationUtilities", "Free-floating utility functions for model part operations.")
         .def("CheckValidityOfModelPartsForOperations", &ModelPartOperationUtilities::CheckValidityOfModelPartsForOperations, py::arg("main_model_part"), py::arg("list_of_checking_model_parts"), py::arg("thow_error"))
-        .def("Union", &ModelPartOperationUtilities::CreateModelPartWithOperation<ModelPartUnionOperator>, py::arg("output_model_part_name"), py::arg("main_model_part"), py::arg("model_parts_to_merge"), py::arg("add_neighbours"), py::return_value_policy::reference_internal)
-        .def("Substract", &ModelPartOperationUtilities::CreateModelPartWithOperation<ModelPartSubstractionOperator>, py::arg("output_model_part_name"), py::arg("main_model_part"), py::arg("model_parts_to_substract"), py::arg("add_neighbours"), py::return_value_policy::reference_internal)
-        .def("Intersect", &ModelPartOperationUtilities::CreateModelPartWithOperation<ModelPartIntersectionOperator>, py::arg("output_model_part_name"), py::arg("main_model_part"), py::arg("model_parts_to_intersect"), py::arg("add_neighbours"), py::return_value_policy::reference_internal)
+        .def("Union", &ModelPartOperationUtilities::FillSubModelPartWithOperation<ModelPartUnionOperator>, py::arg("output_sub_model_part"), py::arg("main_model_part"), py::arg("model_parts_to_merge"), py::arg("add_neighbours"))
+        .def("Substract", &ModelPartOperationUtilities::FillSubModelPartWithOperation<ModelPartSubstractionOperator>, py::arg("output_sub_model_part"), py::arg("main_model_part"), py::arg("model_parts_to_substract"), py::arg("add_neighbours"))
+        .def("Intersect", &ModelPartOperationUtilities::FillSubModelPartWithOperation<ModelPartIntersectionOperator>, py::arg("output_sub_model_part"), py::arg("main_model_part"), py::arg("model_parts_to_intersect"), py::arg("add_neighbours"))
         .def("HasIntersection", &ModelPartOperationUtilities::HasIntersection, py::arg("model_parts_to_intersect"))
     ;
 

--- a/kratos/tests/test_model_part_operation_utilities.py
+++ b/kratos/tests/test_model_part_operation_utilities.py
@@ -74,7 +74,8 @@ class TestModelPartOperationUtilities(KratosUnittest.TestCase):
 
     @KratosUnittest.skipIf(Kratos.IsDistributedRun(), "only the test does not support MPI")
     def test_Order(self):
-        merged_model_part = Kratos.ModelPartOperationUtilities.Union("merge_order", self.model_part, [self.model_part], False)
+        merged_model_part = self.model_part.CreateSubModelPart("merge_order")
+        Kratos.ModelPartOperationUtilities.Union(merged_model_part, self.model_part, [self.model_part], False)
 
         origin_node_ids_list = [entity.Id for entity in self.model_part.Nodes]
         origin_condition_ids_list = [entity.Id for entity in self.model_part.Conditions]
@@ -90,7 +91,8 @@ class TestModelPartOperationUtilities(KratosUnittest.TestCase):
 
     @KratosUnittest.skipIf(Kratos.IsDistributedRun(), "only the test does not support MPI")
     def test_Union(self):
-        merged_model_part = Kratos.ModelPartOperationUtilities.Union("merge_1", self.model_part, self.model_parts_list, False)
+        merged_model_part = self.model_part.CreateSubModelPart("merge_1")
+        Kratos.ModelPartOperationUtilities.Union(merged_model_part, self.model_part, self.model_parts_list, False)
 
         # check
         node_ids = []
@@ -113,12 +115,14 @@ class TestModelPartOperationUtilities(KratosUnittest.TestCase):
         self.assertEqual(sorted(condition_ids), sorted(merged_condition_ids))
         self.assertEqual(sorted(element_ids), sorted(merged_element_ids))
 
-        merged_with_neighbours_model_part = Kratos.ModelPartOperationUtilities.Union("merge_2", self.model_part, self.model_parts_list, True)
+        merged_with_neighbours_model_part = self.model_part.CreateSubModelPart("merge_2")
+        Kratos.ModelPartOperationUtilities.Union(merged_with_neighbours_model_part, self.model_part, self.model_parts_list, True)
         self.__CheckNeighbours(node_ids, element_ids, merged_model_part, merged_with_neighbours_model_part)
 
     @KratosUnittest.skipIf(Kratos.IsDistributedRun(), "only the test does not support MPI")
     def test_Substract(self):
-        merged_model_part = Kratos.ModelPartOperationUtilities.Substract("substract_1", self.model_part, self.model_parts_list, False)
+        substracted_model_part = self.model_part.CreateSubModelPart("substract_1")
+        Kratos.ModelPartOperationUtilities.Substract(substracted_model_part, self.model_part, self.model_parts_list, False)
 
         # check
         node_ids = TestModelPartOperationUtilities.__GenerateUniqueIdsList(self.model_part.Nodes)
@@ -151,20 +155,22 @@ class TestModelPartOperationUtilities(KratosUnittest.TestCase):
             node_ids.extend([node.Id for node in self.model_part.GetElement(element_id).GetGeometry()])
         node_ids = list(set(node_ids))
 
-        merged_node_ids = list(set(TestModelPartOperationUtilities.__GenerateUniqueIdsList(merged_model_part.Nodes)))
-        merged_condition_ids = list(set(TestModelPartOperationUtilities.__GenerateUniqueIdsList(merged_model_part.Conditions)))
-        merged_element_ids = list(set(TestModelPartOperationUtilities.__GenerateUniqueIdsList(merged_model_part.Elements)))
+        merged_node_ids = list(set(TestModelPartOperationUtilities.__GenerateUniqueIdsList(substracted_model_part.Nodes)))
+        merged_condition_ids = list(set(TestModelPartOperationUtilities.__GenerateUniqueIdsList(substracted_model_part.Conditions)))
+        merged_element_ids = list(set(TestModelPartOperationUtilities.__GenerateUniqueIdsList(substracted_model_part.Elements)))
 
         self.assertEqual(sorted(node_ids), sorted(merged_node_ids))
         self.assertEqual(sorted(condition_ids), sorted(merged_condition_ids))
         self.assertEqual(sorted(element_ids), sorted(merged_element_ids))
 
-        merged_with_neighbours_model_part = Kratos.ModelPartOperationUtilities.Substract("substract_2", self.model_part, self.model_parts_list, True)
-        self.__CheckNeighbours(node_ids, element_ids, merged_model_part, merged_with_neighbours_model_part)
+        substract_with_neighbours_model_part = self.model_part.CreateSubModelPart("substract_2")
+        Kratos.ModelPartOperationUtilities.Substract(substract_with_neighbours_model_part, self.model_part, self.model_parts_list, True)
+        self.__CheckNeighbours(node_ids, element_ids, substracted_model_part, substract_with_neighbours_model_part)
 
     @KratosUnittest.skipIf(Kratos.IsDistributedRun(), "only the test does not support MPI")
     def test_Intersect(self):
-        merged_model_part = Kratos.ModelPartOperationUtilities.Intersect("intersect_1", self.model_part, self.model_parts_list, False)
+        intersected_model_part = self.model_part.CreateSubModelPart("intersect_1")
+        Kratos.ModelPartOperationUtilities.Intersect(intersected_model_part, self.model_part, self.model_parts_list, False)
 
         # check
         node_ids = TestModelPartOperationUtilities.__GenerateUniqueIdsList(self.model_parts_list[0].Nodes)
@@ -175,16 +181,17 @@ class TestModelPartOperationUtilities(KratosUnittest.TestCase):
             condition_ids = list(set(condition_ids).intersection(TestModelPartOperationUtilities.__GenerateUniqueIdsList(model_part.Conditions)))
             element_ids = list(set(element_ids).intersection(TestModelPartOperationUtilities.__GenerateUniqueIdsList(model_part.Elements)))
 
-        merged_node_ids = list(set(TestModelPartOperationUtilities.__GenerateUniqueIdsList(merged_model_part.Nodes)))
-        merged_condition_ids = list(set(TestModelPartOperationUtilities.__GenerateUniqueIdsList(merged_model_part.Conditions)))
-        merged_element_ids = list(set(TestModelPartOperationUtilities.__GenerateUniqueIdsList(merged_model_part.Elements)))
+        merged_node_ids = list(set(TestModelPartOperationUtilities.__GenerateUniqueIdsList(intersected_model_part.Nodes)))
+        merged_condition_ids = list(set(TestModelPartOperationUtilities.__GenerateUniqueIdsList(intersected_model_part.Conditions)))
+        merged_element_ids = list(set(TestModelPartOperationUtilities.__GenerateUniqueIdsList(intersected_model_part.Elements)))
 
         self.assertEqual(sorted(node_ids), sorted(merged_node_ids))
         self.assertEqual(sorted(condition_ids), sorted(merged_condition_ids))
         self.assertEqual(sorted(element_ids), sorted(merged_element_ids))
 
-        merged_with_neighbours_model_part = Kratos.ModelPartOperationUtilities.Intersect("intersect_2", self.model_part, self.model_parts_list, True)
-        self.__CheckNeighbours(node_ids, element_ids, merged_model_part, merged_with_neighbours_model_part)
+        intersect_with_neighbours_model_part = self.model_part.CreateSubModelPart("intersect_2")
+        Kratos.ModelPartOperationUtilities.Intersect(intersect_with_neighbours_model_part, self.model_part, self.model_parts_list, True)
+        self.__CheckNeighbours(node_ids, element_ids, intersected_model_part, intersect_with_neighbours_model_part)
 
     @KratosUnittest.skipIf(Kratos.IsDistributedRun(), "only the test does not support MPI")
     def test_HasIntersection(self):
@@ -201,9 +208,12 @@ class TestModelPartOperationUtilities(KratosUnittest.TestCase):
         for element in self.model_part.Elements:
             element.SetValue(Kratos.PRESSURE, element.Id)
 
-        merged_model_part = Kratos.ModelPartOperationUtilities.Union("merge_3", self.model_part, self.model_parts_list, False)
-        substract_model_part = Kratos.ModelPartOperationUtilities.Substract("substract_3", self.model_part, self.model_parts_list, False)
-        intersect_model_part = Kratos.ModelPartOperationUtilities.Intersect("intersect_3", self.model_part, self.model_parts_list, False)
+        merged_model_part = self.model_part.GetSubModelPart("Parts_Solid_sub_domain_1").CreateSubModelPart("merge_3")
+        Kratos.ModelPartOperationUtilities.Union(merged_model_part, self.model_part, self.model_parts_list, False)
+        substract_model_part = self.model_part.GetSubModelPart("Parts_Solid_sub_domain_1").CreateSubModelPart("substract_3")
+        Kratos.ModelPartOperationUtilities.Substract(substract_model_part, self.model_part, self.model_parts_list, False)
+        intersect_model_part = self.model_part.GetSubModelPart("Parts_Solid_sub_domain_1").CreateSubModelPart("intersect_3")
+        Kratos.ModelPartOperationUtilities.Intersect(intersect_model_part, self.model_part, self.model_parts_list, False)
 
         merged_sum = Kratos.VariableUtils().SumNonHistoricalNodeScalarVariable(Kratos.PRESSURE, merged_model_part)
         self.assertEqual(merged_sum, 13415.0)

--- a/kratos/tests/test_model_part_operation_utilities.py
+++ b/kratos/tests/test_model_part_operation_utilities.py
@@ -224,5 +224,21 @@ class TestModelPartOperationUtilities(KratosUnittest.TestCase):
         intersected_sum = Kratos.VariableUtils().SumNonHistoricalNodeScalarVariable(Kratos.PRESSURE, intersect_model_part)
         self.assertEqual(intersected_sum, 2894.0)
 
+    @KratosUnittest.skipIf(Kratos.IsDistributedRun(), "only the test does not support MPI")
+    def test_CheckParentModelPart(self):
+        model = Kratos.Model()
+        model_part = model.CreateModelPart("test")
+        sub_model_part1 = model_part.CreateSubModelPart("sub_test")
+        sub_sub_model_part1 = sub_model_part1.CreateSubModelPart("sub_sub_test1")
+        sub_sub_model_part2 = sub_model_part1.CreateSubModelPart("sub_sub_test2")
+
+        output_model_part = model_part.CreateSubModelPart("output")
+        Kratos.ModelPartOperationUtilities.Intersect(output_model_part, model_part, [sub_sub_model_part1, sub_sub_model_part2], False)
+
+        output_model_part_2 = model.CreateModelPart("test2")
+        with self.assertRaises(RuntimeError):
+            Kratos.ModelPartOperationUtilities.Intersect(output_model_part_2, model_part, [sub_sub_model_part1, sub_sub_model_part2], False)
+
+
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/kratos/utilities/model_part_operation_utilities.cpp
+++ b/kratos/utilities/model_part_operation_utilities.cpp
@@ -188,7 +188,7 @@ void ModelPartOperationUtilities::FillOutputSubModelPart(
     // of rMainModelPart assuming the communicators are not set yet in rOutputSubModelPart
     // since it is assumed to be empty in all contaienrs.
     const auto& r_data_communicator = rMainModelPart.GetCommunicator().GetDataCommunicator();
-    const auto& entity_info = r_data_communicator.SumAll(std::vector<IndexType>{
+    const auto& entity_info = r_data_communicator.SumAll(std::vector<long unsigned int>{
             rOutputSubModelPart.NumberOfNodes(),
             rOutputSubModelPart.NumberOfConditions(),
             rOutputSubModelPart.NumberOfElements()});

--- a/kratos/utilities/model_part_operation_utilities.cpp
+++ b/kratos/utilities/model_part_operation_utilities.cpp
@@ -188,10 +188,10 @@ void ModelPartOperationUtilities::FillOutputSubModelPart(
     // of rMainModelPart assuming the communicators are not set yet in rOutputSubModelPart
     // since it is assumed to be empty in all contaienrs.
     const auto& r_data_communicator = rMainModelPart.GetCommunicator().GetDataCommunicator();
-    const auto& entity_info = r_data_communicator.SumAll(std::vector<long unsigned int>{
-            rOutputSubModelPart.NumberOfNodes(),
-            rOutputSubModelPart.NumberOfConditions(),
-            rOutputSubModelPart.NumberOfElements()});
+    const auto& entity_info = r_data_communicator.SumAll(std::vector<unsigned int>{
+            static_cast<unsigned int>(rOutputSubModelPart.NumberOfNodes()),
+            static_cast<unsigned int>(rOutputSubModelPart.NumberOfConditions()),
+            static_cast<unsigned int>(rOutputSubModelPart.NumberOfElements())});
 
     KRATOS_ERROR_IF(entity_info[0] > 0 || entity_info[1] > 0 || entity_info[2] > 0)
         << rOutputSubModelPart.FullName() << " is not empty.";

--- a/kratos/utilities/model_part_operation_utilities.cpp
+++ b/kratos/utilities/model_part_operation_utilities.cpp
@@ -14,6 +14,7 @@
 #include <set>
 #include <limits>
 #include <sstream>
+#include <algorithm>
 
 // External includes
 
@@ -176,45 +177,50 @@ void ModelPartOperationUtilities::SetCommunicator(
     rOutputModelPart.SetCommunicator(p_output_communicator);
 }
 
-ModelPart& ModelPartOperationUtilities::CreateOutputModelPart(
-    const std::string& rOutputSubModelPartName,
+void ModelPartOperationUtilities::FillOutputSubModelPart(
+    ModelPart& rOutputSubModelPart,
     ModelPart& rMainModelPart,
     std::vector<ModelPart::NodeType*>& rOutputNodes,
     std::vector<ModelPart::ConditionType*>& rOutputConditions,
     std::vector<ModelPart::ElementType*>& rOutputElements)
 {
-    KRATOS_ERROR_IF(rMainModelPart.HasSubModelPart(rOutputSubModelPartName))
-        << "\"" << rOutputSubModelPartName << "\" already exists in the \""
-        << rMainModelPart.FullName() << "\".\n";
+    // check if the sub model part is empty. Here we use the data communicator
+    // of rMainModelPart assuming the communicators are not set yet in rOutputSubModelPart
+    // since it is assumed to be empty in all contaienrs.
+    const auto& r_data_communicator = rMainModelPart.GetCommunicator().GetDataCommunicator();
+    const auto& entity_info = r_data_communicator.SumAll(std::vector<IndexType>{
+            rOutputSubModelPart.NumberOfNodes(),
+            rOutputSubModelPart.NumberOfConditions(),
+            rOutputSubModelPart.NumberOfElements()});
 
-    // create the output sub model part
-    auto& r_output_model_part = rMainModelPart.CreateSubModelPart(rOutputSubModelPartName);
+    KRATOS_ERROR_IF(entity_info[0] > 0 || entity_info[1] > 0 || entity_info[2] > 0)
+        << rOutputSubModelPart.FullName() << " is not empty.";
 
     // add unique conditions
     std::sort(rOutputConditions.begin(), rOutputConditions.end());
     const auto& condition_last = std::unique(rOutputConditions.begin(), rOutputConditions.end());
-    std::for_each(rOutputConditions.begin(), condition_last, [&r_output_model_part](auto p_condition) {
-        r_output_model_part.Conditions().push_back(Kratos::intrusive_ptr<ModelPart::ConditionType>(p_condition));
+    std::for_each(rOutputConditions.begin(), condition_last, [&rOutputSubModelPart](auto p_condition) {
+        rOutputSubModelPart.Conditions().push_back(Kratos::intrusive_ptr<ModelPart::ConditionType>(p_condition));
     });
     FillNodesFromEntities<ModelPart::ConditionType>(rOutputNodes, rOutputConditions.begin(), condition_last);
 
     // add uniqe elements
     std::sort(rOutputElements.begin(), rOutputElements.end());
     const auto& element_last = std::unique(rOutputElements.begin(), rOutputElements.end());
-    std::for_each(rOutputElements.begin(), element_last, [&r_output_model_part](auto p_element) {
-        r_output_model_part.Elements().push_back(Kratos::intrusive_ptr<ModelPart::ElementType>(p_element));
+    std::for_each(rOutputElements.begin(), element_last, [&rOutputSubModelPart](auto p_element) {
+        rOutputSubModelPart.Elements().push_back(Kratos::intrusive_ptr<ModelPart::ElementType>(p_element));
     });
     FillNodesFromEntities<ModelPart::ElementType>(rOutputNodes, rOutputElements.begin(), element_last);
 
     // populate the mesh with nodes.
     std::sort(rOutputNodes.begin(), rOutputNodes.end());
     const auto& node_last = std::unique(rOutputNodes.begin(), rOutputNodes.end());
-    std::for_each(rOutputNodes.begin(), node_last, [&r_output_model_part](auto p_node) {
-        r_output_model_part.Nodes().push_back(Kratos::intrusive_ptr<ModelPart::NodeType>(p_node));
+    std::for_each(rOutputNodes.begin(), node_last, [&rOutputSubModelPart](auto p_node) {
+        rOutputSubModelPart.Nodes().push_back(Kratos::intrusive_ptr<ModelPart::NodeType>(p_node));
     });
 
     // sets the communicator info.
-    SetCommunicator(r_output_model_part, rMainModelPart);
+    SetCommunicator(rOutputSubModelPart, rMainModelPart);
 
     // until now everything is sorted based on the memory location ptrs.
     // sorting them based on the ids.
@@ -224,12 +230,10 @@ ModelPart& ModelPartOperationUtilities::CreateOutputModelPart(
         rMesh.Elements().Sort();
     };
 
-    sort_mesh(r_output_model_part.GetMesh());
-    sort_mesh(r_output_model_part.GetCommunicator().LocalMesh());
-    sort_mesh(r_output_model_part.GetCommunicator().GhostMesh());
-    sort_mesh(r_output_model_part.GetCommunicator().InterfaceMesh());
-
-    return r_output_model_part;
+    sort_mesh(rOutputSubModelPart.GetMesh());
+    sort_mesh(rOutputSubModelPart.GetCommunicator().LocalMesh());
+    sort_mesh(rOutputSubModelPart.GetCommunicator().GhostMesh());
+    sort_mesh(rOutputSubModelPart.GetCommunicator().InterfaceMesh());
 }
 
 void ModelPartOperationUtilities::CheckNodes(

--- a/kratos/utilities/model_part_operation_utilities.h
+++ b/kratos/utilities/model_part_operation_utilities.h
@@ -70,7 +70,7 @@ public:
      * which satisfies the specified @ref TModelPartOperation and adds them to a given @ref rOutputSubModelPart.
      * The @ref TModelPartOperation check is done based on the memory locations of the entities.
      * The corresponding entities from @ref rMainModelPart are usedto populate the sub model part.
-     * @ref rOutputSubModelPart must always a sub model part of the @ref rMainModelPart, but does not
+     * @ref rOutputSubModelPart must be a sub model part of @ref rMainModelPart, but does not
      * necessarily have to be an immediate sub model part.
      *
      * If @ref AddNeighbourEntities is true, then all the neighbours of the newly created model part

--- a/kratos/utilities/model_part_operation_utilities.h
+++ b/kratos/utilities/model_part_operation_utilities.h
@@ -69,7 +69,7 @@ public:
      * This method finds all the nodes, geometries in @ref rModelPartOperationModelParts in the @ref rMainModelPart
      * which satisfies the specified @ref TModelPartOperation and adds them to a given @ref rOutputSubModelPart.
      * The @ref TModelPartOperation check is done based on the memory locations of the entities.
-     * The corresponding entities from @ref rMainModelPart are usedto populate the sub model part.
+     * The corresponding entities from @ref rMainModelPart are used to populate the sub model part.
      * @ref rOutputSubModelPart must be a sub model part of @ref rMainModelPart, but does not
      * necessarily have to be an immediate sub model part.
      *

--- a/kratos/utilities/model_part_operation_utilities.h
+++ b/kratos/utilities/model_part_operation_utilities.h
@@ -66,7 +66,7 @@ public:
     /**
      * @brief Fill a sub model part with the specified operation.
      *
-     * This method finds all the nodes, geometries in @ref rModelPartOperationModelParts in the @ref rMainModelPart
+     * This method finds all the nodes, geometries in @ref rOperands in the @ref rMainModelPart
      * which satisfies the specified @ref TModelPartOperation and adds them to a given @ref rOutputSubModelPart.
      * The @ref TModelPartOperation check is done based on the memory locations of the entities.
      * The corresponding entities from @ref rMainModelPart are used to populate the sub model part.
@@ -84,15 +84,15 @@ public:
      * @tparam TModelPartOperation                  Type of the operation.
      * @param rOutputSubModelPart                   Output sub model part.
      * @param rMainModelPart                        Main Model part.
-     * @param rModelPartOperationModelParts         Model parts to to find satisfying entities w.r.t. @ref TModelPartOperation.
+     * @param rOperands                             Model parts to to find satisfying entities w.r.t. @ref TModelPartOperation.
      * @param AddNeighbourEntities                  To add or not the neighbours.
      * @return ModelPart&                           Output sub model part.
      */
     template<class TModelPartOperation>
-    static void FillSubModelPartWithOperation(
+    static void FillSubModelPart(
         ModelPart& rOutputSubModelPart,
         const ModelPart& rMainModelPart,
-        const std::vector<ModelPart const*>& rModelPartOperationModelParts,
+        const std::vector<ModelPart const*>& rOperands,
         const bool AddNeighbourEntities)
     {
         std::vector<ModelPart::NodeType*> output_nodes;
@@ -103,7 +103,7 @@ public:
         // This is done based on pointers to avoid having same names in model parts
         // which are within two different models.
         ModelPart* p_parent_model_part = &rOutputSubModelPart.GetParentModelPart();
-        while (p_parent_model_part != &rMainModelPart) {
+        while (p_parent_model_part != &rMainModelPart && p_parent_model_part != &p_parent_model_part->GetParentModelPart()) {
             p_parent_model_part = &p_parent_model_part->GetParentModelPart();
         }
 
@@ -112,7 +112,7 @@ public:
             << " is not a sub model part of " << rMainModelPart.FullName() << ".\n";
 
         // fill vectors
-        ModelPartOperation<TModelPartOperation>(output_nodes, output_conditions, output_elements, *p_parent_model_part, rModelPartOperationModelParts, AddNeighbourEntities);
+        ModelPartOperation<TModelPartOperation>(output_nodes, output_conditions, output_elements, *p_parent_model_part, rOperands, AddNeighbourEntities);
 
         // now fill the sub model part
         FillOutputSubModelPart(rOutputSubModelPart, *p_parent_model_part, output_nodes, output_conditions, output_elements);
@@ -201,10 +201,10 @@ private:
         std::vector<ModelPart::ConditionType*>& rOutputConditions,
         std::vector<ModelPart::ElementType*>& rOutputElements,
         ModelPart& rMainModelPart,
-        const std::vector<ModelPart const*>& rModelPartOperationModelParts,
+        const std::vector<ModelPart const*>& rOperands,
         const bool AddNeighbourEntities)
     {
-        const IndexType number_of_operation_model_parts = rModelPartOperationModelParts.size();
+        const IndexType number_of_operation_model_parts = rOperands.size();
 
         std::vector<std::set<ModelPart::NodeType const*>> set_operation_node_sets(number_of_operation_model_parts);
         std::vector<std::set<CNodePointersType>> set_operation_condition_sets(number_of_operation_model_parts);
@@ -212,7 +212,7 @@ private:
 
         // now iterate through model parts' conditions/elements containers and get available main model part entities.
         for (IndexType i = 0; i < number_of_operation_model_parts; ++i) {
-            auto p_model_part = rModelPartOperationModelParts[i];
+            auto p_model_part = rOperands[i];
 
             // fill the set_operation nodes
             FillNodesPointerSet(set_operation_node_sets[i], p_model_part->Nodes());

--- a/kratos/utilities/model_part_operation_utilities.h
+++ b/kratos/utilities/model_part_operation_utilities.h
@@ -103,7 +103,7 @@ public:
         // This is done based on pointers to avoid having same names in model parts
         // which are within two different models.
         ModelPart* p_parent_model_part = &rOutputSubModelPart.GetParentModelPart();
-        while (p_parent_model_part->IsSubModelPart() && p_parent_model_part != &rMainModelPart) {
+        while (p_parent_model_part != &rMainModelPart) {
             p_parent_model_part = &p_parent_model_part->GetParentModelPart();
         }
 


### PR DESCRIPTION
**📝 Description**
This PR changes the signature used in the `ModelPartOperationUtilities`. Now instead of creating the sub model part within the model part boolean operation, an empty submodel part should be provided. The creation is seperated. This is done to allow this utility to be used in `Analysis`, where the submodel part can be created and `SolutionStepVariables` can be added before the filling of entities. Thereafter, the empty submodel part can be populated with the boolean operation.

**🆕 Changelog**
- Changed  `CreateModelPartWithOperation` to `FillSubModelPartWithOperation`
- Updated the tests.
