### PR TITLE
Revert "Bump actions/checkout@v3 to @v4"

### DIFF
--- a/.github/workflows/build_docker_image_wheelbuilder_linux.yml
+++ b/.github/workflows/build_docker_image_wheelbuilder_linux.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Build the Docker image
         run: docker build scripts/docker_files/docker_file_wheelbuilder_linux/ --tag kratosmultiphysics/kratos-wheelbuilder-linux
       - name: Docker Login

--- a/.github/workflows/build_docker_image_wheelbuilder_windows.yml
+++ b/.github/workflows/build_docker_image_wheelbuilder_windows.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Build the Docker image
         run: docker build scripts/docker_files/docker_file_wheelbuilder_windows/ --tag kratosmultiphysics/kratos-wheelbuilder-windows
       - name: Docker Login

--- a/.github/workflows/build_docker_images_for_ci.yml
+++ b/.github/workflows/build_docker_images_for_ci.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - name: Build the Docker image
       run: docker build . --file scripts/docker_files/docker_file_ci_ubuntu_22_04/DockerFile --tag kratosmultiphysics/kratos-image-ci-ubuntu-22-04
     - name: Docker Login
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - name: Build the Docker image
       run: docker build . --file scripts/docker_files/docker_file_ci_centos_7/DockerFile --tag kratosmultiphysics/kratos-image-ci-centos7
     - name: Docker Login

--- a/.github/workflows/build_docker_images_with_kratos.yml
+++ b/.github/workflows/build_docker_images_with_kratos.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - name: Build the Docker image
       run: docker build . --file scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile --tag kratosmultiphysics/kratos-image-ubuntu-20-04
     - name: Docker Login

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       options: --user 1001
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
 
     # - name: Installing dependencies
     # => must be added to the docker container to avoid reinstalling it in every CI run
@@ -144,7 +144,7 @@ jobs:
       KRATOS_BUILD_TYPE: Custom
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
         python-version: '3.8'
@@ -223,7 +223,7 @@ jobs:
         CCACHE_MAXSIZE: 500M
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
 
     - name: Cache Build
       id: cache-build
@@ -335,7 +335,7 @@ jobs:
       KRATOS_BUILD_TYPE: Custom
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
         python-version: '3.8'
@@ -411,7 +411,7 @@ jobs:
       options: --user 1001
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
 
     # - name: Installing dependencies
     # => must be added to the docker container to avoid reinstalling it in every CI run
@@ -497,7 +497,7 @@ jobs:
       options: --user 1001
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
 
     # - name: Installing dependencies
     # => must be added to the docker container to avoid reinstalling it in every CI run

--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -28,13 +28,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout static page content
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           repository: KratosMultiphysics/Documentation
           ref: master
           path: statik_content
       - name: Checkout current branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
         with:
           path: main
       - name: Configure page content

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -39,7 +39,7 @@ jobs:
       options: --user 1001
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
 
     - name: Installing dependencies
       shell: bash
@@ -108,7 +108,7 @@ jobs:
       KRATOS_BUILD_TYPE: Custom
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v3
 
     - uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
Reverts KratosMultiphysics/Kratos#11552

Seems that Fulldebug/Gcc workflows are randomly failing. The reason is not clear to me but it seems to happen since the bumped checkout/actions, so I will revert the change until I can assure its safe.