### PR TITLE
[Core] Refactor nurbs volume quad point interface.

### DIFF
--- a/kratos/geometries/nurbs_volume_geometry.h
+++ b/kratos/geometries/nurbs_volume_geometry.h
@@ -690,7 +690,7 @@ public:
     ///@{
 
     /**
-     * @brief Creates a quadrature point geometries for one knot span / element
+     * @brief Creates a quadrature point geometry for one knot span / element
      *        from a list of integration points.
      * @param rResultGeometries List of quadrature point geometries. Will contain only one geometry.
      * @param rIntegrationPoints List of provided integration points. Must be inside the same element.

--- a/kratos/geometries/nurbs_volume_geometry.h
+++ b/kratos/geometries/nurbs_volume_geometry.h
@@ -690,10 +690,10 @@ public:
     ///@{
 
     /**
-     * @brief Creates a list of quadrature point geometries
+     * @brief Creates a quadrature point geometries for one knot span / element
      *        from a list of integration points.
-     * @param rResultGeometries List of quadrature point geometries.
-     * @param rIntegrationPoints List of provided integration points.
+     * @param rResultGeometries List of quadrature point geometries. Will contain only one geometry.
+     * @param rIntegrationPoints List of provided integration points. Must be inside the same element.
      * @param NumberOfShapeFunctionDerivatives the number of evaluated
      *        derivatives of shape functions at the quadrature point geometries.
      * @see quadrature_point_geometry.h


### PR DESCRIPTION
**📝 Description**
Update CreateQuadraturePointGeometries() of NurbsVolumeGeometry.
So far, one QuadraturePointGeometry was created for each integration point. Consequently, each point was associated with a separate element. This was very expensive for the assembly of the system matrices since the contributions of each point were assembled to the global matrices. 
Now, the quadrature point geometries are created per element and hence contain multiple integration points.

**🆕 Changelog**
- CreateQuadraturePointGeometries() of NurbsVolumeGeometry

