### PR TITLE
[Docker] only new intel compiler

### DIFF
--- a/scripts/docker_files/docker_file_ci_ubuntu_22_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_22_04/DockerFile
@@ -22,11 +22,9 @@ RUN apt-get update -y && apt-get upgrade -y && \
         clang-14 \
         libomp-dev \
         cmake \
-        gfortran \
         git \
         intel-oneapi-compiler-dpcpp-cpp \
         intel-oneapi-mkl-devel \
-        valgrind \
         libboost-dev \
         libhdf5-dev \
         libhdf5-openmpi-dev \

--- a/scripts/docker_files/docker_file_ci_ubuntu_22_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_22_04/DockerFile
@@ -22,6 +22,7 @@ RUN apt-get update -y && apt-get upgrade -y && \
         clang-14 \
         libomp-dev \
         cmake \
+        gfortran \
         git \
         intel-oneapi-compiler-dpcpp-cpp \
         intel-oneapi-mkl-devel \

--- a/scripts/docker_files/docker_file_ci_ubuntu_22_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_22_04/DockerFile
@@ -23,7 +23,7 @@ RUN apt-get update -y && apt-get upgrade -y && \
         cmake \
         gfortran \
         git \
-        intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic \
+        intel-oneapi-compiler-dpcpp-cpp \
         intel-oneapi-mkl-devel \
         valgrind \
         libboost-dev \

--- a/scripts/docker_files/docker_file_ci_ubuntu_22_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_22_04/DockerFile
@@ -14,6 +14,7 @@ RUN apt-get update -y && apt-get upgrade -y && \
     add-apt-repository ppa:git-core/ppa && \
     apt-get -y update && \
     apt-get install -y --no-install-recommends \
+        sudo \
         build-essential \
         ccache \
         g++-12 \


### PR DESCRIPTION
Only install the new intel compiler to reduce the size. I will remove the legacy intel build in a follow-up PR

EDIT remove valgrind, and install sudo to support installations in CI (need this for some experimentation)

hopefully helps with #11566