### PR TITLE
[Core] Expose to python `IsActive` from `GeometricalObject` and `MasterSlaveConstraint`

### DIFF
--- a/kratos/python/add_constraint_to_python.cpp
+++ b/kratos/python/add_constraint_to_python.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //
@@ -21,9 +21,7 @@
 #include "constraints/linear_master_slave_constraint.h"
 #include "constraints/slip_constraint.h"
 
-namespace Kratos
-{
-namespace Python
+namespace Kratos::Python
 {
 
 template <class TVariableType>
@@ -49,6 +47,7 @@ void AddConstraintToPython(pybind11::module &m)
     pybind11::class_<MasterSlaveConstraint, MasterSlaveConstraint::Pointer, MasterSlaveConstraint::BaseType, Flags>(m, "MasterSlaveConstraint")
     .def(pybind11::init<>())
     .def(pybind11::init<int>())
+    .def("IsActive", &MasterSlaveConstraint::IsActive)
 
     .def("__setitem__", SetValueHelperFunctionMasterSlaveConstraint< Variable< array_1d<double, 3>  > >)
     .def("__getitem__", GetValueHelperFunctionMasterSlaveConstraint< Variable< array_1d<double, 3>  > >)
@@ -151,10 +150,6 @@ void AddConstraintToPython(pybind11::module &m)
         array_1d<double,3>
         >())
     ;
-
-
 }
 
-} // namespace Python.
-
-} // Namespace Kratos
+} // namespace Kratos::Python.

--- a/kratos/python/add_geometries_to_python.cpp
+++ b/kratos/python/add_geometries_to_python.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //
@@ -50,20 +50,17 @@
 #include "geometries/nurbs_curve_geometry.h"
 #include "geometries/surface_in_nurbs_volume_geometry.h"
 
-namespace Kratos
+namespace Kratos::Python
 {
-
-namespace Python
-{
-    typedef std::size_t IndexType;
-    typedef std::size_t SizeType;
-    typedef Node NodeType;
-    typedef PointerVector<NodeType> NodeContainerType;
-    typedef Geometry<NodeType> GeometryType;
-    typedef typename GeometryType::PointsArrayType PointsArrayType;
-    typedef typename GeometryType::IntegrationPointsArrayType IntegrationPointsArrayType;
-    typedef typename GeometryType::GeometriesArrayType GeometriesArrayType;
-    typedef typename Point::CoordinatesArrayType CoordinatesArrayType;
+    using IndexType = std::size_t;
+    using SizeType = std::size_t;
+    using NodeType = Node;
+    using NodeContainerType = PointerVector<NodeType>;
+    using GeometryType = Geometry<NodeType>;
+    using PointsArrayType = typename GeometryType::PointsArrayType;
+    using IntegrationPointsArrayType = typename GeometryType::IntegrationPointsArrayType;
+    using GeometriesArrayType = typename GeometryType::GeometriesArrayType;
+    using CoordinatesArrayType = typename Point::CoordinatesArrayType;
 
     const PointerVector< Node >& ConstGetPoints( GeometryType& geom ) { return geom.Points(); }
     PointerVector< Node >& GetPoints( GeometryType& geom ) { return geom.Points(); }
@@ -363,6 +360,4 @@ void  AddGeometriesToPython(pybind11::module& m)
 
 }
 
-}  // namespace Python.
-
-} // Namespace Kratos
+}  // namespace Kratos::Python.

--- a/kratos/python/add_mesh_to_python.cpp
+++ b/kratos/python/add_mesh_to_python.cpp
@@ -5,7 +5,7 @@
 //                   Multi-Physics
 //
 //  License:         BSD License
-//                     Kratos default license: kratos/license.txt
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //
@@ -25,9 +25,7 @@
 #include "python/add_mesh_to_python.h"
 #include "python/containers_interface.h"
 
-namespace Kratos
-{
-namespace Python
+namespace Kratos::Python
 {
 namespace py = pybind11;
 
@@ -382,26 +380,9 @@ void EntityGetSecondDerivativesVector2(
 
 void  AddMeshToPython(pybind11::module& m)
 {
-//             typedef Mesh<Node, Properties, Element, Condition> MeshType;
-//             typedef MeshType::NodeType NodeType;
-
-    //     py::class_<Dof, Dof::Pointer>("Dof", init<int, const Dof::VariableType&,  optional<const Dof::VariableType&, const Dof::VariableType&, const Dof::VariableType&> >())
-    //.def("GetVariable", &Dof::GetVariable, py::return_value_policy::reference_internal)
-    //.def("GetReaction", &Dof::GetReaction, py::return_value_policy::reference_internal)
-    //.def("GetTimeDerivative", &Dof::GetTimeDerivative, py::return_value_policy::reference_internal)
-    //.def("GetSecondTimeDerivative", &Dof::GetSecondTimeDerivative, py::return_value_policy::reference_internal)
-    //.def("NodeIndex", &Dof::NodeIndex)
-    //.def_property("EquationId", &Dof::EquationId, &Dof::SetEquationId)
-    //.def("Fix", &Dof::FixDof)
-    //.def("Free", &Dof::FreeDof)
-    //.def("IsFixed", &Dof::IsFixed)
-    //.def("HasTimeDerivative", &Dof::HasTimeDerivative)
-    //.def("HasSecondTimeDerivative", &Dof::HasSecondTimeDerivative)
-    //.def(self_ns::str(self))
-    //      ;
-
     py::class_<GeometricalObject, GeometricalObject::Pointer, IndexedObject, Flags>(m,"GeometricalObject")
     .def(py::init<Kratos::GeometricalObject::IndexType>())
+    .def("IsActive", &GeometricalObject::IsActive)
     ;
 
     py::class_<Element, Element::Pointer, Element::BaseType>(m,"Element")
@@ -707,5 +688,4 @@ void  AddMeshToPython(pybind11::module& m)
     .def("__str__", PrintObject<MeshType>)
     ;
 }
-}  // namespace Python.
-} // Namespace Kratos
+}  // namespace Kratos::Python.


### PR DESCRIPTION
**📝 Description**

This PR involves refactoring the Python bindings for Kratos Geometries and Constraints. It includes changes in three files:

1. `add_constraint_to_python.cpp`: Refactors code related to constraints and their Python bindings. It updates the license information and adds a method to check if a `MasterSlaveConstraint` is active.

2. `add_geometries_to_python.cpp`: Refactors code related to geometries and their Python bindings. It updates the license information and includes changes to improve code readability  and adds a method to check if a  `GeometricalObject` is active.

3. `add_mesh_to_python.cpp`: Refactors code related to mesh handling and its Python bindings. It updates the license information and includes changes to improve code organization and readability.

**🆕 Changelog**

- [Expose to python IsActive from GeometricalObject and `MasterSlaveConstraint`](https://github.com/KratosMultiphysics/Kratos/commit/b1cf7e2a164d7921b99f624fda2c00eec121a398)
