### PR TITLE
[External] Missing include in Clipper2 library

### DIFF
--- a/external_libraries/clipper/include/clipper2/clipper.core.h
+++ b/external_libraries/clipper/include/clipper2/clipper.core.h
@@ -11,6 +11,7 @@
 #define CLIPPER_CORE_H
 
 #include <cstdlib>
+#include <cinttypes>
 #include <cmath>
 #include <vector>
 #include <string>


### PR DESCRIPTION
**📝 Description**

With last versions of GCC (13) and Clang (14) compilation fails without this include.

**🆕 Changelog**

- [Missing include in Clipper2 library](https://github.com/KratosMultiphysics/Kratos/commit/33860444096485cd655167032bf4a3497ef5fd3f)
