### PR TITLE
[Core] Fix triangle division when one of the nodes has exactly zero distance

### DIFF
--- a/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_modified_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_modified_shape_functions.cpp
@@ -755,6 +755,334 @@ namespace Kratos
             KRATOS_CHECK_NEAR(negative_side_area_normals[1](2), 0.125, 1e-6);
         }
 
+        KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTetrahedra3D4ZeroNodes, KratosCoreFastSuite)
+        {
+            Model current_model;
+
+            // Generate a model part with the previous
+            ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
+            base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+            // Fill the model part geometry data
+            base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+            base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+            base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+            base_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
+            Properties::Pointer p_properties(new Properties(0));
+            base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
+
+            // Set the DISTANCE field
+            base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) =  0.0;
+            base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
+            base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) =  1.0;
+            base_model_part.Nodes()[4].FastGetSolutionStepValue(DISTANCE) =  0.0;
+
+            // Set the elemental distances vector
+            Geometry<Node>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
+
+            array_1d<double, 4> distances_vector;
+            for (unsigned int i = 0; i < p_geometry->size(); ++i) {
+                distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
+            }
+
+            base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+
+            Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+            // Call the modified shape functions calculator
+            Tetrahedra3D4ModifiedShapeFunctions tetrahedra_shape_functions(p_geometry, r_elemental_distances);
+            Matrix positive_side_sh_func, negative_side_sh_func;
+            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
+            Vector positive_side_weights, negative_side_weights;
+
+            tetrahedra_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
+                positive_side_sh_func,
+                positive_side_sh_func_gradients,
+                positive_side_weights,
+                GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            tetrahedra_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
+                negative_side_sh_func,
+                negative_side_sh_func_gradients,
+                negative_side_weights,
+                GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            // Call the interface modified shape functions calculator
+            Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
+            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
+            Vector positive_interface_side_weights, negative_interface_side_weights;
+
+            tetrahedra_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
+                positive_interface_side_sh_func,
+                positive_interface_side_sh_func_gradients,
+                positive_interface_side_weights,
+                GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            tetrahedra_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
+                negative_interface_side_sh_func,
+                negative_interface_side_sh_func_gradients,
+                negative_interface_side_weights,
+                GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            // Call the external face modified shape functions calculator
+            Matrix pos_ext_face_sh_func_0, neg_ext_face_sh_func_0,
+                   pos_ext_face_sh_func_1, neg_ext_face_sh_func_1,
+                   pos_ext_face_sh_func_2, neg_ext_face_sh_func_2,
+                   pos_ext_face_sh_func_3, neg_ext_face_sh_func_3;
+
+            ModifiedShapeFunctions::ShapeFunctionsGradientsType
+                pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
+                pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
+                pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2,
+                pos_ext_face_sh_func_gradients_3, neg_ext_face_sh_func_gradients_3;
+
+            Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
+                   pos_ext_face_weights_1, neg_ext_face_weights_1,
+                   pos_ext_face_weights_2, neg_ext_face_weights_2,
+                   pos_ext_face_weights_3, neg_ext_face_weights_3;
+
+            tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+                pos_ext_face_sh_func_0,
+                pos_ext_face_sh_func_gradients_0,
+                pos_ext_face_weights_0,
+                0,
+                GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+                neg_ext_face_sh_func_0,
+                neg_ext_face_sh_func_gradients_0,
+                neg_ext_face_weights_0,
+                0,
+                GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+                pos_ext_face_sh_func_1,
+                pos_ext_face_sh_func_gradients_1,
+                pos_ext_face_weights_1,
+                1,
+                GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+                neg_ext_face_sh_func_1,
+                neg_ext_face_sh_func_gradients_1,
+                neg_ext_face_weights_1,
+                1,
+                GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+                pos_ext_face_sh_func_2,
+                pos_ext_face_sh_func_gradients_2,
+                pos_ext_face_weights_2,
+                2,
+                GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+                neg_ext_face_sh_func_2,
+                neg_ext_face_sh_func_gradients_2,
+                neg_ext_face_weights_2,
+                2,
+                GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+                pos_ext_face_sh_func_3,
+                pos_ext_face_sh_func_gradients_3,
+                pos_ext_face_weights_3,
+                3,
+                GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+                neg_ext_face_sh_func_3,
+                neg_ext_face_sh_func_gradients_3,
+                neg_ext_face_weights_3,
+                3,
+                GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            // Call the interface outwards normal unit vector calculator
+            std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
+
+            tetrahedra_shape_functions.ComputePositiveSideInterfaceAreaNormals(
+                positive_side_area_normals,
+                GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            tetrahedra_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
+                negative_side_area_normals,
+                GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            // Call the exterior faces outwards normal area vector calculator
+            std::vector<array_1d<double,3>>
+                area_normals_pos_face_0, area_normals_neg_face_0,
+                area_normals_pos_face_1, area_normals_neg_face_1,
+                area_normals_pos_face_2, area_normals_neg_face_2,
+                area_normals_pos_face_3, area_normals_neg_face_3;
+
+            tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+                area_normals_pos_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+                area_normals_neg_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+                area_normals_pos_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+                area_normals_neg_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+                area_normals_pos_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+                area_normals_neg_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+                area_normals_pos_face_3, 3, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+                area_normals_neg_face_3, 3, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+            const double tolerance = 1e-10;
+
+            // Check shape functions values
+            KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 0.250, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 0.125, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 0.375, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func(0,3), 0.250, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 0.250, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 0.375, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 0.125, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func(0,3), 0.250, tolerance);
+
+            // Check Gauss pts. weights
+            KRATOS_CHECK_NEAR(positive_side_weights(0), 1.0/12.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_weights(0), 1.0/12.0, tolerance);
+
+            // Check Gauss pts. shape functions gradients values
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+            // Check interface shape function values
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 1.0/3.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 1.0/6.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,3), 1.0/3.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/3.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 1.0/6.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,3), 1.0/3.0, tolerance);
+
+            // Check interface Gauss pts. weights
+            KRATOS_CHECK_NEAR(positive_interface_side_weights(0), std::sqrt(2.0)/4.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_weights(0), std::sqrt(2.0)/4.0, tolerance);
+
+            // Check Gauss pts. interface shape function gradients values
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+            // Check face 0 values
+            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,0),     0.0, tolerance);
+            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,1), 1.0/6.0, tolerance);
+            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,2), 1.0/2.0, tolerance);
+            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,3), 1.0/3.0, tolerance);
+
+            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,2),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), std::sqrt(3.0)/4.0, tolerance);
+
+            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0),     0.0, tolerance);
+            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1), 1.0/2.0, tolerance);
+            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 1.0/6.0, tolerance);
+            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,3), 1.0/3.0, tolerance);
+
+            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,2),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,0),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,1),  0.0, tolerance);
+            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,2),  1.0, tolerance);
+
+            KRATOS_CHECK_NEAR(neg_ext_face_weights_0(0), std::sqrt(3.0)/4.0, tolerance);
+
+            KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](0), 0.25, tolerance);
+            KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](1), 0.25, tolerance);
+            KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](2), 0.25, tolerance);
+
+            KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](0), 0.25, tolerance);
+            KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](1), 0.25, tolerance);
+            KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](2), 0.25, tolerance);
+
+            // Check Gauss pts. outwards unit normal values
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), 0.25, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](1),-0.25, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.00, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_area_normals[0](0),-0.25, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.25, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.00, tolerance);
+        }
+
 
         KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTetrahedra3D4Volumes, KratosCoreFastSuite)
         {

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_modified_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_modified_shape_functions.cpp
@@ -18,1141 +18,1139 @@
 #include "utilities/divide_tetrahedra_3d_4.h"
 #include "modified_shape_functions/tetrahedra_3d_4_modified_shape_functions.h"
 
-namespace Kratos
+namespace Kratos::Testing
 {
-    namespace Testing
-    {
-
-        KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTetrahedra3D4Horizontal, KratosCoreFastSuite)
-        {
-            Model current_model;
-
-            // Generate a model part with the previous
-            ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
-            base_model_part.AddNodalSolutionStepVariable(DISTANCE);
-
-            // Fill the model part geometry data
-            base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-            base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-            base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
-            base_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
-            Properties::Pointer p_properties(new Properties(0));
-            base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
-
-            // Set the DISTANCE field
-            base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
-            base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
-            base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = -1.0;
-            base_model_part.Nodes()[4].FastGetSolutionStepValue(DISTANCE) =  1.0;
-
-            // Set the elemental distances vector
-            Geometry<Node>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
-
-            array_1d<double, 4> distances_vector;
-            for (unsigned int i = 0; i < p_geometry->size(); ++i) {
-                distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
-            }
-
-            base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
-
-            Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
-
-            // Call the modified shape functions calculator
-            Tetrahedra3D4ModifiedShapeFunctions tetrahedra_shape_functions(p_geometry, r_elemental_distances);
-            Matrix positive_side_sh_func, negative_side_sh_func;
-            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
-            Vector positive_side_weights, negative_side_weights;
-
-            tetrahedra_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
-                positive_side_sh_func,
-                positive_side_sh_func_gradients,
-                positive_side_weights,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
-                negative_side_sh_func,
-                negative_side_sh_func_gradients,
-                negative_side_weights,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            // Call the interface modified shape functions calculator
-            Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
-            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
-            Vector positive_interface_side_weights, negative_interface_side_weights;
-
-            tetrahedra_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
-                positive_interface_side_sh_func,
-                positive_interface_side_sh_func_gradients,
-                positive_interface_side_weights,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
-                negative_interface_side_sh_func,
-                negative_interface_side_sh_func_gradients,
-                negative_interface_side_weights,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            // Call the external face modified shape functions calculator
-            Matrix pos_ext_face_sh_func_0, neg_ext_face_sh_func_0,
-                   pos_ext_face_sh_func_1, neg_ext_face_sh_func_1,
-                   pos_ext_face_sh_func_2, neg_ext_face_sh_func_2,
-                   pos_ext_face_sh_func_3, neg_ext_face_sh_func_3;
-
-            ModifiedShapeFunctions::ShapeFunctionsGradientsType
-                pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
-                pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
-                pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2,
-                pos_ext_face_sh_func_gradients_3, neg_ext_face_sh_func_gradients_3;
-
-            Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
-                   pos_ext_face_weights_1, neg_ext_face_weights_1,
-                   pos_ext_face_weights_2, neg_ext_face_weights_2,
-                   pos_ext_face_weights_3, neg_ext_face_weights_3;
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-                pos_ext_face_sh_func_0,
-                pos_ext_face_sh_func_gradients_0,
-                pos_ext_face_weights_0,
-                0,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-                neg_ext_face_sh_func_0,
-                neg_ext_face_sh_func_gradients_0,
-                neg_ext_face_weights_0,
-                0,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-                pos_ext_face_sh_func_1,
-                pos_ext_face_sh_func_gradients_1,
-                pos_ext_face_weights_1,
-                1,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-                neg_ext_face_sh_func_1,
-                neg_ext_face_sh_func_gradients_1,
-                neg_ext_face_weights_1,
-                1,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-                pos_ext_face_sh_func_2,
-                pos_ext_face_sh_func_gradients_2,
-                pos_ext_face_weights_2,
-                2,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-                neg_ext_face_sh_func_2,
-                neg_ext_face_sh_func_gradients_2,
-                neg_ext_face_weights_2,
-                2,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-                pos_ext_face_sh_func_3,
-                pos_ext_face_sh_func_gradients_3,
-                pos_ext_face_weights_3,
-                3,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-                neg_ext_face_sh_func_3,
-                neg_ext_face_sh_func_gradients_3,
-                neg_ext_face_weights_3,
-                3,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            // Call the interface outwards normal unit vector calculator
-            std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
-
-            tetrahedra_shape_functions.ComputePositiveSideInterfaceAreaNormals(
-                positive_side_area_normals,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
-                negative_side_area_normals,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            // Call the exterior faces outwards normal area vector calculator
-            std::vector<array_1d<double,3>>
-                area_normals_pos_face_0, area_normals_neg_face_0,
-                area_normals_pos_face_1, area_normals_neg_face_1,
-                area_normals_pos_face_2, area_normals_neg_face_2,
-                area_normals_pos_face_3, area_normals_neg_face_3;
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-                area_normals_pos_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-                area_normals_neg_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-                area_normals_pos_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-                area_normals_neg_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-                area_normals_pos_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-                area_normals_neg_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-                area_normals_pos_face_3, 3, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-                area_normals_neg_face_3, 3, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            const double tolerance = 1e-10;
-
-            // Check shape functions values
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,3), 0.625, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 0.375, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,3), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,0), 0.375, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,1), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,2), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,3), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(2,0), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(2,1), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(2,2), 0.375, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(2,3), 0.375, tolerance);
-
-            // Check Gauss pts. weights
-            KRATOS_CHECK_NEAR(positive_side_weights(0), 0.02083333333, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_weights(0), 0.04166666666, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_weights(1), 0.08333333333, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_weights(2), 0.02083333333, tolerance);
-
-            // Check Gauss pts. shape functions gradients values
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            // Check interface shape function values
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,3),     0.5, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,3),     0.5, tolerance);
-
-            // Check interface Gauss pts. weights
-            KRATOS_CHECK_NEAR(positive_interface_side_weights(0), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_weights(0), 0.125, tolerance);
-
-            // Check Gauss pts. interface shape function gradients values
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            // Check face 0 values
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,0),     0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,1), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,2), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,3), 2.0/3.0, tolerance);
-
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), 0.216506, 10e-5);
-
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0),     0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1),     0.5, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,3), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(1,0),     0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(1,1), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(1,2),     0.5, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(1,3), 1.0/3.0, tolerance);
-
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,2),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(neg_ext_face_weights_0(0), 0.433013, 10e-5);
-            KRATOS_CHECK_NEAR(neg_ext_face_weights_0(1), 0.216506, 10e-5);
-
-            KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](0), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](1), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](2), 0.125, tolerance);
-
-            KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](0), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](1), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](2), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_neg_face_0[1](0), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_neg_face_0[1](1), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_neg_face_0[1](2), 0.125, tolerance);
-
-            // Check Gauss pts. outwards unit normal values
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), 0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), 0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), -0.125, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), 0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.125, tolerance);
-        }
-
-
-        KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTetrahedra3D4Oblique, KratosCoreFastSuite)
-        {
-            Model current_model;
-
-            // Generate a model part with the previous
-            ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
-            base_model_part.AddNodalSolutionStepVariable(DISTANCE);
-
-            // Fill the model part geometry data
-            base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-            base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-            base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
-            base_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
-            Properties::Pointer p_properties(new Properties(0));
-            base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
-
-            // Set the DISTANCE field
-            base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
-            base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) =  1.0;
-            base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = -1.0;
-            base_model_part.Nodes()[4].FastGetSolutionStepValue(DISTANCE) =  1.0;
-
-            // Set the elemental distances vector
-            Geometry<Node>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
-
-            array_1d<double, 4> distances_vector;
-            for (unsigned int i = 0; i < p_geometry->size(); ++i) {
-                distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
-            }
-
-            base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
-
-            Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
-
-            // Call the modified shape functions calculator
-            Tetrahedra3D4ModifiedShapeFunctions tetrahedra_shape_functions(p_geometry, r_elemental_distances);
-            Matrix positive_side_sh_func, negative_side_sh_func;
-            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
-            Vector positive_side_weights, negative_side_weights;
-
-            tetrahedra_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
-                positive_side_sh_func,
-                positive_side_sh_func_gradients,
-                positive_side_weights,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
-                negative_side_sh_func,
-                negative_side_sh_func_gradients,
-                negative_side_weights,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            // Call the interface modified shape functions calculator
-            Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
-            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
-            Vector positive_interface_side_weights, negative_interface_side_weights;
-
-            tetrahedra_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
-                positive_interface_side_sh_func,
-                positive_interface_side_sh_func_gradients,
-                positive_interface_side_weights,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
-                negative_interface_side_sh_func,
-                negative_interface_side_sh_func_gradients,
-                negative_interface_side_weights,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            // Call the external face modified shape functions calculator
-            Matrix pos_ext_face_sh_func_0, neg_ext_face_sh_func_0,
-                   pos_ext_face_sh_func_1, neg_ext_face_sh_func_1,
-                   pos_ext_face_sh_func_2, neg_ext_face_sh_func_2,
-                   pos_ext_face_sh_func_3, neg_ext_face_sh_func_3;
-
-            ModifiedShapeFunctions::ShapeFunctionsGradientsType
-                pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
-                pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
-                pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2,
-                pos_ext_face_sh_func_gradients_3, neg_ext_face_sh_func_gradients_3;
-
-            Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
-                   pos_ext_face_weights_1, neg_ext_face_weights_1,
-                   pos_ext_face_weights_2, neg_ext_face_weights_2,
-                   pos_ext_face_weights_3, neg_ext_face_weights_3;
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-                pos_ext_face_sh_func_0,
-                pos_ext_face_sh_func_gradients_0,
-                pos_ext_face_weights_0,
-                0,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-                neg_ext_face_sh_func_0,
-                neg_ext_face_sh_func_gradients_0,
-                neg_ext_face_weights_0,
-                0,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-                pos_ext_face_sh_func_1,
-                pos_ext_face_sh_func_gradients_1,
-                pos_ext_face_weights_1,
-                1,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-                neg_ext_face_sh_func_1,
-                neg_ext_face_sh_func_gradients_1,
-                neg_ext_face_weights_1,
-                1,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-                pos_ext_face_sh_func_2,
-                pos_ext_face_sh_func_gradients_2,
-                pos_ext_face_weights_2,
-                2,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-                neg_ext_face_sh_func_2,
-                neg_ext_face_sh_func_gradients_2,
-                neg_ext_face_weights_2,
-                2,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-                pos_ext_face_sh_func_3,
-                pos_ext_face_sh_func_gradients_3,
-                pos_ext_face_weights_3,
-                3,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-                neg_ext_face_sh_func_3,
-                neg_ext_face_sh_func_gradients_3,
-                neg_ext_face_weights_3,
-                3,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            // Call the interface outwards normal unit vector calculator
-            std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
-
-            tetrahedra_shape_functions.ComputePositiveSideInterfaceAreaNormals(
-                positive_side_area_normals,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
-                negative_side_area_normals,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            // Call the exterior faces outwards normal area vector calculator
-            std::vector<array_1d<double,3>>
-                area_normals_pos_face_0, area_normals_neg_face_0,
-                area_normals_pos_face_1, area_normals_neg_face_1,
-                area_normals_pos_face_2, area_normals_neg_face_2,
-                area_normals_pos_face_3, area_normals_neg_face_3;
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-                area_normals_pos_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-                area_normals_neg_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-                area_normals_pos_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-                area_normals_neg_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-                area_normals_pos_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-                area_normals_neg_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-                area_normals_pos_face_3, 3, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-                area_normals_neg_face_3, 3, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            const double tolerance = 1e-10;
-
-            // Check shape functions values
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,3), 0.500, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(1,0), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(1,1), 0.500, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(1,2), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(1,3), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(2,0), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(2,1), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(2,2), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(2,3), 0.375, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 0.500, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,3), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,0), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,1), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,2), 0.375, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(1,3), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(2,0), 0.500, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(2,1), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(2,2), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(2,3), 0.125, tolerance);
-
-            // Check Gauss pts. weights
-            KRATOS_CHECK_NEAR(positive_side_weights(0), 0.02083333333, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_weights(1), 0.04166666666, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_weights(2), 0.02083333333, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_weights(0), 0.02083333333, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_weights(1), 0.02083333333, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_weights(2), 0.04166666666, tolerance);
-
-            // Check Gauss pts. shape functions gradients values
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            // Check interface shape function values
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,3), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(1,0), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(1,1), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(1,2), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(1,3), 1.0/6.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,3), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(1,0), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(1,1), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(1,2), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(1,3), 1.0/3.0, tolerance);
-
-            // Check interface Gauss pts. weights
-            KRATOS_CHECK_NEAR(positive_interface_side_weights(0), 0.176777, 1e-6);
-            KRATOS_CHECK_NEAR(positive_interface_side_weights(1), 0.176777, 1e-6);
-            KRATOS_CHECK_NEAR(negative_interface_side_weights(0), 0.176777, 1e-6);
-            KRATOS_CHECK_NEAR(negative_interface_side_weights(1), 0.176777, 1e-6);
-
-            // Check Gauss pts. interface shape function gradients values
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            // Check face 0 values
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,0),     0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,1),     0.5, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,2), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,3), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(1,0),     0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(1,1), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(1,2), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(1,3),     0.5, tolerance);
-
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), 0.433013, 10e-5);
-            KRATOS_CHECK_NEAR(pos_ext_face_weights_0(1), 0.216506, 10e-5);
-
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0),     0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 2.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,3), 1.0/6.0, tolerance);
-
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(neg_ext_face_weights_0(0), 0.216506, 10e-5);
-
-            KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](0), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](1), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](2), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_pos_face_0[1](0), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_pos_face_0[1](1), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_pos_face_0[1](2), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](0), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](1), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](2), 0.125, tolerance);
-
-            // Check Gauss pts. outwards unit normal values
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), -0.125, 1e-6);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), 0.0, 1e-6);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), -0.125, 1e-6);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[1](0), -0.125, 1e-6);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[1](1),  0.0, 1e-6);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[1](2), -0.125, 1e-6);
-
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), 0.125, 1e-6);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.0, 1e-6);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.125, 1e-6);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[1](0), 0.125, 1e-6);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[1](1), 0.0, 1e-6);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[1](2), 0.125, 1e-6);
-        }
-
-        KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTetrahedra3D4ZeroNodes, KratosCoreFastSuite)
-        {
-            Model current_model;
-
-            // Generate a model part with the previous
-            ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
-            base_model_part.AddNodalSolutionStepVariable(DISTANCE);
-
-            // Fill the model part geometry data
-            base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-            base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-            base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
-            base_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
-            Properties::Pointer p_properties(new Properties(0));
-            base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
-
-            // Set the DISTANCE field
-            base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) =  0.0;
-            base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
-            base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) =  1.0;
-            base_model_part.Nodes()[4].FastGetSolutionStepValue(DISTANCE) =  0.0;
-
-            // Set the elemental distances vector
-            Geometry<Node>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
-
-            array_1d<double, 4> distances_vector;
-            for (unsigned int i = 0; i < p_geometry->size(); ++i) {
-                distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
-            }
-
-            base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
-
-            Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
-
-            // Call the modified shape functions calculator
-            Tetrahedra3D4ModifiedShapeFunctions tetrahedra_shape_functions(p_geometry, r_elemental_distances);
-            Matrix positive_side_sh_func, negative_side_sh_func;
-            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
-            Vector positive_side_weights, negative_side_weights;
-
-            tetrahedra_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
-                positive_side_sh_func,
-                positive_side_sh_func_gradients,
-                positive_side_weights,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
-                negative_side_sh_func,
-                negative_side_sh_func_gradients,
-                negative_side_weights,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            // Call the interface modified shape functions calculator
-            Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
-            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
-            Vector positive_interface_side_weights, negative_interface_side_weights;
-
-            tetrahedra_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
-                positive_interface_side_sh_func,
-                positive_interface_side_sh_func_gradients,
-                positive_interface_side_weights,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
-                negative_interface_side_sh_func,
-                negative_interface_side_sh_func_gradients,
-                negative_interface_side_weights,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            // Call the external face modified shape functions calculator
-            Matrix pos_ext_face_sh_func_0, neg_ext_face_sh_func_0,
-                   pos_ext_face_sh_func_1, neg_ext_face_sh_func_1,
-                   pos_ext_face_sh_func_2, neg_ext_face_sh_func_2,
-                   pos_ext_face_sh_func_3, neg_ext_face_sh_func_3;
-
-            ModifiedShapeFunctions::ShapeFunctionsGradientsType
-                pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
-                pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
-                pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2,
-                pos_ext_face_sh_func_gradients_3, neg_ext_face_sh_func_gradients_3;
-
-            Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
-                   pos_ext_face_weights_1, neg_ext_face_weights_1,
-                   pos_ext_face_weights_2, neg_ext_face_weights_2,
-                   pos_ext_face_weights_3, neg_ext_face_weights_3;
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-                pos_ext_face_sh_func_0,
-                pos_ext_face_sh_func_gradients_0,
-                pos_ext_face_weights_0,
-                0,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-                neg_ext_face_sh_func_0,
-                neg_ext_face_sh_func_gradients_0,
-                neg_ext_face_weights_0,
-                0,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-                pos_ext_face_sh_func_1,
-                pos_ext_face_sh_func_gradients_1,
-                pos_ext_face_weights_1,
-                1,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-                neg_ext_face_sh_func_1,
-                neg_ext_face_sh_func_gradients_1,
-                neg_ext_face_weights_1,
-                1,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-                pos_ext_face_sh_func_2,
-                pos_ext_face_sh_func_gradients_2,
-                pos_ext_face_weights_2,
-                2,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-                neg_ext_face_sh_func_2,
-                neg_ext_face_sh_func_gradients_2,
-                neg_ext_face_weights_2,
-                2,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-                pos_ext_face_sh_func_3,
-                pos_ext_face_sh_func_gradients_3,
-                pos_ext_face_weights_3,
-                3,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-                neg_ext_face_sh_func_3,
-                neg_ext_face_sh_func_gradients_3,
-                neg_ext_face_weights_3,
-                3,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            // Call the interface outwards normal unit vector calculator
-            std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
-
-            tetrahedra_shape_functions.ComputePositiveSideInterfaceAreaNormals(
-                positive_side_area_normals,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
-                negative_side_area_normals,
-                GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            // Call the exterior faces outwards normal area vector calculator
-            std::vector<array_1d<double,3>>
-                area_normals_pos_face_0, area_normals_neg_face_0,
-                area_normals_pos_face_1, area_normals_neg_face_1,
-                area_normals_pos_face_2, area_normals_neg_face_2,
-                area_normals_pos_face_3, area_normals_neg_face_3;
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-                area_normals_pos_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-                area_normals_neg_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-                area_normals_pos_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-                area_normals_neg_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-                area_normals_pos_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-                area_normals_neg_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-                area_normals_pos_face_3, 3, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-                area_normals_neg_face_3, 3, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-            const double tolerance = 1e-10;
-
-            // Check shape functions values
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 0.375, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func(0,3), 0.250, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 0.250, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 0.375, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 0.125, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func(0,3), 0.250, tolerance);
-
-            // Check Gauss pts. weights
-            KRATOS_CHECK_NEAR(positive_side_weights(0), 1.0/12.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_weights(0), 1.0/12.0, tolerance);
-
-            // Check Gauss pts. shape functions gradients values
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            // Check interface shape function values
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,3), 1.0/3.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/3.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,3), 1.0/3.0, tolerance);
-
-            // Check interface Gauss pts. weights
-            KRATOS_CHECK_NEAR(positive_interface_side_weights(0), std::sqrt(2.0)/4.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_weights(0), std::sqrt(2.0)/4.0, tolerance);
-
-            // Check Gauss pts. interface shape function gradients values
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
-
-            // Check face 0 values
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,0),     0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,1), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,2), 1.0/2.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,3), 1.0/3.0, tolerance);
-
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), std::sqrt(3.0)/4.0, tolerance);
-
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0),     0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1), 1.0/2.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 1.0/6.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,3), 1.0/3.0, tolerance);
-
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,2), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,2),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,0),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,2),  1.0, tolerance);
-
-            KRATOS_CHECK_NEAR(neg_ext_face_weights_0(0), std::sqrt(3.0)/4.0, tolerance);
-
-            KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](0), 0.25, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](1), 0.25, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](2), 0.25, tolerance);
-
-            KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](0), 0.25, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](1), 0.25, tolerance);
-            KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](2), 0.25, tolerance);
-
-            // Check Gauss pts. outwards unit normal values
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), 0.25, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](1),-0.25, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.00, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](0),-0.25, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.25, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.00, tolerance);
-        }
-
-
-        KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTetrahedra3D4Volumes, KratosCoreFastSuite)
-        {
-            Model current_model;
-            // Generate a model part with the previous
-            ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
-            base_model_part.AddNodalSolutionStepVariable(DISTANCE);
-
-            // Fill the model part geometry data
-            base_model_part.CreateNewNode(1, 0.0, 2.0, 0.0);
-            base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-            base_model_part.CreateNewNode(3, 1.0, 2.0, 0.0);
-            base_model_part.CreateNewNode(4, 1.0, 2.0, 2.0);
-            Properties::Pointer p_properties(new Properties(0));
-            base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
-
-            // Set the DISTANCE field
-            base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -0.5;
-            base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) =  1.0;
-            base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = -0.5;
-            base_model_part.Nodes()[4].FastGetSolutionStepValue(DISTANCE) =  1.0;
-
-            // Set the elemental distances vector
-            Geometry<Node>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
-
-            array_1d<double, 4> distances_vector;
-            for (unsigned int i = 0; i < p_geometry->size(); ++i) {
-                distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
-            }
-
-            base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
-
-            Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
-
-            // Call the modified shape functions calculator
-            Tetrahedra3D4ModifiedShapeFunctions tetrahedra_shape_functions(p_geometry, r_elemental_distances);
-            Matrix positive_side_sh_func, negative_side_sh_func;
-            ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
-            Vector positive_side_weights, negative_side_weights;
-
-            tetrahedra_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
-                positive_side_sh_func,
-                positive_side_sh_func_gradients,
-                positive_side_weights,
-                GeometryData::IntegrationMethod::GI_GAUSS_2);
-
-            tetrahedra_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
-                negative_side_sh_func,
-                negative_side_sh_func_gradients,
-                negative_side_weights,
-                GeometryData::IntegrationMethod::GI_GAUSS_2);
-
-            const double tolerance = 1e-10;
-
-            // Check Gauss pts. weights
-            const unsigned int n_gauss_pos = positive_side_weights.size();
-            const unsigned int n_gauss_neg = negative_side_weights.size();
-
-            double pos_vol = 0.0;
-            for (unsigned int i=0; i<n_gauss_pos; ++i) {
-                pos_vol += positive_side_weights(i);
-            }
-
-            double neg_vol = 0.0;
-            for (unsigned int i=0; i<n_gauss_neg; ++i) {
-                neg_vol += negative_side_weights(i);
-            }
-
-            const double tot_vol = 2.0*1.0*2.0/6.0;
-            KRATOS_CHECK_NEAR(pos_vol+neg_vol, tot_vol, tolerance);
-        }
-    }   // namespace Testing.
-}  // namespace Kratos.
+
+KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTetrahedra3D4Horizontal, KratosCoreFastSuite)
+{
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
+    base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    base_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
+    Properties::Pointer p_properties(new Properties(0));
+    base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
+
+    // Set the DISTANCE field
+    base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[4].FastGetSolutionStepValue(DISTANCE) =  1.0;
+
+    // Set the elemental distances vector
+    Geometry<Node>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
+
+    array_1d<double, 4> distances_vector;
+    for (unsigned int i = 0; i < p_geometry->size(); ++i) {
+        distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
+    }
+
+    base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+
+    Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+    // Call the modified shape functions calculator
+    Tetrahedra3D4ModifiedShapeFunctions tetrahedra_shape_functions(p_geometry, r_elemental_distances);
+    Matrix positive_side_sh_func, negative_side_sh_func;
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
+    Vector positive_side_weights, negative_side_weights;
+
+    tetrahedra_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
+        positive_side_sh_func,
+        positive_side_sh_func_gradients,
+        positive_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
+        negative_side_sh_func,
+        negative_side_sh_func_gradients,
+        negative_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the interface modified shape functions calculator
+    Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
+    Vector positive_interface_side_weights, negative_interface_side_weights;
+
+    tetrahedra_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
+        positive_interface_side_sh_func,
+        positive_interface_side_sh_func_gradients,
+        positive_interface_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
+        negative_interface_side_sh_func,
+        negative_interface_side_sh_func_gradients,
+        negative_interface_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the external face modified shape functions calculator
+    Matrix pos_ext_face_sh_func_0, neg_ext_face_sh_func_0,
+            pos_ext_face_sh_func_1, neg_ext_face_sh_func_1,
+            pos_ext_face_sh_func_2, neg_ext_face_sh_func_2,
+            pos_ext_face_sh_func_3, neg_ext_face_sh_func_3;
+
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType
+        pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
+        pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
+        pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2,
+        pos_ext_face_sh_func_gradients_3, neg_ext_face_sh_func_gradients_3;
+
+    Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
+            pos_ext_face_weights_1, neg_ext_face_weights_1,
+            pos_ext_face_weights_2, neg_ext_face_weights_2,
+            pos_ext_face_weights_3, neg_ext_face_weights_3;
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_0,
+        pos_ext_face_sh_func_gradients_0,
+        pos_ext_face_weights_0,
+        0,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_0,
+        neg_ext_face_sh_func_gradients_0,
+        neg_ext_face_weights_0,
+        0,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_1,
+        pos_ext_face_sh_func_gradients_1,
+        pos_ext_face_weights_1,
+        1,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_1,
+        neg_ext_face_sh_func_gradients_1,
+        neg_ext_face_weights_1,
+        1,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_2,
+        pos_ext_face_sh_func_gradients_2,
+        pos_ext_face_weights_2,
+        2,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_2,
+        neg_ext_face_sh_func_gradients_2,
+        neg_ext_face_weights_2,
+        2,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_3,
+        pos_ext_face_sh_func_gradients_3,
+        pos_ext_face_weights_3,
+        3,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_3,
+        neg_ext_face_sh_func_gradients_3,
+        neg_ext_face_weights_3,
+        3,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the interface outwards normal unit vector calculator
+    std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
+
+    tetrahedra_shape_functions.ComputePositiveSideInterfaceAreaNormals(
+        positive_side_area_normals,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
+        negative_side_area_normals,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the exterior faces outwards normal area vector calculator
+    std::vector<array_1d<double,3>>
+        area_normals_pos_face_0, area_normals_neg_face_0,
+        area_normals_pos_face_1, area_normals_neg_face_1,
+        area_normals_pos_face_2, area_normals_neg_face_2,
+        area_normals_pos_face_3, area_normals_neg_face_3;
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_3, 3, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_3, 3, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    const double tolerance = 1e-10;
+
+    // Check shape functions values
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,3), 0.625, tolerance);
+
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 0.375, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,3), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(1,0), 0.375, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(1,1), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(1,2), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(1,3), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(2,0), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(2,1), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(2,2), 0.375, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(2,3), 0.375, tolerance);
+
+    // Check Gauss pts. weights
+    KRATOS_CHECK_NEAR(positive_side_weights(0), 0.02083333333, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_weights(0), 0.04166666666, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_weights(1), 0.08333333333, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_weights(2), 0.02083333333, tolerance);
+
+    // Check Gauss pts. shape functions gradients values
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+    // Check interface shape function values
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,3),     0.5, tolerance);
+
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,3),     0.5, tolerance);
+
+    // Check interface Gauss pts. weights
+    KRATOS_CHECK_NEAR(positive_interface_side_weights(0), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_weights(0), 0.125, tolerance);
+
+    // Check Gauss pts. interface shape function gradients values
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+    // Check face 0 values
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,0),     0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,1), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,2), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,3), 2.0/3.0, tolerance);
+
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,2),  1.0, tolerance);
+
+    KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), 0.216506, 10e-5);
+
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0),     0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1),     0.5, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 1.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,3), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(1,0),     0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(1,1), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(1,2),     0.5, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(1,3), 1.0/3.0, tolerance);
+
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,2),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[1](3,2),  1.0, tolerance);
+
+    KRATOS_CHECK_NEAR(neg_ext_face_weights_0(0), 0.433013, 10e-5);
+    KRATOS_CHECK_NEAR(neg_ext_face_weights_0(1), 0.216506, 10e-5);
+
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](0), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](1), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](2), 0.125, tolerance);
+
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](0), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](1), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](2), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[1](0), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[1](1), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[1](2), 0.125, tolerance);
+
+    // Check Gauss pts. outwards unit normal values
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), -0.125, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.125, tolerance);
+}
+
+
+KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTetrahedra3D4Oblique, KratosCoreFastSuite)
+{
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
+    base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    base_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
+    Properties::Pointer p_properties(new Properties(0));
+    base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
+
+    // Set the DISTANCE field
+    base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) =  1.0;
+    base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[4].FastGetSolutionStepValue(DISTANCE) =  1.0;
+
+    // Set the elemental distances vector
+    Geometry<Node>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
+
+    array_1d<double, 4> distances_vector;
+    for (unsigned int i = 0; i < p_geometry->size(); ++i) {
+        distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
+    }
+
+    base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+
+    Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+    // Call the modified shape functions calculator
+    Tetrahedra3D4ModifiedShapeFunctions tetrahedra_shape_functions(p_geometry, r_elemental_distances);
+    Matrix positive_side_sh_func, negative_side_sh_func;
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
+    Vector positive_side_weights, negative_side_weights;
+
+    tetrahedra_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
+        positive_side_sh_func,
+        positive_side_sh_func_gradients,
+        positive_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
+        negative_side_sh_func,
+        negative_side_sh_func_gradients,
+        negative_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the interface modified shape functions calculator
+    Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
+    Vector positive_interface_side_weights, negative_interface_side_weights;
+
+    tetrahedra_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
+        positive_interface_side_sh_func,
+        positive_interface_side_sh_func_gradients,
+        positive_interface_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
+        negative_interface_side_sh_func,
+        negative_interface_side_sh_func_gradients,
+        negative_interface_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the external face modified shape functions calculator
+    Matrix pos_ext_face_sh_func_0, neg_ext_face_sh_func_0,
+            pos_ext_face_sh_func_1, neg_ext_face_sh_func_1,
+            pos_ext_face_sh_func_2, neg_ext_face_sh_func_2,
+            pos_ext_face_sh_func_3, neg_ext_face_sh_func_3;
+
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType
+        pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
+        pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
+        pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2,
+        pos_ext_face_sh_func_gradients_3, neg_ext_face_sh_func_gradients_3;
+
+    Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
+            pos_ext_face_weights_1, neg_ext_face_weights_1,
+            pos_ext_face_weights_2, neg_ext_face_weights_2,
+            pos_ext_face_weights_3, neg_ext_face_weights_3;
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_0,
+        pos_ext_face_sh_func_gradients_0,
+        pos_ext_face_weights_0,
+        0,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_0,
+        neg_ext_face_sh_func_gradients_0,
+        neg_ext_face_weights_0,
+        0,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_1,
+        pos_ext_face_sh_func_gradients_1,
+        pos_ext_face_weights_1,
+        1,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_1,
+        neg_ext_face_sh_func_gradients_1,
+        neg_ext_face_weights_1,
+        1,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_2,
+        pos_ext_face_sh_func_gradients_2,
+        pos_ext_face_weights_2,
+        2,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_2,
+        neg_ext_face_sh_func_gradients_2,
+        neg_ext_face_weights_2,
+        2,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_3,
+        pos_ext_face_sh_func_gradients_3,
+        pos_ext_face_weights_3,
+        3,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_3,
+        neg_ext_face_sh_func_gradients_3,
+        neg_ext_face_weights_3,
+        3,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the interface outwards normal unit vector calculator
+    std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
+
+    tetrahedra_shape_functions.ComputePositiveSideInterfaceAreaNormals(
+        positive_side_area_normals,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
+        negative_side_area_normals,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the exterior faces outwards normal area vector calculator
+    std::vector<array_1d<double,3>>
+        area_normals_pos_face_0, area_normals_neg_face_0,
+        area_normals_pos_face_1, area_normals_neg_face_1,
+        area_normals_pos_face_2, area_normals_neg_face_2,
+        area_normals_pos_face_3, area_normals_neg_face_3;
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_3, 3, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_3, 3, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    const double tolerance = 1e-10;
+
+    // Check shape functions values
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,3), 0.500, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(1,0), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(1,1), 0.500, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(1,2), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(1,3), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(2,0), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(2,1), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(2,2), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(2,3), 0.375, tolerance);
+
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 0.500, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,3), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(1,0), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(1,1), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(1,2), 0.375, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(1,3), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(2,0), 0.500, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(2,1), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(2,2), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(2,3), 0.125, tolerance);
+
+    // Check Gauss pts. weights
+    KRATOS_CHECK_NEAR(positive_side_weights(0), 0.02083333333, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_weights(1), 0.04166666666, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_weights(2), 0.02083333333, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_weights(0), 0.02083333333, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_weights(1), 0.02083333333, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_weights(2), 0.04166666666, tolerance);
+
+    // Check Gauss pts. shape functions gradients values
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+    // Check interface shape function values
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 1.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,3), 1.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(1,0), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(1,1), 1.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(1,2), 1.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(1,3), 1.0/6.0, tolerance);
+
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 1.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,3), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(1,0), 1.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(1,1), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(1,2), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(1,3), 1.0/3.0, tolerance);
+
+    // Check interface Gauss pts. weights
+    KRATOS_CHECK_NEAR(positive_interface_side_weights(0), 0.176777, 1e-6);
+    KRATOS_CHECK_NEAR(positive_interface_side_weights(1), 0.176777, 1e-6);
+    KRATOS_CHECK_NEAR(negative_interface_side_weights(0), 0.176777, 1e-6);
+    KRATOS_CHECK_NEAR(negative_interface_side_weights(1), 0.176777, 1e-6);
+
+    // Check Gauss pts. interface shape function gradients values
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+    // Check face 0 values
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,0),     0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,1),     0.5, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,2), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,3), 1.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(1,0),     0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(1,1), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(1,2), 1.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(1,3),     0.5, tolerance);
+
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,2),  1.0, tolerance);
+
+    KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), 0.433013, 10e-5);
+    KRATOS_CHECK_NEAR(pos_ext_face_weights_0(1), 0.216506, 10e-5);
+
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0),     0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 2.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,3), 1.0/6.0, tolerance);
+
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,2),  1.0, tolerance);
+
+    KRATOS_CHECK_NEAR(neg_ext_face_weights_0(0), 0.216506, 10e-5);
+
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](0), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](1), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](2), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[1](0), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[1](1), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[1](2), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](0), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](1), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](2), 0.125, tolerance);
+
+    // Check Gauss pts. outwards unit normal values
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), -0.125, 1e-6);
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), 0.0, 1e-6);
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), -0.125, 1e-6);
+    KRATOS_CHECK_NEAR(positive_side_area_normals[1](0), -0.125, 1e-6);
+    KRATOS_CHECK_NEAR(positive_side_area_normals[1](1),  0.0, 1e-6);
+    KRATOS_CHECK_NEAR(positive_side_area_normals[1](2), -0.125, 1e-6);
+
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), 0.125, 1e-6);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.0, 1e-6);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.125, 1e-6);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[1](0), 0.125, 1e-6);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[1](1), 0.0, 1e-6);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[1](2), 0.125, 1e-6);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTetrahedra3D4ZeroNodes, KratosCoreFastSuite)
+{
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
+    base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    base_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
+    Properties::Pointer p_properties(new Properties(0));
+    base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
+
+    // Set the DISTANCE field
+    base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) =  0.0;
+    base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) =  1.0;
+    base_model_part.Nodes()[4].FastGetSolutionStepValue(DISTANCE) =  0.0;
+
+    // Set the elemental distances vector
+    Geometry<Node>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
+
+    array_1d<double, 4> distances_vector;
+    for (unsigned int i = 0; i < p_geometry->size(); ++i) {
+        distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
+    }
+
+    base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+
+    Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+    // Call the modified shape functions calculator
+    Tetrahedra3D4ModifiedShapeFunctions tetrahedra_shape_functions(p_geometry, r_elemental_distances);
+    Matrix positive_side_sh_func, negative_side_sh_func;
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
+    Vector positive_side_weights, negative_side_weights;
+
+    tetrahedra_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
+        positive_side_sh_func,
+        positive_side_sh_func_gradients,
+        positive_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
+        negative_side_sh_func,
+        negative_side_sh_func_gradients,
+        negative_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the interface modified shape functions calculator
+    Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
+    Vector positive_interface_side_weights, negative_interface_side_weights;
+
+    tetrahedra_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
+        positive_interface_side_sh_func,
+        positive_interface_side_sh_func_gradients,
+        positive_interface_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
+        negative_interface_side_sh_func,
+        negative_interface_side_sh_func_gradients,
+        negative_interface_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the external face modified shape functions calculator
+    Matrix pos_ext_face_sh_func_0, neg_ext_face_sh_func_0,
+            pos_ext_face_sh_func_1, neg_ext_face_sh_func_1,
+            pos_ext_face_sh_func_2, neg_ext_face_sh_func_2,
+            pos_ext_face_sh_func_3, neg_ext_face_sh_func_3;
+
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType
+        pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
+        pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
+        pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2,
+        pos_ext_face_sh_func_gradients_3, neg_ext_face_sh_func_gradients_3;
+
+    Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
+            pos_ext_face_weights_1, neg_ext_face_weights_1,
+            pos_ext_face_weights_2, neg_ext_face_weights_2,
+            pos_ext_face_weights_3, neg_ext_face_weights_3;
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_0,
+        pos_ext_face_sh_func_gradients_0,
+        pos_ext_face_weights_0,
+        0,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_0,
+        neg_ext_face_sh_func_gradients_0,
+        neg_ext_face_weights_0,
+        0,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_1,
+        pos_ext_face_sh_func_gradients_1,
+        pos_ext_face_weights_1,
+        1,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_1,
+        neg_ext_face_sh_func_gradients_1,
+        neg_ext_face_weights_1,
+        1,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_2,
+        pos_ext_face_sh_func_gradients_2,
+        pos_ext_face_weights_2,
+        2,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_2,
+        neg_ext_face_sh_func_gradients_2,
+        neg_ext_face_weights_2,
+        2,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_3,
+        pos_ext_face_sh_func_gradients_3,
+        pos_ext_face_weights_3,
+        3,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_3,
+        neg_ext_face_sh_func_gradients_3,
+        neg_ext_face_weights_3,
+        3,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the interface outwards normal unit vector calculator
+    std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
+
+    tetrahedra_shape_functions.ComputePositiveSideInterfaceAreaNormals(
+        positive_side_area_normals,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
+        negative_side_area_normals,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the exterior faces outwards normal area vector calculator
+    std::vector<array_1d<double,3>>
+        area_normals_pos_face_0, area_normals_neg_face_0,
+        area_normals_pos_face_1, area_normals_neg_face_1,
+        area_normals_pos_face_2, area_normals_neg_face_2,
+        area_normals_pos_face_3, area_normals_neg_face_3;
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_3, 3, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    tetrahedra_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_3, 3, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    const double tolerance = 1e-10;
+
+    // Check shape functions values
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 0.375, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,3), 0.250, tolerance);
+
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 0.250, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 0.375, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 0.125, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,3), 0.250, tolerance);
+
+    // Check Gauss pts. weights
+    KRATOS_CHECK_NEAR(positive_side_weights(0), 1.0/12.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_weights(0), 1.0/12.0, tolerance);
+
+    // Check Gauss pts. shape functions gradients values
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+    // Check interface shape function values
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 1.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,3), 1.0/3.0, tolerance);
+
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,3), 1.0/3.0, tolerance);
+
+    // Check interface Gauss pts. weights
+    KRATOS_CHECK_NEAR(positive_interface_side_weights(0), std::sqrt(2.0)/4.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_weights(0), std::sqrt(2.0)/4.0, tolerance);
+
+    // Check Gauss pts. interface shape function gradients values
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
+
+    // Check face 0 values
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,0),     0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,1), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,2), 1.0/2.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,3), 1.0/3.0, tolerance);
+
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](3,2),  1.0, tolerance);
+
+    KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), std::sqrt(3.0)/4.0, tolerance);
+
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0),     0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1), 1.0/2.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,3), 1.0/3.0, tolerance);
+
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,2), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](3,2),  1.0, tolerance);
+
+    KRATOS_CHECK_NEAR(neg_ext_face_weights_0(0), std::sqrt(3.0)/4.0, tolerance);
+
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](0), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](1), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](2), 0.25, tolerance);
+
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](0), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](1), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](2), 0.25, tolerance);
+
+    // Check Gauss pts. outwards unit normal values
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](1),-0.25, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.00, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](0),-0.25, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.00, tolerance);
+}
+
+
+KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTetrahedra3D4Volumes, KratosCoreFastSuite)
+{
+    Model current_model;
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
+    base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 2.0, 0.0);
+    base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(3, 1.0, 2.0, 0.0);
+    base_model_part.CreateNewNode(4, 1.0, 2.0, 2.0);
+    Properties::Pointer p_properties(new Properties(0));
+    base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
+
+    // Set the DISTANCE field
+    base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -0.5;
+    base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) =  1.0;
+    base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = -0.5;
+    base_model_part.Nodes()[4].FastGetSolutionStepValue(DISTANCE) =  1.0;
+
+    // Set the elemental distances vector
+    Geometry<Node>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
+
+    array_1d<double, 4> distances_vector;
+    for (unsigned int i = 0; i < p_geometry->size(); ++i) {
+        distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
+    }
+
+    base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+
+    Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+    // Call the modified shape functions calculator
+    Tetrahedra3D4ModifiedShapeFunctions tetrahedra_shape_functions(p_geometry, r_elemental_distances);
+    Matrix positive_side_sh_func, negative_side_sh_func;
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
+    Vector positive_side_weights, negative_side_weights;
+
+    tetrahedra_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
+        positive_side_sh_func,
+        positive_side_sh_func_gradients,
+        positive_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_2);
+
+    tetrahedra_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
+        negative_side_sh_func,
+        negative_side_sh_func_gradients,
+        negative_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_2);
+
+    const double tolerance = 1e-10;
+
+    // Check Gauss pts. weights
+    const unsigned int n_gauss_pos = positive_side_weights.size();
+    const unsigned int n_gauss_neg = negative_side_weights.size();
+
+    double pos_vol = 0.0;
+    for (unsigned int i=0; i<n_gauss_pos; ++i) {
+        pos_vol += positive_side_weights(i);
+    }
+
+    double neg_vol = 0.0;
+    for (unsigned int i=0; i<n_gauss_neg; ++i) {
+        neg_vol += negative_side_weights(i);
+    }
+
+    const double tot_vol = 2.0*1.0*2.0/6.0;
+    KRATOS_CHECK_NEAR(pos_vol+neg_vol, tot_vol, tolerance);
+}
+
+}  // namespace Kratos::Testing.

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_modified_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_modified_shape_functions.cpp
@@ -683,6 +683,304 @@ namespace Kratos
 			KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](2), 0.0, tolerance);
 		}
 
+		KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTriangle2D3ZeroNode, KratosCoreFastSuite)
+		{
+			Model current_model;
+
+			// Generate a model part with the previous
+			ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
+			base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+			// Fill the model part geometry data
+			base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+			base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+			base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+			Properties::Pointer p_properties(new Properties(0));
+			base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
+
+			// Set the DISTANCE field
+			base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) =  0.0;
+			base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
+			base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) =  1.0;
+
+			// Set the elemental distances vector
+			Geometry<Node>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
+
+			array_1d<double, 3> distances_vector;
+			for (unsigned int i = 0; i < p_geometry->size(); ++i) {
+				distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
+			}
+
+			base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+
+			const Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+			// Call the modified shape functions calculator
+			Triangle2D3ModifiedShapeFunctions triangle_shape_functions(p_geometry, r_elemental_distances);
+			Matrix positive_side_sh_func, negative_side_sh_func;
+			ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
+			Vector positive_side_weights, negative_side_weights;
+
+			triangle_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
+				positive_side_sh_func,
+				positive_side_sh_func_gradients,
+				positive_side_weights,
+				GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			triangle_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
+				negative_side_sh_func,
+				negative_side_sh_func_gradients,
+				negative_side_weights,
+				GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			// Call the interface modified shape functions calculator
+			Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
+			ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
+			Vector positive_interface_side_weights, negative_interface_side_weights;
+
+			triangle_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
+				positive_interface_side_sh_func,
+				positive_interface_side_sh_func_gradients,
+				positive_interface_side_weights,
+				GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			triangle_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
+				negative_interface_side_sh_func,
+				negative_interface_side_sh_func_gradients,
+				negative_interface_side_weights,
+				GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			// Call the external face modified shape functions calculator
+			Matrix pos_ext_face_sh_func_0, neg_ext_face_sh_func_0,
+				   pos_ext_face_sh_func_1, neg_ext_face_sh_func_1,
+				   pos_ext_face_sh_func_2, neg_ext_face_sh_func_2;
+
+			ModifiedShapeFunctions::ShapeFunctionsGradientsType
+				pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
+				pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
+				pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2;
+
+			Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
+				   pos_ext_face_weights_1, neg_ext_face_weights_1,
+				   pos_ext_face_weights_2, neg_ext_face_weights_2;
+
+			triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+				pos_ext_face_sh_func_0,
+				pos_ext_face_sh_func_gradients_0,
+				pos_ext_face_weights_0,
+				0,
+				GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+				neg_ext_face_sh_func_0,
+				neg_ext_face_sh_func_gradients_0,
+				neg_ext_face_weights_0,
+				0,
+				GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+				pos_ext_face_sh_func_1,
+				pos_ext_face_sh_func_gradients_1,
+				pos_ext_face_weights_1,
+				1,
+				GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+				neg_ext_face_sh_func_1,
+				neg_ext_face_sh_func_gradients_1,
+				neg_ext_face_weights_1,
+				1,
+				GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+				pos_ext_face_sh_func_2,
+				pos_ext_face_sh_func_gradients_2,
+				pos_ext_face_weights_2,
+				2,
+				GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+				neg_ext_face_sh_func_2,
+				neg_ext_face_sh_func_gradients_2,
+				neg_ext_face_weights_2,
+				2,
+				GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			// Call the interface outwards normal area vector calculator
+			std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
+
+			triangle_shape_functions.ComputePositiveSideInterfaceAreaNormals(
+				positive_side_area_normals,
+				GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			triangle_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
+				negative_side_area_normals,
+				GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			// Call the exterior faces outwards normal area vector calculator
+			std::vector<array_1d<double,3>>
+				area_normals_pos_face_0, area_normals_neg_face_0,
+				area_normals_pos_face_1, area_normals_neg_face_1,
+				area_normals_pos_face_2, area_normals_neg_face_2;
+
+			triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+				area_normals_pos_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+				area_normals_neg_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+				area_normals_pos_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+				area_normals_neg_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+				area_normals_pos_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+				area_normals_neg_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+			const double tolerance = 1e-10;
+
+			KRATOS_CHECK_EQUAL(positive_side_sh_func.size1(), 1);
+			KRATOS_CHECK_EQUAL(negative_side_sh_func.size1(), 1);
+
+			// Check shape functions values
+			KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 1.0/3.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 1.0/6.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 1.0/2.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 1.0/3.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 1.0/2.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 1.0/6.0, tolerance);
+
+			// Check Gauss pts. weights
+			KRATOS_CHECK_NEAR(positive_side_weights(0), 1.0/4.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_weights(0), 1.0/4.0, tolerance);
+
+			// Check Gauss pts. shape functions gradients values
+			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+
+			// Check interface shape function values
+			KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 1.0/2.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 1.0/4.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 1.0/4.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/2.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 1.0/4.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/4.0, tolerance);
+
+			// Check interface Gauss pts. weights
+			KRATOS_CHECK_NEAR(positive_interface_side_weights(0), std::sqrt(2.0)/2.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_interface_side_weights(0), std::sqrt(2.0)/2.0, tolerance);
+
+			// Check Gauss pts. interface shape function gradients values
+			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+
+			// Check Gauss pts. outwards area normal values
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), -0.5, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), -0.5, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.0, tolerance);
+
+			// Check face 0 values
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,0),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,1), 0.25, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,2), 0.75, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), 0.5*std::sqrt(2.0), tolerance);
+
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1), 0.75, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 0.25, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_weights_0(0), 0.5*std::sqrt(2.0), tolerance);
+
+			KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](0), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](1), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](2), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](0), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](1), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](2), 0.0, tolerance);
+
+			// Check face 1 values
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_1(0,0), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_1(0,1), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_1(0,2), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](0,0), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](0,1), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](1,0),  1.0, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](1,1),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](2,0),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](2,1),  1.0, tolerance);
+			KRATOS_CHECK_NEAR(pos_ext_face_weights_1(0), 1.0, tolerance);
+
+			KRATOS_CHECK_EQUAL(neg_ext_face_sh_func_1.size1(), 0);
+			KRATOS_CHECK_EQUAL(neg_ext_face_sh_func_1.size2(), 3);
+			KRATOS_CHECK_EQUAL(neg_ext_face_sh_func_gradients_1.size(), 0);
+			KRATOS_CHECK_EQUAL(neg_ext_face_weights_1.size(), 0);
+
+			KRATOS_CHECK_NEAR(area_normals_pos_face_1[0](0), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(area_normals_pos_face_1[0](1),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(area_normals_pos_face_1[0](2),  0.0, tolerance);
+			KRATOS_CHECK_EQUAL(area_normals_neg_face_1.size(), 0);
+
+			// Check face 2 values
+			KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_2.size1(), 0);
+			KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_2.size2(), 3);
+			KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_gradients_2.size(), 0);
+			KRATOS_CHECK_EQUAL(pos_ext_face_weights_2.size(), 0);
+
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,0), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,1), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,2), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](0,0), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](0,1), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](1,0),  1.0, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](1,1),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](2,0),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](2,1),  1.0, tolerance);
+			KRATOS_CHECK_NEAR(neg_ext_face_weights_2(0), 1.0, tolerance);
+
+			KRATOS_CHECK_EQUAL(area_normals_pos_face_2.size(), 0);
+			KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](0),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](1), -1.0, tolerance);
+			KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](2),  0.0, tolerance);
+		}
+
 
 		KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTriangle2D3Areas, KratosCoreFastSuite)
 		{

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_modified_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_modified_shape_functions.cpp
@@ -5,7 +5,7 @@
 //                   Multi-Physics
 //
 //  License:     BSD License
-//  			 Kratos default license: kratos/license.txt
+//               Kratos default license: kratos/license.txt
 //
 //  Main authors:    Ruben Zorrilla
 //
@@ -18,1065 +18,1063 @@
 #include "utilities/divide_triangle_2d_3.h"
 #include "modified_shape_functions/triangle_2d_3_modified_shape_functions.h"
 
-namespace Kratos
+namespace Kratos::Testing
 {
-	namespace Testing
-	{
-
-		Triangle2D3ModifiedShapeFunctions::UniquePointer SetTriangle2D3ModifiedShapeFunctionsPointer()
-		{
-			// Generate a test model part
-			Model current_model;
-			ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
-			base_model_part.AddNodalSolutionStepVariable(DISTANCE);
-
-			// Fill the model part geometry data
-			base_model_part.CreateNewNode(1, 0.0, 2.0, 0.0);
-			base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(3, 1.0, 2.0, 0.0);
-			Properties::Pointer p_properties(new Properties(0));
-			base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
-
-			// Set the DISTANCE field
-			base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -0.5;
-			base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) =  1.0;
-			base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = -0.5;
-
-			// Set the elemental distances vector
-			auto p_geometry = base_model_part.Elements()[1].pGetGeometry();
-			array_1d<double, 3> distances_vector;
-			for (unsigned int i = 0; i < p_geometry->size(); ++i) {
-				distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
-			}
-			base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
-			const Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
-
-			// Create and return the modified shape functions instance
-			auto p_modified_shape_functions_triangle = Kratos::make_unique<Triangle2D3ModifiedShapeFunctions>(p_geometry, r_elemental_distances);
-			return p_modified_shape_functions_triangle;
-		}
-
-		KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTriangle2D3Horizontal, KratosCoreFastSuite)
-		{
-			Model current_model;
-
-			// Generate a model part with the previous
-			ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
-			base_model_part.AddNodalSolutionStepVariable(DISTANCE);
-
-			// Fill the model part geometry data
-			base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
-			Properties::Pointer p_properties(new Properties(0));
-			base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
-
-			// Set the DISTANCE field
-			base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
-			base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
-			base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) =  1.0;
-
-			// Set the elemental distances vector
-			Geometry<Node>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
-
-			array_1d<double, 3> distances_vector;
-			for (unsigned int i = 0; i < p_geometry->size(); ++i) {
-				distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
-			}
-
-			base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
-
-			const Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
-
-			// Call the modified shape functions calculator
-			Triangle2D3ModifiedShapeFunctions triangle_shape_functions(p_geometry, r_elemental_distances);
-			Matrix positive_side_sh_func, negative_side_sh_func;
-			ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
-			Vector positive_side_weights, negative_side_weights;
-
-			triangle_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
-				positive_side_sh_func,
-				positive_side_sh_func_gradients,
-				positive_side_weights,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
-				negative_side_sh_func,
-				negative_side_sh_func_gradients,
-				negative_side_weights,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			// Call the interface modified shape functions calculator
-			Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
-			ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
-			Vector positive_interface_side_weights, negative_interface_side_weights;
-
-			triangle_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
-				positive_interface_side_sh_func,
-				positive_interface_side_sh_func_gradients,
-				positive_interface_side_weights,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
-				negative_interface_side_sh_func,
-				negative_interface_side_sh_func_gradients,
-				negative_interface_side_weights,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			// Call the external face modified shape functions calculator
-			Matrix pos_ext_face_sh_func_0, neg_ext_face_sh_func_0,
-				   pos_ext_face_sh_func_1, neg_ext_face_sh_func_1,
-				   pos_ext_face_sh_func_2, neg_ext_face_sh_func_2;
-
-			ModifiedShapeFunctions::ShapeFunctionsGradientsType
-				pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
-				pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
-				pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2;
-
-			Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
-				   pos_ext_face_weights_1, neg_ext_face_weights_1,
-				   pos_ext_face_weights_2, neg_ext_face_weights_2;
-
-			triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-				pos_ext_face_sh_func_0,
-				pos_ext_face_sh_func_gradients_0,
-				pos_ext_face_weights_0,
-				0,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-				neg_ext_face_sh_func_0,
-				neg_ext_face_sh_func_gradients_0,
-				neg_ext_face_weights_0,
-				0,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-				pos_ext_face_sh_func_1,
-				pos_ext_face_sh_func_gradients_1,
-				pos_ext_face_weights_1,
-				1,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-				neg_ext_face_sh_func_1,
-				neg_ext_face_sh_func_gradients_1,
-				neg_ext_face_weights_1,
-				1,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-				pos_ext_face_sh_func_2,
-				pos_ext_face_sh_func_gradients_2,
-				pos_ext_face_weights_2,
-				2,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-				neg_ext_face_sh_func_2,
-				neg_ext_face_sh_func_gradients_2,
-				neg_ext_face_weights_2,
-				2,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			// Call the interface outwards normal area vector calculator
-			std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
-
-			triangle_shape_functions.ComputePositiveSideInterfaceAreaNormals(
-				positive_side_area_normals,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
-				negative_side_area_normals,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			// Call the exterior faces outwards normal area vector calculator
-			std::vector<array_1d<double,3>>
-				area_normals_pos_face_0, area_normals_neg_face_0,
-				area_normals_pos_face_1, area_normals_neg_face_1,
-				area_normals_pos_face_2, area_normals_neg_face_2;
-
-			triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-				area_normals_pos_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-				area_normals_neg_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-				area_normals_pos_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-				area_normals_neg_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-				area_normals_pos_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-				area_normals_neg_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			const double tolerance = 1e-10;
-
-			// Check shape functions values
-			KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 1.0/6.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 1.0/6.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 2.0/3.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 1.0/6.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 1.0/2.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 1.0/3.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func(1,0), 1.0/2.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func(1,1), 1.0/3.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func(1,2), 1.0/6.0, tolerance);
-
-			// Check Gauss pts. weights
-			KRATOS_CHECK_NEAR(positive_side_weights(0), 1.0/8.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_weights(0), 1.0/8.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_weights(1), 1.0/4.0, tolerance);
-
-			// Check Gauss pts. shape functions gradients values
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,1),  1.0, tolerance);
-
-			// Check interface shape function values
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 0.25, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 0.25, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 0.50, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 0.25, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 0.25, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 0.50, tolerance);
-
-			// Check interface Gauss pts. weights
-			KRATOS_CHECK_NEAR(positive_interface_side_weights(0), 0.50, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_weights(0), 0.50, tolerance);
-
-			// Check Gauss pts. interface shape function gradients values
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-
-			// Check Gauss pts. outwards area normal values
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), -0.5, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.0, tolerance);
-
-			// Check face 0 values
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,1), 0.25, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,2), 0.75, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), 0.5*std::sqrt(2.0), tolerance);
-
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1), 0.75, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 0.25, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_weights_0(0), 0.5*std::sqrt(2.0), tolerance);
-
-			KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](0), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](1), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](2), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](0), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](1), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](2), 0.0, tolerance);
-
-			// Check face 1 values
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_1(0,0), 0.25, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_1(0,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_1(0,2), 0.75, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_weights_1(0), 0.5, tolerance);
-
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,0), 0.75, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,2), 0.25, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_weights_1(0), 0.5, tolerance);
-
-			KRATOS_CHECK_NEAR(area_normals_pos_face_1[0](0), -0.5, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_pos_face_1[0](1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_pos_face_1[0](2),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_1[0](0), -0.5, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_1[0](1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_1[0](2),  0.0, tolerance);
-
-			// Check face 2 values
-			KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_2.size1(), 0);
-			KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_2.size2(), 3);
-			KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_gradients_2.size(), 0);
-			KRATOS_CHECK_EQUAL(pos_ext_face_weights_2.size(), 0);
-
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,0), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,1), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,2), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_weights_2(0), 1.0, tolerance);
-
-			KRATOS_CHECK_EQUAL(area_normals_pos_face_2.size(), 0);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](2),  0.0, tolerance);
-		}
-
-
-		KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTriangle2D3Vertical, KratosCoreFastSuite)
-		{
-			Model current_model;
-
-			// Generate a model part with the previous
-			ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
-			base_model_part.AddNodalSolutionStepVariable(DISTANCE);
-
-			// Fill the model part geometry data
-			base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
-			Properties::Pointer p_properties(new Properties(0));
-			base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
-
-			// Set the DISTANCE field
-			base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
-			base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) =  1.0;
-			base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = -1.0;
-
-			// Set the elemental distances vector
-			Geometry<Node>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
-
-			array_1d<double, 3> distances_vector;
-			for (unsigned int i = 0; i < p_geometry->size(); ++i) {
-				distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
-			}
-
-			base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
-
-			const Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
-
-			// Call the modified shape functions calculator
-			Triangle2D3ModifiedShapeFunctions triangle_shape_functions(p_geometry, r_elemental_distances);
-			Matrix positive_side_sh_func, negative_side_sh_func;
-			ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
-			Vector positive_side_weights, negative_side_weights;
-
-			triangle_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
-				positive_side_sh_func,
-				positive_side_sh_func_gradients,
-				positive_side_weights,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
-				negative_side_sh_func,
-				negative_side_sh_func_gradients,
-				negative_side_weights,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			// Call the interface modified shape functions calculator
-			Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
-			ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
-			Vector positive_interface_side_weights, negative_interface_side_weights;
-
-			triangle_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
-				positive_interface_side_sh_func,
-				positive_interface_side_sh_func_gradients,
-				positive_interface_side_weights,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
-				negative_interface_side_sh_func,
-				negative_interface_side_sh_func_gradients,
-				negative_interface_side_weights,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			// Call the interface outwards normal unit vector calculator
-			std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
-
-			triangle_shape_functions.ComputePositiveSideInterfaceAreaNormals(
-				positive_side_area_normals,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
-				negative_side_area_normals,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			// Call the external face modified shape functions calculator
-			Matrix pos_ext_face_sh_func_0, neg_ext_face_sh_func_0,
-				   pos_ext_face_sh_func_1, neg_ext_face_sh_func_1,
-				   pos_ext_face_sh_func_2, neg_ext_face_sh_func_2;
-
-			ModifiedShapeFunctions::ShapeFunctionsGradientsType
-				pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
-				pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
-				pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2;
-
-			Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
-				   pos_ext_face_weights_1, neg_ext_face_weights_1,
-				   pos_ext_face_weights_2, neg_ext_face_weights_2;
-
-			triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-				pos_ext_face_sh_func_0,
-				pos_ext_face_sh_func_gradients_0,
-				pos_ext_face_weights_0,
-				0,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-				neg_ext_face_sh_func_0,
-				neg_ext_face_sh_func_gradients_0,
-				neg_ext_face_weights_0,
-				0,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-				pos_ext_face_sh_func_1,
-				pos_ext_face_sh_func_gradients_1,
-				pos_ext_face_weights_1,
-				1,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-				neg_ext_face_sh_func_1,
-				neg_ext_face_sh_func_gradients_1,
-				neg_ext_face_weights_1,
-				1,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-				pos_ext_face_sh_func_2,
-				pos_ext_face_sh_func_gradients_2,
-				pos_ext_face_weights_2,
-				2,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-				neg_ext_face_sh_func_2,
-				neg_ext_face_sh_func_gradients_2,
-				neg_ext_face_weights_2,
-				2,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			// Call the exterior faces outwards normal area vector calculator
-			std::vector<array_1d<double,3>>
-				area_normals_pos_face_0, area_normals_neg_face_0,
-				area_normals_pos_face_1, area_normals_neg_face_1,
-				area_normals_pos_face_2, area_normals_neg_face_2;
-
-			triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-				area_normals_pos_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-				area_normals_neg_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-				area_normals_pos_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-				area_normals_neg_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-				area_normals_pos_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-				area_normals_neg_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			const double tolerance = 1e-10;
-
-			// Check shape functions values
-			KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 1.0/6.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 2.0/3.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 1.0/6.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 1.0/6.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 1.0/3.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 1.0/2.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func(1,0), 1.0/2.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func(1,1), 1.0/6.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func(1,2), 1.0/3.0, tolerance);
-
-			// Check Gauss pts. weights
-			KRATOS_CHECK_NEAR(positive_side_weights(0), 1.0/8.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_weights(0), 1.0/8.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_weights(1), 1.0/4.0, tolerance);
-
-			// Check Gauss pts. shape functions gradients values
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,1),  1.0, tolerance);
-
-			// Check interface shape function values
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 0.25, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 0.50, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 0.25, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 0.25, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 0.50, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 0.25, tolerance);
-
-			// Check interface Gauss pts. weights
-			KRATOS_CHECK_NEAR(positive_interface_side_weights(0), 0.50, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_weights(0), 0.50, tolerance);
-
-			// Check Gauss pts. interface shape function gradients values
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-
-			// Check Gauss pts. outwards area normal values
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), -0.5, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.0, tolerance);
-
-			// Check face 0 values
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,1), 0.75, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,2), 0.25, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), 0.5*std::sqrt(2.0), tolerance);
-
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1), 0.25, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 0.75, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_weights_0(0), 0.5*std::sqrt(2.0), tolerance);
-
-			KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](0), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](1), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](2), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](0), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](1), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](2), 0.0, tolerance);
-
-			// Check face 1 values
-			KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_1.size1(), 0);
-			KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_1.size2(), 3);
-			KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_gradients_1.size(), 0);
-			KRATOS_CHECK_EQUAL(pos_ext_face_weights_1.size(), 0);
-
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,0), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,1), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,2), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_weights_1(0), 1.0, tolerance);
-
-			KRATOS_CHECK_EQUAL(area_normals_pos_face_1.size(), 0);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_1[0](0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_1[0](1), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_1[0](2), 0.0, tolerance);
-
-			// Check face 2 values
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_2(0,0), 0.25, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_2(0,1), 0.75, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_2(0,2),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_2[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_2[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_2[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_2[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_2[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_2[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_weights_2(0), 0.5, tolerance);
-
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,0), 0.75, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,1), 0.25, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,2),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_weights_2(0), 0.5, tolerance);
-
-			KRATOS_CHECK_NEAR(area_normals_pos_face_2[0](0), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_pos_face_2[0](1), -0.5, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_pos_face_2[0](2), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](0), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](1), -0.5, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](2), 0.0, tolerance);
-		}
-
-		KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTriangle2D3ZeroNode, KratosCoreFastSuite)
-		{
-			Model current_model;
-
-			// Generate a model part with the previous
-			ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
-			base_model_part.AddNodalSolutionStepVariable(DISTANCE);
-
-			// Fill the model part geometry data
-			base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
-			Properties::Pointer p_properties(new Properties(0));
-			base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
-
-			// Set the DISTANCE field
-			base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) =  0.0;
-			base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
-			base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) =  1.0;
-
-			// Set the elemental distances vector
-			Geometry<Node>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
-
-			array_1d<double, 3> distances_vector;
-			for (unsigned int i = 0; i < p_geometry->size(); ++i) {
-				distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
-			}
-
-			base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
-
-			const Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
-
-			// Call the modified shape functions calculator
-			Triangle2D3ModifiedShapeFunctions triangle_shape_functions(p_geometry, r_elemental_distances);
-			Matrix positive_side_sh_func, negative_side_sh_func;
-			ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
-			Vector positive_side_weights, negative_side_weights;
-
-			triangle_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
-				positive_side_sh_func,
-				positive_side_sh_func_gradients,
-				positive_side_weights,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
-				negative_side_sh_func,
-				negative_side_sh_func_gradients,
-				negative_side_weights,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			// Call the interface modified shape functions calculator
-			Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
-			ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
-			Vector positive_interface_side_weights, negative_interface_side_weights;
-
-			triangle_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
-				positive_interface_side_sh_func,
-				positive_interface_side_sh_func_gradients,
-				positive_interface_side_weights,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
-				negative_interface_side_sh_func,
-				negative_interface_side_sh_func_gradients,
-				negative_interface_side_weights,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			// Call the external face modified shape functions calculator
-			Matrix pos_ext_face_sh_func_0, neg_ext_face_sh_func_0,
-				   pos_ext_face_sh_func_1, neg_ext_face_sh_func_1,
-				   pos_ext_face_sh_func_2, neg_ext_face_sh_func_2;
-
-			ModifiedShapeFunctions::ShapeFunctionsGradientsType
-				pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
-				pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
-				pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2;
-
-			Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
-				   pos_ext_face_weights_1, neg_ext_face_weights_1,
-				   pos_ext_face_weights_2, neg_ext_face_weights_2;
-
-			triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-				pos_ext_face_sh_func_0,
-				pos_ext_face_sh_func_gradients_0,
-				pos_ext_face_weights_0,
-				0,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-				neg_ext_face_sh_func_0,
-				neg_ext_face_sh_func_gradients_0,
-				neg_ext_face_weights_0,
-				0,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-				pos_ext_face_sh_func_1,
-				pos_ext_face_sh_func_gradients_1,
-				pos_ext_face_weights_1,
-				1,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-				neg_ext_face_sh_func_1,
-				neg_ext_face_sh_func_gradients_1,
-				neg_ext_face_weights_1,
-				1,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
-				pos_ext_face_sh_func_2,
-				pos_ext_face_sh_func_gradients_2,
-				pos_ext_face_weights_2,
-				2,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
-				neg_ext_face_sh_func_2,
-				neg_ext_face_sh_func_gradients_2,
-				neg_ext_face_weights_2,
-				2,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			// Call the interface outwards normal area vector calculator
-			std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
-
-			triangle_shape_functions.ComputePositiveSideInterfaceAreaNormals(
-				positive_side_area_normals,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
-				negative_side_area_normals,
-				GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			// Call the exterior faces outwards normal area vector calculator
-			std::vector<array_1d<double,3>>
-				area_normals_pos_face_0, area_normals_neg_face_0,
-				area_normals_pos_face_1, area_normals_neg_face_1,
-				area_normals_pos_face_2, area_normals_neg_face_2;
-
-			triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-				area_normals_pos_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-				area_normals_neg_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-				area_normals_pos_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-				area_normals_neg_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
-				area_normals_pos_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
-				area_normals_neg_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
-
-			const double tolerance = 1e-10;
-
-			KRATOS_CHECK_EQUAL(positive_side_sh_func.size1(), 1);
-			KRATOS_CHECK_EQUAL(negative_side_sh_func.size1(), 1);
-
-			// Check shape functions values
-			KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 1.0/3.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 1.0/6.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 1.0/2.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 1.0/3.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 1.0/2.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 1.0/6.0, tolerance);
-
-			// Check Gauss pts. weights
-			KRATOS_CHECK_NEAR(positive_side_weights(0), 1.0/4.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_weights(0), 1.0/4.0, tolerance);
-
-			// Check Gauss pts. shape functions gradients values
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-
-			// Check interface shape function values
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 1.0/2.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 1.0/4.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 1.0/4.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/2.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 1.0/4.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/4.0, tolerance);
-
-			// Check interface Gauss pts. weights
-			KRATOS_CHECK_NEAR(positive_interface_side_weights(0), std::sqrt(2.0)/2.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_weights(0), std::sqrt(2.0)/2.0, tolerance);
-
-			// Check Gauss pts. interface shape function gradients values
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
-
-			// Check Gauss pts. outwards area normal values
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), -0.5, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), -0.5, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.0, tolerance);
-
-			// Check face 0 values
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,1), 0.25, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,2), 0.75, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), 0.5*std::sqrt(2.0), tolerance);
-
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1), 0.75, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 0.25, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_weights_0(0), 0.5*std::sqrt(2.0), tolerance);
-
-			KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](0), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](1), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](2), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](0), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](1), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](2), 0.0, tolerance);
-
-			// Check face 1 values
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_1(0,0), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_1(0,1), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_1(0,2), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(pos_ext_face_weights_1(0), 1.0, tolerance);
-
-			KRATOS_CHECK_EQUAL(neg_ext_face_sh_func_1.size1(), 0);
-			KRATOS_CHECK_EQUAL(neg_ext_face_sh_func_1.size2(), 3);
-			KRATOS_CHECK_EQUAL(neg_ext_face_sh_func_gradients_1.size(), 0);
-			KRATOS_CHECK_EQUAL(neg_ext_face_weights_1.size(), 0);
-
-			KRATOS_CHECK_NEAR(area_normals_pos_face_1[0](0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_pos_face_1[0](1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_pos_face_1[0](2),  0.0, tolerance);
-			KRATOS_CHECK_EQUAL(area_normals_neg_face_1.size(), 0);
-
-			// Check face 2 values
-			KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_2.size1(), 0);
-			KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_2.size2(), 3);
-			KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_gradients_2.size(), 0);
-			KRATOS_CHECK_EQUAL(pos_ext_face_weights_2.size(), 0);
-
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,0), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,1), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,2), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](0,0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](0,1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](1,0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](1,1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](2,0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](2,1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(neg_ext_face_weights_2(0), 1.0, tolerance);
-
-			KRATOS_CHECK_EQUAL(area_normals_pos_face_2.size(), 0);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](2),  0.0, tolerance);
-		}
-
-
-		KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTriangle2D3Areas, KratosCoreFastSuite)
-		{
-			auto p_triangle_shape_functions = SetTriangle2D3ModifiedShapeFunctionsPointer();
-			Matrix positive_side_sh_func, negative_side_sh_func;
-			ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
-			Vector positive_side_weights, negative_side_weights;
-
-			p_triangle_shape_functions->ComputePositiveSideShapeFunctionsAndGradientsValues(
-				positive_side_sh_func,
-				positive_side_sh_func_gradients,
-				positive_side_weights,
-				GeometryData::IntegrationMethod::GI_GAUSS_2);
-
-			p_triangle_shape_functions->ComputeNegativeSideShapeFunctionsAndGradientsValues(
-				negative_side_sh_func,
-				negative_side_sh_func_gradients,
-				negative_side_weights,
-				GeometryData::IntegrationMethod::GI_GAUSS_2);
-
-			const double tolerance = 1e-10;
-
-            // Check Gauss pts. weights
-            const unsigned int n_gauss_pos = positive_side_weights.size();
-            const unsigned int n_gauss_neg = negative_side_weights.size();
-
-            double pos_area = 0.0;
-            for (unsigned int i=0; i<n_gauss_pos; ++i) {
-                pos_area += positive_side_weights(i);
-            }
-
-            double neg_area = 0.0;
-            for (unsigned int i=0; i<n_gauss_neg; ++i) {
-                neg_area += negative_side_weights(i);
-			}
-
-            const double tot_area = 2.0*1.0/2.0;
-            KRATOS_CHECK_NEAR(pos_area+neg_area, tot_area, tolerance);
-		}
-
-		KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTriangle2D3ComputeShapeFunctionsAndWeights, KratosCoreFastSuite)
-		{
-			auto p_triangle_shape_functions = SetTriangle2D3ModifiedShapeFunctionsPointer();
-			Matrix positive_side_sh_func, negative_side_sh_func;
-			Vector positive_side_weights, negative_side_weights;
-
-			p_triangle_shape_functions->ComputePositiveSideShapeFunctionsAndWeights(
-				positive_side_sh_func,
-				positive_side_weights,
-				GeometryData::IntegrationMethod::GI_GAUSS_2);
-
-			p_triangle_shape_functions->ComputeNegativeSideShapeFunctionsAndWeights(
-				negative_side_sh_func,
-				negative_side_weights,
-				GeometryData::IntegrationMethod::GI_GAUSS_2);
-
-			const double tolerance = 1e-10;
-			Matrix ref_pos_N(3,3);
-			ref_pos_N(0,0) = 0.111111111111; ref_pos_N(0,1) = 0.4444444444444; ref_pos_N(0,2) = 0.444444444444;
-			ref_pos_N(1,0) = 0.444444444444; ref_pos_N(1,1) = 0.4444444444444; ref_pos_N(1,2) = 0.111111111111;
-			ref_pos_N(2,0) = 0.111111111111; ref_pos_N(2,1) = 0.7777777777777; ref_pos_N(2,2) = 0.111111111111;
-			Matrix ref_neg_N(6,3);
-			ref_neg_N(0,0) = 0.111111111111; ref_neg_N(0,1) = 0.2777777777777; ref_neg_N(0,2) = 0.611111111111;
-			ref_neg_N(1,0) = 0.111111111111; ref_neg_N(1,1) = 0.1111111111111; ref_neg_N(1,2) = 0.777777777777;
-			ref_neg_N(2,0) = 0.444444444444; ref_neg_N(2,1) = 0.2777777777777; ref_neg_N(2,2) = 0.277777777777;
-			ref_neg_N(3,0) = 0.611111111111; ref_neg_N(3,1) = 0.2222222222222; ref_neg_N(3,2) = 0.166666666666;
-			ref_neg_N(4,0) = 0.277777777777; ref_neg_N(4,1) = 0.0555555555555; ref_neg_N(4,2) = 0.666666666666;
-			ref_neg_N(5,0) = 0.777777777777; ref_neg_N(5,1) = 0.0555555555555; ref_neg_N(5,2) = 0.166666666666;
-
-			Vector ref_pos_weigt(3);
-			ref_pos_weigt(0) = 0.148148148148;
-			ref_pos_weigt(1) = 0.148148148148;
-			ref_pos_weigt(2) = 0.148148148148;
-			Vector ref_neg_weigt(6);
-			ref_neg_weigt(0) = 0.074074074074;
-			ref_neg_weigt(1) = 0.074074074074;
-			ref_neg_weigt(2) = 0.074074074074;
-			ref_neg_weigt(3) = 0.111111111111;
-			ref_neg_weigt(4) = 0.111111111111;
-			ref_neg_weigt(5) = 0.111111111111;
-			KRATOS_CHECK_MATRIX_NEAR(positive_side_sh_func, ref_pos_N, tolerance);
-			KRATOS_CHECK_VECTOR_NEAR(positive_side_weights, ref_pos_weigt, tolerance);
-			KRATOS_CHECK_MATRIX_NEAR(negative_side_sh_func, ref_neg_N, tolerance);
-			KRATOS_CHECK_VECTOR_NEAR(negative_side_weights, ref_neg_weigt, tolerance);
-		}
-
-		KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTriangle2D3DomainSize, KratosCoreFastSuite)
-		{
-			auto p_triangle_shape_functions = SetTriangle2D3ModifiedShapeFunctionsPointer();
-			const double pos_dom_size = p_triangle_shape_functions->ComputePositiveSideDomainSize();
-			const double neg_dom_size = p_triangle_shape_functions->ComputeNegativeSideDomainSize();
-
-			const double tolerance = 1e-10;
-			KRATOS_CHECK_NEAR(pos_dom_size, 0.444444444444, tolerance);
-			KRATOS_CHECK_NEAR(neg_dom_size, 0.555555555555, tolerance);
-            KRATOS_CHECK_NEAR(pos_dom_size+neg_dom_size, 1.0, tolerance);
-		}
-	}   // namespace Testing.
-}  // namespace Kratos.
+
+Triangle2D3ModifiedShapeFunctions::UniquePointer SetTriangle2D3ModifiedShapeFunctionsPointer()
+{
+    // Generate a test model part
+    Model current_model;
+    ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
+    base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 2.0, 0.0);
+    base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(3, 1.0, 2.0, 0.0);
+    Properties::Pointer p_properties(new Properties(0));
+    base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
+
+    // Set the DISTANCE field
+    base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -0.5;
+    base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) =  1.0;
+    base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = -0.5;
+
+    // Set the elemental distances vector
+    auto p_geometry = base_model_part.Elements()[1].pGetGeometry();
+    array_1d<double, 3> distances_vector;
+    for (unsigned int i = 0; i < p_geometry->size(); ++i) {
+        distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
+    }
+    base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+    const Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+    // Create and return the modified shape functions instance
+    auto p_modified_shape_functions_triangle = Kratos::make_unique<Triangle2D3ModifiedShapeFunctions>(p_geometry, r_elemental_distances);
+    return p_modified_shape_functions_triangle;
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTriangle2D3Horizontal, KratosCoreFastSuite)
+{
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
+    base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    Properties::Pointer p_properties(new Properties(0));
+    base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
+
+    // Set the DISTANCE field
+    base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) =  1.0;
+
+    // Set the elemental distances vector
+    Geometry<Node>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
+
+    array_1d<double, 3> distances_vector;
+    for (unsigned int i = 0; i < p_geometry->size(); ++i) {
+        distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
+    }
+
+    base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+
+    const Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+    // Call the modified shape functions calculator
+    Triangle2D3ModifiedShapeFunctions triangle_shape_functions(p_geometry, r_elemental_distances);
+    Matrix positive_side_sh_func, negative_side_sh_func;
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
+    Vector positive_side_weights, negative_side_weights;
+
+    triangle_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
+        positive_side_sh_func,
+        positive_side_sh_func_gradients,
+        positive_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
+        negative_side_sh_func,
+        negative_side_sh_func_gradients,
+        negative_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the interface modified shape functions calculator
+    Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
+    Vector positive_interface_side_weights, negative_interface_side_weights;
+
+    triangle_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
+        positive_interface_side_sh_func,
+        positive_interface_side_sh_func_gradients,
+        positive_interface_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
+        negative_interface_side_sh_func,
+        negative_interface_side_sh_func_gradients,
+        negative_interface_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the external face modified shape functions calculator
+    Matrix pos_ext_face_sh_func_0, neg_ext_face_sh_func_0,
+            pos_ext_face_sh_func_1, neg_ext_face_sh_func_1,
+            pos_ext_face_sh_func_2, neg_ext_face_sh_func_2;
+
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType
+        pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
+        pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
+        pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2;
+
+    Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
+            pos_ext_face_weights_1, neg_ext_face_weights_1,
+            pos_ext_face_weights_2, neg_ext_face_weights_2;
+
+    triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_0,
+        pos_ext_face_sh_func_gradients_0,
+        pos_ext_face_weights_0,
+        0,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_0,
+        neg_ext_face_sh_func_gradients_0,
+        neg_ext_face_weights_0,
+        0,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_1,
+        pos_ext_face_sh_func_gradients_1,
+        pos_ext_face_weights_1,
+        1,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_1,
+        neg_ext_face_sh_func_gradients_1,
+        neg_ext_face_weights_1,
+        1,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_2,
+        pos_ext_face_sh_func_gradients_2,
+        pos_ext_face_weights_2,
+        2,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_2,
+        neg_ext_face_sh_func_gradients_2,
+        neg_ext_face_weights_2,
+        2,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the interface outwards normal area vector calculator
+    std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
+
+    triangle_shape_functions.ComputePositiveSideInterfaceAreaNormals(
+        positive_side_area_normals,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
+        negative_side_area_normals,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the exterior faces outwards normal area vector calculator
+    std::vector<array_1d<double,3>>
+        area_normals_pos_face_0, area_normals_neg_face_0,
+        area_normals_pos_face_1, area_normals_neg_face_1,
+        area_normals_pos_face_2, area_normals_neg_face_2;
+
+    triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    const double tolerance = 1e-10;
+
+    // Check shape functions values
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 2.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 1.0/2.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 1.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(1,0), 1.0/2.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(1,1), 1.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(1,2), 1.0/6.0, tolerance);
+
+    // Check Gauss pts. weights
+    KRATOS_CHECK_NEAR(positive_side_weights(0), 1.0/8.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_weights(0), 1.0/8.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_weights(1), 1.0/4.0, tolerance);
+
+    // Check Gauss pts. shape functions gradients values
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,1),  1.0, tolerance);
+
+    // Check interface shape function values
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 0.50, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 0.50, tolerance);
+
+    // Check interface Gauss pts. weights
+    KRATOS_CHECK_NEAR(positive_interface_side_weights(0), 0.50, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_weights(0), 0.50, tolerance);
+
+    // Check Gauss pts. interface shape function gradients values
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+
+    // Check Gauss pts. outwards area normal values
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), -0.5, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.0, tolerance);
+
+    // Check face 0 values
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,1), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,2), 0.75, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), 0.5*std::sqrt(2.0), tolerance);
+
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1), 0.75, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_weights_0(0), 0.5*std::sqrt(2.0), tolerance);
+
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](0), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](1), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](2), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](0), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](1), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](2), 0.0, tolerance);
+
+    // Check face 1 values
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_1(0,0), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_1(0,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_1(0,2), 0.75, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_weights_1(0), 0.5, tolerance);
+
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,0), 0.75, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,2), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_weights_1(0), 0.5, tolerance);
+
+    KRATOS_CHECK_NEAR(area_normals_pos_face_1[0](0), -0.5, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_1[0](1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_1[0](2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_1[0](0), -0.5, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_1[0](1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_1[0](2),  0.0, tolerance);
+
+    // Check face 2 values
+    KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_2.size1(), 0);
+    KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_2.size2(), 3);
+    KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_gradients_2.size(), 0);
+    KRATOS_CHECK_EQUAL(pos_ext_face_weights_2.size(), 0);
+
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,0), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,1), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,2), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_weights_2(0), 1.0, tolerance);
+
+    KRATOS_CHECK_EQUAL(area_normals_pos_face_2.size(), 0);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](2),  0.0, tolerance);
+}
+
+
+KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTriangle2D3Vertical, KratosCoreFastSuite)
+{
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
+    base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    Properties::Pointer p_properties(new Properties(0));
+    base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
+
+    // Set the DISTANCE field
+    base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) =  1.0;
+    base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = -1.0;
+
+    // Set the elemental distances vector
+    Geometry<Node>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
+
+    array_1d<double, 3> distances_vector;
+    for (unsigned int i = 0; i < p_geometry->size(); ++i) {
+        distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
+    }
+
+    base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+
+    const Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+    // Call the modified shape functions calculator
+    Triangle2D3ModifiedShapeFunctions triangle_shape_functions(p_geometry, r_elemental_distances);
+    Matrix positive_side_sh_func, negative_side_sh_func;
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
+    Vector positive_side_weights, negative_side_weights;
+
+    triangle_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
+        positive_side_sh_func,
+        positive_side_sh_func_gradients,
+        positive_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
+        negative_side_sh_func,
+        negative_side_sh_func_gradients,
+        negative_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the interface modified shape functions calculator
+    Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
+    Vector positive_interface_side_weights, negative_interface_side_weights;
+
+    triangle_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
+        positive_interface_side_sh_func,
+        positive_interface_side_sh_func_gradients,
+        positive_interface_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
+        negative_interface_side_sh_func,
+        negative_interface_side_sh_func_gradients,
+        negative_interface_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the interface outwards normal unit vector calculator
+    std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
+
+    triangle_shape_functions.ComputePositiveSideInterfaceAreaNormals(
+        positive_side_area_normals,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
+        negative_side_area_normals,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the external face modified shape functions calculator
+    Matrix pos_ext_face_sh_func_0, neg_ext_face_sh_func_0,
+            pos_ext_face_sh_func_1, neg_ext_face_sh_func_1,
+            pos_ext_face_sh_func_2, neg_ext_face_sh_func_2;
+
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType
+        pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
+        pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
+        pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2;
+
+    Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
+            pos_ext_face_weights_1, neg_ext_face_weights_1,
+            pos_ext_face_weights_2, neg_ext_face_weights_2;
+
+    triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_0,
+        pos_ext_face_sh_func_gradients_0,
+        pos_ext_face_weights_0,
+        0,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_0,
+        neg_ext_face_sh_func_gradients_0,
+        neg_ext_face_weights_0,
+        0,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_1,
+        pos_ext_face_sh_func_gradients_1,
+        pos_ext_face_weights_1,
+        1,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_1,
+        neg_ext_face_sh_func_gradients_1,
+        neg_ext_face_weights_1,
+        1,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_2,
+        pos_ext_face_sh_func_gradients_2,
+        pos_ext_face_weights_2,
+        2,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_2,
+        neg_ext_face_sh_func_gradients_2,
+        neg_ext_face_weights_2,
+        2,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the exterior faces outwards normal area vector calculator
+    std::vector<array_1d<double,3>>
+        area_normals_pos_face_0, area_normals_neg_face_0,
+        area_normals_pos_face_1, area_normals_neg_face_1,
+        area_normals_pos_face_2, area_normals_neg_face_2;
+
+    triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    const double tolerance = 1e-10;
+
+    // Check shape functions values
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 2.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 1.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 1.0/2.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(1,0), 1.0/2.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(1,1), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(1,2), 1.0/3.0, tolerance);
+
+    // Check Gauss pts. weights
+    KRATOS_CHECK_NEAR(positive_side_weights(0), 1.0/8.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_weights(0), 1.0/8.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_weights(1), 1.0/4.0, tolerance);
+
+    // Check Gauss pts. shape functions gradients values
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[1](2,1),  1.0, tolerance);
+
+    // Check interface shape function values
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 0.50, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 0.50, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 0.25, tolerance);
+
+    // Check interface Gauss pts. weights
+    KRATOS_CHECK_NEAR(positive_interface_side_weights(0), 0.50, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_weights(0), 0.50, tolerance);
+
+    // Check Gauss pts. interface shape function gradients values
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+
+    // Check Gauss pts. outwards area normal values
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), -0.5, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.0, tolerance);
+
+    // Check face 0 values
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,1), 0.75, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,2), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), 0.5*std::sqrt(2.0), tolerance);
+
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 0.75, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_weights_0(0), 0.5*std::sqrt(2.0), tolerance);
+
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](0), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](1), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](2), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](0), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](1), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](2), 0.0, tolerance);
+
+    // Check face 1 values
+    KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_1.size1(), 0);
+    KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_1.size2(), 3);
+    KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_gradients_1.size(), 0);
+    KRATOS_CHECK_EQUAL(pos_ext_face_weights_1.size(), 0);
+
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,0), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,1), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_1(0,2), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_1[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_weights_1(0), 1.0, tolerance);
+
+    KRATOS_CHECK_EQUAL(area_normals_pos_face_1.size(), 0);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_1[0](0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_1[0](1), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_1[0](2), 0.0, tolerance);
+
+    // Check face 2 values
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_2(0,0), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_2(0,1), 0.75, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_2(0,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_2[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_2[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_2[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_2[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_2[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_2[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_weights_2(0), 0.5, tolerance);
+
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,0), 0.75, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,1), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,2),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_weights_2(0), 0.5, tolerance);
+
+    KRATOS_CHECK_NEAR(area_normals_pos_face_2[0](0), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_2[0](1), -0.5, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_2[0](2), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](0), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](1), -0.5, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](2), 0.0, tolerance);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTriangle2D3ZeroNode, KratosCoreFastSuite)
+{
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
+    base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    Properties::Pointer p_properties(new Properties(0));
+    base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
+
+    // Set the DISTANCE field
+    base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) =  0.0;
+    base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) =  1.0;
+
+    // Set the elemental distances vector
+    Geometry<Node>::Pointer p_geometry = base_model_part.Elements()[1].pGetGeometry();
+
+    array_1d<double, 3> distances_vector;
+    for (unsigned int i = 0; i < p_geometry->size(); ++i) {
+        distances_vector(i) = (*p_geometry)[i].FastGetSolutionStepValue(DISTANCE);
+    }
+
+    base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+
+    const Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+    // Call the modified shape functions calculator
+    Triangle2D3ModifiedShapeFunctions triangle_shape_functions(p_geometry, r_elemental_distances);
+    Matrix positive_side_sh_func, negative_side_sh_func;
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
+    Vector positive_side_weights, negative_side_weights;
+
+    triangle_shape_functions.ComputePositiveSideShapeFunctionsAndGradientsValues(
+        positive_side_sh_func,
+        positive_side_sh_func_gradients,
+        positive_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeSideShapeFunctionsAndGradientsValues(
+        negative_side_sh_func,
+        negative_side_sh_func_gradients,
+        negative_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the interface modified shape functions calculator
+    Matrix positive_interface_side_sh_func, negative_interface_side_sh_func;
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_interface_side_sh_func_gradients, negative_interface_side_sh_func_gradients;
+    Vector positive_interface_side_weights, negative_interface_side_weights;
+
+    triangle_shape_functions.ComputeInterfacePositiveSideShapeFunctionsAndGradientsValues(
+        positive_interface_side_sh_func,
+        positive_interface_side_sh_func_gradients,
+        positive_interface_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeInterfaceNegativeSideShapeFunctionsAndGradientsValues(
+        negative_interface_side_sh_func,
+        negative_interface_side_sh_func_gradients,
+        negative_interface_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the external face modified shape functions calculator
+    Matrix pos_ext_face_sh_func_0, neg_ext_face_sh_func_0,
+            pos_ext_face_sh_func_1, neg_ext_face_sh_func_1,
+            pos_ext_face_sh_func_2, neg_ext_face_sh_func_2;
+
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType
+        pos_ext_face_sh_func_gradients_0, neg_ext_face_sh_func_gradients_0,
+        pos_ext_face_sh_func_gradients_1, neg_ext_face_sh_func_gradients_1,
+        pos_ext_face_sh_func_gradients_2, neg_ext_face_sh_func_gradients_2;
+
+    Vector pos_ext_face_weights_0, neg_ext_face_weights_0,
+            pos_ext_face_weights_1, neg_ext_face_weights_1,
+            pos_ext_face_weights_2, neg_ext_face_weights_2;
+
+    triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_0,
+        pos_ext_face_sh_func_gradients_0,
+        pos_ext_face_weights_0,
+        0,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_0,
+        neg_ext_face_sh_func_gradients_0,
+        neg_ext_face_weights_0,
+        0,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_1,
+        pos_ext_face_sh_func_gradients_1,
+        pos_ext_face_weights_1,
+        1,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_1,
+        neg_ext_face_sh_func_gradients_1,
+        neg_ext_face_weights_1,
+        1,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputePositiveExteriorFaceShapeFunctionsAndGradientsValues(
+        pos_ext_face_sh_func_2,
+        pos_ext_face_sh_func_gradients_2,
+        pos_ext_face_weights_2,
+        2,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceShapeFunctionsAndGradientsValues(
+        neg_ext_face_sh_func_2,
+        neg_ext_face_sh_func_gradients_2,
+        neg_ext_face_weights_2,
+        2,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the interface outwards normal area vector calculator
+    std::vector<array_1d<double,3>> positive_side_area_normals, negative_side_area_normals;
+
+    triangle_shape_functions.ComputePositiveSideInterfaceAreaNormals(
+        positive_side_area_normals,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeSideInterfaceAreaNormals(
+        negative_side_area_normals,
+        GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    // Call the exterior faces outwards normal area vector calculator
+    std::vector<array_1d<double,3>>
+        area_normals_pos_face_0, area_normals_neg_face_0,
+        area_normals_pos_face_1, area_normals_neg_face_1,
+        area_normals_pos_face_2, area_normals_neg_face_2;
+
+    triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_0, 0, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_1, 1, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputePositiveExteriorFaceAreaNormals(
+        area_normals_pos_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    triangle_shape_functions.ComputeNegativeExteriorFaceAreaNormals(
+        area_normals_neg_face_2, 2, GeometryData::IntegrationMethod::GI_GAUSS_1);
+
+    const double tolerance = 1e-10;
+
+    KRATOS_CHECK_EQUAL(positive_side_sh_func.size1(), 1);
+    KRATOS_CHECK_EQUAL(negative_side_sh_func.size1(), 1);
+
+    // Check shape functions values
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,0), 1.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,1), 1.0/6.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func(0,2), 1.0/2.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,0), 1.0/3.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,1), 1.0/2.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func(0,2), 1.0/6.0, tolerance);
+
+    // Check Gauss pts. weights
+    KRATOS_CHECK_NEAR(positive_side_weights(0), 1.0/4.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_weights(0), 1.0/4.0, tolerance);
+
+    // Check Gauss pts. shape functions gradients values
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+
+    // Check interface shape function values
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,0), 1.0/2.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,1), 1.0/4.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func(0,2), 1.0/4.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,0), 1.0/2.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,1), 1.0/4.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func(0,2), 1.0/4.0, tolerance);
+
+    // Check interface Gauss pts. weights
+    KRATOS_CHECK_NEAR(positive_interface_side_weights(0), std::sqrt(2.0)/2.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_weights(0), std::sqrt(2.0)/2.0, tolerance);
+
+    // Check Gauss pts. interface shape function gradients values
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(positive_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
+
+    // Check Gauss pts. outwards area normal values
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), -0.5, tolerance);
+    KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), -0.5, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.0, tolerance);
+
+    // Check face 0 values
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,1), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_0(0,2), 0.75, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_weights_0(0), 0.5*std::sqrt(2.0), tolerance);
+
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,1), 0.75, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_0(0,2), 0.25, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_0[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_weights_0(0), 0.5*std::sqrt(2.0), tolerance);
+
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](0), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](1), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_0[0](2), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](0), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](1), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_0[0](2), 0.0, tolerance);
+
+    // Check face 1 values
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_1(0,0), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_1(0,1), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_1(0,2), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_sh_func_gradients_1[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(pos_ext_face_weights_1(0), 1.0, tolerance);
+
+    KRATOS_CHECK_EQUAL(neg_ext_face_sh_func_1.size1(), 0);
+    KRATOS_CHECK_EQUAL(neg_ext_face_sh_func_1.size2(), 3);
+    KRATOS_CHECK_EQUAL(neg_ext_face_sh_func_gradients_1.size(), 0);
+    KRATOS_CHECK_EQUAL(neg_ext_face_weights_1.size(), 0);
+
+    KRATOS_CHECK_NEAR(area_normals_pos_face_1[0](0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_1[0](1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_pos_face_1[0](2),  0.0, tolerance);
+    KRATOS_CHECK_EQUAL(area_normals_neg_face_1.size(), 0);
+
+    // Check face 2 values
+    KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_2.size1(), 0);
+    KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_2.size2(), 3);
+    KRATOS_CHECK_EQUAL(pos_ext_face_sh_func_gradients_2.size(), 0);
+    KRATOS_CHECK_EQUAL(pos_ext_face_weights_2.size(), 0);
+
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,0), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,1), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_2(0,2), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](0,0), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](0,1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](1,0),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](1,1),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](2,0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_sh_func_gradients_2[0](2,1),  1.0, tolerance);
+    KRATOS_CHECK_NEAR(neg_ext_face_weights_2(0), 1.0, tolerance);
+
+    KRATOS_CHECK_EQUAL(area_normals_pos_face_2.size(), 0);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](0),  0.0, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](1), -1.0, tolerance);
+    KRATOS_CHECK_NEAR(area_normals_neg_face_2[0](2),  0.0, tolerance);
+}
+
+
+KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTriangle2D3Areas, KratosCoreFastSuite)
+{
+    auto p_triangle_shape_functions = SetTriangle2D3ModifiedShapeFunctionsPointer();
+    Matrix positive_side_sh_func, negative_side_sh_func;
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients, negative_side_sh_func_gradients;
+    Vector positive_side_weights, negative_side_weights;
+
+    p_triangle_shape_functions->ComputePositiveSideShapeFunctionsAndGradientsValues(
+        positive_side_sh_func,
+        positive_side_sh_func_gradients,
+        positive_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_2);
+
+    p_triangle_shape_functions->ComputeNegativeSideShapeFunctionsAndGradientsValues(
+        negative_side_sh_func,
+        negative_side_sh_func_gradients,
+        negative_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_2);
+
+    const double tolerance = 1e-10;
+
+    // Check Gauss pts. weights
+    const unsigned int n_gauss_pos = positive_side_weights.size();
+    const unsigned int n_gauss_neg = negative_side_weights.size();
+
+    double pos_area = 0.0;
+    for (unsigned int i=0; i<n_gauss_pos; ++i) {
+        pos_area += positive_side_weights(i);
+    }
+
+    double neg_area = 0.0;
+    for (unsigned int i=0; i<n_gauss_neg; ++i) {
+        neg_area += negative_side_weights(i);
+    }
+
+    const double tot_area = 2.0*1.0/2.0;
+    KRATOS_CHECK_NEAR(pos_area+neg_area, tot_area, tolerance);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTriangle2D3ComputeShapeFunctionsAndWeights, KratosCoreFastSuite)
+{
+    auto p_triangle_shape_functions = SetTriangle2D3ModifiedShapeFunctionsPointer();
+    Matrix positive_side_sh_func, negative_side_sh_func;
+    Vector positive_side_weights, negative_side_weights;
+
+    p_triangle_shape_functions->ComputePositiveSideShapeFunctionsAndWeights(
+        positive_side_sh_func,
+        positive_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_2);
+
+    p_triangle_shape_functions->ComputeNegativeSideShapeFunctionsAndWeights(
+        negative_side_sh_func,
+        negative_side_weights,
+        GeometryData::IntegrationMethod::GI_GAUSS_2);
+
+    const double tolerance = 1e-10;
+    Matrix ref_pos_N(3,3);
+    ref_pos_N(0,0) = 0.111111111111; ref_pos_N(0,1) = 0.4444444444444; ref_pos_N(0,2) = 0.444444444444;
+    ref_pos_N(1,0) = 0.444444444444; ref_pos_N(1,1) = 0.4444444444444; ref_pos_N(1,2) = 0.111111111111;
+    ref_pos_N(2,0) = 0.111111111111; ref_pos_N(2,1) = 0.7777777777777; ref_pos_N(2,2) = 0.111111111111;
+    Matrix ref_neg_N(6,3);
+    ref_neg_N(0,0) = 0.111111111111; ref_neg_N(0,1) = 0.2777777777777; ref_neg_N(0,2) = 0.611111111111;
+    ref_neg_N(1,0) = 0.111111111111; ref_neg_N(1,1) = 0.1111111111111; ref_neg_N(1,2) = 0.777777777777;
+    ref_neg_N(2,0) = 0.444444444444; ref_neg_N(2,1) = 0.2777777777777; ref_neg_N(2,2) = 0.277777777777;
+    ref_neg_N(3,0) = 0.611111111111; ref_neg_N(3,1) = 0.2222222222222; ref_neg_N(3,2) = 0.166666666666;
+    ref_neg_N(4,0) = 0.277777777777; ref_neg_N(4,1) = 0.0555555555555; ref_neg_N(4,2) = 0.666666666666;
+    ref_neg_N(5,0) = 0.777777777777; ref_neg_N(5,1) = 0.0555555555555; ref_neg_N(5,2) = 0.166666666666;
+
+    Vector ref_pos_weigt(3);
+    ref_pos_weigt(0) = 0.148148148148;
+    ref_pos_weigt(1) = 0.148148148148;
+    ref_pos_weigt(2) = 0.148148148148;
+    Vector ref_neg_weigt(6);
+    ref_neg_weigt(0) = 0.074074074074;
+    ref_neg_weigt(1) = 0.074074074074;
+    ref_neg_weigt(2) = 0.074074074074;
+    ref_neg_weigt(3) = 0.111111111111;
+    ref_neg_weigt(4) = 0.111111111111;
+    ref_neg_weigt(5) = 0.111111111111;
+    KRATOS_CHECK_MATRIX_NEAR(positive_side_sh_func, ref_pos_N, tolerance);
+    KRATOS_CHECK_VECTOR_NEAR(positive_side_weights, ref_pos_weigt, tolerance);
+    KRATOS_CHECK_MATRIX_NEAR(negative_side_sh_func, ref_neg_N, tolerance);
+    KRATOS_CHECK_VECTOR_NEAR(negative_side_weights, ref_neg_weigt, tolerance);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ModifiedShapeFunctionsTriangle2D3DomainSize, KratosCoreFastSuite)
+{
+    auto p_triangle_shape_functions = SetTriangle2D3ModifiedShapeFunctionsPointer();
+    const double pos_dom_size = p_triangle_shape_functions->ComputePositiveSideDomainSize();
+    const double neg_dom_size = p_triangle_shape_functions->ComputeNegativeSideDomainSize();
+
+    const double tolerance = 1e-10;
+    KRATOS_CHECK_NEAR(pos_dom_size, 0.444444444444, tolerance);
+    KRATOS_CHECK_NEAR(neg_dom_size, 0.555555555555, tolerance);
+    KRATOS_CHECK_NEAR(pos_dom_size+neg_dom_size, 1.0, tolerance);
+}
+
+}  // namespace Kratos::Testing.

--- a/kratos/tests/cpp_tests/utilities/test_divide_tetrahedra_3d_4.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_divide_tetrahedra_3d_4.cpp
@@ -5,7 +5,7 @@
 //                   Multi-Physics
 //
 //  License:     BSD License
-//  			 Kratos default license: kratos/license.txt
+//               Kratos default license: kratos/license.txt
 //
 //  Main authors:    Ruben Zorrilla
 //
@@ -17,691 +17,689 @@
 #include "includes/checks.h"
 #include "utilities/divide_tetrahedra_3d_4.h"
 
-namespace Kratos
+namespace Kratos::Testing
 {
-	namespace Testing
-	{
-
-		KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTetrahedra3D4Horizontal, KratosCoreFastSuite)
-		{
-			Model current_model;
-
-			// Generate a model part with the previous
-			ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
-			base_model_part.AddNodalSolutionStepVariable(DISTANCE);
-
-			// Fill the model part geometry data
-			base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
-			base_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
-			Properties::Pointer p_properties(new Properties(0));
-			base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
-
-			// Set the DISTANCE field
-			base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
-			base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
-			base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = -1.0;
-			base_model_part.Nodes()[4].FastGetSolutionStepValue(DISTANCE) =  1.0;
-
-			// Set the elemental distances vector
-			Geometry < Node >& r_geometry = base_model_part.Elements()[1].GetGeometry();
-
-			array_1d<double, 4> distances_vector;
-			for (unsigned int i = 0; i < r_geometry.size(); ++i) {
-				distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
-			}
-
-			base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
-
-			Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
-
-			// Build the tetrahedra splitting utility
-			DivideTetrahedra3D4<Node> tetrahedra_splitter(r_geometry, r_elemental_distances);
-
-			// Call the divide geometry method
-			tetrahedra_splitter.GenerateDivision();
-
-			// Call the intersection generation method
-			tetrahedra_splitter.GenerateIntersectionsSkin();
-
-			// Call the positive exterior faces generation method
-			std::vector < unsigned int > pos_ext_faces_parent_ids;
-			std::vector < DivideTetrahedra3D4<Node>::IndexedPointGeometryPointerType > pos_ext_faces;
-			tetrahedra_splitter.GenerateExteriorFaces(
-				pos_ext_faces,
-				pos_ext_faces_parent_ids,
-				tetrahedra_splitter.GetPositiveSubdivisions());
-
-			// Call the negative exterior faces generation method
-			std::vector < unsigned int > neg_ext_faces_parent_ids;
-			std::vector < DivideTetrahedra3D4<Node>::IndexedPointGeometryPointerType > neg_ext_faces;
-			tetrahedra_splitter.GenerateExteriorFaces(
-				neg_ext_faces,
-				neg_ext_faces_parent_ids,
-				tetrahedra_splitter.GetNegativeSubdivisions());
-
-			const double tolerance = 1e-10;
-
-			// Check general splitting values
-			KRATOS_CHECK(tetrahedra_splitter.mIsSplit);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mDivisionsNumber, 4);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdgesNumber, 3);
-
-			// Check split edges
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[0],  0);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[1],  1);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[2],  2);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[3],  3);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[4], -1);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[5], -1);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[6],  6);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[7], -1);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[8],  8);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[9],  9);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[10],-1);
-
-			// Check subdivisions
-			const auto& r_positive_subdivision_0 = *(tetrahedra_splitter.GetPositiveSubdivisions()[0]);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Z(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Z(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Z(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].Z(), 0.5, tolerance);
-
-			const auto& r_negative_subdivision_0 = *(tetrahedra_splitter.GetNegativeSubdivisions()[0]);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Z(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Y(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].Z(), 0.5, tolerance);
-
-			// Check interfaces
-			const auto& r_positive_interface_0 = *(tetrahedra_splitter.GetPositiveInterfaces()[0]);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[0].Z(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[1].Z(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[2].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[2].Z(), 0.5, tolerance);
-
-			const auto& r_negative_interface_0 = *(tetrahedra_splitter.GetNegativeInterfaces()[0]);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[0].Z(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[1].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[1].Z(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[2].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[2].Z(), 0.5, tolerance);
-
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.GetPositiveInterfacesParentIds()[0], 0);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.GetNegativeInterfacesParentIds()[0], 2);
-
-			// Check exterior faces
-			KRATOS_CHECK_EQUAL(pos_ext_faces.size(), 3);
-			KRATOS_CHECK_EQUAL(neg_ext_faces.size(), 7);
-
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[0], 0);
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[1], 0);
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[2], 0);
-
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[0], 0);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[1], 2);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[2], 1);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[3], 2);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[4], 0);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[5], 1);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[6], 1);
-
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Z(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Z(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].Z(), 0.5, tolerance);
-
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Z(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].Y(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].Z(), 0.0, tolerance);
-
-		}
-
-		KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTetrahedra3D4Oblique, KratosCoreFastSuite)
-		{
-			Model current_model;
-
-			// Generate a model part with the previous
-			ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
-			base_model_part.AddNodalSolutionStepVariable(DISTANCE);
-
-			// Fill the model part geometry data
-			base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
-			base_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
-			Properties::Pointer p_properties(new Properties(0));
-			base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
-
-			// Set the DISTANCE field
-			base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
-			base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) =  1.0;
-			base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = -1.0;
-			base_model_part.Nodes()[4].FastGetSolutionStepValue(DISTANCE) =  1.0;
-
-			// Set the elemental distances vector
-			Geometry < Node >& r_geometry = base_model_part.Elements()[1].GetGeometry();
-
-			array_1d<double, 4> distances_vector;
-			for (unsigned int i = 0; i < r_geometry.size(); ++i) {
-				distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
-			}
-
-			base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
-
-			Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
-
-			// Build the tetrahedra splitting utility
-			DivideTetrahedra3D4<Node> tetrahedra_splitter(r_geometry, r_elemental_distances);
-
-			// Call the divide geometry method
-			tetrahedra_splitter.GenerateDivision();
-
-			// Call the intersection generation method
-			tetrahedra_splitter.GenerateIntersectionsSkin();
-
-			// Call the positive exterior faces generation method
-			std::vector < unsigned int > pos_ext_faces_parent_ids;
-			std::vector < DivideTetrahedra3D4<Node>::IndexedPointGeometryPointerType > pos_ext_faces;
-			tetrahedra_splitter.GenerateExteriorFaces(
-				pos_ext_faces,
-				pos_ext_faces_parent_ids,
-				tetrahedra_splitter.GetPositiveSubdivisions());
-
-			// Call the negative exterior faces generation method
-			std::vector < unsigned int > neg_ext_faces_parent_ids;
-			std::vector < DivideTetrahedra3D4<Node>::IndexedPointGeometryPointerType > neg_ext_faces;
-			tetrahedra_splitter.GenerateExteriorFaces(
-				neg_ext_faces,
-				neg_ext_faces_parent_ids,
-				tetrahedra_splitter.GetNegativeSubdivisions());
-
-			const double tolerance = 1e-10;
-
-			// Check general splitting values
-			KRATOS_CHECK(tetrahedra_splitter.mIsSplit);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mDivisionsNumber, 6);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdgesNumber, 4);
-
-			// Check split edges
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[0],  0);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[1],  1);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[2],  2);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[3],  3);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[4],  4);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[5], -1);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[6],  6);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[7],  7);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[8], -1);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[9],  9);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[10],-1);
-
-			// Check subdivisions
-			const auto &r_positive_subdivision_0 = *(tetrahedra_splitter.GetPositiveSubdivisions()[0]);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Z(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Z(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].Z(), 0.5, tolerance);
-
-			const auto &r_negative_subdivision_0 = *(tetrahedra_splitter.GetNegativeSubdivisions()[0]);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Z(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].Y(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].Z(), 0.0, tolerance);
-
-			// Check interfaces
-			const auto& r_positive_interface_0 = *(tetrahedra_splitter.GetPositiveInterfaces()[0]);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[0].Z(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[2].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[2].Z(), 0.5, tolerance);
-
-			const auto& r_positive_interface_1 = *(tetrahedra_splitter.GetPositiveInterfaces()[1]);
-			KRATOS_CHECK_NEAR(r_positive_interface_1[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_1[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_1[0].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_1[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_1[1].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_1[1].Z(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_1[2].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_1[2].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_1[2].Z(), 0.0, tolerance);
-
-			const auto& r_negative_interface_0 = *(tetrahedra_splitter.GetNegativeInterfaces()[0]);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[0].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[1].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[2].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[2].Z(), 0.5, tolerance);
-
-			const auto& r_negative_interface_1 = *(tetrahedra_splitter.GetNegativeInterfaces()[1]);
-			KRATOS_CHECK_NEAR(r_negative_interface_1[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_1[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_1[0].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_1[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_1[1].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_1[1].Z(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_1[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_1[2].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_1[2].Z(), 0.5, tolerance);
-
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.GetPositiveInterfacesParentIds()[0], 0);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.GetPositiveInterfacesParentIds()[1], 2);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.GetNegativeInterfacesParentIds()[0], 0);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.GetNegativeInterfacesParentIds()[1], 1);
-
-			// Check exterior faces
-			KRATOS_CHECK_EQUAL(pos_ext_faces.size(), 6);
-			KRATOS_CHECK_EQUAL(neg_ext_faces.size(), 6);
-
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[0], 1);
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[1], 2);
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[2], 0);
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[3], 0);
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[4], 1);
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[5], 1);
-
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[0], 0);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[1], 1);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[2], 2);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[3], 2);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[4], 0);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[5], 2);
-
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Z(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].Z(), 0.0, tolerance);
-
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Y(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].Z(), 0.5, tolerance);
-		}
-
-		KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTetrahedra3D4NoDivision, KratosCoreFastSuite)
-		{
-			Model current_model;
-
-			// Generate a model part with the previous
-			ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
-			base_model_part.AddNodalSolutionStepVariable(DISTANCE);
-
-			// Fill the model part geometry data
-			base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
-			base_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
-			Properties::Pointer p_properties(new Properties(0));
-			base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
-
-			// Set the DISTANCE field
-			base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = 1.0;
-			base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = 1.0;
-			base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = 1.0;
-			base_model_part.Nodes()[4].FastGetSolutionStepValue(DISTANCE) = 1.0;
-
-			// Set the elemental distances vector
-			Geometry < Node >& r_geometry = base_model_part.Elements()[1].GetGeometry();
-
-			array_1d<double, 4> distances_vector;
-			for (unsigned int i = 0; i < r_geometry.size(); ++i) {
-				distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
-			}
-
-			base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
-
-			Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
-
-			// Build the tetrahedra splitting utility
-			DivideTetrahedra3D4<Node> tetrahedra_splitter(r_geometry, r_elemental_distances);
-
-			// Call the divide geometry method
-			tetrahedra_splitter.GenerateDivision();
-
-			// Check general splitting values
-			KRATOS_CHECK_IS_FALSE(tetrahedra_splitter.mIsSplit);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mDivisionsNumber, 1);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdgesNumber, 0);
-
-		}
-
-		KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTetrahedra3D4ZeroNodes, KratosCoreFastSuite)
-		{
-			Model current_model;
-
-			// Generate a model part with the previous
-			ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
-			base_model_part.AddNodalSolutionStepVariable(DISTANCE);
-
-			// Fill the model part geometry data
-			base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
-			base_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
-			Properties::Pointer p_properties(new Properties(0));
-			base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
-
-			// Set the DISTANCE field
-			base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) =  0.0;
-			base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
-			base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) =  1.0;
-			base_model_part.Nodes()[4].FastGetSolutionStepValue(DISTANCE) =  0.0;
-
-			// Set the elemental distances vector
-			Geometry < Node >& r_geometry = base_model_part.Elements()[1].GetGeometry();
-
-			array_1d<double, 4> distances_vector;
-			for (unsigned int i = 0; i < r_geometry.size(); ++i) {
-				distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
-			}
-
-			base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
-
-			Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
-
-			// Build the tetrahedra splitting utility
-			DivideTetrahedra3D4<Node> tetrahedra_splitter(r_geometry, r_elemental_distances);
-
-			// Call the divide geometry method
-			tetrahedra_splitter.GenerateDivision();
-
-			// Call the intersection generation method
-			tetrahedra_splitter.GenerateIntersectionsSkin();
-
-			// Call the positive exterior faces generation method
-			std::vector < unsigned int > pos_ext_faces_parent_ids;
-			std::vector < DivideTetrahedra3D4<Node>::IndexedPointGeometryPointerType > pos_ext_faces;
-			tetrahedra_splitter.GenerateExteriorFaces(
-				pos_ext_faces,
-				pos_ext_faces_parent_ids,
-				tetrahedra_splitter.GetPositiveSubdivisions());
-
-			// Call the negative exterior faces generation method
-			std::vector < unsigned int > neg_ext_faces_parent_ids;
-			std::vector < DivideTetrahedra3D4<Node>::IndexedPointGeometryPointerType > neg_ext_faces;
-			tetrahedra_splitter.GenerateExteriorFaces(
-				neg_ext_faces,
-				neg_ext_faces_parent_ids,
-				tetrahedra_splitter.GetNegativeSubdivisions());
-
-			const double tolerance = 1e-10;
-
-			// Check general splitting values
-			KRATOS_CHECK(tetrahedra_splitter.mIsSplit);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mDivisionsNumber, 2);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdgesNumber, 1);
-
-			// Check split edges
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[0],  0);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[1],  1);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[2],  2);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[3],  3);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[4], -1);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[5], -1);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[6], -1);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[7],  7);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[8], -1);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[9], -1);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[10],-1);
-
-			// Check subdivisions
-			const auto& r_positive_subdivision_0 = *(tetrahedra_splitter.GetPositiveSubdivisions()[0]);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Y(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Z(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].Z(), 0.0, tolerance);
-
-			const auto& r_negative_subdivision_0 = *(tetrahedra_splitter.GetNegativeSubdivisions()[0]);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Z(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].Z(), 0.0, tolerance);
-
-			// Check interfaces
-			const auto& r_positive_interface_0 = *(tetrahedra_splitter.GetPositiveInterfaces()[0]);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[0].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[1].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[2].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[2].Z(), 1.0, tolerance);
-
-			const auto& r_negative_interface_0 = *(tetrahedra_splitter.GetNegativeInterfaces()[0]);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[0].Z(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[1].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[2].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[2].Z(), 0.0, tolerance);
-
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.GetPositiveInterfacesParentIds()[0], 0);
-			KRATOS_CHECK_EQUAL(tetrahedra_splitter.GetNegativeInterfacesParentIds()[0], 0);
-
-			// Check exterior faces
-			KRATOS_CHECK_EQUAL(pos_ext_faces.size(), 3);
-			KRATOS_CHECK_EQUAL(neg_ext_faces.size(), 3);
-
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[0], 0);
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[1], 0);
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[2], 0);
-
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[0], 0);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[1], 0);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[2], 0);
-
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Z(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].Y(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].Z(), 0.0, tolerance);
-
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].Z(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[2].Y(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[2].Z(), 0.0, tolerance);
-
-			KRATOS_CHECK_NEAR((*pos_ext_faces[2])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[2])[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[2])[0].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[2])[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[2])[1].Y(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[2])[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[2])[2].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[2])[2].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[2])[2].Z(), 0.0, tolerance);
-
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Z(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].Z(), 0.0, tolerance);
-
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].Z(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[2].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[2].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[2].Z(), 0.0, tolerance);
-
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].Z(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[2].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[2].Z(), 0.0, tolerance);
-		}
-
-		KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTetrahedra3D4ConformantFaces, KratosCoreFastSuite)
-		{
-			Model current_model;
-
-			// Generate a model part with the previous
-			ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
-			base_model_part.AddNodalSolutionStepVariable(DISTANCE);
-
-			// Fill the model part geometry data
-			base_model_part.CreateNewNode(195, -0.349832, 0.0522541, 0.808642);
-            base_model_part.CreateNewNode(181, -0.132464, 0.144186, 0.788109);
-            base_model_part.CreateNewNode(152, -0.232261, 0.0807726, 1.00046);
-            base_model_part.CreateNewNode(170, -0.157697, -0.0702038, 0.799622);
-            base_model_part.CreateNewNode(163, -0.335408, -0.1450987, 0.920880);
-            Properties::Pointer p_properties(new Properties(0));
-            base_model_part.CreateNewElement("Element3D4N", 471, {195, 181, 152, 170}, p_properties);
-            base_model_part.CreateNewElement("Element3D4N", 526, {170, 195, 163, 152}, p_properties);
-
-            // Set the DISTANCE field
-            base_model_part.GetNode(195).FastGetSolutionStepValue(DISTANCE) = 0.181358;
-            base_model_part.GetNode(181).FastGetSolutionStepValue(DISTANCE) = 0.201891;
-            base_model_part.GetNode(152).FastGetSolutionStepValue(DISTANCE) = -0.0104574;
-            base_model_part.GetNode(170).FastGetSolutionStepValue(DISTANCE) = 0.190378;
-            base_model_part.GetNode(163).FastGetSolutionStepValue(DISTANCE) = 0.06912;
-
-            // Set the elemental distances vector
-            for (auto &i_elem : base_model_part.Elements()) {
-                auto &r_geometry = i_elem.GetGeometry();
-                array_1d<double, 4> distances_vector;
-                for (unsigned int i = 0; i < r_geometry.size(); ++i) {
-                    distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
-                }
-                i_elem.SetValue(ELEMENTAL_DISTANCES, distances_vector);
-            }
-
-			// Build the tetrahedra splitting utilities
-			auto p_elem_471 = base_model_part.pGetElement(471);
-			auto p_elem_526 = base_model_part.pGetElement(526);
-
-			DivideTetrahedra3D4<Node> tetra_split_471(p_elem_471->GetGeometry(), p_elem_471->GetValue(ELEMENTAL_DISTANCES));
-			DivideTetrahedra3D4<Node> tetra_split_526(p_elem_526->GetGeometry(), p_elem_526->GetValue(ELEMENTAL_DISTANCES));
-
-			// Call the divide geometry method
-			tetra_split_471.GenerateDivision();
-			tetra_split_526.GenerateDivision();
-
-			// Call the positive exterior faces generation method
-			std::vector<unsigned int> pos_ext_faces_parent_ids_471;
-			std::vector<unsigned int> pos_ext_faces_parent_ids_526;
-			std::vector<DivideTetrahedra3D4<Node>::IndexedPointGeometryPointerType> pos_ext_faces_471;
-			std::vector<DivideTetrahedra3D4<Node>::IndexedPointGeometryPointerType> pos_ext_faces_526;
-			tetra_split_471.GenerateExteriorFaces(pos_ext_faces_471, pos_ext_faces_parent_ids_471, tetra_split_471.GetPositiveSubdivisions());
-			tetra_split_526.GenerateExteriorFaces(pos_ext_faces_526, pos_ext_faces_parent_ids_526, tetra_split_526.GetPositiveSubdivisions());
-
-			// Check that shared positive faces are have the same splitting pattern
-			KRATOS_CHECK_NEAR((*(pos_ext_faces_471[3])).Area(), (*(pos_ext_faces_526[4])).Area(), 1.0e-12);
-			KRATOS_CHECK_NEAR((*(pos_ext_faces_471[2])).Area(), (*(pos_ext_faces_526[5])).Area(), 1.0e-12);
-		}
-	}
-}  // namespace Kratos.
+
+KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTetrahedra3D4Horizontal, KratosCoreFastSuite)
+{
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
+    base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    base_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
+    Properties::Pointer p_properties(new Properties(0));
+    base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
+
+    // Set the DISTANCE field
+    base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[4].FastGetSolutionStepValue(DISTANCE) =  1.0;
+
+    // Set the elemental distances vector
+    Geometry < Node >& r_geometry = base_model_part.Elements()[1].GetGeometry();
+
+    array_1d<double, 4> distances_vector;
+    for (unsigned int i = 0; i < r_geometry.size(); ++i) {
+        distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
+    }
+
+    base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+
+    Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+    // Build the tetrahedra splitting utility
+    DivideTetrahedra3D4<Node> tetrahedra_splitter(r_geometry, r_elemental_distances);
+
+    // Call the divide geometry method
+    tetrahedra_splitter.GenerateDivision();
+
+    // Call the intersection generation method
+    tetrahedra_splitter.GenerateIntersectionsSkin();
+
+    // Call the positive exterior faces generation method
+    std::vector < unsigned int > pos_ext_faces_parent_ids;
+    std::vector < DivideTetrahedra3D4<Node>::IndexedPointGeometryPointerType > pos_ext_faces;
+    tetrahedra_splitter.GenerateExteriorFaces(
+        pos_ext_faces,
+        pos_ext_faces_parent_ids,
+        tetrahedra_splitter.GetPositiveSubdivisions());
+
+    // Call the negative exterior faces generation method
+    std::vector < unsigned int > neg_ext_faces_parent_ids;
+    std::vector < DivideTetrahedra3D4<Node>::IndexedPointGeometryPointerType > neg_ext_faces;
+    tetrahedra_splitter.GenerateExteriorFaces(
+        neg_ext_faces,
+        neg_ext_faces_parent_ids,
+        tetrahedra_splitter.GetNegativeSubdivisions());
+
+    const double tolerance = 1e-10;
+
+    // Check general splitting values
+    KRATOS_CHECK(tetrahedra_splitter.mIsSplit);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mDivisionsNumber, 4);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdgesNumber, 3);
+
+    // Check split edges
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[0],  0);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[1],  1);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[2],  2);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[3],  3);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[4], -1);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[5], -1);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[6],  6);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[7], -1);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[8],  8);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[9],  9);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[10],-1);
+
+    // Check subdivisions
+    const auto& r_positive_subdivision_0 = *(tetrahedra_splitter.GetPositiveSubdivisions()[0]);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Z(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Z(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Z(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].Z(), 0.5, tolerance);
+
+    const auto& r_negative_subdivision_0 = *(tetrahedra_splitter.GetNegativeSubdivisions()[0]);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Z(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Y(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].X(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].Z(), 0.5, tolerance);
+
+    // Check interfaces
+    const auto& r_positive_interface_0 = *(tetrahedra_splitter.GetPositiveInterfaces()[0]);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[0].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[0].Z(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[1].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[1].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[1].Z(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[2].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[2].Z(), 0.5, tolerance);
+
+    const auto& r_negative_interface_0 = *(tetrahedra_splitter.GetNegativeInterfaces()[0]);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[0].Z(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[1].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[1].Z(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[2].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[2].Z(), 0.5, tolerance);
+
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.GetPositiveInterfacesParentIds()[0], 0);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.GetNegativeInterfacesParentIds()[0], 2);
+
+    // Check exterior faces
+    KRATOS_CHECK_EQUAL(pos_ext_faces.size(), 3);
+    KRATOS_CHECK_EQUAL(neg_ext_faces.size(), 7);
+
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[0], 0);
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[1], 0);
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[2], 0);
+
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[0], 0);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[1], 2);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[2], 1);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[3], 2);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[4], 0);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[5], 1);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[6], 1);
+
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Z(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Z(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].Z(), 0.5, tolerance);
+
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Z(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].X(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].Y(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].Z(), 0.0, tolerance);
+
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTetrahedra3D4Oblique, KratosCoreFastSuite)
+{
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
+    base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    base_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
+    Properties::Pointer p_properties(new Properties(0));
+    base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
+
+    // Set the DISTANCE field
+    base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) =  1.0;
+    base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[4].FastGetSolutionStepValue(DISTANCE) =  1.0;
+
+    // Set the elemental distances vector
+    Geometry < Node >& r_geometry = base_model_part.Elements()[1].GetGeometry();
+
+    array_1d<double, 4> distances_vector;
+    for (unsigned int i = 0; i < r_geometry.size(); ++i) {
+        distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
+    }
+
+    base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+
+    Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+    // Build the tetrahedra splitting utility
+    DivideTetrahedra3D4<Node> tetrahedra_splitter(r_geometry, r_elemental_distances);
+
+    // Call the divide geometry method
+    tetrahedra_splitter.GenerateDivision();
+
+    // Call the intersection generation method
+    tetrahedra_splitter.GenerateIntersectionsSkin();
+
+    // Call the positive exterior faces generation method
+    std::vector < unsigned int > pos_ext_faces_parent_ids;
+    std::vector < DivideTetrahedra3D4<Node>::IndexedPointGeometryPointerType > pos_ext_faces;
+    tetrahedra_splitter.GenerateExteriorFaces(
+        pos_ext_faces,
+        pos_ext_faces_parent_ids,
+        tetrahedra_splitter.GetPositiveSubdivisions());
+
+    // Call the negative exterior faces generation method
+    std::vector < unsigned int > neg_ext_faces_parent_ids;
+    std::vector < DivideTetrahedra3D4<Node>::IndexedPointGeometryPointerType > neg_ext_faces;
+    tetrahedra_splitter.GenerateExteriorFaces(
+        neg_ext_faces,
+        neg_ext_faces_parent_ids,
+        tetrahedra_splitter.GetNegativeSubdivisions());
+
+    const double tolerance = 1e-10;
+
+    // Check general splitting values
+    KRATOS_CHECK(tetrahedra_splitter.mIsSplit);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mDivisionsNumber, 6);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdgesNumber, 4);
+
+    // Check split edges
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[0],  0);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[1],  1);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[2],  2);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[3],  3);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[4],  4);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[5], -1);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[6],  6);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[7],  7);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[8], -1);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[9],  9);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[10],-1);
+
+    // Check subdivisions
+    const auto &r_positive_subdivision_0 = *(tetrahedra_splitter.GetPositiveSubdivisions()[0]);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Z(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Z(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].Z(), 0.5, tolerance);
+
+    const auto &r_negative_subdivision_0 = *(tetrahedra_splitter.GetNegativeSubdivisions()[0]);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Z(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].Y(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].Z(), 0.0, tolerance);
+
+    // Check interfaces
+    const auto& r_positive_interface_0 = *(tetrahedra_splitter.GetPositiveInterfaces()[0]);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[0].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[0].Z(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[1].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[1].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[1].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[2].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[2].Z(), 0.5, tolerance);
+
+    const auto& r_positive_interface_1 = *(tetrahedra_splitter.GetPositiveInterfaces()[1]);
+    KRATOS_CHECK_NEAR(r_positive_interface_1[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_1[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_1[0].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_1[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_1[1].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_1[1].Z(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_1[2].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_1[2].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_1[2].Z(), 0.0, tolerance);
+
+    const auto& r_negative_interface_0 = *(tetrahedra_splitter.GetNegativeInterfaces()[0]);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[0].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[1].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[1].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[1].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[2].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[2].Z(), 0.5, tolerance);
+
+    const auto& r_negative_interface_1 = *(tetrahedra_splitter.GetNegativeInterfaces()[1]);
+    KRATOS_CHECK_NEAR(r_negative_interface_1[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_1[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_1[0].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_1[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_1[1].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_1[1].Z(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_1[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_1[2].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_1[2].Z(), 0.5, tolerance);
+
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.GetPositiveInterfacesParentIds()[0], 0);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.GetPositiveInterfacesParentIds()[1], 2);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.GetNegativeInterfacesParentIds()[0], 0);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.GetNegativeInterfacesParentIds()[1], 1);
+
+    // Check exterior faces
+    KRATOS_CHECK_EQUAL(pos_ext_faces.size(), 6);
+    KRATOS_CHECK_EQUAL(neg_ext_faces.size(), 6);
+
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[0], 1);
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[1], 2);
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[2], 0);
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[3], 0);
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[4], 1);
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[5], 1);
+
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[0], 0);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[1], 1);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[2], 2);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[3], 2);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[4], 0);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[5], 2);
+
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Z(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].X(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].Z(), 0.0, tolerance);
+
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Y(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].Z(), 0.5, tolerance);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTetrahedra3D4NoDivision, KratosCoreFastSuite)
+{
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
+    base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    base_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
+    Properties::Pointer p_properties(new Properties(0));
+    base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
+
+    // Set the DISTANCE field
+    base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = 1.0;
+    base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = 1.0;
+    base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = 1.0;
+    base_model_part.Nodes()[4].FastGetSolutionStepValue(DISTANCE) = 1.0;
+
+    // Set the elemental distances vector
+    Geometry < Node >& r_geometry = base_model_part.Elements()[1].GetGeometry();
+
+    array_1d<double, 4> distances_vector;
+    for (unsigned int i = 0; i < r_geometry.size(); ++i) {
+        distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
+    }
+
+    base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+
+    Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+    // Build the tetrahedra splitting utility
+    DivideTetrahedra3D4<Node> tetrahedra_splitter(r_geometry, r_elemental_distances);
+
+    // Call the divide geometry method
+    tetrahedra_splitter.GenerateDivision();
+
+    // Check general splitting values
+    KRATOS_CHECK_IS_FALSE(tetrahedra_splitter.mIsSplit);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mDivisionsNumber, 1);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdgesNumber, 0);
+
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTetrahedra3D4ZeroNodes, KratosCoreFastSuite)
+{
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
+    base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    base_model_part.CreateNewNode(4, 0.0, 0.0, 1.0);
+    Properties::Pointer p_properties(new Properties(0));
+    base_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
+
+    // Set the DISTANCE field
+    base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) =  0.0;
+    base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) =  1.0;
+    base_model_part.Nodes()[4].FastGetSolutionStepValue(DISTANCE) =  0.0;
+
+    // Set the elemental distances vector
+    Geometry < Node >& r_geometry = base_model_part.Elements()[1].GetGeometry();
+
+    array_1d<double, 4> distances_vector;
+    for (unsigned int i = 0; i < r_geometry.size(); ++i) {
+        distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
+    }
+
+    base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+
+    Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+    // Build the tetrahedra splitting utility
+    DivideTetrahedra3D4<Node> tetrahedra_splitter(r_geometry, r_elemental_distances);
+
+    // Call the divide geometry method
+    tetrahedra_splitter.GenerateDivision();
+
+    // Call the intersection generation method
+    tetrahedra_splitter.GenerateIntersectionsSkin();
+
+    // Call the positive exterior faces generation method
+    std::vector < unsigned int > pos_ext_faces_parent_ids;
+    std::vector < DivideTetrahedra3D4<Node>::IndexedPointGeometryPointerType > pos_ext_faces;
+    tetrahedra_splitter.GenerateExteriorFaces(
+        pos_ext_faces,
+        pos_ext_faces_parent_ids,
+        tetrahedra_splitter.GetPositiveSubdivisions());
+
+    // Call the negative exterior faces generation method
+    std::vector < unsigned int > neg_ext_faces_parent_ids;
+    std::vector < DivideTetrahedra3D4<Node>::IndexedPointGeometryPointerType > neg_ext_faces;
+    tetrahedra_splitter.GenerateExteriorFaces(
+        neg_ext_faces,
+        neg_ext_faces_parent_ids,
+        tetrahedra_splitter.GetNegativeSubdivisions());
+
+    const double tolerance = 1e-10;
+
+    // Check general splitting values
+    KRATOS_CHECK(tetrahedra_splitter.mIsSplit);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mDivisionsNumber, 2);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdgesNumber, 1);
+
+    // Check split edges
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[0],  0);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[1],  1);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[2],  2);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[3],  3);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[4], -1);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[5], -1);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[6], -1);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[7],  7);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[8], -1);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[9], -1);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.mSplitEdges[10],-1);
+
+    // Check subdivisions
+    const auto& r_positive_subdivision_0 = *(tetrahedra_splitter.GetPositiveSubdivisions()[0]);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Y(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Z(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[3].Z(), 0.0, tolerance);
+
+    const auto& r_negative_subdivision_0 = *(tetrahedra_splitter.GetNegativeSubdivisions()[0]);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Z(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].X(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[3].Z(), 0.0, tolerance);
+
+    // Check interfaces
+    const auto& r_positive_interface_0 = *(tetrahedra_splitter.GetPositiveInterfaces()[0]);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[0].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[1].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[1].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[1].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[2].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[2].Z(), 1.0, tolerance);
+
+    const auto& r_negative_interface_0 = *(tetrahedra_splitter.GetNegativeInterfaces()[0]);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[0].Z(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[1].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[1].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[1].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[2].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[2].Z(), 0.0, tolerance);
+
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.GetPositiveInterfacesParentIds()[0], 0);
+    KRATOS_CHECK_EQUAL(tetrahedra_splitter.GetNegativeInterfacesParentIds()[0], 0);
+
+    // Check exterior faces
+    KRATOS_CHECK_EQUAL(pos_ext_faces.size(), 3);
+    KRATOS_CHECK_EQUAL(neg_ext_faces.size(), 3);
+
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[0], 0);
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[1], 0);
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[2], 0);
+
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[0], 0);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[1], 0);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[2], 0);
+
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Z(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].Y(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[2].Z(), 0.0, tolerance);
+
+    KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].Z(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[1])[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[1])[2].Y(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[1])[2].Z(), 0.0, tolerance);
+
+    KRATOS_CHECK_NEAR((*pos_ext_faces[2])[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[2])[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[2])[0].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[2])[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[2])[1].Y(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[2])[1].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[2])[2].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[2])[2].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[2])[2].Z(), 0.0, tolerance);
+
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Z(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].X(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[2].Z(), 0.0, tolerance);
+
+    KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].Z(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[1])[2].X(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[1])[2].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[1])[2].Z(), 0.0, tolerance);
+
+    KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].X(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].Z(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[2])[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[2])[2].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[2])[2].Z(), 0.0, tolerance);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTetrahedra3D4ConformantFaces, KratosCoreFastSuite)
+{
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Tetrahedra");
+    base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(195, -0.349832, 0.0522541, 0.808642);
+    base_model_part.CreateNewNode(181, -0.132464, 0.144186, 0.788109);
+    base_model_part.CreateNewNode(152, -0.232261, 0.0807726, 1.00046);
+    base_model_part.CreateNewNode(170, -0.157697, -0.0702038, 0.799622);
+    base_model_part.CreateNewNode(163, -0.335408, -0.1450987, 0.920880);
+    Properties::Pointer p_properties(new Properties(0));
+    base_model_part.CreateNewElement("Element3D4N", 471, {195, 181, 152, 170}, p_properties);
+    base_model_part.CreateNewElement("Element3D4N", 526, {170, 195, 163, 152}, p_properties);
+
+    // Set the DISTANCE field
+    base_model_part.GetNode(195).FastGetSolutionStepValue(DISTANCE) = 0.181358;
+    base_model_part.GetNode(181).FastGetSolutionStepValue(DISTANCE) = 0.201891;
+    base_model_part.GetNode(152).FastGetSolutionStepValue(DISTANCE) = -0.0104574;
+    base_model_part.GetNode(170).FastGetSolutionStepValue(DISTANCE) = 0.190378;
+    base_model_part.GetNode(163).FastGetSolutionStepValue(DISTANCE) = 0.06912;
+
+    // Set the elemental distances vector
+    for (auto &i_elem : base_model_part.Elements()) {
+        auto &r_geometry = i_elem.GetGeometry();
+        array_1d<double, 4> distances_vector;
+        for (unsigned int i = 0; i < r_geometry.size(); ++i) {
+            distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
+        }
+        i_elem.SetValue(ELEMENTAL_DISTANCES, distances_vector);
+    }
+
+    // Build the tetrahedra splitting utilities
+    auto p_elem_471 = base_model_part.pGetElement(471);
+    auto p_elem_526 = base_model_part.pGetElement(526);
+
+    DivideTetrahedra3D4<Node> tetra_split_471(p_elem_471->GetGeometry(), p_elem_471->GetValue(ELEMENTAL_DISTANCES));
+    DivideTetrahedra3D4<Node> tetra_split_526(p_elem_526->GetGeometry(), p_elem_526->GetValue(ELEMENTAL_DISTANCES));
+
+    // Call the divide geometry method
+    tetra_split_471.GenerateDivision();
+    tetra_split_526.GenerateDivision();
+
+    // Call the positive exterior faces generation method
+    std::vector<unsigned int> pos_ext_faces_parent_ids_471;
+    std::vector<unsigned int> pos_ext_faces_parent_ids_526;
+    std::vector<DivideTetrahedra3D4<Node>::IndexedPointGeometryPointerType> pos_ext_faces_471;
+    std::vector<DivideTetrahedra3D4<Node>::IndexedPointGeometryPointerType> pos_ext_faces_526;
+    tetra_split_471.GenerateExteriorFaces(pos_ext_faces_471, pos_ext_faces_parent_ids_471, tetra_split_471.GetPositiveSubdivisions());
+    tetra_split_526.GenerateExteriorFaces(pos_ext_faces_526, pos_ext_faces_parent_ids_526, tetra_split_526.GetPositiveSubdivisions());
+
+    // Check that shared positive faces are have the same splitting pattern
+    KRATOS_CHECK_NEAR((*(pos_ext_faces_471[3])).Area(), (*(pos_ext_faces_526[4])).Area(), 1.0e-12);
+    KRATOS_CHECK_NEAR((*(pos_ext_faces_471[2])).Area(), (*(pos_ext_faces_526[5])).Area(), 1.0e-12);
+}
+
+}  // namespace Kratos::Testing.

--- a/kratos/tests/cpp_tests/utilities/test_divide_triangle_2d_3.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_divide_triangle_2d_3.cpp
@@ -393,5 +393,42 @@ namespace Kratos
 			KRATOS_CHECK_EQUAL(divider.GetPositiveSubdivisions().size(), 1);
 			KRATOS_CHECK_EQUAL(divider.GetNegativeSubdivisions().size(), 1);
 		}
+
+
+		KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle2D3TwoZeroNodes, KratosCoreFastSuite)
+		{
+			Model current_model;
+
+			// Generate a model part with the previous
+			ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
+
+			// Fill the model part geometry data
+			base_model_part.CreateNewNode(1, 0.0, 0.6, 0.0);
+			base_model_part.CreateNewNode(2, 0.0, 0.9, 0.0);
+			base_model_part.CreateNewNode(3,-0.3, 0.3, 0.0);
+			Properties::Pointer p_properties(new Properties(0));
+			auto p_elem = base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
+
+			Vector nodal_distances = ZeroVector(3);
+			// cut at y = 0.6, across node 0
+			nodal_distances[0] = 0.0;
+			nodal_distances[1] = 0.0;
+			nodal_distances[2] = -0.3;
+
+			auto divider_one_negative = DivideTriangle2D3<Node>(p_elem->GetGeometry(), nodal_distances);
+			divider_one_negative.GenerateDivision();
+
+			KRATOS_CHECK_IS_FALSE(divider_one_negative.mIsSplit);
+			KRATOS_CHECK_EQUAL(divider_one_negative.mDivisionsNumber, 1);
+			KRATOS_CHECK_EQUAL(divider_one_negative.mSplitEdgesNumber, 0);
+
+			nodal_distances[2] = 0.3;
+			auto divider_one_positive = DivideTriangle2D3<Node>(p_elem->GetGeometry(), nodal_distances);
+			divider_one_positive.GenerateDivision();
+
+			KRATOS_CHECK_IS_FALSE(divider_one_positive.mIsSplit);
+			KRATOS_CHECK_EQUAL(divider_one_positive.mDivisionsNumber, 1);
+			KRATOS_CHECK_EQUAL(divider_one_positive.mSplitEdgesNumber, 0);
+		}
 	}
 }  // namespace Kratos.

--- a/kratos/tests/cpp_tests/utilities/test_divide_triangle_2d_3.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_divide_triangle_2d_3.cpp
@@ -5,7 +5,7 @@
 //                   Multi-Physics
 //
 //  License:     BSD License
-//  			 Kratos default license: kratos/license.txt
+//               Kratos default license: kratos/license.txt
 //
 //  Main authors:    Ruben Zorrilla
 //
@@ -17,418 +17,416 @@
 #include "includes/checks.h"
 #include "utilities/divide_triangle_2d_3.h"
 
-namespace Kratos
+namespace Kratos::Testing
 {
-	namespace Testing
-	{
-
-		KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle2D3Horizontal, KratosCoreFastSuite)
-		{
-			Model current_model;
-
-			// Generate a model part with the previous
-			ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
-			base_model_part.AddNodalSolutionStepVariable(DISTANCE);
-
-			// Fill the model part geometry data
-			base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
-			Properties::Pointer p_properties(new Properties(0));
-			base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
-
-			// Set the DISTANCE field
-			base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
-			base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
-			base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) =  1.0;
-
-			// Set the elemental distances vector
-			Geometry < Node >& r_geometry = base_model_part.Elements()[1].GetGeometry();
-
-			array_1d<double, 3> distances_vector;
-			for (unsigned int i = 0; i < r_geometry.size(); ++i) {
-				distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
-			}
-
-			base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
-
-			Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
-
-			// Build the triangle splitting utility
-			DivideTriangle2D3<Node> triangle_splitter(r_geometry, r_elemental_distances);
-
-			// Call the divide geometry method
-			triangle_splitter.GenerateDivision();
-
-			// Call the intersection generation method
-			triangle_splitter.GenerateIntersectionsSkin();
-
-			// Call the positive exterior faces generation method
-			std::vector < unsigned int > pos_ext_faces_parent_ids;
-			std::vector < DivideTriangle2D3<Node>::IndexedPointGeometryPointerType > pos_ext_faces;
-			triangle_splitter.GenerateExteriorFaces(
-				pos_ext_faces,
-				pos_ext_faces_parent_ids,
-				triangle_splitter.GetPositiveSubdivisions());
-
-			// Call the negative exterior faces generation method
-			std::vector < unsigned int > neg_ext_faces_parent_ids;
-			std::vector < DivideTriangle2D3<Node>::IndexedPointGeometryPointerType > neg_ext_faces;
-			triangle_splitter.GenerateExteriorFaces(
-				neg_ext_faces,
-				neg_ext_faces_parent_ids,
-				triangle_splitter.GetNegativeSubdivisions());
-
-			const double tolerance = 1e-10;
-
-			// Check general splitting values
-			KRATOS_CHECK(triangle_splitter.mIsSplit);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mDivisionsNumber, 3);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdgesNumber, 2);
-
-			// Check split edges
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[0],  0);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[1],  1);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[2],  2);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[3], -1);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[4],  4);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[5],  5);
-
-			// Check subdivisions
-			const auto &r_positive_subdivision_0 = *(triangle_splitter.GetPositiveSubdivisions()[0]);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Y(), 1.0, tolerance);
-
-			const auto &r_negative_subdivision_0 = *(triangle_splitter.GetNegativeSubdivisions()[0]);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Y(), 0.5, tolerance);
-
-			const auto &r_negative_subdivision_1 = *(triangle_splitter.GetNegativeSubdivisions()[1]);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[2].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[2].Y(), 0.0, tolerance);
-
-			// Check interfaces
-			const auto &r_positive_interface_0 = *(triangle_splitter.GetPositiveInterfaces()[0]);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[1].Y(), 0.5, tolerance);
-
-			const auto &r_negative_interface_0 = *(triangle_splitter.GetNegativeInterfaces()[0]);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[1].Y(), 0.5, tolerance);
-
-			KRATOS_CHECK_EQUAL(triangle_splitter.GetPositiveInterfacesParentIds()[0], 0);
-			KRATOS_CHECK_EQUAL(triangle_splitter.GetNegativeInterfacesParentIds()[0], 0);
-
-			// Check exterior faces
-			KRATOS_CHECK_EQUAL(pos_ext_faces.size(), 2);
-			KRATOS_CHECK_EQUAL(neg_ext_faces.size(), 3);
-
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[0], 0);
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[1], 0);
-
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[0], 0);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[1], 1);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[2], 1);
-
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Y(), 1.0, tolerance);
-
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].Y(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].Y(), 0.5, tolerance);
-
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Y(), 0.5, tolerance);
-
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].Y(), 0.0, tolerance);
-
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].Y(), 0.0, tolerance);
-		}
-
-		KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle2D3Vertical, KratosCoreFastSuite)
-		{
-			Model current_model;
-
-			// Generate a model part with the previous
-			ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
-			base_model_part.AddNodalSolutionStepVariable(DISTANCE);
-
-			// Fill the model part geometry data
-			base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
-			Properties::Pointer p_properties(new Properties(0));
-			base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
-
-			// Set the DISTANCE field
-			base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
-			base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) =  1.0;
-			base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = -1.0;
-
-			// Set the elemental distances vector
-			Geometry < Node >& r_geometry = base_model_part.Elements()[1].GetGeometry();
-
-			array_1d<double, 3> distances_vector;
-			for (unsigned int i = 0; i < r_geometry.size(); ++i) {
-				distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
-			}
-
-			base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
-
-			Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
-
-			// Build the triangle splitting utility
-			DivideTriangle2D3<Node> triangle_splitter(r_geometry, r_elemental_distances);
-
-			// Call the divide geometry method
-			triangle_splitter.GenerateDivision();
-
-			// Call the intersection generation method
-			triangle_splitter.GenerateIntersectionsSkin();
-
-			// Call the positive exterior faces generation method
-			std::vector < unsigned int > pos_ext_faces_parent_ids;
-			std::vector < DivideTriangle2D3<Node>::IndexedPointGeometryPointerType > pos_ext_faces;
-			triangle_splitter.GenerateExteriorFaces(
-				pos_ext_faces,
-				pos_ext_faces_parent_ids,
-				triangle_splitter.GetPositiveSubdivisions());
-
-			// Call the negative exterior faces generation method
-			std::vector < unsigned int > neg_ext_faces_parent_ids;
-			std::vector < DivideTriangle2D3<Node>::IndexedPointGeometryPointerType > neg_ext_faces;
-			triangle_splitter.GenerateExteriorFaces(
-				neg_ext_faces,
-				neg_ext_faces_parent_ids,
-				triangle_splitter.GetNegativeSubdivisions());
-
-			const double tolerance = 1e-10;
-
-			// Check general splitting values
-			KRATOS_CHECK(triangle_splitter.mIsSplit);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mDivisionsNumber, 3);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdgesNumber, 2);
-
-			// Check split edges
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[0],  0);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[1],  1);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[2],  2);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[3],  3);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[4],  4);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[5], -1);
-
-			// Check subdivisions
-			const auto &r_positive_subdivision_0 = *(triangle_splitter.GetPositiveSubdivisions()[0]);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Y(), 0.0, tolerance);
-
-			const auto &r_negative_subdivision_0 = *(triangle_splitter.GetNegativeSubdivisions()[0]);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Y(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Y(), 0.0, tolerance);
-
-			const auto &r_negative_subdivision_1 = *(triangle_splitter.GetNegativeSubdivisions()[1]);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[1].Y(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[2].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_subdivision_1[2].Y(), 0.0, tolerance);
-
-			// Check interfaces
-			const auto &r_positive_interface_0 = *(triangle_splitter.GetPositiveInterfaces()[0]);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_positive_interface_0[1].Y(), 0.0, tolerance);
-			const auto &r_negative_interface_0 = *(triangle_splitter.GetNegativeInterfaces()[0]);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR(r_negative_interface_0[1].Y(), 0.5, tolerance);
-
-			KRATOS_CHECK_EQUAL(triangle_splitter.GetPositiveInterfacesParentIds()[0], 0);
-			KRATOS_CHECK_EQUAL(triangle_splitter.GetNegativeInterfacesParentIds()[0], 0);
-
-			// Check exterior faces
-			KRATOS_CHECK_EQUAL(pos_ext_faces.size(), 2);
-			KRATOS_CHECK_EQUAL(neg_ext_faces.size(), 3);
-
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[0], 0);
-			KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[1], 0);
-
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[0], 0);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[1], 1);
-			KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[2], 1);
-
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Y(), 0.5, tolerance);
-
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].X(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].Y(), 0.0, tolerance);
-
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Y(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Y(), 1.0, tolerance);
-
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].Y(), 1.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].Y(), 0.0, tolerance);
-
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].X(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].Y(), 0.0, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].X(), 0.5, tolerance);
-			KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].Y(), 0.0, tolerance);
-		}
-
-		KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle2D3NoDivision, KratosCoreFastSuite)
-		{
-			Model current_model;
-
-			// Generate a model part with the previous
-			ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
-			base_model_part.AddNodalSolutionStepVariable(DISTANCE);
-
-			// Fill the model part geometry data
-			base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-			base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
-			Properties::Pointer p_properties(new Properties(0));
-			base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
-
-			// Set the DISTANCE field
-			base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = 1.0;
-			base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = 1.0;
-			base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = 1.0;
-
-			// Set the elemental distances vector
-			Geometry < Node >& r_geometry = base_model_part.Elements()[1].GetGeometry();
-
-			array_1d<double, 3> distances_vector;
-			for (unsigned int i = 0; i < r_geometry.PointsNumber(); ++i) {
-				distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
-			}
-
-			base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
-
-			Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
-
-			// Build the triangle splitting utility
-			DivideTriangle2D3<Node> triangle_splitter(r_geometry, r_elemental_distances);
-
-			// Call the divide geometry method
-			triangle_splitter.GenerateDivision();
-
-			// Check general splitting values
-			KRATOS_CHECK_IS_FALSE(triangle_splitter.mIsSplit);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mDivisionsNumber, 1);
-			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdgesNumber, 0);
-
-		}
-
-		KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle2D3ZeroNode, KratosCoreFastSuite)
-		{
-			Model current_model;
-
-			// Generate a model part with the previous
-			ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
-
-			// Fill the model part geometry data
-			base_model_part.CreateNewNode(1, 0.0, 0.6, 0.0);
-			base_model_part.CreateNewNode(2, 0.0, 0.9, 0.0);
-			base_model_part.CreateNewNode(3,-0.3, 0.3, 0.0);
-			Properties::Pointer p_properties(new Properties(0));
-			auto p_elem = base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
-
-			Vector nodal_distances = ZeroVector(3);
-			// cut at y = 0.6, across node 0
-			nodal_distances[0] = 0.0;
-			nodal_distances[1] = 0.3;
-			nodal_distances[2] = -0.3;
-
-			auto divider = DivideTriangle2D3<Node>(p_elem->GetGeometry(), nodal_distances);
-			divider.GenerateDivision();
-
-			// Should split a single edge and return two triangles
-			KRATOS_CHECK_EQUAL(divider.GetPositiveSubdivisions().size(), 1);
-			KRATOS_CHECK_EQUAL(divider.GetNegativeSubdivisions().size(), 1);
-		}
-
-
-		KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle2D3TwoZeroNodes, KratosCoreFastSuite)
-		{
-			Model current_model;
-
-			// Generate a model part with the previous
-			ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
-
-			// Fill the model part geometry data
-			base_model_part.CreateNewNode(1, 0.0, 0.6, 0.0);
-			base_model_part.CreateNewNode(2, 0.0, 0.9, 0.0);
-			base_model_part.CreateNewNode(3,-0.3, 0.3, 0.0);
-			Properties::Pointer p_properties(new Properties(0));
-			auto p_elem = base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
-
-			Vector nodal_distances = ZeroVector(3);
-			// cut at y = 0.6, across node 0
-			nodal_distances[0] = 0.0;
-			nodal_distances[1] = 0.0;
-			nodal_distances[2] = -0.3;
-
-			auto divider_one_negative = DivideTriangle2D3<Node>(p_elem->GetGeometry(), nodal_distances);
-			divider_one_negative.GenerateDivision();
-
-			KRATOS_CHECK_IS_FALSE(divider_one_negative.mIsSplit);
-			KRATOS_CHECK_EQUAL(divider_one_negative.mDivisionsNumber, 1);
-			KRATOS_CHECK_EQUAL(divider_one_negative.mSplitEdgesNumber, 0);
-
-			nodal_distances[2] = 0.3;
-			auto divider_one_positive = DivideTriangle2D3<Node>(p_elem->GetGeometry(), nodal_distances);
-			divider_one_positive.GenerateDivision();
-
-			KRATOS_CHECK_IS_FALSE(divider_one_positive.mIsSplit);
-			KRATOS_CHECK_EQUAL(divider_one_positive.mDivisionsNumber, 1);
-			KRATOS_CHECK_EQUAL(divider_one_positive.mSplitEdgesNumber, 0);
-		}
-	}
-}  // namespace Kratos.
+
+KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle2D3Horizontal, KratosCoreFastSuite)
+{
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
+    base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    Properties::Pointer p_properties(new Properties(0));
+    base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
+
+    // Set the DISTANCE field
+    base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) =  1.0;
+
+    // Set the elemental distances vector
+    Geometry < Node >& r_geometry = base_model_part.Elements()[1].GetGeometry();
+
+    array_1d<double, 3> distances_vector;
+    for (unsigned int i = 0; i < r_geometry.size(); ++i) {
+        distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
+    }
+
+    base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+
+    Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+    // Build the triangle splitting utility
+    DivideTriangle2D3<Node> triangle_splitter(r_geometry, r_elemental_distances);
+
+    // Call the divide geometry method
+    triangle_splitter.GenerateDivision();
+
+    // Call the intersection generation method
+    triangle_splitter.GenerateIntersectionsSkin();
+
+    // Call the positive exterior faces generation method
+    std::vector < unsigned int > pos_ext_faces_parent_ids;
+    std::vector < DivideTriangle2D3<Node>::IndexedPointGeometryPointerType > pos_ext_faces;
+    triangle_splitter.GenerateExteriorFaces(
+        pos_ext_faces,
+        pos_ext_faces_parent_ids,
+        triangle_splitter.GetPositiveSubdivisions());
+
+    // Call the negative exterior faces generation method
+    std::vector < unsigned int > neg_ext_faces_parent_ids;
+    std::vector < DivideTriangle2D3<Node>::IndexedPointGeometryPointerType > neg_ext_faces;
+    triangle_splitter.GenerateExteriorFaces(
+        neg_ext_faces,
+        neg_ext_faces_parent_ids,
+        triangle_splitter.GetNegativeSubdivisions());
+
+    const double tolerance = 1e-10;
+
+    // Check general splitting values
+    KRATOS_CHECK(triangle_splitter.mIsSplit);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mDivisionsNumber, 3);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdgesNumber, 2);
+
+    // Check split edges
+    KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[0],  0);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[1],  1);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[2],  2);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[3], -1);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[4],  4);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[5],  5);
+
+    // Check subdivisions
+    const auto &r_positive_subdivision_0 = *(triangle_splitter.GetPositiveSubdivisions()[0]);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Y(), 1.0, tolerance);
+
+    const auto &r_negative_subdivision_0 = *(triangle_splitter.GetNegativeSubdivisions()[0]);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].X(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Y(), 0.5, tolerance);
+
+    const auto &r_negative_subdivision_1 = *(triangle_splitter.GetNegativeSubdivisions()[1]);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_1[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_1[0].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_1[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_1[1].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_1[2].X(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_1[2].Y(), 0.0, tolerance);
+
+    // Check interfaces
+    const auto &r_positive_interface_0 = *(triangle_splitter.GetPositiveInterfaces()[0]);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[0].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[1].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[1].Y(), 0.5, tolerance);
+
+    const auto &r_negative_interface_0 = *(triangle_splitter.GetNegativeInterfaces()[0]);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[0].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[1].Y(), 0.5, tolerance);
+
+    KRATOS_CHECK_EQUAL(triangle_splitter.GetPositiveInterfacesParentIds()[0], 0);
+    KRATOS_CHECK_EQUAL(triangle_splitter.GetNegativeInterfacesParentIds()[0], 0);
+
+    // Check exterior faces
+    KRATOS_CHECK_EQUAL(pos_ext_faces.size(), 2);
+    KRATOS_CHECK_EQUAL(neg_ext_faces.size(), 3);
+
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[0], 0);
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[1], 0);
+
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[0], 0);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[1], 1);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[2], 1);
+
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Y(), 1.0, tolerance);
+
+    KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].Y(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].Y(), 0.5, tolerance);
+
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].X(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Y(), 0.5, tolerance);
+
+    KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].Y(), 0.0, tolerance);
+
+    KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].X(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].Y(), 0.0, tolerance);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle2D3Vertical, KratosCoreFastSuite)
+{
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
+    base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    Properties::Pointer p_properties(new Properties(0));
+    base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
+
+    // Set the DISTANCE field
+    base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
+    base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) =  1.0;
+    base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = -1.0;
+
+    // Set the elemental distances vector
+    Geometry < Node >& r_geometry = base_model_part.Elements()[1].GetGeometry();
+
+    array_1d<double, 3> distances_vector;
+    for (unsigned int i = 0; i < r_geometry.size(); ++i) {
+        distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
+    }
+
+    base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+
+    Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+    // Build the triangle splitting utility
+    DivideTriangle2D3<Node> triangle_splitter(r_geometry, r_elemental_distances);
+
+    // Call the divide geometry method
+    triangle_splitter.GenerateDivision();
+
+    // Call the intersection generation method
+    triangle_splitter.GenerateIntersectionsSkin();
+
+    // Call the positive exterior faces generation method
+    std::vector < unsigned int > pos_ext_faces_parent_ids;
+    std::vector < DivideTriangle2D3<Node>::IndexedPointGeometryPointerType > pos_ext_faces;
+    triangle_splitter.GenerateExteriorFaces(
+        pos_ext_faces,
+        pos_ext_faces_parent_ids,
+        triangle_splitter.GetPositiveSubdivisions());
+
+    // Call the negative exterior faces generation method
+    std::vector < unsigned int > neg_ext_faces_parent_ids;
+    std::vector < DivideTriangle2D3<Node>::IndexedPointGeometryPointerType > neg_ext_faces;
+    triangle_splitter.GenerateExteriorFaces(
+        neg_ext_faces,
+        neg_ext_faces_parent_ids,
+        triangle_splitter.GetNegativeSubdivisions());
+
+    const double tolerance = 1e-10;
+
+    // Check general splitting values
+    KRATOS_CHECK(triangle_splitter.mIsSplit);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mDivisionsNumber, 3);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdgesNumber, 2);
+
+    // Check split edges
+    KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[0],  0);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[1],  1);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[2],  2);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[3],  3);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[4],  4);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdges[5], -1);
+
+    // Check subdivisions
+    const auto &r_positive_subdivision_0 = *(triangle_splitter.GetPositiveSubdivisions()[0]);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[0].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[1].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].X(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_subdivision_0[2].Y(), 0.0, tolerance);
+
+    const auto &r_negative_subdivision_0 = *(triangle_splitter.GetNegativeSubdivisions()[0]);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[0].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[1].Y(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_0[2].Y(), 0.0, tolerance);
+
+    const auto &r_negative_subdivision_1 = *(triangle_splitter.GetNegativeSubdivisions()[1]);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_1[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_1[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_1[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_1[1].Y(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_1[2].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_subdivision_1[2].Y(), 0.0, tolerance);
+
+    // Check interfaces
+    const auto &r_positive_interface_0 = *(triangle_splitter.GetPositiveInterfaces()[0]);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[0].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[1].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_positive_interface_0[1].Y(), 0.0, tolerance);
+    const auto &r_negative_interface_0 = *(triangle_splitter.GetNegativeInterfaces()[0]);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[1].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR(r_negative_interface_0[1].Y(), 0.5, tolerance);
+
+    KRATOS_CHECK_EQUAL(triangle_splitter.GetPositiveInterfacesParentIds()[0], 0);
+    KRATOS_CHECK_EQUAL(triangle_splitter.GetNegativeInterfacesParentIds()[0], 0);
+
+    // Check exterior faces
+    KRATOS_CHECK_EQUAL(pos_ext_faces.size(), 2);
+    KRATOS_CHECK_EQUAL(neg_ext_faces.size(), 3);
+
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[0], 0);
+    KRATOS_CHECK_EQUAL(pos_ext_faces_parent_ids[1], 0);
+
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[0], 0);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[1], 1);
+    KRATOS_CHECK_EQUAL(neg_ext_faces_parent_ids[2], 1);
+
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].X(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[0])[1].Y(), 0.5, tolerance);
+
+    KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[1])[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].X(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*pos_ext_faces[1])[1].Y(), 0.0, tolerance);
+
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[0].Y(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[0])[1].Y(), 1.0, tolerance);
+
+    KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[1])[0].Y(), 1.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[1])[1].Y(), 0.0, tolerance);
+
+    KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].X(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[2])[0].Y(), 0.0, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].X(), 0.5, tolerance);
+    KRATOS_CHECK_NEAR((*neg_ext_faces[2])[1].Y(), 0.0, tolerance);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle2D3NoDivision, KratosCoreFastSuite)
+{
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
+    base_model_part.AddNodalSolutionStepVariable(DISTANCE);
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    base_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    Properties::Pointer p_properties(new Properties(0));
+    base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
+
+    // Set the DISTANCE field
+    base_model_part.Nodes()[1].FastGetSolutionStepValue(DISTANCE) = 1.0;
+    base_model_part.Nodes()[2].FastGetSolutionStepValue(DISTANCE) = 1.0;
+    base_model_part.Nodes()[3].FastGetSolutionStepValue(DISTANCE) = 1.0;
+
+    // Set the elemental distances vector
+    Geometry < Node >& r_geometry = base_model_part.Elements()[1].GetGeometry();
+
+    array_1d<double, 3> distances_vector;
+    for (unsigned int i = 0; i < r_geometry.PointsNumber(); ++i) {
+        distances_vector(i) = r_geometry[i].FastGetSolutionStepValue(DISTANCE);
+    }
+
+    base_model_part.Elements()[1].SetValue(ELEMENTAL_DISTANCES, distances_vector);
+
+    Vector& r_elemental_distances = base_model_part.Elements()[1].GetValue(ELEMENTAL_DISTANCES);
+
+    // Build the triangle splitting utility
+    DivideTriangle2D3<Node> triangle_splitter(r_geometry, r_elemental_distances);
+
+    // Call the divide geometry method
+    triangle_splitter.GenerateDivision();
+
+    // Check general splitting values
+    KRATOS_CHECK_IS_FALSE(triangle_splitter.mIsSplit);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mDivisionsNumber, 1);
+    KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdgesNumber, 0);
+
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle2D3ZeroNode, KratosCoreFastSuite)
+{
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 0.6, 0.0);
+    base_model_part.CreateNewNode(2, 0.0, 0.9, 0.0);
+    base_model_part.CreateNewNode(3,-0.3, 0.3, 0.0);
+    Properties::Pointer p_properties(new Properties(0));
+    auto p_elem = base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
+
+    Vector nodal_distances = ZeroVector(3);
+    // cut at y = 0.6, across node 0
+    nodal_distances[0] = 0.0;
+    nodal_distances[1] = 0.3;
+    nodal_distances[2] = -0.3;
+
+    auto divider = DivideTriangle2D3<Node>(p_elem->GetGeometry(), nodal_distances);
+    divider.GenerateDivision();
+
+    // Should split a single edge and return two triangles
+    KRATOS_CHECK_EQUAL(divider.GetPositiveSubdivisions().size(), 1);
+    KRATOS_CHECK_EQUAL(divider.GetNegativeSubdivisions().size(), 1);
+}
+
+
+KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle2D3TwoZeroNodes, KratosCoreFastSuite)
+{
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.0, 0.6, 0.0);
+    base_model_part.CreateNewNode(2, 0.0, 0.9, 0.0);
+    base_model_part.CreateNewNode(3,-0.3, 0.3, 0.0);
+    Properties::Pointer p_properties(new Properties(0));
+    auto p_elem = base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
+
+    Vector nodal_distances = ZeroVector(3);
+    // cut at y = 0.6, across node 0
+    nodal_distances[0] = 0.0;
+    nodal_distances[1] = 0.0;
+    nodal_distances[2] = -0.3;
+
+    auto divider_one_negative = DivideTriangle2D3<Node>(p_elem->GetGeometry(), nodal_distances);
+    divider_one_negative.GenerateDivision();
+
+    KRATOS_CHECK_IS_FALSE(divider_one_negative.mIsSplit);
+    KRATOS_CHECK_EQUAL(divider_one_negative.mDivisionsNumber, 1);
+    KRATOS_CHECK_EQUAL(divider_one_negative.mSplitEdgesNumber, 0);
+
+    nodal_distances[2] = 0.3;
+    auto divider_one_positive = DivideTriangle2D3<Node>(p_elem->GetGeometry(), nodal_distances);
+    divider_one_positive.GenerateDivision();
+
+    KRATOS_CHECK_IS_FALSE(divider_one_positive.mIsSplit);
+    KRATOS_CHECK_EQUAL(divider_one_positive.mDivisionsNumber, 1);
+    KRATOS_CHECK_EQUAL(divider_one_positive.mSplitEdgesNumber, 0);
+}
+
+}  // namespace Kratos::Testing.

--- a/kratos/tests/cpp_tests/utilities/test_divide_triangle_2d_3.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_divide_triangle_2d_3.cpp
@@ -365,5 +365,33 @@ namespace Kratos
 			KRATOS_CHECK_EQUAL(triangle_splitter.mSplitEdgesNumber, 0);
 
 		}
+
+		KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle2D3ZeroNode, KratosCoreFastSuite)
+		{
+			Model current_model;
+
+			// Generate a model part with the previous
+			ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
+
+			// Fill the model part geometry data
+			base_model_part.CreateNewNode(1, 0.0, 0.6, 0.0);
+			base_model_part.CreateNewNode(2, 0.0, 0.9, 0.0);
+			base_model_part.CreateNewNode(3,-0.3, 0.3, 0.0);
+			Properties::Pointer p_properties(new Properties(0));
+			auto p_elem = base_model_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
+
+			Vector nodal_distances = ZeroVector(3);
+			// cut at y = 0.6, across node 0
+			nodal_distances[0] = 0.0;
+			nodal_distances[1] = 0.3;
+			nodal_distances[2] = -0.3;
+
+			auto divider = DivideTriangle2D3<Node>(p_elem->GetGeometry(), nodal_distances);
+			divider.GenerateDivision();
+
+			// Should split a single edge and return two triangles
+			KRATOS_CHECK_EQUAL(divider.GetPositiveSubdivisions().size(), 1);
+			KRATOS_CHECK_EQUAL(divider.GetNegativeSubdivisions().size(), 1);
+		}
 	}
 }  // namespace Kratos.

--- a/kratos/tests/cpp_tests/utilities/test_divide_triangle_3d_3.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_divide_triangle_3d_3.cpp
@@ -16,10 +16,7 @@
 #include "includes/checks.h"
 #include "utilities/divide_triangle_3d_3.h"
 
-namespace Kratos
-{
-namespace Testing
-{
+namespace Kratos::Testing {
 
 KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle3D3, KratosCoreFastSuite)
 {
@@ -100,7 +97,7 @@ KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle3D3, KratosCoreFastSuite)
 
     // Check subdivisions
     const auto &r_positive_subdivision_0 = *(triangle_splitter.GetPositiveSubdivisions()[0]);
-    
+
     Vector positive_subdivision_0_node_0_coordinates(3);
     positive_subdivision_0_node_0_coordinates[0] = 0.0;
     positive_subdivision_0_node_0_coordinates[1] = 0.5;
@@ -112,13 +109,13 @@ KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle3D3, KratosCoreFastSuite)
     positive_subdivision_0_node_1_coordinates[1] = 0.5;
     positive_subdivision_0_node_1_coordinates[2] = -0.5;
     KRATOS_CHECK_VECTOR_EQUAL(r_positive_subdivision_0[1],positive_subdivision_0_node_1_coordinates);
-    
+
     Vector positive_subdivision_0_node_2_coordinates(3);
     positive_subdivision_0_node_2_coordinates[0] = 0.0;
     positive_subdivision_0_node_2_coordinates[1] = 1.0;
     positive_subdivision_0_node_2_coordinates[2] = -1.0;
     KRATOS_CHECK_VECTOR_EQUAL(r_positive_subdivision_0[2],positive_subdivision_0_node_2_coordinates);
-    
+
     KRATOS_CHECK_NEAR(r_positive_subdivision_0.Area(), 0.17677669529,tolerance);
 
     const auto &r_negative_subdivision_0 = *(triangle_splitter.GetNegativeSubdivisions()[0]);
@@ -269,5 +266,33 @@ KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle3D3, KratosCoreFastSuite)
     KRATOS_CHECK_VECTOR_EQUAL((*neg_ext_faces[2])[1],neg_ext_faces_2_node_1_coordinates);
 
 }
+
+KRATOS_TEST_CASE_IN_SUITE(DivideGeometryTriangle3D3ZeroNode, KratosCoreFastSuite)
+{
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& base_model_part = current_model.CreateModelPart("Triangle");
+
+    // Fill the model part geometry data
+    base_model_part.CreateNewNode(1, 0.3,  0.0, 0.6);
+    base_model_part.CreateNewNode(2, 0.3,  0.0, 0.9);
+    base_model_part.CreateNewNode(3, 0.3, -0.3, 0.3);
+    Properties::Pointer p_properties(new Properties(0));
+    auto p_elem = base_model_part.CreateNewElement("Element3D3N", 1, {1, 2, 3}, p_properties);
+
+    Vector nodal_distances = ZeroVector(3);
+    // cut at z = 0.6, across node 0
+    nodal_distances[0] = 0.0;
+    nodal_distances[1] = 0.3;
+    nodal_distances[2] = -0.3;
+
+    auto divider = DivideTriangle3D3<Node>(p_elem->GetGeometry(), nodal_distances);
+    divider.GenerateDivision();
+
+    // Should split a single edge and return two triangles
+    KRATOS_CHECK_EQUAL(divider.GetPositiveSubdivisions().size(), 1);
+    KRATOS_CHECK_EQUAL(divider.GetNegativeSubdivisions().size(), 1);
 }
-}  // namespace Kratos.
+
+}  // namespace Kratos::Testing.

--- a/kratos/utilities/divide_geometry.cpp
+++ b/kratos/utilities/divide_geometry.cpp
@@ -114,7 +114,7 @@ namespace Kratos
         for (unsigned int i = 0; i < mrNodalDistances.size(); ++i) {
             if (mrNodalDistances(i) < 0.0) {
                 n_neg++;
-            } else {
+            } else if (mrNodalDistances(i) > 0.0) {
                 n_pos++;
             }
         }

--- a/kratos/utilities/divide_tetrahedra_3d_4.cpp
+++ b/kratos/utilities/divide_tetrahedra_3d_4.cpp
@@ -245,7 +245,8 @@ namespace Kratos
                     int node_k_key = r_face[2].Id();
 
                     // Check the nodal keys to state which nodes belong to the interface
-                    // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
+                    // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliary interface points
+                    // For the zero distance case, the corresponding node is considered as part of the interface
                     if (NodeIsInterface(node_i_key) && NodeIsInterface(node_j_key) && NodeIsInterface(node_k_key)) {
                         // Generate an indexed point triangle geometry pointer with the two interface nodes
                         IndexedPointGeometryPointerType p_intersection_tri = Kratos::make_shared<IndexedPointTriangleType>(this->mAuxPointsContainer(node_i_key),

--- a/kratos/utilities/divide_tetrahedra_3d_4.cpp
+++ b/kratos/utilities/divide_tetrahedra_3d_4.cpp
@@ -157,7 +157,8 @@ namespace Kratos
                     this->mAuxPointsContainer(i2),
                     this->mAuxPointsContainer(i3));
 
-                // Determine if the subdivision is wether in the negative or the positive side
+                // Determine if the subdivision is whether in the negative or the positive side
+                // Note that zero distance nodes are also identified and stored in here 
                 unsigned int neg = 0, pos = 0;
                 if(i0 <= 3) { if (nodal_distances(i0) < 0.0) neg++; else if (nodal_distances(i0) > 0.0) pos++; else mNodeIsCut.set(i0); }
                 if(i1 <= 3) { if (nodal_distances(i1) < 0.0) neg++; else if (nodal_distances(i1) > 0.0) pos++; else mNodeIsCut.set(i1); }

--- a/kratos/utilities/divide_tetrahedra_3d_4.cpp
+++ b/kratos/utilities/divide_tetrahedra_3d_4.cpp
@@ -187,7 +187,6 @@ namespace Kratos
     template<class TPointType>
     void DivideTetrahedra3D4<TPointType>::GenerateIntersectionsSkin() {
         // Set some geometry constant parameters
-        const int n_nodes = 4;
         const unsigned int n_faces = 4;
 
         // Clear the interfaces vectors

--- a/kratos/utilities/divide_tetrahedra_3d_4.cpp
+++ b/kratos/utilities/divide_tetrahedra_3d_4.cpp
@@ -216,7 +216,8 @@ namespace Kratos
                     int node_k_key = r_face[2].Id();
 
                     // Check the nodal keys to state which nodes belong to the interface
-                    // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
+                    // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliary interface points
+                    // For the zero distance case, the corresponding node is considered as part of the interface
                     if (NodeIsInterface(node_i_key) && NodeIsInterface(node_j_key) && NodeIsInterface(node_k_key)) {
                         // Generate an indexed point triangle geometry pointer with the two interface nodes
                         IndexedPointGeometryPointerType p_intersection_tri = Kratos::make_shared<IndexedPointTriangleType>(this->mAuxPointsContainer(node_i_key),

--- a/kratos/utilities/divide_tetrahedra_3d_4.cpp
+++ b/kratos/utilities/divide_tetrahedra_3d_4.cpp
@@ -152,17 +152,17 @@ namespace Kratos
 
                 // Generate a pointer to an auxiliar triangular geometry made with the subdivision points
                 IndexedPointGeometryPointerType p_aux_partition = Kratos::make_shared<IndexedPointTetrahedraType>(
-                    this->mAuxPointsContainer(i0), 
-                    this->mAuxPointsContainer(i1), 
+                    this->mAuxPointsContainer(i0),
+                    this->mAuxPointsContainer(i1),
                     this->mAuxPointsContainer(i2),
                     this->mAuxPointsContainer(i3));
-                
-                // Determine if the subdivision is wether in the negative or the positive side                                                                                                 
+
+                // Determine if the subdivision is wether in the negative or the positive side
                 unsigned int neg = 0, pos = 0;
-                if(i0 <= 3) {nodal_distances(i0) < 0.0 ? neg++ : pos++;}
-                if(i1 <= 3) {nodal_distances(i1) < 0.0 ? neg++ : pos++;}
-                if(i2 <= 3) {nodal_distances(i2) < 0.0 ? neg++ : pos++;}
-                if(i3 <= 3) {nodal_distances(i3) < 0.0 ? neg++ : pos++;}
+                if(i0 <= 3) { if (nodal_distances(i0) < 0.0) neg++; else if (nodal_distances(i0) > 0.0) pos++; else mNodeIsCut.set(i0); }
+                if(i1 <= 3) { if (nodal_distances(i1) < 0.0) neg++; else if (nodal_distances(i1) > 0.0) pos++; else mNodeIsCut.set(i1); }
+                if(i2 <= 3) { if (nodal_distances(i2) < 0.0) neg++; else if (nodal_distances(i2) > 0.0) pos++; else mNodeIsCut.set(i2); }
+                if(i3 <= 3) { if (nodal_distances(i3) < 0.0) neg++; else if (nodal_distances(i3) > 0.0) pos++; else mNodeIsCut.set(i3); }
 
                 if(neg > 0 && pos > 0)
                     KRATOS_ERROR << "The subgeometry " << i0 << " " << i1 << " " << i2 << " " << i3 << " in tetrahedra has nodes in both positive and negative sides." << std::endl;
@@ -200,7 +200,7 @@ namespace Kratos
 
             const unsigned int n_positive_subdivision = this->mPositiveSubdivisions.size();
             const unsigned int n_negative_subdivision = this->mNegativeSubdivisions.size();
-            
+
             // Compute the positive side intersection geometries
             for (unsigned int i_subdivision = 0; i_subdivision < n_positive_subdivision; ++i_subdivision) {
                 // Get the subdivision geometry faces
@@ -215,12 +215,12 @@ namespace Kratos
                     int node_i_key = r_face[0].Id();
                     int node_j_key = r_face[1].Id();
                     int node_k_key = r_face[2].Id();
-                    
+
                     // Check the nodal keys to state which nodes belong to the interface
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
-                    if ((node_i_key >= n_nodes) && (node_j_key >= n_nodes) && (node_k_key >= n_nodes)) {
+                    if (NodeIsInterface(node_i_key) && NodeIsInterface(node_j_key) && NodeIsInterface(node_k_key)) {
                         // Generate an indexed point triangle geometry pointer with the two interface nodes
-                        IndexedPointGeometryPointerType p_intersection_tri = Kratos::make_shared<IndexedPointTriangleType>(this->mAuxPointsContainer(node_i_key), 
+                        IndexedPointGeometryPointerType p_intersection_tri = Kratos::make_shared<IndexedPointTriangleType>(this->mAuxPointsContainer(node_i_key),
                                                                                                                           this->mAuxPointsContainer(node_j_key),
                                                                                                                           this->mAuxPointsContainer(node_k_key));
                         this->mPositiveInterfaces.push_back(p_intersection_tri);
@@ -243,12 +243,12 @@ namespace Kratos
                     int node_i_key = r_face[0].Id();
                     int node_j_key = r_face[1].Id();
                     int node_k_key = r_face[2].Id();
-                    
+
                     // Check the nodal keys to state which nodes belong to the interface
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
-                    if ((node_i_key >= n_nodes) && (node_j_key >= n_nodes) && (node_k_key >= n_nodes)) {
+                    if (NodeIsInterface(node_i_key) && NodeIsInterface(node_j_key) && NodeIsInterface(node_k_key)) {
                         // Generate an indexed point triangle geometry pointer with the two interface nodes
-                        IndexedPointGeometryPointerType p_intersection_tri = Kratos::make_shared<IndexedPointTriangleType>(this->mAuxPointsContainer(node_i_key), 
+                        IndexedPointGeometryPointerType p_intersection_tri = Kratos::make_shared<IndexedPointTriangleType>(this->mAuxPointsContainer(node_i_key),
                                                                                                                           this->mAuxPointsContainer(node_j_key),
                                                                                                                           this->mAuxPointsContainer(node_k_key));
                         this->mNegativeInterfaces.push_back(p_intersection_tri);
@@ -282,9 +282,9 @@ namespace Kratos
             DivideTetrahedra3D4::GenerateExteriorFaces(
                 aux_ext_faces,
                 aux_ext_faces_parent_ids,
-                rSubdivisionsContainer, 
+                rSubdivisionsContainer,
                 i_face);
-            
+
             rExteriorFacesVector.insert(rExteriorFacesVector.end(), aux_ext_faces.begin(), aux_ext_faces.end());
             rExteriorFacesParentSubdivisionsIdsVector.insert(rExteriorFacesParentSubdivisionsIdsVector.end(), aux_ext_faces_parent_ids.begin(), aux_ext_faces_parent_ids.end());
         }
@@ -352,8 +352,14 @@ namespace Kratos
         }
     };
 
-    
+    template<class TPointType>
+    bool DivideTetrahedra3D4<TPointType>::NodeIsInterface(int NodeKey) const
+    {
+        constexpr int num_nodes = 4;
+        return NodeKey >= num_nodes || mNodeIsCut[NodeKey];
+    }
+
     template class DivideTetrahedra3D4<Node>;
     template class DivideTetrahedra3D4<IndexedPoint>;
-        
+
 };

--- a/kratos/utilities/divide_tetrahedra_3d_4.h
+++ b/kratos/utilities/divide_tetrahedra_3d_4.h
@@ -14,6 +14,7 @@
 #define KRATOS_DIVIDE_TETRAHEDRA_3D_4_UTILS
 
 // System includes
+#include <bitset>
 
 // External includes
 
@@ -162,6 +163,8 @@ private:
     ///@name Member Variables
     ///@{
 
+    std::bitset<4> mNodeIsCut{0x0};
+
     ///@}
     ///@name Serialization
     ///@{
@@ -181,6 +184,8 @@ private:
     ///@}
     ///@name Private Inquiry
     ///@{
+
+    bool NodeIsInterface(int NodeKey) const;
 
     ///@}
     ///@name Un accessible methods

--- a/kratos/utilities/divide_triangle_2d_3.cpp
+++ b/kratos/utilities/divide_triangle_2d_3.cpp
@@ -218,7 +218,8 @@ namespace Kratos
                     int node_j_key = r_subdivision_geom[mEdgeNodeJ[i_face]].Id();
 
                     // Check the nodal keys to state which nodes belong to the interface
-                    // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
+                    // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliary interface points
+                    // For the zero distance case, the corresponding node is considered as part of the interface
                     if ((node_i_key >= n_nodes || this->mNodeIsCut[node_i_key]) && (node_j_key >= n_nodes || this->mNodeIsCut[node_j_key])) {
                         // Generate an indexed point line geometry pointer with the two interface nodes
                         IndexedPointGeometryPointerType p_intersection_line = this->GenerateIntersectionLine(node_i_key, node_j_key);

--- a/kratos/utilities/divide_triangle_2d_3.cpp
+++ b/kratos/utilities/divide_triangle_2d_3.cpp
@@ -244,7 +244,8 @@ namespace Kratos
                     int node_j_key = r_subdivision_geom[mEdgeNodeJ[i_face]].Id();
 
                     // Check the nodal keys to state which nodes belong to the interface
-                    // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
+                    // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliary interface points
+                    // For the zero distance case, the corresponding node is considered as part of the interface
                     if ((node_i_key >= n_nodes || this->mNodeIsCut[node_i_key]) && (node_j_key >= n_nodes || this->mNodeIsCut[node_j_key])) {
                         // Generate an indexed point line geometry pointer with the two interface nodes
                         IndexedPointGeometryPointerType p_intersection_line = this->GenerateIntersectionLine(node_i_key ,node_j_key);

--- a/kratos/utilities/divide_triangle_2d_3.cpp
+++ b/kratos/utilities/divide_triangle_2d_3.cpp
@@ -160,9 +160,9 @@ namespace Kratos
 
                 // Determine if the subdivision is wether in the negative or the positive side
                 unsigned int neg = 0, pos = 0;
-                if(i0 <= 2) {if(nodal_distances(i0) < 0.0) neg++; else if(nodal_distances(i0) > 0.0) pos++;};
-                if(i1 <= 2) {if(nodal_distances(i1) < 0.0) neg++; else if(nodal_distances(i1) > 0.0) pos++;};
-                if(i2 <= 2) {if(nodal_distances(i2) < 0.0) neg++; else if(nodal_distances(i2) > 0.0) pos++;};
+                if(i0 <= 2) {if(nodal_distances(i0) < 0.0) neg++; else if(nodal_distances(i0) > 0.0) pos++; else this->mNodeIsCut.set(i0);};
+                if(i1 <= 2) {if(nodal_distances(i1) < 0.0) neg++; else if(nodal_distances(i1) > 0.0) pos++; else this->mNodeIsCut.set(i1);};
+                if(i2 <= 2) {if(nodal_distances(i2) < 0.0) neg++; else if(nodal_distances(i2) > 0.0) pos++; else this->mNodeIsCut.set(i2);};
 
                 KRATOS_ERROR_IF(neg > 0 && pos > 0) << "The subgeometry " << i0 << " " << i1 << " " << i2 << " in triangle has nodes in both positive and negative sides." << std::endl;
 
@@ -218,7 +218,7 @@ namespace Kratos
 
                     // Check the nodal keys to state which nodes belong to the interface
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
-                    if ((node_i_key >= n_nodes) && (node_j_key >= n_nodes)) {
+                    if ((node_i_key >= n_nodes || this->mNodeIsCut[node_i_key]) && (node_j_key >= n_nodes || this->mNodeIsCut[node_j_key])) {
                         // Generate an indexed point line geometry pointer with the two interface nodes
                         IndexedPointGeometryPointerType p_intersection_line = this->GenerateIntersectionLine(node_i_key, node_j_key);
                         this->mPositiveInterfaces.push_back(p_intersection_line);
@@ -243,7 +243,7 @@ namespace Kratos
 
                     // Check the nodal keys to state which nodes belong to the interface
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
-                    if ((node_i_key >= n_nodes) && (node_j_key >= n_nodes)) {
+                    if ((node_i_key >= n_nodes || this->mNodeIsCut[node_i_key]) && (node_j_key >= n_nodes || this->mNodeIsCut[node_j_key])) {
                         // Generate an indexed point line geometry pointer with the two interface nodes
                         IndexedPointGeometryPointerType p_intersection_line = this->GenerateIntersectionLine(node_i_key ,node_j_key);
                         this->mNegativeInterfaces.push_back(p_intersection_line);

--- a/kratos/utilities/divide_triangle_2d_3.cpp
+++ b/kratos/utilities/divide_triangle_2d_3.cpp
@@ -159,7 +159,7 @@ namespace Kratos
                 IndexedPointGeometryPointerType p_aux_partition = GenerateAuxiliaryPartitionTriangle(i0, i1, i2);
 
                 // Determine if the subdivision is whether in the negative or the positive side
-                // Note that zero distance nodes are also identified and stored in here 
+                // Note that zero distance nodes are also identified and stored in here
                 unsigned int neg = 0, pos = 0;
                 if(i0 <= 2) {if(nodal_distances(i0) < 0.0) neg++; else if(nodal_distances(i0) > 0.0) pos++; else this->mNodeIsCut.set(i0);};
                 if(i1 <= 2) {if(nodal_distances(i1) < 0.0) neg++; else if(nodal_distances(i1) > 0.0) pos++; else this->mNodeIsCut.set(i1);};
@@ -188,7 +188,6 @@ namespace Kratos
     void DivideTriangle2D3<TPointType>::GenerateIntersectionsSkin() {
 
         // Set some geometry constant parameters
-        const int n_nodes = 3;
         const unsigned int n_faces = 3;
 
         // Clear the interfaces vectors
@@ -220,7 +219,7 @@ namespace Kratos
                     // Check the nodal keys to state which nodes belong to the interface
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliary interface points
                     // For the zero distance case, the corresponding node is considered as part of the interface
-                    if ((node_i_key >= n_nodes || this->mNodeIsCut[node_i_key]) && (node_j_key >= n_nodes || this->mNodeIsCut[node_j_key])) {
+                    if (NodeIsInterface(node_i_key) && NodeIsInterface(node_j_key)) {
                         // Generate an indexed point line geometry pointer with the two interface nodes
                         IndexedPointGeometryPointerType p_intersection_line = this->GenerateIntersectionLine(node_i_key, node_j_key);
                         this->mPositiveInterfaces.push_back(p_intersection_line);
@@ -246,7 +245,7 @@ namespace Kratos
                     // Check the nodal keys to state which nodes belong to the interface
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliary interface points
                     // For the zero distance case, the corresponding node is considered as part of the interface
-                    if ((node_i_key >= n_nodes || this->mNodeIsCut[node_i_key]) && (node_j_key >= n_nodes || this->mNodeIsCut[node_j_key])) {
+                    if (NodeIsInterface(node_i_key) && NodeIsInterface(node_j_key)) {
                         // Generate an indexed point line geometry pointer with the two interface nodes
                         IndexedPointGeometryPointerType p_intersection_line = this->GenerateIntersectionLine(node_i_key ,node_j_key);
                         this->mNegativeInterfaces.push_back(p_intersection_line);
@@ -369,6 +368,14 @@ namespace Kratos
             this->mAuxPointsContainer(I0),
             this->mAuxPointsContainer(I1));
     };
+
+    template<class TPointType>
+    bool DivideTriangle2D3<TPointType>::NodeIsInterface(int NodeKey) const
+    {
+        constexpr int num_nodes = 3;
+        return NodeKey >= num_nodes || mNodeIsCut[NodeKey];
+    }
+
 
     template class DivideTriangle2D3<Node>;
     template class DivideTriangle2D3<IndexedPoint>;

--- a/kratos/utilities/divide_triangle_2d_3.cpp
+++ b/kratos/utilities/divide_triangle_2d_3.cpp
@@ -158,7 +158,8 @@ namespace Kratos
                 // Generate a pointer to an auxiliar triangular geometry made with the subdivision points
                 IndexedPointGeometryPointerType p_aux_partition = GenerateAuxiliaryPartitionTriangle(i0, i1, i2);
 
-                // Determine if the subdivision is wether in the negative or the positive side
+                // Determine if the subdivision is whether in the negative or the positive side
+                // Note that zero distance nodes are also identified and stored in here 
                 unsigned int neg = 0, pos = 0;
                 if(i0 <= 2) {if(nodal_distances(i0) < 0.0) neg++; else if(nodal_distances(i0) > 0.0) pos++; else this->mNodeIsCut.set(i0);};
                 if(i1 <= 2) {if(nodal_distances(i1) < 0.0) neg++; else if(nodal_distances(i1) > 0.0) pos++; else this->mNodeIsCut.set(i1);};

--- a/kratos/utilities/divide_triangle_2d_3.cpp
+++ b/kratos/utilities/divide_triangle_2d_3.cpp
@@ -164,8 +164,7 @@ namespace Kratos
                 if(i1 <= 2) {if(nodal_distances(i1) < 0.0) neg++; else if(nodal_distances(i1) > 0.0) pos++;};
                 if(i2 <= 2) {if(nodal_distances(i2) < 0.0) neg++; else if(nodal_distances(i2) > 0.0) pos++;};
 
-                if(neg > 0 && pos > 0)
-                    KRATOS_ERROR << "The subgeometry " << i0 << " " << i1 << " " << i2 << " in triangle has nodes in both positive and negative sides." << std::endl;
+                KRATOS_ERROR_IF(neg > 0 && pos > 0) << "The subgeometry " << i0 << " " << i1 << " " << i2 << " in triangle has nodes in both positive and negative sides." << std::endl;
 
                 bool is_positive = false;
                 if(pos > 0) {is_positive = true;}

--- a/kratos/utilities/divide_triangle_2d_3.cpp
+++ b/kratos/utilities/divide_triangle_2d_3.cpp
@@ -160,9 +160,9 @@ namespace Kratos
 
                 // Determine if the subdivision is wether in the negative or the positive side
                 unsigned int neg = 0, pos = 0;
-                if(i0 <= 2) {nodal_distances(i0) < 0.0 ? neg++ : pos++;}
-                if(i1 <= 2) {nodal_distances(i1) < 0.0 ? neg++ : pos++;}
-                if(i2 <= 2) {nodal_distances(i2) < 0.0 ? neg++ : pos++;}
+                if(i0 <= 2) {if(nodal_distances(i0) < 0.0) neg++; else if(nodal_distances(i0) > 0.0) pos++;};
+                if(i1 <= 2) {if(nodal_distances(i1) < 0.0) neg++; else if(nodal_distances(i1) > 0.0) pos++;};
+                if(i2 <= 2) {if(nodal_distances(i2) < 0.0) neg++; else if(nodal_distances(i2) > 0.0) pos++;};
 
                 if(neg > 0 && pos > 0)
                     KRATOS_ERROR << "The subgeometry " << i0 << " " << i1 << " " << i2 << " in triange has nodes in both positive and negative sides." << std::endl;

--- a/kratos/utilities/divide_triangle_2d_3.cpp
+++ b/kratos/utilities/divide_triangle_2d_3.cpp
@@ -165,7 +165,7 @@ namespace Kratos
                 if(i2 <= 2) {if(nodal_distances(i2) < 0.0) neg++; else if(nodal_distances(i2) > 0.0) pos++;};
 
                 if(neg > 0 && pos > 0)
-                    KRATOS_ERROR << "The subgeometry " << i0 << " " << i1 << " " << i2 << " in triange has nodes in both positive and negative sides." << std::endl;
+                    KRATOS_ERROR << "The subgeometry " << i0 << " " << i1 << " " << i2 << " in triangle has nodes in both positive and negative sides." << std::endl;
 
                 bool is_positive = false;
                 if(pos > 0) {is_positive = true;}

--- a/kratos/utilities/divide_triangle_2d_3.h
+++ b/kratos/utilities/divide_triangle_2d_3.h
@@ -195,6 +195,8 @@ private:
     ///@name Private Inquiry
     ///@{
 
+    bool NodeIsInterface(int NodeKey) const;
+
     ///@}
     ///@name Un accessible methods
     ///@{

--- a/kratos/utilities/divide_triangle_2d_3.h
+++ b/kratos/utilities/divide_triangle_2d_3.h
@@ -14,6 +14,7 @@
 #define KRATOS_DIVIDE_TRIANGLE_2D_3_UTILS
 
 // System includes
+#include <bitset>
 
 // External includes
 
@@ -163,7 +164,7 @@ public:
     virtual IndexedPointGeometryPointerType GenerateIntersectionLine(
         const int I0,
         const int I1);
-    
+
 private:
     ///@name Static Member Variables
     ///@{
@@ -171,6 +172,8 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
+
+    std::bitset<3> mNodeIsCut{0x0}; // If the cut passes through a node, store this information here
 
     ///@}
     ///@name Serialization


### PR DESCRIPTION
**📝 Description**
In the current master DivideTriangle3D3 throws an error if the nodal distance is exactly zero, even though it is actually doing the right thing. This is due to the part where it counts positive and negative nodes, which always counts 0 as positive and reports a change of sign for the negative side triangle.

I assume the same is true for the 2D version, since the proposed change actually involves triangle_2d_3.cpp, but I have not used it.

This PR addresses the issue and introduces a test illustrating the expected behavior.

**🆕 Changelog**
- Fixed issue in DivideTriangle3D3 when one of the nodes has exactly zero distance.
