### PR TITLE
[fix]: update the location of `linear_master_slave_constraint.h`

### DIFF
--- a/docs/pages/Kratos/For_Developers/Data_Structures/MultiPointConstraint_Interface.md
+++ b/docs/pages/Kratos/For_Developers/Data_Structures/MultiPointConstraint_Interface.md
@@ -76,7 +76,7 @@ Carrying out the indicated matrix multiplications yields:
 
 ## Kratos interface (how to use it)
 
-The **MPC** are implemented in *Kratos* via the [*MasterSlaveConstraint* class](https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/includes/master_slave_constraint.h), and particularly the linear kinematic relationship can be found in in the class [*LinearMasterSlaveConstraint* class](https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/includes/linear_master_slave_constraint.h).
+The **MPC** are implemented in *Kratos* via the [*MasterSlaveConstraint* class](https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/includes/master_slave_constraint.h), and particularly the linear kinematic relationship can be found in in the class [*LinearMasterSlaveConstraint* class](https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/constraints/linear_master_slave_constraint.h).
 
 The *LinearMasterSlaveConstraint* is defined by the following:
 


### PR DESCRIPTION
**📝 Description**
PR updates the location of `linear_master_slave_constraint.h` which was moved in PR #6557.