### PR TITLE
[Structural] Adding Info() to ElasticIsotropic3D

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_constitutive/elastic_isotropic_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/elastic_isotropic_3d.cpp
@@ -332,6 +332,22 @@ int ElasticIsotropic3D::Check(
 /***********************************************************************************/
 /***********************************************************************************/
 
+std::string ElasticIsotropic3D::Info() const
+{
+    return "ElasticIsotropic3D ConstitutiveLaw instance";
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void ElasticIsotropic3D::PrintInfo(std::ostream& rOStream) const
+{
+    rOStream << this->Info() << std::endl;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
 void ElasticIsotropic3D::CheckClearElasticMatrix(ConstitutiveLaw::VoigtSizeMatrixType& rConstitutiveMatrix)
 {
     const SizeType size_system = this->GetStrainSize();

--- a/applications/StructuralMechanicsApplication/custom_constitutive/elastic_isotropic_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/elastic_isotropic_3d.h
@@ -359,6 +359,16 @@ public:
         const ProcessInfo& rCurrentProcessInfo
         ) const override;
 
+
+    /** @brief General information identifying this instance. */
+    std::string Info() const override;
+
+    /**
+     * @brief General information identifying this instance.
+     * @param rOstream The stream where the info will be printed.
+     */
+    void PrintInfo(std::ostream& rOStream) const override;
+
 protected:
 
     ///@name Protected static Member Variables


### PR DESCRIPTION
**📝 Description**
Minor change so that the Info method of ElasticIsotropic3D instances prints the actual class name (otherwise they self-report as base ConstitutiveLaw instances). I needed this to debug an issue and I thought it might be useful for someone else in the future.

**🆕 Changelog**

- Added ElasticIsotropic3D::Info and ElasticIsotropic3D::PrintInfo methods

