### PR TITLE
[GeoMechanicsApplication] Reduced code smells of custom strategies

### DIFF
--- a/applications/GeoMechanicsApplication/custom_strategies/builder_and_solvers/residualbased_block_builder_and_solver_with_mass_and_damping.h
+++ b/applications/GeoMechanicsApplication/custom_strategies/builder_and_solvers/residualbased_block_builder_and_solver_with_mass_and_damping.h
@@ -221,11 +221,9 @@ public:
                         BaseType::AssembleLHS(mDampingMatrix, damping_contribution, equation_ids);
                     }
                     
-
                     // Assemble the elemental contribution
                     BaseType::Assemble(rA, rb, lhs_contribution, rhs_contribution, equation_ids);
                 }
-
             }
 
             #pragma omp for  schedule(guided, 512)
@@ -288,7 +286,7 @@ public:
 
         Timer::Stop("Build");
 
-        if(rModelPart.MasterSlaveConstraints().size() != 0) {
+        if(!rModelPart.MasterSlaveConstraints().empty()) {
             const auto timer_constraints = BuiltinTimer();
             Timer::Start("ApplyConstraints");
             BaseType::ApplyConstraints(pScheme, rModelPart, rA, rb);
@@ -302,7 +300,7 @@ public:
         BaseType::ApplyDirichletConditions(pScheme, rModelPart, mMassMatrix, rDx, rb);
         BaseType::ApplyDirichletConditions(pScheme, rModelPart, mDampingMatrix, rDx, rb);
 
-        KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolverWithMassAndDamping", ( this->GetEchoLevel() == 3)) << "Before the solution of the system" << "\nSystem Matrix = " << rA << "\nUnknowns vector = " << rDx << "\nRHS vector = " << rb << std::endl;
+        KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolverWithMassAndDamping", this->GetEchoLevel() == 3) << "Before the solution of the system" << "\nSystem Matrix = " << rA << "\nUnknowns vector = " << rDx << "\nRHS vector = " << rb << std::endl;
 
         const auto timer = BuiltinTimer();
         Timer::Start("Solve");
@@ -312,7 +310,7 @@ public:
         Timer::Stop("Solve");
         KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolverWithMassAndDamping", this->GetEchoLevel() >=1) << "System solve time: " << timer.ElapsedSeconds() << std::endl;
 
-        KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolverWithMassAndDamping", ( this->GetEchoLevel() == 3)) << "After the solution of the system" << "\nSystem Matrix = " << rA << "\nUnknowns vector = " << rDx << "\nRHS vector = " << rb << std::endl;
+        KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolverWithMassAndDamping", this->GetEchoLevel() == 3) << "After the solution of the system" << "\nSystem Matrix = " << rA << "\nUnknowns vector = " << rDx << "\nRHS vector = " << rb << std::endl;
 
         KRATOS_CATCH("")
     }
@@ -338,7 +336,7 @@ public:
 
         BuildRHS(pScheme, rModelPart, rb);
 
-        if (rModelPart.MasterSlaveConstraints().size() != 0) {
+        if (!rModelPart.MasterSlaveConstraints().empty()) {
             Timer::Start("ApplyRHSConstraints");
             BaseType::ApplyRHSConstraints(pScheme, rModelPart, rb);
             Timer::Stop("ApplyRHSConstraints");
@@ -346,7 +344,7 @@ public:
 
         BaseType::ApplyDirichletConditions(pScheme, rModelPart, rA, rDx, rb);
 
-        KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolverWithMassAndDamping", (this->GetEchoLevel() == 3)) << "Before the solution of the system" << "\nSystem Matrix = " << rA << "\nUnknowns vector = " << rDx << "\nRHS vector = " << rb << std::endl;
+        KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolverWithMassAndDamping", this->GetEchoLevel() == 3) << "Before the solution of the system" << "\nSystem Matrix = " << rA << "\nUnknowns vector = " << rDx << "\nRHS vector = " << rb << std::endl;
 
         const auto timer = BuiltinTimer();
         Timer::Start("Solve");
@@ -356,7 +354,7 @@ public:
         Timer::Stop("Solve");
         KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolverWithMassAndDamping", this->GetEchoLevel() >= 1) << "System solve time: " << timer.ElapsedSeconds() << std::endl;
 
-        KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolverWithMassAndDamping", (this->GetEchoLevel() == 3)) << "After the solution of the system" << "\nSystem Matrix = " << rA << "\nUnknowns vector = " << rDx << "\nRHS vector = " << rb << std::endl;
+        KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolverWithMassAndDamping", this->GetEchoLevel() == 3) << "After the solution of the system" << "\nSystem Matrix = " << rA << "\nUnknowns vector = " << rDx << "\nRHS vector = " << rb << std::endl;
 
         KRATOS_CATCH("")
     }
@@ -441,18 +439,6 @@ public:
     std::string Info() const override
     {
         return "ResidualBasedBlockBuilderAndSolverWithMassAndDamping";
-    }
-
-    /// Print information about this object.
-    void PrintInfo(std::ostream& rOStream) const override
-    {
-        rOStream << Info();
-    }
-
-    /// Print object's data.
-    void PrintData(std::ostream& rOStream) const override
-    {
-        rOStream << Info();
     }
 
     ///@}

--- a/applications/GeoMechanicsApplication/custom_strategies/schemes/backward_euler_quasistatic_Pw_scheme.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/schemes/backward_euler_quasistatic_Pw_scheme.hpp
@@ -10,8 +10,7 @@
 //  Main authors:    Vahid Galavi
 //
 
-#if !defined(KRATOS_BACKWARD_EULER_QUASISTATIC_PW_SCHEME )
-#define  KRATOS_BACKWARD_EULER_QUASISTATIC_PW_SCHEME
+#pragma once
 
 // Project includes
 #include "includes/define.h"
@@ -27,48 +26,24 @@ namespace Kratos
 {
 
 template<class TSparseSpace, class TDenseSpace>
-
 class BackwardEulerQuasistaticPwScheme : public NewmarkQuasistaticPwScheme<TSparseSpace,TDenseSpace>
 {
-
 public:
-
     KRATOS_CLASS_POINTER_DEFINITION( BackwardEulerQuasistaticPwScheme );
 
-    typedef Scheme<TSparseSpace,TDenseSpace>          BaseType;
-    typedef typename BaseType::DofsArrayType          DofsArrayType;
-    typedef typename BaseType::TSystemMatrixType      TSystemMatrixType;
-    typedef typename BaseType::TSystemVectorType      TSystemVectorType;
-    typedef typename BaseType::LocalSystemVectorType  LocalSystemVectorType;
-    typedef typename BaseType::LocalSystemMatrixType  LocalSystemMatrixType;
     using NewmarkQuasistaticUPwScheme<TSparseSpace,TDenseSpace>::mDeltaTime;
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-    ///Constructor
     BackwardEulerQuasistaticPwScheme() :
         NewmarkQuasistaticPwScheme<TSparseSpace,TDenseSpace>(1.0)
     {}
 
-    //------------------------------------------------------------------------------------
-
-    ///Destructor
-    ~BackwardEulerQuasistaticPwScheme() override {}
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
 protected:
-
-    /// Member Variables
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
     inline void UpdateVariablesDerivatives(ModelPart& rModelPart) override
     {
         KRATOS_TRY
 
         //Update DtPressure
-
-        block_for_each(rModelPart.Nodes(), [&](Node& rNode){
+       block_for_each(rModelPart.Nodes(), [this](Node& rNode){
             const double DeltaPressure =  rNode.FastGetSolutionStepValue(WATER_PRESSURE)
                                         - rNode.FastGetSolutionStepValue(WATER_PRESSURE, 1);
             rNode.FastGetSolutionStepValue(DT_WATER_PRESSURE) = DeltaPressure / mDeltaTime;
@@ -78,6 +53,5 @@ protected:
     }
 
 }; // Class BackwardEulerQuasistaticPwScheme
-}  // namespace Kratos
 
-#endif // KRATOS_BACKWARD_EULER_QUASISTATIC_PW_SCHEME defined
+}

--- a/applications/GeoMechanicsApplication/custom_strategies/schemes/backward_euler_quasistatic_U_Pw_scheme.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/schemes/backward_euler_quasistatic_U_Pw_scheme.hpp
@@ -10,8 +10,7 @@
 //  Main authors:    Vahid Galavi
 //
 
-#if !defined(KRATOS_BACKWARD_EULER_QUASISTATIC_U_PW_SCHEME )
-#define  KRATOS_BACKWARD_EULER_QUASISTATIC_U_PW_SCHEME
+#pragma once
 
 // Project includes
 #include "includes/define.h"
@@ -26,76 +25,49 @@ namespace Kratos
 {
 
 template<class TSparseSpace, class TDenseSpace>
-
 class BackwardEulerQuasistaticUPwScheme : public NewmarkQuasistaticUPwScheme<TSparseSpace,TDenseSpace>
 {
-
 public:
-
     KRATOS_CLASS_POINTER_DEFINITION( BackwardEulerQuasistaticUPwScheme );
 
-    typedef Scheme<TSparseSpace,TDenseSpace>          BaseType;
-    typedef typename BaseType::DofsArrayType          DofsArrayType;
-    typedef typename BaseType::TSystemMatrixType      TSystemMatrixType;
-    typedef typename BaseType::TSystemVectorType      TSystemVectorType;
-    typedef typename BaseType::LocalSystemVectorType  LocalSystemVectorType;
-    typedef typename BaseType::LocalSystemMatrixType  LocalSystemMatrixType;
     using NewmarkQuasistaticUPwScheme<TSparseSpace,TDenseSpace>::mDeltaTime;
-    using NewmarkQuasistaticUPwScheme<TSparseSpace,TDenseSpace>::mBeta;
-    using NewmarkQuasistaticUPwScheme<TSparseSpace,TDenseSpace>::mGamma;
-    using NewmarkQuasistaticUPwScheme<TSparseSpace,TDenseSpace>::mTheta;
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-    ///Constructor
     BackwardEulerQuasistaticUPwScheme() :
         NewmarkQuasistaticUPwScheme<TSparseSpace,TDenseSpace>(1.0, 1.0, 1.0)
     {
     }
 
-    //------------------------------------------------------------------------------------
-
-    ///Destructor
-    ~BackwardEulerQuasistaticUPwScheme() override {}
-
 protected:
-
-    /// Member Variables
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     inline void SetTimeFactors(ModelPart& rModelPart) override
     {
         KRATOS_TRY
 
         mDeltaTime = rModelPart.GetProcessInfo()[DELTA_TIME];
-        rModelPart.GetProcessInfo()[VELOCITY_COEFFICIENT] = 1.0/mDeltaTime;
+        rModelPart.GetProcessInfo()[VELOCITY_COEFFICIENT]    = 1.0/mDeltaTime;
         rModelPart.GetProcessInfo()[DT_PRESSURE_COEFFICIENT] = 1.0/mDeltaTime;
 
         KRATOS_CATCH("")
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     inline void UpdateVariablesDerivatives(ModelPart& rModelPart) override
     {
         KRATOS_TRY
 
         //Update Acceleration, Velocity and DtPressure
-
-        block_for_each(rModelPart.Nodes(), [&](Node& rNode) {
-
+        block_for_each(rModelPart.Nodes(), [this](Node& rNode) {
+            // refactor, extract the (a -b)/mDeltaTime that happens 3 times here
             noalias(rNode.FastGetSolutionStepValue(VELOCITY))     = (  rNode.FastGetSolutionStepValue(DISPLACEMENT)
-                                                                     - rNode.FastGetSolutionStepValue(DISPLACEMENT, 1)) / mDeltaTime;
+                                                                                   - rNode.FastGetSolutionStepValue(DISPLACEMENT, 1)) / mDeltaTime;
 
             noalias(rNode.FastGetSolutionStepValue(ACCELERATION)) = (  rNode.FastGetSolutionStepValue(VELOCITY)
-                                                                     - rNode.FastGetSolutionStepValue(VELOCITY,1) ) / mDeltaTime;
+                                                                                   - rNode.FastGetSolutionStepValue(VELOCITY,1) ) / mDeltaTime;
 
-            rNode.FastGetSolutionStepValue(DT_WATER_PRESSURE) = (  rNode.FastGetSolutionStepValue(WATER_PRESSURE)
-                                                                 - rNode.FastGetSolutionStepValue(WATER_PRESSURE, 1)) / mDeltaTime;
+            rNode.FastGetSolutionStepValue(DT_WATER_PRESSURE)        = (  rNode.FastGetSolutionStepValue(WATER_PRESSURE)
+                                                                                  - rNode.FastGetSolutionStepValue(WATER_PRESSURE, 1)) / mDeltaTime;
         });
 
         KRATOS_CATCH( "" )
     }
-
 }; // Class BackwardEulerQuasistaticUPwScheme
-}  // namespace Kratos
 
-#endif // KRATOS_BACKWARD_EULER_QUASISTATIC_U_PW_SCHEME defined
+}

--- a/applications/GeoMechanicsApplication/custom_strategies/schemes/newmark_dynamic_U_Pw_scheme.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/schemes/newmark_dynamic_U_Pw_scheme.hpp
@@ -11,8 +11,7 @@
 //                   Vahid Galavi
 //
 
-#if !defined(KRATOS_NEWMARK_DYNAMIC_U_PW_SCHEME )
-#define  KRATOS_NEWMARK_DYNAMIC_U_PW_SCHEME
+#pragma once
 
 #include "utilities/parallel_utilities.h"
 
@@ -24,28 +23,22 @@ namespace Kratos
 {
 
 template<class TSparseSpace, class TDenseSpace>
-
 class NewmarkDynamicUPwScheme : public NewmarkQuasistaticUPwScheme<TSparseSpace,TDenseSpace>
 {
-
 public:
-
     KRATOS_CLASS_POINTER_DEFINITION( NewmarkDynamicUPwScheme );
 
-    typedef Scheme<TSparseSpace,TDenseSpace>                      BaseType;
-    typedef typename BaseType::DofsArrayType                 DofsArrayType;
-    typedef typename BaseType::TSystemMatrixType         TSystemMatrixType;
-    typedef typename BaseType::TSystemVectorType         TSystemVectorType;
-    typedef typename BaseType::LocalSystemVectorType LocalSystemVectorType;
-    typedef typename BaseType::LocalSystemMatrixType LocalSystemMatrixType;
+    using BaseType              = Scheme<TSparseSpace,TDenseSpace>;
+    using DofsArrayType         = typename BaseType::DofsArrayType;
+    using TSystemMatrixType     = typename BaseType::TSystemMatrixType;
+    using TSystemVectorType     = typename BaseType::TSystemVectorType;
+    using LocalSystemVectorType = typename BaseType::LocalSystemVectorType;
+    using LocalSystemMatrixType = typename BaseType::LocalSystemMatrixType;
     using NewmarkQuasistaticUPwScheme<TSparseSpace,TDenseSpace>::mDeltaTime;
     using NewmarkQuasistaticUPwScheme<TSparseSpace,TDenseSpace>::mBeta;
     using NewmarkQuasistaticUPwScheme<TSparseSpace,TDenseSpace>::mGamma;
     using NewmarkQuasistaticUPwScheme<TSparseSpace,TDenseSpace>::mTheta;
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-    ///Constructor
     NewmarkDynamicUPwScheme(double beta, double gamma, double theta)
         : NewmarkQuasistaticUPwScheme<TSparseSpace,TDenseSpace>(beta, gamma, theta)
     {
@@ -56,13 +49,6 @@ public:
         mDampingMatrix.resize(NumThreads);
         mVelocityVector.resize(NumThreads);
     }
-
-    //------------------------------------------------------------------------------------
-
-    ///Destructor
-    ~NewmarkDynamicUPwScheme() override {}
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     void Predict(
         ModelPart& rModelPart,
@@ -75,6 +61,7 @@ public:
 
         // Predict Displacements on free nodes and update Acceleration, Velocity and DtPressure
         block_for_each(rModelPart.Nodes(), [&](Node& rNode){
+ // refactor such that all mathematical formulas appear once only.
             if (rNode.IsFixed(ACCELERATION_X))
             {
                 const double &PreviousDisplacement = rNode.FastGetSolutionStepValue(DISPLACEMENT_X, 1);
@@ -83,9 +70,9 @@ public:
                 const double &CurrentAcceleration  = rNode.FastGetSolutionStepValue(ACCELERATION_X);
 
                 rNode.FastGetSolutionStepValue(DISPLACEMENT_X) =  PreviousDisplacement
-                                                                + mDeltaTime * PreviousVelocity
-                                                                + mDeltaTime * mDeltaTime
-                                                                * ( ( 0.5 - mBeta) * PreviousAcceleration + mBeta * CurrentAcceleration );
+                                                                           + mDeltaTime * PreviousVelocity
+                                                                           + mDeltaTime * mDeltaTime
+                                                                             * ( ( 0.5 - mBeta) * PreviousAcceleration + mBeta * CurrentAcceleration );
             }
             else if (rNode.IsFixed(VELOCITY_X))
             {
@@ -93,8 +80,8 @@ public:
                 const double &PreviousVelocity     = rNode.FastGetSolutionStepValue(VELOCITY_X, 1);
                 const double &CurrentVelocity      = rNode.FastGetSolutionStepValue(VELOCITY_X);
                 rNode.FastGetSolutionStepValue(DISPLACEMENT_X) =  PreviousDisplacement
-                                                                 + mDeltaTime*(mBeta/mGamma*(CurrentVelocity - PreviousVelocity)
-                                                                 + PreviousVelocity);
+                                                                          + mDeltaTime*((mBeta/mGamma)*(CurrentVelocity - PreviousVelocity)
+                                                                          + PreviousVelocity);
             }
             else if (!rNode.IsFixed(DISPLACEMENT_X))
             {
@@ -126,7 +113,7 @@ public:
                 const double &PreviousVelocity     = rNode.FastGetSolutionStepValue(VELOCITY_Y, 1);
                 const double &CurrentVelocity      = rNode.FastGetSolutionStepValue(VELOCITY_Y);
                 rNode.FastGetSolutionStepValue(DISPLACEMENT_Y) =  PreviousDisplacement
-                                                                 + mDeltaTime*(mBeta/mGamma*(CurrentVelocity - PreviousVelocity)
+                                                                 + mDeltaTime*((mBeta/mGamma)*(CurrentVelocity - PreviousVelocity)
                                                                  + PreviousVelocity);
             }
             else if (!rNode.IsFixed(DISPLACEMENT_Y))
@@ -162,7 +149,7 @@ public:
                     const double &PreviousVelocity     = rNode.FastGetSolutionStepValue(VELOCITY_Z, 1);
                     const double &CurrentVelocity      = rNode.FastGetSolutionStepValue(VELOCITY_Z);
                     rNode.FastGetSolutionStepValue(DISPLACEMENT_Z) =  PreviousDisplacement
-                                                                    + mDeltaTime*(mBeta/mGamma*(CurrentVelocity - PreviousVelocity)
+                                                                    + mDeltaTime*((mBeta/mGamma)*(CurrentVelocity - PreviousVelocity)
                                                                     + PreviousVelocity);
                 }
                 else if (!rNode.IsFixed(DISPLACEMENT_Z))
@@ -178,7 +165,7 @@ public:
                 }
             }
 
-            noalias(rNode.FastGetSolutionStepValue(ACCELERATION)) =   1.0/(mBeta*mDeltaTime*mDeltaTime)
+            noalias(rNode.FastGetSolutionStepValue(ACCELERATION)) =   (1.0/(mBeta*mDeltaTime*mDeltaTime))
                                                                     * ( (rNode.FastGetSolutionStepValue(DISPLACEMENT) - rNode.FastGetSolutionStepValue(DISPLACEMENT,1))
                                                                      - mDeltaTime
                                                                      * rNode.FastGetSolutionStepValue(VELOCITY, 1)
@@ -194,7 +181,7 @@ public:
             const double DeltaPressure =  rNode.FastGetSolutionStepValue(WATER_PRESSURE)
                                         - rNode.FastGetSolutionStepValue(WATER_PRESSURE, 1);
 
-            rNode.FastGetSolutionStepValue(DT_WATER_PRESSURE) =  1.0/(mTheta*mDeltaTime)
+            rNode.FastGetSolutionStepValue(DT_WATER_PRESSURE) =  (1.0/(mTheta*mDeltaTime))
                                                                 * ( DeltaPressure
                                                                    - (1.0-mTheta) * mDeltaTime 
                                                                    * rNode.FastGetSolutionStepValue(DT_WATER_PRESSURE,1));
@@ -203,10 +190,6 @@ public:
 
         KRATOS_CATCH( "" )
     }
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-// Note: this is in a parallel loop
 
     void CalculateSystemContributions(
         Condition& rCurrentCondition,
@@ -219,22 +202,20 @@ public:
 
         int thread = OpenMPUtils::ThisThread();
 
-        (rCurrentCondition).CalculateLocalSystem(LHS_Contribution, RHS_Contribution, CurrentProcessInfo);
+        rCurrentCondition.CalculateLocalSystem(LHS_Contribution, RHS_Contribution, CurrentProcessInfo);
 
-        (rCurrentCondition).CalculateMassMatrix(mMassMatrix[thread], CurrentProcessInfo);
+        rCurrentCondition.CalculateMassMatrix(mMassMatrix[thread], CurrentProcessInfo);
 
-        (rCurrentCondition).CalculateDampingMatrix(mDampingMatrix[thread], CurrentProcessInfo);
+        rCurrentCondition.CalculateDampingMatrix(mDampingMatrix[thread], CurrentProcessInfo);
 
         this->AddDynamicsToLHS(LHS_Contribution, mMassMatrix[thread], mDampingMatrix[thread], CurrentProcessInfo);
 
         this->AddDynamicsToRHS(rCurrentCondition, RHS_Contribution, mMassMatrix[thread], mDampingMatrix[thread], CurrentProcessInfo);
 
-        (rCurrentCondition).EquationIdVector(EquationId, CurrentProcessInfo);
+        rCurrentCondition.EquationIdVector(EquationId, CurrentProcessInfo);
 
         KRATOS_CATCH("")
     }
-
-// Note: this is in a parallel loop
 
     void CalculateSystemContributions(
         Element& rCurrentElement,
@@ -247,24 +228,20 @@ public:
 
         int thread = OpenMPUtils::ThisThread();
 
-        (rCurrentElement).CalculateLocalSystem(LHS_Contribution,RHS_Contribution,CurrentProcessInfo);
+        rCurrentElement.CalculateLocalSystem(LHS_Contribution,RHS_Contribution,CurrentProcessInfo);
 
-        (rCurrentElement).CalculateMassMatrix(mMassMatrix[thread],CurrentProcessInfo);
+        rCurrentElement.CalculateMassMatrix(mMassMatrix[thread],CurrentProcessInfo);
 
-        (rCurrentElement).CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
+        rCurrentElement.CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
 
         this->AddDynamicsToLHS(LHS_Contribution, mMassMatrix[thread], mDampingMatrix[thread], CurrentProcessInfo);
 
         this->AddDynamicsToRHS(rCurrentElement, RHS_Contribution, mMassMatrix[thread], mDampingMatrix[thread], CurrentProcessInfo);
 
-        (rCurrentElement).EquationIdVector(EquationId,CurrentProcessInfo);
+        rCurrentElement.EquationIdVector(EquationId,CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-// Note: this is in a parallel loop
 
     void CalculateRHSContribution(
         Element &rCurrentElement,
@@ -276,15 +253,15 @@ public:
 
         int thread = OpenMPUtils::ThisThread();
 
-        (rCurrentElement).CalculateRightHandSide(RHS_Contribution,CurrentProcessInfo);
+        rCurrentElement.CalculateRightHandSide(RHS_Contribution,CurrentProcessInfo);
 
-        (rCurrentElement).CalculateMassMatrix(mMassMatrix[thread], CurrentProcessInfo);
+        rCurrentElement.CalculateMassMatrix(mMassMatrix[thread], CurrentProcessInfo);
 
-        (rCurrentElement).CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
+        rCurrentElement.CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
 
         this->AddDynamicsToRHS(rCurrentElement, RHS_Contribution, mMassMatrix[thread], mDampingMatrix[thread], CurrentProcessInfo);
 
-        (rCurrentElement).EquationIdVector(EquationId,CurrentProcessInfo);
+        rCurrentElement.EquationIdVector(EquationId,CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
@@ -312,12 +289,6 @@ public:
         KRATOS_CATCH("")
     }
 
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-// Note: this is in a parallel loop
-
-
     void CalculateLHSContribution(
         Condition& rCurrentCondition,
         LocalSystemMatrixType& LHS_Contribution,
@@ -328,15 +299,15 @@ public:
 
         int thread = OpenMPUtils::ThisThread();
 
-        (rCurrentCondition).CalculateLeftHandSide(LHS_Contribution, CurrentProcessInfo);
+        rCurrentCondition.CalculateLeftHandSide(LHS_Contribution, CurrentProcessInfo);
 
-        (rCurrentCondition).CalculateMassMatrix(mMassMatrix[thread], CurrentProcessInfo);
+        rCurrentCondition.CalculateMassMatrix(mMassMatrix[thread], CurrentProcessInfo);
 
-        (rCurrentCondition).CalculateDampingMatrix(mDampingMatrix[thread], CurrentProcessInfo);
+        rCurrentCondition.CalculateDampingMatrix(mDampingMatrix[thread], CurrentProcessInfo);
 
         this->AddDynamicsToLHS(LHS_Contribution, mMassMatrix[thread], mDampingMatrix[thread], CurrentProcessInfo);
 
-        (rCurrentCondition).EquationIdVector(EquationId, CurrentProcessInfo);
+        rCurrentCondition.EquationIdVector(EquationId, CurrentProcessInfo);
 
         KRATOS_CATCH("")
     }
@@ -351,31 +322,25 @@ public:
 
         int thread = OpenMPUtils::ThisThread();
 
-        (rCurrentElement).CalculateLeftHandSide(LHS_Contribution,CurrentProcessInfo);
+        rCurrentElement.CalculateLeftHandSide(LHS_Contribution,CurrentProcessInfo);
 
-        (rCurrentElement).CalculateMassMatrix(mMassMatrix[thread],CurrentProcessInfo);
+        rCurrentElement.CalculateMassMatrix(mMassMatrix[thread],CurrentProcessInfo);
 
-        (rCurrentElement).CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
+        rCurrentElement.CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
 
         this->AddDynamicsToLHS(LHS_Contribution, mMassMatrix[thread], mDampingMatrix[thread], CurrentProcessInfo);
 
-        (rCurrentElement).EquationIdVector(EquationId,CurrentProcessInfo);
+        rCurrentElement.EquationIdVector(EquationId,CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
 protected:
-
     /// Member Variables
-
     std::vector< Matrix > mMassMatrix;
     std::vector< Vector > mAccelerationVector;
     std::vector< Matrix > mDampingMatrix;
     std::vector< Vector > mVelocityVector;
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     void AddDynamicsToLHS(LocalSystemMatrixType& LHS_Contribution,
                           LocalSystemMatrixType& M,
@@ -386,16 +351,14 @@ protected:
 
         // adding mass contribution
         if (M.size1() != 0)
-            noalias(LHS_Contribution) += 1.0/(mBeta*mDeltaTime*mDeltaTime)*M;
+            noalias(LHS_Contribution) += (1.0/(mBeta*mDeltaTime*mDeltaTime))*M;
 
         // adding damping contribution
         if (C.size1() != 0)
-            noalias(LHS_Contribution) += mGamma/(mBeta*mDeltaTime)*C;
+            noalias(LHS_Contribution) += (mGamma/(mBeta*mDeltaTime))*C;
 
         KRATOS_CATCH( "" )
     }
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     void AddDynamicsToRHS(Condition& rCurrentCondition,
         LocalSystemVectorType& RHS_Contribution,
@@ -450,8 +413,6 @@ protected:
 
         KRATOS_CATCH( "" )
     }
-
 }; // Class NewmarkDynamicUPwScheme
-}  // namespace Kratos
 
-#endif // KRATOS_NEWMARK_DYNAMIC_U_PW_SCHEME defined
+}

--- a/applications/GeoMechanicsApplication/custom_strategies/schemes/newmark_quasistatic_U_Pw_scheme.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/schemes/newmark_quasistatic_U_Pw_scheme.hpp
@@ -24,38 +24,24 @@ namespace Kratos
 {
 
 template<class TSparseSpace, class TDenseSpace>
-
 class NewmarkQuasistaticUPwScheme : public Scheme<TSparseSpace,TDenseSpace>
 {
-
 public:
-
     KRATOS_CLASS_POINTER_DEFINITION( NewmarkQuasistaticUPwScheme );
 
-    typedef Scheme<TSparseSpace,TDenseSpace>                      BaseType;
-    typedef typename BaseType::DofsArrayType                 DofsArrayType;
-    typedef typename BaseType::TSystemMatrixType         TSystemMatrixType;
-    typedef typename BaseType::TSystemVectorType         TSystemVectorType;
-    typedef typename BaseType::LocalSystemVectorType LocalSystemVectorType;
-    typedef typename BaseType::LocalSystemMatrixType LocalSystemMatrixType;
+    using BaseType              = Scheme<TSparseSpace,TDenseSpace>;
+    using DofsArrayType         = typename BaseType::DofsArrayType;
+    using TSystemMatrixType     = typename BaseType::TSystemMatrixType;
+    using TSystemVectorType     = typename BaseType::TSystemVectorType;
+    using LocalSystemVectorType = typename BaseType::LocalSystemVectorType;
+    using LocalSystemMatrixType = typename BaseType::LocalSystemMatrixType;
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-    ///Constructor
     NewmarkQuasistaticUPwScheme(double beta, double gamma, double theta)
         : Scheme<TSparseSpace,TDenseSpace>()
         , mBeta(beta)
         , mGamma(gamma)
         , mTheta(theta)
-    {
-    }
-
-    //------------------------------------------------------------------------------------
-
-    ///Destructor
-    ~NewmarkQuasistaticUPwScheme() override {}
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    {}
 
     int Check(const ModelPart& rModelPart) const override
     {
@@ -112,23 +98,21 @@ public:
         }
 
         //check for minimum value of the buffer index.
-        if (rModelPart.GetBufferSize() < 2)
-            KRATOS_ERROR << "insufficient buffer size. Buffer size should be greater than 2. Current size is"
-                         << rModelPart.GetBufferSize()
-                         << std::endl;
+        KRATOS_ERROR_IF(rModelPart.GetBufferSize() < 2)
+            << "insufficient buffer size. Buffer size should be greater than 2. Current size is"
+            << rModelPart.GetBufferSize()
+            << std::endl;
 
         // Check beta, gamma and theta
-        if (mBeta <= 0.0 || mGamma<= 0.0 || mTheta <= 0.0)
-            KRATOS_ERROR << "Some of the scheme variables: beta, gamma or theta has an invalid value"
-                         << std::endl;
+        KRATOS_ERROR_IF(mBeta <= 0.0 || mGamma<= 0.0 || mTheta <= 0.0)
+            << "Some of the scheme variables: beta, gamma or theta has an invalid value"
+            << std::endl;
 
         return 0;
 
         KRATOS_CATCH( "" )
     }
 
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     void Initialize(ModelPart& rModelPart) override
     {
         KRATOS_TRY
@@ -140,12 +124,10 @@ public:
         KRATOS_CATCH("")
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    void InitializeSolutionStep(
-        ModelPart& rModelPart,
-        TSystemMatrixType& A,
-        TSystemVectorType& Dx,
-        TSystemVectorType& b) override
+    void InitializeSolutionStep( ModelPart& rModelPart,
+                                 TSystemMatrixType& A,
+                                 TSystemVectorType& Dx,
+                                 TSystemVectorType& b) override
     {
         KRATOS_TRY
 
@@ -166,24 +148,19 @@ public:
         KRATOS_CATCH("")
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    void Predict(
-        ModelPart& rModelPart,
-        DofsArrayType& rDofSet,
-        TSystemMatrixType& A,
-        TSystemVectorType& Dx,
-        TSystemVectorType& b) override
+    void Predict( ModelPart& rModelPart,
+                  DofsArrayType& rDofSet,
+                  TSystemMatrixType& A,
+                  TSystemVectorType& Dx,
+                  TSystemVectorType& b) override
     {
         this->UpdateVariablesDerivatives(rModelPart);
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-    void InitializeNonLinIteration(
-        ModelPart& rModelPart,
-        TSystemMatrixType& A,
-        TSystemVectorType& Dx,
-        TSystemVectorType& b) override
+    void InitializeNonLinIteration( ModelPart& rModelPart,
+                                    TSystemMatrixType& A,
+                                    TSystemVectorType& Dx,
+                                    TSystemVectorType& b) override
     {
         KRATOS_TRY
 
@@ -202,13 +179,10 @@ public:
         KRATOS_CATCH("")
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-    void FinalizeNonLinIteration(
-        ModelPart& rModelPart,
-        TSystemMatrixType& A,
-        TSystemVectorType& Dx,
-        TSystemVectorType& b) override
+    void FinalizeNonLinIteration( ModelPart& rModelPart,
+                                  TSystemMatrixType& A,
+                                  TSystemVectorType& Dx,
+                                  TSystemVectorType& b) override
     {
         KRATOS_TRY
 
@@ -227,8 +201,6 @@ public:
         KRATOS_CATCH("")
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
     void GetDofList( const Element& rElement,
                      Element::DofsVectorType& rDofList,
                      const ProcessInfo& rCurrentProcessInfo ) override
@@ -237,8 +209,6 @@ public:
         if (isActive) rElement.GetDofList(rDofList, rCurrentProcessInfo);
 
     }
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     void GetDofList( const Condition& rCondition,
                      Element::DofsVectorType& rDofList,
@@ -249,39 +219,26 @@ public:
 
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-    void EquationId(
-        const Element& rElement,
-        Element::EquationIdVectorType& rEquationId,
-        const ProcessInfo& rCurrentProcessInfo
-        ) override
+    void EquationId( const Element& rElement,
+                     Element::EquationIdVectorType& rEquationId,
+                     const ProcessInfo& rCurrentProcessInfo ) override
     {
         const bool isActive = (rElement.IsDefined(ACTIVE)) ? rElement.Is(ACTIVE) : true;
         if (isActive) rElement.EquationIdVector(rEquationId, rCurrentProcessInfo);
-        
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-    void EquationId(
-        const Condition& rCondition,
-        Element::EquationIdVectorType& rEquationId,
-        const ProcessInfo& rCurrentProcessInfo
-        ) override
+    void EquationId( const Condition& rCondition,
+                     Element::EquationIdVectorType& rEquationId,
+                     const ProcessInfo& rCurrentProcessInfo ) override
     {
         const bool isActive = (rCondition.IsDefined(ACTIVE)) ? rCondition.Is(ACTIVE) : true;
         if (isActive) rCondition.EquationIdVector(rEquationId, rCurrentProcessInfo);
     }
 
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-    void FinalizeSolutionStep(
-        ModelPart& rModelPart,
-        TSystemMatrixType& A,
-        TSystemVectorType& Dx,
-        TSystemVectorType& b) override
+    void FinalizeSolutionStep( ModelPart& rModelPart,
+                               TSystemMatrixType& A,
+                               TSystemVectorType& Dx,
+                               TSystemVectorType& b) override
     {
         KRATOS_TRY
 
@@ -299,9 +256,9 @@ public:
                     rNodalStress.resize(StressTensorSize,StressTensorSize,false);
                 noalias(rNodalStress) = ZeroMatrix(StressTensorSize, StressTensorSize);
                 rNode.FastGetSolutionStepValue(NODAL_DAMAGE_VARIABLE) = 0.0;
-                rNode.FastGetSolutionStepValue(NODAL_JOINT_AREA) = 0.0;
-                rNode.FastGetSolutionStepValue(NODAL_JOINT_WIDTH) = 0.0;
-                rNode.FastGetSolutionStepValue(NODAL_JOINT_DAMAGE) = 0.0;
+                rNode.FastGetSolutionStepValue(NODAL_JOINT_AREA)      = 0.0;
+                rNode.FastGetSolutionStepValue(NODAL_JOINT_WIDTH)     = 0.0;
+                rNode.FastGetSolutionStepValue(NODAL_JOINT_DAMAGE)    = 0.0;
             });
 
             FinalizeSolutionStepActiveEntities(rModelPart,A,Dx,b);
@@ -335,12 +292,10 @@ public:
         KRATOS_CATCH("")
     }
 
-    //------------------------------------------------------------------------------------------
-    void FinalizeSolutionStepActiveEntities(
-        ModelPart& rModelPart,
-        TSystemMatrixType& A,
-        TSystemVectorType& Dx,
-        TSystemVectorType& b)
+    void FinalizeSolutionStepActiveEntities( ModelPart& rModelPart,
+                                             TSystemMatrixType& A,
+                                             TSystemVectorType& Dx,
+                                             TSystemVectorType& b)
     {
         KRATOS_TRY
 
@@ -359,129 +314,97 @@ public:
         KRATOS_CATCH("")
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-// Note: this is in a parallel loop
-    void CalculateSystemContributions(
-        Element& rCurrentElement,
-        LocalSystemMatrixType& LHS_Contribution,
-        LocalSystemVectorType& RHS_Contribution,
-        Element::EquationIdVectorType& EquationId,
-        const ProcessInfo& CurrentProcessInfo) override
+    void CalculateSystemContributions( Element& rCurrentElement,
+                                       LocalSystemMatrixType& LHS_Contribution,
+                                       LocalSystemVectorType& RHS_Contribution,
+                                       Element::EquationIdVectorType& EquationId,
+                                       const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
-        (rCurrentElement).CalculateLocalSystem(LHS_Contribution,RHS_Contribution,CurrentProcessInfo);
+        rCurrentElement.CalculateLocalSystem(LHS_Contribution,RHS_Contribution,CurrentProcessInfo);
 
-        (rCurrentElement).EquationIdVector(EquationId,CurrentProcessInfo);
+        rCurrentElement.EquationIdVector(EquationId,CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-// Note: this is in a parallel loop
-
-    void CalculateSystemContributions(
-        Condition& rCurrentCondition,
-        LocalSystemMatrixType& LHS_Contribution,
-        LocalSystemVectorType& RHS_Contribution,
-        Element::EquationIdVectorType& EquationId,
-        const ProcessInfo& CurrentProcessInfo) override
+    void CalculateSystemContributions( Condition& rCurrentCondition,
+                                       LocalSystemMatrixType& LHS_Contribution,
+                                       LocalSystemVectorType& RHS_Contribution,
+                                       Element::EquationIdVectorType& EquationId,
+                                       const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
-        (rCurrentCondition).CalculateLocalSystem(LHS_Contribution,RHS_Contribution,CurrentProcessInfo);
+        rCurrentCondition.CalculateLocalSystem(LHS_Contribution,RHS_Contribution,CurrentProcessInfo);
 
-        (rCurrentCondition).EquationIdVector(EquationId,CurrentProcessInfo);
+        rCurrentCondition.EquationIdVector(EquationId,CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-// Note: this is in a parallel loop
-
-    void CalculateRHSContribution(
-        Element &rCurrentElement,
-        LocalSystemVectorType& RHS_Contribution,
-        Element::EquationIdVectorType& EquationId,
-        const ProcessInfo& CurrentProcessInfo) override
+    void CalculateRHSContribution( Element &rCurrentElement,
+                                   LocalSystemVectorType& RHS_Contribution,
+                                   Element::EquationIdVectorType& EquationId,
+                                   const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
-        (rCurrentElement).CalculateRightHandSide(RHS_Contribution,CurrentProcessInfo);
+        rCurrentElement.CalculateRightHandSide(RHS_Contribution,CurrentProcessInfo);
 
-        (rCurrentElement).EquationIdVector(EquationId,CurrentProcessInfo);
+        rCurrentElement.EquationIdVector(EquationId,CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-// Note: this is in a parallel loop
-
-    void CalculateRHSContribution(
-        Condition &rCurrentCondition,
-        LocalSystemVectorType& RHS_Contribution,
-        Element::EquationIdVectorType& EquationId,
-        const ProcessInfo& CurrentProcessInfo) override
+    void CalculateRHSContribution( Condition &rCurrentCondition,
+                                   LocalSystemVectorType& RHS_Contribution,
+                                   Element::EquationIdVectorType& EquationId,
+                                   const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
-        (rCurrentCondition).CalculateRightHandSide(RHS_Contribution, CurrentProcessInfo);
+        rCurrentCondition.CalculateRightHandSide(RHS_Contribution, CurrentProcessInfo);
 
-        (rCurrentCondition).EquationIdVector(EquationId, CurrentProcessInfo);
+        rCurrentCondition.EquationIdVector(EquationId, CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-// Note: this is in a parallel loop
-
-    void CalculateLHSContribution(
-        Element &rCurrentElement,
-        LocalSystemMatrixType& LHS_Contribution,
-        Element::EquationIdVectorType& EquationId,
-        const ProcessInfo& CurrentProcessInfo) override
+    void CalculateLHSContribution( Element &rCurrentElement,
+                                   LocalSystemMatrixType& LHS_Contribution,
+                                   Element::EquationIdVectorType& EquationId,
+                                   const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
-        (rCurrentElement).CalculateLeftHandSide(LHS_Contribution,CurrentProcessInfo);
+        rCurrentElement.CalculateLeftHandSide(LHS_Contribution,CurrentProcessInfo);
 
-        (rCurrentElement).EquationIdVector(EquationId,CurrentProcessInfo);
+        rCurrentElement.EquationIdVector(EquationId,CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-// Note: this is in a parallel loop
-
-    void CalculateLHSContribution(
-        Condition &rCurrentCondition,
-        LocalSystemMatrixType& LHS_Contribution,
-        Element::EquationIdVectorType& EquationId,
-        const ProcessInfo& CurrentProcessInfo) override
+    void CalculateLHSContribution( Condition &rCurrentCondition,
+                                   LocalSystemMatrixType& LHS_Contribution,
+                                   Element::EquationIdVectorType& EquationId,
+                                   const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
-        (rCurrentCondition).CalculateLeftHandSide(LHS_Contribution, CurrentProcessInfo);
+        rCurrentCondition.CalculateLeftHandSide(LHS_Contribution, CurrentProcessInfo);
 
-        (rCurrentCondition).EquationIdVector(EquationId, CurrentProcessInfo);
+        rCurrentCondition.EquationIdVector(EquationId, CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-    void Update(
-        ModelPart& rModelPart,
-        DofsArrayType& rDofSet,
-        TSystemMatrixType& A,
-        TSystemVectorType& Dx,
-        TSystemVectorType& b) override
+    void Update( ModelPart& rModelPart,
+                 DofsArrayType& rDofSet,
+                 TSystemMatrixType& A,
+                 TSystemVectorType& Dx,
+                 TSystemVectorType& b) override
     {
         KRATOS_TRY
 
@@ -498,8 +421,7 @@ public:
 
             //Update Displacement and Pressure (DOFs)
             for (typename DofsArrayType::iterator itDof = DofsBegin; itDof != DofsEnd; ++itDof) {
-                if (itDof->IsFree())
-                    itDof->GetSolutionStepValue() += TSparseSpace::GetValue(Dx, itDof->EquationId());
+                if (itDof->IsFree()) itDof->GetSolutionStepValue() += TSparseSpace::GetValue(Dx, itDof->EquationId());
             }
         }
 
@@ -508,28 +430,23 @@ public:
         KRATOS_CATCH( "" )
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
 protected:
-
-    double mBeta = 0.25;
+    double mBeta  = 0.25;
     double mGamma = 0.5;
     double mTheta = 0.5;
     double mDeltaTime = 0.0;
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     virtual inline void SetTimeFactors(ModelPart& rModelPart)
     {
         KRATOS_TRY
 
         mDeltaTime = rModelPart.GetProcessInfo()[DELTA_TIME];
-        rModelPart.GetProcessInfo()[VELOCITY_COEFFICIENT] = mGamma/(mBeta*mDeltaTime);
+        rModelPart.GetProcessInfo()[VELOCITY_COEFFICIENT]    = mGamma/(mBeta*mDeltaTime);
         rModelPart.GetProcessInfo()[DT_PRESSURE_COEFFICIENT] = 1.0/(mTheta*mDeltaTime);
 
         KRATOS_CATCH("")
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     virtual inline void UpdateVariablesDerivatives(ModelPart& rModelPart)
     {
         KRATOS_TRY
@@ -560,6 +477,6 @@ protected:
 
         KRATOS_CATCH( "" )
     }
-
 }; // Class NewmarkQuasistaticUPwScheme
-}  // namespace Kratos
+
+}

--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_erosion_process_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_erosion_process_strategy.hpp
@@ -11,8 +11,7 @@
 //                   Aron Noordam
 //
 
-#if !defined(KRATOS_GEO_MECHANICS_NEWTON_RAPHSON_EROSION_PROCESS_STRATEGY)
-#define KRATOS_GEO_MECHANICS_NEWTON_RAPHSON_EROSION_PROCESS_STRATEGY
+#pragma once
 
 // Project includes
 #include "includes/define.h"
@@ -30,7 +29,6 @@
 #include <ctime> 
 #include <tuple>
 
-
 namespace Kratos
 {
 
@@ -38,29 +36,22 @@ template<class TSparseSpace, class TDenseSpace, class TLinearSolver>
 class GeoMechanicsNewtonRaphsonErosionProcessStrategy :
     public GeoMechanicsNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>
 {
-
 public:
-
     KRATOS_CLASS_POINTER_DEFINITION(GeoMechanicsNewtonRaphsonErosionProcessStrategy);
 
-    typedef ImplicitSolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver>              BaseType;
-    typedef GeoMechanicsNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>  MotherType;
-    typedef ConvergenceCriteria<TSparseSpace, TDenseSpace>                 TConvergenceCriteriaType;
-    typedef typename BaseType::TBuilderAndSolverType                          TBuilderAndSolverType;
-    typedef typename BaseType::TSchemeType                                              TSchemeType;
-    typedef typename BaseType::DofsArrayType                                          DofsArrayType;
-    typedef typename BaseType::TSystemMatrixType                                  TSystemMatrixType;
-    typedef typename BaseType::TSystemVectorType                                  TSystemVectorType;
-    typedef typename boost::range_detail::filtered_range
-        <std::function<bool(Element*)>, std::vector<Element*>>                         filtered_elements;
-
-    typedef class SteadyStatePwPipingElement<2, 4>               SteadyStatePwPipingElementType;
-    typedef Properties PropertiesType;
-    typedef Node NodeType;
-    typedef Geometry<NodeType> GeometryType;
+    using BaseType                 = ImplicitSolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver>;
+    using TConvergenceCriteriaType = ConvergenceCriteria<TSparseSpace, TDenseSpace>;
+    using TBuilderAndSolverType    = typename BaseType::TBuilderAndSolverType;
+    using TSchemeType              = typename BaseType::TSchemeType;
+    using DofsArrayType            = typename BaseType::DofsArrayType;
+    using TSystemMatrixType        = typename BaseType::TSystemMatrixType;
+    using TSystemVectorType        = typename BaseType::TSystemVectorType;
+    using filtered_elements        = typename boost::range_detail::filtered_range
+                                     <std::function<bool(Element*)>, std::vector<Element*>>;
+    using PropertiesType           = Properties;
+    using NodeType                 = Node;
+    using GeometryType             = Geometry<NodeType>;
 	
-	//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    ///Constructor
     GeoMechanicsNewtonRaphsonErosionProcessStrategy(
         ModelPart& model_part,
         typename TSchemeType::Pointer pScheme,
@@ -83,16 +74,9 @@ public:
                                                                                          ReformDofSetAtEachStep,
                                                                                          MoveMeshFlag)
     {
-
         rank = model_part.GetCommunicator().MyPID();
     	mPipingIterations = rParameters["max_piping_iterations"].GetInt();
-    	
     }
-
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-    ///Destructor
-    ~GeoMechanicsNewtonRaphsonErosionProcessStrategy() override {}
 
     void FinalizeSolutionStep() override
     {
@@ -107,7 +91,7 @@ public:
         // get initially open pipe elements
         unsigned int openPipeElements = this->InitialiseNumActivePipeElements(PipeElements);
 
-        if (PipeElements.size()==0)
+        if (PipeElements.empty())
         {
             KRATOS_INFO_IF("PipingLoop", this->GetEchoLevel() > 0 && rank == 0) << "No Pipe Elements -> Finalizing Solution " << std::endl;
         	GeoMechanicsNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>::FinalizeSolutionStep();
@@ -121,7 +105,6 @@ public:
         {
             // todo: JDN (20220817) : grow not used. 
             // bool Equilibrium = false;
-            bool converged = true;
 
             // get tip element and activate
             Element* tip_element = PipeElements.at(openPipeElements);
@@ -147,8 +130,8 @@ public:
             {
                 save_or_reset_pipe_heights(OpenPipeElements, grow);
             }
-            // recalculate ground water flow
-            converged = Recalculate();
+            // recalculate groundwater flow
+            bool converged = Recalculate();
 
             // error check
             KRATOS_ERROR_IF_NOT(converged) << "Groundwater flow calculation failed to converge." << std::endl;
@@ -199,7 +182,7 @@ public:
             }
         }
 
-        if (PipeElements.size() == 0)
+        if (PipeElements.empty())
         {
             return PipeElements;
         }
@@ -249,21 +232,12 @@ public:
 
         return PipeElements;
     }
-   
 
-	//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-protected:
-
+private:
     unsigned int mPipingIterations; /// This is used to calculate the pipingLength
     int rank;
 	double small_pipe_height = 1e-10;
     double pipe_height_accuracy = small_pipe_height * 10;
-
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-private:
-
 
     /// <summary>
     /// Initialises the number of open pipe elements. This value can be greater than 0 in a multi staged analysis.
@@ -356,7 +330,6 @@ private:
     	GeoMechanicsNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>::InitializeSolutionStep();
         GeoMechanicsNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>::Predict();
         return GeoMechanicsNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>::SolveSolutionStep();
-
     }
 
     bool check_pipe_equilibrium(filtered_elements open_pipe_elements, double amax, unsigned int mPipingIterations)
@@ -372,10 +345,10 @@ private:
 
         while (PipeIter < mPipingIterations && !equilibrium && converged)
         {
-            // set equilibirum on true
+            // set equilibrium on true
             equilibrium = true;
 
-            // perform a flow calculation and stop growing if the calculation doesnt converge
+            // perform a flow calculation and stop growing if the calculation doesn't converge
             converged = Recalculate();
 
             // todo: JDN (20220817) : grow not used. 
@@ -400,13 +373,13 @@ private:
                     double eq_height = pElement->CalculateEquilibriumPipeHeight(prop, Geom, OpenPipeElement->GetValue(PIPE_ELEMENT_LENGTH));
                     double current_height = OpenPipeElement->GetValue(PIPE_HEIGHT);
 
-                    // set erosion on true if current pipe height is greater than the equilibirum height
+                    // set erosion on true if current pipe height is greater than the equilibrium height
                     if (current_height > eq_height)
                     {
                         OpenPipeElement->SetValue(PIPE_EROSION, true);
                     }
 
-                    // check this if statement, I dont understand the check for pipe erosion
+                    // check this if statement, I don't understand the check for pipe erosion
                     if (((!OpenPipeElement->GetValue(PIPE_EROSION) || (current_height > eq_height)) && current_height < amax))
                     {
                         OpenPipeElement->SetValue(PIPE_HEIGHT, OpenPipeElement->GetValue(PIPE_HEIGHT) + da);
@@ -467,7 +440,7 @@ private:
     }
 
     /// <summary>
-    /// Saves pipe heights if pipe grows, else reset pipe hieghts to previous grow step.
+    /// Saves pipe heights if pipe grows, else reset pipe heights to previous grow step.
     /// </summary>
     /// <param name="open_pipe_elements"> open pipe elements</param>
     /// <param name="grow"> boolean to check if pipe grows</param>
@@ -491,6 +464,4 @@ private:
 
 }; // Class GeoMechanicsNewtonRaphsonStrategy
 
-} // namespace Kratos
-
-#endif // KRATOS_GEO_MECHANICS_NEWTON_RAPHSON_EROSION_PROCESS_STRATEGY  defined
+}

--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
@@ -11,8 +11,7 @@
 //                   Vahid Galavi
 //
 
-#if !defined(KRATOS_GEO_MECHANICS_NEWTON_RAPHSON_STRATEGY)
-#define KRATOS_GEO_MECHANICS_NEWTON_RAPHSON_STRATEGY
+#pragma once
 
 // Project includes
 #include "includes/define.h"
@@ -30,19 +29,17 @@ template<class TSparseSpace, class TDenseSpace, class TLinearSolver>
 class GeoMechanicsNewtonRaphsonStrategy :
   public ResidualBasedNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>
 {
-
 public:
-
     KRATOS_CLASS_POINTER_DEFINITION(GeoMechanicsNewtonRaphsonStrategy);
 
-    typedef ImplicitSolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver>              BaseType;
-    typedef ResidualBasedNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver> MotherType;
-    typedef ConvergenceCriteria<TSparseSpace, TDenseSpace>                 TConvergenceCriteriaType;
-    typedef typename BaseType::TBuilderAndSolverType                          TBuilderAndSolverType;
-    typedef typename BaseType::TSchemeType                                              TSchemeType;
-    typedef typename BaseType::DofsArrayType                                          DofsArrayType;
-    typedef typename BaseType::TSystemMatrixType                                  TSystemMatrixType;
-    typedef typename BaseType::TSystemVectorType                                  TSystemVectorType;
+    using BaseType                 = ImplicitSolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver>;
+    using MotherType               = ResidualBasedNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>;
+    using TConvergenceCriteriaType = ConvergenceCriteria<TSparseSpace, TDenseSpace>;
+    using TBuilderAndSolverType    = typename BaseType::TBuilderAndSolverType;
+    using TSchemeType              = typename BaseType::TSchemeType;
+    using DofsArrayType            = typename BaseType::DofsArrayType;
+    using TSystemMatrixType        = typename BaseType::TSystemMatrixType;
+    using TSystemVectorType        = typename BaseType::TSystemVectorType;
     using MotherType::mpScheme;
     using MotherType::mpBuilderAndSolver;
     using MotherType::mpA; //Tangent matrix
@@ -51,8 +48,6 @@ public:
     using MotherType::mMaxIterationNumber;
     using MotherType::mInitializeWasPerformed;
 
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    ///Constructor
     /**
      * @brief Default constructor 
      * @param rModelPart The model part of the problem
@@ -126,21 +121,11 @@ public:
             }
         }
 
-    //------------------------------------------------------------------------------------
-
-    ///Destructor
-    ~GeoMechanicsNewtonRaphsonStrategy() override {}
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
 protected:
-
     /// Member Variables
     Parameters* mpParameters;
     std::vector<ModelPart*> mSubModelPartList; /// List of every SubModelPart associated to an external load
     std::vector<std::string> mVariableNames; /// Name of the nodal variable associated to every SubModelPart
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     int Check() override
     {
@@ -150,8 +135,6 @@ protected:
 
         KRATOS_CATCH( "" )
     }
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     double CalculateReferenceDofsNorm(DofsArrayType& rDofSet)
     {
@@ -166,7 +149,7 @@ protected:
             int k = OpenMPUtils::ThisThread();
 
             typename DofsArrayType::iterator DofsBegin = rDofSet.begin() + DofSetPartition[k];
-            typename DofsArrayType::iterator DofsEnd = rDofSet.begin() + DofSetPartition[k+1];
+            typename DofsArrayType::iterator DofsEnd   = rDofSet.begin() + DofSetPartition[k+1];
 
             for (typename DofsArrayType::iterator itDof = DofsBegin; itDof != DofsEnd; ++itDof)
             {
@@ -180,14 +163,6 @@ protected:
 
         return sqrt(ReferenceDofsNorm);
     }
-
-private:
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-
 }; // Class GeoMechanicsNewtonRaphsonStrategy
 
-} // namespace Kratos
-
-#endif // KRATOS_GEO_MECHANICS_NEWTON_RAPHSON_STRATEGY  defined
+}

--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_ramm_arc_length_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_ramm_arc_length_strategy.hpp
@@ -11,8 +11,7 @@
 //                   Vahid Galavi
 //
 
-#if !defined(KRATOS_GEO_MECHANICS_RAMM_ARC_LENGTH_STRATEGY)
-#define KRATOS_GEO_MECHANICS_RAMM_ARC_LENGTH_STRATEGY
+#pragma once
 
 // Project includes
 #include "custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp"
@@ -24,26 +23,23 @@ namespace Kratos
 {
 
 template<class TSparseSpace,class TDenseSpace,class TLinearSolver>
-
 class GeoMechanicsRammArcLengthStrategy :
   public GeoMechanicsNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>
 {
-
 public:
-
     KRATOS_CLASS_POINTER_DEFINITION(GeoMechanicsRammArcLengthStrategy);
 
-    typedef ImplicitSolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver>                   BaseType;
-    typedef ResidualBasedNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver> GrandMotherType;
-    typedef GeoMechanicsNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>       MotherType;
-    typedef ConvergenceCriteria<TSparseSpace, TDenseSpace>                      TConvergenceCriteriaType;
-    typedef typename BaseType::TBuilderAndSolverType                               TBuilderAndSolverType;
-    typedef typename BaseType::TSchemeType                                                   TSchemeType;
-    typedef TSparseSpace                                                                 SparseSpaceType;
-    typedef typename BaseType::DofsArrayType                                               DofsArrayType;
-    typedef typename BaseType::TSystemMatrixType                                       TSystemMatrixType;
-    typedef typename BaseType::TSystemVectorType                                       TSystemVectorType;
-    typedef typename BaseType::TSystemVectorPointerType                         TSystemVectorPointerType;
+    using BaseType                 = ImplicitSolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver>;
+    using GrandMotherType          = ResidualBasedNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>;
+    using MotherType               = GeoMechanicsNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>;
+    using TConvergenceCriteriaType = ConvergenceCriteria<TSparseSpace, TDenseSpace>;
+    using TBuilderAndSolverType    = typename BaseType::TBuilderAndSolverType;
+    using TSchemeType              = typename BaseType::TSchemeType;
+    using SparseSpaceType          = TSparseSpace;
+    using DofsArrayType            = typename BaseType::DofsArrayType;
+    using TSystemMatrixType        = typename BaseType::TSystemMatrixType;
+    using TSystemVectorType        = typename BaseType::TSystemVectorType;
+    using TSystemVectorPointerType = typename BaseType::TSystemVectorPointerType;
     using GrandMotherType::mpScheme;
     using GrandMotherType::mpBuilderAndSolver;
     using GrandMotherType::mpConvergenceCriteria;
@@ -57,8 +53,6 @@ public:
     using MotherType::mSubModelPartList;
     using MotherType::mVariableNames;
 
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    ///Constructor
     GeoMechanicsRammArcLengthStrategy(
         ModelPart& model_part,
         typename TSchemeType::Pointer pScheme,
@@ -86,21 +80,15 @@ public:
             mMinRadiusFactor   = rParameters["min_radius_factor"].GetDouble();
         }
 
-    //------------------------------------------------------------------------------------
-
-    ///Destructor
-    ~GeoMechanicsRammArcLengthStrategy() override {}
-
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     void Initialize() override
     {
         KRATOS_TRY
 
-        if (mInitializeWasPerformed == false)
+        if (!mInitializeWasPerformed)
         {
             MotherType::Initialize();
 
-            if (mInitializeArcLengthWasPerformed == false)
+            if (!mInitializeArcLengthWasPerformed)
             {
                 //set up the system
                 if (mpBuilderAndSolver->GetDofSetIsInitializedFlag() == false)
@@ -149,7 +137,6 @@ public:
         KRATOS_CATCH( "" )
     }
 
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     void InitializeSolutionStep() override
     {
         KRATOS_TRY
@@ -165,11 +152,9 @@ public:
         KRATOS_CATCH( "" )
     }
 
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     bool SolveSolutionStep() override
     {
         // ********** Prediction phase **********
-
         KRATOS_INFO("Ramm's Arc Length Strategy") << "ARC-LENGTH RADIUS: " << mRadius/mRadius_0 << " X initial radius" << std::endl;
 
         // Initialize variables
@@ -187,9 +172,8 @@ public:
         double NormDx;
         unsigned int iteration_number = 1;
         BaseType::GetModelPart().GetProcessInfo()[NL_ITERATION_NUMBER] = iteration_number;
-        bool is_converged = false;
         mpScheme->InitializeNonLinIteration(BaseType::GetModelPart(), mA, mDx, mb);
-        is_converged = mpConvergenceCriteria->PreCriteria(BaseType::GetModelPart(), rDofSet, mA, mDx, mb);
+        bool is_converged = mpConvergenceCriteria->PreCriteria(BaseType::GetModelPart(), rDofSet, mA, mDx, mb);
 
         TSparseSpace::SetToZero(mA);
         TSparseSpace::SetToZero(mb);
@@ -211,7 +195,7 @@ public:
         //move the mesh if needed
         if (BaseType::MoveMeshFlag()) BaseType::MoveMesh();
 
-        // ********** Correction phase (iteration cicle) **********
+        // ********** Correction phase (iteration cycle) **********
         if (is_converged) {
             mpConvergenceCriteria->InitializeSolutionStep(BaseType::GetModelPart(), rDofSet, mA, mDxf, mb);
             if (mpConvergenceCriteria->GetActualizeRHSflag()) {
@@ -272,7 +256,6 @@ public:
             mpScheme->FinalizeNonLinIteration(BaseType::GetModelPart(), mA, mDx, mb);
 
             // *** Check Convergence ***
-
             if (is_converged) {
                 if (mpConvergenceCriteria->GetActualizeRHSflag()) {
                     TSparseSpace::SetToZero(mb);
@@ -302,7 +285,6 @@ public:
         return is_converged;
     }
 
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     void FinalizeSolutionStep() override
     {
         KRATOS_TRY
@@ -357,7 +339,6 @@ public:
         KRATOS_CATCH("")
     }
 
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     void Clear() override
     {
         KRATOS_TRY
@@ -409,7 +390,6 @@ public:
     //     KRATOS_CATCH("")
     // }
 
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     virtual void UpdateLoads()
     {
         KRATOS_TRY
@@ -423,7 +403,6 @@ public:
         KRATOS_CATCH("")
     }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 protected:
 
     /// Member Variables
@@ -443,20 +422,18 @@ protected:
     double mNormxEquilibrium; /// Norm of the solution vector in equilibrium
     double mDLambdaStep; /// Delta lambda of the current step
 
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     int Check() override
     {
         KRATOS_TRY
 
         return MotherType::Check();
 
-        KRATOS_CATCH( "" )
+        KRATOS_CATCH("")
     }
 
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     void InitializeSystemVector(TSystemVectorPointerType& pv)
     {
-        if (pv == NULL)
+        if (pv == nullptr)
         {
             TSystemVectorPointerType pNewv = TSystemVectorPointerType(new TSystemVectorType(0));
             pv.swap(pNewv);
@@ -468,10 +445,9 @@ protected:
             v.resize(mpBuilderAndSolver->GetEquationSystemSize(), false);
     }
 
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     void SaveInitializeSystemVector(TSystemVectorPointerType& pv)
     {
-        if (pv == NULL)
+        if (pv == nullptr)
         {
             TSystemVectorPointerType pNewv = TSystemVectorPointerType(new TSystemVectorType(0));
             pv.swap(pNewv);
@@ -483,7 +459,6 @@ protected:
             v.resize(mpBuilderAndSolver->GetEquationSystemSize(), true);
     }
 
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     void BuildWithDirichlet(TSystemMatrixType& mA, TSystemVectorType& mDx, TSystemVectorType& mb)
     {
         KRATOS_TRY
@@ -491,10 +466,9 @@ protected:
         mpBuilderAndSolver->Build(mpScheme, BaseType::GetModelPart(), mA, mb);
         mpBuilderAndSolver->ApplyDirichletConditions(mpScheme, BaseType::GetModelPart(), mA, mDx, mb);
 
-        KRATOS_CATCH( "" )
+        KRATOS_CATCH("")
     }
 
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     virtual void Update(DofsArrayType& rDofSet,
                         TSystemMatrixType& mA,
                         TSystemVectorType& mDx,
@@ -508,10 +482,9 @@ protected:
         // Update External Loads
         this->UpdateExternalLoads();
 
-        KRATOS_CATCH( "" )
+        KRATOS_CATCH("")
     }
 
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     void ClearStep()
     {
         KRATOS_TRY
@@ -533,10 +506,9 @@ protected:
 
         GrandMotherType::Clear();
 
-        KRATOS_CATCH("");
+        KRATOS_CATCH("")
     }
 
-    //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     void UpdateExternalLoads()
     {
         // Update External Loads
@@ -578,11 +550,11 @@ protected:
                     for (ModelPart::NodeIterator itNode = NodesBegin; itNode != NodesEnd; ++itNode)
                     {
                         double& rvaluex = itNode->FastGetSolutionStepValue(varx);
-                        rvaluex *= (mLambda/mLambda_old);
+                        rvaluex *= mLambda/mLambda_old;
                         double& rvaluey = itNode->FastGetSolutionStepValue(vary);
-                        rvaluey *= (mLambda/mLambda_old);
+                        rvaluey *= mLambda/mLambda_old;
                         double& rvaluez = itNode->FastGetSolutionStepValue(varz);
-                        rvaluez *= (mLambda/mLambda_old);
+                        rvaluez *= mLambda/mLambda_old;
                     }
                 }
             }
@@ -597,9 +569,6 @@ protected:
         // Save the applied Lambda factor
         mLambda_old = mLambda;
     }
-
 }; // Class GeoMechanicsRammArcLengthStrategy
 
-} // namespace Kratos
-
-#endif // KRATOS_GEO_MECHANICS_RAMM_ARC_LENGTH_STRATEGY  defined
+}


### PR DESCRIPTION
**📝 Description**
Addressed several code smells reported by SonarCloud for custom strategies. Also fixed several problems reported by clang-tidy.

**🆕 Changelog**
- Replaced `typedef`s by `using` aliases.
- Made some `protected` data members `private`.
- Prefer using `!empty()` over `size() != 0`.
- Removed some redundant pairs of parentheses.
- Made a single-argument constructor `explicit`.
- Replaced some occurrences of `NULL` by `nullptr`.

Other improvements include:
- Removed several unused `typedef`s.
- Removed `PrintInfo` override that is identical to the base class implementation.
- Replaced some old-style inclusion guards by `#pragma once`.
- Use `KRATOS_ERROR_IF_NOT` when an error should be raised if some condition does not hold.
- Removed some redundant comments and blank lines.
- Fixed some spelling mistakes.
- Applied the "rule of zero" (C.20 of the C++ Core Guidelines) where appropriate.
