### PR TITLE
[Meshing] do-not-require-root-for-refinement

### DIFF
--- a/applications/MeshingApplication/custom_utilities/local_refine_geometry_mesh.cpp
+++ b/applications/MeshingApplication/custom_utilities/local_refine_geometry_mesh.cpp
@@ -32,8 +32,6 @@ void LocalRefineGeometryMesh::LocalRefineMesh(
 {
     KRATOS_TRY;
 
-    KRATOS_ERROR_IF(mModelPart.IsSubModelPart()) << "modelpart must be root modelpart" << std::endl;
-
     KRATOS_ERROR_IF(RefineOnReference && !(mModelPart.NodesBegin()->SolutionStepsDataHas(DISPLACEMENT))) << "DISPLACEMENT Variable is not in the model part -- needed if refine_on_reference = true" << std::endl;
 
     compressed_matrix<int> coord;                            // The matrix that stores all the index of the geometry


### PR DESCRIPTION
**📝 Description**

for the linear to quadratic tet replacement util, the function replacing elements is calling the root model part, so this test is not needed


Please mark the PR with appropriate tags: 
- Api Breaker, Mpi, etc...

**🆕 Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Remove check to see if the model part is root model part
