### PR TITLE
[Core] Better debugging at `entities_utilities` in debug mode

### DIFF
--- a/kratos/utilities/entities_utilities.cpp
+++ b/kratos/utilities/entities_utilities.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Vicente Mataix Ferrandiz
 //                   Philipp Bucher (https://github.com/philbucher)
@@ -65,6 +65,7 @@ bool EntitityIdentifier<TEntity>::IsInitialized() const
 template<class TEntity>
 const TEntity& EntitityIdentifier<TEntity>::GetPrototypeEntity(typename GeometryType::Pointer pGeometry) const
 {
+    KRATOS_DEBUG_ERROR_IF(mTypes[static_cast<std::size_t>(pGeometry->GetGeometryType())] == nullptr) << "Prototype not initialized for " << GeometryUtils::GetGeometryName(pGeometry->GetGeometryType()) << std::endl;
     return *mTypes[static_cast<std::size_t>(pGeometry->GetGeometryType())];
 }
 
@@ -74,6 +75,7 @@ const TEntity& EntitityIdentifier<TEntity>::GetPrototypeEntity(typename Geometry
 template<class TEntity>
 const TEntity& EntitityIdentifier<TEntity>::GetPrototypeEntity(const GeometryType& rGeometry) const
 {
+    KRATOS_DEBUG_ERROR_IF(mTypes[static_cast<std::size_t>(rGeometry.GetGeometryType())] == nullptr) << "Prototype not initialized for " << GeometryUtils::GetGeometryName(rGeometry.GetGeometryType()) << std::endl;
     return *mTypes[static_cast<std::size_t>(rGeometry.GetGeometryType())];
 }
 


### PR DESCRIPTION
**📝 Description**

This commit affects the `kratos/utilities/entities_utilities.cpp` file. Changes were made in various parts of the file:

1. Licenses were adjusted in lines 7 and 8 to adhere to the proper format and alignment.
2. Verification was added in the `GetPrototypeEntity` functions to ensure that the prototype is initialized before accessing it, generating error messages if not. This is done for both a `GeometryType` pointer and a `GeometryType` reference.  (Only in debug)
3. A specific error message was added that displays the type of geometry that lacks an initialized prototype in case the verification fails. (Only in debug)

This will improve debugging processes

**🆕 Changelog**

- [Better debugging at `entities_utilities`](https://github.com/KratosMultiphysics/Kratos/commit/5045b18877f0cbdca113a4af3c03b1d71444bda3)