### PR TITLE
[Core] Transition changes geometrical object bins, add `PointIsInsideBoundingBox` functionality

### DIFF
--- a/kratos/spatial_containers/geometrical_objects_bins.cpp
+++ b/kratos/spatial_containers/geometrical_objects_bins.cpp
@@ -172,6 +172,52 @@ GeometricalObjectsBins::ResultType GeometricalObjectsBins::SearchIsInside(const 
 /***********************************************************************************/
 /***********************************************************************************/
 
+bool GeometricalObjectsBins::PointIsInsideBoundingBox(const array_1d<double, 3>& rCoords)
+{
+    // Get the bounding box points
+    const auto& r_max_point = mBoundingBox.GetMaxPoint();
+    const auto& r_min_point = mBoundingBox.GetMinPoint();
+
+    // The Bounding Box check
+    if (rCoords[0] < r_max_point[0] && rCoords[0] > r_min_point[0])           // check x-direction
+        if (rCoords[1] < r_max_point[1] && rCoords[1] > r_min_point[1])       // check y-direction
+            if (rCoords[2] < r_max_point[2] && rCoords[2] > r_min_point[2])   // check z-direction
+                return true;
+    return false;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+bool GeometricalObjectsBins::PointIsInsideBoundingBoxWithTolerance(
+    const array_1d<double, 3>& rCoords,
+    const double Tolerance
+    )
+{
+    // Get the bounding box points
+    auto max_point = mBoundingBox.GetMaxPoint();
+    auto min_point = mBoundingBox.GetMinPoint();
+    
+    // Apply Tolerances (only in non zero BB cases)
+    const double epsilon = std::numeric_limits<double>::epsilon();
+    if (norm_2(max_point) > epsilon && norm_2(min_point) > epsilon) {
+        for (unsigned int i=0; i<3; ++i) {
+            max_point[i] += Tolerance;
+            min_point[i] -= Tolerance;
+        }
+    }
+
+    // The Bounding Box check
+    if (rCoords[0] < max_point[0] && rCoords[0] > min_point[0])           // check x-direction
+        if (rCoords[1] < max_point[1] && rCoords[1] > min_point[1])       // check y-direction
+            if (rCoords[2] < max_point[2] && rCoords[2] > min_point[2])   // check z-direction
+                return true;
+    return false;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
 void GeometricalObjectsBins::CalculateCellSize(const std::size_t NumberOfCells)
 {
     const std::size_t avarage_number_of_cells = static_cast<std::size_t>(std::pow(static_cast<double>(NumberOfCells), 1.00 / Dimension));

--- a/kratos/spatial_containers/geometrical_objects_bins.h
+++ b/kratos/spatial_containers/geometrical_objects_bins.h
@@ -79,8 +79,8 @@ public:
             for (TIteratorType i_object = GeometricalObjectsBegin ; i_object != GeometricalObjectsEnd ; i_object++){
                 mBoundingBox.Extend(i_object->GetGeometry().begin() , i_object->GetGeometry().end());
             }
+            mBoundingBox.Extend(Tolerance);
         }
-        mBoundingBox.Extend(mTolerance);
         CalculateCellSize(number_of_objects);
         mCells.resize(GetTotalNumberOfCells());
         AddObjectsToCells(GeometricalObjectsBegin, GeometricalObjectsEnd);
@@ -381,10 +381,23 @@ protected:
     ///@name Protected Operations
     ///@{
 
+    /**
+     * @brief This method checks if a point is inside any bounding box of the global bounding boxes
+     * @param rCoords The coordinates of the point
+     * @return True if the point is inside the bounding box
+     */
+    bool PointIsInsideBoundingBox(const array_1d<double, 3>& rCoords);
 
-    ///@}
-    ///@name Private Operations
-    ///@{
+    /**
+     * @brief This method checks if a point is inside any bounding box of the global bounding boxes considering a certain tolerance
+     * @param rCoords The coordinates of the point
+     * @param Tolerance The tolerance
+     * @return True if the point is inside the bounding box
+     */
+    bool PointIsInsideBoundingBoxWithTolerance(
+        const array_1d<double, 3>& rCoords,
+        const double Tolerance
+        );
 
     /**
      * @brief Calculate the cell sizes to be as equilateral as possible and tries to approximate (roughly) the given number of cells

--- a/kratos/spatial_containers/geometrical_objects_bins.h
+++ b/kratos/spatial_containers/geometrical_objects_bins.h
@@ -376,7 +376,6 @@ protected:
     std::vector<CellType> mCells;                    /// The cells of the domain
     double mTolerance;                               /// The tolerance considered
 
-
     ///@}
     ///@name Protected Operations
     ///@{

--- a/kratos/tests/cpp_tests/spatial_containers/test_geometrical_objects_bins.cpp
+++ b/kratos/tests/cpp_tests/spatial_containers/test_geometrical_objects_bins.cpp
@@ -302,7 +302,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsSearchIsInside, KratosCoreFastSu
 
 /** Checks bins search is inside = not found
 */
-KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsSearchIsNotInside, KratosFastSuite) 
+KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsSearchIsNotInside, KratosCoreFastSuite) 
 {
     Model current_model;
 

--- a/kratos/tests/cpp_tests/spatial_containers/test_geometrical_objects_bins.cpp
+++ b/kratos/tests/cpp_tests/spatial_containers/test_geometrical_objects_bins.cpp
@@ -22,9 +22,16 @@
 #include "containers/model.h"
 #include "geometries/triangle_3d_3.h"
 
-namespace Kratos::Testing {
+namespace Kratos::Testing 
+{
 
-ModelPart& CreateCubeSkinModelPart(Model& rCurrentModel, const double HalfX, const double HalfY, const double HalfZ){
+ModelPart& CreateCubeSkinModelPart(
+    Model& rCurrentModel,
+    const double HalfX = 0.6,
+    const double HalfY = 0.9,
+    const double HalfZ = 0.3
+    )
+{
     // Generate the cube skin
     ModelPart& r_skin_part = rCurrentModel.CreateModelPart("Skin");
     r_skin_part.CreateNewNode(1, -HalfX, -HalfY, -HalfZ);
@@ -50,6 +57,34 @@ ModelPart& CreateCubeSkinModelPart(Model& rCurrentModel, const double HalfX, con
     r_skin_part.CreateNewElement("Element3D3N", 12, { 2,5,6 }, p_properties);
 
     return r_skin_part;
+}
+
+ModelPart& CreateCubeModelPart(Model& rCurrentModel)
+{
+    // Generate the cube skin
+    ModelPart& r_model_part = rCurrentModel.CreateModelPart("Cube");
+
+    // Create properties
+    auto p_properties = r_model_part.CreateNewProperties(1, 0);
+
+    r_model_part.CreateNewNode(1 , 0.0 , 1.0 , 1.0);
+    r_model_part.CreateNewNode(2 , 0.0 , 1.0 , 0.0);
+    r_model_part.CreateNewNode(3 , 0.0 , 0.0 , 1.0);
+    r_model_part.CreateNewNode(4 , 0.5 , 1.0 , 1.0);
+    r_model_part.CreateNewNode(5 , 0.0 , 0.0 , 0.0);
+    r_model_part.CreateNewNode(6 , 0.5 , 1.0 , 0.0);
+    r_model_part.CreateNewNode(7 , 0.5 , 0.0 , 1.0);
+    r_model_part.CreateNewNode(8 , 0.5 , 0.0 , 0.0);
+    r_model_part.CreateNewNode(9 , 1.0 , 1.0 , 1.0);
+    r_model_part.CreateNewNode(10 , 1.0 , 1.0 , 0.0);
+    r_model_part.CreateNewNode(11 , 1.0 , 0.0 , 1.0);
+    r_model_part.CreateNewNode(12 , 1.0 , 0.0 , 0.0);
+
+    // Create elements
+    r_model_part.CreateNewElement("Element3D8N", 1, {{5,8,6,2,3,7,4,1}}, p_properties);
+    r_model_part.CreateNewElement("Element3D8N", 2, {{8,12,10,6,7,11,9,4}}, p_properties);
+
+    return r_model_part;
 }
 
 /** Checks bins bounding box
@@ -114,12 +149,8 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsAddObjectsToCells, KratosCoreFas
 {
     Model current_model;
 
-    const double cube_x = 0.6;
-    const double cube_y = 0.9;
-    const double cube_z = 0.3;
-
     // Generate the cube skin
-    ModelPart& r_skin_part = CreateCubeSkinModelPart(current_model, cube_x, cube_y, cube_z);
+    ModelPart& r_skin_part = CreateCubeSkinModelPart(current_model);
 
     GeometricalObjectsBins bins(r_skin_part.ElementsBegin(), r_skin_part.ElementsEnd());
 
@@ -144,12 +175,8 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsSearchInRadius, KratosCoreFastSu
 {
     Model current_model;
 
-    const double cube_x = 0.6;
-    const double cube_y = 0.9;
-    const double cube_z = 0.3;
-
     // Generate the cube skin
-    ModelPart& r_skin_part = CreateCubeSkinModelPart(current_model, cube_x, cube_y, cube_z);
+    ModelPart& r_skin_part = CreateCubeSkinModelPart(current_model);
 
     GeometricalObjectsBins bins(r_skin_part.ElementsBegin(), r_skin_part.ElementsEnd());
 
@@ -183,12 +210,11 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsSearchNearestInRadius, KratosCor
 
     Model current_model;
 
-    const double cube_x = 0.6;
-    const double cube_y = 0.9;
+    // Cube coordinates
     const double cube_z = 0.3;
 
     // Generate the cube skin
-    ModelPart& r_skin_part = CreateCubeSkinModelPart(current_model, cube_x, cube_y, cube_z);
+    ModelPart& r_skin_part = CreateCubeSkinModelPart(current_model, 0.6, 0.9, cube_z);
 
     GeometricalObjectsBins bins(r_skin_part.ElementsBegin(), r_skin_part.ElementsEnd());
 
@@ -213,12 +239,11 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsSearchNearest, KratosCoreFastSui
 
     Model current_model;
 
-    const double cube_x = 0.6;
-    const double cube_y = 0.9;
+    // Cube coordinates
     const double cube_z = 0.3;
 
     // Generate the cube skin
-    ModelPart& r_skin_part = CreateCubeSkinModelPart(current_model, cube_x, cube_y, cube_z);
+    ModelPart& r_skin_part = CreateCubeSkinModelPart(current_model, 0.6, 0.9, cube_z);
 
     GeometricalObjectsBins bins(r_skin_part.ElementsBegin(), r_skin_part.ElementsEnd());
 


### PR DESCRIPTION
**📝 Description**

This PR introduces new functionality to the `GeometricalObjectsBins` class. Here are the key changes made:

1. Added a new function `bool GeometricalObjectsBins::PointIsInsideBoundingBox(const array_1d<double,3>& rCoords)` that checks if a point is inside the bounding box of geometrical objects.
2. Added another function `bool GeometricalObjectsBins::PointIsInsideBoundingBoxWithTolerance(const array_1d<double,3>& rCoords)` that checks if a point is inside the bounding box with tolerance.
3. Modified the `GeometricalObjectsBins::CalculateCellSize` function to include additional logic.
4. Updated test cases in `test_geometrical_objects_bins.cpp`.

These changes seem to be aimed at improving the functionality of the `GeometricalObjectsBins` class by adding methods to check if a point lies within the bounding box of geometrical objects, with and without tolerance. The changes also include updates to test cases to ensure the new functionality works as expected.

**🆕 Changelog**

- [Transition changes geometrical object bins](https://github.com/KratosMultiphysics/Kratos/commit/a0ae26f9f486e90ae8887cdd7d19220687a96a86)
- [Update test](https://github.com/KratosMultiphysics/Kratos/commit/962b5ffc3c4dc7b5be8cf9d62bcec8dd6a9c024c)
