### PR TITLE
fix computation of the derivative of the equivalent strain

### DIFF
--- a/applications/PoromechanicsApplication/custom_constitutive/isotropic_damage_cohesive_3D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/isotropic_damage_cohesive_3D_law.cpp
@@ -163,10 +163,12 @@ void IsotropicDamageCohesive3DLaw::FinalizeMaterialResponseCauchy (Parameters& r
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-Vector& IsotropicDamageCohesive3DLaw::GetValue( const Variable<Vector>& rThisVariable, Vector& rValue )
+double& IsotropicDamageCohesive3DLaw::GetValue( const Variable<double>& rThisVariable, double& rValue )
 {
-    rValue = mStateVariable;
+    if( rThisVariable == DAMAGE_VARIABLE )
+    {
+        rValue = mDamageVariable;
+    }
     return( rValue );
 }
 
@@ -217,7 +219,7 @@ void IsotropicDamageCohesive3DLaw::ComputeStressVector(Vector& rStressVector, Ve
     double normalStrain = StrainVector[VoigtSize-1];
 
     // Compute the stress vector
-    rStressVector = (1.0 - rVariables.DamageVariable)*EffectiveStressVector;
+    rStressVector = (1.0 - mDamageVariable)*EffectiveStressVector;
 
     // Fix the normal component in case it is a compression in the normal direction
     if (normalStrain < 0.0)
@@ -241,7 +243,7 @@ void IsotropicDamageCohesive3DLaw::ComputeTangentConstitutiveMatrix(Matrix& rCon
     this->ComputeDamageConstitutiveMatrix(DamageConstitutiveMatrix,EffectiveStressVector,rVariables,rValues);
 
     // Compute the tangent constitutive matrix
-    rConstitutiveMatrix = (1.0 - rVariables.DamageVariable)*ElasticConstitutiveMatrix - DamageConstitutiveMatrix;
+    rConstitutiveMatrix = (1.0 - mDamageVariable)*ElasticConstitutiveMatrix - DamageConstitutiveMatrix;
 
     // In case it is a compression in the normal direction:
     if (normalStrain < 0.0)
@@ -292,7 +294,7 @@ void IsotropicDamageCohesive3DLaw::ComputeScalarDamage(ConstitutiveLawVariables&
 {
     // Before damage initiated
     if((rVariables.EquivalentStrain - rVariables.DamageThreshold) <= 0.0){
-        rVariables.DamageVariable = 0.0;
+        mDamageVariable = 0.0;
         rVariables.DerivativeSDV  = 0.0;
     }
     // Damage initiated, but it didn't evolved 
@@ -320,21 +322,21 @@ void IsotropicDamageCohesive3DLaw::DamageLaw(ConstitutiveLawVariables& rVariable
 
     switch (rVariables.DamageEvolutionLaw){
         case 1: // Linear evolution law
-            rVariables.DamageVariable = (wmax / (wmax - w0)) * (1.0 - w0/w); 
+            mDamageVariable = (wmax / (wmax - w0)) * (1.0 - w0/w); 
             if (needsDerivative){
                 rVariables.DerivativeSDV = (w0*wmax)/(w*w*(wmax - w0)); 
             }
             break;
         case 2: // Exponential evolution law
-            rVariables.DamageVariable = 1.0 - w0/w * std::exp(-ft*(w - w0)/Gf);
+            mDamageVariable = 1.0 - w0/w * std::exp(-ft*(w - w0)/Gf);
             if (needsDerivative){
                 rVariables.DerivativeSDV = (ft * w + Gf)* w0/(w * w * Gf) * std::exp(-ft*(w - w0)/Gf);
             }
             break;
     }
 
-    if(rVariables.DamageVariable > 1.0){
-        rVariables.DamageVariable = 0.99999;
+    if(mDamageVariable > 1.0){
+        mDamageVariable = 0.99999;
     }
 }
 

--- a/applications/PoromechanicsApplication/custom_constitutive/isotropic_damage_cohesive_3D_law.cpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/isotropic_damage_cohesive_3D_law.cpp
@@ -276,8 +276,11 @@ void IsotropicDamageCohesive3DLaw::ComputeEquivalentStrain(ConstitutiveLawVariab
     rVariables.OldEquivalentStrain = mOldStateVariable[1] + rVariables.BetaEqStrainShearFactor * mOldStateVariable[0];
 
     // Compute the vector with the derivatives of the equivalent strain wrt to the components of the strain vector
-    rVariables.DerivativeEquivalentStrain[0] = rVariables.BetaEqStrainShearFactor * StrainVector[0] / resShear;
-    rVariables.DerivativeEquivalentStrain[1] = rVariables.BetaEqStrainShearFactor * StrainVector[1] / resShear;
+    rVariables.DerivativeEquivalentStrain = ZeroVector(3);
+    if (resShear > 0.0) {
+        rVariables.DerivativeEquivalentStrain[0] = rVariables.BetaEqStrainShearFactor * StrainVector[0] / resShear;
+        rVariables.DerivativeEquivalentStrain[1] = rVariables.BetaEqStrainShearFactor * StrainVector[1] / resShear;
+    }
     rVariables.DerivativeEquivalentStrain[2] = 1.0;
 }
 

--- a/applications/PoromechanicsApplication/custom_constitutive/isotropic_damage_cohesive_3D_law.hpp
+++ b/applications/PoromechanicsApplication/custom_constitutive/isotropic_damage_cohesive_3D_law.hpp
@@ -72,7 +72,7 @@ public:
     void FinalizeMaterialResponseCauchy(Parameters & rValues) override;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    Vector& GetValue( const Variable<Vector>& rThisVariable, Vector& rValue ) override;
+    double& GetValue( const Variable<double>& rThisVariable, double& rValue ) override;
 
     void SetValue( const Variable<Vector>& rThisVariable,
                    const Vector& rValue,
@@ -97,7 +97,6 @@ protected:
         double DamageThreshold;
 
         // Variables dependent on the state variables
-        double DamageVariable;     // scalar damage variable
         double DerivativeSDV;      // derivative of the scalar damage variable
 
         // Auxiliary variables
@@ -109,6 +108,7 @@ protected:
     };
 
     // Member Variables
+    double mDamageVariable = 0.0;               // scalar damage variable
     Vector mStateVariable = ZeroVector(2);      // [max(|delta_shear|) max(<delta_normal>)]
     Vector mOldStateVariable = ZeroVector(2);
 


### PR DESCRIPTION
**📝 Description**
This PR fixes a bug in the computation of the derivative of the equivalent strain in the cohesive isotropic damage 3D model in the Poromechanics application.

**🆕 Changelog**
- Fix computation of the derivative of the equivalent strain in the 3D cohesive isotropic damage model to avoid division by zero.
