### PR TITLE
[GeoMechanicsApplication] Renamed a few files and classes as suggested by @carloslubbers

### DIFF
--- a/applications/GeoMechanicsApplication/custom_processes/apply_scalar_constraint_table_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_scalar_constraint_table_process.cpp
@@ -10,7 +10,7 @@
 //  Main authors:    Anne van de Graaf,
 //                   Marjan Fathian
 //
-#include "apply_scalar_constraints_table_process.h"
+#include "apply_scalar_constraint_table_process.h"
 #include "includes/model_part.h"
 #include "includes/kratos_parameters.h"
 #include "apply_component_table_process.hpp"
@@ -62,17 +62,17 @@ bool HasTableAttached(const Parameters& rSettings)
 namespace Kratos
 {
 
-ApplyScalarConstraintsTableProcess::ApplyScalarConstraintsTableProcess(ModelPart&        rModelPart,
-                                                                       const Parameters& rProcessSettings)
+ApplyScalarConstraintTableProcess::ApplyScalarConstraintTableProcess(ModelPart&        rModelPart,
+                                                                     const Parameters& rProcessSettings)
         : Process(Flags()),
           mrModelPart{rModelPart}
 {
     MakeInternalProcess(rProcessSettings);
 }
 
-ApplyScalarConstraintsTableProcess::~ApplyScalarConstraintsTableProcess() = default;
+ApplyScalarConstraintTableProcess::~ApplyScalarConstraintTableProcess() = default;
 
-void ApplyScalarConstraintsTableProcess::MakeInternalProcess(const Parameters& rProcessSettings)
+void ApplyScalarConstraintTableProcess::MakeInternalProcess(const Parameters& rProcessSettings)
 {
     auto names_of_settings_to_copy = std::vector<std::string>{"model_part_name",
                                                               "variable_name"};
@@ -82,16 +82,16 @@ void ApplyScalarConstraintsTableProcess::MakeInternalProcess(const Parameters& r
         MakeProcessForFluidPressureType(rProcessSettings, std::move(names_of_settings_to_copy));
     }
     else {
-        MakeScalarConstraintsProcess(rProcessSettings, std::move(names_of_settings_to_copy));
+        MakeScalarConstraintProcess(rProcessSettings, std::move(names_of_settings_to_copy));
     }
 }
 
-void ApplyScalarConstraintsTableProcess::MakeProcessForFluidPressureType(const Parameters&        rProcessSettings,
-                                                                         std::vector<std::string> NamesOfSettingsToCopy)
+void ApplyScalarConstraintTableProcess::MakeProcessForFluidPressureType(const Parameters&        rProcessSettings,
+                                                                        std::vector<std::string> NamesOfSettingsToCopy)
 {
     const auto fluid_pressure_type = rProcessSettings["fluid_pressure_type"].GetString();
     if (fluid_pressure_type == "Uniform") {
-        MakeScalarConstraintsProcess(rProcessSettings, std::move(NamesOfSettingsToCopy));
+        MakeScalarConstraintProcess(rProcessSettings, std::move(NamesOfSettingsToCopy));
     } else if (fluid_pressure_type == "Hydrostatic") {
         MakeProcessForHydrostaticFluidPressure(rProcessSettings, std::move(NamesOfSettingsToCopy));
     } else if (fluid_pressure_type == "Phreatic_Line") {
@@ -105,8 +105,8 @@ void ApplyScalarConstraintsTableProcess::MakeProcessForFluidPressureType(const P
     }
 }
 
-void ApplyScalarConstraintsTableProcess::MakeScalarConstraintsProcess(const Parameters&        rProcessSettings,
-                                                                      std::vector<std::string> NamesOfSettingsToCopy)
+void ApplyScalarConstraintTableProcess::MakeScalarConstraintProcess(const Parameters&        rProcessSettings,
+                                                                    std::vector<std::string> NamesOfSettingsToCopy)
 {
     NamesOfSettingsToCopy.emplace_back("value");
 
@@ -122,8 +122,8 @@ void ApplyScalarConstraintsTableProcess::MakeScalarConstraintsProcess(const Para
     }
 }
 
-void ApplyScalarConstraintsTableProcess::MakeProcessForHydrostaticFluidPressure(const Parameters&        rProcessSettings,
-                                                                                std::vector<std::string> NamesOfSettingsToCopy)
+void ApplyScalarConstraintTableProcess::MakeProcessForHydrostaticFluidPressure(const Parameters&        rProcessSettings,
+                                                                               std::vector<std::string> NamesOfSettingsToCopy)
 {
     NamesOfSettingsToCopy.insert(NamesOfSettingsToCopy.end(), {"gravity_direction",
                                                                "reference_coordinate",
@@ -143,8 +143,8 @@ void ApplyScalarConstraintsTableProcess::MakeProcessForHydrostaticFluidPressure(
     }
 }
 
-void ApplyScalarConstraintsTableProcess::MakeProcessForPhreaticLine(const Parameters&        rProcessSettings,
-                                                                    std::vector<std::string> NamesOfSettingsToCopy)
+void ApplyScalarConstraintTableProcess::MakeProcessForPhreaticLine(const Parameters&        rProcessSettings,
+                                                                   std::vector<std::string> NamesOfSettingsToCopy)
 {
     NamesOfSettingsToCopy.insert(NamesOfSettingsToCopy.end(), {"gravity_direction",
                                                                "out_of_plane_direction",
@@ -166,8 +166,8 @@ void ApplyScalarConstraintsTableProcess::MakeProcessForPhreaticLine(const Parame
     }
 }
 
-void ApplyScalarConstraintsTableProcess::MakeProcessForPhreaticSurface(const Parameters&        rProcessSettings,
-                                                                       std::vector<std::string> NamesOfSettingsToCopy)
+void ApplyScalarConstraintTableProcess::MakeProcessForPhreaticSurface(const Parameters&        rProcessSettings,
+                                                                      std::vector<std::string> NamesOfSettingsToCopy)
 {
     NamesOfSettingsToCopy.insert(NamesOfSettingsToCopy.end(), {"gravity_direction",
                                                                "first_reference_coordinate",
@@ -190,8 +190,8 @@ void ApplyScalarConstraintsTableProcess::MakeProcessForPhreaticSurface(const Par
     }
 }
 
-void ApplyScalarConstraintsTableProcess::MakeProcessForInterpolatedLine(const Parameters&        rProcessSettings,
-                                                                        std::vector<std::string> NamesOfSettingsToCopy)
+void ApplyScalarConstraintTableProcess::MakeProcessForInterpolatedLine(const Parameters&        rProcessSettings,
+                                                                       std::vector<std::string> NamesOfSettingsToCopy)
 {
     KRATOS_ERROR_IF(HasTableAttached(rProcessSettings)) << "No time dependent interpolate line pressure process available" << std::endl;
 
@@ -206,12 +206,12 @@ void ApplyScalarConstraintsTableProcess::MakeProcessForInterpolatedLine(const Pa
 
 }
 
-void ApplyScalarConstraintsTableProcess::ExecuteInitialize()
+void ApplyScalarConstraintTableProcess::ExecuteInitialize()
 {
     mProcess->ExecuteInitialize();
 }
 
-void ApplyScalarConstraintsTableProcess::ExecuteInitializeSolutionStep()
+void ApplyScalarConstraintTableProcess::ExecuteInitializeSolutionStep()
 {
     mProcess->ExecuteInitializeSolutionStep();
 }

--- a/applications/GeoMechanicsApplication/custom_processes/apply_scalar_constraint_table_process.h
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_scalar_constraint_table_process.h
@@ -21,18 +21,18 @@ class ModelPart;
 class Parameters;
 
 
-class KRATOS_API(GEO_MECHANICS_APPLICATION) ApplyScalarConstraintsTableProcess : public Process
+class KRATOS_API(GEO_MECHANICS_APPLICATION) ApplyScalarConstraintTableProcess : public Process
 {
 public:
-    KRATOS_CLASS_POINTER_DEFINITION(ApplyScalarConstraintsTableProcess);
+    KRATOS_CLASS_POINTER_DEFINITION(ApplyScalarConstraintTableProcess);
 
-    ApplyScalarConstraintsTableProcess(ModelPart&        rModelPart,
-                                       const Parameters& rProcessSettings);
+    ApplyScalarConstraintTableProcess(ModelPart&        rModelPart,
+                                      const Parameters& rProcessSettings);
 
-    ~ApplyScalarConstraintsTableProcess() override;
+    ~ApplyScalarConstraintTableProcess() override;
 
-    ApplyScalarConstraintsTableProcess(const ApplyScalarConstraintsTableProcess&) = delete;
-    ApplyScalarConstraintsTableProcess& operator=(const ApplyScalarConstraintsTableProcess&) = delete;
+    ApplyScalarConstraintTableProcess(const ApplyScalarConstraintTableProcess&) = delete;
+    ApplyScalarConstraintTableProcess& operator=(const ApplyScalarConstraintTableProcess&) = delete;
 
     using ProcessUniquePointer = std::unique_ptr<Process>;
 
@@ -43,8 +43,8 @@ private:
     void MakeInternalProcess(const Parameters& rProcessSettings);
     void MakeProcessForFluidPressureType(const Parameters&        rProcessSettings,
                                          std::vector<std::string> NamesOfSettingsToCopy);
-    void MakeScalarConstraintsProcess(const Parameters&        rProcessSettings,
-                                      std::vector<std::string> NamesOfSettingsToCopy);
+    void MakeScalarConstraintProcess(const Parameters&        rProcessSettings,
+                                     std::vector<std::string> NamesOfSettingsToCopy);
     void MakeProcessForHydrostaticFluidPressure(const Parameters&        rProcessSettings,
                                                 std::vector<std::string> NamesOfSettingsToCopy);
     void MakeProcessForPhreaticLine(const Parameters&        rProcessSettings,

--- a/applications/GeoMechanicsApplication/custom_processes/apply_vector_constraint_table_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_vector_constraint_table_process.cpp
@@ -10,7 +10,7 @@
 //  Main authors:    Wijtze Pieter Kikstra,
 //                   Anne van de Graaf
 //
-#include "apply_vector_constraints_table_process.hpp"
+#include "apply_vector_constraint_table_process.h"
 #include "includes/model_part.h"
 #include "includes/kratos_parameters.h"
 #include "apply_component_table_process.hpp"
@@ -19,8 +19,8 @@
 namespace Kratos
 {
 
-ApplyVectorConstraintsTableProcess::ApplyVectorConstraintsTableProcess(Kratos::ModelPart&        rModelPart,
-                                                                       const Kratos::Parameters& rSettings)
+ApplyVectorConstraintTableProcess::ApplyVectorConstraintTableProcess(Kratos::ModelPart&        rModelPart,
+                                                                     const Kratos::Parameters& rSettings)
     : Process(Flags()),
       mrModelPart(rModelPart)
 {
@@ -30,10 +30,10 @@ ApplyVectorConstraintsTableProcess::ApplyVectorConstraintsTableProcess(Kratos::M
     }
 }
 
-ApplyVectorConstraintsTableProcess::~ApplyVectorConstraintsTableProcess() = default;
+ApplyVectorConstraintTableProcess::~ApplyVectorConstraintTableProcess() = default;
 
 
-std::vector<Parameters> ApplyVectorConstraintsTableProcess::CreateParametersForActiveComponents(const Parameters& rSettings)
+std::vector<Parameters> ApplyVectorConstraintTableProcess::CreateParametersForActiveComponents(const Parameters& rSettings)
 {
     std::vector<Parameters> result;
     for (auto component : ActiveComponents(rSettings)) {
@@ -42,7 +42,7 @@ std::vector<Parameters> ApplyVectorConstraintsTableProcess::CreateParametersForA
     return result;
 }
 
-std::vector<char> ApplyVectorConstraintsTableProcess::ActiveComponents(const Parameters& rSettings)
+std::vector<char> ApplyVectorConstraintTableProcess::ActiveComponents(const Parameters& rSettings)
 {
     std::vector<char> result;
     for (auto component : {'X', 'Y', 'Z'}) {
@@ -54,7 +54,7 @@ std::vector<char> ApplyVectorConstraintsTableProcess::ActiveComponents(const Par
     return result;
 }
 
-Parameters ApplyVectorConstraintsTableProcess::CreateParametersForComponent(const Parameters& rSettings, char component)
+Parameters ApplyVectorConstraintTableProcess::CreateParametersForComponent(const Parameters& rSettings, char component)
 {
     Parameters result;
     const auto index = ComponentToIndex(component);
@@ -71,7 +71,7 @@ Parameters ApplyVectorConstraintsTableProcess::CreateParametersForComponent(cons
     return result;
 }
 
-std::size_t ApplyVectorConstraintsTableProcess::ComponentToIndex(char component)
+std::size_t ApplyVectorConstraintTableProcess::ComponentToIndex(char component)
 {
     switch (component) {
         case 'X':
@@ -82,12 +82,12 @@ std::size_t ApplyVectorConstraintsTableProcess::ComponentToIndex(char component)
             return 2;
 
         default:
-            KRATOS_ERROR << "ApplyVectorConstraintsTableProcess: Unknown component '" << component << "'" << std::endl;
+            KRATOS_ERROR << "ApplyVectorConstraintTableProcess: Unknown component '" << component << "'" << std::endl;
     }
 }
 
-ApplyVectorConstraintsTableProcess::ProcessUniquePointer
-ApplyVectorConstraintsTableProcess::MakeProcessFor(const Parameters& rParameters) const
+ApplyVectorConstraintTableProcess::ProcessUniquePointer
+ApplyVectorConstraintTableProcess::MakeProcessFor(const Parameters& rParameters) const
 {
     if (rParameters.Has("table")) {
         return std::make_unique<ApplyComponentTableProcess>(mrModelPart, rParameters);
@@ -96,14 +96,14 @@ ApplyVectorConstraintsTableProcess::MakeProcessFor(const Parameters& rParameters
     return std::make_unique<ApplyConstantScalarValueProcess>(mrModelPart, rParameters);
 }
 
-void ApplyVectorConstraintsTableProcess::ExecuteInitialize()
+void ApplyVectorConstraintTableProcess::ExecuteInitialize()
 {
     for (const auto& process : mProcesses) {
         process->ExecuteInitialize();
     }
 }
 
-void ApplyVectorConstraintsTableProcess::ExecuteInitializeSolutionStep()
+void ApplyVectorConstraintTableProcess::ExecuteInitializeSolutionStep()
 {
     for (const auto& process : mProcesses) {
         process->ExecuteInitializeSolutionStep();

--- a/applications/GeoMechanicsApplication/custom_processes/apply_vector_constraint_table_process.h
+++ b/applications/GeoMechanicsApplication/custom_processes/apply_vector_constraint_table_process.h
@@ -21,18 +21,18 @@ class ModelPart;
 class Parameters;
 
 
-class KRATOS_API(GEO_MECHANICS_APPLICATION) ApplyVectorConstraintsTableProcess : public Process
+class KRATOS_API(GEO_MECHANICS_APPLICATION) ApplyVectorConstraintTableProcess : public Process
 {
 public:
-    KRATOS_CLASS_POINTER_DEFINITION(ApplyVectorConstraintsTableProcess);
+    KRATOS_CLASS_POINTER_DEFINITION(ApplyVectorConstraintTableProcess);
 
-    ApplyVectorConstraintsTableProcess(ModelPart&        rModelPart,
-                                       const Parameters& rSettings);
+    ApplyVectorConstraintTableProcess(ModelPart&        rModelPart,
+                                      const Parameters& rSettings);
 
-    ~ApplyVectorConstraintsTableProcess() override;
+    ~ApplyVectorConstraintTableProcess() override;
 
-    ApplyVectorConstraintsTableProcess(const ApplyVectorConstraintsTableProcess&) = delete;
-    ApplyVectorConstraintsTableProcess& operator=(const ApplyVectorConstraintsTableProcess&) = delete;
+    ApplyVectorConstraintTableProcess(const ApplyVectorConstraintTableProcess&) = delete;
+    ApplyVectorConstraintTableProcess& operator=(const ApplyVectorConstraintTableProcess&) = delete;
 
     using ProcessUniquePointer = std::unique_ptr<Process>;
 

--- a/applications/GeoMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/GeoMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
@@ -41,8 +41,8 @@
 #include "custom_processes/set_absorbing_boundary_parameters_process.hpp"
 #include "custom_processes/set_parameter_field_process.hpp"
 #include "custom_processes/set_multiple_moving_loads.h"
-#include "custom_processes/apply_vector_constraints_table_process.hpp"
-#include "custom_processes/apply_scalar_constraints_table_process.h"
+#include "custom_processes/apply_vector_constraint_table_process.h"
+#include "custom_processes/apply_scalar_constraint_table_process.h"
 
 namespace Kratos {
 namespace Python {
@@ -139,12 +139,12 @@ void  AddCustomProcessesToPython(pybind11::module& m)
         (m, "SetMultipleMovingLoadsProcess")
         .def(py::init < ModelPart&, Parameters>());
 
-    py::class_<ApplyVectorConstraintsTableProcess, ApplyVectorConstraintsTableProcess::Pointer, Process>
-        (m, "ApplyVectorConstraintsTableProcess")
+    py::class_<ApplyVectorConstraintTableProcess, ApplyVectorConstraintTableProcess::Pointer, Process>
+        (m, "ApplyVectorConstraintTableProcess")
         .def(py::init<ModelPart&, const Parameters&>());
 
-    py::class_<ApplyScalarConstraintsTableProcess, ApplyScalarConstraintsTableProcess::Pointer, Process>
-        (m, "ApplyScalarConstraintsTableProcess")
+    py::class_<ApplyScalarConstraintTableProcess, ApplyScalarConstraintTableProcess::Pointer, Process>
+        (m, "ApplyScalarConstraintTableProcess")
         .def(py::init<ModelPart&, const Parameters&>());
 }
 

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
@@ -15,8 +15,8 @@
 
 #include "utilities/variable_utils.h"
 
-#include "custom_processes/apply_scalar_constraints_table_process.h"
-#include "custom_processes/apply_vector_constraints_table_process.hpp"
+#include "custom_processes/apply_scalar_constraint_table_process.h"
+#include "custom_processes/apply_vector_constraint_table_process.h"
 #include "custom_processes/set_parameter_field_process.hpp"
 #include "custom_processes/apply_k0_procedure_process.hpp"
 #include "custom_processes/apply_excavation_process.hpp"
@@ -50,18 +50,18 @@ KratosGeoSettlement::KratosGeoSettlement(std::unique_ptr<InputUtility> pInputUti
 
 void KratosGeoSettlement::InitializeProcessFactory()
 {
-    mProcessFactory->AddCreator("ApplyScalarConstraintsTableProcess",
+    mProcessFactory->AddCreator("ApplyScalarConstraintTableProcess",
                                 [this](const Parameters& rParameters)
                                 {
-                                    return std::make_unique<ApplyScalarConstraintsTableProcess>(mModel.GetModelPart(mModelPartName),
-                                                                                                rParameters);
+                                    return std::make_unique<ApplyScalarConstraintTableProcess>(mModel.GetModelPart(mModelPartName),
+                                                                                               rParameters);
                                 });
 
-    mProcessFactory->AddCreator("ApplyVectorConstraintsTableProcess",
+    mProcessFactory->AddCreator("ApplyVectorConstraintTableProcess",
                                 [this](const Parameters& rParameters)
                                 {
-                                    return std::make_unique<ApplyVectorConstraintsTableProcess>(mModel.GetModelPart(mModelPartName),
-                                                                                                rParameters);
+                                    return std::make_unique<ApplyVectorConstraintTableProcess>(mModel.GetModelPart(mModelPartName),
+                                                                                               rParameters);
                                 });
 
     mProcessFactory->AddCreator("SetParameterFieldProcess",

--- a/applications/GeoMechanicsApplication/python_scripts/apply_scalar_constraint_table_process.py
+++ b/applications/GeoMechanicsApplication/python_scripts/apply_scalar_constraint_table_process.py
@@ -7,4 +7,4 @@ def Factory(settings, Model):
 
     params = settings["Parameters"]
     model_part = Model[params["model_part_name"].GetString()]
-    return KratosGeo.ApplyScalarConstraintsTableProcess(model_part, params)
+    return KratosGeo.ApplyScalarConstraintTableProcess(model_part, params)

--- a/applications/GeoMechanicsApplication/python_scripts/apply_vector_constraint_table_process.py
+++ b/applications/GeoMechanicsApplication/python_scripts/apply_vector_constraint_table_process.py
@@ -8,4 +8,4 @@ def Factory(settings, Model):
 
     params = settings["Parameters"]
     model_part = Model[params["model_part_name"].GetString()]
-    return Geo.ApplyVectorConstraintsTableProcess(model_part, params)
+    return Geo.ApplyVectorConstraintTableProcess(model_part, params)

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/stub_process_info_parser.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/stub_process_info_parser.cpp
@@ -46,7 +46,7 @@ R"({
 })";
 
 const std::vector<ProcessParameters> process_list =
-{ProcessParameters{"ApplyVectorConstraintsTableProcess", Parameters{vector_parameter_string}},
+{ProcessParameters{"ApplyVectorConstraintTableProcess", Parameters{vector_parameter_string}},
  ProcessParameters{"SetParameterFieldProcess", Parameters{parameter_field_string}},
  ProcessParameters{"ApplyExcavationProcess", Parameters{excavation_string}},
  ProcessParameters{"ApplyK0ProcedureProcess", Parameters{k0_string}}};


### PR DESCRIPTION
**📝 Description**
The header and implementation files that contain the process classes for applying a scalar or vector constraint with an optional table have been renamed. We now use the singular form ("constraint") rather than the plural one ("constraints").

The class names now use singular forms, i.e.
`ApplyScalarConstraintTableProcess` and
`ApplyVectorConstraintTableProcess`. All references to the old class names have been updated.
