### PR TITLE
[Core] Improve C++ tests scripts, including import available applications for comprehensive testing

### DIFF
--- a/kratos/python_scripts/testing/run_cpp_mpi_tests.py
+++ b/kratos/python_scripts/testing/run_cpp_mpi_tests.py
@@ -1,5 +1,6 @@
 import argparse
 import sys
+import importlib
 
 from KratosMultiphysics import mpi, Tester
 
@@ -14,8 +15,20 @@ def main():
         metavar='MATCH-STRING',
         nargs='?',
         help="run cases with names matching MATCH-STRING")
-
+    parser.add_argument(
+        '--run-all-apps',
+        default=False,
+        action='store_true',
+        help="If all applicaions tests are run, not only core")
+    
     args = parser.parse_args()
+
+    # Imporing all available applications to make sure that the tests are registered
+    if args.run_all_apps:
+        from KratosMultiphysics.kratos_utilities import GetListOfAvailableApplications
+        available_apps = GetListOfAvailableApplications()
+        for app in available_apps:
+            importlib.import_module("KratosMultiphysics." + app)
 
     if args.match_string:
         Tester.SetVerbosity(Tester.Verbosity.TESTS_OUTPUTS)

--- a/kratos/python_scripts/testing/run_cpp_tests.py
+++ b/kratos/python_scripts/testing/run_cpp_tests.py
@@ -1,9 +1,43 @@
-import KratosMultiphysics as Kratos
+import argparse
 import sys
-if len(sys.argv) < 2:
-    Kratos.Tester.SetVerbosity(Kratos.Tester.Verbosity.TESTS_LIST)
-    Kratos.Tester.RunAllTestCases()
-else :
-    Kratos.Tester.SetVerbosity(Kratos.Tester.Verbosity.TESTS_OUTPUTS)
-    Kratos.Tester.RunTestCases(sys.argv[1])
+import importlib
 
+from KratosMultiphysics import Tester
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'match_string',
+        metavar='MATCH-STRING',
+        nargs='?',
+        help="run cases with names matching MATCH-STRING")
+    parser.add_argument(
+        '--run-all-apps',
+        default=False,
+        action='store_true',
+        help="If all applicaions tests are run, not only core")
+    
+    args = parser.parse_args()
+
+    # Imporing all available applications to make sure that the tests are registered
+    if args.run_all_apps:
+        from KratosMultiphysics.kratos_utilities import GetListOfAvailableApplications
+        available_apps = GetListOfAvailableApplications()
+        for app in available_apps:
+            importlib.import_module("KratosMultiphysics." + app)
+
+    if args.match_string:
+        Tester.SetVerbosity(Tester.Verbosity.TESTS_OUTPUTS)
+        return Tester.RunTestCases(args.match_string)
+    else:
+        Tester.SetVerbosity(Tester.Verbosity.TESTS_LIST)
+        return Tester.RunAllTestCases()
+
+if __name__ == '__main__':
+    try:
+        exit_code = main()
+    except Exception as e:
+        print('[Error]:', e, file=sys.stderr)
+        exit_code = 1
+
+    sys.exit(exit_code)


### PR DESCRIPTION
**📝 Description**

In `run_cpp_mpi_tests.py`, the following changes are made:
- The `importlib` module is imported.
- A new command-line argument `--run-all-apps` is added, which is set to `False` by default. It allows running tests for all applications, not just the core.
- If `--run-all-apps` is enabled, the script imports all available applications using `importlib.import_module()`.

In `run_cpp_tests.py`, the following changes are made (unifying with `run_cpp_mpi_tests.py`):
- The `importlib` module is imported.
- The `main()` function is defined to handle the script's execution.
- The script now accepts a new command-line argument `--run-all-apps`, which is set to `False` by default. It allows running tests for all applications, not just the core.
- If `--run-all-apps` is enabled, the script imports all available applications using `importlib.import_module()`.
- The execution flow is modified based on the command-line arguments:
  - If a `match_string` argument is provided, the script sets the verbosity to `TESTS_OUTPUTS` and runs test cases that match the given string using `Tester.RunTestCases()`.
  - If no `match_string` argument is provided, the script sets the verbosity to `TESTS_LIST` and runs all test cases using `Tester.RunAllTestCases()`.

Overall, this commit adds functionality to import all available applications for comprehensive testing and extends the command-line options to control the test execution behavior.

**🆕 Changelog**

- [Improve C++ tests scripts](https://github.com/KratosMultiphysics/Kratos/commit/7852fd9e70a81f5232df286c0d939c64a8cd381b)
