### PR TITLE
[Core][MPI] Minor fix in STL IO in MPI write

### DIFF
--- a/kratos/input_output/stl_io.cpp
+++ b/kratos/input_output/stl_io.cpp
@@ -135,6 +135,12 @@ void StlIO::WriteModelPart(const ModelPart& rThisModelPart)
     // Get data communicator
     const auto& r_data_communicator = rThisModelPart.GetCommunicator().GetDataCommunicator();
 
+    // If rank is not zeo we remove the stream to avoid conflict
+    if (r_data_communicator.Rank() != 0) {
+        mpInputStream = nullptr;
+    }
+    r_data_communicator.Barrier();
+
     /* Write the solid block */
     // Write header of the file
     if (r_data_communicator.Rank() == 0) {
@@ -231,7 +237,7 @@ void StlIO::WriteEntityBlockMPI(
         << " geometries with area = 0.0, skipping these geometries." << std::endl;
 
     // Getting number of entities
-    std::size_t number_of_entities = rThisEntities.size();
+    unsigned int number_of_entities = rThisEntities.size();
     number_of_entities = rDataCommunicator.SumAll(number_of_entities);
 
     // Retrieve rank and pass to rank 0
@@ -283,7 +289,7 @@ void StlIO::WriteGeometryBlockMPI(
         << " geometries with area = 0.0, skipping these geometries." << std::endl;
 
     // Getting number of entities
-    std::size_t number_of_geometries = rThisGeometries.size();
+    unsigned int number_of_geometries = rThisGeometries.size();
     number_of_geometries = rDataCommunicator.SumAll(number_of_geometries);
 
     // Retrieve rank and pass to rank 0

--- a/kratos/input_output/stl_io.cpp
+++ b/kratos/input_output/stl_io.cpp
@@ -230,8 +230,12 @@ void StlIO::WriteEntityBlockMPI(
         << "Model part contained " << converted_num_degenerate_geometries
         << " geometries with area = 0.0, skipping these geometries." << std::endl;
 
+    // Getting number of entities
+    std::size_t number_of_entities = rThisEntities.size();
+    number_of_entities = rDataCommunicator.SumAll(number_of_entities);
+
     // Retrieve rank and pass to rank 0
-    if (rThisEntities.size() > 0) {
+    if (number_of_entities > 0) {
         const int rank = rDataCommunicator.Rank();
         const int tag = 0;
         if (rank == 0) {
@@ -278,8 +282,12 @@ void StlIO::WriteGeometryBlockMPI(
         << "Model part contained " << converted_num_degenerate_geometries
         << " geometries with area = 0.0, skipping these geometries." << std::endl;
 
+    // Getting number of entities
+    std::size_t number_of_geometries = rThisGeometries.size();
+    number_of_geometries = rDataCommunicator.SumAll(number_of_geometries);
+
     // Retrieve rank and pass to rank 0
-    if (rThisGeometries.size() > 0) {
+    if (number_of_geometries > 0) {
         const int rank = rDataCommunicator.Rank();
         const int tag = 0;
         if (rank == 0) {


### PR DESCRIPTION
**📝 Description**

In this PR , changes have been made to the `stl_io.cpp`. The PR introduces fixes in MPI communication. Specifically, it improves the handling of the number of entities and geometries in the code.

Here's a breakdown of the changes made in the PR:

1. A new variable "number_of_entities" has been introduced to store the count of entities.
2. The count of entities is calculated and summed across all processes using "rDataCommunicator.SumAll(number_of_entities)".
3. Similar changes have been made for the count of geometries, with the introduction of the variable "number_of_geometries."
4. The condition for checking if there are entities or geometries has been updated to use these new count variables, improving efficiency in MPI communication.

Until now, due to the previous check, if a partition was empty the communication could get stuck.

**🆕 Changelog**

- [Minor fix in STL IO in MPI write](https://github.com/KratosMultiphysics/Kratos/commit/47f0d0147e2d5055a31a22b22b6c902234a94b18)
