### PR TITLE
[Core] Adding hash for `std::pair`

### DIFF
--- a/kratos/includes/key_hash.h
+++ b/kratos/includes/key_hash.h
@@ -463,7 +463,7 @@ namespace std
     struct hash<std::pair<T1, T2>> 
     {
         /**
-         * @brief Calculates the hash value of a given pair of values in a way that combines the hash values of the individual elements, using bitwise XOR (^).
+         * @brief Calculates the hash value of a given pair of values in a way that combines the hash values of the individual elements
          * @param p the pair of values to be hashed.
          * @return the resulting hash value.
          */
@@ -474,8 +474,6 @@ namespace std
             const size_t h2 = std::hash<T2>()(p.second);
             Kratos::HashCombine(seed, h1);
             Kratos::HashCombine(seed, h2);
-            // Combine the hash values of the pair's elements
-            // in a suitable way, e.g., using bitwise XOR (^)
             return seed;
         }
     };

--- a/kratos/includes/key_hash.h
+++ b/kratos/includes/key_hash.h
@@ -446,3 +446,37 @@ namespace Kratos
 ///@{
 
 } // namespace Kratos.
+
+/**
+ * @brief This defines the missing hashs for the std namespace
+*/
+namespace std 
+{
+    /**
+     * @brief This is a hasher for pairs
+     * @details Used for example for edges ids
+     * @tparam T1 The first type of the pair
+     * @tparam T2 The second type of the pair
+     * @note This is needed to use pairs as keys in unordered maps
+     */
+    template<typename T1, typename T2>
+    struct hash<std::pair<T1, T2>> 
+    {
+        /**
+         * @brief Calculates the hash value of a given pair of values in a way that combines the hash values of the individual elements, using bitwise XOR (^).
+         * @param p the pair of values to be hashed.
+         * @return the resulting hash value.
+         */
+        size_t operator()(const std::pair<T1, T2>& p) const 
+        {
+            size_t seed = 0;
+            const size_t h1 = std::hash<T1>()(p.first);
+            const size_t h2 = std::hash<T2>()(p.second);
+            Kratos::HashCombine(seed, h1);
+            Kratos::HashCombine(seed, h2);
+            // Combine the hash values of the pair's elements
+            // in a suitable way, e.g., using bitwise XOR (^)
+            return seed;
+        }
+    };
+} // namespace std.

--- a/kratos/tests/cpp_tests/sources/test_key_hash.cpp
+++ b/kratos/tests/cpp_tests/sources/test_key_hash.cpp
@@ -77,8 +77,15 @@ KRATOS_TEST_CASE_IN_SUITE(HashSTLPair, KratosCoreFastSuite)
 {
     std::pair<int, int> test_pair(1, 2);
 
+    // Calculate the reference solution
+    std::size_t reference_solution = 0;
+    const std::size_t h1 = std::hash<int>()(1);
+    const std::size_t h2 = std::hash<int>()(2);
+    HashCombine(reference_solution, h1);
+    HashCombine(reference_solution, h2);
+
     std::hash<std::pair<int, int>> hash_func;
-    KRATOS_CHECK_EQUAL(hash_func(test_pair), 175247769363);
+    KRATOS_CHECK_EQUAL(hash_func(test_pair), reference_solution);
 }
 
 /**

--- a/kratos/tests/cpp_tests/sources/test_key_hash.cpp
+++ b/kratos/tests/cpp_tests/sources/test_key_hash.cpp
@@ -29,28 +29,28 @@ namespace Kratos::Testing
  */
 KRATOS_TEST_CASE_IN_SUITE(HashCombine, KratosCoreFastSuite) 
 {
-  HashType seed = 0;
-  const int value1 = 42;
-  const std::string value2 = "hello world";
-  
-  HashCombine(seed, value1);
-  HashCombine(seed, value2);
-  
-  // Expected hash value 
-  const int value3 = 42;
-  const std::string value4 = "hello world";
-  HashType expected_hash = 0;
-  
-  HashCombine(expected_hash, value3);
-  HashCombine(expected_hash, value4);
+    HashType seed = 0;
+    const int value1 = 42;
+    const std::string value2 = "hello world";
+    
+    HashCombine(seed, value1);
+    HashCombine(seed, value2);
+    
+    // Expected hash value 
+    const int value3 = 42;
+    const std::string value4 = "hello world";
+    HashType expected_hash = 0;
+    
+    HashCombine(expected_hash, value3);
+    HashCombine(expected_hash, value4);
 
-  // Not expected hash value
-  const double value5 = 3.14159265358979323846;
-  HashType not_expected_hash = expected_hash;
-  HashCombine(not_expected_hash, value5);
-  
-  KRATOS_CHECK_EQUAL(seed, expected_hash);
-  KRATOS_CHECK_NOT_EQUAL(seed, not_expected_hash);
+    // Not expected hash value
+    const double value5 = 3.14159265358979323846;
+    HashType not_expected_hash = expected_hash;
+    HashCombine(not_expected_hash, value5);
+    
+    KRATOS_CHECK_EQUAL(seed, expected_hash);
+    KRATOS_CHECK_NOT_EQUAL(seed, not_expected_hash);
 }
 
 /**
@@ -58,16 +58,27 @@ KRATOS_TEST_CASE_IN_SUITE(HashCombine, KratosCoreFastSuite)
  */
 KRATOS_TEST_CASE_IN_SUITE(HashRange, KratosCoreFastSuite) 
 {
-  std::vector<int> values1 = {1, 2, 3, 4, 5};
-  std::vector<int> values2 = {1, 2, 3, 4, 5};
-  std::vector<int> values3 = {1, 2, 3, 4};
+    std::vector<int> values1 = {1, 2, 3, 4, 5};
+    std::vector<int> values2 = {1, 2, 3, 4, 5};
+    std::vector<int> values3 = {1, 2, 3, 4};
 
-  const HashType actual_hash = HashRange(values1.begin(), values1.end());
-  const HashType expected_hash = HashRange(values2.begin(), values2.end());
-  const HashType not_expected_hash = HashRange(values3.begin(), values3.end());
+    const HashType actual_hash = HashRange(values1.begin(), values1.end());
+    const HashType expected_hash = HashRange(values2.begin(), values2.end());
+    const HashType not_expected_hash = HashRange(values3.begin(), values3.end());
 
-  KRATOS_CHECK_EQUAL(actual_hash, expected_hash);
-  KRATOS_CHECK_NOT_EQUAL(actual_hash, not_expected_hash);
+    KRATOS_CHECK_EQUAL(actual_hash, expected_hash);
+    KRATOS_CHECK_NOT_EQUAL(actual_hash, not_expected_hash);
+}
+
+/**
+ *  Here the hash STL std::pair is test
+ */
+KRATOS_TEST_CASE_IN_SUITE(HashSTLPair, KratosCoreFastSuite)
+{
+    std::pair<int, int> test_pair(1, 2);
+
+    std::hash<std::pair<int, int>> hash_func;
+    KRATOS_CHECK_EQUAL(hash_func(test_pair), 175247769363);
 }
 
 /**


### PR DESCRIPTION
**📝 Description**

This PR adds missing hash definitions and tests for STL pair (`std::pair`). The changes include:
- In the file "key_hash.h", a hash definition for pairs is added to the `std namespace`. It calculates the hash value of a given pair of values by combining the hash values of the individual elements using `HasCombine`.
- In the file "test_key_hash.cpp" a new test case "HashSTLPair" is added to test the hash function for STL pairs.

**🆕 Changelog**

- [Adding hash for std::pair](https://github.com/KratosMultiphysics/Kratos/commit/3246bb04932ea043dbd1f8bb8ae0a58a22c2cc37)
