### PR TITLE
[GeoMechanicsApplication] Reduced code smells of custom constitutive laws

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/bilinear_cohesive_2D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/bilinear_cohesive_2D_law.cpp
@@ -12,27 +12,15 @@
 //                   Vahid Galavi
 //
 
-
 // Application includes
 #include "custom_constitutive/bilinear_cohesive_2D_law.hpp"
+#include "utilities/math_utils.h"
+#include "geo_mechanics_application_constants.h"
 
 namespace Kratos
 {
 
-//Default Constructor
-BilinearCohesive2DLaw::BilinearCohesive2DLaw() : BilinearCohesive3DLaw() {}
-
-//----------------------------------------------------------------------------------------
-
-//Copy Constructor
-BilinearCohesive2DLaw::BilinearCohesive2DLaw(const BilinearCohesive2DLaw& rOther) : BilinearCohesive3DLaw(rOther) {}
-
-//----------------------------------------------------------------------------------------
-
-//Destructor
-BilinearCohesive2DLaw::~BilinearCohesive2DLaw() {}
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+BilinearCohesive2DLaw::BilinearCohesive2DLaw() = default;
 
 void BilinearCohesive2DLaw::GetLawFeatures(Features& rFeatures)
 {
@@ -41,18 +29,15 @@ void BilinearCohesive2DLaw::GetLawFeatures(Features& rFeatures)
     rFeatures.mOptions.Set( INFINITESIMAL_STRAINS );
     rFeatures.mOptions.Set( ISOTROPIC );
 
-    //Set strain measure required by the consitutive law
+    //Set strain measure required by the constitutive law
     rFeatures.mStrainMeasures.push_back(StrainMeasure_Infinitesimal);
-    //rFeatures.mStrainMeasures.push_back(StrainMeasure_Deformation_Gradient);
 
-    //Set the spacedimension
+    //Set the space dimension
     rFeatures.mSpaceDimension = WorkingSpaceDimension();
 
     //Set the strain size
     rFeatures.mStrainSize = GetStrainSize();
 }
-
-//----------------------------------------------------------------------------------------
 
 ConstitutiveLaw::Pointer BilinearCohesive2DLaw::Clone() const
 {
@@ -60,43 +45,34 @@ ConstitutiveLaw::Pointer BilinearCohesive2DLaw::Clone() const
     return p_clone;
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-void BilinearCohesive2DLaw::
-    ComputeEquivalentStrain(double& rEquivalentStrain,
-                            const Vector& StrainVector,
-                            const double& CriticalDisplacement)
+void BilinearCohesive2DLaw::ComputeEquivalentStrain(double& rEquivalentStrain,
+                                                    const Vector& StrainVector,
+                                                    const double& CriticalDisplacement)
 {
     KRATOS_TRY
 
-    rEquivalentStrain = sqrt(StrainVector[0]*StrainVector[0]+StrainVector[1]*StrainVector[1])/CriticalDisplacement;
+    rEquivalentStrain = MathUtils<>::Norm(StrainVector) / CriticalDisplacement;
 
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-
-void BilinearCohesive2DLaw::
-    ComputeEquivalentStrainContact(double& rEquivalentStrain,
-                                   const Vector& StrainVector,
-                                   const double& CriticalDisplacement)
+void BilinearCohesive2DLaw::ComputeEquivalentStrainContact(double& rEquivalentStrain,
+                                                           const Vector& StrainVector,
+                                                           const double& CriticalDisplacement)
 {
     KRATOS_TRY
 
-    rEquivalentStrain = fabs(StrainVector[0])/CriticalDisplacement;
+    rEquivalentStrain = std::abs(StrainVector[0]) / CriticalDisplacement;
 
     KRATOS_CATCH("")
 
 }
 
-//----------------------------------------------------------------------------------------
-
-void BilinearCohesive2DLaw::
-    ComputeConstitutiveMatrixLoading(Matrix& rConstitutiveMatrix,
-                                     const Vector& StrainVector,
-                                     const double& YieldStress,
-                                     const double& DamageThreshold,
-                                     const double& CriticalDisplacement)
+void BilinearCohesive2DLaw::ComputeConstitutiveMatrixLoading(Matrix& rConstitutiveMatrix,
+                                                             const Vector& StrainVector,
+                                                             const double& YieldStress,
+                                                             const double& DamageThreshold,
+                                                             const double& CriticalDisplacement)
 {
     KRATOS_TRY
 
@@ -110,19 +86,15 @@ void BilinearCohesive2DLaw::
     rConstitutiveMatrix(1,0) = rConstitutiveMatrix(0,1);
 
     KRATOS_CATCH("")
-
 }
 
-//----------------------------------------------------------------------------------------
-
-void BilinearCohesive2DLaw::
-    ComputeConstitutiveMatrixContactLoading(Matrix& rConstitutiveMatrix,
-                                            const Vector& StrainVector,
-                                            const double& YoungModulus,
-                                            const double& FrictionCoefficient,
-                                            const double& YieldStress,
-                                            const double& DamageThreshold,
-                                            const double& CriticalDisplacement)
+void BilinearCohesive2DLaw::ComputeConstitutiveMatrixContactLoading(Matrix& rConstitutiveMatrix,
+                                                                    const Vector& StrainVector,
+                                                                    const double& YoungModulus,
+                                                                    const double& FrictionCoefficient,
+                                                                    const double& YieldStress,
+                                                                    const double& DamageThreshold,
+                                                                    const double& CriticalDisplacement)
 {
     KRATOS_TRY
 
@@ -130,36 +102,24 @@ void BilinearCohesive2DLaw::
                                 StrainVector[0]*StrainVector[0]/(CriticalDisplacement*CriticalDisplacement*mStateVariable*mStateVariable*mStateVariable) );
     rConstitutiveMatrix(1,1) = YoungModulus/(DamageThreshold*CriticalDisplacement);
 
-    if(StrainVector[0] > 1.0e-20)
-    {
-        rConstitutiveMatrix(0,1) = -YieldStress*StrainVector[0]*StrainVector[1]/( (1.0-DamageThreshold)*
-                                    CriticalDisplacement*CriticalDisplacement*CriticalDisplacement*mStateVariable*mStateVariable*mStateVariable ) -
-                                    YoungModulus*FrictionCoefficient/(DamageThreshold*CriticalDisplacement);
-    }
-    else if(StrainVector[0] < -1.0e-20)
-    {
-        rConstitutiveMatrix(0,1) = -YieldStress*StrainVector[0]*StrainVector[1]/( (1.0-DamageThreshold)*
-                                    CriticalDisplacement*CriticalDisplacement*CriticalDisplacement*mStateVariable*mStateVariable*mStateVariable ) +
-                                    YoungModulus*FrictionCoefficient/(DamageThreshold*CriticalDisplacement);
-    }
-    else
-    {
+    if (std::abs(StrainVector[0]) <= 1.e-20) {
         rConstitutiveMatrix(0,1) = 0.0;
+    } else {
+        rConstitutiveMatrix(0,1) = - YieldStress*StrainVector[0]*StrainVector[1]/( (1.0-DamageThreshold)*
+                                          CriticalDisplacement*CriticalDisplacement*CriticalDisplacement*mStateVariable*mStateVariable*mStateVariable )
+                                        - std::copysign(1.0, StrainVector[0])
+                                          * YoungModulus*FrictionCoefficient/(DamageThreshold*CriticalDisplacement);
     }
 
     rConstitutiveMatrix(1,0) = 0.0;
 
     KRATOS_CATCH("")
-
 }
 
-//----------------------------------------------------------------------------------------
-
-void BilinearCohesive2DLaw::
-    ComputeConstitutiveMatrixUnloading(Matrix& rConstitutiveMatrix,
-                                       const double& YieldStress,
-                                       const double& DamageThreshold,
-                                       const double& CriticalDisplacement)
+void BilinearCohesive2DLaw::ComputeConstitutiveMatrixUnloading(Matrix& rConstitutiveMatrix,
+                                                               const double& YieldStress,
+                                                               const double& DamageThreshold,
+                                                               const double& CriticalDisplacement)
 {
     KRATOS_TRY
 
@@ -170,51 +130,38 @@ void BilinearCohesive2DLaw::
     rConstitutiveMatrix(1,0) = 0.0;
 
     KRATOS_CATCH("")
-
 }
 
-//----------------------------------------------------------------------------------------
-
-void BilinearCohesive2DLaw::
-    ComputeConstitutiveMatrixContactUnloading(Matrix& rConstitutiveMatrix,
-                                              const Vector& StrainVector,
-                                              const double& YoungModulus,
-                                              const double& FrictionCoefficient,
-                                              const double& YieldStress,
-                                              const double& DamageThreshold,
-                                              const double& CriticalDisplacement)
+void BilinearCohesive2DLaw::ComputeConstitutiveMatrixContactUnloading(Matrix& rConstitutiveMatrix,
+                                                                      const Vector& StrainVector,
+                                                                      const double& YoungModulus,
+                                                                      const double& FrictionCoefficient,
+                                                                      const double& YieldStress,
+                                                                      const double& DamageThreshold,
+                                                                      const double& CriticalDisplacement)
 {
     KRATOS_TRY
 
     rConstitutiveMatrix(0,0) = YieldStress/(CriticalDisplacement*mStateVariable)*(1.0-mStateVariable)/(1.0-DamageThreshold);
     rConstitutiveMatrix(1,1) = YoungModulus/(DamageThreshold*CriticalDisplacement);
 
-    if(StrainVector[0] > 1.0e-20)
-    {
-        rConstitutiveMatrix(0,1) = -YoungModulus*FrictionCoefficient/(DamageThreshold*CriticalDisplacement);
-    }
-    else if(StrainVector[0] < -1.0e-20)
-    {
-        rConstitutiveMatrix(0,1) = YoungModulus*FrictionCoefficient/(DamageThreshold*CriticalDisplacement);
-    }
-    else
-    {
+    if (std::abs(StrainVector[0]) <= 1.e-20) {
         rConstitutiveMatrix(0,1) = 0.0;
+    } else {
+        rConstitutiveMatrix(0,1) = - std::copysign(1.0, StrainVector[0])
+                                          * YoungModulus*FrictionCoefficient/(DamageThreshold*CriticalDisplacement);
     }
 
     rConstitutiveMatrix(1,0) = 0.0;
-    KRATOS_CATCH("")
 
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-
-void BilinearCohesive2DLaw::
-    ComputeStressVector(Vector& rStressVector,
-                        const Vector& StrainVector,
-                        const double& YieldStress,
-                        const double& DamageThreshold,
-                        const double& CriticalDisplacement)
+void BilinearCohesive2DLaw::ComputeStressVector(Vector& rStressVector,
+                                                const Vector& StrainVector,
+                                                const double& YieldStress,
+                                                const double& DamageThreshold,
+                                                const double& CriticalDisplacement)
 {
     KRATOS_TRY
 
@@ -222,40 +169,30 @@ void BilinearCohesive2DLaw::
     rStressVector[1] = YieldStress/(CriticalDisplacement*mStateVariable)*(1.0-mStateVariable)/(1.0-DamageThreshold) * StrainVector[1];
 
     KRATOS_CATCH("")
-
 }
 
-//----------------------------------------------------------------------------------------
-
-void BilinearCohesive2DLaw::
-    ComputeStressVectorContact(Vector& rStressVector,
-                               const Vector& StrainVector,
-                               const double& YoungModulus,
-                               const double& FrictionCoefficient,
-                               const double& YieldStress,
-                               const double& DamageThreshold,
-                               const double& CriticalDisplacement)
+void BilinearCohesive2DLaw::ComputeStressVectorContact(Vector& rStressVector,
+                                                       const Vector& StrainVector,
+                                                       const double& YoungModulus,
+                                                       const double& FrictionCoefficient,
+                                                       const double& YieldStress,
+                                                       const double& DamageThreshold,
+                                                       const double& CriticalDisplacement)
 {
     KRATOS_TRY
 
     // Note: StrainVector[1] < 0.0
-    rStressVector[1] = YoungModulus/(DamageThreshold*CriticalDisplacement)*StrainVector[1];
+    rStressVector[indexStress2DInterface::INDEX_2D_INTERFACE_ZZ] = YoungModulus/(DamageThreshold*CriticalDisplacement)*StrainVector[indexStress2DInterface::INDEX_2D_INTERFACE_ZZ];
 
-    if(StrainVector[0] > 1.0e-20)
-    {
-        rStressVector[0] = YieldStress/(CriticalDisplacement*mStateVariable)*(1.0-mStateVariable)/(1.0-DamageThreshold)*StrainVector[0] - FrictionCoefficient*rStressVector[1];
-    }
-    else if(StrainVector[0] < -1.0e-20)
-    {
-        rStressVector[0] = YieldStress/(CriticalDisplacement*mStateVariable)*(1.0-mStateVariable)/(1.0-DamageThreshold)*StrainVector[0] + FrictionCoefficient*rStressVector[1];
-    }
-    else
-    {
-        rStressVector[0] = 0.0;
+    if (std::abs(StrainVector[indexStress2DInterface::INDEX_2D_INTERFACE_XZ]) <= 1.e-20) {
+        rStressVector[indexStress2DInterface::INDEX_2D_INTERFACE_XZ] = 0.0;
+    } else {
+        rStressVector[indexStress2DInterface::INDEX_2D_INTERFACE_XZ] =
+                YieldStress/(CriticalDisplacement*mStateVariable)*(1.0-mStateVariable)/(1.0-DamageThreshold)*StrainVector[indexStress2DInterface::INDEX_2D_INTERFACE_XZ]
+                - std::copysign(1.0, StrainVector[indexStress2DInterface::INDEX_2D_INTERFACE_XZ]) * FrictionCoefficient*rStressVector[indexStress2DInterface::INDEX_2D_INTERFACE_ZZ];
     }
 
     KRATOS_CATCH("")
-
 }
 
 } // Namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_constitutive/bilinear_cohesive_2D_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/bilinear_cohesive_2D_law.hpp
@@ -13,8 +13,7 @@
 //
 
 
-#if !defined (KRATOS_BILINEAR_COHESIVE_2D_LAW_H_INCLUDED)
-#define  KRATOS_BILINEAR_COHESIVE_2D_LAW_H_INCLUDED
+#pragma once
 
 // Project includes
 #include "includes/serializer.h"
@@ -32,72 +31,51 @@ public:
 
     KRATOS_CLASS_POINTER_DEFINITION(BilinearCohesive2DLaw);
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-    // Default Constructor
     BilinearCohesive2DLaw();
-
-    // Copy Constructor
-    BilinearCohesive2DLaw (const BilinearCohesive2DLaw& rOther);
-
-    // Destructor
-    ~BilinearCohesive2DLaw() override;
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     void GetLawFeatures(Features& rFeatures) override;
 
     ConstitutiveLaw::Pointer Clone() const override;
 
-    virtual SizeType GetStrainSize() const override
+    SizeType GetStrainSize() const override
     {
         return 2;
     }
 
-    virtual SizeType WorkingSpaceDimension() override
+    SizeType WorkingSpaceDimension() override
     {
         return 2;
     }
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 protected:
-
-    // Member Variables
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
     void ComputeEquivalentStrain(double& rEquivalentStrain,const Vector& StrainVector,const double& CriticalDisplacement) override;
 
     void ComputeEquivalentStrainContact(double& rEquivalentStrain,const Vector& StrainVector,const double& CriticalDisplacement) override;
 
 
     void ComputeConstitutiveMatrixLoading(Matrix& rConstitutiveMatrix,const Vector& StrainVector,const double& JointStrength,
-                                                        const double& DamageThreshold,const double& CriticalDisplacement) override;
+                                          const double& DamageThreshold,const double& CriticalDisplacement) override;
 
     void ComputeConstitutiveMatrixContactLoading(Matrix& rConstitutiveMatrix,const Vector& StrainVector,const double& YoungModulus,const double& FrictionCoefficient,
-                                                            const double& JointStrength,const double& DamageThreshold,const double& CriticalDisplacement) override;
+                                                 const double& JointStrength,const double& DamageThreshold,const double& CriticalDisplacement) override;
 
 
     void ComputeConstitutiveMatrixUnloading(Matrix& rConstitutiveMatrix,const double& JointStrength,
-                                                        const double& DamageThreshold,const double& CriticalDisplacement) override;
+                                            const double& DamageThreshold,const double& CriticalDisplacement) override;
 
     void ComputeConstitutiveMatrixContactUnloading(Matrix& rConstitutiveMatrix,const Vector& StrainVector,const double& YoungModulus,const double& FrictionCoefficient,
-                                                            const double& JointStrength,const double& DamageThreshold,const double& CriticalDisplacement) override;
+                                                   const double& JointStrength,const double& DamageThreshold,const double& CriticalDisplacement) override;
 
 
     void ComputeStressVector(Vector& rStressVector,const Vector& StrainVector,const double& JointStrength,
-                                                const double& DamageThreshold,const double& CriticalDisplacement) override;
+                             const double& DamageThreshold,const double& CriticalDisplacement) override;
 
     void ComputeStressVectorContact(Vector& rStressVector,const Vector& StrainVector,const double& YoungModulus,const double& FrictionCoefficient,
-                                                        const double& JointStrength,const double& DamageThreshold,const double& CriticalDisplacement) override;
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                    const double& JointStrength,const double& DamageThreshold,const double& CriticalDisplacement) override;
 
 private:
 
     // Serialization
-
     friend class Serializer;
 
     void save(Serializer& rSerializer) const override
@@ -111,5 +89,5 @@ private:
     }
 
 }; // Class BilinearCohesive2DLaw
-}  // namespace Kratos.
-#endif // KRATOS_BILINEAR_COHESIVE_2D_LAW_H_INCLUDED  defined
+
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/bilinear_cohesive_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/bilinear_cohesive_3D_law.cpp
@@ -12,27 +12,14 @@
 //                   Vahid Galavi
 //
 
-
 // Application includes
 #include "custom_constitutive/bilinear_cohesive_3D_law.hpp"
+#include "utilities/math_utils.h"
 
 namespace Kratos
 {
 
-//Default Constructor
-BilinearCohesive3DLaw::BilinearCohesive3DLaw() : ConstitutiveLaw() {}
-
-//----------------------------------------------------------------------------------------
-
-//Copy Constructor
-BilinearCohesive3DLaw::BilinearCohesive3DLaw(const BilinearCohesive3DLaw& rOther) : ConstitutiveLaw(rOther) {}
-
-//----------------------------------------------------------------------------------------
-
-//Destructor
-BilinearCohesive3DLaw::~BilinearCohesive3DLaw() {}
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+BilinearCohesive3DLaw::BilinearCohesive3DLaw() = default;
 
 void BilinearCohesive3DLaw::GetLawFeatures(Features& rFeatures)
 {
@@ -41,24 +28,21 @@ void BilinearCohesive3DLaw::GetLawFeatures(Features& rFeatures)
     rFeatures.mOptions.Set( INFINITESIMAL_STRAINS );
     rFeatures.mOptions.Set( ISOTROPIC );
 
-    //Set strain measure required by the consitutive law
+    //Set strain measure required by the constitutive law
     rFeatures.mStrainMeasures.push_back(StrainMeasure_Infinitesimal);
-    //rFeatures.mStrainMeasures.push_back(StrainMeasure_Deformation_Gradient);
 
-    //Set the spacedimension
+    //Set the space dimension
     rFeatures.mSpaceDimension = WorkingSpaceDimension();
 
     //Set the strain size
     rFeatures.mStrainSize = GetStrainSize();
 }
 
-//----------------------------------------------------------------------------------------
 int BilinearCohesive3DLaw::
     Check(const Properties& rMaterialProperties,
           const GeometryType& rElementGeometry,
           const ProcessInfo& rCurrentProcessInfo) const
 {
-    // Verify ProcessInfo variables
     // Verify Properties variables
     if (rMaterialProperties.Has( CRITICAL_DISPLACEMENT ) == false || rMaterialProperties[CRITICAL_DISPLACEMENT] <= 0.0)
         KRATOS_ERROR << "CRITICAL_DISPLACEMENT has Key zero, is not defined or has an invalid value for property: " << rMaterialProperties.Id() << std::endl;
@@ -79,14 +63,12 @@ int BilinearCohesive3DLaw::
     return 0;
 }
 
-//----------------------------------------------------------------------------------------
 ConstitutiveLaw::Pointer BilinearCohesive3DLaw::Clone() const
 {
     BilinearCohesive3DLaw::Pointer p_clone(new BilinearCohesive3DLaw(*this));
     return p_clone;
 }
 
-//----------------------------------------------------------------------------------------
 void BilinearCohesive3DLaw::
     InitializeMaterial( const Properties& rMaterialProperties,
                         const GeometryType& rElementGeometry,
@@ -95,83 +77,51 @@ void BilinearCohesive3DLaw::
     mStateVariable = rMaterialProperties[DAMAGE_THRESHOLD];
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 void BilinearCohesive3DLaw::CalculateMaterialResponseCauchy(Parameters& rValues)
 {
     KRATOS_TRY
+
     //Check
     rValues.CheckAllParameters();
 
     //Initialize main variables
-    Vector& rStrainVector = rValues.GetStrainVector();
+    const Vector& rStrainVector = rValues.GetStrainVector();
     double EquivalentStrain;
 
     //Material properties
-    Flags& Options = rValues.GetOptions();
+    const Flags& Options = rValues.GetOptions();
     const Properties& MaterialProperties = rValues.GetMaterialProperties();
-    const double& CriticalDisplacement = MaterialProperties[CRITICAL_DISPLACEMENT];
-    const double& DamageThreshold = MaterialProperties[DAMAGE_THRESHOLD];
-    const double& YieldStress = MaterialProperties[YIELD_STRESS];
+    const double& CriticalDisplacement   = MaterialProperties[CRITICAL_DISPLACEMENT];
+    const double& DamageThreshold        = MaterialProperties[DAMAGE_THRESHOLD];
+    const double& YieldStress            = MaterialProperties[YIELD_STRESS];
 
     if ( Options.Is(ConstitutiveLaw::COMPUTE_STRAIN_ENERGY) )
     {
-         // No contact between interfaces
+        // No contact between interfaces
         this->ComputeEquivalentStrain(EquivalentStrain,rStrainVector,CriticalDisplacement);
 
         if (Options.Is(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR))
         {
-            if (Options.IsNot(ConstitutiveLaw::COMPUTE_STRESS))
-            {
-                // COMPUTE_CONSTITUTIVE_TENSOR
-                Matrix& rConstitutiveMatrix = rValues.GetConstitutiveMatrix();
+            // COMPUTE_CONSTITUTIVE_TENSOR
+            Matrix& rConstitutiveMatrix = rValues.GetConstitutiveMatrix();
 
-                if(EquivalentStrain >= mStateVariable) //Loading
-                {
-                    this->ComputeConstitutiveMatrixLoading(rConstitutiveMatrix,
-                                                           rStrainVector,
-                                                           YieldStress,
-                                                           DamageThreshold,
-                                                           CriticalDisplacement);
-                }
-                else //Unloading
-                {
-                    this->ComputeConstitutiveMatrixUnloading(rConstitutiveMatrix,
-                                                             YieldStress,
-                                                             DamageThreshold,
-                                                             CriticalDisplacement);
-                }
+            if (EquivalentStrain >= mStateVariable) //Loading
+            {
+                this->ComputeConstitutiveMatrixLoading(rConstitutiveMatrix,
+                                                       rStrainVector,
+                                                       YieldStress,
+                                                       DamageThreshold,
+                                                       CriticalDisplacement);
             }
-            else
+            else //Unloading
             {
-                // COMPUTE_CONSTITUTIVE_TENSOR && COMPUTE_STRESS
-                Matrix& rConstitutiveMatrix = rValues.GetConstitutiveMatrix();
-                Vector& rStressVector = rValues.GetStressVector();
-
-                if(EquivalentStrain >= mStateVariable)
-                {
-                    // loading
-                    this->ComputeConstitutiveMatrixLoading(rConstitutiveMatrix,
-                                                           rStrainVector,
-                                                           YieldStress,
-                                                           DamageThreshold,
-                                                           CriticalDisplacement);
-                }
-                else
-                {
-                    // unloading
-                    this->ComputeConstitutiveMatrixUnloading(rConstitutiveMatrix,
-                                                             YieldStress,
-                                                             DamageThreshold,
-                                                             CriticalDisplacement);
-                }
-                this->ComputeStressVector(rStressVector,
-                                          rStrainVector,
-                                          YieldStress,
-                                          DamageThreshold,
-                                          CriticalDisplacement);
+                this->ComputeConstitutiveMatrixUnloading(rConstitutiveMatrix,
+                                                         YieldStress,
+                                                         DamageThreshold,
+                                                         CriticalDisplacement);
             }
         }
-        else if (Options.Is(ConstitutiveLaw::COMPUTE_STRESS))
+        if (Options.Is(ConstitutiveLaw::COMPUTE_STRESS))
         {
             // COMPUTE_STRESS
             Vector& rStressVector = rValues.GetStressVector();
@@ -185,77 +135,41 @@ void BilinearCohesive3DLaw::CalculateMaterialResponseCauchy(Parameters& rValues)
     }
     else  // Contact between interfaces
     {
-        const double& YoungModulus = MaterialProperties[YOUNG_MODULUS];
+        const double& YoungModulus        = MaterialProperties[YOUNG_MODULUS];
         const double& FrictionCoefficient = MaterialProperties[FRICTION_COEFFICIENT];
 
-        this->ComputeEquivalentStrainContact(EquivalentStrain,rStrainVector,CriticalDisplacement);
+        this->ComputeEquivalentStrainContact(EquivalentStrain, rStrainVector, CriticalDisplacement);
 
         if (Options.Is(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR))
         {
-            if (Options.IsNot(ConstitutiveLaw::COMPUTE_STRESS))
-            {
-                // COMPUTE_CONSTITUTIVE_TENSOR
-                Matrix& rConstitutiveMatrix = rValues.GetConstitutiveMatrix();
+            // COMPUTE CONSTITUTIVE TENSOR
+            Matrix& rConstitutiveMatrix = rValues.GetConstitutiveMatrix();
 
-                if(EquivalentStrain >= mStateVariable) //Loading
-                {
-                    this->ComputeConstitutiveMatrixContactLoading(rConstitutiveMatrix,
-                                                                  rStrainVector,
-                                                                  YoungModulus,
-                                                                  FrictionCoefficient,
-                                                                  YieldStress,
-                                                                  DamageThreshold,
-                                                                  CriticalDisplacement);
-                }
-                else //Unloading
-                {
-                    this->ComputeConstitutiveMatrixContactUnloading(rConstitutiveMatrix,
-                                                                    rStrainVector,
-                                                                    YoungModulus,
-                                                                    FrictionCoefficient,
-                                                                    YieldStress,
-                                                                    DamageThreshold,
-                                                                    CriticalDisplacement);
-                }
+            if (EquivalentStrain >= mStateVariable) //Loading
+            {
+                this->ComputeConstitutiveMatrixContactLoading(rConstitutiveMatrix,
+                                                              rStrainVector,
+                                                              YoungModulus,
+                                                              FrictionCoefficient,
+                                                              YieldStress,
+                                                              DamageThreshold,
+                                                              CriticalDisplacement);
             }
-            else
+            else //Unloading
             {
-                // COMPUTE_CONSTITUTIVE_TENSOR && COMPUTE_STRESS
-                Matrix& rConstitutiveMatrix = rValues.GetConstitutiveMatrix();
-                Vector& rStressVector = rValues.GetStressVector();
-
-                if(EquivalentStrain >= mStateVariable) //Loading
-                {
-                    this->ComputeConstitutiveMatrixContactLoading(rConstitutiveMatrix,
-                                                                  rStrainVector,
-                                                                  YoungModulus,
-                                                                  FrictionCoefficient,
-                                                                  YieldStress,
-                                                                  DamageThreshold,
-                                                                  CriticalDisplacement);
-                }
-                else //Unloading
-                {
-                    this->ComputeConstitutiveMatrixContactUnloading(rConstitutiveMatrix,
-                                                                    rStrainVector,
-                                                                    YoungModulus,
-                                                                    FrictionCoefficient,
-                                                                    YieldStress,
-                                                                    DamageThreshold,
-                                                                    CriticalDisplacement);
-                }
-                this->ComputeStressVectorContact(rStressVector,
-                                                 rStrainVector,
-                                                 YoungModulus,
-                                                 FrictionCoefficient,
-                                                 YieldStress,
-                                                 DamageThreshold,
-                                                 CriticalDisplacement);
+                this->ComputeConstitutiveMatrixContactUnloading(rConstitutiveMatrix,
+                                                                rStrainVector,
+                                                                YoungModulus,
+                                                                FrictionCoefficient,
+                                                                YieldStress,
+                                                                DamageThreshold,
+                                                                CriticalDisplacement);
             }
         }
-        else if(Options.Is(ConstitutiveLaw::COMPUTE_STRESS))
+
+        if(Options.Is(ConstitutiveLaw::COMPUTE_STRESS))
         {
-            // COMPUTE_STRESS
+            // COMPUTE STRESS
             Vector& rStressVector = rValues.GetStressVector();
 
             this->ComputeStressVectorContact(rStressVector,
@@ -270,11 +184,9 @@ void BilinearCohesive3DLaw::CalculateMaterialResponseCauchy(Parameters& rValues)
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-
 void BilinearCohesive3DLaw::FinalizeMaterialResponseCauchy( Parameters& rValues )
 {
-    if (rValues.GetProcessInfo()[IS_CONVERGED]==true) //Convergence is achieved. Save equilibrium state variable
+    if (rValues.GetProcessInfo()[IS_CONVERGED]) //Convergence is achieved. Save equilibrium state variable
     {
         //Check
         rValues.CheckAllParameters();
@@ -297,15 +209,10 @@ void BilinearCohesive3DLaw::FinalizeMaterialResponseCauchy( Parameters& rValues 
             this->ComputeEquivalentStrainContact(EquivalentStrain,rStrainVector,CriticalDisplacement);
         }
 
-        if (EquivalentStrain >= mStateVariable)
-        {
-            mStateVariable = EquivalentStrain;
-            if(mStateVariable > 1.0) mStateVariable = 1.0;
-        }
+        if (EquivalentStrain >= mStateVariable) mStateVariable = std::min(EquivalentStrain, 1.0);
     }
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 double& BilinearCohesive3DLaw::GetValue( const Variable<double>& rThisVariable, double& rValue )
 {
     if ( rThisVariable == DAMAGE_VARIABLE || rThisVariable == STATE_VARIABLE )
@@ -316,7 +223,6 @@ double& BilinearCohesive3DLaw::GetValue( const Variable<double>& rThisVariable, 
     return rValue;
 }
 
-//----------------------------------------------------------------------------------------
 void BilinearCohesive3DLaw::SetValue(const Variable<double>& rThisVariable,
                                      const double& rValue,
                                      const ProcessInfo& rCurrentProcessInfo )
@@ -327,25 +233,20 @@ void BilinearCohesive3DLaw::SetValue(const Variable<double>& rThisVariable,
     }
 }
 
-//----------------------------------------------------------------------------------------
 void BilinearCohesive3DLaw::SetValue(const Variable<Vector>& rThisVariable,
                                      const Vector& rValue,
                                      const ProcessInfo& rCurrentProcessInfo )
 {
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
 void BilinearCohesive3DLaw::ComputeEquivalentStrain(double& rEquivalentStrain,const Vector& StrainVector,const double& CriticalDisplacement)
 {
     KRATOS_TRY
 
-    rEquivalentStrain = sqrt(StrainVector[0]*StrainVector[0]+StrainVector[1]*StrainVector[1]+StrainVector[2]*StrainVector[2])/CriticalDisplacement;
+    rEquivalentStrain = MathUtils<>::Norm(StrainVector) / CriticalDisplacement;
 
     KRATOS_CATCH("")
 }
-
-//----------------------------------------------------------------------------------------
 
 void BilinearCohesive3DLaw::ComputeEquivalentStrainContact(double& rEquivalentStrain,const Vector& StrainVector,const double& CriticalDisplacement)
 {
@@ -355,8 +256,6 @@ void BilinearCohesive3DLaw::ComputeEquivalentStrainContact(double& rEquivalentSt
 
     KRATOS_CATCH("")
 }
-
-//----------------------------------------------------------------------------------------
 
 void BilinearCohesive3DLaw::
     ComputeConstitutiveMatrixLoading(Matrix& rConstitutiveMatrix,
@@ -385,15 +284,13 @@ void BilinearCohesive3DLaw::
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-void BilinearCohesive3DLaw::
-    ComputeConstitutiveMatrixContactLoading(Matrix& rConstitutiveMatrix,
-                                            const Vector& StrainVector,
-                                            const double& YoungModulus,
-                                            const double& FrictionCoefficient,
-                                            const double& YieldStress,
-                                            const double& DamageThreshold,
-                                            const double& CriticalDisplacement)
+void BilinearCohesive3DLaw::ComputeConstitutiveMatrixContactLoading(Matrix& rConstitutiveMatrix,
+                                                                    const Vector& StrainVector,
+                                                                    const double& YoungModulus,
+                                                                    const double& FrictionCoefficient,
+                                                                    const double& YieldStress,
+                                                                    const double& DamageThreshold,
+                                                                    const double& CriticalDisplacement)
 {
     KRATOS_TRY
     rConstitutiveMatrix(0,0) = YieldStress/((1.0-DamageThreshold)*CriticalDisplacement) * ( (1.0-mStateVariable)/mStateVariable-
@@ -407,20 +304,9 @@ void BilinearCohesive3DLaw::
 
     for (int i=indexStress3DInterface::INDEX_3D_INTERFACE_XZ; i!=indexStress3DInterface::INDEX_3D_INTERFACE_ZZ; ++i)
     {
-        if (StrainVector[i] > 1.0e-20)
-        {
-            rConstitutiveMatrix(i,indexStress3DInterface::INDEX_3D_INTERFACE_ZZ) = 
-              - YieldStress*StrainVector[i]*StrainVector[indexStress3DInterface::INDEX_3D_INTERFACE_ZZ]/( (1.0-DamageThreshold)
-                                                                                                         * CriticalDisplacement
-                                                                                                         * CriticalDisplacement
-                                                                                                         * CriticalDisplacement
-                                                                                                         * mStateVariable
-                                                                                                         * mStateVariable
-                                                                                                         * mStateVariable )
-                                       - YoungModulus*FrictionCoefficient/(DamageThreshold*CriticalDisplacement);
-        }
-        else if (StrainVector[i] < -1.0e-20)
-        {
+        if (std::abs(StrainVector[i]) <= 1.0e-20) {
+            rConstitutiveMatrix(i,indexStress3DInterface::INDEX_3D_INTERFACE_ZZ) = 0.0;
+        } else {
             rConstitutiveMatrix(i,indexStress3DInterface::INDEX_3D_INTERFACE_ZZ) =
               - YieldStress*StrainVector[i]*StrainVector[indexStress3DInterface::INDEX_3D_INTERFACE_ZZ]/( (1.0-DamageThreshold)
                                                                                                          * CriticalDisplacement
@@ -429,11 +315,7 @@ void BilinearCohesive3DLaw::
                                                                                                          * mStateVariable
                                                                                                          * mStateVariable
                                                                                                          * mStateVariable )
-              + YoungModulus*FrictionCoefficient/(DamageThreshold*CriticalDisplacement);
-        }
-        else
-        {
-            rConstitutiveMatrix(i,indexStress3DInterface::INDEX_3D_INTERFACE_ZZ) = 0.0;
+              - std::copysign(1.0, StrainVector[i]) * YoungModulus*FrictionCoefficient/(DamageThreshold*CriticalDisplacement);
         }
     }
 
@@ -443,8 +325,6 @@ void BilinearCohesive3DLaw::
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-
 void BilinearCohesive3DLaw::ComputeConstitutiveMatrixUnloading( Matrix& rConstitutiveMatrix,
                                                                 const double& YieldStress,
                                                                 const double& DamageThreshold,
@@ -452,7 +332,7 @@ void BilinearCohesive3DLaw::ComputeConstitutiveMatrixUnloading( Matrix& rConstit
 {
     KRATOS_TRY
     rConstitutiveMatrix(0,0) = YieldStress/(CriticalDisplacement*mStateVariable)
-                              *(1.0-mStateVariable)/(1.0-DamageThreshold);
+                                    *(1.0-mStateVariable)/(1.0-DamageThreshold);
     rConstitutiveMatrix(1,1) = rConstitutiveMatrix(0,0);
     rConstitutiveMatrix(2,2) = rConstitutiveMatrix(0,0);
 
@@ -462,23 +342,21 @@ void BilinearCohesive3DLaw::ComputeConstitutiveMatrixUnloading( Matrix& rConstit
     rConstitutiveMatrix(1,0) = 0.0;
     rConstitutiveMatrix(2,0) = 0.0;
     rConstitutiveMatrix(2,1) = 0.0;
-    KRATOS_CATCH("")
 
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-void BilinearCohesive3DLaw::
-    ComputeConstitutiveMatrixContactUnloading(Matrix& rConstitutiveMatrix,
-                                              const Vector& StrainVector,
-                                              const double& YoungModulus,
-                                              const double& FrictionCoefficient,
-                                              const double& YieldStress,
-                                              const double& DamageThreshold,
-                                              const double& CriticalDisplacement)
+void BilinearCohesive3DLaw::ComputeConstitutiveMatrixContactUnloading(Matrix& rConstitutiveMatrix,
+                                                                      const Vector& StrainVector,
+                                                                      const double& YoungModulus,
+                                                                      const double& FrictionCoefficient,
+                                                                      const double& YieldStress,
+                                                                      const double& DamageThreshold,
+                                                                      const double& CriticalDisplacement)
 {
     KRATOS_TRY
     rConstitutiveMatrix(0,0) = YieldStress/(CriticalDisplacement*mStateVariable)
-                              *(1.0-mStateVariable)/(1.0-DamageThreshold);
+                                    *(1.0-mStateVariable)/(1.0-DamageThreshold);
     rConstitutiveMatrix(1,1) = rConstitutiveMatrix(0,0);
     rConstitutiveMatrix(2,2) = YoungModulus/(DamageThreshold*CriticalDisplacement);
 
@@ -486,30 +364,19 @@ void BilinearCohesive3DLaw::
 
     for (int i=indexStress3DInterface::INDEX_3D_INTERFACE_XZ; i!=indexStress3DInterface::INDEX_3D_INTERFACE_ZZ; ++i)
     {
-        if (StrainVector[i] > 1.0e-20)
-        {
-            rConstitutiveMatrix(i, indexStress3DInterface::INDEX_3D_INTERFACE_ZZ) = 
-                -YoungModulus*FrictionCoefficient/(DamageThreshold*CriticalDisplacement);
-        }
-        else if (StrainVector[i] < -1.0e-20)
-        {
-            rConstitutiveMatrix(i, indexStress3DInterface::INDEX_3D_INTERFACE_ZZ) = 
-                YoungModulus*FrictionCoefficient/(DamageThreshold*CriticalDisplacement);
-        }
-        else
-        {
+        if (std::abs(StrainVector[i]) <= 1.0e-20){
             rConstitutiveMatrix(i, indexStress3DInterface::INDEX_3D_INTERFACE_ZZ) = 0.0;
+        } else {
+            rConstitutiveMatrix(i, indexStress3DInterface::INDEX_3D_INTERFACE_ZZ) = 
+                - std::copysign(1.0, StrainVector[i]) * YoungModulus*FrictionCoefficient/(DamageThreshold*CriticalDisplacement);
         }
     }
-
-
     rConstitutiveMatrix(1,0) = 0.0;
     rConstitutiveMatrix(2,0) = 0.0;
     rConstitutiveMatrix(2,1) = 0.0;
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 void BilinearCohesive3DLaw::ComputeStressVector(Vector& rStressVector,
                                                 const Vector& StrainVector,
                                                 const double& YieldStress,
@@ -518,7 +385,7 @@ void BilinearCohesive3DLaw::ComputeStressVector(Vector& rStressVector,
 {
     KRATOS_TRY
 
-    for (unsigned int i=0; i<rStressVector.size(); ++i)
+    for (unsigned int i = 0; i < rStressVector.size(); ++i)
     {
         rStressVector[i] =  YieldStress/(CriticalDisplacement*mStateVariable)
                           * (1.0-mStateVariable)/(1.0-DamageThreshold)
@@ -528,7 +395,6 @@ void BilinearCohesive3DLaw::ComputeStressVector(Vector& rStressVector,
     KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 void BilinearCohesive3DLaw::ComputeStressVectorContact(Vector& rStressVector,
                                                        const Vector& StrainVector,
                                                        const double& YoungModulus,
@@ -546,26 +412,16 @@ void BilinearCohesive3DLaw::ComputeStressVectorContact(Vector& rStressVector,
 
     for (int i=indexStress3DInterface::INDEX_3D_INTERFACE_XZ; i!=indexStress3DInterface::INDEX_3D_INTERFACE_ZZ; ++i)
     {
-        if (StrainVector[i] > 1.0e-20)
-        {
-            rStressVector[i] =  YieldStress/(CriticalDisplacement*mStateVariable)
-                              * (1.0-mStateVariable)/(1.0-DamageThreshold)*StrainVector[i]
-                              - FrictionCoefficient*rStressVector[indexStress3DInterface::INDEX_3D_INTERFACE_ZZ];
-        }
-        else if (StrainVector[i] < -1.0e-20)
-        {
-            rStressVector[i] =  YieldStress/(CriticalDisplacement*mStateVariable)
-                              * (1.0-mStateVariable)/(1.0-DamageThreshold)*StrainVector[i]
-                              + FrictionCoefficient*rStressVector[indexStress3DInterface::INDEX_3D_INTERFACE_ZZ];
-        }
-        else
-        {
+        if (std::abs(StrainVector[i]) <= 1.0e-20) {
             rStressVector[i] = 0.0;
+        } else {
+            rStressVector[i] =  YieldStress/(CriticalDisplacement*mStateVariable)
+                                * (1.0-mStateVariable)/(1.0-DamageThreshold)*StrainVector[i]
+                              - std::copysign(1.0, StrainVector[i]) * FrictionCoefficient*rStressVector[indexStress3DInterface::INDEX_3D_INTERFACE_ZZ];
         }
     }
 
     KRATOS_CATCH("")
-
 }
 
 } // Namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_constitutive/bilinear_cohesive_3D_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/bilinear_cohesive_3D_law.hpp
@@ -12,10 +12,7 @@
 //                   Vahid Galavi
 //
 
-
-
-#if !defined (KRATOS_BILINEAR_COHESIVE_3D_LAW_H_INCLUDED)
-#define  KRATOS_BILINEAR_COHESIVE_3D_LAW_H_INCLUDED
+#pragma once
 
 // System includes
 #include <cmath>
@@ -37,18 +34,7 @@ public:
 
     KRATOS_CLASS_POINTER_DEFINITION(BilinearCohesive3DLaw);
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-    // Default Constructor
     BilinearCohesive3DLaw();
-
-    // Copy Constructor
-    BilinearCohesive3DLaw (const BilinearCohesive3DLaw& rOther);
-
-    // Destructor
-    virtual ~BilinearCohesive3DLaw();
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     void GetLawFeatures(Features& rFeatures) override;
 
@@ -60,24 +46,19 @@ public:
 
     void InitializeMaterial( const Properties& rMaterialProperties,const GeometryType& rElementGeometry,const Vector& rShapeFunctionsValues ) override;
 
-    virtual SizeType GetStrainSize() const override
+    SizeType GetStrainSize() const override
     {
         return 3;
     }
 
-
-    virtual SizeType WorkingSpaceDimension() override
+    SizeType WorkingSpaceDimension() override
     {
         return 3;
     }
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     void CalculateMaterialResponseCauchy(Parameters & rValues) override;
 
     void FinalizeMaterialResponseCauchy(Parameters & rValues) override;
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     double& GetValue( const Variable<double>& rThisVariable, double& rValue ) override;
 
@@ -89,15 +70,9 @@ public:
                    const Vector& rValue,
                    const ProcessInfo& rCurrentProcessInfo ) override;
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
 protected:
-
     // Member Variables
-
     double mStateVariable;
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     virtual void ComputeEquivalentStrain(double& rEquivalentStrain,const Vector& StrainVector,const double& CriticalDisplacement);
 
@@ -105,31 +80,27 @@ protected:
 
 
     virtual void ComputeConstitutiveMatrixLoading(Matrix& rConstitutiveMatrix,const Vector& StrainVector,const double& JointStrength,
-                                                        const double& DamageThreshold,const double& CriticalDisplacement);
+                                                  const double& DamageThreshold,const double& CriticalDisplacement);
 
     virtual void ComputeConstitutiveMatrixContactLoading(Matrix& rConstitutiveMatrix,const Vector& StrainVector,const double& YoungModulus,const double& FrictionCoefficient,
-                                                            const double& JointStrength,const double& DamageThreshold,const double& CriticalDisplacement);
+                                                         const double& JointStrength,const double& DamageThreshold,const double& CriticalDisplacement);
 
 
     virtual void ComputeConstitutiveMatrixUnloading(Matrix& rConstitutiveMatrix,const double& JointStrength,
-                                                        const double& DamageThreshold,const double& CriticalDisplacement);
+                                                    const double& DamageThreshold,const double& CriticalDisplacement);
 
     virtual void ComputeConstitutiveMatrixContactUnloading(Matrix& rConstitutiveMatrix,const Vector& StrainVector,const double& YoungModulus,const double& FrictionCoefficient,
-                                                            const double& JointStrength,const double& DamageThreshold,const double& CriticalDisplacement);
+                                                           const double& JointStrength,const double& DamageThreshold,const double& CriticalDisplacement);
 
 
     virtual void ComputeStressVector(Vector& rStressVector,const Vector& StrainVector,const double& JointStrength,
-                                                const double& DamageThreshold,const double& CriticalDisplacement);
+                                     const double& DamageThreshold,const double& CriticalDisplacement);
 
     virtual void ComputeStressVectorContact(Vector& rStressVector,const Vector& StrainVector,const double& YoungModulus,const double& FrictionCoefficient,
-                                                        const double& JointStrength,const double& DamageThreshold,const double& CriticalDisplacement);
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                            const double& JointStrength,const double& DamageThreshold,const double& CriticalDisplacement);
 
 private:
-
     // Serialization
-
     friend class Serializer;
 
     void save(Serializer& rSerializer) const override
@@ -143,5 +114,5 @@ private:
     }
 
 }; // Class BilinearCohesive3DLaw
-}  // namespace Kratos.
-#endif // KRATOS_BILINEAR_COHESIVE_3D_LAW_H_INCLUDED  defined
+
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/elastic_isotropic_K0_3d_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/elastic_isotropic_K0_3d_law.cpp
@@ -11,11 +11,6 @@
 //  Main authors:    Vahid Galavi
 //
 
-// System includes
-#include <iostream>
-
-// External includes
-
 // Project includes
 #include "custom_constitutive/elastic_isotropic_K0_3d_law.h"
 #include "includes/checks.h"
@@ -24,45 +19,17 @@
 
 namespace Kratos
 {
-/******************************CONSTRUCTOR******************************************/
-/***********************************************************************************/
-
-ElasticIsotropicK03DLaw::ElasticIsotropicK03DLaw()
-    : ConstitutiveLaw()
-{
-}
-
-/******************************COPY CONSTRUCTOR*************************************/
-/***********************************************************************************/
-
-ElasticIsotropicK03DLaw::ElasticIsotropicK03DLaw(const ElasticIsotropicK03DLaw& rOther)
-    : ConstitutiveLaw(rOther)
-{
-}
-
-/********************************CLONE**********************************************/
-/***********************************************************************************/
 
 ConstitutiveLaw::Pointer ElasticIsotropicK03DLaw::Clone() const
 {
     return Kratos::make_shared<ElasticIsotropicK03DLaw>(*this);
 }
 
-/*******************************DESTRUCTOR******************************************/
-/***********************************************************************************/
-
-ElasticIsotropicK03DLaw::~ElasticIsotropicK03DLaw()
-{
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
 void  ElasticIsotropicK03DLaw::CalculateMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues)
 {
     KRATOS_TRY
     // b.- Get Values to compute the constitutive law:
-    Flags & r_options=rValues.GetOptions();
+    const Flags & r_options=rValues.GetOptions();
 
     Vector& r_strain_vector = rValues.GetStrainVector();
 
@@ -84,66 +51,26 @@ void  ElasticIsotropicK03DLaw::CalculateMaterialResponsePK2(ConstitutiveLaw::Par
     KRATOS_CATCH("")
 }
 
-/***********************************************************************************/
-/***********************************************************************************/
-
 // NOTE: Since we are in the hypothesis of small strains we can use the same function for everything
-
 void ElasticIsotropicK03DLaw::CalculateMaterialResponsePK1(ConstitutiveLaw::Parameters& rValues)
 {
     CalculateMaterialResponsePK2(rValues);
 }
-
-/***********************************************************************************/
-/***********************************************************************************/
 
 void ElasticIsotropicK03DLaw::CalculateMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues)
 {
     CalculateMaterialResponsePK2(rValues);
 }
 
-/***********************************************************************************/
-/***********************************************************************************/
-
 void ElasticIsotropicK03DLaw::CalculateMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues)
 {
     CalculateMaterialResponsePK2(rValues);
 }
 
-/***********************************************************************************/
-/***********************************************************************************/
-
-void ElasticIsotropicK03DLaw::FinalizeMaterialResponsePK1(ConstitutiveLaw::Parameters& rValues)
+bool ElasticIsotropicK03DLaw::RequiresFinalizeMaterialResponse()
 {
-    // TODO: Add if necessary
+    return false;
 }
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-void ElasticIsotropicK03DLaw::FinalizeMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues)
-{
-    // TODO: Add if necessary
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-void ElasticIsotropicK03DLaw::FinalizeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues)
-{
-    // TODO: Add if necessary
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-void ElasticIsotropicK03DLaw::FinalizeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues)
-{
-    // TODO: Add if necessary
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
 
 double& ElasticIsotropicK03DLaw::CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
                                                 const Variable<double>& rThisVariable,
@@ -159,11 +86,8 @@ double& ElasticIsotropicK03DLaw::CalculateValue(ConstitutiveLaw::Parameters& rPa
         rValue = 0.5 * inner_prod( r_strain_vector, r_stress_vector); // Strain energy = 0.5*E:C:E
     }
 
-    return( rValue );
+    return rValue;
 }
-
-/***********************************************************************************/
-/***********************************************************************************/
 
 Vector& ElasticIsotropicK03DLaw::CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
                                                 const Variable<Vector>& rThisVariable,
@@ -199,11 +123,8 @@ Vector& ElasticIsotropicK03DLaw::CalculateValue(ConstitutiveLaw::Parameters& rPa
         r_flags.Set( ConstitutiveLaw::COMPUTE_STRESS, flag_stress );
     }
 
-    return( rValue );
+    return rValue;
 }
-
-/***********************************************************************************/
-/***********************************************************************************/
 
 Matrix& ElasticIsotropicK03DLaw::CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
                                                 const Variable<Matrix>& rThisVariable,
@@ -215,11 +136,8 @@ Matrix& ElasticIsotropicK03DLaw::CalculateValue(ConstitutiveLaw::Parameters& rPa
         this->CalculateElasticMatrix(rValue, rParameterValues);
     }
 
-    return( rValue );
+    return rValue;
 }
-
-//*************************CONSTITUTIVE LAW GENERAL FEATURES *************************
-/***********************************************************************************/
 
 void ElasticIsotropicK03DLaw::GetLawFeatures(Features& rFeatures)
 {
@@ -228,44 +146,36 @@ void ElasticIsotropicK03DLaw::GetLawFeatures(Features& rFeatures)
     rFeatures.mOptions.Set( INFINITESIMAL_STRAINS );
     rFeatures.mOptions.Set( ISOTROPIC );
 
-    //Set strain measure required by the consitutive law
+    //Set strain measure required by the constitutive law
     rFeatures.mStrainMeasures.push_back(StrainMeasure_Infinitesimal);
     rFeatures.mStrainMeasures.push_back(StrainMeasure_Deformation_Gradient);
 
     //Set the strain size
     rFeatures.mStrainSize = GetStrainSize();
 
-    //Set the spacedimension
+    //Set the space dimension
     rFeatures.mSpaceDimension = WorkingSpaceDimension();
 }
 
-
 void ElasticIsotropicK03DLaw::InitializeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues) {}
-
-
-/***********************************************************************************/
-/***********************************************************************************/
 
 int ElasticIsotropicK03DLaw::Check(const Properties& rMaterialProperties,
                                    const GeometryType& rElementGeometry,
                                    const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_ERROR_IF_NOT(rMaterialProperties.Has(YOUNG_MODULUS))
-                        << "YOUNG_MODULUS is not availabe in material parameters" << std::endl;
+                        << "YOUNG_MODULUS is not available in material parameters" << std::endl;
     KRATOS_ERROR_IF(rMaterialProperties[YOUNG_MODULUS] <= 0.0) << "YOUNG_MODULUS is invalid value " << std::endl;
 
     KRATOS_ERROR_IF_NOT(rMaterialProperties.Has(POISSON_RATIO))
-                        << "POISSON_RATIO is not availabe in material parameters" << std::endl;
+                        << "POISSON_RATIO is not available in material parameters" << std::endl;
 
     const double& nu = rMaterialProperties[POISSON_RATIO];
-    const bool check = ((nu >0.499 && nu<0.501) || (nu < -0.999 && nu > -1.01));
-    KRATOS_ERROR_IF(check) << "POISSON_RATIO has invalid value " << std::endl;
+    KRATOS_ERROR_IF((nu > 0.499 && nu < 0.501) || (nu < -0.999 && nu > -1.01))
+                    << "POISSON_RATIO has invalid value " << std::endl;
 
     return 0;
 }
-
-/***********************************************************************************/
-/***********************************************************************************/
 
 void ElasticIsotropicK03DLaw::CheckClearElasticMatrix(Matrix& rConstitutiveMatrix)
 {
@@ -275,42 +185,36 @@ void ElasticIsotropicK03DLaw::CheckClearElasticMatrix(Matrix& rConstitutiveMatri
     rConstitutiveMatrix.clear();
 }
 
-/***********************************************************************************/
-/***********************************************************************************/
-
 void ElasticIsotropicK03DLaw::CalculateElasticMatrix(Matrix& rConstitutiveMatrix,
                                                      ConstitutiveLaw::Parameters& rValues)
 {
     const Properties& r_material_properties = rValues.GetMaterialProperties();
     const double E = r_material_properties[YOUNG_MODULUS];
-    double NU = r_material_properties[POISSON_RATIO];
 
     const double& K0ValueXX = r_material_properties[K0_VALUE_XX];
     const double& K0ValueYY = r_material_properties[K0_VALUE_YY];
     const double& K0ValueZZ = r_material_properties[K0_VALUE_ZZ];
 
-    double K0 = 0.0;
+    double K0_value;
     const int &K0MainDirection = r_material_properties[K0_MAIN_DIRECTION];
     if (K0MainDirection == INDEX_3D_XX) {
-        K0 = 0.5*(K0ValueYY + K0ValueZZ);
+        K0_value = 0.5*(K0ValueYY + K0ValueZZ);
     } else if (K0MainDirection == INDEX_3D_YY) {
-        K0 = 0.5*(K0ValueXX + K0ValueZZ);
+        K0_value = 0.5*(K0ValueXX + K0ValueZZ);
     } else if (K0MainDirection == INDEX_3D_ZZ) {
-        K0 = 0.5*(K0ValueXX + K0ValueYY);
+        K0_value = 0.5*(K0ValueXX + K0ValueYY);
     } else {
          KRATOS_ERROR << "undefined K0_MAIN_DIRECTION in LinearElasticK03DLaw: " << K0MainDirection << std::endl;
     }
 
-    NU = K0 / (K0 + 1.0);
-    NU = std::max<double>(NU, 0.0);
-
+    double NU = std::max(K0_value / (K0_value + 1.0), 0.0);
     const double limit = 0.005;
     if (NU < (0.5 + limit) && NU > (0.5 - limit)) NU = 0.5 - limit;
 
-    const double c1 = E / (( 1.00 + NU ) * ( 1 - 2 * NU ) );
-    const double c2 = c1 * ( 1 - NU );
+    const double c1 = E / (( 1.0 + NU ) * ( 1.0 - 2.0 * NU ) );
+    const double c2 = c1 * ( 1.0 - NU );
     const double c3 = c1 * NU;
-    const double c4 = c1 * 0.5 * ( 1 - 2 * NU );
+    const double c4 = c1 * 0.5 * ( 1.0 - 2.0 * NU );
 
     this->CheckClearElasticMatrix(rConstitutiveMatrix);
     rConstitutiveMatrix( 0, 0 ) = c2;
@@ -326,9 +230,6 @@ void ElasticIsotropicK03DLaw::CalculateElasticMatrix(Matrix& rConstitutiveMatrix
     rConstitutiveMatrix( 4, 4 ) = c4;
     rConstitutiveMatrix( 5, 5 ) = c4;
 }
-
-/***********************************************************************************/
-/***********************************************************************************/
 
 void ElasticIsotropicK03DLaw::CalculatePK2Stress(const Vector& rStrainVector,
                                                  Vector& rStressVector,
@@ -359,9 +260,6 @@ void ElasticIsotropicK03DLaw::CalculatePK2Stress(const Vector& rStrainVector,
     }
 }
 
-/***********************************************************************************/
-/***********************************************************************************/
-
 void ElasticIsotropicK03DLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector)
 {
     const SizeType space_dimension = this->WorkingSpaceDimension();
@@ -372,7 +270,7 @@ void ElasticIsotropicK03DLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parame
         << "expected size of F " << space_dimension << "x" << space_dimension << ", got " << F.size1() << "x" << F.size2() << std::endl;
 
     Matrix E_tensor = prod(trans(F),F);
-    for(unsigned int i=0; i<space_dimension; ++i)
+    for (unsigned int i=0; i<space_dimension; ++i)
       E_tensor(i,i) -= 1.0;
     E_tensor *= 0.5;
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/elastic_isotropic_K0_3d_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/elastic_isotropic_K0_3d_law.h
@@ -76,28 +76,13 @@ public:
     KRATOS_CLASS_POINTER_DEFINITION( ElasticIsotropicK03DLaw );
 
     ///@}
-    ///@name Lyfe Cycle
+    ///@name Life Cycle
     ///@{
-
-    /**
-     * @brief Default constructor.
-     */
-    ElasticIsotropicK03DLaw();
 
     /**
      * @brief Clone method
      */
     ConstitutiveLaw::Pointer Clone() const override;
-
-    /**
-     * Copy constructor.
-     */
-    ElasticIsotropicK03DLaw (const ElasticIsotropicK03DLaw& rOther);
-
-    /**
-     * @brief Destructor.
-     */
-    ~ElasticIsotropicK03DLaw() override;
 
     ///@}
     ///@name Operators
@@ -181,37 +166,7 @@ public:
      */
     void CalculateMaterialResponseCauchy(ConstitutiveLaw::Parameters & rValues) override;
 
-    /**
-      * @brief Updates the material response:
-      * @details Cauchy stresses and Internal Variables
-      * @param rValues The internal values of the law
-      * @see   Parameters
-      */
-    void FinalizeMaterialResponsePK1(ConstitutiveLaw::Parameters & rValues) override;
-
-    /**
-     * @brief Updates the material response:
-     * Cauchy stresses and Internal Variables
-     * @param rValues The internal values of the law
-     * @see   Parameters
-     */
-    void FinalizeMaterialResponsePK2(ConstitutiveLaw::Parameters & rValues) override;
-
-    /**
-     * @brief Updates the material response:
-     * @details Cauchy stresses and Internal Variables
-     * @param rValues The internal values of the law
-     * @see   Parameters
-     */
-    void FinalizeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters & rValues)  override;
-
-    /**
-     * @brief Updates the material response:
-     * @details Cauchy stresses and Internal Variables
-     * @param rValues The internal values of the law
-     * @see   Parameters
-     */
-    void FinalizeMaterialResponseCauchy(ConstitutiveLaw::Parameters & rValues) override;
+    bool RequiresFinalizeMaterialResponse() override;
 
     /**
      * @brief It calculates the value of a specified variable (double case)

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_beam_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_beam_law.cpp
@@ -13,8 +13,6 @@
 // System includes
 #include <iostream>
 
-// External includes
-
 // Project includes
 #include "custom_constitutive/linear_elastic_2D_beam_law.h"
 
@@ -23,37 +21,10 @@
 namespace Kratos
 {
 
-//******************************CONSTRUCTOR*******************************************
-/***********************************************************************************/
-
-LinearElastic2DBeamLaw::
-    LinearElastic2DBeamLaw()
-    : GeoLinearElasticPlaneStrain2DLaw()
-{
-}
-
-//******************************COPY CONSTRUCTOR**************************************
-/***********************************************************************************/
-
-LinearElastic2DBeamLaw::
-    LinearElastic2DBeamLaw(const LinearElastic2DBeamLaw& rOther)
-    : GeoLinearElasticPlaneStrain2DLaw(rOther) {}
-
-//********************************CLONE***********************************************
-/***********************************************************************************/
-
 ConstitutiveLaw::Pointer LinearElastic2DBeamLaw::Clone() const
 {
     return Kratos::make_shared< LinearElastic2DBeamLaw>(*this);
 }
-
-//*******************************DESTRUCTOR*******************************************
-/***********************************************************************************/
-
-    LinearElastic2DBeamLaw::~LinearElastic2DBeamLaw() {}
-
-//*************************CONSTITUTIVE LAW GENERAL FEATURES *************************
-/***********************************************************************************/
 
 void LinearElastic2DBeamLaw::GetLawFeatures(Features& rFeatures)
 {
@@ -67,39 +38,34 @@ void LinearElastic2DBeamLaw::GetLawFeatures(Features& rFeatures)
     rFeatures.mStrainMeasures.push_back(StrainMeasure_Deformation_Gradient);
 
     //Set the strain size
-    // for the time being
     rFeatures.mStrainSize = GetStrainSize();
 
-    //Set the spacedimension
+    //Set the space dimension
     rFeatures.mSpaceDimension = WorkingSpaceDimension();
 }
 
-/***********************************************************************************/
-/***********************************************************************************/
-
-void LinearElastic2DBeamLaw::
-    CalculateElasticMatrix(Matrix& C, ConstitutiveLaw::Parameters& rValues)
+void LinearElastic2DBeamLaw::CalculateElasticMatrix(Matrix& C, ConstitutiveLaw::Parameters& rValues)
 {
     KRATOS_TRY
 
     // Stiffness of beams is based on Eq.16b and 17c of the following paper:
     // Pica, Wood, Hinton (1980) "Finite element analysis of geometrically 
     //                            nonlinear plate behaviour using a 
-    //                            mindlin formulation"
+    //                            Mindlin formulation"
 
     const Properties& rMaterialProperties = rValues.GetMaterialProperties();
-    const double E = rMaterialProperties[YOUNG_MODULUS];
+    const double E  = rMaterialProperties[YOUNG_MODULUS];
     const double NU = rMaterialProperties[POISSON_RATIO];
 
-    double K = 1.2; // assuming rectangular cross section
+    double K = 1.2; // assuming rectangular crosssection
     if (rMaterialProperties.Has(PLATE_SHAPE_CORRECTION_FACTOR) && rMaterialProperties[PLATE_SHAPE_CORRECTION_FACTOR] > 0.0) {
         K = rMaterialProperties[PLATE_SHAPE_CORRECTION_FACTOR];
     }
 
     this->CheckClearElasticMatrix(C);
 
-    const double c0 = E / (1.00 - NU*NU);
-    const double G  = E / (2.0*(1.00 + NU));
+    const double c0 = E / (1.0 - NU*NU);
+    const double G  = E / (2.0 * (1.0 + NU));
 
     C(INDEX_2D_PLANE_STRESS_XX, INDEX_2D_PLANE_STRESS_XX) = c0;
     C(INDEX_2D_PLANE_STRESS_YY, INDEX_2D_PLANE_STRESS_YY) = c0;
@@ -110,11 +76,9 @@ void LinearElastic2DBeamLaw::
     KRATOS_CATCH("")
 }
 
-//-------------------------------------------------------------------------------------------------
-void LinearElastic2DBeamLaw::
-    CalculatePK2Stress(const Vector& rStrainVector,
-                       Vector& rStressVector,
-                       ConstitutiveLaw::Parameters& rValues)
+void LinearElastic2DBeamLaw::CalculatePK2Stress(const Vector& rStrainVector,
+                                                Vector& rStressVector,
+                                                ConstitutiveLaw::Parameters& rValues)
 {
     KRATOS_TRY
 
@@ -125,8 +89,4 @@ void LinearElastic2DBeamLaw::
     KRATOS_CATCH("")
 }
 
-/***********************************************************************************/
-/***********************************************************************************/
-
-
-} // Namespace Kratos
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_beam_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_beam_law.h
@@ -10,12 +10,7 @@
 //  Main authors:    Vahid Galavi
 //
 
-#if !defined (KRATOS_LINEAR_ELASTIC_2D_BEAM_LAW_GEO_H_INCLUDED)
-#define  KRATOS_LINEAR_ELASTIC_2D_BEAM_LAW_GEO_H_INCLUDED
-
-// System includes
-
-// External includes
+#pragma once
 
 // Project includes
 #include "custom_constitutive/linear_elastic_plane_strain_2D_law.h"
@@ -71,25 +66,9 @@ public:
     ///@{
 
     /**
-     * @brief Default constructor.
-     */
-    LinearElastic2DBeamLaw();
-
-    /**
      * @brief The clone operation
      */
     ConstitutiveLaw::Pointer Clone() const override;
-
-    /**
-     * Copy constructor.
-     */
-    LinearElastic2DBeamLaw (const LinearElastic2DBeamLaw& rOther);
-
-
-    /**
-     * @brief Destructor.
-     */
-    ~LinearElastic2DBeamLaw() override;
 
     ///@}
     ///@name Operators
@@ -208,6 +187,6 @@ private:
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, GeoLinearElasticPlaneStrain2DLaw)
     }
-}; // Class GeoLinearElasticPlaneStrain2DLaw
-}  // namespace Kratos.
-#endif // KRATOS_LINEAR_PLANE_STRAIN_K0_LAW_H_INCLUDED  defined
+}; // Class LinearElastic2DBeamLaw
+
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_interface_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_interface_law.h
@@ -10,12 +10,7 @@
 //  Main authors:    Vahid Galavi
 //
 
-#if !defined (KRATOS_LINEAR_ELASTIC_2D_INTERFACE_LAW_GEO_H_INCLUDED)
-#define  KRATOS_LINEAR_ELASTIC_2D_INTERFACE_LAW_GEO_H_INCLUDED
-
-// System includes
-
-// External includes
+#pragma once
 
 // Project includes
 #include "custom_constitutive/linear_elastic_plane_strain_2D_law.h"
@@ -74,25 +69,9 @@ public:
     ///@{
 
     /**
-     * @brief Default constructor.
-     */
-    LinearElastic2DInterfaceLaw();
-
-    /**
      * @brief The clone operation
      */
     ConstitutiveLaw::Pointer Clone() const override;
-
-    /**
-     * Copy constructor.
-     */
-    LinearElastic2DInterfaceLaw (const LinearElastic2DInterfaceLaw& rOther);
-
-
-    /**
-     * @brief Destructor.
-     */
-    ~LinearElastic2DInterfaceLaw() override;
 
     ///@}
     ///@name Operators
@@ -232,6 +211,6 @@ private:
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, GeoLinearElasticPlaneStrain2DLaw)
     }
-}; // Class GeoLinearElasticPlaneStrain2DLaw
-}  // namespace Kratos.
-#endif // KRATOS_LINEAR_PLANE_STRAIN_K0_LAW_H_INCLUDED  defined
+}; // Class LinearElastic2DInterfaceLaw
+
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_3D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_3D_interface_law.cpp
@@ -13,8 +13,6 @@
 // System includes
 #include <iostream>
 
-// External includes
-
 // Project includes
 #include "custom_constitutive/linear_elastic_3D_interface_law.h"
 
@@ -23,37 +21,10 @@
 namespace Kratos
 {
 
-//******************************CONSTRUCTOR*******************************************
-/***********************************************************************************/
-
-LinearElastic3DInterfaceLaw::
-    LinearElastic3DInterfaceLaw()
-    : LinearElastic2DInterfaceLaw()
-{
-}
-
-//******************************COPY CONSTRUCTOR**************************************
-/***********************************************************************************/
-
-LinearElastic3DInterfaceLaw::
-    LinearElastic3DInterfaceLaw(const LinearElastic3DInterfaceLaw& rOther)
-    : LinearElastic2DInterfaceLaw(rOther) {}
-
-//********************************CLONE***********************************************
-/***********************************************************************************/
-
 ConstitutiveLaw::Pointer LinearElastic3DInterfaceLaw::Clone() const
 {
     return Kratos::make_shared< LinearElastic3DInterfaceLaw>(*this);
 }
-
-//*******************************DESTRUCTOR*******************************************
-/***********************************************************************************/
-
-    LinearElastic3DInterfaceLaw::~LinearElastic3DInterfaceLaw() {}
-
-/***********************************************************************************/
-/***********************************************************************************/
 
 bool& LinearElastic3DInterfaceLaw::GetValue(const Variable<bool>& rThisVariable, bool& rValue)
 {
@@ -64,9 +35,6 @@ bool& LinearElastic3DInterfaceLaw::GetValue(const Variable<bool>& rThisVariable,
 
     return rValue;
 }
-
-//*************************CONSTITUTIVE LAW GENERAL FEATURES *************************
-/***********************************************************************************/
 
 void LinearElastic3DInterfaceLaw::GetLawFeatures(Features& rFeatures)
 {
@@ -80,15 +48,11 @@ void LinearElastic3DInterfaceLaw::GetLawFeatures(Features& rFeatures)
     rFeatures.mStrainMeasures.push_back(StrainMeasure_Deformation_Gradient);
 
     //Set the strain size
-    // for the time being
     rFeatures.mStrainSize = GetStrainSize();
 
-    //Set the spacedimension
+    //Set the space dimension
     rFeatures.mSpaceDimension = WorkingSpaceDimension();
 }
-
-/***********************************************************************************/
-/***********************************************************************************/
 
 void LinearElastic3DInterfaceLaw::
     CalculateElasticMatrix(Matrix& C, ConstitutiveLaw::Parameters& rValues)
@@ -96,44 +60,31 @@ void LinearElastic3DInterfaceLaw::
     KRATOS_TRY
 
     const Properties& r_material_properties = rValues.GetMaterialProperties();
-    const double E = r_material_properties[YOUNG_MODULUS];
+    const double E  = r_material_properties[YOUNG_MODULUS];
     const double NU = r_material_properties[POISSON_RATIO];
 
     this->CheckClearElasticMatrix(C);
 
-    const double c0 = E / ((1.00 + NU)*(1 - 2 * NU));
+    const double c0 = E / ((1.0 + NU)*(1.0 - 2.0 * NU));
 
-    C(INDEX_3D_INTERFACE_ZZ, INDEX_3D_INTERFACE_ZZ) = (1.00 - NU)*c0;
     C(INDEX_3D_INTERFACE_XZ, INDEX_3D_INTERFACE_XZ) = (0.5 - NU)*c0;
     C(INDEX_3D_INTERFACE_YZ, INDEX_3D_INTERFACE_YZ) = (0.5 - NU)*c0;
+    C(INDEX_3D_INTERFACE_ZZ, INDEX_3D_INTERFACE_ZZ) = (1.0 - NU)*c0;
 
     KRATOS_CATCH("")
 }
 
-/***********************************************************************************/
-/***********************************************************************************/
-
-void LinearElastic3DInterfaceLaw::
-    CalculatePK2Stress(const Vector& rStrainVector,
-                       Vector& rStressVector,
-                       ConstitutiveLaw::Parameters& rValues)
+void LinearElastic3DInterfaceLaw::CalculatePK2Stress(const Vector& rStrainVector,
+                                                     Vector& rStressVector,
+                                                     ConstitutiveLaw::Parameters& rValues)
 {
     KRATOS_TRY
 
-    const Properties& r_material_properties = rValues.GetMaterialProperties();
-    const double E = r_material_properties[YOUNG_MODULUS];
-    const double NU = r_material_properties[POISSON_RATIO];
-
-    const double c0 = E / ((1.00 + NU)*(1 - 2 * NU));
-    const double c1 = (1.00 - NU)*c0;
-    const double c3 = (0.5 - NU)*c0;
-
-    rStressVector[INDEX_3D_INTERFACE_XZ] = c3 * rStrainVector[INDEX_3D_INTERFACE_XZ];
-    rStressVector[INDEX_3D_INTERFACE_YZ] = c3 * rStrainVector[INDEX_3D_INTERFACE_YZ];
-    rStressVector[INDEX_3D_INTERFACE_ZZ] = c1 * rStrainVector[INDEX_3D_INTERFACE_ZZ];
+    Matrix C;
+    this->CalculateElasticMatrix(C, rValues);
+    rStressVector = prod(C, rStrainVector);
 
     KRATOS_CATCH("")
 }
-
 
 } // Namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_3D_interface_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_3D_interface_law.h
@@ -74,25 +74,9 @@ public:
     ///@{
 
     /**
-     * @brief Default constructor.
-     */
-    LinearElastic3DInterfaceLaw();
-
-    /**
      * @brief The clone operation
      */
     ConstitutiveLaw::Pointer Clone() const override;
-
-    /**
-     * Copy constructor.
-     */
-    LinearElastic3DInterfaceLaw (const LinearElastic3DInterfaceLaw& rOther);
-
-
-    /**
-     * @brief Destructor.
-     */
-    ~LinearElastic3DInterfaceLaw() override;
 
     ///@}
     ///@name Operators

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_2D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_2D_law.cpp
@@ -23,37 +23,12 @@
 namespace Kratos
 {
 
-//******************************CONSTRUCTOR*******************************************
-/***********************************************************************************/
-
-GeoLinearElasticPlaneStrain2DLaw::
-    GeoLinearElasticPlaneStrain2DLaw(): LinearPlaneStrainK0Law()
-{
-}
-
-//******************************COPY CONSTRUCTOR**************************************
-/***********************************************************************************/
-
-GeoLinearElasticPlaneStrain2DLaw::
-    GeoLinearElasticPlaneStrain2DLaw(const GeoLinearElasticPlaneStrain2DLaw& rOther): LinearPlaneStrainK0Law(rOther) {}
-
-//********************************CLONE***********************************************
-/***********************************************************************************/
-
 ConstitutiveLaw::Pointer GeoLinearElasticPlaneStrain2DLaw::Clone() const
 {
     return Kratos::make_shared<    GeoLinearElasticPlaneStrain2DLaw>(*this);
 }
 
-//*******************************DESTRUCTOR*******************************************
-/***********************************************************************************/
-
-    GeoLinearElasticPlaneStrain2DLaw::~GeoLinearElasticPlaneStrain2DLaw() {}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-bool&     GeoLinearElasticPlaneStrain2DLaw::GetValue(const Variable<bool>& rThisVariable, bool& rValue)
+bool& GeoLinearElasticPlaneStrain2DLaw::GetValue(const Variable<bool>& rThisVariable, bool& rValue)
 {
     // This Constitutive Law has been checked with Stenberg Stabilization
     if (rThisVariable == STENBERG_SHEAR_STABILIZATION_SUITABLE) {
@@ -63,9 +38,6 @@ bool&     GeoLinearElasticPlaneStrain2DLaw::GetValue(const Variable<bool>& rThis
     return rValue;
 }
 
-//*************************CONSTITUTIVE LAW GENERAL FEATURES *************************
-/***********************************************************************************/
-
 void GeoLinearElasticPlaneStrain2DLaw::GetLawFeatures(Features& rFeatures)
 {
     //Set the type of law
@@ -73,33 +45,29 @@ void GeoLinearElasticPlaneStrain2DLaw::GetLawFeatures(Features& rFeatures)
     rFeatures.mOptions.Set( INFINITESIMAL_STRAINS );
     rFeatures.mOptions.Set( ISOTROPIC );
 
-    //Set strain measure required by the consitutive law
+    //Set strain measure required by the constitutive law
     rFeatures.mStrainMeasures.push_back(StrainMeasure_Infinitesimal);
     rFeatures.mStrainMeasures.push_back(StrainMeasure_Deformation_Gradient);
 
     //Set the strain size
-    // for the time being
     rFeatures.mStrainSize = GetStrainSize();
 
-    //Set the spacedimension
+    //Set the space dimension
     rFeatures.mSpaceDimension = WorkingSpaceDimension();
 }
 
-/***********************************************************************************/
-/***********************************************************************************/
-void GeoLinearElasticPlaneStrain2DLaw::
-    CalculateElasticMatrix(Matrix& C, ConstitutiveLaw::Parameters& rValues)
+void GeoLinearElasticPlaneStrain2DLaw::CalculateElasticMatrix(Matrix& C, ConstitutiveLaw::Parameters& rValues)
 {
     KRATOS_TRY
 
     const Properties &r_material_properties = rValues.GetMaterialProperties();
-    const double &E = r_material_properties[YOUNG_MODULUS];
-    const double &NU = r_material_properties[POISSON_RATIO];
+    const double &  E = r_material_properties[YOUNG_MODULUS];
+    const double & NU = r_material_properties[POISSON_RATIO];
 
     this->CheckClearElasticMatrix(C);
 
-    const double c0 = E / ((1.00 + NU)*(1 - 2 * NU));
-    const double c1 = (1.00 - NU)*c0;
+    const double c0 = E / ((1.0 + NU)*(1.0 - 2.0 * NU));
+    const double c1 = (1.0 - NU)*c0;
     const double c2 = c0 * NU;
     const double c3 = (0.5 - NU)*c0;
 
@@ -120,20 +88,18 @@ void GeoLinearElasticPlaneStrain2DLaw::
     KRATOS_CATCH("")
 }
 
-//------------------------------------------------------------------------------------------------
-void GeoLinearElasticPlaneStrain2DLaw::
-    CalculatePK2Stress(const Vector& rStrainVector,
-                       Vector& rStressVector,
-                       ConstitutiveLaw::Parameters& rValues)
+void GeoLinearElasticPlaneStrain2DLaw::CalculatePK2Stress(const Vector& rStrainVector,
+                                                          Vector& rStressVector,
+                                                          ConstitutiveLaw::Parameters& rValues)
 {
     KRATOS_TRY
 
     Matrix C;
     this->CalculateElasticMatrix(C, rValues);
+    // Total formulation
     noalias(rStressVector) = prod(C, rStrainVector);
 
     KRATOS_CATCH("")
 }
-
 
 } // Namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_2D_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_2D_law.h
@@ -10,12 +10,7 @@
 //  Main authors:    Vahid Galavi
 //
 
-#if !defined (KRATOS_LINEAR_PLANE_STRAIN_2D_LAW_GEO_H_INCLUDED)
-#define  KRATOS_LINEAR_PLANE_STRAIN_2D_LAW_GEO_H_INCLUDED
-
-// System includes
-
-// External includes
+#pragma once
 
 // Project includes
 #include "custom_constitutive/linear_elastic_plane_strain_K0_law.h"
@@ -78,25 +73,9 @@ public:
     ///@{
 
     /**
-     * @brief Default constructor.
-     */
-    GeoLinearElasticPlaneStrain2DLaw();
-
-    /**
      * @brief The clone operation
      */
     ConstitutiveLaw::Pointer Clone() const override;
-
-    /**
-     * Copy constructor.
-     */
-    GeoLinearElasticPlaneStrain2DLaw (const GeoLinearElasticPlaneStrain2DLaw& rOther);
-
-
-    /**
-     * @brief Destructor.
-     */
-    ~GeoLinearElasticPlaneStrain2DLaw() override;
 
     ///@}
     ///@name Operators
@@ -236,6 +215,6 @@ private:
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, LinearPlaneStrainK0Law)
     }
-}; // Class LinearPlaneStrainK0Law
-}  // namespace Kratos.
-#endif // KRATOS_LINEAR_PLANE_STRAIN_K0_LAW_H_INCLUDED  defined
+}; // Class GeoLinearElasticPlaneStrain2DLaw
+
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_K0_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_K0_law.cpp
@@ -13,8 +13,6 @@
 // System includes
 #include <iostream>
 
-// External includes
-
 // Project includes
 #include "custom_constitutive/linear_elastic_plane_strain_K0_law.h"
 
@@ -23,39 +21,10 @@
 namespace Kratos
 {
 
-//******************************CONSTRUCTOR*******************************************
-/***********************************************************************************/
-
-LinearPlaneStrainK0Law::LinearPlaneStrainK0Law()
-    : ElasticIsotropicK03DLaw()
-{
-}
-
-//******************************COPY CONSTRUCTOR**************************************
-/***********************************************************************************/
-
-LinearPlaneStrainK0Law::LinearPlaneStrainK0Law(const LinearPlaneStrainK0Law& rOther)
-    : ElasticIsotropicK03DLaw(rOther)
-{
-}
-
-//********************************CLONE***********************************************
-/***********************************************************************************/
-
 ConstitutiveLaw::Pointer LinearPlaneStrainK0Law::Clone() const
 {
     return Kratos::make_shared<LinearPlaneStrainK0Law>(*this);
 }
-
-//*******************************DESTRUCTOR*******************************************
-/***********************************************************************************/
-
-LinearPlaneStrainK0Law::~LinearPlaneStrainK0Law()
-{
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
 
 bool& LinearPlaneStrainK0Law::GetValue(const Variable<bool>& rThisVariable, bool& rValue)
 {
@@ -67,9 +36,6 @@ bool& LinearPlaneStrainK0Law::GetValue(const Variable<bool>& rThisVariable, bool
     return rValue;
 }
 
-//*************************CONSTITUTIVE LAW GENERAL FEATURES *************************
-/***********************************************************************************/
-
 void LinearPlaneStrainK0Law::GetLawFeatures(Features& rFeatures)
 {
     //Set the type of law
@@ -77,54 +43,45 @@ void LinearPlaneStrainK0Law::GetLawFeatures(Features& rFeatures)
     rFeatures.mOptions.Set( INFINITESIMAL_STRAINS );
     rFeatures.mOptions.Set( ISOTROPIC );
 
-    //Set strain measure required by the consitutive law
+    //Set strain measure required by the constitutive law
     rFeatures.mStrainMeasures.push_back(StrainMeasure_Infinitesimal);
     rFeatures.mStrainMeasures.push_back(StrainMeasure_Deformation_Gradient);
 
     //Set the strain size
-    // for the time being
     rFeatures.mStrainSize = GetStrainSize();
 
-    //Set the spacedimension
+    //Set the space dimension
     rFeatures.mSpaceDimension = WorkingSpaceDimension();
 }
 
-/***********************************************************************************/
-/***********************************************************************************/
-
-void LinearPlaneStrainK0Law::
-    CalculateElasticMatrix(Matrix& C, ConstitutiveLaw::Parameters& rValues)
+void LinearPlaneStrainK0Law::CalculateElasticMatrix(Matrix& C, ConstitutiveLaw::Parameters& rValues)
 {
     KRATOS_TRY
 
     const Properties& r_material_properties = rValues.GetMaterialProperties();
-    const double &E = r_material_properties[YOUNG_MODULUS];
-    double NU = r_material_properties[POISSON_RATIO];
-
+    const double& E         = r_material_properties[YOUNG_MODULUS];
     const double& K0ValueXX = r_material_properties[K0_VALUE_XX];
     const double& K0ValueYY = r_material_properties[K0_VALUE_YY];
     const double& K0ValueZZ = r_material_properties[K0_VALUE_ZZ];
 
-    double K0 = 0.0;
+    double K0_value;
     const int &K0MainDirection = r_material_properties[K0_MAIN_DIRECTION];
     if (K0MainDirection == INDEX_2D_PLANE_STRAIN_XX) {
-        K0 = 0.5*(K0ValueYY + K0ValueZZ);
+        K0_value = 0.5*(K0ValueYY + K0ValueZZ);
     } else if (K0MainDirection == INDEX_2D_PLANE_STRAIN_YY) {
-        K0 = 0.5*(K0ValueXX + K0ValueZZ);
+        K0_value = 0.5*(K0ValueXX + K0ValueZZ);
     } else {
          KRATOS_ERROR << "undefined K0_MAIN_DIRECTION in LinearElasticPlaneStrainK02DLaw: " << K0MainDirection << std::endl;
     }
 
-    NU = K0 / (K0 + 1.0);
-    NU = std::max<double>(NU, 0.0);
-
+    double NU = std::max(K0_value / (K0_value + 1.0), 0.0);
     const double limit = 0.005;
     if (NU < (0.5 + limit) && NU > (0.5 - limit)) NU = 0.5 - limit;
 
     this->CheckClearElasticMatrix(C);
 
-    const double c0 = E / ((1.00 + NU)*(1 - 2 * NU));
-    const double c1 = (1.00 - NU)*c0;
+    const double c0 = E / ((1.0 + NU)*(1.0 - 2.0 * NU));
+    const double c1 = (1.0 - NU)*c0;
     const double c2 = c0 * NU;
     const double c3 = (0.5 - NU)*c0;
 
@@ -144,9 +101,6 @@ void LinearPlaneStrainK0Law::
 
     KRATOS_CATCH("")
 }
-
-/***********************************************************************************/
-/***********************************************************************************/
 
 void LinearPlaneStrainK0Law::CalculatePK2Stress(const Vector& rStrainVector,
                                                 Vector& rStressVector,
@@ -177,8 +131,6 @@ void LinearPlaneStrainK0Law::CalculatePK2Stress(const Vector& rStrainVector,
 
     KRATOS_CATCH("")
 }
-
-/***********************************************************************************/
 
 void LinearPlaneStrainK0Law::CalculateCauchyGreenStrain(Parameters& rValues, Vector& rStrainVector)
 {

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_K0_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_K0_law.h
@@ -10,12 +10,7 @@
 //  Main authors:    Vahid Galavi
 //
 
-#if !defined (KRATOS_LINEAR_PLANE_STRAIN_K0_LAW_H_INCLUDED)
-#define  KRATOS_LINEAR_PLANE_STRAIN_K0_LAW_H_INCLUDED
-
-// System includes
-
-// External includes
+#pragma once
 
 // Project includes
 #include "custom_constitutive/elastic_isotropic_K0_3d_law.h"
@@ -78,25 +73,9 @@ public:
     ///@{
 
     /**
-     * @brief Default constructor.
-     */
-    LinearPlaneStrainK0Law();
-
-    /**
      * @brief The clone operation
      */
     ConstitutiveLaw::Pointer Clone() const override;
-
-    /**
-     * Copy constructor.
-     */
-    LinearPlaneStrainK0Law (const LinearPlaneStrainK0Law& rOther);
-
-
-    /**
-     * @brief Destructor.
-     */
-    ~LinearPlaneStrainK0Law() override;
 
     ///@}
     ///@name Operators
@@ -237,5 +216,5 @@ private:
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, ElasticIsotropicK03DLaw)
     }
 }; // Class LinearPlaneStrainK0Law
-}  // namespace Kratos.
-#endif // KRATOS_LINEAR_PLANE_STRAIN_K0_LAW_H_INCLUDED  defined
+
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_stress_2D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_stress_2D_law.cpp
@@ -10,11 +10,6 @@
 //  Main authors:    Vahid Galavi
 //
 
-// System includes
-#include <iostream>
-
-// External includes
-
 // Project includes
 #include "custom_constitutive/linear_elastic_plane_stress_2D_law.h"
 
@@ -23,40 +18,11 @@
 namespace Kratos
 {
 
-//******************************CONSTRUCTOR*******************************************
-//************************************************************************************
-
-GeoLinearElasticPlaneStress2DLaw::GeoLinearElasticPlaneStress2DLaw()
-    : ElasticIsotropicK03DLaw()
-{
-}
-
-//******************************COPY CONSTRUCTOR**************************************
-//************************************************************************************
-
-GeoLinearElasticPlaneStress2DLaw::GeoLinearElasticPlaneStress2DLaw(const GeoLinearElasticPlaneStress2DLaw& rOther)
-    : ElasticIsotropicK03DLaw(rOther)
-{
-}
-
-//********************************CLONE***********************************************
-//************************************************************************************
-
 ConstitutiveLaw::Pointer GeoLinearElasticPlaneStress2DLaw::Clone() const
 {
     GeoLinearElasticPlaneStress2DLaw::Pointer p_clone(new GeoLinearElasticPlaneStress2DLaw(*this));
     return p_clone;
 }
-
-//*******************************DESTRUCTOR*******************************************
-//************************************************************************************
-
-GeoLinearElasticPlaneStress2DLaw::~GeoLinearElasticPlaneStress2DLaw()
-{
-}
-
-//************************************************************************************
-//************************************************************************************
 
 bool& GeoLinearElasticPlaneStress2DLaw::GetValue(const Variable<bool>& rThisVariable, bool& rValue)
 {
@@ -66,9 +32,6 @@ bool& GeoLinearElasticPlaneStress2DLaw::GetValue(const Variable<bool>& rThisVari
 
     return rValue;
 }
-
-//*************************CONSTITUTIVE LAW GENERAL FEATURES *************************
-//************************************************************************************
 
 void GeoLinearElasticPlaneStress2DLaw::GetLawFeatures(Features& rFeatures)
 {
@@ -88,20 +51,17 @@ void GeoLinearElasticPlaneStress2DLaw::GetLawFeatures(Features& rFeatures)
     rFeatures.mSpaceDimension = 2;
 }
 
-//************************************************************************************
-//************************************************************************************
-
 void GeoLinearElasticPlaneStress2DLaw::CalculateElasticMatrix(Matrix& C, ConstitutiveLaw::Parameters& rValues)
 {
     const Properties& r_material_properties = rValues.GetMaterialProperties();
-    const double E = r_material_properties[YOUNG_MODULUS];
+    const double E  = r_material_properties[YOUNG_MODULUS];
     const double NU = r_material_properties[POISSON_RATIO];
 
     this->CheckClearElasticMatrix(C);
 
-    const double c1 = E / (1.00 - NU * NU);
+    const double c1 = E / (1.0 - NU * NU);
     const double c2 = c1 * NU;
-    const double c3 = 0.5*E / (1 + NU);
+    const double c3 = 0.5*E / (1.0 + NU);
 
     C(0, 0) = c1;
     C(0, 1) = c2;
@@ -110,30 +70,14 @@ void GeoLinearElasticPlaneStress2DLaw::CalculateElasticMatrix(Matrix& C, Constit
     C(2, 2) = c3;
 }
 
-//************************************************************************************
-//************************************************************************************
-
-void GeoLinearElasticPlaneStress2DLaw::CalculatePK2Stress(
-    const Vector& rStrainVector,
-    Vector& rStressVector,
-    ConstitutiveLaw::Parameters& rValues
-)
+void GeoLinearElasticPlaneStress2DLaw::CalculatePK2Stress(const Vector& rStrainVector,
+                                                          Vector& rStressVector,
+                                                          ConstitutiveLaw::Parameters& rValues)
 {
-    const Properties& r_material_properties = rValues.GetMaterialProperties();
-    const double E = r_material_properties[YOUNG_MODULUS];
-    const double NU = r_material_properties[POISSON_RATIO];
-
-    const double c1 = E / (1.00 - NU * NU);
-    const double c2 = c1 * NU;
-    const double c3 = 0.5* E / (1 + NU);
-
-    rStressVector[0] = c1 * rStrainVector[0] + c2 * rStrainVector[1];
-    rStressVector[1] = c2 * rStrainVector[0] + c1 * rStrainVector[1];
-    rStressVector[2] = c3 * rStrainVector[2];
+    Matrix C;
+    this->CalculateElasticMatrix(C, rValues);
+    noalias(rStressVector) = prod(C, rStrainVector);
 }
-
-//************************************************************************************
-//************************************************************************************
 
 void GeoLinearElasticPlaneStress2DLaw::CalculateCauchyGreenStrain(Parameters& rValues, Vector& rStrainVector)
 {
@@ -156,4 +100,4 @@ void GeoLinearElasticPlaneStress2DLaw::CalculateCauchyGreenStrain(Parameters& rV
     noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
 }
 
-} // Namespace Kratos
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_stress_2D_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_stress_2D_law.h
@@ -10,12 +10,7 @@
 //  Main authors:    Vahid Galavi
 //
 
-#if !defined (KRATOS_GEO_LINEAR_ELASTIC_PLANE_STRESS_LAW_H_INCLUDED)
-#define  KRATOS_GEO_LINEAR_ELASTIC_PLANE_STRESS_LAW_H_INCLUDED
-
-// System includes
-
-// External includes
+#pragma once
 
 // Project includes
 #include "custom_constitutive/elastic_isotropic_K0_3d_law.h"
@@ -79,23 +74,7 @@ public:
     ///@name Life Cycle
     ///@{
 
-    /**
-     * Default constructor.
-     */
-    GeoLinearElasticPlaneStress2DLaw();
-
     ConstitutiveLaw::Pointer Clone() const override;
-
-    /**
-     * Copy constructor.
-     */
-    GeoLinearElasticPlaneStress2DLaw (const GeoLinearElasticPlaneStress2DLaw& rOther);
-
-
-    /**
-     * Destructor.
-     */
-    ~GeoLinearElasticPlaneStress2DLaw() override;
 
     ///@}
     ///@name Operators
@@ -241,5 +220,5 @@ private:
 
 
 }; // Class GeoLinearElasticPlaneStress2DLaw
-}  // namespace Kratos.
-#endif // KRATOS_GEO_LINEAR_ELASTIC_PLANE_STRESS_LAW_H_INCLUDED  defined
+
+}


### PR DESCRIPTION
**📝 Description**
Addressed several code smells in `custom_constitutive` reported by SonarCloud. Also fixed several problems found by clang-tidy.

**🆕 Changelog**
- Removed some commented out code.
- Avoid decorating a function with `virtual` as well as `override`.
- Removed some redundant pairs of parentheses.
- Renamed some local variables to avoid shadowing a global variable.

Other improvements include:
- Replaced some old-style inclusion guards by `#pragma once`.
- Applied the "rule of zero" (C.20 of the C++ Core Guidelines) to some classes.
- Don't repeat the code for computing the L2 norm of a vector.
- Fixed some spelling mistakes.
- Removed some redundant comments and blank lines.
- Improved the source code layout.
- Added `const` to some references (when immutability is desired).
- Removed some unused `#include`s.
- Removed some concrete template parameter types that were identical to the default value.
