### PR TITLE
[StructuralMechanicsApplication] bugfix jumping moving load

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_conditions/moving_load_condition.h
+++ b/applications/StructuralMechanicsApplication/custom_conditions/moving_load_condition.h
@@ -356,7 +356,7 @@ private:
     void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseLoadCondition );
-        rSerializer.save("mIsMovingLoad", mIsMovingLoad);
+        rSerializer.load("mIsMovingLoad", mIsMovingLoad);
     }
 
     ///@}

--- a/applications/StructuralMechanicsApplication/custom_processes/set_moving_load_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_moving_load_process.cpp
@@ -151,7 +151,6 @@ bool SetMovingLoadProcess::IsConditionReversed(const Condition& rCondition, cons
 }
 
 
-
 std::vector<Condition> SetMovingLoadProcess::SortConditions(ModelPart::ConditionsContainerType& rUnsortedConditions, Condition& rFirstCondition)
 {
 
@@ -160,40 +159,42 @@ std::vector<Condition> SetMovingLoadProcess::SortConditions(ModelPart::Condition
     std::vector<Condition> sorted_conditions;
     std::vector<int> visited_indices;
     GeometricalObject::GeometryType& r_geom_first = rFirstCondition.GetGeometry();
-    std::set<IndexType> node_id_vector{ r_geom_first[0].Id(),r_geom_first[1].Id() };
+    std::vector<IndexType> node_id_vector{ r_geom_first[0].Id(),r_geom_first[1].Id() };
 
     bool is_cond_reversed = mIsCondReversedVector[0];
-    while (visited_indices.size() != unsorted_conditions_v.size()){
-        for (IndexType i =0; i< unsorted_conditions_v.size(); i++){
+    while (visited_indices.size() != unsorted_conditions_v.size()) {
+        for (IndexType i = 0; i < unsorted_conditions_v.size(); i++) {
             Condition& r_cond = unsorted_conditions_v[i];
             GeometricalObject::GeometryType& r_geom = r_cond.GetGeometry();
 
 
             // check if current index is already added to sorted condition vector
-            if (!std::count(visited_indices.begin(), visited_indices.end(), i)){
+            if (!std::count(visited_indices.begin(), visited_indices.end(), i)) {
                 // check if geom has a shared node with previous geom
-                if (node_id_vector.find(r_geom.Points()[0].Id()) != node_id_vector.end() || node_id_vector.find(r_geom.Points()[1].Id()) != node_id_vector.end()){
-                    if (sorted_conditions.size() == 0){
+                if (std::find(node_id_vector.begin(), node_id_vector.end(), r_geom.Points()[0].Id()) != node_id_vector.end() || std::find(node_id_vector.begin(), node_id_vector.end(), r_geom.Points()[1].Id()) != node_id_vector.end()) {
+                    if (sorted_conditions.size() == 0) {
                         // check if both nodes of geom are equal to nodes in start element, only do this to add the first element in the sorted conditions vector
-                        if (node_id_vector.find(r_geom[0].Id()) != node_id_vector.end() && node_id_vector.find(r_geom.Points()[1].Id()) != node_id_vector.end()){
+                        if (std::find(node_id_vector.begin(), node_id_vector.end(), r_geom.Points()[0].Id()) != node_id_vector.end() && std::find(node_id_vector.begin(), node_id_vector.end(), r_geom.Points()[1].Id()) != node_id_vector.end()) {
                             node_id_vector = { r_geom[0].Id(),r_geom[1].Id() };
                             sorted_conditions.push_back(r_cond);
                             visited_indices.push_back(i);
                         }
-                    } else {
+                    }
+                    else {
                         // sort nodes in condition, such that new node is connected to previous condition
-                        std::set<IndexType>::iterator prev_id;
-                        if (is_cond_reversed){
-                            prev_id = node_id_vector.begin();
-                        } else {
-                            prev_id = node_id_vector.end();
-                            --prev_id;
+                        IndexType prev_id;
+                        if (is_cond_reversed) {
+                            prev_id = node_id_vector[0];
+                        }
+                        else {
+                            prev_id = node_id_vector[1];
                         }
 
-                        if (*prev_id != r_geom.Points()[0].Id()){
+                        if (prev_id != r_geom.Points()[0].Id()) {
                             is_cond_reversed = true;
                             mIsCondReversedVector.push_back(is_cond_reversed);
-                        } else {
+                        }
+                        else {
                             is_cond_reversed = false;
                             mIsCondReversedVector.push_back(is_cond_reversed);
                         }
@@ -205,13 +206,12 @@ std::vector<Condition> SetMovingLoadProcess::SortConditions(ModelPart::Condition
                     }
                 }
             }
-            
+
         }
     }
 
     return sorted_conditions;
 }
-
 
 std::vector<Condition> SetMovingLoadProcess::FindEndConditions()
 {

--- a/applications/StructuralMechanicsApplication/custom_processes/set_moving_load_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/set_moving_load_process.cpp
@@ -179,22 +179,19 @@ std::vector<Condition> SetMovingLoadProcess::SortConditions(ModelPart::Condition
                             sorted_conditions.push_back(r_cond);
                             visited_indices.push_back(i);
                         }
-                    }
-                    else {
+                    } else {
                         // sort nodes in condition, such that new node is connected to previous condition
                         IndexType prev_id;
                         if (is_cond_reversed) {
                             prev_id = node_id_vector[0];
-                        }
-                        else {
+                        } else {
                             prev_id = node_id_vector[1];
                         }
 
                         if (prev_id != r_geom.Points()[0].Id()) {
                             is_cond_reversed = true;
                             mIsCondReversedVector.push_back(is_cond_reversed);
-                        }
-                        else {
+                        } else {
                             is_cond_reversed = false;
                             mIsCondReversedVector.push_back(is_cond_reversed);
                         }

--- a/applications/StructuralMechanicsApplication/tests/test_set_moving_load_process.py
+++ b/applications/StructuralMechanicsApplication/tests/test_set_moving_load_process.py
@@ -463,14 +463,14 @@ class TestSetMovingLoadProcess(KratosUnittest.TestCase):
         #create nodes
         second_coord = [1.0, 0.0, 0.0]
         third_coord = [2.0, 0.0, 0.0]
-        mp.CreateNewNode(1, 0.0, 0.0, 0.0)
+        mp.CreateNewNode(4, 0.0, 0.0, 0.0)
         mp.CreateNewNode(2, second_coord[0],second_coord[1],second_coord[2])
         mp.CreateNewNode(3, third_coord[0], third_coord[1], third_coord[2])
 
         strategy = self.setup_strategy(mp)
         # create condition
         conditions = []
-        conditions.append(mp.CreateNewCondition("MovingLoadCondition2D2N", 1, [1, 2], mp.GetProperties()[1]))
+        conditions.append(mp.CreateNewCondition("MovingLoadCondition2D2N", 1, [4, 2], mp.GetProperties()[1]))
         conditions.append(mp.CreateNewCondition("MovingLoadCondition2D2N", 2, [2, 3], mp.GetProperties()[1]))
 
         parameters = KratosMultiphysics.Parameters("""


### PR DESCRIPTION
the moving load jumped unintentially between nodes, this could happened in case the node ids of the moving load conditions were not in ascending order

this is fixed now
