### PR TITLE
[Core] Fix pycaster casting data to wrong types in data_communicator

### DIFF
--- a/kratos/mpi/tests/test_mpi_data_communicator_python.py
+++ b/kratos/mpi/tests/test_mpi_data_communicator_python.py
@@ -5,7 +5,7 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 class TestMPIDataCommunicatorPython(KratosUnittest.TestCase):
 
     def setUp(self):
-        self.world = Kratos.Testing.GetDefaultDataCommunicator()
+        self.world: Kratos.DataCommunicator = Kratos.Testing.GetDefaultDataCommunicator()
         self.rank = self.world.Rank()
         self.size = self.world.Size()
 
@@ -260,6 +260,68 @@ class TestMPIDataCommunicatorPython(KratosUnittest.TestCase):
 
         self.assertEqual(gathered_ints, [ [i, i+1, i+2] for i in range(self.size)])
         self.assertEqual(gathered_doubles, [ [1.0 + i, 2.0 + i , 3.0 + i] for i in range(self.size)])
+
+    def test_CastingTypes(self):
+        n = self.world.Size()
+
+        def check_value_in_rank(ref_value, value, ranks_to_check: 'list[int]'):
+            self.assertTrue(isinstance(value, type(ref_value)))
+            if self.rank in ranks_to_check:
+                if isinstance(ref_value, int) or isinstance(ref_value, float):
+                    self.assertEqual(ref_value, value)
+                elif isinstance(ref_value, Kratos.Array3) or isinstance(ref_value, Kratos.Array4) or isinstance(ref_value, Kratos.Array6) or isinstance(ref_value, Kratos.Array9) or isinstance(ref_value, Kratos.Vector):
+                    self.assertVectorAlmostEqual(ref_value, value)
+                elif isinstance(ref_value, Kratos.Matrix):
+                    self.assertMatrixAlmostEqual(ref_value, value)
+                elif isinstance(ref_value, list):
+                    check_value_in_rank(ref_value[0], value[0], ranks_to_check)
+
+        def simple_reduce_check(method, rank: int, ref_value: float, ranks_to_check: 'list[int]'):
+            check_value_in_rank(method(self.rank+1, rank), int(ref_value), ranks_to_check)
+            check_value_in_rank(method(float(self.rank+1), rank), float(ref_value), ranks_to_check)
+            check_value_in_rank(method(Kratos.Array3(self.rank+1), rank), Kratos.Array3(ref_value), ranks_to_check)
+            check_value_in_rank(method(Kratos.Array4(self.rank+1), rank), Kratos.Array4(ref_value), ranks_to_check)
+            check_value_in_rank(method(Kratos.Array6(self.rank+1), rank), Kratos.Array6(ref_value), ranks_to_check)
+            check_value_in_rank(method(Kratos.Array9(self.rank+1), rank), Kratos.Array9(ref_value), ranks_to_check)
+            check_value_in_rank(method(Kratos.Vector(2, self.rank+1), rank), Kratos.Vector(2, ref_value), ranks_to_check)
+            check_value_in_rank(method(Kratos.Matrix(2, 2, self.rank+1), rank), Kratos.Matrix(2, 2, ref_value), ranks_to_check)
+
+            check_value_in_rank(getattr(self.world, method.__name__ + "Ints")([self.rank+1], rank), [int(ref_value)], ranks_to_check)
+            check_value_in_rank(getattr(self.world, method.__name__ + "Doubles")([float(self.rank+1)], rank), [float(ref_value)], ranks_to_check)
+            check_value_in_rank(getattr(self.world, method.__name__ + "Array3s")([Kratos.Array3(self.rank+1)], rank), [Kratos.Array3(ref_value)], ranks_to_check)
+            check_value_in_rank(getattr(self.world, method.__name__ + "Array4s")([Kratos.Array4(self.rank+1)], rank), [Kratos.Array4(ref_value)], ranks_to_check)
+            check_value_in_rank(getattr(self.world, method.__name__ + "Array6s")([Kratos.Array6(self.rank+1)], rank), [Kratos.Array6(ref_value)], ranks_to_check)
+            check_value_in_rank(getattr(self.world, method.__name__ + "Array9s")([Kratos.Array9(self.rank+1)], rank), [Kratos.Array9(ref_value)], ranks_to_check)
+            check_value_in_rank(getattr(self.world, method.__name__ + "Vectors")([Kratos.Vector(2, self.rank+1)], rank), [Kratos.Vector(2, ref_value)], ranks_to_check)
+            check_value_in_rank(getattr(self.world, method.__name__ + "Matrices")([Kratos.Matrix(2, 2, self.rank+1)], rank), [Kratos.Matrix(2, 2, ref_value)], ranks_to_check)
+
+        def simple_all_reduce_check(method, ref_value: float):
+            ranks_to_check = [i for i in range(n)]
+            check_value_in_rank(method(self.rank+1), int(ref_value), ranks_to_check)
+            check_value_in_rank(method(float(self.rank+1)), float(ref_value), ranks_to_check)
+            check_value_in_rank(method(Kratos.Array3(self.rank+1)), Kratos.Array3(ref_value), ranks_to_check)
+            check_value_in_rank(method(Kratos.Array3(self.rank+1)), Kratos.Array3(ref_value), ranks_to_check)
+            check_value_in_rank(method(Kratos.Array3(self.rank+1)), Kratos.Array3(ref_value), ranks_to_check)
+            check_value_in_rank(method(Kratos.Array3(self.rank+1)), Kratos.Array3(ref_value), ranks_to_check)
+            check_value_in_rank(method(Kratos.Vector(2, self.rank+1)), Kratos.Vector(2, ref_value), ranks_to_check)
+            check_value_in_rank(method(Kratos.Matrix(2, 2, self.rank+1)), Kratos.Matrix(2, 2, ref_value), ranks_to_check)
+
+            check_value_in_rank(getattr(self.world, method.__name__ + "Ints")([self.rank+1]), [int(ref_value)], ranks_to_check)
+            check_value_in_rank(getattr(self.world, method.__name__ + "Doubles")([float(self.rank+1)]), [float(ref_value)], ranks_to_check)
+            check_value_in_rank(getattr(self.world, method.__name__ + "Array3s")([Kratos.Array3(self.rank+1)]), [Kratos.Array3(ref_value)], ranks_to_check)
+            check_value_in_rank(getattr(self.world, method.__name__ + "Array4s")([Kratos.Array4(self.rank+1)]), [Kratos.Array4(ref_value)], ranks_to_check)
+            check_value_in_rank(getattr(self.world, method.__name__ + "Array6s")([Kratos.Array6(self.rank+1)]), [Kratos.Array6(ref_value)], ranks_to_check)
+            check_value_in_rank(getattr(self.world, method.__name__ + "Array9s")([Kratos.Array9(self.rank+1)]), [Kratos.Array9(ref_value)], ranks_to_check)
+            check_value_in_rank(getattr(self.world, method.__name__ + "Vectors")([Kratos.Vector(2, self.rank+1)]), [Kratos.Vector(2, ref_value)], ranks_to_check)
+            check_value_in_rank(getattr(self.world, method.__name__ + "Matrices")([Kratos.Matrix(2, 2, self.rank+1)]), [Kratos.Matrix(2, 2, ref_value)], ranks_to_check)
+
+        simple_reduce_check(self.world.Sum, 0, n*(n+1)/2, [0])
+        simple_reduce_check(self.world.Min, 0, 1, [0])
+        simple_reduce_check(self.world.Max, 0, n, [0])
+        simple_reduce_check(self.world.Broadcast, 0, 1, [i for i in range(n)])
+        simple_all_reduce_check(self.world.SumAll, n*(n+1)/2)
+        simple_all_reduce_check(self.world.MinAll, 1)
+        simple_all_reduce_check(self.world.MaxAll, n)
 
 if __name__ == "__main__":
     Kratos.Logger.GetDefaultOutput().SetSeverity(Kratos.Logger.Severity.WARNING)

--- a/kratos/python/add_data_communicator_to_python.cpp
+++ b/kratos/python/add_data_communicator_to_python.cpp
@@ -85,46 +85,47 @@ void AddDataCommunicatorMethodForDataType(
     }
 
     const std::string& value_text = arg_text + "_value";
-    const std::string& list_of_values = "list_of_" + arg_text + "_values";
-    const std::string& list_of_v_values = "list_of_" + arg_text + "_per_ranks";
+    const std::string& plural_arg_text = (std::is_same_v<TDataType, Matrix> ? "Matrices" : arg_text + "s");
+    const std::string& list_of_values = "list_of_" + plural_arg_text;
+    const std::string& list_of_v_values = "list_of_" + plural_arg_text + "_per_ranks";
 
     namespace py = pybind11;
 
     rDataCommunicatorModule.def("Sum", py::overload_cast<const TDataType&, const int>(&DataCommunicator::Sum, py::const_), py::arg(value_text.c_str()), py::arg("root"));
-    rDataCommunicatorModule.def(("Sum" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Sum, py::const_), py::arg(list_of_values.c_str()), py::arg("root"));
+    rDataCommunicatorModule.def(("Sum" + plural_arg_text).c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Sum, py::const_), py::arg(list_of_values.c_str()), py::arg("root"));
     rDataCommunicatorModule.def("Min", py::overload_cast<const TDataType&, const int>(&DataCommunicator::Min, py::const_), py::arg(value_text.c_str()), py::arg("root"));
-    rDataCommunicatorModule.def(("Min" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Min, py::const_), py::arg(list_of_values.c_str()), py::arg("root"));
+    rDataCommunicatorModule.def(("Min" + plural_arg_text).c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Min, py::const_), py::arg(list_of_values.c_str()), py::arg("root"));
     rDataCommunicatorModule.def("Max", py::overload_cast<const TDataType&, const int>(&DataCommunicator::Max, py::const_), py::arg(value_text.c_str()), py::arg("root"));
-    rDataCommunicatorModule.def(("Max" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Max, py::const_), py::arg(list_of_values.c_str()), py::arg("root"));
+    rDataCommunicatorModule.def(("Max" + plural_arg_text).c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Max, py::const_), py::arg(list_of_values.c_str()), py::arg("root"));
 
     rDataCommunicatorModule.def("SumAll", py::overload_cast<const TDataType&>(&DataCommunicator::SumAll, py::const_), py::arg(value_text.c_str()));
-    rDataCommunicatorModule.def(("SumAll" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::SumAll, py::const_), py::arg(list_of_values.c_str()));
+    rDataCommunicatorModule.def(("SumAll" + plural_arg_text).c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::SumAll, py::const_), py::arg(list_of_values.c_str()));
     rDataCommunicatorModule.def("MinAll", py::overload_cast<const TDataType&>(&DataCommunicator::MinAll, py::const_), py::arg(value_text.c_str()));
-    rDataCommunicatorModule.def(("MinAll" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::MinAll, py::const_), py::arg(list_of_values.c_str()));
+    rDataCommunicatorModule.def(("MinAll" + plural_arg_text).c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::MinAll, py::const_), py::arg(list_of_values.c_str()));
     rDataCommunicatorModule.def("MaxAll", py::overload_cast<const TDataType&>(&DataCommunicator::MaxAll, py::const_), py::arg(value_text.c_str()));
-    rDataCommunicatorModule.def(("MaxAll" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::MaxAll, py::const_), py::arg(list_of_values.c_str()));
+    rDataCommunicatorModule.def(("MaxAll" + plural_arg_text).c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::MaxAll, py::const_), py::arg(list_of_values.c_str()));
 
     rDataCommunicatorModule.def("ScanSum", py::overload_cast<const TDataType&>(&DataCommunicator::ScanSum, py::const_), py::arg(value_text.c_str()));
-    rDataCommunicatorModule.def(("ScanSum" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::ScanSum, py::const_), py::arg(list_of_values.c_str()));
+    rDataCommunicatorModule.def(("ScanSum" + plural_arg_text).c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::ScanSum, py::const_), py::arg(list_of_values.c_str()));
 
-    rDataCommunicatorModule.def(("SendRecv" + arg_text + "s").c_str(), pybind11::overload_cast<const std::vector<TDataType>&, const int, const int>(&DataCommunicator::SendRecv<std::vector<TDataType>>, pybind11::const_), py::arg(list_of_values.c_str()), py::arg("send_destination"), py::arg("recv_source"));
+    rDataCommunicatorModule.def(("SendRecv" + plural_arg_text).c_str(), pybind11::overload_cast<const std::vector<TDataType>&, const int, const int>(&DataCommunicator::SendRecv<std::vector<TDataType>>, pybind11::const_), py::arg(list_of_values.c_str()), py::arg("send_destination"), py::arg("recv_source"));
 
     rDataCommunicatorModule.def("Broadcast", [](const DataCommunicator& rSelf, TDataType& rSourceMessage, const int SourceRank){
         rSelf.Broadcast(rSourceMessage, SourceRank);
         return rSourceMessage;
     }, py::arg(value_text.c_str()), py::arg("source_rank"));
-    rDataCommunicatorModule.def(("Broadcast" + arg_text + "s").c_str(), [](const DataCommunicator& rSelf, std::vector<TDataType>& rSourceMessage, const int SourceRank) {
+    rDataCommunicatorModule.def(("Broadcast" + plural_arg_text).c_str(), [](const DataCommunicator& rSelf, std::vector<TDataType>& rSourceMessage, const int SourceRank) {
         return VectorBroadcastWrapper<TDataType>(rSelf, &DataCommunicator::Broadcast, rSourceMessage, SourceRank);
     }, py::arg(list_of_values.c_str()), py::arg("source_rank"));
 
-    rDataCommunicatorModule.def(("Scatter" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Scatter, py::const_), py::arg(list_of_values.c_str()), py::arg("source_rank"));
-    rDataCommunicatorModule.def(("Scatterv" + arg_text + "s").c_str(), py::overload_cast<const std::vector<std::vector<TDataType>>&, const int>(&DataCommunicator::Scatterv, py::const_), py::arg(list_of_v_values.c_str()), py::arg("source_rank"));
+    rDataCommunicatorModule.def(("Scatter" + plural_arg_text).c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Scatter, py::const_), py::arg(list_of_values.c_str()), py::arg("source_rank"));
+    rDataCommunicatorModule.def(("Scatterv" + plural_arg_text).c_str(), py::overload_cast<const std::vector<std::vector<TDataType>>&, const int>(&DataCommunicator::Scatterv, py::const_), py::arg(list_of_v_values.c_str()), py::arg("source_rank"));
 
-    rDataCommunicatorModule.def(("Gather" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Gather, py::const_), py::arg(list_of_values.c_str()), py::arg("destination_rank"));
-    rDataCommunicatorModule.def(("Gatherv" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Gatherv, py::const_), py::arg(list_of_values.c_str()), py::arg("destination_rank"));
+    rDataCommunicatorModule.def(("Gather" + plural_arg_text).c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Gather, py::const_), py::arg(list_of_values.c_str()), py::arg("destination_rank"));
+    rDataCommunicatorModule.def(("Gatherv" + plural_arg_text).c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Gatherv, py::const_), py::arg(list_of_values.c_str()), py::arg("destination_rank"));
 
-    rDataCommunicatorModule.def(("AllGather" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::AllGather, py::const_), py::arg(list_of_values.c_str()));
-    rDataCommunicatorModule.def(("AllGatherv" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::AllGatherv, py::const_), py::arg(list_of_values.c_str()));
+    rDataCommunicatorModule.def(("AllGather" + plural_arg_text).c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::AllGather, py::const_), py::arg(list_of_values.c_str()));
+    rDataCommunicatorModule.def(("AllGatherv" + plural_arg_text).c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::AllGatherv, py::const_), py::arg(list_of_values.c_str()));
 
     rDataCommunicatorModule.def("SynchronizeShape", [](const DataCommunicator& rSelf, TDataType& rValue) { rSelf.SynchronizeShape(rValue); return rValue; }, py::arg(value_text.c_str()));
 }

--- a/kratos/python/add_data_communicator_to_python.cpp
+++ b/kratos/python/add_data_communicator_to_python.cpp
@@ -65,9 +65,9 @@ void AddDataCommunicatorMethodForDataType(
 {
     std::string arg_text;
     if constexpr(std::is_same_v<TDataType, int>) {
-        arg_text = "int";
+        arg_text = "Int";
     } else if constexpr(std::is_same_v<TDataType, double>) {
-        arg_text = "double";
+        arg_text = "Double";
     } else if constexpr(std::is_same_v<TDataType, array_1d<double, 3>>) {
         arg_text = "Array3";
     } else if constexpr(std::is_same_v<TDataType, array_1d<double, 4>>) {
@@ -90,47 +90,41 @@ void AddDataCommunicatorMethodForDataType(
 
     namespace py = pybind11;
 
-    // rDataCommunicatorModule.def("SynchronizeShape", py::overlo)
-
     rDataCommunicatorModule.def("Sum", py::overload_cast<const TDataType&, const int>(&DataCommunicator::Sum, py::const_), py::arg(value_text.c_str()), py::arg("root"));
-    rDataCommunicatorModule.def("Sum", py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Sum, py::const_), py::arg(list_of_values.c_str()), py::arg("root"));
+    rDataCommunicatorModule.def(("Sum" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Sum, py::const_), py::arg(list_of_values.c_str()), py::arg("root"));
     rDataCommunicatorModule.def("Min", py::overload_cast<const TDataType&, const int>(&DataCommunicator::Min, py::const_), py::arg(value_text.c_str()), py::arg("root"));
-    rDataCommunicatorModule.def("Min", py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Min, py::const_), py::arg(list_of_values.c_str()), py::arg("root"));
+    rDataCommunicatorModule.def(("Min" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Min, py::const_), py::arg(list_of_values.c_str()), py::arg("root"));
     rDataCommunicatorModule.def("Max", py::overload_cast<const TDataType&, const int>(&DataCommunicator::Max, py::const_), py::arg(value_text.c_str()), py::arg("root"));
-    rDataCommunicatorModule.def("Max", py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Max, py::const_), py::arg(list_of_values.c_str()), py::arg("root"));
+    rDataCommunicatorModule.def(("Max" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Max, py::const_), py::arg(list_of_values.c_str()), py::arg("root"));
 
     rDataCommunicatorModule.def("SumAll", py::overload_cast<const TDataType&>(&DataCommunicator::SumAll, py::const_), py::arg(value_text.c_str()));
-    rDataCommunicatorModule.def("SumAll", py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::SumAll, py::const_), py::arg(list_of_values.c_str()));
+    rDataCommunicatorModule.def(("SumAll" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::SumAll, py::const_), py::arg(list_of_values.c_str()));
     rDataCommunicatorModule.def("MinAll", py::overload_cast<const TDataType&>(&DataCommunicator::MinAll, py::const_), py::arg(value_text.c_str()));
-    rDataCommunicatorModule.def("MinAll", py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::MinAll, py::const_), py::arg(list_of_values.c_str()));
+    rDataCommunicatorModule.def(("MinAll" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::MinAll, py::const_), py::arg(list_of_values.c_str()));
     rDataCommunicatorModule.def("MaxAll", py::overload_cast<const TDataType&>(&DataCommunicator::MaxAll, py::const_), py::arg(value_text.c_str()));
-    rDataCommunicatorModule.def("MaxAll", py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::MaxAll, py::const_), py::arg(list_of_values.c_str()));
+    rDataCommunicatorModule.def(("MaxAll" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::MaxAll, py::const_), py::arg(list_of_values.c_str()));
 
     rDataCommunicatorModule.def("ScanSum", py::overload_cast<const TDataType&>(&DataCommunicator::ScanSum, py::const_), py::arg(value_text.c_str()));
-    rDataCommunicatorModule.def("ScanSum", py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::ScanSum, py::const_), py::arg(list_of_values.c_str()));
+    rDataCommunicatorModule.def(("ScanSum" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::ScanSum, py::const_), py::arg(list_of_values.c_str()));
 
-    rDataCommunicatorModule.def("SendRecv", pybind11::overload_cast<const std::vector<TDataType>&, const int, const int>(&DataCommunicator::SendRecv<std::vector<TDataType>>, pybind11::const_), py::arg(list_of_values.c_str()), py::arg("send_destination"), py::arg("recv_source"));
+    rDataCommunicatorModule.def(("SendRecv" + arg_text + "s").c_str(), pybind11::overload_cast<const std::vector<TDataType>&, const int, const int>(&DataCommunicator::SendRecv<std::vector<TDataType>>, pybind11::const_), py::arg(list_of_values.c_str()), py::arg("send_destination"), py::arg("recv_source"));
 
     rDataCommunicatorModule.def("Broadcast", [](const DataCommunicator& rSelf, TDataType& rSourceMessage, const int SourceRank){
         rSelf.Broadcast(rSourceMessage, SourceRank);
         return rSourceMessage;
     }, py::arg(value_text.c_str()), py::arg("source_rank"));
+    rDataCommunicatorModule.def(("Broadcast" + arg_text + "s").c_str(), [](const DataCommunicator& rSelf, std::vector<TDataType>& rSourceMessage, const int SourceRank) {
+        return VectorBroadcastWrapper<TDataType>(rSelf, &DataCommunicator::Broadcast, rSourceMessage, SourceRank);
+    }, py::arg(list_of_values.c_str()), py::arg("source_rank"));
 
-    // TODO: Following vector version of Broadcast cannot be uncommented, because if TDataType=Matrix, then
-    //       Pybind11 tries to cast standalone Matrix to std::vector<Matrix> for some reason. Hence, this is deactivated
-    //       for the time being.
-    // rDataCommunicatorModule.def("Broadcast", [](const DataCommunicator& rSelf, std::vector<TDataType>& rSourceMessage, const int SourceRank) {
-    //     return VectorBroadcastWrapper<TDataType>(rSelf, &DataCommunicator::Broadcast, rSourceMessage, SourceRank);
-    // }, py::arg(list_of_values.c_str()), py::arg("source_rank"));
+    rDataCommunicatorModule.def(("Scatter" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Scatter, py::const_), py::arg(list_of_values.c_str()), py::arg("source_rank"));
+    rDataCommunicatorModule.def(("Scatterv" + arg_text + "s").c_str(), py::overload_cast<const std::vector<std::vector<TDataType>>&, const int>(&DataCommunicator::Scatterv, py::const_), py::arg(list_of_v_values.c_str()), py::arg("source_rank"));
 
-    rDataCommunicatorModule.def("Scatter", py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Scatter, py::const_), py::arg(list_of_values.c_str()), py::arg("source_rank"));
-    rDataCommunicatorModule.def("Scatterv", py::overload_cast<const std::vector<std::vector<TDataType>>&, const int>(&DataCommunicator::Scatterv, py::const_), py::arg(list_of_v_values.c_str()), py::arg("source_rank"));
+    rDataCommunicatorModule.def(("Gather" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Gather, py::const_), py::arg(list_of_values.c_str()), py::arg("destination_rank"));
+    rDataCommunicatorModule.def(("Gatherv" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Gatherv, py::const_), py::arg(list_of_values.c_str()), py::arg("destination_rank"));
 
-    rDataCommunicatorModule.def("Gather", py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Gather, py::const_), py::arg(list_of_values.c_str()), py::arg("destination_rank"));
-    rDataCommunicatorModule.def("Gatherv", py::overload_cast<const std::vector<TDataType>&, const int>(&DataCommunicator::Gatherv, py::const_), py::arg(list_of_values.c_str()), py::arg("destination_rank"));
-
-    rDataCommunicatorModule.def("AllGather", py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::AllGather, py::const_), py::arg(list_of_values.c_str()));
-    rDataCommunicatorModule.def("AllGatherv", py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::AllGatherv, py::const_), py::arg(list_of_values.c_str()));
+    rDataCommunicatorModule.def(("AllGather" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::AllGather, py::const_), py::arg(list_of_values.c_str()));
+    rDataCommunicatorModule.def(("AllGatherv" + arg_text + "s").c_str(), py::overload_cast<const std::vector<TDataType>&>(&DataCommunicator::AllGatherv, py::const_), py::arg(list_of_values.c_str()));
 
     rDataCommunicatorModule.def("SynchronizeShape", [](const DataCommunicator& rSelf, TDataType& rValue) { rSelf.SynchronizeShape(rValue); return rValue; }, py::arg(value_text.c_str()));
 }
@@ -153,65 +147,17 @@ void AddDataCommunicatorToPython(pybind11::module &m)
     AddDataCommunicatorMethodForDataType<data_communicator_module_type, Vector>(data_communicator_module);
     AddDataCommunicatorMethodForDataType<data_communicator_module_type, Matrix>(data_communicator_module);
 
-    // followings  "*Ints" and "*Doubles" versions are kept to have backward compatibility, but they are no longer required.
     data_communicator_module.def("Barrier", &DataCommunicator::Barrier)
-    // Reduce sum
-    .def("SumInts", (std::vector<int> (DataCommunicator::*)(const std::vector<int>&, const int) const) &DataCommunicator::Sum)
-    .def("SumDoubles", (std::vector<double> (DataCommunicator::*)(const std::vector<double>&, const int) const) &DataCommunicator::Sum)
-    // Reduce min
-    .def("MinInts", (std::vector<int> (DataCommunicator::*)(const std::vector<int>&, const int) const) &DataCommunicator::Min)
-    .def("MinDoubles", (std::vector<double> (DataCommunicator::*)(const std::vector<double>&, const int) const) &DataCommunicator::Min)
-    // Reduce max
-    .def("MaxInts", (std::vector<int> (DataCommunicator::*)(const std::vector<int>&, const int) const) &DataCommunicator::Max)
-    .def("MaxDoubles", (std::vector<double> (DataCommunicator::*)(const std::vector<double>&, const int) const) &DataCommunicator::Max)
-    // Allreduce sum
-    .def("SumAllInts", (std::vector<int> (DataCommunicator::*)(const std::vector<int>&) const) &DataCommunicator::SumAll)
-    .def("SumAllDoubles", (std::vector<double> (DataCommunicator::*)(const std::vector<double>&) const) &DataCommunicator::SumAll)
-    // Allreduce min
-    .def("MinAllInts", (std::vector<int> (DataCommunicator::*)(const std::vector<int>&) const) &DataCommunicator::MinAll)
-    .def("MinAllDoubles", (std::vector<double> (DataCommunicator::*)(const std::vector<double>&) const) &DataCommunicator::MinAll)
-    // Allreduce max
-    .def("MaxAllInts", (std::vector<int> (DataCommunicator::*)(const std::vector<int>&) const) &DataCommunicator::MaxAll)
-    .def("MaxAllDoubles", (std::vector<double> (DataCommunicator::*)(const std::vector<double>&) const) &DataCommunicator::MaxAll)
-    // ScanSum
-    .def("ScanSumInts", (std::vector<int> (DataCommunicator::*)(const std::vector<int>&) const) &DataCommunicator::ScanSum)
-    .def("ScanSumDoubles",(std::vector<double> (DataCommunicator::*)(const std::vector<double>&) const) &DataCommunicator::ScanSum)
     // SendRecv
-    .def("SendRecvInts",(std::vector<int> (DataCommunicator::*)(const std::vector<int>&, const int, const int) const) &DataCommunicator::SendRecv)
-    .def("SendRecvDoubles",(std::vector<double> (DataCommunicator::*)(const std::vector<double>&, const int, const int) const) &DataCommunicator::SendRecv)
     .def("SendRecvString",(std::string (DataCommunicator::*)(const std::string&, const int, const int) const) &DataCommunicator::SendRecv)
     // Broadcast
     .def("Broadcast", [](DataCommunicator& rSelf, std::string& rSourceMessage, const int SourceRank){
         rSelf.Broadcast(rSourceMessage, SourceRank);
         return rSourceMessage;
     })
-    .def("BroadcastInts", [](DataCommunicator& rSelf, const std::vector<int>& rSourceMessage, const int SourceRank) {
-        return VectorBroadcastWrapper<int>(rSelf, &DataCommunicator::Broadcast, rSourceMessage, SourceRank);
-    })
-    .def("BroadcastDoubles", [](DataCommunicator& rSelf, const std::vector<double>& rSourceMessage, const int SourceRank) {
-        return VectorBroadcastWrapper<double>(rSelf, &DataCommunicator::Broadcast, rSourceMessage, SourceRank);
-    })
     .def("BroadcastStrings", [](DataCommunicator& rSelf, const std::vector<std::string>& rSourceMessage, const int SourceRank){
         return VectorBroadcastWrapper<std::string>(rSelf, &DataCommunicator::Broadcast, rSourceMessage, SourceRank);
     })
-    // Scatter
-    .def("ScatterInts", (std::vector<int> (DataCommunicator::*)(const std::vector<int>&, const int) const) &DataCommunicator::Scatter)
-    .def("ScatterDoubles", (std::vector<double> (DataCommunicator::*)(const std::vector<double>&, const int) const) &DataCommunicator::Scatter)
-    // Scatterv
-    .def("ScattervInts", (std::vector<int> (DataCommunicator::*)(const std::vector<std::vector<int>>&, const int) const) &DataCommunicator::Scatterv)
-    .def("ScattervDoubles", (std::vector<double> (DataCommunicator::*)(const std::vector<std::vector<double>>&, const int) const) &DataCommunicator::Scatterv)
-    // Gather
-    .def("GatherInts",(std::vector<int> (DataCommunicator::*)(const std::vector<int>&, const int) const) &DataCommunicator::Gather)
-    .def("GatherDoubles",(std::vector<double> (DataCommunicator::*)(const std::vector<double>&, const int) const) &DataCommunicator::Gather)
-    // Gatherv
-    .def("GathervInts",(std::vector<std::vector<int>> (DataCommunicator::*)(const std::vector<int>&, const int) const) &DataCommunicator::Gatherv)
-    .def("GathervDoubles",(std::vector<std::vector<double>> (DataCommunicator::*)(const std::vector<double>&, const int) const) &DataCommunicator::Gatherv)
-    // AllGather
-    .def("AllGatherInts",(std::vector<int> (DataCommunicator::*)(const std::vector<int>&) const) &DataCommunicator::AllGather)
-    .def("AllGatherDoubles",(std::vector<double> (DataCommunicator::*)(const std::vector<double>&) const) &DataCommunicator::AllGather)
-    // AllGatherv
-    .def("AllGathervInts",(std::vector<std::vector<int>> (DataCommunicator::*)(const std::vector<int>&) const) &DataCommunicator::AllGatherv)
-    .def("AllGathervDoubles",(std::vector<std::vector<double>> (DataCommunicator::*)(const std::vector<double>&) const) &DataCommunicator::AllGatherv)
     // Common MPI operations
     .def("Rank", &DataCommunicator::Rank)
     .def("Size", &DataCommunicator::Size)


### PR DESCRIPTION
**📝 Description**
Recently I introduced all data types support and their `std::vector` support in `DataCommunicator` (#11433). But the pybind caster cannot deduce correctly different types as in the following case:
```python
   result = data_communicator.SumAll(Kratos.Array3(2.0))
```
In there, the type of `result` is `list` with `[2, 2, 2]` and not `Array3` type which is wrong. This happens because, pybind caster cast `Array3` to `std::vector<double>`, hence the result is a list. Therefore, I used the existing trick to all the data types by suffixing the python exposed method names with their data types such as in the following `Sum` example

- `SumInts`
- `SumDoubles`
- `SumArray3s`
- `SumArray4s`
- `SumArray6s`
- `SumArray9s`
- `SumVectors`
- `SumMatrices`

**🆕 Changelog**
- Fix list type casting identification problem in pybind
