### PR TITLE
[GeoMechanicsApplication] Some more cleanup in `custom_constitutive`

### DIFF
--- a/applications/GeoMechanicsApplication/custom_constitutive/bilinear_cohesive_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/bilinear_cohesive_3D_law.cpp
@@ -38,10 +38,9 @@ void BilinearCohesive3DLaw::GetLawFeatures(Features& rFeatures)
     rFeatures.mStrainSize = GetStrainSize();
 }
 
-int BilinearCohesive3DLaw::
-    Check(const Properties& rMaterialProperties,
-          const GeometryType& rElementGeometry,
-          const ProcessInfo& rCurrentProcessInfo) const
+int BilinearCohesive3DLaw::Check(const Properties& rMaterialProperties,
+                                 const GeometryType& rElementGeometry,
+                                 const ProcessInfo& rCurrentProcessInfo) const
 {
     // Verify Properties variables
     if (rMaterialProperties.Has( CRITICAL_DISPLACEMENT ) == false || rMaterialProperties[CRITICAL_DISPLACEMENT] <= 0.0)
@@ -69,10 +68,9 @@ ConstitutiveLaw::Pointer BilinearCohesive3DLaw::Clone() const
     return p_clone;
 }
 
-void BilinearCohesive3DLaw::
-    InitializeMaterial( const Properties& rMaterialProperties,
-                        const GeometryType& rElementGeometry,
-                        const Vector& rShapeFunctionsValues )
+void BilinearCohesive3DLaw::InitializeMaterial(const Properties& rMaterialProperties,
+                                               const GeometryType& rElementGeometry,
+                                               const Vector& rShapeFunctionsValues)
 {
     mStateVariable = rMaterialProperties[DAMAGE_THRESHOLD];
 }
@@ -192,7 +190,7 @@ void BilinearCohesive3DLaw::FinalizeMaterialResponseCauchy( Parameters& rValues 
         rValues.CheckAllParameters();
 
         //Initialize main variables
-        Vector& rStrainVector = rValues.GetStrainVector();
+        const Vector& rStrainVector = rValues.GetStrainVector();
         double EquivalentStrain;
 
         //Material properties

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_beam_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_beam_law.h
@@ -137,11 +137,11 @@ protected:
     ///@name Protected Operations
     ///@{
 
-    // /**
-    //  * @brief It calculates the constitutive matrix C
-    //  * @param C The constitutive matrix
-    //  * @param rValues Parameters of the constitutive law
-    //  */
+    /**
+     * @brief It calculates the constitutive matrix C
+     * @param C The constitutive matrix
+     * @param rValues Parameters of the constitutive law
+     */
     void CalculateElasticMatrix(Matrix& C, ConstitutiveLaw::Parameters& rValues) override;
 
     void CalculatePK2Stress(const Vector& rStrainVector,

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_interface_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_2D_interface_law.h
@@ -148,11 +148,11 @@ protected:
     ///@name Protected Operations
     ///@{
 
-    // /**
-    //  * @brief It calculates the constitutive matrix C
-    //  * @param C The constitutive matrix
-    //  * @param rValues Parameters of the constitutive law
-    //  */
+    /**
+     * @brief It calculates the constitutive matrix C
+     * @param C The constitutive matrix
+     * @param rValues Parameters of the constitutive law
+     */
     void CalculateElasticMatrix(Matrix& C, ConstitutiveLaw::Parameters& rValues) override;
 
     /**
@@ -164,13 +164,6 @@ protected:
     void CalculatePK2Stress(const Vector& rStrainVector,
                             Vector& rStressVector,
                             ConstitutiveLaw::Parameters& rValues) override;
-
-    // /**
-    //  * @brief It calculates the strain vector
-    //  * @param rValues The internal values of the law
-    //  * @param rStrainVector The strain vector in Voigt notation
-    //  */
-    // void CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector) override;
 
     ///@}
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_3D_interface_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_3D_interface_law.h
@@ -10,12 +10,7 @@
 //  Main authors:    Vahid Galavi
 //
 
-#if !defined (KRATOS_LINEAR_ELASTIC_3D_INTERFACE_LAW_GEO_H_INCLUDED)
-#define  KRATOS_LINEAR_ELASTIC_3D_INTERFACE_LAW_GEO_H_INCLUDED
-
-// System includes
-
-// External includes
+#pragma once
 
 // Project includes
 #include "custom_constitutive/linear_elastic_2D_interface_law.h"
@@ -153,11 +148,11 @@ protected:
     ///@name Protected Operations
     ///@{
 
-    // /**
-    //  * @brief It calculates the constitutive matrix C
-    //  * @param C The constitutive matrix
-    //  * @param rValues Parameters of the constitutive law
-    //  */
+    /**
+     * @brief It calculates the constitutive matrix C
+     * @param C The constitutive matrix
+     * @param rValues Parameters of the constitutive law
+     */
     void CalculateElasticMatrix(Matrix& C, ConstitutiveLaw::Parameters& rValues) override;
 
     /**
@@ -169,13 +164,6 @@ protected:
     void CalculatePK2Stress(const Vector& rStrainVector,
                             Vector& rStressVector,
                             ConstitutiveLaw::Parameters& rValues) override;
-
-    // /**
-    //  * @brief It calculates the strain vector
-    //  * @param rValues The internal values of the law
-    //  * @param rStrainVector The strain vector in Voigt notation
-    //  */
-    // void CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector) override;
 
     ///@}
 
@@ -217,5 +205,4 @@ private:
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, LinearElastic2DInterfaceLaw)
     }
 }; // Class LinearElastic2DInterfaceLaw
-}  // namespace Kratos.
-#endif // KRATOS_LINEAR_PLANE_STRAIN_K0_LAW_H_INCLUDED  defined
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_2D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_2D_law.cpp
@@ -13,8 +13,6 @@
 // System includes
 #include <iostream>
 
-// External includes
-
 // Project includes
 #include "custom_constitutive/linear_elastic_plane_strain_2D_law.h"
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_2D_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_2D_law.h
@@ -169,13 +169,6 @@ protected:
                             Vector& rStressVector,
                             ConstitutiveLaw::Parameters& rValues) override;
 
-    // /**
-    //  * @brief It calculates the strain vector
-    //  * @param rValues The internal values of the law
-    //  * @param rStrainVector The strain vector in Voigt notation
-    //  */
-    // void CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues, Vector& rStrainVector) override;
-
     ///@}
 
 private:

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_K0_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_strain_K0_law.cpp
@@ -29,9 +29,7 @@ ConstitutiveLaw::Pointer LinearPlaneStrainK0Law::Clone() const
 bool& LinearPlaneStrainK0Law::GetValue(const Variable<bool>& rThisVariable, bool& rValue)
 {
     // This Constitutive Law has been checked with Stenberg Stabilization
-    if (rThisVariable == STENBERG_SHEAR_STABILIZATION_SUITABLE) {
-        rValue = true;
-    }
+    if (rThisVariable == STENBERG_SHEAR_STABILIZATION_SUITABLE) rValue = true;
 
     return rValue;
 }
@@ -134,7 +132,6 @@ void LinearPlaneStrainK0Law::CalculatePK2Stress(const Vector& rStrainVector,
 
 void LinearPlaneStrainK0Law::CalculateCauchyGreenStrain(Parameters& rValues, Vector& rStrainVector)
 {
-
     //1.-Compute total deformation gradient
     const Matrix& F = rValues.GetDeformationGradientF();
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_stress_2D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_stress_2D_law.cpp
@@ -27,8 +27,7 @@ ConstitutiveLaw::Pointer GeoLinearElasticPlaneStress2DLaw::Clone() const
 bool& GeoLinearElasticPlaneStress2DLaw::GetValue(const Variable<bool>& rThisVariable, bool& rValue)
 {
     // This Constitutive Law has been checked with Stenberg Stabilization
-    if (rThisVariable == STENBERG_SHEAR_STABILIZATION_SUITABLE)
-        rValue = true;
+    if (rThisVariable == STENBERG_SHEAR_STABILIZATION_SUITABLE) rValue = true;
 
     return rValue;
 }

--- a/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_stress_2D_law.h
+++ b/applications/GeoMechanicsApplication/custom_constitutive/linear_elastic_plane_stress_2D_law.h
@@ -162,21 +162,19 @@ protected:
     * @param rStressVector The stress vector in Voigt notation
     * @param rValues Parameters of the constitutive law
     */
-    void CalculatePK2Stress(
-        const Vector& rStrainVector,
-        Vector& rStressVector,
-        ConstitutiveLaw::Parameters& rValues
-        ) override;
+    void CalculatePK2Stress(const Vector& rStrainVector,
+                            Vector& rStressVector,
+                            ConstitutiveLaw::Parameters& rValues
+                           ) override;
 
     /**
     * It calculates the strain vector
     * @param rValues The internal values of the law
     * @param rStrainVector The strain vector in Voigt notation
     */
-    void CalculateCauchyGreenStrain(
-        ConstitutiveLaw::Parameters& rValues,
-        Vector& rStrainVector
-        ) override;
+    void CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues,
+                                    Vector& rStrainVector
+                                   ) override;
 
     ///@}
 

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.cpp
@@ -10,81 +10,19 @@
 //  Main authors:    Vahid Galavi
 //
 
-// System includes
-
-// External includes
-
 #include "custom_constitutive/small_strain_udsm_2D_interface_law.hpp"
-
 
 namespace Kratos
 {
 
-//******************************CONSTRUCTOR*******************************************
-//************************************************************************************
-
-SmallStrainUDSM2DInterfaceLaw::SmallStrainUDSM2DInterfaceLaw()
-   : SmallStrainUDSM3DLaw()
-   {
-    KRATOS_TRY
-    //KRATOS_INFO("SmallStrainUDSM2DInterfaceLaw()") << std::endl;
-
-    KRATOS_CATCH("")
-
-   }
-
-//******************************COPY CONSTRUCTOR**************************************
-//************************************************************************************
-SmallStrainUDSM2DInterfaceLaw::
-   SmallStrainUDSM2DInterfaceLaw(const SmallStrainUDSM2DInterfaceLaw &rOther)
-   : SmallStrainUDSM3DLaw(rOther)
-{
-   KRATOS_TRY
-   //KRATOS_INFO("SmallStrainUDSM2DInterfaceLaw(const...)") << std::endl;
-
-   KRATOS_CATCH("")
-}
-
-//********************************CLONE***********************************************
-//************************************************************************************
-
 ConstitutiveLaw::Pointer SmallStrainUDSM2DInterfaceLaw::Clone() const
 {
    KRATOS_TRY
-   //KRATOS_INFO("Clone()") << std::endl;
 
    return Kratos::make_shared<SmallStrainUDSM2DInterfaceLaw>(*this);
 
    KRATOS_CATCH("")
 }
-
-//********************************ASSIGNMENT******************************************
-//************************************************************************************
-SmallStrainUDSM2DInterfaceLaw 
-  &SmallStrainUDSM2DInterfaceLaw::operator=(SmallStrainUDSM2DInterfaceLaw const &rOther)
-{
-   KRATOS_TRY
-
-   SmallStrainUDSM3DLaw::operator=(rOther);
-
-   //KRATOS_INFO("operator=") << std::endl;
-
-   return *this;
-
-   KRATOS_CATCH("")
-}
-
-//*******************************DESTRUCTOR*******************************************
-//************************************************************************************
-
-SmallStrainUDSM2DInterfaceLaw::~SmallStrainUDSM2DInterfaceLaw()
-{
-   //KRATOS_INFO("~SmallStrainUDSM3DLaw()") << std::endl;
-}
-
-
-//************************************************************************************
-//************************************************************************************
 
 void SmallStrainUDSM2DInterfaceLaw::UpdateInternalDeltaStrainVector(ConstitutiveLaw::Parameters &rValues)
 {
@@ -96,8 +34,6 @@ void SmallStrainUDSM2DInterfaceLaw::UpdateInternalDeltaStrainVector(Constitutive
 
 void SmallStrainUDSM2DInterfaceLaw::SetExternalStressVector(Vector& rStressVector)
 {
-   //KRATOS_INFO("mStressVector") << mStressVector << std::endl;
-
    rStressVector(INDEX_2D_INTERFACE_ZZ) = mStressVector[INDEX_3D_ZZ];
    rStressVector(INDEX_2D_INTERFACE_XZ) = mStressVector[INDEX_3D_XZ];
 }
@@ -105,7 +41,6 @@ void SmallStrainUDSM2DInterfaceLaw::SetExternalStressVector(Vector& rStressVecto
 
 void SmallStrainUDSM2DInterfaceLaw::SetInternalStressVector(const Vector& rStressVector)
 {
-   // KRATOS_INFO("SetInternalStressVector:rStressVector") << rStressVector << std::endl;
    KRATOS_TRY
    std::fill(mStressVectorFinalized.begin(), mStressVectorFinalized.end(), 0.0);
 
@@ -116,7 +51,6 @@ void SmallStrainUDSM2DInterfaceLaw::SetInternalStressVector(const Vector& rStres
 
 void SmallStrainUDSM2DInterfaceLaw::SetInternalStrainVector(const Vector& rStrainVector)
 {
-   // KRATOS_INFO("SetInternalStrainVector:rStrainVector") << rStrainVector << std::endl;
    std::fill(mStrainVectorFinalized.begin(), mStrainVectorFinalized.end(), 0.0);
 
    mStrainVectorFinalized[INDEX_3D_ZZ] = rStrainVector(INDEX_2D_INTERFACE_ZZ);
@@ -124,8 +58,8 @@ void SmallStrainUDSM2DInterfaceLaw::SetInternalStrainVector(const Vector& rStrai
 }
 
 
-void SmallStrainUDSM2DInterfaceLaw::CopyConstitutiveMatrix( ConstitutiveLaw::Parameters &rValues,
-                                                            Matrix& rConstitutiveMatrix )
+void SmallStrainUDSM2DInterfaceLaw::CopyConstitutiveMatrix(ConstitutiveLaw::Parameters &rValues,
+                                                           Matrix& rConstitutiveMatrix)
 {
    if (rValues.GetMaterialProperties()[IS_FORTRAN_UDSM])
    {
@@ -160,61 +94,36 @@ indexStress3D SmallStrainUDSM2DInterfaceLaw::getIndex3D(indexStress2DInterface i
 }
 
 
-/***********************************************************************************/
-/***********************************************************************************/
-void SmallStrainUDSM2DInterfaceLaw::
-   CalculateCauchyGreenStrain( ConstitutiveLaw::Parameters& rValues,
-                               Vector& rStrainVector )
+void SmallStrainUDSM2DInterfaceLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues,
+                                                               Vector& rStrainVector)
 {
    KRATOS_ERROR << "CalculateCauchyGreenStrain is not implemented in SmallStrainUDSM2DInterfaceLaw" << std::endl;
 }
 
-//----------------------------------------------------------------------------------------
-Vector& SmallStrainUDSM2DInterfaceLaw::
-   GetValue( const Variable<Vector> &rThisVariable,
-             Vector &rValue )
+Vector& SmallStrainUDSM2DInterfaceLaw::GetValue(const Variable<Vector> &rThisVariable,
+                                                Vector &rValue)
 {
-   // KRATOS_INFO("0-SmallStrainUDSM2DInterfaceLaw::GetValue()") << std::endl;
-
-   if (rThisVariable == STATE_VARIABLES)
-   {
+   if (rThisVariable == STATE_VARIABLES) {
       SmallStrainUDSM3DLaw::GetValue(rThisVariable, rValue );
-   }
-   else if (rThisVariable == CAUCHY_STRESS_VECTOR)
-   {
-      if (rValue.size() != VoigtSize)
-         rValue.resize(VoigtSize);
+   } else if (rThisVariable == CAUCHY_STRESS_VECTOR) {
+      if (rValue.size() != VoigtSize) rValue.resize(VoigtSize);
 
       rValue[INDEX_2D_INTERFACE_ZZ] = mStressVectorFinalized[INDEX_3D_ZZ];
       rValue[INDEX_2D_INTERFACE_XZ] = mStressVectorFinalized[INDEX_3D_XZ];
-
    }
-
-   // KRATOS_INFO("1-SmallStrainUDSM2DInterfaceLaw::GetValue()") << std::endl;
-
     return rValue;
 }
 
-//----------------------------------------------------------------------------------------
-void SmallStrainUDSM2DInterfaceLaw::SetValue( const Variable<Vector>& rThisVariable,
-                                                const Vector& rValue,
-                                                const ProcessInfo& rCurrentProcessInfo )
+void SmallStrainUDSM2DInterfaceLaw::SetValue(const Variable<Vector>& rThisVariable,
+                                             const Vector& rValue,
+                                             const ProcessInfo& rCurrentProcessInfo)
 {
-   // KRATOS_INFO("02-SmallStrainUDSM2DInterfaceLaw::SetValue()") << std::endl;
-
-   if (rThisVariable == STATE_VARIABLES)
-   {
+   if (rThisVariable == STATE_VARIABLES) {
       SmallStrainUDSM3DLaw::SetValue(rThisVariable, rValue, rCurrentProcessInfo );
+   } else if ((rThisVariable == CAUCHY_STRESS_VECTOR) &&
+              (rValue.size() == VoigtSize)) {
+      this->SetInternalStressVector(rValue);
    }
-   else if (rThisVariable == CAUCHY_STRESS_VECTOR)
-   {
-      if (rValue.size() == VoigtSize) 
-      {
-         this->SetInternalStressVector(rValue);
-      }
-   }
-
-   // KRATOS_INFO("12-SmallStrainUDSM2DInterfaceLaw::SetValue()") << std::endl;
 }
 
 } // Namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_interface_law.hpp
@@ -10,13 +10,10 @@
 //  Main authors:    Vahid Galavi
 //
 
-#if !defined(KRATOS_SMALL_STRAIN_UDSM_2D_INTERFACE_LAW_H_INCLUDED )
-#define  KRATOS_SMALL_STRAIN_UDSM_2D_INTERFACE_LAW_H_INCLUDED
+#pragma once
 
 // System includes
 #include "includes/define.h"
-
-// External includes
 
 // Project includes
 #include "small_strain_udsm_3D_law.hpp"
@@ -67,42 +64,21 @@ namespace Kratos
       /// Pointer definition of SmallStrainUDSM2DInterfaceLaw
       KRATOS_CLASS_POINTER_DEFINITION( SmallStrainUDSM2DInterfaceLaw );
 
-
       //@}
       //@name Life Cycle
       //@{
-
-      //----------------------------------------------------------------------------------------
-      /**
-       * @brief Default constructor.
-       */
-      SmallStrainUDSM2DInterfaceLaw();
 
       /**
        * @brief Clone method
        */
       ConstitutiveLaw::Pointer Clone() const override;
 
-      /**
-       * Copy constructor.
-       */
-      SmallStrainUDSM2DInterfaceLaw(SmallStrainUDSM2DInterfaceLaw const& rOther);
+      Vector& GetValue(const Variable<Vector> &rThisVariable, Vector &rValue) override;
 
-      /**
-       * @brief Destructor.
-       */
-      virtual ~SmallStrainUDSM2DInterfaceLaw();
+      void SetValue(const Variable<Vector>& rVariable,
+                    const Vector& rValue,
+                    const ProcessInfo& rCurrentProcessInfo) override;
 
-      // Assignment operator:
-      SmallStrainUDSM2DInterfaceLaw& operator=(SmallStrainUDSM2DInterfaceLaw const& rOther);
-
-      Vector& GetValue( const Variable<Vector> &rThisVariable, Vector &rValue ) override;
-
-      void SetValue( const Variable<Vector>& rVariable,
-                     const Vector& rValue,
-                     const ProcessInfo& rCurrentProcessInfo ) override;
-
-      //----------------------------------------------------------------------------------------
       /**
        * @brief Dimension of the law:
        */
@@ -137,7 +113,6 @@ namespace Kratos
          return StressMeasure_Cauchy;
       }
 
-
       /**
        * @brief It calculates the strain vector
        * @param rValues The internal values of the law
@@ -149,36 +124,31 @@ namespace Kratos
       ///@name Inquiry
       ///@{
 
-
       ///@}
       ///@name Input and output
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override
+      std::string Info() const override
       {
-         std::stringstream buffer;
-         buffer << "SmallStrainUDSM2DInterfaceLaw";
-         return buffer.str();
+         return "SmallStrainUDSM2DInterfaceLaw";
       }
 
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override
+      void PrintInfo(std::ostream& rOStream) const override
       {
-         rOStream << "SmallStrainUDSM2DInterfaceLaw";
+         rOStream << Info();
       }
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override
+      void PrintData(std::ostream& rOStream) const override
       {
          rOStream << "SmallStrainUDSM2DInterfaceLaw Data";
       }
 
-
       ///@}
       ///@name Friends
       ///@{
-
 
       ///@}
 
@@ -194,7 +164,6 @@ namespace Kratos
       ///@name Protected Operators
       ///@{
 
-
       ///@}
       ///@name Protected Operations
       ///@{
@@ -208,16 +177,13 @@ namespace Kratos
       void SetInternalStrainVector(const Vector& rStrainVector) override;
       void CopyConstitutiveMatrix(ConstitutiveLaw::Parameters &rValues, Matrix& rConstitutiveMatrix) override;
 
-
       ///@}
       ///@name Protected Inquiry
       ///@{
 
-
       ///@}
       ///@name Protected LifeCycle
       ///@{
-
 
       ///@}
 
@@ -235,29 +201,25 @@ namespace Kratos
       ///@name Private Operators
       ///@{
 
-
       ///@}
       ///@name Private Operations
       ///@{
 
-
       ///@}
       ///@name Private  Access
       ///@{
-
-
 
       ///@}
       ///@name Serialization
       ///@{
       friend class Serializer;
 
-      virtual void save(Serializer& rSerializer) const override
+      void save(Serializer& rSerializer) const override
       {
          KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, ConstitutiveLaw)
       }
 
-      virtual void load(Serializer& rSerializer) override
+      void load(Serializer& rSerializer) override
       {
          KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, ConstitutiveLaw)
       }
@@ -265,7 +227,6 @@ namespace Kratos
       ///@}
       ///@name Private Inquiry
       ///@{
-
 
       ///@}
       ///@name Un accessible methods
@@ -280,7 +241,6 @@ namespace Kratos
    ///@name Type Definitions
    ///@{
 
-
    ///@}
    ///@name Input and output
    ///@{
@@ -289,8 +249,4 @@ namespace Kratos
 
    ///@} addtogroup block
 
-}  // namespace Kratos.
-
-#endif // KRATOS_SMALL_STRAIN_UDSM_2D_INTERFACE_LAW_H_INCLUDED  defined
-
-
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.cpp
@@ -10,41 +10,11 @@
 //  Main authors:    Vahid Galavi
 //
 
-// System includes
-
 // External includes
-
 #include "custom_constitutive/small_strain_udsm_2D_plane_strain_law.hpp"
-
 
 namespace Kratos
 {
-
-//******************************CONSTRUCTOR*******************************************
-//************************************************************************************
-
-SmallStrainUDSM2DPlaneStrainLaw::SmallStrainUDSM2DPlaneStrainLaw()
-   : SmallStrainUDSM3DLaw()
-   {
-    KRATOS_TRY
-
-    KRATOS_CATCH("")
-
-   }
-
-//******************************COPY CONSTRUCTOR**************************************
-//************************************************************************************
-SmallStrainUDSM2DPlaneStrainLaw::
-   SmallStrainUDSM2DPlaneStrainLaw(const SmallStrainUDSM2DPlaneStrainLaw &rOther)
-   : SmallStrainUDSM3DLaw(rOther)
-{
-   KRATOS_TRY
-
-   KRATOS_CATCH("")
-}
-
-//********************************CLONE***********************************************
-//************************************************************************************
 
 ConstitutiveLaw::Pointer SmallStrainUDSM2DPlaneStrainLaw::Clone() const
 {
@@ -55,174 +25,110 @@ ConstitutiveLaw::Pointer SmallStrainUDSM2DPlaneStrainLaw::Clone() const
    KRATOS_CATCH("")
 }
 
-//********************************ASSIGNMENT******************************************
-//************************************************************************************
-SmallStrainUDSM2DPlaneStrainLaw 
-  &SmallStrainUDSM2DPlaneStrainLaw::operator=(SmallStrainUDSM2DPlaneStrainLaw const &rOther)
+void SmallStrainUDSM2DPlaneStrainLaw::UpdateInternalDeltaStrainVector(ConstitutiveLaw::Parameters &rValues)
 {
-   KRATOS_TRY
+    const Vector& rStrainVector = rValues.GetStrainVector();
 
-   SmallStrainUDSM3DLaw::operator=(rOther);
+    for (unsigned int i = 0; i < VoigtSize; ++i) {
+       mDeltaStrainVector[i] = rStrainVector(i) - mStrainVectorFinalized[i];
+    }
+}
 
-   return *this;
+void SmallStrainUDSM2DPlaneStrainLaw::SetExternalStressVector(Vector& rStressVector)
+{
+    KRATOS_TRY
+    for (unsigned int i = 0; i < VoigtSize; ++i) {
+       rStressVector(i) = mStressVector[i];
+    }
+    KRATOS_CATCH("")
+}
 
+void SmallStrainUDSM2DPlaneStrainLaw::SetInternalStressVector(const Vector& rStressVector)
+{
+    KRATOS_TRY
+    for (unsigned int i = 0; i < VoigtSize; ++i) {
+       mStressVectorFinalized[i] = rStressVector(i);
+    }
    KRATOS_CATCH("")
 }
 
-//*******************************DESTRUCTOR*******************************************
-//************************************************************************************
-
-SmallStrainUDSM2DPlaneStrainLaw::~SmallStrainUDSM2DPlaneStrainLaw() {}
-
-
-//************************************************************************************
-//************************************************************************************
-
-void SmallStrainUDSM2DPlaneStrainLaw::
-   UpdateInternalDeltaStrainVector(ConstitutiveLaw::Parameters &rValues)
+void SmallStrainUDSM2DPlaneStrainLaw::SetInternalStrainVector(const Vector& rStrainVector)
 {
-   const Vector& rStrainVector = rValues.GetStrainVector();
-
-   for (unsigned int i = 0; i < VoigtSize; ++i) {
-      mDeltaStrainVector[i] = rStrainVector(i) - mStrainVectorFinalized[i];
-   }
-
-}
-
-void SmallStrainUDSM2DPlaneStrainLaw::
-   SetExternalStressVector(Vector& rStressVector)
-{
-   KRATOS_TRY
-
-   for (unsigned int i = 0; i < VoigtSize; ++i) {
-      rStressVector(i) = mStressVector[i];
-   }
-
+    KRATOS_TRY
+    for (unsigned int i = 0; i < VoigtSize; ++i) {
+        mStrainVectorFinalized[i] = rStrainVector(i);
+    }
    KRATOS_CATCH("")
 }
 
-
-void SmallStrainUDSM2DPlaneStrainLaw::
-   SetInternalStressVector(const Vector& rStressVector)
+void SmallStrainUDSM2DPlaneStrainLaw::CopyConstitutiveMatrix(ConstitutiveLaw::Parameters &rValues,
+                                                             Matrix& rConstitutiveMatrix)
 {
-   KRATOS_TRY
+    KRATOS_TRY
 
-   for (unsigned int i = 0; i < VoigtSize; ++i) {
-      mStressVectorFinalized[i] = rStressVector(i);
-   }
+    if (rValues.GetMaterialProperties()[IS_FORTRAN_UDSM]) {
+        // transfer Fortran style matrix to C++ style
+        for (unsigned int i = 0; i < VoigtSize; ++i) {
+            for (unsigned int j = 0; j < VoigtSize; ++j) {
+                rConstitutiveMatrix(i,j) = mMatrixD[j][i];
+            }
+        }
+    } else {
+        for (unsigned int i = 0; i < VoigtSize; ++i) {
+            for (unsigned int j = 0; j < VoigtSize; ++j) {
+                rConstitutiveMatrix(i,j) = mMatrixD[i][j];
+            }
+        }
+    }
 
-   KRATOS_CATCH("")
+    KRATOS_CATCH("")
 }
 
-void SmallStrainUDSM2DPlaneStrainLaw::
-   SetInternalStrainVector(const Vector& rStrainVector)
+void SmallStrainUDSM2DPlaneStrainLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues,
+                                                                 Vector& rStrainVector)
 {
-   KRATOS_TRY
+    //1.-Compute total deformation gradient
+    const Matrix& F = rValues.GetDeformationGradientF();
 
-   for (unsigned int i = 0; i < VoigtSize; ++i) {
-      mStrainVectorFinalized[i] = rStrainVector(i);
-   }
+    // for shells/membranes in case the DeformationGradient is of size 3x3
+    BoundedMatrix<double, 2, 2> F2x2;
+    for (unsigned int i = 0; i<2; ++i)
+        for (unsigned int j = 0; j<2; ++j)
+            F2x2(i, j) = F(i, j);
 
-   KRATOS_CATCH("")
+    Matrix E_tensor = prod(trans(F2x2), F2x2);
+
+    for (unsigned int i = 0; i<2; ++i)
+        E_tensor(i, i) -= 1.0;
+
+    E_tensor *= 0.5;
+    noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
 }
 
-void SmallStrainUDSM2DPlaneStrainLaw::
-   CopyConstitutiveMatrix( ConstitutiveLaw::Parameters &rValues,
-                           Matrix& rConstitutiveMatrix )
+Vector& SmallStrainUDSM2DPlaneStrainLaw::GetValue(const Variable<Vector> &rThisVariable,
+                                                  Vector &rValue)
 {
-   KRATOS_TRY
-
-   if (rValues.GetMaterialProperties()[IS_FORTRAN_UDSM])
-   {
-      // transfer fortran style matrix to C++ style
-      for (unsigned int i = 0; i < VoigtSize; ++i) {
-         for (unsigned int j = 0; j < VoigtSize; ++j) {
-            rConstitutiveMatrix(i,j) = mMatrixD[j][i];
-         }
-      }
-   }
-   else
-   {
-      for (unsigned int i = 0; i < VoigtSize; ++i) {
-         for (unsigned int j = 0; j < VoigtSize; ++j) {
-            rConstitutiveMatrix(i,j) = mMatrixD[i][j];
-         }
-      }
-   }
-
-   KRATOS_CATCH("")
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-void SmallStrainUDSM2DPlaneStrainLaw::
-   CalculateCauchyGreenStrain( ConstitutiveLaw::Parameters& rValues,
-                               Vector& rStrainVector )
-{
-   //1.-Compute total deformation gradient
-   const Matrix& F = rValues.GetDeformationGradientF();
-
-   // for shells/membranes in case the DeformationGradient is of size 3x3
-   BoundedMatrix<double, 2, 2> F2x2;
-   for (unsigned int i = 0; i<2; ++i)
-      for (unsigned int j = 0; j<2; ++j)
-         F2x2(i, j) = F(i, j);
-
-   Matrix E_tensor = prod(trans(F2x2), F2x2);
-
-   for (unsigned int i = 0; i<2; ++i)
-      E_tensor(i, i) -= 1.0;
-
-   E_tensor *= 0.5;
-   noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
-}
-
-//----------------------------------------------------------------------------------------
-Vector& SmallStrainUDSM2DPlaneStrainLaw::
-   GetValue( const Variable<Vector> &rThisVariable,
-             Vector &rValue )
-{
-   // KRATOS_INFO("0-SmallStrainUDSM2DPlaneStrainLaw::GetValue()") << std::endl;
-
-   if (rThisVariable == STATE_VARIABLES) {
-      SmallStrainUDSM3DLaw::GetValue(rThisVariable, rValue );
-   }
-   else if (rThisVariable == CAUCHY_STRESS_VECTOR) {
-      if (rValue.size() != VoigtSize)
-         rValue.resize(VoigtSize);
-
-      for (unsigned int i = 0; i < VoigtSize; ++i) {
-         rValue[i] = mStressVectorFinalized[i];
-      }
-   }
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::GetValue()") << std::endl;
-
+    if (rThisVariable == STATE_VARIABLES) {
+        SmallStrainUDSM3DLaw::GetValue(rThisVariable, rValue );
+    } else if (rThisVariable == CAUCHY_STRESS_VECTOR) {
+        if (rValue.size() != VoigtSize) rValue.resize(VoigtSize);
+        for (unsigned int i = 0; i < VoigtSize; ++i) {
+            rValue[i] = mStressVectorFinalized[i];
+        }
+    }
     return rValue;
 }
 
-//----------------------------------------------------------------------------------------
-void SmallStrainUDSM2DPlaneStrainLaw::
-   SetValue( const Variable<Vector>& rThisVariable,
-             const Vector& rValue,
-             const ProcessInfo& rCurrentProcessInfo )
+void SmallStrainUDSM2DPlaneStrainLaw::SetValue(const Variable<Vector>& rThisVariable,
+                                               const Vector& rValue,
+                                               const ProcessInfo& rCurrentProcessInfo)
 {
-   // KRATOS_INFO("02-SmallStrainUDSM2DPlaneStrainLaw::SetValue()") << std::endl;
-
-   if (rThisVariable == STATE_VARIABLES)
-   {
-      SmallStrainUDSM3DLaw::SetValue(rThisVariable, rValue, rCurrentProcessInfo );
-   }
-   else if (rThisVariable == CAUCHY_STRESS_VECTOR)
-   {
-      if (rValue.size() == VoigtSize) 
-      {
-         this->SetInternalStressVector(rValue);
-      }
-   }
-
-   // KRATOS_INFO("12-SmallStrainUDSM2DPlaneStrainLaw::SetValue()") << std::endl;
+    if (rThisVariable == STATE_VARIABLES) {
+        SmallStrainUDSM3DLaw::SetValue(rThisVariable, rValue, rCurrentProcessInfo );
+    } else if ((rThisVariable == CAUCHY_STRESS_VECTOR) &&
+               (rValue.size() == VoigtSize)) {
+        this->SetInternalStressVector(rValue);
+    }
 }
 
-} // Namespace Kratos
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_2D_plane_strain_law.hpp
@@ -10,13 +10,10 @@
 //  Main authors:    Vahid Galavi
 //
 
-#if !defined(KRATOS_SMALL_STRAIN_UDSM_2D_PLANE_STRAIN_LAW_H_INCLUDED )
-#define  KRATOS_SMALL_STRAIN_UDSM_2D_PLANE_STRAIN_LAW_H_INCLUDED
+#pragma once
 
 // System includes
 #include "includes/define.h"
-
-// External includes
 
 // Project includes
 #include "custom_constitutive/small_strain_udsm_3D_law.hpp"
@@ -71,29 +68,10 @@ namespace Kratos
       //@name Life Cycle
       //@{
 
-      //----------------------------------------------------------------------------------------
-      /**
-       * @brief Default constructor.
-       */
-      SmallStrainUDSM2DPlaneStrainLaw();
-
       /**
        * @brief Clone method
        */
       ConstitutiveLaw::Pointer Clone() const override;
-
-      /**
-       * Copy constructor.
-       */
-      SmallStrainUDSM2DPlaneStrainLaw(SmallStrainUDSM2DPlaneStrainLaw const& rOther);
-
-      /**
-       * @brief Destructor.
-       */
-      virtual ~SmallStrainUDSM2DPlaneStrainLaw();
-
-      // Assignment operator:
-      SmallStrainUDSM2DPlaneStrainLaw& operator=(SmallStrainUDSM2DPlaneStrainLaw const& rOther);
 
       Vector& GetValue( const Variable<Vector> &rThisVariable, Vector &rValue ) override;
 
@@ -131,7 +109,7 @@ namespace Kratos
        * returns the stress measure of this constitutive law (by default 1st Piola-Kirchhoff stress in voigt notation)
        * @return the expected stress measure
        */
-      virtual StressMeasure GetStressMeasure() override
+      StressMeasure GetStressMeasure() override
       {
          return StressMeasure_Cauchy;
       }
@@ -154,21 +132,19 @@ namespace Kratos
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override
+      std::string Info() const override
       {
-         std::stringstream buffer;
-         buffer << "SmallStrainUDSM2DPlaneStrainLaw";
-         return buffer.str();
+         return "SmallStrainUDSM2DPlaneStrainLaw";
       }
 
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override
+      void PrintInfo(std::ostream& rOStream) const override
       {
-         rOStream << "SmallStrainUDSM2DPlaneStrainLaw";
+         rOStream << Info();
       }
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override
+      void PrintData(std::ostream& rOStream) const override
       {
          rOStream << "SmallStrainUDSM2DPlaneStrainLaw Data";
       }
@@ -249,12 +225,12 @@ namespace Kratos
       ///@{
       friend class Serializer;
 
-      virtual void save(Serializer& rSerializer) const override
+      void save(Serializer& rSerializer) const override
       {
          KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, ConstitutiveLaw)
       }
 
-      virtual void load(Serializer& rSerializer) override
+      void load(Serializer& rSerializer) override
       {
          KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, ConstitutiveLaw)
       }
@@ -262,7 +238,6 @@ namespace Kratos
       ///@}
       ///@name Private Inquiry
       ///@{
-
 
       ///@}
       ///@name Un accessible methods
@@ -286,8 +261,4 @@ namespace Kratos
 
    ///@} addtogroup block
 
-}  // namespace Kratos.
-
-#endif // KRATOS_SMALL_STRAIN_UDSM_2D_PLANE_STRAIN_LAW_H_INCLUDED  defined
-
-
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.cpp
@@ -16,73 +16,19 @@
 
 #include "custom_constitutive/small_strain_udsm_3D_interface_law.hpp"
 
-
 namespace Kratos
 {
 
-//******************************CONSTRUCTOR*******************************************
-//************************************************************************************
-SmallStrainUDSM3DInterfaceLaw::SmallStrainUDSM3DInterfaceLaw()
-   : SmallStrainUDSM3DLaw()
-   {
-    KRATOS_TRY
-    //KRATOS_INFO("SmallStrainUDSM3DInterfaceLaw()") << std::endl;
-
-    KRATOS_CATCH("")
-
-   }
-
-//******************************COPY CONSTRUCTOR**************************************
-//************************************************************************************
-SmallStrainUDSM3DInterfaceLaw::
-   SmallStrainUDSM3DInterfaceLaw(const SmallStrainUDSM3DInterfaceLaw &rOther)
-   : SmallStrainUDSM3DLaw(rOther)
-{
-   KRATOS_TRY
-   //KRATOS_INFO("SmallStrainUDSM3DInterfaceLaw(const...)") << std::endl;
-
-   KRATOS_CATCH("")
-}
-
-//********************************CLONE***********************************************
-//************************************************************************************
 ConstitutiveLaw::Pointer SmallStrainUDSM3DInterfaceLaw::Clone() const
 {
    KRATOS_TRY
-   //KRATOS_INFO("Clone()") << std::endl;
 
    return Kratos::make_shared<SmallStrainUDSM3DInterfaceLaw>(*this);
 
    KRATOS_CATCH("")
 }
 
-//********************************ASSIGNMENT******************************************
-//************************************************************************************
-SmallStrainUDSM3DInterfaceLaw 
-  &SmallStrainUDSM3DInterfaceLaw::operator=(SmallStrainUDSM3DInterfaceLaw const &rOther)
-{
-   KRATOS_TRY
-
-   SmallStrainUDSM3DLaw::operator=(rOther);
-
-   //KRATOS_INFO("operator=") << std::endl;
-
-   return *this;
-
-   KRATOS_CATCH("")
-}
-
-//*******************************DESTRUCTOR*******************************************
-//************************************************************************************
-SmallStrainUDSM3DInterfaceLaw::~SmallStrainUDSM3DInterfaceLaw()
-{
-   //KRATOS_INFO("~SmallStrainUDSM3DLaw()") << std::endl;
-}
-
-//************************************************************************************
-//************************************************************************************
-void SmallStrainUDSM3DInterfaceLaw::
-   UpdateInternalDeltaStrainVector(ConstitutiveLaw::Parameters &rValues)
+void SmallStrainUDSM3DInterfaceLaw::UpdateInternalDeltaStrainVector(ConstitutiveLaw::Parameters &rValues)
 {
    const Vector& rStrainVector = rValues.GetStrainVector();
 
@@ -92,20 +38,15 @@ void SmallStrainUDSM3DInterfaceLaw::
 
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DInterfaceLaw::SetExternalStressVector(Vector& rStressVector)
 {
-   //KRATOS_INFO("mStressVector") << mStressVector << std::endl;
-
    rStressVector(INDEX_3D_INTERFACE_ZZ) = mStressVector[INDEX_3D_ZZ];
    rStressVector(INDEX_3D_INTERFACE_YZ) = mStressVector[INDEX_3D_YZ];
    rStressVector(INDEX_3D_INTERFACE_XZ) = mStressVector[INDEX_3D_XZ];
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DInterfaceLaw::SetInternalStressVector(const Vector& rStressVector)
 {
-   // KRATOS_INFO("SetInternalStressVector:rStressVector") << rStressVector << std::endl;
    KRATOS_TRY
    std::fill(mStressVectorFinalized.begin(), mStressVectorFinalized.end(), 0.0);
 
@@ -116,10 +57,8 @@ void SmallStrainUDSM3DInterfaceLaw::SetInternalStressVector(const Vector& rStres
    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DInterfaceLaw::SetInternalStrainVector(const Vector& rStrainVector)
 {
-   // KRATOS_INFO("SetInternalStrainVector:rStrainVector") << rStrainVector << std::endl;
    std::fill(mStrainVectorFinalized.begin(), mStrainVectorFinalized.end(), 0.0);
 
    mStrainVectorFinalized[INDEX_3D_ZZ] = rStrainVector(INDEX_3D_INTERFACE_ZZ);
@@ -127,21 +66,17 @@ void SmallStrainUDSM3DInterfaceLaw::SetInternalStrainVector(const Vector& rStrai
    mStrainVectorFinalized[INDEX_3D_XZ] = rStrainVector(INDEX_3D_INTERFACE_XZ);
 }
 
-//----------------------------------------------------------------------------------------
-void SmallStrainUDSM3DInterfaceLaw::CopyConstitutiveMatrix( ConstitutiveLaw::Parameters &rValues,
-                                                            Matrix& rConstitutiveMatrix )
+void SmallStrainUDSM3DInterfaceLaw::CopyConstitutiveMatrix(ConstitutiveLaw::Parameters &rValues,
+                                                           Matrix& rConstitutiveMatrix )
 {
-   if (rValues.GetMaterialProperties()[IS_FORTRAN_UDSM])
-   {
+   if (rValues.GetMaterialProperties()[IS_FORTRAN_UDSM]) {
       // transfer fortran style matrix to C++ style
       for (unsigned int i = 0; i < VoigtSize; i++) {
          for (unsigned int j = 0; j < VoigtSize; j++) {
             rConstitutiveMatrix(i,j) = mMatrixD[getIndex3D(static_cast<indexStress3DInterface>(j))][getIndex3D(static_cast<indexStress3DInterface>(i))];
          }
       }
-   }
-   else
-   {
+   } else {
       for (unsigned int i = 0; i < VoigtSize; i++) {
          for (unsigned int j = 0; j < VoigtSize; j++) {
             rConstitutiveMatrix(i,j) = mMatrixD[getIndex3D(static_cast<indexStress3DInterface>(i))][getIndex3D(static_cast<indexStress3DInterface>(j))];
@@ -150,7 +85,6 @@ void SmallStrainUDSM3DInterfaceLaw::CopyConstitutiveMatrix( ConstitutiveLaw::Par
    }
 }
 
-//----------------------------------------------------------------------------------------
 indexStress3D SmallStrainUDSM3DInterfaceLaw::getIndex3D(indexStress3DInterface index3D)
 {
    switch (index3D)
@@ -166,63 +100,37 @@ indexStress3D SmallStrainUDSM3DInterfaceLaw::getIndex3D(indexStress3DInterface i
    }
 }
 
-/***********************************************************************************/
-/***********************************************************************************/
-
-void SmallStrainUDSM3DInterfaceLaw::
-   CalculateCauchyGreenStrain( ConstitutiveLaw::Parameters& rValues,
-                               Vector& rStrainVector )
+void SmallStrainUDSM3DInterfaceLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues,
+                                                               Vector& rStrainVector)
 {
    KRATOS_ERROR << "CalculateCauchyGreenStrain is not implemented in SmallStrainUDSM3DInterfaceLaw" << std::endl;
 }
 
-//----------------------------------------------------------------------------------------
-Vector& SmallStrainUDSM3DInterfaceLaw::
-   GetValue( const Variable<Vector> &rThisVariable,
-             Vector &rValue )
+Vector& SmallStrainUDSM3DInterfaceLaw::GetValue(const Variable<Vector> &rThisVariable,
+                                                Vector &rValue)
 {
-   // KRATOS_INFO("0-SmallStrainUDSM3DInterfaceLaw::GetValue()") << std::endl;
+    if (rThisVariable == STATE_VARIABLES) {
+        SmallStrainUDSM3DLaw::GetValue(rThisVariable, rValue );
+    } else if (rThisVariable == CAUCHY_STRESS_VECTOR) {
+        if (rValue.size() != VoigtSize) rValue.resize(VoigtSize);
 
-   if (rThisVariable == STATE_VARIABLES)
-   {
-      SmallStrainUDSM3DLaw::GetValue(rThisVariable, rValue );
-   }
-   else if (rThisVariable == CAUCHY_STRESS_VECTOR)
-   {
-      if (rValue.size() != VoigtSize)
-         rValue.resize(VoigtSize);
-
-      rValue[INDEX_3D_INTERFACE_ZZ] = mStressVectorFinalized[INDEX_3D_ZZ];
-      rValue[INDEX_3D_INTERFACE_YZ] = mStressVectorFinalized[INDEX_3D_YZ];
-      rValue[INDEX_3D_INTERFACE_XZ] = mStressVectorFinalized[INDEX_3D_XZ];
-
-   }
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DInterfaceLaw::GetValue()") << std::endl;
-
+        rValue[INDEX_3D_INTERFACE_ZZ] = mStressVectorFinalized[INDEX_3D_ZZ];
+        rValue[INDEX_3D_INTERFACE_YZ] = mStressVectorFinalized[INDEX_3D_YZ];
+        rValue[INDEX_3D_INTERFACE_XZ] = mStressVectorFinalized[INDEX_3D_XZ];
+    }
     return rValue;
 }
 
-//----------------------------------------------------------------------------------------
-void SmallStrainUDSM3DInterfaceLaw::SetValue( const Variable<Vector>& rThisVariable,
-                                                const Vector& rValue,
-                                                const ProcessInfo& rCurrentProcessInfo )
+void SmallStrainUDSM3DInterfaceLaw::SetValue(const Variable<Vector>& rThisVariable,
+                                             const Vector& rValue,
+                                             const ProcessInfo& rCurrentProcessInfo)
 {
-   // KRATOS_INFO("02-SmallStrainUDSM3DInterfaceLaw::SetValue()") << std::endl;
-
-   if (rThisVariable == STATE_VARIABLES)
-   {
-      SmallStrainUDSM3DLaw::SetValue(rThisVariable, rValue, rCurrentProcessInfo );
-   }
-   else if (rThisVariable == CAUCHY_STRESS_VECTOR)
-   {
-      if (rValue.size() == VoigtSize) 
-      {
-         this->SetInternalStressVector(rValue);
-      }
-   }
-
-   // KRATOS_INFO("12-SmallStrainUDSM2DInterfaceLaw::SetValue()") << std::endl;
+    if (rThisVariable == STATE_VARIABLES) {
+        SmallStrainUDSM3DLaw::SetValue(rThisVariable, rValue, rCurrentProcessInfo );
+    } else if ((rThisVariable == CAUCHY_STRESS_VECTOR) &&
+               (rValue.size() == VoigtSize)) {
+        this->SetInternalStressVector(rValue);
+    }
 }
 
-} // Namespace Kratos
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_interface_law.hpp
@@ -10,13 +10,10 @@
 //  Main authors:    Vahid Galavi
 //
 
-#if !defined(KRATOS_SMALL_STRAIN_UDSM_3D_INTERFACE_LAW_H_INCLUDED )
-#define  KRATOS_SMALL_STRAIN_UDSM_3D_INTERFACE_LAW_H_INCLUDED
+#pragma once
 
 // System includes
 #include "includes/define.h"
-
-// External includes
 
 // Project includes
 #include "custom_constitutive/small_strain_udsm_3D_law.hpp"
@@ -71,29 +68,10 @@ namespace Kratos
       //@name Life Cycle
       //@{
 
-      //----------------------------------------------------------------------------------------
-      /**
-       * @brief Default constructor.
-       */
-      SmallStrainUDSM3DInterfaceLaw();
-
       /**
        * @brief Clone method
        */
       ConstitutiveLaw::Pointer Clone() const override;
-
-      /**
-       * Copy constructor.
-       */
-      SmallStrainUDSM3DInterfaceLaw(SmallStrainUDSM3DInterfaceLaw const& rOther);
-
-      /**
-       * @brief Destructor.
-       */
-      virtual ~SmallStrainUDSM3DInterfaceLaw();
-
-      // Assignment operator:
-      SmallStrainUDSM3DInterfaceLaw& operator=(SmallStrainUDSM3DInterfaceLaw const& rOther);
 
       Vector& GetValue( const Variable<Vector> &rThisVariable, Vector &rValue ) override;
 
@@ -131,7 +109,7 @@ namespace Kratos
        * returns the stress measure of this constitutive law (by default 1st Piola-Kirchhoff stress in voigt notation)
        * @return the expected stress measure
        */
-      virtual StressMeasure GetStressMeasure() override
+      StressMeasure GetStressMeasure() override
       {
          return StressMeasure_Cauchy;
       }
@@ -153,21 +131,19 @@ namespace Kratos
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override
+      std::string Info() const override
       {
-         std::stringstream buffer;
-         buffer << "SmallStrainUDSM3DInterfaceLaw";
-         return buffer.str();
+         return "SmallStrainUDSM3DInterfaceLaw";
       }
 
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override
+      void PrintInfo(std::ostream& rOStream) const override
       {
-         rOStream << "SmallStrainUDSM3DInterfaceLaw";
+         rOStream << Info();
       }
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override
+      void PrintData(std::ostream& rOStream) const override
       {
          rOStream << "SmallStrainUDSM3DInterfaceLaw Data";
       }
@@ -205,7 +181,6 @@ namespace Kratos
       void SetInternalStressVector(const Vector& rStressVector) override;
       void SetInternalStrainVector(const Vector& rStrainVector) override;
       void CopyConstitutiveMatrix(ConstitutiveLaw::Parameters &rValues, Matrix& rConstitutiveMatrix) override;
-
 
       ///@}
       ///@name Protected Inquiry
@@ -250,12 +225,12 @@ namespace Kratos
       ///@{
       friend class Serializer;
 
-      virtual void save(Serializer& rSerializer) const override
+      void save(Serializer& rSerializer) const override
       {
          KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, ConstitutiveLaw)
       }
 
-      virtual void load(Serializer& rSerializer) override
+      void load(Serializer& rSerializer) override
       {
          KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, ConstitutiveLaw)
       }
@@ -287,8 +262,4 @@ namespace Kratos
 
    ///@} addtogroup block
 
-}  // namespace Kratos.
-
-#endif // KRATOS_SMALL_STRAIN_UDSM_3D_INTERFACE_LAW_H_INCLUDED  defined
-
-
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.cpp
@@ -11,11 +11,9 @@
 //
 
 // System includes
-
-// External includes
+#include <algorithm>
 
 #include "custom_constitutive/small_strain_udsm_3D_law.hpp"
-#include <algorithm>
 
 #ifdef KRATOS_COMPILED_IN_WINDOWS
 #include "windows.hpp"
@@ -74,20 +72,6 @@ typedef void(*f_UserMod) (int    *, int     *, int    *,
                           int    *, int     *, int    *);
 #endif
 
-//******************************CONSTRUCTOR*******************************************
-//************************************************************************************
-
-SmallStrainUDSM3DLaw::SmallStrainUDSM3DLaw()
-   : ConstitutiveLaw()
-   {
-    KRATOS_TRY
-
-    KRATOS_CATCH("")
-
-   }
-
-//******************************COPY CONSTRUCTOR**************************************
-//************************************************************************************
 SmallStrainUDSM3DLaw::SmallStrainUDSM3DLaw(const SmallStrainUDSM3DLaw &rOther)
    : ConstitutiveLaw(rOther),
      mStressVector(rOther.mStressVector),
@@ -102,378 +86,315 @@ SmallStrainUDSM3DLaw::SmallStrainUDSM3DLaw(const SmallStrainUDSM3DLaw &rOther)
 
 {
    KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::ConstitutiveLaw()") << std::endl;
 
    for (unsigned int i = 0; i < VOIGT_SIZE_3D; ++i)
       for (unsigned int j = 0; j < VOIGT_SIZE_3D; ++j)
          mMatrixD[i][j] = rOther.mMatrixD[i][j];
 
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::ConstitutiveLaw()") << std::endl;
-
    KRATOS_CATCH("")
 }
-
-//********************************CLONE***********************************************
-//************************************************************************************
 
 ConstitutiveLaw::Pointer SmallStrainUDSM3DLaw::Clone() const
 {
    KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::Clone()") << std::endl;
 
    return Kratos::make_shared<SmallStrainUDSM3DLaw>(*this);
 
    KRATOS_CATCH("")
 }
 
-//********************************ASSIGNMENT******************************************
-//************************************************************************************
 SmallStrainUDSM3DLaw &SmallStrainUDSM3DLaw::operator=(SmallStrainUDSM3DLaw const &rOther)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::operator=()") << std::endl;
+    KRATOS_TRY
 
-   ConstitutiveLaw::operator=(rOther);
-   this->mIsModelInitialized      = rOther.mIsModelInitialized;
-   this->mIsUDSMLoaded            = rOther.mIsUDSMLoaded;
-   this->mAttributes              = rOther.mAttributes;
-   this->mStateVariables          = rOther.mStateVariables;
-   this->mStateVariablesFinalized = rOther.mStateVariablesFinalized;
-   this->mStressVector            = rOther.mStressVector;
-   this->mStressVectorFinalized   = rOther.mStressVectorFinalized;
-   this->mDeltaStrainVector       = rOther.mDeltaStrainVector;
-   this->mStrainVectorFinalized   = rOther.mStrainVectorFinalized;
+    ConstitutiveLaw::operator=(rOther);
+    this->mIsModelInitialized      = rOther.mIsModelInitialized;
+    this->mIsUDSMLoaded            = rOther.mIsUDSMLoaded;
+    this->mAttributes              = rOther.mAttributes;
+    this->mStateVariables          = rOther.mStateVariables;
+    this->mStateVariablesFinalized = rOther.mStateVariablesFinalized;
+    this->mStressVector            = rOther.mStressVector;
+    this->mStressVectorFinalized   = rOther.mStressVectorFinalized;
+    this->mDeltaStrainVector       = rOther.mDeltaStrainVector;
+    this->mStrainVectorFinalized   = rOther.mStrainVectorFinalized;
 
-   for (unsigned int i = 0; i < VOIGT_SIZE_3D; ++i)
-      for (unsigned int j = 0; j < VOIGT_SIZE_3D; ++j)
-         this->mMatrixD[i][j] = rOther.mMatrixD[i][j];
+    for (unsigned int i = 0; i < VOIGT_SIZE_3D; ++i)
+        for (unsigned int j = 0; j < VOIGT_SIZE_3D; ++j)
+            this->mMatrixD[i][j] = rOther.mMatrixD[i][j];
 
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::operator=()") << std::endl;
+    return *this;
 
-   return *this;
-
-   KRATOS_CATCH("")
+    KRATOS_CATCH("")
 }
-
-//*******************************DESTRUCTOR*******************************************
-//************************************************************************************
-
-SmallStrainUDSM3DLaw::~SmallStrainUDSM3DLaw() {}
-
-//***********************PUBLIC OPERATIONS FROM BASE CLASS****************************
-//************************************************************************************
 
 void SmallStrainUDSM3DLaw::GetLawFeatures(Features &rFeatures)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::GetLawFeatures()") << std::endl;
+    KRATOS_TRY
 
-   //Set the type of law
-   rFeatures.mOptions.Set(THREE_DIMENSIONAL_LAW);
-   rFeatures.mOptions.Set(INFINITESIMAL_STRAINS);
+    //Set the type of law
+    rFeatures.mOptions.Set(THREE_DIMENSIONAL_LAW);
+    rFeatures.mOptions.Set(INFINITESIMAL_STRAINS);
 
-   if (mIsModelInitialized) {
-      if (mAttributes[IS_NON_SYMMETRIC] == 1) {
-         rFeatures.mOptions.Set(ANISOTROPIC);
-      } else {
-         rFeatures.mOptions.Set(ISOTROPIC);
-      }
-   } else {
-      rFeatures.mOptions.Set(ISOTROPIC);
-   }
+    if (mIsModelInitialized) {
+        if (mAttributes[IS_NON_SYMMETRIC] == 1) {
+            rFeatures.mOptions.Set(ANISOTROPIC);
+        } else {
+            rFeatures.mOptions.Set(ISOTROPIC);
+        }
+    } else {
+        rFeatures.mOptions.Set(ISOTROPIC);
+    }
 
-   //Set strain measure required by the consitutive law
-   rFeatures.mStrainMeasures.push_back(StrainMeasure_Infinitesimal);
-   //rFeatures.mStrainMeasures.push_back(StrainMeasure_Deformation_Gradient);
+    //Set strain measure required by the consitutive law
+    rFeatures.mStrainMeasures.push_back(StrainMeasure_Infinitesimal);
 
-   //Set the spacedimension
-   rFeatures.mSpaceDimension = WorkingSpaceDimension();
+    //Set the space dimension
+    rFeatures.mSpaceDimension = WorkingSpaceDimension();
 
-   //Set the strain size
-   rFeatures.mStrainSize = GetStrainSize();
+    //Set the strain size
+    rFeatures.mStrainSize = GetStrainSize();
 
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::GetLawFeatures()") << std::endl;
-
-   KRATOS_CATCH("")
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 int SmallStrainUDSM3DLaw::Check(const Properties &rMaterialProperties,
                                 const GeometryType &rElementGeometry,
                                 const ProcessInfo &rCurrentProcessInfo) const
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::Check()") << std::endl;
+    KRATOS_TRY
 
-   // Verify Properties variables
-   if (rMaterialProperties.Has(UDSM_NAME) == false || rMaterialProperties[UDSM_NAME] == "")
-      KRATOS_ERROR << "UDSM_NAME has Key zero, is not defined or has an invalid value for property"
-                   << rMaterialProperties.Id()
-                   << std::endl;
+    // Verify Properties variables
+    KRATOS_ERROR_IF(!rMaterialProperties.Has(UDSM_NAME) || rMaterialProperties[UDSM_NAME].empty())
+        << "UDSM_NAME has Key zero, is not defined or has an invalid value for property"
+        << rMaterialProperties.Id()
+        << std::endl;
 
-   if (rMaterialProperties.Has(UDSM_NUMBER) == false || rMaterialProperties[UDSM_NUMBER] <= 0)
-      KRATOS_ERROR << "UDSM_NUMBER has Key zero, is not defined or has an invalid value for property"
-                   << rMaterialProperties.Id()
-                   << std::endl;
+    KRATOS_ERROR_IF(!rMaterialProperties.Has(UDSM_NUMBER) || rMaterialProperties[UDSM_NUMBER] <= 0)
+        << "UDSM_NUMBER has Key zero, is not defined or has an invalid value for property"
+        << rMaterialProperties.Id()
+        << std::endl;
 
-   if (rMaterialProperties.Has(IS_FORTRAN_UDSM) == false)
-      KRATOS_ERROR << "IS_FORTRAN_UDSM has Key zero, is not defined or has an invalid value for property"
-                   << rMaterialProperties.Id()
-                   << std::endl;
+    KRATOS_ERROR_IF_NOT(rMaterialProperties.Has(IS_FORTRAN_UDSM))
+        << "IS_FORTRAN_UDSM has Key zero, is not defined or has an invalid value for property"
+        << rMaterialProperties.Id()
+        << std::endl;
 
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::Check()") << std::endl;
-   return 0;
-   KRATOS_CATCH("")
+    return 0;
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::InitializeMaterial(const Properties &rMaterialProperties,
                                               const GeometryType &rElementGeometry,
                                               const Vector &rShapeFunctionsValues)
-
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::InitializeMaterial()") << std::endl;
+    KRATOS_TRY
 
-   // loading the model
-   mIsUDSMLoaded = loadUDSM(rMaterialProperties);
+    // loading the model
+    mIsUDSMLoaded = loadUDSM(rMaterialProperties);
 
-   KRATOS_ERROR_IF_NOT(mIsUDSMLoaded) << "cannot load the specified UDSM " << rMaterialProperties[UDSM_NAME] << std::endl;
+    KRATOS_ERROR_IF_NOT(mIsUDSMLoaded) << "cannot load the specified UDSM " << rMaterialProperties[UDSM_NAME] << std::endl;
 
-   const int nUmatParametersSize = rMaterialProperties[UMAT_PARAMETERS].size();
-   const int nParametersUDSM = GetNumberOfMaterialParametersFromUDSM(rMaterialProperties);
-   if ( nUmatParametersSize != nParametersUDSM) {
-      KRATOS_ERROR << "Number of parameters is wrong."
-                   << " The UDSM gives " 
-                   << std::to_string(nParametersUDSM)
-                   << " while size of UMAT_PARAMETERS is "
-                   << std::to_string(nUmatParametersSize)
-                   << rMaterialProperties[UDSM_NAME]
-                   << std::endl;
-   }
+    const int nUmatParametersSize = rMaterialProperties[UMAT_PARAMETERS].size();
+    const int nParametersUDSM = GetNumberOfMaterialParametersFromUDSM(rMaterialProperties);
+    if ( nUmatParametersSize != nParametersUDSM) {
+        KRATOS_ERROR << "Number of parameters is wrong."
+                     << " The UDSM gives "
+                     << std::to_string(nParametersUDSM)
+                     << " while size of UMAT_PARAMETERS is "
+                     << std::to_string(nUmatParametersSize)
+                     << rMaterialProperties[UDSM_NAME]
+                     << std::endl;
+    }
 
-   ResetMaterial(rMaterialProperties, rElementGeometry, rShapeFunctionsValues);
+    ResetMaterial(rMaterialProperties, rElementGeometry, rShapeFunctionsValues);
 
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::InitializeMaterial()") << std::endl;
-
-   KRATOS_CATCH(" ")
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::ResetStateVariables(const Properties& rMaterialProperties)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::ResetStateVariables()") << std::endl;
+    KRATOS_TRY
 
-   // reset state variables
-   int nStateVariables = GetNumberOfStateVariablesFromUDSM(rMaterialProperties);
-   nStateVariables = std::max(nStateVariables, 1);
-   mStateVariables.resize(nStateVariables);
-   noalias(mStateVariables) = ZeroVector(nStateVariables);
+    // reset state variables
+    int nStateVariables = GetNumberOfStateVariablesFromUDSM(rMaterialProperties);
+    nStateVariables = std::max(nStateVariables, 1);
+    mStateVariables.resize(nStateVariables);
+    noalias(mStateVariables) = ZeroVector(nStateVariables);
 
-   mStateVariablesFinalized.resize(nStateVariables);
-   noalias(mStateVariablesFinalized) = ZeroVector(nStateVariables);
+    mStateVariablesFinalized.resize(nStateVariables);
+    noalias(mStateVariablesFinalized) = ZeroVector(nStateVariables);
 
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::ResetStateVariables()") << std::endl;
-
-   KRATOS_CATCH(" ")
+   KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::ResetMaterial(const Properties& rMaterialProperties,
                                          const GeometryType& rElementGeometry,
                                          const Vector& rShapeFunctionsValues)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::ResetMaterial()") << std::endl;
+    KRATOS_TRY
 
-   // reset state variables
-   SetAttributes(rMaterialProperties);
-   ResetStateVariables(rMaterialProperties);
+    // reset state variables
+    SetAttributes(rMaterialProperties);
+    ResetStateVariables(rMaterialProperties);
 
-   // set stress vectors:
-   noalias(mStressVector)          = ZeroVector(mStressVector.size());
-   noalias(mStressVectorFinalized) = ZeroVector(mStressVectorFinalized.size());
+    // set stress vectors:
+    noalias(mStressVector)          = ZeroVector(mStressVector.size());
+    noalias(mStressVectorFinalized) = ZeroVector(mStressVectorFinalized.size());
 
-   // set strain vectors:
-   noalias(mDeltaStrainVector)     = ZeroVector(mDeltaStrainVector.size());
-   noalias(mStrainVectorFinalized) = ZeroVector(mStrainVectorFinalized.size());
+    // set strain vectors:
+    noalias(mDeltaStrainVector)     = ZeroVector(mDeltaStrainVector.size());
+    noalias(mStrainVectorFinalized) = ZeroVector(mStrainVectorFinalized.size());
 
-   for (unsigned int i = 0; i < VOIGT_SIZE_3D; ++i)
-      for (unsigned int j = 0; j < VOIGT_SIZE_3D; ++j)
-         mMatrixD[i][j] = 0.0;
+    for (unsigned int i = 0; i < VOIGT_SIZE_3D; ++ i)
+        for (unsigned int j = 0; j < VOIGT_SIZE_3D; ++j)
+            mMatrixD[i][j] = 0.0;
 
-   // state variables
-   noalias(mStateVariables)         = ZeroVector(mStateVariables.size());
-   noalias(mStateVariablesFinalized)= ZeroVector(mStateVariablesFinalized.size());
+    // state variables
+    noalias(mStateVariables)         = ZeroVector(mStateVariables.size());
+    noalias(mStateVariablesFinalized)= ZeroVector(mStateVariablesFinalized.size());
 
-   mIsModelInitialized = false;
+    mIsModelInitialized = false;
 
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::ResetMaterial()") << std::endl;
-
-   KRATOS_CATCH(" ")
+    KRATOS_CATCH(" ")
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::SetAttributes(const Properties& rMaterialProperties)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::SetAttributes()") << std::endl;
+    KRATOS_TRY
 
-   if (!mIsUDSMLoaded) mIsUDSMLoaded = loadUDSM(rMaterialProperties);
+    if (!mIsUDSMLoaded) mIsUDSMLoaded = loadUDSM(rMaterialProperties);
 
-   int IDTask = ATTRIBUTES;
+    int IDTask = ATTRIBUTES;
 
-   // process data
-   double deltaTime = 0.0;
-   double time      = 0.0;
-   int    iStep     = 0;
-   int    iteration = 0;
+    // process data
+    double deltaTime = 0.0;
+    double time      = 0.0;
+    int    iStep     = 0;
+    int    iteration = 0;
 
-   // number of the model in the shared libaray (DLL)
-   int modelNumber = rMaterialProperties[UDSM_NUMBER];
+    // number of the model in the shared library (DLL)
+    int modelNumber = rMaterialProperties[UDSM_NUMBER];
 
-   // not needed:
-   double bulkWater = 0.0;
-   double excessPorePressurePrevious = 0.0;
-   double excessPorePressureCurrent = 0.0;
-   double X(0.0), Y(0.0), Z(0.0);
-   int iElement = 0;
-   int integrationNumber = 0;
-   int iPlastic = 0;
-   int isUndr = 0;
-   int nStateVariables = 0;
+    // not needed:
+    double bulkWater = 0.0;
+    double excessPorePressurePrevious = 0.0;
+    double excessPorePressureCurrent = 0.0;
+    double X(0.0), Y(0.0), Z(0.0);
+    int iElement = 0;
+    int integrationNumber = 0;
+    int iPlastic = 0;
+    int isUndr = 0;
+    int nStateVariables = 0;
 
-   // variable to check if an error happend in the model:
-   int iAbort = 0;
-   int nSizeProjectDirectory = mProjectDirectory.size();
-   std::vector<double> StateVariablesFinalized;
-   std::vector<double> StateVariables;
+    // variable to check if an error happend in the model:
+    int iAbort = 0;
+    int nSizeProjectDirectory = mProjectDirectory.size();
+    std::vector<double> StateVariablesFinalized;
+    std::vector<double> StateVariables;
 
-   const auto &MaterialParameters = rMaterialProperties[UMAT_PARAMETERS];
-   pUserMod(&IDTask, &modelNumber, &isUndr,
-            &iStep, &iteration, &iElement, &integrationNumber,
-            &X, &Y, &Z,
-            &time, &deltaTime,
-            &(MaterialParameters.data()[0]), &(mStressVectorFinalized.data()[0]), &excessPorePressurePrevious, 
-            StateVariablesFinalized.data(),
-            &(mDeltaStrainVector.data()[0]), (double **)mMatrixD, &bulkWater,
-            &(mStressVector.data()[0]), &excessPorePressureCurrent, StateVariables.data(), &iPlastic,
-            &nStateVariables, 
-            &mAttributes[IS_NON_SYMMETRIC], &mAttributes[IS_STRESS_DEPENDENT],
-            &mAttributes[IS_TIME_DEPENDENT], &mAttributes[USE_TANGENT_MATRIX],
-            mProjectDirectory.data(), &nSizeProjectDirectory, 
-            &iAbort);
+    const auto &MaterialParameters = rMaterialProperties[UMAT_PARAMETERS];
+    pUserMod(&IDTask, &modelNumber, &isUndr,
+             &iStep, &iteration, &iElement, &integrationNumber,
+             &X, &Y, &Z,
+             &time, &deltaTime,
+             &(MaterialParameters.data()[0]), &(mStressVectorFinalized.data()[0]), &excessPorePressurePrevious,
+             StateVariablesFinalized.data(),
+             &(mDeltaStrainVector.data()[0]), (double **)mMatrixD, &bulkWater,
+             &(mStressVector.data()[0]), &excessPorePressureCurrent, StateVariables.data(), &iPlastic,
+             &nStateVariables,
+             &mAttributes[IS_NON_SYMMETRIC], &mAttributes[IS_STRESS_DEPENDENT],
+             &mAttributes[IS_TIME_DEPENDENT], &mAttributes[USE_TANGENT_MATRIX],
+             mProjectDirectory.data(), &nSizeProjectDirectory,
+             &iAbort);
 
-   if (iAbort != 0)
-   {
-      KRATOS_ERROR << "The specified UDSM returns an error while call UDSM with IDTASK"
-                   << std::to_string(IDTask) 
-                   << ". UDSM"
-                   << rMaterialProperties[UDSM_NAME]
-                   << std::endl;
-   }
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::SetAttributes()") << std::endl;
-
-   KRATOS_CATCH(" ")
+       KRATOS_ERROR_IF_NOT(iAbort==0) << "The specified UDSM returns an error while call UDSM with IDTASK"
+                                      << std::to_string(IDTask)
+                                      << ". UDSM"
+                                      << rMaterialProperties[UDSM_NAME]
+                                      << std::endl;
+    KRATOS_CATCH(" ")
 }
 
-//----------------------------------------------------------------------------------------
 int SmallStrainUDSM3DLaw::GetNumberOfStateVariablesFromUDSM(const Properties& rMaterialProperties)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::GetNumberOfStateVariablesFromUDSM()") << std::endl;
+    KRATOS_TRY
+    if (!mIsUDSMLoaded) mIsUDSMLoaded = loadUDSM(rMaterialProperties);
 
-   if (!mIsUDSMLoaded) mIsUDSMLoaded = loadUDSM(rMaterialProperties);
+    int IDTask = NUMBER_OF_STATE_VARIABLES;
 
-   int IDTask = NUMBER_OF_STATE_VARIABLES;
+    // process data
+    double deltaTime = 0.0;
+    double time      = 0.0;
+    int    iStep     = 0;
+    int    iteration = 0;
 
-   // process data
-   double deltaTime = 0.0;
-   double time      = 0.0;
-   int    iStep     = 0;
-   int    iteration = 0;
+    // number of the model in the shared libaray (DLL)
+    int modelNumber = rMaterialProperties[UDSM_NUMBER];
 
-   // number of the model in the shared libaray (DLL)
-   int modelNumber = rMaterialProperties[UDSM_NUMBER];
+    // not needed:
+    double bulkWater = 0.0;
+    double excessPorePressurePrevious = 0.0;
+    double excessPorePressureCurrent = 0.0;
+    double X(0.0), Y(0.0), Z(0.0);
+    int iElement = 0;
+    int integrationNumber = 0;
+    int iPlastic = 0;
+    int isUndr = 0;
+    int nStateVariables = 0;
 
-   // not needed:
-   double bulkWater = 0.0;
-   double excessPorePressurePrevious = 0.0;
-   double excessPorePressureCurrent = 0.0;
-   double X(0.0), Y(0.0), Z(0.0);
-   int iElement = 0;
-   int integrationNumber = 0;
-   int iPlastic = 0;
-   int isUndr = 0;
-   int nStateVariables = 0;
+    // variable to check if an error happend in the model:
+    int iAbort = 0;
+    int nSizeProjectDirectory = mProjectDirectory.size();
+    std::vector<double> StateVariablesFinalized;
+    std::vector<double> StateVariables;
 
-   // variable to check if an error happend in the model:
-   int iAbort = 0;
-   int nSizeProjectDirectory = mProjectDirectory.size();
-   std::vector<double> StateVariablesFinalized;
-   std::vector<double> StateVariables;
+    const auto &MaterialParameters = rMaterialProperties[UMAT_PARAMETERS];
+    pUserMod(&IDTask, &modelNumber, &isUndr,
+             &iStep, &iteration, &iElement, &integrationNumber,
+             &X, &Y, &Z,
+             &time, &deltaTime,
+             &(MaterialParameters.data()[0]), &(mStressVectorFinalized.data()[0]), &excessPorePressurePrevious,
+             StateVariablesFinalized.data(),
+             &(mDeltaStrainVector.data()[0]), (double **)mMatrixD, &bulkWater,
+             &(mStressVector.data()[0]), &excessPorePressureCurrent, StateVariables.data(), &iPlastic,
+             &nStateVariables,
+             &mAttributes[IS_NON_SYMMETRIC], &mAttributes[IS_STRESS_DEPENDENT],
+             &mAttributes[IS_TIME_DEPENDENT], &mAttributes[USE_TANGENT_MATRIX],
+             mProjectDirectory.data(), &nSizeProjectDirectory,
+             &iAbort);
 
-   const auto &MaterialParameters = rMaterialProperties[UMAT_PARAMETERS];
-   pUserMod(&IDTask, &modelNumber, &isUndr,
-            &iStep, &iteration, &iElement, &integrationNumber,
-            &X, &Y, &Z,
-            &time, &deltaTime,
-            &(MaterialParameters.data()[0]), &(mStressVectorFinalized.data()[0]), &excessPorePressurePrevious, 
-            StateVariablesFinalized.data(),
-            &(mDeltaStrainVector.data()[0]), (double **)mMatrixD, &bulkWater,
-            &(mStressVector.data()[0]), &excessPorePressureCurrent, StateVariables.data(), &iPlastic,
-            &nStateVariables, 
-            &mAttributes[IS_NON_SYMMETRIC], &mAttributes[IS_STRESS_DEPENDENT],
-            &mAttributes[IS_TIME_DEPENDENT], &mAttributes[USE_TANGENT_MATRIX],
-            mProjectDirectory.data(), &nSizeProjectDirectory, 
-            &iAbort);
+       KRATOS_ERROR_IF_NOT(iAbort==0) << "The specified UDSM returns an error while call UDSM with IDTASK"
+                                      << std::to_string(IDTask)
+                                      << ". UDSM"
+                                      << rMaterialProperties[UDSM_NAME]
+                                      << std::endl;
 
-   if (iAbort != 0)
-   {
-      KRATOS_ERROR << "The specified UDSM returns an error while call UDSM with IDTASK"
-                   << std::to_string(IDTask)
-                   << ". UDSM"
-                   << rMaterialProperties[UDSM_NAME]
-                   << std::endl;
-   }
+    return nStateVariables;
 
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::GetNumberOfStateVariablesFromUDSM()") << std::endl;
-
-   return nStateVariables;
-
-   KRATOS_CATCH(" ")
+    KRATOS_CATCH(" ")
 }
 
-//----------------------------------------------------------------------------------------
 int SmallStrainUDSM3DLaw::GetNumberOfMaterialParametersFromUDSM(const Properties& rMaterialProperties)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::GetNumberOfMaterialParametersFromUDSM()") << std::endl;
+    KRATOS_TRY
 
-   if (!mIsUDSMLoaded) mIsUDSMLoaded = loadUDSM(rMaterialProperties);
+    if (!mIsUDSMLoaded) mIsUDSMLoaded = loadUDSM(rMaterialProperties);
 
-   int nUDSM = rMaterialProperties[UDSM_NUMBER];
-   int nParameters(0);
-   pGetParamCount(&nUDSM, &nParameters);
+    int nUDSM = rMaterialProperties[UDSM_NUMBER];
+    int nParameters(0);
+    pGetParamCount(&nUDSM, &nParameters);
 
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::GetNumberOfMaterialParametersFromUDSM()") << std::endl;
+    return nParameters;
 
-   return nParameters;
-
-   KRATOS_CATCH(" ")
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 bool SmallStrainUDSM3DLaw::loadUDSM(const Properties &rMaterialProperties)
 {
    KRATOS_TRY
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::loadUDSM()") << std::endl;
 
 #ifdef KRATOS_COMPILED_IN_WINDOWS
    const auto isLoaded = loadUDSMWindows(rMaterialProperties);
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::loadUDSM()") << std::endl;
    return isLoaded;
 #elif defined(KRATOS_COMPILED_IN_LINUX) || defined(KRATOS_COMPILED_IN_OS)
    return loadUDSMLinux(rMaterialProperties);
@@ -481,10 +402,9 @@ bool SmallStrainUDSM3DLaw::loadUDSM(const Properties &rMaterialProperties)
    KRATOS_ERROR << "loadUDSM is not supported yet for Mac OS applications" << std::endl;
 #endif
 
-   KRATOS_CATCH(" ")
+    KRATOS_CATCH(" ")
 }
 
-//----------------------------------------------------------------------------------------
 bool SmallStrainUDSM3DLaw::loadUDSMLinux(const Properties &rMaterialProperties)
 {
 #ifdef KRATOS_COMPILED_IN_LINUX
@@ -543,777 +463,583 @@ bool SmallStrainUDSM3DLaw::loadUDSMLinux(const Properties &rMaterialProperties)
 #endif
 }
 
-//----------------------------------------------------------------------------------------
 bool SmallStrainUDSM3DLaw::loadUDSMWindows(const Properties &rMaterialProperties)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::loadUDSMWindows()") << std::endl;
+    KRATOS_TRY
 
 #ifdef KRATOS_COMPILED_IN_WINDOWS
 
-   HINSTANCE hGetProcIDDLL = LoadLibrary((rMaterialProperties[UDSM_NAME]).c_str());
+    HINSTANCE hGetProcIDDLL = LoadLibrary((rMaterialProperties[UDSM_NAME]).c_str());
 
-   if (!hGetProcIDDLL)
-   {
-      std::string name = rMaterialProperties[UDSM_NAME];
-      // check if the name of the file is based on Linux extension
-      std::size_t found = name.find(".so");
-      if (found!=std::string::npos)
-      {
-         // check if there is an equivalent .dll file
-         name.replace(found, 3, ".dll");
-         hGetProcIDDLL = LoadLibrary(name.c_str());
-      }
-   }
+    if (!hGetProcIDDLL) {
+        std::string name = rMaterialProperties[UDSM_NAME];
+        // check if the name of the file is based on Linux extension
+        std::size_t found = name.find(".so");
+        if (found!=std::string::npos) {
+            // check if there is an equivalent .dll file
+            name.replace(found, 3, ".dll");
+            hGetProcIDDLL = LoadLibrary(name.c_str());
+        }
+    }
 
-   if (!hGetProcIDDLL)
-   {
-      KRATOS_INFO("Error in loadUDSMWindows") << "cannot load the specified UDSM: " << rMaterialProperties[UDSM_NAME] << std::endl;
-      KRATOS_ERROR << "cannot load the specified UDSM " << rMaterialProperties[UDSM_NAME] << std::endl;
-   }
+    if (!hGetProcIDDLL) {
+        KRATOS_INFO("Error in loadUDSMWindows") << "cannot load the specified UDSM: " << rMaterialProperties[UDSM_NAME] << std::endl;
+        KRATOS_ERROR << "cannot load the specified UDSM " << rMaterialProperties[UDSM_NAME] << std::endl;
+    }
 
-   // resolve function GetParamCount address
-   pGetParamCount = (f_GetParamCount)GetProcAddress(hGetProcIDDLL, "getparamcount");
-   if (!pGetParamCount)
-   {
-      // check if the dll is compiled with gfortran
-      pGetParamCount = (f_GetParamCount)GetProcAddress(hGetProcIDDLL, "getparamcount_");
-      if (!pGetParamCount)
-      {
-         KRATOS_INFO("Error in loadUDSMWindows") << "cannot load function GetParamCount in the specified UDSM: " << rMaterialProperties[UDSM_NAME] << std::endl;
-         KRATOS_ERROR << "cannot load function GetParamCount in the specified UDSM " << rMaterialProperties[UDSM_NAME] << std::endl;
-      }
-   }
+    // resolve function GetParamCount address
+    pGetParamCount = (f_GetParamCount)GetProcAddress(hGetProcIDDLL, "getparamcount");
+    if (!pGetParamCount) {
+        // check if the dll is compiled with gfortran
+        pGetParamCount = (f_GetParamCount)GetProcAddress(hGetProcIDDLL, "getparamcount_");
+        if (!pGetParamCount) {
+            KRATOS_INFO("Error in loadUDSMWindows") << "cannot load function GetParamCount in the specified UDSM: " << rMaterialProperties[UDSM_NAME] << std::endl;
+            KRATOS_ERROR << "cannot load function GetParamCount in the specified UDSM " << rMaterialProperties[UDSM_NAME] << std::endl;
+        }
+    }
 
-   // resolve function GetStateVarCount address
-   pGetStateVarCount = (f_GetStateVarCount)GetProcAddress(hGetProcIDDLL, "getstatevarcount");
+    // resolve function GetStateVarCount address
+    pGetStateVarCount = (f_GetStateVarCount)GetProcAddress(hGetProcIDDLL, "getstatevarcount");
 
-   pUserMod = (f_UserMod)GetProcAddress(hGetProcIDDLL, "user_mod");
-   if (!pUserMod)
-   {
-      // check if the dll is compiled with gfortran
-      pUserMod = (f_UserMod)GetProcAddress(hGetProcIDDLL, "user_mod_");
-      if (!pUserMod)
-      {
-         KRATOS_INFO("Error in loadUDSMWindows") << "cannot load function User_Mod in the specified UDSM: " << rMaterialProperties[UDSM_NAME] << std::endl;
-         KRATOS_ERROR << "cannot load function User_Mod in the specified UDSM " << rMaterialProperties[UDSM_NAME] << std::endl;
-      }
-   }
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::loadUDSMWindows()") << std::endl;
-
-   return true;
+    pUserMod = (f_UserMod)GetProcAddress(hGetProcIDDLL, "user_mod");
+    if (!pUserMod) {
+        // check if the dll is compiled with gfortran
+        pUserMod = (f_UserMod)GetProcAddress(hGetProcIDDLL, "user_mod_");
+        if (!pUserMod) {
+            KRATOS_INFO("Error in loadUDSMWindows") << "cannot load function User_Mod in the specified UDSM: " << rMaterialProperties[UDSM_NAME] << std::endl;
+            KRATOS_ERROR << "cannot load function User_Mod in the specified UDSM " << rMaterialProperties[UDSM_NAME] << std::endl;
+        }
+    }
+    return true;
 #else
-   KRATOS_ERROR << "loadUDSMWindows should be called in Windows applications" << rMaterialProperties[UDSM_NAME] << std::endl;
+    KRATOS_ERROR << "loadUDSMWindows should be called in Windows applications" << rMaterialProperties[UDSM_NAME] << std::endl;
 #endif
 
-   KRATOS_CATCH("")
+    KRATOS_CATCH("")
 }
-
-
-//************************************************************************************
-//************************************************************************************
 
 void SmallStrainUDSM3DLaw::CalculateMaterialResponsePK1(ConstitutiveLaw::Parameters & rValues)
 {
-   KRATOS_TRY
+    KRATOS_TRY
 
    CalculateMaterialResponseCauchy(rValues);
 
    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::CalculateMaterialResponsePK2(ConstitutiveLaw::Parameters & rValues)
 {
-   KRATOS_TRY
-
-   CalculateMaterialResponseCauchy(rValues);
-
-   KRATOS_CATCH("")
+    KRATOS_TRY
+    CalculateMaterialResponseCauchy(rValues);
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::CalculateMaterialResponseKirchhoff(ConstitutiveLaw::Parameters & rValues)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::CalculateMaterialResponseKirchhoff()") << std::endl;
-
-   CalculateMaterialResponseCauchy(rValues);
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::CalculateMaterialResponseKirchhoff()") << std::endl;
-   KRATOS_CATCH("")
+    KRATOS_TRY
+    CalculateMaterialResponseCauchy(rValues);
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::CalculateMaterialResponseCauchy(ConstitutiveLaw::Parameters &rValues)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::CalculateMaterialResponseCauchy()") << std::endl;
+    KRATOS_TRY
 
-   // Get Values to compute the constitutive law:
-   Flags &rOptions=rValues.GetOptions();
+    // Get Values to compute the constitutive law:
+    Flags &rOptions=rValues.GetOptions();
 
-   //NOTE: SINCE THE ELEMENT IS IN SMALL STRAINS WE CAN USE ANY STRAIN MEASURE. HERE EMPLOYING THE CAUCHY_GREEN
-   if (rOptions.IsNot( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN ))
-   {
-      Vector& rStrainVector = rValues.GetStrainVector();
-      CalculateCauchyGreenStrain( rValues, rStrainVector);
-   }
+    //NOTE: SINCE THE ELEMENT IS IN SMALL STRAINS WE CAN USE ANY STRAIN MEASURE. HERE EMPLOYING THE CAUCHY_GREEN
+    if (rOptions.IsNot( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
+        Vector& rStrainVector = rValues.GetStrainVector();
+        CalculateCauchyGreenStrain( rValues, rStrainVector);
+    }
 
-   if (rOptions.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR )) 
-   {
-      // Constitutive matrix (D matrix)
-      Matrix& rConstitutiveMatrix = rValues.GetConstitutiveMatrix();
-      CalculateConstitutiveMatrix(rValues, rConstitutiveMatrix);
-   }
+    if (rOptions.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR )) {
+        // Constitutive matrix (D matrix)
+        Matrix& rConstitutiveMatrix = rValues.GetConstitutiveMatrix();
+        CalculateConstitutiveMatrix(rValues, rConstitutiveMatrix);
+    }
 
-   if (rOptions.Is( ConstitutiveLaw::COMPUTE_STRESS ))
-   {
-      Vector& rStressVector = rValues.GetStressVector();
-      CalculateStress(rValues, rStressVector);
-   }
+    if (rOptions.Is( ConstitutiveLaw::COMPUTE_STRESS )) {
+        Vector& rStressVector = rValues.GetStressVector();
+        CalculateStress(rValues, rStressVector);
+    }
 
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::CalculateMaterialResponseCauchy()") << std::endl;
-   KRATOS_CATCH("")
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-void SmallStrainUDSM3DLaw::
-   UpdateInternalDeltaStrainVector(ConstitutiveLaw::Parameters &rValues)
+void SmallStrainUDSM3DLaw::UpdateInternalDeltaStrainVector(ConstitutiveLaw::Parameters &rValues)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::UpdateInternalDeltaStrainVector()") << std::endl;
+    KRATOS_TRY
+    const Vector& rStrainVector = rValues.GetStrainVector();
 
-   const Vector& rStrainVector = rValues.GetStrainVector();
-
-   for (unsigned int i=0; i < mDeltaStrainVector.size(); ++i)
-   {
-      mDeltaStrainVector[i] = rStrainVector(i) - mStrainVectorFinalized[i];
-   }
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::UpdateInternalDeltaStrainVector()") << std::endl;
-   KRATOS_CATCH("")
+    for (unsigned int i=0; i < mDeltaStrainVector.size(); ++i) {
+        mDeltaStrainVector[i] = rStrainVector(i) - mStrainVectorFinalized[i];
+    }
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::SetExternalStressVector(Vector& rStressVector)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::SetExternalStressVector()") << std::endl;
-
-   for (unsigned int i=0; i < rStressVector.size(); ++i)
-   {
-      rStressVector(i) = mStressVector[i];
-   }
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::SetExternalStressVector()") << std::endl;
-   KRATOS_CATCH("")
+    KRATOS_TRY
+    std::copy_n(mStressVector.begin(), rStressVector.size(), rStressVector.begin());
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::SetInternalStressVector(const Vector& rStressVector)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::SetInternalStressVector()") << std::endl;
-
-   for (unsigned int i=0; i < mStressVectorFinalized.size(); ++i)
-   {
-      mStressVectorFinalized[i] = rStressVector(i);
-   }
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::SetInternalStressVector()") << std::endl;
-   KRATOS_CATCH("")
+    KRATOS_TRY
+    std::copy_n(rStressVector.begin(), mStressVectorFinalized.size(), mStressVectorFinalized.begin());
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-void SmallStrainUDSM3DLaw::CopyConstitutiveMatrix( ConstitutiveLaw::Parameters &rValues,
-                                                   Matrix& rConstitutiveMatrix )
+void SmallStrainUDSM3DLaw::CopyConstitutiveMatrix(ConstitutiveLaw::Parameters &rValues,
+                                                  Matrix& rConstitutiveMatrix)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::CopyConstitutiveMatrix()") << std::endl;
+    KRATOS_TRY
 
-   if (rValues.GetMaterialProperties()[IS_FORTRAN_UDSM])
-   {
-      // transfer fortran style matrix to C++ style
-      for (unsigned int i = 0; i < VOIGT_SIZE_3D; i++) {
-         for (unsigned int j = 0; j < VOIGT_SIZE_3D; j++) {
-            rConstitutiveMatrix(i,j) = mMatrixD[j][i];
-         }
-      }
-   }
-   else
-   {
-      for (unsigned int i = 0; i < VOIGT_SIZE_3D; i++) {
-         for (unsigned int j = 0; j < VOIGT_SIZE_3D; j++) {
-            rConstitutiveMatrix(i,j) = mMatrixD[i][j];
-         }
-      }
-   }
+    if (rValues.GetMaterialProperties()[IS_FORTRAN_UDSM]) {
+        // transfer Fortran style matrix to C++ style
+        for (unsigned int i = 0; i < VOIGT_SIZE_3D; i++) {
+            for (unsigned int j = 0; j < VOIGT_SIZE_3D; j++) {
+                rConstitutiveMatrix(i,j) = mMatrixD[j][i];
+            }
+        }
+    } else {
+        for (unsigned int i = 0; i < VOIGT_SIZE_3D; i++) {
+            for (unsigned int j = 0; j < VOIGT_SIZE_3D; j++) {
+                rConstitutiveMatrix(i,j) = mMatrixD[i][j];
+            }
+        }
+    }
 
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::CopyConstitutiveMatrix()") << std::endl;
-   KRATOS_CATCH("")
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-void SmallStrainUDSM3DLaw::CalculateConstitutiveMatrix( ConstitutiveLaw::Parameters &rValues,
-                                                        Matrix& rConstitutiveMatrix )
+void SmallStrainUDSM3DLaw::CalculateConstitutiveMatrix(ConstitutiveLaw::Parameters &rValues,
+                                                       Matrix& rConstitutiveMatrix)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::CalculateConstitutiveMatrix()") << std::endl;
+    KRATOS_TRY
+    // update strain vector
+    UpdateInternalDeltaStrainVector(rValues);
 
-   // update strain vector
-   UpdateInternalDeltaStrainVector(rValues);
+    int IDTask = MATRIX_ELASTO_PLASTIC;
+    CallUDSM(&IDTask, rValues);
 
-   int IDTask = MATRIX_ELASTO_PLASTIC;
+    CopyConstitutiveMatrix(rValues, rConstitutiveMatrix);
 
-   CallUDSM(&IDTask, rValues);
-
-   CopyConstitutiveMatrix(rValues, rConstitutiveMatrix);
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::CalculateConstitutiveMatrix()") << std::endl;
-   KRATOS_CATCH("")
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-void SmallStrainUDSM3DLaw::CalculateStress( ConstitutiveLaw::Parameters &rValues,
-                                            Vector& rStressVector )
+void SmallStrainUDSM3DLaw::CalculateStress(ConstitutiveLaw::Parameters &rValues,
+                                           Vector& rStressVector)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::CalculateStress()") << std::endl;
+    KRATOS_TRY
+    // update strain vector
+    UpdateInternalDeltaStrainVector(rValues);
 
-   // update strain vector
-   UpdateInternalDeltaStrainVector(rValues);
+    int IDTask = STRESS_CALCULATION;
+    CallUDSM(&IDTask, rValues);
 
-   int IDTask = STRESS_CALCULATION;
-
-   CallUDSM(&IDTask, rValues);
-
-   SetExternalStressVector(rStressVector);
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::CalculateStress()") << std::endl;
-   KRATOS_CATCH("")
+    SetExternalStressVector(rStressVector);
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::CallUDSM(int *pIDTask, ConstitutiveLaw::Parameters &rValues)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::CallUDSM()") << std::endl;
+    KRATOS_TRY
 
-   // process data
-   double deltaTime = rValues.GetProcessInfo()[DELTA_TIME];
-   double time      = rValues.GetProcessInfo()[TIME] - deltaTime;
-   int    iStep     = rValues.GetProcessInfo()[STEP];
-   int    iteration = rValues.GetProcessInfo()[NL_ITERATION_NUMBER];
+    // process data
+    double deltaTime = rValues.GetProcessInfo()[DELTA_TIME];
+    double time      = rValues.GetProcessInfo()[TIME] - deltaTime;
+    int    iStep     = rValues.GetProcessInfo()[STEP];
+    int    iteration = rValues.GetProcessInfo()[NL_ITERATION_NUMBER];
 
-   // number of the model in the shared libaray (DLL)
-   const Properties& rMaterialProperties = rValues.GetMaterialProperties();
-   int modelNumber = rMaterialProperties[UDSM_NUMBER];
+    // number of the model in the shared libaray (DLL)
+    const Properties& rMaterialProperties = rValues.GetMaterialProperties();
+    int modelNumber = rMaterialProperties[UDSM_NUMBER];
 
-   // number of state variables
-   int nStateVariables = mStateVariablesFinalized.size();
+    // number of state variables
+    int nStateVariables = mStateVariablesFinalized.size();
 
-   // not needed:
-   double bulkWater = 0.0;
-   double excessPorePressurePrevious = 0.0;
-   double excessPorePressureCurrent = 0.0;
-   double X(0.0), Y(0.0), Z(0.0);
-   int iElement = 0;
-   int integrationNumber = 0;
-   int iPlastic = 0;
-   int isUndr = 0;
+    // not needed:
+    double bulkWater = 0.0;
+    double excessPorePressurePrevious = 0.0;
+    double excessPorePressureCurrent = 0.0;
+    double X(0.0), Y(0.0), Z(0.0);
+    int iElement = 0;
+    int integrationNumber = 0;
+    int iPlastic = 0;
+    int isUndr = 0;
 
-   // variable to check if an error happend in the model:
-   int iAbort = 0;
-   int nSizeProjectDirectory = mProjectDirectory.size();
+    // variable to check if an error happend in the model:
+    int iAbort = 0;
+    int nSizeProjectDirectory = mProjectDirectory.size();
 
-   // KRATOS_INFO("IDTask") << *pIDTask << std::endl;
-   // KRATOS_INFO("mStressVectorFinalized") << mStressVectorFinalized << std::endl;
-   // KRATOS_INFO("mDeltaStrainVector") << mDeltaStrainVector << std::endl;
-   // KRATOS_INFO("mStateVariablesFinalized") << mStateVariablesFinalized << std::endl;
-   // KRATOS_INFO("deltaTime") << deltaTime << std::endl;
+    const auto &MaterialParameters = rMaterialProperties[UMAT_PARAMETERS];
+    pUserMod(pIDTask, &modelNumber, &isUndr,
+             &iStep, &iteration, &iElement, &integrationNumber,
+             &X, &Y, &Z,
+             &time, &deltaTime,
+             &(MaterialParameters.data()[0]), &(mStressVectorFinalized.data()[0]), &excessPorePressurePrevious,
+             &(mStateVariablesFinalized.data()[0]),
+             &(mDeltaStrainVector.data()[0]), (double **) mMatrixD, &bulkWater,
+             &(mStressVector.data()[0]), &excessPorePressureCurrent, &(mStateVariables.data()[0]), &iPlastic,
+             &nStateVariables,
+             &mAttributes[IS_NON_SYMMETRIC], &mAttributes[IS_STRESS_DEPENDENT],
+             &mAttributes[IS_TIME_DEPENDENT], &mAttributes[USE_TANGENT_MATRIX],
+             mProjectDirectory.data(), &nSizeProjectDirectory,
+             &iAbort);
 
-   const auto &MaterialParameters = rMaterialProperties[UMAT_PARAMETERS];
-   pUserMod(pIDTask, &modelNumber, &isUndr,
-            &iStep, &iteration, &iElement, &integrationNumber,
-            &X, &Y, &Z,
-            &time, &deltaTime,
-            &(MaterialParameters.data()[0]), &(mStressVectorFinalized.data()[0]), &excessPorePressurePrevious, 
-            &(mStateVariablesFinalized.data()[0]),
-            &(mDeltaStrainVector.data()[0]), (double **) mMatrixD, &bulkWater,
-            &(mStressVector.data()[0]), &excessPorePressureCurrent, &(mStateVariables.data()[0]), &iPlastic,
-            &nStateVariables, 
-            &mAttributes[IS_NON_SYMMETRIC], &mAttributes[IS_STRESS_DEPENDENT],
-            &mAttributes[IS_TIME_DEPENDENT], &mAttributes[USE_TANGENT_MATRIX],
-            mProjectDirectory.data(), &nSizeProjectDirectory, 
-            &iAbort);
-
-   if (iAbort != 0) {
-      KRATOS_INFO("CallUDSM, iAbort !=0")
-                  << " iAbort: " << iAbort
-                  << " the specified UDSM returns an error while call UDSM with IDTASK: " 
-                  << std::to_string(*pIDTask) << "." 
-                  << " UDSM: " << rMaterialProperties[UDSM_NAME] 
-                  << " UDSM_NUMBER: " << rMaterialProperties[UDSM_NUMBER]
-                  << " Parameters: " << MaterialParameters
-                  << std::endl;
-      KRATOS_ERROR << "the specified UDSM returns an error while call UDSM with IDTASK: " 
-                   << std::to_string(*pIDTask)
-                   << ". UDSM: "
-                   << rMaterialProperties[UDSM_NAME]
-                   << std::endl;
-   }
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::CallUDSM()") << std::endl;
-   KRATOS_CATCH("")
+    if (iAbort != 0) {
+        KRATOS_INFO("CallUDSM, iAbort !=0")
+                    << " iAbort: " << iAbort
+                    << " the specified UDSM returns an error while call UDSM with IDTASK: "
+                    << std::to_string(*pIDTask) << "."
+                    << " UDSM: " << rMaterialProperties[UDSM_NAME]
+                    << " UDSM_NUMBER: " << rMaterialProperties[UDSM_NUMBER]
+                    << " Parameters: " << MaterialParameters
+                    << std::endl;
+        KRATOS_ERROR << "the specified UDSM returns an error while call UDSM with IDTASK: "
+                     << std::to_string(*pIDTask)
+                     << ". UDSM: "
+                     << rMaterialProperties[UDSM_NAME]
+                     << std::endl;
+    }
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::InitializeMaterialResponsePK1(ConstitutiveLaw::Parameters& rValues)
 {
-   // Small deformation so we can call the Cauchy method
-   InitializeMaterialResponseCauchy(rValues);
-
+    // Small deformation so we can call the Cauchy method
+    InitializeMaterialResponseCauchy(rValues);
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::InitializeMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues)
 {
-   // Small deformation so we can call the Cauchy method
-   InitializeMaterialResponseCauchy(rValues);
+    // Small deformation so we can call the Cauchy method
+    InitializeMaterialResponseCauchy(rValues);
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::InitializeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues)
 {
-   // Small deformation so we can call the Cauchy method
-   InitializeMaterialResponseCauchy(rValues);
-
+    // Small deformation so we can call the Cauchy method
+    InitializeMaterialResponseCauchy(rValues);
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::InitializeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::InitializeMaterialResponseCauchy()") << std::endl;
+    KRATOS_TRY
 
-   if (!mIsModelInitialized)
-   {
-      // stress and strain vectors must be initialized:
-      const Vector& rStressVector = rValues.GetStressVector();
-      SetInternalStressVector(rStressVector);
+    if (!mIsModelInitialized) {
+        // stress and strain vectors must be initialized:
+        const Vector& rStressVector = rValues.GetStressVector();
+        SetInternalStressVector(rStressVector);
 
-      const Vector& rStrainVector = rValues.GetStrainVector();
-      SetInternalStrainVector(rStrainVector);
+        const Vector& rStrainVector = rValues.GetStrainVector();
+        SetInternalStrainVector(rStrainVector);
 
-      int IDTask = INITIALISATION;
-      CallUDSM(&IDTask, rValues);
+        int IDTask = INITIALISATION;
+        CallUDSM(&IDTask, rValues);
 
-      mIsModelInitialized = true;
-   }
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::InitializeMaterialResponseCauchy()") << std::endl;
-
-   KRATOS_CATCH("")
+        mIsModelInitialized = true;
+    }
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::FinalizeMaterialResponsePK1(ConstitutiveLaw::Parameters& rValues)
 {
     // Small deformation so we can call the Cauchy method
     FinalizeMaterialResponseCauchy(rValues);
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::FinalizeMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues)
 {
     // Small deformation so we can call the Cauchy method
     FinalizeMaterialResponseCauchy(rValues);
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::FinalizeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues)
 {
     // Small deformation so we can call the Cauchy method
     FinalizeMaterialResponseCauchy(rValues);
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::FinalizeMaterialResponseCauchy(ConstitutiveLaw::Parameters & rValues)
 {
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::FinalizeMaterialResponseCauchy()") << std::endl;
-
-   UpdateInternalStrainVectorFinalized(rValues);
-   mStateVariablesFinalized = mStateVariables;
-   mStressVectorFinalized   = mStressVector;
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::FinalizeMaterialResponseCauchy()") << std::endl;
-
+    UpdateInternalStrainVectorFinalized(rValues);
+    mStateVariablesFinalized = mStateVariables;
+    mStressVectorFinalized   = mStressVector;
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUDSM3DLaw::SetInternalStrainVector(const Vector& rStrainVector)
 {
-   KRATOS_TRY
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::SetInternalStrainVector()") << std::endl;
-
-   for (unsigned int i=0; i < mStrainVectorFinalized.size(); ++i)
-   {
-      mStrainVectorFinalized[i] = rStrainVector(i);
-   }
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::SetInternalStrainVector()") << std::endl;
-   KRATOS_CATCH("")
+    KRATOS_TRY
+    std::copy_n(rStrainVector.begin(), mStrainVectorFinalized.size(), mStrainVectorFinalized.begin());
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
-void SmallStrainUDSM3DLaw::
-   UpdateInternalStrainVectorFinalized(ConstitutiveLaw::Parameters &rValues)
+void SmallStrainUDSM3DLaw::UpdateInternalStrainVectorFinalized(ConstitutiveLaw::Parameters &rValues)
 {
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::UpdateInternalStrainVectorFinalized()") << std::endl;
-   const Vector& rStrainVector = rValues.GetStrainVector();
-   this->SetInternalStrainVector(rStrainVector);
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::UpdateInternalStrainVectorFinalized()") << std::endl;
+    const Vector& rStrainVector = rValues.GetStrainVector();
+    this->SetInternalStrainVector(rStrainVector);
 }
 
-//----------------------------------------------------------------------------------------
-void SmallStrainUDSM3DLaw::CalculateCauchyGreenStrain( ConstitutiveLaw::Parameters& rValues, 
-                                                       Vector& rStrainVector )
+void SmallStrainUDSM3DLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues,
+                                                      Vector& rStrainVector)
 {
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::CalculateCauchyGreenStrain()") << std::endl;
+    const SizeType space_dimension = this->WorkingSpaceDimension();
 
-   const SizeType space_dimension = this->WorkingSpaceDimension();
+    //-Compute total deformation gradient
+    const Matrix& F = rValues.GetDeformationGradientF();
+    KRATOS_DEBUG_ERROR_IF(F.size1()!= space_dimension || F.size2() != space_dimension)
+                          << "expected size of F " << space_dimension
+                          << "x" << space_dimension
+                          << ", got " << F.size1()
+                          << "x" << F.size2() << std::endl;
 
-   //-Compute total deformation gradient
-   const Matrix& F = rValues.GetDeformationGradientF();
-   KRATOS_DEBUG_ERROR_IF(F.size1()!= space_dimension || F.size2() != space_dimension)
-                         << "expected size of F " << space_dimension 
-                         << "x" << space_dimension 
-                         << ", got " << F.size1() 
-                         << "x" << F.size2() << std::endl;
+    Matrix E_tensor = prod(trans(F), F);
+    for (unsigned int i=0; i<space_dimension; ++i)
+        E_tensor(i,i) -= 1.0;
+    E_tensor *= 0.5;
 
-   Matrix E_tensor = prod(trans(F), F);
-   for (unsigned int i=0; i<space_dimension; ++i)
-      E_tensor(i,i) -= 1.0;
-   E_tensor *= 0.5;
+    noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
 
-   noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::CalculateCauchyGreenStrain()") << std::endl;
 }
 
-//----------------------------------------------------------------------------------------
-double& SmallStrainUDSM3DLaw::CalculateValue( ConstitutiveLaw::Parameters& rParameterValues,
-                                              const Variable<double>& rThisVariable,
-                                              double& rValue )
+double& SmallStrainUDSM3DLaw::CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
+                                             const Variable<double>& rThisVariable,
+                                             double& rValue)
 {
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::CalculateValue()") << std::endl;
+    if (rThisVariable == STRAIN_ENERGY) {
+        Vector& rStrainVector = rParameterValues.GetStrainVector();
+        this->CalculateCauchyGreenStrain(rParameterValues, rStrainVector);
+        Vector& rStressVector = rParameterValues.GetStressVector();
+        this->CalculateStress(rParameterValues, rStressVector);
 
-   Vector& rStrainVector = rParameterValues.GetStrainVector();
-   Vector& rStressVector = rParameterValues.GetStressVector();
-
-   if (rThisVariable == STRAIN_ENERGY)
-   {
-      this->CalculateCauchyGreenStrain(rParameterValues, rStrainVector);
-      this->CalculateStress(rParameterValues, rStressVector);
-
-      rValue = 0.5 * inner_prod( rStrainVector, rStressVector); // Strain energy = 0.5*E:C:E
-   }
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::CalculateValue()") << std::endl;
-
-   return( rValue );
+        rValue = 0.5 * inner_prod( rStrainVector, rStressVector); // Strain energy = 0.5*E:C:E
+    }
+    return rValue;
 }
 
-//----------------------------------------------------------------------------------------
-Vector& SmallStrainUDSM3DLaw::CalculateValue( ConstitutiveLaw::Parameters& rParameterValues,
-                                              const Variable<Vector>& rThisVariable,
-                                              Vector& rValue )
+Vector& SmallStrainUDSM3DLaw::CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
+                                             const Variable<Vector>& rThisVariable,
+                                             Vector& rValue)
 {
-   // KRATOS_INFO("01-SmallStrainUDSM3DLaw::CalculateValue()") << std::endl;
-
-   if (rThisVariable == STRAIN ||
-       rThisVariable == GREEN_LAGRANGE_STRAIN_VECTOR ||
-       rThisVariable == ALMANSI_STRAIN_VECTOR) 
-   {
-      this->CalculateCauchyGreenStrain( rParameterValues, rValue);
-
-   } else if (rThisVariable == STRESSES ||
-              rThisVariable == CAUCHY_STRESS_VECTOR ||
-              rThisVariable == KIRCHHOFF_STRESS_VECTOR ||
-              rThisVariable == PK2_STRESS_VECTOR) 
-   {
+    if (rThisVariable == STRAIN ||
+        rThisVariable == GREEN_LAGRANGE_STRAIN_VECTOR ||
+        rThisVariable == ALMANSI_STRAIN_VECTOR) {
+        this->CalculateCauchyGreenStrain( rParameterValues, rValue);
+    } else if (rThisVariable == STRESSES ||
+               rThisVariable == CAUCHY_STRESS_VECTOR ||
+               rThisVariable == KIRCHHOFF_STRESS_VECTOR ||
+               rThisVariable == PK2_STRESS_VECTOR) {
         // Get Values to compute the constitutive law:
-      Flags& rFlags = rParameterValues.GetOptions();
+        Flags& rFlags = rParameterValues.GetOptions();
 
-      // Previous flags saved
-      const bool flagConstTensor = rFlags.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR );
-      const bool flagStress = rFlags.Is( ConstitutiveLaw::COMPUTE_STRESS );
+        // Previous flags saved
+        const bool flagConstTensor = rFlags.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR );
+        const bool flagStress = rFlags.Is( ConstitutiveLaw::COMPUTE_STRESS );
 
-      rFlags.Set( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true );
-      rFlags.Set( ConstitutiveLaw::COMPUTE_STRESS, true );
+        rFlags.Set( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true );
+        rFlags.Set( ConstitutiveLaw::COMPUTE_STRESS, true );
 
-      // We compute the stress
-      CalculateMaterialResponseCauchy(rParameterValues);
-      rValue = rParameterValues.GetStressVector();
+        // We compute the stress
+        CalculateMaterialResponseCauchy(rParameterValues);
+        rValue = rParameterValues.GetStressVector();
 
-      // Previous flags restored
-      rFlags.Set( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, flagConstTensor );
-      rFlags.Set( ConstitutiveLaw::COMPUTE_STRESS, flagStress );
-   }
-
-   // KRATOS_INFO("11-SmallStrainUDSM3DLaw::CalculateValue()") << std::endl;
-
-   return( rValue );
-}
-
-//----------------------------------------------------------------------------------------
-Matrix& SmallStrainUDSM3DLaw::CalculateValue( ConstitutiveLaw::Parameters& rParameterValues,
-                                              const Variable<Matrix>& rThisVariable,
-                                              Matrix& rValue )
-{
-   // KRATOS_INFO("02-SmallStrainUDSM3DLaw::CalculateValue()") << std::endl;
-
-   if (rThisVariable == CONSTITUTIVE_MATRIX ||
-       rThisVariable == CONSTITUTIVE_MATRIX_PK2 ||
-       rThisVariable == CONSTITUTIVE_MATRIX_KIRCHHOFF) 
-   {
-      this->CalculateConstitutiveMatrix(rParameterValues, rValue);
-   }
-
-   // KRATOS_INFO("12-SmallStrainUDSM3DLaw::CalculateValue()") << std::endl;
-
-   return( rValue );
-}
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-int SmallStrainUDSM3DLaw::GetStateVariableIndex(const Variable<double>& rThisVariable)
-{
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::GetStateVariableIndex()") << std::endl;
-
-   int index = -1;
-
-   if (rThisVariable == STATE_VARIABLE_1)
-       index = 1;
-    else if (rThisVariable == STATE_VARIABLE_2)
-       index = 2;
-    else if (rThisVariable == STATE_VARIABLE_3)
-       index = 3;
-    else if (rThisVariable == STATE_VARIABLE_4)
-       index = 4;
-    else if (rThisVariable == STATE_VARIABLE_5)
-       index = 5;
-    else if (rThisVariable == STATE_VARIABLE_6)
-       index = 6;
-    else if (rThisVariable == STATE_VARIABLE_7)
-       index = 7;
-    else if (rThisVariable == STATE_VARIABLE_8)
-       index = 8;
-    else if (rThisVariable == STATE_VARIABLE_9)
-       index = 9;
-
-    else if (rThisVariable == STATE_VARIABLE_10)
-       index = 10;
-    else if (rThisVariable == STATE_VARIABLE_11)
-       index = 11;
-    else if (rThisVariable == STATE_VARIABLE_12)
-       index = 12;
-    else if (rThisVariable == STATE_VARIABLE_13)
-       index = 13;
-    else if (rThisVariable == STATE_VARIABLE_14)
-       index = 14;
-    else if (rThisVariable == STATE_VARIABLE_15)
-       index = 15;
-    else if (rThisVariable == STATE_VARIABLE_16)
-       index = 16;
-    else if (rThisVariable == STATE_VARIABLE_17)
-       index = 17;
-    else if (rThisVariable == STATE_VARIABLE_18)
-       index = 18;
-    else if (rThisVariable == STATE_VARIABLE_19)
-       index = 19;
-    else if (rThisVariable == STATE_VARIABLE_20)
-       index = 20;
-
-    else if (rThisVariable == STATE_VARIABLE_21)
-       index = 21;
-    else if (rThisVariable == STATE_VARIABLE_22)
-       index = 22;
-    else if (rThisVariable == STATE_VARIABLE_23)
-       index = 23;
-    else if (rThisVariable == STATE_VARIABLE_24)
-       index = 24;
-    else if (rThisVariable == STATE_VARIABLE_25)
-       index = 25;
-    else if (rThisVariable == STATE_VARIABLE_26)
-       index = 26;
-    else if (rThisVariable == STATE_VARIABLE_27)
-       index = 27;
-    else if (rThisVariable == STATE_VARIABLE_28)
-       index = 28;
-    else if (rThisVariable == STATE_VARIABLE_29)
-       index = 29;
-
-    else if (rThisVariable == STATE_VARIABLE_30)
-       index = 30;
-    else if (rThisVariable == STATE_VARIABLE_31)
-       index = 31;
-    else if (rThisVariable == STATE_VARIABLE_32)
-       index = 32;
-    else if (rThisVariable == STATE_VARIABLE_33)
-       index = 33;
-    else if (rThisVariable == STATE_VARIABLE_34)
-       index = 34;
-    else if (rThisVariable == STATE_VARIABLE_35)
-       index = 35;
-    else if (rThisVariable == STATE_VARIABLE_36)
-       index = 36;
-    else if (rThisVariable == STATE_VARIABLE_37)
-       index = 37;
-    else if (rThisVariable == STATE_VARIABLE_38)
-       index = 38;
-    else if (rThisVariable == STATE_VARIABLE_39)
-       index = 39;
-
-    else if (rThisVariable == STATE_VARIABLE_40)
-       index = 40;
-    else if (rThisVariable == STATE_VARIABLE_41)
-       index = 41;
-    else if (rThisVariable == STATE_VARIABLE_42)
-       index = 42;
-    else if (rThisVariable == STATE_VARIABLE_43)
-       index = 43;
-    else if (rThisVariable == STATE_VARIABLE_44)
-       index = 44;
-    else if (rThisVariable == STATE_VARIABLE_45)
-       index = 45;
-    else if (rThisVariable == STATE_VARIABLE_46)
-       index = 46;
-    else if (rThisVariable == STATE_VARIABLE_47)
-       index = 47;
-    else if (rThisVariable == STATE_VARIABLE_48)
-       index = 48;
-    else if (rThisVariable == STATE_VARIABLE_49)
-       index = 49;
-
-    else if (rThisVariable == STATE_VARIABLE_50)
-       index = 50;
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::GetStateVariableIndex()") << std::endl;
-
-   return index - 1;
-}
-
-//----------------------------------------------------------------------------------------
-Vector& SmallStrainUDSM3DLaw::GetValue( const Variable<Vector> &rThisVariable, Vector &rValue )
-{
-   // KRATOS_INFO("0-SmallStrainUDSM3DLaw::GetValue()") << std::endl;
-
-   if (rThisVariable == STATE_VARIABLES)
-   {
-      if (rValue.size() != mStateVariablesFinalized.size())
-         rValue.resize(mStateVariablesFinalized.size());
-
-      noalias(rValue) = mStateVariablesFinalized;
-   }
-   else if (rThisVariable == CAUCHY_STRESS_VECTOR)
-   {
-      if (rValue.size() != mStressVectorFinalized.size())
-         rValue.resize(mStressVectorFinalized.size());
-
-      noalias(rValue) = mStressVectorFinalized;
-   }
-
-   // KRATOS_INFO("1-SmallStrainUDSM3DLaw::GetValue()") << std::endl;
+        // Previous flags restored
+        rFlags.Set( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, flagConstTensor );
+        rFlags.Set( ConstitutiveLaw::COMPUTE_STRESS, flagStress );
+    }
 
     return rValue;
 }
 
-//----------------------------------------------------------------------------------------
-double& SmallStrainUDSM3DLaw::GetValue( const Variable<double>& rThisVariable, double& rValue )
+Matrix& SmallStrainUDSM3DLaw::CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
+                                             const Variable<Matrix>& rThisVariable,
+                                             Matrix& rValue )
 {
-   // KRATOS_INFO("01-SmallStrainUDSM3DLaw::GetValue()") << std::endl;
-
-   const int index = GetStateVariableIndex(rThisVariable);
-
-   KRATOS_DEBUG_ERROR_IF( index < 0 || index > (static_cast<int>(mStateVariablesFinalized.size()) - 1) )
-                        << "GetValue: Variable: "
-                        << rThisVariable
-                        << " does not exist in UDSM. Requested index: " << index << std::endl;
-
-   rValue = mStateVariablesFinalized[index];
-
-   // KRATOS_INFO("11-SmallStrainUDSM3DLaw::GetValue()") << std::endl;
-
-   return rValue;
+    if (rThisVariable == CONSTITUTIVE_MATRIX ||
+        rThisVariable == CONSTITUTIVE_MATRIX_PK2 ||
+        rThisVariable == CONSTITUTIVE_MATRIX_KIRCHHOFF) {
+        this->CalculateConstitutiveMatrix(rParameterValues, rValue);
+    }
+    return rValue;
 }
 
-//----------------------------------------------------------------------------------------
+int SmallStrainUDSM3DLaw::GetStateVariableIndex(const Variable<double>& rThisVariable)
+{
+    int index = -1;
+
+    if (rThisVariable == STATE_VARIABLE_1)
+        index = 1;
+    else if (rThisVariable == STATE_VARIABLE_2)
+        index = 2;
+    else if (rThisVariable == STATE_VARIABLE_3)
+        index = 3;
+    else if (rThisVariable == STATE_VARIABLE_4)
+        index = 4;
+    else if (rThisVariable == STATE_VARIABLE_5)
+        index = 5;
+    else if (rThisVariable == STATE_VARIABLE_6)
+        index = 6;
+    else if (rThisVariable == STATE_VARIABLE_7)
+        index = 7;
+    else if (rThisVariable == STATE_VARIABLE_8)
+        index = 8;
+    else if (rThisVariable == STATE_VARIABLE_9)
+        index = 9;
+
+    else if (rThisVariable == STATE_VARIABLE_10)
+        index = 10;
+    else if (rThisVariable == STATE_VARIABLE_11)
+        index = 11;
+    else if (rThisVariable == STATE_VARIABLE_12)
+        index = 12;
+    else if (rThisVariable == STATE_VARIABLE_13)
+        index = 13;
+    else if (rThisVariable == STATE_VARIABLE_14)
+        index = 14;
+    else if (rThisVariable == STATE_VARIABLE_15)
+        index = 15;
+    else if (rThisVariable == STATE_VARIABLE_16)
+        index = 16;
+    else if (rThisVariable == STATE_VARIABLE_17)
+        index = 17;
+    else if (rThisVariable == STATE_VARIABLE_18)
+        index = 18;
+    else if (rThisVariable == STATE_VARIABLE_19)
+        index = 19;
+    else if (rThisVariable == STATE_VARIABLE_20)
+        index = 20;
+
+    else if (rThisVariable == STATE_VARIABLE_21)
+        index = 21;
+    else if (rThisVariable == STATE_VARIABLE_22)
+        index = 22;
+    else if (rThisVariable == STATE_VARIABLE_23)
+        index = 23;
+    else if (rThisVariable == STATE_VARIABLE_24)
+        index = 24;
+    else if (rThisVariable == STATE_VARIABLE_25)
+        index = 25;
+    else if (rThisVariable == STATE_VARIABLE_26)
+        index = 26;
+    else if (rThisVariable == STATE_VARIABLE_27)
+        index = 27;
+    else if (rThisVariable == STATE_VARIABLE_28)
+        index = 28;
+    else if (rThisVariable == STATE_VARIABLE_29)
+        index = 29;
+
+    else if (rThisVariable == STATE_VARIABLE_30)
+        index = 30;
+    else if (rThisVariable == STATE_VARIABLE_31)
+        index = 31;
+    else if (rThisVariable == STATE_VARIABLE_32)
+        index = 32;
+    else if (rThisVariable == STATE_VARIABLE_33)
+        index = 33;
+    else if (rThisVariable == STATE_VARIABLE_34)
+        index = 34;
+    else if (rThisVariable == STATE_VARIABLE_35)
+        index = 35;
+    else if (rThisVariable == STATE_VARIABLE_36)
+        index = 36;
+    else if (rThisVariable == STATE_VARIABLE_37)
+        index = 37;
+    else if (rThisVariable == STATE_VARIABLE_38)
+        index = 38;
+    else if (rThisVariable == STATE_VARIABLE_39)
+        index = 39;
+
+    else if (rThisVariable == STATE_VARIABLE_40)
+        index = 40;
+    else if (rThisVariable == STATE_VARIABLE_41)
+        index = 41;
+    else if (rThisVariable == STATE_VARIABLE_42)
+        index = 42;
+    else if (rThisVariable == STATE_VARIABLE_43)
+        index = 43;
+    else if (rThisVariable == STATE_VARIABLE_44)
+        index = 44;
+    else if (rThisVariable == STATE_VARIABLE_45)
+        index = 45;
+    else if (rThisVariable == STATE_VARIABLE_46)
+        index = 46;
+    else if (rThisVariable == STATE_VARIABLE_47)
+        index = 47;
+    else if (rThisVariable == STATE_VARIABLE_48)
+        index = 48;
+    else if (rThisVariable == STATE_VARIABLE_49)
+        index = 49;
+
+    else if (rThisVariable == STATE_VARIABLE_50)
+        index = 50;
+
+    return index - 1;
+}
+
+Vector& SmallStrainUDSM3DLaw::GetValue(const Variable<Vector> &rThisVariable, Vector &rValue)
+{
+    if (rThisVariable == STATE_VARIABLES) {
+        if (rValue.size() != mStateVariablesFinalized.size()) rValue.resize(mStateVariablesFinalized.size());
+
+        noalias(rValue) = mStateVariablesFinalized;
+    } else if (rThisVariable == CAUCHY_STRESS_VECTOR) {
+        if (rValue.size() != mStressVectorFinalized.size()) rValue.resize(mStressVectorFinalized.size());
+
+        noalias(rValue) = mStressVectorFinalized;
+    }
+    return rValue;
+}
+
+double& SmallStrainUDSM3DLaw::GetValue(const Variable<double>& rThisVariable, double& rValue)
+{
+    const int index = GetStateVariableIndex(rThisVariable);
+
+    KRATOS_DEBUG_ERROR_IF( index < 0 || index > (static_cast<int>(mStateVariablesFinalized.size()) - 1) )
+                         << "GetValue: Variable: "
+                         << rThisVariable
+                         << " does not exist in UDSM. Requested index: " << index << std::endl;
+
+    rValue = mStateVariablesFinalized[index];
+
+    return rValue;
+}
+
 int& SmallStrainUDSM3DLaw::GetValue( const Variable<int>& rThisVariable, int& rValue )
 {
-   // KRATOS_INFO("02-SmallStrainUDSM3DLaw::GetValue()") << std::endl;
-
-   if (rThisVariable == NUMBER_OF_UMAT_STATE_VARIABLES)
-   {
-      rValue = mStateVariablesFinalized.size();
-   }
-
-   // KRATOS_INFO("12-SmallStrainUDSM3DLaw::GetValue()") << std::endl;
-
+   if (rThisVariable == NUMBER_OF_UMAT_STATE_VARIABLES) rValue = static_cast<int>(mStateVariablesFinalized.size());
    return rValue;
 }
 
-//----------------------------------------------------------------------------------------
-void SmallStrainUDSM3DLaw::SetValue( const Variable<double>& rThisVariable,
-                                     const double& rValue,
-                                     const ProcessInfo& rCurrentProcessInfo )
+void SmallStrainUDSM3DLaw::SetValue(const Variable<double>& rThisVariable,
+                                    const double& rValue,
+                                    const ProcessInfo& rCurrentProcessInfo)
 {
-   // KRATOS_INFO("01-SmallStrainUDSM3DLaw::SetValue()") << std::endl;
+    const int index = GetStateVariableIndex(rThisVariable);
 
-   const int index = GetStateVariableIndex(rThisVariable);
+    KRATOS_DEBUG_ERROR_IF( index < 0 || index > (static_cast<int>(mStateVariablesFinalized.size()) - 1) )
+                         << "GetValue: Variable: "
+                         << rThisVariable
+                         << " does not exist in UDSM. Requested index: " << index << std::endl;
 
-   KRATOS_DEBUG_ERROR_IF( index < 0 || index > (static_cast<int>(mStateVariablesFinalized.size()) - 1) )
-                        << "GetValue: Variable: "
-                        << rThisVariable
-                        << " does not exist in UDSM. Requested index: " << index << std::endl;
-
-   mStateVariablesFinalized[index] = rValue;
-
-   // KRATOS_INFO("11-SmallStrainUDSM3DLaw::SetValue()") << std::endl;
-
+    mStateVariablesFinalized[index] = rValue;
 }
 
-//----------------------------------------------------------------------------------------
-void SmallStrainUDSM3DLaw::SetValue( const Variable<Vector>& rThisVariable,
-                                     const Vector& rValue,
-                                     const ProcessInfo& rCurrentProcessInfo )
+void SmallStrainUDSM3DLaw::SetValue(const Variable<Vector>& rThisVariable,
+                                    const Vector& rValue,
+                                    const ProcessInfo& rCurrentProcessInfo)
 {
-   // KRATOS_INFO("02-SmallStrainUDSM3DLaw::SetValue()") << std::endl;
-
-   if (rThisVariable == STATE_VARIABLES)
-   {
-      if (rValue.size() == mStateVariablesFinalized.size()) 
-      {
-         for (unsigned int i=0; i < rValue.size(); ++i)
-         {
-            mStateVariablesFinalized[i] = rValue[i];
-         }
-      }
-   }
-   else if (rThisVariable == CAUCHY_STRESS_VECTOR)
-   {
-      if (rValue.size() == mStressVectorFinalized.size()) 
-      {
-         for (unsigned int i=0; i < rValue.size(); ++i)
-         {
-            mStressVectorFinalized[i] = rValue[i];
-         }
-      }
-   }
-
-   // KRATOS_INFO("12-SmallStrainUDSM3DLaw::SetValue()") << std::endl;
-
+    if ((rThisVariable == STATE_VARIABLES) &&
+        (rValue.size() == mStateVariablesFinalized.size())) {
+        std::copy(rValue.begin(), rValue.end(), mStateVariablesFinalized.begin());
+    } else if ((rThisVariable == CAUCHY_STRESS_VECTOR) &&
+               (rValue.size() == mStressVectorFinalized.size())) {
+        std::copy(rValue.begin(), rValue.end(), mStressVectorFinalized.begin());
+    }
 }
 
 } // Namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_udsm_3D_law.hpp
@@ -10,14 +10,12 @@
 //  Main authors:    Vahid Galavi
 //
 
-#if !defined(KRATOS_SMALL_STRAIN_UDSM_3D_LAW_H_INCLUDED )
-#define  KRATOS_SMALL_STRAIN_UDSM_3D_LAW_H_INCLUDED
+#pragma once
 
 // System includes
 #include <string>
 #include <iostream>
 #include "includes/define.h"
-// External includes
 
 // Project includes
 #include "includes/serializer.h"
@@ -25,7 +23,6 @@
 
 // Application includes
 #include "geo_mechanics_application_variables.h"
-
 
 namespace Kratos
 {
@@ -102,7 +99,6 @@ typedef void(*pF_UserMod) (int    *, int     *, int    *,
       /// Pointer definition of SmallStrainUDSM3DLaw
       KRATOS_CLASS_POINTER_DEFINITION( SmallStrainUDSM3DLaw );
 
-
       //@}
       //@name Life Cycle
       //@{
@@ -111,7 +107,7 @@ typedef void(*pF_UserMod) (int    *, int     *, int    *,
       /**
        * @brief Default constructor.
        */
-      SmallStrainUDSM3DLaw();
+      SmallStrainUDSM3DLaw() = default;
 
       /**
        * @brief Clone method
@@ -126,13 +122,11 @@ typedef void(*pF_UserMod) (int    *, int     *, int    *,
       /**
        * @brief Destructor.
        */
-      virtual ~SmallStrainUDSM3DLaw();
-
+      ~SmallStrainUDSM3DLaw() override = default;
 
       // Assignment operator:
       SmallStrainUDSM3DLaw& operator=(SmallStrainUDSM3DLaw const& rOther);
 
-      //----------------------------------------------------------------------------------------
       /**
        * @brief This function is designed to be called once to check compatibility with element
        * @param rFeatures The Features of the law
@@ -142,33 +136,33 @@ typedef void(*pF_UserMod) (int    *, int     *, int    *,
       /**
        * @brief Dimension of the law:
        */
-      virtual SizeType WorkingSpaceDimension() override
+      SizeType WorkingSpaceDimension() override
       {
-         return Dimension;
+          return Dimension;
       }
 
       /**
        * @brief Voigt tensor size:
        */
-      virtual SizeType GetStrainSize() const override
+      SizeType GetStrainSize() const override
       {
-         return VoigtSize;
+          return VoigtSize;
       }
 
       /**
        * @brief Returns the expected strain measure of this constitutive law (by default Green-Lagrange)
        * @return the expected strain measure
        */
-      virtual StrainMeasure GetStrainMeasure() override
+      StrainMeasure GetStrainMeasure() override
       {
-         return StrainMeasure_Infinitesimal;
+          return StrainMeasure_Infinitesimal;
       }
 
       /**
-       * returns the stress measure of this constitutive law (by default 1st Piola-Kirchhoff stress in voigt notation)
+       * returns the stress measure of this constitutive law (by default 1st Piola-Kirchhoff stress in Voigt notation)
        * @return the expected stress measure
        */
-      virtual StressMeasure GetStressMeasure() override
+      StressMeasure GetStressMeasure() override
       {
          return StressMeasure_Cauchy;
       }
@@ -223,9 +217,9 @@ typedef void(*pF_UserMod) (int    *, int     *, int    *,
        * @param rValue a reference to the returned value
        * @return rValue output: the value of the specified variable
        */
-      virtual double& CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
-                                     const Variable<double>& rThisVariable,
-                                     double& rValue) override;
+      double& CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
+                             const Variable<double>&      rThisVariable,
+                             double&                      rValue) override;
 
       /**
        * @brief It calculates the value of a specified variable (Vector case)
@@ -234,9 +228,9 @@ typedef void(*pF_UserMod) (int    *, int     *, int    *,
        * @param rValue a reference to the returned value
        * @return rValue output: the value of the specified variable
        */
-      virtual Vector& CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
-                                     const Variable<Vector>& rThisVariable,
-                                     Vector& rValue) override;
+      Vector& CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
+                             const Variable<Vector>&      rThisVariable,
+                             Vector&                      rValue) override;
 
       /**
        * @brief It calculates the value of a specified variable (Matrix case)
@@ -245,10 +239,11 @@ typedef void(*pF_UserMod) (int    *, int     *, int    *,
        * @param rValue a reference to the returned value
        * @return rValue output: the value of the specified variable
        */
-      virtual Matrix& CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
-                                     const Variable<Matrix>& rThisVariable,
-                                     Matrix& rValue) override;
+      Matrix& CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
+                             const Variable<Matrix>&      rThisVariable,
+                             Matrix&                      rValue) override;
 
+      using ConstitutiveLaw::CalculateValue;
 
       // @brief This function provides the place to perform checks on the completeness of the input.
       // @details It is designed to be called only once (or anyway, not often) typically at the beginning
@@ -299,57 +294,46 @@ typedef void(*pF_UserMod) (int    *, int     *, int    *,
                         const GeometryType& rElementGeometry,
                         const Vector& rShapeFunctionsValues) override;
 
-   //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     double& GetValue( const Variable<double> &rThisVariable, double &rValue ) override;
     int& GetValue( const Variable<int> &rThisVariable, int &rValue ) override;
     Vector& GetValue( const Variable<Vector> &rThisVariable, Vector &rValue ) override;
 
-    void SetValue( const Variable<double>& rVariable,
-                   const double& rValue,
-                   const ProcessInfo& rCurrentProcessInfo ) override;
+    void SetValue(const Variable<double>& rVariable,
+                  const double&           rValue,
+                  const ProcessInfo&      rCurrentProcessInfo) override;
 
-    void SetValue( const Variable<Vector>& rVariable,
-                   const Vector& rValue,
-                   const ProcessInfo& rCurrentProcessInfo ) override;
-
-   //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-
-
+    void SetValue(const Variable<Vector>& rVariable,
+                  const Vector&           rValue,
+                  const ProcessInfo&      rCurrentProcessInfo) override;
       ///@}
       ///@name Inquiry
       ///@{
-
 
       ///@}
       ///@name Input and output
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override
+      std::string Info() const override
       {
-         std::stringstream buffer;
-         buffer << "SmallStrainUDSM3DLaw";
-         return buffer.str();
+         return "SmallStrainUDSM3DLaw";
       }
 
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override
+      void PrintInfo(std::ostream& rOStream) const override
       {
-         rOStream << "SmallStrainUDSM3DLaw";
+         rOStream << Info();
       }
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override
+      void PrintData(std::ostream& rOStream) const override
       {
          rOStream << "SmallStrainUDSM3DLaw Data";
       }
 
-
       ///@}
       ///@name Friends
       ///@{
-
 
       ///@}
 
@@ -387,7 +371,6 @@ typedef void(*pF_UserMod) (int    *, int     *, int    *,
       ///@name Protected Operators
       ///@{
 
-
       ///@}
       ///@name Protected Operations
       ///@{
@@ -402,11 +385,10 @@ typedef void(*pF_UserMod) (int    *, int     *, int    *,
       virtual void SetInternalStrainVector(const Vector& rStrainVector);
       virtual void CopyConstitutiveMatrix(ConstitutiveLaw::Parameters &rValues, Matrix& rConstitutiveMatrix);
 
-
       void CalculateConstitutiveMatrix(ConstitutiveLaw::Parameters &rValues, Matrix& rConstitutiveMatrix);
       void CalculateStress(ConstitutiveLaw::Parameters &rValues, Vector& rStressVector);
 
-      // returns 1 if the stiffness matrix of the material is non symmetric
+      // returns 1 if the stiffness matrix of the material is non-symmetric
       int getIsNonSymmetric() {return mAttributes[IS_NON_SYMMETRIC];}
 
       // returns 1 if the stiffness matrix of the material is stress dependent
@@ -415,25 +397,22 @@ typedef void(*pF_UserMod) (int    *, int     *, int    *,
       // returns 1 if material is time dependent
       int getIsTimeDependent() {return mAttributes[IS_TIME_DEPENDENT];}
 
-      // returns 1 if the stiffness matrix of the material is tanential
+      // returns 1 if the stiffness matrix of the material is tangential
       int getUseTangentMatrix() {return mAttributes[USE_TANGENT_MATRIX];}
 
       ///@}
       ///@name Protected Inquiry
       ///@{
 
-
       ///@}
       ///@name Protected LifeCycle
       ///@{
-
 
       ///@}
 
    private:
       ///@name Static Member Variables
       ///@{
-
 
       ///@}
       ///@name Member Variables
@@ -453,16 +432,13 @@ typedef void(*pF_UserMod) (int    *, int     *, int    *,
       Vector mStateVariables;
       Vector mStateVariablesFinalized;
 
-
       ///@}
       ///@name Private Operators
       ///@{
 
-
       ///@}
       ///@name Private Operations
       ///@{
-
 
       ///@}
       ///@name Private  Access
@@ -489,13 +465,12 @@ typedef void(*pF_UserMod) (int    *, int     *, int    *,
       int GetNumberOfMaterialParametersFromUDSM(const Properties& rMaterialProperties);
       int GetStateVariableIndex(const Variable<double>& rThisVariable);
 
-
       ///@}
       ///@name Serialization
       ///@{
       friend class Serializer;
 
-      virtual void save(Serializer& rSerializer) const override
+      void save(Serializer& rSerializer) const override
       {
          KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, ConstitutiveLaw)
          rSerializer.save("InitializedModel",           mIsModelInitialized);
@@ -505,7 +480,7 @@ typedef void(*pF_UserMod) (int    *, int     *, int    *,
          rSerializer.save("StateVariablesFinalized",    mStateVariablesFinalized);
       }
 
-      virtual void load(Serializer& rSerializer) override
+      void load(Serializer& rSerializer) override
       {
          KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, ConstitutiveLaw)
          rSerializer.load("InitializedModel",           mIsModelInitialized);
@@ -518,7 +493,6 @@ typedef void(*pF_UserMod) (int    *, int     *, int    *,
       ///@}
       ///@name Private Inquiry
       ///@{
-
 
       ///@}
       ///@name Un accessible methods
@@ -533,7 +507,6 @@ typedef void(*pF_UserMod) (int    *, int     *, int    *,
    ///@name Type Definitions
    ///@{
 
-
    ///@}
    ///@name Input and output
    ///@{
@@ -542,8 +515,4 @@ typedef void(*pF_UserMod) (int    *, int     *, int    *,
 
    ///@} addtogroup block
 
-}  // namespace Kratos.
-
-#endif // KRATOS_SMALL_STRAIN_UDSM_3D_LAW_H_INCLUDED  defined
-
-
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_interface_law.cpp
@@ -10,136 +10,64 @@
 //  Main authors:    Vahid Galavi
 //
 
-// System includes
-
-// External includes
-
 #include "custom_constitutive/small_strain_umat_2D_interface_law.hpp"
-
 
 namespace Kratos
 {
 
-//******************************CONSTRUCTOR*******************************************
-//************************************************************************************
-
-SmallStrainUMAT2DInterfaceLaw::SmallStrainUMAT2DInterfaceLaw()
-   : SmallStrainUMAT3DLaw()
-   {
-    KRATOS_TRY
-    //KRATOS_INFO("SmallStrainUMAT2DInterfaceLaw()") << std::endl;
-
-    KRATOS_CATCH("")
-
-   }
-
-//******************************COPY CONSTRUCTOR**************************************
-//************************************************************************************
-SmallStrainUMAT2DInterfaceLaw::
-   SmallStrainUMAT2DInterfaceLaw(const SmallStrainUMAT2DInterfaceLaw &rOther)
-   : SmallStrainUMAT3DLaw(rOther)
-{
-   KRATOS_TRY
-   //KRATOS_INFO("SmallStrainUMAT2DInterfaceLaw(const...)") << std::endl;
-
-   KRATOS_CATCH("")
-}
-
-//********************************CLONE***********************************************
-//************************************************************************************
-
 ConstitutiveLaw::Pointer SmallStrainUMAT2DInterfaceLaw::Clone() const
 {
-   KRATOS_TRY
-   //KRATOS_INFO("Clone()") << std::endl;
+    KRATOS_TRY
 
-   return Kratos::make_shared<SmallStrainUMAT2DInterfaceLaw>(*this);
+    return Kratos::make_shared<SmallStrainUMAT2DInterfaceLaw>(*this);
 
-   KRATOS_CATCH("")
+    KRATOS_CATCH("")
 }
-
-//********************************ASSIGNMENT******************************************
-//************************************************************************************
-SmallStrainUMAT2DInterfaceLaw 
-  &SmallStrainUMAT2DInterfaceLaw::operator=(SmallStrainUMAT2DInterfaceLaw const &rOther)
-{
-   KRATOS_TRY
-
-   SmallStrainUMAT3DLaw::operator=(rOther);
-
-   //KRATOS_INFO("operator=") << std::endl;
-
-   return *this;
-
-   KRATOS_CATCH("")
-}
-
-//*******************************DESTRUCTOR*******************************************
-//************************************************************************************
-
-SmallStrainUMAT2DInterfaceLaw::~SmallStrainUMAT2DInterfaceLaw()
-{
-   //KRATOS_INFO("~SmallStrainUMAT3DLaw()") << std::endl;
-}
-
-
-//************************************************************************************
-//************************************************************************************
 
 void SmallStrainUMAT2DInterfaceLaw::UpdateInternalDeltaStrainVector(ConstitutiveLaw::Parameters &rValues)
 {
-   const Vector& rStrainVector = rValues.GetStrainVector();
+    const Vector& rStrainVector = rValues.GetStrainVector();
 
-   mDeltaStrainVector[INDEX_3D_ZZ] = rStrainVector(INDEX_2D_INTERFACE_ZZ) - mStrainVectorFinalized[INDEX_3D_ZZ];
-   mDeltaStrainVector[INDEX_3D_XZ] = rStrainVector(INDEX_2D_INTERFACE_XZ) - mStrainVectorFinalized[INDEX_3D_XZ];
+    mDeltaStrainVector[INDEX_3D_ZZ] = rStrainVector(INDEX_2D_INTERFACE_ZZ) - mStrainVectorFinalized[INDEX_3D_ZZ];
+    mDeltaStrainVector[INDEX_3D_XZ] = rStrainVector(INDEX_2D_INTERFACE_XZ) - mStrainVectorFinalized[INDEX_3D_XZ];
 }
 
 void SmallStrainUMAT2DInterfaceLaw::SetExternalStressVector(Vector& rStressVector)
 {
-   //KRATOS_INFO("mStressVector") << mStressVector << std::endl;
-
-   rStressVector(INDEX_2D_INTERFACE_ZZ) = mStressVector[INDEX_3D_ZZ];
-   rStressVector(INDEX_2D_INTERFACE_XZ) = mStressVector[INDEX_3D_XZ];
+    rStressVector(INDEX_2D_INTERFACE_ZZ) = mStressVector[INDEX_3D_ZZ];
+    rStressVector(INDEX_2D_INTERFACE_XZ) = mStressVector[INDEX_3D_XZ];
 }
-
 
 void SmallStrainUMAT2DInterfaceLaw::SetInternalStressVector(const Vector& rStressVector)
 {
-   // KRATOS_INFO("SetInternalStressVector:rStressVector") << rStressVector << std::endl;
-   KRATOS_TRY
-   mStressVectorFinalized[INDEX_3D_ZZ] = rStressVector(INDEX_2D_INTERFACE_ZZ);
-   mStressVectorFinalized[INDEX_3D_XZ] = rStressVector(INDEX_2D_INTERFACE_XZ);
-   KRATOS_CATCH("")
+    KRATOS_TRY
+    mStressVectorFinalized[INDEX_3D_ZZ] = rStressVector(INDEX_2D_INTERFACE_ZZ);
+    mStressVectorFinalized[INDEX_3D_XZ] = rStressVector(INDEX_2D_INTERFACE_XZ);
+    KRATOS_CATCH("")
 }
 
 void SmallStrainUMAT2DInterfaceLaw::SetInternalStrainVector(const Vector& rStrainVector)
 {
-   // KRATOS_INFO("SetInternalStrainVector:rStrainVector") << rStrainVector << std::endl;
-
-   mStrainVectorFinalized[INDEX_3D_ZZ] = rStrainVector(INDEX_2D_INTERFACE_ZZ);
-   mStrainVectorFinalized[INDEX_3D_XZ] = rStrainVector(INDEX_2D_INTERFACE_XZ);
+    mStrainVectorFinalized[INDEX_3D_ZZ] = rStrainVector(INDEX_2D_INTERFACE_ZZ);
+    mStrainVectorFinalized[INDEX_3D_XZ] = rStrainVector(INDEX_2D_INTERFACE_XZ);
 }
 
-
-void SmallStrainUMAT2DInterfaceLaw::CopyConstitutiveMatrix( ConstitutiveLaw::Parameters &rValues,
-                                                            Matrix& rConstitutiveMatrix )
+void SmallStrainUMAT2DInterfaceLaw::CopyConstitutiveMatrix(ConstitutiveLaw::Parameters &rValues,
+                                                           Matrix& rConstitutiveMatrix)
 {
-   if (rValues.GetMaterialProperties()[IS_FORTRAN_UDSM])
-   {
-      // transfer fortran style matrix to C++ style
-      for (unsigned int i = 0; i < VoigtSize; i++) {
-         for (unsigned int j = 0; j < VoigtSize; j++) {
-            rConstitutiveMatrix(i,j) = mMatrixD[getIndex3D(static_cast<indexStress2DInterface>(j))][getIndex3D(static_cast<indexStress2DInterface>(i))];
-         }
-      }
-   }
-   else
-   {
-      for (unsigned int i = 0; i < VoigtSize; i++) {
-         for (unsigned int j = 0; j < VoigtSize; j++) {
-            rConstitutiveMatrix(i,j) = mMatrixD[getIndex3D(static_cast<indexStress2DInterface>(i))][getIndex3D(static_cast<indexStress2DInterface>(j))];
-         }
-      }
+    if (rValues.GetMaterialProperties()[IS_FORTRAN_UDSM]) {
+        // transfer fortran style matrix to C++ style
+        for (unsigned int i = 0; i < VoigtSize; i++) {
+            for (unsigned int j = 0; j < VoigtSize; j++) {
+                rConstitutiveMatrix(i,j) = mMatrixD[getIndex3D(static_cast<indexStress2DInterface>(j))][getIndex3D(static_cast<indexStress2DInterface>(i))];
+            }
+        }
+    } else {
+        for (unsigned int i = 0; i < VoigtSize; i++) {
+            for (unsigned int j = 0; j < VoigtSize; j++) {
+                rConstitutiveMatrix(i,j) = mMatrixD[getIndex3D(static_cast<indexStress2DInterface>(i))][getIndex3D(static_cast<indexStress2DInterface>(j))];
+            }
+        }
    }
 }
 
@@ -156,63 +84,36 @@ indexStress3D SmallStrainUMAT2DInterfaceLaw::getIndex3D(indexStress2DInterface i
    }
 }
 
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-void SmallStrainUMAT2DInterfaceLaw::
-   CalculateCauchyGreenStrain( ConstitutiveLaw::Parameters& rValues,
-                               Vector& rStrainVector )
+void SmallStrainUMAT2DInterfaceLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues,
+                                                               Vector& rStrainVector)
 {
-   KRATOS_ERROR << "CalculateCauchyGreenStrain is not implemented in SmallStrainUMAT2DInterfaceLaw" << std::endl;
+    KRATOS_ERROR << "CalculateCauchyGreenStrain is not implemented in SmallStrainUMAT2DInterfaceLaw" << std::endl;
 }
 
-//----------------------------------------------------------------------------------------
-Vector& SmallStrainUMAT2DInterfaceLaw::
-   GetValue( const Variable<Vector> &rThisVariable,
-             Vector &rValue )
+Vector& SmallStrainUMAT2DInterfaceLaw::GetValue(const Variable<Vector> &rThisVariable,
+                                                Vector &rValue)
 {
-   // KRATOS_INFO("0-SmallStrainUMAT2DInterfaceLaw::GetValue()") << std::endl;
+    if (rThisVariable == STATE_VARIABLES) {
+       SmallStrainUMAT3DLaw::GetValue(rThisVariable, rValue );
+    } else if (rThisVariable == CAUCHY_STRESS_VECTOR) {
+        if (rValue.size() != VoigtSize) rValue.resize(VoigtSize);
 
-   if (rThisVariable == STATE_VARIABLES)
-   {
-      SmallStrainUMAT3DLaw::GetValue(rThisVariable, rValue );
-   }
-   else if (rThisVariable == CAUCHY_STRESS_VECTOR)
-   {
-      if (rValue.size() != VoigtSize)
-         rValue.resize(VoigtSize);
-
-      rValue[INDEX_2D_INTERFACE_ZZ] = mStressVectorFinalized[INDEX_3D_ZZ];
-      rValue[INDEX_2D_INTERFACE_XZ] = mStressVectorFinalized[INDEX_3D_XZ];
-
-   }
-
-   // KRATOS_INFO("1-SmallStrainUMAT2DInterfaceLaw::GetValue()") << std::endl;
-
+        rValue[INDEX_2D_INTERFACE_ZZ] = mStressVectorFinalized[INDEX_3D_ZZ];
+        rValue[INDEX_2D_INTERFACE_XZ] = mStressVectorFinalized[INDEX_3D_XZ];
+    }
     return rValue;
 }
 
-//----------------------------------------------------------------------------------------
-void SmallStrainUMAT2DInterfaceLaw::SetValue( const Variable<Vector>& rThisVariable,
-                                                const Vector& rValue,
-                                                const ProcessInfo& rCurrentProcessInfo )
+void SmallStrainUMAT2DInterfaceLaw::SetValue(const Variable<Vector>& rThisVariable,
+                                             const Vector& rValue,
+                                             const ProcessInfo& rCurrentProcessInfo)
 {
-   // KRATOS_INFO("02-SmallStrainUMAT2DInterfaceLaw::SetValue()") << std::endl;
-
-   if (rThisVariable == STATE_VARIABLES)
-   {
-      SmallStrainUMAT3DLaw::SetValue(rThisVariable, rValue, rCurrentProcessInfo );
-   }
-   else if (rThisVariable == CAUCHY_STRESS_VECTOR)
-   {
-      if (rValue.size() == VoigtSize) 
-      {
-         this->SetInternalStressVector(rValue);
-      }
-   }
-
-   // KRATOS_INFO("12-SmallStrainUMAT2DInterfaceLaw::SetValue()") << std::endl;
+    if (rThisVariable == STATE_VARIABLES) {
+        SmallStrainUMAT3DLaw::SetValue(rThisVariable, rValue, rCurrentProcessInfo );
+    } else if ((rThisVariable == CAUCHY_STRESS_VECTOR) &&
+               (rValue.size() == VoigtSize)) {
+        this->SetInternalStressVector(rValue);
+    }
 }
 
-} // Namespace Kratos
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_interface_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_interface_law.hpp
@@ -10,13 +10,10 @@
 //  Main authors:    Vahid Galavi
 //
 
-#if !defined(KRATOS_SMALL_STRAIN_UMAT_2D_INTERFACE_LAW_H_INCLUDED )
-#define  KRATOS_SMALL_STRAIN_UMAT_2D_INTERFACE_LAW_H_INCLUDED
+#pragma once
 
 // System includes
 #include "includes/define.h"
-
-// External includes
 
 // Project includes
 #include "small_strain_umat_3D_law.hpp"
@@ -71,37 +68,17 @@ namespace Kratos
       //@name Life Cycle
       //@{
 
-      //----------------------------------------------------------------------------------------
-      /**
-       * @brief Default constructor.
-       */
-      SmallStrainUMAT2DInterfaceLaw();
-
       /**
        * @brief Clone method
        */
       ConstitutiveLaw::Pointer Clone() const override;
 
-      /**
-       * Copy constructor.
-       */
-      SmallStrainUMAT2DInterfaceLaw(SmallStrainUMAT2DInterfaceLaw const& rOther);
-
-      /**
-       * @brief Destructor.
-       */
-      virtual ~SmallStrainUMAT2DInterfaceLaw();
-
-      // Assignment operator:
-      SmallStrainUMAT2DInterfaceLaw& operator=(SmallStrainUMAT2DInterfaceLaw const& rOther);
-
       Vector& GetValue( const Variable<Vector> &rThisVariable, Vector &rValue ) override;
 
-      void SetValue( const Variable<Vector>& rVariable,
-                     const Vector& rValue,
-                     const ProcessInfo& rCurrentProcessInfo ) override;
+      void SetValue(const Variable<Vector>& rVariable,
+                    const Vector& rValue,
+                    const ProcessInfo& rCurrentProcessInfo ) override;
 
-      //----------------------------------------------------------------------------------------
       /**
        * @brief Dimension of the law:
        */
@@ -131,7 +108,7 @@ namespace Kratos
        * returns the stress measure of this constitutive law (by default 1st Piola-Kirchhoff stress in voigt notation)
        * @return the expected stress measure
        */
-      virtual StressMeasure GetStressMeasure() override
+      StressMeasure GetStressMeasure() override
       {
          return StressMeasure_Cauchy;
       }
@@ -154,30 +131,26 @@ namespace Kratos
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override
+      std::string Info() const override
       {
-         std::stringstream buffer;
-         buffer << "SmallStrainUMAT2DInterfaceLaw";
-         return buffer.str();
+         return "SmallStrainUMAT2DInterfaceLaw";
       }
 
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override
+      void PrintInfo(std::ostream& rOStream) const override
       {
-         rOStream << "SmallStrainUMAT2DInterfaceLaw";
+         rOStream << Info();
       }
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override
+      void PrintData(std::ostream& rOStream) const override
       {
          rOStream << "SmallStrainUMAT2DInterfaceLaw Data";
       }
 
-
       ///@}
       ///@name Friends
       ///@{
-
 
       ///@}
 
@@ -207,16 +180,13 @@ namespace Kratos
       void SetInternalStrainVector(const Vector& rStrainVector) override;
       void CopyConstitutiveMatrix(ConstitutiveLaw::Parameters &rValues, Matrix& rConstitutiveMatrix) override;
 
-
       ///@}
       ///@name Protected Inquiry
       ///@{
 
-
       ///@}
       ///@name Protected LifeCycle
       ///@{
-
 
       ///@}
 
@@ -244,19 +214,17 @@ namespace Kratos
       ///@name Private  Access
       ///@{
 
-
-
       ///@}
       ///@name Serialization
       ///@{
       friend class Serializer;
 
-      virtual void save(Serializer& rSerializer) const override
+      void save(Serializer& rSerializer) const override
       {
          KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, ConstitutiveLaw)
       }
 
-      virtual void load(Serializer& rSerializer) override
+      void load(Serializer& rSerializer) override
       {
          KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, ConstitutiveLaw)
       }
@@ -264,7 +232,6 @@ namespace Kratos
       ///@}
       ///@name Private Inquiry
       ///@{
-
 
       ///@}
       ///@name Un accessible methods
@@ -279,7 +246,6 @@ namespace Kratos
    ///@name Type Definitions
    ///@{
 
-
    ///@}
    ///@name Input and output
    ///@{
@@ -288,8 +254,4 @@ namespace Kratos
 
    ///@} addtogroup block
 
-}  // namespace Kratos.
-
-#endif // KRATOS_SMALL_STRAIN_UMAT_2D_INTERFACE_LAW_H_INCLUDED  defined
-
-
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_plane_strain_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_plane_strain_law.cpp
@@ -10,41 +10,11 @@
 //  Main authors:    Vahid Galavi
 //
 
-// System includes
-
-// External includes
-
 #include "custom_constitutive/small_strain_umat_2D_plane_strain_law.hpp"
 
 
 namespace Kratos
 {
-
-//******************************CONSTRUCTOR*******************************************
-//************************************************************************************
-
-SmallStrainUMAT2DPlaneStrainLaw::SmallStrainUMAT2DPlaneStrainLaw()
-   : SmallStrainUMAT3DLaw()
-   {
-    KRATOS_TRY
-
-    KRATOS_CATCH("")
-
-   }
-
-//******************************COPY CONSTRUCTOR**************************************
-//************************************************************************************
-SmallStrainUMAT2DPlaneStrainLaw::
-   SmallStrainUMAT2DPlaneStrainLaw(const SmallStrainUMAT2DPlaneStrainLaw &rOther)
-   : SmallStrainUMAT3DLaw(rOther)
-{
-   KRATOS_TRY
-
-   KRATOS_CATCH("")
-}
-
-//********************************CLONE***********************************************
-//************************************************************************************
 
 ConstitutiveLaw::Pointer SmallStrainUMAT2DPlaneStrainLaw::Clone() const
 {
@@ -55,31 +25,7 @@ ConstitutiveLaw::Pointer SmallStrainUMAT2DPlaneStrainLaw::Clone() const
    KRATOS_CATCH("")
 }
 
-//********************************ASSIGNMENT******************************************
-//************************************************************************************
-SmallStrainUMAT2DPlaneStrainLaw 
-  &SmallStrainUMAT2DPlaneStrainLaw::operator=(SmallStrainUMAT2DPlaneStrainLaw const &rOther)
-{
-   KRATOS_TRY
-
-   SmallStrainUMAT3DLaw::operator=(rOther);
-
-   return *this;
-
-   KRATOS_CATCH("")
-}
-
-//*******************************DESTRUCTOR*******************************************
-//************************************************************************************
-
-SmallStrainUMAT2DPlaneStrainLaw::~SmallStrainUMAT2DPlaneStrainLaw() {}
-
-
-//************************************************************************************
-//************************************************************************************
-
-void SmallStrainUMAT2DPlaneStrainLaw::
-   UpdateInternalDeltaStrainVector(ConstitutiveLaw::Parameters &rValues)
+void SmallStrainUMAT2DPlaneStrainLaw::UpdateInternalDeltaStrainVector(ConstitutiveLaw::Parameters &rValues)
 {
    const Vector& rStrainVector = rValues.GetStrainVector();
 
@@ -89,140 +35,94 @@ void SmallStrainUMAT2DPlaneStrainLaw::
 
 }
 
-void SmallStrainUMAT2DPlaneStrainLaw::
-   SetExternalStressVector(Vector& rStressVector)
+void SmallStrainUMAT2DPlaneStrainLaw::SetExternalStressVector(Vector& rStressVector)
 {
    KRATOS_TRY
+   std::copy_n(mStressVector.begin(), VoigtSize, rStressVector.begin());
+   KRATOS_CATCH("")
+}
 
-   for (unsigned int i = 0; i < VoigtSize; ++i) {
-      rStressVector(i) = mStressVector[i];
-   }
+void SmallStrainUMAT2DPlaneStrainLaw::SetInternalStressVector(const Vector& rStressVector)
+{
+   KRATOS_TRY
+   std::copy_n(rStressVector.begin(), VoigtSize, mStressVectorFinalized.begin());
+   KRATOS_CATCH("")
+}
+
+void SmallStrainUMAT2DPlaneStrainLaw::SetInternalStrainVector(const Vector& rStrainVector)
+{
+   KRATOS_TRY
+   std::copy_n(rStrainVector.begin(), VoigtSize, mStrainVectorFinalized.begin());
+   KRATOS_CATCH("")
+}
+
+void SmallStrainUMAT2DPlaneStrainLaw::CopyConstitutiveMatrix(ConstitutiveLaw::Parameters &rValues,
+                                                             Matrix& rConstitutiveMatrix)
+{
+    KRATOS_TRY
+
+    if (rValues.GetMaterialProperties()[IS_FORTRAN_UDSM]) {
+        // transfer fortran style matrix to C++ style
+        for (unsigned int i = 0; i < VoigtSize; i++) {
+            for (unsigned int j = 0; j < VoigtSize; j++) {
+                 rConstitutiveMatrix(i,j) = mMatrixD[j][i];
+            }
+        }
+    } else {
+        for (unsigned int i = 0; i < VoigtSize; i++) {
+            for (unsigned int j = 0; j < VoigtSize; j++) {
+                rConstitutiveMatrix(i,j) = mMatrixD[i][j];
+            }
+        }
+    }
 
    KRATOS_CATCH("")
 }
 
-void SmallStrainUMAT2DPlaneStrainLaw::
-   SetInternalStressVector(const Vector& rStressVector)
+void SmallStrainUMAT2DPlaneStrainLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues,
+                                                                 Vector& rStrainVector)
 {
-   KRATOS_TRY
+    //1.-Compute total deformation gradient
+    const Matrix& F = rValues.GetDeformationGradientF();
 
-   for (unsigned int i = 0; i < VoigtSize; ++i) {
-      mStressVectorFinalized[i] = rStressVector(i);
-   }
+    // for shells/membranes in case the DeformationGradient is of size 3x3
+    BoundedMatrix<double, 2, 2> F2x2;
+    for (unsigned int i = 0; i<2; ++i)
+        for (unsigned int j = 0; j<2; ++j)
+            F2x2(i, j) = F(i, j);
 
-   KRATOS_CATCH("")
+    Matrix E_tensor = prod(trans(F2x2), F2x2);
+    for (unsigned int i = 0; i<2; ++i)
+        E_tensor(i, i) -= 1.0;
+    E_tensor *= 0.5;
+
+    noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
 }
 
-void SmallStrainUMAT2DPlaneStrainLaw::
-   SetInternalStrainVector(const Vector& rStrainVector)
+Vector& SmallStrainUMAT2DPlaneStrainLaw::GetValue(const Variable<Vector> &rThisVariable,
+                                                  Vector &rValue)
 {
-   KRATOS_TRY
-
-   for (unsigned int i = 0; i < VoigtSize; ++i) {
-      mStrainVectorFinalized[i] = rStrainVector(i);
-   }
-
-   KRATOS_CATCH("")
-}
-
-void SmallStrainUMAT2DPlaneStrainLaw::
-   CopyConstitutiveMatrix( ConstitutiveLaw::Parameters &rValues,
-                           Matrix& rConstitutiveMatrix )
-{
-   KRATOS_TRY
-
-   if (rValues.GetMaterialProperties()[IS_FORTRAN_UDSM])
-   {
-      // transfer fortran style matrix to C++ style
-      for (unsigned int i = 0; i < VoigtSize; i++) {
-         for (unsigned int j = 0; j < VoigtSize; j++) {
-            rConstitutiveMatrix(i,j) = mMatrixD[j][i];
-         }
-      }
-   }
-   else
-   {
-      for (unsigned int i = 0; i < VoigtSize; i++) {
-         for (unsigned int j = 0; j < VoigtSize; j++) {
-            rConstitutiveMatrix(i,j) = mMatrixD[i][j];
-         }
-      }
-   }
-
-   KRATOS_CATCH("")
-}
-
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-void SmallStrainUMAT2DPlaneStrainLaw::
-   CalculateCauchyGreenStrain( ConstitutiveLaw::Parameters& rValues,
-                               Vector& rStrainVector )
-{
-   //1.-Compute total deformation gradient
-   const Matrix& F = rValues.GetDeformationGradientF();
-
-   // for shells/membranes in case the DeformationGradient is of size 3x3
-   BoundedMatrix<double, 2, 2> F2x2;
-   for (unsigned int i = 0; i<2; ++i)
-      for (unsigned int j = 0; j<2; ++j)
-         F2x2(i, j) = F(i, j);
-
-   Matrix E_tensor = prod(trans(F2x2), F2x2);
-
-   for (unsigned int i = 0; i<2; ++i)
-      E_tensor(i, i) -= 1.0;
-
-   E_tensor *= 0.5;
-   noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
-}
-
-//----------------------------------------------------------------------------------------
-Vector& SmallStrainUMAT2DPlaneStrainLaw::
-   GetValue( const Variable<Vector> &rThisVariable,
-             Vector &rValue )
-{
-   // KRATOS_INFO("0-SmallStrainUMAT2DPlaneStrainLaw::GetValue()") << std::endl;
-
-   if (rThisVariable == STATE_VARIABLES) {
-      SmallStrainUMAT3DLaw::GetValue(rThisVariable, rValue );
-   }
-   else if (rThisVariable == CAUCHY_STRESS_VECTOR) {
-      if (rValue.size() != VoigtSize)
-         rValue.resize(VoigtSize);
-
-      for (unsigned int i = 0; i < VoigtSize; ++i) {
-         rValue[i] = mStressVectorFinalized[i];
-      }
-   }
-
-   // KRATOS_INFO("1-SmallStrainUMAT2DPlaneStrainLaw::GetValue()") << std::endl;
-
+    if (rThisVariable == STATE_VARIABLES) {
+        SmallStrainUMAT3DLaw::GetValue(rThisVariable, rValue );
+    } else if (rThisVariable == CAUCHY_STRESS_VECTOR) {
+        if (rValue.size() != VoigtSize) rValue.resize(VoigtSize);
+        for (unsigned int i = 0; i < VoigtSize; ++i) {
+            rValue[i] = mStressVectorFinalized[i];
+        }
+    }
     return rValue;
 }
 
-//----------------------------------------------------------------------------------------
-void SmallStrainUMAT2DPlaneStrainLaw::
-   SetValue( const Variable<Vector>& rThisVariable,
-             const Vector& rValue,
-             const ProcessInfo& rCurrentProcessInfo )
+void SmallStrainUMAT2DPlaneStrainLaw::SetValue(const Variable<Vector>& rThisVariable,
+                                               const Vector& rValue,
+                                               const ProcessInfo& rCurrentProcessInfo)
 {
-   // KRATOS_INFO("02-SmallStrainUMAT2DPlaneStrainLaw::SetValue()") << std::endl;
-
-   if (rThisVariable == STATE_VARIABLES)
-   {
-      SmallStrainUMAT3DLaw::SetValue(rThisVariable, rValue, rCurrentProcessInfo );
-   }
-   else if (rThisVariable == CAUCHY_STRESS_VECTOR)
-   {
-      if (rValue.size() == VoigtSize) 
-      {
-         this->SetInternalStressVector(rValue);
-      }
-   }
-
-   // KRATOS_INFO("12-SmallStrainUMAT2DPlaneStrainLaw::SetValue()") << std::endl;
+    if (rThisVariable == STATE_VARIABLES) {
+        SmallStrainUMAT3DLaw::SetValue(rThisVariable, rValue, rCurrentProcessInfo );
+    } else if ((rThisVariable == CAUCHY_STRESS_VECTOR) &&
+               (rValue.size() == VoigtSize)) {
+        this->SetInternalStressVector(rValue);
+    }
 }
 
-} // Namespace Kratos
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_plane_strain_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_2D_plane_strain_law.hpp
@@ -10,13 +10,10 @@
 //  Main authors:    Vahid Galavi
 //
 
-#if !defined(KRATOS_SMALL_STRAIN_UMAT_2D_PLANE_STRAIN_LAW_H_INCLUDED )
-#define  KRATOS_SMALL_STRAIN_UMAT_2D_PLANE_STRAIN_LAW_H_INCLUDED
+#pragma once
 
 // System includes
 #include "includes/define.h"
-
-// External includes
 
 // Project includes
 #include "small_strain_umat_3D_law.hpp"
@@ -66,42 +63,21 @@ namespace Kratos
       /// Pointer definition of SmallStrainUMAT2DPlaneStrainLaw
       KRATOS_CLASS_POINTER_DEFINITION( SmallStrainUMAT2DPlaneStrainLaw );
 
-
       //@}
       //@name Life Cycle
       //@{
-
-      //----------------------------------------------------------------------------------------
-      /**
-       * @brief Default constructor.
-       */
-      SmallStrainUMAT2DPlaneStrainLaw();
 
       /**
        * @brief Clone method
        */
       ConstitutiveLaw::Pointer Clone() const override;
 
-      /**
-       * Copy constructor.
-       */
-      SmallStrainUMAT2DPlaneStrainLaw(SmallStrainUMAT2DPlaneStrainLaw const& rOther);
+      Vector& GetValue(const Variable<Vector> &rThisVariable, Vector &rValue) override;
 
-      /**
-       * @brief Destructor.
-       */
-      virtual ~SmallStrainUMAT2DPlaneStrainLaw();
+      void SetValue(const Variable<Vector>& rVariable,
+                    const Vector& rValue,
+                    const ProcessInfo& rCurrentProcessInfo) override;
 
-      // Assignment operator:
-      SmallStrainUMAT2DPlaneStrainLaw& operator=(SmallStrainUMAT2DPlaneStrainLaw const& rOther);
-
-      Vector& GetValue( const Variable<Vector> &rThisVariable, Vector &rValue ) override;
-
-      void SetValue( const Variable<Vector>& rVariable,
-                     const Vector& rValue,
-                     const ProcessInfo& rCurrentProcessInfo ) override;
-
-      //----------------------------------------------------------------------------------------
       /**
        * @brief Dimension of the law:
        */
@@ -131,11 +107,10 @@ namespace Kratos
        * returns the stress measure of this constitutive law (by default 1st Piola-Kirchhoff stress in voigt notation)
        * @return the expected stress measure
        */
-      virtual StressMeasure GetStressMeasure() override
+      StressMeasure GetStressMeasure() override
       {
          return StressMeasure_Cauchy;
       }
-
 
       /**
        * @brief It calculates the strain vector
@@ -148,36 +123,31 @@ namespace Kratos
       ///@name Inquiry
       ///@{
 
-
       ///@}
       ///@name Input and output
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override
+      std::string Info() const override
       {
-         std::stringstream buffer;
-         buffer << "SmallStrainUMAT2DPlaneStrainLaw";
-         return buffer.str();
+         return "SmallStrainUMAT2DPlaneStrainLaw";
       }
 
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override
+      void PrintInfo(std::ostream& rOStream) const override
       {
-         rOStream << "SmallStrainUMAT2DPlaneStrainLaw";
+         rOStream << Info();
       }
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override
+      void PrintData(std::ostream& rOStream) const override
       {
          rOStream << "SmallStrainUMAT2DPlaneStrainLaw Data";
       }
 
-
       ///@}
       ///@name Friends
       ///@{
-
 
       ///@}
 
@@ -193,7 +163,6 @@ namespace Kratos
       ///@name Protected Operators
       ///@{
 
-
       ///@}
       ///@name Protected Operations
       ///@{
@@ -207,16 +176,13 @@ namespace Kratos
       void SetInternalStrainVector(const Vector& rStrainVector) override;
       void CopyConstitutiveMatrix(ConstitutiveLaw::Parameters &rValues, Matrix& rConstitutiveMatrix) override;
 
-
       ///@}
       ///@name Protected Inquiry
       ///@{
 
-
       ///@}
       ///@name Protected LifeCycle
       ///@{
-
 
       ///@}
 
@@ -232,29 +198,25 @@ namespace Kratos
       ///@name Private Operators
       ///@{
 
-
       ///@}
       ///@name Private Operations
       ///@{
 
-
       ///@}
       ///@name Private  Access
       ///@{
-
-
 
       ///@}
       ///@name Serialization
       ///@{
       friend class Serializer;
 
-      virtual void save(Serializer& rSerializer) const override
+      void save(Serializer& rSerializer) const override
       {
          KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, ConstitutiveLaw)
       }
 
-      virtual void load(Serializer& rSerializer) override
+      void load(Serializer& rSerializer) override
       {
          KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, ConstitutiveLaw)
       }
@@ -262,7 +224,6 @@ namespace Kratos
       ///@}
       ///@name Private Inquiry
       ///@{
-
 
       ///@}
       ///@name Un accessible methods
@@ -286,8 +247,4 @@ namespace Kratos
 
    ///@} addtogroup block
 
-}  // namespace Kratos.
-
-#endif // KRATOS_SMALL_STRAIN_UMAT_2D_PLANE_STRAIN_LAW_H_INCLUDED  defined
-
-
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_interface_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_interface_law.cpp
@@ -10,81 +10,17 @@
 //  Main authors:    Vahid Galavi
 //
 
-// System includes
-
-// External includes
-
 #include "custom_constitutive/small_strain_umat_3D_interface_law.hpp"
-
 
 namespace Kratos
 {
 
-//******************************CONSTRUCTOR*******************************************
-//************************************************************************************
-
-SmallStrainUMAT3DInterfaceLaw::SmallStrainUMAT3DInterfaceLaw()
-   : SmallStrainUMAT3DLaw()
-   {
-    KRATOS_TRY
-    //KRATOS_INFO("SmallStrainUMAT3DInterfaceLaw()") << std::endl;
-
-    KRATOS_CATCH("")
-
-   }
-
-//******************************COPY CONSTRUCTOR**************************************
-//************************************************************************************
-SmallStrainUMAT3DInterfaceLaw::
-   SmallStrainUMAT3DInterfaceLaw(const SmallStrainUMAT3DInterfaceLaw &rOther)
-   : SmallStrainUMAT3DLaw(rOther)
-{
-   KRATOS_TRY
-   //KRATOS_INFO("SmallStrainUMAT3DInterfaceLaw(const...)") << std::endl;
-
-   KRATOS_CATCH("")
-}
-
-//********************************CLONE***********************************************
-//************************************************************************************
-
 ConstitutiveLaw::Pointer SmallStrainUMAT3DInterfaceLaw::Clone() const
 {
-   KRATOS_TRY
-   //KRATOS_INFO("Clone()") << std::endl;
-
-   return Kratos::make_shared<SmallStrainUMAT3DInterfaceLaw>(*this);
-
-   KRATOS_CATCH("")
+    KRATOS_TRY
+    return Kratos::make_shared<SmallStrainUMAT3DInterfaceLaw>(*this);
+    KRATOS_CATCH("")
 }
-
-//********************************ASSIGNMENT******************************************
-//************************************************************************************
-SmallStrainUMAT3DInterfaceLaw 
-  &SmallStrainUMAT3DInterfaceLaw::operator=(SmallStrainUMAT3DInterfaceLaw const &rOther)
-{
-   KRATOS_TRY
-
-   SmallStrainUMAT3DLaw::operator=(rOther);
-
-   //KRATOS_INFO("operator=") << std::endl;
-
-   return *this;
-
-   KRATOS_CATCH("")
-}
-
-//*******************************DESTRUCTOR*******************************************
-//************************************************************************************
-
-SmallStrainUMAT3DInterfaceLaw::~SmallStrainUMAT3DInterfaceLaw()
-{
-   //KRATOS_INFO("~SmallStrainUMAT3DLaw()") << std::endl;
-}
-
-
-//************************************************************************************
-//************************************************************************************
 
 void SmallStrainUMAT3DInterfaceLaw::UpdateInternalDeltaStrainVector(ConstitutiveLaw::Parameters &rValues)
 {
@@ -93,22 +29,17 @@ void SmallStrainUMAT3DInterfaceLaw::UpdateInternalDeltaStrainVector(Constitutive
    mDeltaStrainVector[INDEX_3D_ZZ] = rStrainVector(INDEX_3D_INTERFACE_ZZ) - mStrainVectorFinalized[INDEX_3D_ZZ];
    mDeltaStrainVector[INDEX_3D_YZ] = rStrainVector(INDEX_3D_INTERFACE_YZ) - mStrainVectorFinalized[INDEX_3D_YZ];
    mDeltaStrainVector[INDEX_3D_XZ] = rStrainVector(INDEX_3D_INTERFACE_XZ) - mStrainVectorFinalized[INDEX_3D_XZ];
-
 }
 
 void SmallStrainUMAT3DInterfaceLaw::SetExternalStressVector(Vector& rStressVector)
 {
-   //KRATOS_INFO("mStressVector") << mStressVector << std::endl;
-
    rStressVector(INDEX_3D_INTERFACE_ZZ) = mStressVector[INDEX_3D_ZZ];
    rStressVector(INDEX_3D_INTERFACE_YZ) = mStressVector[INDEX_3D_YZ];
    rStressVector(INDEX_3D_INTERFACE_XZ) = mStressVector[INDEX_3D_XZ];
 }
 
-
 void SmallStrainUMAT3DInterfaceLaw::SetInternalStressVector(const Vector& rStressVector)
 {
-   // KRATOS_INFO("SetInternalStressVector:rStressVector") << rStressVector << std::endl;
    KRATOS_TRY
    std::fill(mStressVectorFinalized.begin(), mStressVectorFinalized.end(), 0.0);
 
@@ -120,36 +51,30 @@ void SmallStrainUMAT3DInterfaceLaw::SetInternalStressVector(const Vector& rStres
 
 void SmallStrainUMAT3DInterfaceLaw::SetInternalStrainVector(const Vector& rStrainVector)
 {
-   // KRATOS_INFO("SetInternalStrainVector:rStrainVector") << rStrainVector << std::endl;
    std::fill(mStrainVectorFinalized.begin(), mStrainVectorFinalized.end(), 0.0);
 
    mStrainVectorFinalized[INDEX_3D_ZZ] = rStrainVector(INDEX_3D_INTERFACE_ZZ);
    mStrainVectorFinalized[INDEX_3D_YZ] = rStrainVector(INDEX_3D_INTERFACE_YZ);
    mStrainVectorFinalized[INDEX_3D_XZ] = rStrainVector(INDEX_3D_INTERFACE_XZ);
-
 }
-
 
 void SmallStrainUMAT3DInterfaceLaw::CopyConstitutiveMatrix( ConstitutiveLaw::Parameters &rValues,
                                                             Matrix& rConstitutiveMatrix )
 {
-   if (rValues.GetMaterialProperties()[IS_FORTRAN_UDSM])
-   {
-      // transfer fortran style matrix to C++ style
-      for (unsigned int i = 0; i < VoigtSize; i++) {
-         for (unsigned int j = 0; j < VoigtSize; j++) {
-            rConstitutiveMatrix(i,j) = mMatrixD[getIndex3D(static_cast<indexStress3DInterface>(j))][getIndex3D(static_cast<indexStress3DInterface>(i))];
-         }
-      }
-   }
-   else
-   {
-      for (unsigned int i = 0; i < VoigtSize; i++) {
-         for (unsigned int j = 0; j < VoigtSize; j++) {
-            rConstitutiveMatrix(i,j) = mMatrixD[getIndex3D(static_cast<indexStress3DInterface>(i))][getIndex3D(static_cast<indexStress3DInterface>(j))];
-         }
-      }
-   }
+    if (rValues.GetMaterialProperties()[IS_FORTRAN_UDSM]) {
+        // transfer fortran style matrix to C++ style
+        for (unsigned int i = 0; i < VoigtSize; i++) {
+            for (unsigned int j = 0; j < VoigtSize; j++) {
+                rConstitutiveMatrix(i,j) = mMatrixD[getIndex3D(static_cast<indexStress3DInterface>(j))][getIndex3D(static_cast<indexStress3DInterface>(i))];
+            }
+        }
+    } else {
+       for (unsigned int i = 0; i < VoigtSize; i++) {
+           for (unsigned int j = 0; j < VoigtSize; j++) {
+               rConstitutiveMatrix(i,j) = mMatrixD[getIndex3D(static_cast<indexStress3DInterface>(i))][getIndex3D(static_cast<indexStress3DInterface>(j))];
+           }
+       }
+    }
 }
 
 indexStress3D SmallStrainUMAT3DInterfaceLaw::getIndex3D(indexStress3DInterface index3D)
@@ -167,63 +92,37 @@ indexStress3D SmallStrainUMAT3DInterfaceLaw::getIndex3D(indexStress3DInterface i
    }
 }
 
-/***********************************************************************************/
-/***********************************************************************************/
-
-void SmallStrainUMAT3DInterfaceLaw::
-   CalculateCauchyGreenStrain( ConstitutiveLaw::Parameters& rValues,
-                               Vector& rStrainVector )
+void SmallStrainUMAT3DInterfaceLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues,
+                                                               Vector& rStrainVector)
 {
    KRATOS_ERROR << "CalculateCauchyGreenStrain is not implemented in SmallStrainUMAT3DInterfaceLaw" << std::endl;
 }
 
-//----------------------------------------------------------------------------------------
-Vector& SmallStrainUMAT3DInterfaceLaw::
-   GetValue( const Variable<Vector> &rThisVariable,
-             Vector &rValue )
+Vector& SmallStrainUMAT3DInterfaceLaw::GetValue(const Variable<Vector> &rThisVariable,
+                                                Vector &rValue)
 {
-   // KRATOS_INFO("0-SmallStrainUMAT3DInterfaceLaw::GetValue()") << std::endl;
+    if (rThisVariable == STATE_VARIABLES) {
+        SmallStrainUMAT3DLaw::GetValue(rThisVariable, rValue );
+    } else if (rThisVariable == CAUCHY_STRESS_VECTOR) {
+         if (rValue.size() != VoigtSize) rValue.resize(VoigtSize);
 
-   if (rThisVariable == STATE_VARIABLES)
-   {
-      SmallStrainUMAT3DLaw::GetValue(rThisVariable, rValue );
+         rValue[INDEX_3D_INTERFACE_ZZ] = mStressVectorFinalized[INDEX_3D_ZZ];
+         rValue[INDEX_3D_INTERFACE_YZ] = mStressVectorFinalized[INDEX_3D_YZ];
+         rValue[INDEX_3D_INTERFACE_XZ] = mStressVectorFinalized[INDEX_3D_XZ];
    }
-   else if (rThisVariable == CAUCHY_STRESS_VECTOR)
-   {
-      if (rValue.size() != VoigtSize)
-         rValue.resize(VoigtSize);
-
-      rValue[INDEX_3D_INTERFACE_ZZ] = mStressVectorFinalized[INDEX_3D_ZZ];
-      rValue[INDEX_3D_INTERFACE_YZ] = mStressVectorFinalized[INDEX_3D_YZ];
-      rValue[INDEX_3D_INTERFACE_XZ] = mStressVectorFinalized[INDEX_3D_XZ];
-
-   }
-
-   // KRATOS_INFO("1-SmallStrainUMAT3DInterfaceLaw::GetValue()") << std::endl;
-
     return rValue;
 }
 
-//----------------------------------------------------------------------------------------
-void SmallStrainUMAT3DInterfaceLaw::SetValue( const Variable<Vector>& rThisVariable,
-                                                const Vector& rValue,
-                                                const ProcessInfo& rCurrentProcessInfo )
+void SmallStrainUMAT3DInterfaceLaw::SetValue(const Variable<Vector>& rThisVariable,
+                                             const Vector& rValue,
+                                             const ProcessInfo& rCurrentProcessInfo)
 {
-   // KRATOS_INFO("02-SmallStrainUMAT3DInterfaceLaw::SetValue()") << std::endl;
-
-   if (rThisVariable == STATE_VARIABLES)
-   {
-      SmallStrainUMAT3DLaw::SetValue(rThisVariable, rValue, rCurrentProcessInfo );
-   }
-   else if (rThisVariable == CAUCHY_STRESS_VECTOR)
-   {
-      if (rValue.size() == VoigtSize) 
-      {
-         this->SetInternalStressVector(rValue);
-      }
-   }
-
-   // KRATOS_INFO("12-SmallStrainUMAT3DInterfaceLaw::SetValue()") << std::endl;
+    if (rThisVariable == STATE_VARIABLES) {
+        SmallStrainUMAT3DLaw::SetValue(rThisVariable, rValue, rCurrentProcessInfo );
+    } else if ((rThisVariable == CAUCHY_STRESS_VECTOR) &&
+               (rValue.size() == VoigtSize)){
+        this->SetInternalStressVector(rValue);
+    }
 }
 
-} // Namespace Kratos
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_interface_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_interface_law.hpp
@@ -10,13 +10,10 @@
 //  Main authors:    Vahid Galavi
 //
 
-#if !defined(KRATOS_SMALL_STRAIN_UMAT_3D_INTERFACE_LAW_H_INCLUDED )
-#define  KRATOS_SMALL_STRAIN_UMAT_3D_INTERFACE_LAW_H_INCLUDED
+#pragma once
 
 // System includes
 #include "includes/define.h"
-
-// External includes
 
 // Project includes
 #include "small_strain_umat_3D_law.hpp"
@@ -69,42 +66,21 @@ namespace Kratos
       /// Pointer definition of SmallStrainUMAT3DInterfaceLaw
       KRATOS_CLASS_POINTER_DEFINITION( SmallStrainUMAT3DInterfaceLaw );
 
-
       //@}
       //@name Life Cycle
       //@{
-
-      //----------------------------------------------------------------------------------------
-      /**
-       * @brief Default constructor.
-       */
-      SmallStrainUMAT3DInterfaceLaw();
 
       /**
        * @brief Clone method
        */
       ConstitutiveLaw::Pointer Clone() const override;
 
-      /**
-       * Copy constructor.
-       */
-      SmallStrainUMAT3DInterfaceLaw(SmallStrainUMAT3DInterfaceLaw const& rOther);
+      Vector& GetValue(const Variable<Vector> &rThisVariable, Vector &rValue) override;
 
-      /**
-       * @brief Destructor.
-       */
-      virtual ~SmallStrainUMAT3DInterfaceLaw();
+      void SetValue(const Variable<Vector>& rVariable,
+                    const Vector& rValue,
+                    const ProcessInfo& rCurrentProcessInfo) override;
 
-      // Assignment operator:
-      SmallStrainUMAT3DInterfaceLaw& operator=(SmallStrainUMAT3DInterfaceLaw const& rOther);
-
-      Vector& GetValue( const Variable<Vector> &rThisVariable, Vector &rValue ) override;
-
-      void SetValue( const Variable<Vector>& rVariable,
-                     const Vector& rValue,
-                     const ProcessInfo& rCurrentProcessInfo ) override;
-
-      //----------------------------------------------------------------------------------------
       /**
        * @brief Dimension of the law:
        */
@@ -134,7 +110,7 @@ namespace Kratos
        * returns the stress measure of this constitutive law (by default 1st Piola-Kirchhoff stress in voigt notation)
        * @return the expected stress measure
        */
-      virtual StressMeasure GetStressMeasure() override
+      StressMeasure GetStressMeasure() override
       {
          return StressMeasure_Cauchy;
       }
@@ -157,21 +133,19 @@ namespace Kratos
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override
+      std::string Info() const override
       {
-         std::stringstream buffer;
-         buffer << "SmallStrainUMAT3DInterfaceLaw";
-         return buffer.str();
+         return "SmallStrainUMAT3DInterfaceLaw";
       }
 
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override
+      void PrintInfo(std::ostream& rOStream) const override
       {
-         rOStream << "SmallStrainUMAT3DInterfaceLaw";
+         rOStream << Info();
       }
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override
+      void PrintData(std::ostream& rOStream) const override
       {
          rOStream << "SmallStrainUMAT3DInterfaceLaw Data";
       }
@@ -254,12 +228,12 @@ namespace Kratos
       ///@{
       friend class Serializer;
 
-      virtual void save(Serializer& rSerializer) const override
+      void save(Serializer& rSerializer) const override
       {
          KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, ConstitutiveLaw)
       }
 
-      virtual void load(Serializer& rSerializer) override
+      void load(Serializer& rSerializer) override
       {
          KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, ConstitutiveLaw)
       }
@@ -291,8 +265,4 @@ namespace Kratos
 
    ///@} addtogroup block
 
-}  // namespace Kratos.
-
-#endif // KRATOS_SMALL_STRAIN_UMAT_3D_INTERFACE_LAW_H_INCLUDED  defined
-
-
+}

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_law.cpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_law.cpp
@@ -48,21 +48,7 @@ typedef void(*f_UMATMod) (double* STRESS, double* STATEV, double** DDSDDE, doubl
                           int* kinc);
 #endif
 
-//******************************CONSTRUCTOR*******************************************
-//************************************************************************************
-
-SmallStrainUMAT3DLaw::SmallStrainUMAT3DLaw()
-   : ConstitutiveLaw()
-   {
-    KRATOS_TRY
-
-    KRATOS_CATCH("")
-
-   }
-
-//******************************COPY CONSTRUCTOR**************************************
-//************************************************************************************
-SmallStrainUMAT3DLaw::SmallStrainUMAT3DLaw(const SmallStrainUMAT3DLaw &rOther)
+SmallStrainUMAT3DLaw::SmallStrainUMAT3DLaw(const SmallStrainUMAT3DLaw& rOther)
    : ConstitutiveLaw(rOther),
      mStressVector(rOther.mStressVector),
      mStressVectorFinalized(rOther.mStressVectorFinalized),
@@ -83,9 +69,6 @@ SmallStrainUMAT3DLaw::SmallStrainUMAT3DLaw(const SmallStrainUMAT3DLaw &rOther)
    KRATOS_CATCH("")
 }
 
-//********************************CLONE***********************************************
-//************************************************************************************
-
 ConstitutiveLaw::Pointer SmallStrainUMAT3DLaw::Clone() const
 {
    KRATOS_TRY
@@ -95,9 +78,7 @@ ConstitutiveLaw::Pointer SmallStrainUMAT3DLaw::Clone() const
    KRATOS_CATCH("")
 }
 
-//********************************ASSIGNMENT******************************************
-//************************************************************************************
-SmallStrainUMAT3DLaw &SmallStrainUMAT3DLaw::operator=(SmallStrainUMAT3DLaw const &rOther)
+SmallStrainUMAT3DLaw& SmallStrainUMAT3DLaw::operator=(const SmallStrainUMAT3DLaw& rOther)
 {
    KRATOS_TRY
 
@@ -120,14 +101,6 @@ SmallStrainUMAT3DLaw &SmallStrainUMAT3DLaw::operator=(SmallStrainUMAT3DLaw const
    KRATOS_CATCH("")
 }
 
-//*******************************DESTRUCTOR*******************************************
-//************************************************************************************
-
-SmallStrainUMAT3DLaw::~SmallStrainUMAT3DLaw() {}
-
-//***********************PUBLIC OPERATIONS FROM BASE CLASS****************************
-//************************************************************************************
-
 void SmallStrainUMAT3DLaw::GetLawFeatures(Features &rFeatures)
 {
    //Set the type of law
@@ -136,12 +109,11 @@ void SmallStrainUMAT3DLaw::GetLawFeatures(Features &rFeatures)
 
    rFeatures.mOptions.Set(ISOTROPIC);
 
-
-   //Set strain measure required by the consitutive law
+   //Set strain measure required by the constitutive law
    rFeatures.mStrainMeasures.push_back(StrainMeasure_Infinitesimal);
    //rFeatures.mStrainMeasures.push_back(StrainMeasure_Deformation_Gradient);
 
-   //Set the spacedimension
+   //Set the space dimension
    rFeatures.mSpaceDimension = WorkingSpaceDimension();
 
    //Set the strain size
@@ -175,13 +147,11 @@ void SmallStrainUMAT3DLaw::InitializeMaterial(const Properties &rMaterialPropert
    // we need to check if the model is loaded or not
    mIsUMATLoaded = loadUMAT(rMaterialProperties);
 
-   if (!mIsUMATLoaded) {
-      KRATOS_ERROR << "cannot load the specified UMAT" << rMaterialProperties[UDSM_NAME] << std::endl;
-   }
+   if (!mIsUMATLoaded) KRATOS_ERROR << "cannot load the specified UMAT" << rMaterialProperties[UDSM_NAME] << std::endl;
 
    ResetMaterial(rMaterialProperties, rElementGeometry, rShapeFunctionsValues);
 
-   KRATOS_CATCH(" ")
+   KRATOS_CATCH("")
 }
 
 void SmallStrainUMAT3DLaw::ResetStateVariables(const Properties& rMaterialProperties)
@@ -198,7 +168,7 @@ void SmallStrainUMAT3DLaw::ResetStateVariables(const Properties& rMaterialProper
    noalias(mStateVariables)          = StateVariables;
    noalias(mStateVariablesFinalized) = StateVariables;
 
-   KRATOS_CATCH(" ")
+   KRATOS_CATCH("")
 }
 
 
@@ -225,7 +195,7 @@ void SmallStrainUMAT3DLaw::ResetMaterial(const Properties& rMaterialProperties,
 
    mIsModelInitialized = false;
 
-   KRATOS_CATCH(" ")
+   KRATOS_CATCH("")
 }
 
 bool SmallStrainUMAT3DLaw::loadUMAT(const Properties &rMaterialProperties)
@@ -240,7 +210,7 @@ bool SmallStrainUMAT3DLaw::loadUMAT(const Properties &rMaterialProperties)
    KRATOS_ERROR << "loadUMAT is not supported yet for Mac OS applications" << std::endl;
 #endif
 
-   KRATOS_CATCH(" ")
+   KRATOS_CATCH("")
 }
 
 bool SmallStrainUMAT3DLaw::loadUMATLinux(const Properties &rMaterialProperties)
@@ -328,10 +298,6 @@ bool SmallStrainUMAT3DLaw::loadUMATWindows(const Properties &rMaterialProperties
    return false;
 #endif
 }
-
-
-//************************************************************************************
-//************************************************************************************
 
 void SmallStrainUMAT3DLaw::CalculateMaterialResponsePK1(ConstitutiveLaw::Parameters & rValues)
 {
@@ -425,8 +391,8 @@ void SmallStrainUMAT3DLaw::SetInternalStrainVector(const Vector& rStrainVector)
    }
 }
 
-void SmallStrainUMAT3DLaw::CopyConstitutiveMatrix( ConstitutiveLaw::Parameters &rValues,
-                                                   Matrix& rConstitutiveMatrix )
+void SmallStrainUMAT3DLaw::CopyConstitutiveMatrix(ConstitutiveLaw::Parameters &rValues,
+                                                  Matrix& rConstitutiveMatrix)
 {
    if (rValues.GetMaterialProperties()[IS_FORTRAN_UDSM])
    {
@@ -448,8 +414,8 @@ void SmallStrainUMAT3DLaw::CopyConstitutiveMatrix( ConstitutiveLaw::Parameters &
 }
 
 
-void SmallStrainUMAT3DLaw::CalculateConstitutiveMatrix( ConstitutiveLaw::Parameters &rValues,
-                                                        Matrix& rConstitutiveMatrix )
+void SmallStrainUMAT3DLaw::CalculateConstitutiveMatrix(ConstitutiveLaw::Parameters &rValues,
+                                                       Matrix& rConstitutiveMatrix)
 {
    KRATOS_TRY
 
@@ -463,8 +429,8 @@ void SmallStrainUMAT3DLaw::CalculateConstitutiveMatrix( ConstitutiveLaw::Paramet
    KRATOS_CATCH("")
 }
 
-void SmallStrainUMAT3DLaw::CalculateStress( ConstitutiveLaw::Parameters &rValues,
-                                            Vector& rStressVector )
+void SmallStrainUMAT3DLaw::CalculateStress(ConstitutiveLaw::Parameters &rValues,
+                                           Vector& rStressVector)
 {
    KRATOS_TRY
 
@@ -478,7 +444,7 @@ void SmallStrainUMAT3DLaw::CalculateStress( ConstitutiveLaw::Parameters &rValues
    KRATOS_CATCH("")
 }
 
-void SmallStrainUMAT3DLaw::CallUMAT( ConstitutiveLaw::Parameters &rValues)
+void SmallStrainUMAT3DLaw::CallUMAT(ConstitutiveLaw::Parameters &rValues)
 {
    KRATOS_TRY
 
@@ -503,22 +469,23 @@ void SmallStrainUMAT3DLaw::CallUMAT( ConstitutiveLaw::Parameters &rValues)
 
    int ndi = N_DIM_3D;
    int nshr = 3;
-   int ntens = VOIGT_SIZE_3D; // ??@@
+   int ntens = VOIGT_SIZE_3D;
 
 
    // stresses and state variables in the beginning of the steps needs to be given:
-   mStressVector  = mStressVectorFinalized;
+   mStressVector   = mStressVectorFinalized;
    mStateVariables = mStateVariablesFinalized;
 
-   // variable to check if an error happend in the model:
+   // variable to check if an error happened in the model:
    const auto &MaterialParameters = rValues.GetMaterialProperties()[UMAT_PARAMETERS];
    int nProperties = MaterialParameters.size();
-   pUserMod(&(mStressVector.data()[0]), &(mStateVariables.data()[0]), (double **)mMatrixD,  &SSE,   &SPD,                          &SCD,
-            NULL,                 NULL,                   NULL,                 NULL,   &(mStrainVectorFinalized.data()[0]), &(mDeltaStrainVector.data()[0]),
-            &time,                &deltaTime,             NULL,                 NULL,   NULL,                          NULL,
-            &materialName,        &ndi,                   &nshr,                &ntens, &nStateVariables,              &(MaterialParameters.data()[0]),
-            &nProperties,         NULL,                   NULL,                 NULL,   NULL,                          NULL,
-            NULL,                 &iElement,              &integrationNumber,   NULL,   NULL,                          &iStep,
+   pUserMod(&(mStressVector.data()[0]), &(mStateVariables.data()[0]), (double **) mMatrixD, &SSE, &SPD, &SCD,
+            nullptr, nullptr, nullptr, nullptr, &(mStrainVectorFinalized.data()[0]),
+            &(mDeltaStrainVector.data()[0]),
+            &time, &deltaTime, nullptr, nullptr, nullptr, nullptr,
+            &materialName, &ndi, &nshr, &ntens, &nStateVariables, &(MaterialParameters.data()[0]),
+            &nProperties, nullptr, nullptr, nullptr, nullptr, nullptr,
+            nullptr, &iElement, &integrationNumber, nullptr, nullptr, &iStep,
             &iteration);
 
    KRATOS_CATCH("")
@@ -589,18 +556,14 @@ void SmallStrainUMAT3DLaw::FinalizeMaterialResponseCauchy(ConstitutiveLaw::Param
    mStressVectorFinalized   = mStressVector;
 }
 
-void SmallStrainUMAT3DLaw::
-   UpdateInternalStrainVectorFinalized(ConstitutiveLaw::Parameters &rValues)
+void SmallStrainUMAT3DLaw::UpdateInternalStrainVectorFinalized(ConstitutiveLaw::Parameters &rValues)
 {
    const Vector& rStrainVector = rValues.GetStrainVector();
    this->SetInternalStrainVector(rStrainVector);
 }
 
-/***********************************************************************************/
-/***********************************************************************************/
-
-void SmallStrainUMAT3DLaw::CalculateCauchyGreenStrain( ConstitutiveLaw::Parameters& rValues, 
-                                                       Vector& rStrainVector )
+void SmallStrainUMAT3DLaw::CalculateCauchyGreenStrain(ConstitutiveLaw::Parameters& rValues,
+                                                      Vector& rStrainVector)
 {
    const SizeType space_dimension = this->WorkingSpaceDimension();
 
@@ -620,10 +583,9 @@ void SmallStrainUMAT3DLaw::CalculateCauchyGreenStrain( ConstitutiveLaw::Paramete
    noalias(rStrainVector) = MathUtils<double>::StrainTensorToVector(E_tensor);
 }
 
-
-double& SmallStrainUMAT3DLaw::CalculateValue( ConstitutiveLaw::Parameters& rParameterValues,
-                                              const Variable<double>& rThisVariable,
-                                              double& rValue )
+double& SmallStrainUMAT3DLaw::CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
+                                             const Variable<double>& rThisVariable,
+                                             double& rValue)
 {
    Vector& rStrainVector = rParameterValues.GetStrainVector();
    Vector& rStressVector = rParameterValues.GetStressVector();
@@ -636,27 +598,22 @@ double& SmallStrainUMAT3DLaw::CalculateValue( ConstitutiveLaw::Parameters& rPara
       rValue = 0.5 * inner_prod( rStrainVector, rStressVector); // Strain energy = 0.5*E:C:E
    }
 
-   return( rValue );
+   return rValue;
 }
 
-/***********************************************************************************/
-/***********************************************************************************/
-
-Vector& SmallStrainUMAT3DLaw::CalculateValue( ConstitutiveLaw::Parameters& rParameterValues,
-                                              const Variable<Vector>& rThisVariable,
-                                              Vector& rValue )
+Vector& SmallStrainUMAT3DLaw::CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
+                                             const Variable<Vector>& rThisVariable,
+                                             Vector& rValue)
 {
    if (rThisVariable == STRAIN ||
        rThisVariable == GREEN_LAGRANGE_STRAIN_VECTOR ||
-       rThisVariable == ALMANSI_STRAIN_VECTOR) 
-   {
+       rThisVariable == ALMANSI_STRAIN_VECTOR) {
       this->CalculateCauchyGreenStrain( rParameterValues, rValue);
 
    } else if (rThisVariable == STRESSES ||
               rThisVariable == CAUCHY_STRESS_VECTOR ||
               rThisVariable == KIRCHHOFF_STRESS_VECTOR ||
-              rThisVariable == PK2_STRESS_VECTOR) 
-   {
+              rThisVariable == PK2_STRESS_VECTOR) {
         // Get Values to compute the constitutive law:
       Flags& rFlags = rParameterValues.GetOptions();
 
@@ -676,192 +633,175 @@ Vector& SmallStrainUMAT3DLaw::CalculateValue( ConstitutiveLaw::Parameters& rPara
       rFlags.Set( ConstitutiveLaw::COMPUTE_STRESS, flagStress );
    }
 
-   return( rValue );
+   return rValue;
 }
 
-/***********************************************************************************/
-/***********************************************************************************/
-
-Matrix& SmallStrainUMAT3DLaw::CalculateValue( ConstitutiveLaw::Parameters& rParameterValues,
-                                              const Variable<Matrix>& rThisVariable,
-                                              Matrix& rValue )
+Matrix& SmallStrainUMAT3DLaw::CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
+                                             const Variable<Matrix>& rThisVariable,
+                                             Matrix& rValue)
 {
    if (rThisVariable == CONSTITUTIVE_MATRIX ||
        rThisVariable == CONSTITUTIVE_MATRIX_PK2 ||
-       rThisVariable == CONSTITUTIVE_MATRIX_KIRCHHOFF) 
-   {
+       rThisVariable == CONSTITUTIVE_MATRIX_KIRCHHOFF) {
       this->CalculateConstitutiveMatrix(rParameterValues, rValue);
    }
 
-   return( rValue );
+   return rValue;
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 int SmallStrainUMAT3DLaw::GetStateVariableIndex(const Variable<double>& rThisVariable)
 {
-
    int index = -1;
 
-   if (rThisVariable == STATE_VARIABLE_1)
-       index = 1;
+    if (rThisVariable == STATE_VARIABLE_1)
+        index = 1;
     else if (rThisVariable == STATE_VARIABLE_2)
-       index = 2;
+        index = 2;
     else if (rThisVariable == STATE_VARIABLE_3)
-       index = 3;
+        index = 3;
     else if (rThisVariable == STATE_VARIABLE_4)
-       index = 4;
+        index = 4;
     else if (rThisVariable == STATE_VARIABLE_5)
-       index = 5;
+        index = 5;
     else if (rThisVariable == STATE_VARIABLE_6)
-       index = 6;
+        index = 6;
     else if (rThisVariable == STATE_VARIABLE_7)
-       index = 7;
+        index = 7;
     else if (rThisVariable == STATE_VARIABLE_8)
-       index = 8;
+        index = 8;
     else if (rThisVariable == STATE_VARIABLE_9)
-       index = 9;
+        index = 9;
 
     else if (rThisVariable == STATE_VARIABLE_10)
-       index = 10;
+        index = 10;
     else if (rThisVariable == STATE_VARIABLE_11)
-       index = 11;
+        index = 11;
     else if (rThisVariable == STATE_VARIABLE_12)
-       index = 12;
+        index = 12;
     else if (rThisVariable == STATE_VARIABLE_13)
-       index = 13;
+        index = 13;
     else if (rThisVariable == STATE_VARIABLE_14)
-       index = 14;
+        index = 14;
     else if (rThisVariable == STATE_VARIABLE_15)
-       index = 15;
+        index = 15;
     else if (rThisVariable == STATE_VARIABLE_16)
-       index = 16;
+        index = 16;
     else if (rThisVariable == STATE_VARIABLE_17)
-       index = 17;
+        index = 17;
     else if (rThisVariable == STATE_VARIABLE_18)
-       index = 18;
+        index = 18;
     else if (rThisVariable == STATE_VARIABLE_19)
-       index = 19;
+        index = 19;
     else if (rThisVariable == STATE_VARIABLE_20)
-       index = 20;
+        index = 20;
 
     else if (rThisVariable == STATE_VARIABLE_21)
-       index = 21;
+        index = 21;
     else if (rThisVariable == STATE_VARIABLE_22)
-       index = 22;
+        index = 22;
     else if (rThisVariable == STATE_VARIABLE_23)
-       index = 23;
+        index = 23;
     else if (rThisVariable == STATE_VARIABLE_24)
-       index = 24;
+        index = 24;
     else if (rThisVariable == STATE_VARIABLE_25)
-       index = 25;
+        index = 25;
     else if (rThisVariable == STATE_VARIABLE_26)
-       index = 26;
+        index = 26;
     else if (rThisVariable == STATE_VARIABLE_27)
-       index = 27;
+        index = 27;
     else if (rThisVariable == STATE_VARIABLE_28)
-       index = 28;
+        index = 28;
     else if (rThisVariable == STATE_VARIABLE_29)
-       index = 29;
+        index = 29;
 
     else if (rThisVariable == STATE_VARIABLE_30)
-       index = 30;
+        index = 30;
     else if (rThisVariable == STATE_VARIABLE_31)
-       index = 31;
+        index = 31;
     else if (rThisVariable == STATE_VARIABLE_32)
-       index = 32;
+        index = 32;
     else if (rThisVariable == STATE_VARIABLE_33)
-       index = 33;
+        index = 33;
     else if (rThisVariable == STATE_VARIABLE_34)
-       index = 34;
+        index = 34;
     else if (rThisVariable == STATE_VARIABLE_35)
-       index = 35;
+        index = 35;
     else if (rThisVariable == STATE_VARIABLE_36)
-       index = 36;
+        index = 36;
     else if (rThisVariable == STATE_VARIABLE_37)
-       index = 37;
+        index = 37;
     else if (rThisVariable == STATE_VARIABLE_38)
-       index = 38;
+        index = 38;
     else if (rThisVariable == STATE_VARIABLE_39)
-       index = 39;
+        index = 39;
 
     else if (rThisVariable == STATE_VARIABLE_40)
-       index = 40;
+        index = 40;
     else if (rThisVariable == STATE_VARIABLE_41)
-       index = 41;
+        index = 41;
     else if (rThisVariable == STATE_VARIABLE_42)
-       index = 42;
+        index = 42;
     else if (rThisVariable == STATE_VARIABLE_43)
-       index = 43;
+        index = 43;
     else if (rThisVariable == STATE_VARIABLE_44)
-       index = 44;
+        index = 44;
     else if (rThisVariable == STATE_VARIABLE_45)
-       index = 45;
+        index = 45;
     else if (rThisVariable == STATE_VARIABLE_46)
-       index = 46;
+        index = 46;
     else if (rThisVariable == STATE_VARIABLE_47)
-       index = 47;
+        index = 47;
     else if (rThisVariable == STATE_VARIABLE_48)
-       index = 48;
+        index = 48;
     else if (rThisVariable == STATE_VARIABLE_49)
-       index = 49;
+        index = 49;
 
     else if (rThisVariable == STATE_VARIABLE_50)
-       index = 50;
+        index = 50;
 
    return index -1;
 }
 
-//----------------------------------------------------------------------------------------
 Vector& SmallStrainUMAT3DLaw::GetValue( const Variable<Vector> &rThisVariable, Vector &rValue )
 {
 
-   if (rThisVariable == STATE_VARIABLES)
-   {
-      if (rValue.size() != mStateVariablesFinalized.size())
-         rValue.resize(mStateVariablesFinalized.size());
+    if (rThisVariable == STATE_VARIABLES) {
+        if (rValue.size() != mStateVariablesFinalized.size()) rValue.resize(mStateVariablesFinalized.size());
 
-      noalias(rValue) = mStateVariablesFinalized;
-   }
-   else if (rThisVariable == CAUCHY_STRESS_VECTOR)
-   {
-      if (rValue.size() != mStressVectorFinalized.size())
-         rValue.resize(mStressVectorFinalized.size());
+        noalias(rValue) = mStateVariablesFinalized;
+    } else if (rThisVariable == CAUCHY_STRESS_VECTOR) {
+        if (rValue.size() != mStressVectorFinalized.size()) rValue.resize(mStressVectorFinalized.size());
 
-      noalias(rValue) = mStressVectorFinalized;
-   }
-
-    return rValue;
-}
-
-//----------------------------------------------------------------------------------------
-double& SmallStrainUMAT3DLaw::GetValue( const Variable<double>& rThisVariable, double& rValue )
-{
-
-   int index = GetStateVariableIndex(rThisVariable);
-
-   KRATOS_DEBUG_ERROR_IF( index < 0 || index > (static_cast<int>(mStateVariablesFinalized.size()) - 1) )
-                        << "GetValue: State variable does not exist in UDSM. Requested index: " << index << std::endl;
-
-   rValue = mStateVariablesFinalized[index];
-
-    return rValue;
-}
-
-//----------------------------------------------------------------------------------------
-int& SmallStrainUMAT3DLaw::GetValue( const Variable<int>& rThisVariable, int& rValue )
-{
-    if (rThisVariable == NUMBER_OF_UMAT_STATE_VARIABLES)
-    {
-       rValue = mStateVariablesFinalized.size();
+        noalias(rValue) = mStressVectorFinalized;
     }
 
     return rValue;
 }
 
-//----------------------------------------------------------------------------------------
-void SmallStrainUMAT3DLaw::SetValue( const Variable<double>& rThisVariable,
-                                     const double& rValue,
-                                     const ProcessInfo& rCurrentProcessInfo )
+double& SmallStrainUMAT3DLaw::GetValue( const Variable<double>& rThisVariable, double& rValue )
+{
+
+    int index = GetStateVariableIndex(rThisVariable);
+
+    KRATOS_DEBUG_ERROR_IF( index < 0 || index > (static_cast<int>(mStateVariablesFinalized.size()) - 1) )
+                        << "GetValue: State variable does not exist in UDSM. Requested index: " << index << std::endl;
+
+    rValue = mStateVariablesFinalized[index];
+
+    return rValue;
+}
+
+int& SmallStrainUMAT3DLaw::GetValue(const Variable<int>& rThisVariable,
+                                    int& rValue)
+{
+    if (rThisVariable == NUMBER_OF_UMAT_STATE_VARIABLES) rValue = static_cast<int>(mStateVariablesFinalized.size());
+
+    return rValue;
+}
+
+void SmallStrainUMAT3DLaw::SetValue(const Variable<double>& rThisVariable,
+                                    const double& rValue,
+                                    const ProcessInfo& rCurrentProcessInfo)
 {
    const int index = GetStateVariableIndex(rThisVariable);
 
@@ -871,31 +811,17 @@ void SmallStrainUMAT3DLaw::SetValue( const Variable<double>& rThisVariable,
    mStateVariablesFinalized[index] = rValue;
 }
 
-//----------------------------------------------------------------------------------------
 void SmallStrainUMAT3DLaw::SetValue( const Variable<Vector>& rThisVariable,
                                      const Vector& rValue,
                                      const ProcessInfo& rCurrentProcessInfo )
 {
-   if (rThisVariable == STATE_VARIABLES)
-   {
-      if (rValue.size() == mStateVariablesFinalized.size()) 
-      {
-         for (unsigned int i=0; i < rValue.size(); ++i)
-         {
-            mStateVariablesFinalized[i] = rValue[i];
-         }
-      }
+    if ((rThisVariable == STATE_VARIABLES) &&
+        (rValue.size() == mStateVariablesFinalized.size())) {
+        std::copy(rValue.begin(), rValue.end(), mStateVariablesFinalized.begin());
+    } else if ((rThisVariable == CAUCHY_STRESS_VECTOR) &&
+               (rValue.size() == mStressVectorFinalized.size())) {
+        std::copy(rValue.begin(), rValue.end(), mStressVectorFinalized.begin());
    }
-   else if (rThisVariable == CAUCHY_STRESS_VECTOR)
-   {
-      if (rValue.size() == mStressVectorFinalized.size()) 
-      {
-         for (unsigned int i=0; i < rValue.size(); ++i)
-         {
-            mStressVectorFinalized[i] = rValue[i];
-         }
-      }
-   }
-
 }
+
 } // Namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_law.hpp
+++ b/applications/GeoMechanicsApplication/custom_constitutive/small_strain_umat_3D_law.hpp
@@ -10,15 +10,12 @@
 //  Main authors:    Vahid Galavi
 //
 
-#if !defined(KRATOS_SMALL_STRAIN_UMAT_3D_LAW_H_INCLUDED )
-#define  KRATOS_SMALL_STRAIN_UMAT_3D_LAW_H_INCLUDED
+#pragma once
 
 // System includes
 #include <string>
 #include <iostream>
 #include "includes/define.h"
-
-// External includes
 
 // Project includes
 #include "includes/serializer.h"
@@ -26,7 +23,6 @@
 
 // Application includes
 #include "geo_mechanics_application_variables.h"
-
 
 namespace Kratos
 {
@@ -104,32 +100,18 @@ typedef void(*pF_UMATMod) (double* STRESS, double* STATEV, double** DDSDDE, doub
       //@name Life Cycle
       //@{
 
-      //----------------------------------------------------------------------------------------
-      /**
-       * @brief Default constructor.
-       */
-      SmallStrainUMAT3DLaw();
+      SmallStrainUMAT3DLaw() = default;
+      ~SmallStrainUMAT3DLaw() override = default;
+      SmallStrainUMAT3DLaw(const SmallStrainUMAT3DLaw& rOther);
+      SmallStrainUMAT3DLaw& operator=(const SmallStrainUMAT3DLaw& rOther);
+      SmallStrainUMAT3DLaw(SmallStrainUMAT3DLaw&&) = delete;
+      SmallStrainUMAT3DLaw& operator=(SmallStrainUMAT3DLaw&&) = delete;
 
       /**
        * @brief Clone method
        */
       ConstitutiveLaw::Pointer Clone() const override;
 
-      /**
-       * Copy constructor.
-       */
-      SmallStrainUMAT3DLaw(SmallStrainUMAT3DLaw const& rOther);
-
-      /**
-       * @brief Destructor.
-       */
-      virtual ~SmallStrainUMAT3DLaw();
-
-
-      // Assignment operator:
-      SmallStrainUMAT3DLaw& operator=(SmallStrainUMAT3DLaw const& rOther);
-
-      //----------------------------------------------------------------------------------------
       /**
        * @brief This function is designed to be called once to check compatibility with element
        * @param rFeatures The Features of the law
@@ -139,7 +121,7 @@ typedef void(*pF_UMATMod) (double* STRESS, double* STATEV, double** DDSDDE, doub
       /**
        * @brief Dimension of the law:
        */
-      virtual SizeType WorkingSpaceDimension() override
+      SizeType WorkingSpaceDimension() override
       {
          return Dimension;
       }
@@ -147,7 +129,7 @@ typedef void(*pF_UMATMod) (double* STRESS, double* STATEV, double** DDSDDE, doub
       /**
        * @brief Voigt tensor size:
        */
-      virtual SizeType GetStrainSize() const override
+      SizeType GetStrainSize() const override
       {
          return VoigtSize;
       }
@@ -156,7 +138,7 @@ typedef void(*pF_UMATMod) (double* STRESS, double* STATEV, double** DDSDDE, doub
        * @brief Returns the expected strain measure of this constitutive law (by default Green-Lagrange)
        * @return the expected strain measure
        */
-      virtual StrainMeasure GetStrainMeasure() override
+      StrainMeasure GetStrainMeasure() override
       {
          return StrainMeasure_Infinitesimal;
       }
@@ -165,7 +147,7 @@ typedef void(*pF_UMATMod) (double* STRESS, double* STATEV, double** DDSDDE, doub
        * returns the stress measure of this constitutive law (by default 1st Piola-Kirchhoff stress in voigt notation)
        * @return the expected stress measure
        */
-      virtual StressMeasure GetStressMeasure() override
+      StressMeasure GetStressMeasure() override
       {
          return StressMeasure_Cauchy;
       }
@@ -220,9 +202,9 @@ typedef void(*pF_UMATMod) (double* STRESS, double* STATEV, double** DDSDDE, doub
        * @param rValue a reference to the returned value
        * @return rValue output: the value of the specified variable
        */
-      virtual double& CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
-                                     const Variable<double>& rThisVariable,
-                                     double& rValue) override;
+      double& CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
+                             const Variable<double>&      rThisVariable,
+                             double&                      rValue) override;
 
       /**
        * @brief It calculates the value of a specified variable (Vector case)
@@ -231,9 +213,9 @@ typedef void(*pF_UMATMod) (double* STRESS, double* STATEV, double** DDSDDE, doub
        * @param rValue a reference to the returned value
        * @return rValue output: the value of the specified variable
        */
-      virtual Vector& CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
-                                     const Variable<Vector>& rThisVariable,
-                                     Vector& rValue) override;
+      Vector& CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
+                             const Variable<Vector>&      rThisVariable,
+                             Vector&                      rValue) override;
 
       /**
        * @brief It calculates the value of a specified variable (Matrix case)
@@ -242,9 +224,11 @@ typedef void(*pF_UMATMod) (double* STRESS, double* STATEV, double** DDSDDE, doub
        * @param rValue a reference to the returned value
        * @return rValue output: the value of the specified variable
        */
-      virtual Matrix& CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
-                                     const Variable<Matrix>& rThisVariable,
-                                     Matrix& rValue) override;
+      Matrix& CalculateValue(ConstitutiveLaw::Parameters& rParameterValues,
+                             const Variable<Matrix>&      rThisVariable,
+                             Matrix&                      rValue) override;
+
+      using ConstitutiveLaw::CalculateValue;
 
 
       // @brief This function provides the place to perform checks on the completeness of the input.
@@ -321,21 +305,19 @@ typedef void(*pF_UMATMod) (double* STRESS, double* STATEV, double** DDSDDE, doub
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override
+      std::string Info() const override
       {
-         std::stringstream buffer;
-         buffer << "SmallStrainUMAT3DLaw";
-         return buffer.str();
+         return "SmallStrainUMAT3DLaw";
       }
 
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override
+      void PrintInfo(std::ostream& rOStream) const override
       {
-         rOStream << "SmallStrainUMAT3DLaw";
+         rOStream << Info();
       }
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override
+      void PrintData(std::ostream& rOStream) const override
       {
          rOStream << "SmallStrainUMAT3DLaw Data";
       }
@@ -446,7 +428,7 @@ typedef void(*pF_UMATMod) (double* STRESS, double* STATEV, double** DDSDDE, doub
       ///@{
       friend class Serializer;
 
-      virtual void save(Serializer& rSerializer) const override
+      void save(Serializer& rSerializer) const override
       {
          KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, ConstitutiveLaw)
          rSerializer.save("InitializedModel",           mIsModelInitialized);
@@ -455,7 +437,7 @@ typedef void(*pF_UMATMod) (double* STRESS, double* STATEV, double** DDSDDE, doub
          rSerializer.save("StateVariablesFinalized",    mStateVariablesFinalized);
       }
 
-      virtual void load(Serializer& rSerializer) override
+      void load(Serializer& rSerializer) override
       {
          KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, ConstitutiveLaw)
          rSerializer.load("InitializedModel",           mIsModelInitialized);
@@ -491,8 +473,4 @@ typedef void(*pF_UMATMod) (double* STRESS, double* STATEV, double** DDSDDE, doub
 
    ///@} addtogroup block
 
-}  // namespace Kratos.
-
-#endif // KRATOS_SMALL_STRAIN_UMAT_3D_LAW_H_INCLUDED  defined
-
-
+}

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.h
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.h
@@ -521,15 +521,15 @@ private:
     const ElasticIsotropicK03DLaw           mElasticIsotropicK03DLaw;
     const GeoLinearElasticPlaneStress2DLaw  mLinearElasticPlaneStress2DLaw;
 
-    const SmallStrainUDSM3DLaw            mSmallStrainUDSM3DLaw;
-    const SmallStrainUDSM2DPlaneStrainLaw mSmallStrainUDSM2DPlaneStrainLaw;
-    const SmallStrainUDSM2DInterfaceLaw   mSmallStrainUDSM2DInterfaceLaw;
-    const SmallStrainUDSM3DInterfaceLaw   mSmallStrainUDSM3DInterfaceLaw;
+    const SmallStrainUDSM3DLaw            mSmallStrainUDSM3DLaw{};
+    const SmallStrainUDSM2DPlaneStrainLaw mSmallStrainUDSM2DPlaneStrainLaw{};
+    const SmallStrainUDSM2DInterfaceLaw   mSmallStrainUDSM2DInterfaceLaw{};
+    const SmallStrainUDSM3DInterfaceLaw   mSmallStrainUDSM3DInterfaceLaw{};
 
-    const SmallStrainUMAT3DLaw            mSmallStrainUMAT3DLaw;
-    const SmallStrainUMAT2DPlaneStrainLaw mSmallStrainUMAT2DPlaneStrainLaw;
-    const SmallStrainUMAT2DInterfaceLaw   mSmallStrainUMAT2DInterfaceLaw;
-    const SmallStrainUMAT3DInterfaceLaw   mSmallStrainUMAT3DInterfaceLaw;
+    const SmallStrainUMAT3DLaw            mSmallStrainUMAT3DLaw{};
+    const SmallStrainUMAT2DPlaneStrainLaw mSmallStrainUMAT2DPlaneStrainLaw{};
+    const SmallStrainUMAT2DInterfaceLaw   mSmallStrainUMAT2DInterfaceLaw{};
+    const SmallStrainUMAT3DInterfaceLaw   mSmallStrainUMAT3DInterfaceLaw{};
 
     const LinearElastic2DInterfaceLaw     mLinearElastic2DInterfaceLaw;
     const LinearElastic3DInterfaceLaw     mLinearElastic3DInterfaceLaw;


### PR DESCRIPTION
**📝 Description**
Fixed several code smells reported by SonarQube in directory `custom_constitutive`. Also addressed several problems found by clang-tidy.

**🆕 Changelog**
- Removed some commented out code.
- Applied the rule of zero to some classes.
- Merged some enclosing `if` statements with outer ones.
- Avoid implicit narrowing conversions.
- When a default constructor can be generated by the compiler use that.
- Applied the rule of five to a class.
- Put `const` in front of the type name rather than after it.
- Replaced several raw `for` loops by calls to `std::copy` and `std::copy_n`.
- Some minor layout improvements.
- Changed a reference to a reference-to-const.
- Uncommented some multi-line comments.
- Replaced some old-style inclusion guards by `#pragma once`.
- Removed some redundant comments and blank lines.
- Don't annotate a member function with both `virtual` and `override`.
- Simplified some tests in `if` statements.
- Corrected a few spelling mistakes.
- Make better use of `KRATOS_ERROR_IF` and `KRATOS_ERROR_IF_NOT`.
- Removed some redundant pairs of parentheses.
- Avoid hiding member functions that are inherited from a base class (see "C.138: Create an overload set for a derived class and its bases with `using`" from the C++ Core Guidelines).
- Replaced some occurrences of `NULL` by `nullptr`.
