### PR TITLE
[Core][MPI] Minor clean up header `parallel_fill_communicator.h`

### DIFF
--- a/kratos/mpi/utilities/parallel_fill_communicator.h
+++ b/kratos/mpi/utilities/parallel_fill_communicator.h
@@ -5,7 +5,7 @@
 //                   Multi-Physics
 //
 //  License:         BSD License
-//	                 Kratos default license: kratos/license.txt
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //
@@ -190,7 +190,7 @@ private:
     ///@name Member Variables
     ///@{
 
-    bool mPartitionIndexCheckPerformed = false;
+    bool mPartitionIndexCheckPerformed = false; /// If the partition index check is performed
 
     ///@}
     ///@name Private Operators


### PR DESCRIPTION
**📝 Description**

This PR fixes the formatting in the `parallel_fill_communicator.h` file and adds comments to improve code readability. It updates the license information and includes a boolean flag `mPartitionIndexCheckPerformed` to indicate whether the partition index check is performed. 

**🆕 Changelog**

- [Minor clean up header `parallel_fill_communicator.h`](https://github.com/KratosMultiphysics/Kratos/commit/8c54c4c6d5addbeb83a16e5bd1ec533136089a33)
