### PR TITLE
[ContactStructuralMechanicsApplication] Adding `PARENT_ELEMENT`

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/contact_structural_mechanics_application.cpp
+++ b/applications/ContactStructuralMechanicsApplication/contact_structural_mechanics_application.cpp
@@ -169,6 +169,7 @@ void KratosContactStructuralMechanicsApplication::Register()
 
     /* For mesh tying mortar condition */
     KRATOS_REGISTER_VARIABLE( TYING_VARIABLE )                                        // The variable name for the mesh tying
+    KRATOS_REGISTER_VARIABLE( PARENT_ELEMENT )                                        // The parent element considered in the mesh tying with static condensation
 
     /* For mesh tying mortar condition */
     KRATOS_REGISTER_VARIABLE( MAX_GAP_THRESHOLD )                                     // The gap considered as threshold to rescale penalty

--- a/applications/ContactStructuralMechanicsApplication/contact_structural_mechanics_application_variables.cpp
+++ b/applications/ContactStructuralMechanicsApplication/contact_structural_mechanics_application_variables.cpp
@@ -61,6 +61,7 @@ KRATOS_CREATE_VARIABLE( double, MAX_GAP_FACTOR )                                
 
 /* For mesh tying mortar condition */
 KRATOS_CREATE_VARIABLE( std::string, TYING_VARIABLE )                             // The variable name for the mesh tying
+KRATOS_CREATE_VARIABLE( Element::Pointer, PARENT_ELEMENT )                        // The parent element considered in the mesh tying with static condensation
 
 /* Explicit simulation */
 KRATOS_CREATE_VARIABLE( double, MAX_GAP_THRESHOLD )                               // The gap considered as threshold to rescale penalty

--- a/applications/ContactStructuralMechanicsApplication/contact_structural_mechanics_application_variables.h
+++ b/applications/ContactStructuralMechanicsApplication/contact_structural_mechanics_application_variables.h
@@ -105,6 +105,7 @@ KRATOS_DEFINE_APPLICATION_VARIABLE( CONTACT_STRUCTURAL_MECHANICS_APPLICATION, do
 
 /* For mesh tying mortar condition */
 KRATOS_DEFINE_APPLICATION_VARIABLE( CONTACT_STRUCTURAL_MECHANICS_APPLICATION, std::string, TYING_VARIABLE )                            // The variable name for the mesh tying
+KRATOS_DEFINE_APPLICATION_VARIABLE( CONTACT_STRUCTURAL_MECHANICS_APPLICATION, Element::Pointer, PARENT_ELEMENT )                       // The parent element considered in the mesh tying with static condensation
 
 /* Explicit simulation */
 KRATOS_DEFINE_APPLICATION_VARIABLE( CONTACT_STRUCTURAL_MECHANICS_APPLICATION, double, MAX_GAP_THRESHOLD )                              // The gap considered as threshold to rescale penalty

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/assign_parent_element_conditions_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/assign_parent_element_conditions_process.cpp
@@ -1,0 +1,97 @@
+// KRATOS    ______            __             __  _____ __                  __                   __
+//          / ____/___  ____  / /_____ ______/ /_/ ___// /________  _______/ /___  ___________ _/ /
+//         / /   / __ \/ __ \/ __/ __ `/ ___/ __/\__ \/ __/ ___/ / / / ___/ __/ / / / ___/ __ `/ / 
+//        / /___/ /_/ / / / / /_/ /_/ / /__/ /_ ___/ / /_/ /  / /_/ / /__/ /_/ /_/ / /  / /_/ / /  
+//        \____/\____/_/ /_/\__/\__,_/\___/\__//____/\__/_/   \__,_/\___/\__/\__,_/_/   \__,_/_/  MECHANICS
+//
+//  License:         BSD License
+//                   license: ContactStructuralMechanicsApplication/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/key_hash.h"
+#include "utilities/parallel_utilities.h"
+#include "contact_structural_mechanics_application_variables.h"
+#include "custom_processes/assign_parent_element_conditions_process.h"
+
+namespace Kratos
+{
+void AssignParentElementConditionsProcess::Execute()
+{
+    KRATOS_TRY;
+
+    /// Definition of the vector indexes considered
+    using VectorIndexType = std::vector<std::size_t>;
+
+    /// Definition of the hasher considered
+    using VectorIndexHasherType = VectorIndexHasher<VectorIndexType>;
+
+    /// Definition of the key comparor considered
+    using VectorIndexComparorType = VectorIndexComparor<VectorIndexType>;
+
+    /// Define the map considered for face ids
+    using HashMapVectorIntType = std::unordered_map<VectorIndexType, std::size_t, VectorIndexHasherType, VectorIndexComparorType>;
+
+    // The array of elements
+    auto& r_elements_array = mrElementsModelPart.Elements();
+    HashMapVectorIntType map_face_ids;
+    for (auto& r_element : r_elements_array) {
+        const std::size_t id = r_element.Id();
+        auto& r_element_geometry = r_element.GetGeometry();
+        const auto faces = r_element_geometry.GenerateBoundariesEntities();
+        for (auto& r_face : faces) {
+            const std::size_t face_size = r_face.size();
+            std::vector<std::size_t> face_indexes(face_size);
+            for (std::size_t i_node = 0; i_node < face_size; ++i_node) {
+                face_indexes[i_node] = r_face[i_node].Id();
+            }
+            std::sort(face_indexes.begin(), face_indexes.end());
+            map_face_ids.insert({face_indexes, id});
+        }
+    }
+
+    // We iterate over the conditions
+    auto& r_conditions_array = mrConditionsModelPart.Conditions();
+    block_for_each(r_conditions_array, [&](Condition& rCondition) {
+        auto& r_condition_geometry = rCondition.GetGeometry();
+        const std::size_t condition_size = r_condition_geometry.size();
+        std::vector<std::size_t> indexes(condition_size);
+        for (std::size_t i_node = 0; i_node < condition_size; ++i_node) {
+            indexes[i_node] = r_condition_geometry[i_node].Id();
+        }
+        std::sort(indexes.begin(), indexes.end());
+        
+        // Find and assign if found
+        auto it_find = map_face_ids.find(indexes);
+        if (it_find != map_face_ids.end()) {
+            rCondition.SetValue(PARENT_ELEMENT, mrElementsModelPart.pGetElement(it_find->second));
+        } else {
+            KRATOS_WARNING("AssignParentElementConditionsProcess") << "Condition " << rCondition.Id() << " has not been found in the elements model part" << std::endl;
+        }
+    });
+    
+    KRATOS_CATCH("");
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+const Parameters AssignParentElementConditionsProcess::GetDefaultParameters() const
+{
+    const Parameters default_parameters = Parameters(R"(
+    {
+        "conditions_model_part_name" : "PLEASE_SPECIFY_MODEL_PART_NAME",
+        "elements_model_part_name"   : "PLEASE_SPECIFY_MODEL_PART_NAME",
+        "echo_level"                 : 0
+    })");
+
+    return default_parameters;
+}
+
+} // namespace Kratos.

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/assign_parent_element_conditions_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/assign_parent_element_conditions_process.h
@@ -1,0 +1,251 @@
+// KRATOS    ______            __             __  _____ __                  __                   __
+//          / ____/___  ____  / /_____ ______/ /_/ ___// /________  _______/ /___  ___________ _/ /
+//         / /   / __ \/ __ \/ __/ __ `/ ___/ __/\__ \/ __/ ___/ / / / ___/ __/ / / / ___/ __ `/ / 
+//        / /___/ /_/ / / / / /_/ /_/ / /__/ /_ ___/ / /_/ /  / /_/ / /__/ /_/ /_/ / /  / /_/ / /  
+//        \____/\____/_/ /_/\__/\__,_/\___/\__//____/\__/_/   \__,_/\___/\__/\__,_/_/   \__,_/_/  MECHANICS
+//
+//  License:         BSD License
+//                   license: ContactStructuralMechanicsApplication/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "processes/process.h"
+#include "includes/model_part.h"
+
+namespace Kratos
+{
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+/**
+ * @class AssignParentElementConditionsProcess
+ * @ingroup ContactStructuralMechanicsApplication
+ * @brief This process initializes the variables related with the ALM
+ * @author Vicente Mataix Ferrandiz
+*/
+class KRATOS_API(CONTACT_STRUCTURAL_MECHANICS_APPLICATION) AssignParentElementConditionsProcess
+    : public Process
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of AssignParentElementConditionsProcess
+    KRATOS_CLASS_POINTER_DEFINITION(AssignParentElementConditionsProcess);
+
+    /// Geometry type definition
+    using GeometryType = Geometry<Node>;
+
+    /// Nodes array type definition
+    using NodesArrayType = ModelPart::NodesContainerType;
+
+    /// Conditions array type definition
+    using ConditionsArrayType = ModelPart::ConditionsContainerType;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /**
+     * @brief Constructor that takes the conditions and elements model parts.
+     * @param rConditionsModelPart The conditions model part.
+     * @param rElementsModelPart The elements model part.
+     */
+    AssignParentElementConditionsProcess( 
+        ModelPart& rConditionsModelPart,
+        ModelPart& rElementsModelPart
+        )
+        : mrConditionsModelPart(rConditionsModelPart),
+          mrElementsModelPart(rElementsModelPart)
+    {
+        KRATOS_TRY;
+
+        KRATOS_CATCH("");
+    }
+
+    /**
+     * @brief Constructs an AssignParentElementConditionsProcess object.
+     * @param rModel The model containing the model parts.
+     * @param ThisParameters The parameters defining the process.
+     */
+    AssignParentElementConditionsProcess(
+        Model& rModel,
+        Parameters ThisParameters
+        ) : mrConditionsModelPart(rModel.GetModelPart(ThisParameters["conditions_model_part_name"].GetString())),
+            mrElementsModelPart(rModel.GetModelPart(ThisParameters["elements_model_part_name"].GetString()))
+    {
+        KRATOS_TRY;
+
+        Parameters default_parameters = GetDefaultParameters();
+        ThisParameters.RecursivelyValidateAndAssignDefaults(default_parameters);
+
+        mEchoLevel = ThisParameters["echo_level"].GetInt();
+
+        KRATOS_CATCH("");
+    }
+
+    /// Destructor.
+    ~AssignParentElementConditionsProcess() override = default;
+
+    /// Copy constructor.
+    AssignParentElementConditionsProcess( AssignParentElementConditionsProcess const& rOther) = delete;
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /**
+     * @brief Executes the function.
+     */
+    void operator()()
+    {
+        Execute();
+    }
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Executes the function.
+     */
+    void Execute() override;
+
+    /**
+     * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
+     */
+    const Parameters GetDefaultParameters() const override;
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        return "AssignParentElementConditionsProcess";
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const override
+    {
+        rOStream << "AssignParentElementConditionsProcess";
+    }
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const override
+    {
+    }
+
+    ///@}
+private:
+    ///@name Static Member Variables
+    ///@{
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+    ModelPart& mrConditionsModelPart; /// The model part of conditions
+    ModelPart& mrElementsModelPart;   /// The model part of elements
+    int mEchoLevel;                   /// The echo level
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+    ///@}
+    ///@name Private Inquiry
+    ///@{
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+    /// Assignment operator.
+    AssignParentElementConditionsProcess& operator=(AssignParentElementConditionsProcess const& rOther) = delete;
+
+    /// Copy constructor.
+    //AssignParentElementConditionsProcess(AssignParentElementConditionsProcess const& rOther);
+
+    ///@}
+
+}; // Class AssignParentElementConditionsProcess
+
+///@}
+
+///@name Type Definitions
+///@{
+
+///@}
+///@name Input and output
+///@{
+
+/// input stream function
+inline std::istream& operator >> (std::istream& rIStream,
+                                  AssignParentElementConditionsProcess& rThis);
+
+/// output stream function
+inline std::ostream& operator << (std::ostream& rOStream,
+                                  const AssignParentElementConditionsProcess& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+
+} // namespace Kratos.

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/assign_parent_element_conditions_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/assign_parent_element_conditions_process.h
@@ -19,6 +19,7 @@
 // Project includes
 #include "processes/process.h"
 #include "includes/model_part.h"
+#include "includes/key_hash.h"
 
 namespace Kratos
 {
@@ -52,6 +53,18 @@ public:
 
     /// Pointer definition of AssignParentElementConditionsProcess
     KRATOS_CLASS_POINTER_DEFINITION(AssignParentElementConditionsProcess);
+
+    /// Definition of the vector indexes considered
+    using VectorIndexType = std::vector<std::size_t>;
+
+    /// Definition of the hasher considered
+    using VectorIndexHasherType = VectorIndexHasher<VectorIndexType>;
+
+    /// Definition of the key comparor considered
+    using VectorIndexComparorType = VectorIndexComparor<VectorIndexType>;
+
+    /// Define the map considered for face ids
+    using HashMapVectorIntType = std::unordered_map<VectorIndexType, std::size_t, VectorIndexHasherType, VectorIndexComparorType>;
 
     /// Geometry type definition
     using GeometryType = Geometry<Node>;
@@ -148,6 +161,16 @@ public:
     void Execute() override;
 
     /**
+     * @brief This function is designed for being called at the beginning of the computations  right after reading the model and the groups
+     */
+    void ExecuteInitialize() override;
+
+    /**
+     * @brief This function will be executed at every time step BEFORE performing the solve phase
+     */
+    void ExecuteInitializeSolutionStep() override;
+
+    /**
      * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
      */
     const Parameters GetDefaultParameters() const override;
@@ -193,6 +216,7 @@ private:
     ModelPart& mrConditionsModelPart; /// The model part of conditions
     ModelPart& mrElementsModelPart;   /// The model part of elements
     int mEchoLevel;                   /// The echo level
+    HashMapVectorIntType mMapFaceIds; /// The map containing the face ids of the elements
 
     ///@}
     ///@name Private Operators

--- a/applications/ContactStructuralMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
@@ -35,6 +35,7 @@
 #include "custom_processes/normal_check_process.h"
 #include "custom_processes/mpc_contact_search_process.h"
 #include "custom_processes/mpc_contact_search_wrapper_process.h"
+#include "custom_processes/assign_parent_element_conditions_process.h"
 
 namespace Kratos::Python
 {
@@ -203,6 +204,12 @@ void  AddCustomProcessesToPython(pybind11::module& m)
     py::class_<FindIntersectedGeometricalObjectsWithOBBContactSearchProcess, FindIntersectedGeometricalObjectsWithOBBContactSearchProcess::Pointer, Process>(m,"FindIntersectedGeometricalObjectsWithOBBContactSearchProcess")
     .def(py::init<ModelPart&,ModelPart&>())
     .def(py::init<ModelPart&,ModelPart&, const double>())
+    .def(py::init<Model&, Parameters>())
+    ;
+
+    // AssignParentElementConditionsProcess
+    py::class_<AssignParentElementConditionsProcess, AssignParentElementConditionsProcess::Pointer, Process>(m,"AssignParentElementConditionsProcess")
+    .def(py::init<ModelPart&,ModelPart&>())
     .def(py::init<Model&, Parameters>())
     ;
 }

--- a/applications/ContactStructuralMechanicsApplication/custom_python/contact_structural_mechanics_python_application.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_python/contact_structural_mechanics_python_application.cpp
@@ -91,7 +91,6 @@ PYBIND11_MODULE(KratosContactStructuralMechanicsApplication, m)
     KRATOS_REGISTER_IN_PYTHON_VARIABLE(m, MAX_GAP_FACTOR )                                        // The factor between the nodal H and the max gap considered to recalculate the penalty
     KRATOS_REGISTER_IN_PYTHON_VARIABLE(m, MAX_GAP_THRESHOLD )                                     // The gap considered as threshold to rescale penalty
     KRATOS_REGISTER_IN_PYTHON_VARIABLE(m, TYING_VARIABLE )                                        // The variable name for the mesh tying
-    KRATOS_REGISTER_IN_PYTHON_VARIABLE(m, PARENT_ELEMENT )                                        // The parent element considered in the mesh tying with static condensation
     KRATOS_REGISTER_IN_PYTHON_VARIABLE(m, TRESCA_FRICTION_THRESHOLD )                             // The threshold value for Tresca frictional contact
 }
 

--- a/applications/ContactStructuralMechanicsApplication/custom_python/contact_structural_mechanics_python_application.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_python/contact_structural_mechanics_python_application.cpp
@@ -91,6 +91,7 @@ PYBIND11_MODULE(KratosContactStructuralMechanicsApplication, m)
     KRATOS_REGISTER_IN_PYTHON_VARIABLE(m, MAX_GAP_FACTOR )                                        // The factor between the nodal H and the max gap considered to recalculate the penalty
     KRATOS_REGISTER_IN_PYTHON_VARIABLE(m, MAX_GAP_THRESHOLD )                                     // The gap considered as threshold to rescale penalty
     KRATOS_REGISTER_IN_PYTHON_VARIABLE(m, TYING_VARIABLE )                                        // The variable name for the mesh tying
+    KRATOS_REGISTER_IN_PYTHON_VARIABLE(m, PARENT_ELEMENT )                                        // The parent element considered in the mesh tying with static condensation
     KRATOS_REGISTER_IN_PYTHON_VARIABLE(m, TRESCA_FRICTION_THRESHOLD )                             // The threshold value for Tresca frictional contact
 }
 

--- a/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/processes/test_assign_parent_element_conditions_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/processes/test_assign_parent_element_conditions_process.cpp
@@ -1,0 +1,61 @@
+// KRATOS    ______            __             __  _____ __                  __                   __
+//          / ____/___  ____  / /_____ ______/ /_/ ___// /________  _______/ /___  ___________ _/ /
+//         / /   / __ \/ __ \/ __/ __ `/ ___/ __/\__ \/ __/ ___/ / / / ___/ __/ / / / ___/ __ `/ / 
+//        / /___/ /_/ / / / / /_/ /_/ / /__/ /_ ___/ / /_/ /  / /_/ / /__/ /_/ /_/ / /  / /_/ / /  
+//        \____/\____/_/ /_/\__/\__,_/\___/\__//____/\__/_/   \__,_/\___/\__/\__,_/_/   \__,_/_/  MECHANICS
+//
+//  License:         BSD License
+//                   license: ContactStructuralMechanicsApplication/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "testing/testing.h"
+#include "containers/model.h"
+#include "contact_structural_mechanics_application_variables.h"
+
+/* Processes */
+#include "custom_processes/assign_parent_element_conditions_process.h"
+
+namespace Kratos::Testing 
+{
+
+/** 
+* Checks the correct work of the AssignParentElementConditionsProcess
+*/
+KRATOS_TEST_CASE_IN_SUITE(AssignParentElementConditionsProcess1, KratosContactStructuralMechanicsFastSuite)
+{
+    Model this_model;
+    ModelPart& r_model_part = this_model.CreateModelPart("Main", 3);
+    
+    Properties::Pointer p_prop = r_model_part.CreateNewProperties(0);
+
+    // First we create the nodes
+    r_model_part.CreateNewNode(1, 0.0 , 0.0 , 0.0);
+    r_model_part.CreateNewNode(2, 1.0 , 0.0 , 0.0);
+    r_model_part.CreateNewNode(3, 1.0 , 1.0 , 0.0);
+    r_model_part.CreateNewNode(4, 0.0 , 1.0 , 0.0);
+
+    // Now we create the elements and conditions
+    auto p_element = r_model_part.CreateNewElement("Element2D4N", 1, {{1,2,3,4}}, p_prop);
+    auto p_cond1 = r_model_part.CreateNewCondition("LineCondition2D2N", 1, {{1,2}}, p_prop);
+    auto p_cond2 = r_model_part.CreateNewCondition("LineCondition2D2N", 2, {{2,3}}, p_prop);
+    auto p_cond3 = r_model_part.CreateNewCondition("LineCondition2D2N", 3, {{3,4}}, p_prop);
+    auto p_cond4 = r_model_part.CreateNewCondition("LineCondition2D2N", 4, {{4,1}}, p_prop);
+
+    // Call the process
+    AssignParentElementConditionsProcess(r_model_part, r_model_part).Execute();
+
+    // Check the parent element
+    KRATOS_CHECK_EQUAL(p_cond1->GetValue(PARENT_ELEMENT), p_element);
+    KRATOS_CHECK_EQUAL(p_cond2->GetValue(PARENT_ELEMENT), p_element);
+    KRATOS_CHECK_EQUAL(p_cond3->GetValue(PARENT_ELEMENT), p_element);
+    KRATOS_CHECK_EQUAL(p_cond4->GetValue(PARENT_ELEMENT), p_element);
+}
+
+}  // namespace Kratos::Testing.


### PR DESCRIPTION
**📝 Description**

This PR adds the `PARENT_ELEMENT` variable to the ContactStructuralMechanicsApplication. The variable is registered in multiple files, including `contact_structural_mechanics_application.cpp`, `contact_structural_mechanics_application_variables.cpp`, `contact_structural_mechanics_application_variables.h`, and `contact_structural_mechanics_python_application.cpp`. The `PARENT_ELEMENT` variable will be used in the mesh tying with static condensation. 

Also add `AssignParentElementConditionsProcess`, in `assign_parent_element_conditions_process.cpp`, the code defines a process called `AssignParentElementConditionsProcess` that is executed on the elements model part. The process assigns parent element conditions based on face ids criteria. It includes the necessary headers, declarations, and implementations for the process.

**🆕 Changelog**

- [Adding `PARENT_ELEMENT`](https://github.com/KratosMultiphysics/Kratos/commit/7962c34dc16e1957f46c954d64806389d9f37d70)
- [Adding `AssignParentElementConditionsProcess`](https://github.com/KratosMultiphysics/Kratos/pull/11397/commits/027c62181bc9831c2a00137665aa346358472afb)
- [Expose  `AssignParentElementConditionsProcess` to python](https://github.com/KratosMultiphysics/Kratos/pull/11397/commits/54cb3df909e485e325a0e3669620b8b468f83bae)
- [Adding test for  `AssignParentElementConditionsProcess`](https://github.com/KratosMultiphysics/Kratos/pull/11397/commits/082559e04445f6e96018013f64327852fa905d03)