### PR TITLE
[GeoMechanicsAnalysis] start_time and end_time single definition

### DIFF
--- a/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
+++ b/applications/GeoMechanicsApplication/custom_strategies/strategies/geo_mechanics_newton_raphson_strategy.hpp
@@ -87,7 +87,6 @@ public:
                     "number_cycles":    5,
                     "increase_factor":  2.0,
                     "reduction_factor": 0.5,
-                    "end_time": 1.0,
                     "max_piping_iterations": 50,
                     "desired_iterations": 4,
                     "max_radius_factor": 20.0,

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
@@ -147,7 +147,6 @@ namespace Kratos
         "number_cycles":    100,
         "increase_factor":  2.0,
         "reduction_factor": 0.5,
-        "end_time": 1.0,
 		"max_piping_iterations": 500,
         "desired_iterations": 4,
         "max_radius_factor": 10.0,

--- a/applications/GeoMechanicsApplication/python_scripts/collect_stages.py
+++ b/applications/GeoMechanicsApplication/python_scripts/collect_stages.py
@@ -246,7 +246,6 @@ def update_project_parameters_files(all_project_parameters):
         if project_parameters["problem_data"]["start_time"] < previous_end_time:
             dt = project_parameters["problem_data"]["end_time"] - project_parameters["problem_data"]["start_time"]
             project_parameters["problem_data"]["start_time"] = previous_end_time
-            project_parameters["solver_settings"]["start_time"] = previous_end_time
             project_parameters["problem_data"]["end_time"] = previous_end_time + dt
 
         previous_end_time = project_parameters["problem_data"]["end_time"]

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_Pw_solver.py
@@ -25,7 +25,6 @@ class PwSolver(GeoSolver):
             "solver_type": "geomechanics_U_Pw_solver",
             "model_part_name": "PorousDomain",
             "domain_size": 2,
-            "start_time": 0.0,
             "model_import_settings":{
                 "input_type": "mdpa",
                 "input_filename": "unknown_name"
@@ -34,7 +33,6 @@ class PwSolver(GeoSolver):
                 "materials_filename": ""
             },
             "time_stepping": {
-                "end_time" : 1.0,
                 "time_step": 0.1
             },
             "buffer_size": 2,
@@ -130,32 +128,32 @@ class PwSolver(GeoSolver):
 
     def _ConstructScheme(self, scheme_type, solution_type):
 
-        self.main_model_part.ProcessInfo.SetValue(KratosGeo.VELOCITY_COEFFICIENT, 1.0)
+        self.main_model_part.ProcessInfo.SetValue(KratosGeo.VELOCITY_COEFFICIENT,    1.0)
         self.main_model_part.ProcessInfo.SetValue(KratosGeo.DT_PRESSURE_COEFFICIENT, 1.0)
 
         if (scheme_type.lower() == "newmark" or scheme_type.lower() == "newmark_flow"):
-            theta = self.settings["newmark_theta"].GetDouble()
+            theta      = self.settings["newmark_theta"].GetDouble()
             rayleigh_m = self.settings["rayleigh_m"].GetDouble()
             rayleigh_k = self.settings["rayleigh_k"].GetDouble()
             self.main_model_part.ProcessInfo.SetValue(KratosStructure.RAYLEIGH_ALPHA, rayleigh_m)
-            self.main_model_part.ProcessInfo.SetValue(KratosStructure.RAYLEIGH_BETA, rayleigh_k)
+            self.main_model_part.ProcessInfo.SetValue(KratosStructure.RAYLEIGH_BETA,  rayleigh_k)
             KratosMultiphysics.Logger.PrintInfo("GeoMechanics_Pw_Solver, solution_type", solution_type)
             if (solution_type.lower() == "transient-groundwater-flow" or solution_type.lower() == "transient_groundwater_flow"):
                 KratosMultiphysics.Logger.PrintInfo("GeoMechanics_Pw_Solver, scheme", "Newmark Transient groundwater flow.")
-                scheme = scheme = KratosGeo.NewmarkQuasistaticPwScheme(theta)
+                scheme = KratosGeo.NewmarkQuasistaticPwScheme(theta)
             elif (solution_type.lower() == "steady-state-groundwater-flow" or solution_type.lower() == "steady_state_groundwater_flow"):
                 KratosMultiphysics.Logger.PrintInfo("GeoMechanics_Pw_Solver, scheme", "Newmark Steady-state groundwater flow.")
-                scheme = scheme = KratosGeo.NewmarkQuasistaticPwScheme(theta)
+                scheme = KratosGeo.NewmarkQuasistaticPwScheme(theta)
 
             else:
               raise Exception("Undefined solution type", solution_type)
         elif (scheme_type.lower() == "backward_euler"):
             if (solution_type.lower() == "transient-groundwater-flow" or solution_type.lower() == "transient_groundwater_flow"):
                 KratosMultiphysics.Logger.PrintInfo("GeoMechanics_Pw_Solver, scheme", "Backward Euler Transient groundwater flow.")
-                scheme = scheme = KratosGeo.BackwardEulerQuasistaticPwScheme()
+                scheme = KratosGeo.BackwardEulerQuasistaticPwScheme()
             elif (solution_type.lower() == "steady-state-groundwater-flow" or solution_type.lower() == "steady_state_groundwater_flow"):
                 KratosMultiphysics.Logger.PrintInfo("GeoMechanics_Pw_Solver, scheme", "Backward Euler Steady-state groundwater flow.")
-                scheme = scheme = KratosGeo.BackwardEulerQuasistaticPwScheme()
+                scheme = KratosGeo.BackwardEulerQuasistaticPwScheme()
         else:
             raise Exception("Apart from Newmark, other scheme_type are not available.")
 
@@ -169,19 +167,19 @@ class PwSolver(GeoSolver):
         R_AT = self.settings["residual_absolute_tolerance"].GetDouble()
         echo_level = self.settings["echo_level"].GetInt()
 
-        if(convergence_criterion.lower() == "water_pressure_criterion"):
+        if (convergence_criterion.lower() == "water_pressure_criterion"):
             convergence_criterion = KratosMultiphysics.MixedGenericCriteria([(KratosMultiphysics.WATER_PRESSURE, D_RT, D_AT)])
             convergence_criterion.SetEchoLevel(echo_level)
-        elif(convergence_criterion.lower() == "residual_criterion"):
+        elif (convergence_criterion.lower() == "residual_criterion"):
             convergence_criterion = KratosMultiphysics.ResidualCriteria(R_RT, R_AT)
             convergence_criterion.SetEchoLevel(echo_level)
-        elif(convergence_criterion.lower() == "and_criterion"):
+        elif (convergence_criterion.lower() == "and_criterion"):
             WaterPressure = KratosMultiphysics.MixedGenericCriteria([(KratosMultiphysics.WATER_PRESSURE, D_RT, D_AT)])
             WaterPressure.SetEchoLevel(echo_level)
             Residual = KratosMultiphysics.ResidualCriteria(R_RT, R_AT)
             Residual.SetEchoLevel(echo_level)
             convergence_criterion = KratosMultiphysics.AndCriteria(Residual, WaterPressure)
-        elif(convergence_criterion.lower() == "or_criterion"):
+        elif (convergence_criterion.lower() == "or_criterion"):
             WaterPressure = KratosMultiphysics.MixedGenericCriteria([(KratosMultiphysics.WATER_PRESSURE, D_RT, D_AT)])
             WaterPressure.SetEchoLevel(echo_level)
             Residual = KratosMultiphysics.ResidualCriteria(R_RT, R_AT)

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
@@ -26,7 +26,6 @@ class UPwSolver(GeoSolver):
             "solver_type": "geomechanics_U_Pw_solver",
             "model_part_name": "PorousDomain",
             "domain_size": 2,
-            "start_time": 0.0,
             "model_import_settings":{
                 "input_type": "mdpa",
                 "input_filename": "unknown_name"
@@ -35,7 +34,6 @@ class UPwSolver(GeoSolver):
                 "materials_filename": ""
             },
             "time_stepping": {
-                "end_time" : 1.0,
                 "time_step": 0.1
             },
             "buffer_size": 2,
@@ -173,17 +171,17 @@ class UPwSolver(GeoSolver):
 
     def _ConstructScheme(self, scheme_type, solution_type):
 
-        self.main_model_part.ProcessInfo.SetValue(KratosGeo.VELOCITY_COEFFICIENT, 1.0)
+        self.main_model_part.ProcessInfo.SetValue(KratosGeo.VELOCITY_COEFFICIENT,    1.0)
         self.main_model_part.ProcessInfo.SetValue(KratosGeo.DT_PRESSURE_COEFFICIENT, 1.0)
 
         if (scheme_type.lower() == "newmark"):
-            beta = self.settings["newmark_beta"].GetDouble()
+            beta  = self.settings["newmark_beta"].GetDouble()
             gamma = self.settings["newmark_gamma"].GetDouble()
             theta = self.settings["newmark_theta"].GetDouble()
             rayleigh_m = self.settings["rayleigh_m"].GetDouble()
             rayleigh_k = self.settings["rayleigh_k"].GetDouble()
             self.main_model_part.ProcessInfo.SetValue(KratosStructure.RAYLEIGH_ALPHA, rayleigh_m)
-            self.main_model_part.ProcessInfo.SetValue(KratosStructure.RAYLEIGH_BETA, rayleigh_k)
+            self.main_model_part.ProcessInfo.SetValue(KratosStructure.RAYLEIGH_BETA,  rayleigh_k)
             KratosMultiphysics.Logger.PrintInfo("GeoMechanics_U_Pw_Solver, solution_type", solution_type)
             if (solution_type.lower() == "quasi-static" or solution_type.lower() == "quasi_static"):
                 if (rayleigh_m < 1.0e-20 and rayleigh_k < 1.0e-20):
@@ -212,7 +210,7 @@ class UPwSolver(GeoSolver):
                 KratosMultiphysics.Logger.PrintInfo("GeoMechanics_U_Pw_Solver, scheme", "Backward Euler.")
                 scheme = KratosGeo.BackwardEulerQuasistaticUPwScheme()
             else:
-              raise Exception("Undefined/uncompatible solution type with Backward Euler", solution_type)
+              raise Exception("Undefined/incompatible solution type with Backward Euler", solution_type)
         else:
             raise Exception("Apart from Newmark, other scheme_type are not available.")
 
@@ -226,15 +224,15 @@ class UPwSolver(GeoSolver):
         R_AT = self.settings["residual_absolute_tolerance"].GetDouble()
         echo_level = self.settings["echo_level"].GetInt()
 
-        if(convergence_criterion.lower() == "displacement_criterion"):
+        if (convergence_criterion.lower() == "displacement_criterion"):
             convergence_criterion = KratosMultiphysics.DisplacementCriteria(D_RT, D_AT)
             convergence_criterion.SetEchoLevel(echo_level)
-        elif(convergence_criterion.lower() == "residual_criterion"):
+        elif (convergence_criterion.lower() == "residual_criterion"):
             convergence_criterion = KratosMultiphysics.ResidualCriteria(R_RT, R_AT)
             # other_dof_name = "WATER_PRESSURE"
             # convergence_criterion = KratosStructure.ResidualDisplacementAndOtherDoFCriteria(R_RT, R_AT, other_dof_name)
             convergence_criterion.SetEchoLevel(echo_level)
-        elif(convergence_criterion.lower() == "and_criterion"):
+        elif (convergence_criterion.lower() == "and_criterion"):
             Displacement = KratosMultiphysics.DisplacementCriteria(D_RT, D_AT)
             Displacement.SetEchoLevel(echo_level)
             Residual = KratosMultiphysics.ResidualCriteria(R_RT, R_AT)
@@ -242,7 +240,7 @@ class UPwSolver(GeoSolver):
             # Residual = KratosStructure.ResidualDisplacementAndOtherDoFCriteria(R_RT, R_AT, other_dof_name)
             Residual.SetEchoLevel(echo_level)
             convergence_criterion = KratosMultiphysics.AndCriteria(Residual, Displacement)
-        elif(convergence_criterion.lower() == "or_criterion"):
+        elif (convergence_criterion.lower() == "or_criterion"):
             Displacement = KratosMultiphysics.DisplacementCriteria(D_RT, D_AT)
             Displacement.SetEchoLevel(echo_level)
             # Residual = KratosMultiphysics.ResidualCriteria(R_RT, R_AT)
@@ -250,10 +248,10 @@ class UPwSolver(GeoSolver):
             Residual = KratosStructure.ResidualDisplacementAndOtherDoFCriteria(R_RT, R_AT, other_dof_name)
             Residual.SetEchoLevel(echo_level)
             convergence_criterion = KratosMultiphysics.OrCriteria(Residual, Displacement)
-        elif(convergence_criterion.lower() == "water_pressure_criterion"):
+        elif (convergence_criterion.lower() == "water_pressure_criterion"):
             convergence_criterion = KratosMultiphysics.MixedGenericCriteria([(KratosMultiphysics.WATER_PRESSURE, D_RT, D_AT)])
             convergence_criterion.SetEchoLevel(echo_level)
-        elif(convergence_criterion.lower() == "displacement_and_water_pressure_criterion"):
+        elif (convergence_criterion.lower() == "displacement_and_water_pressure_criterion"):
             convergence_criterion = KratosMultiphysics.MixedGenericCriteria([(KratosMultiphysics.DisplacementCriteria(D_RT, D_AT)),(KratosMultiphysics.WATER_PRESSURE, D_RT, D_AT)])
             convergence_criterion.SetEchoLevel(echo_level)
         else:

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
@@ -117,7 +117,7 @@ class GeoMechanicsAnalysis(GeoMechanicsAnalysisBase):
             self.max_delta_time_factor = project_parameters["solver_settings"]["time_stepping"]["max_delta_time_factor"].GetDouble()
         self.max_delta_time      = self.delta_time * self.max_delta_time_factor
         self.number_cycles       = project_parameters["solver_settings"]["number_cycles"].GetInt()
-        
+
         self.max_iterations      = project_parameters["solver_settings"]["max_iterations"].GetInt()
         self.solution_type       = project_parameters["solver_settings"]["solution_type"].GetString()
         self.reset_displacements = project_parameters["solver_settings"]["reset_displacements"].GetBool()

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
@@ -102,35 +102,39 @@ class GeoMechanicsAnalysis(GeoMechanicsAnalysisBase):
     def __init__(self, model, project_parameters):
         super().__init__(model, project_parameters)
 
+        # time step related stuff
+        self.start_time          = project_parameters["problem_data"]["start_time"].GetDouble()
+        self.end_time            = project_parameters["problem_data"]["end_time"].GetDouble()
+
+        self.delta_time          = project_parameters["solver_settings"]["time_stepping"]["time_step"].GetDouble()
+        self.delta_time          = min(self.delta_time, self.end_time - self.start_time)
+
         self.reduction_factor    = project_parameters["solver_settings"]["reduction_factor"].GetDouble()
         self.increase_factor     = project_parameters["solver_settings"]["increase_factor"].GetDouble()
-        self.delta_time          = project_parameters["solver_settings"]["time_stepping"]["time_step"].GetDouble()
-
+        self.min_iterations      = project_parameters["solver_settings"]["min_iterations"].GetInt()
         self.max_delta_time_factor = 1000.0
         if project_parameters["solver_settings"]["time_stepping"].Has("max_delta_time_factor"):
-            self.max_delta_time_factor = \
-                project_parameters["solver_settings"]["time_stepping"]["max_delta_time_factor"].GetDouble()
-
+            self.max_delta_time_factor = project_parameters["solver_settings"]["time_stepping"]["max_delta_time_factor"].GetDouble()
         self.max_delta_time      = self.delta_time * self.max_delta_time_factor
-        self.max_iterations      = project_parameters["solver_settings"]["max_iterations"].GetInt()
-        self.min_iterations      = project_parameters["solver_settings"]["min_iterations"].GetInt()
         self.number_cycles       = project_parameters["solver_settings"]["number_cycles"].GetInt()
+        
+        self.max_iterations      = project_parameters["solver_settings"]["max_iterations"].GetInt()
         self.solution_type       = project_parameters["solver_settings"]["solution_type"].GetString()
         self.reset_displacements = project_parameters["solver_settings"]["reset_displacements"].GetBool()
-        self.start_time          = project_parameters["solver_settings"]["start_time"].GetDouble()
-        self.end_time            = project_parameters["problem_data"]["end_time"].GetDouble()
         self.rebuild_level       = project_parameters["solver_settings"]["rebuild_level"].GetInt()
 
     def FinalizeSolutionStep(self):
         super().FinalizeSolutionStep()
 
-        if(self._GetSolver().GetComputingModelPart().ProcessInfo[KratosMultiphysics.NL_ITERATION_NUMBER] > self.max_iterations):
+        if (self._GetSolver().GetComputingModelPart().ProcessInfo[KratosMultiphysics.NL_ITERATION_NUMBER] > self.max_iterations):
             raise Exception("max_number_of_iterations_exceeded")
 
     def RunSolutionLoop(self):
         """This function executes the solution loop of the AnalysisStage
         It can be overridden by derived classes
         """
+
+        # store total displacement field for reset_displacements
         if self._GetSolver().settings["reset_displacements"].GetBool():
             old_total_displacements = [node.GetSolutionStepValue(KratosGeo.TOTAL_DISPLACEMENT)
                                        for node in self._GetSolver().GetComputingModelPart().Nodes]
@@ -138,14 +142,17 @@ class GeoMechanicsAnalysis(GeoMechanicsAnalysisBase):
         self._GetSolver().solver.SetRebuildLevel(self.rebuild_level)
 
         while self.KeepAdvancingSolutionLoop():
+            # check against max_delta_time should only be necessary when trying to scale up
             if (self.delta_time > self.max_delta_time):
                 self.delta_time = self.max_delta_time
                 KratosMultiphysics.Logger.PrintInfo(self._GetSimulationName(), "reducing delta_time to max_delta_time: ", self.max_delta_time)
-            t = self._GetSolver().GetComputingModelPart().ProcessInfo[KratosMultiphysics.TIME]
-            new_time = t + self.delta_time
-            if (new_time > self.end_time):
-                new_time = self.end_time
-                self.delta_time = new_time - t
+            
+            # maximize delta_time to avoid exceeding the end_time
+            t               = self._GetSolver().GetComputingModelPart().ProcessInfo[KratosMultiphysics.TIME]
+            self.delta_time = min( self.delta_time, self.end_time - t )
+            new_time        = t + self.delta_time
+
+            # start the new step
             self._GetSolver().GetComputingModelPart().ProcessInfo[KratosMultiphysics.STEP] += 1
             self._GetSolver().main_model_part.CloneTimeStep(new_time)
 
@@ -157,36 +164,43 @@ class GeoMechanicsAnalysis(GeoMechanicsAnalysisBase):
 
                 number_cycle +=1
                 KratosMultiphysics.Logger.PrintInfo(self._GetSimulationName(), "cycle: ", number_cycle)
-                t = self._GetSolver().GetComputingModelPart().ProcessInfo[KratosMultiphysics.TIME]
-                new_time = t - self._GetSolver().GetComputingModelPart().ProcessInfo[KratosMultiphysics.DELTA_TIME] + self.delta_time
-                self._GetSolver().GetComputingModelPart().ProcessInfo[KratosMultiphysics.TIME] = new_time
+
+
+                # set new_time and delta_time in the nonlinear solver
+                new_time = t + self.delta_time
+                self._GetSolver().GetComputingModelPart().ProcessInfo[KratosMultiphysics.TIME]       = new_time
                 self._GetSolver().GetComputingModelPart().ProcessInfo[KratosMultiphysics.DELTA_TIME] = self.delta_time
 
+                # do the nonlinear solver iterations
                 self.InitializeSolutionStep()
                 self._GetSolver().Predict()
                 converged = self._GetSolver().SolveSolutionStep()
                 self._GetSolver().solver.SetStiffnessMatrixIsBuilt(True)
 
-                if (self._GetSolver().GetComputingModelPart().ProcessInfo[KratosMultiphysics.NL_ITERATION_NUMBER] >= self.max_iterations or not converged):
+                if (converged):
+                    # scale next step if desired
+                    if (new_time < self.end_time):
+                        if (self._GetSolver().GetComputingModelPart().ProcessInfo[KratosMultiphysics.NL_ITERATION_NUMBER] < self.min_iterations):
+                            # scale up next step
+                            self.delta_time = min( self.increase_factor * self.delta_time, self.max_delta_time )
+                            if ( new_time + self.delta_time <= self.end_time ):
+                                KratosMultiphysics.Logger.PrintInfo(self._GetSimulationName(), "Up-scaling to delta time: ", self.delta_time)
+                            else:
+                                KratosMultiphysics.Logger.PrintInfo(self._GetSimulationName(), "Up-scaling to reach end_time: ", self.end_time)
+                                self.delta_time = self.end_time - new_time
+                        elif (self._GetSolver().GetComputingModelPart().ProcessInfo[KratosMultiphysics.NL_ITERATION_NUMBER] == self.max_iterations):
+                            # converged, but max_iterations reached, scale down next step
+                            self.delta_time *= self.reduction_factor
+                            KratosMultiphysics.Logger.PrintInfo(self._GetSimulationName(), "Down-scaling with factor: ", self.reduction_factor)
+                else:
+                    # scale down step and restart
                     KratosMultiphysics.Logger.PrintInfo(self._GetSimulationName(), "Down-scaling with factor: ", self.reduction_factor)
                     self.delta_time *= self.reduction_factor
-
-                    #converged = False
                     # Reset displacements to the initial
                     KratosMultiphysics.VariableUtils().UpdateCurrentPosition(self._GetSolver().GetComputingModelPart().Nodes, KratosMultiphysics.DISPLACEMENT,1)
                     for node in self._GetSolver().GetComputingModelPart().Nodes:
                         dold = node.GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT,1)
-                        node.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT,0,dold)
-
-                elif (self._GetSolver().GetComputingModelPart().ProcessInfo[KratosMultiphysics.NL_ITERATION_NUMBER] < self.min_iterations):
-                    KratosMultiphysics.Logger.PrintInfo(self._GetSimulationName(), "Up-scaling with factor: ", self.increase_factor)
-                    #converged = True
-                    self.delta_time *= self.increase_factor
-                    t = self._GetSolver().GetComputingModelPart().ProcessInfo[KratosMultiphysics.TIME]
-                    new_time = t + self.delta_time
-                    if (new_time > self.end_time):
-                        new_time = self.end_time
-                        self.delta_time = new_time - t
+                        node.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT, 0, dold)
 
             if not converged:
                 raise Exception('The maximum number of cycles is reached without convergence!')
@@ -197,7 +211,6 @@ class GeoMechanicsAnalysis(GeoMechanicsAnalysisBase):
 
             self.FinalizeSolutionStep()
             self.OutputSolutionStep()
-
 
 if __name__ == '__main__':
     from sys import argv

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_analysis.py
@@ -146,7 +146,7 @@ class GeoMechanicsAnalysis(GeoMechanicsAnalysisBase):
             if (self.delta_time > self.max_delta_time):
                 self.delta_time = self.max_delta_time
                 KratosMultiphysics.Logger.PrintInfo(self._GetSimulationName(), "reducing delta_time to max_delta_time: ", self.max_delta_time)
-            
+
             # maximize delta_time to avoid exceeding the end_time
             t               = self._GetSolver().GetComputingModelPart().ProcessInfo[KratosMultiphysics.TIME]
             self.delta_time = min( self.delta_time, self.end_time - t )
@@ -164,7 +164,6 @@ class GeoMechanicsAnalysis(GeoMechanicsAnalysisBase):
 
                 number_cycle +=1
                 KratosMultiphysics.Logger.PrintInfo(self._GetSimulationName(), "cycle: ", number_cycle)
-
 
                 # set new_time and delta_time in the nonlinear solver
                 new_time = t + self.delta_time

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
@@ -60,7 +60,6 @@ class GeoMechanicalSolver(PythonSolver):
             "solver_type": "geomechanics_U_Pw_solver",
             "model_part_name": "PorousDomain",
             "domain_size": 2,
-            "start_time": 0.0,
             "model_import_settings":{
                 "input_type": "mdpa",
                 "input_filename": "unknown_name"
@@ -69,7 +68,6 @@ class GeoMechanicalSolver(PythonSolver):
                 "materials_filename": ""
             },
             "time_stepping": {
-                "end_time" : 1.0,
                 "time_step": 0.1
             },
             "buffer_size": 2,
@@ -155,8 +153,6 @@ class GeoMechanicalSolver(PythonSolver):
                 self.settings["prebuild_dynamics"].GetBool()):
                 raise ValueError("Scaling can not be used if prebuild dynamics is true")
 
-
-
     def AddVariables(self):
         # this can safely be called also for restarts, it is internally checked if the variables exist already
         # Variables for 1-phase types of calculations:
@@ -201,17 +197,11 @@ class GeoMechanicalSolver(PythonSolver):
         """This function prepares the ModelPart for being used by the PythonSolver
         """
         # Set ProcessInfo variables
-        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.TIME,
-                                                  self.settings["start_time"].GetDouble())
-        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DELTA_TIME,
-                                                  self.settings["time_stepping"]["time_step"].GetDouble())
-        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.STEP, 0)
-
         self.main_model_part.ProcessInfo.SetValue(GeoMechanicsApplication.TIME_UNIT_CONVERTER, 1.0)
-
         self.main_model_part.ProcessInfo.SetValue(GeoMechanicsApplication.NODAL_SMOOTHING,
                                                   self.settings["nodal_smoothing"].GetBool())
 
+        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.STEP, 0)
         if not self.main_model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED]:
             ## Executes the check and prepare model process (Create computing_model_part and set constitutive law)
             self._ExecuteCheckAndPrepare()
@@ -419,22 +409,19 @@ class GeoMechanicalSolver(PythonSolver):
         if materials_imported:
             KratosMultiphysics.Logger.PrintInfo("::[GeoMechanicalSolver]:: ", "Constitutive law was successfully imported.")
         else:
-            # KratosMultiphysics.Logger.PrintInfo("::[GeoMechanicalSolver]:: ", "Constitutive law was not imported.")
             raise Exception("::[GeoMechanicalSolver]:: ", "Constitutive law was not imported.")
 
     def _SetBufferSize(self):
-        required_buffer_size = self.settings["buffer_size"].GetInt()
-        if required_buffer_size < self.GetMinimumBufferSize():
-            required_buffer_size = self.GetMinimumBufferSize()
-        current_buffer_size = self.main_model_part.GetBufferSize()
-        buffer_size = max(current_buffer_size, required_buffer_size)
+        required_buffer_size = max( self.settings["buffer_size"].GetInt(), self.GetMinimumBufferSize())
+        current_buffer_size  = self.main_model_part.GetBufferSize()
+        buffer_size          = max(current_buffer_size, required_buffer_size)
         self.main_model_part.SetBufferSize(buffer_size)
 
     def _FillBuffer(self):
         buffer_size = self.main_model_part.GetBufferSize()
-        time = self.main_model_part.ProcessInfo[KratosMultiphysics.TIME]
-        delta_time = self.main_model_part.ProcessInfo[KratosMultiphysics.DELTA_TIME]
-        step = self.main_model_part.ProcessInfo[KratosMultiphysics.STEP]
+        time        = self.main_model_part.ProcessInfo[KratosMultiphysics.TIME]
+        delta_time  = self.main_model_part.ProcessInfo[KratosMultiphysics.DELTA_TIME]
+        step        = self.main_model_part.ProcessInfo[KratosMultiphysics.STEP]
 
         step = step - (buffer_size-1)*1
         self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.STEP, step)
@@ -465,40 +452,40 @@ class GeoMechanicalSolver(PythonSolver):
         self.main_model_part.ProcessInfo.SetValue(GeoMechanicsApplication.IS_CONVERGED, True)
         self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.NL_ITERATION_NUMBER, 1)
 
-        max_iters = self.settings["max_iterations"].GetInt()
+        max_iters         = self.settings["max_iterations"].GetInt()
         compute_reactions = self.settings["compute_reactions"].GetBool()
-        reform_step_dofs = self.settings["reform_dofs_at_each_step"].GetBool()
-        move_mesh_flag = self.settings["move_mesh_flag"].GetBool()
+        reform_step_dofs  = self.settings["reform_dofs_at_each_step"].GetBool()
+        move_mesh_flag    = self.settings["move_mesh_flag"].GetBool()
 
         if strategy_type.lower() == "newton_raphson":
             self.strategy_params = KratosMultiphysics.Parameters("{}")
             self.strategy_params.AddValue("loads_sub_model_part_list",self.loads_sub_sub_model_part_list)
             self.strategy_params.AddValue("loads_variable_list",self.settings["loads_variable_list"])
             solving_strategy = GeoMechanicsApplication.GeoMechanicsNewtonRaphsonStrategy(self.computing_model_part,
-                                                                           self.scheme,
-                                                                           self.linear_solver,
-                                                                           self.convergence_criterion,
-                                                                           builder_and_solver,
-                                                                           self.strategy_params,
-                                                                           max_iters,
-                                                                           compute_reactions,
-                                                                           reform_step_dofs,
-                                                                           move_mesh_flag)
+                                                                                         self.scheme,
+                                                                                         self.linear_solver,
+                                                                                         self.convergence_criterion,
+                                                                                         builder_and_solver,
+                                                                                         self.strategy_params,
+                                                                                         max_iters,
+                                                                                         compute_reactions,
+                                                                                         reform_step_dofs,
+                                                                                         move_mesh_flag)
         elif strategy_type.lower() == "newton_raphson_with_piping":
             self.strategy_params = KratosMultiphysics.Parameters("{}")
             self.strategy_params.AddValue("loads_sub_model_part_list",self.loads_sub_sub_model_part_list)
             self.strategy_params.AddValue("loads_variable_list",self.settings["loads_variable_list"])
             self.strategy_params.AddValue("max_piping_iterations", self.settings["max_piping_iterations"])
             solving_strategy = GeoMechanicsApplication.GeoMechanicsNewtonRaphsonErosionProcessStrategy(self.computing_model_part,
-                                                                                             self.scheme,
-                                                                                             self.linear_solver,
-                                                                                             self.convergence_criterion,
-                                                                                             builder_and_solver,
-                                                                                             self.strategy_params,
-                                                                                             max_iters,
-                                                                                             compute_reactions,
-                                                                                             reform_step_dofs,
-                                                                                             move_mesh_flag)
+                                                                                                       self.scheme,
+                                                                                                       self.linear_solver,
+                                                                                                       self.convergence_criterion,
+                                                                                                       builder_and_solver,
+                                                                                                       self.strategy_params,
+                                                                                                       max_iters,
+                                                                                                       compute_reactions,
+                                                                                                       reform_step_dofs,
+                                                                                                       move_mesh_flag)
 
         elif strategy_type.lower() == "line_search":
             self.strategy_params = KratosMultiphysics.Parameters("{}")
@@ -532,15 +519,15 @@ class GeoMechanicalSolver(PythonSolver):
             self.strategy_params.AddValue("loads_sub_model_part_list",self.loads_sub_sub_model_part_list)
             self.strategy_params.AddValue("loads_variable_list",self.settings["loads_variable_list"])
             solving_strategy = GeoMechanicsApplication.GeoMechanicsRammArcLengthStrategy(self.computing_model_part,
-                                                                           self.scheme,
-                                                                           self.linear_solver,
-                                                                           self.convergence_criterion,
-                                                                           builder_and_solver,
-                                                                           self.strategy_params,
-                                                                           max_iters,
-                                                                           compute_reactions,
-                                                                           reform_step_dofs,
-                                                                           move_mesh_flag)
+                                                                                         self.scheme,
+                                                                                         self.linear_solver,
+                                                                                         self.convergence_criterion,
+                                                                                         builder_and_solver,
+                                                                                         self.strategy_params,
+                                                                                         max_iters,
+                                                                                         compute_reactions,
+                                                                                         reform_step_dofs,
+                                                                                         move_mesh_flag)
 
         elif strategy_type.lower() == "linear":
             solving_strategy = KratosMultiphysics.ResidualBasedLinearStrategy(self.computing_model_part,

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solvers_wrapper.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solvers_wrapper.py
@@ -16,11 +16,9 @@ def CreateSolver(model, custom_settings):
     if (parallelism == "OpenMP"):
         solver_type = solver_type_raw.lower()
         if solver_type in ("u_pw", "geomechanics_u_pw_solver", "twophase"):
-            custom_settings["solver_settings"]["time_stepping"].AddValue("end_time", custom_settings["problem_data"]["end_time"])
             solver_module_name = "geomechanics_U_Pw_solver"
 
         elif solver_type in ("pw", "geomechanics_pw_solver"):
-            custom_settings["solver_settings"]["time_stepping"].AddValue("end_time", custom_settings["problem_data"]["end_time"])
             solver_module_name = "geomechanics_Pw_solver"
         else:
             err_msg =  "The requested solver type \"" + solver_type + "\" is not in the python solvers wrapper\n"

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage1.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage1.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "1D-Consolidationtest_stage1"

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage10.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage10.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         1728001,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "1D-Consolidationtest_stage10"

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage11.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage11.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         8640000,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "1D-Consolidationtest_stage11"

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage2.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage2.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         1.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "1D-Consolidationtest_stage2"

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage3.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage3.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         8641,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "1D-Consolidationtest_stage3"

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage4.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage4.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         17281,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "1D-Consolidationtest_stage4"

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage5.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage5.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         43201,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "1D-Consolidationtest_stage5"

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage6.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage6.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         86401,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "1D-Consolidationtest_stage6"

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage7.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage7.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         172801,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "1D-Consolidationtest_stage7"

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage8.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage8.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         432001,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "1D-Consolidationtest_stage8"

--- a/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage9.json
+++ b/applications/GeoMechanicsApplication/tests/1D-Consolidation_all_stages/ProjectParameters_stage9.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         864001,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "1D-Consolidationtest_stage9"

--- a/applications/GeoMechanicsApplication/tests/Biaxialshearstresswithlinearelasticmodel.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/Biaxialshearstresswithlinearelasticmodel.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "Biaxialshearstresswithlinearelasticmodel"

--- a/applications/GeoMechanicsApplication/tests/Simple_Dike_Gravity_Loading/line_body_all_stage_new_units_kPa/ProjectParameters_stage1.json
+++ b/applications/GeoMechanicsApplication/tests/Simple_Dike_Gravity_Loading/line_body_all_stage_new_units_kPa/ProjectParameters_stage1.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "line_body_all_stage_new_units_kPa_stage1"

--- a/applications/GeoMechanicsApplication/tests/Simple_Dike_Gravity_Loading/line_body_all_stage_new_units_kPa/ProjectParameters_stage2.json
+++ b/applications/GeoMechanicsApplication/tests/Simple_Dike_Gravity_Loading/line_body_all_stage_new_units_kPa/ProjectParameters_stage2.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         1.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "line_body_all_stage_new_units_kPa_stage2"

--- a/applications/GeoMechanicsApplication/tests/Simple_Dike_Gravity_Loading/simple_dike_test_with_gravity_umat.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/Simple_Dike_Gravity_Loading/simple_dike_test_with_gravity_umat.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "simple_dike_test_with_gravity_umat"

--- a/applications/GeoMechanicsApplication/tests/Simple_Dike_Gravity_Loading/simple_dike_test_with_gravity_umat.gid/ProjectParameters_stage1.json
+++ b/applications/GeoMechanicsApplication/tests/Simple_Dike_Gravity_Loading/simple_dike_test_with_gravity_umat.gid/ProjectParameters_stage1.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "simple_dike_test_with_gravity_umat_stage1"

--- a/applications/GeoMechanicsApplication/tests/Simple_Dike_Gravity_Loading/simple_dike_test_with_gravity_umat.gid/ProjectParameters_stage2.json
+++ b/applications/GeoMechanicsApplication/tests/Simple_Dike_Gravity_Loading/simple_dike_test_with_gravity_umat.gid/ProjectParameters_stage2.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         1.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "simple_dike_test_with_gravity_umat_stage2"

--- a/applications/GeoMechanicsApplication/tests/excavation_tests/base_test.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/excavation_tests/base_test.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "base_test"

--- a/applications/GeoMechanicsApplication/tests/excavation_tests/excavation_test.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/excavation_tests/excavation_test.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "excavation_test"

--- a/applications/GeoMechanicsApplication/tests/excavation_tests/excavation_test2.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/excavation_tests/excavation_test2.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "excavation_test2"

--- a/applications/GeoMechanicsApplication/tests/excavation_tests/excavation_test3.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/excavation_tests/excavation_test3.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "excavation_test3"

--- a/applications/GeoMechanicsApplication/tests/excavation_tests/excavation_test4.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/excavation_tests/excavation_test4.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "excavation_test4"

--- a/applications/GeoMechanicsApplication/tests/flow_rate_heterogeneous_soil.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/flow_rate_heterogeneous_soil.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "flow_rate_heterogeneous_soil"

--- a/applications/GeoMechanicsApplication/tests/geo_beam_with_reset_displacemnet.gid/ProjectParameters_stage1.json
+++ b/applications/GeoMechanicsApplication/tests/geo_beam_with_reset_displacemnet.gid/ProjectParameters_stage1.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "geo_beam_with_reset_displacemnet_stage_1"

--- a/applications/GeoMechanicsApplication/tests/geo_beam_with_reset_displacemnet.gid/ProjectParameters_stage2.json
+++ b/applications/GeoMechanicsApplication/tests/geo_beam_with_reset_displacemnet.gid/ProjectParameters_stage2.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         1.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "geo_beam_with_reset_displacemnet_stage_2"

--- a/applications/GeoMechanicsApplication/tests/geo_beam_with_reset_displacemnet.gid/ProjectParameters_stage3.json
+++ b/applications/GeoMechanicsApplication/tests/geo_beam_with_reset_displacemnet.gid/ProjectParameters_stage3.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         2.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "geo_beam_with_reset_displacemnet_stage_3"

--- a/applications/GeoMechanicsApplication/tests/geo_beam_with_reset_displacemnet.gid/ProjectParameters_stage4.json
+++ b/applications/GeoMechanicsApplication/tests/geo_beam_with_reset_displacemnet.gid/ProjectParameters_stage4.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         3.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "geo_beam_with_reset_displacemnet_stage_4"

--- a/applications/GeoMechanicsApplication/tests/geo_truss_with_reset_displacemnet.gid/ProjectParameters_stage1.json
+++ b/applications/GeoMechanicsApplication/tests/geo_truss_with_reset_displacemnet.gid/ProjectParameters_stage1.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "geo_truss_with_reset_displacemnet_stage_1"

--- a/applications/GeoMechanicsApplication/tests/geo_truss_with_reset_displacemnet.gid/ProjectParameters_stage2.json
+++ b/applications/GeoMechanicsApplication/tests/geo_truss_with_reset_displacemnet.gid/ProjectParameters_stage2.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         1.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "geo_truss_with_reset_displacemnet_stage_2"

--- a/applications/GeoMechanicsApplication/tests/geo_truss_with_reset_displacemnet.gid/ProjectParameters_stage3.json
+++ b/applications/GeoMechanicsApplication/tests/geo_truss_with_reset_displacemnet.gid/ProjectParameters_stage3.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         2.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "geo_truss_with_reset_displacemnet_stage_3"

--- a/applications/GeoMechanicsApplication/tests/geo_truss_with_reset_displacemnet.gid/ProjectParameters_stage4.json
+++ b/applications/GeoMechanicsApplication/tests/geo_truss_with_reset_displacemnet.gid/ProjectParameters_stage4.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         3.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "geo_truss_with_reset_displacemnet_stage_4"

--- a/applications/GeoMechanicsApplication/tests/interpolate_line_1.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/interpolate_line_1.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "interpolate_line_1"

--- a/applications/GeoMechanicsApplication/tests/interpolate_line_2.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/interpolate_line_2.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "interpolate_line_2"

--- a/applications/GeoMechanicsApplication/tests/line_load_tests/line_load_3D2N_hex.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/line_load_tests/line_load_3D2N_hex.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        3,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "line_load_3D2N_hex"

--- a/applications/GeoMechanicsApplication/tests/line_load_tests/line_load_3D2N_tet.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/line_load_tests/line_load_3D2N_tet.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        3,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "line_load_3D2N_tet"

--- a/applications/GeoMechanicsApplication/tests/line_load_tests/line_load_3D3N_hex.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/line_load_tests/line_load_3D3N_hex.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        3,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "line_load_3D3N_hex"

--- a/applications/GeoMechanicsApplication/tests/line_load_tests/line_load_3D3N_tet.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/line_load_tests/line_load_3D3N_tet.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        3,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "line_load_3D3N_tet"

--- a/applications/GeoMechanicsApplication/tests/test_1d_wave_prop_drained_soil.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_1d_wave_prop_drained_soil.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_1d_wave_prop_drained_soil"

--- a/applications/GeoMechanicsApplication/tests/test_1d_wave_prop_drained_soil_constant_mass_damping.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_1d_wave_prop_drained_soil_constant_mass_damping.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_1d_wave_prop_drained_soil_constant_mass_damping"

--- a/applications/GeoMechanicsApplication/tests/test_Abc_1_1_0_True_Deformations/ProjectParameters_stage1.json
+++ b/applications/GeoMechanicsApplication/tests/test_Abc_1_1_0_True_Deformations/ProjectParameters_stage1.json
@@ -11,7 +11,6 @@
     "solver_type": "U_Pw",
     "model_part_name": "PorousDomain",
     "domain_size": 2,
-    "start_time": -1E-06,
     "model_import_settings": {
       "input_type": "mdpa",
       "input_filename": "mesh_stage1"

--- a/applications/GeoMechanicsApplication/tests/test_Abc_1_1_0_True_Deformations/ProjectParameters_stage2.json
+++ b/applications/GeoMechanicsApplication/tests/test_Abc_1_1_0_True_Deformations/ProjectParameters_stage2.json
@@ -11,7 +11,6 @@
     "solver_type": "U_Pw",
     "model_part_name": "PorousDomain",
     "domain_size": 2,
-    "start_time": 0.0,
     "model_import_settings": {
       "input_type": "mdpa",
       "input_filename": "mesh_stage2"

--- a/applications/GeoMechanicsApplication/tests/test_SteadyState_DamConfinedFlowWithSheetPile_2D6N.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_SteadyState_DamConfinedFlowWithSheetPile_2D6N.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_SteadyState_DamConfinedFlowWithSheetPile_2D6N"

--- a/applications/GeoMechanicsApplication/tests/test_SteadyState_DamConfinedFlow_2D3N.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_SteadyState_DamConfinedFlow_2D3N.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_SteadyState_DamConfinedFlow_2D3N"

--- a/applications/GeoMechanicsApplication/tests/test_SteadyState_DamConfinedFlow_2D6N.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_SteadyState_DamConfinedFlow_2D6N.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_SteadyState_DamConfinedFlow_2D6N"

--- a/applications/GeoMechanicsApplication/tests/test_SteadyState_OneDFlow_2D3N.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_SteadyState_OneDFlow_2D3N.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_SteadyState_OneDFlow_2D3N"

--- a/applications/GeoMechanicsApplication/tests/test_Transient_Case_A1_2D3N.gid/ProjectParameters_stage1.json
+++ b/applications/GeoMechanicsApplication/tests/test_Transient_Case_A1_2D3N.gid/ProjectParameters_stage1.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         -1.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_Transient_Case_A1_2D3N_stage1"

--- a/applications/GeoMechanicsApplication/tests/test_Transient_Case_A1_2D3N.gid/ProjectParameters_stage2.json
+++ b/applications/GeoMechanicsApplication/tests/test_Transient_Case_A1_2D3N.gid/ProjectParameters_stage2.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_Transient_Case_A1_2D3N_stage2"

--- a/applications/GeoMechanicsApplication/tests/test_Transient_Case_A1_2D6N.gid/ProjectParameters_stage1.json
+++ b/applications/GeoMechanicsApplication/tests/test_Transient_Case_A1_2D6N.gid/ProjectParameters_stage1.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         -1.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_Transient_Case_A1_2D3N_stage1"

--- a/applications/GeoMechanicsApplication/tests/test_Transient_Case_A1_2D6N.gid/ProjectParameters_stage2.json
+++ b/applications/GeoMechanicsApplication/tests/test_Transient_Case_A1_2D6N.gid/ProjectParameters_stage2.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_Transient_Case_A1_2D3N_stage2"

--- a/applications/GeoMechanicsApplication/tests/test_Transient_Case_B1_2D3N.gid/ProjectParameters_stage1.json
+++ b/applications/GeoMechanicsApplication/tests/test_Transient_Case_B1_2D3N.gid/ProjectParameters_stage1.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         -1.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_Transient_Case_B1_2D3N_stage1"

--- a/applications/GeoMechanicsApplication/tests/test_Transient_Case_B1_2D3N.gid/ProjectParameters_stage2.json
+++ b/applications/GeoMechanicsApplication/tests/test_Transient_Case_B1_2D3N.gid/ProjectParameters_stage2.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_Transient_Case_B1_2D3N_stage2"

--- a/applications/GeoMechanicsApplication/tests/test_bugfixes/KRATOSGEO_14_hydrostatic_case/test_1.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_bugfixes/KRATOSGEO_14_hydrostatic_case/test_1.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_1"

--- a/applications/GeoMechanicsApplication/tests/test_bugfixes/KRATOSGEO_14_hydrostatic_case/test_2.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_bugfixes/KRATOSGEO_14_hydrostatic_case/test_2.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_2"

--- a/applications/GeoMechanicsApplication/tests/test_bugfixes/KRATOSGEO_14_hydrostatic_case/test_3.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_bugfixes/KRATOSGEO_14_hydrostatic_case/test_3.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_3"

--- a/applications/GeoMechanicsApplication/tests/test_bugfixes/KRATOSGEO_14_hydrostatic_case/test_4.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_bugfixes/KRATOSGEO_14_hydrostatic_case/test_4.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_4"

--- a/applications/GeoMechanicsApplication/tests/test_bugfixes/KRATOSGEO_14_hydrostatic_case/test_5.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_bugfixes/KRATOSGEO_14_hydrostatic_case/test_5.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_5"

--- a/applications/GeoMechanicsApplication/tests/test_cable_between_soils.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_cable_between_soils.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_cable_between_soils"

--- a/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD10L30.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD10L30.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "HeightAquiferD10L30"

--- a/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD10L60.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD10L60.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "HeightAquiferD10L60"

--- a/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD10L90.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD10L90.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "HeightAquiferD10L90"

--- a/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD20L30.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD20L30.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "HeightAquiferD20L30"

--- a/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD20L60.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD20L60.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "HeightAquiferD20L60"

--- a/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD20L90.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD20L90.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "HeightAquiferD20L90"

--- a/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD30L30.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD30L30.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "HeightAquiferD30L30"

--- a/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD30L60.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD30L60.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "HeightAquiferD30L60"

--- a/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD30L90.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_compare_sellmeijer/HeightAquiferD30L90.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "HeightAquiferD30L90"

--- a/applications/GeoMechanicsApplication/tests/test_consecutive_pipe_lines/reference_geometry/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_consecutive_pipe_lines/reference_geometry/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "HeightAquiferD10L30"

--- a/applications/GeoMechanicsApplication/tests/test_consecutive_pipe_lines/split_geometry_double_lines_pipe2_added/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_consecutive_pipe_lines/split_geometry_double_lines_pipe2_added/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "pipe2_added"

--- a/applications/GeoMechanicsApplication/tests/test_consecutive_pipe_lines/split_geometry_permeability_soil1_e10/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_consecutive_pipe_lines/split_geometry_permeability_soil1_e10/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "HeightAquiferD10L30"

--- a/applications/GeoMechanicsApplication/tests/test_consecutive_pipe_lines/split_geometry_permeability_soil1_soil2_e10/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_consecutive_pipe_lines/split_geometry_permeability_soil1_soil2_e10/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "HeightAquiferD10L30"

--- a/applications/GeoMechanicsApplication/tests/test_consecutive_pipe_lines/split_geometry_permeability_soil2_e10/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_consecutive_pipe_lines/split_geometry_permeability_soil2_e10/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "HeightAquiferD10L30"

--- a/applications/GeoMechanicsApplication/tests/test_consecutive_pipe_lines/split_geometry_pipe2_D70_3e4/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_consecutive_pipe_lines/split_geometry_pipe2_D70_3e4/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "pipe2_added"

--- a/applications/GeoMechanicsApplication/tests/test_darcy_law.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_darcy_law.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_darcy_law"

--- a/applications/GeoMechanicsApplication/tests/test_element_lab/oedometer_ULFEM/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_element_lab/oedometer_ULFEM/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "Oedometer_ULFEM"

--- a/applications/GeoMechanicsApplication/tests/test_element_lab/oedometer_ULFEM_diff_order/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_element_lab/oedometer_ULFEM_diff_order/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "Oedometer_ULFEM_diff_order"

--- a/applications/GeoMechanicsApplication/tests/test_element_lab/triaxial_comp_6n/Stage_1/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_element_lab/triaxial_comp_6n/Stage_1/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "triaxial_comp_6n_stage1"

--- a/applications/GeoMechanicsApplication/tests/test_element_lab/triaxial_comp_6n/Stage_2/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_element_lab/triaxial_comp_6n/Stage_2/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         1.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "triaxial_comp_6n_stage2"

--- a/applications/GeoMechanicsApplication/tests/test_elementary_groundwater_flow/benchmark_1_hydrostatic.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_elementary_groundwater_flow/benchmark_1_hydrostatic.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "benchmark_1_hydrostatic"

--- a/applications/GeoMechanicsApplication/tests/test_elementary_groundwater_flow/benchmark_1_saturated_flow_pressure_bound.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_elementary_groundwater_flow/benchmark_1_saturated_flow_pressure_bound.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "benchmark_1_saturated_flow_pressure_bound"

--- a/applications/GeoMechanicsApplication/tests/test_elementary_groundwater_flow/benchmark_3_saturated_flow_head_bound.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_elementary_groundwater_flow/benchmark_3_saturated_flow_head_bound.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "benchmark_3_saturated_flow_head_bound"

--- a/applications/GeoMechanicsApplication/tests/test_elementary_groundwater_flow/benchmark_4_saturated_flux_bound.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_elementary_groundwater_flow/benchmark_4_saturated_flux_bound.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "benchmark_4_saturated_flux_bound"

--- a/applications/GeoMechanicsApplication/tests/test_flow_under_dam/test_pressure_in_confined_aquifer_higher.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_flow_under_dam/test_pressure_in_confined_aquifer_higher.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_pressure_in_confined_aquifer_higher"

--- a/applications/GeoMechanicsApplication/tests/test_flow_under_dam/test_pressure_in_confined_aquifer_lower.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_flow_under_dam/test_pressure_in_confined_aquifer_lower.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_pressure_in_confined_aquifer_lower"

--- a/applications/GeoMechanicsApplication/tests/test_flow_under_dam/test_pressure_in_confined_aquifer_reversed.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_flow_under_dam/test_pressure_in_confined_aquifer_reversed.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_pressure_in_confined_aquifer_reversed"

--- a/applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow/ProjectParameters_1.json
+++ b/applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow/ProjectParameters_1.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "test_head_extrapolate"

--- a/applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow/ProjectParameters_2.json
+++ b/applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow/ProjectParameters_2.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "test_head_extrapolate"

--- a/applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow/ProjectParameters_3.json
+++ b/applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow/ProjectParameters_3.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "test_head_extrapolate"

--- a/applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow/ProjectParameters_4.json
+++ b/applications/GeoMechanicsApplication/tests/test_head_extrapolation_custom_workflow_flow/ProjectParameters_4.json
@@ -11,7 +11,6 @@
         "solver_type": "Pw",
         "model_part_name": "PorousDomain",
         "domain_size": 2,
-        "start_time": 0.0,
         "model_import_settings": {
             "input_type": "mdpa",
             "input_filename": "test_head_extrapolate"

--- a/applications/GeoMechanicsApplication/tests/test_inclinded_phreatic_line.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_inclinded_phreatic_line.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_inclinded_phreatic_line"

--- a/applications/GeoMechanicsApplication/tests/test_inclinded_phreatic_line_smaller_line.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_inclinded_phreatic_line_smaller_line.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_inclinded_phreatic_line_smaller_line"

--- a/applications/GeoMechanicsApplication/tests/test_inclinded_phreatic_line_time_dependent.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_inclinded_phreatic_line_time_dependent.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_inclinded_phreatic_line_time_dependent"

--- a/applications/GeoMechanicsApplication/tests/test_inclinded_phreatic_surface.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_inclinded_phreatic_surface.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        3,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_inclinded_phreatic_surface"

--- a/applications/GeoMechanicsApplication/tests/test_inclinded_phreatic_surface_time_dependent.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_inclinded_phreatic_surface_time_dependent.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        3,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_inclinded_phreatic_surface_time_dependent"

--- a/applications/GeoMechanicsApplication/tests/test_inclined_beam_2D3N.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_inclined_beam_2D3N.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_inclined_beam_2D3N"

--- a/applications/GeoMechanicsApplication/tests/test_interface.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_interface.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_interface"

--- a/applications/GeoMechanicsApplication/tests/test_interface.gid/ProjectParametersOutput.json
+++ b/applications/GeoMechanicsApplication/tests/test_interface.gid/ProjectParametersOutput.json
@@ -260,10 +260,8 @@
         "second_alpha_value": 1.0,
         "solution_type": "Quasi-Static",
         "solver_type": "geomechanics_U_Pw_solver",
-        "start_time": 0.0,
         "strategy_type": "newton_raphson",
         "time_stepping": {
-            "end_time": 1.0,
             "time_step": 0.25
         }
     }

--- a/applications/GeoMechanicsApplication/tests/test_interface.gid/run.txt
+++ b/applications/GeoMechanicsApplication/tests/test_interface.gid/run.txt
@@ -245,7 +245,6 @@ Parameters Object {
         "start_time": 0.0,
         "strategy_type": "arc_length",
         "time_stepping": {
-            "end_time": 1.0,
             "time_step": 0.25
         }
     }

--- a/applications/GeoMechanicsApplication/tests/test_interfaces/test_beam.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_interfaces/test_beam.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_beam"

--- a/applications/GeoMechanicsApplication/tests/test_interfaces/test_interface_on_beam.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_interfaces/test_interface_on_beam.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_interface_on_beam"

--- a/applications/GeoMechanicsApplication/tests/test_interfaces/test_interface_side_cohesive.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_interfaces/test_interface_side_cohesive.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_interface_side_cohesive"

--- a/applications/GeoMechanicsApplication/tests/test_interfaces/test_weak_interface_on_beam.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_interfaces/test_weak_interface_on_beam.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_interface_on_beam"

--- a/applications/GeoMechanicsApplication/tests/test_lysmer_boundary_column2d_quad.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_lysmer_boundary_column2d_quad.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_lysmer_boundary_column2d_quad"

--- a/applications/GeoMechanicsApplication/tests/test_lysmer_boundary_column3d_tetra.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_lysmer_boundary_column3d_tetra.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_lysmer_boundary_column3d_tetra"

--- a/applications/GeoMechanicsApplication/tests/test_lysmer_boundary_column3d_tetra_hor.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_lysmer_boundary_column3d_tetra_hor.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        3,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_lysmer_boundary_column3d_tetra_hor"

--- a/applications/GeoMechanicsApplication/tests/test_lysmer_boundary_stiff_column2d_quad/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_lysmer_boundary_stiff_column2d_quad/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_lysmer_boundary_stiff_column2d_quad"

--- a/applications/GeoMechanicsApplication/tests/test_lysmer_column3d_hexa.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_lysmer_column3d_hexa.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_lysmer_column3d_hexa"

--- a/applications/GeoMechanicsApplication/tests/test_normal_load_on_beam.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_normal_load_on_beam.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_normal_load_on_beam"

--- a/applications/GeoMechanicsApplication/tests/test_normal_load_on_beam_and_soil.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_normal_load_on_beam_and_soil.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_normal_load_on_beam_and_soil"

--- a/applications/GeoMechanicsApplication/tests/test_normal_load_on_beam_higher_order.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_normal_load_on_beam_higher_order.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_normal_load_on_beam_higher_order"

--- a/applications/GeoMechanicsApplication/tests/test_normal_load_quad_8n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_normal_load_quad_8n.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_normal_load_quad_8n"

--- a/applications/GeoMechanicsApplication/tests/test_normal_load_tetra_10n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_normal_load_tetra_10n.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_normal_load_tetra_10n"

--- a/applications/GeoMechanicsApplication/tests/test_normal_load_triangle_3n_fic.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_normal_load_triangle_3n_fic.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_normal_load_triangle_3n_fic"

--- a/applications/GeoMechanicsApplication/tests/test_normal_load_triangle_6n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_normal_load_triangle_6n.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_normal_load_triangle_6n"

--- a/applications/GeoMechanicsApplication/tests/test_parameter_field/invalid_parameter_field_json/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_parameter_field/invalid_parameter_field_json/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "parameter_field"

--- a/applications/GeoMechanicsApplication/tests/test_parameter_field/parameter_field_input/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_parameter_field/parameter_field_input/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "parameter_field"

--- a/applications/GeoMechanicsApplication/tests/test_parameter_field/parameter_field_json/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_parameter_field/parameter_field_json/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "parameter_field"

--- a/applications/GeoMechanicsApplication/tests/test_parameter_field/parameter_field_python/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_parameter_field/parameter_field_python/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "parameter_field"

--- a/applications/GeoMechanicsApplication/tests/test_piping_method/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_piping_method/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "SteadyStatePipeElementWithEmbankment"

--- a/applications/GeoMechanicsApplication/tests/test_pressure_in_confined_aquifer.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_pressure_in_confined_aquifer.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_pressure_in_confined_aquifer"

--- a/applications/GeoMechanicsApplication/tests/test_quad_4n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_quad_4n.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_quad_4n"

--- a/applications/GeoMechanicsApplication/tests/test_quad_8n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_quad_8n.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_quad_8n"

--- a/applications/GeoMechanicsApplication/tests/test_sheet_pile_in_dike_phases/InitialPhase1a_redefinition.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_sheet_pile_in_dike_phases/InitialPhase1a_redefinition.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "InitialPhase1a_redefinition"

--- a/applications/GeoMechanicsApplication/tests/test_soil_weight_saturated_below_and_above_phreatic_quad_4n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_soil_weight_saturated_below_and_above_phreatic_quad_4n.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "SaturatedBelowPhreatic"

--- a/applications/GeoMechanicsApplication/tests/test_soil_weight_saturated_below_and_above_phreatic_quad_8n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_soil_weight_saturated_below_and_above_phreatic_quad_8n.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "SaturatedBelowPhreatic"

--- a/applications/GeoMechanicsApplication/tests/test_soil_weight_saturated_below_phreatic_quad_4n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_soil_weight_saturated_below_phreatic_quad_4n.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "SaturatedBelowPhreatic"

--- a/applications/GeoMechanicsApplication/tests/test_soil_weight_saturated_below_phreatic_quad_8n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_soil_weight_saturated_below_phreatic_quad_8n.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "SaturatedBelowPhreatic"

--- a/applications/GeoMechanicsApplication/tests/test_soil_weight_van_genuchten_above_phreatic_quad_4n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_soil_weight_van_genuchten_above_phreatic_quad_4n.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "SaturatedBelowPhreatic"

--- a/applications/GeoMechanicsApplication/tests/test_soil_weight_van_genuchten_above_phreatic_quad_8n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_soil_weight_van_genuchten_above_phreatic_quad_8n.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "SaturatedBelowPhreatic"

--- a/applications/GeoMechanicsApplication/tests/test_tetra_10n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_tetra_10n.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_tetra_10n"

--- a/applications/GeoMechanicsApplication/tests/test_tetra_4n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_tetra_4n.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_tetra_4n"

--- a/applications/GeoMechanicsApplication/tests/test_triangle_10n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_10n.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_triangle_10n"

--- a/applications/GeoMechanicsApplication/tests/test_triangle_15n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_15n.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_triangle_15n"

--- a/applications/GeoMechanicsApplication/tests/test_triangle_3n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_3n.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_triangle_3n"

--- a/applications/GeoMechanicsApplication/tests/test_triangle_3n_fic.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_3n_fic.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_triangle_3n_fic"

--- a/applications/GeoMechanicsApplication/tests/test_triangle_3n_rebuild_0.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_3n_rebuild_0.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_triangle_3n"

--- a/applications/GeoMechanicsApplication/tests/test_triangle_6n.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_6n.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_triangle_6n"

--- a/applications/GeoMechanicsApplication/tests/test_triangle_6n_fic.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_triangle_6n_fic.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_triangle_6n_fic"

--- a/applications/GeoMechanicsApplication/tests/test_truss_between_soils.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_truss_between_soils.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_truss_between_soils"

--- a/applications/GeoMechanicsApplication/tests/test_tunnel.gid/ProjectParameters.json
+++ b/applications/GeoMechanicsApplication/tests/test_tunnel.gid/ProjectParameters.json
@@ -11,7 +11,6 @@
         "solver_type":                        "U_Pw",
         "model_part_name":                    "PorousDomain",
         "domain_size":                        2,
-        "start_time":                         0.0,
         "model_import_settings":              {
             "input_type":       "mdpa",
             "input_filename":   "test_tunnel"


### PR DESCRIPTION
On ProjectParameters.json start_time was defined twice: in problem_data and in solver_settings
end_time was defined twice: in problem_data and in solver_settings - time_stepping
The definition in problem _data is kept, the others removed.

**🆕 Changelog**
The double defaults are removed from .hpp and .py files
Reading and setting in the pythonscripts now use only the
All ProjectParameters.json in applications/GeoMechanicsApplication/tests were adapted.
