### PR TITLE
[GeoMechanicsApplication] Add a time incrementor that models a collection of prescribed time increments

### DIFF
--- a/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
@@ -18,12 +18,13 @@ namespace Kratos
 {
 
 PrescribedTimeIncrementor::PrescribedTimeIncrementor(const std::vector<double>& increments)
-    : mIncrements(increments)
+    : mIncrements(increments),
+      mPos(mIncrements.begin())
 {}
 
 bool PrescribedTimeIncrementor::WantNextStep(const Kratos::TimeStepEndState& rPreviousState) const
 {
-    return !mIncrements.empty();
+    return mPos != mIncrements.end();
 }
 
 bool PrescribedTimeIncrementor::WantRetryStep(std::size_t             CycleNumber,
@@ -39,6 +40,7 @@ double PrescribedTimeIncrementor::GetIncrement() const
 
 void PrescribedTimeIncrementor::PostTimeStepExecution(const Kratos::TimeStepEndState& rResultantState)
 {
+    ++mPos;
 }
 
 }

--- a/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
@@ -1,0 +1,43 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Wijtze Pieter Kikstra
+//                   Anne van de Graaf
+//
+
+#include "prescribed_time_incrementor.h"
+
+
+namespace Kratos
+{
+
+PrescribedTimeIncrementor::PrescribedTimeIncrementor(const std::vector<double>& increments)
+{}
+
+bool PrescribedTimeIncrementor::WantNextStep(const Kratos::TimeStepEndState& rPreviousState) const
+{
+    return false;
+}
+
+bool PrescribedTimeIncrementor::WantRetryStep(std::size_t             CycleNumber,
+                                              const TimeStepEndState& rPreviousState) const
+{
+    return false;
+}
+
+double PrescribedTimeIncrementor::GetIncrement() const
+{
+    return 0.0;
+}
+
+void PrescribedTimeIncrementor::PostTimeStepExecution(const Kratos::TimeStepEndState& rResultantState)
+{
+}
+
+}

--- a/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
@@ -27,7 +27,7 @@ PrescribedTimeIncrementor::PrescribedTimeIncrementor(const std::vector<double>& 
 {
     KRATOS_ERROR_IF(std::any_of(mIncrements.begin(), mIncrements.end(),
                                 [](auto value){return value < 0.0;}))
-        << "All prescribed increments must be positive";
+        << "All prescribed increments must not be negative";
 }
 
 bool PrescribedTimeIncrementor::WantNextStep(const Kratos::TimeStepEndState& rPreviousState) const

--- a/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
@@ -18,11 +18,12 @@ namespace Kratos
 {
 
 PrescribedTimeIncrementor::PrescribedTimeIncrementor(const std::vector<double>& increments)
+    : mIncrements(increments)
 {}
 
 bool PrescribedTimeIncrementor::WantNextStep(const Kratos::TimeStepEndState& rPreviousState) const
 {
-    return false;
+    return !mIncrements.empty();
 }
 
 bool PrescribedTimeIncrementor::WantRetryStep(std::size_t             CycleNumber,

--- a/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
@@ -35,7 +35,7 @@ bool PrescribedTimeIncrementor::WantRetryStep(std::size_t             CycleNumbe
 
 double PrescribedTimeIncrementor::GetIncrement() const
 {
-    return 0.0;
+    return *mPos;
 }
 
 void PrescribedTimeIncrementor::PostTimeStepExecution(const Kratos::TimeStepEndState& rResultantState)

--- a/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
@@ -30,7 +30,7 @@ bool PrescribedTimeIncrementor::WantNextStep(const Kratos::TimeStepEndState& rPr
 bool PrescribedTimeIncrementor::WantRetryStep(std::size_t             CycleNumber,
                                               const TimeStepEndState& rPreviousState) const
 {
-    return false;
+    return true;
 }
 
 double PrescribedTimeIncrementor::GetIncrement() const

--- a/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
@@ -13,6 +13,10 @@
 
 #include "prescribed_time_incrementor.h"
 
+#include "includes/exception.h"
+
+#include <algorithm>
+
 
 namespace Kratos
 {
@@ -20,7 +24,11 @@ namespace Kratos
 PrescribedTimeIncrementor::PrescribedTimeIncrementor(const std::vector<double>& increments)
     : mIncrements(increments),
       mPos(mIncrements.begin())
-{}
+{
+    KRATOS_ERROR_IF(std::any_of(mIncrements.begin(), mIncrements.end(),
+                                [](auto value){return value < 0.0;}))
+        << "All prescribed increments must be positive";
+}
 
 bool PrescribedTimeIncrementor::WantNextStep(const Kratos::TimeStepEndState& rPreviousState) const
 {

--- a/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
@@ -30,7 +30,7 @@ bool PrescribedTimeIncrementor::WantNextStep(const Kratos::TimeStepEndState& rPr
 bool PrescribedTimeIncrementor::WantRetryStep(std::size_t             CycleNumber,
                                               const TimeStepEndState& rPreviousState) const
 {
-    return true;
+    return CycleNumber == 0;
 }
 
 double PrescribedTimeIncrementor::GetIncrement() const

--- a/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
@@ -32,6 +32,8 @@ PrescribedTimeIncrementor::PrescribedTimeIncrementor(const std::vector<double>& 
 
 bool PrescribedTimeIncrementor::WantNextStep(const Kratos::TimeStepEndState& rPreviousState) const
 {
+    if (rPreviousState.NonConverged()) return false;
+
     return mPos != mIncrements.end();
 }
 

--- a/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.cpp
@@ -43,6 +43,8 @@ bool PrescribedTimeIncrementor::WantRetryStep(std::size_t             CycleNumbe
 
 double PrescribedTimeIncrementor::GetIncrement() const
 {
+    KRATOS_ERROR_IF(mPos == mIncrements.end()) << "Out of increment range";
+
     return *mPos;
 }
 

--- a/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.h
@@ -1,0 +1,36 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Wijtze Pieter Kikstra
+//                   Anne van de Graaf
+//
+
+#pragma once
+
+#include "time_incrementor.h"
+
+#include <vector>
+
+
+namespace Kratos
+{
+
+class PrescribedTimeIncrementor : public TimeIncrementor
+{
+public:
+    explicit PrescribedTimeIncrementor(const std::vector<double>& increments);
+
+    [[nodiscard]] bool WantNextStep(const TimeStepEndState& rPreviousState) const override;
+    [[nodiscard]] bool WantRetryStep(std::size_t             CycleNumber,
+                                     const TimeStepEndState& rPreviousState) const override;
+    [[nodiscard]] double GetIncrement() const override;
+    void PostTimeStepExecution(const TimeStepEndState& rResultantState) override;
+};
+
+}

--- a/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.h
@@ -33,7 +33,8 @@ public:
     void PostTimeStepExecution(const TimeStepEndState& rResultantState) override;
 
 private:
-    std::vector<double> mIncrements;
+    std::vector<double>                 mIncrements;
+    std::vector<double>::const_iterator mPos;
 };
 
 }

--- a/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/prescribed_time_incrementor.h
@@ -31,6 +31,9 @@ public:
                                      const TimeStepEndState& rPreviousState) const override;
     [[nodiscard]] double GetIncrement() const override;
     void PostTimeStepExecution(const TimeStepEndState& rResultantState) override;
+
+private:
+    std::vector<double> mIncrements;
 };
 
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
@@ -50,6 +50,7 @@ KRATOS_TEST_CASE_IN_SUITE(WantFirstTwoTimesNewStepWhenPrescribedTimeIncrementorH
     KRATOS_EXPECT_TRUE(incrementor.WantNextStep(previous_state))
     incrementor.PostTimeStepExecution(previous_state);
     KRATOS_EXPECT_FALSE(incrementor.WantNextStep(previous_state))
+    KRATOS_EXPECT_FALSE(incrementor.WantNextStep(previous_state))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(PrescribedTimeIncrementorThrowsIfAnyIncrementIsNegative, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
@@ -72,4 +72,15 @@ KRATOS_TEST_CASE_IN_SUITE(WantRetryStepAlwaysReturnsFalseOnAnySubsequentCycle, K
     KRATOS_EXPECT_FALSE(incrementor.WantRetryStep(cycle_number, previous_state))
 }
 
+KRATOS_TEST_CASE_IN_SUITE(PrescribedTimeIncrementsMustMatchInput, KratosGeoMechanicsFastSuite)
+{
+    std::vector<double> increments{0.4, 0.6};
+    PrescribedTimeIncrementor incrementor{increments};
+    TimeStepEndState previous_state;
+
+    KRATOS_EXPECT_DOUBLE_EQ(increments.front(), incrementor.GetIncrement());
+    incrementor.PostTimeStepExecution(previous_state);
+    KRATOS_EXPECT_DOUBLE_EQ(increments.back(), incrementor.GetIncrement());
+}
+
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
@@ -131,4 +131,13 @@ KRATOS_TEST_CASE_IN_SUITE(WithoutPostTimeStepExecutionAlwaysGetSameIncrement, Kr
     KRATOS_EXPECT_DOUBLE_EQ(increments.back(), incrementor.GetIncrement());
 }
 
+KRATOS_TEST_CASE_IN_SUITE(NoNextTimeStepWhenPreviousEndStateDidNotConverge, KratosGeoMechanicsFastSuite)
+{
+    std::vector<double> increments{0.4, 0.6};
+    PrescribedTimeIncrementor incrementor{increments};
+    TimeStepEndState previous_state;  // contains non-converged state
+
+    KRATOS_EXPECT_FALSE(incrementor.WantNextStep(previous_state));
+}
+
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
@@ -17,6 +17,18 @@
 
 using namespace Kratos;
 
+namespace
+{
+
+TimeStepEndState MakeConvergedEndState()
+{
+    auto result = TimeStepEndState{};
+    result.convergence_state = TimeStepEndState::ConvergenceState::converged;
+    return result;
+}
+
+}
+
 
 namespace Kratos::Testing
 {
@@ -25,7 +37,7 @@ KRATOS_TEST_CASE_IN_SUITE(NoNextTimeStepWhenPrescribedTimeIncrementorHasEmptyLis
 {
     std::vector<double> increments;
     PrescribedTimeIncrementor incrementor{increments};
-    TimeStepEndState previous_state;
+    const auto previous_state = MakeConvergedEndState();
 
     KRATOS_EXPECT_FALSE(incrementor.WantNextStep(previous_state))
 }
@@ -34,7 +46,7 @@ KRATOS_TEST_CASE_IN_SUITE(WantFirstTimeStepWhenPrescribedTimeIncrementorHasNonEm
 {
     std::vector<double> increments{0.4, 0.6};
     PrescribedTimeIncrementor incrementor{increments};
-    TimeStepEndState previous_state;
+    const auto previous_state = MakeConvergedEndState();
 
     KRATOS_EXPECT_TRUE(incrementor.WantNextStep(previous_state))
 }
@@ -43,7 +55,7 @@ KRATOS_TEST_CASE_IN_SUITE(WantFirstTwoTimesNewStepWhenPrescribedTimeIncrementorH
 {
     std::vector<double> increments{0.4, 0.6};
     PrescribedTimeIncrementor incrementor{increments};
-    TimeStepEndState previous_state;
+    const auto previous_state = MakeConvergedEndState();
 
     KRATOS_EXPECT_TRUE(incrementor.WantNextStep(previous_state))
     incrementor.PostTimeStepExecution(previous_state);
@@ -65,7 +77,7 @@ KRATOS_TEST_CASE_IN_SUITE(WantRetryStepAlwaysReturnsTrueOnFirstCycle, KratosGeoM
 {
     std::vector<double> increments{0.4, 0.6};
     PrescribedTimeIncrementor incrementor{increments};
-    TimeStepEndState previous_state;
+    const auto previous_state = MakeConvergedEndState();
     const auto cycle_number = std::size_t{0};
 
     KRATOS_EXPECT_TRUE(incrementor.WantRetryStep(cycle_number, previous_state))
@@ -75,7 +87,7 @@ KRATOS_TEST_CASE_IN_SUITE(WantRetryStepAlwaysReturnsFalseOnAnySubsequentCycle, K
 {
     std::vector<double> increments{0.4, 0.6};
     PrescribedTimeIncrementor incrementor{increments};
-    TimeStepEndState previous_state;
+    const auto previous_state = MakeConvergedEndState();
     const auto cycle_number = std::size_t{1};
 
     KRATOS_EXPECT_FALSE(incrementor.WantRetryStep(cycle_number, previous_state))
@@ -85,7 +97,7 @@ KRATOS_TEST_CASE_IN_SUITE(PrescribedTimeIncrementsMustMatchInput, KratosGeoMecha
 {
     std::vector<double> increments{0.4, 0.6};
     PrescribedTimeIncrementor incrementor{increments};
-    TimeStepEndState previous_state;
+    const auto previous_state = MakeConvergedEndState();
 
     KRATOS_EXPECT_DOUBLE_EQ(increments.front(), incrementor.GetIncrement());
     incrementor.PostTimeStepExecution(previous_state);
@@ -96,7 +108,7 @@ KRATOS_TEST_CASE_IN_SUITE(PrescribedTimeIncrementorThrowsWhenAskingForIncrementB
 {
     std::vector<double> increments{0.4, 0.6};
     PrescribedTimeIncrementor incrementor{increments};
-    TimeStepEndState previous_state;
+    const auto previous_state = MakeConvergedEndState();
     incrementor.PostTimeStepExecution(previous_state);
     incrementor.PostTimeStepExecution(previous_state);
     // Now we are beyond the end of the increment vector
@@ -112,7 +124,7 @@ KRATOS_TEST_CASE_IN_SUITE(WithoutPostTimeStepExecutionAlwaysGetSameIncrement, Kr
     KRATOS_EXPECT_DOUBLE_EQ(increments.front(), incrementor.GetIncrement());
     KRATOS_EXPECT_DOUBLE_EQ(increments.front(), incrementor.GetIncrement());
 
-    TimeStepEndState previous_state;
+    const auto previous_state = MakeConvergedEndState();
     incrementor.PostTimeStepExecution(previous_state);
 
     KRATOS_EXPECT_DOUBLE_EQ(increments.back(), incrementor.GetIncrement());

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
@@ -30,4 +30,13 @@ KRATOS_TEST_CASE_IN_SUITE(NoNextTimeStepWhenPrescribedTimeIncrementorHasEmptyLis
     KRATOS_EXPECT_FALSE(incrementor.WantNextStep(previous_state));
 }
 
+KRATOS_TEST_CASE_IN_SUITE(WantFirstTimeStepWhenPrescribedTimeIncrementorHasNonEmptyList, KratosGeoMechanicsFastSuite)
+{
+    std::vector<double> increments{0.4, 0.6};
+    PrescribedTimeIncrementor incrementor{increments};
+    TimeStepEndState previous_state;
+
+    KRATOS_EXPECT_TRUE(incrementor.WantNextStep(previous_state));
+}
+
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
@@ -27,7 +27,7 @@ KRATOS_TEST_CASE_IN_SUITE(NoNextTimeStepWhenPrescribedTimeIncrementorHasEmptyLis
     PrescribedTimeIncrementor incrementor{increments};
     TimeStepEndState previous_state;
 
-    KRATOS_EXPECT_FALSE(incrementor.WantNextStep(previous_state));
+    KRATOS_EXPECT_FALSE(incrementor.WantNextStep(previous_state))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(WantFirstTimeStepWhenPrescribedTimeIncrementorHasNonEmptyList, KratosGeoMechanicsFastSuite)
@@ -36,7 +36,20 @@ KRATOS_TEST_CASE_IN_SUITE(WantFirstTimeStepWhenPrescribedTimeIncrementorHasNonEm
     PrescribedTimeIncrementor incrementor{increments};
     TimeStepEndState previous_state;
 
-    KRATOS_EXPECT_TRUE(incrementor.WantNextStep(previous_state));
+    KRATOS_EXPECT_TRUE(incrementor.WantNextStep(previous_state))
+}
+
+KRATOS_TEST_CASE_IN_SUITE(WantFirstTwoTimesNewStepWhenPrescribedTimeIncrementorHasTwoItems, KratosGeoMechanicsFastSuite)
+{
+    std::vector<double> increments{0.4, 0.6};
+    PrescribedTimeIncrementor incrementor{increments};
+    TimeStepEndState previous_state;
+
+    KRATOS_EXPECT_TRUE(incrementor.WantNextStep(previous_state))
+    incrementor.PostTimeStepExecution(previous_state);
+    KRATOS_EXPECT_TRUE(incrementor.WantNextStep(previous_state))
+    incrementor.PostTimeStepExecution(previous_state);
+    KRATOS_EXPECT_FALSE(incrementor.WantNextStep(previous_state))
 }
 
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
@@ -35,8 +35,8 @@ namespace Kratos::Testing
 
 KRATOS_TEST_CASE_IN_SUITE(NoNextTimeStepWhenPrescribedTimeIncrementorHasEmptyList, KratosGeoMechanicsFastSuite)
 {
-    std::vector<double> increments;
-    PrescribedTimeIncrementor incrementor{increments};
+    const auto increments     = std::vector<double>{};
+    const auto incrementor    = PrescribedTimeIncrementor{increments};
     const auto previous_state = MakeConvergedEndState();
 
     KRATOS_EXPECT_FALSE(incrementor.WantNextStep(previous_state))
@@ -44,8 +44,8 @@ KRATOS_TEST_CASE_IN_SUITE(NoNextTimeStepWhenPrescribedTimeIncrementorHasEmptyLis
 
 KRATOS_TEST_CASE_IN_SUITE(WantFirstTimeStepWhenPrescribedTimeIncrementorHasNonEmptyList, KratosGeoMechanicsFastSuite)
 {
-    std::vector<double> increments{0.4, 0.6};
-    PrescribedTimeIncrementor incrementor{increments};
+    const auto increments     = std::vector<double>{0.4, 0.6};
+    const auto incrementor    = PrescribedTimeIncrementor{increments};
     const auto previous_state = MakeConvergedEndState();
 
     KRATOS_EXPECT_TRUE(incrementor.WantNextStep(previous_state))
@@ -53,8 +53,8 @@ KRATOS_TEST_CASE_IN_SUITE(WantFirstTimeStepWhenPrescribedTimeIncrementorHasNonEm
 
 KRATOS_TEST_CASE_IN_SUITE(WantFirstTwoTimesNewStepWhenPrescribedTimeIncrementorHasTwoItems, KratosGeoMechanicsFastSuite)
 {
-    std::vector<double> increments{0.4, 0.6};
-    PrescribedTimeIncrementor incrementor{increments};
+    const auto increments     = std::vector<double>{0.4, 0.6};
+    auto       incrementor    = PrescribedTimeIncrementor{increments};
     const auto previous_state = MakeConvergedEndState();
 
     KRATOS_EXPECT_TRUE(incrementor.WantNextStep(previous_state))
@@ -67,7 +67,7 @@ KRATOS_TEST_CASE_IN_SUITE(WantFirstTwoTimesNewStepWhenPrescribedTimeIncrementorH
 
 KRATOS_TEST_CASE_IN_SUITE(PrescribedTimeIncrementorThrowsIfAnyIncrementIsNegative, KratosGeoMechanicsFastSuite)
 {
-    std::vector<double> increments{0.4, -0.6};
+    const auto increments = std::vector<double>{0.4, -0.6};
 
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(PrescribedTimeIncrementor{increments},
                                       "All prescribed increments must not be negative")
@@ -75,28 +75,28 @@ KRATOS_TEST_CASE_IN_SUITE(PrescribedTimeIncrementorThrowsIfAnyIncrementIsNegativ
 
 KRATOS_TEST_CASE_IN_SUITE(WantRetryStepAlwaysReturnsTrueOnFirstCycle, KratosGeoMechanicsFastSuite)
 {
-    std::vector<double> increments{0.4, 0.6};
-    PrescribedTimeIncrementor incrementor{increments};
+    const auto increments     = std::vector<double>{0.4, 0.6};
+    const auto incrementor    = PrescribedTimeIncrementor{increments};
     const auto previous_state = MakeConvergedEndState();
-    const auto cycle_number = std::size_t{0};
+    const auto cycle_number   = std::size_t{0};
 
     KRATOS_EXPECT_TRUE(incrementor.WantRetryStep(cycle_number, previous_state))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(WantRetryStepAlwaysReturnsFalseOnAnySubsequentCycle, KratosGeoMechanicsFastSuite)
 {
-    std::vector<double> increments{0.4, 0.6};
-    PrescribedTimeIncrementor incrementor{increments};
+    const auto increments     = std::vector<double>{0.4, 0.6};
+    const auto incrementor    = PrescribedTimeIncrementor{increments};
     const auto previous_state = MakeConvergedEndState();
-    const auto cycle_number = std::size_t{1};
+    const auto cycle_number   = std::size_t{1};
 
     KRATOS_EXPECT_FALSE(incrementor.WantRetryStep(cycle_number, previous_state))
 }
 
 KRATOS_TEST_CASE_IN_SUITE(PrescribedTimeIncrementsMustMatchInput, KratosGeoMechanicsFastSuite)
 {
-    std::vector<double> increments{0.4, 0.6};
-    PrescribedTimeIncrementor incrementor{increments};
+    const auto increments     = std::vector<double>{0.4, 0.6};
+    auto       incrementor    = PrescribedTimeIncrementor{increments};
     const auto previous_state = MakeConvergedEndState();
 
     KRATOS_EXPECT_DOUBLE_EQ(increments.front(), incrementor.GetIncrement());
@@ -106,8 +106,8 @@ KRATOS_TEST_CASE_IN_SUITE(PrescribedTimeIncrementsMustMatchInput, KratosGeoMecha
 
 KRATOS_TEST_CASE_IN_SUITE(PrescribedTimeIncrementorThrowsWhenAskingForIncrementBeyondEnd, KratosGeoMechanicsFastSuite)
 {
-    std::vector<double> increments{0.4, 0.6};
-    PrescribedTimeIncrementor incrementor{increments};
+    const auto increments     = std::vector<double>{0.4, 0.6};
+    auto       incrementor    = PrescribedTimeIncrementor{increments};
     const auto previous_state = MakeConvergedEndState();
     incrementor.PostTimeStepExecution(previous_state);
     incrementor.PostTimeStepExecution(previous_state);
@@ -122,8 +122,8 @@ KRATOS_TEST_CASE_IN_SUITE(PrescribedTimeIncrementorThrowsWhenAskingForIncrementB
 
 KRATOS_TEST_CASE_IN_SUITE(WithoutPostTimeStepExecutionAlwaysGetSameIncrement, KratosGeoMechanicsFastSuite)
 {
-    std::vector<double> increments{0.4, 0.6};
-    PrescribedTimeIncrementor incrementor{increments};
+    const auto increments  = std::vector<double>{0.4, 0.6};
+    auto       incrementor = PrescribedTimeIncrementor{increments};
 
     KRATOS_EXPECT_DOUBLE_EQ(increments.front(), incrementor.GetIncrement());
     KRATOS_EXPECT_DOUBLE_EQ(increments.front(), incrementor.GetIncrement());
@@ -137,9 +137,9 @@ KRATOS_TEST_CASE_IN_SUITE(WithoutPostTimeStepExecutionAlwaysGetSameIncrement, Kr
 
 KRATOS_TEST_CASE_IN_SUITE(NoNextTimeStepWhenPreviousEndStateDidNotConverge, KratosGeoMechanicsFastSuite)
 {
-    std::vector<double> increments{0.4, 0.6};
-    PrescribedTimeIncrementor incrementor{increments};
-    TimeStepEndState previous_state;  // contains non-converged state
+    const auto increments     = std::vector<double>{0.4, 0.6};
+    const auto incrementor    = PrescribedTimeIncrementor{increments};
+    const auto previous_state = TimeStepEndState{};  // contains non-converged state
 
     KRATOS_EXPECT_FALSE(incrementor.WantNextStep(previous_state))
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
@@ -1,0 +1,33 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Wijtze Pieter Kikstra
+//                   Anne van de Graaf
+//
+
+#include "testing/testing.h"
+#include "custom_workflows/prescribed_time_incrementor.h"
+#include "custom_workflows/time_step_end_state.hpp"
+
+using namespace Kratos;
+
+
+namespace Kratos::Testing
+{
+
+KRATOS_TEST_CASE_IN_SUITE(NoNextTimeStepWhenPrescribedTimeIncrementorHasEmptyList, KratosGeoMechanicsFastSuite)
+{
+    std::vector<double> increments;
+    PrescribedTimeIncrementor incrementor{increments};
+    TimeStepEndState previous_state;
+
+    KRATOS_EXPECT_FALSE(incrementor.WantNextStep(previous_state));
+}
+
+}

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
@@ -91,4 +91,16 @@ KRATOS_TEST_CASE_IN_SUITE(PrescribedTimeIncrementsMustMatchInput, KratosGeoMecha
     KRATOS_EXPECT_DOUBLE_EQ(increments.back(), incrementor.GetIncrement());
 }
 
+KRATOS_TEST_CASE_IN_SUITE(PrescribedTimeIncrementorThrowsWhenAskingForIncrementBeyondEnd, KratosGeoMechanicsFastSuite)
+{
+    std::vector<double> increments{0.4, 0.6};
+    PrescribedTimeIncrementor incrementor{increments};
+    TimeStepEndState previous_state;
+    incrementor.PostTimeStepExecution(previous_state);
+    incrementor.PostTimeStepExecution(previous_state);
+    // Now we are beyond the end of the increment vector
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(incrementor.GetIncrement(), "Out of increment range");
+}
+
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
@@ -57,7 +57,7 @@ KRATOS_TEST_CASE_IN_SUITE(PrescribedTimeIncrementorThrowsIfAnyIncrementIsNegativ
     std::vector<double> increments{0.4, -0.6};
 
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(PrescribedTimeIncrementor{increments},
-                                      "All prescribed increments must be positive")
+                                      "All prescribed increments must not be negative")
 }
 
 KRATOS_TEST_CASE_IN_SUITE(WantRetryStepAlwaysReturnsTrueOnFirstCycle, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
@@ -104,4 +104,19 @@ KRATOS_TEST_CASE_IN_SUITE(PrescribedTimeIncrementorThrowsWhenAskingForIncrementB
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(incrementor.GetIncrement(), "Out of increment range");
 }
 
+KRATOS_TEST_CASE_IN_SUITE(WithoutPostTimeStepExecutionAlwaysGetSameIncrement, KratosGeoMechanicsFastSuite)
+{
+    std::vector<double> increments{0.4, 0.6};
+    PrescribedTimeIncrementor incrementor{increments};
+
+    KRATOS_EXPECT_DOUBLE_EQ(increments.front(), incrementor.GetIncrement());
+    KRATOS_EXPECT_DOUBLE_EQ(increments.front(), incrementor.GetIncrement());
+
+    TimeStepEndState previous_state;
+    incrementor.PostTimeStepExecution(previous_state);
+
+    KRATOS_EXPECT_DOUBLE_EQ(increments.back(), incrementor.GetIncrement());
+    KRATOS_EXPECT_DOUBLE_EQ(increments.back(), incrementor.GetIncrement());
+}
+
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
@@ -52,6 +52,14 @@ KRATOS_TEST_CASE_IN_SUITE(WantFirstTwoTimesNewStepWhenPrescribedTimeIncrementorH
     KRATOS_EXPECT_FALSE(incrementor.WantNextStep(previous_state))
 }
 
+KRATOS_TEST_CASE_IN_SUITE(PrescribedTimeIncrementorThrowsIfAnyIncrementIsNegative, KratosGeoMechanicsFastSuite)
+{
+    std::vector<double> increments{0.4, -0.6};
+
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(PrescribedTimeIncrementor{increments},
+                                      "All prescribed increments must be positive")
+}
+
 KRATOS_TEST_CASE_IN_SUITE(WantRetryStepAlwaysReturnsTrueOnFirstCycle, KratosGeoMechanicsFastSuite)
 {
     std::vector<double> increments{0.4, 0.6};

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
@@ -52,4 +52,14 @@ KRATOS_TEST_CASE_IN_SUITE(WantFirstTwoTimesNewStepWhenPrescribedTimeIncrementorH
     KRATOS_EXPECT_FALSE(incrementor.WantNextStep(previous_state))
 }
 
+KRATOS_TEST_CASE_IN_SUITE(WantRetryStepAlwaysReturnsFalse, KratosGeoMechanicsFastSuite)
+{
+    std::vector<double> increments{0.4, 0.6};
+    PrescribedTimeIncrementor incrementor{increments};
+    TimeStepEndState previous_state;
+    const auto cycle_number = std::size_t{0};
+
+    KRATOS_EXPECT_TRUE(incrementor.WantRetryStep(cycle_number, previous_state))
+}
+
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
@@ -113,7 +113,11 @@ KRATOS_TEST_CASE_IN_SUITE(PrescribedTimeIncrementorThrowsWhenAskingForIncrementB
     incrementor.PostTimeStepExecution(previous_state);
     // Now we are beyond the end of the increment vector
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(const auto increment = incrementor.GetIncrement(), "Out of increment range")
+    // Note: avoid a warning triggered by the `[[nodiscard]]` attribute of the `GetIncrement()` member function by
+    // assigning the return value to a dummy variable. In turn, the dummy variable needs to be marked `[[maybe_unused]]`
+    // to avoid a warning about an unused variable.
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN([[maybe_unused]] const auto increment = incrementor.GetIncrement(),
+                                      "Out of increment range")
 }
 
 KRATOS_TEST_CASE_IN_SUITE(WithoutPostTimeStepExecutionAlwaysGetSameIncrement, KratosGeoMechanicsFastSuite)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
@@ -113,7 +113,7 @@ KRATOS_TEST_CASE_IN_SUITE(PrescribedTimeIncrementorThrowsWhenAskingForIncrementB
     incrementor.PostTimeStepExecution(previous_state);
     // Now we are beyond the end of the increment vector
 
-    KRATOS_EXPECT_EXCEPTION_IS_THROWN(incrementor.GetIncrement(), "Out of increment range");
+    KRATOS_EXPECT_EXCEPTION_IS_THROWN(const auto increment = incrementor.GetIncrement(), "Out of increment range")
 }
 
 KRATOS_TEST_CASE_IN_SUITE(WithoutPostTimeStepExecutionAlwaysGetSameIncrement, KratosGeoMechanicsFastSuite)
@@ -137,7 +137,7 @@ KRATOS_TEST_CASE_IN_SUITE(NoNextTimeStepWhenPreviousEndStateDidNotConverge, Krat
     PrescribedTimeIncrementor incrementor{increments};
     TimeStepEndState previous_state;  // contains non-converged state
 
-    KRATOS_EXPECT_FALSE(incrementor.WantNextStep(previous_state));
+    KRATOS_EXPECT_FALSE(incrementor.WantNextStep(previous_state))
 }
 
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_prescribed_time_incrementor.cpp
@@ -52,7 +52,7 @@ KRATOS_TEST_CASE_IN_SUITE(WantFirstTwoTimesNewStepWhenPrescribedTimeIncrementorH
     KRATOS_EXPECT_FALSE(incrementor.WantNextStep(previous_state))
 }
 
-KRATOS_TEST_CASE_IN_SUITE(WantRetryStepAlwaysReturnsFalse, KratosGeoMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(WantRetryStepAlwaysReturnsTrueOnFirstCycle, KratosGeoMechanicsFastSuite)
 {
     std::vector<double> increments{0.4, 0.6};
     PrescribedTimeIncrementor incrementor{increments};
@@ -60,6 +60,16 @@ KRATOS_TEST_CASE_IN_SUITE(WantRetryStepAlwaysReturnsFalse, KratosGeoMechanicsFas
     const auto cycle_number = std::size_t{0};
 
     KRATOS_EXPECT_TRUE(incrementor.WantRetryStep(cycle_number, previous_state))
+}
+
+KRATOS_TEST_CASE_IN_SUITE(WantRetryStepAlwaysReturnsFalseOnAnySubsequentCycle, KratosGeoMechanicsFastSuite)
+{
+    std::vector<double> increments{0.4, 0.6};
+    PrescribedTimeIncrementor incrementor{increments};
+    TimeStepEndState previous_state;
+    const auto cycle_number = std::size_t{1};
+
+    KRATOS_EXPECT_FALSE(incrementor.WantRetryStep(cycle_number, previous_state))
 }
 
 }


### PR DESCRIPTION
**📝 Description**
Added a time incrementor that implements the time incrementor interface for the case where we have a collection of prescribed time increments. This class is probably one of the simplest (and most fundamental) ways to step through time. We will use it when developing the time loop executor. (But we may consider to also make it accessible through the `ProjectParameters.json` file.)
