### PR TITLE
Template autoregister alternative

### DIFF
--- a/kratos/includes/define_registry.h
+++ b/kratos/includes/define_registry.h
@@ -56,7 +56,7 @@
 #define KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE(NAME, X, ...)                                            \
     static inline bool KRATOS_REGISTRY_NAME(_is_registered_, __LINE__) = []() -> bool {                 \
         using TFunctionType = std::function<std::shared_ptr<X<__VA_ARGS__>>()>;                         \
-        std::string key_name = NAME + std::string(".") + std::string(#X) + "<" + #__VA_ARGS__ + ">";    \
+        std::string key_name = NAME + std::string(".") + std::string(#X) + "<" + Kratos::Registry::RegistryTemplateToString(__VA_ARGS__) + ">";    \
         if (!Registry::HasItem(key_name))                                                               \
         {                                                                                               \
             auto &r_item = Registry::AddItem<RegistryItem>(key_name);                                   \

--- a/kratos/includes/registry.h
+++ b/kratos/includes/registry.h
@@ -104,6 +104,13 @@ public:
         KRATOS_CATCH("")
     }
 
+    template<typename... Types>
+    static std::string RegistryTemplateToString(Types&&... args) {
+        std::string f_name = (... += ("," + std::to_string(args)));
+        f_name.erase(0,1);
+        return f_name;
+    }
+
     ///@}
     ///@name Access
     ///@{

--- a/kratos/processes/apply_ray_casting_process.h
+++ b/kratos/processes/apply_ray_casting_process.h
@@ -51,10 +51,8 @@ public:
     /// Pointer definition of ApplyRayCastingProcess
     KRATOS_CLASS_POINTER_DEFINITION(ApplyRayCastingProcess);
 
-    KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.KratosMultiphysics", ApplyRayCastingProcess, 2)
-    KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.KratosMultiphysics", ApplyRayCastingProcess, 3)
-    KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.All", ApplyRayCastingProcess, 2)
-    KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.All", ApplyRayCastingProcess, 3)
+    KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.KratosMultiphysics", ApplyRayCastingProcess, TDim)
+    KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.All", ApplyRayCastingProcess, TDim)
 
     //TODO: These using statements have been included to make the old functions able to compile. It is still pending to update them.
     using ConfigurationType = Internals::DistanceSpatialContainersConfigure;


### PR DESCRIPTION
**📝 Description**
This should fix new problems in #11062  

After considering suggestions from @matekelemen, this implementation should avoid the usage of template alias, template recursion, and explicitly using instantiations inside the class definition.

The drawback is that registry key is more complex to generate.
Current solution will fail if the type of the template argument is not supported by `std::to_string`. For complex cases it can be implemented, but its a known limitation.

@rlrangel please, try this branch to see if the error is solved.

**🆕 Changelog**
- Re-implemented auto registry of template classes.
