### PR TITLE
Added custom_docker_scripts 

### DIFF
--- a/applications/GeoMechanicsApplication/custom_docker_scripts/linux/configure.sh
+++ b/applications/GeoMechanicsApplication/custom_docker_scripts/linux/configure.sh
@@ -23,6 +23,7 @@ export KRATOS_INSTALL_PYTHON_USING_LINKS=ON
 add_app ${KRATOS_APP_DIR}/LinearSolversApplication;
 add_app ${KRATOS_APP_DIR}/StructuralMechanicsApplication;
 add_app ${KRATOS_APP_DIR}/GeoMechanicsApplication;
+add_app ${KRATOS_APP_DIR}/ConstitutiveLawsApplication;
 
 # Clean
 clear

--- a/applications/GeoMechanicsApplication/custom_docker_scripts/linux/configure.sh
+++ b/applications/GeoMechanicsApplication/custom_docker_scripts/linux/configure.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# You can use your interpreter of choice (bash, sh, zsh, ...)
+
+# For any question please contact with us in:
+#   - https://github.com/KratosMultiphysics/Kratos
+
+# Optional parameters:
+# You can find a list with all the compilation options in INSTALL.md or here:
+#   - https://github.com/KratosMultiphysics/Kratos/wiki/Compilation-options
+
+add_app () {
+    export KRATOS_APPLICATIONS="${KRATOS_APPLICATIONS}$1;"
+}
+
+# Set variables
+export KRATOS_SOURCE="${KRATOS_SOURCE:-${PWD}}"
+export KRATOS_BUILD="${KRATOS_SOURCE}/build"
+export KRATOS_APP_DIR="${KRATOS_SOURCE}/applications"
+export PYTHON_EXECUTABLE="/usr/bin/python3.8"
+export KRATOS_INSTALL_PYTHON_USING_LINKS=ON
+
+# Set applications to compile
+add_app ${KRATOS_APP_DIR}/LinearSolversApplication;
+add_app ${KRATOS_APP_DIR}/StructuralMechanicsApplication;
+add_app ${KRATOS_APP_DIR}/GeoMechanicsApplication;
+
+# Clean
+clear
+rm -rf "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}/cmake_install.cmake"
+rm -rf "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}/CMakeCache.txt"
+rm -rf "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}/CMakeFiles"
+
+echo "Kratos build type is ${KRATOS_BUILD_TYPE}"
+
+# Configure
+cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
+${KRATOS_CMAKE_OPTIONS_FLAGS} \
+-DUSE_MPI=ON \
+-DPYTHON_EXECUTABLE="/usr/bin/python3.10" \
+-DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall" \
+-DTRILINOS_INCLUDE_DIR="/usr/include/trilinos" \
+-DTRILINOS_LIBRARY_DIR="/usr/lib/x86_64-linux-gnu" \
+-DTRILINOS_LIBRARY_PREFIX="trilinos_" \
+-DCMAKE_UNITY_BUILD=ON \
+-DINCLUDE_MMG=ON                                    \
+
+# Build
+cmake --build "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" --target install -- -j2


### PR DESCRIPTION
including configuration for Deltares TeamCity build GCC Linux configuration

**📝 Description**
This is a script injected into our process to reduce Deltares GCC builds to only those needed for GeoMechanics application.

i.e.:

- GeoMechanicsAplication
- StructuralMechanicsApplication
- LinearSolverApplication

The teamcity build configuration has been added to copy this script rather than the general one in github actions (https://dpcbuild.deltares.nl/buildConfiguration/GEOFEA_KratosGeo_Docker_GccFullDebug?buildTypeTab=overview&mode=builds)

**🆕 Changelog**
Added custom configuration script