### PR TITLE
[Core] Missing test (`test_spatial_search`) to be registered in `test_KratosCore`

### DIFF
--- a/kratos/tests/test_KratosCore.py
+++ b/kratos/tests/test_KratosCore.py
@@ -84,6 +84,7 @@ import test_check_same_modelpart_using_skin_distance
 import test_kratos_globals
 import test_container_expression
 import test_model_part_operation_utilities
+import test_spatial_search
 
 if sympy_available:
     import test_sympy_fe_utilities
@@ -188,6 +189,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_container_expression.TestConditionContainerExpression]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_container_expression.TestElementContainerExpression]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_model_part_operation_utilities.TestModelPartOperationUtilities]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_spatial_search.TestSpatialSearchSphere]))
 
     if sympy_available:
         smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_sympy_fe_utilities.TestSympyFEUtilities]))


### PR DESCRIPTION
**📝 Description**

This PR adds the `test_spatial_search` module to the unit tests of KratosCore. The patch includes modifications to the `test_KratosCore.py` file. Specifically, two lines were inserted into the file: an import statement for `test_spatial_search` and a test suite addition for `test_spatial_search.TestSpatialSearchSphere`. This change ensures that the `test_spatial_search` module is included and executed as part of the KratosCore unit tests.

**🆕 Changelog**

- [Missing test to be register in `test_KratosCore`](https://github.com/KratosMultiphysics/Kratos/commit/bcc50956f7164e478927a7071f6a3093fec85379)
