### PR TITLE
[Core] Adding more BB methods to `SearchUtilities`

### DIFF
--- a/kratos/utilities/search_utilities.cpp
+++ b/kratos/utilities/search_utilities.cpp
@@ -41,7 +41,7 @@ bool SearchUtilities::PointIsInsideBoundingBox(
 /***********************************************************************************/
 /***********************************************************************************/
 
-bool SearchUtilities::PointIsInsideBoundingBoxWithTolerance(
+bool SearchUtilities::PointIsInsideBoundingBox(
     const BoundingBox<Point>& rBoundingBox,
     const array_1d<double, 3>& rCoords,
     const double Tolerance

--- a/kratos/utilities/search_utilities.cpp
+++ b/kratos/utilities/search_utilities.cpp
@@ -41,22 +41,6 @@ bool SearchUtilities::PointIsInsideBoundingBox(
 /***********************************************************************************/
 /***********************************************************************************/
 
-bool SearchUtilities::PointIsInsideBoundingBox(
-    const BoundingBoxType& rBoundingBox,
-    const array_1d<double, 3>& rCoords
-    )
-{
-    // The Bounding Box should have some tolerance already!
-    if (rCoords[0] < rBoundingBox[0] && rCoords[0] > rBoundingBox[1])           // check x-direction
-        if (rCoords[1] < rBoundingBox[2] && rCoords[1] > rBoundingBox[3])       // check y-direction
-            if (rCoords[2] < rBoundingBox[4] && rCoords[2] > rBoundingBox[5])   // check z-direction
-                return true;
-    return false;
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
 bool SearchUtilities::PointIsInsideBoundingBoxWithTolerance(
     const BoundingBox<Point>& rBoundingBox,
     const array_1d<double, 3>& rCoords,

--- a/kratos/utilities/search_utilities.cpp
+++ b/kratos/utilities/search_utilities.cpp
@@ -21,6 +21,72 @@
 namespace Kratos
 {
 
+bool SearchUtilities::PointIsInsideBoundingBox(
+    const BoundingBox<Point>& rBoundingBox,
+    const array_1d<double, 3>& rCoords
+    )
+{
+    // Get the bounding box points
+    const auto& r_max_point = rBoundingBox.GetMaxPoint();
+    const auto& r_min_point = rBoundingBox.GetMinPoint();
+
+    // The Bounding Box check
+    if (rCoords[0] < r_max_point[0] && rCoords[0] > r_min_point[0])           // check x-direction
+        if (rCoords[1] < r_max_point[1] && rCoords[1] > r_min_point[1])       // check y-direction
+            if (rCoords[2] < r_max_point[2] && rCoords[2] > r_min_point[2])   // check z-direction
+                return true;
+    return false;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+bool SearchUtilities::PointIsInsideBoundingBox(
+    const BoundingBoxType& rBoundingBox,
+    const array_1d<double, 3>& rCoords
+    )
+{
+    // The Bounding Box should have some tolerance already!
+    if (rCoords[0] < rBoundingBox[0] && rCoords[0] > rBoundingBox[1])           // check x-direction
+        if (rCoords[1] < rBoundingBox[2] && rCoords[1] > rBoundingBox[3])       // check y-direction
+            if (rCoords[2] < rBoundingBox[4] && rCoords[2] > rBoundingBox[5])   // check z-direction
+                return true;
+    return false;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+bool SearchUtilities::PointIsInsideBoundingBoxWithTolerance(
+    const BoundingBox<Point>& rBoundingBox,
+    const array_1d<double, 3>& rCoords,
+    const double Tolerance
+    )
+{
+    // Get the bounding box points
+    auto max_point = rBoundingBox.GetMaxPoint();
+    auto min_point = rBoundingBox.GetMinPoint();
+    
+    // Apply Tolerances (only in non zero BB cases)
+    const double epsilon = std::numeric_limits<double>::epsilon();
+    if (norm_2(max_point) > epsilon && norm_2(min_point) > epsilon) {
+        for (unsigned int i=0; i<3; ++i) {
+            max_point[i] += Tolerance;
+            min_point[i] -= Tolerance;
+        }
+    }
+
+    // The Bounding Box check
+    if (rCoords[0] < max_point[0] && rCoords[0] > min_point[0])           // check x-direction
+        if (rCoords[1] < max_point[1] && rCoords[1] > min_point[1])       // check y-direction
+            if (rCoords[2] < max_point[2] && rCoords[2] > min_point[2])   // check z-direction
+                return true;
+    return false;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
 void SearchUtilities::ComputeBoundingBoxesWithTolerance(
     const std::vector<double>& rBoundingBoxes,
     const double Tolerance,

--- a/kratos/utilities/search_utilities.h
+++ b/kratos/utilities/search_utilities.h
@@ -105,7 +105,7 @@ public:
     }
 
     /**
-     * @brief This method checks if a point is inside any bounding box of the global bounding boxes considering a certain tolerance
+     * @brief This method checks if a point is inside a bounding box considering a certain tolerance
      * @param rBoundingBox The bounding box
      * @param rCoords The coordinates of the point
      * @param Tolerance The tolerance

--- a/kratos/utilities/search_utilities.h
+++ b/kratos/utilities/search_utilities.h
@@ -18,7 +18,8 @@
 // External includes
 
 // Project includes
-#include "containers/array_1d.h"
+#include "geometries/bounding_box.h"
+#include "geometries/point.h"
 
 namespace Kratos
 {
@@ -73,6 +74,31 @@ public:
 
     /**
      * @brief Check if a point is inside a bounding box
+     * @details Bounding box class implementation
+     * @param rBoundingBox The bounding box
+     * @param rCoords The point
+     * @return true if the point is inside the bounding box
+     */
+    static bool PointIsInsideBoundingBox(
+        const BoundingBox<Point>& rBoundingBox,
+        const array_1d<double, 3>& rCoords
+        )
+    {
+        // Get the bounding box points
+        const auto& r_max_point = rBoundingBox.GetMaxPoint();
+        const auto& r_min_point = rBoundingBox.GetMinPoint();
+
+        // The Bounding Box check
+        if (rCoords[0] < r_max_point[0] && rCoords[0] > r_min_point[0])           // check x-direction
+            if (rCoords[1] < r_max_point[1] && rCoords[1] > r_min_point[1])       // check y-direction
+                if (rCoords[2] < r_max_point[2] && rCoords[2] > r_min_point[2])   // check z-direction
+                    return true;
+        return false;
+    }
+
+    /**
+     * @brief Check if a point is inside a bounding box
+     * @details Bounding box array of 6 doubles implementation
      * @param rBoundingBox The bounding box
      * @param rCoords The point
      * @return true if the point is inside the bounding box
@@ -101,6 +127,40 @@ public:
         const double Tolerance,
         std::vector<double>& rBoundingBoxesWithTolerance
         );
+
+    /**
+     * @brief This method checks if a point is inside any bounding box of the global bounding boxes considering a certain tolerance
+     * @param rBoundingBox The bounding box
+     * @param rCoords The coordinates of the point
+     * @param Tolerance The tolerance
+     * @return True if the point is inside the bounding box
+     */
+    static bool PointIsInsideBoundingBoxWithTolerance(
+        const BoundingBox<Point>& rBoundingBox,
+        const array_1d<double, 3>& rCoords,
+        const double Tolerance
+        )
+    {
+        // Get the bounding box points
+        auto max_point = rBoundingBox.GetMaxPoint();
+        auto min_point = rBoundingBox.GetMinPoint();
+        
+        // Apply Tolerances (only in non zero BB cases)
+        const double epsilon = std::numeric_limits<double>::epsilon();
+        if (norm_2(max_point) > epsilon && norm_2(min_point) > epsilon) {
+            for (unsigned int i=0; i<3; ++i) {
+                max_point[i] += Tolerance;
+                min_point[i] -= Tolerance;
+            }
+        }
+
+        // The Bounding Box check
+        if (rCoords[0] < max_point[0] && rCoords[0] > min_point[0])           // check x-direction
+            if (rCoords[1] < max_point[1] && rCoords[1] > min_point[1])       // check y-direction
+                if (rCoords[2] < max_point[2] && rCoords[2] > min_point[2])   // check z-direction
+                    return true;
+        return false;
+    }
 
     /**
      * @brief Compute the bounding boxes of the given bounding boxes from a given tolerance, additionally checking if the bounding boxes are initialized

--- a/kratos/utilities/search_utilities.h
+++ b/kratos/utilities/search_utilities.h
@@ -94,7 +94,15 @@ public:
     static bool PointIsInsideBoundingBox(
         const BoundingBoxType& rBoundingBox,
         const array_1d<double, 3>& rCoords
-        );
+        )
+    {
+        // The Bounding Box should have some tolerance already!
+        if (rCoords[0] < rBoundingBox[0] && rCoords[0] > rBoundingBox[1])           // check x-direction
+            if (rCoords[1] < rBoundingBox[2] && rCoords[1] > rBoundingBox[3])       // check y-direction
+                if (rCoords[2] < rBoundingBox[4] && rCoords[2] > rBoundingBox[5])   // check z-direction
+                    return true;
+        return false;
+    }
 
     /**
      * @brief This method checks if a point is inside any bounding box of the global bounding boxes considering a certain tolerance

--- a/kratos/utilities/search_utilities.h
+++ b/kratos/utilities/search_utilities.h
@@ -111,7 +111,7 @@ public:
      * @param Tolerance The tolerance
      * @return True if the point is inside the bounding box
      */
-    static bool PointIsInsideBoundingBoxWithTolerance(
+    static bool PointIsInsideBoundingBox(
         const BoundingBox<Point>& rBoundingBox,
         const array_1d<double, 3>& rCoords,
         const double Tolerance

--- a/kratos/utilities/search_utilities.h
+++ b/kratos/utilities/search_utilities.h
@@ -82,19 +82,7 @@ public:
     static bool PointIsInsideBoundingBox(
         const BoundingBox<Point>& rBoundingBox,
         const array_1d<double, 3>& rCoords
-        )
-    {
-        // Get the bounding box points
-        const auto& r_max_point = rBoundingBox.GetMaxPoint();
-        const auto& r_min_point = rBoundingBox.GetMinPoint();
-
-        // The Bounding Box check
-        if (rCoords[0] < r_max_point[0] && rCoords[0] > r_min_point[0])           // check x-direction
-            if (rCoords[1] < r_max_point[1] && rCoords[1] > r_min_point[1])       // check y-direction
-                if (rCoords[2] < r_max_point[2] && rCoords[2] > r_min_point[2])   // check z-direction
-                    return true;
-        return false;
-    }
+        );
 
     /**
      * @brief Check if a point is inside a bounding box
@@ -106,26 +94,6 @@ public:
     static bool PointIsInsideBoundingBox(
         const BoundingBoxType& rBoundingBox,
         const array_1d<double, 3>& rCoords
-        )
-    {
-        // The Bounding Box should have some tolerance already!
-        if (rCoords[0] < rBoundingBox[0] && rCoords[0] > rBoundingBox[1])           // check x-direction
-            if (rCoords[1] < rBoundingBox[2] && rCoords[1] > rBoundingBox[3])       // check y-direction
-                if (rCoords[2] < rBoundingBox[4] && rCoords[2] > rBoundingBox[5])   // check z-direction
-                    return true;
-        return false;
-    }
-
-    /**
-     * @brief Compute the bounding boxes of the given bounding boxes from a given tolerance
-     * @param rBoundingBoxes The bounding boxes
-     * @param Tolerance The tolerance
-     * @param rBoundingBoxesWithTolerance The resulting bounding boxes with the applied tolerance
-     */
-    static void ComputeBoundingBoxesWithTolerance(
-        const std::vector<double>& rBoundingBoxes,
-        const double Tolerance,
-        std::vector<double>& rBoundingBoxesWithTolerance
         );
 
     /**
@@ -139,28 +107,19 @@ public:
         const BoundingBox<Point>& rBoundingBox,
         const array_1d<double, 3>& rCoords,
         const double Tolerance
-        )
-    {
-        // Get the bounding box points
-        auto max_point = rBoundingBox.GetMaxPoint();
-        auto min_point = rBoundingBox.GetMinPoint();
-        
-        // Apply Tolerances (only in non zero BB cases)
-        const double epsilon = std::numeric_limits<double>::epsilon();
-        if (norm_2(max_point) > epsilon && norm_2(min_point) > epsilon) {
-            for (unsigned int i=0; i<3; ++i) {
-                max_point[i] += Tolerance;
-                min_point[i] -= Tolerance;
-            }
-        }
+        );
 
-        // The Bounding Box check
-        if (rCoords[0] < max_point[0] && rCoords[0] > min_point[0])           // check x-direction
-            if (rCoords[1] < max_point[1] && rCoords[1] > min_point[1])       // check y-direction
-                if (rCoords[2] < max_point[2] && rCoords[2] > min_point[2])   // check z-direction
-                    return true;
-        return false;
-    }
+    /**
+     * @brief Compute the bounding boxes of the given bounding boxes from a given tolerance
+     * @param rBoundingBoxes The bounding boxes
+     * @param Tolerance The tolerance
+     * @param rBoundingBoxesWithTolerance The resulting bounding boxes with the applied tolerance
+     */
+    static void ComputeBoundingBoxesWithTolerance(
+        const std::vector<double>& rBoundingBoxes,
+        const double Tolerance,
+        std::vector<double>& rBoundingBoxesWithTolerance
+        );
 
     /**
      * @brief Compute the bounding boxes of the given bounding boxes from a given tolerance, additionally checking if the bounding boxes are initialized


### PR DESCRIPTION
**📝 Description**

Part of https://github.com/KratosMultiphysics/Kratos/pull/11224

This pull request introduces changes to the `SearchUtilities` class, specifically to the `PointIsInsideBoundingBox` method. The method is responsible for determining whether a given point is inside a bounding box.

The changes include three different versions of the method, each with its own purpose:

1. **PointIsInsideBoundingBox**:
   - Parameters:
     - `const BoundingBox<Point>& rBoundingBox`: The bounding box object containing the maximum and minimum points.
     - `const array_1d<double, 3>& rCoords`: The coordinates of the point to check.
   - Description:
     - The method checks if the `rCoords` point is inside the specified `rBoundingBox` by comparing the coordinates in each direction (x, y, and z) to the maximum and minimum points of the bounding box.
     - If the point is inside the bounding box, `true` is returned; otherwise, `false` is returned.

2. **PointIsInsideBoundingBoxWithTolerance**:
   - Parameters:
     - `const BoundingBox<Point>& rBoundingBox`: The bounding box object containing the maximum and minimum points.
     - `const array_1d<double, 3>& rCoords`: The coordinates of the point to check.
     - `const double Tolerance`: The tolerance value to be applied to the bounding box.
   - Description:
     - This version of the method includes an additional tolerance parameter.
     - The method first applies the tolerance to the maximum and minimum points of the bounding box.
     - After applying the tolerance, the method checks if the `rCoords` point is inside the adjusted bounding box, similar to the previous versions.
     - If the point is inside the bounding box, `true` is returned; otherwise, `false` is returned.

**🆕 Changelog**

- [Adding more BB methods to SearchUtilities](https://github.com/KratosMultiphysics/Kratos/commit/2c124c6142385a47069556d0b71de27fe5c3cc52)
