### PR TITLE
[GeoMechanicsApplication] Add an adaptive time incrementor

### DIFF
--- a/applications/GeoMechanicsApplication/custom_workflows/adaptive_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/adaptive_time_incrementor.cpp
@@ -1,0 +1,87 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Wijtze Pieter Kikstra
+//                   Anne van de Graaf
+//
+
+#include "adaptive_time_incrementor.h"
+#include "time_step_end_state.hpp"
+
+#include "includes/exception.h"
+
+
+namespace Kratos
+{
+
+AdaptiveTimeIncrementor::AdaptiveTimeIncrementor(double      StartTime,
+                                                 double      EndTime,
+                                                 double      StartIncrement,
+                                                 std::size_t MaxNumOfCycles,
+                                                 double      ReductionFactor,
+                                                 double      IncreaseFactor,
+                                                 std::size_t MinNumOfIterations,
+                                                 std::size_t MaxNumOfIterations) :
+    TimeIncrementor(),
+    mEndTime(EndTime),
+    mDeltaTime(std::min(StartIncrement, EndTime - StartTime)), // avoid exceeding the end time
+    mMaxNumOfCycles(MaxNumOfCycles),
+    mReductionFactor(ReductionFactor),
+    mIncreaseFactor(IncreaseFactor),
+    mMinNumOfIterations(MinNumOfIterations),
+    mMaxNumOfIterations(MaxNumOfIterations)
+{
+    KRATOS_ERROR_IF(StartTime >= mEndTime) << "Start time (" << StartTime << ") must be smaller than end time (" << mEndTime << ")";
+    KRATOS_ERROR_IF(mDeltaTime <= 0.0) << "Start increment must be positive, but got " << mDeltaTime;
+    KRATOS_ERROR_IF(mMaxNumOfCycles == std::size_t(0)) << "Maximum number of cycles must be positive";
+    KRATOS_ERROR_IF(mMinNumOfIterations >= mMaxNumOfIterations) << "Minimum number of iterations ("
+                                                                << mMinNumOfIterations
+                                                                << ") is not less than maximum number of iterations ("
+                                                                << mMaxNumOfIterations << ")";
+    KRATOS_ERROR_IF(mReductionFactor >  1.0) << "Reduction factor must not be greater than 1, but got " << mReductionFactor;
+    KRATOS_ERROR_IF(mReductionFactor <= 0.0) << "Reduction factor must be positive, but got " << mReductionFactor;
+    KRATOS_ERROR_IF(mIncreaseFactor  <  1.0) << "Increase factor must be greater than or equal to 1, but got " << mIncreaseFactor;
+}
+
+bool AdaptiveTimeIncrementor::WantNextStep(const TimeStepEndState& rPreviousState) const
+{
+    return rPreviousState.time < mEndTime;
+}
+
+bool AdaptiveTimeIncrementor::WantRetryStep(std::size_t             CycleNumber,
+                                            const TimeStepEndState& rPreviousState) const
+{
+    if (CycleNumber == 0) return true;  // always carry out a first attempt
+
+    if (rPreviousState.Converged()) return false;  // the time step is done
+
+    return CycleNumber < mMaxNumOfCycles;  // stopping criterion
+}
+
+double AdaptiveTimeIncrementor::GetIncrement() const
+{
+    return mDeltaTime;
+}
+
+void AdaptiveTimeIncrementor::PostTimeStepExecution(const TimeStepEndState& rResultantState)
+{
+    if (rResultantState.NonConverged() ||
+        (rResultantState.Converged() && (rResultantState.num_of_iterations == mMaxNumOfIterations))) {
+        mDeltaTime *= mReductionFactor;
+    }
+    else if (rResultantState.Converged() &&
+             (rResultantState.num_of_iterations < mMinNumOfIterations)) {
+        mDeltaTime *= mIncreaseFactor;
+    }
+
+    // Avoid incrementing the time beyond the end time
+    mDeltaTime = std::min(mDeltaTime, mEndTime - rResultantState.time);
+}
+
+}

--- a/applications/GeoMechanicsApplication/custom_workflows/adaptive_time_incrementor.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/adaptive_time_incrementor.h
@@ -1,0 +1,50 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Wijtze Pieter Kikstra
+//                   Anne van de Graaf
+//
+
+#pragma once
+
+#include "time_incrementor.h"
+
+
+namespace Kratos
+{
+
+class AdaptiveTimeIncrementor : public TimeIncrementor
+{
+public:
+    AdaptiveTimeIncrementor(double      StartTime,
+                            double      EndTime,
+                            double      StartIncrement,
+                            std::size_t MaxNumOfCycles     = 10,
+                            double      ReductionFactor    = 0.5,
+                            double      IncreaseFactor     = 2.0,
+                            std::size_t MinNumOfIterations = 3,
+                            std::size_t MaxNumOfIterations = 15);
+
+    [[nodiscard]] bool WantNextStep(const TimeStepEndState& rPreviousState) const override;
+    [[nodiscard]] bool WantRetryStep(std::size_t             CycleNumber,
+                                     const TimeStepEndState& rPreviousState) const override;
+    [[nodiscard]] double GetIncrement() const override;
+    void PostTimeStepExecution(const TimeStepEndState& rResultantState) override;
+
+private:
+    double      mEndTime;
+    double      mDeltaTime;
+    std::size_t mMaxNumOfCycles;
+    double      mReductionFactor;
+    double      mIncreaseFactor;
+    std::size_t mMinNumOfIterations;
+    std::size_t mMaxNumOfIterations;
+};
+
+}

--- a/applications/GeoMechanicsApplication/custom_workflows/time_incrementor.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/time_incrementor.h
@@ -1,0 +1,36 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Wijtze Pieter Kikstra
+//                   Anne van de Graaf
+//
+
+#pragma once
+
+#include "time_step_end_state.hpp"
+
+#include <optional>
+
+
+namespace Kratos
+{
+
+class TimeIncrementor
+{
+public:
+    virtual ~TimeIncrementor() = default;
+
+    [[nodiscard]] virtual bool WantNextStep(const TimeStepEndState& rPreviousState) const = 0;
+    [[nodiscard]] virtual bool WantRetryStep(std::size_t             CycleNumber,
+                                             const TimeStepEndState& rPreviousState) const = 0;
+    [[nodiscard]] virtual double GetIncrement() const = 0;
+    virtual void PostTimeStepExecution(const TimeStepEndState& rResultantState) = 0;
+};
+
+}

--- a/applications/GeoMechanicsApplication/custom_workflows/time_step_end_state.hpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/time_step_end_state.hpp
@@ -1,0 +1,36 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Wijtze Pieter Kikstra
+//                   Marjan Fathian
+//                   Richard Faasse
+//                   Anne van de Graaf
+//
+
+#pragma once
+
+#include <cstddef>
+
+
+namespace Kratos
+{
+
+struct TimeStepEndState
+{
+    enum class ConvergenceState {converged, non_converged};
+
+    double           time              = 0.0;
+    ConvergenceState convergence_state = ConvergenceState::non_converged;
+    std::size_t      num_of_iterations = 0;
+
+    [[nodiscard]] bool Converged()    const {return convergence_state == ConvergenceState::converged;}
+    [[nodiscard]] bool NonConverged() const {return convergence_state == ConvergenceState::non_converged;}
+};
+
+}

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_incrementor.cpp
@@ -1,0 +1,389 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Wijtze Pieter Kikstra
+//                   Anne van de Graaf
+//
+
+#include "testing/testing.h"
+#include "custom_workflows/adaptive_time_incrementor.h"
+#include "custom_workflows/time_step_end_state.hpp"
+
+using namespace Kratos;
+
+
+namespace
+{
+
+struct AdaptiveTimeIncrementorSettings
+{
+    double      StartTime{0.0};
+    double      EndTime{8.0};
+    double      StartIncrement{0.5};
+    std::size_t MaxNumOfCycles{8};
+    double      ReductionFactor{0.5};
+    double      IncreaseFactor{2.0};
+    std::size_t MinNumOfIterations{3};
+    std::size_t MaxNumOfIterations{15};
+};
+
+AdaptiveTimeIncrementor MakeAdaptiveTimeIncrementor(const AdaptiveTimeIncrementorSettings& rSettings)
+{
+    return AdaptiveTimeIncrementor{rSettings.StartTime,
+                                   rSettings.EndTime,
+                                   rSettings.StartIncrement,
+                                   rSettings.MaxNumOfCycles,
+                                   rSettings.ReductionFactor,
+                                   rSettings.IncreaseFactor,
+                                   rSettings.MinNumOfIterations,
+                                   rSettings.MaxNumOfIterations};
+}
+
+}
+
+
+namespace Kratos::Testing
+{
+
+KRATOS_TEST_CASE_IN_SUITE(AdaptiveTimeIncrementorThrowsWhenStartTimeExceedsEndTime, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.EndTime = settings.StartTime - 2.0;
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(MakeAdaptiveTimeIncrementor(settings),
+                                      "Start time (0) must be smaller than end time (-2)")
+}
+
+KRATOS_TEST_CASE_IN_SUITE(AdaptiveTimeIncrementorThrowsWhenStartTimeEqualsEndTime, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.EndTime = settings.StartTime;
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(MakeAdaptiveTimeIncrementor(settings),
+                                      "Start time (0) must be smaller than end time (0)")
+}
+
+KRATOS_TEST_CASE_IN_SUITE(AdaptiveTimeIncrementorThrowsWhenStartIncrementIsNegative, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.StartIncrement = -0.5;
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(MakeAdaptiveTimeIncrementor(settings),
+                                      "Start increment must be positive, but got -0.5")
+}
+
+KRATOS_TEST_CASE_IN_SUITE(AdaptiveTimeIncrementorThrowsWhenStartIncrementEqualsZero, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.StartIncrement = 0.0;
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(MakeAdaptiveTimeIncrementor(settings),
+                                      "Start increment must be positive, but got 0")
+}
+
+KRATOS_TEST_CASE_IN_SUITE(AdaptiveTimeIncrementorThrowsWhenMaxNumberOfCyclesEqualsZero, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.MaxNumOfCycles = std::size_t{0};
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(MakeAdaptiveTimeIncrementor(settings),
+                                      "Maximum number of cycles must be positive")
+}
+
+KRATOS_TEST_CASE_IN_SUITE(AdaptiveTimeIncrementorThrowsWhenReductionFactorIsGreaterThanOne, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.ReductionFactor = 2.0;
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(MakeAdaptiveTimeIncrementor(settings),
+                                      "Reduction factor must not be greater than 1, but got 2")
+}
+
+KRATOS_TEST_CASE_IN_SUITE(AdaptiveTimeIncrementorThrowsWhenReductionFactorIsNegative, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.ReductionFactor = -0.5;
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(MakeAdaptiveTimeIncrementor(settings),
+                                      "Reduction factor must be positive, but got -0.5")
+}
+
+KRATOS_TEST_CASE_IN_SUITE(AdaptiveTimeIncrementorThrowsWhenReductionFactorEqualsZero, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.ReductionFactor = 0.0;
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(MakeAdaptiveTimeIncrementor(settings),
+                                      "Reduction factor must be positive, but got 0")
+}
+
+KRATOS_TEST_CASE_IN_SUITE(AdaptiveTimeIncrementorDoesNotThrowWhenReductionFactorIsInRange, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.ReductionFactor = 0.5;
+    auto has_thrown = false;
+
+    try
+    {
+        MakeAdaptiveTimeIncrementor(settings);
+    }
+    catch (const Exception&)
+    {
+        has_thrown = true;
+    }
+
+    KRATOS_EXPECT_FALSE(has_thrown) // No other way to check that the constructor does not throw
+}
+
+KRATOS_TEST_CASE_IN_SUITE(AdaptiveTimeIncrementorDoesNotThrowWhenReductionFactorEqualsOne, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.ReductionFactor = 1.0;
+    auto has_thrown = false;
+
+    try
+    {
+        MakeAdaptiveTimeIncrementor(settings);
+    }
+    catch (const Exception&)
+    {
+        has_thrown = true;
+    }
+
+    KRATOS_EXPECT_FALSE(has_thrown) // No other way to check that the constructor does not throw
+}
+
+KRATOS_TEST_CASE_IN_SUITE(AdaptiveTimeIncrementorThrowsWhenIncreaseFactorIsSmallerThanOne, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.IncreaseFactor = 0.5;
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(MakeAdaptiveTimeIncrementor(settings),
+                                      "Increase factor must be greater than or equal to 1, but got 0.5")
+}
+
+KRATOS_TEST_CASE_IN_SUITE(AdaptiveTimeIncrementorDoesNotThrowWhenIncreaseFactorEqualsOne, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.IncreaseFactor = 1.0;
+    auto has_thrown = false;
+
+    try
+    {
+        MakeAdaptiveTimeIncrementor(settings);
+    }
+    catch (const Exception&)
+    {
+        has_thrown = true;
+    }
+
+    KRATOS_EXPECT_FALSE(has_thrown) // No other way to check that the constructor does not throw
+}
+
+KRATOS_TEST_CASE_IN_SUITE(AdaptiveTimeIncrementorThrowsWhenMaxNumberOfIterationsEqualsZero, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.MinNumOfIterations = std::size_t{0};
+    settings.MaxNumOfIterations = std::size_t{0};
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(MakeAdaptiveTimeIncrementor(settings),
+                                      "Minimum number of iterations (0) is not less than maximum number of iterations (0)")
+}
+
+KRATOS_TEST_CASE_IN_SUITE(AdaptiveTimeIncrementorThrowsWhenMinNumberOfIterationsIsGreaterThanMaxNumberOfIterations, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.MaxNumOfIterations = std::size_t{10};
+    settings.MinNumOfIterations = settings.MaxNumOfIterations + 1;
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(MakeAdaptiveTimeIncrementor(settings),
+                                      "Minimum number of iterations (11) is not less than maximum number of iterations (10)")
+}
+
+KRATOS_TEST_CASE_IN_SUITE(WantNextTimeStepWhenMoreThanStartIncrementLeftUntilEndTime, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    const auto time_incrementor = MakeAdaptiveTimeIncrementor(settings);
+    auto       previous_state   = TimeStepEndState{};
+    previous_state.time         = settings.EndTime - 2 * settings.StartIncrement;
+
+    KRATOS_EXPECT_TRUE(time_incrementor.WantNextStep(previous_state))
+}
+
+KRATOS_TEST_CASE_IN_SUITE(WantNextTimeStepWhenLessThanStartIncrementLeftUntilEndTime, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    const auto time_incrementor = MakeAdaptiveTimeIncrementor(settings);
+    auto       previous_state   = TimeStepEndState{};
+    previous_state.time         = settings.EndTime - 0.5 * settings.StartIncrement;
+
+    KRATOS_EXPECT_TRUE(time_incrementor.WantNextStep(previous_state))
+}
+
+KRATOS_TEST_CASE_IN_SUITE(NoNextTimeStepWhenEndTimeIsExceeded, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    const auto time_incrementor = MakeAdaptiveTimeIncrementor(settings);
+    auto       previous_state   = TimeStepEndState{};
+    previous_state.time         = settings.EndTime + 1.0;
+
+    KRATOS_EXPECT_FALSE(time_incrementor.WantNextStep(previous_state))
+}
+
+KRATOS_TEST_CASE_IN_SUITE(NoNextTimeStepWhenAtEndTime, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    const auto time_incrementor = MakeAdaptiveTimeIncrementor(settings);
+    auto       previous_state   = TimeStepEndState{};
+    previous_state.time         = settings.EndTime;
+
+    KRATOS_EXPECT_FALSE(time_incrementor.WantNextStep(previous_state))
+}
+
+KRATOS_TEST_CASE_IN_SUITE(RetryWhenNotAttemptedYet, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.MaxNumOfCycles     = std::size_t{4};
+    const auto time_incrementor = MakeAdaptiveTimeIncrementor(settings);
+    const auto cycle_number     = std::size_t{0};
+    const auto previous_state   = TimeStepEndState{};
+
+    KRATOS_EXPECT_TRUE(time_incrementor.WantRetryStep(cycle_number, previous_state))
+}
+
+KRATOS_TEST_CASE_IN_SUITE(RetryWhenPreviousAttemptDidNotConvergeButAtLeastOneMoreLeft, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.MaxNumOfCycles     = std::size_t{4};
+    const auto time_incrementor = MakeAdaptiveTimeIncrementor(settings);
+    const auto cycle_number     = settings.MaxNumOfCycles - 1;
+    auto previous_state         = TimeStepEndState{};
+    previous_state.convergence_state = TimeStepEndState::ConvergenceState::non_converged;
+
+    KRATOS_EXPECT_TRUE(time_incrementor.WantRetryStep(cycle_number, previous_state))
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DontRetryWhenPreviousAttemptDidNotConvergeAndNoAttemptsLeft, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.MaxNumOfCycles     = std::size_t{4};
+    const auto time_incrementor = MakeAdaptiveTimeIncrementor(settings);
+    auto previous_state         = TimeStepEndState{};
+    previous_state.convergence_state = TimeStepEndState::ConvergenceState::non_converged;
+
+    KRATOS_EXPECT_FALSE(time_incrementor.WantRetryStep(settings.MaxNumOfCycles, previous_state))
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DontRetryWhenPreviousAttemptConverged, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.MaxNumOfCycles     = std::size_t{4};
+    const auto time_incrementor = MakeAdaptiveTimeIncrementor(settings);
+    const auto cycle_number     = std::size_t{1};
+    auto previous_state         = TimeStepEndState{};
+    previous_state.convergence_state = TimeStepEndState::ConvergenceState::converged;
+
+    KRATOS_EXPECT_FALSE(time_incrementor.WantRetryStep(cycle_number, previous_state))
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GetStartIncrementWhenItWouldNotResultInExceedingTheEndTime, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.StartIncrement = 0.6;
+    const auto time_incrementor = MakeAdaptiveTimeIncrementor(settings);
+
+    KRATOS_EXPECT_DOUBLE_EQ(settings.StartIncrement, time_incrementor.GetIncrement());
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ReduceStartIncrementWhenItWouldResultInExceedingTheEndTime, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    settings.StartTime      = 0.0;
+    settings.StartIncrement = 1.0;
+    settings.EndTime        = settings.StartTime + 0.5 * settings.StartIncrement; // EndTime would be exceeded if StartIncrement is applied
+    const auto time_incrementor = MakeAdaptiveTimeIncrementor(settings);
+
+    KRATOS_EXPECT_DOUBLE_EQ(settings.EndTime - settings.StartTime, time_incrementor.GetIncrement());
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ReduceIncrementWhenPreviousAttemptDidNotConverge, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    auto time_incrementor = MakeAdaptiveTimeIncrementor(settings);
+    auto previous_state   = TimeStepEndState{};
+    previous_state.convergence_state = TimeStepEndState::ConvergenceState::non_converged;
+
+    time_incrementor.PostTimeStepExecution(previous_state); // process previous non-converged state
+    KRATOS_EXPECT_DOUBLE_EQ(settings.StartIncrement * settings.ReductionFactor, time_incrementor.GetIncrement());
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ReduceIncrementEvenMoreWhenPreviousTwoAttemptsDidNotConverge, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    auto time_incrementor = MakeAdaptiveTimeIncrementor(settings);
+    auto previous_state   = TimeStepEndState{};
+    previous_state.convergence_state = TimeStepEndState::ConvergenceState::non_converged;
+
+    time_incrementor.PostTimeStepExecution(previous_state); // process first non-converged state
+    time_incrementor.PostTimeStepExecution(previous_state); // process second non-converged state
+    KRATOS_EXPECT_DOUBLE_EQ(settings.StartIncrement * settings.ReductionFactor * settings.ReductionFactor,
+                            time_incrementor.GetIncrement());
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ReduceIncrementWhenStepConvergedAndMaxNumberOfIterationsWasAttained, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    auto time_incrementor = MakeAdaptiveTimeIncrementor(settings);
+    auto previous_state   = TimeStepEndState{};
+    previous_state.convergence_state = TimeStepEndState::ConvergenceState::converged;
+    previous_state.num_of_iterations = settings.MaxNumOfIterations;
+
+    time_incrementor.PostTimeStepExecution(previous_state); // previous attempt converged, but required maximum number of iterations
+    KRATOS_EXPECT_DOUBLE_EQ(settings.StartIncrement * settings.ReductionFactor, time_incrementor.GetIncrement());
+}
+
+KRATOS_TEST_CASE_IN_SUITE(IncreaseIncrementWhenStepRequiredLessThanMinNumberOfIterations, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    auto time_incrementor = MakeAdaptiveTimeIncrementor(settings);
+    auto previous_state   = TimeStepEndState{};
+    previous_state.convergence_state = TimeStepEndState::ConvergenceState::converged;
+    previous_state.num_of_iterations = settings.MinNumOfIterations - 1;
+
+    time_incrementor.PostTimeStepExecution(previous_state); // previous attempt converged and required less than minimum number of iterations
+    KRATOS_EXPECT_DOUBLE_EQ(settings.StartIncrement * settings.IncreaseFactor, time_incrementor.GetIncrement());
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ReduceIncrementToAvoidExceedingEndTime, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    auto time_incrementor = MakeAdaptiveTimeIncrementor(settings);
+    auto previous_state   = TimeStepEndState{};
+    previous_state.convergence_state = TimeStepEndState::ConvergenceState::converged;
+    previous_state.num_of_iterations = settings.MinNumOfIterations + 1; // don't attempt to increase the increment
+    previous_state.time              = settings.EndTime - 0.5 * settings.StartIncrement; // only half of StartIncrement left before reaching EndTime
+
+    time_incrementor.PostTimeStepExecution(previous_state);
+    KRATOS_EXPECT_DOUBLE_EQ(0.5 * settings.StartIncrement, time_incrementor.GetIncrement());
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ReduceUpscaledIncrementToAvoidExceedingEndTime, KratosGeoMechanicsFastSuite)
+{
+    AdaptiveTimeIncrementorSettings settings;
+    auto time_incrementor = MakeAdaptiveTimeIncrementor(settings);
+    auto previous_state   = TimeStepEndState{};
+    previous_state.convergence_state = TimeStepEndState::ConvergenceState::converged;
+    previous_state.num_of_iterations = settings.MinNumOfIterations - 1; // this should normally increase the increment
+    previous_state.time              = settings.EndTime - 0.5 * settings.StartIncrement; // only half of StartIncrement left before reaching EndTime
+
+    time_incrementor.PostTimeStepExecution(previous_state);
+    KRATOS_EXPECT_DOUBLE_EQ(0.5 * settings.StartIncrement, time_incrementor.GetIncrement());
+}
+
+}


### PR DESCRIPTION
**📝 Description**
This PR adds an adaptive time incrementor to be used by the C++ custom workflows for geomechanics. It is a time incrementor that starts with a prescribed increment size, which may be adjusted as needed. That is, when no convergence is achieved, the applied time increment will be reduced on each failed attempt. (The maximum number of attempt, aka cycles, is limited by the user.) Conversely, when convergence took only a few iterations, the time increment will be increased.
