### PR TITLE
[Core] Fix Matrix from Sliced Array

### DIFF
--- a/kratos/python/add_matrix_to_python.cpp
+++ b/kratos/python/add_matrix_to_python.cpp
@@ -75,7 +75,8 @@ namespace Kratos::Python
           KRATOS_ERROR_IF( info.format != py::format_descriptor<double>::value ) << "Expected a double array\n";
           KRATOS_ERROR_IF( info.ndim != 2 ) << "Buffer dimension of 2 is required, got: " << info.ndim << std::endl;
           DenseMatrix<double> matrix = DenseMatrix<double>(info.shape[0], info.shape[1]);
-          std::array<std::size_t,2> strides {info.strides[0] / sizeof(info.itemsize), info.strides[1] / sizeof(info.itemsize)};
+          std::array<std::size_t,2> strides {info.strides[0] / static_cast<std::size_t>(info.itemsize),
+                                             info.strides[1] / static_cast<std::size_t>(info.itemsize)};
 
           for( int i=0; i<info.shape[0]; ++i ) {
             for( int j=0; j<info.shape[1]; ++j ) {

--- a/kratos/python/add_matrix_to_python.cpp
+++ b/kratos/python/add_matrix_to_python.cpp
@@ -75,12 +75,11 @@ namespace Kratos::Python
           KRATOS_ERROR_IF( info.format != py::format_descriptor<double>::value ) << "Expected a double array\n";
           KRATOS_ERROR_IF( info.ndim != 2 ) << "Buffer dimension of 2 is required, got: " << info.ndim << std::endl;
           DenseMatrix<double> matrix = DenseMatrix<double>(info.shape[0], info.shape[1]);
+          std::array<std::size_t,2> strides {info.strides[0] / sizeof(info.itemsize), info.strides[1] / sizeof(info.itemsize)};
 
-          std::size_t count = 0;
           for( int i=0; i<info.shape[0]; ++i ) {
             for( int j=0; j<info.shape[1]; ++j ) {
-              matrix(i,j) = static_cast<double *>(info.ptr)[count];
-              count++;
+              matrix(i,j) = static_cast<double *>(info.ptr)[i * strides[0] + j * strides[1]];
             }
           }
 

--- a/kratos/tests/test_matrix_interface.py
+++ b/kratos/tests/test_matrix_interface.py
@@ -1,6 +1,8 @@
 ﻿import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics as KM
 
+import numpy
+
 class TestMatrixInterface(KratosUnittest.TestCase):
 
     def test_len(self):
@@ -147,6 +149,49 @@ class TestMatrixInterface(KratosUnittest.TestCase):
         for i in range(D.Size1()):
             for j in range(D.Size2()):
                 self.assertEqual(D[i,j], i + (j*0.1))
+
+    def test_buffer_protocol(self) -> None:
+        # + ------------ +
+        # |  0  1  2  3  |
+        # |  4  5  6  7  |
+        # |  8  9 10 11  |
+        # | 12 13 14 15  |
+        # | 16 17 18 19  |
+        # + ------------ +
+        numpy_matrix = numpy.arange(20.0, dtype=numpy.float64).reshape((5, 4))
+
+        # Test default casting
+        kratos_matrix = KM.Matrix(numpy_matrix)
+        self.assertEqual(kratos_matrix.Size1(), numpy_matrix.shape[0])
+        self.assertEqual(kratos_matrix.Size2(), numpy_matrix.shape[1])
+        for i_row in range(numpy_matrix.shape[0]):
+            for i_column in range(numpy_matrix.shape[1]):
+                self.assertEqual(kratos_matrix[i_row, i_column], numpy_matrix[i_row, i_column])
+
+        # Test slicing
+        # + ------ +
+        # |  5  6  |
+        # |  9 10  |
+        # | 13 14  |
+        # + ------ +
+        sliced_numpy_matrix = numpy_matrix[1:4,1:3]
+        kratos_matrix = KM.Matrix(sliced_numpy_matrix)
+        self.assertEqual(kratos_matrix.Size1(), 3)
+        self.assertEqual(kratos_matrix.Size2(), 2)
+        self.assertEqual(kratos_matrix[0, 0], 5.0)
+        self.assertEqual(kratos_matrix[1, 0], 9.0)
+        self.assertEqual(kratos_matrix[2, 0], 13.0)
+        self.assertEqual(kratos_matrix[0, 1], 6.0)
+        self.assertEqual(kratos_matrix[1, 1], 10.0)
+        self.assertEqual(kratos_matrix[2, 1], 14.0)
+
+        # Test empty slice
+        # ++
+        # ++
+        sliced_numpy_matrix = numpy_matrix[10:10,20:20]
+        kratos_matrix = KM.Matrix(sliced_numpy_matrix)
+        self.assertEqual(kratos_matrix.Size1(), 0)
+        self.assertEqual(kratos_matrix.Size2(), 0)
 
     def test_list_of_list_construction_error_hand(self):
         with self.assertRaisesRegex(RuntimeError, r'Error: Wrong size of a row 1! Expected 2, got 3'):

--- a/kratos/tests/test_matrix_interface.py
+++ b/kratos/tests/test_matrix_interface.py
@@ -182,6 +182,17 @@ class TestMatrixInterface(KratosUnittest.TestCase):
                                       [13.0, 14.0]])
         self.assertMatrixAlmostEqual(kratos_matrix, reference_matrix)
 
+        # Test slicing with steps
+        # + ----- +
+        # |  1  3 |
+        # | 13 15 |
+        # + ----- +
+        sliced_numpy_matrix = numpy_matrix[0::3, 1::2]
+        kratos_matrix = KM.Matrix(sliced_numpy_matrix)
+        reference_matrix = KM.Matrix([[ 1.0,  3.0],
+                                      [13.0, 15.0]])
+        self.assertMatrixAlmostEqual(kratos_matrix, reference_matrix)
+
         # Test empty slice
         # ++
         # ++

--- a/kratos/tests/test_matrix_interface.py
+++ b/kratos/tests/test_matrix_interface.py
@@ -162,11 +162,12 @@ class TestMatrixInterface(KratosUnittest.TestCase):
 
         # Test default casting
         kratos_matrix = KM.Matrix(numpy_matrix)
-        self.assertEqual(kratos_matrix.Size1(), numpy_matrix.shape[0])
-        self.assertEqual(kratos_matrix.Size2(), numpy_matrix.shape[1])
-        for i_row in range(numpy_matrix.shape[0]):
-            for i_column in range(numpy_matrix.shape[1]):
-                self.assertEqual(kratos_matrix[i_row, i_column], numpy_matrix[i_row, i_column])
+        reference_matrix = KM.Matrix([[ 0.0,  1.0,  2.0,  3.0],
+                                      [ 4.0,  5.0,  6.0,  7.0],
+                                      [ 8.0,  9.0, 10.0, 11.0],
+                                      [12.0, 13.0, 14.0, 15.0],
+                                      [16.0, 17.0, 18.0, 19.0]])
+        self.assertMatrixAlmostEqual(kratos_matrix, reference_matrix)
 
         # Test slicing
         # + ------ +
@@ -176,22 +177,18 @@ class TestMatrixInterface(KratosUnittest.TestCase):
         # + ------ +
         sliced_numpy_matrix = numpy_matrix[1:4,1:3]
         kratos_matrix = KM.Matrix(sliced_numpy_matrix)
-        self.assertEqual(kratos_matrix.Size1(), 3)
-        self.assertEqual(kratos_matrix.Size2(), 2)
-        self.assertEqual(kratos_matrix[0, 0], 5.0)
-        self.assertEqual(kratos_matrix[1, 0], 9.0)
-        self.assertEqual(kratos_matrix[2, 0], 13.0)
-        self.assertEqual(kratos_matrix[0, 1], 6.0)
-        self.assertEqual(kratos_matrix[1, 1], 10.0)
-        self.assertEqual(kratos_matrix[2, 1], 14.0)
+        reference_matrix = KM.Matrix([[ 5.0,  6.0],
+                                      [ 9.0, 10.0],
+                                      [13.0, 14.0]])
+        self.assertMatrixAlmostEqual(kratos_matrix, reference_matrix)
 
         # Test empty slice
         # ++
         # ++
         sliced_numpy_matrix = numpy_matrix[10:10,20:20]
         kratos_matrix = KM.Matrix(sliced_numpy_matrix)
-        self.assertEqual(kratos_matrix.Size1(), 0)
-        self.assertEqual(kratos_matrix.Size2(), 0)
+        reference_matrix = KM.Matrix([])
+        self.assertMatrixAlmostEqual(kratos_matrix, reference_matrix)
 
     def test_list_of_list_construction_error_hand(self):
         with self.assertRaisesRegex(RuntimeError, r'Error: Wrong size of a row 1! Expected 2, got 3'):


### PR DESCRIPTION
Fixes #11610
Renders #11613 obsolete.

The `Kratos::Matrix` python interface disregarded the buffer protocol's `strides` property.

FYI @Rbravo555; thanks for the bug report! Please double check whether this PR fixes the issues you had.


