### PR TITLE
[GeoMechanicsApplication] Add the missing surface conditions to Geomechanics Application for 3D elements

### DIFF
--- a/applications/GeoMechanicsApplication/custom_conditions/Pw_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/Pw_condition.cpp
@@ -159,6 +159,9 @@ template class PwCondition<2,2>;
 template class PwCondition<3,1>;
 template class PwCondition<3,3>;
 template class PwCondition<3,4>;
+template class PwCondition<3,6>;
+template class PwCondition<3,8>;
+template class PwCondition<3,9>;
 
 template class PwCondition<2,3>;
 

--- a/applications/GeoMechanicsApplication/custom_conditions/Pw_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/Pw_normal_flux_condition.cpp
@@ -88,60 +88,24 @@ void PwNormalFluxCondition<TDim,TNumNodes>::
                                                 rVariables.PVector);
 }
 
-
-//----------------------------------------------------------------------------------------
-template< >
-double PwNormalFluxCondition<2, 2>::
-CalculateIntegrationCoefficient(const Matrix& Jacobian, const double& Weight)
-{
-    double dx_dxi = Jacobian(0, 0);
-    double dy_dxi = Jacobian(1, 0);
-
-    double ds = sqrt(dx_dxi * dx_dxi + dy_dxi * dy_dxi);
-
-    return ds * Weight;
-}
-
-
-//----------------------------------------------------------------------------------------
-template< >
-double PwNormalFluxCondition<3, 3>::
-CalculateIntegrationCoefficient(const Matrix& Jacobian,
+// ============================================================================================
+// ============================================================================================
+template<unsigned int TDim, unsigned int TNumNodes>
+double PwNormalFluxCondition<TDim, TNumNodes>::CalculateIntegrationCoefficient(
+    const Matrix& Jacobian,
     const double& Weight)
 {
-    double NormalVector[3];
+    Vector NormalVector = ZeroVector(TDim);
 
-    NormalVector[0] = Jacobian(1, 0) * Jacobian(2, 1) - Jacobian(2, 0) * Jacobian(1, 1);
-
-    NormalVector[1] = Jacobian(2, 0) * Jacobian(0, 1) - Jacobian(0, 0) * Jacobian(2, 1);
-
-    NormalVector[2] = Jacobian(0, 0) * Jacobian(1, 1) - Jacobian(1, 0) * Jacobian(0, 1);
-
-    double dA = sqrt(NormalVector[0] * NormalVector[0]
-        + NormalVector[1] * NormalVector[1]
-        + NormalVector[2] * NormalVector[2]);
-
-    return dA * Weight;
-}
-
-//----------------------------------------------------------------------------------------
-template< >
-double PwNormalFluxCondition<3, 4>::
-CalculateIntegrationCoefficient(const Matrix& Jacobian, const double& Weight)
-{
-    double NormalVector[3];
-
-    NormalVector[0] = Jacobian(1, 0) * Jacobian(2, 1) - Jacobian(2, 0) * Jacobian(1, 1);
-
-    NormalVector[1] = Jacobian(2, 0) * Jacobian(0, 1) - Jacobian(0, 0) * Jacobian(2, 1);
-
-    NormalVector[2] = Jacobian(0, 0) * Jacobian(1, 1) - Jacobian(1, 0) * Jacobian(0, 1);
-
-    double dA = sqrt(NormalVector[0] * NormalVector[0]
-        + NormalVector[1] * NormalVector[1]
-        + NormalVector[2] * NormalVector[2]);
-
-    return dA * Weight;
+    if constexpr (TDim == 2)
+    {
+        NormalVector = column(Jacobian, 0);
+    }
+    else if constexpr (TDim == 3)
+    {
+        MathUtils<double>::CrossProduct(NormalVector, column(Jacobian, 0), column(Jacobian, 1));
+    }
+    return MathUtils<double>::Norm(NormalVector) * Weight;
 }
 
 
@@ -150,5 +114,8 @@ CalculateIntegrationCoefficient(const Matrix& Jacobian, const double& Weight)
 template class PwNormalFluxCondition<2,2>;
 template class PwNormalFluxCondition<3,3>;
 template class PwNormalFluxCondition<3,4>;
+template class PwNormalFluxCondition<3,6>;
+template class PwNormalFluxCondition<3,8>;
+template class PwNormalFluxCondition<3,9>;
 
 } // Namespace Kratos.

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_condition.cpp
@@ -183,12 +183,16 @@ void UPwCondition<TDim,TNumNodes>::
     KRATOS_CATCH( "" )
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+// ============================================================================================
+// ============================================================================================
 template class UPwCondition<2,1>;
 template class UPwCondition<2,2>;
 template class UPwCondition<3,1>;
 template class UPwCondition<3,3>;
 template class UPwCondition<3,4>;
+template class UPwCondition<3,6>;
+template class UPwCondition<3,8>;
+template class UPwCondition<3,9>;
 
 template class UPwCondition<2,3>;
 template class UPwCondition<2,4>;

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_face_load_condition.cpp
@@ -75,107 +75,35 @@ void UPwFaceLoadCondition<TDim,TNumNodes>::
     }
 }
 
-//----------------------------------------------------------------------------------------
-template< >
-double UPwFaceLoadCondition<2,2>::
-    CalculateIntegrationCoefficient(const Matrix& Jacobian, const double& Weight)
+// ============================================================================================
+// ============================================================================================
+template<unsigned int TDim, unsigned int TNumNodes>
+double UPwFaceLoadCondition<TDim, TNumNodes>::CalculateIntegrationCoefficient(
+    const Matrix& Jacobian,
+    const double& Weight)
 {
-    double dx_dxi = Jacobian(0,0);
-    double dy_dxi = Jacobian(1,0);
+    Vector NormalVector = ZeroVector(TDim);
 
-    double ds = sqrt(dx_dxi*dx_dxi + dy_dxi*dy_dxi);
+    if constexpr (TDim == 2) {
+        NormalVector = column(Jacobian, 0);
+    }
+    else if constexpr (TDim == 3) {
+        MathUtils<double>::CrossProduct(NormalVector, column(Jacobian, 0), column(Jacobian, 1));
+    }
 
-    return ds * Weight;
+    return MathUtils<double>::Norm(NormalVector) * Weight;
 }
 
-//----------------------------------------------------------------------------------------
-template< >
-double UPwFaceLoadCondition<2,3>::
-    CalculateIntegrationCoefficient(const Matrix& Jacobian, const double& Weight)
-{
-    double dx_dxi = Jacobian(0,0);
-    double dy_dxi = Jacobian(1,0);
-
-    double ds = sqrt(dx_dxi*dx_dxi + dy_dxi*dy_dxi);
-
-    return ds * Weight;
-}
-
-//----------------------------------------------------------------------------------------
-template< >
-double UPwFaceLoadCondition<2,4>::
-CalculateIntegrationCoefficient(const Matrix& Jacobian, const double& Weight)
-{
-    const double dx_dxi = Jacobian(0, 0);
-    const double dy_dxi = Jacobian(1, 0);
-
-    const double ds = std::sqrt(dx_dxi * dx_dxi + dy_dxi * dy_dxi);
-
-    return ds * Weight;
-}
-
-//----------------------------------------------------------------------------------------
-template< >
-double UPwFaceLoadCondition<2,5>::
-CalculateIntegrationCoefficient(const Matrix& Jacobian, const double& Weight)
-{
-    const double dx_dxi = Jacobian(0, 0);
-    const double dy_dxi = Jacobian(1, 0);
-
-    const double ds = std::sqrt(dx_dxi * dx_dxi + dy_dxi * dy_dxi);
-
-    return ds * Weight;
-}
-
-//----------------------------------------------------------------------------------------
-template< >
-double UPwFaceLoadCondition<3,3>::
-    CalculateIntegrationCoefficient(const Matrix& Jacobian, const double& Weight)
-{
-    double NormalVector[3];
-
-    NormalVector[0] = Jacobian(1,0) * Jacobian(2,1) - Jacobian(2,0) * Jacobian(1,1);
-
-    NormalVector[1] = Jacobian(2,0) * Jacobian(0,1) - Jacobian(0,0) * Jacobian(2,1);
-
-    NormalVector[2] = Jacobian(0,0) * Jacobian(1,1) - Jacobian(1,0) * Jacobian(0,1);
-
-    double dA = sqrt(  NormalVector[0]*NormalVector[0]
-                     + NormalVector[1]*NormalVector[1]
-                     + NormalVector[2]*NormalVector[2]);
-
-    return dA * Weight;
-}
-
-//----------------------------------------------------------------------------------------
-template< >
-double UPwFaceLoadCondition<3,4>::
-    CalculateIntegrationCoefficient(const Matrix& Jacobian, const double& Weight)
-{
-    double NormalVector[3];
-
-    NormalVector[0] = Jacobian(1,0) * Jacobian(2,1) - Jacobian(2,0) * Jacobian(1,1);
-
-    NormalVector[1] = Jacobian(2,0) * Jacobian(0,1) - Jacobian(0,0) * Jacobian(2,1);
-
-    NormalVector[2] = Jacobian(0,0) * Jacobian(1,1) - Jacobian(1,0) * Jacobian(0,1);
-
-    double dA = sqrt(  NormalVector[0]*NormalVector[0]
-                     + NormalVector[1]*NormalVector[1]
-                     + NormalVector[2]*NormalVector[2]);
-
-    return dA * Weight;
-}
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
+// ============================================================================================
+// ============================================================================================
 template class UPwFaceLoadCondition<2,2>;
 template class UPwFaceLoadCondition<2,3>;
 template class UPwFaceLoadCondition<2,4>;
 template class UPwFaceLoadCondition<2,5>;
-
 template class UPwFaceLoadCondition<3,3>;
 template class UPwFaceLoadCondition<3,4>;
-
+template class UPwFaceLoadCondition<3,6>;
+template class UPwFaceLoadCondition<3,8>;
+template class UPwFaceLoadCondition<3,9>;
 
 } // Namespace Kratos.

--- a/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_condition.cpp
+++ b/applications/GeoMechanicsApplication/custom_conditions/U_Pw_normal_flux_condition.cpp
@@ -93,5 +93,7 @@ void UPwNormalFluxCondition<TDim,TNumNodes>::
 template class UPwNormalFluxCondition<2,2>;
 template class UPwNormalFluxCondition<3,3>;
 template class UPwNormalFluxCondition<3,4>;
-
+template class UPwNormalFluxCondition<3,6>;
+template class UPwNormalFluxCondition<3,8>;
+template class UPwNormalFluxCondition<3,9>;
 } // Namespace Kratos.

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.cpp
@@ -209,18 +209,34 @@ void KratosGeoMechanicsApplication::Register() {
     //Register Conditions
     KRATOS_REGISTER_CONDITION("UPwForceCondition2D1N", mUPwForceCondition2D1N)
     KRATOS_REGISTER_CONDITION("UPwForceCondition3D1N", mUPwForceCondition3D1N)
+
     KRATOS_REGISTER_CONDITION("UPwFaceLoadCondition2D2N", mUPwFaceLoadCondition2D2N)
     KRATOS_REGISTER_CONDITION("UPwFaceLoadCondition3D3N", mUPwFaceLoadCondition3D3N)
     KRATOS_REGISTER_CONDITION("UPwFaceLoadCondition3D4N", mUPwFaceLoadCondition3D4N)
+    KRATOS_REGISTER_CONDITION("UPwFaceLoadCondition3D6N", mUPwFaceLoadCondition3D6N)
+    KRATOS_REGISTER_CONDITION("UPwFaceLoadCondition3D8N", mUPwFaceLoadCondition3D8N)
+    KRATOS_REGISTER_CONDITION("UPwFaceLoadCondition3D9N", mUPwFaceLoadCondition3D9N)
+
     KRATOS_REGISTER_CONDITION("UPwNormalFaceLoadCondition2D2N", mUPwNormalFaceLoadCondition2D2N)
     KRATOS_REGISTER_CONDITION("UPwNormalFaceLoadCondition3D3N", mUPwNormalFaceLoadCondition3D3N)
     KRATOS_REGISTER_CONDITION("UpwNormalFaceLoadCondition3D4N", mUPwNormalFaceLoadCondition3D4N)
+    KRATOS_REGISTER_CONDITION("UpwNormalFaceLoadCondition3D6N", mUPwNormalFaceLoadCondition3D6N)
+    KRATOS_REGISTER_CONDITION("UpwNormalFaceLoadCondition3D8N", mUPwNormalFaceLoadCondition3D8N)
+    KRATOS_REGISTER_CONDITION("UpwNormalFaceLoadCondition3D9N", mUPwNormalFaceLoadCondition3D9N)
+
     KRATOS_REGISTER_CONDITION("UPwNormalFluxCondition2D2N", mUPwNormalFluxCondition2D2N)
     KRATOS_REGISTER_CONDITION("UPwNormalFluxCondition3D3N", mUPwNormalFluxCondition3D3N)
     KRATOS_REGISTER_CONDITION("UPwNormalFluxCondition3D4N", mUPwNormalFluxCondition3D4N)
+    KRATOS_REGISTER_CONDITION("UPwNormalFluxCondition3D6N", mUPwNormalFluxCondition3D6N)
+    KRATOS_REGISTER_CONDITION("UPwNormalFluxCondition3D8N", mUPwNormalFluxCondition3D8N)
+    KRATOS_REGISTER_CONDITION("UPwNormalFluxCondition3D9N", mUPwNormalFluxCondition3D9N)
+
     KRATOS_REGISTER_CONDITION("PwNormalFluxCondition2D2N", mPwNormalFluxCondition2D2N)
     KRATOS_REGISTER_CONDITION("PwNormalFluxCondition3D3N", mPwNormalFluxCondition3D3N)
     KRATOS_REGISTER_CONDITION("PwNormalFluxCondition3D4N", mPwNormalFluxCondition3D4N)
+    KRATOS_REGISTER_CONDITION("PwNormalFluxCondition3D6N", mPwNormalFluxCondition3D6N)
+    KRATOS_REGISTER_CONDITION("PwNormalFluxCondition3D8N", mPwNormalFluxCondition3D8N)
+    KRATOS_REGISTER_CONDITION("PwNormalFluxCondition3D9N", mPwNormalFluxCondition3D9N)
 
     KRATOS_REGISTER_CONDITION("UPwFaceLoadCondition2D3N", mUPwFaceLoadCondition2D3N)
     KRATOS_REGISTER_CONDITION("UPwFaceLoadCondition2D4N", mUPwFaceLoadCondition2D4N)

--- a/applications/GeoMechanicsApplication/geo_mechanics_application.h
+++ b/applications/GeoMechanicsApplication/geo_mechanics_application.h
@@ -451,18 +451,30 @@ private:
     const UPwFaceLoadCondition<2,2> mUPwFaceLoadCondition2D2N{ 0, Kratos::make_shared< Line2D2          <NodeType> >(Condition::GeometryType::PointsArrayType(2)) };
     const UPwFaceLoadCondition<3,3> mUPwFaceLoadCondition3D3N{ 0, Kratos::make_shared< Triangle3D3      <NodeType> >(Condition::GeometryType::PointsArrayType(3)) };
     const UPwFaceLoadCondition<3,4> mUPwFaceLoadCondition3D4N{ 0, Kratos::make_shared< Quadrilateral3D4 <NodeType> >(Condition::GeometryType::PointsArrayType(4)) };
+    const UPwFaceLoadCondition<3,6> mUPwFaceLoadCondition3D6N{ 0, Kratos::make_shared< Triangle3D6      <NodeType> >(Condition::GeometryType::PointsArrayType(6)) };
+    const UPwFaceLoadCondition<3,8> mUPwFaceLoadCondition3D8N{ 0, Kratos::make_shared< Quadrilateral3D8 <NodeType> >(Condition::GeometryType::PointsArrayType(8)) };
+    const UPwFaceLoadCondition<3,9> mUPwFaceLoadCondition3D9N{ 0, Kratos::make_shared< Quadrilateral3D9 <NodeType> >(Condition::GeometryType::PointsArrayType(9)) };
 
     const UPwNormalFaceLoadCondition<2,2> mUPwNormalFaceLoadCondition2D2N{ 0, Kratos::make_shared< Line2D2          <NodeType> >(Condition::GeometryType::PointsArrayType(2)) };
     const UPwNormalFaceLoadCondition<3,3> mUPwNormalFaceLoadCondition3D3N{ 0, Kratos::make_shared< Triangle3D3      <NodeType> >(Condition::GeometryType::PointsArrayType(3)) };
     const UPwNormalFaceLoadCondition<3,4> mUPwNormalFaceLoadCondition3D4N{ 0, Kratos::make_shared< Quadrilateral3D4 <NodeType> >(Condition::GeometryType::PointsArrayType(4)) };
+    const UPwNormalFaceLoadCondition<3,6> mUPwNormalFaceLoadCondition3D6N{ 0, Kratos::make_shared< Triangle3D6      <NodeType> >(Condition::GeometryType::PointsArrayType(6)) };
+    const UPwNormalFaceLoadCondition<3,8> mUPwNormalFaceLoadCondition3D8N{ 0, Kratos::make_shared< Quadrilateral3D8 <NodeType> >(Condition::GeometryType::PointsArrayType(8)) };
+    const UPwNormalFaceLoadCondition<3,9> mUPwNormalFaceLoadCondition3D9N{ 0, Kratos::make_shared< Quadrilateral3D9 <NodeType> >(Condition::GeometryType::PointsArrayType(9)) };
 
     const UPwNormalFluxCondition<2,2> mUPwNormalFluxCondition2D2N{ 0, Kratos::make_shared< Line2D2          <NodeType> >(Condition::GeometryType::PointsArrayType(2)) };
     const UPwNormalFluxCondition<3,3> mUPwNormalFluxCondition3D3N{ 0, Kratos::make_shared< Triangle3D3      <NodeType> >(Condition::GeometryType::PointsArrayType(3)) };
     const UPwNormalFluxCondition<3,4> mUPwNormalFluxCondition3D4N{ 0, Kratos::make_shared< Quadrilateral3D4 <NodeType> >(Condition::GeometryType::PointsArrayType(4)) };
+    const UPwNormalFluxCondition<3,6> mUPwNormalFluxCondition3D6N{ 0, Kratos::make_shared< Triangle3D6      <NodeType> >(Condition::GeometryType::PointsArrayType(6)) };
+    const UPwNormalFluxCondition<3,8> mUPwNormalFluxCondition3D8N{ 0, Kratos::make_shared< Quadrilateral3D8 <NodeType> >(Condition::GeometryType::PointsArrayType(8)) };
+    const UPwNormalFluxCondition<3,9> mUPwNormalFluxCondition3D9N{ 0, Kratos::make_shared< Quadrilateral3D9 <NodeType> >(Condition::GeometryType::PointsArrayType(9)) };
 
     const PwNormalFluxCondition<2,2> mPwNormalFluxCondition2D2N{ 0, Kratos::make_shared< Line2D2          <NodeType> >(Condition::GeometryType::PointsArrayType(2)) };
     const PwNormalFluxCondition<3,3> mPwNormalFluxCondition3D3N{ 0, Kratos::make_shared< Triangle3D3      <NodeType> >(Condition::GeometryType::PointsArrayType(3)) };
     const PwNormalFluxCondition<3,4> mPwNormalFluxCondition3D4N{ 0, Kratos::make_shared< Quadrilateral3D4 <NodeType> >(Condition::GeometryType::PointsArrayType(4)) };
+    const PwNormalFluxCondition<3,6> mPwNormalFluxCondition3D6N{ 0, Kratos::make_shared< Triangle3D6      <NodeType> >(Condition::GeometryType::PointsArrayType(6)) };
+    const PwNormalFluxCondition<3,8> mPwNormalFluxCondition3D8N{ 0, Kratos::make_shared< Quadrilateral3D8 <NodeType> >(Condition::GeometryType::PointsArrayType(8)) };
+    const PwNormalFluxCondition<3,9> mPwNormalFluxCondition3D9N{ 0, Kratos::make_shared< Quadrilateral3D9 <NodeType> >(Condition::GeometryType::PointsArrayType(9)) };
 
     const UPwFaceLoadCondition<2,3> mUPwFaceLoadCondition2D3N{ 0, Kratos::make_shared< Line2D3 <NodeType> >(Condition::GeometryType::PointsArrayType(3)) };
     const UPwFaceLoadCondition<2,4> mUPwFaceLoadCondition2D4N{ 0, Kratos::make_shared< Line2D4 <NodeType> >(Condition::GeometryType::PointsArrayType(4)) };


### PR DESCRIPTION
**📝 Description**
This pull request addresses the issue regarding the absence of higher order surface conditions for 3D elements in the Geomechanics Application. Surface conditions, encompassing boundary conditions, loadings, and constraints applied to the external faces of 3D geometries, are essential for accurate geomechanical simulations.

**🆕 Changelog**
I have implemented the necessary code changes to enable the application to handle surface conditions for 3D elements. These changes include:

- Added UPwFaceLoadCondition3D6N, 8N, 9N
- Added UPwNormalFaceLoadCondition3D6N, 8N, 9N
- Added UPwNormalFluxCondition3D6N, 8N, 9N
- Added PwNormalFluxCondition3D6N, 8N, 9N

**Expected Behavior**
Upon merging this PR, users will be able to:

- Specify and apply surface conditions to 3D elements within the Geomechanics Application.
- Experience improved accuracy and completeness in their geomechanical simulations.

*Related Issues*
#11616
in order to avoid conflicts, issue #11616 needs to be merged. There are overlaping coding between the current issue and 11616.

**Contributor Guidance**
- Reviewers and contributors are encouraged to provide feedback on the code changes, design considerations, and implementation details.

**TODO**
Conditions for UPwLysmerAbsorbingCondition needs to be added. Because of nature of the code, this issue has to be discussed with the authur of this part, namely @aronnoordam 