### PR TITLE
[CI] improve intel compiler handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,7 +418,7 @@ jobs:
 
     - name: Installing intel compiler
       shell: bash
-      run: sudo apt-get install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+      run: apt-get install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
 
     - name: Build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,7 +417,7 @@ jobs:
     # => must be added to the docker container to avoid reinstalling it in every CI run
 
     - name: Installing intel compiler
-      run: auso apt-get install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+      run: sudo apt-get install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
 
     - name: Build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,92 +399,6 @@ jobs:
         python kratos/python_scripts/testing/run_tests.py -l nightly -c python
 
 
-  ubuntu-intel-legacy:
-    runs-on: ubuntu-latest
-    env:
-      KRATOS_BUILD_TYPE: Custom
-      OMPI_MCA_rmaps_base_oversubscribe: 1 # Allow oversubscription for MPI (needed for OpenMPI >= 3.0)
-      OMPI_MCA_btl_vader_single_copy_mechanism: none # suppressing some annoying OpenMPI messages
-
-    container:
-      image: kratosmultiphysics/kratos-image-ci-ubuntu-22-04:latest
-      options: --user 1001
-
-    steps:
-    - uses: actions/checkout@v4
-
-    # - name: Installing dependencies
-    # => must be added to the docker container to avoid reinstalling it in every CI run
-
-    - name: Build
-      shell: bash
-      run: |
-        export CC=icc
-        export CXX=icpc
-        source /opt/intel/oneapi/setvars.sh
-        cp .github/workflows/intel_configure.sh configure.sh
-        bash configure.sh
-
-    - name: Running python tests
-      shell: bash
-      run: |
-        source /opt/intel/oneapi/setvars.sh
-        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
-        python3 kratos/python_scripts/testing/run_tests.py -l nightly -c python3
-
-    - name: Running MPI C++ tests (2 Cores)
-      shell: bash
-      timeout-minutes : 10
-      run: |
-        source /opt/intel/oneapi/setvars.sh
-        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
-        mpiexec -np 2 python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --using-mpi
-
-    - name: Running MPI C++ tests (3 Cores)
-      shell: bash
-      timeout-minutes : 10
-      run: |
-        source /opt/intel/oneapi/setvars.sh
-        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
-        mpiexec -np 3 python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --using-mpi
-
-    - name: Running MPI C++ tests (4 Cores)
-      shell: bash
-      timeout-minutes : 10
-      run: |
-        source /opt/intel/oneapi/setvars.sh
-        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
-        mpiexec -np 4 python3 kratos/python_scripts/testing/run_cpp_mpi_tests.py --using-mpi
-
-    - name: Running Python MPI tests (2 Cores)
-      shell: bash
-      run: |
-        source /opt/intel/oneapi/setvars.sh
-        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
-        python3 kratos/python_scripts/testing/run_python_mpi_tests.py -l mpi_nightly -n 2
-
-    - name: Running Python MPI tests (3 Cores)
-      shell: bash
-      run: |
-        source /opt/intel/oneapi/setvars.sh
-        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
-        python3 kratos/python_scripts/testing/run_python_mpi_tests.py -l mpi_nightly -n 3
-
-    - name: Running Python MPI tests (4 Cores)
-      shell: bash
-      run: |
-        source /opt/intel/oneapi/setvars.sh
-        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/Custom
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/Custom/libs
-        python3 kratos/python_scripts/testing/run_python_mpi_tests.py -l mpi_nightly -n 4
-
-
   ubuntu-intel:
     runs-on: ubuntu-latest
     env:
@@ -499,8 +413,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    # - name: Installing dependencies
-    # => must be added to the docker container to avoid reinstalling it in every CI run
+    - name: Installing intel compiler
+      run: auso apt-get install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
 
     - name: Build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,7 +417,7 @@ jobs:
     # => must be added to the docker container to avoid reinstalling it in every CI run
 
     - name: Installing intel compiler
-      run: sudo apt-get install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+      run: apt-get install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
 
     - name: Build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,7 +417,8 @@ jobs:
     # => must be added to the docker container to avoid reinstalling it in every CI run
 
     - name: Installing intel compiler
-      run: apt-get install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+      shell: bash
+      run: sudo apt-get install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
 
     - name: Build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,6 +413,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    # - name: Installing dependencies
+    # => must be added to the docker container to avoid reinstalling it in every CI run
+
     - name: Installing intel compiler
       run: auso apt-get install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
 

--- a/scripts/docker_files/docker_file_ci_ubuntu_22_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_22_04/DockerFile
@@ -23,7 +23,6 @@ RUN apt-get update -y && apt-get upgrade -y && \
         cmake \
         gfortran \
         git \
-        intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic \
         intel-oneapi-mkl-devel \
         valgrind \
         libboost-dev \


### PR DESCRIPTION
Instead of installing the intel compiler in the CI, this PR does the following:
- Remove the intel compilers from the docker file
- Remove the legacy intel build (icc and icpc are deprecated)
- Manually install the intel compiler only for the intel build. I will experiment with this more in the future
- closes #11566