### PR TITLE
[GeoMechanics] Adding dummy class "GeomechanicsAnalysis"

### DIFF
--- a/applications/GeoMechanicsApplication/python_scripts/geo_mechanics_analysis.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geo_mechanics_analysis.py
@@ -1,0 +1,6 @@
+from KratosMultiphysics.GeoMechanicsApplication import geomechanics_analysis
+
+class GeoMechanicsAnalysis(geomechanics_analysis.GeoMechanicsAnalysis):
+
+    def __init__(self, model, project_parameters):
+        super().__init__(model, project_parameters)

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
@@ -199,12 +199,6 @@ class GeoMechanicsAnalysis(GeoMechanicsAnalysisBase):
             self.OutputSolutionStep()
 
 
-class GeomechanicsAnalysis(GeoMechanicsAnalysis):
-
-    def __init__(self, model, project_parameters):
-        super().__init__(model, project_parameters)
-
-
 if __name__ == '__main__':
     from sys import argv
 

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
@@ -199,6 +199,11 @@ class GeoMechanicsAnalysis(GeoMechanicsAnalysisBase):
             self.OutputSolutionStep()
 
 
+class GeomechanicsAnalysis(GeoMechanicsAnalysis):
+
+    def __init__(self, model, project_parameters):
+        super().__init__(model, project_parameters)
+
 
 if __name__ == '__main__':
     from sys import argv

--- a/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
+++ b/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
@@ -11,7 +11,8 @@ def _GetAvailableSolverWrapperModules():
         "KratosMultiphysics.FluidDynamicsApplication"       : "python_solvers_wrapper_fluid",
         "KratosMultiphysics.StructuralMechanicsApplication" : "python_solvers_wrapper_structural",
         "KratosMultiphysics.ConvectionDiffusionApplication" : "python_solvers_wrapper_convection_diffusion",
-        "KratosMultiphysics.CompressiblePotentialFlowApplication" : "python_solvers_wrapper_compressible_potential"
+        "KratosMultiphysics.CompressiblePotentialFlowApplication" : "python_solvers_wrapper_compressible_potential",
+        "KratosMultiphysics.GeoMechanicsApplication" : "geomechanics_solvers_wrapper"
     }
 
 


### PR DESCRIPTION
This is the **1st of 3** PRs for using the RomApp with the GeoMechanicsApp 


**📝 Description**
In the RomApplication, the analysis stage class is obtained by transforming the name of the file containing it from "snake_case" to "PascalCase". The class GeoMechanicsAnalysis is contained in the file "geomechanics_analysis.py" which get transformed into GeomechanicsAnalysis, without the capital M. 

This PR therefore defines a dummy class with the expected name allowing to use the ROM and the GeoMechanics appps as they are

**🆕 Changelog**
- Added dummy class GeomechanicsAnalysis to geomechanics_analysis.py
- Added GeoMechanicsApp to the Rom's solvers wrapper
