### PR TITLE
[Poro] Add new joint constitutive laws to python

### DIFF
--- a/applications/PoromechanicsApplication/custom_python/add_custom_constitutive_laws_to_python.cpp
+++ b/applications/PoromechanicsApplication/custom_python/add_custom_constitutive_laws_to_python.cpp
@@ -58,6 +58,20 @@ namespace py = pybind11;
 void  AddCustomConstitutiveLawsToPython(pybind11::module& m)
 {
     // Module local to avoid conflicts with other apps
+    py::class_< ElastoPlasticMohrCoulombCohesive3DLaw, ElastoPlasticMohrCoulombCohesive3DLaw::Pointer, ConstitutiveLaw >
+    (m, "ElastoPlasticMohrCoulombCohesive3DLaw", py::module_local())
+    .def( py::init<>() );
+    py::class_< ElastoPlasticMohrCoulombCohesive2DLaw, ElastoPlasticMohrCoulombCohesive2DLaw::Pointer, ConstitutiveLaw >
+    (m, "ElastoPlasticMohrCoulombCohesive2DLaw", py::module_local())
+    .def( py::init<>() ) ;
+
+    py::class_< ElastoPlasticModMohrCoulombCohesive3DLaw, ElastoPlasticModMohrCoulombCohesive3DLaw::Pointer, ConstitutiveLaw >
+    (m, "ElastoPlasticModMohrCoulombCohesive3DLaw", py::module_local())
+    .def( py::init<>() );
+    py::class_< ElastoPlasticModMohrCoulombCohesive2DLaw, ElastoPlasticModMohrCoulombCohesive2DLaw::Pointer, ConstitutiveLaw >
+    (m, "ElastoPlasticModMohrCoulombCohesive2DLaw", py::module_local())
+    .def( py::init<>() ) ;
+
     py::class_< ElasticCohesive2DLaw, ElasticCohesive2DLaw::Pointer, ConstitutiveLaw >
     (m, "ElasticCohesive2DLaw", py::module_local())
     .def( py::init<>() ) ;


### PR DESCRIPTION
**📝 Description**
After trying to use the new Mohr-Coulomb with tension cut-off cohesive laws I realized that they were not properly added to python.

- Bugfix

**🆕 Changelog**
- Added new constitutive laws to python