### PR TITLE
[Core] Minor CMake typo fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,7 +620,7 @@ message("\t Geometry old closest point methods deprecation: https://github.com/K
 message("\t Model 'CreateModelPart' behavior change (no error thrown if model part exists): https://github.com/KratosMultiphysics/Kratos/pull/9598")
 message("\t Make GetIntegrationMethod method of Condition const: https://github.com/KratosMultiphysics/Kratos/pull/9769")
 message("\t Behavior change of ModelPart.GetProperties (MeshIndex removed): https://github.com/KratosMultiphysics/Kratos/pull/9774")
-message("\t Behavior change of Testing. Please esnure you sue KRATOS_EXPECT for testing instead of KRATOS_CHECK")
+message("\t Behavior change of Testing. Please ensure you use KRATOS_EXPECT for testing instead of KRATOS_CHECK")
 
 # Compiling the clipper library
 add_subdirectory(${KRATOS_SOURCE_DIR}/external_libraries/clipper)


### PR DESCRIPTION
**📝 Description**

This PR makes a minor change to the CMakeLists.txt file. Specifically, it corrects a typographical error in a message related to testing behavior. The original message contained a typo where "sue" should have been "use." The corrected message now reads, "Behavior change of Testing. Please ensure you use KRATOS_EXPECT for testing instead of KRATOS_CHECK."

**🆕 Changelog**

- [Minor CMake typo fix](https://github.com/KratosMultiphysics/Kratos/commit/1c7f38b3bf86789760aa3c6a88f5ae3fddb77b06)
