### PR TITLE
[Core][ContactStructuralMechanicsApplication] Variable definition conflict in C++ tests

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/processes/test_weighted_gap.cpp
+++ b/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/processes/test_weighted_gap.cpp
@@ -331,7 +331,7 @@ void SimplestCreateNewProblem3D(
 /**
 * This method can be used to create a 2D plane condition set
 */
-void SimpleCreateNewProblem3D(
+void SimpleCreateNewProblem3DGapGap(
     ModelPart& rModelPart,
     const double MoveMesh = 0.0
     )
@@ -965,7 +965,7 @@ KRATOS_TEST_CASE_IN_SUITE(WeightedGap3b, KratosContactStructuralMechanicsFastSui
 
     // We create our problem
     const double delta_x = 1.0e-1;
-    SimpleCreateNewProblem3D(r_model_part, delta_x);
+    SimpleCreateNewProblem3DGapGap(r_model_part, delta_x);
 
     // We compute the explicit contribution
     const array_1d<double, 3> zero_vector = ZeroVector(3);;
@@ -1080,7 +1080,7 @@ KRATOS_TEST_CASE_IN_SUITE(WeightedGap4b, KratosContactStructuralMechanicsFastSui
 
     // We create our problem
     const double delta_x = 1.0e-1;
-    SimpleCreateNewProblem3D(r_model_part, delta_x);
+    SimpleCreateNewProblem3DGapGap(r_model_part, delta_x);
 
     // We compute the explicit contribution
     const array_1d<double, 3> zero_vector = ZeroVector(3);;

--- a/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/utilities/test_selfcontact_utilities.cpp
+++ b/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/utilities/test_selfcontact_utilities.cpp
@@ -49,7 +49,7 @@ namespace Kratos::Testing
 /**
 * This method can be used to create a 3D plane condition set
 */
-void SimpleCreateNewProblem3D(ModelPart& rModelPart)
+void SimpleCreateNewProblem3DSelfContact(ModelPart& rModelPart)
 {
     // Creating nodes
     rModelPart.CreateNewNode(1, 4.0, 4.0, 0.0);
@@ -213,7 +213,7 @@ KRATOS_TEST_CASE_IN_SUITE(SelfContactUtilities1, KratosContactStructuralMechanic
     r_process_info[NL_ITERATION_NUMBER] = 1;
 
     // We create our problem
-    SimpleCreateNewProblem3D(r_model_part);
+    SimpleCreateNewProblem3DSelfContact(r_model_part);
 
     // All potential pairs
     SelfContactUtilities::FullAssignmentOfPairs(r_model_part);

--- a/kratos/tests/cpp_tests/utilities/test_polynomial_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_polynomial_utilities.cpp
@@ -25,7 +25,7 @@ namespace {
     using Polynomial = PolynomialUtilities::PolynomialType;
     using Interval = PolynomialUtilities::IntervalType;
     using RootIntervals = std::vector<PolynomialUtilities::IntervalType>;
-    constexpr double TOLERANCE = 1e-9;
+    constexpr double POLYNOMIAL_TOLERANCE = 1e-9;
 
     std::size_t CountIntervalsContaining(const RootIntervals& rIntervals, double Coordinate) {
         std::size_t containing = 0;
@@ -46,15 +46,15 @@ KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesDegree, KratosCoreFastSuite) {
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesEvaluate, KratosCoreFastSuite) {
     Polynomial p{1.0, 2.0, 3.0, 4.0}; // x^3 + 2x^2 + 3x + 4
 
-    KRATOS_CHECK_NEAR(PolynomialUtilities::Evaluate(p, 0.0), 4.0, TOLERANCE);
-    KRATOS_CHECK_NEAR(PolynomialUtilities::Evaluate(p, 0.5), 6.125, TOLERANCE);
+    KRATOS_CHECK_NEAR(PolynomialUtilities::Evaluate(p, 0.0), 4.0, POLYNOMIAL_TOLERANCE);
+    KRATOS_CHECK_NEAR(PolynomialUtilities::Evaluate(p, 0.5), 6.125, POLYNOMIAL_TOLERANCE);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesDifferentiate, KratosCoreFastSuite) {
     Polynomial p{1.0, 2.0, 3.0, 4.0}; // x^3 + 2x^2 + 3x + 4
     Polynomial d{3.0, 4.0, 3.0}; // 3x^2 + 4x + 3
 
-    KRATOS_CHECK_VECTOR_NEAR(PolynomialUtilities::Differentiate(p), d, TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(PolynomialUtilities::Differentiate(p), d, POLYNOMIAL_TOLERANCE);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesMultiply, KratosCoreFastSuite) {
@@ -62,7 +62,7 @@ KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesMultiply, KratosCoreFastSuite) {
     Polynomial b{4.0, 5.0}; // 4x + 5
     Polynomial c{4.0, 13.0, 22.0, 15.0}; // 4x^3 + 13x^2 + 22x + 15
 
-    KRATOS_CHECK_VECTOR_NEAR(PolynomialUtilities::Multiply(a, b), c, TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(PolynomialUtilities::Multiply(a, b), c, POLYNOMIAL_TOLERANCE);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesDivide, KratosCoreFastSuite) {
@@ -75,13 +75,13 @@ KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesDivide, KratosCoreFastSuite) {
     Polynomial expected_quotient{1.0/4.0, 3.0/16.0};
     Polynomial expected_remainder{33.0/16.0};
 
-    KRATOS_CHECK_VECTOR_NEAR(q, expected_quotient, TOLERANCE);
-    KRATOS_CHECK_VECTOR_NEAR(r, expected_remainder, TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(q, expected_quotient, POLYNOMIAL_TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(r, expected_remainder, POLYNOMIAL_TOLERANCE);
 
     Polynomial c{4.0, 13.0, 22.0, 15.0}; // a*b
     PolynomialUtilities::Divide(q, r, c, a);
-    KRATOS_CHECK_VECTOR_NEAR(q, b, TOLERANCE);
-    KRATOS_CHECK_VECTOR_NEAR(r, Polynomial{0.0}, TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(q, b, POLYNOMIAL_TOLERANCE);
+    KRATOS_CHECK_VECTOR_NEAR(r, Polynomial{0.0}, POLYNOMIAL_TOLERANCE);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesIsolateRoots, KratosCoreFastSuite) {
@@ -105,9 +105,9 @@ KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesIsolateRoots, KratosCoreFastSuite) 
 KRATOS_TEST_CASE_IN_SUITE(PolynomialUtilitiesFindRoot, KratosCoreFastSuite) {
     Polynomial a{1.06, 0.75, -0.26, -0.175}; // Has three roots in [-1, 1]
 
-    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{-1, -0.5}), -0.7360625845831237, TOLERANCE);
-    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{-0.5, 0}), -0.45955361708183773, TOLERANCE);
-    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{0, 1}), 0.4880690318514098, TOLERANCE);
+    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{-1, -0.5}), -0.7360625845831237, POLYNOMIAL_TOLERANCE);
+    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{-0.5, 0}), -0.45955361708183773, POLYNOMIAL_TOLERANCE);
+    KRATOS_CHECK_NEAR(PolynomialUtilities::FindRoot(a, Interval{0, 1}), 0.4880690318514098, POLYNOMIAL_TOLERANCE);
 }
 
 }


### PR DESCRIPTION
**📝 Description**

This PR refactors the test cases in the `test_polynomial_utilities.cpp` file and introduces a new constant `POLYNOMIAL_TOLERANCE`. The changes include:
- Renaming the existing `TOLERANCE` constant to `POLYNOMIAL_TOLERANCE`.
- Modifying the test cases `PolynomialUtilitiesEvaluate`, `PolynomialUtilitiesDifferentiate`, `PolynomialUtilitiesMultiply`, `PolynomialUtilitiesDivide`, `PolynomialUtilitiesIsolateRoots`, and `PolynomialUtilitiesFindRoot` to use the `POLYNOMIAL_TOLERANCE` constant instead of the previous `TOLERANCE`.

Also, renaming conflicting methods in `ContactStructuralMechanicsApplication`.

**🆕 Changelog**

- [Variable definition conflict in C++ tests](https://github.com/KratosMultiphysics/Kratos/commit/4a0c7a8d7c40e7a9fb5f42e8295aa8b57ecbd515)
- [Renaming conflict](https://github.com/KratosMultiphysics/Kratos/pull/11402/commits/6f02d56043578a00432e7bb4b0095e3fb887d0fd)
