### PR TITLE
[Core] Refactor and clean up `SimpleMortarMapper`

### DIFF
--- a/kratos/processes/simple_mortar_mapper_process.cpp
+++ b/kratos/processes/simple_mortar_mapper_process.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Vicente Mataix Ferrandiz
 //
@@ -16,8 +16,6 @@
 
 // Project includes
 #include "processes/simple_mortar_mapper_process.h"
-
-/* Custom utilities */
 #include "utilities/geometrical_projection_utilities.h"
 #include "utilities/mortar_utilities.h"
 #include "utilities/normal_calculation_utils.h"

--- a/kratos/processes/simple_mortar_mapper_process.h
+++ b/kratos/processes/simple_mortar_mapper_process.h
@@ -4,14 +4,13 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Vicente Mataix Ferrandiz
 //
 
-#if !defined(KRATOS_SIMPLE_MORTAR_MAPPER_PROCESS)
-#define KRATOS_SIMPLE_MORTAR_MAPPER_PROCESS
+#pragma once
 
 // System includes
 #include <unordered_map>
@@ -46,7 +45,7 @@ namespace Kratos
 ///@{
 
     /// The definition of the size type
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
 
 ///@}
 ///@name  Enum's
@@ -74,7 +73,7 @@ public:
     ///@name Type Definitions
     ///@{
 
-    typedef Point BaseType;
+    using BaseType = Point;
 
     /// Counted pointer of PointMapper
     KRATOS_CLASS_POINTER_DEFINITION( PointMapper );
@@ -222,54 +221,65 @@ public:
     /// Pointer definition of SimpleMortarMapperProcess
     KRATOS_CLASS_POINTER_DEFINITION(SimpleMortarMapperProcess);
 
-    typedef Point                                        PointType;
-    typedef Node                                       NodeType;
-    typedef Geometry<NodeType>                        GeometryType;
-    typedef Geometry<PointType>                  GeometryPointType;
+    //// Type definition for Point
+    using PointType = Point;
 
-    /// Type definition for integration methods
-    typedef GeometryData::IntegrationMethod      IntegrationMethod;
+    /// Type definition for node geometry
+    using GeometryType = Geometry<Node>;
 
-    /// Auxiliar geometries
-    typedef Line2D2<PointType>                            LineType;
-    typedef Triangle3D3<PointType>                    TriangleType;
-    typedef typename std::conditional<TDim == 2, LineType, TriangleType >::type DecompositionType;
+    /// Type definition for point geometry
+    using GeometryPointType = Geometry<PointType>;
 
+    //// Type definition for integration methods
+    using IntegrationMethod = GeometryData::IntegrationMethod;
 
-    /// Linear solver
-    typedef UblasSpace<double, CompressedMatrix, Vector>    SparseSpaceType;
-    typedef UblasSpace<double, Matrix, Vector>               LocalSpaceType;
-    typedef typename SparseSpaceType::MatrixType                 MatrixType;
-    typedef typename SparseSpaceType::VectorType                 VectorType;
-    typedef LinearSolver<SparseSpaceType, LocalSpaceType > LinearSolverType;
+    /// Type definition for LineType
+    using LineType = Line2D2<PointType>;
 
+    /// Type definition for TriangleType
+    using TriangleType = Triangle3D3<PointType>;
+
+    /// Type definition for DecompositionType based on TDim value
+    using DecompositionType = typename std::conditional<TDim == 2, LineType, TriangleType>::type;
+
+    /// Type definition for sparse space type
+    using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;
+
+    /// Type definition for local space type
+    using LocalSpaceType = UblasSpace<double, Matrix, Vector>;
+
+    /// Type definition for matrix
+    using MatrixType = typename SparseSpaceType::MatrixType;
+
+    /// Type definition for vector
+    using VectorType = typename SparseSpaceType::VectorType;
+
+    /// Type definition for linear solver
+    using LinearSolverType = LinearSolver<SparseSpaceType, LocalSpaceType>;
 
     /// Index type definition
-    typedef std::size_t                                          IndexType;
+    using IndexType = std::size_t;
 
     /// A map for integers
-    typedef std::unordered_map<IndexType, IndexType>                IntMap;
+    using IntMap = std::unordered_map<IndexType, IndexType>;
 
     /// BoundedMatrix
-    typedef BoundedMatrix<double, TNumNodes, TNumNodes>  BoundedMatrixType;
+    using BoundedMatrixType = BoundedMatrix<double, TNumNodes, TNumNodes>;
 
-    // Type definitions for the tree
-    typedef PointMapper                                     PointMapperType;
-    typedef PointMapperType::Pointer                       PointTypePointer;
-    typedef std::vector<PointTypePointer>                       PointVector;
-    typedef PointVector::iterator                             PointIterator;
-    typedef std::vector<double>                              DistanceVector;
-    typedef DistanceVector::iterator                       DistanceIterator;
+    /// Type definitions for the tree
+    using PointMapperType = PointMapper;
+    using PointTypePointer = typename PointMapperType::Pointer;
+    using PointVector = std::vector<PointTypePointer>;
 
     // KDtree definitions
-    typedef Bucket< 3ul, PointMapperType, PointVector, PointTypePointer, PointIterator, DistanceIterator > BucketType;
-    typedef Tree< KDTreePartition<BucketType> > KDTreeType;
+    using BucketType = Bucket<3ul, PointMapperType, PointVector>;
+    using KDTreeType = Tree<KDTreePartition<BucketType>>;
 
     /// Mortar definition
-    typedef MortarKinematicVariables<TNumNodes, TNumNodesMaster>                        MortarKinematicVariablesType;
-    typedef MortarOperator<TNumNodes, TNumNodesMaster>                                            MortarOperatorType;
-    typedef DualLagrangeMultiplierOperators<TNumNodes, TNumNodesMaster>          DualLagrangeMultiplierOperatorsType;
-    typedef ExactMortarIntegrationUtility<TDim, TNumNodes, false, TNumNodesMaster> ExactMortarIntegrationUtilityType;
+    using MortarKinematicVariablesType = MortarKinematicVariables<TNumNodes, TNumNodesMaster>;
+    using MortarOperatorType = MortarOperator<TNumNodes, TNumNodesMaster>;
+    using DualLagrangeMultiplierOperatorsType = DualLagrangeMultiplierOperators<TNumNodes, TNumNodesMaster>;
+    using ExactMortarIntegrationUtilityType = ExactMortarIntegrationUtility<TDim, TNumNodes, false, TNumNodesMaster>;
 
     /// Auxiliar struct for mapping
     struct TLS {
@@ -401,11 +411,9 @@ public:
     ///@name Access
     ///@{
 
-
     ///@}
     ///@name Inquiry
     ///@{
-
 
     ///@}
     ///@name Input and output
@@ -433,36 +441,6 @@ public:
     ///@{
 
     ///@}
-protected:
-
-    ///@name Protected static Member Variables
-    ///@{
-
-    ///@}
-    ///@name Protected member Variables
-    ///@{
-
-    ///@}
-    ///@name Protected Operators
-    ///@{
-
-    ///@}
-    ///@name Protected Operations
-    ///@{
-
-    ///@}
-    ///@name Protected  Access
-    ///@{
-
-    ///@}
-    ///@name Protected Inquiry
-    ///@{
-
-    ///@}
-    ///@name Protected LifeCycle
-    ///@{
-    ///@}
-
 private:
     ///@name Static Member Variables
     ///@{
@@ -992,4 +970,3 @@ private:
 ///@}
 
 }  // namespace Kratos.
-#endif /* KRATOS_SIMPLE_MORTAR_MAPPER_PROCESS defined */

--- a/kratos/processes/simple_mortar_mapper_wrapper_process.h
+++ b/kratos/processes/simple_mortar_mapper_wrapper_process.h
@@ -4,14 +4,13 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Vicente Mataix Ferrandiz
 //
 
-#if !defined(KRATOS_SIMPLE_MORTAR_MAPPER_WRAPPER_PROCESS)
-#define KRATOS_SIMPLE_MORTAR_MAPPER_WRAPPER_PROCESS
+#pragma once
 
 // System includes
 
@@ -30,7 +29,7 @@ namespace Kratos
 ///@{
 
     /// The definition of the size type
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
 
 ///@}
 ///@name  Enum's
@@ -60,15 +59,23 @@ public:
     /// Pointer definition of SimpleMortarMapperProcessWrapper
     KRATOS_CLASS_POINTER_DEFINITION(SimpleMortarMapperProcessWrapper);
 
-    /// Linear solver
-    typedef UblasSpace<double, CompressedMatrix, Vector>    SparseSpaceType;
-    typedef UblasSpace<double, Matrix, Vector>               LocalSpaceType;
-    typedef typename SparseSpaceType::MatrixType                 MatrixType;
-    typedef typename SparseSpaceType::VectorType                 VectorType;
-    typedef LinearSolver<SparseSpaceType, LocalSpaceType > LinearSolverType;
+    /// Type definition for sparse space type
+    using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;
+
+    /// Type definition for local space type
+    using LocalSpaceType = UblasSpace<double, Matrix, Vector>;
+
+    /// Type definition for matrix
+    using MatrixType = typename SparseSpaceType::MatrixType;
+
+    /// Type definition for vector
+    using VectorType = typename SparseSpaceType::VectorType;
+
+    /// Type definition for linear solver
+    using LinearSolverType = LinearSolver<SparseSpaceType, LocalSpaceType>;
 
     /// Index type definition
-    typedef std::size_t                                          IndexType;
+    using IndexType = std::size_t;
 
     ///@}
     ///@name Life Cycle
@@ -268,11 +275,9 @@ public:
     ///@name Access
     ///@{
 
-
     ///@}
     ///@name Inquiry
     ///@{
-
 
     ///@}
     ///@name Input and output
@@ -300,36 +305,6 @@ public:
     ///@{
 
     ///@}
-protected:
-
-    ///@name Protected static Member Variables
-    ///@{
-
-    ///@}
-    ///@name Protected member Variables
-    ///@{
-
-    ///@}
-    ///@name Protected Operators
-    ///@{
-
-    ///@}
-    ///@name Protected Operations
-    ///@{
-
-    ///@}
-    ///@name Protected  Access
-    ///@{
-
-    ///@}
-    ///@name Protected Inquiry
-    ///@{
-
-    ///@}
-    ///@name Protected LifeCycle
-    ///@{
-    ///@}
-
 private:
     ///@name Static Member Variables
     ///@{
@@ -350,8 +325,7 @@ private:
     ///@}
     ///@name Private  Access
     ///@{
-    ///@}
-
+        
     ///@}
     ///@name Serialization
     ///@{
@@ -365,12 +339,9 @@ private:
 
     ///@}
 };// class SimpleMortarMapperProcessWrapper
-
-
 ///@}
 ///@name Type Definitions
 ///@{
-
 
 ///@}
 ///@name Input and output
@@ -379,4 +350,3 @@ private:
 ///@}
 
 }  // namespace Kratos.
-#endif /* KRATOS_SIMPLE_MORTAR_MAPPER_WRAPPER_PROCESS defined */

--- a/kratos/spatial_containers/specialized_spatial_search.cpp
+++ b/kratos/spatial_containers/specialized_spatial_search.cpp
@@ -21,39 +21,6 @@
 namespace Kratos
 {
 
-template<>
-void PointObject<Node>::UpdatePoint()
-{
-    noalias(this->Coordinates()) = mpObject->Coordinates();
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template<>
-void PointObject<GeometricalObject>::UpdatePoint()
-{
-    noalias(this->Coordinates()) = mpObject->GetGeometry().Center().Coordinates();
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template<>
-void PointObject<Condition>::UpdatePoint()
-{
-    noalias(this->Coordinates()) = mpObject->GetGeometry().Center().Coordinates();
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template<>
-void PointObject<Element>::UpdatePoint()
-{
-    noalias(this->Coordinates()) = mpObject->GetGeometry().Center().Coordinates();
-}
-
 template class PointObject<Node>;
 template class PointObject<GeometricalObject>;
 template class PointObject<Condition>;

--- a/kratos/spatial_containers/specialized_spatial_search.cpp
+++ b/kratos/spatial_containers/specialized_spatial_search.cpp
@@ -31,6 +31,15 @@ void PointObject<Node>::UpdatePoint()
 /***********************************************************************************/
 
 template<>
+void PointObject<GeometricalObject>::UpdatePoint()
+{
+    noalias(this->Coordinates()) = mpObject->GetGeometry().Center().Coordinates();
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<>
 void PointObject<Condition>::UpdatePoint()
 {
     noalias(this->Coordinates()) = mpObject->GetGeometry().Center().Coordinates();
@@ -46,6 +55,7 @@ void PointObject<Element>::UpdatePoint()
 }
 
 template class PointObject<Node>;
+template class PointObject<GeometricalObject>;
 template class PointObject<Condition>;
 template class PointObject<Element>;
 

--- a/kratos/spatial_containers/specialized_spatial_search.h
+++ b/kratos/spatial_containers/specialized_spatial_search.h
@@ -117,7 +117,16 @@ public:
     /**
      * @brief This function updates the database, using as base for the coordinates the condition center
      */
-    void UpdatePoint();
+    void UpdatePoint()
+    {
+        if constexpr (std::is_same<TObject, Node>::value) {
+            noalias(this->Coordinates()) = mpObject->Coordinates();
+        } else if constexpr (std::is_same<TObject, GeometricalObject>::value || std::is_same<TObject, Condition>::value || std::is_same<TObject, Element>::value) {
+            noalias(this->Coordinates()) = mpObject->GetGeometry().Center().Coordinates();
+        } else {
+            static_assert((std::is_same<TObject, Node>::value || std::is_same<TObject, GeometricalObject>::value || std::is_same<TObject, Condition>::value || std::is_same<TObject, Element>::value), "PointObject is implemented for Node, GeometricalObject, Condition and Element");
+        }
+    }
 
     ///@}
     ///@name Acess

--- a/kratos/spatial_containers/specialized_spatial_search.h
+++ b/kratos/spatial_containers/specialized_spatial_search.h
@@ -92,6 +92,15 @@ public:
     }
 
     /**
+     * @brief Constructor that takes the coordinates of the point.
+     * @param Coords The coordinates of the point.
+     */
+    PointObject(const array_1d<double, 3>& Coords)
+        :BaseType(Coords)
+    {}
+
+
+    /**
      * @brief Constructor with object
      * @param pObject The pointer to the object
      */

--- a/kratos/spatial_containers/specialized_spatial_search.h
+++ b/kratos/spatial_containers/specialized_spatial_search.h
@@ -76,7 +76,7 @@ public:
     ///@{
 
     /// Base class definition
-    typedef Point BaseType;
+    using BaseType = Point;
 
     /// Counted pointer of PointObject
     KRATOS_CLASS_POINTER_DEFINITION( PointObject );


### PR DESCRIPTION
**📝 Description**

Refactor and clean up `SimpleMortarMapper`

- Use `pragma once`
- Clean up header
- Replace `typedef` by `using`
- Replace `PointMapper` by `PointObject`
- Reduce code duplication when exposing to python using templates

**🆕 Changelog**

- [Clean up `SimpleMortarMapper`](https://github.com/KratosMultiphysics/Kratos/commit/2c51ff8c77e87ef25a670ea51fdde0adecb4c045)
- [Extend `PointObject`](https://github.com/KratosMultiphysics/Kratos/commit/9850991d860d7ca6f26d2f420b28ff35c205bcee)
- [Replace `PointMapper` by `PointObject`](https://github.com/KratosMultiphysics/Kratos/commit/7b5878aa14c71fd195f4af0bae46acd2aad0d4f6)
