### PR TITLE
[Core] Refactor nurbs volume quadrature point interface.

### DIFF
--- a/applications/IgaApplication/custom_processes/assign_integration_points_to_background_elements_process.cpp
+++ b/applications/IgaApplication/custom_processes/assign_integration_points_to_background_elements_process.cpp
@@ -73,10 +73,14 @@ namespace Kratos
             }
             IntegrationInfo integration_info = p_geometry->GetDefaultIntegrationInfo();
             GeometriesArrayType geometry_list;
+            // Make sure one qudrature point geometry is created for each integration point.
+            integration_info.SetQuadratureMethod(0, IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS);
+            integration_info.SetQuadratureMethod(1, IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS);
+            integration_info.SetQuadratureMethod(2, IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS);
             p_geometry->CreateQuadraturePointGeometries(geometry_list, 2, integration_points, integration_info);
 
             // Get properties from main model part
-            auto p_properties = main_model_part.pGetProperties(0);
+            auto p_properties = main_model_part.pGetProperties(1);
 
             const auto p_background_element = main_model_part.ElementsBegin();
             const auto& r_proces_info = main_model_part.GetProcessInfo();

--- a/applications/IgaApplication/custom_processes/map_nurbs_volume_results_to_embedded_geometry_process.cpp
+++ b/applications/IgaApplication/custom_processes/map_nurbs_volume_results_to_embedded_geometry_process.cpp
@@ -64,6 +64,10 @@ namespace Kratos
 
         IntegrationInfo integration_info = p_geometry->GetDefaultIntegrationInfo();
         GeometriesArrayType geometry_list;
+        // Make sure one qudrature point geometry is created for each integration point.
+        integration_info.SetQuadratureMethod(0, IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS);
+        integration_info.SetQuadratureMethod(1, IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS);
+        integration_info.SetQuadratureMethod(2, IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS);
         p_geometry->CreateQuadraturePointGeometries(geometry_list, 1, integration_points, integration_info);
 
         IndexPartition<IndexType>(embedded_model_part.NumberOfNodes()).for_each([&](IndexType i) {

--- a/kratos/geometries/nurbs_volume_geometry.h
+++ b/kratos/geometries/nurbs_volume_geometry.h
@@ -690,7 +690,7 @@ public:
     ///@{
 
     /**
-     * @brief Creates a list of quadrature point geometries.
+     * @brief Creates a list of quadrature point geometries
      *        from a list of integration points.
      * @param rResultGeometries List of quadrature point geometries.
      * @param NumberOfShapeFunctionDerivatives the number of evaluated
@@ -758,7 +758,6 @@ public:
             ShapeFunctionsValuesContainerType shape_function_values;
             ShapeFunctionsLocalGradientsContainerType shape_function_gradients;
 
-            // Only default integration method Gauss_1=0 is used.
             integration_points[0] = rIntegrationPoints;
             shape_function_gradients[0].resize(rIntegrationPoints.size());
             shape_function_values[0].resize(rIntegrationPoints.size(), num_nonzero_cps);

--- a/kratos/geometries/nurbs_volume_geometry.h
+++ b/kratos/geometries/nurbs_volume_geometry.h
@@ -690,12 +690,42 @@ public:
     ///@{
 
     /**
-     * @brief Creates a quadrature point geometry for one knot span / element
+     * @brief Creates a list of quadrature point geometries.
      *        from a list of integration points.
-     * @param rResultGeometries List of quadrature point geometries. Will contain only one geometry.
-     * @param rIntegrationPoints List of provided integration points. Must be inside the same element.
+     * @param rResultGeometries List of quadrature point geometries.
      * @param NumberOfShapeFunctionDerivatives the number of evaluated
      *        derivatives of shape functions at the quadrature point geometries.
+     * @param rIntegrationInfo.
+     * @see quadrature_point_geometry.h
+     */
+    void CreateQuadraturePointGeometries(
+        GeometriesArrayType& rResultGeometries,
+        IndexType NumberOfShapeFunctionDerivatives,
+        IntegrationInfo& rIntegrationInfo) override
+    {
+        IntegrationPointsArrayType IntegrationPoints;
+        CreateIntegrationPoints(IntegrationPoints, rIntegrationInfo);
+
+        // Makes sure we use assembly Option 2 in CreateQuadraturePointGeometries().
+        IntegrationInfo integration_info(
+            { PolynomialDegreeU() + 1, PolynomialDegreeV() + 1, PolynomialDegreeW() + 1 },
+            { IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS, IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS, IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS });
+
+        this->CreateQuadraturePointGeometries(
+            rResultGeometries,
+            NumberOfShapeFunctionDerivatives,
+            IntegrationPoints,
+            integration_info);
+    }
+
+    /**
+     * @brief Creates a list of quadrature point geometries.
+     *        from a list of integration points.
+     * @param rResultGeometries List of quadrature point geometries.
+     * @param rIntegrationPoints List of provided integration points.
+     * @param NumberOfShapeFunctionDerivatives the number of evaluated
+     *        derivatives of shape functions at the quadrature point geometries.
+     * @param rIntegrationInfo.
      * @see quadrature_point_geometry.h
      */
     void CreateQuadraturePointGeometries(
@@ -704,101 +734,162 @@ public:
         const IntegrationPointsArrayType& rIntegrationPoints,
         IntegrationInfo& rIntegrationInfo) override
     {
-        KRATOS_ERROR_IF(NumberOfShapeFunctionDerivatives != 2) << "NumberOfShapeFunctionDerivatives must be 2.\n";
-        // Shape function container.
-        NurbsVolumeShapeFunction shape_function_container(
-            mPolynomialDegreeU, mPolynomialDegreeV, mPolynomialDegreeW, NumberOfShapeFunctionDerivatives);
+        // Option 1: One QuadraturePointGeometry is created containing all integration points. This should be used
+        // when all rIntegrationPoints are located inside the same element.
+        if(  IntegrationInfo::QuadratureMethod::GAUSS == rIntegrationInfo.GetQuadratureMethod(0) ){
+            KRATOS_ERROR_IF(NumberOfShapeFunctionDerivatives != 2) << "NumberOfShapeFunctionDerivatives must be 2.\n";
+            // Shape function container.
+            NurbsVolumeShapeFunction shape_function_container(
+                mPolynomialDegreeU, mPolynomialDegreeV, mPolynomialDegreeW, NumberOfShapeFunctionDerivatives);
 
-        // Resize containers.
-        if (rResultGeometries.size() != 1){
-            rResultGeometries.resize(1);
-        }
-
-        const auto default_method = this->GetDefaultIntegrationMethod();
-
-        const SizeType num_nonzero_cps = shape_function_container.NumberOfNonzeroControlPoints();
-        const SizeType num_points = rIntegrationPoints.size();
-        KRATOS_ERROR_IF(num_points < 1) << "List of integration points is empty.\n";
-
-        // Initialize containers.
-        IntegrationPointsContainerType integration_points;
-        ShapeFunctionsValuesContainerType shape_function_values;
-        ShapeFunctionsLocalGradientsContainerType shape_function_gradients;
-
-        // Only default integration method Gauss_1=0 is used.
-        integration_points[0] = rIntegrationPoints;
-        shape_function_gradients[0].resize(rIntegrationPoints.size());
-        shape_function_values[0].resize(rIntegrationPoints.size(), num_nonzero_cps);
-
-        for( IndexType i_point = 0; i_point < num_points; ++i_point){
-            for (IndexType i = 0; i < NumberOfShapeFunctionDerivatives - 1; ++i) {
-                const IndexType num_derivatives = (2 + i) * (3 + i) / 2;
-                shape_function_gradients[0][i_point].resize(num_nonzero_cps, num_derivatives);
-            }
-        }
-
-        // Centroid of points. This will be used to identify knot span.
-        // Single point might be located on the boundary of two knot spans.
-        array_1d<double, 3> centroid(3, 0.0);
-
-        // Fill containers
-        for (IndexType i_point = 0; i_point < num_points; ++i_point)
-        {
-            // Attention: Weights are not yet implemented.
-            // if (IsRational()) {
-            //     shape_function_container.ComputeNurbsShapeFunctionValues(
-            //         mKnotsU, mKnotsV, mKnotsW, mWeights, rIntegrationPoints[i][0], rIntegrationPoints[i][1], rIntegrationPoints[i][2]);
-            // }
-
-            // Compute centroid.
-            centroid += rIntegrationPoints[i_point].Coordinates();
-
-            shape_function_container.ComputeBSplineShapeFunctionValues(
-                mKnotsU, mKnotsV, mKnotsW,
-                rIntegrationPoints[i_point][0], rIntegrationPoints[i_point][1], rIntegrationPoints[i_point][2]);
-
-            /// Get Shape Functions.
-            for (IndexType j = 0; j < num_nonzero_cps; ++j) {
-                shape_function_values[0](i_point, j) = shape_function_container(j, 0);
+            // Resize containers.
+            if (rResultGeometries.size() != 1){
+                rResultGeometries.resize(1);
             }
 
-            // Get Shape Function Derivatives DN_De, ...
-            if (NumberOfShapeFunctionDerivatives > 0) {
-                IndexType shape_derivative_index = 1;
-                for (IndexType n = 0; n < NumberOfShapeFunctionDerivatives - 1; ++n) {
-                    const IndexType num_derivatives = (2 + n) * (3 + n) / 2;
-                    for (IndexType k = 0; k < num_derivatives; ++k) {
-                        for (IndexType j = 0; j < num_nonzero_cps; ++j) {
-                            shape_function_gradients[0][i_point](j, k) = shape_function_container(j, shape_derivative_index + k);
-                        }
-                    }
-                    shape_derivative_index += num_derivatives;
+            const auto default_method = this->GetDefaultIntegrationMethod();
+
+            const SizeType num_nonzero_cps = shape_function_container.NumberOfNonzeroControlPoints();
+            const SizeType num_points = rIntegrationPoints.size();
+            KRATOS_ERROR_IF(num_points < 1) << "List of integration points is empty.\n";
+
+            // Initialize containers.
+            IntegrationPointsContainerType integration_points;
+            ShapeFunctionsValuesContainerType shape_function_values;
+            ShapeFunctionsLocalGradientsContainerType shape_function_gradients;
+
+            // Only default integration method Gauss_1=0 is used.
+            integration_points[0] = rIntegrationPoints;
+            shape_function_gradients[0].resize(rIntegrationPoints.size());
+            shape_function_values[0].resize(rIntegrationPoints.size(), num_nonzero_cps);
+
+            for( IndexType i_point = 0; i_point < num_points; ++i_point){
+                for (IndexType i = 0; i < NumberOfShapeFunctionDerivatives - 1; ++i) {
+                    const IndexType num_derivatives = (2 + i) * (3 + i) / 2;
+                    shape_function_gradients[0][i_point].resize(num_nonzero_cps, num_derivatives);
                 }
             }
+
+            // Centroid of points. This will be used to identify knot span.
+            // Single point might be located on the boundary of two knot spans.
+            array_1d<double, 3> centroid(3, 0.0);
+
+            // Fill containers
+            for (IndexType i_point = 0; i_point < num_points; ++i_point)
+            {
+                // Compute centroid.
+                centroid += rIntegrationPoints[i_point].Coordinates();
+
+                shape_function_container.ComputeBSplineShapeFunctionValues(
+                    mKnotsU, mKnotsV, mKnotsW,
+                    rIntegrationPoints[i_point][0], rIntegrationPoints[i_point][1], rIntegrationPoints[i_point][2]);
+
+                /// Get Shape Functions.
+                for (IndexType j = 0; j < num_nonzero_cps; ++j) {
+                    shape_function_values[0](i_point, j) = shape_function_container(j, 0);
+                }
+
+                // Get Shape Function Derivatives DN_De, ...
+                if (NumberOfShapeFunctionDerivatives > 0) {
+                    IndexType shape_derivative_index = 1;
+                    for (IndexType n = 0; n < NumberOfShapeFunctionDerivatives - 1; ++n) {
+                        const IndexType num_derivatives = (2 + n) * (3 + n) / 2;
+                        for (IndexType k = 0; k < num_derivatives; ++k) {
+                            for (IndexType j = 0; j < num_nonzero_cps; ++j) {
+                                shape_function_gradients[0][i_point](j, k) = shape_function_container(j, shape_derivative_index + k);
+                            }
+                        }
+                        shape_derivative_index += num_derivatives;
+                    }
+                }
+            }
+
+            /// Get List of Control Points.
+            PointsArrayType nonzero_control_points(num_nonzero_cps);
+            centroid /= num_points;
+            shape_function_container.ComputeBSplineShapeFunctionValues(
+                    mKnotsU, mKnotsV, mKnotsW,
+                    centroid[0], centroid[1], centroid[2]);
+
+            auto cp_indices = shape_function_container.ControlPointIndices(
+                NumberOfControlPointsU(), NumberOfControlPointsV(), NumberOfControlPointsW());
+
+            for (IndexType j = 0; j < num_nonzero_cps; ++j) {
+                nonzero_control_points(j) = pGetPoint(cp_indices[j]);
+            }
+
+            // Instantiate shape function container.
+            GeometryShapeFunctionContainer<GeometryData::IntegrationMethod> data_container(
+                default_method, integration_points,
+                shape_function_values, shape_function_gradients);
+
+            // Create quadrature point geometry.
+            rResultGeometries(0) = CreateQuadraturePointsUtility<NodeType>::CreateQuadraturePoint(
+                this->WorkingSpaceDimension(), 3, data_container, nonzero_control_points, this);
         }
+        // Option 2: A list of QuadraturePointGeometry is created, one for each integration points.
+        else if ( IntegrationInfo::QuadratureMethod::EXTENDED_GAUSS == rIntegrationInfo.GetQuadratureMethod(0) ) {
+            // Shape function container.
+            NurbsVolumeShapeFunction shape_function_container(
+                mPolynomialDegreeU, mPolynomialDegreeV, mPolynomialDegreeW, NumberOfShapeFunctionDerivatives);
 
-        /// Get List of Control Points.
-        PointsArrayType nonzero_control_points(num_nonzero_cps);
-        centroid /= num_points;
-        shape_function_container.ComputeBSplineShapeFunctionValues(
-                mKnotsU, mKnotsV, mKnotsW,
-                centroid[0], centroid[1], centroid[2]);
+            // Resize containers.
+            if (rResultGeometries.size() != rIntegrationPoints.size())
+                rResultGeometries.resize(rIntegrationPoints.size());
 
-        auto cp_indices = shape_function_container.ControlPointIndices(
-            NumberOfControlPointsU(), NumberOfControlPointsV(), NumberOfControlPointsW());
+            auto default_method = this->GetDefaultIntegrationMethod();
+            SizeType num_nonzero_cps = shape_function_container.NumberOfNonzeroControlPoints();
 
-        for (IndexType j = 0; j < num_nonzero_cps; ++j) {
-            nonzero_control_points(j) = pGetPoint(cp_indices[j]);
+            Matrix N(1, num_nonzero_cps);
+            DenseVector<Matrix> shape_function_derivatives(NumberOfShapeFunctionDerivatives - 1);
+
+            for (IndexType i = 0; i < NumberOfShapeFunctionDerivatives - 1; ++i) {
+                const IndexType num_derivatives = (2 + i) * (3 + i) / 2;
+                shape_function_derivatives[i].resize(num_nonzero_cps, num_derivatives);
+            }
+
+            for (IndexType i = 0; i < rIntegrationPoints.size(); ++i)
+            {
+                shape_function_container.ComputeBSplineShapeFunctionValues(
+                    mKnotsU, mKnotsV, mKnotsW, rIntegrationPoints[i][0], rIntegrationPoints[i][1], rIntegrationPoints[i][2]);
+
+
+                /// Get List of Control Points
+                PointsArrayType nonzero_control_points(num_nonzero_cps);
+                auto cp_indices = shape_function_container.ControlPointIndices(
+                    NumberOfControlPointsU(), NumberOfControlPointsV(), NumberOfControlPointsW());
+                for (IndexType j = 0; j < num_nonzero_cps; ++j) {
+                    nonzero_control_points(j) = pGetPoint(cp_indices[j]);
+                }
+                /// Get Shape Functions N
+                for (IndexType j = 0; j < num_nonzero_cps; ++j) {
+                    N(0, j) = shape_function_container(j, 0);
+                }
+
+                /// Get Shape Function Derivatives DN_De, ...
+                if (NumberOfShapeFunctionDerivatives > 0) {
+                    IndexType shape_derivative_index = 1;
+                    for (IndexType n = 0; n < NumberOfShapeFunctionDerivatives - 1; ++n) {
+                        const IndexType num_derivatives = (2 + n) * (3 + n) / 2;
+                        for (IndexType k = 0; k < num_derivatives; ++k) {
+                            for (IndexType j = 0; j < num_nonzero_cps; ++j) {
+                                shape_function_derivatives[n](j, k) = shape_function_container(j, shape_derivative_index + k);
+                            }
+                        }
+                        shape_derivative_index += num_derivatives;
+                    }
+                }
+
+                GeometryShapeFunctionContainer<GeometryData::IntegrationMethod> data_container(
+                    default_method, rIntegrationPoints[i],
+                    N, shape_function_derivatives);
+
+                rResultGeometries(i) = CreateQuadraturePointsUtility<NodeType>::CreateQuadraturePoint(
+                    this->WorkingSpaceDimension(), 3, data_container, nonzero_control_points, this);
+            }
+        } else {
+            KRATOS_ERROR << "Integration method not available.\n";
         }
-
-        // Instantiate shape function container.
-        GeometryShapeFunctionContainer<GeometryData::IntegrationMethod> data_container(
-            default_method, integration_points,
-            shape_function_values, shape_function_gradients);
-
-        // Create quadrature point geometry.
-        rResultGeometries(0) = CreateQuadraturePointsUtility<NodeType>::CreateQuadraturePoint(
-            this->WorkingSpaceDimension(), 3, data_container, nonzero_control_points, this);
     }
 
     ///@}

--- a/kratos/geometries/nurbs_volume_geometry.h
+++ b/kratos/geometries/nurbs_volume_geometry.h
@@ -690,7 +690,7 @@ public:
     ///@{
 
     /**
-     * @brief Creates a quadrature point geometries for one knot span / element
+     * @brief Creates a quadrature point geometry for one knot span / element
      *        from a list of integration points.
      * @param rResultGeometries List of quadrature point geometries. Will contain only one geometry.
      * @param rIntegrationPoints List of provided integration points. Must be inside the same element.

--- a/kratos/geometries/nurbs_volume_geometry.h
+++ b/kratos/geometries/nurbs_volume_geometry.h
@@ -690,10 +690,10 @@ public:
     ///@{
 
     /**
-     * @brief Creates a list of quadrature point geometries
+     * @brief Creates a quadrature point geometries for one knot span / element
      *        from a list of integration points.
-     * @param rResultGeometries List of quadrature point geometries.
-     * @param rIntegrationPoints List of provided integration points.
+     * @param rResultGeometries List of quadrature point geometries. Will contain only one geometry.
+     * @param rIntegrationPoints List of provided integration points. Must be inside the same element.
      * @param NumberOfShapeFunctionDerivatives the number of evaluated
      *        derivatives of shape functions at the quadrature point geometries.
      * @see quadrature_point_geometry.h

--- a/kratos/geometries/nurbs_volume_geometry.h
+++ b/kratos/geometries/nurbs_volume_geometry.h
@@ -763,10 +763,7 @@ public:
             shape_function_values[0].resize(rIntegrationPoints.size(), num_nonzero_cps);
 
             for( IndexType i_point = 0; i_point < num_points; ++i_point){
-                for (IndexType i = 0; i < NumberOfShapeFunctionDerivatives - 1; ++i) {
-                    const IndexType num_derivatives = (2 + i) * (3 + i) / 2;
-                    shape_function_gradients[0][i_point].resize(num_nonzero_cps, num_derivatives);
-                }
+                shape_function_gradients[0][i_point].resize(num_nonzero_cps, 3);
             }
 
             // Centroid of points. This will be used to identify knot span.
@@ -789,16 +786,9 @@ public:
                 }
 
                 // Get Shape Function Derivatives DN_De, ...
-                if (NumberOfShapeFunctionDerivatives > 0) {
-                    IndexType shape_derivative_index = 1;
-                    for (IndexType n = 0; n < NumberOfShapeFunctionDerivatives - 1; ++n) {
-                        const IndexType num_derivatives = (2 + n) * (3 + n) / 2;
-                        for (IndexType k = 0; k < num_derivatives; ++k) {
-                            for (IndexType j = 0; j < num_nonzero_cps; ++j) {
-                                shape_function_gradients[0][i_point](j, k) = shape_function_container(j, shape_derivative_index + k);
-                            }
-                        }
-                        shape_derivative_index += num_derivatives;
+                for (IndexType k = 0; k < 3; ++k) {
+                    for (IndexType j = 0; j < num_nonzero_cps; ++j) {
+                        shape_function_gradients[0][i_point](j, k) = shape_function_container(j, 1 + k);
                     }
                 }
             }

--- a/kratos/tests/cpp_tests/geometries/test_nurbs_volume.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_nurbs_volume.cpp
@@ -443,10 +443,9 @@ namespace Testing {
         // Check general information, input to ouput
         typename Geometry<NodeType>::IntegrationPointsArrayType integration_points;
         IntegrationInfo integration_info = pyramid.GetDefaultIntegrationInfo();
-        pyramid.CreateIntegrationPoints(integration_points, integration_info);
 
         typename Geometry<NodeType>::GeometriesArrayType quadrature_points;
-        pyramid.CreateQuadraturePointGeometries(quadrature_points, 3, integration_points, integration_info);
+        pyramid.CreateQuadraturePointGeometries(quadrature_points, 3, integration_info);
 
         KRATOS_CHECK_EQUAL(quadrature_points.size(), 1440);
         double sum = 0;


### PR DESCRIPTION
**📝 Description**
Refactor CreateQuadraturePointGeometries() of NurbsVolumeGeometry.
So far, in IGA  in Kratos one QuadraturePointGeometry is created for each integration point. Consequently, each point is associated with a separate element. This is quite expensive (at least for solids) for the assembly of the system matrices since the contributions of each point are assembled to the global matrices.
I added an additional interface that allows to create one quadrature point geometry per knot span, which contains all integration points.

**🆕 Changelog**
- CreateQuadraturePointGeometries() of NurbsVolumeGeometry
