### PR TITLE
[Core] Improve combine model part modeler

### DIFF
--- a/kratos/mpi/tests/test_KratosMPICore.py
+++ b/kratos/mpi/tests/test_KratosMPICore.py
@@ -31,6 +31,7 @@ with KratosUnittest.WorkFolderScope("../../tests", __file__, True):
     from test_model_part_io import TestModelPartIOMPI
     import test_variable_redistribution
     import test_container_expression
+    import test_combine_model_part_modeler
     from test_model_part_operation_utilities import TestModelPartOperationUtilities
 
 def AssembleTestSuites():
@@ -80,6 +81,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestModelPartIOMPI]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_variable_redistribution.TestVariableRedistributionUtility]))
     smallSuite.addTest(TestModelPartOperationUtilities("test_Sum"))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_combine_model_part_modeler.TestCombineModelPartModeler]))
 
     # Create a test suite with the selected tests plus all small tests
     nightSuite = suites['mpi_nightly']

--- a/kratos/tests/test_combine_model_part_modeler.py
+++ b/kratos/tests/test_combine_model_part_modeler.py
@@ -8,7 +8,7 @@ if KratosMultiphysics.IsDistributedRun():
     import KratosMultiphysics.mpi as KratosMPI
     try:
         import KratosMultiphysics.MetisApplication
-    except:
+    except ImportError:
         skip_test = True
 
 def SetParameters(name, use_memory="false"):

--- a/kratos/tests/test_combine_model_part_modeler.py
+++ b/kratos/tests/test_combine_model_part_modeler.py
@@ -3,6 +3,9 @@ import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as KratosUtilities
 
+# STL imports
+import pathlib
+
 skip_test = False
 if KratosMultiphysics.IsDistributedRun():
     import KratosMultiphysics.mpi as KratosMPI
@@ -36,8 +39,8 @@ def ImportModelPart(model_part, import_settings):
         import_flags = KratosMultiphysics.ModelPartIO.READ
         KratosMultiphysics.ModelPartIO(import_settings['model_import_settings']['input_filename'].GetString(), import_flags).ReadModelPart(model_part)
 
-def GetFilePath(fileName):
-    return os.path.join(os.path.dirname(os.path.realpath(__file__)), fileName)
+def GetFilePath(file_name):
+    return pathlib.Path(__file__).absolute().parent / file_name
 
 @KratosUnittest.skipIf(skip_test, "This test requires MetisApplication in MPI runs")
 class TestCombineModelPartModeler(KratosUnittest.TestCase):

--- a/kratos/tests/test_combine_model_part_modeler.py
+++ b/kratos/tests/test_combine_model_part_modeler.py
@@ -92,7 +92,7 @@ class TestCombineModelPartModeler(KratosUnittest.TestCase):
             }
         }''')
         full_path = GetFilePath(material_settings["Parameters"]["materials_filename"].GetString())
-        material_settings["Parameters"]["materials_filename"].SetString(full_path)
+        material_settings["Parameters"]["materials_filename"].SetString(str(full_path))
         KratosMultiphysics.ReadMaterialsUtility(material_settings,model_part.GetModel())
         settings = KratosMultiphysics.Parameters('''{
             "combined_model_part_name" : "thermal_model_part",

--- a/kratos/tests/test_combine_model_part_modeler.py
+++ b/kratos/tests/test_combine_model_part_modeler.py
@@ -4,6 +4,7 @@ import KratosMultiphysics.kratos_utilities as KratosUtilities
 
 if KratosMultiphysics.IsDistributedRun():
     import KratosMultiphysics.mpi as KratosMPI
+    import KratosMultiphysics.mpi.distributed_import_model_part_utility as distributed_import_model_part_utility
 
 def SetParameters(name, use_memory="false"):
     parameters = """{
@@ -22,7 +23,7 @@ def ImportModelPart(model_part, import_settings):
     if KratosMultiphysics.IsDistributedRun():
         model_part.AddNodalSolutionStepVariable(KratosMultiphysics.PARTITION_INDEX)
         # Construct the Trilinos import model part utility
-        distributed_model_part_importer = KratosMPI.distributed_import_model_part_utility.DistributedImportModelPartUtility(model_part, import_settings)
+        distributed_model_part_importer = distributed_import_model_part_utility.DistributedImportModelPartUtility(model_part, import_settings)
         # Execute the Metis partitioning and reading
         distributed_model_part_importer.ImportModelPart()
         distributed_model_part_importer.CreateCommunicators()

--- a/kratos/tests/test_combine_model_part_modeler.py
+++ b/kratos/tests/test_combine_model_part_modeler.py
@@ -1,4 +1,3 @@
-import os
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as KratosUtilities

--- a/kratos/tests/test_combine_model_part_modeler.py
+++ b/kratos/tests/test_combine_model_part_modeler.py
@@ -3,8 +3,13 @@ import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as KratosUtilities
 
+skip_test = False
 if KratosMultiphysics.IsDistributedRun():
     import KratosMultiphysics.mpi as KratosMPI
+    try:
+        import KratosMultiphysics.MetisApplication
+    except:
+        skip_test = True
 
 def SetParameters(name, use_memory="false"):
     parameters = """{
@@ -34,6 +39,7 @@ def ImportModelPart(model_part, import_settings):
 def GetFilePath(fileName):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), fileName)
 
+@KratosUnittest.skipIf(skip_test, "This test requires MetisApplication in MPI runs")
 class TestCombineModelPartModeler(KratosUnittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
**📝 Description**
In this modeler we are readding all elements to local mesh in omp when it is not necessary, local mesh in communicator is by default the same object as the normal mesh, so Im skipping these steps in omp.
TODO: improve code in MPI to fill the local, interface meshes etc as it is really slow right now. One option could be call parallel fill communicator directly after this modeler is finished and do not touch anything related to communicators here...

**🆕 Changelog**
- Do not refill local mesh in combine model part modeler
- FIx test and add it to mpi suite 
