### PR TITLE
[CoSimulationApplication] Minor refactor and typo correction in documentation and solver wrapper 

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/solver_wrappers/external/acusolve_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/solver_wrappers/external/acusolve_wrapper.py
@@ -8,7 +8,6 @@ from KratosMultiphysics.vtk_output_process import VtkOutputProcess
 # CoSimulation imports
 from KratosMultiphysics.CoSimulationApplication.utilities import model_part_utilities
 import KratosMultiphysics.CoSimulationApplication.co_simulation_tools as cs_tools
-import KratosMultiphysics.CoSimulationApplication.colors as colors
 
 # System imports
 import subprocess

--- a/applications/CoSimulationApplication/python_scripts/solver_wrappers/sdof/sdof_solver_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/solver_wrappers/sdof/sdof_solver_wrapper.py
@@ -49,7 +49,7 @@ class SdofSolverWrapper(CoSimulationSolverWrapper):
         self.mp[KMC.SCALAR_VOLUME_ACCELERATION] = self._sdof_solver.GetSolutionStepValue("VOLUME_ACCELERATION", 0)
 
     def Check(self):
-        # making sure only a set of vaiables can be used
+        # making sure only a set of variables can be used
         admissible_variables = [
             "SCALAR_ROOT_POINT_DISPLACEMENT",
             "SCALAR_FORCE",


### PR DESCRIPTION
**📝 Description**

This PR involves changes in two main areas: the `acusolve_wrapper.py`, `sdof_solver_wrapper.py` files and the `README.md` documentation file. Additionally, some code snippets and formatting changes are present in the diff.

1. In the `acusolve_wrapper.py` file:
   - Import statement for `KratosMultiphysics.CoSimulationApplication.colors` has been removed. (not used)
2. In the `sdof_solver_wrapper.py` file:
   - Typo corrected
3. In the `README.md` documentation:
   - The content under the "Overview" section has been reorganized (improved with a VSCode extension that automatically generates the structure).
   - Several typos corrected

**🆕 Changelog**

- [Remove unused](https://github.com/KratosMultiphysics/Kratos/commit/9611681ca28b26d6f80201101a2ee271cf476fac)
- [Typos and minor improvements](https://github.com/KratosMultiphysics/Kratos/commit/125faa0002c46f6bf7487c8132ce4bb6cecbe70a)
