### PR TITLE
Adding registry macro with templates

### DIFF
--- a/kratos/includes/define_registry.h
+++ b/kratos/includes/define_registry.h
@@ -44,11 +44,32 @@
     static inline bool KRATOS_REGISTRY_NAME(_is_registered_, __LINE__) = []() -> bool {   \
         using TFunctionType = std::function<std::shared_ptr<X>()>;                        \
         std::string key_name = NAME + std::string(".") + std::string(#X);                 \
+        std::cout << "Registring: " << key_name << std::endl;                             \
         if (!Registry::HasItem(key_name))                                                 \
         {                                                                                 \
+            std::cout << "\t S: Was successfully registered" << std::endl;                \
             auto &r_item = Registry::AddItem<RegistryItem>(key_name);                     \
             TFunctionType dispatcher = [](){return std::make_shared<X>();};               \
             r_item.AddItem<TFunctionType>("Prototype", std::move(dispatcher));            \
+        } else {                                                                          \
+            std::cout << "\t F: Was already registered" << std::endl;                     \
+        }                                                                                 \
+        return Registry::HasItem(key_name);                                               \
+    }();
+
+#define KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE(NAME, X, ...)                                \
+    static inline bool KRATOS_REGISTRY_NAME(_is_registered_, __LINE__) = []() -> bool {         \
+        using TFunctionType = std::function<std::shared_ptr<X<__VA_ARGS__>>()>;                     \
+        std::string key_name = NAME + std::string(".") + std::string(#X) + "<" + #__VA_ARGS__ + ">";    \
+        std::cout << "Registring: " << key_name << std::endl;                                       \
+        if (!Registry::HasItem(key_name))                                                       \
+        {                                                                                   \
+            std::cout << "\t S: Was successfully registered" << std::endl;                \
+            auto &r_item = Registry::AddItem<RegistryItem>(key_name);                     \
+            TFunctionType dispatcher = [](){return std::make_shared<X<__VA_ARGS__>>();};  \
+            r_item.AddItem<TFunctionType>("Prototype", std::move(dispatcher));            \
+        } else {                                                                          \
+            std::cout << "\t F: Was already registered" << std::endl;                     \
         }                                                                                 \
         return Registry::HasItem(key_name);                                               \
     }();

--- a/kratos/includes/define_registry.h
+++ b/kratos/includes/define_registry.h
@@ -44,32 +44,26 @@
     static inline bool KRATOS_REGISTRY_NAME(_is_registered_, __LINE__) = []() -> bool {   \
         using TFunctionType = std::function<std::shared_ptr<X>()>;                        \
         std::string key_name = NAME + std::string(".") + std::string(#X);                 \
-        std::cout << "Registring: " << key_name << std::endl;                             \
         if (!Registry::HasItem(key_name))                                                 \
         {                                                                                 \
-            std::cout << "\t S: Was successfully registered" << std::endl;                \
             auto &r_item = Registry::AddItem<RegistryItem>(key_name);                     \
             TFunctionType dispatcher = [](){return std::make_shared<X>();};               \
             r_item.AddItem<TFunctionType>("Prototype", std::move(dispatcher));            \
         } else {                                                                          \
-            std::cout << "\t F: Was already registered" << std::endl;                     \
         }                                                                                 \
         return Registry::HasItem(key_name);                                               \
     }();
 
-#define KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE(NAME, X, ...)                                \
-    static inline bool KRATOS_REGISTRY_NAME(_is_registered_, __LINE__) = []() -> bool {         \
-        using TFunctionType = std::function<std::shared_ptr<X<__VA_ARGS__>>()>;                     \
+#define KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE(NAME, X, ...)                                            \
+    static inline bool KRATOS_REGISTRY_NAME(_is_registered_, __LINE__) = []() -> bool {                 \
+        using TFunctionType = std::function<std::shared_ptr<X<__VA_ARGS__>>()>;                         \
         std::string key_name = NAME + std::string(".") + std::string(#X) + "<" + #__VA_ARGS__ + ">";    \
-        std::cout << "Registring: " << key_name << std::endl;                                       \
-        if (!Registry::HasItem(key_name))                                                       \
-        {                                                                                   \
-            std::cout << "\t S: Was successfully registered" << std::endl;                \
-            auto &r_item = Registry::AddItem<RegistryItem>(key_name);                     \
-            TFunctionType dispatcher = [](){return std::make_shared<X<__VA_ARGS__>>();};  \
-            r_item.AddItem<TFunctionType>("Prototype", std::move(dispatcher));            \
-        } else {                                                                          \
-            std::cout << "\t F: Was already registered" << std::endl;                     \
-        }                                                                                 \
-        return Registry::HasItem(key_name);                                               \
+        if (!Registry::HasItem(key_name))                                                               \
+        {                                                                                               \
+            auto &r_item = Registry::AddItem<RegistryItem>(key_name);                                   \
+            TFunctionType dispatcher = [](){return std::make_shared<X<__VA_ARGS__>>();};                \
+            r_item.AddItem<TFunctionType>("Prototype", std::move(dispatcher));                          \
+        } else {                                                                                        \
+        }                                                                                               \
+        return Registry::HasItem(key_name);                                                             \
     }();

--- a/kratos/includes/define_registry.h
+++ b/kratos/includes/define_registry.h
@@ -49,7 +49,6 @@
             auto &r_item = Registry::AddItem<RegistryItem>(key_name);                     \
             TFunctionType dispatcher = [](){return std::make_shared<X>();};               \
             r_item.AddItem<TFunctionType>("Prototype", std::move(dispatcher));            \
-        } else {                                                                          \
         }                                                                                 \
         return Registry::HasItem(key_name);                                               \
     }();

--- a/kratos/processes/apply_ray_casting_process.h
+++ b/kratos/processes/apply_ray_casting_process.h
@@ -51,8 +51,10 @@ public:
     /// Pointer definition of ApplyRayCastingProcess
     KRATOS_CLASS_POINTER_DEFINITION(ApplyRayCastingProcess);
 
-    KRATOS_REGISTRY_ADD_PROTOTYPE("Processes.KratosMultiphysics", ApplyRayCastingProcess<TDim>)
-    KRATOS_REGISTRY_ADD_PROTOTYPE("Processes.All", ApplyRayCastingProcess<TDim>)
+    KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.KratosMultiphysics", ApplyRayCastingProcess, 2)
+    KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.KratosMultiphysics", ApplyRayCastingProcess, 3)
+    KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.All", ApplyRayCastingProcess, 2)
+    KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.All", ApplyRayCastingProcess, 3)
 
     //TODO: These using statements have been included to make the old functions able to compile. It is still pending to update them.
     using ConfigurationType = Internals::DistanceSpatialContainersConfigure;


### PR DESCRIPTION
**📝 Description**
As @RiccardoRossi pointed out, registering templated classes in the registry yield to wrong results. 

With this new macro it should be possible to use it as:
- `KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE(KEY, NAME, TEMPLTED_ARGS)`

As example:
```c++
KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.KratosMultiphysics", ApplyRayCastingProcess, 2);
KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.KratosMultiphysics", ApplyRayCastingProcess, 3);
KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.All", ApplyRayCastingProcess, 2);
KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.All", ApplyRayCastingProcess, 3);
```

Which will generate:

```
Registring: Processes.KratosMultiphysics.ApplyRayCastingProcess<2>
	 S: Was successfully registered
Registring: Processes.KratosMultiphysics.ApplyRayCastingProcess<3>
	 S: Was successfully registered
Registring: Processes.All.ApplyRayCastingProcess<2>
	 S: Was successfully registered
Registring: Processes.All.ApplyRayCastingProcess<3>
	 S: Was successfully registered
```

On runtime.

**🆕 Changelog**
- Added templated registry
