### PR TITLE
[Core] Expose `HasMasterSlaveConstraint` from `ModelPart` to python

### DIFF
--- a/kratos/python/add_model_part_to_python.cpp
+++ b/kratos/python/add_model_part_to_python.cpp
@@ -26,10 +26,7 @@
 #include "python/add_model_part_to_python.h"
 #include "python/containers_interface.h"
 
-namespace Kratos
-{
-
-namespace Python
+namespace Kratos::Python
 {
 
 template<class TDataType>
@@ -938,6 +935,9 @@ void AddModelPartToPython(pybind11::module& m)
         .def("GetNonHistoricalVariablesNames", [](ModelPart& rModelPart, ModelPart::ConditionsContainerType& rContainer, bool doFullSearch=false) -> std::unordered_set<std::string> {
             return GetNonHistoricalVariablesNames(rModelPart, rContainer, doFullSearch);
         })
+        .def("HasMasterSlaveConstraint", [](ModelPart& rModelPart, ModelPart::IndexType MasterSlaveConstraintId) -> bool {
+            return rModelPart.HasMasterSlaveConstraint(MasterSlaveConstraintId);
+        })
         .def("GetMasterSlaveConstraint", ModelPartGetMasterSlaveConstraint1)
         .def("GetMasterSlaveConstraints", ModelPartGetMasterSlaveConstraints1)
         .def("RemoveMasterSlaveConstraint", ModelPartRemoveMasterSlaveConstraint1)
@@ -954,6 +954,4 @@ void AddModelPartToPython(pybind11::module& m)
         ;
 }
 
-} // namespace Python.
-
-} // Namespace Kratos
+} // namespace Kratos::Python.

--- a/kratos/tests/test_model_part.py
+++ b/kratos/tests/test_model_part.py
@@ -2,6 +2,14 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 
 class TestModelPart(KratosUnittest.TestCase):
+    """
+    This class defines a set of unit tests for the ModelParts. ModelParts are hierarchical structures within the Kratos simulation framework that allow for organizing and managing various aspects of a computational model, such as nodes, elements, conditions, constraints, and subdomains.
+
+    The tests within this class cover a range of ModelPart-related operations, including the creation of ModelParts, retrieval of parent and root ModelParts, the creation and removal of sub-model parts, and verification of ModelPart hierarchy and structure.
+
+    By running these tests, it is possible to ensure that the ModelPart management features in KratosMultiphysics are functioning as expected, facilitating the setup and manipulation of complex computational models for various engineering and scientific simulations.
+    """
+
     def test_model_part_sub_model_parts(self):
         current_model = KratosMultiphysics.Model()
 
@@ -910,6 +918,8 @@ class TestModelPart(KratosUnittest.TestCase):
 
         c1 = KratosMultiphysics.MasterSlaveConstraint(10)
         model_part.CreateNewMasterSlaveConstraint("LinearMasterSlaveConstraint", 1, n1, KratosMultiphysics.PRESSURE, n2, KratosMultiphysics.PRESSURE, 0.5, 0.0)
+        self.assertTrue(model_part.HasMasterSlaveConstraint(1))
+        self.assertFalse(model_part.HasMasterSlaveConstraint(2))
 
         model_part.AddMasterSlaveConstraint(c1)
 
@@ -925,6 +935,8 @@ class TestModelPart(KratosUnittest.TestCase):
         subsub1 = sub1.CreateSubModelPart("subsub1")
 
         ss1 = subsub1.CreateNewMasterSlaveConstraint("LinearMasterSlaveConstraint", 2, n1, KratosMultiphysics.PRESSURE, n2, KratosMultiphysics.PRESSURE, 0.5, 0.0)
+        self.assertTrue(model_part.HasMasterSlaveConstraint(1))
+        self.assertTrue(model_part.HasMasterSlaveConstraint(2))
 
         self.assertTrue(ss1 in subsub1.MasterSlaveConstraints)
         self.assertTrue(ss1 in sub1.MasterSlaveConstraints)
@@ -993,4 +1005,5 @@ class TestModelPart(KratosUnittest.TestCase):
         self.assertEqual(model_part.NumberOfNodes(0), 4)
 
 if __name__ == '__main__':
+    KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.WARNING)
     KratosUnittest.main()


### PR DESCRIPTION
**📝 Description**

Expose `HasMasterSlaveConstraint` from `ModelPart` to python +  adding test

**🆕 Changelog**

- [Expose HasMasterSlaveConstraint from ModelPart to python](https://github.com/KratosMultiphysics/Kratos/commit/063a668025c7d95ccdf13c3bb67a0dfa030ab201)
- [Adding test + doc](https://github.com/KratosMultiphysics/Kratos/commit/1d8c57d596d4f668ba31018853cb366d0943f738)
