### PR TITLE
[Core] clean filesystem inlcudes

### DIFF
--- a/kratos/includes/kratos_filesystem.h
+++ b/kratos/includes/kratos_filesystem.h
@@ -13,6 +13,7 @@
 #pragma once
 
 // System includes
+#include <filesystem>
 #include <string>
 #include <vector>
 

--- a/kratos/includes/kratos_filesystem.h
+++ b/kratos/includes/kratos_filesystem.h
@@ -15,17 +15,6 @@
 // System includes
 #include <string>
 #include <vector>
-#if __has_include(<filesystem>) // Check if the header "<filesystem>" exists
-    #include <filesystem> // We have a decent compiler and can use the normal version
-#elif __has_include(<experimental/filesystem>) // Check if the header "<experimental/filesystem>" exists
-    #include <experimental/filesystem>
-    // We need the alias from std::experimental::filesystem to std::filesystem
-    namespace std {
-      namespace filesystem = experimental::filesystem;
-    }
-#else // Fail if neither header is available with a nice error message
-    #error Could not find system header "<filesystem>" or "<experimental/filesystem>"
-#endif // #if __has_include(<filesystem>)
 
 // External includes
 

--- a/kratos/sources/kratos_filesystem.cpp
+++ b/kratos/sources/kratos_filesystem.cpp
@@ -12,9 +12,10 @@
 
 // System includes
 #include <algorithm>
-#include <thread>
 #include <chrono>
+#include <filesystem>
 #include <set>
+#include <thread>
 
 // External includes
 

--- a/kratos/sources/kratos_filesystem.cpp
+++ b/kratos/sources/kratos_filesystem.cpp
@@ -13,7 +13,6 @@
 // System includes
 #include <algorithm>
 #include <chrono>
-#include <filesystem>
 #include <set>
 #include <thread>
 


### PR DESCRIPTION
Basically reverts #10198

@rubenzorrilla had issues with an older CLANG compiler, but now we have as minimum version 12 which is quite new, thus we can remove this flaaback solution