### PR TITLE
[Core] Fix python name exposure

### DIFF
--- a/kratos/python/add_containers_to_python.cpp
+++ b/kratos/python/add_containers_to_python.cpp
@@ -93,7 +93,7 @@ void  AddContainersToPython(pybind11::module& m)
     .def("Name", &VariableData::Name, py::return_value_policy::copy)
     .def("Key", &VariableData::Key)
     .def("GetSourceVariable", &VariableData::GetSourceVariable)
-    .def("GetComponentIndex()", &VariableData::GetComponentIndex)
+    .def("GetComponentIndex", &VariableData::GetComponentIndex)
     .def("IsComponent", &VariableData::IsComponent)
     .def("__str__", PrintObject<VariableData>)
     ;


### PR DESCRIPTION
**📝 Description**
The stub generation and mypy static type checking fail for the core since the name used for the `GetComponentIndex` when exposing is wrong. This PR fixes it.

**🆕 Changelog**
- Fix python exposure name.
