### PR TITLE
[FastPR][Core] Adding HasPrototypeEntity to EntityIdentifier

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_entities_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_entities_utilities.cpp
@@ -1,0 +1,35 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+//
+
+// Project includes
+#include "testing/testing.h"
+#include "containers/model.h"
+#include "includes/expect.h"
+#include "utilities/entities_utilities.h"
+
+namespace Kratos::Testing
+{
+
+KRATOS_TEST_CASE_IN_SUITE(EntityIdentifierHasPrototype, KratosCoreFastSuite)
+{
+    Model model;
+    auto& r_model_part = model.CreateModelPart("MainModelPart");
+    r_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    r_model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+    r_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+    auto p_tri_geom = r_model_part.CreateNewGeometry("Triangle2D3", 1, {{1, 2, 3}});
+    auto entity_identifier = EntitiesUtilities::EntitityIdentifier<Element>("Element2D3N");
+    KRATOS_EXPECT_TRUE(entity_identifier.HasPrototypeEntity(*p_tri_geom));
+}
+
+}  // namespace Kratos::Testing.

--- a/kratos/utilities/entities_utilities.cpp
+++ b/kratos/utilities/entities_utilities.cpp
@@ -63,15 +63,6 @@ bool EntitityIdentifier<TEntity>::IsInitialized() const
 /***********************************************************************************/
 
 template<class TEntity>
-bool EntitityIdentifier<TEntity>::HasPrototypeEntity(typename GeometryType::Pointer pGeometry) const
-{
-    return mTypes[static_cast<std::size_t>(pGeometry->GetGeometryType())] != nullptr;
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-template<class TEntity>
 bool EntitityIdentifier<TEntity>::HasPrototypeEntity(const GeometryType& rGeometry) const
 {
     return mTypes[static_cast<std::size_t>(rGeometry.GetGeometryType())] != nullptr;

--- a/kratos/utilities/entities_utilities.cpp
+++ b/kratos/utilities/entities_utilities.cpp
@@ -63,7 +63,7 @@ bool EntitityIdentifier<TEntity>::IsInitialized() const
 /***********************************************************************************/
 
 template<class TEntity>
-const bool EntitityIdentifier<TEntity>::HasPrototypeEntity(typename GeometryType::Pointer pGeometry) const
+bool EntitityIdentifier<TEntity>::HasPrototypeEntity(typename GeometryType::Pointer pGeometry) const
 {
     return mTypes[static_cast<std::size_t>(pGeometry->GetGeometryType())] != nullptr;
 }
@@ -72,7 +72,7 @@ const bool EntitityIdentifier<TEntity>::HasPrototypeEntity(typename GeometryType
 /***********************************************************************************/
 
 template<class TEntity>
-const bool EntitityIdentifier<TEntity>::HasPrototypeEntity(const GeometryType& rGeometry) const
+bool EntitityIdentifier<TEntity>::HasPrototypeEntity(const GeometryType& rGeometry) const
 {
     return mTypes[static_cast<std::size_t>(rGeometry.GetGeometryType())] != nullptr;
 }

--- a/kratos/utilities/entities_utilities.cpp
+++ b/kratos/utilities/entities_utilities.cpp
@@ -63,6 +63,24 @@ bool EntitityIdentifier<TEntity>::IsInitialized() const
 /***********************************************************************************/
 
 template<class TEntity>
+const bool EntitityIdentifier<TEntity>::HasPrototypeEntity(typename GeometryType::Pointer pGeometry) const
+{
+    return mTypes[static_cast<std::size_t>(pGeometry->GetGeometryType())] != nullptr;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<class TEntity>
+const bool EntitityIdentifier<TEntity>::HasPrototypeEntity(const GeometryType& rGeometry) const
+{
+    return mTypes[static_cast<std::size_t>(rGeometry.GetGeometryType())] != nullptr;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<class TEntity>
 const TEntity& EntitityIdentifier<TEntity>::GetPrototypeEntity(typename GeometryType::Pointer pGeometry) const
 {
     KRATOS_DEBUG_ERROR_IF(mTypes[static_cast<std::size_t>(pGeometry->GetGeometryType())] == nullptr) << "Prototype not initialized for " << GeometryUtils::GetGeometryName(pGeometry->GetGeometryType()) << std::endl;

--- a/kratos/utilities/entities_utilities.h
+++ b/kratos/utilities/entities_utilities.h
@@ -106,6 +106,22 @@ namespace EntitiesUtilities
         /**
          * @brief Get the prototype entity.
          * @param pGeometry The pointer to the geometry.
+         * @return true there is a prototype for the provided entity.
+         * @return false there is no prototype for the provided entity.
+         */
+        const bool HasPrototypeEntity(typename GeometryType::Pointer pGeometry) const;
+
+        /**
+         * @brief Get the prototype entity.
+         * @param rGeometry The reference to the geometry.
+         * @return true there is a prototype for the provided entity.
+         * @return false there is no prototype for the provided entity.
+         */
+        const bool HasPrototypeEntity(const GeometryType& rGeometry) const;
+
+        /**
+         * @brief Get the prototype entity.
+         * @param pGeometry The pointer to the geometry.
          * @return const TEntity& The prototype entity.
          */
         const TEntity& GetPrototypeEntity(typename GeometryType::Pointer pGeometry) const;

--- a/kratos/utilities/entities_utilities.h
+++ b/kratos/utilities/entities_utilities.h
@@ -109,7 +109,7 @@ namespace EntitiesUtilities
          * @return true there is a prototype for the provided entity.
          * @return false there is no prototype for the provided entity.
          */
-        const bool HasPrototypeEntity(typename GeometryType::Pointer pGeometry) const;
+        bool HasPrototypeEntity(typename GeometryType::Pointer pGeometry) const;
 
         /**
          * @brief Get the prototype entity.
@@ -117,7 +117,7 @@ namespace EntitiesUtilities
          * @return true there is a prototype for the provided entity.
          * @return false there is no prototype for the provided entity.
          */
-        const bool HasPrototypeEntity(const GeometryType& rGeometry) const;
+        bool HasPrototypeEntity(const GeometryType& rGeometry) const;
 
         /**
          * @brief Get the prototype entity.

--- a/kratos/utilities/entities_utilities.h
+++ b/kratos/utilities/entities_utilities.h
@@ -105,14 +105,6 @@ namespace EntitiesUtilities
 
         /**
          * @brief Get the prototype entity.
-         * @param pGeometry The pointer to the geometry.
-         * @return true there is a prototype for the provided entity.
-         * @return false there is no prototype for the provided entity.
-         */
-        bool HasPrototypeEntity(typename GeometryType::Pointer pGeometry) const;
-
-        /**
-         * @brief Get the prototype entity.
          * @param rGeometry The reference to the geometry.
          * @return true there is a prototype for the provided entity.
          * @return false there is no prototype for the provided entity.


### PR DESCRIPTION
**📝 Description**
On top of being handy, this is required to avoid the error thrown of the getter when using the EntityIdentifier in a context that mixes elements and conditions (see #11370 as an example).
