### PR TITLE
[OptApp] Allowing sub-model-parts to work with ModelPartUtils

### DIFF
--- a/applications/OptimizationApplication/python_scripts/filtering/helmholtz_scalar_solver.py
+++ b/applications/OptimizationApplication/python_scripts/filtering/helmholtz_scalar_solver.py
@@ -11,21 +11,21 @@ def CreateSolver(model: KM.Model, custom_settings: KM.Parameters):
     return HelmholtzScalarSolver(model, custom_settings)
 
 class HelmholtzScalarSolver(HelmholtzSolverBase):
-    def AddVariables(self):
+    def AddVariables(self) -> None:
         # Add variables required for the helmholtz filtering
-        self.original_model_part.AddNodalSolutionStepVariable(KOA.HELMHOLTZ_SCALAR)
-        self.helmholtz_model_part.AddNodalSolutionStepVariable(KOA.HELMHOLTZ_SCALAR)
+        self.GetOriginRootModelPart().AddNodalSolutionStepVariable(KOA.HELMHOLTZ_SCALAR)
+        self.GetComputingModelPart().AddNodalSolutionStepVariable(KOA.HELMHOLTZ_SCALAR)
         KM.Logger.PrintInfo("::[HelmholtzScalarSolver]:: Variables ADDED.")
 
-    def AddDofs(self):
-        KM.VariableUtils().AddDof(KOA.HELMHOLTZ_SCALAR, self.helmholtz_model_part)
+    def AddDofs(self) -> None:
+        KM.VariableUtils().AddDof(KOA.HELMHOLTZ_SCALAR, self.GetComputingModelPart())
         KM.Logger.PrintInfo("::[HelmholtzScalarSolver]:: DOFs ADDED.")
 
-    def PrepareModelPart(self):
+    def PrepareModelPart(self) -> None:
         #check elements types
         is_surface = False
         num_nodes = None
-        for elem in self.original_model_part.Elements:
+        for elem in self.GetOriginModelPart().Elements:
             geom = elem.GetGeometry()
             if geom.WorkingSpaceDimension() != geom.LocalSpaceDimension():
                 is_surface = True
@@ -37,4 +37,4 @@ class HelmholtzScalarSolver(HelmholtzSolverBase):
         else:
             element_name = f"HelmholtzSolidElement3D{num_nodes}N"
 
-        KM.ConnectivityPreserveModeler().GenerateModelPart(self.original_model_part, self.helmholtz_model_part, element_name)
+        KM.ConnectivityPreserveModeler().GenerateModelPart(self.GetOriginModelPart(), self.GetComputingModelPart(), element_name)

--- a/applications/OptimizationApplication/python_scripts/filtering/helmholtz_solver_base.py
+++ b/applications/OptimizationApplication/python_scripts/filtering/helmholtz_solver_base.py
@@ -16,24 +16,29 @@ class HelmholtzSolverBase(PythonSolver):
         super().__init__(model, custom_settings)
 
         # Either retrieve the model part from the model or create a new one
-        model_part_name = self.settings["model_part_name"].GetString()
+        self.filtering_model_part_name = self.settings["model_part_name"].GetString()
 
-        if model_part_name == "":
+        if self.filtering_model_part_name == "":
             raise Exception('Please provide the model part name as the "model_part_name" (string) parameter!')
 
-        if self.model.HasModelPart(model_part_name):
-            self.original_model_part = self.model.GetModelPart(model_part_name)
+        # the filtering_model_part_name can be a sub model part. Hence we need the main model part
+        # for variable and dof addition.
+        root_model_part_name = self.filtering_model_part_name.split(".")[0]
+        if self.model.HasModelPart(root_model_part_name):
+            self.origin_root_model_part = self.model.GetModelPart(root_model_part_name)
         else:
-            self.original_model_part = model.CreateModelPart(model_part_name)
+            self.origin_root_model_part = model.CreateModelPart(root_model_part_name)
 
         domain_size = self.settings["domain_size"].GetInt()
         if domain_size == -1:
             raise Exception('Please provide the domain size as the "domain_size" (int) parameter!')
-
-        self.original_model_part.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, domain_size)
+        self.origin_root_model_part.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, domain_size)
 
         # Create Helmholtz model part
-        self.helmholtz_model_part = self.model.CreateModelPart(self.original_model_part.Name+"_helmholtz_filter_mdp")
+        # replacing "." with "_" if the filtering model part is a sub model part since model part names
+        # cannot have ".", and helmholtz_model_part needs to be a root model part
+        helmholtz_model_part_name = self.filtering_model_part_name.replace(".", "_") + "_helmholtz_filter_mdp"
+        self.helmholtz_model_part = self.model.CreateModelPart(helmholtz_model_part_name)
 
         # Get the filter radius
         self.filter_radius = self.settings["filter_radius"].GetDouble()
@@ -78,7 +83,7 @@ class HelmholtzSolverBase(PythonSolver):
 
     #### Public user interface functions ####
 
-    def AdvanceInTime(self, current_time) -> float:
+    def AdvanceInTime(self, current_time: float) -> float:
         dt = self.settings["time_stepping"]["time_step"].GetDouble()
         new_time = current_time + dt
         self.helmholtz_model_part.ProcessInfo[KratosMultiphysics.STEP] += 1
@@ -86,39 +91,44 @@ class HelmholtzSolverBase(PythonSolver):
 
         return new_time
 
-    def Initialize(self):
+    def Initialize(self) -> None:
         self._GetSolutionStrategy().Initialize()
         KOA.ImplicitFilterUtils.CalculateNodeNeighbourCount(self.helmholtz_model_part)
         KratosMultiphysics.Logger.PrintInfo("::[HelmholtzSolverBase]:: Finished initialization.")
 
-    def InitializeSolutionStep(self):
+    def InitializeSolutionStep(self) -> None:
         self._GetSolutionStrategy().InitializeSolutionStep()
 
-    def FinalizeSolutionStep(self):
+    def FinalizeSolutionStep(self) -> None:
         self._GetSolutionStrategy().FinalizeSolutionStep()
 
-    def Predict(self):
+    def Predict(self) -> None:
         self._GetSolutionStrategy().Predict()
 
-    def SolveSolutionStep(self):
+    def SolveSolutionStep(self) -> None:
         is_converged = bool(self._GetSolutionStrategy().Solve())
         return is_converged
 
-    def SetEchoLevel(self, level):
+    def SetEchoLevel(self, level: int) -> None:
         self._GetSolutionStrategy().SetEchoLevel(level)
 
-    def GetEchoLevel(self):
+    def GetEchoLevel(self) -> int:
         self._GetSolutionStrategy().GetEchoLevel()
 
-    def Clear(self):
+    def Clear(self) -> None:
         self._GetSolutionStrategy().Clear()
 
-    def ImportModelPart(self):
-        # we can use the default implementation in the base class
-        self._ImportModelPart(self.original_model_part, self.settings["model_import_settings"])
+    def ImportModelPart(self) -> None:
+        self._ImportModelPart(self.origin_root_model_part, self.settings["model_import_settings"])
 
-    def GetComputingModelPart(self):
+    def GetComputingModelPart(self) -> KratosMultiphysics.ModelPart:
         return self.helmholtz_model_part
+
+    def GetOriginRootModelPart(self) -> KratosMultiphysics.ModelPart:
+        return self.origin_root_model_part
+
+    def GetOriginModelPart(self) -> KratosMultiphysics.ModelPart:
+        return self.model[self.filtering_model_part_name]
 
     def GetFilterType(self) -> str:
         return self.filter_type

--- a/applications/OptimizationApplication/python_scripts/utilities/model_part_utilities.py
+++ b/applications/OptimizationApplication/python_scripts/utilities/model_part_utilities.py
@@ -53,7 +53,7 @@ class ModelPartOperation:
         if self.root_model_part.HasSubModelPart(self.suggested_model_part_name):
             # this means, it already has a model part with suggeted name, but
             # it does not match the operation identifier. So throw an error
-            raise RuntimeError(f"Found an already existing submodel part named \"{self.suggested_model_part_name}\" in {self.root_model_part.FullName()} without the required operation identifier = \"{operation_identifier}\".")
+            raise RuntimeError(f"Found an already existing submodel part named \"{self.suggested_model_part_name}\" in {self.root_model_part.FullName()} without the required operation identifier = \"{status_msg_suffix}\".")
 
         self.status_msg = f"{status_msg_prefix}{self.suggested_model_part_name}{status_msg_suffix}"
         KratosOA.ModelPartUtils.LogModelPartStatus(self.GetRootModelPart(), self.status_msg)

--- a/applications/OptimizationApplication/python_scripts/utilities/model_part_utilities.py
+++ b/applications/OptimizationApplication/python_scripts/utilities/model_part_utilities.py
@@ -3,11 +3,84 @@ from enum import Enum
 import KratosMultiphysics as Kratos
 import KratosMultiphysics.OptimizationApplication as KratosOA
 
-class ModelPartUtilities:
+class ModelPartOperation:
     class OperationType(Enum):
         UNION = 1,
         INTERSECT = 2
 
+    def __init__(self, model: Kratos.Model, operation_type: OperationType, suggested_model_part_name: str, list_of_operation_model_part_full_names: 'list[str]', add_neighbours: bool) -> None:
+        self.model = model
+        self.operation_type = operation_type
+        self.suggested_model_part_name = suggested_model_part_name
+        self.list_of_operation_model_part_full_names = sorted(list(set(list_of_operation_model_part_full_names)))
+        self.add_neighbours = add_neighbours
+
+        if len(list_of_operation_model_part_full_names) == 0:
+            raise RuntimeError("No operating model part names are provided.")
+
+        if suggested_model_part_name.find("#") != -1 or any([mp_name.find("#") != -1 for mp_name in list_of_operation_model_part_full_names]):
+            # find '#' in the model part names which is not allwed.
+            raise RuntimeError(f"The model part names cannot contain '#' character. Parsed model part names are as followings:\n\t suggested model part name: \"{suggested_model_part_name}\"\n\toperation model part names:\n\t" + "\n\t\t".join(list_of_operation_model_part_full_names))
+
+        # set the root model part. This needs to always exist.
+        self.root_model_part = self.model[self.list_of_operation_model_part_full_names[0].split(".")[0]]
+        self.status_msg = ""
+
+    def GetRootModelPart(self) -> Kratos.ModelPart:
+        return self.root_model_part
+
+    def GetModelPartFullName(self) -> str:
+        # check whether is there a need to perform binary operations
+        if self.operation_type == ModelPartOperation.OperationType.UNION or self.operation_type == ModelPartOperation.OperationType.INTERSECT:
+            if len(self.list_of_operation_model_part_full_names) == 1:
+                # all the operation model parts are the same, hence no need of doing an operation.
+                self.status_msg = ""
+                return self.list_of_operation_model_part_full_names[0]
+
+        # now check in the status messages of the root model part whether this operation is already added.
+        status_msg_prefix = "ModelPartUtilities_created#"
+        status_msg_suffix = f"#{self.operation_type.name}#{self.add_neighbours:d}#" + "#".join(self.list_of_operation_model_part_full_names)
+        status_msg_log = KratosOA.ModelPartUtils.GetModelPartStatusLog(self.GetRootModelPart())
+        for status_msg in status_msg_log:
+            if status_msg.startswith(status_msg_prefix) and status_msg.endswith(status_msg_suffix):
+                # found the same operation done on a different model part, hence sending that name
+                self.status_msg = status_msg
+                full_model_part_name = f"{self.GetRootModelPart().FullName()}.{status_msg.split('#')[1]}"
+                Kratos.Logger.PrintInfo("ModelPartUtilities", f"Using \"{full_model_part_name}\" with the same operation instead of suggested model part with name = \"{self.GetRootModelPart().FullName()}.{self.suggested_model_part_name}\".")
+                return full_model_part_name
+
+        # it is not already called for creation. Then put that in the status msg.
+        if self.root_model_part.HasSubModelPart(self.suggested_model_part_name):
+            # this means, it already has a model part with suggeted name, but
+            # it does not match the operation identifier. So throw an error
+            raise RuntimeError(f"Found an already existing submodel part named \"{self.suggested_model_part_name}\" in {self.root_model_part.FullName()} without the required operation identifier = \"{operation_identifier}\".")
+
+        self.status_msg = f"{status_msg_prefix}{self.suggested_model_part_name}{status_msg_suffix}"
+        KratosOA.ModelPartUtils.LogModelPartStatus(self.GetRootModelPart(), self.status_msg)
+        return f"{self.GetRootModelPart().FullName()}.{self.suggested_model_part_name}"
+
+    def GetModelPart(self) -> Kratos.ModelPart:
+        model_part_name = self.GetModelPartFullName()
+        if self.status_msg == "" or self.model.HasModelPart(model_part_name):
+            # if it is already there, that means it is already created. Hence return it or
+            # if the self.status_msg == "" means, there is no need to do any model part operations.
+            # therefore the model part should exist already.
+            return self.model[model_part_name]
+        else:
+            # the model part with the required operation not found. Hence creating it.
+            sub_model_part = self.model.CreateModelPart(model_part_name)
+            # now fill the submodel part
+            operation_model_parts = [self.model[name] for name in self.list_of_operation_model_part_full_names]
+            if self.operation_type == ModelPartOperation.OperationType.UNION:
+                Kratos.ModelPartOperationUtilities.Union(sub_model_part, self.root_model_part, operation_model_parts, self.add_neighbours)
+            elif self.operation_type == ModelPartOperation.OperationType.INTERSECT:
+                Kratos.ModelPartOperationUtilities.Intersect(sub_model_part, self.root_model_part, operation_model_parts, self.add_neighbours)
+
+            Kratos.Logger.PrintInfo("ModelPartUtilities", f"Created sub model part \"{sub_model_part.FullName()}\".")
+
+            return sub_model_part
+
+class ModelPartUtilities:
     @staticmethod
     def __GenerateUniqueIdentifier(prefix: str, list_of_names: 'list[str]', add_neighbours: bool) -> str:
         if not all([name.find("#") == -1 for name in list_of_names]):
@@ -18,80 +91,16 @@ class ModelPartUtilities:
         return (f"{prefix}_{post_fix}_" + "_".join(sorted_names)).replace(".", "-")
 
     @staticmethod
-    def GetOperatingModelPart(operation_type: OperationType, suggested_model_part_name: str, operation_model_parts: 'list[Kratos.ModelPart]', add_neighbours: bool) -> Kratos.ModelPart:
-        if len(operation_model_parts) == 0:
-            raise RuntimeError("No operating model parts are provided.")
-
-        # check whether is there a need to perform binary operations
-        if operation_type == ModelPartUtilities.OperationType.UNION or operation_type == ModelPartUtilities.OperationType.INTERSECT:
-            if len(set(operation_model_parts)) == 1:
-                # all the operation model parts are the same, hence no need of doing an operation.
-                return operation_model_parts[0]
-
-        model_part_names = [model_part.FullName() for model_part in operation_model_parts]
-        model_part_names = sorted(model_part_names)
-        root_model_part: Kratos.ModelPart = operation_model_parts[0].GetModel()[model_part_names[0]].GetRootModelPart()
-        operation_identifier = f"ModelPartUtilities_created#{operation_type.name}#{add_neighbours:d}#" + "#".join(model_part_names)
-
-        for sub_model_part in root_model_part.SubModelParts:
-            if KratosOA.ModelPartUtils.CheckModelPartStatus(sub_model_part, operation_identifier):
-                Kratos.Logger.PrintInfo("ModelPartUtilities", f"Using {sub_model_part.FullName()} with the same operation instead of suggested model part with name = \"{suggested_model_part_name}\".")
-                return sub_model_part
-
-        if root_model_part.HasSubModelPart(suggested_model_part_name):
-            # this means, it already has a model part with suggeted name, but
-            # it does not match the operation identifier. So throw an error
-            raise RuntimeError(f"Found an already existing submodel part named \"{suggested_model_part_name}\" in {root_model_part.FullName()} without the required operation identifier = \"{operation_identifier}\".")
-
-        # if the operation identifier is not found with multiple operation_model_partss, then have to create it
-        # the sub model part
-        sub_model_part = root_model_part.CreateSubModelPart(suggested_model_part_name)
-        KratosOA.ModelPartUtils.LogModelPartStatus(sub_model_part, operation_identifier)
-        Kratos.Logger.PrintInfo("ModelPartUtilities", f"Created sub model part \"{sub_model_part.FullName()}\".")
-        return sub_model_part
-
-    @staticmethod
-    def ExecuteOperationOnModelPart(model_part: Kratos.ModelPart) -> bool:
-        statuses = KratosOA.ModelPartUtils.GetModelPartStatusLog(model_part)
-        for status in statuses:
-            status_data = status.split("#")
-            if len(status_data) > 0 and status_data[0].startswith("ModelPartUtilities_created"):
-                # found a model part which was created using this utility. check whether it is
-                # filled with necessary entitites.
-
-                filled_status = "ModelPartUtilities_filled#" + "#".join(status_data[1:])
-                if not KratosOA.ModelPartUtils.CheckModelPartStatus(model_part, filled_status):
-                    # the model part is not filled with the corresponding entities
-                    # hence, fill it now
-                    if len(status_data) > 3:
-                        model = model_part.GetModel()
-                        operation_type = status_data[1]
-                        add_neighbours = bool(status_data[2])
-                        operation_model_parts = [model[name] for name in status_data[3:]]
-                        main_model_part = model_part.GetParentModelPart()
-
-                        if operation_type == "UNION":
-                            Kratos.ModelPartOperationUtilities.Union(model_part, main_model_part, operation_model_parts, add_neighbours)
-                        elif operation_type == "INTERSECT":
-                            Kratos.ModelPartOperationUtilities.Intersect(model_part, main_model_part, operation_model_parts, add_neighbours)
-                        else:
-                            raise RuntimeError(f"Unsupported operation type found [ operation_type = {operation_type}, model_part = {model_part.FullName()}]. Followings are list of statuses:\n\t" + "\n\t".join(statuses))
-
-                        KratosOA.ModelPartUtils.LogModelPartStatus(model_part, filled_status)
-                        return True
-                    else:
-                        raise RuntimeError(f"The model part {model_part.FullName()} cannot be properly constructed. Followings are list of statuses:\n\t" + "\n\t".join(statuses))
-
-        return False
-
-    @staticmethod
     def GetMergedMap(input_dict: 'dict[Any, KratosOA.CollectiveExpression]', add_neghbours: bool) -> 'dict[Any, Kratos.ModelPart]':
         result: 'dict[Any, Kratos.ModelPart]' = {}
         for k, v in input_dict.items():
-            merging_model_parts = [container_expression.GetModelPart() for container_expression in v.GetContainerExpressions()]
-            uniqe_identifier_name = ModelPartUtilities.__GenerateUniqueIdentifier("UNION", [model_part.FullName() for model_part in merging_model_parts], add_neghbours)
-            merged_model_part = ModelPartUtilities.GetOperatingModelPart(ModelPartUtilities.OperationType.UNION, uniqe_identifier_name, merging_model_parts, add_neghbours)
-            ModelPartUtilities.ExecuteOperationOnModelPart(merged_model_part)
+            merging_model_part_names = [container_expression.GetModelPart().FullName() for container_expression in v.GetContainerExpressions()]
+
+            if not merging_model_part_names:
+                raise RuntimeError("Merging requires atleast one model part.")
+
+            uniqe_identifier_name = ModelPartUtilities.__GenerateUniqueIdentifier("UNION", merging_model_part_names, add_neghbours)
+            merged_model_part = ModelPartOperation(v.GetContainerExpressions()[0].GetModelPart().GetModel(), ModelPartOperation.OperationType.UNION, uniqe_identifier_name, merging_model_part_names, add_neghbours).GetModelPart()
             result[k] = merged_model_part
 
         return result
@@ -100,9 +109,9 @@ class ModelPartUtilities:
     def GetIntersectedMap(main_model_part: Kratos.ModelPart, input_dict: 'dict[Any, Kratos.ModelPart]', add_neghbours: bool) -> 'dict[Any, Kratos.ModelPart]':
         result: 'dict[Any, Kratos.ModelPart]' = {}
         for k, v in input_dict.items():
-            uniqe_identifier_name = ModelPartUtilities.__GenerateUniqueIdentifier("INTERSECT", [main_model_part.FullName(), v.FullName()], add_neghbours)
-            intersected_model_part = ModelPartUtilities.GetOperatingModelPart(ModelPartUtilities.OperationType.INTERSECT, uniqe_identifier_name, [main_model_part, v], add_neghbours)
-            ModelPartUtilities.ExecuteOperationOnModelPart(intersected_model_part)
+            intersecting_model_part_names = [main_model_part.FullName(), v.FullName()]
+            uniqe_identifier_name = ModelPartUtilities.__GenerateUniqueIdentifier("INTERSECT", intersecting_model_part_names, add_neghbours)
+            intersected_model_part = ModelPartOperation(main_model_part.GetModel(), ModelPartOperation.OperationType.INTERSECT, uniqe_identifier_name, intersecting_model_part_names, add_neghbours).GetModelPart()
             result[k] = intersected_model_part
 
         return result

--- a/applications/OptimizationApplication/tests/test_model_part_utils.py
+++ b/applications/OptimizationApplication/tests/test_model_part_utils.py
@@ -6,7 +6,7 @@ import KratosMultiphysics.OptimizationApplication as KratosOA
 # Import KratosUnittest
 import KratosMultiphysics.KratosUnittest as kratos_unittest
 from KratosMultiphysics.testing.utilities import ReadModelPart
-from KratosMultiphysics.OptimizationApplication.utilities.model_part_utilities import ModelPartUtilities
+from KratosMultiphysics.OptimizationApplication.utilities.model_part_utilities import ModelPartOperation
 
 class TestModelPartUtils(kratos_unittest.TestCase):
     @classmethod
@@ -238,42 +238,71 @@ class TestModelPartUtilities(kratos_unittest.TestCase):
         cls.model = Kratos.Model()
         cls.model_part = cls.model.CreateModelPart("test")
 
-        cls.sub_model_part_list: 'list[Kratos.ModelPart]' = []
-        cls.sub_model_part_list.append(cls.model_part.CreateSubModelPart("sub_1"))
-        cls.sub_model_part_list.append(cls.model_part.CreateSubModelPart("sub_2"))
-        cls.sub_model_part_list.append(cls.model_part.CreateSubModelPart("sub_3"))
+        cls.sub_model_part_names_list: 'list[str]' = []
+        cls.sub_model_part_names_list.append(cls.model_part.CreateSubModelPart("sub_1").FullName())
+        cls.sub_model_part_names_list.append(cls.model_part.CreateSubModelPart("sub_2").FullName())
+        cls.sub_model_part_names_list.append(cls.model_part.CreateSubModelPart("sub_3").FullName())
+
+    def test_GetModelPartFullName(self):
+        dummy_names = ["test.sub_full_name_1", "test.sub_full_name_2", "test.sub_full_name_3", "test.sub_full_name_4"]
+        mp_operation_1 = ModelPartOperation(self.model, ModelPartOperation.OperationType.UNION, "full_name_t1", dummy_names, False)
+        self.assertEqual(mp_operation_1.GetModelPartFullName(), "test.full_name_t1")
+
+        random.shuffle(dummy_names)
+        mp_operation_2 = ModelPartOperation(self.model, ModelPartOperation.OperationType.UNION, "full_name_t2", dummy_names, False)
+        self.assertEqual(mp_operation_2.GetModelPartFullName(), "test.full_name_t1")
+
+        random.shuffle(dummy_names)
+        mp_operation_3 = ModelPartOperation(self.model, ModelPartOperation.OperationType.UNION, "full_name_t3", dummy_names, True)
+        self.assertEqual(mp_operation_3.GetModelPartFullName(), "test.full_name_t3")
+
+        random.shuffle(dummy_names)
+        mp_operation_3 = ModelPartOperation(self.model, ModelPartOperation.OperationType.INTERSECT, "full_name_t4", dummy_names, True)
+        self.assertEqual(mp_operation_3.GetModelPartFullName(), "test.full_name_t4")
+
+        random.shuffle(dummy_names)
+        mp_operation_3 = ModelPartOperation(self.model, ModelPartOperation.OperationType.INTERSECT, "full_name_t5", dummy_names, True)
+        self.assertEqual(mp_operation_3.GetModelPartFullName(), "test.full_name_t4")
+
+        random.shuffle(dummy_names)
+        mp_operation_3 = ModelPartOperation(self.model, ModelPartOperation.OperationType.INTERSECT, "full_name_t6", dummy_names, True)
+        self.assertEqual(mp_operation_3.GetModelPartFullName(), "test.full_name_t4")
+
+        random.shuffle(dummy_names)
+        mp_operation_3 = ModelPartOperation(self.model, ModelPartOperation.OperationType.UNION, "full_name_t6", dummy_names, True)
+        self.assertEqual(mp_operation_3.GetModelPartFullName(), "test.full_name_t3")
 
     def test_UnionNoOperation(self):
-        ModelPartUtilities.GetOperatingModelPart(ModelPartUtilities.OperationType.UNION, "t1", [self.model_part], False)
+        _ = ModelPartOperation(self.model, ModelPartOperation.OperationType.UNION, "t1", [self.model_part.FullName()], False).GetModelPart()
         self.assertFalse(self.model_part.HasSubModelPart("t1"))
 
     def test_IntersectNoOperation(self):
-        ModelPartUtilities.GetOperatingModelPart(ModelPartUtilities.OperationType.INTERSECT, "t2", [self.model_part], False)
+        _ = ModelPartOperation(self.model, ModelPartOperation.OperationType.INTERSECT, "t2", [self.model_part.FullName()], False).GetModelPart()
         self.assertFalse(self.model_part.HasSubModelPart("t2"))
 
     def test_UnionOperation(self):
-        random.shuffle(self.sub_model_part_list)
-        model_part = ModelPartUtilities.GetOperatingModelPart(ModelPartUtilities.OperationType.UNION, "t3", self.sub_model_part_list, False)
+        random.shuffle(self.sub_model_part_names_list)
+        _ = ModelPartOperation(self.model, ModelPartOperation.OperationType.UNION, "t3", self.sub_model_part_names_list, False).GetModelPart()
         self.assertTrue(self.model_part.HasSubModelPart("t3"))
 
-        random.shuffle(self.sub_model_part_list)
-        ModelPartUtilities.GetOperatingModelPart(ModelPartUtilities.OperationType.UNION, "t4", self.sub_model_part_list, False)
+        random.shuffle(self.sub_model_part_names_list)
+        model_part = ModelPartOperation(self.model, ModelPartOperation.OperationType.UNION, "t4", self.sub_model_part_names_list, False).GetModelPart()
         self.assertFalse(self.model_part.HasSubModelPart("t4"))
 
-        random.shuffle(self.sub_model_part_list)
-        self.assertEqual(model_part, ModelPartUtilities.GetOperatingModelPart(ModelPartUtilities.OperationType.UNION, "t4", self.sub_model_part_list, False))
+        random.shuffle(self.sub_model_part_names_list)
+        self.assertEqual(model_part, ModelPartOperation(self.model, ModelPartOperation.OperationType.UNION, "t5", self.sub_model_part_names_list, False).GetModelPart())
 
     def test_IntersectNoOperation(self):
-        random.shuffle(self.sub_model_part_list)
-        model_part = ModelPartUtilities.GetOperatingModelPart(ModelPartUtilities.OperationType.INTERSECT, "t5", self.sub_model_part_list, False)
+        random.shuffle(self.sub_model_part_names_list)
+        _ = ModelPartOperation(self.model, ModelPartOperation.OperationType.INTERSECT, "t5", self.sub_model_part_names_list, False).GetModelPart()
         self.assertTrue(self.model_part.HasSubModelPart("t5"))
 
-        random.shuffle(self.sub_model_part_list)
-        ModelPartUtilities.GetOperatingModelPart(ModelPartUtilities.OperationType.INTERSECT, "t6", self.sub_model_part_list, False)
+        random.shuffle(self.sub_model_part_names_list)
+        model_part = ModelPartOperation(self.model, ModelPartOperation.OperationType.INTERSECT, "t6", self.sub_model_part_names_list, False).GetModelPart()
         self.assertFalse(self.model_part.HasSubModelPart("t6"))
 
-        random.shuffle(self.sub_model_part_list)
-        self.assertEqual(model_part, ModelPartUtilities.GetOperatingModelPart(ModelPartUtilities.OperationType.INTERSECT, "t6", self.sub_model_part_list, False))
+        random.shuffle(self.sub_model_part_names_list)
+        self.assertEqual(model_part, ModelPartOperation(self.model, ModelPartOperation.OperationType.INTERSECT, "t7", self.sub_model_part_names_list, False).GetModelPart())
 
 if __name__ == "__main__":
     Kratos.Tester.SetVerbosity(Kratos.Tester.Verbosity.PROGRESS)  # TESTS_OUTPUTS


### PR DESCRIPTION
**📝 Description**
This allows sub model parts to be used with `ModelPartUtils`. This is required because, at the `__init__` of the python classes the sub model parts are not prresent hence no model part operations can be done. But we still need to add solution step variables and dofs accordingly at the init before model part is populated. This new class `ModelPartOperation` keeps track of the operation and performs the operation when `GetModelPart` method is called. It will always check whether a similar operation is already performed (hence it only requires a 'suggestive_model_part_name`), if is is already performed, then that model part is returned avoiding performing the same operation.

I updated the `HelmholtzSolver` accordingly, but unfortunately i cannot test it since I don't have proper test cases. Could you check @RezaNajian .


**🆕 Changelog**
- Adds `ModelPartOperation` class to keep track of the model part operations and not to perform the same model part operation multiple times.
- Updated responses and controls
- Added tests to new functionalities
- Updated exisiting tests.
