### PR TITLE
[Core] Adding missing checks to `test_dofs` and document it

### DIFF
--- a/kratos/tests/test_dofs.py
+++ b/kratos/tests/test_dofs.py
@@ -55,15 +55,29 @@ class TestDofs(KratosUnittest.TestCase):
         dz = n.GetDof(KratosMultiphysics.DISPLACEMENT_Z)
         p2 = n2.GetDof(KratosMultiphysics.PRESSURE)
 
+        # Fixing only displacement in X
         n.Fix(KratosMultiphysics.DISPLACEMENT_X)
         self.assertTrue(n.IsFixed(KratosMultiphysics.DISPLACEMENT_X))
         self.assertFalse(n.IsFixed(KratosMultiphysics.DISPLACEMENT_Y))
         self.assertFalse(n.IsFixed(KratosMultiphysics.DISPLACEMENT_Z))
         self.assertFalse(n.IsFixed(KratosMultiphysics.PRESSURE))
+
+        # Release the displacement in X and checking again
+        n.Free(KratosMultiphysics.DISPLACEMENT_X)
+        self.assertFalse(n.IsFixed(KratosMultiphysics.DISPLACEMENT_X))
+        self.assertFalse(n.IsFixed(KratosMultiphysics.DISPLACEMENT_Y))
+        self.assertFalse(n.IsFixed(KratosMultiphysics.DISPLACEMENT_Z))
+        self.assertFalse(n.IsFixed(KratosMultiphysics.PRESSURE))
+
+        # Fixing again dof
+        n.Fix(KratosMultiphysics.DISPLACEMENT_X)
+
+        # Assign equation Id
         dx.EquationId = 5
         dy.EquationId = 6
         dz.EquationId = 7
 
+        # Checks
         self.assertEqual(p.GetVariable(), KratosMultiphysics.PRESSURE)
         self.assertEqual(dx.GetVariable(), KratosMultiphysics.DISPLACEMENT_X)
         self.assertEqual(dx.GetReaction(), KratosMultiphysics.REACTION_X)

--- a/kratos/tests/test_dofs.py
+++ b/kratos/tests/test_dofs.py
@@ -2,8 +2,21 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 
 class TestDofs(KratosUnittest.TestCase):
+    """
+    This module contains unit tests for KratosMultiphysics DOF-related functionality.
+    It covers DOF creation, manipulation, and DOF lists.
+    """
 
     def __SetUpTestModelPart(self, model):
+        """
+        Set up a test ModelPart with nodes and DOFs.
+
+        Args:
+            model (KratosMultiphysics.Model): The Kratos model to create the ModelPart in.
+
+        Returns:
+            KratosMultiphysics.ModelPart: The created ModelPart with nodes and DOFs.
+        """
         mp = model.CreateModelPart("Main")
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.REACTION)
@@ -24,6 +37,13 @@ class TestDofs(KratosUnittest.TestCase):
         return mp
 
     def testDofExport(self):
+        """
+        Test the export of DOF information.
+
+        This test creates a ModelPart with nodes and DOFs, exports and manipulates DOFs,
+        and performs various assertions.
+
+        """
         current_model = KratosMultiphysics.Model()
         test_model_part = self.__SetUpTestModelPart(current_model)
 
@@ -36,6 +56,10 @@ class TestDofs(KratosUnittest.TestCase):
         p2 = n2.GetDof(KratosMultiphysics.PRESSURE)
 
         n.Fix(KratosMultiphysics.DISPLACEMENT_X)
+        self.assertTrue(n.IsFixed(KratosMultiphysics.DISPLACEMENT_X))
+        self.assertFalse(n.IsFixed(KratosMultiphysics.DISPLACEMENT_Y))
+        self.assertFalse(n.IsFixed(KratosMultiphysics.DISPLACEMENT_Z))
+        self.assertFalse(n.IsFixed(KratosMultiphysics.PRESSURE))
         dx.EquationId = 5
         dy.EquationId = 6
         dz.EquationId = 7
@@ -50,6 +74,13 @@ class TestDofs(KratosUnittest.TestCase):
         self.assertGreater(p2,dz)
 
     def testDofListValues(self):
+        """
+        Test DOF list values and manipulation.
+
+        This test creates a ModelPart with nodes and DOFs, creates a DOF list, sets and
+        retrieves values, and performs assertions.
+
+        """
         current_model = KratosMultiphysics.Model()
         test_model_part = self.__SetUpTestModelPart(current_model)
 
@@ -83,6 +114,13 @@ class TestDofs(KratosUnittest.TestCase):
         self.assertEqual(p.GetSolutionStepValue(), 14.0)
 
     def testDofListAppend(self):
+        """
+        Test appending DOFs to a list.
+
+        This test creates a ModelPart with nodes and DOFs and appends DOFs to a list,
+        asserting the length of the list.
+
+        """
         current_model = KratosMultiphysics.Model()
         test_model_part = self.__SetUpTestModelPart(current_model)
 
@@ -93,6 +131,13 @@ class TestDofs(KratosUnittest.TestCase):
         self.assertEqual(len(dofs_vector), test_model_part.NumberOfNodes())
 
     def testDofListUnique(self):
+        """
+        Test making a DOF list unique.
+
+        This test creates a ModelPart with nodes and DOFs, appends multiple copies of
+        the same DOF to a list, makes the list unique, and asserts its length.
+
+        """
         current_model = KratosMultiphysics.Model()
         test_model_part = self.__SetUpTestModelPart(current_model)
 
@@ -107,4 +152,5 @@ class TestDofs(KratosUnittest.TestCase):
         self.assertEqual(len(dofs_vector), test_model_part.NumberOfNodes())
 
 if __name__ == '__main__':
+    KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.WARNING)
     KratosUnittest.main()


### PR DESCRIPTION
**📝 Description**

This PR adds testing for the `IsFixed` methods in `test_dofs`. Also adds a test for `Free` method.

In addition, the PR adds documentation to the following methods from `test_dofs`:

1. **SetUpTestModelPart Method**: A method called `__SetUpTestModelPart` is added to set up a test ModelPart with nodes and DOFs. 

2. **testDofExport Method**: This test case checks the export of DOF information. It creates a ModelPart with nodes and DOFs, exports and manipulates DOFs, and performs various assertions.

3. **testDofListValues Method**: This test case focuses on DOF list values and manipulation. It creates a ModelPart with nodes and DOFs, creates a DOF list, sets and retrieves values, and performs assertions.

4. **testDofListAppend Method**: This test case checks the appending of DOFs to a list. It creates a ModelPart with nodes and DOFs and appends DOFs to a list, asserting the length of the list.

5. **testDofListUnique Method**: This test case examines making a DOF list unique. It creates a ModelPart with nodes and DOFs, appends multiple copies of the same DOF to a list, makes the list unique, and asserts its length.

**🆕 Changelog**

- [Adding missing checks to test_dofs and document it](https://github.com/KratosMultiphysics/Kratos/commit/c5d3bdc87c1d3eecb3e92d2e6019f3fd71f8e1ca)
- [Improve test with testing Free too](https://github.com/KratosMultiphysics/Kratos/pull/11568/commits/d4d7c45016fff86b494406dd449a6d3ccfb80395)