### PR TITLE
[Pip] Adding missing modules for packaging

### DIFF
--- a/kratos/KratosMultiphysics.json
+++ b/kratos/KratosMultiphysics.json
@@ -1,6 +1,6 @@
 {
 	"wheel_name": "KratosMultiphysics",
-    "included_modules":  ["response_functions", "mpi"],
+    "included_modules":  ["response_functions", "mpi", "modelers", "orchestrators"],
 	"included_binaries": ["Kratos.*", "KratosCore.*", "KratosCore.*", "KratosMPICore.*", "KratosMPI.*", "zlib.*", "libz.*"],
 	"dependencies": ["numpy"],
 	"author": "Kratos Team",


### PR DESCRIPTION
**📝 Description**
Adding missing core modules for pip packaging. they were ignored by pip as they were not in the meta.
@rubenzorrilla We have to take this into account when we add new submodules. I forgot to check it in the PR.

**🆕 Changelog**
- Added `orchestrators` and `modelers` to the list of allow core submodules.
