### PR TITLE
[GeoMechanicsApplication] Fixed calls to `static` member functions

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -1140,14 +1140,12 @@ void SmallStrainUPwDiffOrderElement::
     if ( rVariable == VON_MISES_STRESS ) {
         //Loop over integration points
         for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); ++GPoint ) {
-            StressStrainUtilities EquivalentStress;
-            rOutput[GPoint] =  EquivalentStress.CalculateVonMisesStress(mStressVector[GPoint]);
+            rOutput[GPoint] = StressStrainUtilities::CalculateVonMisesStress(mStressVector[GPoint]);
         }
     } else if (rVariable == MEAN_EFFECTIVE_STRESS ) {
         //Loop over integration points
         for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); ++GPoint ) {
-            StressStrainUtilities EquivalentStress;
-            rOutput[GPoint] = EquivalentStress.CalculateMeanStress(mStressVector[GPoint]);
+            rOutput[GPoint] = StressStrainUtilities::CalculateMeanStress(mStressVector[GPoint]);
         }
     } else if (rVariable == MEAN_STRESS ) {
         std::vector<Vector> StressVector;
@@ -1155,8 +1153,7 @@ void SmallStrainUPwDiffOrderElement::
 
         //loop integration points
         for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); ++GPoint ) {
-            StressStrainUtilities EquivalentStress;
-            rOutput[GPoint] =  EquivalentStress.CalculateMeanStress(StressVector[GPoint]);
+            rOutput[GPoint] = StressStrainUtilities::CalculateMeanStress(StressVector[GPoint]);
         }
     } else if (rVariable == ENGINEERING_VON_MISES_STRAIN ) {
         std::vector<Vector> StrainVector;
@@ -1164,8 +1161,7 @@ void SmallStrainUPwDiffOrderElement::
 
         //loop integration points
         for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); ++GPoint ) {
-            StressStrainUtilities EquivalentStress;
-            rOutput[GPoint] =  EquivalentStress.CalculateVonMisesStrain(StrainVector[GPoint]);
+            rOutput[GPoint] = StressStrainUtilities::CalculateVonMisesStrain(StrainVector[GPoint]);
         }
     } else if (rVariable == ENGINEERING_VOLUMETRIC_STRAIN ) {
         std::vector<Vector> StrainVector;
@@ -1173,8 +1169,7 @@ void SmallStrainUPwDiffOrderElement::
 
         //loop integration points
         for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); ++GPoint ) {
-            StressStrainUtilities EquivalentStress;
-            rOutput[GPoint] =  EquivalentStress.CalculateTrace(StrainVector[GPoint]);
+            rOutput[GPoint] = StressStrainUtilities::CalculateTrace(StrainVector[GPoint]);
         }
     } else if (rVariable == GREEN_LAGRANGE_VON_MISES_STRAIN ) {
         std::vector<Vector> StrainVector;
@@ -1182,8 +1177,7 @@ void SmallStrainUPwDiffOrderElement::
 
         //loop integration points
         for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); ++GPoint ) {
-            StressStrainUtilities EquivalentStress;
-            rOutput[GPoint] =  EquivalentStress.CalculateVonMisesStrain(StrainVector[GPoint]);
+            rOutput[GPoint] = StressStrainUtilities::CalculateVonMisesStrain(StrainVector[GPoint]);
         }
     } else if (rVariable == GREEN_LAGRANGE_VOLUMETRIC_STRAIN ) {
         std::vector<Vector> StrainVector;
@@ -1191,8 +1185,7 @@ void SmallStrainUPwDiffOrderElement::
 
         //loop integration points
         for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); ++GPoint ) {
-            StressStrainUtilities EquivalentStress;
-            rOutput[GPoint] =  EquivalentStress.CalculateTrace(StrainVector[GPoint]);
+            rOutput[GPoint] = StressStrainUtilities::CalculateTrace(StrainVector[GPoint]);
         }
     } else if (rVariable == DEGREE_OF_SATURATION     ||
                rVariable == EFFECTIVE_SATURATION     ||
@@ -1936,8 +1929,7 @@ void SmallStrainUPwDiffOrderElement::
 
     if (rProp[PERMEABILITY_CHANGE_INVERSE_FACTOR] > 0.0) {
         const double InverseCK = rProp[PERMEABILITY_CHANGE_INVERSE_FACTOR];
-        StressStrainUtilities EquivalentStress;
-        const double epsV = EquivalentStress.CalculateTrace(rVariables.StrainVector);
+        const double epsV = StressStrainUtilities::CalculateTrace(rVariables.StrainVector);
         const double ePrevious = rProp[POROSITY] / (1.0 - rProp[POROSITY]);
         const double eCurrent = (1.0 + ePrevious) * std::exp(epsV) - 1.0;
         const double permLog10 = (eCurrent - ePrevious) * InverseCK;


### PR DESCRIPTION
**📝 Description**
These changes have been overlooked in a previous commit and where now reported as code smells by SonarQube.

**🆕 Changelog**
No longer instantiate the utilities class in order to call its member functions (since those had been made `static`).
