### PR TITLE
[GeoMechanicsApplication] Isolated Hencky strain computation, such that it appears once. 

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -311,7 +311,6 @@ protected:
     virtual void CalculateCauchyAlmansiStrain( ElementVariables &rVariables );
     virtual void CalculateCauchyGreenStrain( ElementVariables &rVariables );
     virtual void CalculateCauchyStrain( ElementVariables &rVariables );
-    virtual void CalculateHenckyStrain( ElementVariables& rVariables );
     virtual void CalculateStrain( ElementVariables &rVariables, unsigned int GPoint );
     virtual void CalculateDeformationGradient( ElementVariables& rVariables,
                                                unsigned int GPoint );

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -2451,7 +2451,6 @@ GeometryData::IntegrationMethod
         break;
     }
 
-    //return GeometryData::IntegrationMethod::GI_GAUSS_2;
     return GI_GAUSS;
 }
 
@@ -2461,7 +2460,10 @@ void SmallStrainUPwDiffOrderElement::
 {
     if (rVariables.UseHenckyStrain) {
         this->CalculateDeformationGradient(rVariables, GPoint);
-        this->CalculateHenckyStrain( rVariables );
+        const GeometryType& rGeom = GetGeometry();
+        const SizeType Dim        = rGeom.WorkingSpaceDimension();
+        const SizeType VoigtSize  = ( Dim == N_DIM_3D ? VOIGT_SIZE_3D : VOIGT_SIZE_2D_PLANE_STRAIN);
+        noalias(rVariables.StrainVector) = StressStrainUtilities::CalculateHenckyStrain(rVariables.F, VoigtSize);
     } else {
         this->CalculateCauchyStrain( rVariables );
     }
@@ -2571,52 +2573,6 @@ void SmallStrainUPwDiffOrderElement::
 
     ETensor *= 0.5;
 
-    if (Dim==2) {
-        Vector StrainVector;
-        StrainVector = MathUtils<double>::StrainTensorToVector(ETensor);
-        rVariables.StrainVector[INDEX_2D_PLANE_STRAIN_XX] = StrainVector[0];
-        rVariables.StrainVector[INDEX_2D_PLANE_STRAIN_YY] = StrainVector[1];
-        rVariables.StrainVector[INDEX_2D_PLANE_STRAIN_ZZ] = 0.0;
-        rVariables.StrainVector[INDEX_2D_PLANE_STRAIN_XY] = StrainVector[2];
-    } else {
-        noalias(rVariables.StrainVector) = MathUtils<double>::StrainTensorToVector(ETensor);
-    }
-
-    KRATOS_CATCH( "" )
-}
-
-//----------------------------------------------------------------------------------------
-void SmallStrainUPwDiffOrderElement::
-    CalculateHenckyStrain( ElementVariables& rVariables )
-{
-    KRATOS_TRY
-
-    const GeometryType& rGeom = GetGeometry();
-    const SizeType Dim = rGeom.WorkingSpaceDimension();
-
-    //-Compute total deformation gradient
-    const Matrix& F = rVariables.F;
-
-    Matrix CMatrix;
-    CMatrix = prod(trans(F), F);
-
-    // Declare the different matrix
-    Matrix EigenValuesMatrix = ZeroMatrix(Dim, Dim);
-    Matrix EigenVectorsMatrix = ZeroMatrix(Dim, Dim);
-
-    // Decompose matrix
-    MathUtils<double>::GaussSeidelEigenSystem(CMatrix, EigenVectorsMatrix, EigenValuesMatrix, 1.0e-16, 20);
-
-    // Calculate the eigenvalues of the E matrix
-    for (IndexType i = 0; i < Dim; ++i) {
-        EigenValuesMatrix(i, i) = 0.5 * std::log(EigenValuesMatrix(i, i));
-    }
-
-    // Calculate E matrix
-    Matrix ETensor = ZeroMatrix(Dim, Dim);
-    MathUtils<double>::BDBtProductOperation(ETensor, EigenValuesMatrix, EigenVectorsMatrix);
-
-    // Hencky Strain Calculation
     if (Dim==2) {
         Vector StrainVector;
         StrainVector = MathUtils<double>::StrainTensorToVector(ETensor);

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -2460,8 +2460,7 @@ void SmallStrainUPwDiffOrderElement::
 {
     if (rVariables.UseHenckyStrain) {
         this->CalculateDeformationGradient(rVariables, GPoint);
-        const GeometryType& rGeom = GetGeometry();
-        const SizeType Dim        = rGeom.WorkingSpaceDimension();
+        const SizeType Dim        = GetGeometry().WorkingSpaceDimension();
         const SizeType VoigtSize  = ( Dim == N_DIM_3D ? VOIGT_SIZE_3D : VOIGT_SIZE_2D_PLANE_STRAIN);
         noalias(rVariables.StrainVector) = StressStrainUtilities::CalculateHenckyStrain(rVariables.F, VoigtSize);
     } else {

--- a/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -309,7 +309,6 @@ protected:
     virtual void CalculateCauchyGreenStrain( ElementVariables& rVariables );
     virtual void CalculateCauchyStrain( ElementVariables& rVariables );
     virtual void CalculateStrain( ElementVariables& rVariables, unsigned int GPoint );
-    virtual void CalculateHenckyStrain( ElementVariables& rVariables );
 
     virtual void CalculateDeformationGradient( ElementVariables& rVariables,
                                                unsigned int GPoint );

--- a/applications/GeoMechanicsApplication/custom_utilities/stress_strain_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/stress_strain_utilities.hpp
@@ -15,51 +15,14 @@
 
 /* Project includes */
 #include "custom_utilities/math_utilities.hpp"
+#include "geo_mechanics_application_constants.h"
 
 namespace Kratos
 {
 
-/**@name Kratos Globals */
-/*@{ */
-
-
-/*@} */
-/**@name Type Definitions */
-/*@{ */
-
-/*@} */
-
-
-/**@name  Enum's */
-/*@{ */
-
-
-/*@} */
-/**@name  Functions */
-/*@{ */
-
-
-
-/*@} */
-/**@name Kratos Classes */
-/*@{ */
-
-
 class KRATOS_API(GEO_MECHANICS_APPLICATION) StressStrainUtilities
 {
 public:
-    /**@name Type Definitions */
-    /*@{ */
-
-
-    /*@} */
-    /**@name Life Cycle
-     */
-    /*@{ */
-
-    /** Operators.
-     */
-
     static double CalculateStressNorm(const Vector& StressVector)
     {
         KRATOS_TRY
@@ -74,7 +37,7 @@ public:
         }
         return std::sqrt(StressNorm);
 
-        KRATOS_CATCH( "" )
+        KRATOS_CATCH("")
     }
 
     static double CalculateVonMisesStress(const Vector& StressVector)
@@ -87,7 +50,7 @@ public:
         noalias(StressTensor) = ZeroMatrix(3,3);
         for (std::size_t i=0; i < LocalStressTensor.size1(); ++i) {
             for (std::size_t j=0; j < LocalStressTensor.size2(); ++j) {
-            StressTensor(i,j) = LocalStressTensor(i,j);
+                StressTensor(i,j) = LocalStressTensor(i,j);
             }
         }
 
@@ -100,7 +63,7 @@ public:
 
         return std::sqrt(std::max(SigmaEquivalent, 0.));
 
-        KRATOS_CATCH( "" )
+        KRATOS_CATCH("")
     }
 
     static double CalculateTrace(const Vector& StressVector)
@@ -116,131 +79,59 @@ public:
 
         return trace;
 
-        KRATOS_CATCH( "" )
+        KRATOS_CATCH("")
     }
 
     static double CalculateMeanStress(const Vector& StressVector)
     {
         KRATOS_TRY
-
         return CalculateTrace(StressVector) / (StressVector.size() == 3 ? 2.0 : 3.0);
-
-        KRATOS_CATCH( "" )
+        KRATOS_CATCH("")
     }
 
     static double CalculateVonMisesStrain(const Vector& StrainVector)
     {
         KRATOS_TRY
-
         return (2.0/3.0) * CalculateVonMisesStress(StrainVector);
-
-        KRATOS_CATCH( "" )
+        KRATOS_CATCH("")
     }
 
-    /*@} */
-    /**@name Operations */
-    /*@{ */
+    static Vector CalculateHenckyStrain(const Matrix& DeformationGradient, size_t VoigtSize)
+    {
+        KRATOS_TRY
 
+        // right Cauchy Green deformation tensor C
+        Matrix C = prod(trans(DeformationGradient), DeformationGradient);
+        // Eigenvalues of C matrix, so principal right Cauchy Green deformation tensor C
+        Matrix EigenValuesMatrix, EigenVectorsMatrix;
+        MathUtils<double>::GaussSeidelEigenSystem(C, EigenVectorsMatrix, EigenValuesMatrix, 1.0e-16, 20);
+        // Compute natural strain == Logarithmic strain == Hencky strain from principal strains
+        for (size_t i = 0; i < DeformationGradient.size1(); ++i){
+            EigenValuesMatrix(i,i) = 0.5 * std::log(EigenValuesMatrix(i,i));
+        }
 
-    /*@} */
-    /**@name Access */
-    /*@{ */
+        // Rotate from principal strains back to the used coordinate system
+        Matrix ETensor;
+        MathUtils<double>::BDBtProductOperation(ETensor, EigenValuesMatrix, EigenVectorsMatrix);
 
+        // From tensor to vector
+        if (DeformationGradient.size1()==2 && VoigtSize == 4) {
+            // Plane strain
+            Vector StrainVector2D;
+            StrainVector2D = MathUtils<double>::StrainTensorToVector(ETensor, 3);
+            Vector StrainVector(4);
+            StrainVector[INDEX_2D_PLANE_STRAIN_XX] = StrainVector2D[0];
+            StrainVector[INDEX_2D_PLANE_STRAIN_YY] = StrainVector2D[1];
+            StrainVector[INDEX_2D_PLANE_STRAIN_ZZ] = 0.0;
+            StrainVector[INDEX_2D_PLANE_STRAIN_XY] = StrainVector2D[2];
+            return StrainVector;
+        } else {
+            return MathUtils<double>::StrainTensorToVector(ETensor, VoigtSize);
+        }
 
-    /*@} */
-    /**@name Inquiry */
-    /*@{ */
+        KRATOS_CATCH("")
+    }
 
-
-    /*@} */
-    /**@name Friends */
-    /*@{ */
-
-
-    /*@} */
-
-protected:
-    /**@name Protected static Member Variables */
-    /*@{ */
-
-
-    /*@} */
-    /**@name Protected member Variables */
-    /*@{ */
-
-
-    /*@} */
-    /**@name Protected Operators*/
-    /*@{ */
-
-
-    /*@} */
-    /**@name Protected Operations*/
-    /*@{ */
-
-
-    /*@} */
-    /**@name Protected  Access */
-    /*@{ */
-
-
-    /*@} */
-    /**@name Protected Inquiry */
-    /*@{ */
-
-
-    /*@} */
-    /**@name Protected LifeCycle */
-    /*@{ */
-
-
-
-    /*@} */
-
-private:
-    /**@name Static Member Variables */
-    /*@{ */
-
-
-    /*@} */
-    /**@name Member Variables */
-    /*@{ */
-
-    /*@} */
-    /**@name Private Operators*/
-    /*@{ */
-
-
-    /*@} */
-    /**@name Private Operations*/
-    /*@{ */
-
-
-    /*@} */
-    /**@name Private  Access */
-    /*@{ */
-
-
-    /*@} */
-    /**@name Private Inquiry */
-    /*@{ */
-
-
-    /*@} */
-    /**@name Un accessible methods */
-    /*@{ */
-
-
-    /*@} */
-
-}; /* Class StressStrainUtilities */
-
-/*@} */
-
-/**@name Type Definitions */
-/*@{ */
-
-
-/*@} */
+};
 
 }

--- a/applications/GeoMechanicsApplication/custom_utilities/stress_strain_utilities.hpp
+++ b/applications/GeoMechanicsApplication/custom_utilities/stress_strain_utilities.hpp
@@ -106,7 +106,7 @@ public:
         Matrix EigenValuesMatrix, EigenVectorsMatrix;
         MathUtils<double>::GaussSeidelEigenSystem(C, EigenVectorsMatrix, EigenValuesMatrix, 1.0e-16, 20);
         // Compute natural strain == Logarithmic strain == Hencky strain from principal strains
-        for (size_t i = 0; i < DeformationGradient.size1(); ++i){
+        for (std::size_t i = 0; i < DeformationGradient.size1(); ++i){
             EigenValuesMatrix(i,i) = 0.5 * std::log(EigenValuesMatrix(i,i));
         }
 

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_Hencky_strain.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_Hencky_strain.cpp
@@ -1,0 +1,95 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Wijtze Pieter Kikstra
+//
+
+#include "testing/testing.h"
+#include "custom_utilities/math_utilities.hpp"
+#include "custom_utilities/stress_strain_utilities.hpp"
+
+using namespace Kratos;
+
+namespace Kratos::Testing
+{
+
+KRATOS_TEST_CASE_IN_SUITE(CheckHenckyStrainIncompressibleUniaxialElongation, KratosGeoMechanicsFastSuite)
+{
+    double stretch = 2.0;
+    Matrix Fmatrix = ZeroMatrix(3,3);
+    Fmatrix(0,0) = stretch;
+    Fmatrix(1,1) = 1.0/std::sqrt(stretch);
+    Fmatrix(2,2) = Fmatrix(1,1);
+
+    Vector Evector = StressStrainUtilities::CalculateHenckyStrain(Fmatrix, 6);
+    KRATOS_EXPECT_DOUBLE_EQ(0.5*std::log(stretch*stretch), Evector[0]);
+    KRATOS_EXPECT_DOUBLE_EQ(0.5*std::log(1./stretch), Evector[1]);
+    KRATOS_EXPECT_DOUBLE_EQ(0.5*std::log(1./stretch), Evector[2]);
+    KRATOS_EXPECT_DOUBLE_EQ(0., Evector[3]);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(CheckHenckyStrainRigidRotation, KratosGeoMechanicsFastSuite)
+{
+    double RotationAngle = 1.;
+    Matrix Fmatrix = ZeroMatrix(2,2);
+    Fmatrix(0,0) =  std::cos(RotationAngle); Fmatrix(0,1) =  std::sin(RotationAngle);
+    Fmatrix(1,0) = -std::sin(RotationAngle); Fmatrix(1,1) =  std::cos(RotationAngle);
+
+    // Plane strain has VoigtSize 4, rigid rotation results in all zero strain components
+    Vector Evector = StressStrainUtilities::CalculateHenckyStrain(Fmatrix, 4);
+    KRATOS_EXPECT_DOUBLE_EQ(0., Evector[0]);
+    KRATOS_EXPECT_DOUBLE_EQ(0., Evector[1]);
+    KRATOS_EXPECT_DOUBLE_EQ(0., Evector[2]);
+    KRATOS_EXPECT_DOUBLE_EQ(0., Evector[3]);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(CheckHenckyStrainPureShear, KratosGeoMechanicsFastSuite)
+{
+    double gamma = 0.5;
+    Matrix Fmatrix = IdentityMatrix (2,2);
+    Fmatrix(0,1) = gamma;
+    Fmatrix(1,0) = gamma;
+    Vector Evector = StressStrainUtilities::CalculateHenckyStrain(Fmatrix, 4);
+
+    // analytical eigenvalues of right Cauchy-Green deformation tensor
+    // ( such that we can do the natural logarithm for the Hencky strain on a diagonal )
+    Matrix C = prod(trans(Fmatrix), Fmatrix);
+    double T = C(0,0) + C(1,1);
+    double D = C(0,0)*C(1,1) - C(0,1)*C(1,0);
+    double L1 = 0.5*T + std::sqrt(0.25*T*T - D);
+    double L2 = 0.5*T - std::sqrt(0.25*T*T - D);
+    // normalized eigen vectors
+    Vector V1(2);
+    V1(0) = L1 - C(1,1);
+    V1(1) = C(1,0);
+    V1 /= norm_2(V1);
+    Vector V2(2);
+    V2(0) = L2- C(1,1);
+    V2(1) = C(1,0);
+    V2 /= norm_2(V2);
+    // natural logarithm on diagonal followed by triple product to rotate back to original coordinate system
+    Matrix Eprin = zero_matrix(2,2);
+    Eprin(0,0) = 0.5*std::log(L1);
+    Eprin(1,1) = 0.5*std::log(L2);
+    Matrix V12(2,2);
+    V12(0,0) = V1(0);
+    V12(1,0) = V1(1);
+    V12(0,1) = V2(0);
+    V12(1,1) = V2(1);
+
+    Matrix Eaux = prod(V12,Eprin);
+    Matrix Eana = prod( Eaux, trans(V12));
+
+    KRATOS_EXPECT_DOUBLE_EQ(Eana(0,0),Evector(0));
+    KRATOS_EXPECT_DOUBLE_EQ(Eana(1,1),Evector(1));
+    KRATOS_EXPECT_DOUBLE_EQ(0.,Evector(2));
+    KRATOS_EXPECT_DOUBLE_EQ(2.*Eana(1,0),Evector(3));
+}
+
+}

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_Hencky_strain.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_Hencky_strain.cpp
@@ -21,28 +21,31 @@ namespace Kratos::Testing
 
 KRATOS_TEST_CASE_IN_SUITE(CheckHenckyStrainIncompressibleUniaxialElongation, KratosGeoMechanicsFastSuite)
 {
-    double stretch = 2.0;
+    const double stretch = 2.0;
     Matrix Fmatrix = ZeroMatrix(3,3);
     Fmatrix(0,0) = stretch;
     Fmatrix(1,1) = 1.0/std::sqrt(stretch);
     Fmatrix(2,2) = Fmatrix(1,1);
 
-    Vector Evector = StressStrainUtilities::CalculateHenckyStrain(Fmatrix, 6);
+    const Vector Evector = StressStrainUtilities::CalculateHenckyStrain(Fmatrix, 6);
+    // E = 0.5 ln(C) = 0.5 ln(F^T F)
     KRATOS_EXPECT_DOUBLE_EQ(0.5*std::log(stretch*stretch), Evector[0]);
     KRATOS_EXPECT_DOUBLE_EQ(0.5*std::log(1./stretch), Evector[1]);
     KRATOS_EXPECT_DOUBLE_EQ(0.5*std::log(1./stretch), Evector[2]);
     KRATOS_EXPECT_DOUBLE_EQ(0., Evector[3]);
+    KRATOS_EXPECT_DOUBLE_EQ(0., Evector[4]);
+    KRATOS_EXPECT_DOUBLE_EQ(0., Evector[5]);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(CheckHenckyStrainRigidRotation, KratosGeoMechanicsFastSuite)
 {
-    double RotationAngle = 1.;
-    Matrix Fmatrix = ZeroMatrix(2,2);
+    const double RotationAngle = 1.;
+    Matrix Fmatrix(2,2);
     Fmatrix(0,0) =  std::cos(RotationAngle); Fmatrix(0,1) =  std::sin(RotationAngle);
     Fmatrix(1,0) = -std::sin(RotationAngle); Fmatrix(1,1) =  std::cos(RotationAngle);
 
     // Plane strain has VoigtSize 4, rigid rotation results in all zero strain components
-    Vector Evector = StressStrainUtilities::CalculateHenckyStrain(Fmatrix, 4);
+    const Vector Evector = StressStrainUtilities::CalculateHenckyStrain(Fmatrix, 4);
     KRATOS_EXPECT_DOUBLE_EQ(0., Evector[0]);
     KRATOS_EXPECT_DOUBLE_EQ(0., Evector[1]);
     KRATOS_EXPECT_DOUBLE_EQ(0., Evector[2]);
@@ -51,45 +54,45 @@ KRATOS_TEST_CASE_IN_SUITE(CheckHenckyStrainRigidRotation, KratosGeoMechanicsFast
 
 KRATOS_TEST_CASE_IN_SUITE(CheckHenckyStrainPureShear, KratosGeoMechanicsFastSuite)
 {
-    double gamma = 0.5;
+    const double gamma = 0.5;
     Matrix Fmatrix = IdentityMatrix (2,2);
     Fmatrix(0,1) = gamma;
     Fmatrix(1,0) = gamma;
-    Vector Evector = StressStrainUtilities::CalculateHenckyStrain(Fmatrix, 4);
+    const Vector Evector = StressStrainUtilities::CalculateHenckyStrain(Fmatrix, 4);
 
     // analytical eigenvalues of right Cauchy-Green deformation tensor
     // ( such that we can do the natural logarithm for the Hencky strain on a diagonal )
-    Matrix C = prod(trans(Fmatrix), Fmatrix);
-    double T = C(0,0) + C(1,1);
-    double D = C(0,0)*C(1,1) - C(0,1)*C(1,0);
-    double L1 = 0.5*T + std::sqrt(0.25*T*T - D);
-    double L2 = 0.5*T - std::sqrt(0.25*T*T - D);
+    const Matrix C = prod(trans(Fmatrix), Fmatrix); // Cauchy-Green
+    const double T = C(0,0) + C(1,1); // Trace of C
+    const double D = C(0,0)*C(1,1) - C(0,1)*C(1,0); // Determinant of C
+    const double L1 = 0.5*T + std::sqrt(0.25*T*T - D); // First eigenvalue
+    const double L2 = 0.5*T - std::sqrt(0.25*T*T - D); // Second eigenvalue
     // normalized eigen vectors
-    Vector V1(2);
-    V1(0) = L1 - C(1,1);
-    V1(1) = C(1,0);
-    V1 /= norm_2(V1);
-    Vector V2(2);
-    V2(0) = L2- C(1,1);
-    V2(1) = C(1,0);
-    V2 /= norm_2(V2);
+    Vector eigV1(2);
+    eigV1(0) = L1 - C(1,1);
+    eigV1(1) = C(1,0);
+    eigV1 /= norm_2(eigV1);
+    Vector eigV2(2);
+    eigV2(0) = L2- C(1,1);
+    eigV2(1) = C(1,0);
+    eigV2 /= norm_2(eigV2);
     // natural logarithm on diagonal followed by triple product to rotate back to original coordinate system
-    Matrix Eprin = zero_matrix(2,2);
-    Eprin(0,0) = 0.5*std::log(L1);
-    Eprin(1,1) = 0.5*std::log(L2);
-    Matrix V12(2,2);
-    V12(0,0) = V1(0);
-    V12(1,0) = V1(1);
-    V12(0,1) = V2(0);
-    V12(1,1) = V2(1);
+    Matrix EHenckyPrincipal = zero_matrix(2,2);
+    EHenckyPrincipal(0,0) = 0.5*std::log(L1);
+    EHenckyPrincipal(1,1) = 0.5*std::log(L2);
+    Matrix eigV12(2,2);
+    eigV12(0,0) = eigV1(0);
+    eigV12(1,0) = eigV1(1);
+    eigV12(0,1) = eigV2(0);
+    eigV12(1,1) = eigV2(1);
 
-    Matrix Eaux = prod(V12,Eprin);
-    Matrix Eana = prod( Eaux, trans(V12));
+    const Matrix Eaux = prod(eigV12,EHenckyPrincipal);
+    const Matrix EHenckyAnalytical = prod( Eaux, trans(eigV12));
 
-    KRATOS_EXPECT_DOUBLE_EQ(Eana(0,0),Evector(0));
-    KRATOS_EXPECT_DOUBLE_EQ(Eana(1,1),Evector(1));
+    KRATOS_EXPECT_DOUBLE_EQ(EHenckyAnalytical(0,0),Evector(0));
+    KRATOS_EXPECT_DOUBLE_EQ(EHenckyAnalytical(1,1),Evector(1));
     KRATOS_EXPECT_DOUBLE_EQ(0.,Evector(2));
-    KRATOS_EXPECT_DOUBLE_EQ(2.*Eana(1,0),Evector(3));
+    KRATOS_EXPECT_DOUBLE_EQ(2.*EHenckyAnalytical(1,0),Evector(3));
 }
 
 }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_Hencky_strain.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_Hencky_strain.cpp
@@ -32,24 +32,24 @@ KRATOS_TEST_CASE_IN_SUITE(CheckHenckyStrainIncompressibleUniaxialElongation, Kra
     KRATOS_EXPECT_DOUBLE_EQ(0.5*std::log(stretch*stretch), Evector[0]);
     KRATOS_EXPECT_DOUBLE_EQ(0.5*std::log(1./stretch), Evector[1]);
     KRATOS_EXPECT_DOUBLE_EQ(0.5*std::log(1./stretch), Evector[2]);
-    KRATOS_EXPECT_DOUBLE_EQ(0., Evector[3]);
-    KRATOS_EXPECT_DOUBLE_EQ(0., Evector[4]);
-    KRATOS_EXPECT_DOUBLE_EQ(0., Evector[5]);
+    KRATOS_EXPECT_DOUBLE_EQ(0.0, Evector[3]);
+    KRATOS_EXPECT_DOUBLE_EQ(0.0, Evector[4]);
+    KRATOS_EXPECT_DOUBLE_EQ(0.0, Evector[5]);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(CheckHenckyStrainRigidRotation, KratosGeoMechanicsFastSuite)
 {
-    const double RotationAngle = 1.;
+    const double RotationAngle = 1.0;
     Matrix Fmatrix(2,2);
     Fmatrix(0,0) =  std::cos(RotationAngle); Fmatrix(0,1) =  std::sin(RotationAngle);
     Fmatrix(1,0) = -std::sin(RotationAngle); Fmatrix(1,1) =  std::cos(RotationAngle);
 
     // Plane strain has VoigtSize 4, rigid rotation results in all zero strain components
     const Vector Evector = StressStrainUtilities::CalculateHenckyStrain(Fmatrix, 4);
-    KRATOS_EXPECT_DOUBLE_EQ(0., Evector[0]);
-    KRATOS_EXPECT_DOUBLE_EQ(0., Evector[1]);
-    KRATOS_EXPECT_DOUBLE_EQ(0., Evector[2]);
-    KRATOS_EXPECT_DOUBLE_EQ(0., Evector[3]);
+    KRATOS_EXPECT_DOUBLE_EQ(0.0, Evector[0]);
+    KRATOS_EXPECT_DOUBLE_EQ(0.0, Evector[1]);
+    KRATOS_EXPECT_DOUBLE_EQ(0.0, Evector[2]);
+    KRATOS_EXPECT_DOUBLE_EQ(0.0, Evector[3]);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(CheckHenckyStrainPureShear, KratosGeoMechanicsFastSuite)
@@ -89,10 +89,10 @@ KRATOS_TEST_CASE_IN_SUITE(CheckHenckyStrainPureShear, KratosGeoMechanicsFastSuit
     const Matrix Eaux = prod(eigV12,EHenckyPrincipal);
     const Matrix EHenckyAnalytical = prod( Eaux, trans(eigV12));
 
-    KRATOS_EXPECT_DOUBLE_EQ(EHenckyAnalytical(0,0),Evector(0));
-    KRATOS_EXPECT_DOUBLE_EQ(EHenckyAnalytical(1,1),Evector(1));
-    KRATOS_EXPECT_DOUBLE_EQ(0.,Evector(2));
-    KRATOS_EXPECT_DOUBLE_EQ(2.*EHenckyAnalytical(1,0),Evector(3));
+    KRATOS_EXPECT_DOUBLE_EQ(EHenckyAnalytical(0,0), Evector(0));
+    KRATOS_EXPECT_DOUBLE_EQ(EHenckyAnalytical(1,1), Evector(1));
+    KRATOS_EXPECT_DOUBLE_EQ(0.0, Evector(2));
+    KRATOS_EXPECT_DOUBLE_EQ(2.0*EHenckyAnalytical(1,0), Evector(3));
 }
 
 }


### PR DESCRIPTION
The computation of Hencky strain ( logarithmic strain or natural strain ) has been moved from the element implementations to stress_strain_utilities, such that code duplication is avoided.
Added stretch, rigid rotation and pure shear unit tests.
