### PR TITLE
[Core] KratosMultiphysics on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,12 @@ else(NOT DEFINED ENV{KRATOS_INSTALL_PYTHON_USING_LINKS})
 endif(NOT DEFINED ENV{KRATOS_INSTALL_PYTHON_USING_LINKS})
 
 # Setting the libs folder for the shared objects built in kratos
-set(CMAKE_INSTALL_RPATH "$ORIGIN/../libs")
+if (APPLE)
+  cmake_policy(SET CMP0042 NEW)
+  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/libs")
+else()
+  set(CMAKE_INSTALL_RPATH "$ORIGIN/../libs")
+endif()
 
 # If no test policy enable by default
 option(KRATOS_BUILD_TESTING "KRATOS_BUILD_TESTING defines if the C++ tests are compiled. These increase compilation time, but if not set only python tests can be executed. Default setting is ON" ON)

--- a/scripts/mac_build
+++ b/scripts/mac_build
@@ -1,0 +1,246 @@
+#!/bin/bash
+# authors: Máté Kelemen
+# Run this script with the -h flag for info.
+
+# Name of this script
+script_name="$(basename ${BASH_SOURCE[0]})"
+
+# Function for printing usage info
+print_help() {
+    echo "$script_name - Configure, build, and install KratosMultiphysics."
+    echo "-h                    : print this help and exit"
+    echo "-C                    : clean build and install directories, then exit"
+    echo "-b build_path         : path to the build directory (created if it does not exist yet)"
+    echo "-i install_path       : path to the install directory (created if it does not exist yet)"
+    echo "-t build_type         : build type [FullDebug, Debug, Release, RelWithDebInfo] (Default: Release)"
+    echo "-a application_name   : name of the application to build (can be passed repeatedly to add more applications)"
+    echo
+    echo "This script provides a build environment for KratosMultiphysics targeting systems running on Apple Silicon."
+    echo "The interface is minimal, so users seeking more control over the build process are invited to tweak this"
+    echo "script to suit their requirements better."
+    echo
+    echo "By default, Kratos is installed to the site-packages directory of the available python"
+    echo "interpreter. This makes KratosMultiphysics and its applications immediately available from"
+    echo "anywhere on the system without having to append PYTHONPATH, provided that the same interpreter"
+    echo "is used. Note however, that it is recommend to use a virtual python environment to avoid tainting"
+    echo "the system python."
+    echo
+    echo "Build requirements:"
+    echo " - Homebrew"
+    echo " - CMake (can be installed from homebrew via 'brew install cmake')"
+    echo " - LLVM (can be installed from homebrew via 'brew install llvm')"
+    echo " - Boost (can be installed from homebrew via 'brew install boost')"
+    echo
+    echo "Recommended build tools:"
+    echo " - ccache ('brew install ccache')"
+    echo " - ninja ('brew install ccache')"
+    echo 
+    echo "Caveats:"
+    echo "The clang that gets shipped by default lacks OpenMP binaries, so one option is to use another version"
+    echo "of the compiler without this shortcoming. Therefore, this script relies on LLVM installed from Homebrew."
+    echo "Note that the version of LLVM provided by Homebrew is likely different from that of the system, and is not"
+    echo "put on the PATH to avoid braking the standard build system."
+}
+
+# Require python3
+if ! command -v python3 &> /dev/null; then
+    echo "python3 is not available"
+    exit 1
+fi
+
+# Function for getting the module paths associated with the current interpreter
+get_site_packages_dir() {
+    echo $(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
+}
+
+# Utility variables
+# Path to the directory containing this script
+# (assumed to be kratos_repo_root/scripts)
+script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+source_dir="$(dirname "${script_dir}")" # <== path to the kratos repo root
+app_dir="${source_dir}/applications"    # <== path to the app directory of the kratos repo
+
+toolchain_root=""                       # <== root path of the compiler package (llvm)
+toolchain_bin=""                        # <== directory containing compiler executables
+toolchain_lib=""                        # <== directory containing compiler libraries
+toolchain_include=""                    # <== directory containing compiler headers
+
+generator_target="Unix Makefiles"       # <== name of the generator program in CMake
+ccache_flag=""                          # <== sets CXX_COMPILER_LAUNCHER in CMake to ccache if available
+mpi_flag="OFF"                          # <== MPI flag to pass to CMake via USE_MPI
+
+# Define default arguments
+build_type="Release".                   # <== passed to CMAKE_BUILD_TYPE
+build_dir="${source_dir}/build"         # <== path to the build directory
+install_dir="$(get_site_packages_dir)"  # <== path to install kratos to
+clean=0                                 # <== clean the build and install directories, then exit
+app_names=""                            # <== list of app names to build
+
+# Function to append the list of applications to build
+add_app() {
+    if [ "$1" != "${1#/}" ]; then       # <== absolute path
+        if [ -d "$1" ]; then
+            export KRATOS_APPLICATIONS="${KRATOS_APPLICATIONS}$1;"
+        fi
+    elif [ -d "$PWD/$1" ]; then         # <== relative path
+        export KRATOS_APPLICATIONS="${KRATOS_APPLICATIONS}$PWD/$1;"
+    elif [ -d "${app_dir}/$1" ]; then   # <== kratos app name
+        export KRATOS_APPLICATIONS="${KRATOS_APPLICATIONS}${app_dir}/$1;"
+    else
+        echo "Cannot find application: $1"
+        exit 1
+    fi
+}
+
+# Parse command line arguments
+while getopts "hCb:i:t:a:" arg; do
+    case "$arg" in
+        h)  # Print help and exit without doing anything
+            print_help
+            exit 0
+            ;;
+        C)  # Set clean flag
+            clean=1
+            ;;
+        b)  # Set build directory
+            build_dir="$OPTARG"
+            ;;
+        i)  # Set install directory
+            install_dir="$OPTARG"
+            ;;
+        t)  # Set build type
+            build_type="$OPTARG"
+            (("${build_type}" == "FullDebug" || "${build_type}" == "Debug" || "${build_type}" == "RelWithDebInfo" || "${build_type}" == "Release")) || (print_help && echo "Invalid build type: ${build_type}" && exit 1)
+            ;;
+        a)  # Add application
+            add_app "$OPTARG"
+            ;;
+        \?) # Unrecognized argumnet
+            echo "Unrecognized argument: $OPTARG"
+            exit 1
+    esac
+done
+
+# Check write access to the build directory
+if [ -d "$build_dir" ]; then
+    if ! [[ -w "$build_dir" ]]; then
+        echo "User '$(hostname)' has no write access to the build directory: '$build_dir'"
+        exit 1
+    fi
+fi
+
+# Check write access to the install dir
+if [ -d "$install_dir" ]; then
+    if ! [[ -w "$install_dir" ]]; then
+        echo "User '$(hostname)' has no write access to the install directory: '$install_dir'"
+        exit 1
+    fi
+fi
+
+# If requested, clear build and install directories, then exit
+if [ $clean -ne 0 ]; then
+    for item in "$build_dir"; do
+        rm -rf "$item"
+    done
+    for item in "$install_dir/KratosMultiphysics"; do
+        rm -rf "$item"
+    done
+    for item in "$install_dir/libs"; do
+        rm -rf "$item"
+    done
+    exit 0
+fi
+
+# Check whether CMake is available
+if ! command -v cmake &> /dev/null; then
+    echo "$script_name requires CMake"
+    echo "Consider running 'brew install cmake'"
+    exit 1
+fi
+
+# OpenMP is not available on the default clang
+# that Apple ships with its system, so another
+# toolchain must be used.
+# => this script relies on Homebrew to install
+# and find necessary packages (such as llvm).
+if ! command -v brew &> /dev/null; then
+    echo "$script_name requires Homebrew"
+    exit 1
+fi
+
+check_homebrew_package() {
+    if ! brew list "$1" >/dev/null 2>&1; then
+        echo "Missing dependency: $1"
+        echo "Consider running 'brew install $1'"
+        exit 1
+    fi
+}
+
+# Check whether LLVM is installed, and populate related paths
+check_homebrew_package llvm
+toolchain_root="$(brew --prefix llvm)"
+toolchain_bin="${toolchain_root}/bin"
+toolchain_lib="${toolchain_root}/lib"
+toolchain_include="${toolchain_root}/include"
+
+# Check other required homebrew dependencies
+check_homebrew_package boost
+
+check_recommended_homebrew_package() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Missing recommended dependency: $1. Consider running 'brew install $1'."
+        return 1
+    fi
+    return 0
+}
+
+# Optional dependency - ccache
+if check_recommended_homebrew_package ccache; then
+    ccache_flag="-DCXX_COMPILER_LAUNCHER:STRING=ccache"
+fi
+
+# Optional dependency - ninja
+if check_recommended_homebrew_package ninja; then
+    generator_target="Ninja"
+fi
+
+# Check whether MPI is available
+if command -v mpirun $> /dev/null; then
+    mpi_flag="ON"
+fi
+
+# Create the build directory if it does not exist yet
+if [ ! -d "$build_dir" ]; then
+    mkdir -p "$build_dir"
+fi
+
+# Configure
+if ! cmake                                                  \
+    "-H$source_dir"                                         \
+    "-B$build_dir"                                          \
+    "-DCMAKE_INSTALL_PREFIX:STRING=$install_dir"            \
+    "-G$generator_target"                                   \
+    "-DCMAKE_C_COMPILER:STRING=${toolchain_bin}/clang"      \
+    "-DCMAKE_CXX_COMPILER:STRING=${toolchain_bin}/clang++"  \
+    "-DOPENMP_LIBRARIES:STRING=${toolchain_lib}"            \
+    "-DOPENMP_INCLUDES:STRING=${toolchain_include}"         \
+    "-DOPENMP_C:STRING=${toolchain_bin}/clang"              \
+    "-DOPENMP_CXX:STRING=${toolchain_bin}/clang++"          \
+    "-DCMAKE_COLOR_DIAGNOSTICS:BOOL=ON"                     \
+    "$ccache_flag"                                          \
+    "-DUSE_MPI:BOOL=$mpi_flag"                              \
+    "-DUSE_EIGEN_MKL:BOOL=OFF"                              \
+    "-DKRATOS_GENERATE_PYTHON_STUBS:BOOL=ON"                \
+    "-DKRATOS_INSTALL_PYTHON_USING_LINKS:BOOL=ON"           \
+    "-DKRATOS_ENABLE_PROFILING:BOOL=OFF"                    \
+    ; then
+    exit $?
+fi
+
+# Build and install
+if ! cmake --build "$build_dir" --target install -j; then
+    exit $?
+fi
+
+exit 0

--- a/scripts/post_install/stub_generation.py
+++ b/scripts/post_install/stub_generation.py
@@ -62,10 +62,13 @@ def __GetPythonModulesImportingCppModules(kratos_python_module_path: Path, krato
     for custom_library_path in kratos_library_path.iterdir():
         custom_library_name = custom_library_path.name
 
-        cpython_location = custom_library_name.find(".cpython")
-        if cpython_location != -1:
-            custom_library_name = custom_library_name[:cpython_location]
-            list_of_binary_modules.append(custom_library_name)
+        if any(key in custom_library_name for key in (".cpython", "Application")):
+            cpython_location = custom_library_name.find(".cpython")
+            if cpython_location != -1:
+                custom_library_name = custom_library_name[:cpython_location]
+                list_of_binary_modules.append(custom_library_name)
+            else:
+                list_of_binary_modules.append(custom_library_path.stem)
 
     cpp_python_modules_dict = {}
     copy_list_of_binary_modules = list(list_of_binary_modules)


### PR DESCRIPTION
## Description

`KratosMultiphysics` on an M1.

The two main headaches of compiling on MacOS are
1) the default `clang` provided by the system lacks `OpenMP`
2) `CMake`, `pybind11`, or our importing scheme isn't consistent with how `@rpath` works on MacOS

1 is solved by installing another `llvm` from `Homebrew`, which seems to be the standard solution among Mac users. Unfortunately, this means that the config script must explicitly set this specific toolchain.

I couldn't solve 2 nicely because I can't find who's messing up the `@rpath`, though our import gymnastics in the root `__init__.py` sure look suspicious. Anyway, I baked the absolute install path into binaries instead of relying on `@rpath`, so `${CMAKE_INSTALL_PREFIX}` must be correctly set at configure time. This shouldn't be a problem in most cases tho, unless someone does `cmake -DCMAKE_INSTALL_PREFIX=some_install_path ... && cmake --build ... --prefix some_completely_different_install_path`.

## Changelog

- embed the full install path in built binaries' `RPath` on MacOS (I just couldn't figure out what the problem with `@rpath` was, so I baked the full path of `${CMAKE_INSTALL_PREFIX}/libs` into every target's `RPath`.)
- update stub generation to consider libraries with `Application` in their names, not just `.cpython` (Another weird thing: only `KratosCore` and the `LinearSolversApplication` have `.cpython` in their python bindings' names. All others just end with `...Application.so`)
- add a build script that helps setting up Kratos from scratch

##

I'm open to guidance and suggestions if there's a MacOS veteran aroun.

##

Edit: a companion PR for `CoSimIO` KratosMultiphysics/CoSimIO#348 is required to get the `CoSimulationApplication` working.
