### PR TITLE
install med in docker

### DIFF
--- a/scripts/docker_files/docker_file_ci_ubuntu_22_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_22_04/DockerFile
@@ -44,6 +44,7 @@ RUN apt-get update -y && apt-get upgrade -y && \
         libtrilinos-kokkos-dev \
         libtrilinos-kokkos-kernels-dev \
         libtrilinos-shylu-dev \
+        libmedc-dev \
         openmpi-bin \
         python3-dev \
         python3-h5py \


### PR DESCRIPTION
I would like to enable the MedApplication in the CI due to the growing interest from the community.
For this we need to install the Med-library itself. It is not very large so I think it should not be an issue to add it