### PR TITLE
[Core] Remove deprecated "new_linear_solver_factory.py" script

### DIFF
--- a/kratos/python_scripts/new_linear_solver_factory.py
+++ b/kratos/python_scripts/new_linear_solver_factory.py
@@ -1,9 +1,0 @@
-def ConstructSolver(configuration):
-    import KratosMultiphysics
-
-    depr_msg  = '"kratos/python_scripts/new_linear_solver_factory.py" is deprecated and will be removed\n'
-    depr_msg += 'Please use "kratos/python_scripts/python_linear_solver_factory.py" instead!'
-    KratosMultiphysics.Logger.PrintWarning('DEPRECATION-WARNING', depr_msg)
-
-    from KratosMultiphysics import python_linear_solver_factory
-    return python_linear_solver_factory.ConstructSolver(configuration)


### PR DESCRIPTION
**📝 Description**

This PR deletes the file "kratos/python_scripts/new_linear_solver_factory.py," which ironically had the name "new" but is now deprecated. It has been replaced with "kratos/python_scripts/python_linear_solver_factory.py." 

**🆕 Changelog**

- [Remove legacy legacy python solver factory](https://github.com/KratosMultiphysics/Kratos/commit/d7199f6e0fed67e7d1a844c550fd5e271e878d5a)
