### PR TITLE
[Core] Refactor `set_identity_function.h`

### DIFF
--- a/kratos/containers/set_identity_function.h
+++ b/kratos/containers/set_identity_function.h
@@ -4,49 +4,65 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics 
 //
-//  License:		 BSD License 
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                    
 //
 
-
-#if !defined(KRATOS_SET_IDENTITY_FUNCTION_H_INCLUDED )
-#define  KRATOS_SET_IDENTITY_FUNCTION_H_INCLUDED
-
-
+#pragma once
 
 // System includes
 #include <functional>
 
+// External includes
 
+// Project includes
 
 namespace Kratos
 {
-	///@}
-	///@name Kratos Classes
-	///@{
+///@name Kratos Classes
+///@{
 
-	/// Identity function is for having the object also as key in sets
-	/**
-	*/
-	template<class TDataType> class SetIdentityFunction
-	{
-	public:
-		TDataType& operator()(TDataType& data)
-		{
-			return data;
-		}
-		const TDataType& operator()(const TDataType& data) const
-		{
-			return data;
-		}
-	};
+/**
+ * @class SetIdentityFunction
+ * @brief A functor that serves as the identity function.
+ * @details This class provides two overloaded operator() functions, one for non-const objects
+ * and another for const objects. The operator() returns the input object as it is,
+ * effectively acting as an identity function.
+ * The purpose of this functor is to allow objects to be used as keys in sets or other
+ * containers that require comparison. By using this functor, you can avoid defining
+ * custom comparison functions or operators when the object itself can be considered
+ * for comparison.
+ * @tparam TDataType The data type of the object that the functor operates on.
+ * @author Pooyan Dadvand
+ */
+template<class TDataType> 
+class SetIdentityFunction
+{
+public:
+    /**
+     * @brief Operator that returns a non-const reference to the input object.
+     * @param data The input object of type TDataType.
+     * @return A non-const reference to the same object as provided in the parameter.
+     */
+    TDataType& operator()(TDataType& data)
+    {
+        return data;
+    }
 
-	///@}
+    /**
+     * @brief Operator that returns a const reference to the input object.
+     * @param data The input object of type TDataType.
+     * @return A const reference to the same object as provided in the parameter.
+     */
+    const TDataType& operator()(const TDataType& data) const
+    {
+        return data;
+    }
+};
 
+///@}
 
 }  // namespace Kratos.
-
-#endif // KRATOS_SET_IDENTITY_FUNCTION_H_INCLUDED  defined 


### PR DESCRIPTION
**📝 Description**

This PR refactors the `SetIdentityFunction` class in the `kratos/containers/set_identity_function.h` file. The changes include modifying the class definition and providing additional comments and documentation. The `SetIdentityFunction` class is a functor that serves as the identity function, allowing objects to be used as keys in sets or other containers that require comparison. The class provides two overloaded `operator()` functions, one for `non-const` objects and another for `const` objects, both of which return the input object as it is. The purpose of this refactoring is to improve code clarity and maintainability. The PR also adds appropriate `pragma` once directives and organizes the include statements. 

**🆕 Changelog**

- [Clean up `set_identity_function.h`](https://github.com/KratosMultiphysics/Kratos/commit/af473983f9c35127a862044194e94e42ccbe9ee8)
