### PR TITLE
[GeoMechanicsApplication] Improved reading of input files from settlement workflow

### DIFF
--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
@@ -31,8 +31,8 @@ KratosGeoSettlement::KratosGeoSettlement()
     }
 }
 
-int KratosGeoSettlement::RunStage(const std::string&                      rWorkingDirectory,
-                                  const std::string&                      rProjectParametersFileName,
+int KratosGeoSettlement::RunStage(const std::filesystem::path&            rWorkingDirectory,
+                                  const std::filesystem::path&            rProjectParametersFile,
                                   const std::function<void(const char*)>& ,
                                   const std::function<void(double)>&      ,
                                   const std::function<void(const char*)>& ,
@@ -40,35 +40,51 @@ int KratosGeoSettlement::RunStage(const std::string&                      rWorki
 {
     KRATOS_INFO("KratosGeoSettlement") << "About to run a stage..." << std::endl;
 
-    const auto project_parameters_file_path = rWorkingDirectory + "/" + rProjectParametersFileName;
-    const auto project_parameters = InputUtilities::ProjectParametersFrom(project_parameters_file_path);
+    const auto project_parameters_file_path = rWorkingDirectory / rProjectParametersFile;
+    const auto project_parameters = InputUtilities::ProjectParametersFrom(project_parameters_file_path.generic_string());
     KRATOS_INFO("KratosGeoSettlement") << "Parsed project parameters file " << project_parameters_file_path << std::endl;
 
-    const auto model_part_name = project_parameters["solver_settings"]["model_part_name"].GetString();
-    ModelPart& model_part = mModel.CreateModelPart(model_part_name);
-    model_part.SetBufferSize(2);
-    KRATOS_INFO("KratosGeoSettlement") << "Created a model part" << std::endl;
+    if (const auto model_part_name = project_parameters["solver_settings"]["model_part_name"].GetString();
+        !mModel.HasModelPart(model_part_name)) {
+        auto& model_part = AddNewModelPart(model_part_name);
+        const auto mesh_file_name = project_parameters["solver_settings"]["model_import_settings"]["input_filename"].GetString();
+        ReadModelFromFile(rWorkingDirectory / mesh_file_name, model_part);
+    }
 
-    AddNodalSolutionStepVariablesTo(model_part);
-    KRATOS_INFO("KratosGeoSettlement") << "Added nodal solution step variables" << std::endl;
-
-    AddDegreesOfFreedomTo(model_part);
-    KRATOS_INFO("KratosGeoSettlement") << "Added degrees of freedom" << std::endl;
-
-    // Don't include the file extension of the mesh file name, since that is automatically appended by the
-    // constructor of class ModelPartIO
-    const auto mesh_file_name = project_parameters["solver_settings"]["model_import_settings"]["input_filename"].GetString();
-    const auto mesh_file_path = rWorkingDirectory + "/" + mesh_file_name;
-    ModelPartIO reader{mesh_file_path};
-    reader.ReadModelPart(model_part);
-    KRATOS_INFO("KratosGeoSettlement") << "Read the mesh data from " << mesh_file_path << std::endl;
-
-    const auto material_file_name = project_parameters["solver_settings"]["material_import_settings"]["materials_filename"].GetString();
-    const auto material_file_path = rWorkingDirectory + "/" + material_file_name;
-    InputUtilities::AddMaterialsFrom(material_file_path, mModel);
-    KRATOS_INFO("KratosGeoSettlement") << "Read the materials from " << material_file_path << std::endl;
+    if (project_parameters["solver_settings"].Has("material_import_settings")) {
+        const auto material_file_name = project_parameters["solver_settings"]["material_import_settings"]["materials_filename"].GetString();
+        const auto material_file_path = rWorkingDirectory / material_file_name;
+        InputUtilities::AddMaterialsFrom(material_file_path.generic_string(), mModel);
+        KRATOS_INFO("KratosGeoSettlement") << "Read the materials from " << material_file_path << std::endl;
+    }
 
     return 0;
+}
+
+ModelPart& KratosGeoSettlement::AddNewModelPart(const std::string& rModelPartName)
+{
+    auto& result = mModel.CreateModelPart(rModelPartName);
+    KRATOS_INFO("KratosGeoSettlement") << "Created a new model part named '" << rModelPartName << "'" << std::endl;
+
+    result.SetBufferSize(2);
+
+    AddNodalSolutionStepVariablesTo(result);
+    KRATOS_INFO("KratosGeoSettlement") << "Added nodal solution step variables" << std::endl;
+
+    AddDegreesOfFreedomTo(result);
+    KRATOS_INFO("KratosGeoSettlement") << "Added degrees of freedom" << std::endl;
+
+    return result;
+}
+
+void KratosGeoSettlement::ReadModelFromFile(const std::filesystem::path& rModelPartFilePath,
+                                            Kratos::ModelPart&           rModelPart)
+{
+    // Note that the file extension of the model part file must be excluded, since that is automatically appended by the
+    // constructor of class ModelPartIO
+    ModelPartIO reader{rModelPartFilePath.generic_string()};
+    reader.ReadModelPart(rModelPart);
+    KRATOS_INFO("KratosGeoSettlement") << "Read the mesh data from " << rModelPartFilePath << std::endl;
 }
 
 void KratosGeoSettlement::AddNodalSolutionStepVariablesTo(ModelPart& rModelPart)

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h
@@ -12,8 +12,9 @@
 
 #pragma once
 
-#include <string>
+#include <filesystem>
 #include <functional>
+#include <string>
 
 #include "includes/kernel.h"
 #include "includes/kratos_export_api.h"
@@ -29,14 +30,18 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) KratosGeoSettlement
 public:
     KratosGeoSettlement();
 
-    int RunStage(const std::string&                      rWorkingDirectory,
-                 const std::string&                      rProjectParametersFileName,
+    int RunStage(const std::filesystem::path&            rWorkingDirectory,
+                 const std::filesystem::path&            rProjectParametersFile,
                  const std::function<void(const char*)>& rLogCallback,
                  const std::function<void(double)>&      rReportProgress,
                  const std::function<void(const char*)>& rReportTextualProgress,
                  const std::function<bool()>&            rShouldCancel);
 
 private:
+    ModelPart& AddNewModelPart(const std::string& rModelPartName);
+    static void ReadModelFromFile(const std::filesystem::path& rModelPartFilePath,
+                                  ModelPart&                   rModelPart);
+
     static void AddNodalSolutionStepVariablesTo(ModelPart& rModelPart);
     static void AddDegreesOfFreedomTo(ModelPart& rModelPart);
 


### PR DESCRIPTION
**📝 Description**
So far, when a stage was run using the settlement workflow (in C++), it always attempted to read the given `mdpa` file. Although the set of input files worked using the Python workflow, it raised an error when the custom workflow was used (about already existing elements). To prevent that, we now follow the same approach as in our Python workflow. That is, when the model part corresponding to the given model part name already exists, don't attempt to create a new one and also don't attempt to read the `mdpa` file. With these changes, the Python workflow and the custom (C++) workflow are more consistent.

**🆕 Changelog**
- Use `std::filesystem::path`s rather than strings when handling file paths. This implicitly addresses problems related to path separators on different platforms. Use "generic strings" when the API expects a string rather than a path object.
- Only attempt to read from a material file when one is specified in the `ProjectParameters.json` file.
- The approach for reading of `.mdpa` files in `KratosGeoSettlement` is now more in line with how this is handled by the Python code. We first check whether the given model part name corresponds to an existing model part. If not, we create a new one and populate it using the data from the `.mdpa` file.
