### PR TITLE
Do not use depth serializer on gp

### DIFF
--- a/kratos/python_scripts/project.py
+++ b/kratos/python_scripts/project.py
@@ -79,6 +79,8 @@ class Project:
         with open(save_folder_path / checkpoint_file_path, 'wb+') as checkpoint_file:
             # Serialize current model and stages
             serializer = KratosMultiphysics.StreamSerializer()
+            serializer.Set(KratosMultiphysics.Serializer.SHALLOW_GLOBAL_POINTERS_SERIALIZATION)
+            
             serializer.Save("Model", self.__model)
             stage_names_list = []
             stage_instances_list = []


### PR DESCRIPTION
**📝 Description**
Prevents the new Project class from serializing `gobal_pointer` contents as it would cause deadlock (Same as restart).

**🆕 Changelog**
- Global Pointer contents are now not serialized during checkpoint.
