### PR TITLE
[ContactStructuralMechanicsApplication] Missing `constexpr` in ternary operators

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
@@ -144,9 +144,14 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Initiali
 
             DecompositionType decomp_geom( points_array );
 
-            const bool bad_shape = (TDim == 2) ? MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * 1.0e-6) : MortarUtilities::HeronCheck(decomp_geom);
+            bool bad_shape;
+            if constexpr (TDim == 2) {
+                bad_shape = MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * CheckThresholdCoefficient);
+            } else { 
+                bad_shape = MortarUtilities::HeronCheck(decomp_geom);
+            }
 
-            if (bad_shape == false) {
+            if (!bad_shape) {
                 const GeometryType::IntegrationPointsArrayType& integration_points_slave = decomp_geom.IntegrationPoints( this_integration_method );
 
                 // Integrating the mortar operators
@@ -433,9 +438,14 @@ bool MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Calculat
 
         DecompositionType decomp_geom( points_array );
 
-        const bool bad_shape = (TDim == 2) ? MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * 1.0e-6) : MortarUtilities::HeronCheck(decomp_geom);
+        bool bad_shape;
+        if constexpr (TDim == 2) {
+            bad_shape = MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * CheckThresholdCoefficient);
+        } else { 
+            bad_shape = MortarUtilities::HeronCheck(decomp_geom);
+        }
 
-        if (bad_shape == false) {
+        if (!bad_shape) {
             const GeometryType::IntegrationPointsArrayType& integration_points_slave = decomp_geom.IntegrationPoints( ThisIntegrationMethod );
 
             // Integrating the mortar operators

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.h
@@ -131,6 +131,9 @@ public:
 
     typedef ExactMortarIntegrationUtility<TDim, NumNodes, false, NumNodesMaster> IntegrationUtility;
 
+    // The threshold coefficient considered for checking
+    static constexpr double CheckThresholdCoefficient = 1.0e-12;
+
     ///@}
     ///@name  Enum's
     ///@{

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mortar_contact_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mortar_contact_condition.cpp
@@ -365,9 +365,14 @@ void MortarContactCondition<TDim, TNumNodes, TFrictional, TNormalVariation, TNum
 
             DecompositionType decomp_geom( points_array );
 
-            const bool bad_shape = (TDim == 2) ? MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * 1.0e-12) : MortarUtilities::HeronCheck(decomp_geom);
+            bool bad_shape;
+            if constexpr (TDim == 2) {
+                bad_shape = MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * CheckThresholdCoefficient);
+            } else { 
+                bad_shape = MortarUtilities::HeronCheck(decomp_geom);
+            }
 
-            if (bad_shape == false) {
+            if (!bad_shape) {
                 const GeometryType::IntegrationPointsArrayType& integration_points_slave = decomp_geom.IntegrationPoints( this_integration_method );
 
                 // Integrating the mortar operators

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mortar_contact_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mortar_contact_condition.h
@@ -150,6 +150,9 @@ public:
 
     typedef DerivativesUtilities<TDim, TNumNodes, IsFrictional, TNormalVariation, TNumNodesMaster>         DerivativesUtilitiesType;
 
+    // The threshold coefficient considered for checking
+    static constexpr double CheckThresholdCoefficient = 1.0e-12;
+
     ///@}
     ///@name Life Cycle
     ///@{

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.cpp
@@ -947,7 +947,7 @@ bool DerivativesUtilities<TDim, TNumNodes, TFrictional, TNormalVariation, TNumNo
 
         bool bad_shape;
         if constexpr (TDim == 2) {
-            bad_shape = MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * CheckThresholdCoefficient);
+            bad_shape = MortarUtilities::LengthCheck(decomp_geom, rSlaveGeometry.Length() * CheckThresholdCoefficient);
         } else { 
             bad_shape = MortarUtilities::HeronCheck(decomp_geom);
         }

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.cpp
@@ -300,7 +300,11 @@ void DerivativesUtilities<TDim, TNumNodes, TFrictional, TNormalVariation, TNumNo
     // We iterate over the nodes of the geometry
     for ( IndexType i_geometry = 0; i_geometry < TNumNodes; ++i_geometry ) {
         // Computing auxiliary matrix
-        noalias(renormalizer_matrix) = (TDim == 3) ? ComputeRenormalizerMatrix(diff_matrix, aux_delta_normal_geometry, i_geometry) : IdentityMatrix(2, 2);
+        if constexpr (TDim == 3) {
+            noalias(renormalizer_matrix) = ComputeRenormalizerMatrix(diff_matrix, aux_delta_normal_geometry, i_geometry);
+        } else {
+            noalias(renormalizer_matrix) = IdentityMatrix(2, 2);
+        }
 
         // We compute the gradient and jacobian
         rThisGeometry.PointLocalCoordinates( point_local, rThisGeometry[i_geometry].Coordinates( ) ) ;
@@ -375,7 +379,11 @@ void DerivativesUtilities<TDim, TNumNodes, TFrictional, TNormalVariation, TNumNo
     array_1d<array_1d<double, 3>, TDim * TNumNodesMaster> delta_normal_node;
     for ( IndexType i_geometry = 0; i_geometry < TNumNodesMaster; ++i_geometry ) {
         // Computing auxiliary matrix
-        noalias(renormalizer_matrix) = (TDim == 3) ? ComputeRenormalizerMatrix(diff_matrix, aux_delta_normal_geometry, i_geometry) : IdentityMatrix(2, 2);
+        if constexpr (TDim == 3) {
+            noalias(renormalizer_matrix) = ComputeRenormalizerMatrix(diff_matrix, aux_delta_normal_geometry, i_geometry);
+        } else {
+            noalias(renormalizer_matrix) = IdentityMatrix(2, 2);
+        }
 
         // We compute the gradient and jacobian
         rThisGeometry.PointLocalCoordinates( point_local, rThisGeometry[i_geometry].Coordinates( ) ) ;
@@ -937,7 +945,12 @@ bool DerivativesUtilities<TDim, TNumNodes, TFrictional, TNormalVariation, TNumNo
 
         DecompositionType decomp_geom( points_array );
 
-        const bool bad_shape = (TDim == 2) ? MortarUtilities::LengthCheck(decomp_geom, rSlaveGeometry.Length() * 1.0e-12) : MortarUtilities::HeronCheck(decomp_geom);
+        bool bad_shape;
+        if constexpr (TDim == 2) {
+            bad_shape = MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * CheckThresholdCoefficient);
+        } else { 
+            bad_shape = MortarUtilities::HeronCheck(decomp_geom);
+        }
 
         if (!bad_shape) {
             const GeometryType::IntegrationPointsArrayType& integration_points_slave = decomp_geom.IntegrationPoints( ThisIntegrationMethod );

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.h
@@ -110,6 +110,9 @@ public:
     /// The mortar operators
     typedef MortarOperatorWithDerivatives<TDim, TNumNodes, TFrictional, TNumNodesMaster>                   MortarConditionMatrices;
 
+    // The threshold coefficient considered for checking
+    static constexpr double CheckThresholdCoefficient = 1.0e-12;
+
     /// Definition of epsilon
     static constexpr double ZeroTolerance = std::numeric_limits<double>::epsilon();
 

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/mortar_explicit_contribution_utilities.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/mortar_explicit_contribution_utilities.cpp
@@ -94,7 +94,12 @@ typename MortarExplicitContributionUtilities<TDim,TNumNodes,TFrictional, TNormal
 
             DecompositionType decomp_geom( points_array );
 
-            const bool bad_shape = (TDim == 2) ? MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * 1.0e-12) : MortarUtilities::HeronCheck(decomp_geom);
+            bool bad_shape;
+            if constexpr (TDim == 2) {
+                bad_shape = MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * CheckThresholdCoefficient);
+            } else { 
+                bad_shape = MortarUtilities::HeronCheck(decomp_geom);
+            }
 
             if (!bad_shape) {
                 const GeometryType::IntegrationPointsArrayType& integration_points_slave = decomp_geom.IntegrationPoints( this_integration_method );
@@ -242,7 +247,12 @@ typename MortarExplicitContributionUtilities<TDim,TNumNodes,TFrictional, TNormal
 
             DecompositionType decomp_geom( points_array );
 
-            const bool bad_shape = (TDim == 2) ? MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * 1.0e-12) : MortarUtilities::HeronCheck(decomp_geom);
+            bool bad_shape;
+            if constexpr (TDim == 2) {
+                bad_shape = MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * CheckThresholdCoefficient);
+            } else { 
+                bad_shape = MortarUtilities::HeronCheck(decomp_geom);
+            }
 
             if (!bad_shape) {
                 const GeometryType::IntegrationPointsArrayType& integration_points_slave = decomp_geom.IntegrationPoints( this_integration_method );
@@ -438,7 +448,12 @@ bool MortarExplicitContributionUtilities<TDim,TNumNodes,TFrictional, TNormalVari
 
             DecompositionType decomp_geom( points_array );
 
-            const bool bad_shape = (TDim == 2) ? MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * 1.0e-12) : MortarUtilities::HeronCheck(decomp_geom);
+            bool bad_shape;
+            if constexpr (TDim == 2) {
+                bad_shape = MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * CheckThresholdCoefficient);
+            } else { 
+                bad_shape = MortarUtilities::HeronCheck(decomp_geom);
+            }
 
             if (!bad_shape) {
                 const GeometryType::IntegrationPointsArrayType& integration_points_slave = decomp_geom.IntegrationPoints( this_integration_method );
@@ -508,7 +523,12 @@ bool MortarExplicitContributionUtilities<TDim,TNumNodes,TFrictional, TNormalVari
 
         DecompositionType decomp_geom( PointerVector<PointType>{points_array} );
 
-        const bool bad_shape = (TDim == 2) ? MortarUtilities::LengthCheck(decomp_geom, rSlaveGeometry.Length() * 1.0e-12) : MortarUtilities::HeronCheck(decomp_geom);
+        bool bad_shape;
+        if constexpr (TDim == 2) {
+            bad_shape = MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * CheckThresholdCoefficient);
+        } else { 
+            bad_shape = MortarUtilities::HeronCheck(decomp_geom);
+        }
 
         if (!bad_shape) {
             const GeometryType::IntegrationPointsArrayType& r_integration_points_slave = decomp_geom.IntegrationPoints( rIntegrationMethod );

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/mortar_explicit_contribution_utilities.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/mortar_explicit_contribution_utilities.cpp
@@ -525,7 +525,7 @@ bool MortarExplicitContributionUtilities<TDim,TNumNodes,TFrictional, TNormalVari
 
         bool bad_shape;
         if constexpr (TDim == 2) {
-            bad_shape = MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * CheckThresholdCoefficient);
+            bad_shape = MortarUtilities::LengthCheck(decomp_geom, rSlaveGeometry.Length() * CheckThresholdCoefficient);
         } else { 
             bad_shape = MortarUtilities::HeronCheck(decomp_geom);
         }

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/mortar_explicit_contribution_utilities.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/mortar_explicit_contribution_utilities.h
@@ -80,7 +80,7 @@ public:
     typedef Node                                                                       NodeType;
 
     /// Geoemtry type definition
-    typedef Geometry<NodeType>                                                        GeometryType;
+    typedef Geometry<Node>                                                            GeometryType;
 
     // Type definition for integration methods
     typedef GeometryType::IntegrationPointsArrayType                         IntegrationPointsType;
@@ -118,6 +118,9 @@ public:
     typedef ExactMortarIntegrationUtility<TDim, TNumNodes, true, TNumNodesMaster>                                IntegrationUtility;
 
     typedef DerivativesUtilities<TDim, TNumNodes, IsFrictional, TNormalVariation, TNumNodesMaster>         DerivativesUtilitiesType;
+
+    // The threshold coefficient considered for checking
+    static constexpr double CheckThresholdCoefficient = 1.0e-12;
 
     ///@}
     ///@name Operators

--- a/applications/ContactStructuralMechanicsApplication/symbolic_generation/mesh_tying_mortar_condition/mesh_tying_mortar_condition_template.cpp
+++ b/applications/ContactStructuralMechanicsApplication/symbolic_generation/mesh_tying_mortar_condition/mesh_tying_mortar_condition_template.cpp
@@ -144,9 +144,14 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Initiali
 
             DecompositionType decomp_geom( points_array );
 
-            const bool bad_shape = (TDim == 2) ? MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * 1.0e-6) : MortarUtilities::HeronCheck(decomp_geom);
+            bool bad_shape;
+            if constexpr (TDim == 2) {
+                bad_shape = MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * CheckThresholdCoefficient);
+            } else { 
+                bad_shape = MortarUtilities::HeronCheck(decomp_geom);
+            }
 
-            if (bad_shape == false) {
+            if (!bad_shape) {
                 const GeometryType::IntegrationPointsArrayType& integration_points_slave = decomp_geom.IntegrationPoints( this_integration_method );
 
                 // Integrating the mortar operators
@@ -433,9 +438,14 @@ bool MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Calculat
 
         DecompositionType decomp_geom( points_array );
 
-        const bool bad_shape = (TDim == 2) ? MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * 1.0e-6) : MortarUtilities::HeronCheck(decomp_geom);
+        bool bad_shape;
+        if constexpr (TDim == 2) {
+            bad_shape = MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry.Length() * CheckThresholdCoefficient);
+        } else { 
+            bad_shape = MortarUtilities::HeronCheck(decomp_geom);
+        }
 
-        if (bad_shape == false) {
+        if (!bad_shape) {
             const GeometryType::IntegrationPointsArrayType& integration_points_slave = decomp_geom.IntegrationPoints( ThisIntegrationMethod );
 
             // Integrating the mortar operators

--- a/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/test_derivatives.cpp
+++ b/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/test_derivatives.cpp
@@ -66,15 +66,15 @@ static inline void TestDerivatives(
     )
 {
     // Type definitions
-    using PointBelongType = PointBelong<TNumNodes>;
-    using ConditionArrayType = std::array<PointBelongType, TDim>;
-    using ConditionArrayListType = std::vector<ConditionArrayType>;
-    using LineType = Line2D2<Point>;
-    using TriangleType = Triangle3D3<Point>;
-    using DecompositionType = typename std::conditional<TDim == 2, LineType, TriangleType>::type;
-    using BelongType = typename std::conditional<TNumNodes == 2, PointBelongsLine2D2N, typename std::conditional<TNumNodes == 3, PointBelongsTriangle3D3N, PointBelongsQuadrilateral3D4N>::type>::type;
-    using DerivativesUtilitiesType = DerivativesUtilities<TDim, TNumNodes, false, true>;
-    using IntegrationUtility = ExactMortarIntegrationUtility<TDim, TNumNodes, true>;
+    typedef PointBelong<TNumNodes> PointBelongType;
+    typedef array_1d<PointBelongType, TDim> ConditionArrayType;
+    typedef typename std::vector<ConditionArrayType> ConditionArrayListType;
+    typedef Line2D2<Point> LineType;
+    typedef Triangle3D3<Point> TriangleType;
+    typedef typename std::conditional<TDim == 2, LineType, TriangleType >::type DecompositionType;
+    typedef typename std::conditional<TNumNodes == 2, PointBelongsLine2D2N, typename std::conditional<TNumNodes == 3, PointBelongsTriangle3D3N, PointBelongsQuadrilateral3D4N>::type>::type BelongType;
+    typedef DerivativesUtilities<TDim, TNumNodes, false, true> DerivativesUtilitiesType;
+    typedef ExactMortarIntegrationUtility<TDim, TNumNodes, true> IntegrationUtility;
     static constexpr double CheckThresholdCoefficient = 1.0e-12;
 
     // Some definitions

--- a/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/test_derivatives.cpp
+++ b/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/test_derivatives.cpp
@@ -66,15 +66,16 @@ static inline void TestDerivatives(
     )
 {
     // Type definitions
-    typedef PointBelong<TNumNodes> PointBelongType;
-    typedef array_1d<PointBelongType, TDim> ConditionArrayType;
-    typedef typename std::vector<ConditionArrayType> ConditionArrayListType;
-    typedef Line2D2<Point> LineType;
-    typedef Triangle3D3<Point> TriangleType;
-    typedef typename std::conditional<TDim == 2, LineType, TriangleType >::type DecompositionType;
-    typedef typename std::conditional<TNumNodes == 2, PointBelongsLine2D2N, typename std::conditional<TNumNodes == 3, PointBelongsTriangle3D3N, PointBelongsQuadrilateral3D4N>::type>::type BelongType;
-    typedef DerivativesUtilities<TDim, TNumNodes, false, true> DerivativesUtilitiesType;
-    typedef ExactMortarIntegrationUtility<TDim, TNumNodes, true> IntegrationUtility;
+    using PointBelongType = PointBelong<TNumNodes>;
+    using ConditionArrayType = std::array<PointBelongType, TDim>;
+    using ConditionArrayListType = std::vector<ConditionArrayType>;
+    using LineType = Line2D2<Point>;
+    using TriangleType = Triangle3D3<Point>;
+    using DecompositionType = typename std::conditional<TDim == 2, LineType, TriangleType>::type;
+    using BelongType = typename std::conditional<TNumNodes == 2, PointBelongsLine2D2N, typename std::conditional<TNumNodes == 3, PointBelongsTriangle3D3N, PointBelongsQuadrilateral3D4N>::type>::type;
+    using DerivativesUtilitiesType = DerivativesUtilities<TDim, TNumNodes, false, true>;
+    using IntegrationUtility = ExactMortarIntegrationUtility<TDim, TNumNodes, true>;
+    static constexpr double CheckThresholdCoefficient = 1.0e-12;
 
     // Some definitions
     const NormalDerivativesComputation consider_normal_variation = static_cast<NormalDerivativesComputation>(rModelPart.GetProcessInfo()[CONSIDER_NORMAL_VARIATION]);
@@ -197,8 +198,8 @@ static inline void TestDerivatives(
                     DecompositionType decomp_geom( points_array );
                     DecompositionType decomp_geom0( points_array0 );
 
-                    const bool bad_shape = (TDim == 2) ? MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry_0.Length() * 1.0e-6) : MortarUtilities::HeronCheck(decomp_geom);
-                    const bool bad_shape0 = (TDim == 2) ? MortarUtilities::LengthCheck(decomp_geom0, r_slave_geometry_0.Length() * 1.0e-6) : MortarUtilities::HeronCheck(decomp_geom0);
+                    const bool bad_shape = (TDim == 2) ? MortarUtilities::LengthCheck(decomp_geom, r_slave_geometry_0.Length() * CheckThresholdCoefficient) : MortarUtilities::HeronCheck(decomp_geom);
+                    const bool bad_shape0 = (TDim == 2) ? MortarUtilities::LengthCheck(decomp_geom0, r_slave_geometry_0.Length() * CheckThresholdCoefficient) : MortarUtilities::HeronCheck(decomp_geom0);
 
                     if ((bad_shape == false) && (bad_shape0 == false)) {
                         const GeometryType::IntegrationPointsArrayType& integration_points_slave = decomp_geom.IntegrationPoints( this_integration_method );


### PR DESCRIPTION
**📝 Description**

Missing `constexpr` in ternary operators

**🆕 Changelog**

- [Missing `constexpr` in ternary operators](https://github.com/KratosMultiphysics/Kratos/commit/7f86ce2bf189510b2cf299ad388d336c225afcc5)
