### PR TITLE
[Core] Preserve Error Messages During Stub Generation

### DIFF
--- a/scripts/post_install/stub_generation.py
+++ b/scripts/post_install/stub_generation.py
@@ -234,7 +234,8 @@ if __name__ == "__main__":
     error_and_warning_outut_file = f"{sys.argv[1]}/stub_generation_errors_and_warnings.txt"
     if "--quiet" in sys.argv: # suppress output from Kratos imports
         args = [arg for arg in sys.argv if arg != "--quiet"]
-        exit(subprocess.run([sys.executable] + args, stdout = subprocess.PIPE, stderr = sys.stderr).returncode)
+        subprocess.run([sys.executable] + args, stdout = subprocess.PIPE, stderr = sys.stderr, check=True)
+
     else:
         Main()
         PostProcessGeneratedStubFiles()

--- a/scripts/post_install/stub_generation.py
+++ b/scripts/post_install/stub_generation.py
@@ -234,9 +234,7 @@ if __name__ == "__main__":
     error_and_warning_outut_file = f"{sys.argv[1]}/stub_generation_errors_and_warnings.txt"
     if "--quiet" in sys.argv: # suppress output from Kratos imports
         args = [arg for arg in sys.argv if arg != "--quiet"]
-        output = subprocess.run([sys.executable] + args, stdout = subprocess.PIPE, stderr = subprocess.PIPE)
-        for matched_group in re.finditer(r"(Error|Warning|error|warning)(.*?\\n)", str(output.stdout) + str(output.stderr)):
-            print("---- ", matched_group[1], matched_group[2])
+        exit(subprocess.run([sys.executable] + args, stdout = subprocess.PIPE, stderr = sys.stderr).returncode)
     else:
         Main()
         PostProcessGeneratedStubFiles()


### PR DESCRIPTION
The stub generating script swallowed everything from `stdout` and `stderr` and displayed only a very limited error message if something failed. This PR lets `stderr` past, to get tracebacks in their full glory (the junk generated by Kratos apps while importing is still blocked) if an exception occurs.
