### PR TITLE
[Hotfix][Core] Project serialization fix

### DIFF
--- a/kratos/python/add_serializer_to_python.cpp
+++ b/kratos/python/add_serializer_to_python.cpp
@@ -84,6 +84,10 @@ void  AddSerializerToPython(pybind11::module& m)
     .def("LoadFromBeginning",SerializerLoadFromBeginning<Model>)
     .def("Save",SerializerSave<Model>)
 
+    .def("Load",SerializerLoad<Flags>)
+    .def("LoadFromBeginning",SerializerLoadFromBeginning<Flags>)
+    .def("Save",SerializerSave<Flags>)
+
     .def("Set",   &Serializer::Set)
     .def("Print", SerializerPrint)
     ;


### PR DESCRIPTION
**📝 Description**
This PR adds a tiny but crucial fix to the `Project` save. When loading a model I realized that the global pointers were giving problems. The problem was that we were not pickling the `Flags` of the serializer so the `SHALLOW_GLOBAL_POINTERS_SERIALIZATION` was never applied when unpickling the model. Now we save both the serializer as well as its flags, so we can reset them when unpickling it.

While doing so, we also note that the current behavior of the `Serializer` is a bit tricky as the order of things matter. In this regard, I note for the record that @roigcarlo  suggested changing the underlying implementation to a map.
