### PR TITLE
[GeoMechanicsApplication] Fixed several problems found by clang-tidy in DGeoFlow

### DIFF
--- a/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.h
@@ -50,15 +50,17 @@ namespace Kratos
     {
     public:
         KratosExecute();
-        ~KratosExecute(){};
 
-        int execute_flow_analysis(std::string workingDirectory, std::string parameterName,
-                                  double minCriticalHead, double maxCriticalHead, double stepCriticalHead,
-                                  std::string criticalHeadBoundaryModelPartName,
-                                  std::function<void(char*)> logCallback,
-                                  std::function<void(double)> reportProgress,
-                                  std::function<void(char*)> reportTextualProgress,
-                                  std::function<bool()> shouldCancel);
+        int ExecuteFlowAnalysis(const std::string&                       rWorkingDirectory,
+                                const std::string&                       rProjectParamsFileName,
+                                double                                   minCriticalHead,
+                                double                                   maxCriticalHead,
+                                double                                   stepCriticalHead,
+                                const std::string&                       rCriticalHeadBoundaryModelPartName,
+                                const std::function<void(const char*)>&  rLogCallback,
+                                const std::function<void(double)>&       rReportProgress,
+                                const std::function<void(const char*)>&  rReportTextualProgress,
+                                const std::function<bool()>&             rShouldCancel);
 
         typedef Node NodeType;
         typedef Geometry<NodeType> GeometryType;
@@ -74,21 +76,6 @@ namespace Kratos
         typedef MixedGenericCriteria<SparseSpaceType, LocalSpaceType> MixedGenericCriteriaType;
         typedef typename MixedGenericCriteriaType::ConvergenceVariableListType ConvergenceVariableListType;
 
-        // The builder ans solver type
-        typedef BuilderAndSolver<SparseSpaceType, LocalSpaceType, LinearSolverType> BuilderAndSolverType;
-        typedef ResidualBasedBlockBuilderAndSolver<SparseSpaceType, LocalSpaceType, LinearSolverType> ResidualBasedBlockBuilderAndSolverType;
-
-        // The time scheme
-        typedef Scheme<SparseSpaceType, LocalSpaceType> SchemeType;
-        typedef BackwardEulerQuasistaticPwScheme<SparseSpaceType, LocalSpaceType> BackwardEulerQuasistaticPwSchemeType;
-
-        // The strategies
-        typedef ImplicitSolvingStrategy<SparseSpaceType, LocalSpaceType, LinearSolverType>
-            ImplicitSolvingStrategyType;
-
-        typedef ResidualBasedNewtonRaphsonStrategy<SparseSpaceType, LocalSpaceType, LinearSolverType>
-            ResidualBasedNewtonRaphsonStrategyType;
-
         typedef GeoMechanicsNewtonRaphsonErosionProcessStrategy<SparseSpaceType, LocalSpaceType, LinearSolverType>
             GeoMechanicsNewtonRaphsonErosionProcessStrategyType;
 
@@ -98,13 +85,13 @@ namespace Kratos
                                  std::equal_to<result_type>, Dof<double> *>
             DofsArrayType;
 
-        ConvergenceCriteriaType::Pointer setup_criteria_dgeoflow();
-        LinearSolverType::Pointer setup_solver_dgeoflow();
-        GeoMechanicsNewtonRaphsonErosionProcessStrategyType::Pointer setup_strategy_dgeoflow(ModelPart &model_part);
-        void parseMaterial(Model &model, std::string filepath);
+        static ConvergenceCriteriaType::Pointer setup_criteria_dgeoflow();
+        static LinearSolverType::Pointer setup_solver_dgeoflow();
+        static GeoMechanicsNewtonRaphsonErosionProcessStrategyType::Pointer setup_strategy_dgeoflow(ModelPart &model_part);
+        static void parseMaterial(Model &model, const std::string& rMaterialFilePath);
 
-        Parameters openProjectParamsFile(std::string filepath);
-        std::vector<std::shared_ptr<Process>> parseProcess(ModelPart &model_part, Parameters projFile);
+        static Parameters openProjectParamsFile(const std::string& rProjectParamsFilePath);
+        static std::vector<std::shared_ptr<Process>> parseProcess(ModelPart &model_part, Parameters projFile);
 
     private:
         // Initial Setup
@@ -116,19 +103,21 @@ namespace Kratos
 
         int echoLevel = 1;
 
-        int GetEchoLevel();
+        [[nodiscard]] int GetEchoLevel() const;
 
         void SetEchoLevel(int level);
 
-        shared_ptr<Process> FindRiverBoundaryByName(std::string criticalHeadBoundaryModelPartName,
-                                                    std::vector<std::shared_ptr<Process>> processes);
+        static shared_ptr<Process> FindRiverBoundaryByName(const std::string& rCriticalHeadBoundaryModelPartName,
+                                                           const std::vector<std::shared_ptr<Process>>& rProcesses);
 
-        shared_ptr<Process> FindRiverBoundaryAutomatically(KratosExecute::GeoMechanicsNewtonRaphsonErosionProcessStrategyType::Pointer p_solving_strategy,
-                                                           std::vector<std::shared_ptr<Process>> processes);
+        static shared_ptr<Process> FindRiverBoundaryAutomatically(const KratosExecute::GeoMechanicsNewtonRaphsonErosionProcessStrategyType::Pointer& rpSolvingStrategy,
+                                                                  const std::vector<std::shared_ptr<Process>>& rProcesses);
 
-        int mainExecution(ModelPart &model_part,
-                          std::vector<std::shared_ptr<Process>> processes,
-                          KratosExecute::GeoMechanicsNewtonRaphsonErosionProcessStrategyType::Pointer p_solving_strategy,
-                          double time, double delta_time, double number_iterations);
+        static int MainExecution(ModelPart&                                                          rModelPart,
+                                 const std::vector<std::shared_ptr<Process>>&                        rProcesses,
+                                 const GeoMechanicsNewtonRaphsonErosionProcessStrategyType::Pointer& rpSolvingStrategy,
+                                 double                                                              Time,
+                                 double                                                              DeltaTime,
+                                 unsigned int                                                        NumberOfIterations);
     };
 }

--- a/applications/GeoMechanicsApplication/external_bindings/kratos_external_bindings.cpp
+++ b/applications/GeoMechanicsApplication/external_bindings/kratos_external_bindings.cpp
@@ -18,21 +18,21 @@ extern "C"
                                                double maxCriticalHead,
                                                double stepCriticalHead,
                                                char *criticalHeadBoundaryModelPartName,
-                                               void __stdcall logCallback(char *),
+                                               void __stdcall logCallback(const char*),
                                                void __stdcall reportProgress(double),
-                                               void __stdcall reportTextualProgress(char *),
+                                               void __stdcall reportTextualProgress(const char*),
                                                bool __stdcall shouldCancel())
     {
-        int errorCode = instance->execute_flow_analysis(workingDirectory,
-                                                        projectFile,
-                                                        minCriticalHead,
-                                                        maxCriticalHead,
-                                                        stepCriticalHead,
-                                                        criticalHeadBoundaryModelPartName,
-                                                        logCallback,
-                                                        reportProgress,
-                                                        reportTextualProgress,
-                                                        shouldCancel);
+        int errorCode = instance->ExecuteFlowAnalysis(workingDirectory,
+                                                      projectFile,
+                                                      minCriticalHead,
+                                                      maxCriticalHead,
+                                                      stepCriticalHead,
+                                                      criticalHeadBoundaryModelPartName,
+                                                      logCallback,
+                                                      reportProgress,
+                                                      reportTextualProgress,
+                                                      shouldCancel);
         return errorCode;
     }
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/flow_stubs.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/flow_stubs.cpp
@@ -15,7 +15,7 @@
 namespace flow_stubs
 {
     void emptyProgress(double progress) {}
-    void emptyLog(char* log) {}
+    void emptyLog(const char* log) {}
     bool emptyCancel() {
         return false;
     }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/flow_stubs.h
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/flow_stubs.h
@@ -13,6 +13,6 @@
 namespace flow_stubs
 {
     void emptyProgress(double progress);
-    void emptyLog(char* log);
+    void emptyLog(const char* log);
     bool emptyCancel();
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_GeoMechanicsNewtonRaphsonErosionProcessStrategy.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_GeoMechanicsNewtonRaphsonErosionProcessStrategy.cpp
@@ -36,8 +36,9 @@ namespace Kratos
             auto projectFile = "ProjectParameters.json";
 
             auto execute = KratosExecute();
-            int status = execute.execute_flow_analysis(workingDirectory, projectFile, 3, 4, 0.1, "PorousDomain.Left_head", 
-            &flow_stubs::emptyLog, &flow_stubs::emptyProgress, &flow_stubs::emptyLog, &flow_stubs::emptyCancel);
+            int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile, 3, 4, 0.1, "PorousDomain.Left_head",
+                                                     &flow_stubs::emptyLog, &flow_stubs::emptyProgress,
+                                                     &flow_stubs::emptyLog, &flow_stubs::emptyCancel);
 
             KRATOS_CHECK_EQUAL(status, 0);
         }
@@ -53,7 +54,7 @@ namespace Kratos
             bool finalMessageFound = false;
             int messageCount = 0;
 
-            std::function<void(char*)> reportTextualProgress = [&firstMessageFound, &finalMessageFound, &messageCount](char* message) 
+            std::function<void(const char*)> reportTextualProgress = [&firstMessageFound, &finalMessageFound, &messageCount](const char* message)
             {
                 messageCount++;
                 std::cout << "Captured: " << message << std::endl;
@@ -67,8 +68,9 @@ namespace Kratos
                 }
             };
             
-            int status = execute.execute_flow_analysis(workingDirectory, projectFile, 3, 4, 0.1, "PorousDomain.Left_head", 
-            &flow_stubs::emptyLog, &flow_stubs::emptyProgress, reportTextualProgress, &flow_stubs::emptyCancel);
+            int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile, 3, 4, 0.1, "PorousDomain.Left_head",
+                                                     &flow_stubs::emptyLog, &flow_stubs::emptyProgress,
+                                                     reportTextualProgress, &flow_stubs::emptyCancel);
 
             KRATOS_CHECK_EQUAL(status, 0);
             KRATOS_CHECK_EQUAL(firstMessageFound, true);
@@ -101,8 +103,9 @@ namespace Kratos
                 }
             };
             
-            int status = execute.execute_flow_analysis(workingDirectory, projectFile, 3, 4, 0.1, "PorousDomain.Left_head",
-            &flow_stubs::emptyLog, reportProgress, &flow_stubs::emptyLog, &flow_stubs::emptyCancel);
+            int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile, 3, 4, 0.1, "PorousDomain.Left_head",
+                                                     &flow_stubs::emptyLog, reportProgress, &flow_stubs::emptyLog,
+                                                     &flow_stubs::emptyCancel);
 
             KRATOS_CHECK_EQUAL(status, 0);
             KRATOS_CHECK_EQUAL(startProgressFound, true);

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_head_extrapolation_flow_workflow.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_head_extrapolation_flow_workflow.cpp
@@ -57,10 +57,10 @@ namespace Kratos
             auto projectFile = "ProjectParameters_1.json";
 
             auto execute = Kratos::KratosExecute();
-            int status = execute.execute_flow_analysis(workingDirectory, projectFile,
-                                                       0, 0, 0,
-                                                       "", &flow_stubs::emptyLog, &flow_stubs::emptyProgress,
-                                                       &flow_stubs::emptyLog, &flow_stubs::emptyCancel);
+            int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile,
+                                                     0, 0, 0,
+                                                     "", &flow_stubs::emptyLog, &flow_stubs::emptyProgress,
+                                                     &flow_stubs::emptyLog, &flow_stubs::emptyCancel);
 
             KRATOS_CHECK_EQUAL(status, 0);
 
@@ -77,10 +77,10 @@ namespace Kratos
             auto projectFile = "ProjectParameters_2.json";
 
             auto execute = Kratos::KratosExecute();
-            int status = execute.execute_flow_analysis(workingDirectory, projectFile,
-                                                       0, 0, 0,
-                                                       "", &flow_stubs::emptyLog, &flow_stubs::emptyProgress,
-                                                       &flow_stubs::emptyLog, &flow_stubs::emptyCancel);
+            int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile,
+                                                     0, 0, 0,
+                                                     "", &flow_stubs::emptyLog, &flow_stubs::emptyProgress,
+                                                     &flow_stubs::emptyLog, &flow_stubs::emptyCancel);
 
             KRATOS_CHECK_EQUAL(status, 0);
 
@@ -97,10 +97,10 @@ namespace Kratos
             auto projectFile = "ProjectParameters_3.json";
 
             auto execute = Kratos::KratosExecute();
-            int status = execute.execute_flow_analysis(workingDirectory, projectFile,
-                                                       0, 0, 0,
-                                                       "", &flow_stubs::emptyLog, &flow_stubs::emptyProgress,
-                                                       &flow_stubs::emptyLog, &flow_stubs::emptyCancel);
+            int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile,
+                                                     0, 0, 0,
+                                                     "", &flow_stubs::emptyLog, &flow_stubs::emptyProgress,
+                                                     &flow_stubs::emptyLog, &flow_stubs::emptyCancel);
 
             KRATOS_CHECK_EQUAL(status, 0);
 
@@ -117,10 +117,10 @@ namespace Kratos
             auto projectFile = "ProjectParameters_4.json";
 
             auto execute = Kratos::KratosExecute();
-            int status = execute.execute_flow_analysis(workingDirectory, projectFile,
-                                                       0, 0, 0,
-                                                       "", &flow_stubs::emptyLog, &flow_stubs::emptyProgress,
-                                                       &flow_stubs::emptyLog, &flow_stubs::emptyCancel);
+            int status = execute.ExecuteFlowAnalysis(workingDirectory, projectFile,
+                                                     0, 0, 0,
+                                                     "", &flow_stubs::emptyLog, &flow_stubs::emptyProgress,
+                                                     &flow_stubs::emptyLog, &flow_stubs::emptyCancel);
 
             KRATOS_CHECK_EQUAL(status, 0);
 


### PR DESCRIPTION
**🆕 Changelog**
- Removed two unused member functions.
- Improved `const` correctness.
- Removed an intermediate (redundant) local variable.
- Removed some commented-out code.
- Declared several member functions `static`.
- Pass by reference-to-const rather than pass by value.
- Renamed several function parameters to be in line with Kratos' Style Guide.
- Use raw string literals to avoid having to escape certain characters.
- Used the more effective overload to find a single character.
- Avoid copying loop variables when a `const` reference will do.
- Reformatted some function signatures such that each parameter is on its own line. Also lined up the parameter names.
- Removed some narrowing conversions.
- Removed a local variable that shadowed another one.
- Removed an empty statement.
- Replaced `NULL` by `nullptr`.
- Removed a destructor that can be generated by the compiler.
- Removed some unused aliases.
- Marked a function `[[nodiscard]]`.