### PR TITLE
[Core] Extend `CppTestsUtilities` with `CreateCubeSkinModelPart` and `CreateCubeModelPart`

### DIFF
--- a/kratos/tests/cpp_tests/spatial_containers/test_geometrical_objects_bins.cpp
+++ b/kratos/tests/cpp_tests/spatial_containers/test_geometrical_objects_bins.cpp
@@ -21,71 +21,10 @@
 #include "spatial_containers/geometrical_objects_bins.h"
 #include "containers/model.h"
 #include "geometries/triangle_3d_3.h"
+#include "utilities/cpp_tests_utilities.h"
 
 namespace Kratos::Testing 
 {
-
-ModelPart& CreateCubeSkinModelPart(
-    Model& rCurrentModel,
-    const double HalfX = 0.6,
-    const double HalfY = 0.9,
-    const double HalfZ = 0.3
-    )
-{
-    // Generate the cube skin
-    ModelPart& r_skin_part = rCurrentModel.CreateModelPart("Skin");
-    r_skin_part.CreateNewNode(1, -HalfX, -HalfY, -HalfZ);
-    r_skin_part.CreateNewNode(2,  HalfX, -HalfY, -HalfZ);
-    r_skin_part.CreateNewNode(3,  HalfX,  HalfY, -HalfZ);
-    r_skin_part.CreateNewNode(4, -HalfX,  HalfY, -HalfZ);
-    r_skin_part.CreateNewNode(5, -HalfX, -HalfY,  HalfZ);
-    r_skin_part.CreateNewNode(6,  HalfX, -HalfY,  HalfZ);
-    r_skin_part.CreateNewNode(7,  HalfX,  HalfY,  HalfZ);
-    r_skin_part.CreateNewNode(8, -HalfX,  HalfY,  HalfZ);
-    Properties::Pointer p_properties(new Properties(0));
-    r_skin_part.CreateNewElement("Element3D3N",  1, { 1,2,3 }, p_properties);
-    r_skin_part.CreateNewElement("Element3D3N",  2, { 1,3,4 }, p_properties);
-    r_skin_part.CreateNewElement("Element3D3N",  3, { 5,6,7 }, p_properties);
-    r_skin_part.CreateNewElement("Element3D3N",  4, { 5,7,8 }, p_properties);
-    r_skin_part.CreateNewElement("Element3D3N",  5, { 3,6,2 }, p_properties);
-    r_skin_part.CreateNewElement("Element3D3N",  6, { 3,7,6 }, p_properties);
-    r_skin_part.CreateNewElement("Element3D3N",  7, { 4,5,1 }, p_properties);
-    r_skin_part.CreateNewElement("Element3D3N",  8, { 4,8,5 }, p_properties);
-    r_skin_part.CreateNewElement("Element3D3N",  9, { 3,4,8 }, p_properties);
-    r_skin_part.CreateNewElement("Element3D3N", 10, { 3,8,7 }, p_properties);
-    r_skin_part.CreateNewElement("Element3D3N", 11, { 2,1,5 }, p_properties);
-    r_skin_part.CreateNewElement("Element3D3N", 12, { 2,5,6 }, p_properties);
-
-    return r_skin_part;
-}
-
-ModelPart& CreateCubeModelPart(Model& rCurrentModel)
-{
-    // Generate the cube skin
-    ModelPart& r_model_part = rCurrentModel.CreateModelPart("Cube");
-
-    // Create properties
-    auto p_properties = r_model_part.CreateNewProperties(1, 0);
-
-    r_model_part.CreateNewNode(1 , 0.0 , 1.0 , 1.0);
-    r_model_part.CreateNewNode(2 , 0.0 , 1.0 , 0.0);
-    r_model_part.CreateNewNode(3 , 0.0 , 0.0 , 1.0);
-    r_model_part.CreateNewNode(4 , 0.5 , 1.0 , 1.0);
-    r_model_part.CreateNewNode(5 , 0.0 , 0.0 , 0.0);
-    r_model_part.CreateNewNode(6 , 0.5 , 1.0 , 0.0);
-    r_model_part.CreateNewNode(7 , 0.5 , 0.0 , 1.0);
-    r_model_part.CreateNewNode(8 , 0.5 , 0.0 , 0.0);
-    r_model_part.CreateNewNode(9 , 1.0 , 1.0 , 1.0);
-    r_model_part.CreateNewNode(10 , 1.0 , 1.0 , 0.0);
-    r_model_part.CreateNewNode(11 , 1.0 , 0.0 , 1.0);
-    r_model_part.CreateNewNode(12 , 1.0 , 0.0 , 0.0);
-
-    // Create elements
-    r_model_part.CreateNewElement("Element3D8N", 1, {{5,8,6,2,3,7,4,1}}, p_properties);
-    r_model_part.CreateNewElement("Element3D8N", 2, {{8,12,10,6,7,11,9,4}}, p_properties);
-
-    return r_model_part;
-}
 
 /** Checks bins bounding box
 */
@@ -100,7 +39,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsBoundingBox, KratosCoreFastSuite
     const double cube_z = 0.3;
 
     // Generate the cube skin
-    ModelPart& r_skin_part = CreateCubeSkinModelPart(current_model, cube_x, cube_y, cube_z);
+    ModelPart& r_skin_part = CppTestsUtilities::CreateCubeSkinModelPart(current_model, cube_x, cube_y, cube_z);
 
     GeometricalObjectsBins bins(r_skin_part.ElementsBegin(), r_skin_part.ElementsEnd());
 
@@ -127,7 +66,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsCellSizes, KratosCoreFastSuite)
     const double cube_z = 0.3;
 
     // Generate the cube skin
-    ModelPart& r_skin_part = CreateCubeSkinModelPart(current_model, cube_x, cube_y, cube_z);
+    ModelPart& r_skin_part = CppTestsUtilities::CreateCubeSkinModelPart(current_model, cube_x, cube_y, cube_z);
 
     GeometricalObjectsBins bins(r_skin_part.ElementsBegin(), r_skin_part.ElementsEnd());
 
@@ -150,7 +89,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsAddObjectsToCells, KratosCoreFas
     Model current_model;
 
     // Generate the cube skin
-    ModelPart& r_skin_part = CreateCubeSkinModelPart(current_model);
+    ModelPart& r_skin_part = CppTestsUtilities::CreateCubeSkinModelPart(current_model);
 
     GeometricalObjectsBins bins(r_skin_part.ElementsBegin(), r_skin_part.ElementsEnd());
 
@@ -176,7 +115,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsSearchInRadius, KratosCoreFastSu
     Model current_model;
 
     // Generate the cube skin
-    ModelPart& r_skin_part = CreateCubeSkinModelPart(current_model);
+    ModelPart& r_skin_part = CppTestsUtilities::CreateCubeSkinModelPart(current_model);
 
     GeometricalObjectsBins bins(r_skin_part.ElementsBegin(), r_skin_part.ElementsEnd());
 
@@ -214,7 +153,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsSearchNearestInRadius, KratosCor
     const double cube_z = 0.3;
 
     // Generate the cube skin
-    ModelPart& r_skin_part = CreateCubeSkinModelPart(current_model, 0.6, 0.9, cube_z);
+    ModelPart& r_skin_part = CppTestsUtilities::CreateCubeSkinModelPart(current_model, 0.6, 0.9, cube_z);
 
     GeometricalObjectsBins bins(r_skin_part.ElementsBegin(), r_skin_part.ElementsEnd());
 
@@ -243,7 +182,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsSearchNearest, KratosCoreFastSui
     const double cube_z = 0.3;
 
     // Generate the cube skin
-    ModelPart& r_skin_part = CreateCubeSkinModelPart(current_model, 0.6, 0.9, cube_z);
+    ModelPart& r_skin_part = CppTestsUtilities::CreateCubeSkinModelPart(current_model, 0.6, 0.9, cube_z);
 
     GeometricalObjectsBins bins(r_skin_part.ElementsBegin(), r_skin_part.ElementsEnd());
 

--- a/kratos/utilities/cpp_tests_utilities.cpp
+++ b/kratos/utilities/cpp_tests_utilities.cpp
@@ -15,7 +15,7 @@
 // External includes
 
 // Project includes
-#include "includes/model_part.h"
+#include "containers/model.h"
 #include "geometries/triangle_2d_3.h"
 #include "geometries/tetrahedra_3d_4.h"
 #include "utilities/cpp_tests_utilities.h"
@@ -394,6 +394,74 @@ void Create3DQuadraticGeometry(
         for (auto& r_elem : rModelPart.Elements())
             r_elem.Initialize(r_process_info);
     }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+ModelPart& CreateCubeSkinModelPart(
+    Model& rCurrentModel,
+    const double HalfX,
+    const double HalfY,
+    const double HalfZ
+    )
+{
+    // Generate the cube skin
+    ModelPart& r_skin_part = rCurrentModel.CreateModelPart("Skin");
+    r_skin_part.CreateNewNode(1, -HalfX, -HalfY, -HalfZ);
+    r_skin_part.CreateNewNode(2,  HalfX, -HalfY, -HalfZ);
+    r_skin_part.CreateNewNode(3,  HalfX,  HalfY, -HalfZ);
+    r_skin_part.CreateNewNode(4, -HalfX,  HalfY, -HalfZ);
+    r_skin_part.CreateNewNode(5, -HalfX, -HalfY,  HalfZ);
+    r_skin_part.CreateNewNode(6,  HalfX, -HalfY,  HalfZ);
+    r_skin_part.CreateNewNode(7,  HalfX,  HalfY,  HalfZ);
+    r_skin_part.CreateNewNode(8, -HalfX,  HalfY,  HalfZ);
+    Properties::Pointer p_properties(new Properties(0));
+    r_skin_part.CreateNewElement("Element3D3N",  1, { 1,2,3 }, p_properties);
+    r_skin_part.CreateNewElement("Element3D3N",  2, { 1,3,4 }, p_properties);
+    r_skin_part.CreateNewElement("Element3D3N",  3, { 5,6,7 }, p_properties);
+    r_skin_part.CreateNewElement("Element3D3N",  4, { 5,7,8 }, p_properties);
+    r_skin_part.CreateNewElement("Element3D3N",  5, { 3,6,2 }, p_properties);
+    r_skin_part.CreateNewElement("Element3D3N",  6, { 3,7,6 }, p_properties);
+    r_skin_part.CreateNewElement("Element3D3N",  7, { 4,5,1 }, p_properties);
+    r_skin_part.CreateNewElement("Element3D3N",  8, { 4,8,5 }, p_properties);
+    r_skin_part.CreateNewElement("Element3D3N",  9, { 3,4,8 }, p_properties);
+    r_skin_part.CreateNewElement("Element3D3N", 10, { 3,8,7 }, p_properties);
+    r_skin_part.CreateNewElement("Element3D3N", 11, { 2,1,5 }, p_properties);
+    r_skin_part.CreateNewElement("Element3D3N", 12, { 2,5,6 }, p_properties);
+
+    return r_skin_part;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+ModelPart& CreateCubeModelPart(Model& rCurrentModel)
+{
+    // Generate the cube skin
+    ModelPart& r_model_part = rCurrentModel.CreateModelPart("Cube");
+
+    // Create properties
+    auto p_properties = r_model_part.CreateNewProperties(1, 0);
+
+    r_model_part.CreateNewNode(1 , 0.0 , 1.0 , 1.0);
+    r_model_part.CreateNewNode(2 , 0.0 , 1.0 , 0.0);
+    r_model_part.CreateNewNode(3 , 0.0 , 0.0 , 1.0);
+    r_model_part.CreateNewNode(4 , 0.5 , 1.0 , 1.0);
+    r_model_part.CreateNewNode(5 , 0.0 , 0.0 , 0.0);
+    r_model_part.CreateNewNode(6 , 0.5 , 1.0 , 0.0);
+    r_model_part.CreateNewNode(7 , 0.5 , 0.0 , 1.0);
+    r_model_part.CreateNewNode(8 , 0.5 , 0.0 , 0.0);
+    r_model_part.CreateNewNode(9 , 1.0 , 1.0 , 1.0);
+    r_model_part.CreateNewNode(10 , 1.0 , 1.0 , 0.0);
+    r_model_part.CreateNewNode(11 , 1.0 , 0.0 , 1.0);
+    r_model_part.CreateNewNode(12 , 1.0 , 0.0 , 0.0);
+
+    // Create elements
+    r_model_part.CreateNewElement("Element3D8N", 1, {{5,8,6,2,3,7,4,1}}, p_properties);
+    r_model_part.CreateNewElement("Element3D8N", 2, {{8,12,10,6,7,11,9,4}}, p_properties);
+
+    return r_model_part;
 }
 
 } // namespace ConstraintUtilities

--- a/kratos/utilities/cpp_tests_utilities.h
+++ b/kratos/utilities/cpp_tests_utilities.h
@@ -38,8 +38,9 @@ namespace Kratos
 ///@}
 ///@name Kratos Classes
 ///@{
-// forward declaring ModelPart to be avoid including heavy header here
+// forward declaring ModelPart adn Model to be avoid including heavy header here
 class ModelPart;
+class Model;
 
 /**
  * @namespace CppTestsUtilities
@@ -127,6 +128,28 @@ namespace CppTestsUtilities
         const std::string& rElementName = "Element3D10N",
         const bool Initialize = true
         );
+
+    /**
+     * @brief Create a cube skin model part.
+     * @param rCurrentModel The current model.
+     * @param HalfX The half-length of the cube in the X-direction.
+     * @param HalfY The half-length of the cube in the Y-direction.
+     * @param HalfZ The half-length of the cube in the Z-direction.
+     * @return ModelPart& The created cube skin model part.
+     */
+    ModelPart& KRATOS_API(KRATOS_CORE) CreateCubeSkinModelPart(
+        Model& rCurrentModel,
+        const double HalfX = 0.6,
+        const double HalfY = 0.9,
+        const double HalfZ = 0.3
+        );
+
+    /**
+     * @brief Create a cube model part.
+     * @param rCurrentModel The current model.
+     * @return The created cube model part.
+     */
+    ModelPart& KRATOS_API(KRATOS_CORE) CreateCubeModelPart(Model& rCurrentModel);
 
 }; // namespace CppTestsUtilities
 }  // namespace Kratos

--- a/kratos/utilities/cpp_tests_utilities.h
+++ b/kratos/utilities/cpp_tests_utilities.h
@@ -137,7 +137,7 @@ namespace CppTestsUtilities
      * @param HalfZ The half-length of the cube in the Z-direction.
      * @return ModelPart& The created cube skin model part.
      */
-    ModelPart& KRATOS_API(KRATOS_CORE) CreateCubeSkinModelPart(
+    KRATOS_API(KRATOS_CORE) ModelPart& CreateCubeSkinModelPart(
         Model& rCurrentModel,
         const double HalfX = 0.6,
         const double HalfY = 0.9,
@@ -149,7 +149,7 @@ namespace CppTestsUtilities
      * @param rCurrentModel The current model.
      * @return The created cube model part.
      */
-    ModelPart& KRATOS_API(KRATOS_CORE) CreateCubeModelPart(Model& rCurrentModel);
+    KRATOS_API(KRATOS_CORE) ModelPart& CreateCubeModelPart(Model& rCurrentModel);
 
 }; // namespace CppTestsUtilities
 }  // namespace Kratos

--- a/kratos/utilities/cpp_tests_utilities.h
+++ b/kratos/utilities/cpp_tests_utilities.h
@@ -38,7 +38,7 @@ namespace Kratos
 ///@}
 ///@name Kratos Classes
 ///@{
-// forward declaring ModelPart adn Model to be avoid including heavy header here
+// forward declaring ModelPart and Model to be avoid including heavy header here
 class ModelPart;
 class Model;
 


### PR DESCRIPTION
**📝 Description**

Code related to the creation of a cube skin model part (`CreateCubeSkinModelPart`) and a cube model part (`CreateCubeModelPart`) were removed. Instead, the `CppTestsUtilities::CreateCubeSkinModelPart` and `CppTestsUtilities::CreateCubeModelPart`  functions has been moved to the `utilities/cpp_tests_utilities.h` file, and it is now used to create the model part.

**🆕 Changelog**

- [Extend `CppTestsUtilities` with `CreateCubeSkinModelPart` and `CreateCubeModelPart`](https://github.com/KratosMultiphysics/Kratos/commit/677e7081fe2b92b0ac0235251cd51835423f3dc4)
- [Replace calls](https://github.com/KratosMultiphysics/Kratos/commit/bf1f36dd690780f5927eca43f2063de95d7cc4c8)
