### PR TITLE
[Core] Fix Comb Corner Case

### DIFF
--- a/kratos/expression/unary_combine_expression.h
+++ b/kratos/expression/unary_combine_expression.h
@@ -49,7 +49,7 @@ public:
         TIteratorType Begin,
         TIteratorType End)
         : Expression(Begin != End ? (*Begin)->NumberOfEntities() : 0),
-        mSourceExpressions(Begin, End)
+          mSourceExpressions(Begin, End)
 
     {
         mStrides.resize(mSourceExpressions.size());
@@ -59,7 +59,7 @@ public:
         for (IndexType i = 0; i < mSourceExpressions.size(); ++i) {
             const auto& p_expression = mSourceExpressions[i];
 
-            KRATOS_ERROR_IF_NOT(p_expression->NumberOfEntities() == NumberOfEntities())
+            KRATOS_ERROR_IF_NOT(p_expression->NumberOfEntities() == this->NumberOfEntities())
                 << "Expression number of entities mismatch. [ required number of entities = "
                 << NumberOfEntities() << ", found number of entities = "
                 << p_expression->NumberOfEntities() << " ].\n"
@@ -71,6 +71,7 @@ public:
             mStrides[i] = local_stride;
         }
 
+        // Corner case: empty expression range provided
         KRATOS_ERROR_IF(this->GetItemComponentCount() == 0)
             << "No expressions were given.\n";
     }
@@ -109,7 +110,7 @@ public:
 
     const std::vector<IndexType> GetItemShape() const override
     {
-        return {mStrides.back()};
+        return mStrides.size() == 1 && mStrides.back() == 1 ? std::vector<IndexType> {} : std::vector<IndexType> {mStrides.back()};
     }
 
     std::string Info() const override

--- a/kratos/tests/test_container_expression.py
+++ b/kratos/tests/test_container_expression.py
@@ -520,6 +520,16 @@ class TestContainerExpression(ABC):
             new_matrix[1, 2] = original_value[5]
             self.assertMatrixAlmostEqual(self._GetValue(entity, Kratos.PK2_STRESS_TENSOR), new_matrix * 2, 12)
 
+    def test_CornerCaseReshape(self) -> None:
+        # Reshape a single scalar expression to itself
+        input_expression = self._GetContainerExpression()
+        self._Read(input_expression, Kratos.PRESSURE)
+        combed = input_expression.Reshape([])
+        array = Kratos.Vector(input_expression.GetExpression().NumberOfEntities() * input_expression.GetItemComponentCount())
+        Kratos.Expression.CArrayExpressionIO.Write(combed, array)
+        for i_entity, entity in enumerate(combed.GetContainer()):
+            self.assertAlmostEqual(array[i_entity], self._GetValue(entity, Kratos.PRESSURE), 12)
+
     def test_Comb(self):
         a = self._GetContainerExpression()
         self._Read(a, Kratos.PRESSURE)
@@ -554,6 +564,16 @@ class TestContainerExpression(ABC):
             new_vector[3] = original_v[2]
             new_vector[4] = original_p
             self.assertVectorAlmostEqual(self._GetValue(entity, Kratos.PENALTY), new_vector * 2, 12)
+
+    def test_CornerCaseComb(self) -> None:
+        # Comb from a single scalar expression
+        input_expression = self._GetContainerExpression()
+        self._Read(input_expression, Kratos.PRESSURE)
+        combed = input_expression.Comb([])
+        array = Kratos.Vector(input_expression.GetExpression().NumberOfEntities() * input_expression.GetItemComponentCount())
+        Kratos.Expression.CArrayExpressionIO.Write(combed, array)
+        for i_entity, entity in enumerate(combed.GetContainer()):
+            self.assertAlmostEqual(array[i_entity], self._GetValue(entity, Kratos.PRESSURE), 12)
 
     def test_SliceCombReshape(self):
         a = self._GetContainerExpression()


### PR DESCRIPTION
## Description

Fix a corner case of the `Comb` operation when the input is a single scalar expression. The problem was that the item shape of the resulting expression was `{1}` instead of `{}`, which is the correct notation in the current implementation for scalar items.

I also added a test for this corner case.

FYI @sunethwarna 
