### PR TITLE
[Meshing] do not renumber nodes when remeshing

### DIFF
--- a/applications/MeshingApplication/custom_utilities/local_refine_geometry_mesh.cpp
+++ b/applications/MeshingApplication/custom_utilities/local_refine_geometry_mesh.cpp
@@ -32,6 +32,8 @@ void LocalRefineGeometryMesh::LocalRefineMesh(
 {
     KRATOS_TRY;
 
+    KRATOS_ERROR_IF(mModelPart.IsSubModelPart()) << "modelpart must be root modelpart" << std::endl;
+
     KRATOS_ERROR_IF(RefineOnReference && !(mModelPart.NodesBegin()->SolutionStepsDataHas(DISPLACEMENT))) << "DISPLACEMENT Variable is not in the model part -- needed if refine_on_reference = true" << std::endl;
 
     compressed_matrix<int> coord;                            // The matrix that stores all the index of the geometry
@@ -44,9 +46,10 @@ void LocalRefineGeometryMesh::LocalRefineMesh(
     // Initial renumber of nodes and elements and finding refinement level
     // TODO: Using parallel utilities here
     mCurrentRefinementLevel=0;
-    std::size_t id = 1;
+    std::size_t pos = 0;
     for (auto it = mModelPart.NodesBegin(); it != mModelPart.NodesEnd(); ++it) {
-        it->SetId(id++);
+        mMapNodeIdToPos[it->Id()] = pos++;
+        mMapPosToNodeId.push_back(it->Id());
         int node_refinement_level = 0;
         if (it->Has(REFINEMENT_LEVEL)) {
             node_refinement_level = it->GetValue(REFINEMENT_LEVEL);
@@ -59,15 +62,6 @@ void LocalRefineGeometryMesh::LocalRefineMesh(
     }
     mCurrentRefinementLevel++;
 
-    IndexPartition<std::size_t>(mModelPart.NumberOfElements()).for_each([&](std::size_t i) {
-        auto it = mModelPart.ElementsBegin() + i;
-        it->SetId(i + 1);
-    });
-
-    IndexPartition<std::size_t>(mModelPart.NumberOfConditions()).for_each([&](std::size_t i) {
-        auto it = mModelPart.ConditionsBegin() + i;
-        it->SetId(i + 1);
-    });
 
     if (RefineOnReference) {
         block_for_each(mModelPart.Nodes(), [&](Node& rNode) {
@@ -92,8 +86,6 @@ void LocalRefineGeometryMesh::LocalRefineMesh(
 
     EraseOldConditionsAndCreateNew(mModelPart, coord);
 
-    RenumeringElementsAndNodes(mModelPart, new_elements);
-
     // Assigning refinement level to newly created nodes
     block_for_each(mModelPart.Nodes(), [&](Node& rNode) {
         if(!rNode.Has(REFINEMENT_LEVEL)){
@@ -112,6 +104,9 @@ void LocalRefineGeometryMesh::LocalRefineMesh(
 
     UpdateSubModelPartNodes(mModelPart);
 
+    mMapNodeIdToPos.clear();
+    mMapPosToNodeId.clear();
+
     KRATOS_CATCH("");
 }
 
@@ -129,13 +124,13 @@ void LocalRefineGeometryMesh::CSRRowMatrix(
     rCoord.resize(number_of_nodes, number_of_nodes, false);
 
     for (auto it = rModelPart.NodesBegin(); it != rModelPart.NodesEnd(); ++it) {
-        int index_i = it->Id() - 1; // WARNING: MESH MUST BE IN ORDER
+        int index_i = mMapNodeIdToPos[it->Id()]; 
         auto& r_neighb_nodes = it->GetValue(NEIGHBOUR_NODES);
 
         std::vector<unsigned int> aux(r_neighb_nodes.size());
         unsigned int active = 0;
         for (auto inode = r_neighb_nodes.begin(); inode != r_neighb_nodes.end(); inode++) {
-            int index_j = inode->Id() - 1;
+            int index_j = mMapNodeIdToPos[inode->Id()];
             if (index_j > index_i) {
                 aux[active] = index_j;
                 active++;
@@ -195,9 +190,9 @@ void LocalRefineGeometryMesh::CreateListOfNewNodes(
 
     // New ID of the nodes
     rListNewNodes.resize(number_of_new_nodes, false);
-    int total_node = pNodes.size();
+    const unsigned int highest_id = (rModelPart.NodesEnd() -1)->Id();
     for (unsigned int i = 0; i < number_of_new_nodes; i++) {
-        rListNewNodes[i] = total_node + i + 1;
+        rListNewNodes[i] = highest_id + i + 1;
     }
 
     // Setting edges -2 to the new id of the new node
@@ -207,8 +202,8 @@ void LocalRefineGeometryMesh::CreateListOfNewNodes(
         for (i2_t i2 = i1.begin(); i2 != i1.end(); ++i2) {
             if (rCoord(i2.index1(), i2.index2()) == -2) {
                 rCoord(i2.index1(), i2.index2()) = rListNewNodes[index];
-                rPositionNode[index][0] = i2.index1() + 1;
-                rPositionNode[index][1] = i2.index2() + 1;
+                rPositionNode[index][0] = mMapPosToNodeId[i2.index1()];
+                rPositionNode[index][1] = mMapPosToNodeId[i2.index2()];
                 index++;
             }
         }
@@ -354,36 +349,6 @@ void LocalRefineGeometryMesh::CalculateEdges(
 
     KRATOS_CATCH( "" );
 
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-void LocalRefineGeometryMesh::RenumeringElementsAndNodes(
-    ModelPart& rModelPart,
-    PointerVector< Element >& rNewElements
-    )
-{
-    KRATOS_TRY;
-
-    unsigned int id_node = 1;
-    unsigned int id_elem = 1;
-
-    for (auto i = rModelPart.NodesBegin(); i != rModelPart.NodesEnd(); ++i) {
-        if (i->Id() != id_node) {
-            i->SetId(id_node);
-        }
-        id_node++;
-    }
-
-    for (auto it = rModelPart.ElementsBegin(); it != rModelPart.ElementsEnd(); ++it) {
-        if (it->Id() != id_elem) {
-            it->SetId(id_elem);
-        }
-        id_elem++;
-    }
-
-    KRATOS_CATCH("");
 }
 
 /***********************************************************************************/

--- a/applications/MeshingApplication/custom_utilities/local_refine_geometry_mesh.cpp
+++ b/applications/MeshingApplication/custom_utilities/local_refine_geometry_mesh.cpp
@@ -175,8 +175,6 @@ void LocalRefineGeometryMesh::CreateListOfNewNodes(
 
     unsigned int number_of_new_nodes = 0;
 
-    NodesArrayType& pNodes = rModelPart.Nodes();
-
     typedef compressed_matrix<int>::iterator1 i1_t;
     typedef compressed_matrix<int>::iterator2 i2_t;
 

--- a/applications/MeshingApplication/custom_utilities/local_refine_geometry_mesh.hpp
+++ b/applications/MeshingApplication/custom_utilities/local_refine_geometry_mesh.hpp
@@ -189,17 +189,6 @@ public:
         );
 
     /**
-    * This process renumerates the elements and nodes
-    * @param New_Elements: Pointers to the new elements created
-    * @return this_model_part: The model part of the model (it is the input too)
-    */
-
-    virtual void RenumeringElementsAndNodes(
-        ModelPart& this_model_part,
-        PointerVector< Element >& New_Elements
-        );
-
-    /**
     * It creates a partition of the process between the different threads
     * @param number_of_threads: Number the threads considered in the computation
     * @param number_of_rows:
@@ -248,7 +237,8 @@ protected:
 
         ModelPart& mModelPart;       /// The model part to be refined
         int mCurrentRefinementLevel; /// The current refinement level
-
+        std::unordered_map<std::size_t, unsigned int> mMapNodeIdToPos;
+        std::vector<std::size_t> mMapPosToNodeId;
     ///@}
     ///@name Protected Operators
     ///@{
@@ -266,9 +256,9 @@ protected:
             if (it->GetValue(SPLIT_ELEMENT)) {
                 auto& r_geom = it->GetGeometry(); // Nodes of the element
                 for (unsigned int i = 0; i < r_geom.size(); i++) {
-                    int index_i = r_geom[i].Id() - 1;
+                    int index_i = mMapNodeIdToPos[r_geom[i].Id()];
                     for (unsigned int j = 0; j < r_geom.size(); j++) {
-                        int index_j = r_geom[j].Id() - 1;
+                        int index_j = mMapNodeIdToPos[r_geom[j].Id()];
                         if (index_j > index_i)
                         {
                             rCoord(index_i, index_j) = -2;

--- a/applications/MeshingApplication/custom_utilities/local_refine_prism_mesh.hpp
+++ b/applications/MeshingApplication/custom_utilities/local_refine_prism_mesh.hpp
@@ -407,18 +407,18 @@ public:
         aux.resize(12, false);
 
         // Lower face
-        int index_0 = geom[0].Id() - 1;
-        int index_1 = geom[1].Id() - 1;
-        int index_2 = geom[2].Id() - 1;
+        int index_0 = mMapNodeIdToPos[geom[0].Id()];
+        int index_1 = mMapNodeIdToPos[geom[1].Id()];
+        int index_2 = mMapNodeIdToPos[geom[2].Id()];
 
         aux[0] = geom[0].Id();
         aux[1] = geom[1].Id();
         aux[2] = geom[2].Id();
 
         // Upper face
-        int index_3 = geom[3].Id() - 1;
-        int index_4 = geom[4].Id() - 1;
-        int index_5 = geom[5].Id() - 1;
+        int index_3 = mMapNodeIdToPos[geom[3].Id()];
+        int index_4 = mMapNodeIdToPos[geom[4].Id()];
+        int index_5 = mMapNodeIdToPos[geom[5].Id()];
 
         aux[3] = geom[3].Id();
         aux[4] = geom[4].Id();

--- a/applications/MeshingApplication/custom_utilities/local_refine_tetrahedra_mesh.hpp
+++ b/applications/MeshingApplication/custom_utilities/local_refine_tetrahedra_mesh.hpp
@@ -473,12 +473,6 @@ public:
                 this_model_part.Conditions().push_back( *iCond );
             }
 
-            /* Renumber id */
-            unsigned int my_index = 1;
-            for(ModelPart::ConditionsContainerType::iterator it = this_model_part.ConditionsBegin(); it != this_model_part.ConditionsEnd(); it++)
-            {
-                it->SetId(my_index++);
-            }
 
 
             // Now update the conditions in SubModelParts
@@ -550,10 +544,10 @@ public:
     {
       aux.resize(11, false);
 
-      int index_0 = geom[0].Id() - 1;
-      int index_1 = geom[1].Id() - 1;
-      int index_2 = geom[2].Id() - 1;
-      int index_3 = geom[3].Id() - 1;
+      int index_0 = mMapNodeIdToPos[geom[0].Id()];
+      int index_1 = mMapNodeIdToPos[geom[1].Id()];
+      int index_2 = mMapNodeIdToPos[geom[2].Id()];
+      int index_3 = mMapNodeIdToPos[geom[3].Id()];
 
       // Put the global ids in aux
       aux[0] = geom[0].Id();
@@ -638,9 +632,9 @@ public:
 		      array_1d<int, 6>& aux
 		      )
     {
-        int index_0 = geom[0].Id() - 1;
-        int index_1 = geom[1].Id() - 1;
-        int index_2 = geom[2].Id() - 1;
+        int index_0 = mMapNodeIdToPos[geom[0].Id()];
+        int index_1 = mMapNodeIdToPos[geom[1].Id()];
+        int index_2 = mMapNodeIdToPos[geom[2].Id()];
 
         aux[0] = geom[0].Id();
         aux[1] = geom[1].Id();

--- a/applications/MeshingApplication/custom_utilities/local_refine_tetrahedra_mesh_only_on_boundaries.hpp
+++ b/applications/MeshingApplication/custom_utilities/local_refine_tetrahedra_mesh_only_on_boundaries.hpp
@@ -71,10 +71,10 @@ public:
             if (r_elem.GetValue(SPLIT_ELEMENT)) {
                 Element::GeometryType& r_geom = r_elem.GetGeometry(); // Nodes of the element
                 for (unsigned int i = 0; i < r_geom.size(); i++) {
-                    int index_i = r_geom[i].Id() - 1;
+                    int index_i = mMapNodeIdToPos[r_geom[i].Id()];
                     bool is_boundary_i = r_geom[i].Is(BOUNDARY);
                     for (unsigned int j = 0; j < r_geom.size(); j++) {
-                        int index_j = r_geom[j].Id() - 1;
+                        int index_j = mMapNodeIdToPos[r_geom[j].Id()];
                         bool is_boundary_j = r_geom[j].Is(BOUNDARY);
                         if (index_j > index_i && (is_boundary_j&&is_boundary_i)) {
                             rCoord(index_i, index_j) = -2;

--- a/applications/MeshingApplication/custom_utilities/local_refine_tetrahedra_mesh_parallel_to_boundaries.hpp
+++ b/applications/MeshingApplication/custom_utilities/local_refine_tetrahedra_mesh_parallel_to_boundaries.hpp
@@ -119,10 +119,10 @@ public:
             if (r_elem.GetValue(SPLIT_ELEMENT)) {
                 Element::GeometryType& r_geom = r_elem.GetGeometry(); // Nodes of the element
                 for (unsigned int i = 0; i < r_geom.size(); i++) {
-                    int index_i = r_geom[i].Id() - 1;
+                    int index_i = mMapNodeIdToPos[r_geom[i].Id()];
                     bool is_boundary_i = r_geom[i].Is(BOUNDARY);
                     for (unsigned int j = 0; j < r_geom.size(); j++) {
-                        int index_j = r_geom[j].Id() - 1;
+                        int index_j = mMapNodeIdToPos[r_geom[j].Id()];
                         bool is_boundary_j = r_geom[j].Is(BOUNDARY);
                         if (index_j > index_i && (is_boundary_j||is_boundary_i)) {
                             rCoord(index_i, index_j) = -2;
@@ -136,9 +136,9 @@ public:
         for (auto& r_cond : rThisModelPart.Conditions()) {
             auto& r_geom = r_cond.GetGeometry(); // Nodes of the condition
             for (unsigned int i = 0; i < r_geom.size(); i++) {
-                int index_i = r_geom[i].Id() - 1;
+                int index_i = mMapNodeIdToPos[r_geom[i].Id()];
                 for (unsigned int j = 0; j < r_geom.size(); j++) {
-                    int index_j = r_geom[j].Id() - 1;
+                    int index_j = mMapNodeIdToPos[r_geom[j].Id()];
                     if (index_j > index_i)  {
                         rCoord(index_i, index_j) = -1;
                     }

--- a/applications/MeshingApplication/custom_utilities/local_refine_triangle_mesh.hpp
+++ b/applications/MeshingApplication/custom_utilities/local_refine_triangle_mesh.hpp
@@ -145,8 +145,8 @@ public:
 
                 if (geom.size() == 2)
                 {
-                    int index_0 = geom[0].Id() - 1;
-                    int index_1 = geom[1].Id() - 1;
+                    int index_0 = mMapNodeIdToPos[geom[0].Id()];
+                    int index_1 = mMapNodeIdToPos[geom[1].Id()];
                     int new_id;
 
                     if (index_0 > index_1)

--- a/applications/MeshingApplication/custom_utilities/local_refine_triangle_mesh_conditions.hpp
+++ b/applications/MeshingApplication/custom_utilities/local_refine_triangle_mesh_conditions.hpp
@@ -200,13 +200,13 @@ public:
         rCoord.resize(pNodes.size(), pNodes.size(), false);
 
         for(auto i = it_begin; i!=it_end; i++) {
-            int index_i = i->Id() - 1; // WARNING: MESH MUST BE IN ORDER
+            int index_i = mMapNodeIdToPos[i->Id()]; // WARNING: MESH MUST BE IN ORDER
             GlobalPointersVector< Node >& neighb_nodes = i->GetValue(NEIGHBOUR_CONDITION_NODES);
 
             std::vector<unsigned int> aux(neighb_nodes.size());
             unsigned int active = 0;
             for (auto inode = neighb_nodes.begin(); inode != neighb_nodes.end(); inode++) {
-                int index_j = inode->Id() - 1;
+                int index_j = mMapNodeIdToPos[inode->Id()];
                 if (index_j > index_i) {
                     aux[active] = index_j;
                     active++;

--- a/applications/MeshingApplication/custom_utilities/local_refine_triangle_mesh_conditions.hpp
+++ b/applications/MeshingApplication/custom_utilities/local_refine_triangle_mesh_conditions.hpp
@@ -200,7 +200,7 @@ public:
         rCoord.resize(pNodes.size(), pNodes.size(), false);
 
         for(auto i = it_begin; i!=it_end; i++) {
-            int index_i = mMapNodeIdToPos[i->Id()]; // WARNING: MESH MUST BE IN ORDER
+            int index_i = mMapNodeIdToPos[i->Id()];
             GlobalPointersVector< Node >& neighb_nodes = i->GetValue(NEIGHBOUR_CONDITION_NODES);
 
             std::vector<unsigned int> aux(neighb_nodes.size());


### PR DESCRIPTION
**📝 Description**
This MR avoids the renumbering of existing nodes when refining meshes. It was causing problems when used in combination with the connectivity preserve modeler, since some of the nodes of the "cousin" model parts are not seen by the model part used when refining, thus leading to repeated nodal IDs


**🆕 Changelog**
-Removes renumbering
-Adds a map and vector of Ids to move back and forth between model parts and CSR matrix, while keeping performance to reduce the coordinates in the CSR.
