### PR TITLE
[Core] Change Registry GetValue

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_operations/potential_to_compressible_navier_stokes_operation.h
@@ -45,8 +45,8 @@ public:
     KRATOS_CLASS_POINTER_DEFINITION(PotentialToCompressibleNavierStokesOperation);
 
     /// Registry current operation
-    KRATOS_REGISTRY_ADD_PROTOTYPE("Operations.KratosMultiphysics.CompressiblePotentialFlowApplication", PotentialToCompressibleNavierStokesOperation)
-    KRATOS_REGISTRY_ADD_PROTOTYPE("Operations.All", PotentialToCompressibleNavierStokesOperation)
+    KRATOS_REGISTRY_ADD_PROTOTYPE("Operations.KratosMultiphysics.CompressiblePotentialFlowApplication", Operation, PotentialToCompressibleNavierStokesOperation)
+    KRATOS_REGISTRY_ADD_PROTOTYPE("Operations.All", Operation, PotentialToCompressibleNavierStokesOperation)
 
     ///@}
     ///@name Life Cycle

--- a/kratos/includes/define_registry.h
+++ b/kratos/includes/define_registry.h
@@ -40,27 +40,27 @@
  * the dispatcher function directly inside the std::move would break current code as the compiler will deduce the type
  * of the lambda function to something that is not an std::function.
  */
-#define KRATOS_REGISTRY_ADD_PROTOTYPE(NAME, X)                                            \
+#define KRATOS_REGISTRY_ADD_PROTOTYPE(NAME, X, Y)                                         \
     static inline bool KRATOS_REGISTRY_NAME(_is_registered_, __LINE__) = []() -> bool {   \
         using TFunctionType = std::function<std::shared_ptr<X>()>;                        \
-        std::string key_name = NAME + std::string(".") + std::string(#X);                 \
+        std::string key_name = NAME + std::string(".") + std::string(#Y);                 \
         if (!Registry::HasItem(key_name))                                                 \
         {                                                                                 \
             auto &r_item = Registry::AddItem<RegistryItem>(key_name);                     \
-            TFunctionType dispatcher = [](){return std::make_shared<X>();};               \
+            TFunctionType dispatcher = [](){return std::make_shared<Y>();};               \
             r_item.AddItem<TFunctionType>("Prototype", std::move(dispatcher));            \
         }                                                                                 \
         return Registry::HasItem(key_name);                                               \
     }();
 
-#define KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE(NAME, X, ...)                                            \
+#define KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE(NAME, X, Y, ...)                                            \
     static inline bool KRATOS_REGISTRY_NAME(_is_registered_, __LINE__) = []() -> bool {                 \
-        using TFunctionType = std::function<std::shared_ptr<X<__VA_ARGS__>>()>;                         \
-        std::string key_name = NAME + std::string(".") + std::string(#X) + "<" + Kratos::Registry::RegistryTemplateToString(__VA_ARGS__) + ">";    \
+        using TFunctionType = std::function<std::shared_ptr<X>()>;                         \
+        std::string key_name = NAME + std::string(".") + std::string(#Y) + "<" + Kratos::Registry::RegistryTemplateToString(__VA_ARGS__) + ">";    \
         if (!Registry::HasItem(key_name))                                                               \
         {                                                                                               \
             auto &r_item = Registry::AddItem<RegistryItem>(key_name);                                   \
-            TFunctionType dispatcher = [](){return std::make_shared<X<__VA_ARGS__>>();};                \
+            TFunctionType dispatcher = [](){return std::make_shared<Y<__VA_ARGS__>>();};                \
             r_item.AddItem<TFunctionType>("Prototype", std::move(dispatcher));                          \
         } else {                                                                                        \
         }                                                                                               \

--- a/kratos/includes/registry.h
+++ b/kratos/includes/registry.h
@@ -143,6 +143,12 @@ public:
         return GetItem(rItemFullName).GetValue<TDataType>();
     }
 
+    template<typename TDataType, typename TCastType>
+    static typename std::enable_if<std::is_base_of<TDataType, TCastType>::value, TCastType>::type const GetValueAs(std::string const& rItemFullName)
+    {
+        return GetItem(rItemFullName).GetValueAs<TDataType, TCastType>();
+    }
+
     static void RemoveItem(std::string const& ItemName);
 
     ///@}

--- a/kratos/includes/registry_item.h
+++ b/kratos/includes/registry_item.h
@@ -238,11 +238,22 @@ public:
 
     RegistryItem& GetItem(std::string const& rItemName);
 
-    template<typename TDataType> TDataType const& GetValue() const
+    template<typename TDataType>
+    TDataType const& GetValue() const
     {
         KRATOS_TRY
 
         return *(std::any_cast<std::shared_ptr<TDataType>>(mpValue));
+
+        KRATOS_CATCH("");
+    }
+
+    template<typename TDataType, typename TCastType> 
+    TCastType const& GetValueAs() const
+    {
+        KRATOS_TRY
+
+        return *std::dynamic_pointer_cast<TCastType>(std::any_cast<std::shared_ptr<TDataType>>(mpValue));
 
         KRATOS_CATCH("");
     }

--- a/kratos/operations/operation.h
+++ b/kratos/operations/operation.h
@@ -149,8 +149,8 @@ private:
     ///@name Static Member Variables
     ///@{
 
-    KRATOS_REGISTRY_ADD_PROTOTYPE("Operations.KratosMultiphysics", Operation)
-    KRATOS_REGISTRY_ADD_PROTOTYPE("Operations.All", Operation)
+    KRATOS_REGISTRY_ADD_PROTOTYPE("Operations.KratosMultiphysics", Operation, Operation)
+    KRATOS_REGISTRY_ADD_PROTOTYPE("Operations.All", Operation, Operation)
 
     ///@}
 }; // Class Operation

--- a/kratos/processes/apply_ray_casting_interface_recognition_process.h
+++ b/kratos/processes/apply_ray_casting_interface_recognition_process.h
@@ -44,8 +44,8 @@ public:
     /// Pointer definition of ApplyRayCastingInterfaceRecognitionProcess
     KRATOS_CLASS_POINTER_DEFINITION(ApplyRayCastingInterfaceRecognitionProcess);
 
-    KRATOS_REGISTRY_ADD_PROTOTYPE("Processes.KratosMultiphysics", ApplyRayCastingInterfaceRecognitionProcess<TDim>)
-    KRATOS_REGISTRY_ADD_PROTOTYPE("Processes.All", ApplyRayCastingInterfaceRecognitionProcess<TDim>)
+    KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.KratosMultiphysics", Process, ApplyRayCastingInterfaceRecognitionProcess, TDim)
+    KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.All", Process, ApplyRayCastingInterfaceRecognitionProcess, TDim)
 
     ///@}
     ///@name Life Cycle

--- a/kratos/processes/apply_ray_casting_process.h
+++ b/kratos/processes/apply_ray_casting_process.h
@@ -51,8 +51,8 @@ public:
     /// Pointer definition of ApplyRayCastingProcess
     KRATOS_CLASS_POINTER_DEFINITION(ApplyRayCastingProcess);
 
-    KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.KratosMultiphysics", ApplyRayCastingProcess, TDim)
-    KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.All", ApplyRayCastingProcess, TDim)
+    KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.KratosMultiphysics", Process, ApplyRayCastingProcess, TDim)
+    KRATOS_REGISTRY_ADD_TEMPLATE_PROTOTYPE("Processes.All", Process, ApplyRayCastingProcess, TDim)
 
     //TODO: These using statements have been included to make the old functions able to compile. It is still pending to update them.
     using ConfigurationType = Internals::DistanceSpatialContainersConfigure;

--- a/kratos/processes/output_process.h
+++ b/kratos/processes/output_process.h
@@ -100,8 +100,8 @@ private:
     ///@name Static Member Variables
     ///@{
 
-    KRATOS_REGISTRY_ADD_PROTOTYPE("Processes.KratosMultiphysics", OutputProcess)
-    KRATOS_REGISTRY_ADD_PROTOTYPE("Processes.All", OutputProcess)
+    KRATOS_REGISTRY_ADD_PROTOTYPE("Processes.KratosMultiphysics", Process, OutputProcess)
+    KRATOS_REGISTRY_ADD_PROTOTYPE("Processes.All", Process, OutputProcess)
 
     ///@}
 

--- a/kratos/processes/process.h
+++ b/kratos/processes/process.h
@@ -220,8 +220,8 @@ private:
     ///@name Static Member Variables
     ///@{
 
-    KRATOS_REGISTRY_ADD_PROTOTYPE("Processes.KratosMultiphysics", Process)
-    KRATOS_REGISTRY_ADD_PROTOTYPE("Processes.All", Process)
+    KRATOS_REGISTRY_ADD_PROTOTYPE("Processes.KratosMultiphysics", Process, Process)
+    KRATOS_REGISTRY_ADD_PROTOTYPE("Processes.All", Process, Process)
 
     ///@}
     ///@name Un accessible methods

--- a/kratos/tests/cpp_tests/sources/test_registry.cpp
+++ b/kratos/tests/cpp_tests/sources/test_registry.cpp
@@ -301,9 +301,6 @@ KRATOS_TEST_CASE_IN_SUITE(RegistryParallelAddAndRemove, KratosCoreFastSuite)
                 KRATOS_EXPECT_FALSE(Registry::HasItem(item_name));
             }
         );
-
-        
-
 }
 
 KRATOS_TEST_CASE_IN_SUITE(RegistrySomeRegisteredVariables, KratosCoreFastSuite){

--- a/kratos/tests/cpp_tests/sources/test_registry_access.cpp
+++ b/kratos/tests/cpp_tests/sources/test_registry_access.cpp
@@ -1,0 +1,50 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//
+//
+
+// System includes
+#include <numeric>
+
+// External includes
+
+// Project includes
+#include "testing/testing.h"
+#include "includes/expect.h"
+#include "includes/registry.h"
+#include "processes/process.h"
+#include "processes/output_process.h"
+
+namespace Kratos::Testing {
+
+KRATOS_TEST_CASE_IN_SUITE(RegistryItemGetValue, KratosCoreFastSuite)
+{
+    auto pProcess = Registry::GetValue<Process>("Processes.KratosMultiphysics.Process.Prototype");
+
+    KRATOS_EXPECT_TRUE((std::is_base_of<Process,decltype(pProcess)>::value))
+}
+
+KRATOS_TEST_CASE_IN_SUITE(RegistryItemGetValueDerivedAsBase, KratosCoreFastSuite)
+{
+    auto pProcess = Registry::GetValue<Process>("Processes.KratosMultiphysics.OutputProcess.Prototype");
+
+    KRATOS_EXPECT_TRUE((std::is_same<Process,decltype(pProcess)>::value))
+}
+
+
+KRATOS_TEST_CASE_IN_SUITE(RegistryItemGetValueDerivedasDerived, KratosCoreFastSuite)
+{
+    auto pProcess = Registry::GetValueAs<Process, OutputProcess>("Processes.KratosMultiphysics.OutputProcess.Prototype");
+
+    KRATOS_EXPECT_TRUE((std::is_base_of<OutputProcess,decltype(pProcess)>::value))
+}
+
+}  // namespace Kratos::Testing.

--- a/kratos/tests/cpp_tests/sources/test_registry_access.cpp
+++ b/kratos/tests/cpp_tests/sources/test_registry_access.cpp
@@ -7,7 +7,7 @@
 //  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
-//  Main authors:    Pooyan Dadvand
+//  Main authors:    Carlos Roig
 //
 //
 

--- a/kratos/tests/cpp_tests/sources/test_registry_access.cpp
+++ b/kratos/tests/cpp_tests/sources/test_registry_access.cpp
@@ -44,7 +44,7 @@ KRATOS_TEST_CASE_IN_SUITE(RegistryItemGetValueDerivedasDerived, KratosCoreFastSu
 {
     auto pProcess = Registry::GetValueAs<Process, OutputProcess>("Processes.KratosMultiphysics.OutputProcess.Prototype");
 
-    KRATOS_EXPECT_TRUE((std::is_base_of<OutputProcess,decltype(pProcess)>::value))
+    KRATOS_EXPECT_TRUE((std::is_same<OutputProcess,decltype(pProcess)>::value))
 }
 
 }  // namespace Kratos::Testing.


### PR DESCRIPTION
**📝 Description**
- Registry now expects for items to be registered with their bases
- `GetValue<T>` now expects you to obtain the base value (Like current KratosComponents)
- `GetValueAs<T,C>` now makes the cast so you can retrieve the actual downcasted object, if possible

Example:

```C++
class Process {};
class MyProcess : public Process {};
class MyBadProcess {};

ADD_REGISTRY_PROTOTYPE("Key", Process, MyProcess)

auto p = Registry::GetValue<Process>("Key.MyProcess.Prototype")  // Correct, p is of type Process
auto p = Registry::GetValue<MyProcess>("Key.MyProcess.Prototype")  // Compilation Error
auto p = Registry::GetValueAs<Process, MyProcess>("Key.MyProcess.Prototype")  // Correct, p is of type MyProcess
auto p = Registry::GetValueAs<Process, MyBadProcess>("Key.MyProcess.Prototype")  // Compilation Error (Process is not a base of MyBadProcess)
```

Test to check that GetValueAs with non derived classes cannot be compiled is super ugly and involves dark templates, so left it behind.
