### PR TITLE
Let PrintInfo use Info() in process base class.

### DIFF
--- a/kratos/processes/process.h
+++ b/kratos/processes/process.h
@@ -203,7 +203,7 @@ public:
     /// Print information about this object.
     void PrintInfo(std::ostream& rOStream) const override
     {
-        rOStream << "Process";
+        rOStream << Info();
     }
 
     /// Print object's data.


### PR DESCRIPTION
Info() and PrintInfo() contain repeated text strings that made override in derived classes necessary.

This commit changes the PrintInfo() implementation such that it uses Info(). This avoids overrides in derived classes if only its default behavior is wanted.