### PR TITLE
[RomApp] Adding candidate elements (and/or conditions) to HROM

### DIFF
--- a/applications/RomApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/RomApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -54,6 +54,8 @@ void AddCustomUtilitiesToPython(pybind11::module& m)
         .def_static("GetElementIdsNotInHRomModelPart", &RomAuxiliaryUtilities::GetElementIdsNotInHRomModelPart)
         .def_static("GetHRomMinimumConditionsIds", &RomAuxiliaryUtilities::GetHRomMinimumConditionsIds)
         .def_static("ProjectRomSolutionIncrementToNodes", &RomAuxiliaryUtilities::ProjectRomSolutionIncrementToNodes)
+        .def_static("GetElementIdsInModelPart", &RomAuxiliaryUtilities::GetElementIdsInModelPart)
+        .def_static("GetConditionIdsInModelPart", &RomAuxiliaryUtilities::GetConditionIdsInModelPart)
         ;
 }
 

--- a/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.cpp
+++ b/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.cpp
@@ -342,7 +342,7 @@ std::vector<IndexType> RomAuxiliaryUtilities::GetNodalNeighbouringElementIdsNotI
 {
     std::vector<IndexType> new_element_ids;
     const auto& r_elem_weights = rHRomWeights.at("Elements");
-    
+
     FindGlobalNodalEntityNeighboursProcess<ModelPart::ElementsContainerType> find_nodal_elements_neighbours_process(rModelPart);
     find_nodal_elements_neighbours_process.Execute();
 
@@ -373,7 +373,7 @@ std::vector<IndexType> RomAuxiliaryUtilities::GetElementIdsNotInHRomModelPart(
 
     for (const auto& r_elem : rModelPartWithElementsToInclude.Elements()) {
         IndexType element_id = r_elem.Id();
-        
+
         // Check if the element is already added
         if (r_elem_weights.find(element_id - 1) == r_elem_weights.end()) {
             new_element_ids.push_back(element_id - 1);
@@ -382,6 +382,7 @@ std::vector<IndexType> RomAuxiliaryUtilities::GetElementIdsNotInHRomModelPart(
 
     return new_element_ids;
 }
+
 
 std::vector<IndexType> RomAuxiliaryUtilities::GetConditionIdsNotInHRomModelPart(
     const ModelPart& rModelPart,
@@ -393,7 +394,7 @@ std::vector<IndexType> RomAuxiliaryUtilities::GetConditionIdsNotInHRomModelPart(
 
     for (const auto& r_cond : rModelPartWithConditionsToInclude.Conditions()) {
         IndexType condition_id = r_cond.Id();
-        
+
         // Check if the condition is already added
         if (r_cond_weights.find(condition_id - 1) == r_cond_weights.end()) {
             new_condition_ids.push_back(condition_id - 1);
@@ -401,6 +402,28 @@ std::vector<IndexType> RomAuxiliaryUtilities::GetConditionIdsNotInHRomModelPart(
     }
 
     return new_condition_ids;
+}
+
+std::vector<IndexType> RomAuxiliaryUtilities::GetElementIdsInModelPart(
+    const ModelPart& rModelPart)
+{
+    std::vector<IndexType> element_ids;
+
+    for (const auto& r_elem : rModelPart.Elements()) {
+        element_ids.push_back(r_elem.Id());
+    }
+    return element_ids;
+}
+
+std::vector<IndexType> RomAuxiliaryUtilities::GetConditionIdsInModelPart(
+    const ModelPart& rModelPart)
+{
+    std::vector<IndexType> condition_ids;
+
+    for (const auto& r_cond : rModelPart.Conditions()) {
+        condition_ids.push_back(r_cond.Id());
+    }
+    return condition_ids;
 }
 
 std::vector<IndexType> RomAuxiliaryUtilities::GetHRomMinimumConditionsIds(
@@ -567,6 +590,6 @@ void RomAuxiliaryUtilities::GetPsiElemental(
                 noalias(row(rPsiElemental, i)) = row(r_nodal_rom_basis, row_id);
             }
         }
-    } 
+    }
 
 } // namespace Kratos

--- a/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.h
+++ b/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.h
@@ -169,11 +169,11 @@ public:
         const std::map<IndexType, double>& rHRomConditionWeights);
 
 
-    std::vector<IndexType> GetElementIdsInModelPart(
+    static std::vector<IndexType> GetElementIdsInModelPart(
         const ModelPart& rModelPart
     );
 
-    std::vector<IndexType> GetConditionIdsInModelPart(
+    static std::vector<IndexType> GetConditionIdsInModelPart(
         const ModelPart& rModelPart
     );
 

--- a/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.h
+++ b/applications/RomApplication/custom_utilities/rom_auxiliary_utilities.h
@@ -107,14 +107,14 @@ public:
     static std::vector<IndexType> GetHRomConditionParentsIds(
         const ModelPart& rModelPart,
         const std::map<std::string, std::map<IndexType, double>>& rHRomWeights);
-    
+
     /**
      * @brief Retrieve the IDs of elements neighboring nodes in a given sub-model part but not present in HRom weights.
      *
-     * This function iterates over all the nodes in the provided sub-model part (`rGivenModelPart`) and collects 
-     * the IDs of the elements neighboring each node. The neighboring elements are determined using the 
-     * 'NEIGHBOUR_ELEMENTS' value attached to each node. The function then checks if these elements are already 
-     * present in `rHRomWeights`. If not, their IDs are added to the return vector. It's important to note that 
+     * This function iterates over all the nodes in the provided sub-model part (`rGivenModelPart`) and collects
+     * the IDs of the elements neighboring each node. The neighboring elements are determined using the
+     * 'NEIGHBOUR_ELEMENTS' value attached to each node. The function then checks if these elements are already
+     * present in `rHRomWeights`. If not, their IDs are added to the return vector. It's important to note that
      * this function assumes that the 'NEIGHBOUR_ELEMENTS' values are already computed for the nodes in the model part.
      *
      * @param rModelPart The complete model part which houses all the elements.
@@ -167,6 +167,15 @@ public:
     static std::vector<IndexType> GetHRomMinimumConditionsIds(
         const ModelPart& rModelPart,
         const std::map<IndexType, double>& rHRomConditionWeights);
+
+
+    std::vector<IndexType> GetElementIdsInModelPart(
+        const ModelPart& rModelPart
+    );
+
+    std::vector<IndexType> GetConditionIdsInModelPart(
+        const ModelPart& rModelPart
+    );
 
     /**
      * @brief Project the ROM solution increment onto the nodal basis

--- a/applications/RomApplication/python_scripts/empirical_cubature_method.py
+++ b/applications/RomApplication/python_scripts/empirical_cubature_method.py
@@ -127,7 +127,8 @@ class EmpiricalCubatureMethod():
         MaximumLengthZ = 0
         ExpandedSetFlag = False
         k = 1 # number of iterations
-        while self.nerrorACTUAL > self.ECM_tolerance and self.mPOS < self.m and len(self.y) != 0:
+        self.success = True
+        while self.nerrorACTUAL > self.ECM_tolerance and self.mPOS < self.m and np.size(self.y) != 0:
 
             if  self.UnsuccesfulIterations >  self.MaximumNumberUnsuccesfulIterations and not ExpandedSetFlag:
                 ExpandedSetFlag = self.expand_candidates_with_complement()
@@ -153,7 +154,13 @@ class EmpiricalCubatureMethod():
                 self.z = i
             else:
                 self.z = np.r_[self.z,i]
-            self.y = np.delete(self.y,indSORT)
+
+            #self.y = np.delete(self.y,indSORT)
+            if isinstance(self.y, np.int64) or isinstance(self.y, np.int32):
+                self.expand_candidates_with_complement()
+                self.y = np.delete(self.y,indSORT)
+            else:
+                self.y = np.delete(self.y,indSORT)
 
             # Step 4. Find possible negative weights
             if any(alpha < 0):
@@ -191,6 +198,7 @@ class EmpiricalCubatureMethod():
                 ERROR_GLO = np.c_[ ERROR_GLO , self.nerrorACTUAL]
                 NPOINTS = np.c_[ NPOINTS , np.size(self.z)]
 
+            MaximumLengthZ = max(MaximumLengthZ, np.size(self.z))
             k = k+1
 
             if k>1000:
@@ -222,6 +230,7 @@ class EmpiricalCubatureMethod():
         s = np.dot(a.T, a) - np.dot(c.T, d)
         aux1 = np.hstack([Aast + np.outer(d, d) / s, -d / s])
         if np.shape(-d.T / s)[1]==1:
+            s = s.reshape(1,-1)
             aux2 = np.squeeze(np.hstack([-d.T / s, 1 / s]))
         else:
             aux2 = np.hstack([np.squeeze(-d.T / s), 1 / s])

--- a/applications/RomApplication/python_scripts/empirical_cubature_method.py
+++ b/applications/RomApplication/python_scripts/empirical_cubature_method.py
@@ -18,7 +18,9 @@ class EmpiricalCubatureMethod():
         self,
         ECM_tolerance = 0,
         Filter_tolerance = 1e-16,
-        Plotting = False):
+        Plotting = False,
+        MaximumNumberUnsuccesfulIterations = 100
+    ):
         """
         Constructor setting up the parameters for the Element Selection Strategy
             ECM_tolerance: approximation tolerance for the element selection algorithm
@@ -35,7 +37,8 @@ class EmpiricalCubatureMethod():
         ResidualsBasis,
         constrain_sum_of_weights=True,
         constrain_conditions = False,
-        number_of_conditions = 0):
+        number_of_conditions = 0
+    ):
         """
         Method for setting up the element selection
         input:  - ResidualsBasis: numpy array containing a basis to the residuals projected

--- a/applications/RomApplication/python_scripts/empirical_cubature_method.py
+++ b/applications/RomApplication/python_scripts/empirical_cubature_method.py
@@ -148,7 +148,6 @@ class EmpiricalCubatureMethod():
         while self.nerrorACTUAL > self.ECM_tolerance and self.mPOS < self.m and np.size(self.y) != 0:
 
             if  self.UnsuccesfulIterations >  self.MaximumNumberUnsuccesfulIterations and not ExpandedSetFlag:
-                Logger.PrintWarning("EmpiricalCubatureMethod", "The Empirical Cubature Method did not converge using the initial set of candidates.")
                 ExpandedSetFlag = self.expand_candidates_with_complement()
 
             #Step 1. Compute new point

--- a/applications/RomApplication/python_scripts/empirical_cubature_method.py
+++ b/applications/RomApplication/python_scripts/empirical_cubature_method.py
@@ -1,5 +1,5 @@
 import numpy as np
-
+from KratosMultiphysics import Logger
 
 try:
     from matplotlib import pyplot as plt
@@ -148,6 +148,7 @@ class EmpiricalCubatureMethod():
         while self.nerrorACTUAL > self.ECM_tolerance and self.mPOS < self.m and np.size(self.y) != 0:
 
             if  self.UnsuccesfulIterations >  self.MaximumNumberUnsuccesfulIterations and not ExpandedSetFlag:
+                Logger.PrintWarning("EmpiricalCubatureMethod", "The Empirical Cubature Method did not converge using the initial set of candidates.")
                 ExpandedSetFlag = self.expand_candidates_with_complement()
 
             #Step 1. Compute new point

--- a/applications/RomApplication/python_scripts/empirical_cubature_method.py
+++ b/applications/RomApplication/python_scripts/empirical_cubature_method.py
@@ -135,7 +135,7 @@ class EmpiricalCubatureMethod():
                 i = self.y
             else:
                 ObjFun = self.G[:,self.y].T @ self.r.T
-                ObjFun = ObjFun.T / self.Gnorm[self.y]
+                ObjFun = ObjFun.T / self.GnormNOONE[self.y]
                 indSORT = np.argmax(ObjFun)
                 i = self.y[indSORT]
             if k==1:

--- a/applications/RomApplication/python_scripts/empirical_cubature_method.py
+++ b/applications/RomApplication/python_scripts/empirical_cubature_method.py
@@ -134,10 +134,10 @@ class EmpiricalCubatureMethod():
                 ExpandedSetFlag = self.expand_candidates_with_complement()
 
             #Step 1. Compute new point
-            if isinstance(self.y, np.int64) or isinstance(self.y, np.int32):
+            if np.size(self.y)==1:
                 #candidate set consists of a single element
                 indSORT = 0
-                i = self.y
+                i = int(self.y)
             else:
                 ObjFun = self.G[:,self.y].T @ self.r.T
                 ObjFun = ObjFun.T / self.GnormNOONE[self.y]
@@ -156,7 +156,7 @@ class EmpiricalCubatureMethod():
                 self.z = np.r_[self.z,i]
 
             #self.y = np.delete(self.y,indSORT)
-            if isinstance(self.y, np.int64) or isinstance(self.y, np.int32):
+            if np.size(self.y)==1:
                 self.expand_candidates_with_complement()
                 self.y = np.delete(self.y,indSORT)
             else:

--- a/applications/RomApplication/python_scripts/empirical_cubature_method.py
+++ b/applications/RomApplication/python_scripts/empirical_cubature_method.py
@@ -31,10 +31,12 @@ class EmpiricalCubatureMethod():
         self.Filter_tolerance = Filter_tolerance
         self.Name = "EmpiricalCubature"
         self.Plotting = Plotting
+        self.MaximumNumberUnsuccesfulIterations = MaximumNumberUnsuccesfulIterations
 
     def SetUp(
         self,
         ResidualsBasis,
+        InitialCandidatesSet = None,
         constrain_sum_of_weights=True,
         constrain_conditions = False,
         number_of_conditions = 0
@@ -47,6 +49,7 @@ class EmpiricalCubatureMethod():
         """
         self.W = np.ones(np.shape(ResidualsBasis)[0])
         self.G = ResidualsBasis.T
+        self.y = InitialCandidatesSet
         self.add_constrain_count = None
         total_number_of_entities = np.shape(self.G)[1]
         elements_constraint = np.ones(total_number_of_entities)

--- a/applications/RomApplication/python_scripts/empirical_cubature_method.py
+++ b/applications/RomApplication/python_scripts/empirical_cubature_method.py
@@ -14,29 +14,34 @@ class EmpiricalCubatureMethod():
     Reference: Hernandez 2020. "A multiscale method for periodic structures using domain decomposition and ECM-hyperreduction"
     """
 
-
-    """
-    Constructor setting up the parameters for the Element Selection Strategy
-        ECM_tolerance: approximation tolerance for the element selection algorithm
-        Filter_tolerance: parameter limiting the number of candidate points (elements) to those above this tolerance
-        Plotting: whether to plot the error evolution of the element selection algorithm
-    """
-    def __init__(self, ECM_tolerance = 0, Filter_tolerance = 1e-16, Plotting = False):
+    def __init__(
+        self,
+        ECM_tolerance = 0,
+        Filter_tolerance = 1e-16,
+        Plotting = False):
+        """
+        Constructor setting up the parameters for the Element Selection Strategy
+            ECM_tolerance: approximation tolerance for the element selection algorithm
+            Filter_tolerance: parameter limiting the number of candidate points (elements) to those above this tolerance
+            Plotting: whether to plot the error evolution of the element selection algorithm
+        """
         self.ECM_tolerance = ECM_tolerance
         self.Filter_tolerance = Filter_tolerance
         self.Name = "EmpiricalCubature"
         self.Plotting = Plotting
 
-
-
-    """
-    Method for setting up the element selection
-    input:  - ResidualsBasis: numpy array containing a basis to the residuals projected
-            - constrain_sum_of_weights: enable the user to constrain weights to be the sum of the number of entities.
-            - constrain_conditions: enable the user to enforce weights to consider conditions (for specific boundary conditions).
-    """
-    def SetUp(self, ResidualsBasis, constrain_sum_of_weights=True, constrain_conditions = False, number_of_conditions = 0):
-
+    def SetUp(
+        self,
+        ResidualsBasis,
+        constrain_sum_of_weights=True,
+        constrain_conditions = False,
+        number_of_conditions = 0):
+        """
+        Method for setting up the element selection
+        input:  - ResidualsBasis: numpy array containing a basis to the residuals projected
+                - constrain_sum_of_weights: enable the user to constrain weights to be the sum of the number of entities.
+                - constrain_conditions: enable the user to enforce weights to consider conditions (for specific boundary conditions).
+        """
         self.W = np.ones(np.shape(ResidualsBasis)[0])
         self.G = ResidualsBasis.T
         self.add_constrain_count = None
@@ -67,11 +72,10 @@ class EmpiricalCubatureMethod():
             self.add_constrain_count = -2
         self.b = self.G @ self.W
 
-
-    """
-    Method performing calculations required before launching the Calculate method
-    """
     def Initialize(self):
+        """
+        Method performing calculations required before launching the Calculate method
+        """
         self.Gnorm = np.sqrt(sum(np.multiply(self.G, self.G), 0))
         M = np.shape(self.G)[1]
         normB = np.linalg.norm(self.b)
@@ -88,17 +92,14 @@ class EmpiricalCubatureMethod():
         self.nerror = np.linalg.norm(self.r)/normB
         self.nerrorACTUAL = self.nerror
 
-
     def Run(self):
         self.Initialize()
         self.Calculate()
 
-
-    """
-    Method launching the element selection algorithm to find a set of elements: self.z, and wiegths: self.w
-    """
     def Calculate(self):
-
+        """
+        Method launching the element selection algorithm to find a set of elements: self.z, and wiegths: self.w
+        """
         k = 1 # number of iterations
         while self.nerrorACTUAL > self.ECM_tolerance and self.mPOS < self.m and len(self.y) != 0:
 
@@ -163,12 +164,10 @@ class EmpiricalCubatureMethod():
             plt.ylabel('Error %')
             plt.show()
 
-
-
-    """
-    Method for the quick update of weights (self.w), whenever a negative weight is found
-    """
     def _UpdateWeightsInverse(self, A,Aast,a,xold):
+        """
+        Method for the quick update of weights (self.w), whenever a negative weight is found
+        """
         c = np.dot(A.T, a)
         d = np.dot(Aast, c).reshape(-1, 1)
         s = np.dot(a.T, a) - np.dot(c.T, d)
@@ -182,24 +181,20 @@ class EmpiricalCubatureMethod():
         x = np.vstack([(xold - d * v), v])
         return Bast, x
 
-
-
-    """
-    Method for the quick update of weights (self.w), whenever a negative weight is found
-    """
     def _MultiUpdateInverseHermitian(self, invH, neg_indexes):
+        """
+        Method for the quick update of weights (self.w), whenever a negative weight is found
+        """
         neg_indexes = np.sort(neg_indexes)
         for i in range(np.size(neg_indexes)):
             neg_index = neg_indexes[i] - i
             invH = self._UpdateInverseHermitian(invH, neg_index)
         return invH
 
-
-
-    """
-    Method for the quick update of weights (self.w), whenever a negative weight is found
-    """
     def _UpdateInverseHermitian(self, invH, neg_index):
+        """
+        Method for the quick update of weights (self.w), whenever a negative weight is found
+        """
         if neg_index == np.shape(invH)[1]:
             aux = (invH[0:-1, -1] * invH[-1, 0:-1]) / invH(-1, -1)
             invH_new = invH[:-1, :-1] - aux

--- a/applications/RomApplication/python_scripts/empirical_cubature_method.py
+++ b/applications/RomApplication/python_scripts/empirical_cubature_method.py
@@ -115,7 +115,7 @@ class EmpiricalCubatureMethod():
         self.Calculate()
 
     def expand_candidates_with_complement(self):
-        self.y = np.union1d(self.y, self.y_complement)
+        self.y = np.r_[self.y,self.y_complement]
         print('expanding set to include the complement...')
         ExpandedSetFlag = True
         return ExpandedSetFlag

--- a/applications/RomApplication/python_scripts/empirical_cubature_method.py
+++ b/applications/RomApplication/python_scripts/empirical_cubature_method.py
@@ -77,6 +77,7 @@ class EmpiricalCubatureMethod():
             self.G = np.vstack([ self.G , projection_of_constant_vector_conditions ] )
             self.add_constrain_count = -2
         self.b = self.G @ self.W
+        self.UnsuccesfulIterations = 0
 
     def Initialize(self):
         """
@@ -127,6 +128,9 @@ class EmpiricalCubatureMethod():
         ExpandedSetFlag = False
         k = 1 # number of iterations
         while self.nerrorACTUAL > self.ECM_tolerance and self.mPOS < self.m and len(self.y) != 0:
+
+            if  self.UnsuccesfulIterations >  self.MaximumNumberUnsuccesfulIterations and not ExpandedSetFlag:
+                ExpandedSetFlag = self.expand_candidates_with_complement()
 
             #Step 1. Compute new point
             if isinstance(self.y, np.int64) or isinstance(self.y, np.int32):

--- a/applications/RomApplication/python_scripts/hrom_training_utility.py
+++ b/applications/RomApplication/python_scripts/hrom_training_utility.py
@@ -126,6 +126,7 @@ class HRomTrainingUtility(object):
         self.hyper_reduction_element_selector.SetUp(residual_basis, InitialCandidatesSet = self.candidate_ids, constrain_sum_of_weights=True, constrain_conditions = False, number_of_conditions = n_conditions)
         self.hyper_reduction_element_selector.Run()
         if not self.hyper_reduction_element_selector.success:
+            KratosMultiphysics.Logger.PrintWarning("HRomTrainingUtility", "The Empirical Cubature Method did not converge using the initial set of candidates. Launching again without initial candidates.")
             #Imposing an initial candidate set can lead to no convergence. Restart without imposing the initial candidate set
             self.hyper_reduction_element_selector.SetUp(residual_basis, InitialCandidatesSet = None, constrain_sum_of_weights=True, constrain_conditions = False, number_of_conditions = n_conditions)
             self.hyper_reduction_element_selector.Run()

--- a/applications/RomApplication/python_scripts/hrom_training_utility.py
+++ b/applications/RomApplication/python_scripts/hrom_training_utility.py
@@ -317,6 +317,8 @@ class HRomTrainingUtility(object):
         # If required, add the HROM conditions parent elements
         # Note that we add these with zero weight so their future assembly will have no effect
         if self.include_condition_parents:
+            KratosMultiphysics.Logger.PrintWarning("HRomTrainingUtility", 'Make sure you set "assign_neighbour_elements_to_conditions": true in the solver_settings to have a parent element for each condition.')
+
             # Get the HROM condition parents from the current HROM weights
             missing_condition_parents = KratosROM.RomAuxiliaryUtilities.GetHRomConditionParentsIds(
                 self.solver.GetComputingModelPart().GetRootModelPart(), #TODO: I think this one should be the root

--- a/applications/RomApplication/python_scripts/hrom_training_utility.py
+++ b/applications/RomApplication/python_scripts/hrom_training_utility.py
@@ -125,7 +125,10 @@ class HRomTrainingUtility(object):
         n_conditions = self.solver.GetComputingModelPart().NumberOfConditions() # Conditions must be included as an extra restriction to enforce ECM to capture all BC's regions.
         self.hyper_reduction_element_selector.SetUp(residual_basis, InitialCandidatesSet = self.candidate_ids, constrain_sum_of_weights=True, constrain_conditions = False, number_of_conditions = n_conditions)
         self.hyper_reduction_element_selector.Run()
-
+        if not self.hyper_reduction_element_selector.success:
+            #Imposing an initial candidate set can lead to no convergence. Restart without imposing the initial candidate set
+            self.hyper_reduction_element_selector.SetUp(residual_basis, InitialCandidatesSet = None, constrain_sum_of_weights=True, constrain_conditions = False, number_of_conditions = n_conditions)
+            self.hyper_reduction_element_selector.Run()
         # Save the HROM weights in the RomParameters.json
         # Note that in here we are assuming this naming convention for the ROM json file
         self.AppendHRomWeightsToRomParameters()

--- a/applications/RomApplication/python_scripts/hrom_training_utility.py
+++ b/applications/RomApplication/python_scripts/hrom_training_utility.py
@@ -83,7 +83,7 @@ class HRomTrainingUtility(object):
                 candidate_ids = np.r_[candidate_ids, np.array(this_modelpart_condition_ids)+number_of_elements]
 
         if np.size(candidate_ids)>0:
-            self.candidate_ids = np.unique(candidate_ids) - 1 # this -1 takes into account the id difference in numpy and Kratos
+            self.candidate_ids = np.unique(candidate_ids).astype(int) - 1 # this -1 takes into account the id difference in numpy and Kratos
         else:
             self.candidate_ids = None
 

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -313,7 +313,7 @@ class RomManager(object):
         simulation.GetHROM_utility().hyper_reduction_element_selector.Run()
         if not simulation.GetHROM_utility().hyper_reduction_element_selector.success:
             #Imposing an initial candidate set can lead to no convergence. Restart without imposing the initial candidate set
-            self.hyper_reduction_element_selector.SetUp(u, InitialCandidatesSet = None, constrain_sum_of_weights=True, constrain_conditions = False, number_of_conditions = n_conditions)
+            self.hyper_reduction_element_selector.SetUp(u, InitialCandidatesSet = None)
             self.hyper_reduction_element_selector.Run()
         simulation.GetHROM_utility().AppendHRomWeightsToRomParameters()
         simulation.GetHROM_utility().CreateHRomModelParts()

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -492,9 +492,9 @@ class RomManager(object):
         f["hrom_settings"]["element_selection_svd_truncation_tolerance"] = self.general_rom_manager_parameters["HROM"]["element_selection_svd_truncation_tolerance"].GetDouble()
         f["hrom_settings"]["create_hrom_visualization_model_part"] = self.general_rom_manager_parameters["HROM"]["create_hrom_visualization_model_part"].GetBool()
         f["hrom_settings"]["echo_level"] = self.general_rom_manager_parameters["HROM"]["echo_level"].GetInt()
-        f["hrom_settings"]["include_condition_parents"] = self.general_rom_manager_parameters["HROM"]["include_condition_parents"].GetBool()
-        f["hrom_settings"]["initial_candidate_elements_model_part_list"] = self.general_rom_manager_parameters["HROM"]["initial_candidate_elements_model_part_list"].GetStringArray()
-        f["hrom_settings"]["initial_candidate_conditions_model_part_list"] = self.general_rom_manager_parameters["HROM"]["initial_candidate_conditions_model_part_list"].GetStringArray()
+        f["hrom_settings"]["include_condition_parents"] = self.general_rom_manager_parameters["HROM"]["include_condition_parents"].GetBool() if self.general_rom_manager_parameters["HROM"].Has("include_condition_parents") else False
+        f["hrom_settings"]["initial_candidate_elements_model_part_list"] = self.general_rom_manager_parameters["HROM"]["initial_candidate_elements_model_part_list"].GetStringArray() if self.general_rom_manager_parameters["HROM"].Has("initial_candidate_elements_model_part_list") else []
+        f["hrom_settings"]["initial_candidate_conditions_model_part_list"] = self.general_rom_manager_parameters["HROM"]["initial_candidate_conditions_model_part_list"].GetStringArray() if self.general_rom_manager_parameters["HROM"].Has("initial_candidate_conditions_model_part_list") else []
 
     def _ChangeRomFlags(self, simulation_to_run = 'ROM'):
         """

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -312,6 +312,7 @@ class RomManager(object):
         simulation.GetHROM_utility().hyper_reduction_element_selector.SetUp(u, InitialCandidatesSet = simulation.GetHROM_utility().candidate_ids)
         simulation.GetHROM_utility().hyper_reduction_element_selector.Run()
         if not simulation.GetHROM_utility().hyper_reduction_element_selector.success:
+            KratosMultiphysics.Logger.PrintWarning("HRomTrainingUtility", "The Empirical Cubature Method did not converge using the initial set of candidates. Launching again without initial candidates.")
             #Imposing an initial candidate set can lead to no convergence. Restart without imposing the initial candidate set
             self.hyper_reduction_element_selector.SetUp(u, InitialCandidatesSet = None)
             self.hyper_reduction_element_selector.Run()

--- a/applications/RomApplication/tests/test_empirical_cubature_method.py
+++ b/applications/RomApplication/tests/test_empirical_cubature_method.py
@@ -27,11 +27,12 @@ class TestEmpiricalCubatureMethod(KratosUnittest.TestCase):
             TestMatrix = synthetic_matrix(degree) #Get a synthetic matrix (During the training of a ROM model, this is a matrix of residuals projected onto a basis)
             TestMatrixBasis = calculate_basis(TestMatrix)
             ElementSelector = EmpiricalCubatureMethod()
-            ElementSelector.SetUp(TestMatrixBasis, constrain_sum_of_weights=False)
-            ElementSelector.Initialize()
-            ElementSelector.Calculate()
-
-            self.assertEqual( len(ElementSelector.z) , degree + 1) #for a polynomial of degree n, n+1 points are to be selected
+            ElementSelector.SetUp(TestMatrixBasis, InitialCandidatesSet = np.array([0]), constrain_sum_of_weights=False)
+            ElementSelector.Run()
+            if ElementSelector.success is not True:
+                ElementSelector.SetUp(TestMatrixBasis, InitialCandidatesSet = None, constrain_sum_of_weights=False)
+                ElementSelector.Run()
+            self.assertEqual( np.size(ElementSelector.z) , degree + 1) #for a polynomial of degree n, n+1 points are to be selected
     # Cleaning
     kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
 


### PR DESCRIPTION
**📝 Description**
This PR will allow to make the element selector algorithm choose from a specific candidate set of elements or conditions. In case choosing the provided candidates the algorithm cannot converge, then the candidate set is expanded to include the rest of the elements and conditions in the computing model part.

It is also possible that by using the provided candidate elements, no solution can be achived that results in all weights positive. In such a case, the algorithm will run again from scratch (ignoring the provided candidates).

**🆕 Changelog**
- Added two function to the RomAuxiliaryUtilities to retrieve the ids from elements and conditions in a modelpart
- Added candidate set to Empirical Cubature Method
- Modified the HromTraining utility to account for a list of model parts to include as candidates for the ECM
- Modified the RomManager to account for a list of model parts to include as candidates for the ECM
- Expanded ECM test
