### PR TITLE
[GeoMechanics] Matching Function Names in GeoMechanicsAnalysis

### DIFF
--- a/applications/GeoMechanicsApplication/python_scripts/geo_mechanics_analysis.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geo_mechanics_analysis.py
@@ -1,0 +1,6 @@
+from KratosMultiphysics.GeoMechanicsApplication import geomechanics_analysis
+
+class GeoMechanicsAnalysis(geomechanics_analysis.GeoMechanicsAnalysis):
+
+    def __init__(self, model, project_parameters):
+        super().__init__(model, project_parameters)

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
@@ -199,12 +199,6 @@ class GeoMechanicsAnalysis(GeoMechanicsAnalysisBase):
             self.OutputSolutionStep()
 
 
-class GeomechanicsAnalysis(GeoMechanicsAnalysis):
-
-    def __init__(self, model, project_parameters):
-        super().__init__(model, project_parameters)
-
-
 if __name__ == '__main__':
     from sys import argv
 

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
@@ -199,6 +199,11 @@ class GeoMechanicsAnalysis(GeoMechanicsAnalysisBase):
             self.OutputSolutionStep()
 
 
+class GeomechanicsAnalysis(GeoMechanicsAnalysis):
+
+    def __init__(self, model, project_parameters):
+        super().__init__(model, project_parameters)
+
 
 if __name__ == '__main__':
     from sys import argv

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
@@ -216,7 +216,7 @@ class GeoMechanicalSolver(PythonSolver):
         self.linear_solver = self._ConstructLinearSolver()
 
         # Builder and solver creation
-        builder_and_solver = self._ConstructBuilderAndSolver(self.settings["block_builder"].GetBool())
+        builder_and_solver = self._CreateBuilderAndSolver()
 
         # Solution scheme creation
         self.scheme = self._ConstructScheme(self.settings["scheme_type"].GetString(),
@@ -360,6 +360,9 @@ class GeoMechanicalSolver(PythonSolver):
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_Y,self.main_model_part)
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_Z,self.main_model_part)
 
+    def _GetLinearSolver(self):
+        return self.linear_solver
+
     def _ExecuteCheckAndPrepare(self):
 
         self.computing_model_part_name = "porous_computational_model_part"
@@ -430,7 +433,8 @@ class GeoMechanicalSolver(PythonSolver):
         import KratosMultiphysics.python_linear_solver_factory as linear_solver_factory
         return linear_solver_factory.ConstructSolver(self.settings["linear_solver_settings"])
 
-    def _ConstructBuilderAndSolver(self, block_builder):
+    def _CreateBuilderAndSolver(self):
+        block_builder = self.settings["block_builder"].GetBool()
 
         # Creating the builder and solver
         if (block_builder):

--- a/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
+++ b/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
@@ -11,7 +11,8 @@ def _GetAvailableSolverWrapperModules():
         "KratosMultiphysics.FluidDynamicsApplication"       : "python_solvers_wrapper_fluid",
         "KratosMultiphysics.StructuralMechanicsApplication" : "python_solvers_wrapper_structural",
         "KratosMultiphysics.ConvectionDiffusionApplication" : "python_solvers_wrapper_convection_diffusion",
-        "KratosMultiphysics.CompressiblePotentialFlowApplication" : "python_solvers_wrapper_compressible_potential"
+        "KratosMultiphysics.CompressiblePotentialFlowApplication" : "python_solvers_wrapper_compressible_potential",
+        "KratosMultiphysics.GeoMechanicsApplication" : "geomechanics_solvers_wrapper"
     }
 
 


### PR DESCRIPTION
depends on #11320

This is the **2nd of 3** PRs for using the RomApp with the GeoMechanicsApp 


**📝 Description**
The RomApp will use all of the features of the GeoMechanicsAnalysis, except for the BuilderAndSolver, which will be set as the RomB&S. For this, the required functions should be named _CreateBuilderAndSolver rather than _ConstructBuilderAndSolver, and there should be a function returning the linear solver.

**🆕 Changelog**
- changed _ConstructBuilderAndSolver(self, param1) ==> _CreateBuilderAndSolver(self)
- added method _GetLinearSolver(self)