### PR TITLE
[ContactStructuralMechanicsApplication] Also consider `BUILD_SCALE_FACTOR` when no `SCALE_FACTOR` is defined

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
@@ -541,7 +541,7 @@ void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateLocalLH
     const SizeType dof_size = mpDoFVariables.size();
 
     // Get the scale factor
-    const double scale_factor = rCurrentProcessInfo.Has(SCALE_FACTOR) ? rCurrentProcessInfo[SCALE_FACTOR] : 1.0;
+    const double scale_factor = rCurrentProcessInfo.Has(SCALE_FACTOR) ? rCurrentProcessInfo[SCALE_FACTOR] : rCurrentProcessInfo.Has(BUILD_SCALE_FACTOR) ? rCurrentProcessInfo[BUILD_SCALE_FACTOR] : 1.0;
 
     // Initial index 
     IndexType initial_row_index = 0;
@@ -600,7 +600,7 @@ void MeshTyingMortarCondition<TDim,TNumNodes, TNumNodesMaster>::CalculateLocalRH
     const SizeType dof_size = mpDoFVariables.size();
 
     // Get the scale factor
-    const double scale_factor = rCurrentProcessInfo.Has(SCALE_FACTOR) ? rCurrentProcessInfo[SCALE_FACTOR] : 1.0;
+    const double scale_factor = rCurrentProcessInfo.Has(SCALE_FACTOR) ? rCurrentProcessInfo[SCALE_FACTOR] : rCurrentProcessInfo.Has(BUILD_SCALE_FACTOR) ? rCurrentProcessInfo[BUILD_SCALE_FACTOR] : 1.0;
 
     // Initial index 
     IndexType initial_index = 0;


### PR DESCRIPTION
**📝 Description**

This PR refactors the code in the `MeshTyingMortarCondition` class in the `ContactStructuralMechanicsApplication`. The changes involve the retrieval of the scale factor from the `rCurrentProcessInfo` object. Instead of only checking for the presence of the `SCALE_FACTOR` key, the code now also checks for the presence of the `BUILD_SCALE_FACTOR` key. If the `BUILD_SCALE_FACTOR` key exists, it is used as the scale factor; otherwise, the default value of 1.0 is used. The modifications were made in the `CalculateLocalLHS` and `CalculateLocalRHS` functions of the class.

**🆕 Changelog**

- [Also consider `BUILD_SCALE_FACTOR` when no `SCALE_FACTOR` is defined](https://github.com/KratosMultiphysics/Kratos/commit/a99a46cafe30e32ab9efbb34346baa813ab10218)