### PR TITLE
[ContactStructuralMechanicsApplications] Adding scale factor to meshtying in order to improve conditioning

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
@@ -379,13 +379,13 @@ void MeshTyingMortarCondition<TDim, TNumNodes, TNumNodesMaster>::CalculateCondit
     // Assemble of the matrix is required
     if ( ComputeLHS ) {
         // Calculate the local contribution
-        this->CalculateLocalLHS(rLeftHandSideMatrix, mMortarConditionMatrices, dof_data);
+        this->CalculateLocalLHS(rLeftHandSideMatrix, mMortarConditionMatrices, dof_data, rCurrentProcessInfo);
     }
 
     // Assemble of the vector is required
     if ( ComputeRHS) {
         // Calculate the local contribution
-        this->CalculateLocalRHS( rRightHandSideVector, mMortarConditionMatrices, dof_data);
+        this->CalculateLocalRHS( rRightHandSideVector, mMortarConditionMatrices, dof_data, rCurrentProcessInfo);
     }
 
     KRATOS_CATCH( "" );
@@ -526,7 +526,8 @@ template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
 void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateLocalLHS(
     Matrix& rLocalLHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
-    const DofData& rDofData
+    const DofData& rDofData,
+    const ProcessInfo& rCurrentProcessInfo
     )
 {
     // We get the mortar operators
@@ -539,6 +540,9 @@ void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateLocalLH
     // Get the DoF size
     const SizeType dof_size = mpDoFVariables.size();
 
+    // Get the scale factor
+    const double scale_factor = rCurrentProcessInfo.Has(SCALE_FACTOR) ? rCurrentProcessInfo[SCALE_FACTOR] : 1.0;
+
     // Initial index 
     IndexType initial_row_index = 0;
     const IndexType initial_column_index = dof_size * (TNumNodes + TNumNodesMaster);
@@ -547,8 +551,9 @@ void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateLocalLH
     for (IndexType i = 0; i < dof_size; ++i) {
         for (IndexType j = 0; j < TNumNodesMaster; ++j) {
             for (IndexType k = 0; k < TNumNodes; ++k) {
-                rLocalLHS(initial_row_index + j * dof_size + i, initial_column_index + k * dof_size + i) = - r_MOperator(k, j);
-                rLocalLHS(initial_column_index + k * dof_size + i, initial_row_index + j * dof_size + i) = - r_MOperator(k, j);
+                const double value = - scale_factor * r_MOperator(k, j);
+                rLocalLHS(initial_row_index + j * dof_size + i, initial_column_index + k * dof_size + i) = value;
+                rLocalLHS(initial_column_index + k * dof_size + i, initial_row_index + j * dof_size + i) = value;
             }
         }
     }
@@ -560,8 +565,9 @@ void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateLocalLH
     for (IndexType i = 0; i < dof_size; ++i) {
         for (IndexType j = 0; j < TNumNodes; ++j) {
             for (IndexType k = 0; k < TNumNodes; ++k) {
-                rLocalLHS(initial_row_index + j * dof_size + i, initial_column_index + k * dof_size + i) = r_DOperator(k, j);
-                rLocalLHS(initial_column_index + k * dof_size + i, initial_row_index + j * dof_size + i) = r_DOperator(k, j);
+                const double value = scale_factor * r_DOperator(k, j);
+                rLocalLHS(initial_row_index + j * dof_size + i, initial_column_index + k * dof_size + i) = value;
+                rLocalLHS(initial_column_index + k * dof_size + i, initial_row_index + j * dof_size + i) = value;
             }
         }
     }
@@ -577,7 +583,8 @@ template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
 void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateLocalRHS(
     Vector& rLocalRHS,
     const MortarConditionMatrices& rMortarConditionMatrices,
-    const DofData& rDofData
+    const DofData& rDofData,
+    const ProcessInfo& rCurrentProcessInfo
     )
 {
     // Initialize values
@@ -592,11 +599,14 @@ void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateLocalRH
     // Get the DoF size
     const SizeType dof_size = mpDoFVariables.size();
 
+    // Get the scale factor
+    const double scale_factor = rCurrentProcessInfo.Has(SCALE_FACTOR) ? rCurrentProcessInfo[SCALE_FACTOR] : 1.0;
+
     // Initial index 
     IndexType initial_index = 0;
 
     // Master side
-    const Matrix Mlm = prod(trans(r_MOperator), r_lm);
+    const Matrix Mlm = scale_factor * prod(trans(r_MOperator), r_lm);
     for (IndexType i = 0; i < TNumNodesMaster; ++i) {
         for (IndexType j = 0; j < dof_size; ++j) {
             rLocalRHS[initial_index + i * dof_size + j] = Mlm(i, j);
@@ -605,7 +615,7 @@ void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateLocalRH
 
     // Slave side
     initial_index = TNumNodesMaster * dof_size;
-    const Matrix Dlm = prod(trans(r_DOperator), r_lm);
+    const Matrix Dlm = scale_factor * prod(trans(r_DOperator), r_lm);
     for (IndexType i = 0; i < TNumNodes; ++i) {
         for (IndexType j = 0; j < dof_size; ++j) {
             rLocalRHS[initial_index + i * dof_size + j] = - Dlm(i, j);
@@ -614,7 +624,7 @@ void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateLocalRH
 
     // LM slave side
     initial_index = (TNumNodes + TNumNodesMaster) * dof_size;
-    const Matrix Du1Mu2 = prod(r_DOperator, r_u1) - prod(r_MOperator, r_u2);
+    const Matrix Du1Mu2 = scale_factor * (prod(r_DOperator, r_u1) - prod(r_MOperator, r_u2));
     for (IndexType i = 0; i < TNumNodes; ++i) {
         for (IndexType j = 0; j < dof_size; ++j) {
             rLocalRHS[initial_index + i * dof_size + j] = - Du1Mu2(i, j);

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.h
@@ -585,11 +585,13 @@ protected:
      * @param rLocalLHS The local LHS to compute
      * @param rMortarConditionMatrices The mortar operators to be considered
      * @param rDofData The class containing all the information needed in order to compute the jacobian
+     * @param rCurrentProcessInfo the current process info instance
      */
     void CalculateLocalLHS(
         Matrix& rLocalLHS,
         const MortarConditionMatrices& rMortarConditionMatrices,
-        const DofData& rDofData
+        const DofData& rDofData,
+        const ProcessInfo& rCurrentProcessInfo
         );
 
     /**
@@ -597,11 +599,13 @@ protected:
      * @param rLocalRHS The local RHS to compute
      * @param rMortarConditionMatrices The mortar operators to be considered
      * @param rDofData The class containing all the information needed in order to compute the jacobian
+     * @param rCurrentProcessInfo the current process info instance
      */
     void CalculateLocalRHS(
         Vector& rLocalRHS,
         const MortarConditionMatrices& rMortarConditionMatrices,
-        const DofData& rDofData
+        const DofData& rDofData,
+        const ProcessInfo& rCurrentProcessInfo
         );
 
     /***********************************************************************************/

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/alm_fast_init_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/alm_fast_init_process.h
@@ -84,8 +84,7 @@ public:
     }
 
     /// Destructor.
-    ~ALMFastInit() override
-    = default;
+    ~ALMFastInit() override = default;
 
     ///@}
     ///@name Access
@@ -148,10 +147,6 @@ public:
     }
 
     ///@}
-    ///@name Friends
-    ///@{
-
-    ///@}
 private:
     ///@name Static Member Variables
     ///@{
@@ -203,18 +198,18 @@ private:
 ///@{
 
 /// input stream function
-// inline std::istream& operator >> (std::istream& rIStream,
-//                                   ALMFastInit& rThis);
-//
-// /// output stream function
-// inline std::ostream& operator << (std::ostream& rOStream,
-//                                   const ALMFastInit& rThis)
-// {
-//     rThis.PrintInfo(rOStream);
-//     rOStream << std::endl;
-//     rThis.PrintData(rOStream);
-//
-//     return rOStream;
-// }
+inline std::istream& operator >> (std::istream& rIStream,
+                                  ALMFastInit& rThis);
+
+/// output stream function
+inline std::ostream& operator << (std::ostream& rOStream,
+                                  const ALMFastInit& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
 
 }

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/alm_variables_calculation_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/alm_variables_calculation_process.cpp
@@ -94,19 +94,42 @@ void ALMVariablesCalculationProcess::Execute()
     mean_nodal_h_master       /= (total_area_master   + tolerance);
     mean_young_modulus_master /= (total_volume_master + tolerance);
 
+    // Prepare the string stream
+    std::stringstream buffer;
+
     // Finally we compute the penalty factor
-    const double penalty_parameter_slave  = (mean_young_modulus_slave > epsilon) ? mFactorStiffness * mean_young_modulus_slave/(mean_nodal_h_slave + tolerance) : mFactorStiffness * mean_young_modulus_master/(mean_nodal_h_master + tolerance);
-    const double scale_factor_slave       = mPenaltyScale * mFactorStiffness * mean_young_modulus_slave/(mean_nodal_h_slave + tolerance);
-    const double penalty_parameter_master = mFactorStiffness * mean_young_modulus_master/(mean_nodal_h_master + tolerance);
-    const double scale_factor_master      = mPenaltyScale * mFactorStiffness * mean_young_modulus_master/(mean_nodal_h_master + tolerance);
+    if (mComputePenalty) {
+        const double penalty_parameter_slave  = (mean_young_modulus_slave > epsilon) ? mFactorStiffness * mean_young_modulus_slave/(mean_nodal_h_slave + tolerance) : mFactorStiffness * mean_young_modulus_master/(mean_nodal_h_master + tolerance);
+        const double penalty_parameter_master = mFactorStiffness * mean_young_modulus_master/(mean_nodal_h_master + tolerance);
 
-    KRATOS_INFO("ALM Values") << "The potential parameters for penalty and scale factor are: \n" << "PENALTY SLAVE:\t" << penalty_parameter_slave << "\tPENALTY MASTER:\t" << penalty_parameter_master << "\nSCALE FACTOR SLAVE:\t" << scale_factor_slave << "\tSCALE FACTOR MASTER:\t" << scale_factor_master << std::endl;
+        // Fill the buffer
+        if (mComputeScaleFactor) buffer << "The potential parameters for penalty and scale factor are: \n";
+        buffer << "PENALTY SLAVE:\t" << penalty_parameter_slave << "\tPENALTY MASTER:\t" << penalty_parameter_master;
 
-    // NOTE: > or <? , we are supposed to take the smallest of the values (less stiff)
-    const double final_penalty = (penalty_parameter_slave < penalty_parameter_master) ? penalty_parameter_slave : penalty_parameter_master;
-    const double final_scale_factor = (scale_factor_slave < scale_factor_master) ? scale_factor_slave : scale_factor_master;
-    mrThisModelPart.GetProcessInfo().SetValue(INITIAL_PENALTY, final_penalty);
-    mrThisModelPart.GetProcessInfo().SetValue(SCALE_FACTOR, final_scale_factor);
+        // NOTE: > or <? , we are supposed to take the smallest of the values (less stiff)
+        const double final_penalty = (penalty_parameter_slave < penalty_parameter_master) ? penalty_parameter_slave : penalty_parameter_master;
+        
+        // Setting value
+        mrThisModelPart.GetProcessInfo().SetValue(INITIAL_PENALTY, final_penalty);
+    }
+
+    // Finally we compute the scale factor
+    if (mComputeScaleFactor) {
+        const double scale_factor_slave  = mPenaltyScale * mFactorStiffness * mean_young_modulus_slave/(mean_nodal_h_slave + tolerance);
+        const double scale_factor_master = mPenaltyScale * mFactorStiffness * mean_young_modulus_master/(mean_nodal_h_master + tolerance);
+
+        // Fill the buffer
+        if (!mComputePenalty) buffer << "The potential parameters for scale factor are: \n";
+        buffer << "\nSCALE FACTOR SLAVE:\t" << scale_factor_slave << "\tSCALE FACTOR MASTER:\t" << scale_factor_master;
+
+        // NOTE: > or <? , we are supposed to take the smallest of the values (less stiff)
+        const double final_scale_factor = (scale_factor_slave < scale_factor_master) ? scale_factor_slave : scale_factor_master;
+
+        // Setting value
+        mrThisModelPart.GetProcessInfo().SetValue(SCALE_FACTOR, final_scale_factor);
+    }
+
+    KRATOS_INFO("ALM Values") << buffer.str() << std::endl;
 
     KRATOS_CATCH("")
 } // class ALMVariablesCalculationProcess

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/alm_variables_calculation_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/alm_variables_calculation_process.h
@@ -87,8 +87,11 @@ public:
 
         ThisParameters.ValidateAndAssignDefaults(GetDefaultParameters());
 
+        // Assign members variables from parameters
         mFactorStiffness = ThisParameters["stiffness_factor"].GetDouble();
         mPenaltyScale = ThisParameters["penalty_scale_factor"].GetDouble();
+        mComputeScaleFactor = ThisParameters["compute_scale_factor"].GetBool();
+        mComputePenalty = ThisParameters["compute_penalty"].GetBool();
 
         KRATOS_ERROR_IF_NOT(rThisModelPart.HasNodalSolutionStepVariable( rNodalLengthVariable )) << "Missing variable " << rNodalLengthVariable;
 
@@ -96,8 +99,7 @@ public:
     }
 
     /// Destructor.
-    ~ALMVariablesCalculationProcess() override
-    = default;
+    ~ALMVariablesCalculationProcess() override = default;
 
     ///@}
     ///@name Access
@@ -108,17 +110,12 @@ public:
     ///@{
 
     ///@}
-    ///@name Input and output
-    ///@{
-
-    ///@}
-    ///@name Friends
-    ///@{
-
-    ///@}
     ///@name Operators
     ///@{
 
+    /**
+     * @brief Executes the process
+     */
     void operator()()
     {
         Execute();
@@ -128,6 +125,9 @@ public:
     ///@name Operations
     ///@{
 
+    /**
+     * @brief Executes the process
+     */
     void Execute() override;
 
     /**
@@ -137,8 +137,10 @@ public:
     {
         const Parameters default_parameters = Parameters(R"(
         {
-            "stiffness_factor"                     : 10.0,
-            "penalty_scale_factor"                 : 1.0
+            "stiffness_factor"     : 10.0,
+            "penalty_scale_factor" : 1.0,
+            "compute_scale_factor" : true,
+            "compute_penalty"      : true
         })" );
 
         return default_parameters;
@@ -148,11 +150,9 @@ public:
     ///@name Access
     ///@{
 
-
     ///@}
     ///@name Inquiry
     ///@{
-
 
     ///@}
     ///@name Input and output
@@ -176,10 +176,6 @@ public:
     }
 
     ///@}
-    ///@name Friends
-    ///@{
-
-    ///@}
 private:
     ///@name Static Member Variables
     ///@{
@@ -188,10 +184,12 @@ private:
     ///@name Member Variables
     ///@{
 
-    ModelPart& mrThisModelPart;              // The main model part
-    Variable<double>& mrNodalLengthVariable; // The variable used to messure the lenght of the element
-    double mFactorStiffness;                 // The proportion between stiffness and penalty/scale factor
-    double mPenaltyScale;                    // The penalty/scale factor proportion
+    ModelPart& mrThisModelPart;              /// The main model part
+    Variable<double>& mrNodalLengthVariable; /// The variable used to messure the lenght of the element
+    double mFactorStiffness;                 /// The proportion between stiffness and penalty/scale factor
+    double mPenaltyScale;                    /// The penalty/scale factor proportion
+    bool mComputeScaleFactor;                /// If compute the scale factor
+    bool mComputePenalty;                    /// If compute the penalty
 
     ///@}
     ///@name Private Operators
@@ -224,28 +222,26 @@ private:
 }; // Class ALMVariablesCalculationProcess
 
 ///@}
-
 ///@name Type Definitions
 ///@{
-
 
 ///@}
 ///@name Input and output
 ///@{
 
 /// input stream function
-// inline std::istream& operator >> (std::istream& rIStream,
-//                                   ALMVariablesCalculationProcess& rThis);
-//
-// /// output stream function
-// inline std::ostream& operator << (std::ostream& rOStream,
-//                                   const ALMVariablesCalculationProcess& rThis)
-// {
-//     rThis.PrintInfo(rOStream);
-//     rOStream << std::endl;
-//     rThis.PrintData(rOStream);
-//
-//     return rOStream;
-// }
+inline std::istream& operator >> (std::istream& rIStream,
+                                  ALMVariablesCalculationProcess& rThis);
+
+/// output stream function
+inline std::ostream& operator << (std::ostream& rOStream,
+                                  const ALMVariablesCalculationProcess& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
 
 }

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/mesh_tying_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/mesh_tying_process.py
@@ -65,6 +65,11 @@ class MeshTyingProcess(search_base_process.SearchBaseProcess):
                     "lower_bounding_box_coefficient"  : 0.0,
                     "higher_bounding_box_coefficient" : 1.0
                 }
+            },
+            "scale_factor_parameters" : {
+                "manual_scale_factor"         : false,
+                "stiffness_factor"            : 1.0,
+                "scale_factor"                : 1.0e0
             }
         }
         """)
@@ -106,6 +111,17 @@ class MeshTyingProcess(search_base_process.SearchBaseProcess):
 
         # We call to the base process
         super().ExecuteInitialize()
+
+        # Scale factor settings
+        if self.mesh_tying_settings["scale_factor_parameters"]["manual_scale_factor"].GetBool():
+            self.scale_factor = self.mesh_tying_settings["scale_factor_parameters"]["scale_factor"].GetDouble()
+        else:
+            scale_factor_var_parameters = KM.Parameters("""{
+                "compute_penalty"      : false
+            }""")
+            scale_factor_var_parameters.AddValue("stiffness_factor", self.mesh_tying_settings["scale_factor_parameters"]["stiffness_factor"])
+            self.scale_factor_process = CSMA.ALMVariablesCalculationProcess(self._get_process_model_part(), KM.NODAL_H, scale_factor_var_parameters)
+            self.scale_factor_process.Execute()
 
     def ExecuteBeforeSolutionLoop(self):
         """ This method is executed before starting the time loop


### PR DESCRIPTION
**📝 Description**

Scale factor was considered for contact mechanics, but not for meshtying. This brings the scale factor in order to improve conditioning of the system of equations (mesh tying mostly adds 1s to the matrix and makes terrible conditioning...in addition to the saddle point, which I am trying to remove right now)

**🆕 Changelog**

- [Adding scale factor to meshtying in order to improve conditioning](https://github.com/KratosMultiphysics/Kratos/commit/64f43e0f96408119a63af12e180f2cf5316130de)
- [Extend scale factor only calculation](https://github.com/KratosMultiphysics/Kratos/commit/5b8cfeb7a07fc2653971106d1e6ef6d452062626)
- [Initialize scale factor](https://github.com/KratosMultiphysics/Kratos/commit/107124a442e9bd7b110ad4b1ae6f4065669b03b6)
