### PR TITLE
[Core] `pragma once` in function_parser_utility.h file

### DIFF
--- a/kratos/utilities/function_parser_utility.h
+++ b/kratos/utilities/function_parser_utility.h
@@ -11,8 +11,7 @@
 //  Collaborator:    Vicente Mataix Ferrandiz
 //
 
-#if !defined(KRATOS_FUNCTION_PARSER_UTILITY_H_INCLUDED)
-#define  KRATOS_FUNCTION_PARSER_UTILITY_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -359,5 +358,3 @@ private:
 }; /// FunctionParser
 
 } /// namespace Kratos
-
-#endif // KRATOS_FUNCTION_PARSER_UTILITY_H_INCLUDED


### PR DESCRIPTION
**📝 Description**

The inclusion guard is replaced with a `#pragma once` directive, which provides a more concise and modern way to prevent multiple inclusions of the header file. 

**🆕 Changelog**

- [pragma once](https://github.com/KratosMultiphysics/Kratos/commit/f6558453a1cd230c05813eb327f6b2ab9b0c4043)
