### PR TITLE
[RomApp] Fixing bug in ECM

### DIFF
--- a/applications/RomApplication/python_scripts/empirical_cubature_method.py
+++ b/applications/RomApplication/python_scripts/empirical_cubature_method.py
@@ -218,7 +218,7 @@ class EmpiricalCubatureMethod():
             MaximumLengthZ = max(MaximumLengthZ, np.size(self.z))
             k = k+1
 
-            if k>1000:
+            if k-MaximumLengthZ>1000:
                 """
                 this means using the initial candidate set, it was impossible to obtain a set of positive weights.
                 Try again without constraints!!!

--- a/applications/RomApplication/python_scripts/rom_manager.py
+++ b/applications/RomApplication/python_scripts/rom_manager.py
@@ -314,8 +314,8 @@ class RomManager(object):
         if not simulation.GetHROM_utility().hyper_reduction_element_selector.success:
             KratosMultiphysics.Logger.PrintWarning("HRomTrainingUtility", "The Empirical Cubature Method did not converge using the initial set of candidates. Launching again without initial candidates.")
             #Imposing an initial candidate set can lead to no convergence. Restart without imposing the initial candidate set
-            self.hyper_reduction_element_selector.SetUp(u, InitialCandidatesSet = None)
-            self.hyper_reduction_element_selector.Run()
+            simulation.GetHROM_utility().hyper_reduction_element_selector.SetUp(u, InitialCandidatesSet = None)
+            simulation.GetHROM_utility().hyper_reduction_element_selector.Run()
         simulation.GetHROM_utility().AppendHRomWeightsToRomParameters()
         simulation.GetHROM_utility().CreateHRomModelParts()
 


### PR DESCRIPTION
This PR fixes a bug found in the Empirical Cubature Method which was introduced in a recent addition (#11577)

**📝 Description**
An iteration counter inside the ECM was used to monitor whether the initial candidate set is not converging. However this was done incorrectly. The idea was that after a "large" number of unsuccessful iterations (this is still hard-coded to 1000), the algorithm should be considered not succesful. The counter now works correctly

Another change was performed to the RomManager in case a candidate set was passed and, it was not successful. Then the algorithm should be invoked again without any candidate set. This was done incorrectly in the RomManger due to a typo. 


**🆕 Changelog**
- Added the correct unsuccessful iteration counter to the ECM
- Added the correct invocation to the ECM to the RomManager, if the algorithm did not converge
