### PR TITLE
[Core] Correct some typos in `Geometry`

### DIFF
--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -2103,7 +2103,7 @@ public:
      * @see EdgesNumber()
      * @see Edge()
      */
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version (use GenerateEdgesInstead)") virtual GeometriesArrayType Edges( void )
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version (use GenerateEdges instead)") virtual GeometriesArrayType Edges( void )
     {
         return this->GenerateEdges();
     }
@@ -2163,7 +2163,7 @@ public:
      * @see Edges
      * @see FacesNumber
      */
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version (use GenerateEdgesInstead)") virtual GeometriesArrayType Faces( void )
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version (use GenerateFaces instead)") virtual GeometriesArrayType Faces( void )
     {
         const SizeType dimension = this->LocalSpaceDimension();
         if (dimension == 3) {


### PR DESCRIPTION
**📝 Description**

Correct some typos in `Geometry`, in deprecated warning for `Faces` and `Edges`

**🆕 Changelog**

- [Correct some typos](https://github.com/KratosMultiphysics/Kratos/commit/d71aba44fa6b2b33815ab30333875efdf3593837)
