### PR TITLE
[ContactStructuralMechanicsApplication] Toward clean up mesh tying conditions

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/contact_structural_mechanics_application.cpp
+++ b/applications/ContactStructuralMechanicsApplication/contact_structural_mechanics_application.cpp
@@ -27,13 +27,12 @@ KratosContactStructuralMechanicsApplication::KratosContactStructuralMechanicsApp
     /* CONDITIONS */
     // Mesh tying mortar conditions
     // 2D
-    mMeshTyingMortarCondition2D2NTriangle( 0, GeometryPointerType(new LineType(PointsArrayType(2))), nullptr, GeometryPointerType(new LineType(PointsArrayType(2)))),
-    mMeshTyingMortarCondition2D2NQuadrilateral( 0, GeometryPointerType(new LineType(PointsArrayType(2))), nullptr, GeometryPointerType(new LineType(PointsArrayType(2)))),
+    mMeshTyingMortarCondition2D2N( 0, GeometryPointerType(new LineType(PointsArrayType(2))), nullptr, GeometryPointerType(new LineType(PointsArrayType(2)))),
     // 3D
-    mMeshTyingMortarCondition3D3NTetrahedron( 0, GeometryPointerType(new TriangleType(PointsArrayType(3))), nullptr, GeometryPointerType(new TriangleType(PointsArrayType(3)))),
-    mMeshTyingMortarCondition3D4NHexahedron( 0, GeometryPointerType(new QuadrilateralType(PointsArrayType(4))), nullptr, GeometryPointerType(new QuadrilateralType(PointsArrayType(4)))),
-    mMeshTyingMortarCondition3D3NTetrahedron4NHexahedron( 0, GeometryPointerType(new TriangleType(PointsArrayType(3))), nullptr, GeometryPointerType(new TriangleType(PointsArrayType(3)))),
-    mMeshTyingMortarCondition3D4NHexahedron3NTetrahedron( 0, GeometryPointerType(new QuadrilateralType(PointsArrayType(4))), nullptr, GeometryPointerType(new QuadrilateralType(PointsArrayType(4)))),
+    mMeshTyingMortarCondition3D3N( 0, GeometryPointerType(new TriangleType(PointsArrayType(3))), nullptr, GeometryPointerType(new TriangleType(PointsArrayType(3)))),
+    mMeshTyingMortarCondition3D4N( 0, GeometryPointerType(new QuadrilateralType(PointsArrayType(4))), nullptr, GeometryPointerType(new QuadrilateralType(PointsArrayType(4)))),
+    mMeshTyingMortarCondition3D3N4N( 0, GeometryPointerType(new TriangleType(PointsArrayType(3))), nullptr, GeometryPointerType(new TriangleType(PointsArrayType(3)))),
+    mMeshTyingMortarCondition3D4N3N( 0, GeometryPointerType(new QuadrilateralType(PointsArrayType(4))), nullptr, GeometryPointerType(new QuadrilateralType(PointsArrayType(4)))),
 
     // ALM Contact mortar conditions
     // Frictionless
@@ -180,12 +179,11 @@ void KratosContactStructuralMechanicsApplication::Register()
 
     // CONDITIONS
     // Mesh tying mortar condition
-    KRATOS_REGISTER_CONDITION( "MeshTyingMortarCondition2D2NTriangle", mMeshTyingMortarCondition2D2NTriangle );
-    KRATOS_REGISTER_CONDITION( "MeshTyingMortarCondition2D2NQuadrilateral", mMeshTyingMortarCondition2D2NQuadrilateral );
-    KRATOS_REGISTER_CONDITION( "MeshTyingMortarCondition3D3NTetrahedron", mMeshTyingMortarCondition3D3NTetrahedron );
-    KRATOS_REGISTER_CONDITION( "MeshTyingMortarCondition3D4NHexahedron", mMeshTyingMortarCondition3D4NHexahedron );
-    KRATOS_REGISTER_CONDITION( "MeshTyingMortarCondition3D3NTetrahedron4NHexahedron", mMeshTyingMortarCondition3D3NTetrahedron4NHexahedron );
-    KRATOS_REGISTER_CONDITION( "MeshTyingMortarCondition3D4NHexahedron3NTetrahedron", mMeshTyingMortarCondition3D4NHexahedron3NTetrahedron );
+    KRATOS_REGISTER_CONDITION( "MeshTyingMortarCondition2D2N", mMeshTyingMortarCondition2D2N );
+    KRATOS_REGISTER_CONDITION( "MeshTyingMortarCondition3D3N", mMeshTyingMortarCondition3D3N );
+    KRATOS_REGISTER_CONDITION( "MeshTyingMortarCondition3D4N", mMeshTyingMortarCondition3D4N );
+    KRATOS_REGISTER_CONDITION( "MeshTyingMortarCondition3D3N4N", mMeshTyingMortarCondition3D3N4N );
+    KRATOS_REGISTER_CONDITION( "MeshTyingMortarCondition3D4N3N", mMeshTyingMortarCondition3D4N3N );
 
     // Mortar contact condition
     // Frictionless cases

--- a/applications/ContactStructuralMechanicsApplication/contact_structural_mechanics_application.h
+++ b/applications/ContactStructuralMechanicsApplication/contact_structural_mechanics_application.h
@@ -79,26 +79,23 @@ public:
     ///@name Type Definitions
     ///@{
 
-    /// Definition of the node type
-    typedef Node NodeType;
+    /// Definition of the geometry type
+    using GeometryType = Geometry<Node>;
 
     /// Definition of the geometry type
-    typedef Geometry<NodeType> GeometryType;
-
-    /// Definition of the geometry type
-    typedef GeometryType::Pointer GeometryPointerType;
+    using GeometryPointerType = typename GeometryType::Pointer;
 
     /// Definition of the points array type
-    typedef GeometryType::PointsArrayType PointsArrayType;
+    using PointsArrayType = typename GeometryType::PointsArrayType;
 
     /// Line type definition
-    typedef Line2D2<NodeType> LineType;
+    using LineType = Line2D2<Node>;
 
     /// Triangle type definition
-    typedef Triangle3D3<NodeType> TriangleType;
+    using TriangleType = Triangle3D3<Node>;
 
     /// Quadrilateral type definition
-    typedef Quadrilateral3D4<NodeType> QuadrilateralType;
+    using QuadrilateralType = Quadrilateral3D4<Node>;
 
     /// Pointer definition of KratosContactStructuralMechanicsApplication
     KRATOS_CLASS_POINTER_DEFINITION(KratosContactStructuralMechanicsApplication);
@@ -170,46 +167,36 @@ public:
     ///@name Friends
     ///@{
 
-
     ///@}
-
 protected:
     ///@name Protected static Member Variables
     ///@{
-
 
     ///@}
     ///@name Protected member Variables
     ///@{
 
-
     ///@}
     ///@name Protected Operators
     ///@{
-
 
     ///@}
     ///@name Protected Operations
     ///@{
 
-
     ///@}
     ///@name Protected  Access
     ///@{
-
 
     ///@}
     ///@name Protected Inquiry
     ///@{
 
-
     ///@}
     ///@name Protected LifeCycle
     ///@{
 
-
     ///@}
-
 private:
     ///@name Static Member Variables
     ///@{
@@ -220,12 +207,11 @@ private:
 
     /* CONDITIONS*/
     // Mesh tying mortar condition
-    const MeshTyingMortarCondition<2, 3> mMeshTyingMortarCondition2D2NTriangle;                   // 2DLine/Triangle
-    const MeshTyingMortarCondition<2, 4> mMeshTyingMortarCondition2D2NQuadrilateral;              // 2DLine/Quadrilateral
-    const MeshTyingMortarCondition<3, 4> mMeshTyingMortarCondition3D3NTetrahedron;                // 3D Triangle/Tetrahedron
-    const MeshTyingMortarCondition<3, 8> mMeshTyingMortarCondition3D4NHexahedron;                 // 3D Quadrilateral/Hexahedra
-    const MeshTyingMortarCondition<3, 4, 8> mMeshTyingMortarCondition3D3NTetrahedron4NHexahedron; // 3D Triangle/Tetrahedron-Quadrilateral/Hexahedra
-    const MeshTyingMortarCondition<3, 8, 4> mMeshTyingMortarCondition3D4NHexahedron3NTetrahedron; // 3D Quadrilateral/Hexahedra-Triangle/Tetrahedron
+    const MeshTyingMortarCondition<2, 2> mMeshTyingMortarCondition2D2N;      // 2D Line/Line
+    const MeshTyingMortarCondition<3, 3> mMeshTyingMortarCondition3D3N;      // 3D Triangle/Triangle
+    const MeshTyingMortarCondition<3, 4> mMeshTyingMortarCondition3D4N;      // 3D Quadrilateral/Quadrilateral
+    const MeshTyingMortarCondition<3, 3, 4> mMeshTyingMortarCondition3D3N4N; // 3D Triangle/Quadrilateral
+    const MeshTyingMortarCondition<3, 4, 3> mMeshTyingMortarCondition3D4N3N; // 3D Quadrilateral/Triangle
 
     // ALM Mortar contact conditions
     // Frictionless cases

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
@@ -6232,9 +6232,9 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Equation
         }
     } else {
         const std::string& r_variable_name = (*mpArray1DVariables[0]).Name();
-        const Array1DComponentsType& r_var_x = KratosComponents<Array1DComponentsType>::Get(r_variable_name+"_X");
-        const Array1DComponentsType& r_var_y = KratosComponents<Array1DComponentsType>::Get(r_variable_name+"_Y");
-        const Array1DComponentsType& r_var_z = KratosComponents<Array1DComponentsType>::Get(r_variable_name+"_Z");
+        const auto& r_var_x = KratosComponents<Variable<double>>::Get(r_variable_name+"_X");
+        const auto& r_var_y = KratosComponents<Variable<double>>::Get(r_variable_name+"_Y");
+        const auto& r_var_z = KratosComponents<Variable<double>>::Get(r_variable_name+"_Z");
         for ( IndexType i_master = 0; i_master < NumNodesMaster; ++i_master ) {
             const NodeType& r_master_node = r_current_master[i_master];
             rResult[index++] = r_master_node.GetDof( r_var_x ).EquationId( );
@@ -6251,9 +6251,9 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Equation
         }
     } else {
         const std::string& r_variable_name = (*mpArray1DVariables[0]).Name();
-        const Array1DComponentsType& r_var_x = KratosComponents<Array1DComponentsType>::Get(r_variable_name+"_X");
-        const Array1DComponentsType& r_var_y = KratosComponents<Array1DComponentsType>::Get(r_variable_name+"_Y");
-        const Array1DComponentsType& r_var_z = KratosComponents<Array1DComponentsType>::Get(r_variable_name+"_Z");
+        const auto& r_var_x = KratosComponents<Variable<double>>::Get(r_variable_name+"_X");
+        const auto& r_var_y = KratosComponents<Variable<double>>::Get(r_variable_name+"_Y");
+        const auto& r_var_z = KratosComponents<Variable<double>>::Get(r_variable_name+"_Z");
         for ( IndexType i_slave = 0; i_slave < NumNodes; ++i_slave ) {
             const NodeType& r_slave_node = r_current_slave[i_slave];
             rResult[index++] = r_slave_node.GetDof( r_var_x ).EquationId( );
@@ -6310,9 +6310,9 @@ void MeshTyingMortarCondition<TDim, TNumNodesElem, TNumNodesElemMaster>::GetDofL
         }
     } else {
         const std::string& r_variable_name = (*mpArray1DVariables[0]).Name();
-        const Array1DComponentsType& r_var_x = KratosComponents< Array1DComponentsType>::Get(r_variable_name+"_X");
-        const Array1DComponentsType& r_var_y = KratosComponents< Array1DComponentsType>::Get(r_variable_name+"_Y");
-        const Array1DComponentsType& r_var_z = KratosComponents< Array1DComponentsType>::Get(r_variable_name+"_Z");
+        const auto& r_var_x = KratosComponents<Variable<double>>::Get(r_variable_name+"_X");
+        const auto& r_var_y = KratosComponents<Variable<double>>::Get(r_variable_name+"_Y");
+        const auto& r_var_z = KratosComponents<Variable<double>>::Get(r_variable_name+"_Z");
         for ( IndexType i_master = 0; i_master < NumNodesMaster; ++i_master ) {
             const NodeType& r_master_node = r_current_master[i_master];
             rConditionalDofList[index++] = r_master_node.pGetDof( r_var_x );
@@ -6329,9 +6329,9 @@ void MeshTyingMortarCondition<TDim, TNumNodesElem, TNumNodesElemMaster>::GetDofL
         }
     } else {
         const std::string& r_variable_name = (*mpArray1DVariables[0]).Name();
-        const Array1DComponentsType& r_var_x = KratosComponents< Array1DComponentsType>::Get(r_variable_name+"_X");
-        const Array1DComponentsType& r_var_y = KratosComponents< Array1DComponentsType>::Get(r_variable_name+"_Y");
-        const Array1DComponentsType& r_var_z = KratosComponents< Array1DComponentsType>::Get(r_variable_name+"_Z");
+        const auto& r_var_x = KratosComponents<Variable<double>>::Get(r_variable_name+"_X");
+        const auto& r_var_y = KratosComponents<Variable<double>>::Get(r_variable_name+"_Y");
+        const auto& r_var_z = KratosComponents<Variable<double>>::Get(r_variable_name+"_Z");
         for ( IndexType i_slave = 0; i_slave < NumNodes; ++i_slave ) {
             const NodeType& r_slave_node = r_current_slave[i_slave];
             rConditionalDofList[index++] = r_slave_node.pGetDof( r_var_x );

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
@@ -16,7 +16,6 @@
 
 // Project includes
 #include "utilities/geometrical_projection_utilities.h"
-/* Mortar includes */
 #include "custom_conditions/mesh_tying_mortar_condition.h"
 
 namespace Kratos
@@ -24,64 +23,76 @@ namespace Kratos
 /************************************* OPERATIONS **********************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-Condition::Pointer MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Create(
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+Condition::Pointer MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::Create(
     IndexType NewId,
     NodesArrayType const& rThisNodes,
     PropertiesType::Pointer pProperties ) const
 {
-    return Kratos::make_intrusive< MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster> >( NewId, this->GetParentGeometry().Create( rThisNodes ), pProperties );
+    return Kratos::make_intrusive< MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster> >( NewId, this->GetParentGeometry().Create( rThisNodes ), pProperties );
 }
 
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-Condition::Pointer MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Create(
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+Condition::Pointer MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::Create(
     IndexType NewId,
     GeometryType::Pointer pGeom,
     PropertiesType::Pointer pProperties) const
 {
-    return Kratos::make_intrusive< MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster> >( NewId, pGeom, pProperties );
+    return Kratos::make_intrusive< MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster> >( NewId, pGeom, pProperties );
 }
 
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-Condition::Pointer MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Create(
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+Condition::Pointer MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::Create(
     IndexType NewId,
     GeometryType::Pointer pGeom,
     PropertiesType::Pointer pProperties,
     GeometryType::Pointer pMasterGeom) const
 {
-    return Kratos::make_intrusive< MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster> >( NewId, pGeom, pProperties, pMasterGeom);
+    return Kratos::make_intrusive< MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster> >( NewId, pGeom, pProperties, pMasterGeom);
 }
 
 /************************************* DESTRUCTOR **********************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::~MeshTyingMortarCondition( )
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::~MeshTyingMortarCondition( )
 = default;
 
 //************************** STARTING - ENDING  METHODS ***************************//
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Initialize(const ProcessInfo& rCurrentProcessInfo)
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY;
 
+    // Initialize BaseType
     BaseType::Initialize(rCurrentProcessInfo);
 
     // We get the unkown variable
     const std::string r_variable_name = GetProperties().Has(TYING_VARIABLE) ? GetProperties().GetValue(TYING_VARIABLE) : "DISPLACEMENT";
     if (KratosComponents<Variable<double>>::Has(r_variable_name)) {
-        mpDoubleVariables.push_back(&KratosComponents<Variable<double>>::Get(r_variable_name));
+        mpDoFVariables.push_back(&KratosComponents<Variable<double>>::Get(r_variable_name));
+        mpLMVariables.push_back(&SCALAR_LAGRANGE_MULTIPLIER);
     } else if (KratosComponents<Variable<array_1d<double, 3>>>::Has(r_variable_name)) {
-        mpArray1DVariables.push_back(&KratosComponents<Variable<array_1d<double, 3>>>::Get(r_variable_name));
+        mpDoFVariables.reserve(TDim);
+        mpLMVariables.reserve(TDim);
+        mpDoFVariables.push_back(&KratosComponents<Variable<double>>::Get(r_variable_name + "_X"));
+        mpLMVariables.push_back(&VECTOR_LAGRANGE_MULTIPLIER_X);
+        mpDoFVariables.push_back(&KratosComponents<Variable<double>>::Get(r_variable_name + "_Y"));
+        mpLMVariables.push_back(&VECTOR_LAGRANGE_MULTIPLIER_Y);
+        // In case of 3D, we add the Z variable
+        if constexpr (TDim == 3) {
+            mpDoFVariables.push_back(&KratosComponents<Variable<double>>::Get(r_variable_name + "_Z"));
+            mpLMVariables.push_back(&VECTOR_LAGRANGE_MULTIPLIER_Z);
+        }
     } else {
         KRATOS_ERROR << "Compatible variables are: double or array_1d<double, 3> " << std::endl;
     }
@@ -182,8 +193,8 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Initiali
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY;
 
@@ -195,8 +206,8 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Initiali
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY;
 
@@ -208,8 +219,8 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Initiali
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY;
 
@@ -221,8 +232,8 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Finalize
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY;
 
@@ -234,8 +245,8 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Finalize
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::CalculateLocalSystem(
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateLocalSystem(
     MatrixType& rLeftHandSideMatrix,
     VectorType& rRightHandSideVector,
     const ProcessInfo& rCurrentProcessInfo
@@ -244,16 +255,17 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Calculat
     KRATOS_TRY;
 
     // Compute the matrix size
-    const TensorValue tensor_value = (mpDoubleVariables.size() == 1) ? ScalarValue : static_cast<TensorValue>(TDim);
-    const SizeType matrix_size = tensor_value * (2 * NumNodes + NumNodesMaster);
+    const SizeType matrix_size = mpDoFVariables.size() * (2 * TNumNodes + TNumNodesMaster);
 
     // Resizing as needed the LHS
-    if ( rLeftHandSideMatrix.size1() != matrix_size || rLeftHandSideMatrix.size2() != matrix_size )
-            rLeftHandSideMatrix.resize( matrix_size, matrix_size, false );
+    if ( rLeftHandSideMatrix.size1() != matrix_size || rLeftHandSideMatrix.size2() != matrix_size ) {
+        rLeftHandSideMatrix.resize( matrix_size, matrix_size, false );
+    }
 
     // Resizing as needed the RHS
-    if ( rRightHandSideVector.size() != matrix_size )
+    if ( rRightHandSideVector.size() != matrix_size ) {
         rRightHandSideVector.resize( matrix_size, false );
+    }
 
     // Calculate condition system
     CalculateConditionSystem(rLeftHandSideMatrix, rRightHandSideVector, rCurrentProcessInfo );
@@ -264,19 +276,19 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Calculat
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::CalculateLeftHandSide(
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateLeftHandSide(
     MatrixType& rLeftHandSideMatrix,
     const ProcessInfo& rCurrentProcessInfo
     )
 {
     // Compute the matrix size
-    const TensorValue tensor_value = (mpDoubleVariables.size() == 1) ? ScalarValue : static_cast<TensorValue>(TDim);
-    const SizeType matrix_size = tensor_value * (2 * NumNodes + NumNodesMaster);
+    const SizeType matrix_size = mpDoFVariables.size() * (2 * TNumNodes + TNumNodesMaster);
 
     // Resizing as needed the LHS
-    if ( rLeftHandSideMatrix.size1() != matrix_size || rLeftHandSideMatrix.size2() != matrix_size )
+    if ( rLeftHandSideMatrix.size1() != matrix_size || rLeftHandSideMatrix.size2() != matrix_size ) {
         rLeftHandSideMatrix.resize( matrix_size, matrix_size, false );
+    }
 
     // Creating an auxiliary vector
     VectorType aux_right_hand_side_vector = Vector();
@@ -288,8 +300,8 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Calculat
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::CalculateRightHandSide(
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateRightHandSide(
     VectorType& rRightHandSideVector,
     const ProcessInfo& rCurrentProcessInfo
     )
@@ -298,12 +310,12 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Calculat
     MatrixType aux_left_hand_side_matrix = Matrix();
 
     // Compute the matrix size
-    const TensorValue tensor_value = (mpDoubleVariables.size() == 1) ? ScalarValue : static_cast<TensorValue>(TDim);
-    const SizeType matrix_size = tensor_value * (2 * NumNodes + NumNodesMaster);
+    const SizeType matrix_size = mpDoFVariables.size() * (2 * TNumNodes + TNumNodesMaster);
 
     // Resizing as needed the RHS
-    if ( rRightHandSideVector.size() != matrix_size )
+    if ( rRightHandSideVector.size() != matrix_size ) {
         rRightHandSideVector.resize( matrix_size, false );
+    }
 
     // Calculate condition system
     CalculateConditionSystem(aux_left_hand_side_matrix, rRightHandSideVector, rCurrentProcessInfo, false );
@@ -312,8 +324,8 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Calculat
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::CalculateMassMatrix(
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateMassMatrix(
     MatrixType& rMassMatrix,
     const ProcessInfo& rCurrentProcessInfo
     )
@@ -328,8 +340,8 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Calculat
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::CalculateDampingMatrix(
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateDampingMatrix(
     MatrixType& rDampingMatrix,
     const ProcessInfo& rCurrentProcessInfo
     )
@@ -344,8 +356,8 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Calculat
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim, TNumNodesElem, TNumNodesElemMaster>::CalculateConditionSystem(
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim, TNumNodes, TNumNodesMaster>::CalculateConditionSystem(
     MatrixType& rLeftHandSideMatrix,
     VectorType& rRightHandSideVector,
     const ProcessInfo& rCurrentProcessInfo,
@@ -356,16 +368,17 @@ void MeshTyingMortarCondition<TDim, TNumNodesElem, TNumNodesElemMaster>::Calcula
     KRATOS_TRY;
 
     // Create the current DoF data
-    const TensorValue tensor_value = (mpDoubleVariables.size() == 1) ? ScalarValue : static_cast<TensorValue>(TDim);
+    const TensorValue tensor_value = static_cast<TensorValue>(mpDoFVariables.size());
 
-    if (tensor_value ==  ScalarValue) {
+    if (tensor_value == ScalarValue) {
+        // Create the current DoF data
         DofData<ScalarValue> dof_data;
 
         // Initialize the DoF data
         this->InitializeDofData<ScalarValue>(dof_data);
 
         // Update slave element info
-        dof_data.UpdateMasterPair(this->GetPairedGeometry(), mpDoubleVariables, mpArray1DVariables);
+        dof_data.UpdateMasterPair(this->GetPairedGeometry(), mpDoFVariables);
 
         // Assemble of the matrix is required
         if ( ComputeLHS ) {
@@ -379,24 +392,28 @@ void MeshTyingMortarCondition<TDim, TNumNodesElem, TNumNodesElemMaster>::Calcula
             this->CalculateLocalRHS<ScalarValue>( rRightHandSideVector, mrThisMortarConditionMatrices, dof_data);
         }
     } else {
-        DofData<static_cast<TensorValue>(TDim)> dof_data;
+        // Template argument
+        constexpr TensorValue TTensor = static_cast<TensorValue>(TDim);
+
+        // Create the current DoF data
+        DofData<TTensor> dof_data;
 
         // Initialize the DoF data
-        this->InitializeDofData<static_cast<TensorValue>(TDim)>(dof_data);
+        this->InitializeDofData<TTensor>(dof_data);
 
         // Update slave element info
-        dof_data.UpdateMasterPair(this->GetPairedGeometry(), mpDoubleVariables, mpArray1DVariables);
+        dof_data.UpdateMasterPair(this->GetPairedGeometry(), mpDoFVariables);
 
         // Assemble of the matrix is required
         if ( ComputeLHS ) {
             // Calculate the local contribution
-            this->CalculateLocalLHS<static_cast<TensorValue>(TDim)>(rLeftHandSideMatrix, mrThisMortarConditionMatrices, dof_data);
+            this->CalculateLocalLHS<TTensor>(rLeftHandSideMatrix, mrThisMortarConditionMatrices, dof_data);
         }
 
         // Assemble of the vector is required
         if ( ComputeRHS) {
             // Calculate the local contribution
-            this->CalculateLocalRHS<static_cast<TensorValue>(TDim)>( rRightHandSideVector, mrThisMortarConditionMatrices, dof_data);
+            this->CalculateLocalRHS<TTensor>( rRightHandSideVector, mrThisMortarConditionMatrices, dof_data);
         }
     }
 
@@ -406,8 +423,8 @@ void MeshTyingMortarCondition<TDim, TNumNodesElem, TNumNodesElemMaster>::Calcula
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-bool MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::CalculateAe(
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+bool MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateAe(
     const array_1d<double, 3>& rNormalMaster,
     MatrixDualLM& rAe,
     GeneralVariables& rVariables,
@@ -419,7 +436,7 @@ bool MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Calculat
     AeData rAeData;
     rAeData.Initialize();
 
-    rAe = ZeroMatrix(NumNodes, NumNodes);
+    rAe = ZeroMatrix(TNumNodes, TNumNodes);
 
     // The slave geometry
     GeometryType& r_slave_geometry = this->GetParentGeometry();
@@ -478,8 +495,8 @@ bool MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Calculat
 /*********************************COMPUTE KINEMATICS*********************************/
 /************************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::CalculateKinematics(
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateKinematics(
     GeneralVariables& rVariables,
     const MatrixDualLM& rAe,
     const array_1d<double, 3>& rNormalMaster,
@@ -507,8 +524,8 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Calculat
 /*************** METHODS TO CALCULATE THE CONTACT CONDITION MATRICES ***************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::MasterShapeFunctionValue(
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::MasterShapeFunctionValue(
     GeneralVariables& rVariables,
     const array_1d<double, 3>& rNormalMaster,
     const PointType& rLocalPoint
@@ -536,7 +553,7 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::MasterSh
 
 template< >
 template< >
-void MeshTyingMortarCondition<2,3,3>::CalculateLocalLHS<MeshTyingMortarCondition<2,3,3>::ScalarValue>(
+void MeshTyingMortarCondition<2,2,2>::CalculateLocalLHS<MeshTyingMortarCondition<2,2,2>::ScalarValue>(
     Matrix& rLocalLHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<ScalarValue>& rDofData
@@ -595,7 +612,7 @@ void MeshTyingMortarCondition<2,3,3>::CalculateLocalLHS<MeshTyingMortarCondition
 
 template< >
 template< >
-void MeshTyingMortarCondition<2,3,3>::CalculateLocalLHS<MeshTyingMortarCondition<2,3,3>::Vector2DValue>(
+void MeshTyingMortarCondition<2,2,2>::CalculateLocalLHS<MeshTyingMortarCondition<2,2,2>::Vector2DValue>(
     Matrix& rLocalLHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<Vector2DValue>& rDofData
@@ -762,233 +779,7 @@ void MeshTyingMortarCondition<2,3,3>::CalculateLocalLHS<MeshTyingMortarCondition
 
 template< >
 template< >
-void MeshTyingMortarCondition<2,4,4>::CalculateLocalLHS<MeshTyingMortarCondition<2,4,4>::ScalarValue>(
-    Matrix& rLocalLHS,
-    const MortarConditionMatrices& rMortarConditionMatrices,
-    const DofData<ScalarValue>& rDofData
-    )
-{
-    // We get the mortar operators
-    const BoundedMatrix<double, 2, 2>& MOperator = rMortarConditionMatrices.MOperator;
-    const BoundedMatrix<double, 2, 2>& DOperator = rMortarConditionMatrices.DOperator;
-
-    const double clhs0 =     -MOperator(0,0);
-    const double clhs1 =     -MOperator(1,0);
-    const double clhs2 =     -MOperator(0,1);
-    const double clhs3 =     -MOperator(1,1);
-
-    rLocalLHS(0,0)=0;
-    rLocalLHS(0,1)=0;
-    rLocalLHS(0,2)=0;
-    rLocalLHS(0,3)=0;
-    rLocalLHS(0,4)=clhs0;
-    rLocalLHS(0,5)=clhs1;
-    rLocalLHS(1,0)=0;
-    rLocalLHS(1,1)=0;
-    rLocalLHS(1,2)=0;
-    rLocalLHS(1,3)=0;
-    rLocalLHS(1,4)=clhs2;
-    rLocalLHS(1,5)=clhs3;
-    rLocalLHS(2,0)=0;
-    rLocalLHS(2,1)=0;
-    rLocalLHS(2,2)=0;
-    rLocalLHS(2,3)=0;
-    rLocalLHS(2,4)=DOperator(0,0);
-    rLocalLHS(2,5)=DOperator(1,0);
-    rLocalLHS(3,0)=0;
-    rLocalLHS(3,1)=0;
-    rLocalLHS(3,2)=0;
-    rLocalLHS(3,3)=0;
-    rLocalLHS(3,4)=DOperator(0,1);
-    rLocalLHS(3,5)=DOperator(1,1);
-    rLocalLHS(4,0)=clhs0;
-    rLocalLHS(4,1)=clhs2;
-    rLocalLHS(4,2)=DOperator(0,0);
-    rLocalLHS(4,3)=DOperator(0,1);
-    rLocalLHS(4,4)=0;
-    rLocalLHS(4,5)=0;
-    rLocalLHS(5,0)=clhs1;
-    rLocalLHS(5,1)=clhs3;
-    rLocalLHS(5,2)=DOperator(1,0);
-    rLocalLHS(5,3)=DOperator(1,1);
-    rLocalLHS(5,4)=0;
-    rLocalLHS(5,5)=0;
-
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template< >
-template< >
-void MeshTyingMortarCondition<2,4,4>::CalculateLocalLHS<MeshTyingMortarCondition<2,4,4>::Vector2DValue>(
-    Matrix& rLocalLHS,
-    const MortarConditionMatrices& rMortarConditionMatrices,
-    const DofData<Vector2DValue>& rDofData
-    )
-{
-    // We get the mortar operators
-    const BoundedMatrix<double, 2, 2>& MOperator = rMortarConditionMatrices.MOperator;
-    const BoundedMatrix<double, 2, 2>& DOperator = rMortarConditionMatrices.DOperator;
-
-    const double clhs0 =     -MOperator(0,0);
-    const double clhs1 =     -MOperator(1,0);
-    const double clhs2 =     -MOperator(0,1);
-    const double clhs3 =     -MOperator(1,1);
-
-    rLocalLHS(0,0)=0;
-    rLocalLHS(0,1)=0;
-    rLocalLHS(0,2)=0;
-    rLocalLHS(0,3)=0;
-    rLocalLHS(0,4)=0;
-    rLocalLHS(0,5)=0;
-    rLocalLHS(0,6)=0;
-    rLocalLHS(0,7)=0;
-    rLocalLHS(0,8)=clhs0;
-    rLocalLHS(0,9)=0;
-    rLocalLHS(0,10)=clhs1;
-    rLocalLHS(0,11)=0;
-    rLocalLHS(1,0)=0;
-    rLocalLHS(1,1)=0;
-    rLocalLHS(1,2)=0;
-    rLocalLHS(1,3)=0;
-    rLocalLHS(1,4)=0;
-    rLocalLHS(1,5)=0;
-    rLocalLHS(1,6)=0;
-    rLocalLHS(1,7)=0;
-    rLocalLHS(1,8)=0;
-    rLocalLHS(1,9)=clhs0;
-    rLocalLHS(1,10)=0;
-    rLocalLHS(1,11)=clhs1;
-    rLocalLHS(2,0)=0;
-    rLocalLHS(2,1)=0;
-    rLocalLHS(2,2)=0;
-    rLocalLHS(2,3)=0;
-    rLocalLHS(2,4)=0;
-    rLocalLHS(2,5)=0;
-    rLocalLHS(2,6)=0;
-    rLocalLHS(2,7)=0;
-    rLocalLHS(2,8)=clhs2;
-    rLocalLHS(2,9)=0;
-    rLocalLHS(2,10)=clhs3;
-    rLocalLHS(2,11)=0;
-    rLocalLHS(3,0)=0;
-    rLocalLHS(3,1)=0;
-    rLocalLHS(3,2)=0;
-    rLocalLHS(3,3)=0;
-    rLocalLHS(3,4)=0;
-    rLocalLHS(3,5)=0;
-    rLocalLHS(3,6)=0;
-    rLocalLHS(3,7)=0;
-    rLocalLHS(3,8)=0;
-    rLocalLHS(3,9)=clhs2;
-    rLocalLHS(3,10)=0;
-    rLocalLHS(3,11)=clhs3;
-    rLocalLHS(4,0)=0;
-    rLocalLHS(4,1)=0;
-    rLocalLHS(4,2)=0;
-    rLocalLHS(4,3)=0;
-    rLocalLHS(4,4)=0;
-    rLocalLHS(4,5)=0;
-    rLocalLHS(4,6)=0;
-    rLocalLHS(4,7)=0;
-    rLocalLHS(4,8)=DOperator(0,0);
-    rLocalLHS(4,9)=0;
-    rLocalLHS(4,10)=DOperator(1,0);
-    rLocalLHS(4,11)=0;
-    rLocalLHS(5,0)=0;
-    rLocalLHS(5,1)=0;
-    rLocalLHS(5,2)=0;
-    rLocalLHS(5,3)=0;
-    rLocalLHS(5,4)=0;
-    rLocalLHS(5,5)=0;
-    rLocalLHS(5,6)=0;
-    rLocalLHS(5,7)=0;
-    rLocalLHS(5,8)=0;
-    rLocalLHS(5,9)=DOperator(0,0);
-    rLocalLHS(5,10)=0;
-    rLocalLHS(5,11)=DOperator(1,0);
-    rLocalLHS(6,0)=0;
-    rLocalLHS(6,1)=0;
-    rLocalLHS(6,2)=0;
-    rLocalLHS(6,3)=0;
-    rLocalLHS(6,4)=0;
-    rLocalLHS(6,5)=0;
-    rLocalLHS(6,6)=0;
-    rLocalLHS(6,7)=0;
-    rLocalLHS(6,8)=DOperator(0,1);
-    rLocalLHS(6,9)=0;
-    rLocalLHS(6,10)=DOperator(1,1);
-    rLocalLHS(6,11)=0;
-    rLocalLHS(7,0)=0;
-    rLocalLHS(7,1)=0;
-    rLocalLHS(7,2)=0;
-    rLocalLHS(7,3)=0;
-    rLocalLHS(7,4)=0;
-    rLocalLHS(7,5)=0;
-    rLocalLHS(7,6)=0;
-    rLocalLHS(7,7)=0;
-    rLocalLHS(7,8)=0;
-    rLocalLHS(7,9)=DOperator(0,1);
-    rLocalLHS(7,10)=0;
-    rLocalLHS(7,11)=DOperator(1,1);
-    rLocalLHS(8,0)=clhs0;
-    rLocalLHS(8,1)=0;
-    rLocalLHS(8,2)=clhs2;
-    rLocalLHS(8,3)=0;
-    rLocalLHS(8,4)=DOperator(0,0);
-    rLocalLHS(8,5)=0;
-    rLocalLHS(8,6)=DOperator(0,1);
-    rLocalLHS(8,7)=0;
-    rLocalLHS(8,8)=0;
-    rLocalLHS(8,9)=0;
-    rLocalLHS(8,10)=0;
-    rLocalLHS(8,11)=0;
-    rLocalLHS(9,0)=0;
-    rLocalLHS(9,1)=clhs0;
-    rLocalLHS(9,2)=0;
-    rLocalLHS(9,3)=clhs2;
-    rLocalLHS(9,4)=0;
-    rLocalLHS(9,5)=DOperator(0,0);
-    rLocalLHS(9,6)=0;
-    rLocalLHS(9,7)=DOperator(0,1);
-    rLocalLHS(9,8)=0;
-    rLocalLHS(9,9)=0;
-    rLocalLHS(9,10)=0;
-    rLocalLHS(9,11)=0;
-    rLocalLHS(10,0)=clhs1;
-    rLocalLHS(10,1)=0;
-    rLocalLHS(10,2)=clhs3;
-    rLocalLHS(10,3)=0;
-    rLocalLHS(10,4)=DOperator(1,0);
-    rLocalLHS(10,5)=0;
-    rLocalLHS(10,6)=DOperator(1,1);
-    rLocalLHS(10,7)=0;
-    rLocalLHS(10,8)=0;
-    rLocalLHS(10,9)=0;
-    rLocalLHS(10,10)=0;
-    rLocalLHS(10,11)=0;
-    rLocalLHS(11,0)=0;
-    rLocalLHS(11,1)=clhs1;
-    rLocalLHS(11,2)=0;
-    rLocalLHS(11,3)=clhs3;
-    rLocalLHS(11,4)=0;
-    rLocalLHS(11,5)=DOperator(1,0);
-    rLocalLHS(11,6)=0;
-    rLocalLHS(11,7)=DOperator(1,1);
-    rLocalLHS(11,8)=0;
-    rLocalLHS(11,9)=0;
-    rLocalLHS(11,10)=0;
-    rLocalLHS(11,11)=0;
-
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template< >
-template< >
-void MeshTyingMortarCondition<3,4,4>::CalculateLocalLHS<MeshTyingMortarCondition<3,4,4>::ScalarValue>(
+void MeshTyingMortarCondition<3,3,3>::CalculateLocalLHS<MeshTyingMortarCondition<3,3,3>::ScalarValue>(
     Matrix& rLocalLHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<ScalarValue>& rDofData
@@ -1097,7 +888,7 @@ void MeshTyingMortarCondition<3,4,4>::CalculateLocalLHS<MeshTyingMortarCondition
 
 template< >
 template< >
-void MeshTyingMortarCondition<3,4,4>::CalculateLocalLHS<MeshTyingMortarCondition<3,4,4>::Vector3DValue>(
+void MeshTyingMortarCondition<3,3,3>::CalculateLocalLHS<MeshTyingMortarCondition<3,3,3>::Vector3DValue>(
     Matrix& rLocalLHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<Vector3DValue>& rDofData
@@ -1854,7 +1645,7 @@ void MeshTyingMortarCondition<3,4,4>::CalculateLocalLHS<MeshTyingMortarCondition
 
 template< >
 template< >
-void MeshTyingMortarCondition<3,8,8>::CalculateLocalLHS<MeshTyingMortarCondition<3,8,8>::ScalarValue>(
+void MeshTyingMortarCondition<3,4,4>::CalculateLocalLHS<MeshTyingMortarCondition<3,4,4>::ScalarValue>(
     Matrix& rLocalLHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<ScalarValue>& rDofData
@@ -2033,7 +1824,7 @@ void MeshTyingMortarCondition<3,8,8>::CalculateLocalLHS<MeshTyingMortarCondition
 
 template< >
 template< >
-void MeshTyingMortarCondition<3,8,8>::CalculateLocalLHS<MeshTyingMortarCondition<3,8,8>::Vector3DValue>(
+void MeshTyingMortarCondition<3,4,4>::CalculateLocalLHS<MeshTyingMortarCondition<3,4,4>::Vector3DValue>(
     Matrix& rLocalLHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<Vector3DValue>& rDofData
@@ -3364,7 +3155,7 @@ void MeshTyingMortarCondition<3,8,8>::CalculateLocalLHS<MeshTyingMortarCondition
 
 template< >
 template< >
-void MeshTyingMortarCondition<3,4,8>::CalculateLocalLHS<MeshTyingMortarCondition<3,4,8>::ScalarValue>(
+void MeshTyingMortarCondition<3,3,4>::CalculateLocalLHS<MeshTyingMortarCondition<3,3,4>::ScalarValue>(
     Matrix& rLocalLHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<ScalarValue>& rDofData
@@ -3495,7 +3286,7 @@ void MeshTyingMortarCondition<3,4,8>::CalculateLocalLHS<MeshTyingMortarCondition
 
 template< >
 template< >
-void MeshTyingMortarCondition<3,4,8>::CalculateLocalLHS<MeshTyingMortarCondition<3,4,8>::Vector3DValue>(
+void MeshTyingMortarCondition<3,3,4>::CalculateLocalLHS<MeshTyingMortarCondition<3,3,4>::Vector3DValue>(
     Matrix& rLocalLHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<Vector3DValue>& rDofData
@@ -4426,7 +4217,7 @@ void MeshTyingMortarCondition<3,4,8>::CalculateLocalLHS<MeshTyingMortarCondition
 
 template< >
 template< >
-void MeshTyingMortarCondition<3,8,4>::CalculateLocalLHS<MeshTyingMortarCondition<3,8,4>::ScalarValue>(
+void MeshTyingMortarCondition<3,4,3>::CalculateLocalLHS<MeshTyingMortarCondition<3,4,3>::ScalarValue>(
     Matrix& rLocalLHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<ScalarValue>& rDofData
@@ -4578,7 +4369,7 @@ void MeshTyingMortarCondition<3,8,4>::CalculateLocalLHS<MeshTyingMortarCondition
 
 template< >
 template< >
-void MeshTyingMortarCondition<3,8,4>::CalculateLocalLHS<MeshTyingMortarCondition<3,8,4>::Vector3DValue>(
+void MeshTyingMortarCondition<3,4,3>::CalculateLocalLHS<MeshTyingMortarCondition<3,4,3>::Vector3DValue>(
     Matrix& rLocalLHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<Vector3DValue>& rDofData
@@ -5693,7 +5484,6 @@ void MeshTyingMortarCondition<3,8,4>::CalculateLocalLHS<MeshTyingMortarCondition
 
 }
 
-
 /****************************** END AD REPLACEMENT *********************************/
 /***********************************************************************************/
 
@@ -5702,7 +5492,7 @@ void MeshTyingMortarCondition<3,8,4>::CalculateLocalLHS<MeshTyingMortarCondition
 
 template<>
 template<>
-void MeshTyingMortarCondition<2,3, 3>::CalculateLocalRHS<MeshTyingMortarCondition<2,3,3>::ScalarValue>(
+void MeshTyingMortarCondition<2,2,2>::CalculateLocalRHS<MeshTyingMortarCondition<2,2,2>::ScalarValue>(
     Vector& rLocalRHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<ScalarValue>& rDofData
@@ -5733,7 +5523,7 @@ void MeshTyingMortarCondition<2,3, 3>::CalculateLocalRHS<MeshTyingMortarConditio
 
 template<>
 template<>
-void MeshTyingMortarCondition<2,3, 3>::CalculateLocalRHS<MeshTyingMortarCondition<2,3,3>::Vector2DValue>(
+void MeshTyingMortarCondition<2,2,2>::CalculateLocalRHS<MeshTyingMortarCondition<2,2,2>::Vector2DValue>(
     Vector& rLocalRHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<Vector2DValue>& rDofData
@@ -5748,7 +5538,6 @@ void MeshTyingMortarCondition<2,3, 3>::CalculateLocalRHS<MeshTyingMortarConditio
     // Mortar operators
     const BoundedMatrix<double, 2, 2>& MOperator = rMortarConditionMatrices.MOperator;
     const BoundedMatrix<double, 2, 2>& DOperator = rMortarConditionMatrices.DOperator;
-
 
     rLocalRHS[0]=MOperator(0,0)*lm(0,0) + MOperator(1,0)*lm(1,0);
     rLocalRHS[1]=MOperator(0,0)*lm(0,1) + MOperator(1,0)*lm(1,1);
@@ -5770,75 +5559,7 @@ void MeshTyingMortarCondition<2,3, 3>::CalculateLocalRHS<MeshTyingMortarConditio
 
 template<>
 template<>
-void MeshTyingMortarCondition<2,4, 4>::CalculateLocalRHS<MeshTyingMortarCondition<2,4,4>::ScalarValue>(
-    Vector& rLocalRHS,
-    const MortarConditionMatrices& rMortarConditionMatrices,
-    const DofData<ScalarValue>& rDofData
-    )
-{
-    // Initialize values
-    const BoundedMatrix<double, 2, ScalarValue> u1 = rDofData.u1;
-    const BoundedMatrix<double, 2, ScalarValue> u2 = rDofData.u2;
-
-    const BoundedMatrix<double, 2, ScalarValue> lm = rDofData.LagrangeMultipliers;
-
-    // Mortar operators
-    const BoundedMatrix<double, 2, 2>& MOperator = rMortarConditionMatrices.MOperator;
-    const BoundedMatrix<double, 2, 2>& DOperator = rMortarConditionMatrices.DOperator;
-
-
-    rLocalRHS[0]=MOperator(0,0)*lm(0,0) + MOperator(1,0)*lm(1,0);
-    rLocalRHS[1]=MOperator(0,1)*lm(0,0) + MOperator(1,1)*lm(1,0);
-    rLocalRHS[2]=-(DOperator(0,0)*lm(0,0) + DOperator(1,0)*lm(1,0));
-    rLocalRHS[3]=-(DOperator(0,1)*lm(0,0) + DOperator(1,1)*lm(1,0));
-    rLocalRHS[4]=-DOperator(0,0)*u1(0,0) - DOperator(0,1)*u1(1,0) + MOperator(0,0)*u2(0,0) + MOperator(0,1)*u2(1,0);
-    rLocalRHS[5]=-DOperator(1,0)*u1(0,0) - DOperator(1,1)*u1(1,0) + MOperator(1,0)*u2(0,0) + MOperator(1,1)*u2(1,0);
-
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template<>
-template<>
-void MeshTyingMortarCondition<2,4, 4>::CalculateLocalRHS<MeshTyingMortarCondition<2,4,4>::Vector2DValue>(
-    Vector& rLocalRHS,
-    const MortarConditionMatrices& rMortarConditionMatrices,
-    const DofData<Vector2DValue>& rDofData
-    )
-{
-    // Initialize values
-    const BoundedMatrix<double, 2, Vector2DValue> u1 = rDofData.u1;
-    const BoundedMatrix<double, 2, Vector2DValue> u2 = rDofData.u2;
-
-    const BoundedMatrix<double, 2, Vector2DValue> lm = rDofData.LagrangeMultipliers;
-
-    // Mortar operators
-    const BoundedMatrix<double, 2, 2>& MOperator = rMortarConditionMatrices.MOperator;
-    const BoundedMatrix<double, 2, 2>& DOperator = rMortarConditionMatrices.DOperator;
-
-
-    rLocalRHS[0]=MOperator(0,0)*lm(0,0) + MOperator(1,0)*lm(1,0);
-    rLocalRHS[1]=MOperator(0,0)*lm(0,1) + MOperator(1,0)*lm(1,1);
-    rLocalRHS[2]=MOperator(0,1)*lm(0,0) + MOperator(1,1)*lm(1,0);
-    rLocalRHS[3]=MOperator(0,1)*lm(0,1) + MOperator(1,1)*lm(1,1);
-    rLocalRHS[4]=-(DOperator(0,0)*lm(0,0) + DOperator(1,0)*lm(1,0));
-    rLocalRHS[5]=-(DOperator(0,0)*lm(0,1) + DOperator(1,0)*lm(1,1));
-    rLocalRHS[6]=-(DOperator(0,1)*lm(0,0) + DOperator(1,1)*lm(1,0));
-    rLocalRHS[7]=-(DOperator(0,1)*lm(0,1) + DOperator(1,1)*lm(1,1));
-    rLocalRHS[8]=-DOperator(0,0)*u1(0,0) - DOperator(0,1)*u1(1,0) + MOperator(0,0)*u2(0,0) + MOperator(0,1)*u2(1,0);
-    rLocalRHS[9]=-DOperator(0,0)*u1(0,1) - DOperator(0,1)*u1(1,1) + MOperator(0,0)*u2(0,1) + MOperator(0,1)*u2(1,1);
-    rLocalRHS[10]=-DOperator(1,0)*u1(0,0) - DOperator(1,1)*u1(1,0) + MOperator(1,0)*u2(0,0) + MOperator(1,1)*u2(1,0);
-    rLocalRHS[11]=-DOperator(1,0)*u1(0,1) - DOperator(1,1)*u1(1,1) + MOperator(1,0)*u2(0,1) + MOperator(1,1)*u2(1,1);
-
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template<>
-template<>
-void MeshTyingMortarCondition<3,4, 4>::CalculateLocalRHS<MeshTyingMortarCondition<3,4,4>::ScalarValue>(
+void MeshTyingMortarCondition<3,3,3>::CalculateLocalRHS<MeshTyingMortarCondition<3,3,3>::ScalarValue>(
     Vector& rLocalRHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<ScalarValue>& rDofData
@@ -5853,7 +5574,6 @@ void MeshTyingMortarCondition<3,4, 4>::CalculateLocalRHS<MeshTyingMortarConditio
     // Mortar operators
     const BoundedMatrix<double, 3, 3>& MOperator = rMortarConditionMatrices.MOperator;
     const BoundedMatrix<double, 3, 3>& DOperator = rMortarConditionMatrices.DOperator;
-
 
     rLocalRHS[0]=MOperator(0,0)*lm(0,0) + MOperator(1,0)*lm(1,0) + MOperator(2,0)*lm(2,0);
     rLocalRHS[1]=MOperator(0,1)*lm(0,0) + MOperator(1,1)*lm(1,0) + MOperator(2,1)*lm(2,0);
@@ -5872,7 +5592,7 @@ void MeshTyingMortarCondition<3,4, 4>::CalculateLocalRHS<MeshTyingMortarConditio
 
 template<>
 template<>
-void MeshTyingMortarCondition<3,4, 4>::CalculateLocalRHS<MeshTyingMortarCondition<3,4,4>::Vector3DValue>(
+void MeshTyingMortarCondition<3,3,3>::CalculateLocalRHS<MeshTyingMortarCondition<3,3,3>::Vector3DValue>(
     Vector& rLocalRHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<Vector3DValue>& rDofData
@@ -5887,7 +5607,6 @@ void MeshTyingMortarCondition<3,4, 4>::CalculateLocalRHS<MeshTyingMortarConditio
     // Mortar operators
     const BoundedMatrix<double, 3, 3>& MOperator = rMortarConditionMatrices.MOperator;
     const BoundedMatrix<double, 3, 3>& DOperator = rMortarConditionMatrices.DOperator;
-
 
     rLocalRHS[0]=MOperator(0,0)*lm(0,0) + MOperator(1,0)*lm(1,0) + MOperator(2,0)*lm(2,0);
     rLocalRHS[1]=MOperator(0,0)*lm(0,1) + MOperator(1,0)*lm(1,1) + MOperator(2,0)*lm(2,1);
@@ -5924,7 +5643,7 @@ void MeshTyingMortarCondition<3,4, 4>::CalculateLocalRHS<MeshTyingMortarConditio
 
 template<>
 template<>
-void MeshTyingMortarCondition<3,8, 8>::CalculateLocalRHS<MeshTyingMortarCondition<3,8,8>::ScalarValue>(
+void MeshTyingMortarCondition<3,4,4>::CalculateLocalRHS<MeshTyingMortarCondition<3,4,4>::ScalarValue>(
     Vector& rLocalRHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<ScalarValue>& rDofData
@@ -5939,7 +5658,6 @@ void MeshTyingMortarCondition<3,8, 8>::CalculateLocalRHS<MeshTyingMortarConditio
     // Mortar operators
     const BoundedMatrix<double, 4, 4>& MOperator = rMortarConditionMatrices.MOperator;
     const BoundedMatrix<double, 4, 4>& DOperator = rMortarConditionMatrices.DOperator;
-
 
     rLocalRHS[0]=MOperator(0,0)*lm(0,0) + MOperator(1,0)*lm(1,0) + MOperator(2,0)*lm(2,0) + MOperator(3,0)*lm(3,0);
     rLocalRHS[1]=MOperator(0,1)*lm(0,0) + MOperator(1,1)*lm(1,0) + MOperator(2,1)*lm(2,0) + MOperator(3,1)*lm(3,0);
@@ -5961,7 +5679,7 @@ void MeshTyingMortarCondition<3,8, 8>::CalculateLocalRHS<MeshTyingMortarConditio
 
 template<>
 template<>
-void MeshTyingMortarCondition<3,8, 8>::CalculateLocalRHS<MeshTyingMortarCondition<3,8,8>::Vector3DValue>(
+void MeshTyingMortarCondition<3,4,4>::CalculateLocalRHS<MeshTyingMortarCondition<3,4,4>::Vector3DValue>(
     Vector& rLocalRHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<Vector3DValue>& rDofData
@@ -5976,7 +5694,6 @@ void MeshTyingMortarCondition<3,8, 8>::CalculateLocalRHS<MeshTyingMortarConditio
     // Mortar operators
     const BoundedMatrix<double, 4, 4>& MOperator = rMortarConditionMatrices.MOperator;
     const BoundedMatrix<double, 4, 4>& DOperator = rMortarConditionMatrices.DOperator;
-
 
     rLocalRHS[0]=MOperator(0,0)*lm(0,0) + MOperator(1,0)*lm(1,0) + MOperator(2,0)*lm(2,0) + MOperator(3,0)*lm(3,0);
     rLocalRHS[1]=MOperator(0,0)*lm(0,1) + MOperator(1,0)*lm(1,1) + MOperator(2,0)*lm(2,1) + MOperator(3,0)*lm(3,1);
@@ -6022,7 +5739,7 @@ void MeshTyingMortarCondition<3,8, 8>::CalculateLocalRHS<MeshTyingMortarConditio
 
 template<>
 template<>
-void MeshTyingMortarCondition<3,4, 8>::CalculateLocalRHS<MeshTyingMortarCondition<3,4,8>::ScalarValue>(
+void MeshTyingMortarCondition<3,3,4>::CalculateLocalRHS<MeshTyingMortarCondition<3,3,4>::ScalarValue>(
     Vector& rLocalRHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<ScalarValue>& rDofData
@@ -6037,7 +5754,6 @@ void MeshTyingMortarCondition<3,4, 8>::CalculateLocalRHS<MeshTyingMortarConditio
     // Mortar operators
     const BoundedMatrix<double, 3, 4>& MOperator = rMortarConditionMatrices.MOperator;
     const BoundedMatrix<double, 3, 3>& DOperator = rMortarConditionMatrices.DOperator;
-
 
     rLocalRHS[0]=MOperator(0,0)*lm(0,0) + MOperator(1,0)*lm(1,0) + MOperator(2,0)*lm(2,0);
     rLocalRHS[1]=MOperator(0,1)*lm(0,0) + MOperator(1,1)*lm(1,0) + MOperator(2,1)*lm(2,0);
@@ -6057,7 +5773,7 @@ void MeshTyingMortarCondition<3,4, 8>::CalculateLocalRHS<MeshTyingMortarConditio
 
 template<>
 template<>
-void MeshTyingMortarCondition<3,4, 8>::CalculateLocalRHS<MeshTyingMortarCondition<3,4,8>::Vector3DValue>(
+void MeshTyingMortarCondition<3,3,4>::CalculateLocalRHS<MeshTyingMortarCondition<3,3,4>::Vector3DValue>(
     Vector& rLocalRHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<Vector3DValue>& rDofData
@@ -6072,7 +5788,6 @@ void MeshTyingMortarCondition<3,4, 8>::CalculateLocalRHS<MeshTyingMortarConditio
     // Mortar operators
     const BoundedMatrix<double, 3, 4>& MOperator = rMortarConditionMatrices.MOperator;
     const BoundedMatrix<double, 3, 3>& DOperator = rMortarConditionMatrices.DOperator;
-
 
     rLocalRHS[0]=MOperator(0,0)*lm(0,0) + MOperator(1,0)*lm(1,0) + MOperator(2,0)*lm(2,0);
     rLocalRHS[1]=MOperator(0,0)*lm(0,1) + MOperator(1,0)*lm(1,1) + MOperator(2,0)*lm(2,1);
@@ -6112,7 +5827,7 @@ void MeshTyingMortarCondition<3,4, 8>::CalculateLocalRHS<MeshTyingMortarConditio
 
 template<>
 template<>
-void MeshTyingMortarCondition<3,8, 4>::CalculateLocalRHS<MeshTyingMortarCondition<3,8,4>::ScalarValue>(
+void MeshTyingMortarCondition<3,4,3>::CalculateLocalRHS<MeshTyingMortarCondition<3,4,3>::ScalarValue>(
     Vector& rLocalRHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<ScalarValue>& rDofData
@@ -6127,7 +5842,6 @@ void MeshTyingMortarCondition<3,8, 4>::CalculateLocalRHS<MeshTyingMortarConditio
     // Mortar operators
     const BoundedMatrix<double, 4, 3>& MOperator = rMortarConditionMatrices.MOperator;
     const BoundedMatrix<double, 4, 4>& DOperator = rMortarConditionMatrices.DOperator;
-
 
     rLocalRHS[0]=MOperator(0,0)*lm(0,0) + MOperator(1,0)*lm(1,0) + MOperator(2,0)*lm(2,0) + MOperator(3,0)*lm(3,0);
     rLocalRHS[1]=MOperator(0,1)*lm(0,0) + MOperator(1,1)*lm(1,0) + MOperator(2,1)*lm(2,0) + MOperator(3,1)*lm(3,0);
@@ -6148,7 +5862,7 @@ void MeshTyingMortarCondition<3,8, 4>::CalculateLocalRHS<MeshTyingMortarConditio
 
 template<>
 template<>
-void MeshTyingMortarCondition<3,8, 4>::CalculateLocalRHS<MeshTyingMortarCondition<3,8,4>::Vector3DValue>(
+void MeshTyingMortarCondition<3,4,3>::CalculateLocalRHS<MeshTyingMortarCondition<3,4,3>::Vector3DValue>(
     Vector& rLocalRHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
     const DofData<Vector3DValue>& rDofData
@@ -6163,7 +5877,6 @@ void MeshTyingMortarCondition<3,8, 4>::CalculateLocalRHS<MeshTyingMortarConditio
     // Mortar operators
     const BoundedMatrix<double, 4, 3>& MOperator = rMortarConditionMatrices.MOperator;
     const BoundedMatrix<double, 4, 4>& DOperator = rMortarConditionMatrices.DOperator;
-
 
     rLocalRHS[0]=MOperator(0,0)*lm(0,0) + MOperator(1,0)*lm(1,0) + MOperator(2,0)*lm(2,0) + MOperator(3,0)*lm(3,0);
     rLocalRHS[1]=MOperator(0,0)*lm(0,1) + MOperator(1,0)*lm(1,1) + MOperator(2,0)*lm(2,1) + MOperator(3,0)*lm(3,1);
@@ -6204,8 +5917,8 @@ void MeshTyingMortarCondition<3,8, 4>::CalculateLocalRHS<MeshTyingMortarConditio
 /****************************** END AD REPLACEMENT *********************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::EquationIdVector(
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::EquationIdVector(
     EquationIdVectorType& rResult,
     const ProcessInfo& rCurrentProcessInfo
     ) const
@@ -6213,8 +5926,7 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Equation
     KRATOS_TRY;
 
     // Compute the matrix size
-    const TensorValue tensor_value = (mpDoubleVariables.size() == 1) ? ScalarValue : static_cast<TensorValue>(TDim);
-    const SizeType matrix_size = tensor_value * (2 * NumNodes + NumNodesMaster);
+    const SizeType matrix_size = mpDoFVariables.size() * (2 * TNumNodes + TNumNodesMaster);
 
     if (rResult.size() != matrix_size) {
         rResult.resize( matrix_size, false );
@@ -6225,55 +5937,28 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Equation
     /* ORDER - [ MASTER, SLAVE, LM ] */
     // Master Nodes DoF Equation IDs
     const GeometryType& r_current_master = this->GetPairedGeometry();
-
-    if (tensor_value == ScalarValue) {
-        for ( IndexType i_master = 0; i_master < NumNodesMaster; ++i_master ) {
-            rResult[index++] = r_current_master[i_master].GetDof( *mpDoubleVariables[0] ).EquationId( );
-        }
-    } else {
-        const std::string& r_variable_name = (*mpArray1DVariables[0]).Name();
-        const auto& r_var_x = KratosComponents<Variable<double>>::Get(r_variable_name+"_X");
-        const auto& r_var_y = KratosComponents<Variable<double>>::Get(r_variable_name+"_Y");
-        const auto& r_var_z = KratosComponents<Variable<double>>::Get(r_variable_name+"_Z");
-        for ( IndexType i_master = 0; i_master < NumNodesMaster; ++i_master ) {
-            const NodeType& r_master_node = r_current_master[i_master];
-            rResult[index++] = r_master_node.GetDof( r_var_x ).EquationId( );
-            rResult[index++] = r_master_node.GetDof( r_var_y ).EquationId( );
-            if constexpr (TDim == 3) rResult[index++] = r_master_node.GetDof( r_var_z ).EquationId( );
+    for ( IndexType i_master = 0; i_master < TNumNodesMaster; ++i_master ) {
+        const Node& r_master_node = r_current_master[i_master];
+        for (auto& p_var : mpDoFVariables) {
+            rResult[index++] = r_master_node.GetDof(*p_var).EquationId( );
         }
     }
 
+
     // Slave Nodes DoF Equation IDs
     const GeometryType& r_current_slave = this->GetParentGeometry();
-    if (tensor_value == ScalarValue) {
-        for ( IndexType i_slave = 0; i_slave < NumNodes; ++i_slave ) {
-            rResult[index++] = r_current_slave[i_slave].GetDof( *mpDoubleVariables[0] ).EquationId( );
-        }
-    } else {
-        const std::string& r_variable_name = (*mpArray1DVariables[0]).Name();
-        const auto& r_var_x = KratosComponents<Variable<double>>::Get(r_variable_name+"_X");
-        const auto& r_var_y = KratosComponents<Variable<double>>::Get(r_variable_name+"_Y");
-        const auto& r_var_z = KratosComponents<Variable<double>>::Get(r_variable_name+"_Z");
-        for ( IndexType i_slave = 0; i_slave < NumNodes; ++i_slave ) {
-            const NodeType& r_slave_node = r_current_slave[i_slave];
-            rResult[index++] = r_slave_node.GetDof( r_var_x ).EquationId( );
-            rResult[index++] = r_slave_node.GetDof( r_var_y ).EquationId( );
-            if constexpr (TDim == 3) rResult[index++] = r_slave_node.GetDof( r_var_z ).EquationId( );
+    for ( IndexType i_slave = 0; i_slave < TNumNodes; ++i_slave ) {
+        const Node& r_slave_node = r_current_slave[i_slave];
+        for (auto& p_var : mpDoFVariables) {
+            rResult[index++] = r_slave_node.GetDof(*p_var).EquationId( );
         }
     }
 
     // Slave Nodes LM Equation IDs
-    if (tensor_value == ScalarValue) {
-        for ( IndexType i_slave = 0; i_slave < NumNodes; ++i_slave )  {
-            const NodeType& r_slave_node = r_current_slave[i_slave];
-            rResult[index++] = r_slave_node.GetDof( SCALAR_LAGRANGE_MULTIPLIER ).EquationId( );
-        }
-    } else {
-        for ( IndexType i_slave = 0; i_slave < NumNodes; ++i_slave ) {
-            const NodeType& r_slave_node = r_current_slave[i_slave];
-            rResult[index++] = r_slave_node.GetDof( VECTOR_LAGRANGE_MULTIPLIER_X ).EquationId( );
-            rResult[index++] = r_slave_node.GetDof( VECTOR_LAGRANGE_MULTIPLIER_Y ).EquationId( );
-            if constexpr (TDim == 3) rResult[index++] = r_slave_node.GetDof( VECTOR_LAGRANGE_MULTIPLIER_Z ).EquationId( );
+    for ( IndexType i_slave = 0; i_slave < TNumNodes; ++i_slave ) {
+        const Node& r_slave_node = r_current_slave[i_slave];
+        for (auto& p_var : mpLMVariables) {
+            rResult[index++] = r_slave_node.GetDof(*p_var).EquationId( );
         }
     }
 
@@ -6283,16 +5968,16 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Equation
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim, TNumNodesElem, TNumNodesElemMaster>::GetDofList(
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim, TNumNodes, TNumNodesMaster>::GetDofList(
     DofsVectorType& rConditionalDofList,
     const ProcessInfo& rCurrentProcessInfo
     ) const
 {
     KRATOS_TRY;
 
-    const TensorValue tensor_value = (mpDoubleVariables.size() == 1) ? ScalarValue : static_cast<TensorValue>(TDim);
-    const SizeType matrix_size = tensor_value * (2 * NumNodes + NumNodesMaster);
+    // Compute the matrix size
+    const SizeType matrix_size = mpDoFVariables.size() * (2 * TNumNodes + TNumNodesMaster);
 
     if (rConditionalDofList.size() != matrix_size) {
         rConditionalDofList.resize( matrix_size );
@@ -6303,55 +5988,28 @@ void MeshTyingMortarCondition<TDim, TNumNodesElem, TNumNodesElemMaster>::GetDofL
     /* ORDER - [ MASTER, SLAVE, LM ] */
     // Master Nodes DoF Equation IDs
     const GeometryType& r_current_master = this->GetPairedGeometry();
-
-    if (tensor_value == ScalarValue) {
-        for ( IndexType i_master = 0; i_master < NumNodesMaster; ++i_master )  {
-            rConditionalDofList[index++] = r_current_master[i_master].pGetDof( *mpDoubleVariables[0] );
-        }
-    } else {
-        const std::string& r_variable_name = (*mpArray1DVariables[0]).Name();
-        const auto& r_var_x = KratosComponents<Variable<double>>::Get(r_variable_name+"_X");
-        const auto& r_var_y = KratosComponents<Variable<double>>::Get(r_variable_name+"_Y");
-        const auto& r_var_z = KratosComponents<Variable<double>>::Get(r_variable_name+"_Z");
-        for ( IndexType i_master = 0; i_master < NumNodesMaster; ++i_master ) {
-            const NodeType& r_master_node = r_current_master[i_master];
-            rConditionalDofList[index++] = r_master_node.pGetDof( r_var_x );
-            rConditionalDofList[index++] = r_master_node.pGetDof( r_var_y );
-            if constexpr (TDim == 3) rConditionalDofList[index++] = r_master_node.pGetDof( r_var_z );
+    for ( IndexType i_master = 0; i_master < TNumNodesMaster; ++i_master ) {
+        const Node& r_master_node = r_current_master[i_master];
+        for (auto& p_var : mpDoFVariables) {
+            rConditionalDofList[index++] = r_master_node.pGetDof(*p_var);
         }
     }
 
+
     // Slave Nodes DoF Equation IDs
     const GeometryType& r_current_slave = this->GetParentGeometry();
-    if (tensor_value == ScalarValue) {
-        for ( IndexType i_slave = 0; i_slave < NumNodes; ++i_slave ) {
-            rConditionalDofList[index++] = r_current_slave[i_slave].pGetDof( *mpDoubleVariables[0] );
-        }
-    } else {
-        const std::string& r_variable_name = (*mpArray1DVariables[0]).Name();
-        const auto& r_var_x = KratosComponents<Variable<double>>::Get(r_variable_name+"_X");
-        const auto& r_var_y = KratosComponents<Variable<double>>::Get(r_variable_name+"_Y");
-        const auto& r_var_z = KratosComponents<Variable<double>>::Get(r_variable_name+"_Z");
-        for ( IndexType i_slave = 0; i_slave < NumNodes; ++i_slave ) {
-            const NodeType& r_slave_node = r_current_slave[i_slave];
-            rConditionalDofList[index++] = r_slave_node.pGetDof( r_var_x );
-            rConditionalDofList[index++] = r_slave_node.pGetDof( r_var_y );
-            if constexpr (TDim == 3) rConditionalDofList[index++] = r_slave_node.pGetDof( r_var_z );
+    for ( IndexType i_slave = 0; i_slave < TNumNodes; ++i_slave ) {
+        const Node& r_slave_node = r_current_slave[i_slave];
+        for (auto& p_var : mpDoFVariables) {
+            rConditionalDofList[index++] = r_slave_node.pGetDof(*p_var);
         }
     }
 
     // Slave Nodes LM Equation IDs
-    if (tensor_value == ScalarValue) {
-        for ( IndexType i_slave = 0; i_slave < NumNodes; ++i_slave ) {
-            const NodeType& r_slave_node = r_current_slave[i_slave];
-            rConditionalDofList[index++] = r_slave_node.pGetDof( SCALAR_LAGRANGE_MULTIPLIER );
-        }
-    } else {
-        for ( IndexType i_slave = 0; i_slave < NumNodes; ++i_slave ) {
-            const NodeType& r_slave_node = r_current_slave[i_slave];
-            rConditionalDofList[index++] = r_slave_node.pGetDof( VECTOR_LAGRANGE_MULTIPLIER_X );
-            rConditionalDofList[index++] = r_slave_node.pGetDof( VECTOR_LAGRANGE_MULTIPLIER_Y );
-            if constexpr (TDim == 3) rConditionalDofList[index++] = r_slave_node.pGetDof( VECTOR_LAGRANGE_MULTIPLIER_Z );
+    for ( IndexType i_slave = 0; i_slave < TNumNodes; ++i_slave ) {
+        const Node& r_slave_node = r_current_slave[i_slave];
+        for (auto& p_var : mpLMVariables) {
+            rConditionalDofList[index++] = r_slave_node.pGetDof(*p_var);
         }
     }
 
@@ -6361,8 +6019,8 @@ void MeshTyingMortarCondition<TDim, TNumNodesElem, TNumNodesElemMaster>::GetDofL
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::CalculateOnIntegrationPoints(
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateOnIntegrationPoints(
     const Variable<double>& rVariable,
     std::vector<double>& rOutput,
     const ProcessInfo& rCurrentProcessInfo
@@ -6386,8 +6044,8 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Calculat
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::CalculateOnIntegrationPoints(
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateOnIntegrationPoints(
     const Variable<array_1d<double, 3 > >& rVariable,
     std::vector< array_1d<double, 3 > >& rOutput,
     const ProcessInfo& rCurrentProcessInfo
@@ -6411,8 +6069,8 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Calculat
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::CalculateOnIntegrationPoints(
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateOnIntegrationPoints(
     const Variable<Vector>& rVariable,
     std::vector<Vector>& rOutput,
     const ProcessInfo& rCurrentProcessInfo
@@ -6436,8 +6094,8 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Calculat
 /***********************************************************************************/
 /***********************************************************************************/
 
-template< SizeType TDim, SizeType TNumNodesElem, SizeType TNumNodesElemMaster>
-int MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Check(const ProcessInfo& rCurrentProcessInfo) const
+template< SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+int MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::Check(const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 
@@ -6455,11 +6113,10 @@ int MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Check(con
 /***********************************************************************************/
 /***********************************************************************************/
 
-template class MeshTyingMortarCondition<2, 3, 3>; // 2DLine/Triangle
-template class MeshTyingMortarCondition<2, 4, 4>; // 2DLine/Quadrilateral
-template class MeshTyingMortarCondition<3, 4, 4>; // 3D Triangle/Tetrahedron
-template class MeshTyingMortarCondition<3, 8, 8>; // 3D Quadrilateral/Hexahedra
-template class MeshTyingMortarCondition<3, 4, 8>; // 3D Triangle/Tetrahedron
-template class MeshTyingMortarCondition<3, 8, 4>; // 3D Quadrilateral/Hexahedra
+template class MeshTyingMortarCondition<2, 2, 2>; // 2D Line/Line
+template class MeshTyingMortarCondition<3, 3, 3>; // 3D Triangle/Triangle
+template class MeshTyingMortarCondition<3, 4, 4>; // 3D Quadrilateral/Quadrilateral
+template class MeshTyingMortarCondition<3, 3, 4>; // 3D Triangle/Quadrilateral
+template class MeshTyingMortarCondition<3, 4, 3>; // 3D Quadrilateral/Triangle
 
 } // Namespace Kratos

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.h
@@ -27,7 +27,6 @@
 
 namespace Kratos
 {
-
 ///@name Kratos Globals
 ///@{
 
@@ -36,7 +35,7 @@ namespace Kratos
 ///@{
 
     /// The definition of the size type
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
 
 ///@}
 ///@name  Enum's
@@ -59,10 +58,10 @@ namespace Kratos
  * Popp, Alexander: Mortar Methods for Computational Contact Mechanics and General Interface Problems, Technische Universität München, jul 2012
  * @author Vicente Mataix Ferrandiz
  * @tparam TDim The dimension of work
- * @tparam TNumNodesElem The number of nodes of the slave
- * @tparam TNumNodesElemMaster The number of nodes of the master
+ * @tparam TNumNodes The number of nodes of the slave
+ * @tparam TNumNodesMaster The number of nodes of the master
  */
-template< const SizeType TDim, const SizeType TNumNodesElem, const SizeType TNumNodesElemMaster = TNumNodesElem>
+template< const SizeType TDim, const SizeType TNumNodes, const SizeType TNumNodesMaster = TNumNodes>
 class KRATOS_API(CONTACT_STRUCTURAL_MECHANICS_APPLICATION) MeshTyingMortarCondition
     : public PairedCondition
 {
@@ -111,19 +110,15 @@ public:
 
     using DecompositionType = typename std::conditional<TDim == 2, LineType, TriangleType>::type;
 
-    static constexpr SizeType NumNodes = (TNumNodesElem == 3 || (TDim == 2 && TNumNodesElem == 4)) ? 2 : TNumNodesElem == 4 ? 3 : 4;
+    using MatrixDualLM = BoundedMatrix<double, TNumNodes, TNumNodes>;
 
-    static constexpr SizeType NumNodesMaster = (TNumNodesElemMaster == 3 || (TDim == 2 && TNumNodesElemMaster == 4)) ? 2 : TNumNodesElemMaster == 4 ? 3 : 4;
+    using GeneralVariables = MortarKinematicVariables<TNumNodes, TNumNodesMaster>;
 
-    using MatrixDualLM = BoundedMatrix<double, NumNodes, NumNodes>;
+    using AeData = DualLagrangeMultiplierOperators<TNumNodes, TNumNodesMaster>;
 
-    using GeneralVariables = MortarKinematicVariables<NumNodes, NumNodesMaster>;
+    using MortarConditionMatrices = MortarOperator<TNumNodes, TNumNodesMaster>;
 
-    using AeData = DualLagrangeMultiplierOperators<NumNodes, NumNodesMaster>;
-
-    using MortarConditionMatrices = MortarOperator<NumNodes, NumNodesMaster>;
-
-    using IntegrationUtility = ExactMortarIntegrationUtility<TDim, NumNodes, false, NumNodesMaster>;
+    using IntegrationUtility = ExactMortarIntegrationUtility<TDim, TNumNodes, false, TNumNodesMaster>;
 
     // The threshold coefficient considered for checking
     static constexpr double CheckThresholdCoefficient = 1.0e-12;
@@ -184,36 +179,38 @@ public:
     ///@{
 
    /**
-    * Called at the beginning of each solution step
+    * @brief Called at the beginning of each solution step
     */
     void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
    /**
-    * Called at the beginning of each solution step
+    * @brief Called at the beginning of each solution step
     * @param rCurrentProcessInfo The current process info instance
     */
     void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
    /**
-    * Called at the beginning of each iteration
+    * @brief Called at the beginning of each iteration
     * @param rCurrentProcessInfo The current process info instance
     */
     void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
-    * Called at the ending of each solution step
+    * @brief Called at the ending of each solution step
     * @param rCurrentProcessInfo The current process info instance
     */
     void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
    /**
-    * Called at the end of each iteration
+    * @brief Called at the end of each iteration
     * @param rCurrentProcessInfo The current process info instance
     */
     void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
-    * Initialize Mass Matrix
+    * @brief Initialize Mass Matrix
+    * @param rMassMatrix The mass matrix
+    * @param rCurrentProcessInfo The current process info
     */
     void CalculateMassMatrix(
         MatrixType& rMassMatrix,
@@ -221,7 +218,9 @@ public:
         ) override;
 
     /**
-    * Initialize Damping Matrix
+    * @brief Initialize Damping Matrix
+    * @param rDampingMatrix The damping matrix
+    * @param rCurrentProcessInfo The current process info
     */
     void CalculateDampingMatrix(
         MatrixType& rDampingMatrix,
@@ -229,7 +228,7 @@ public:
         ) override;
 
     /**
-     * Creates a new element pointer from an arry of nodes
+     * @brief Creates a new element pointer from an arry of nodes
      * @param NewId the ID of the new element
      * @param rThisNodes the nodes of the new element
      * @param pProperties the properties assigned to the new element
@@ -242,7 +241,7 @@ public:
         ) const override;
 
     /**
-     * Creates a new element pointer from an existing geometry
+     * @brief Creates a new element pointer from an existing geometry
      * @param NewId the ID of the new element
      * @param pGeom the  geometry taken to create the condition
      * @param pProperties the properties assigned to the new element
@@ -255,7 +254,7 @@ public:
         ) const override;
 
     /**
-     * Creates a new element pointer from an existing geometry
+     * @brief Creates a new element pointer from an existing geometry
      * @param NewId the ID of the new element
      * @param pGeom the  geometry taken to create the condition
      * @param pProperties the properties assigned to the new element
@@ -274,7 +273,7 @@ public:
     /******************************************************************/
 
     /**
-     * Sets on rResult the ID's of the element degrees of freedom
+     * @brief Sets on rResult the ID's of the element degrees of freedom
      * @param rResult The result vector with the ID's of the DOF
      * @param rCurrentProcessInfo the current process info instance
      */
@@ -284,7 +283,7 @@ public:
         ) const override;
 
     /**
-     * Sets on ConditionalDofList the degrees of freedom of the considered element geometry
+     * @brief Sets on ConditionalDofList the degrees of freedom of the considered element geometry
      * @param rConditionalDofList The list of DOFs
      * @param rCurrentProcessInfo the current process info instance
      */
@@ -294,7 +293,10 @@ public:
         ) const override;
 
     /**
-     * Calculate a double Variable
+     * @brief Calculate a double Variable
+     * @param rVariable The variable to calculate
+     * @param rOutput The output variable
+     * @param rCurrentProcessInfo The current process info
      */
     void CalculateOnIntegrationPoints(
         const Variable<double>& rVariable,
@@ -303,16 +305,22 @@ public:
         ) override;
 
     /**
-     * Calculate a array_1d Variable
+     * @brief Calculate a array_1d Variable
+     * @param rVariable The variable to calculate
+     * @param rOutput The output variable
+     * @param rCurrentProcessInfo The current process info
      */
     void CalculateOnIntegrationPoints(
-        const Variable<array_1d<double, 3 > >& rVariable,
-        std::vector< array_1d<double, 3 > >& rOutput,
+        const Variable<array_1d<double, 3>>& rVariable,
+        std::vector< array_1d<double, 3>>& rOutput,
         const ProcessInfo& rCurrentProcessInfo
         ) override;
 
     /**
-     * Calculate a Vector Variable
+     * @brief Calculate a Vector Variable
+     * @param rVariable The variable to calculate
+     * @param rOutput The output variable
+     * @param rCurrentProcessInfo The current process info
      */
     void CalculateOnIntegrationPoints(
         const Variable<Vector>& rVariable,
@@ -380,8 +388,8 @@ protected:
     public:
 
         // Auxiliary types
-        typedef BoundedMatrix<double, NumNodes, TTensor>  MatrixUnknownSlave;
-        typedef BoundedMatrix<double, NumNodesMaster, TTensor>  MatrixUnknownMaster;
+        using MatrixUnknownSlave = BoundedMatrix<double, TNumNodes, TTensor>;
+        using MatrixUnknownMaster = BoundedMatrix<double, TNumNodesMaster, TTensor>;
 
         // The DoF
         MatrixUnknownSlave LagrangeMultipliers, u1;
@@ -391,40 +399,32 @@ protected:
         ~DofData()= default;
 
         /**
-         * Updating the Slave pair
+         * @brief Updating the Slave pair
          * @param rGeometryInput The pointer of the current master
          */
         void Initialize(const GeometryType& rGeometryInput)
         {
             // The current Lagrange Multipliers
-            u1 = ZeroMatrix(NumNodes, TTensor);
-            u2 = ZeroMatrix(NumNodesMaster, TTensor);
-            LagrangeMultipliers = ZeroMatrix(NumNodes, TTensor);
+            u1 = ZeroMatrix(TNumNodes, TTensor);
+            u2 = ZeroMatrix(TNumNodesMaster, TTensor);
+            LagrangeMultipliers = ZeroMatrix(TNumNodes, TTensor);
         }
 
         /**
          * @brief Updating the Master pair
          * @param rGeometryInput The pointer of the current master
-         * @param rDoubleVariables The list of double variables
-         * @param rArray1DVariables The list of components array1d
+         * @param rpDoFVariables The list of DoF variables
          */
         void UpdateMasterPair(
             const GeometryType& rGeometryInput,
-            std::vector<const Variable<double>*>& rpDoubleVariables,
-            std::vector<const Variable<array_1d<double, 3>>*>& rpArray1DVariables
+            std::vector<const Variable<double>*>& rpDoFVariables
             )
         {
-            /* DoF */
-            if constexpr (TTensor == 1) {
-                for (IndexType i_node = 0; i_node < NumNodesMaster; ++i_node) {
-                    u2(i_node, 0) = rGeometryInput[i_node].FastGetSolutionStepValue(*rpDoubleVariables[0]);
-                }
-            } else {
-                for (IndexType i_node = 0; i_node < NumNodesMaster; ++i_node) {
-                    const array_1d<double, 3>& value = rGeometryInput[i_node].FastGetSolutionStepValue(*rpArray1DVariables[0]);
-                    for (IndexType i_dof = 0; i_dof < TTensor; ++i_dof) {
-                        u2(i_node, i_dof) = value[i_dof];
-                    }
+            // Fill master information
+            for (IndexType i_node = 0; i_node < TNumNodesMaster; ++i_node) {
+                const auto& r_node = rGeometryInput[i_node];
+                for (IndexType i_dof = 0; i_dof < TTensor; ++i_dof) {
+                    u2(i_node, i_dof) = r_node.FastGetSolutionStepValue(*rpDoFVariables[i_dof]);
                 }
             }
         }
@@ -435,11 +435,11 @@ protected:
     ///@name Protected member Variables
     ///@{
 
-    MortarConditionMatrices mrThisMortarConditionMatrices;                /// The mortar operators
+    MortarConditionMatrices mrThisMortarConditionMatrices; /// The mortar operators
 
-    std::vector<const Variable<double>*> mpDoubleVariables;               /// The list of double variables
+    std::vector<const Variable<double>*> mpDoFVariables;   /// The list of DoF variables
 
-    std::vector<const Variable<array_1d<double, 3>>*> mpArray1DVariables; /// The list of components array1d
+    std::vector<const Variable<double>*> mpLMVariables;    /// The list of LM variables
 
     ///@}
     ///@name Protected Operators
@@ -454,9 +454,7 @@ protected:
     /******************************************************************/
 
     /**
-     * This is called during the assembling process in order
-     * to calculate all condition contributions to the global system
-     * matrix and the right hand side
+     * @brief This is called during the assembling process in order to calculate all condition contributions to the global system matrix and the right hand side
      * @param rLeftHandSideMatrix the condition left hand side matrix
      * @param rRightHandSideVector the condition right hand side
      * @param rCurrentProcessInfo the current process info instance
@@ -468,8 +466,7 @@ protected:
         ) override;
 
     /**
-     * This is called during the assembling process in order
-     * to calculate the condition right hand side vector only
+     * @brief This is called during the assembling process in order to calculate the condition right hand side vector only
      * @param rRightHandSideVector the condition right hand side vector
      * @param rCurrentProcessInfo the current process info instance
      */
@@ -479,8 +476,7 @@ protected:
         ) override;
 
     /**
-     * This is called during the assembling process in order
-     * to calculate the condition left hand side matrix only
+     * @brief This is called during the assembling process in order to calculate the condition left hand side matrix only
      * @param rLeftHandSideMatrix the condition left hand side matrix
      * @param rCurrentProcessInfo the current process info instance
      */
@@ -490,7 +486,12 @@ protected:
         ) override;
 
     /**
-     * Calculates the condition contribution
+     * @brief Calculates the condition contribution
+     * @param rLeftHandSideMatrix the condition left hand side matrix
+     * @param rRightHandSideVector the condition right hand side
+     * @param rCurrentProcessInfo the current process info instance
+     * @param ComputeLHS whether to compute the left hand side
+     * @param ComputeRHS whether to compute the right hand side
      */
     void CalculateConditionSystem(
         MatrixType& rLeftHandSideMatrix,
@@ -501,35 +502,36 @@ protected:
         );
 
     /**
-     * Initialize Contact data
+     * @brief Initializes the DofData object.
+     * @param rDofData the DofData object to be initialized
+     * @tparam TTensor The type of the DoF variables
      */
-    template< const TensorValue TTensor >
+    template<const TensorValue TTensor>
     void InitializeDofData(DofData<TTensor>& rDofData)
     {
-        // Slave element info
-        rDofData.Initialize(GetParentGeometry());
+        // The slave geometry
+        auto& r_slave_geometry = this->GetParentGeometry();
 
-        if constexpr (TTensor == ScalarValue) {
-            for (IndexType i_node = 0; i_node < NumNodes; i_node++) {
-                const double value = GetParentGeometry()[i_node].FastGetSolutionStepValue(*mpDoubleVariables[0]);
-                const double lm = GetParentGeometry()[i_node].FastGetSolutionStepValue(SCALAR_LAGRANGE_MULTIPLIER);
-                rDofData.u1(i_node, 0) = value;
-                rDofData.LagrangeMultipliers(i_node, 0) = lm;
-            }
-        } else {
-            for (IndexType i_node = 0; i_node < NumNodes; i_node++) {
-                const array_1d<double, 3>& value = GetParentGeometry()[i_node].FastGetSolutionStepValue(*mpArray1DVariables[0]);
-                const array_1d<double, 3>& lm = GetParentGeometry()[i_node].FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER);
-                for (IndexType i_dof = 0; i_dof < TDim; i_dof++) {
-                    rDofData.u1(i_node, i_dof) = value[i_dof];
-                    rDofData.LagrangeMultipliers(i_node, i_dof) = lm[i_dof];
-                }
+        // Slave element info
+        rDofData.Initialize(r_slave_geometry);
+
+        // Retrieve values
+        for (IndexType i_node = 0; i_node < TNumNodes; i_node++) {
+            const auto& r_node = r_slave_geometry[i_node];
+            for (IndexType i_dof = 0; i_dof < TTensor; ++i_dof) {
+                rDofData.u1(i_node, i_dof) = r_node.FastGetSolutionStepValue(*mpDoFVariables[i_dof]);
+                rDofData.LagrangeMultipliers(i_node, i_dof) = r_node.FastGetSolutionStepValue(*mpLMVariables[i_dof]);
             }
         }
     }
 
     /**
-     * Calculate Ae matrix
+     * @brief Calculate Ae matrix
+     * @param rNormalMaster The master normal
+     * @param rAe The Ae matrix
+     * @param rVariables The variables
+     * @param rConditionsPointsSlave The conditions points slave
+     * @param ThisIntegrationMethod The integration method
      */
     bool CalculateAe(
         const array_1d<double, 3>& rNormalMaster,
@@ -540,7 +542,14 @@ protected:
         );
 
     /**
-     * Calculate condition kinematics
+     * @brief Calculate condition kinematics
+     * @param rVariables The variables
+     * @param rAe The Ae matrix
+     * @param rNormalMaster The master normal
+     * @param rLocalPointDecomp The local point decomposition
+     * @param rLocalPointParent The local point parent
+     * @param rGeometryDecomp The geometry decomposition
+     * @param rDualLM The dual LM flag
      */
     void CalculateKinematics(
         GeneralVariables& rVariables,
@@ -586,8 +595,11 @@ protected:
     /**************** AUXILLIARY METHODS FOR CONDITION LHS CONTRIBUTION ****************/
     /***********************************************************************************/
 
-    /*
-     * Calculates the values of the shape functions for the master element
+    /**
+     * @brief Calculates the values of the shape functions for the master element
+     * @param rVariables The variables
+     * @param rNormalMaster The master normal
+     * @param rLocalPoint The local point
      */
     void MasterShapeFunctionValue(
         GeneralVariables& rVariables,
@@ -600,9 +612,9 @@ protected:
     /******************************************************************/
 
     /**
-     * It returns theintegration method considered
+     * @brief It returns theintegration method considered
+     * @return The integration method
      */
-
     IntegrationMethod GetIntegrationMethod() const override
     {
         // Setting the auxiliary integration points
@@ -659,17 +671,18 @@ private:
     ///@{
 
     // Serialization
-
     friend class Serializer;
 
     void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, PairedCondition );
+        // TODO
     }
 
     void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, PairedCondition );
+        // TODO
     }
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.h
@@ -74,62 +74,56 @@ public:
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( MeshTyingMortarCondition );
 
     /// Base class definitions
-    typedef PairedCondition                                                               BaseType;
+    using BaseType = PairedCondition;
 
     /// Vector type definition
-    typedef typename BaseType::VectorType                                               VectorType;
+    using VectorType = typename BaseType::VectorType;
 
     /// Matrix type definition
-    typedef typename BaseType::MatrixType                                               MatrixType;
+    using MatrixType = typename BaseType::MatrixType;
 
     /// Index type definition
-    typedef typename BaseType::IndexType                                                 IndexType;
+    using IndexType = typename BaseType::IndexType;
 
     /// Geometry pointer definition
-    typedef typename BaseType::GeometryType::Pointer                           GeometryPointerType;
+    using GeometryPointerType = typename BaseType::GeometryType::Pointer;
 
     /// Nodes array type definition
-    typedef typename BaseType::NodesArrayType                                       NodesArrayType;
+    using NodesArrayType = typename BaseType::NodesArrayType;
 
     /// Properties pointer definition
-    typedef typename BaseType::PropertiesType::Pointer                       PropertiesPointerType;
+    using PropertiesPointerType = typename BaseType::PropertiesType::Pointer;
 
     /// Point definition
-    typedef Point                                                                        PointType;
-
-    /// Node type definition
-    typedef Node                                                                       NodeType;
+    using PointType = Point;
 
     /// Geoemtry type definition
-    typedef Geometry<NodeType>                                                        GeometryType;
+    using GeometryType = Geometry<Node>;
 
     // Type definition for integration methods
-    typedef GeometryType::IntegrationPointsArrayType                         IntegrationPointsType;
+    using IntegrationPointsType = typename GeometryType::IntegrationPointsArrayType;
 
-    // Type definition of the components of an array_1d
-    typedef Variable<double> Array1DComponentsType;
+    using ConditionArrayListType = typename std::vector<array_1d<PointType, TDim>>;
 
-    typedef typename std::vector<array_1d<PointType,TDim>>                  ConditionArrayListType;
+    using LineType = Line2D2<Point>;
 
-    typedef Line2D2<Point>                                                                LineType;
+    using TriangleType = Triangle3D3<Point>;
 
-    typedef Triangle3D3<Point>                                                        TriangleType;
-
-    typedef typename std::conditional<TDim == 2, LineType, TriangleType >::type  DecompositionType;
+    using DecompositionType = typename std::conditional<TDim == 2, LineType, TriangleType>::type;
 
     static constexpr SizeType NumNodes = (TNumNodesElem == 3 || (TDim == 2 && TNumNodesElem == 4)) ? 2 : TNumNodesElem == 4 ? 3 : 4;
 
     static constexpr SizeType NumNodesMaster = (TNumNodesElemMaster == 3 || (TDim == 2 && TNumNodesElemMaster == 4)) ? 2 : TNumNodesElemMaster == 4 ? 3 : 4;
 
-    typedef BoundedMatrix<double, NumNodes, NumNodes>                                  MatrixDualLM;
+    using MatrixDualLM = BoundedMatrix<double, NumNodes, NumNodes>;
 
-    typedef MortarKinematicVariables<NumNodes, NumNodesMaster>                     GeneralVariables;
+    using GeneralVariables = MortarKinematicVariables<NumNodes, NumNodesMaster>;
 
-    typedef DualLagrangeMultiplierOperators<NumNodes, NumNodesMaster>                        AeData;
+    using AeData = DualLagrangeMultiplierOperators<NumNodes, NumNodesMaster>;
 
-    typedef MortarOperator<NumNodes, NumNodesMaster>                        MortarConditionMatrices;
+    using MortarConditionMatrices = MortarOperator<NumNodes, NumNodesMaster>;
 
-    typedef ExactMortarIntegrationUtility<TDim, NumNodes, false, NumNodesMaster> IntegrationUtility;
+    using IntegrationUtility = ExactMortarIntegrationUtility<TDim, NumNodes, false, NumNodesMaster>;
 
     // The threshold coefficient considered for checking
     static constexpr double CheckThresholdCoefficient = 1.0e-12;

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/alm_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/alm_contact_process.py
@@ -349,22 +349,6 @@ class ALMContactProcess(search_base_process.SearchBaseProcess):
 
         return condition_name
 
-    def _get_final_string(self, key = "0"):
-        """ This method returns the final string of the condition name
-
-        Keyword arguments:
-        self -- It signifies an instance of a class.
-        key -- The key to identify the current pair
-        """
-        # Determine the geometry of the element
-        super()._get_final_string(key)
-        # We compute the number of nodes of the conditions
-        number_nodes, number_nodes_master = super()._compute_number_nodes()
-        if number_nodes != number_nodes_master:
-            return str(number_nodes_master) + "N"
-        else:
-            return ""
-
     def _get_problem_name(self):
         """ This method returns the problem name to be solved
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/mesh_tying_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/mesh_tying_process.py
@@ -180,15 +180,12 @@ class MeshTyingProcess(search_base_process.SearchBaseProcess):
         """
         # Determine the geometry of the element
         super()._get_final_string(key)
-        number_nodes, number_nodes_master = self._compute_number_nodes_elements()
-        geometry_element = self.__type_element(number_nodes)
-        geometry_element_master = self.__type_element(number_nodes_master)
         # We compute the number of nodes of the conditions
         number_nodes, number_nodes_master = super()._compute_number_nodes()
         if number_nodes != number_nodes_master:
-            return geometry_element + str(number_nodes_master) + "N" + geometry_element_master
+            return str(number_nodes_master) + "N"
         else:
-            return geometry_element
+            return ""
 
     def _initialize_search_conditions(self):
         """ This method initializes some conditions values
@@ -218,49 +215,3 @@ class MeshTyingProcess(search_base_process.SearchBaseProcess):
 
         # Setting the conditions
         KM.VariableUtils().SetNonHistoricalVariable(KM.NORMAL, zero_vector, self._get_process_model_part().Conditions)
-
-    def _compute_number_nodes_elements(self):
-        """ This method computes the  number of nodes per element
-
-        Keyword arguments:
-        self -- It signifies an instance of a class.
-        """
-        # We compute the number of nodes of the geometry
-        if self.predefined_master_slave and self.dimension == 3:
-            slave_defined = False
-            master_defined = False
-            for elem in self.main_model_part.Elements:
-                nodes = elem.GetNodes()
-                for node in nodes:
-                    if node.Is(KM.SLAVE):
-                        number_nodes = len(elem.GetNodes())
-                        slave_defined = True
-                    if node.Is(KM.MASTER):
-                        number_nodes_master = len(elem.GetNodes())
-                        master_defined = True
-                if slave_defined and master_defined:
-                    break
-        else:
-            number_nodes = len(self.main_model_part.Elements[1].GetNodes())
-            number_nodes_master = number_nodes
-
-        return number_nodes, number_nodes_master
-
-    def __type_element(self, number_nodes):
-        """ This method computes the type of element considered
-
-        Keyword arguments:
-        self -- It signifies an instance of a class.
-        number_nodes -- The number of nodes of the element
-        """
-
-        if self.dimension == 2:
-            if number_nodes == 3:
-                return "Triangle"
-            elif number_nodes == 4:
-                return "Quadrilateral"
-        else:
-            if number_nodes == 4:
-                return "Tetrahedron"
-            elif number_nodes == 8:
-                return "Hexahedron"

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/mesh_tying_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/mesh_tying_process.py
@@ -171,22 +171,6 @@ class MeshTyingProcess(search_base_process.SearchBaseProcess):
         # We define the condition name to be used
         return "MeshTyingMortar"
 
-    def _get_final_string(self, key = "0"):
-        """ This method returns the final string of the condition name
-
-        Keyword arguments:
-        self -- It signifies an instance of a class.
-        key -- The key to identify the current pair
-        """
-        # Determine the geometry of the element
-        super()._get_final_string(key)
-        # We compute the number of nodes of the conditions
-        number_nodes, number_nodes_master = super()._compute_number_nodes()
-        if number_nodes != number_nodes_master:
-            return str(number_nodes_master) + "N"
-        else:
-            return ""
-
     def _initialize_search_conditions(self):
         """ This method initializes some conditions values
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/mesh_tying_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/mesh_tying_process.py
@@ -46,7 +46,7 @@ class MeshTyingProcess(search_base_process.SearchBaseProcess):
             "variable_name"               : "DISPLACEMENT",
             "zero_tolerance_factor"       : 1.0,
             "integration_order"           : 2,
-            "consider_tessellation"       : false,
+            "consider_tessellation"       : true,
             "normal_check_proportion"     : 0.1,
             "search_parameters" : {
                 "type_search"                 : "in_radius_with_obb",

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/mpc_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/mpc_contact_process.py
@@ -314,22 +314,6 @@ class MPCContactProcess(search_base_process.SearchBaseProcess):
 
         return condition_name
 
-    def _get_final_string(self, key = "0"):
-        """ This method returns the final string of the condition name
-
-        Keyword arguments:
-        self -- It signifies an instance of a class.
-        key -- The key to identify the current pair
-        """
-        # Determine the geometry of the element
-        super()._get_final_string(key)
-        # We compute the number of nodes of the conditions
-        number_nodes, number_nodes_master = super()._compute_number_nodes()
-        if number_nodes != number_nodes_master:
-            return str(number_nodes_master) + "N"
-        else:
-            return ""
-
     def _get_problem_name(self):
         """ This method returns the problem name to be solved
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/search_base_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/search_base_process.py
@@ -310,8 +310,14 @@ class SearchBaseProcess(KM.Process):
         self -- It signifies an instance of a class.
         key -- The key to identify the current pair
         """
+        # Determine the geometry of the element
         self.__assume_master_slave(key)
-        return ""
+        # We compute the number of nodes of the conditions
+        number_nodes, number_nodes_master = self._compute_number_nodes()
+        if number_nodes != number_nodes_master:
+            return str(number_nodes_master) + "N"
+        else:
+            return ""
 
     def _get_problem_name(self):
         """ This method returns the problem name to be solved

--- a/applications/ContactStructuralMechanicsApplication/symbolic_generation/mesh_tying_mortar_condition/generate_mesh_tying_mortar_condition.py
+++ b/applications/ContactStructuralMechanicsApplication/symbolic_generation/mesh_tying_mortar_condition/generate_mesh_tying_mortar_condition.py
@@ -13,18 +13,18 @@ mode = "c" #to output to a c++ file
 impose_partion_of_unity = False
 
 dim_combinations = [2,2,2,2,3,3,3,3,3,3,3,3]
-nnodeselement_combinations = [3,3,4,4,4,4,8,8,4,4,8,8]
-nnodeselement_master_combinations = [3,3,4,4,4,4,8,8,8,8,4,4]
+nnodeselement_combinations = [2,2,3,3,4,4,3,3,4,4]
+nnodeselement_master_combinations = [2,2,3,3,4,4,4,4,3,3]
 tensor_combinations = [1,2,1,2,1,3,1,3,1,3,1,3]
 
 lhs_string = ""
-lhs_template_begin_string = "\n/***********************************************************************************/\n/***********************************************************************************/\n\ntemplate< >\ntemplate< >\nvoid MeshTyingMortarCondition<TDim,TNumNodesElem,TNumNodesElemMaster>::CalculateLocalLHS<MeshTyingMortarCondition<TDim,TNumNodesElem,TNumNodesElemMaster>::TTensor>(\n    Matrix& rLocalLHS,\n    const MortarConditionMatrices& rMortarConditionMatrices,\n    const DofData<TTensor>& rDofData\n    )\n{\n    // We get the mortar operators\n    const BoundedMatrix<double, NumNodes, NumNodesMaster>& MOperator = rMortarConditionMatrices.MOperator;\n    const BoundedMatrix<double, NumNodes, NumNodes>& DOperator = rMortarConditionMatrices.DOperator;\n\n"
+lhs_template_begin_string = "\n/***********************************************************************************/\n/***********************************************************************************/\n\ntemplate< >\ntemplate< >\nvoid MeshTyingMortarCondition<TDim,TNumNodesElem,TNumNodesElemMaster>::CalculateLocalLHS<MeshTyingMortarCondition<TDim,TNumNodesElem,TNumNodesElemMaster>::TTensor>(\n    Matrix& rLocalLHS,\n    const MortarConditionMatrices& rMortarConditionMatrices,\n    const DofData<TTensor>& rDofData\n    )\n{\n    // We get the mortar operators\n    const BoundedMatrix<double, TNumNodes, TNumNodesMaster>& MOperator = rMortarConditionMatrices.MOperator;\n    const BoundedMatrix<double, TNumNodes, TNumNodes>& DOperator = rMortarConditionMatrices.DOperator;\n"
 
 lhs_template_end_string = "\n}\n"
 
 rhs_string = ""
 
-rhs_template_begin_string = "\n/***********************************************************************************/\n/***********************************************************************************/\n\ntemplate<>\ntemplate<>\nvoid MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::CalculateLocalRHS<MeshTyingMortarCondition<TDim,TNumNodesElem,TNumNodesElemMaster>::TTensor>(\n    Vector& rLocalRHS,\n    const MortarConditionMatrices& rMortarConditionMatrices,\n    const DofData<TTensor>& rDofData\n    )\n{\n    // Initialize values\n    const BoundedMatrix<double, NumNodes, TTensor> u1 = rDofData.u1;\n    const BoundedMatrix<double, NumNodesMaster, TTensor> u2 = rDofData.u2;\n\n    const BoundedMatrix<double, NumNodes, TTensor> lm = rDofData.LagrangeMultipliers; \n\n    // Mortar operators\n    const BoundedMatrix<double, NumNodes, NumNodesMaster>& MOperator = rMortarConditionMatrices.MOperator;\n    const BoundedMatrix<double, NumNodes, NumNodes>& DOperator = rMortarConditionMatrices.DOperator;\n\n"
+rhs_template_begin_string = "\n/***********************************************************************************/\n/***********************************************************************************/\n\ntemplate<>\ntemplate<>\nvoid MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::CalculateLocalRHS<MeshTyingMortarCondition<TDim,TNumNodesElem,TNumNodesElemMaster>::TTensor>(\n    Vector& rLocalRHS,\n    const MortarConditionMatrices& rMortarConditionMatrices,\n    const DofData<TTensor>& rDofData\n    )\n{\n    // Initialize values\n    const BoundedMatrix<double, TNumNodes, TTensor> u1 = rDofData.u1;\n    const BoundedMatrix<double, TNumNodesMaster, TTensor> u2 = rDofData.u2;\n\n    const BoundedMatrix<double, TNumNodes, TTensor> lm = rDofData.LagrangeMultipliers; \n\n    // Mortar operators\n    const BoundedMatrix<double, TNumNodes, TNumNodesMaster>& MOperator = rMortarConditionMatrices.MOperator;\n    const BoundedMatrix<double, TNumNodes, TNumNodes>& DOperator = rMortarConditionMatrices.DOperator;\n"
 
 rhs_template_end_string = "\n}\n"
 
@@ -136,8 +136,8 @@ for dim, nnodeselement, nnodeselement_master, tensor in zip(dim_combinations, nn
         lhs_string = lhs_string.replace("TTensor", "Vector2DValue")
     elif (tensor == 3):
         lhs_string = lhs_string.replace("TTensor", "Vector3DValue")
-    lhs_string = lhs_string.replace("NumNodesMaster", str(nnodes_master))
-    lhs_string = lhs_string.replace("NumNodes", str(nnodes))
+    lhs_string = lhs_string.replace("TNumNodesMaster", str(nnodes_master))
+    lhs_string = lhs_string.replace("TNumNodes", str(nnodes))
     lhs_string = lhs_string.replace("MatrixSize", str(lhs.shape[0]))
 
     rhs_string = rhs_string.replace("TDim", str(dim))
@@ -149,8 +149,8 @@ for dim, nnodeselement, nnodeselement_master, tensor in zip(dim_combinations, nn
         rhs_string = rhs_string.replace("TTensor", "Vector2DValue")
     elif (tensor == 3):
         rhs_string = rhs_string.replace("TTensor", "Vector3DValue")
-    rhs_string = rhs_string.replace("NumNodesMaster", str(nnodes_master))
-    rhs_string = rhs_string.replace("NumNodes", str(nnodes))
+    rhs_string = rhs_string.replace("TNumNodesMaster", str(nnodes_master))
+    rhs_string = rhs_string.replace("TNumNodes", str(nnodes))
     rhs_string = rhs_string.replace("MatrixSize", str(rhs.shape[0]))
     lhs_string = lhs_string.replace("lhs(", "rLocalLHS(")
     rhs_string = rhs_string.replace("rhs[", "rLocalRHS[")

--- a/applications/ContactStructuralMechanicsApplication/tests/test_ContactStructuralMechanicsApplication.py
+++ b/applications/ContactStructuralMechanicsApplication/tests/test_ContactStructuralMechanicsApplication.py
@@ -189,234 +189,236 @@ def AssembleTestSuites():
     '''
     suites = KratosUnittest.KratosSuites
 
+    # If defined manually, for debugging
+    manual_tests = False
+
     # Create a test suit with the selected tests (Small tests):
     smallSuite = suites['small']
 
     # Create a test suit with the selected tests plus all small tests
     nightlySuite = suites['nightly']
 
-    ### BEGIN SMALL SUITE ###
-
-    # Test ProcessFactoryUtility
-    smallSuite.addTest(TTestProcessFactory('test_process_factory'))
-    smallSuite.addTest(TTestProcessFactory('test_processes_list_factory'))
-
-    # Test normal check
-    smallSuite.addTest(TTestCheckNormals('test_check_normals'))
-    smallSuite.addTest(TTestCheckNormals('test_check_normals_quads'))
-
-    # Mesh tying tests
-    smallSuite.addTest(TSimplePatchTestTwoDMeshTying('test_execution'))
-    smallSuite.addTest(TSimpleSlopePatchTestTwoDMeshTying('test_execution'))
-    smallSuite.addTest(TSimplestPatchTestThreeDMeshTying('test_execution'))
-
-    # ALM frictionless tests
-    smallSuite.addTest(TALMHyperSimplePatchTestContact('test_execution'))
-    smallSuite.addTest(TALMHyperSimplePatchTrianglesTestContact('test_execution'))
-    smallSuite.addTest(TALMHyperSimplePatchTestWithEliminationContact('test_execution'))
-    smallSuite.addTest(TALMHyperSimplePatchTestWithEliminationWithConstraintContact('test_execution'))
-    smallSuite.addTest(TALMHyperSimpleSlopePatchTestContact('test_execution'))
-    if has_CL_application:
-        smallSuite.addTest(TALMThreeDSimplestPatchMatchingTestContact('test_execution'))
-
-    # Penalty frictionless tests
-    smallSuite.addTest(TPenaltyFrictionlessHyperSimplePatchTestContact('test_execution'))
-    if has_CL_application:
-        smallSuite.addTest(TPenaltyThreeDSimplestPatchMatchingTestContact('test_execution'))
-
-    # Components ALM frictionless tests
-    smallSuite.addTest(TComponentsALMHyperSimpleTrianglePatchTestContact('test_execution'))
-    smallSuite.addTest(TComponentsALMHyperSimplePatchTestContact('test_execution'))
-    smallSuite.addTest(TComponentsALMHyperSimplePatchTestWithEliminationContact('test_execution'))
-    smallSuite.addTest(TComponentsALMHyperSimplePatchTestWithEliminationWithConstraintContact('test_execution'))
-    smallSuite.addTest(TComponentsALMHyperSimpleSlopePatchTestContact('test_execution'))
-    if has_CL_application:
-        smallSuite.addTest(TComponentsALMThreeDSimplestPatchMatchingTestContact('test_execution'))
-
-    # ALM frictional tests
-    smallSuite.addTest(TALMHyperSimplePatchFrictionalTestContact('test_execution'))
-    smallSuite.addTest(TALMNoFrictionHyperSimplePatchFrictionalTestContact('test_execution'))
-    smallSuite.addTest(TALMPerfectStickHyperSimplePatchFrictionalTestContact('test_execution'))
-    smallSuite.addTest(TALMThresholdSlipHyperSimplePatchFrictionalTestContact('test_execution'))
-    smallSuite.addTest(TALMHyperSimplePatchFrictionalSlipTestContact('test_execution'))
-    smallSuite.addTest(TALMHyperSimplePatchFrictionalStickTestContact('test_execution'))
-
-    # Penalty frictional tests
-    smallSuite.addTest(TPenaltyNoFrictionHyperSimplePatchFrictionalTestContact('test_execution'))
-    smallSuite.addTest(TPenaltyPerfectStickHyperSimplePatchFrictionalTestContact('test_execution'))
-    smallSuite.addTest(TPenaltyThresholdSlipHyperSimplePatchFrictionalTestContact('test_execution'))
-    smallSuite.addTest(TPenaltyHyperSimplePatchFrictionalSlipTestContact('test_execution'))
-    smallSuite.addTest(TPenaltyHyperSimplePatchFrictionalStickTestContact('test_execution'))
-
-    # MPC contact test
-    smallSuite.addTest(TTwoDSimplestPatchMatchingTestContact('test_execution'))
-    smallSuite.addTest(TTwoDSimplestWithFrictionPatchMatchingTestContact('test_execution'))
-    if has_CL_application:
-        smallSuite.addTest(TThreeDSimplestPatchMatchingTestContact('test_execution'))
-        smallSuite.addTest(TThreeDSimplestWithFrictionPatchMatchingTestContact('test_execution'))
-    smallSuite.addTest(TThreeDSimplestPatchMatchingSlopeTestContact('test_execution'))
-    smallSuite.addTest(TThreeDPatchMatchingTestContact('test_execution'))
-    smallSuite.addTest(TThreeDPatchNotMatchingTestContact('test_execution'))
-
-    ### END SMALL SUITE ###
-
-    ### BEGIN NIGHTLY SUITE ###
-
-    # Fill with all small tests
-    nightlySuite.addTests(smallSuite)
-
-    # Test normal check
-    nightlySuite.addTest(TTestCheckNormals('test_check_normals_s_shape'))
-
-    # Exact integration tests
-    nightlySuite.addTest(TTestDoubleCurvatureIntegration('test_moving_mesh_integration_quad'))
-
-    # Mortar mapping
-    nightlySuite.addTest(TTestMortarMapperCore('test_less_basic_mortar_mapping_triangle'))
-    nightlySuite.addTest(TTestMortarMapperCore('test_simple_curvature_mortar_mapping_triangle'))
-
-    # Mesh tying tests
-    nightlySuite.addTest(TSimplestPatchTestThreeDTriQuadMeshTying('test_execution'))
-    nightlySuite.addTest(TSimplestPatchTestThreeDQuadTriMeshTying('test_execution'))
-    nightlySuite.addTest(TSimplePatchTestThreeDMeshTying('test_execution'))
-
-    # ALM frictionless tests
-    nightlySuite.addTest(TALMTwoDPatchComplexGeomTestContact('test_execution'))
-    nightlySuite.addTest(TALMTwoDPatchComplexGeomSlopeTestContact('test_execution'))
-    nightlySuite.addTest(TALMSimplePatchTestContact('test_execution'))
-    nightlySuite.addTest(TALMSimpleSlopePatchTestContact('test_execution'))
-    nightlySuite.addTest(TALMSimplePatchNotMatchingATestContact('test_execution'))
-    nightlySuite.addTest(TALMSimplePatchNotMatchingBTestContact('test_execution'))
-    if has_CL_application:
-        nightlySuite.addTest(TALMThreeDSimplestPatchTestTriQuadContact('test_execution'))
-        nightlySuite.addTest(TALMThreeDSimplestPatchTestQuadTriContact('test_execution'))
-        nightlySuite.addTest(TALMThreeDSimplestPatchMatchingAdaptativeTestContact('test_execution'))
-    nightlySuite.addTest(TALMThreeDSimplestPatchMatchingSlopeTestContact('test_execution'))
-    nightlySuite.addTest(TALMThreeDPatchComplexGeomTestContact('test_execution'))
-    nightlySuite.addTest(TALMTThreeDPatchMatchingTestContact('test_execution'))
-    nightlySuite.addTest(TALMThreeDPatchNotMatchingTestContact('test_execution'))
-    nightlySuite.addTest(TALMTaylorPatchTestContact('test_execution'))
-    nightlySuite.addTest(TALMHertzSimpleSphereTestContact('test_execution'))
-    nightlySuite.addTest(TALMBeamsTestContact('test_execution'))
-
-    # Components ALM frictionless tests
-    nightlySuite.addTest(TComponentsALMTwoDPatchComplexGeomTestContact('test_execution'))
-    nightlySuite.addTest(TComponentsALMTwoDPatchComplexGeomSlopeTestContact('test_execution'))
-    nightlySuite.addTest(TComponentsALMSimplePatchTestContact('test_execution'))
-    nightlySuite.addTest(TComponentsALMSimpleSlopePatchTestContact('test_execution'))
-    nightlySuite.addTest(TComponentsALMSimplePatchNotMatchingATestContact('test_execution'))
-    nightlySuite.addTest(TComponentsALMSimplePatchNotMatchingBTestContact('test_execution'))
-    if has_CL_application:
-        nightlySuite.addTest(TComponentsALMThreeDSimplestPatchTestTriQuadContact('test_execution'))
-        nightlySuite.addTest(TComponentsALMThreeDSimplestPatchTestQuadTriContact('test_execution'))
-        nightlySuite.addTest(TComponentsALMThreeDSimplestPatchMatchingAdaptativeTestContact('test_execution'))
-    nightlySuite.addTest(TComponentsALMThreeDSimplestPatchMatchingSlopeTestContact('test_execution'))
-    nightlySuite.addTest(TComponentsALMThreeDPatchComplexGeomTestContact('test_execution'))
-    nightlySuite.addTest(TComponentsALMTThreeDPatchMatchingTestContact('test_execution'))
-    nightlySuite.addTest(TComponentsALMThreeDPatchNotMatchingTestContact('test_execution'))
-    nightlySuite.addTest(TComponentsALMTaylorPatchTestContact('test_execution'))
-    nightlySuite.addTest(TComponentsALMHertzSimpleSphereTestContact('test_execution'))
-    nightlySuite.addTest(TComponentsALMBeamsTestContact('test_execution'))
-
-    # ALM frictional tests
-    nightlySuite.addTest(TALMPureFrictionalTestContact('test_execution'))
-    nightlySuite.addTest(TALMBasicFrictionTestContact('test_execution'))
-    nightlySuite.addTest(TALMStaticEvolutionLoadFrictionTestContact('test_execution'))
-
-    # MPC contact test
-    nightlySuite.addTest(TBeamAxilSimpleContactTest('test_execution'))
-    nightlySuite.addTest(TBeamContactTest('test_execution'))
-    nightlySuite.addTest(TBeamContactWithTyingTest('test_execution'))
-    nightlySuite.addTest(TBeamContactWithFrictionTest('test_execution'))
-
-    ### END VALIDATION SUITE ###
-
-    ### BEGIN VALIDATION SUITE ###
-
-    # For very long tests that should not be in nighly and you can use to validate
-    validationSuite = suites['validation']
-    validationSuite.addTests(nightlySuite)
-
-    # ALM frictionless tests
-    #nightlySuite.addTest(TALMHertzSphereTestContact('test_execution'))
-    validationSuite.addTest(TALMHertzSimpleTestContact('test_execution'))
-    validationSuite.addTest(TALMHertzCompleteTestContact('test_execution'))
-
-    # Components ALM frictionless tests
-    #nightlySuite.addTest(TComponentsALMHertzSphereTestContact('test_execution'))
-    validationSuite.addTest(TComponentsALMHertzSimpleTestContact('test_execution'))
-    validationSuite.addTest(TComponentsALMHertzCompleteTestContact('test_execution'))
-
-    # Penalty frictionless tests
-    if has_CL_application:
-        validationSuite.addTest(TExplicitPenaltyThreeDSimplestPatchMatchingTestContact('test_execution'))
-
-    # Exact integration tests
-    validationSuite.addTest(TTestDoubleCurvatureIntegration('test_double_curvature_integration_triangle'))
-    validationSuite.addTest(TTestDoubleCurvatureIntegration('test_double_curvature_integration_quad'))
-    validationSuite.addTest(TTestDoubleCurvatureIntegration('test_moving_mesh_integration_quad'))
-
-    # Dynamic search
-    validationSuite.addTest(TTestDynamicSearch('test_dynamic_search_triangle'))
-    validationSuite.addTest(TTestDynamicSearch('test_dynamic_search_quad'))
-
-    # Mortar mapping
-    validationSuite.addTest(TTestMortarMapperCore('test_mortar_mapping_triangle'))
-    validationSuite.addTest(TTestMortarMapperCore('test_mortar_mapping_quad'))
-
-    # Some large displacement tests
-    if has_CL_application:
-        validationSuite.addTest(TLargeDisplacementPatchTestHexa('test_execution'))
-        validationSuite.addTest(TMeshTyingValidationTest('test_execution'))
-
-    # ALM frictionless tests
-    validationSuite.addTest(TALMTaylorPatchDynamicTestContact('test_execution'))
-    validationSuite.addTest(TALMMeshMovingMatchingTestContact('test_execution'))
-    validationSuite.addTest(TALMMeshMovingNotMatchingTestContact('test_execution'))
-    #validationSuite.addTest(TALMIroningTestContact('test_execution'))
-    #validationSuite.addTest(TALMIroningDieTestContact('test_execution'))
-    if has_CL_application:
-        validationSuite.addTest(TALMLargeDisplacementPatchTestTetra('test_execution'))
-        validationSuite.addTest(TALMLargeDisplacementPatchTestHexa('test_execution'))
-    validationSuite.addTest(TALMMultiLayerContactTest('test_execution'))
-    validationSuite.addTest(TALMSelfContactContactTest('test_execution'))
-
-    # Components ALM frictionless tests
-    validationSuite.addTest(TComponentsALMTaylorPatchDynamicTestContact('test_execution'))
-    validationSuite.addTest(TComponentsALMMeshMovingMatchingTestContact('test_execution'))
-    validationSuite.addTest(TComponentsALMMeshMovingNotMatchingTestContact('test_execution'))
-    if has_CL_application:
-        validationSuite.addTest(TComponentsALMLargeDisplacementPatchTestTetra('test_execution'))
-        validationSuite.addTest(TComponentsALMLargeDisplacementPatchTestHexa('test_execution'))
-    validationSuite.addTest(TComponentsALMMultiLayerContactTest('test_execution'))
-    validationSuite.addTest(TComponentsALMSelfContactContactTest('test_execution'))
-
-    # ALM frictional tests
-    validationSuite.addTest(TALMEvolutionLoadFrictionTestContact('test_execution'))
-    validationSuite.addTest(TALMTaylorPatchFrictionalTestContact('test_execution'))
-    validationSuite.addTest(TALMMeshMovingMatchingTestFrictionalPureSlipContact('test_execution'))
-    validationSuite.addTest(TALMMeshMovingNotMatchingTestFrictionalPureSlipContact('test_execution'))
-    if has_CL_application:
-        validationSuite.addTest(TALMHertzTestFrictionalContact('test_execution'))
-        validationSuite.addTest(TALMBlockTestFrictionalContact('test_execution'))
-
-    # MPC contact test
-    validationSuite.addTest(TBeamAxilContactTest('test_execution'))
-    validationSuite.addTest(TBeamAxilTetraContactTest('test_execution'))
-    validationSuite.addTest(TPlateTest('test_execution'))
-    #validationSuite.addTest(TMultiLayerContactTest('test_execution'))
-
-    ### END VALIDATION ###
-
-    # Create a test suit that contains all the tests:
-    allSuite = suites['all']
-    manual_tests = False
+    # Not manual tests
     if not manual_tests:
-      allSuite.addTests(nightlySuite) # Already contains the smallSuite
-      validationSuite.addTests(allSuite) # Validation contains all
-    else:
-      ## Manual list for debugging
-      allSuite.addTests(
+        ### BEGIN SMALL SUITE ###
+
+        # Test ProcessFactoryUtility
+        smallSuite.addTest(TTestProcessFactory('test_process_factory'))
+        smallSuite.addTest(TTestProcessFactory('test_processes_list_factory'))
+
+        # Test normal check
+        smallSuite.addTest(TTestCheckNormals('test_check_normals'))
+        smallSuite.addTest(TTestCheckNormals('test_check_normals_quads'))
+
+        # Mesh tying tests
+        smallSuite.addTest(TSimplePatchTestTwoDMeshTying('test_execution'))
+        smallSuite.addTest(TSimpleSlopePatchTestTwoDMeshTying('test_execution'))
+        smallSuite.addTest(TSimplestPatchTestThreeDMeshTying('test_execution'))
+
+        # ALM frictionless tests
+        smallSuite.addTest(TALMHyperSimplePatchTestContact('test_execution'))
+        smallSuite.addTest(TALMHyperSimplePatchTrianglesTestContact('test_execution'))
+        smallSuite.addTest(TALMHyperSimplePatchTestWithEliminationContact('test_execution'))
+        smallSuite.addTest(TALMHyperSimplePatchTestWithEliminationWithConstraintContact('test_execution'))
+        smallSuite.addTest(TALMHyperSimpleSlopePatchTestContact('test_execution'))
+        if has_CL_application:
+            smallSuite.addTest(TALMThreeDSimplestPatchMatchingTestContact('test_execution'))
+
+        # Penalty frictionless tests
+        smallSuite.addTest(TPenaltyFrictionlessHyperSimplePatchTestContact('test_execution'))
+        if has_CL_application:
+            smallSuite.addTest(TPenaltyThreeDSimplestPatchMatchingTestContact('test_execution'))
+
+        # Components ALM frictionless tests
+        smallSuite.addTest(TComponentsALMHyperSimpleTrianglePatchTestContact('test_execution'))
+        smallSuite.addTest(TComponentsALMHyperSimplePatchTestContact('test_execution'))
+        smallSuite.addTest(TComponentsALMHyperSimplePatchTestWithEliminationContact('test_execution'))
+        smallSuite.addTest(TComponentsALMHyperSimplePatchTestWithEliminationWithConstraintContact('test_execution'))
+        smallSuite.addTest(TComponentsALMHyperSimpleSlopePatchTestContact('test_execution'))
+        if has_CL_application:
+            smallSuite.addTest(TComponentsALMThreeDSimplestPatchMatchingTestContact('test_execution'))
+
+        # ALM frictional tests
+        smallSuite.addTest(TALMHyperSimplePatchFrictionalTestContact('test_execution'))
+        smallSuite.addTest(TALMNoFrictionHyperSimplePatchFrictionalTestContact('test_execution'))
+        smallSuite.addTest(TALMPerfectStickHyperSimplePatchFrictionalTestContact('test_execution'))
+        smallSuite.addTest(TALMThresholdSlipHyperSimplePatchFrictionalTestContact('test_execution'))
+        smallSuite.addTest(TALMHyperSimplePatchFrictionalSlipTestContact('test_execution'))
+        smallSuite.addTest(TALMHyperSimplePatchFrictionalStickTestContact('test_execution'))
+
+        # Penalty frictional tests
+        smallSuite.addTest(TPenaltyNoFrictionHyperSimplePatchFrictionalTestContact('test_execution'))
+        smallSuite.addTest(TPenaltyPerfectStickHyperSimplePatchFrictionalTestContact('test_execution'))
+        smallSuite.addTest(TPenaltyThresholdSlipHyperSimplePatchFrictionalTestContact('test_execution'))
+        smallSuite.addTest(TPenaltyHyperSimplePatchFrictionalSlipTestContact('test_execution'))
+        smallSuite.addTest(TPenaltyHyperSimplePatchFrictionalStickTestContact('test_execution'))
+
+        # MPC contact test
+        smallSuite.addTest(TTwoDSimplestPatchMatchingTestContact('test_execution'))
+        smallSuite.addTest(TTwoDSimplestWithFrictionPatchMatchingTestContact('test_execution'))
+        if has_CL_application:
+            smallSuite.addTest(TThreeDSimplestPatchMatchingTestContact('test_execution'))
+            smallSuite.addTest(TThreeDSimplestWithFrictionPatchMatchingTestContact('test_execution'))
+        smallSuite.addTest(TThreeDSimplestPatchMatchingSlopeTestContact('test_execution'))
+        smallSuite.addTest(TThreeDPatchMatchingTestContact('test_execution'))
+        smallSuite.addTest(TThreeDPatchNotMatchingTestContact('test_execution'))
+
+        ### END SMALL SUITE ###
+
+        ### BEGIN NIGHTLY SUITE ###
+
+        # Fill with all small tests
+        nightlySuite.addTests(smallSuite)
+
+        # Test normal check
+        nightlySuite.addTest(TTestCheckNormals('test_check_normals_s_shape'))
+
+        # Exact integration tests
+        nightlySuite.addTest(TTestDoubleCurvatureIntegration('test_moving_mesh_integration_quad'))
+
+        # Mortar mapping
+        nightlySuite.addTest(TTestMortarMapperCore('test_less_basic_mortar_mapping_triangle'))
+        nightlySuite.addTest(TTestMortarMapperCore('test_simple_curvature_mortar_mapping_triangle'))
+
+        # Mesh tying tests
+        nightlySuite.addTest(TSimplestPatchTestThreeDTriQuadMeshTying('test_execution'))
+        nightlySuite.addTest(TSimplestPatchTestThreeDQuadTriMeshTying('test_execution'))
+        nightlySuite.addTest(TSimplePatchTestThreeDMeshTying('test_execution'))
+
+        # ALM frictionless tests
+        nightlySuite.addTest(TALMTwoDPatchComplexGeomTestContact('test_execution'))
+        nightlySuite.addTest(TALMTwoDPatchComplexGeomSlopeTestContact('test_execution'))
+        nightlySuite.addTest(TALMSimplePatchTestContact('test_execution'))
+        nightlySuite.addTest(TALMSimpleSlopePatchTestContact('test_execution'))
+        nightlySuite.addTest(TALMSimplePatchNotMatchingATestContact('test_execution'))
+        nightlySuite.addTest(TALMSimplePatchNotMatchingBTestContact('test_execution'))
+        if has_CL_application:
+            nightlySuite.addTest(TALMThreeDSimplestPatchTestTriQuadContact('test_execution'))
+            nightlySuite.addTest(TALMThreeDSimplestPatchTestQuadTriContact('test_execution'))
+            nightlySuite.addTest(TALMThreeDSimplestPatchMatchingAdaptativeTestContact('test_execution'))
+        nightlySuite.addTest(TALMThreeDSimplestPatchMatchingSlopeTestContact('test_execution'))
+        nightlySuite.addTest(TALMThreeDPatchComplexGeomTestContact('test_execution'))
+        nightlySuite.addTest(TALMTThreeDPatchMatchingTestContact('test_execution'))
+        nightlySuite.addTest(TALMThreeDPatchNotMatchingTestContact('test_execution'))
+        nightlySuite.addTest(TALMTaylorPatchTestContact('test_execution'))
+        nightlySuite.addTest(TALMHertzSimpleSphereTestContact('test_execution'))
+        nightlySuite.addTest(TALMBeamsTestContact('test_execution'))
+
+        # Components ALM frictionless tests
+        nightlySuite.addTest(TComponentsALMTwoDPatchComplexGeomTestContact('test_execution'))
+        nightlySuite.addTest(TComponentsALMTwoDPatchComplexGeomSlopeTestContact('test_execution'))
+        nightlySuite.addTest(TComponentsALMSimplePatchTestContact('test_execution'))
+        nightlySuite.addTest(TComponentsALMSimpleSlopePatchTestContact('test_execution'))
+        nightlySuite.addTest(TComponentsALMSimplePatchNotMatchingATestContact('test_execution'))
+        nightlySuite.addTest(TComponentsALMSimplePatchNotMatchingBTestContact('test_execution'))
+        if has_CL_application:
+            nightlySuite.addTest(TComponentsALMThreeDSimplestPatchTestTriQuadContact('test_execution'))
+            nightlySuite.addTest(TComponentsALMThreeDSimplestPatchTestQuadTriContact('test_execution'))
+            nightlySuite.addTest(TComponentsALMThreeDSimplestPatchMatchingAdaptativeTestContact('test_execution'))
+        nightlySuite.addTest(TComponentsALMThreeDSimplestPatchMatchingSlopeTestContact('test_execution'))
+        nightlySuite.addTest(TComponentsALMThreeDPatchComplexGeomTestContact('test_execution'))
+        nightlySuite.addTest(TComponentsALMTThreeDPatchMatchingTestContact('test_execution'))
+        nightlySuite.addTest(TComponentsALMThreeDPatchNotMatchingTestContact('test_execution'))
+        nightlySuite.addTest(TComponentsALMTaylorPatchTestContact('test_execution'))
+        nightlySuite.addTest(TComponentsALMHertzSimpleSphereTestContact('test_execution'))
+        nightlySuite.addTest(TComponentsALMBeamsTestContact('test_execution'))
+
+        # ALM frictional tests
+        nightlySuite.addTest(TALMPureFrictionalTestContact('test_execution'))
+        nightlySuite.addTest(TALMBasicFrictionTestContact('test_execution'))
+        nightlySuite.addTest(TALMStaticEvolutionLoadFrictionTestContact('test_execution'))
+
+        # MPC contact test
+        nightlySuite.addTest(TBeamAxilSimpleContactTest('test_execution'))
+        nightlySuite.addTest(TBeamContactTest('test_execution'))
+        nightlySuite.addTest(TBeamContactWithTyingTest('test_execution'))
+        nightlySuite.addTest(TBeamContactWithFrictionTest('test_execution'))
+
+        ### END VALIDATION SUITE ###
+
+        ### BEGIN VALIDATION SUITE ###
+
+        # For very long tests that should not be in nighly and you can use to validate
+        validationSuite = suites['validation']
+        validationSuite.addTests(nightlySuite)
+
+        # ALM frictionless tests
+        #nightlySuite.addTest(TALMHertzSphereTestContact('test_execution'))
+        validationSuite.addTest(TALMHertzSimpleTestContact('test_execution'))
+        validationSuite.addTest(TALMHertzCompleteTestContact('test_execution'))
+
+        # Components ALM frictionless tests
+        #nightlySuite.addTest(TComponentsALMHertzSphereTestContact('test_execution'))
+        validationSuite.addTest(TComponentsALMHertzSimpleTestContact('test_execution'))
+        validationSuite.addTest(TComponentsALMHertzCompleteTestContact('test_execution'))
+
+        # Penalty frictionless tests
+        if has_CL_application:
+            validationSuite.addTest(TExplicitPenaltyThreeDSimplestPatchMatchingTestContact('test_execution'))
+
+        # Exact integration tests
+        validationSuite.addTest(TTestDoubleCurvatureIntegration('test_double_curvature_integration_triangle'))
+        validationSuite.addTest(TTestDoubleCurvatureIntegration('test_double_curvature_integration_quad'))
+        validationSuite.addTest(TTestDoubleCurvatureIntegration('test_moving_mesh_integration_quad'))
+
+        # Dynamic search
+        validationSuite.addTest(TTestDynamicSearch('test_dynamic_search_triangle'))
+        validationSuite.addTest(TTestDynamicSearch('test_dynamic_search_quad'))
+
+        # Mortar mapping
+        validationSuite.addTest(TTestMortarMapperCore('test_mortar_mapping_triangle'))
+        validationSuite.addTest(TTestMortarMapperCore('test_mortar_mapping_quad'))
+
+        # Some large displacement tests
+        if has_CL_application:
+            validationSuite.addTest(TLargeDisplacementPatchTestHexa('test_execution'))
+            validationSuite.addTest(TMeshTyingValidationTest('test_execution'))
+
+        # ALM frictionless tests
+        validationSuite.addTest(TALMTaylorPatchDynamicTestContact('test_execution'))
+        validationSuite.addTest(TALMMeshMovingMatchingTestContact('test_execution'))
+        validationSuite.addTest(TALMMeshMovingNotMatchingTestContact('test_execution'))
+        #validationSuite.addTest(TALMIroningTestContact('test_execution'))
+        #validationSuite.addTest(TALMIroningDieTestContact('test_execution'))
+        if has_CL_application:
+            validationSuite.addTest(TALMLargeDisplacementPatchTestTetra('test_execution'))
+            validationSuite.addTest(TALMLargeDisplacementPatchTestHexa('test_execution'))
+        validationSuite.addTest(TALMMultiLayerContactTest('test_execution'))
+        validationSuite.addTest(TALMSelfContactContactTest('test_execution'))
+
+        # Components ALM frictionless tests
+        validationSuite.addTest(TComponentsALMTaylorPatchDynamicTestContact('test_execution'))
+        validationSuite.addTest(TComponentsALMMeshMovingMatchingTestContact('test_execution'))
+        validationSuite.addTest(TComponentsALMMeshMovingNotMatchingTestContact('test_execution'))
+        if has_CL_application:
+            validationSuite.addTest(TComponentsALMLargeDisplacementPatchTestTetra('test_execution'))
+            validationSuite.addTest(TComponentsALMLargeDisplacementPatchTestHexa('test_execution'))
+        validationSuite.addTest(TComponentsALMMultiLayerContactTest('test_execution'))
+        validationSuite.addTest(TComponentsALMSelfContactContactTest('test_execution'))
+
+        # ALM frictional tests
+        validationSuite.addTest(TALMEvolutionLoadFrictionTestContact('test_execution'))
+        validationSuite.addTest(TALMTaylorPatchFrictionalTestContact('test_execution'))
+        validationSuite.addTest(TALMMeshMovingMatchingTestFrictionalPureSlipContact('test_execution'))
+        validationSuite.addTest(TALMMeshMovingNotMatchingTestFrictionalPureSlipContact('test_execution'))
+        if has_CL_application:
+            validationSuite.addTest(TALMHertzTestFrictionalContact('test_execution'))
+            validationSuite.addTest(TALMBlockTestFrictionalContact('test_execution'))
+
+        # MPC contact test
+        validationSuite.addTest(TBeamAxilContactTest('test_execution'))
+        validationSuite.addTest(TBeamAxilTetraContactTest('test_execution'))
+        validationSuite.addTest(TPlateTest('test_execution'))
+        #validationSuite.addTest(TMultiLayerContactTest('test_execution'))
+
+        ### END VALIDATION ###
+
+        # Create a test suit that contains all the tests:
+        allSuite = suites['all']
+        allSuite.addTests(nightlySuite) # Already contains the smallSuite
+        validationSuite.addTests(allSuite) # Validation contains all
+    else: ## Manual list for debugging
+      smallSuite.addTests(
           KratosUnittest.TestLoader().loadTestsFromTestCases([
               ### STANDALONE
               TTestProcessFactory,


### PR DESCRIPTION
**📝 Description**

This is a transition PR which objective is to clean up MeshTying condition. More clean up is on the way. 

- Remove parent geometry dependency (not relevant).
- Better variable management (to be improved after AD is removed)
- Rename definitions to be consistent.
- Default tesellation.

**NOTE**: Next step will be removed AD, as meshtying is quite simple and can be implemented manually, reducing significantly the code without any relevant performance lost (there are not many terms to take into account).

**🆕 Changelog**

- [Update manual test definition](https://github.com/KratosMultiphysics/Kratos/commit/5f454a5f3cbab67599617daebeb78e5ea7fcd20c)
- [Cleaning typedef](https://github.com/KratosMultiphysics/Kratos/commit/b61956c2a17b11643045a60b3fe8a879ed45038a)
- [Cleaning current implementation of MeshTying condition](https://github.com/KratosMultiphysics/Kratos/commit/71c0762274f7db6ceb20b2bb6c35f017fd27bee7)
- [Reduce code duplication](https://github.com/KratosMultiphysics/Kratos/commit/27c69f808c5f6fb1a11f59c5470ff34f99c9fbde)
- [Update AD](https://github.com/KratosMultiphysics/Kratos/commit/387313904c4e8da5ae1ee372fbd28608fadb70e6)
- [Default consider_tessellation](https://github.com/KratosMultiphysics/Kratos/pull/11346/commits/37b20ea792c916e4864c91995ecc693722369e9f)
