### PR TITLE
[Core] Fix Kernel Destructor

### DIFF
--- a/kratos/includes/kernel.h
+++ b/kratos/includes/kernel.h
@@ -76,10 +76,10 @@ class KRATOS_API(KRATOS_CORE) Kernel {
     /// Copy constructor.
     /** This constructor is empty
     */
-    Kernel(Kernel const& rOther) {}
+    Kernel(Kernel const& rOther);
 
     /// Destructor.
-    virtual ~Kernel() {}
+    virtual ~Kernel();
 
     ///@}
     ///@name Operations

--- a/kratos/includes/kratos_components.h
+++ b/kratos/includes/kratos_components.h
@@ -119,6 +119,15 @@ public:
     }
 
     /**
+     * @brief Removes all components.
+     * @details This function removes all components form the ComponentsContainer and leaves it empty.
+     */
+    static void Clear() 
+    {
+        msComponents.clear();
+    }
+
+    /**
      * @brief Registers the function.
      */
     static void Register()

--- a/kratos/sources/kernel.cpp
+++ b/kratos/sources/kernel.cpp
@@ -36,6 +36,36 @@ Kernel::Kernel(bool IsDistributedRun) : mpKratosCoreApplication(Kratos::make_sha
     Initialize();
 }
 
+Kernel::~Kernel() {
+    KratosComponents<Variable<bool>>::Clear();
+    KratosComponents<Variable<int>>::Clear();
+    KratosComponents<Variable<unsigned int>>::Clear();
+    KratosComponents<Variable<double>>::Clear();
+    KratosComponents<Variable<array_1d<double, 3>>>::Clear();
+    KratosComponents<Variable<array_1d<double, 4>>>::Clear();
+    KratosComponents<Variable<array_1d<double, 6>>>::Clear();
+    KratosComponents<Variable<array_1d<double, 9>>>::Clear();
+    KratosComponents<Variable<Quaternion<double>>>::Clear();
+    KratosComponents<Variable<Vector>>::Clear();
+    KratosComponents<Variable<Matrix>>::Clear();
+    KratosComponents<Variable<std::string>>::Clear();
+    KratosComponents<Variable<Flags>>::Clear();
+    KratosComponents<Flags>::Clear();
+
+    // This one seems to be handled correctly
+    // KratosComponents<DataCommunicator>::Clear();
+
+    KratosComponents<Geometry<Node>>::Clear();
+    KratosComponents<Element>::Clear();
+    KratosComponents<Condition>::Clear();
+    KratosComponents<ConstitutiveLaw>::Clear();
+    KratosComponents<Variable<ConstitutiveLaw::Pointer>>::Clear();
+    KratosComponents<MasterSlaveConstraint>::Clear();
+    KratosComponents<Modeler>::Clear();
+
+    GetApplicationsList().clear();
+}
+
 void Kernel::Initialize() {
     KRATOS_INFO("") << " |  /           |                  \n"
                     << " ' /   __| _` | __|  _ \\   __|    \n"


### PR DESCRIPTION
**📝 Description**
Kratos kernel now cleans the list of applications registered and components once destroyed, preventing pointers to deleted instances of Components and no longer available applications from existing after calling the kernel initialization and application registry without unloading the shared lib.

Related #11506

**🆕 Changelog**
- Fixing Kernel destruction leaving registered components and applications