### PR TITLE
[Core][HDF5] Fixing HDF5App tests in win

### DIFF
--- a/kratos/testing/testing.h
+++ b/kratos/testing/testing.h
@@ -26,6 +26,6 @@
 namespace Kratos::Testing 
 {
 
-DataCommunicator& KRATOS_API(KRATOS_CORE) GetDefaultDataCommunicator();
+KRATOS_API(KRATOS_CORE) DataCommunicator& GetDefaultDataCommunicator();
 
 }

--- a/kratos/testing/testing.h
+++ b/kratos/testing/testing.h
@@ -26,6 +26,6 @@
 namespace Kratos::Testing 
 {
 
-DataCommunicator& GetDefaultDataCommunicator();
+DataCommunicator& KRATOS_API(KRATOS_CORE) GetDefaultDataCommunicator();
 
 }


### PR DESCRIPTION
**📝 Description**
Missing export. Is usually not a problem because `GetDefaultCommunicator` was only use in mpi testing classes, but HDF5 now makes use of it in serial as well.

Also this is not tested on the CI. I will try to update the win container so it can be compiled.

Ping @jcotela and @philbucher so you are aware of this just in case.

**🆕 Changelog**
- Exported `GetDefaultCommunicator` 
