### PR TITLE
[Core] Adding echo level to the `FillCommunicator`

### DIFF
--- a/kratos/includes/fill_communicator.h
+++ b/kratos/includes/fill_communicator.h
@@ -51,6 +51,17 @@ namespace Kratos
 class KRATOS_API(KRATOS_CORE) FillCommunicator
 {
 public:
+    ///@name  Enum's
+    ///@{
+
+    enum class FillCommunicatorEchoLevel
+    {
+        NO_PRINTING = 0, // No printing at all
+        INFO = 1,        // Just some additional info is printed
+        DEBUG_INFO = 2   // Debug info (+ INFO level) is printed
+    };
+
+    ///@}
     ///@name Type Definitions
     ///@{
 
@@ -120,6 +131,24 @@ public:
     ///@name Access
     ///@{
 
+    /**
+     * @brief Set the echo level
+     * @param EchoLevel The echo level
+     */
+    void SetEchoLevel(const FillCommunicatorEchoLevel EchoLevel)
+    {
+        mEchoLevel = EchoLevel;
+    }
+
+    /**
+     * @brief Get the echo level
+     * @return The echo level
+     */
+    FillCommunicatorEchoLevel& GetEchoLevel()
+    {
+        return mEchoLevel;
+    }
+
     ///@}
     ///@name Inquiry
     ///@{
@@ -151,6 +180,8 @@ protected:
     ///@{
 
     const DataCommunicator& mrDataComm; /// Data communicator reference
+
+    FillCommunicatorEchoLevel mEchoLevel = FillCommunicatorEchoLevel::NO_PRINTING; /// Echo level
 
     ///@}
     ///@name Protected Operators

--- a/kratos/mpi/utilities/parallel_fill_communicator.cpp
+++ b/kratos/mpi/utilities/parallel_fill_communicator.cpp
@@ -42,6 +42,12 @@ void ParallelFillCommunicator::Execute()
     mPartitionIndexCheckPerformed = false;
     auto& r_base_model_part = GetBaseModelPart();
     ComputeCommunicationPlan(r_base_model_part);
+
+    // Depending of the echo level, print the debug info
+    if (this->GetEchoLevel() == FillCommunicatorEchoLevel::DEBUG_INFO) {
+        PrintModelPartDebugInfo(r_base_model_part);
+    }
+
     KRATOS_CATCH("");
 }
 
@@ -50,53 +56,41 @@ void ParallelFillCommunicator::PrintModelPartDebugInfo(const ModelPart& rModelPa
     KRATOS_TRY
 
     std::cout.flush();
-    const DataCommunicator& r_data_communicator = rModelPart.GetCommunicator().GetDataCommunicator();
+    const auto& r_communicator = rModelPart.GetCommunicator();
+    const auto& r_data_communicator = r_communicator.GetDataCommunicator();
     r_data_communicator.Barrier();
 
     int rank = r_data_communicator.Rank();
 
-    //get number of processors
+    // Get number of processors
     int num_processors = r_data_communicator.Size();
 
-    for (int i = 0; i < num_processors; i++)
-    {
-        if (rank == i)
-        {
+    for (int i = 0; i < num_processors; i++) {
+        if (rank == i) {
             std::stringstream message;
 
             message << " *************************************** " << std::endl;
-            message << " proc = " << rank << "communication colors " << rModelPart.GetCommunicator().NeighbourIndices() << std::endl;
+            message << " Proc = " << rank << "communication colors " << r_communicator.NeighbourIndices() << std::endl;
 
-            //print ghost mesh
-            message << " proc = " << rank << " ghost mesh" << std::endl;
-            for (ModelPart::NodesContainerType::const_iterator it = rModelPart.GetCommunicator().GhostMesh().NodesBegin();
-                    it != rModelPart.GetCommunicator().GhostMesh().NodesEnd();
-                    ++it)
-            {
-                KRATOS_ERROR_IF(it->FastGetSolutionStepValue(PARTITION_INDEX)==rank)
-                << "error partition index can not be = to rank for ghost nodes" << it->Id();
+            // Print ghost mesh
+            message << " Proc = " << rank << " ghost mesh" << std::endl;
+            for (auto it = r_communicator.GhostMesh().NodesBegin(); it != r_communicator.GhostMesh().NodesEnd(); ++it) {
+                KRATOS_ERROR_IF(it->FastGetSolutionStepValue(PARTITION_INDEX)==rank) << "Error partition index can not be = to rank for ghost nodes" << it->Id() << std::endl;
                 message << it->Id() << " " ;
             }
             message << std::endl;
 
-            //print local mesh
+            // Print local mesh
             message << " proc = " << rank << " local mesh" << std::endl;
-            for (ModelPart::NodesContainerType::const_iterator it = rModelPart.GetCommunicator().LocalMesh().NodesBegin();
-                    it != rModelPart.GetCommunicator().LocalMesh().NodesEnd();
-                    ++it)
-            {
-                KRATOS_ERROR_IF(it->FastGetSolutionStepValue(PARTITION_INDEX)!=rank)
-                << "error partition index can not be != from rank for local nodes" << it->Id();
+            for (auto it = r_communicator.LocalMesh().NodesBegin(); it != r_communicator.LocalMesh().NodesEnd(); ++it) {
+                KRATOS_ERROR_IF(it->FastGetSolutionStepValue(PARTITION_INDEX)!=rank) << "Error partition index can not be != from rank for local nodes" << it->Id() << std::endl;
                 message << it->Id() << " " ;
             }
             message << std::endl;
 
-            //print interface mesh
-            message << " proc = " << rank << " interface mesh" << std::endl;
-            for (ModelPart::NodesContainerType::const_iterator it = rModelPart.GetCommunicator().InterfaceMesh().NodesBegin();
-                    it != rModelPart.GetCommunicator().InterfaceMesh().NodesEnd();
-                    ++it)
-            {
+            // Print interface mesh
+            message << " Proc = " << rank << " interface mesh" << std::endl;
+            for (auto it = r_communicator.InterfaceMesh().NodesBegin(); it != r_communicator.InterfaceMesh().NodesEnd(); ++it) {
                 message << it->Id() << " " ;
             }
             message << std::endl;
@@ -104,76 +98,54 @@ void ParallelFillCommunicator::PrintModelPartDebugInfo(const ModelPart& rModelPa
             //now print everything color by color
             int destination = 0;
             message << "NeighbourIndices " ;
-            const vector<int>& neighbours_indices = rModelPart.GetCommunicator().NeighbourIndices();
-            for (unsigned int i_color = 0; i_color < neighbours_indices.size(); i_color++)
-                message << neighbours_indices[i_color] << " " ;
+            const auto& r_neighbours_indices = r_communicator.NeighbourIndices();
+            for (unsigned int i_color = 0; i_color < r_neighbours_indices.size(); i_color++)
+                message << r_neighbours_indices[i_color] << " " ;
             message << std::endl;
-            for (unsigned int i_color = 0; i_color < neighbours_indices.size(); i_color++)
-            {
-                message << "color = " << i_color << std::endl;
-                if ((destination = neighbours_indices[i_color]) >= 0)
-                {
-                    message << "ghost mesh for color --> " << i_color << std::endl;
-                    for (ModelPart::NodesContainerType::const_iterator it = rModelPart.GetCommunicator().GhostMesh(i_color).NodesBegin();
-                            it != rModelPart.GetCommunicator().GhostMesh(i_color).NodesEnd();
-                            ++it)
-                    {
-                        KRATOS_ERROR_IF(it->FastGetSolutionStepValue(PARTITION_INDEX)==rank)
-                        << "error partition index can not be = to rank for ghost nodes" << it->Id();
+            for (unsigned int i_color = 0; i_color < r_neighbours_indices.size(); i_color++) {
+                message << "Color = " << i_color << std::endl;
+                if ((destination = r_neighbours_indices[i_color]) >= 0) {
+                    message << "Ghost mesh for color --> " << i_color << std::endl;
+                    for (auto it = r_communicator.GhostMesh(i_color).NodesBegin(); it != r_communicator.GhostMesh(i_color).NodesEnd(); ++it) {
+                        KRATOS_ERROR_IF(it->FastGetSolutionStepValue(PARTITION_INDEX)==rank) << "Error partition index can not be = to rank for ghost nodes" << it->Id() << std::endl;
                         message << it->Id() << " " ;
                     }
 
-                    message << "finished printing ghost mesh for color --> " << i_color<< std::endl;
+                    message << "Finished printing ghost mesh for color --> " << i_color<< std::endl;
 
-                    message << "local mesh for color --> " << i_color << std::endl;
-                    for (ModelPart::NodesContainerType::const_iterator it = rModelPart.GetCommunicator().LocalMesh(i_color).NodesBegin();
-                            it != rModelPart.GetCommunicator().LocalMesh(i_color).NodesEnd();
-                            ++it)
-                    {
-                        KRATOS_ERROR_IF(it->FastGetSolutionStepValue(PARTITION_INDEX)!=rank)
-                        << "error partition index can not be != from rank for local nodes" << it->Id();
+                    message << "Local mesh for color --> " << i_color << std::endl;
+                    for (auto it = r_communicator.LocalMesh(i_color).NodesBegin(); it != r_communicator.LocalMesh(i_color).NodesEnd(); ++it) {
+                        KRATOS_ERROR_IF(it->FastGetSolutionStepValue(PARTITION_INDEX)!=rank) << "Error partition index can not be != from rank for local nodes" << it->Id() << std::endl;
                         message << it->Id() << " " ;
                     }
-                    message << "finished printing local mesh for color --> " << i_color<< std::endl;
+                    message << "Finished printing local mesh for color --> " << i_color<< std::endl;
 
-                    message << "interface mesh for color --> " << i_color << std::endl;
-                    for (ModelPart::NodesContainerType::const_iterator it = rModelPart.GetCommunicator().InterfaceMesh(i_color).NodesBegin();
-                            it != rModelPart.GetCommunicator().InterfaceMesh(i_color).NodesEnd();
-                            ++it)
-                    {
+                    message << "Interface mesh for color --> " << i_color << std::endl;
+                    for (auto it = r_communicator.InterfaceMesh(i_color).NodesBegin(); it != r_communicator.InterfaceMesh(i_color).NodesEnd(); ++it) {
                         message << it->Id() << " " ;
                     }
-                    message << "finished printing interface mesh for color --> " << i_color<< std::endl;
-                }
-                else
-                {
-                    if(rModelPart.GetCommunicator().GhostMesh(i_color).Nodes().size()!=0)
-                    {
-                        message << "rank = " << rank << " color = " << i_color << std::endl;
-                        KRATOS_ERROR << "nodes found in ghost mesh when communication is not expected";
+                    message << "Finished printing interface mesh for color --> " << i_color<< std::endl;
+                } else {
+                    if(r_communicator.GhostMesh(i_color).Nodes().size()!=0) {
+                        message << "Rank = " << rank << " color = " << i_color << std::endl;
+                        KRATOS_ERROR << "Nodes found in ghost mesh when communication is not expected" << std::endl;
                     }
-                    if(rModelPart.GetCommunicator().LocalMesh(i_color).Nodes().size()!=0)
-                    {
-                        message << "local mesh for color --> " << i_color << "*********************************" <<  std::endl;
-                        for (ModelPart::NodesContainerType::const_iterator it = rModelPart.GetCommunicator().LocalMesh(i_color).NodesBegin();
-                                it != rModelPart.GetCommunicator().LocalMesh(i_color).NodesEnd();
-                                ++it)
-                        {
-                            KRATOS_ERROR_IF(it->FastGetSolutionStepValue(PARTITION_INDEX)!=rank)
-                            << "error partition index can not be != from rank for local nodes" << it->Id();
+                    if(r_communicator.LocalMesh(i_color).Nodes().size()!=0) {
+                        message << "Local mesh for color --> " << i_color << "*********************************" <<  std::endl;
+                        for (auto it = r_communicator.LocalMesh(i_color).NodesBegin(); it != r_communicator.LocalMesh(i_color).NodesEnd(); ++it) {
+                            KRATOS_ERROR_IF(it->FastGetSolutionStepValue(PARTITION_INDEX)!=rank) << "Error partition index can not be != from rank for local nodes" << it->Id() << std::endl;
                             message << it->Id() << " " << it->FastGetSolutionStepValue(PARTITION_INDEX) << std::endl ;
                         }
-                        message << "finished printing local mesh for color --> " << i_color<< std::endl;
-                        message << "nodes found in local mesh when communication is not expected" << std::endl;
-                        KRATOS_ERROR << "nodes found in local mesh when communication is not expected";
+                        message << "Finished printing local mesh for color --> " << i_color<< std::endl;
+                        message << "Nodes found in local mesh when communication is not expected" << std::endl;
+                        KRATOS_ERROR << "Nodes found in local mesh when communication is not expected" << std::endl;
                     }
-                    KRATOS_ERROR_IF(rModelPart.GetCommunicator().InterfaceMesh(i_color).Nodes().size()!=0)
-                    << "nodes found in interface mesh when communication is not expected";
+                    KRATOS_ERROR_IF(r_communicator.InterfaceMesh(i_color).Nodes().size()!=0)
+                    << "Nodes found in interface mesh when communication is not expected" << std::endl;
                 }
             }
 
-            message << "finished printing proc -> " << rank << "*********************" << std::endl;
-            message << std::endl;
+            message << "Finished printing proc -> " << rank << "*********************\n" << std::endl;
             KRATOS_INFO_ALL_RANKS("ParallelFillCommunicator Debug Info") << message.str();
 
         }

--- a/kratos/python/add_other_utilities_to_python.cpp
+++ b/kratos/python/add_other_utilities_to_python.cpp
@@ -670,6 +670,13 @@ void AddOtherUtilitiesToPython(pybind11::module &m)
         .def("__eq__", &FileNameDataCollector::FileNameData::operator==)
         ;
 
+    py::enum_<FillCommunicator::FillCommunicatorEchoLevel>(m, "FillCommunicatorEchoLevel")
+        .value("NO_PRINTING", FillCommunicator::FillCommunicatorEchoLevel::NO_PRINTING)
+        .value("INFO", FillCommunicator::FillCommunicatorEchoLevel::INFO)
+        .value("DEBUG_INFO", FillCommunicator::FillCommunicatorEchoLevel::DEBUG_INFO)
+        .export_values()
+        ;
+
     py::class_<FillCommunicator, FillCommunicator::Pointer>(m,"FillCommunicator")
         .def(py::init([](ModelPart& rModelPart){
             KRATOS_WARNING("FillCommunicator") << "Using deprecated constructor. Please use constructor with data communicator!";
@@ -678,7 +685,10 @@ void AddOtherUtilitiesToPython(pybind11::module &m)
         .def(py::init<ModelPart&, const DataCommunicator& >() )
         .def("Execute", &FillCommunicator::Execute)
         .def("PrintDebugInfo", &FillCommunicator::PrintDebugInfo)
-    ;
+        .def("SetEchoLevel", &FillCommunicator::SetEchoLevel)
+        .def("GetEchoLevel", &FillCommunicator::GetEchoLevel)
+        .def("__str__", PrintObject<FillCommunicator>)
+        ;
 
     typedef DenseQRDecomposition<LocalSpaceType> DenseQRDecompositionType;
     py::class_<DenseQRDecompositionType, DenseQRDecompositionType::Pointer>(m,"DenseQRDecompositionType")


### PR DESCRIPTION
**📝 Description**

This PR includes changes to two files: `fill_communicator.h` and `parallel_fill_communicator.cpp`. 

In `fill_communicator.h`:
- Added an enum class `FillCommunicatorEchoLevel` with three levels: `NO_PRINTING`, `INFO`, and `DEBUG_INFO`.
- Added a member function `GetEchoLevel()` to retrieve the echo level.
- Modified the Python bindings for `FillCommunicator`, including the addition of a `GetEchoLevel()` function.

In `parallel_fill_communicator.cpp`:
- Modified the code to print debug information only when the echo level is set to `DEBUG_INFO`.
- Added additional debug info printing for the model part and its communicator.
- Improved error handling and error messages.

Overall, these changes enhance the fill communicator functionality and improve debugging capabilities.

**🆕 Changelog**

- [Adding echo level to the `FillCommunicator`](https://github.com/KratosMultiphysics/Kratos/commit/2ed168a5fbe35435fe2483887d68bd5d901cfdf5)