### PR TITLE
[GeoMechanicsApplication] Some more cleanup due to reported code smells

### DIFF
--- a/applications/GeoMechanicsApplication/custom_retention/retention_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_retention/retention_law.cpp
@@ -10,51 +10,39 @@
 //  Main authors:    Vahid Galavi
 //
 
-/* System includes */
-#include <iostream>
-
-/* External includes */
-
 /* Project includes */
 #include "custom_retention/saturated_law.h"
 
 namespace Kratos
 {
 
-//-------------------------------------------------------------------------------------------------
-void RetentionLaw::
-    InitializeMaterial(const Properties& rMaterialProperties,
-                       const GeometryType& rElementGeometry,
-                       const Vector& rShapeFunctionsValues)
+void RetentionLaw::InitializeMaterial(const Properties& rMaterialProperties,
+                                      const GeometryType& rElementGeometry,
+                                      const Vector& rShapeFunctionsValues)
 {
     // nothing
 }
 
-//-------------------------------------------------------------------------------------------------
 void RetentionLaw::Initialize(Parameters &rParameters)
 {
     // nothing
 }
 
-//-------------------------------------------------------------------------------------------------
 void RetentionLaw::InitializeSolutionStep(Parameters &rParameters)
 {
     // nothing
 }
 
-//-------------------------------------------------------------------------------------------------
 void RetentionLaw::FinalizeSolutionStep(Parameters &rParameters)
 {
     // nothing
 }
 
-//-------------------------------------------------------------------------------------------------
 void RetentionLaw::Finalize(Parameters &rParameters)
 {
     // nothing
 }
 
-//-------------------------------------------------------------------------------------------------
 void RetentionLaw::ResetMaterial(const Properties &rMaterialProperties,
                                  const GeometryType &rElementGeometry,
                                  const Vector &rShapeFunctionsValues)
@@ -62,16 +50,14 @@ void RetentionLaw::ResetMaterial(const Properties &rMaterialProperties,
     // nothing
 }
 
-//-------------------------------------------------------------------------------------------------
 void RetentionLaw::save(Serializer& rSerializer) const
 {
     // there is no member variables to be saved
 }
 
-//-------------------------------------------------------------------------------------------------
 void RetentionLaw::load(Serializer& rSerializer)
 {
     // there is no member variables to be loaded
 }
 
-} /* namespace Kratos.*/
+}

--- a/applications/GeoMechanicsApplication/custom_retention/retention_law.h
+++ b/applications/GeoMechanicsApplication/custom_retention/retention_law.h
@@ -63,10 +63,6 @@ public:
         *** NOTE: Pointers are used only to point to a certain variable, 
         *   no "new" or "malloc" can be used for this Parameters ***
 
-        * @param mVolumetricStrain copy of the determinant of the Current DeformationGradient (although Current F  is also included as a matrix) (input data)
-        * @param mMeanStress pointer to the current stresses (*OUTPUT with COMPUTE_STRESS flag)
-        * @param mpConstitutiveMatrix pointer to the material tangent matrix (*OUTPUT with COMPUTE_CONSTITUTIVE_TENSOR flag)
-
         * GEOMETRIC PARAMETERS:
         * @param mrElementGeometry reference to the element's geometry (input data)
 
@@ -79,12 +75,7 @@ public:
         */
 
     private:
-
         double mFluidPressure = 0.0;
-        double mMeanStress = 0.0;
-        double mTemperature = 0.0;
-        double mVolumetricStrain = 0.0;
-
         const ProcessInfo &mrCurrentProcessInfo;
         const Properties &mrMaterialProperties;
         const GeometryType &mrElementGeometry;
@@ -100,15 +91,9 @@ public:
 
         ~Parameters() = default;
 
-        void SetVolumetricStrain(const double rVolumetricStrain) { mVolumetricStrain = rVolumetricStrain; };
-        void SetMeanStress      (const double rMeanStress)       { mMeanStress = rMeanStress; };
         void SetFluidPressure   (const double rFluidPressure)    { mFluidPressure = rFluidPressure; };
-        void SetTemperature     (const double rTemperature)      { mTemperature = rTemperature; };
 
-        double GetVolumetricStrain() const { return mVolumetricStrain; }
-        double GetMeanStress()       const { return mMeanStress;       }
         double GetFluidPressure()    const { return mFluidPressure;    }
-        double GetTemperature()      const { return mTemperature;      }
 
         const ProcessInfo &GetProcessInfo() const
         {
@@ -238,15 +223,13 @@ public:
     /// Turn back information as a string.
     virtual std::string Info() const
     {
-        std::stringstream buffer;
-        buffer << "RetentionLaw";
-        return buffer.str();
+        return "RetentionLaw";
     }
 
     /// Print information about this object.
     virtual void PrintInfo(std::ostream &rOStream) const
     {
-        rOStream << "RetentionLaw";
+        rOStream << Info();
     }
 
     /// Print object's data.

--- a/applications/GeoMechanicsApplication/custom_retention/saturated_below_phreatic_level_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_retention/saturated_below_phreatic_level_law.cpp
@@ -39,14 +39,11 @@ RetentionLaw::Pointer SaturatedBelowPhreaticLevelLaw::Clone() const
     return Kratos::make_shared<SaturatedBelowPhreaticLevelLaw>(*this);
 }
 
-//-------------------------------------------------------------------------------------------------
 SaturatedBelowPhreaticLevelLaw::~SaturatedBelowPhreaticLevelLaw()
 {
 }
 
-//-------------------------------------------------------------------------------------------------
-double SaturatedBelowPhreaticLevelLaw::
-    CalculateSaturation(Parameters &rParameters)
+double SaturatedBelowPhreaticLevelLaw::CalculateSaturation(Parameters &rParameters)
 {
     KRATOS_TRY
 
@@ -61,9 +58,7 @@ double SaturatedBelowPhreaticLevelLaw::
     KRATOS_CATCH("")
 }
 
-//-------------------------------------------------------------------------------------------------
-double SaturatedBelowPhreaticLevelLaw::
-    CalculateEffectiveSaturation(Parameters &rParameters)
+double SaturatedBelowPhreaticLevelLaw::CalculateEffectiveSaturation(Parameters &rParameters)
 {
     KRATOS_TRY
 
@@ -72,16 +67,12 @@ double SaturatedBelowPhreaticLevelLaw::
     KRATOS_CATCH("")
 }
 
-//-------------------------------------------------------------------------------------------------
-double SaturatedBelowPhreaticLevelLaw::
-    CalculateDerivativeOfSaturation(Parameters &rParameters)
+double SaturatedBelowPhreaticLevelLaw::CalculateDerivativeOfSaturation(Parameters &rParameters)
 {
     return 0.0;
 }
 
-//-------------------------------------------------------------------------------------------------
-double SaturatedBelowPhreaticLevelLaw::
-    CalculateRelativePermeability(Parameters &rParameters)
+double SaturatedBelowPhreaticLevelLaw::CalculateRelativePermeability(Parameters &rParameters)
 {
     KRATOS_TRY
 
@@ -96,9 +87,7 @@ double SaturatedBelowPhreaticLevelLaw::
     KRATOS_CATCH("")
 }
 
-//-------------------------------------------------------------------------------------------------
-double SaturatedBelowPhreaticLevelLaw::
-    CalculateBishopCoefficient(Parameters &rParameters)
+double SaturatedBelowPhreaticLevelLaw::CalculateBishopCoefficient(Parameters &rParameters)
 {
     KRATOS_TRY
 
@@ -107,7 +96,6 @@ double SaturatedBelowPhreaticLevelLaw::
     KRATOS_CATCH("")
 }
 
-//-------------------------------------------------------------------------------------------------
 double& SaturatedBelowPhreaticLevelLaw::CalculateValue(RetentionLaw::Parameters& rParameterValues,
                                         const Variable<double>& rThisVariable,
                                         double& rValue)
@@ -133,54 +121,45 @@ double& SaturatedBelowPhreaticLevelLaw::CalculateValue(RetentionLaw::Parameters&
 }
 
 //------------------------- RETENSION LAW GENERAL FEATURES ----------------------------------------
-//-------------------------------------------------------------------------------------------------
-void SaturatedBelowPhreaticLevelLaw::
-    InitializeMaterial(const Properties& rMaterialProperties,
-                       const GeometryType& rElementGeometry,
-                       const Vector& rShapeFunctionsValues)
+void SaturatedBelowPhreaticLevelLaw::InitializeMaterial(const Properties& rMaterialProperties,
+                                                        const GeometryType& rElementGeometry,
+                                                        const Vector& rShapeFunctionsValues)
 {
     // nothing is needed
 }
 
 //-------------------------------------------------------------------------------------------------
-void SaturatedBelowPhreaticLevelLaw::
-    Initialize(Parameters &rParameters)
+void SaturatedBelowPhreaticLevelLaw::Initialize(Parameters &rParameters)
 {
     // nothing is needed
 }
 
 //-------------------------------------------------------------------------------------------------
-void SaturatedBelowPhreaticLevelLaw::
-    InitializeSolutionStep(Parameters &rParameters)
+void SaturatedBelowPhreaticLevelLaw::InitializeSolutionStep(Parameters &rParameters)
 {
     // nothing is needed
 }
 
-//-------------------------------------------------------------------------------------------------
-void SaturatedBelowPhreaticLevelLaw::
-    Finalize(Parameters &rParameters)
+void SaturatedBelowPhreaticLevelLaw::Finalize(Parameters &rParameters)
 {
     // nothing is needed
 }
 
-//-------------------------------------------------------------------------------------------------
-void SaturatedBelowPhreaticLevelLaw::
-    FinalizeSolutionStep(Parameters &rParameters)
+void SaturatedBelowPhreaticLevelLaw::FinalizeSolutionStep(Parameters &rParameters)
 {
     // nothing is needed
 }
 
-//-------------------------------------------------------------------------------------------------
 int SaturatedBelowPhreaticLevelLaw::Check(const Properties& rMaterialProperties,
-                           const ProcessInfo& rCurrentProcessInfo)
+                                          const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_ERROR_IF_NOT(rMaterialProperties.Has(SATURATED_SATURATION))
-                        << "SATURATED_SATURATION is not availabe in material parameters" << std::endl;
+                        << "SATURATED_SATURATION is not available in material parameters" << std::endl;
     KRATOS_ERROR_IF(rMaterialProperties[SATURATED_SATURATION] < 0.0)
                     << "SATURATED_SATURATION cannot be less than 0 " << std::endl;
 
     KRATOS_ERROR_IF_NOT(rMaterialProperties.Has(RESIDUAL_SATURATION))
-                        << "RESIDUAL_SATURATION is not availabe in material parameters" << std::endl;
+                        << "RESIDUAL_SATURATION is not available in material parameters" << std::endl;
     KRATOS_DEBUG_ERROR_IF_NOT(rMaterialProperties[RESIDUAL_SATURATION] > 0.0)
                             << "RESIDUAL_SATURATION must be greater than 0 " << std::endl;
     KRATOS_ERROR_IF(rMaterialProperties[RESIDUAL_SATURATION] > 1.0)
@@ -190,7 +169,7 @@ int SaturatedBelowPhreaticLevelLaw::Check(const Properties& rMaterialProperties,
                     << "RESIDUAL_SATURATION cannot be greater than SATURATED_SATURATION " << std::endl;
 
     KRATOS_ERROR_IF_NOT(rMaterialProperties.Has(MINIMUM_RELATIVE_PERMEABILITY))
-                        << "MINIMUM_RELATIVE_PERMEABILITY is not availabe in material parameters" << std::endl;
+                        << "MINIMUM_RELATIVE_PERMEABILITY is not available in material parameters" << std::endl;
     KRATOS_ERROR_IF_NOT((rMaterialProperties[MINIMUM_RELATIVE_PERMEABILITY] > 0.0))
                         << "MINIMUM_RELATIVE_PERMEABILITY must be greater than 0 " << std::endl;
 

--- a/applications/GeoMechanicsApplication/custom_retention/saturated_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_retention/saturated_law.cpp
@@ -21,32 +21,13 @@
 
 namespace Kratos
 {
-//-------------------------------------------------------------------------------------------------
-SaturatedLaw::SaturatedLaw()
-    : RetentionLaw()
-{
-}
 
-//-------------------------------------------------------------------------------------------------
-SaturatedLaw::SaturatedLaw(const SaturatedLaw& rOther)
-    : RetentionLaw(rOther)
-{
-}
-
-//-------------------------------------------------------------------------------------------------
 RetentionLaw::Pointer SaturatedLaw::Clone() const
 {
     return Kratos::make_shared<SaturatedLaw>(*this);
 }
 
-//-------------------------------------------------------------------------------------------------
-SaturatedLaw::~SaturatedLaw()
-{
-}
-
-//-------------------------------------------------------------------------------------------------
-double SaturatedLaw::
-    CalculateSaturation(Parameters &rParameters)
+double SaturatedLaw::CalculateSaturation(Parameters &rParameters)
 {
     KRATOS_TRY
 
@@ -64,28 +45,21 @@ double SaturatedLaw::
     KRATOS_CATCH("")
 }
 
-//-------------------------------------------------------------------------------------------------
-double SaturatedLaw::
-    CalculateEffectiveSaturation(Parameters &rParameters)
+double SaturatedLaw::CalculateEffectiveSaturation(Parameters &rParameters)
 {
     return 1.0;
 }
 
-//-------------------------------------------------------------------------------------------------
-double SaturatedLaw::
-    CalculateDerivativeOfSaturation(Parameters &rParameters)
+double SaturatedLaw::CalculateDerivativeOfSaturation(Parameters &rParameters)
 {
     return 0.0;
 }
 
-//-------------------------------------------------------------------------------------------------
-double SaturatedLaw::
-    CalculateRelativePermeability(Parameters &rParameters)
+double SaturatedLaw::CalculateRelativePermeability(Parameters &rParameters)
 {
     return 1.0;
 }
 
-//-------------------------------------------------------------------------------------------------
 double SaturatedLaw::
     CalculateBishopCoefficient(Parameters &rParameters)
 {
@@ -96,7 +70,6 @@ double SaturatedLaw::
     KRATOS_CATCH("")
 }
 
-//-------------------------------------------------------------------------------------------------
 double& SaturatedLaw::CalculateValue(RetentionLaw::Parameters& rParameterValues,
                                      const Variable<double>& rThisVariable,
                                      double& rValue)
@@ -125,45 +98,34 @@ double& SaturatedLaw::CalculateValue(RetentionLaw::Parameters& rParameterValues,
     return rValue;
 }
 
-
 //------------------------- RETENSION LAW GENERAL FEATURES ----------------------------------------
-//-------------------------------------------------------------------------------------------------
-void SaturatedLaw::
-    InitializeMaterial(const Properties& rMaterialProperties,
-                       const GeometryType& rElementGeometry,
-                       const Vector& rShapeFunctionsValues)
+void SaturatedLaw::InitializeMaterial(const Properties& rMaterialProperties,
+                                      const GeometryType& rElementGeometry,
+                                      const Vector& rShapeFunctionsValues)
 {
     // nothing is needed
 }
 
-//-------------------------------------------------------------------------------------------------
-void SaturatedLaw::
-    Initialize(Parameters &rParameters)
-{
-    // nothing is needed
-}
-//-------------------------------------------------------------------------------------------------
-void SaturatedLaw::
-    InitializeSolutionStep(Parameters &rParameters)
+void SaturatedLaw::Initialize(Parameters &rParameters)
 {
     // nothing is needed
 }
 
-//-------------------------------------------------------------------------------------------------
-void SaturatedLaw::
-    Finalize(Parameters &rParameters)
+void SaturatedLaw::InitializeSolutionStep(Parameters &rParameters)
 {
     // nothing is needed
 }
 
-//-------------------------------------------------------------------------------------------------
-void SaturatedLaw::
-    FinalizeSolutionStep(Parameters &rParameters)
+void SaturatedLaw::Finalize(Parameters &rParameters)
 {
     // nothing is needed
 }
 
-//-------------------------------------------------------------------------------------------------
+void SaturatedLaw::FinalizeSolutionStep(Parameters &rParameters)
+{
+    // nothing is needed
+}
+
 int SaturatedLaw::Check(const Properties& rMaterialProperties,
                         const ProcessInfo& rCurrentProcessInfo)
 {
@@ -179,4 +141,4 @@ int SaturatedLaw::Check(const Properties& rMaterialProperties,
     return 0;
 }
 
-} // Namespace Kratos
+}

--- a/applications/GeoMechanicsApplication/custom_retention/saturated_law.h
+++ b/applications/GeoMechanicsApplication/custom_retention/saturated_law.h
@@ -51,13 +51,7 @@ public:
     /// Counted pointer of SaturatedLaw
     KRATOS_CLASS_POINTER_DEFINITION( SaturatedLaw );
 
-    SaturatedLaw();
-
     RetentionLaw::Pointer Clone() const override;
-
-    SaturatedLaw(const SaturatedLaw& rOther);
-
-    ~SaturatedLaw() override;
 
     void InitializeMaterial(const Properties& rMaterialProperties,
                             const GeometryType& rElementGeometry,

--- a/applications/GeoMechanicsApplication/custom_retention/van_genuchten_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_retention/van_genuchten_law.cpp
@@ -14,39 +14,18 @@
 // System includes
 #include <iostream>
 
-// External includes
-
 // Project includes
 #include "custom_retention/van_genuchten_law.h"
 
 namespace Kratos
 {
-//-------------------------------------------------------------------------------------------------
-VanGenuchtenLaw::VanGenuchtenLaw()
-    : RetentionLaw()
-{
-}
 
-//-------------------------------------------------------------------------------------------------
-VanGenuchtenLaw::VanGenuchtenLaw(const VanGenuchtenLaw& rOther)
-    : RetentionLaw(rOther)
-{
-}
-
-//-------------------------------------------------------------------------------------------------
 RetentionLaw::Pointer VanGenuchtenLaw::Clone() const
 {
     return Kratos::make_shared<VanGenuchtenLaw>(*this);
 }
 
-//-------------------------------------------------------------------------------------------------
-VanGenuchtenLaw::~VanGenuchtenLaw()
-{
-}
-
-//-------------------------------------------------------------------------------------------------
-double VanGenuchtenLaw::
-    CalculateSaturation(Parameters &rParameters)
+double VanGenuchtenLaw::CalculateSaturation(Parameters &rParameters)
 {
     KRATOS_TRY
 
@@ -60,8 +39,7 @@ double VanGenuchtenLaw::
         const double &gn     = rMaterialProperties[VAN_GENUCHTEN_GN];
         const double gc      = (1.0 - gn) / gn;
 
-        double sat = satMin + (satMax - satMin) * pow(1.0 + pow(p/pb, gn), gc);
-        return sat;
+        return satMin + (satMax - satMin) * pow(1.0 + pow(p/pb, gn), gc);
     } else {
         return rMaterialProperties[SATURATED_SATURATION];
     }
@@ -69,28 +47,20 @@ double VanGenuchtenLaw::
     KRATOS_CATCH("")
 }
 
-//-------------------------------------------------------------------------------------------------
-double VanGenuchtenLaw::
-    CalculateEffectiveSaturation(Parameters &rParameters)
+double VanGenuchtenLaw::CalculateEffectiveSaturation(Parameters &rParameters)
 {
     KRATOS_TRY
-
-    const double sat = CalculateSaturation(rParameters);
 
     const auto &rMaterialProperties = rParameters.GetMaterialProperties();
     const double &satMax = rMaterialProperties[SATURATED_SATURATION];
     const double &satMin = rMaterialProperties[RESIDUAL_SATURATION];
 
-    double effectiveSat = (sat - satMin) / (satMax - satMin);
-
-    return effectiveSat;
+    return (CalculateSaturation(rParameters) - satMin) / (satMax - satMin);
 
     KRATOS_CATCH("")
 }
 
-//-------------------------------------------------------------------------------------------------
-double VanGenuchtenLaw::
-    CalculateDerivativeOfSaturation(Parameters &rParameters)
+double VanGenuchtenLaw::CalculateDerivativeOfSaturation(Parameters &rParameters)
 {
     KRATOS_TRY
     const double &p = rParameters.GetFluidPressure();
@@ -103,9 +73,8 @@ double VanGenuchtenLaw::
         const double &gn     = rMaterialProperties[VAN_GENUCHTEN_GN];
         const double gc      = (1.0 - gn) / gn;
 
-        double dSdp = (satMax - satMin) * gc * pow((1.0 + pow(p/pb, gn)), gc-1.0)
-                                        * gn * pow(pb,-gn) * pow(p, gn-1.0);
-        return dSdp;
+        return (satMax - satMin) * gc * pow((1.0 + pow(p/pb, gn)), gc-1.0)
+                                 * gn * pow(pb,-gn) * pow(p, gn-1.0);
     } else {
         return 0.0;
     }
@@ -113,9 +82,7 @@ double VanGenuchtenLaw::
     KRATOS_CATCH("")
 }
 
-//-------------------------------------------------------------------------------------------------
-double VanGenuchtenLaw::
-    CalculateRelativePermeability(Parameters &rParameters)
+double VanGenuchtenLaw::CalculateRelativePermeability(Parameters &rParameters)
 {
     KRATOS_TRY
 
@@ -127,18 +94,12 @@ double VanGenuchtenLaw::
 
     double relPerm = pow(effSat, gl) * pow(1.0 - pow(1.0 - pow(effSat, gn/(gn-1.0)), (gn-1.0)/gn), 2);
 
-    const double &minRelPerm = rMaterialProperties[MINIMUM_RELATIVE_PERMEABILITY];
-
-    relPerm = std::max(relPerm, minRelPerm);
-
-    return relPerm;
+    return std::max(relPerm, rMaterialProperties[MINIMUM_RELATIVE_PERMEABILITY]);
 
     KRATOS_CATCH("")
 }
 
-//-------------------------------------------------------------------------------------------------
-double VanGenuchtenLaw::
-    CalculateBishopCoefficient(Parameters &rParameters)
+double VanGenuchtenLaw::CalculateBishopCoefficient(Parameters &rParameters)
 {
     KRATOS_TRY
 
@@ -147,7 +108,6 @@ double VanGenuchtenLaw::
     KRATOS_CATCH("")
 }
 
-//-------------------------------------------------------------------------------------------------
 double& VanGenuchtenLaw::CalculateValue(RetentionLaw::Parameters& rParameterValues,
                                         const Variable<double>& rThisVariable,
                                         double& rValue)
@@ -173,56 +133,45 @@ double& VanGenuchtenLaw::CalculateValue(RetentionLaw::Parameters& rParameterValu
 }
 
 //------------------------- RETENSION LAW GENERAL FEATURES ----------------------------------------
-//-------------------------------------------------------------------------------------------------
-void VanGenuchtenLaw::
-    InitializeMaterial(const Properties& rMaterialProperties,
-                       const GeometryType& rElementGeometry,
-                       const Vector& rShapeFunctionsValues)
+void VanGenuchtenLaw::InitializeMaterial(const Properties& rMaterialProperties,
+                                         const GeometryType& rElementGeometry,
+                                         const Vector& rShapeFunctionsValues)
 {
     // nothing is needed
 }
 
-//-------------------------------------------------------------------------------------------------
-void VanGenuchtenLaw::
-    Initialize(Parameters &rParameters)
+void VanGenuchtenLaw::Initialize(Parameters &rParameters)
 {
     // nothing is needed
 }
 
-//-------------------------------------------------------------------------------------------------
-void VanGenuchtenLaw::
-    InitializeSolutionStep(Parameters &rParameters)
+void VanGenuchtenLaw::InitializeSolutionStep(Parameters &rParameters)
 {
     // nothing is needed
 }
 
-//-------------------------------------------------------------------------------------------------
-void VanGenuchtenLaw::
-    Finalize(Parameters &rParameters)
+void VanGenuchtenLaw::Finalize(Parameters &rParameters)
 {
     // nothing is needed
 }
 
-//-------------------------------------------------------------------------------------------------
-void VanGenuchtenLaw::
-    FinalizeSolutionStep(Parameters &rParameters)
+void VanGenuchtenLaw::FinalizeSolutionStep(Parameters &rParameters)
 {
     // nothing is needed
 }
 
-//-------------------------------------------------------------------------------------------------
 int VanGenuchtenLaw::Check(const Properties& rMaterialProperties,
                            const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_ERROR_IF_NOT(rMaterialProperties.Has(SATURATED_SATURATION))
-                    << "SATURATED_SATURATION is not availabe in material parameters" << std::endl;
+                    << "SATURATED_SATURATION is not available in material parameters" << std::endl;
     KRATOS_ERROR_IF(rMaterialProperties[SATURATED_SATURATION] < 0.0)
                     << "SATURATED_SATURATION cannot be less than 0 " << std::endl;
     KRATOS_ERROR_IF(rMaterialProperties[SATURATED_SATURATION] > 1.0)
                     << "SATURATED_SATURATION cannot be greater than 1.0 " << std::endl;
 
     KRATOS_ERROR_IF_NOT(rMaterialProperties.Has(RESIDUAL_SATURATION))
-                    << "RESIDUAL_SATURATION is not availabe in material parameters" << std::endl;
+                    << "RESIDUAL_SATURATION is not available in material parameters" << std::endl;
     KRATOS_DEBUG_ERROR_IF_NOT(rMaterialProperties[RESIDUAL_SATURATION] > 0.0)
                             << "RESIDUAL_SATURATION must be greater than 0 " << std::endl;
     KRATOS_ERROR_IF(rMaterialProperties[RESIDUAL_SATURATION] > 1.0)
@@ -232,16 +181,16 @@ int VanGenuchtenLaw::Check(const Properties& rMaterialProperties,
                     << "RESIDUAL_SATURATION cannot be greater than SATURATED_SATURATION " << std::endl;
 
     KRATOS_ERROR_IF_NOT(rMaterialProperties.Has(VAN_GENUCHTEN_AIR_ENTRY_PRESSURE))
-                    << "VAN_GENUCHTEN_AIR_ENTRY_PRESSURE is not availabe in material parameters" << std::endl;
+                    << "VAN_GENUCHTEN_AIR_ENTRY_PRESSURE is not available in material parameters" << std::endl;
     KRATOS_ERROR_IF_NOT((rMaterialProperties[VAN_GENUCHTEN_AIR_ENTRY_PRESSURE] > 0.0))
                     << "VAN_GENUCHTEN_AIR_ENTRY_PRESSURE must be greater than 0 " << std::endl;
 
     KRATOS_ERROR_IF_NOT(rMaterialProperties.Has(MINIMUM_RELATIVE_PERMEABILITY))
-                    << "MINIMUM_RELATIVE_PERMEABILITY is not availabe in material parameters" << std::endl;
+                    << "MINIMUM_RELATIVE_PERMEABILITY is not available in material parameters" << std::endl;
     KRATOS_ERROR_IF_NOT((rMaterialProperties[MINIMUM_RELATIVE_PERMEABILITY] > 0.0))
                     << "MINIMUM_RELATIVE_PERMEABILITY must be greater than 0 " << std::endl;
 
     return 0;
 }
 
-} // Namespace Kratos
+}

--- a/applications/GeoMechanicsApplication/custom_retention/van_genuchten_law.h
+++ b/applications/GeoMechanicsApplication/custom_retention/van_genuchten_law.h
@@ -50,13 +50,7 @@ public:
     /// Counted pointer of VanGenuchtenLaw
     KRATOS_CLASS_POINTER_DEFINITION( VanGenuchtenLaw );
 
-    VanGenuchtenLaw();
-
     RetentionLaw::Pointer Clone() const override;
-
-    VanGenuchtenLaw(const VanGenuchtenLaw& rOther);
-
-    ~VanGenuchtenLaw() override;
 
     void InitializeMaterial(const Properties& rMaterialProperties,
                             const GeometryType& rElementGeometry,

--- a/applications/GeoMechanicsApplication/custom_utilities/stress_strain_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/stress_strain_utilities.hpp
@@ -11,11 +11,7 @@
 //                   Vahid Galavi
 //
 
-#if !defined(KRATOS_GEO_COMPARISON_UTILITIES )
-#define  KRATOS_GEO_COMPARISON_UTILITIES
-
-
-/* System includes */
+#pragma once
 
 /* Project includes */
 #include "custom_utilities/math_utilities.hpp"
@@ -61,55 +57,27 @@ public:
      */
     /*@{ */
 
-    /** Constructor.
-     */
-    StressStrainUtilities() {};
-
-    /** Destructor.
-     */
-    ~StressStrainUtilities() {};
-
     /** Operators.
      */
 
-    //**************************************************************************
-    //**************************************************************************
-
-
-    //**************************************************************************
-    //**************************************************************************
-
-    double CalculateStressNorm(const Vector& StressVector)
+    static double CalculateStressNorm(const Vector& StressVector)
     {
         KRATOS_TRY
 
-        Matrix LocalStressTensor  = MathUtils<double>::StressVectorToTensor(StressVector); //reduced dimension stress tensor
+        Matrix LocalStressTensor = MathUtils<>::StressVectorToTensor(StressVector); //reduced dimension stress tensor
 
-        Matrix StressTensor(3,3); //3D stress tensor
-        noalias(StressTensor) = ZeroMatrix(3,3);
-        for(unsigned int i=0; i<LocalStressTensor.size1(); ++i)
-        {
-            for(unsigned int j=0; j<LocalStressTensor.size2(); ++j)
-            {
-                StressTensor(i,j) = LocalStressTensor(i,j);
+        double StressNorm = 0.;
+        for(unsigned int i = 0; i < LocalStressTensor.size1(); ++i) {
+            for(unsigned int j = 0; j < LocalStressTensor.size2(); ++j) {
+                StressNorm += LocalStressTensor(i,j)*LocalStressTensor(i,j);
             }
         }
-
-        double StressNorm = ((StressTensor(0,0)*StressTensor(0,0))+(StressTensor(1,1)*StressTensor(1,1))+(StressTensor(2,2)*StressTensor(2,2))+
-                             (StressTensor(0,1)*StressTensor(0,1))+(StressTensor(0,2)*StressTensor(0,2))+(StressTensor(1,2)*StressTensor(1,2))+
-                             (StressTensor(1,0)*StressTensor(1,0))+(StressTensor(2,0)*StressTensor(2,0))+(StressTensor(2,1)*StressTensor(2,1)));
-
-        StressNorm = sqrt(StressNorm);
-
-        return StressNorm;
+        return std::sqrt(StressNorm);
 
         KRATOS_CATCH( "" )
     }
 
-    //**************************************************************************
-    //**************************************************************************
-
-    double CalculateVonMisesStress(const Vector& StressVector)
+    static double CalculateVonMisesStress(const Vector& StressVector)
     {
         KRATOS_TRY
 
@@ -123,30 +91,26 @@ public:
             }
         }
 
-        //in general coordinates:
-        double SigmaEquivalent =  (0.5)*((StressTensor(0,0)-StressTensor(1,1))*((StressTensor(0,0)-StressTensor(1,1)))+
-                                         (StressTensor(1,1)-StressTensor(2,2))*((StressTensor(1,1)-StressTensor(2,2)))+
-                                         (StressTensor(2,2)-StressTensor(0,0))*((StressTensor(2,2)-StressTensor(0,0)))+
-                                       6*(StressTensor(0,1)*StressTensor(1,0)+StressTensor(1,2)*StressTensor(2,1)+StressTensor(2,0)*StressTensor(0,2)));
+        double SigmaEquivalent = 0.5*((StressTensor(0,0)-StressTensor(1,1))*(StressTensor(0,0)-StressTensor(1,1))+
+                                      (StressTensor(1,1)-StressTensor(2,2))*(StressTensor(1,1)-StressTensor(2,2))+
+                                      (StressTensor(2,2)-StressTensor(0,0))*(StressTensor(2,2)-StressTensor(0,0))+
+                                      6.0*(StressTensor(0,1)*StressTensor(1,0)+
+                                           StressTensor(1,2)*StressTensor(2,1)+
+                                           StressTensor(2,0)*StressTensor(0,2) ));
 
-        if ( SigmaEquivalent < 0 )
-             SigmaEquivalent = 0;
-
-        SigmaEquivalent = sqrt(SigmaEquivalent);
-
-        return SigmaEquivalent;
+        return std::sqrt(std::max(SigmaEquivalent, 0.));
 
         KRATOS_CATCH( "" )
     }
 
-    double CalculateTrace(const Vector& StressVector)
+    static double CalculateTrace(const Vector& StressVector)
     {
         KRATOS_TRY
 
         Matrix StressTensor = MathUtils<double>::StressVectorToTensor(StressVector); //reduced dimension stress tensor
 
         double trace = 0.0;
-        for (std::size_t i=0; i < StressTensor.size1(); ++i) {
+        for (std::size_t i = 0; i < StressTensor.size1(); ++i) {
             trace += StressTensor(i,i);
         }
 
@@ -155,24 +119,16 @@ public:
         KRATOS_CATCH( "" )
     }
 
-    double CalculateMeanStress(const Vector& StressVector)
+    static double CalculateMeanStress(const Vector& StressVector)
     {
         KRATOS_TRY
 
-        Matrix StressTensor = MathUtils<double>::StressVectorToTensor(StressVector); //reduced dimension stress tensor
-
-        double trace = 0.0;
-        for (std::size_t i=0; i < StressTensor.size1(); ++i) {
-            trace += StressTensor(i,i);
-        }
-
-        return (trace / StressTensor.size1());
+        return CalculateTrace(StressVector) / (StressVector.size() == 3 ? 2.0 : 3.0);
 
         KRATOS_CATCH( "" )
     }
 
-
-    double CalculateVonMisesStrain(const Vector& StrainVector)
+    static double CalculateVonMisesStrain(const Vector& StrainVector)
     {
         KRATOS_TRY
 
@@ -287,7 +243,4 @@ private:
 
 /*@} */
 
-} /* namespace Kratos.*/
-
-#endif /* KRATOS_GEO_COMPARISON_UTILITIES defined */
-
+}

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
@@ -11,13 +11,6 @@
 //                   Aron Noordam
 //
 
-
-// System includes
-
-// External includes
-
-// Project includes
-
 // Application includes
 #include "geo_mechanics_application.h"
 

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.h
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.h
@@ -11,9 +11,7 @@
 //
 
 
-#if !defined(KRATOS_GEO_MECHANICS_APPLICATION_H_INCLUDED )
-#define  KRATOS_GEO_MECHANICS_APPLICATION_H_INCLUDED
-
+#pragma once
 
 // System includes
 #include <string>
@@ -172,12 +170,12 @@ public:
     ///@name Life Cycle
     ///@{
 
-    /// Default constructor.
     KratosGeoMechanicsApplication();
-
-    /// Destructor.
-    virtual ~KratosGeoMechanicsApplication(){}
-
+    ~KratosGeoMechanicsApplication() override = default;
+    KratosGeoMechanicsApplication(const KratosGeoMechanicsApplication&) = delete;
+    KratosGeoMechanicsApplication& operator=(const KratosGeoMechanicsApplication&) = delete;
+    KratosGeoMechanicsApplication(KratosGeoMechanicsApplication&&) = delete;
+    KratosGeoMechanicsApplication& operator=(KratosGeoMechanicsApplication&&) = delete;
 
     ///@}
     ///@name Operators
@@ -188,7 +186,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Register() override;
+    void Register() override;
 
 
 
@@ -207,20 +205,20 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "KratosGeoMechanicsApplication";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info();
         PrintData(rOStream);
     }
 
     ///// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         KRATOS_WATCH("in KratosGeoMechanicsApplication")
         KRATOS_WATCH(KratosComponents<VariableData>::GetComponents().size() )
@@ -243,43 +241,6 @@ public:
 
     ///@}
 
-protected:
-    ///@name Protected static Member Variables
-    ///@{
-
-
-    ///@}
-    ///@name Protected member Variables
-    ///@{
-
-
-    ///@}
-    ///@name Protected Operators
-    ///@{
-
-
-    ///@}
-    ///@name Protected Operations
-    ///@{
-
-
-    ///@}
-    ///@name Protected  Access
-    ///@{
-
-
-    ///@}
-    ///@name Protected Inquiry
-    ///@{
-
-
-    ///@}
-    ///@name Protected LifeCycle
-    ///@{
-
-
-    ///@}
-
 private:
     ///@name Static Member Variables
     ///@{
@@ -289,9 +250,6 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
-
-    // const Elem2D   mElem2D;
-    // const Elem3D   mElem3D;
 
     ///@}
     ///@name Private Operators
@@ -455,7 +413,7 @@ private:
     const UpdatedLagrangianUPwDiffOrderElement mUpdatedLagrangianUPwDiffOrderElement3D20N{ 0, Kratos::make_shared< Hexahedra3D20    <NodeType> >(Element::GeometryType::PointsArrayType(20)) };
     const UpdatedLagrangianUPwDiffOrderElement mUpdatedLagrangianUPwDiffOrderElement3D27N{ 0, Kratos::make_shared< Hexahedra3D27    <NodeType> >(Element::GeometryType::PointsArrayType(27)) };
 
-    // Update-Lagrangian axisymmetric elements
+    // Updated-Lagrangian axisymmetric elements
     const UPwUpdatedLagrangianAxisymmetricElement<2, 3> mUPwUpdatedLagrangianAxisymmetricElement2D3N { 0, Kratos::make_shared< Triangle2D3      <NodeType> >(Element::GeometryType::PointsArrayType(3)) };
     const UPwUpdatedLagrangianAxisymmetricElement<2, 4> mUPwUpdatedLagrangianAxisymmetricElement2D4N { 0, Kratos::make_shared< Quadrilateral2D4 <NodeType> >(Element::GeometryType::PointsArrayType(4)) };
     const UPwUpdatedLagrangianAxisymmetricElement<2, 6> mUPwUpdatedLagrangianAxisymmetricElement2D6N { 0, Kratos::make_shared< Triangle2D6      <NodeType> >(Element::GeometryType::PointsArrayType(6)) };
@@ -578,12 +536,6 @@ private:
 
     const LinearElastic2DBeamLaw          mLinearElastic2DBeamLaw;
 
-    /// Assignment operator.
-    KratosGeoMechanicsApplication& operator=(KratosGeoMechanicsApplication const& rOther);
-
-    /// Copy constructor.
-    KratosGeoMechanicsApplication(KratosGeoMechanicsApplication const& rOther);
-
 
     ///@}
 
@@ -603,6 +555,4 @@ private:
 ///@}
 
 
-}  // namespace Kratos.
-
-#endif // KRATOS_GEO_MECHANICS_APPLICATION_H_INCLUDED  defined
+}

--- a/applications/GeoMechanicsApplication/geo_mechanics_application_constants.h
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application_constants.h
@@ -10,23 +10,16 @@
 //  Main authors:    Vahid Galavi
 //
 
-#if !defined(KRATOS_GEO_MECHANICS_APPLICATION_CONSTANTS_H_INCLUDED )
-#define  KRATOS_GEO_MECHANICS_APPLICATION_CONSTANTS_H_INCLUDED
-
-// System includes
-
-// External includes
+#pragma once
 
 // Project includes
 #include "includes/define.h"
-
 
 namespace Kratos
 {
     /* Contants used in GeoMechanicsApplication */
     // The size type definition
-    typedef std::size_t         SizeType;
-
+    using SizeType = std::size_t;
 
     // Static definition of the dimension
     constexpr SizeType N_DIM_3D = 3;
@@ -47,7 +40,7 @@ namespace Kratos
     // Static definition of the VoigtSize
     constexpr SizeType VOIGT_SIZE_3D = 6;
     constexpr SizeType VOIGT_SIZE_2D_PLANE_STRESS = 3;
-    constexpr SizeType VOIGT_SIZE_2D_PLANE_STRAIN = 4; // This needs to be changed
+    constexpr SizeType VOIGT_SIZE_2D_PLANE_STRAIN = 4;
     constexpr SizeType VOIGT_SIZE_2D_AXISYMMETRIC = 4;
     constexpr SizeType VOIGT_SIZE_2D_INTERFACE    = 2;
     constexpr SizeType VOIGT_SIZE_3D_INTERFACE    = 3;
@@ -101,5 +94,3 @@ namespace Kratos
                               INDEX_2D_BEAM_T };
 
 }
-
-#endif  /* KRATOS_GEO_MECHANICS_APPLICATION_CONSTANTS_H_INCLUDED */


### PR DESCRIPTION
**📝 Description**
Addressed several code smells reported by SonarQube. Also fixed some problems found by clang-tidy.

**🆕 Changelog**
- Removed an unused `#include`.
- Removed some redundant comments and blank lines.
- Several layout improvements.
- Removed a few unused data members.
- Let `PrintInfo` use the result returned by `Info`.
- Fixed some spelling mistakes.
- Applied the rule of zero to a few classes. Also applied the rule of five to a class.
- Simplified some function bodies.
- Replaced some old-style inclusion guards by `#pragma once`.
- Removed a value for a template parameter, since it was identical to its default value.
- Use `std::sqrt` rather than `sqrt`.
- Made some member functions `static`.
- Removed some redundant pairs of parentheses.
- Don't decorate member functions with `virtual` and `override`. Removed `virtual` where `override` only is needed.
- Modernized a `typedef` by using `using`.
