### PR TITLE
[HDF5] Controller and XDMF Bugfixes

### DIFF
--- a/applications/HDF5Application/python_scripts/core/__init__.py
+++ b/applications/HDF5Application/python_scripts/core/__init__.py
@@ -26,7 +26,7 @@ import typing
 ##!@{
 def CreateController(parameters: KratosMultiphysics.Parameters,
                      model: KratosMultiphysics.Model,
-                     operation: operations.AggregateOperation):
+                     operation: operations.AggregateOperation) -> controllers.Controller:
     parameters.AddMissingParameters(KratosMultiphysics.Parameters("""{
         "model_part_name" : "PLEASE_SPECIFY_MODEL_PART_NAME",
         "process_step" : "initialize",

--- a/applications/HDF5Application/python_scripts/core/controllers.py
+++ b/applications/HDF5Application/python_scripts/core/controllers.py
@@ -26,8 +26,8 @@ class Controller(abc.ABC):
     def __init__(self,
                  model_part: KratosMultiphysics.ModelPart,
                  operation: operations.AggregateOperation):
-        self._model_part = model_part
-        self.__operation = operation
+        self._model_part: KratosMultiphysics.ModelPart = model_part
+        self.__operation: operations.AggregateOperation = operation
 
     @abc.abstractmethod
     def IsExecuteStep(self) -> bool:

--- a/applications/HDF5Application/python_scripts/core/controllers.py
+++ b/applications/HDF5Application/python_scripts/core/controllers.py
@@ -65,8 +65,8 @@ class TemporalController(Controller):
                  operation: operations.AggregateOperation,
                  settings: KratosMultiphysics.Parameters):
         super().__init__(model_part, operation)
-        time_frequency: typing.Optional[float] = None
-        step_frequency: typing.Optional[int] = None
+        time_frequency: Optional[float] = None
+        step_frequency: Optional[int] = None
         if settings.Has("time_frequency"):
             time_frequency = settings["time_frequency"].GetDouble()
         if settings.Has("step_frequency"):
@@ -82,12 +82,8 @@ class TemporalController(Controller):
         if time_frequency is None:
             time_frequency = float("inf")
 
-        # Step frequency was not defined => the output won't be triggered by changes in STEP
-        if step_frequency is None:
-            step_frequency = -1
-
-        self.__time_frequency = time_frequency
-        self.__step_frequency = step_frequency
+        self.__time_frequency: float = time_frequency
+        self.__step_frequency: Optional[int] = step_frequency
         self.__last_output_time = self._model_part.ProcessInfo[KratosMultiphysics.TIME]
         self.__last_output_step = self._model_part.ProcessInfo[KratosMultiphysics.STEP]
 
@@ -105,9 +101,10 @@ class TemporalController(Controller):
         # TODO: separately keeping track of steps and time internally is not a good
         # idea. What happens if the solution process involves jumping back and forth
         # in time (restarts, checkpointing)? @matekelemen
-        step_difference = self._model_part.ProcessInfo[KratosMultiphysics.STEP] - self.__last_output_step
-        if self.__step_frequency <= step_difference:
-            return True
+        if self.__step_frequency is not None:
+            step_difference = self._model_part.ProcessInfo[KratosMultiphysics.STEP] - self.__last_output_step
+            if self.__step_frequency <= step_difference:
+                return True
 
         time_difference = self._model_part.ProcessInfo[KratosMultiphysics.TIME] - self.__last_output_time
         if self.__time_frequency <= time_difference:

--- a/applications/HDF5Application/python_scripts/core/controllers.py
+++ b/applications/HDF5Application/python_scripts/core/controllers.py
@@ -15,7 +15,7 @@ from . import operations
 
 # STL imports
 import abc
-import typing
+from typing import Optional
 
 
 ##!@addtogroup HDF5Application

--- a/applications/HDF5Application/python_scripts/core/controllers.py
+++ b/applications/HDF5Application/python_scripts/core/controllers.py
@@ -15,17 +15,18 @@ from . import operations
 
 # STL imports
 import abc
+import typing
 
 
 ##!@addtogroup HDF5Application
 ##!@{
 ##!@name Kratos classes
 ##!@{
-class Controller(metaclass=abc.ABCMeta):
+class Controller(abc.ABC):
     def __init__(self,
                  model_part: KratosMultiphysics.ModelPart,
                  operation: operations.AggregateOperation):
-        self.model_part = model_part
+        self._model_part = model_part
         self.__operation = operation
 
     @abc.abstractmethod
@@ -64,14 +65,36 @@ class TemporalController(Controller):
                  operation: operations.AggregateOperation,
                  settings: KratosMultiphysics.Parameters):
         super().__init__(model_part, operation)
-        settings.AddMissingParameters(KratosMultiphysics.Parameters("""{
-            "time_frequency" : 1.0,
-            "step_frequency" : 1
-        }"""))
-        self.time_frequency = settings['time_frequency'].GetDouble()
-        self.step_frequency = settings['step_frequency'].GetInt()
-        self.current_time = 0.0
-        self.current_step = 0
+        time_frequency: typing.Optional[float] = None
+        step_frequency: typing.Optional[int] = None
+        if settings.Has("time_frequency"):
+            time_frequency = settings["time_frequency"].GetDouble()
+        if settings.Has("step_frequency"):
+            step_frequency = settings["step_frequency"].GetInt()
+
+        # Neither step nor time frequency were defined => apply defaults
+        # => output at every time step (step_frequency is 1, time_frequency is undefined)
+        if time_frequency is None and step_frequency is None:
+            settings.AddInt("step_frequency", 1)
+            step_frequency = 1
+
+        # Time frequency was not defined => the output won't be triggered by changes in TIME
+        if time_frequency is None:
+            time_frequency = float("inf")
+
+        # Step frequency was not defined => the output won't be triggered by changes in STEP
+        if step_frequency is None:
+            step_frequency = -1
+
+        self.__time_frequency = time_frequency
+        self.__step_frequency = step_frequency
+        self.__last_output_time = self._model_part.ProcessInfo[KratosMultiphysics.TIME]
+        self.__last_output_step = self._model_part.ProcessInfo[KratosMultiphysics.STEP]
+
+    def ExecuteOperation(self) -> None:
+        super().ExecuteOperation()
+        self.__last_output_time = self._model_part.ProcessInfo[KratosMultiphysics.TIME]
+        self.__last_output_step = self._model_part.ProcessInfo[KratosMultiphysics.STEP]
 
     def IsExecuteStep(self) -> bool:
         """!@brief Return true if the current step/time is a multiple of the output frequency.
@@ -79,27 +102,26 @@ class TemporalController(Controller):
         the machine epsilon, and include a lower bound based on
         https://github.com/chromium/chromium, cc::IsNearlyTheSame.
         """
-        if self.current_step == self.step_frequency:
+        # TODO: separately keeping track of steps and time internally is not a good
+        # idea. What happens if the solution process involves jumping back and forth
+        # in time (restarts, checkpointing)? @matekelemen
+        step_difference = self._model_part.ProcessInfo[KratosMultiphysics.STEP] - self.__last_output_step
+        if self.__step_frequency <= step_difference:
             return True
-        if self.current_time > self.time_frequency:
+
+        time_difference = self._model_part.ProcessInfo[KratosMultiphysics.TIME] - self.__last_output_time
+        if self.__time_frequency <= time_difference:
             return True
+
         eps = 1e-6
-        tol = eps * max(abs(self.current_time), abs(self.time_frequency), eps)
-        if abs(self.current_time - self.time_frequency) < tol:
+        tol = eps * max(abs(time_difference), abs(self.__time_frequency), eps)
+        if abs(time_difference - self.__time_frequency) < tol:
             return True
         return False
 
     def __call__(self) -> None:
-        # TODO: separately keeping track of steps and time internally is not a good
-        # idea. What happens if the solution process involves jumping back and forth
-        # in time (restarts, checkpointing)? @matekelemen
-        delta_time = self.model_part.ProcessInfo[KratosMultiphysics.DELTA_TIME]
-        self.current_time += delta_time
-        self.current_step += 1
         if self.IsExecuteStep():
             self.ExecuteOperation()
-            self.current_time = 0.0
-            self.current_step = 0
 ##!@}
 
 

--- a/applications/HDF5Application/python_scripts/core/xdmf.py
+++ b/applications/HDF5Application/python_scripts/core/xdmf.py
@@ -227,16 +227,32 @@ class TopologyCellType:
 
     _topologies = {
         (2,1): "Polyvertex_1",
-        (2,2): "Polyline_2",
-        (2,3): "Triangle",
-        (2,4): "Quadrilateral",
-
         (3,1): "Polyvertex_1",
+
+        (2,2): "Polyline_2",
         (3,2): "Polyline_2",
+
+        (2,3): "Triangle",
+        (2,6): "Triangle_6",
         (3,3): "Triangle",
+
+        (2,4): "Quadrilateral",
+        (2,8): "Quadrilateral_8",
+        (2,9): "Quadrilateral_9",
+
         (3,4): "Tetrahedron",
-        (3,8): "Hexahedron"
-        }
+        (3,10): "Tetrahedron_10",
+
+        (3,5): "Pyramid",
+        (3,13): "Pyramid_13",
+
+        (3,6): "Wedge",
+        (3,15): "Wedge_15",
+
+        (3,8): "Hexahedron",
+        (3,20): "Hexahedron_20",
+        (3,27): "Hexahedron_27"
+    }
 
     def __init__(self, dim, num_points):
         """Construct the object.

--- a/applications/HDF5Application/python_scripts/create_xdmf_file.py
+++ b/applications/HDF5Application/python_scripts/create_xdmf_file.py
@@ -25,14 +25,23 @@ def main():
                         default="/ModelData", help="internal HDF5 file path to the mesh")
     parser.add_argument("-r", "--results-path", dest="results_path", metavar="<results-path>",
                         default="/ResultsData", help="internal HDF5 file path to the results")
+    parser.add_argument("--require-results",
+                        dest = "require_results",
+                        action = "store_const",
+                        default = False,
+                        const = True,
+                        help = "Ignore outputs that have mesh data but lack results.")
     print('\nCreate XDMF:')
     args = parser.parse_args()
     if args.type == "multiple" and args.analysis == "temporal":
-        WriteMultifileTemporalAnalysisToXdmf(
-            args.file_name, args.mesh_path, args.results_path)
+        WriteMultifileTemporalAnalysisToXdmf(args.file_name,
+                                             args.mesh_path,
+                                             args.results_path)
     elif args.type == "single" and args.analysis == "temporal":
-        WriteSinglefileTemporalAnalysisToXdmf(
-            args.file_name, args.mesh_path, args.results_path)        
+        WriteSinglefileTemporalAnalysisToXdmf(args.file_name,
+                                              args.mesh_path,
+                                              args.results_path,
+                                              require_results = args.require_results)
     else:
         raise RuntimeError("Unsupported command line options.")
 

--- a/applications/HDF5Application/python_scripts/multiple_mesh_temporal_output_process.py
+++ b/applications/HDF5Application/python_scripts/multiple_mesh_temporal_output_process.py
@@ -86,14 +86,6 @@ def CreateCoreSettings(user_settings, model):
     core_settings = ParametersWrapper("""
         [{
             "model_part_name" : "",
-            "process_step": "before_solution_loop",
-            "io_settings": {
-                "io_type": "serial_hdf5_file_io",
-                "file_name": "<model_part_name>-<time>.h5"
-            },
-            "list_of_operations": []
-        },{
-            "model_part_name" : "",
             "process_step": "finalize_solution_step",
             "controller_settings": {
                 "controller_type": "temporal_controller"
@@ -160,5 +152,5 @@ def CreateCoreSettings(user_settings, model):
                                     user_settings["condition_gauss_point_value_settings"])
         ]
     for key in user_settings["output_time_settings"]:
-        core_settings[1]["controller_settings"][key] = user_settings["output_time_settings"][key]
+        core_settings[0]["controller_settings"][key] = user_settings["output_time_settings"][key]
     return core_settings

--- a/applications/HDF5Application/python_scripts/single_mesh_primal_output_process.py
+++ b/applications/HDF5Application/python_scripts/single_mesh_primal_output_process.py
@@ -141,16 +141,7 @@ def CreateCoreSettings(user_settings, model):
         core_settings[0]["io_settings"]["io_type"] = "serial_hdf5_file_io"
         core_settings[1]["io_settings"]["io_type"] = "serial_hdf5_file_io"
     core_settings[0]["list_of_operations"] = [
-        CreateOperationSettings(model_part_output_type, user_settings["model_part_output_settings"]),
-        CreateOperationSettings("primal_bossak_output", user_settings["nodal_solution_step_data_settings"]),
-        CreateOperationSettings("nodal_data_value_output", user_settings["nodal_data_value_settings"]),
-        CreateOperationSettings("element_data_value_output", user_settings["element_data_value_settings"]),
-        CreateOperationSettings("element_gauss_point_output", user_settings["element_gauss_point_value_settings"]),
-        CreateOperationSettings("nodal_flag_value_output", user_settings["nodal_flag_value_settings"]),
-        CreateOperationSettings("element_flag_value_output", user_settings["element_flag_value_settings"]),
-        CreateOperationSettings("condition_data_value_output", user_settings["nodal_data_value_settings"]),
-        CreateOperationSettings("condition_flag_value_output", user_settings["condition_flag_value_settings"]),
-        CreateOperationSettings("condition_gauss_point_output", user_settings["condition_gauss_point_value_settings"])
+        CreateOperationSettings(model_part_output_type, user_settings["model_part_output_settings"])
     ]
     core_settings[1]["list_of_operations"] = [
         CreateOperationSettings("primal_bossak_output", user_settings["nodal_solution_step_data_settings"]),

--- a/applications/HDF5Application/python_scripts/single_mesh_temporal_output_process.py
+++ b/applications/HDF5Application/python_scripts/single_mesh_temporal_output_process.py
@@ -134,25 +134,7 @@ def CreateCoreSettings(user_settings, model):
             core_settings[i]["io_settings"]["io_type"] = "serial_hdf5_file_io"
     core_settings[0]["list_of_operations"] = [
         CreateOperationSettings(model_part_output_type,
-                                user_settings["model_part_output_settings"]),
-        CreateOperationSettings("nodal_solution_step_data_output",
-                                user_settings["nodal_solution_step_data_settings"]),
-        CreateOperationSettings("nodal_data_value_output",
-                                user_settings["nodal_data_value_settings"]),
-        CreateOperationSettings("element_data_value_output",
-                                user_settings["element_data_value_settings"]),
-        CreateOperationSettings("element_gauss_point_output",
-                                user_settings["element_gauss_point_value_settings"]),
-        CreateOperationSettings("nodal_flag_value_output",
-                                user_settings["nodal_flag_value_settings"]),
-        CreateOperationSettings("element_flag_value_output",
-                                user_settings["element_flag_value_settings"]),
-        CreateOperationSettings("condition_flag_value_output",
-                                user_settings["condition_flag_value_settings"]),
-        CreateOperationSettings("condition_data_value_output",
-                                user_settings["condition_data_value_settings"]),
-        CreateOperationSettings("condition_gauss_point_output",
-                                user_settings["condition_gauss_point_value_settings"])
+                                user_settings["model_part_output_settings"])
     ]
     core_settings[1]["list_of_operations"] = [
         CreateOperationSettings("nodal_solution_step_data_output",

--- a/applications/HDF5Application/python_scripts/xdmf_utils.py
+++ b/applications/HDF5Application/python_scripts/xdmf_utils.py
@@ -15,7 +15,6 @@ import warnings
 from itertools import chain
 from contextlib import contextmanager
 import re
-import collections
 
 
 import KratosMultiphysics

--- a/applications/HDF5Application/python_scripts/xdmf_utils.py
+++ b/applications/HDF5Application/python_scripts/xdmf_utils.py
@@ -544,7 +544,10 @@ def WriteMultifileTemporalAnalysisToXdmf(ospath, h5path_to_mesh, h5path_to_resul
     ET.ElementTree(xdmf.create_xml_element()).write(pat + ".xdmf")
 
 
-def CreateXdmfTemporalGridFromSinglefile(h5_file_name, h5path_pattern_to_mesh, h5path_pattern_to_results):
+def CreateXdmfTemporalGridFromSinglefile(h5_file_name,
+                                         h5path_pattern_to_mesh,
+                                         h5path_pattern_to_results,
+                                         require_results: bool = False):
     """Return an XDMF Grid object for a list of temporal results in a single HDF5 file.
 
     Keyword arguments:
@@ -619,12 +622,17 @@ def CreateXdmfTemporalGridFromSinglefile(h5_file_name, h5path_pattern_to_mesh, h
                     current_sgrid.add_grid(UniformGrid(g.name, g.geometry, g.topology))
                 for result in XdmfResults(file_[output_results_dict[key]]):
                     current_sgrid.add_attribute(result)
+
+            if has_results or not (require_results and not has_results):
                 tgrid.add_grid(Time(key), current_sgrid)
 
     return tgrid
 
 
-def WriteSinglefileTemporalAnalysisToXdmf(h5_file_name, h5path_pattern_to_mesh, h5path_pattern_to_results):
+def WriteSinglefileTemporalAnalysisToXdmf(h5_file_name,
+                                          h5path_pattern_to_mesh,
+                                          h5path_pattern_to_results,
+                                          require_results: bool = False):
     """Write XDMF metadata for a temporal analysis from single HDF5 file.
 
     Keyword arguments:
@@ -639,8 +647,10 @@ def WriteSinglefileTemporalAnalysisToXdmf(h5_file_name, h5path_pattern_to_mesh, 
     if (h5path_pattern_to_results.startswith("/")):
         h5path_pattern_to_results = h5path_pattern_to_results[1:]
 
-    temporal_grid = CreateXdmfTemporalGridFromSinglefile(
-        h5_file_name, h5path_pattern_to_mesh, h5path_pattern_to_results)
+    temporal_grid = CreateXdmfTemporalGridFromSinglefile(h5_file_name,
+                                                         h5path_pattern_to_mesh,
+                                                         h5path_pattern_to_results,
+                                                         require_results = require_results)
     domain = Domain(temporal_grid)
     xdmf = Xdmf(domain)
     # Write the XML tree containing the XDMF metadata to the file.

--- a/applications/HDF5Application/python_scripts/xdmf_utils.py
+++ b/applications/HDF5Application/python_scripts/xdmf_utils.py
@@ -598,7 +598,7 @@ def CreateXdmfTemporalGridFromSinglefile(h5_file_name, h5path_pattern_to_mesh, h
         compound_dict = {}
         for key in output_meshes_dict:
             compound_dict[key] = (True, False)
-        for key in output_results_dict.keys():
+        for key in output_results_dict:
             if key in compound_dict:
                 compound_dict[key][1] = True
             else:

--- a/applications/HDF5Application/python_scripts/xdmf_utils.py
+++ b/applications/HDF5Application/python_scripts/xdmf_utils.py
@@ -592,7 +592,7 @@ def CreateXdmfTemporalGridFromSinglefile(h5_file_name, h5path_pattern_to_mesh, h
         output_results_dict = {}
         file_.visit(lambda x : GetMatchingGroupNames(output_results_dict, x, h5path_patterns_to_results, h5path_pattern_to_results_wild_cards))
 
-        if len(output_results_dict.keys()) == 0:
+        if not output_results_dict:
             raise RuntimeError("No results data is found in the given hdf5 file matching the given pattern [ file_name = {:s}, pattern = {:s} ].".format(h5_file_name, h5path_pattern_to_results))
 
         compound_dict = {}

--- a/applications/HDF5Application/python_scripts/xdmf_utils.py
+++ b/applications/HDF5Application/python_scripts/xdmf_utils.py
@@ -596,7 +596,7 @@ def CreateXdmfTemporalGridFromSinglefile(h5_file_name, h5path_pattern_to_mesh, h
             raise RuntimeError("No results data is found in the given hdf5 file matching the given pattern [ file_name = {:s}, pattern = {:s} ].".format(h5_file_name, h5path_pattern_to_results))
 
         compound_dict = {}
-        for key in output_meshes_dict.keys():
+        for key in output_meshes_dict:
             compound_dict[key] = (True, False)
         for key in output_results_dict.keys():
             if key in compound_dict:

--- a/applications/HDF5Application/tests/test_hdf5_processes.py
+++ b/applications/HDF5Application/tests/test_hdf5_processes.py
@@ -126,6 +126,7 @@ class TestHDF5Processes(KratosUnittest.TestCase):
             self.HDF5FileSerial.call_args[0][0]['file_name'].GetString(), 'test_model_part.h5')
         for time in [0.09999999, 0.19999998]:
             self.model_part.CloneTimeStep(time)
+            self.model_part.ProcessInfo[KratosMultiphysics.STEP] += 1
             process.ExecuteFinalizeSolutionStep()
         self.assertEqual(self.HDF5FileSerial.call_count, 2)
         self.assertEqual(self.HDF5FileSerial.call_args[0][0]['file_name'].GetString(
@@ -138,91 +139,91 @@ class TestHDF5Processes(KratosUnittest.TestCase):
             self.HDF5FileSerial.return_value, '/ModelData/test_model_part')
         self.HDF5ModelPartIO.return_value.WriteModelPart.assert_called_once_with(
             self.model_part)
-        self.assertEqual(self.HDF5NodalSolutionStepDataIO.call_count, 2)
+        self.assertEqual(self.HDF5NodalSolutionStepDataIO.call_count, 1)
         self.assertEqual(self.HDF5NodalSolutionStepDataIO.call_args[0][0]['prefix'].GetString(), '/ResultsData/test_model_part/0.20')
         self.assertEqual(
             self.HDF5NodalSolutionStepDataIO.call_args[0][0]['list_of_variables'][0].GetString(), 'DISPLACEMENT')
         self.assertEqual(
-            self.HDF5NodalSolutionStepDataIO.return_value.WriteNodalResults.call_count, 2)
+            self.HDF5NodalSolutionStepDataIO.return_value.WriteNodalResults.call_count, 1)
         self.HDF5NodalSolutionStepDataIO.return_value.WriteNodalResults.assert_called_with(
             self.model_part, 0)
-        self.assertEqual(self.HDF5NodalDataValueIO.call_count, 2)
+        self.assertEqual(self.HDF5NodalDataValueIO.call_count, 1)
         self.assertEqual(
             self.HDF5NodalDataValueIO.call_args[0][0]['prefix'].GetString(), '/ResultsData')
         self.assertEqual(
             self.HDF5NodalDataValueIO.call_args[0][0]['list_of_variables'].size(), 0)
         self.assertEqual(
-            self.HDF5NodalDataValueIO.return_value.WriteNodalResults.call_count, 2)
+            self.HDF5NodalDataValueIO.return_value.WriteNodalResults.call_count, 1)
         self.HDF5NodalDataValueIO.return_value.WriteNodalResults.assert_called_with(
             self.model_part.Nodes)
 
-        self.assertEqual(self.HDF5NodalFlagValueIO.call_count, 2)
+        self.assertEqual(self.HDF5NodalFlagValueIO.call_count, 1)
         self.assertEqual(
             self.HDF5NodalFlagValueIO.call_args[0][0]['prefix'].GetString(), '/ResultsData/NodalFlagValues')
         self.assertEqual(
             self.HDF5NodalFlagValueIO.call_args[0][0]['list_of_variables'].size(), 0)
         self.assertEqual(
-            self.HDF5NodalFlagValueIO.return_value.WriteNodalFlags.call_count, 2)
+            self.HDF5NodalFlagValueIO.return_value.WriteNodalFlags.call_count, 1)
         self.HDF5NodalFlagValueIO.return_value.WriteNodalFlags.assert_called_with(
             self.model_part.Nodes)
 
-        self.assertEqual(self.HDF5ElementDataValueIO.call_count, 2)
+        self.assertEqual(self.HDF5ElementDataValueIO.call_count, 1)
         self.assertEqual(self.HDF5ElementDataValueIO.call_args[0][0]['prefix'].GetString(
         ), '/ResultsData/ElementDataValues')
         self.assertEqual(
             self.HDF5ElementDataValueIO.call_args[0][0]['list_of_variables'].size(), 0)
         self.assertEqual(
-            self.HDF5ElementDataValueIO.return_value.WriteElementResults.call_count, 2)
+            self.HDF5ElementDataValueIO.return_value.WriteElementResults.call_count, 1)
         self.HDF5ElementDataValueIO.return_value.WriteElementResults.assert_called_with(
             self.model_part.Elements)
 
-        self.assertEqual(self.HDF5ElementFlagValueIO.call_count, 2)
+        self.assertEqual(self.HDF5ElementFlagValueIO.call_count, 1)
         self.assertEqual(self.HDF5ElementFlagValueIO.call_args[0][0]['prefix'].GetString(
         ), '/ResultsData/ElementFlagValues')
         self.assertEqual(
             self.HDF5ElementFlagValueIO.call_args[0][0]['list_of_variables'].size(), 0)
         self.assertEqual(
-            self.HDF5ElementFlagValueIO.return_value.WriteElementFlags.call_count, 2)
+            self.HDF5ElementFlagValueIO.return_value.WriteElementFlags.call_count, 1)
         self.HDF5ElementFlagValueIO.return_value.WriteElementFlags.assert_called_with(
             self.model_part.Elements)
 
-        self.assertEqual(self.HDF5ElementGaussPointOutput.call_count, 2)
+        self.assertEqual(self.HDF5ElementGaussPointOutput.call_count, 1)
         self.assertEqual(self.HDF5ElementGaussPointOutput.call_args[0][0]['prefix'].GetString(
         ), '/ResultsData/ElementGaussPointValues')
         self.assertEqual(
             self.HDF5ElementGaussPointOutput.call_args[0][0]['list_of_variables'].size(), 0)
         self.assertEqual(
-            self.HDF5ElementGaussPointOutput.return_value.WriteElementGaussPointValues.call_count, 2)
+            self.HDF5ElementGaussPointOutput.return_value.WriteElementGaussPointValues.call_count, 1)
         self.HDF5ElementGaussPointOutput.return_value.WriteElementGaussPointValues.assert_called_with(
             self.model_part.Elements, self.model_part.GetCommunicator().GetDataCommunicator(), self.model_part.ProcessInfo)
 
-        self.assertEqual(self.HDF5ConditionDataValueIO.call_count, 2)
+        self.assertEqual(self.HDF5ConditionDataValueIO.call_count, 1)
         self.assertEqual(self.HDF5ConditionDataValueIO.call_args[0][0]['prefix'].GetString(
         ), '/ResultsData/ConditionDataValues')
         self.assertEqual(
             self.HDF5ConditionDataValueIO.call_args[0][0]['list_of_variables'].size(), 0)
         self.assertEqual(
-            self.HDF5ConditionDataValueIO.return_value.WriteConditionResults.call_count, 2)
+            self.HDF5ConditionDataValueIO.return_value.WriteConditionResults.call_count, 1)
         self.HDF5ConditionDataValueIO.return_value.WriteConditionResults.assert_called_with(
             self.model_part.Conditions)
 
-        self.assertEqual(self.HDF5ConditionFlagValueIO.call_count, 2)
+        self.assertEqual(self.HDF5ConditionFlagValueIO.call_count, 1)
         self.assertEqual(self.HDF5ConditionFlagValueIO.call_args[0][0]['prefix'].GetString(
         ), '/ResultsData/ConditionFlagValues')
         self.assertEqual(
             self.HDF5ConditionFlagValueIO.call_args[0][0]['list_of_variables'].size(), 0)
         self.assertEqual(
-            self.HDF5ConditionFlagValueIO.return_value.WriteConditionFlags.call_count, 2)
+            self.HDF5ConditionFlagValueIO.return_value.WriteConditionFlags.call_count, 1)
         self.HDF5ConditionFlagValueIO.return_value.WriteConditionFlags.assert_called_with(
             self.model_part.Conditions)
 
-        self.assertEqual(self.HDF5ConditionGaussPointOutput.call_count, 2)
+        self.assertEqual(self.HDF5ConditionGaussPointOutput.call_count, 1)
         self.assertEqual(self.HDF5ConditionGaussPointOutput.call_args[0][0]['prefix'].GetString(
         ), '/ResultsData/ConditionGaussPointValues')
         self.assertEqual(
             self.HDF5ConditionGaussPointOutput.call_args[0][0]['list_of_variables'].size(), 0)
         self.assertEqual(
-            self.HDF5ConditionGaussPointOutput.return_value.WriteConditionGaussPointValues.call_count, 2)
+            self.HDF5ConditionGaussPointOutput.return_value.WriteConditionGaussPointValues.call_count, 1)
         self.HDF5ConditionGaussPointOutput.return_value.WriteConditionGaussPointValues.assert_called_with(
             self.model_part.Conditions, self.model_part.GetCommunicator().GetDataCommunicator(), self.model_part.ProcessInfo)
 
@@ -244,24 +245,22 @@ class TestHDF5Processes(KratosUnittest.TestCase):
         process = multiple_mesh_temporal_output_process.Factory(
             settings, self.model)
         process.ExecuteBeforeSolutionLoop()
-        self.assertEqual(self.HDF5FileSerial.call_count, 1)
-        self.assertEqual(
-            self.HDF5FileSerial.call_args[0][0]['file_name'].GetString(), 'kratos-0.0000.h5')
         for time in [0.09999999, 0.19999998]:
             self.model_part.CloneTimeStep(time)
+            self.model_part.ProcessInfo[KratosMultiphysics.STEP] += 1
             process.ExecuteFinalizeSolutionStep()
-        self.assertEqual(self.HDF5FileSerial.call_count, 3)
+        self.assertEqual(self.HDF5FileSerial.call_count, 2)
         self.assertEqual(
             self.HDF5FileSerial.call_args[0][0]['file_name'].GetString(), 'kratos-0.2000.h5')
         self.assertEqual(
             self.HDF5FileSerial.call_args[0][0]['file_access_mode'].GetString(), 'exclusive')
         self.assertEqual(
             self.HDF5FileSerial.call_args[0][0]['echo_level'].GetInt(), 0)
-        self.assertEqual(self.HDF5ModelPartIO.call_count, 3)
+        self.assertEqual(self.HDF5ModelPartIO.call_count, 2)
         self.HDF5ModelPartIO.assert_called_with(
             self.HDF5FileSerial.return_value, '/ModelData')
         self.assertEqual(
-            self.HDF5ModelPartIO.return_value.WriteModelPart.call_count, 3)
+            self.HDF5ModelPartIO.return_value.WriteModelPart.call_count, 2)
         self.HDF5ModelPartIO.return_value.WriteModelPart.assert_called_with(
             self.model_part)
 
@@ -286,7 +285,7 @@ class TestHDF5Processes(KratosUnittest.TestCase):
         for time in [0.09999999, 0.19999998]:
             self.model_part.CloneTimeStep(time)
             process.ExecuteFinalizeSolutionStep()
-        self.assertEqual(self.HDF5NodalSolutionStepBossakIO.call_count, 3)
+        self.assertEqual(self.HDF5NodalSolutionStepBossakIO.call_count, 2)
         self.assertEqual(
             self.HDF5NodalSolutionStepBossakIO.call_args[0][0]['prefix'].GetString(), '/ResultsData')
         self.assertEqual(
@@ -294,11 +293,11 @@ class TestHDF5Processes(KratosUnittest.TestCase):
         self.assertEqual(
             self.HDF5NodalSolutionStepBossakIO.call_args[0][1], self.HDF5FileSerial.return_value)
         self.assertEqual(
-            self.HDF5NodalSolutionStepBossakIO.return_value.SetAlphaBossak.call_count, 3)
+            self.HDF5NodalSolutionStepBossakIO.return_value.SetAlphaBossak.call_count, 2)
         self.HDF5NodalSolutionStepBossakIO.return_value.SetAlphaBossak.assert_called_with(
             -0.2)
         self.assertEqual(
-            self.HDF5NodalSolutionStepBossakIO.return_value.WriteNodalResults.call_count, 3)
+            self.HDF5NodalSolutionStepBossakIO.return_value.WriteNodalResults.call_count, 2)
         self.HDF5NodalSolutionStepBossakIO.return_value.WriteNodalResults.assert_called_with(
             self.model_part)
 
@@ -548,12 +547,12 @@ class TestHDF5Processes(KratosUnittest.TestCase):
             ''')
 
         with patch("KratosMultiphysics.HDF5Application.core.controllers.Controller.ExecuteOperation") as mocked_execute:
+            self.assertEqual(mocked_execute.call_count, 0)
             with ScopedMDPA("test_OutputProcess"):
                 from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_analysis import StructuralMechanicsAnalysis
                 model = KratosMultiphysics.Model()
                 simulation = StructuralMechanicsAnalysis(model, settings)
                 simulation.Run()
-
             self.assertEqual(mocked_execute.call_count, 1 + 5)
 
 


### PR DESCRIPTION
This PR adds some temporary fixes to controllers and XDMF generation. The entire HDF5Application will eventually need an overhaul to fix persistent problems and reliability issues, but hopefully this will be enough until that happens.

The bugs this PR fixes were detected by attempting to apply `SingleMeshTemporalOutputProcess` to the model provided in  #11448.
- XDMF generation didn't support quadratic elements. I added some XDMF topologies that we have already implemented in Kratos Core. They're untested though because one would have to manually check whether the node orderings match with what XDMF/paraview expect.
- All HDF5 output processes write the mesh in `ExecuteBeforeSolutionLoop`, which isn't great. However, they also wrote results in there which is flat out wrong. The model parts aren't necessarily fully initialized yet by that point, so non-historical values may not be present in entities yet. This results in null values for statically sized variables, but empty values for dynamic ones. => the result was empty data fields in the first output, which broke paraview.
- `TemporalController` changed its state every time `IsExecuteStep` was called because it expected that function to be called exactly once per solution step. However, this wasn't the case so output scheduling was completely broken. Furthermore, the tests relied on implementation details so they had to be heavily modified as well.