### PR TITLE
[GeoMechanics] Modifications on geomechanics_solvers_wrapper.py

### DIFF
--- a/applications/GeoMechanicsApplication/python_scripts/geo_mechanics_analysis.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geo_mechanics_analysis.py
@@ -1,0 +1,6 @@
+from KratosMultiphysics.GeoMechanicsApplication import geomechanics_analysis
+
+class GeoMechanicsAnalysis(geomechanics_analysis.GeoMechanicsAnalysis):
+
+    def __init__(self, model, project_parameters):
+        super().__init__(model, project_parameters)

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
@@ -199,12 +199,6 @@ class GeoMechanicsAnalysis(GeoMechanicsAnalysisBase):
             self.OutputSolutionStep()
 
 
-class GeomechanicsAnalysis(GeoMechanicsAnalysis):
-
-    def __init__(self, model, project_parameters):
-        super().__init__(model, project_parameters)
-
-
 if __name__ == '__main__':
     from sys import argv
 

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
@@ -199,6 +199,11 @@ class GeoMechanicsAnalysis(GeoMechanicsAnalysisBase):
             self.OutputSolutionStep()
 
 
+class GeomechanicsAnalysis(GeoMechanicsAnalysis):
+
+    def __init__(self, model, project_parameters):
+        super().__init__(model, project_parameters)
+
 
 if __name__ == '__main__':
     from sys import argv

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
@@ -216,7 +216,7 @@ class GeoMechanicalSolver(PythonSolver):
         self.linear_solver = self._ConstructLinearSolver()
 
         # Builder and solver creation
-        builder_and_solver = self._ConstructBuilderAndSolver(self.settings["block_builder"].GetBool())
+        builder_and_solver = self._CreateBuilderAndSolver()
 
         # Solution scheme creation
         self.scheme = self._ConstructScheme(self.settings["scheme_type"].GetString(),
@@ -360,6 +360,9 @@ class GeoMechanicalSolver(PythonSolver):
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_Y,self.main_model_part)
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_Z,self.main_model_part)
 
+    def _GetLinearSolver(self):
+        return self.linear_solver
+
     def _ExecuteCheckAndPrepare(self):
 
         self.computing_model_part_name = "porous_computational_model_part"
@@ -430,7 +433,8 @@ class GeoMechanicalSolver(PythonSolver):
         import KratosMultiphysics.python_linear_solver_factory as linear_solver_factory
         return linear_solver_factory.ConstructSolver(self.settings["linear_solver_settings"])
 
-    def _ConstructBuilderAndSolver(self, block_builder):
+    def _CreateBuilderAndSolver(self):
+        block_builder = self.settings["block_builder"].GetBool()
 
         # Creating the builder and solver
         if (block_builder):

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solvers_wrapper.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solvers_wrapper.py
@@ -1,37 +1,46 @@
 import KratosMultiphysics
 from importlib import import_module
 
-def CreateSolver(model, custom_settings):
 
+def CreateSolverByParameters(model, custom_settings, parallelism):
     if (type(model) != KratosMultiphysics.Model):
         raise Exception("input is expected to be provided as a Kratos Model object")
 
     if (type(custom_settings) != KratosMultiphysics.Parameters):
         raise Exception("input is expected to be provided as a Kratos Parameters object")
 
-    parallelism = custom_settings["problem_data"]["parallel_type"].GetString()
-    solver_type_raw = custom_settings["solver_settings"]["solver_type"].GetString()
+    solver_type_raw = 'Pw'#custom_settings["solver_settings"]["solver_type"].GetString()
+    default_settings = KratosMultiphysics.Parameters("""{ "end_time" : 1.0 }""")
+    end_time = default_settings["end_time"]
+
+    try:
+        params = custom_settings["solver_settings"]
+    except: params = custom_settings
 
     # Solvers for OpenMP parallelism
     if (parallelism == "OpenMP"):
         solver_type = solver_type_raw.lower()
         if solver_type in ("u_pw", "geomechanics_u_pw_solver", "twophase"):
-            custom_settings["solver_settings"]["time_stepping"].AddValue("end_time", custom_settings["problem_data"]["end_time"])
+            params["time_stepping"].AddValue("end_time", end_time)
             solver_module_name = "geomechanics_U_Pw_solver"
 
         elif solver_type in ("pw", "geomechanics_pw_solver"):
-            custom_settings["solver_settings"]["time_stepping"].AddValue("end_time", custom_settings["problem_data"]["end_time"])
+            params["time_stepping"].AddValue("end_time", end_time)
             solver_module_name = "geomechanics_Pw_solver"
         else:
-            err_msg =  "The requested solver type \"" + solver_type + "\" is not in the python solvers wrapper\n"
+            err_msg = "The requested solver type \"" + solver_type + "\" is not in the python solvers wrapper\n"
             err_msg += "Available options are: \"geomechanics_U_Pw_solver\", \"geomechanics_Pw_solver\""
             raise Exception(err_msg)
     else:
-        err_msg =  "The requested parallel type \"" + parallelism + "\" is not available!\n"
+        err_msg = "The requested parallel type \"" + parallelism + "\" is not available!\n"
         err_msg += "Available options are: \"OpenMP\""
         raise Exception(err_msg)
 
     module_full_name = 'KratosMultiphysics.GeoMechanicsApplication.' + solver_module_name
-    solver = import_module(module_full_name).CreateSolver(model, custom_settings["solver_settings"])
-
+    solver = import_module(module_full_name).CreateSolver(model, params)
     return solver
+
+
+def CreateSolver(model, custom_settings):
+    parallelism =  custom_settings["problem_data"]["parallel_type"].GetString()
+    return CreateSolverByParameters(model, custom_settings,parallelism)

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solvers_wrapper.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solvers_wrapper.py
@@ -12,9 +12,10 @@ def CreateSolverByParameters(model, custom_settings, parallelism):
     default_settings = KratosMultiphysics.Parameters("""{ "end_time" : 1.0 }""")
     end_time = default_settings["end_time"]
 
-    try:
+    if custom_settings.Has("solver_settings"):
         params = custom_settings["solver_settings"]
-    except:
+        #To conform with other apps where only the "solver_settings" are passed
+    else:
         params = custom_settings
 
     solver_type_raw = params["solver_type"].GetString()

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solvers_wrapper.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solvers_wrapper.py
@@ -9,13 +9,15 @@ def CreateSolverByParameters(model, custom_settings, parallelism):
     if (type(custom_settings) != KratosMultiphysics.Parameters):
         raise Exception("input is expected to be provided as a Kratos Parameters object")
 
-    solver_type_raw = 'Pw'#custom_settings["solver_settings"]["solver_type"].GetString()
     default_settings = KratosMultiphysics.Parameters("""{ "end_time" : 1.0 }""")
     end_time = default_settings["end_time"]
 
     try:
         params = custom_settings["solver_settings"]
-    except: params = custom_settings
+    except:
+        params = custom_settings
+
+    solver_type_raw = params["solver_type"].GetString()
 
     # Solvers for OpenMP parallelism
     if (parallelism == "OpenMP"):

--- a/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
+++ b/applications/RomApplication/python_scripts/new_python_solvers_wrapper_rom.py
@@ -11,7 +11,8 @@ def _GetAvailableSolverWrapperModules():
         "KratosMultiphysics.FluidDynamicsApplication"       : "python_solvers_wrapper_fluid",
         "KratosMultiphysics.StructuralMechanicsApplication" : "python_solvers_wrapper_structural",
         "KratosMultiphysics.ConvectionDiffusionApplication" : "python_solvers_wrapper_convection_diffusion",
-        "KratosMultiphysics.CompressiblePotentialFlowApplication" : "python_solvers_wrapper_compressible_potential"
+        "KratosMultiphysics.CompressiblePotentialFlowApplication" : "python_solvers_wrapper_compressible_potential",
+        "KratosMultiphysics.GeoMechanicsApplication" : "geomechanics_solvers_wrapper"
     }
 
 


### PR DESCRIPTION
depends on #11320 and #11321

This is the **3rd of 3** PRs for using the RomApp with the GeoMechanicsApp 


**📝 Description**
The mechanism inside the RomApp for setting the RomBuilderAndSolver requires the existance of the CreateSolver and CreateSolverByParameters functions.

Notice that this PR still requires some work because the parameters being passed to the CreateSolverByParameters function are in general not the complete parameters contained in the ProjectParameters.json, but only the "solver_settings". Therefore,  **end_time** is a problematic term because it is not contained in the "solver_settings" but in the "problem_data". What I have done here was to set it to 1.0, but we need to find a more robust alternative. 

**🆕 Changelog**
- splitted operations  CreateSolver(model, custom_settings) ==> CreateSolver(model, custom_settings) + CreateSolverByParameters(model, custom_settings, parallelism)