### PR TITLE
[Hotfix][Core] Quad element size fix

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_element_size_calculator.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_element_size_calculator.cpp
@@ -98,9 +98,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(1, 0.0, 0.0, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(2, 1.0, 0.0, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(3, 0.0, 1.0, 0.0)));
-            auto geometry = *GeometryType::Pointer(new Triangle2D3<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Triangle2D3<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<2, 3>::MinimumElementSize,
+                *p_geometry, ElementSizeCalculator<2, 3>::MinimumElementSize,
                 ElementSizeCalculator<2, 3>::MinimumElementSizeDerivative, 1e-8, 1e-7);
         }
 
@@ -110,9 +110,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(1, 0.0, 0.0, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(2, 1.0, 0.0, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(3, 0.0, 1.0, 0.0)));
-            auto geometry = *GeometryType::Pointer(new Triangle2D3<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Triangle2D3<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<2, 3>::AverageElementSize,
+                *p_geometry, ElementSizeCalculator<2, 3>::AverageElementSize,
                 ElementSizeCalculator<2, 3>::AverageElementSizeDerivative, 1e-8, 1e-7);
         }
 
@@ -125,9 +125,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(4, 0.5, 0.0, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(5, 0.5, 0.5, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(6, 0.0, 0.5, 0.0)));
-            auto geometry = *GeometryType::Pointer(new Triangle2D6<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Triangle2D6<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<2, 6>::MinimumElementSize,
+                *p_geometry, ElementSizeCalculator<2, 6>::MinimumElementSize,
                 ElementSizeCalculator<2, 6>::MinimumElementSizeDerivative, 1e-8, 1e-7);
         }
 
@@ -140,9 +140,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(4, 0.5, 0.0, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(5, 0.5, 0.5, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(6, 0.0, 0.5, 0.0)));
-            auto geometry = *GeometryType::Pointer(new Triangle2D6<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Triangle2D6<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<2, 6>::AverageElementSize,
+                *p_geometry, ElementSizeCalculator<2, 6>::AverageElementSize,
                 ElementSizeCalculator<2, 6>::AverageElementSizeDerivative, 1e-8, 1e-7);
         }
 
@@ -153,9 +153,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(2, 1.0, 0.0, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(3, 1.0, 1.0, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(4, 0.0, 1.0, 0.0)));
-            auto geometry = *GeometryType::Pointer(new Quadrilateral2D4<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Quadrilateral2D4<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<2, 4>::MinimumElementSize,
+                *p_geometry, ElementSizeCalculator<2, 4>::MinimumElementSize,
                 ElementSizeCalculator<2, 4>::MinimumElementSizeDerivative, 1e-8, 1e-7);
         }
 
@@ -166,9 +166,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(2, 1.0, 0.0, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(3, 1.0, 1.0, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(4, 0.0, 1.0, 0.0)));
-            auto geometry = *GeometryType::Pointer(new Quadrilateral2D4<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Quadrilateral2D4<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<2, 4>::AverageElementSize,
+                *p_geometry, ElementSizeCalculator<2, 4>::AverageElementSize,
                 ElementSizeCalculator<2, 4>::AverageElementSizeDerivative, 1e-8, 1e-7);
         }
 
@@ -184,9 +184,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(7, 0.5, 1.0, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(8, 0.0, 0.5, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(9, 0.5, 0.5, 0.0)));
-            auto geometry = *GeometryType::Pointer(new Quadrilateral2D9<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Quadrilateral2D9<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<2, 9>::MinimumElementSize,
+                *p_geometry, ElementSizeCalculator<2, 9>::MinimumElementSize,
                 ElementSizeCalculator<2, 9>::MinimumElementSizeDerivative, 1e-8, 1e-7);
         }
 
@@ -202,9 +202,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(7, 0.5, 1.0, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(8, 0.0, 0.5, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(9, 0.5, 0.5, 0.0)));
-            auto geometry = *GeometryType::Pointer(new Quadrilateral2D9<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Quadrilateral2D9<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<2, 9>::AverageElementSize,
+                *p_geometry, ElementSizeCalculator<2, 9>::AverageElementSize,
                 ElementSizeCalculator<2, 9>::AverageElementSizeDerivative, 1e-8, 1e-7);
         }
 
@@ -215,9 +215,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(2, 1.0, 2.0, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(3, 0.5, 0.5, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(4, 0.2, 0.3, 1.0)));
-            auto geometry = *GeometryType::Pointer(new Tetrahedra3D4<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Tetrahedra3D4<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<3, 4>::MinimumElementSize,
+                *p_geometry, ElementSizeCalculator<3, 4>::MinimumElementSize,
                 ElementSizeCalculator<3, 4>::MinimumElementSizeDerivative, 1e-8, 1e-7);
         }
 
@@ -228,9 +228,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(2, 1.0, 2.0, 0.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(3, 0.2, 0.3, 1.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(4, 0.5, 0.5, 0.0)));
-            auto geometry = *GeometryType::Pointer(new Tetrahedra3D4<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Tetrahedra3D4<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<3, 4>::AverageElementSize,
+                *p_geometry, ElementSizeCalculator<3, 4>::AverageElementSize,
                 ElementSizeCalculator<3, 4>::AverageElementSizeDerivative, 1e-8, 1e-7);
         }
 
@@ -247,9 +247,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(8, 0.1, 0.15, 0.5)));
             nodes.push_back(NodeType::Pointer(new NodeType(9, 0.35, 0.4, 0.5)));
             nodes.push_back(NodeType::Pointer(new NodeType(10, 0.6, 1.15, 0.5)));
-            auto geometry = *GeometryType::Pointer(new Tetrahedra3D10<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Tetrahedra3D10<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<3, 10>::MinimumElementSize,
+                *p_geometry, ElementSizeCalculator<3, 10>::MinimumElementSize,
                 ElementSizeCalculator<3, 10>::MinimumElementSizeDerivative, 1e-8, 1e-7);
         }
 
@@ -266,9 +266,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(8, 0.1, 0.15, 0.5)));
             nodes.push_back(NodeType::Pointer(new NodeType(9, 0.35, 0.4, 0.5)));
             nodes.push_back(NodeType::Pointer(new NodeType(10, 0.6, 1.15, 0.5)));
-            auto geometry = *GeometryType::Pointer(new Tetrahedra3D10<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Tetrahedra3D10<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<3, 10>::AverageElementSize,
+                *p_geometry, ElementSizeCalculator<3, 10>::AverageElementSize,
                 ElementSizeCalculator<3, 10>::AverageElementSizeDerivative, 1e-8, 1e-7);
         }
 
@@ -281,9 +281,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(4, 0.0, 0.0, 1.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(5, 1.0, 0.0, 1.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(6, 0.0, 1.0, 1.0)));
-            auto geometry = *GeometryType::Pointer(new Prism3D6<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Prism3D6<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<3, 6>::MinimumElementSize,
+                *p_geometry, ElementSizeCalculator<3, 6>::MinimumElementSize,
                 ElementSizeCalculator<3, 6>::MinimumElementSizeDerivative, 1e-8, 1e-7);
         }
 
@@ -296,9 +296,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(4, 0.0, 0.0, 1.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(5, 1.0, 0.0, 1.0)));
             nodes.push_back(NodeType::Pointer(new NodeType(6, 0.0, 1.0, 1.0)));
-            auto geometry = *GeometryType::Pointer(new Prism3D6<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Prism3D6<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<3, 6>::AverageElementSize,
+                *p_geometry, ElementSizeCalculator<3, 6>::AverageElementSize,
                 ElementSizeCalculator<3, 6>::AverageElementSizeDerivative, 1e-8, 1e-7);
         }
 
@@ -313,9 +313,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(6, 0.7, 0.1, 0.4)));
             nodes.push_back(NodeType::Pointer(new NodeType(7, 0.7, 0.8, 0.3)));
             nodes.push_back(NodeType::Pointer(new NodeType(8, 0.1, 0.8, 0.6)));
-            auto geometry = *GeometryType::Pointer(new Hexahedra3D8<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Hexahedra3D8<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<3, 8>::MinimumElementSize,
+                *p_geometry, ElementSizeCalculator<3, 8>::MinimumElementSize,
                 ElementSizeCalculator<3, 8>::MinimumElementSizeDerivative, 1e-8, 1e-7);
         }
 
@@ -330,9 +330,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(6, 0.7, 0.1, 0.4)));
             nodes.push_back(NodeType::Pointer(new NodeType(7, 0.7, 0.8, 0.3)));
             nodes.push_back(NodeType::Pointer(new NodeType(8, 0.1, 0.8, 0.6)));
-            auto geometry = *GeometryType::Pointer(new Hexahedra3D8<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Hexahedra3D8<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<3, 8>::AverageElementSize,
+                *p_geometry, ElementSizeCalculator<3, 8>::AverageElementSize,
                 ElementSizeCalculator<3, 8>::AverageElementSizeDerivative, 1e-8, 1e-7);
         }
 
@@ -366,9 +366,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(25, 0.05, 0.55, 0.15)));
             nodes.push_back(NodeType::Pointer(new NodeType(26, 0.7, 0.4, 0.45)));
             nodes.push_back(NodeType::Pointer(new NodeType(27, 0.45, 0.5, 0.1625)));
-            auto geometry = *GeometryType::Pointer(new Hexahedra3D27<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Hexahedra3D27<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<3, 27>::MinimumElementSize,
+                *p_geometry, ElementSizeCalculator<3, 27>::MinimumElementSize,
                 ElementSizeCalculator<3, 27>::MinimumElementSizeDerivative, 1e-8, 1e-7);
         }
 
@@ -402,9 +402,9 @@ namespace Kratos
             nodes.push_back(NodeType::Pointer(new NodeType(25, 0.05, 0.55, 0.15)));
             nodes.push_back(NodeType::Pointer(new NodeType(26, 0.7, 0.4, 0.45)));
             nodes.push_back(NodeType::Pointer(new NodeType(27, 0.45, 0.5, 0.1625)));
-            auto geometry = *GeometryType::Pointer(new Hexahedra3D27<NodeType>(nodes));
+            auto p_geometry = GeometryType::Pointer(new Hexahedra3D27<NodeType>(nodes));
             RunElementSizeCalculatorDerivativesTest(
-                geometry, ElementSizeCalculator<3, 27>::AverageElementSize,
+                *p_geometry, ElementSizeCalculator<3, 27>::AverageElementSize,
                 ElementSizeCalculator<3, 27>::AverageElementSizeDerivative, 1e-8, 1e-7);
         }
 

--- a/kratos/utilities/element_size_calculator.cpp
+++ b/kratos/utilities/element_size_calculator.cpp
@@ -831,13 +831,14 @@ template<>
 double ElementSizeCalculator<2,4>::AverageElementSize(const Geometry<Node >& rGeometry)
 {
 
-    const double x10 = rGeometry[1].X() - rGeometry[0].X();
-    const double y10 = rGeometry[1].Y() - rGeometry[0].Y();
+    // const double x10 = rGeometry[1].X() - rGeometry[0].X();
+    // const double y10 = rGeometry[1].Y() - rGeometry[0].Y();
 
-    const double x30 = rGeometry[3].X() - rGeometry[0].X();
-    const double y30 = rGeometry[3].Y() - rGeometry[0].Y();
+    // const double x30 = rGeometry[3].X() - rGeometry[0].X();
+    // const double y30 = rGeometry[3].Y() - rGeometry[0].Y();
 
-    return std::sqrt(x10*y30-x30*y10);
+    // return std::sqrt(x10*y30-x30*y10);
+    return std::sqrt(rGeometry.Area());
 }
 
 template<>

--- a/kratos/utilities/element_size_calculator.cpp
+++ b/kratos/utilities/element_size_calculator.cpp
@@ -8,8 +8,16 @@
 //                   Kratos default license: kratos/license.txt
 //
 //  Main author:     Jordi Cotela
+//                   Suneth Warnakulasuriya
 //
 
+// System includes
+#include <cmath>
+
+// Project includes
+#include "integration_utilities.h"
+
+// Include base h
 #include "element_size_calculator.h"
 
 namespace Kratos {
@@ -841,27 +849,16 @@ double ElementSizeCalculator<2,4>::AverageElementSizeDerivative(
 {
     KRATOS_TRY
 
-    KRATOS_DEBUG_ERROR_IF(DerivativeNodeIndex > 3)
-        << "Invalid DerivativeNodeIndex [ DerivativeNodeIndex = " << DerivativeNodeIndex
-        << ", expected DerivativeNodeIndex < 4 ].\n";
+    const double area = rGeometry.Area();
+    const double area_derivative = IntegrationUtilities::ComputeArea2DGeometryDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, rGeometry);
 
-    KRATOS_DEBUG_ERROR_IF(DerivativeDirectionIndex > 1)
-        << "Invalid DerivativeDirectionIndex [ DerivativeDirectionIndex = " << DerivativeDirectionIndex
-        << ", expected DerivativeDirectionIndex < 2 ].\n";
-
-    const double x10 = rGeometry[1].X() - rGeometry[0].X();
-    const double x10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 0);
-
-    const double y10 = rGeometry[1].Y() - rGeometry[0].Y();
-    const double y10_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 1, 0, 1);
-
-    const double x30 = rGeometry[3].X() - rGeometry[0].X();
-    const double x30_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 3, 0, 0);
-
-    const double y30 = rGeometry[3].Y() - rGeometry[0].Y();
-    const double y30_derivative = EdgeLengthDerivative(DerivativeNodeIndex, DerivativeDirectionIndex, 3, 0, 1);
-
-    return 0.5 * (x10_derivative*y30+x10*y30_derivative-x30_derivative*y10-x30*y10_derivative) / (x10*y30-x30*y10);
+    if (area > 0.0) {
+        return 0.5 * area_derivative / std::sqrt(area);
+    } else if (area < 0.0) {
+        return -0.5 * area_derivative / std::sqrt(-area);
+    } else {
+        return 0.0;
+    }
 
     KRATOS_CATCH("");
 }
@@ -870,10 +867,7 @@ double ElementSizeCalculator<2,4>::AverageElementSizeDerivative(
 template<>
 double ElementSizeCalculator<2,9>::AverageElementSize(const Geometry<Node >& rGeometry)
 {
-
-    const double average_element_size = ElementSizeCalculator<2,4>::AverageElementSize(rGeometry);
-
-    return average_element_size;
+    return rGeometry.Length();
 }
 
 template<>
@@ -882,14 +876,29 @@ double ElementSizeCalculator<2,9>::AverageElementSizeDerivative(
     const unsigned int DerivativeDirectionIndex,
     const Geometry<Node >& rGeometry)
 {
+    Matrix jacobian(2, 2);
+    Matrix shape_function_local_gradients(rGeometry.size(), 2), rdNdXDerivative;
+    double detJ_derivative;
+    ShapeParameter shape_param;
 
-    double element_size_derivative = 0.0;
+    shape_param.NodeIndex = DerivativeNodeIndex;
+    shape_param.Direction = DerivativeDirectionIndex;
 
-    if (DerivativeNodeIndex < 4)
-        element_size_derivative = ElementSizeCalculator<2,4>::AverageElementSizeDerivative(DerivativeNodeIndex,DerivativeDirectionIndex,rGeometry);
+    rGeometry.ShapeFunctionsLocalGradients(shape_function_local_gradients, Point());
+    rGeometry.Jacobian(jacobian, Point());
 
-    return element_size_derivative;
+    GeometricalSensitivityUtility geometrical_sensitivity_utility(jacobian, shape_function_local_gradients);
+    geometrical_sensitivity_utility.CalculateSensitivity(shape_param, detJ_derivative, rdNdXDerivative);
 
+    const auto detJ = MathUtils<double>::Det2(jacobian);
+
+    if (detJ > 0.0) {
+        return 0.5 * detJ_derivative / (std::sqrt(detJ));
+    } else if (detJ < 0.0) {
+        return -0.5 * detJ_derivative / (std::sqrt(-detJ));
+    } else {
+        return 0.0;
+    }
 }
 
 // Tetrahedra3D4 version.

--- a/kratos/utilities/element_size_calculator.cpp
+++ b/kratos/utilities/element_size_calculator.cpp
@@ -830,15 +830,7 @@ double ElementSizeCalculator<2,6>::AverageElementSizeDerivative(
 template<>
 double ElementSizeCalculator<2,4>::AverageElementSize(const Geometry<Node >& rGeometry)
 {
-
-    // const double x10 = rGeometry[1].X() - rGeometry[0].X();
-    // const double y10 = rGeometry[1].Y() - rGeometry[0].Y();
-
-    // const double x30 = rGeometry[3].X() - rGeometry[0].X();
-    // const double y30 = rGeometry[3].Y() - rGeometry[0].Y();
-
-    // return std::sqrt(x10*y30-x30*y10);
-    return std::sqrt(rGeometry.Area());
+    return rGeometry.Length();
 }
 
 template<>


### PR DESCRIPTION
**📝 Description**
Quadrilateral `AverageElementSize` formula in `ElementSizeCalculator`  is only valid for rectangular quadrilaterals. Changes in here make it valid for any quadrilateral.
