### PR TITLE
[Core] Replace `fscanf` with `fscanf_s`

### DIFF
--- a/kratos/includes/matrix_market_interface.h
+++ b/kratos/includes/matrix_market_interface.h
@@ -52,14 +52,14 @@ constexpr inline bool IsCorrectType<std::complex<double>>(MM_typecode& mm_code)
 inline bool ReadMatrixMarketMatrixEntry(FILE *f, int& I, int& J, double& V)
 {
 
-    return fscanf(f, "%d %d %lg", &I, &J, &V) == 3;
+    return fscanf_s(f, "%d %d %lg", &I, &J, &V) == 3;
 }
 
 inline bool ReadMatrixMarketMatrixEntry(FILE *f, int& I, int& J, std::complex<double>& V)
 {
     double real;
     double imag;
-    const int i = fscanf(f, "%d %d %lg %lg", &I, &J, &real, &imag);
+    const int i = fscanf_s(f, "%d %d %lg %lg", &I, &J, &real, &imag);
     V = std::complex<double>(real, imag);
     return i == 4;
 }
@@ -131,7 +131,7 @@ template <typename CompressedMatrixType> inline bool ReadMatrixMarketMatrix(cons
     if (mm_is_pattern(mm_code))
         for (int i = 0; i < nnz; i++)
         {
-            if (fscanf(f, "%d %d", &I[i], &J[i]) != 2)
+            if (fscanf_s(f, "%d %d", &I[i], &J[i]) != 2)
             {
                 printf("ReadMatrixMarketMatrix(): invalid data.\n");
                 fclose(f);
@@ -423,14 +423,14 @@ template <typename CompressedMatrixType> inline bool WriteMatrixMarketMatrix(con
 
 inline bool ReadMatrixMarketVectorEntry(FILE *f, double& entry)
 {
-    return fscanf(f, "%lg", &entry) == 1;
+    return fscanf_s(f, "%lg", &entry) == 1;
 }
 
 inline bool ReadMatrixMarketVectorEntry(FILE *f, std::complex<double>& entry)
 {
     double real;
     double imag;
-    const int i = fscanf(f, "%lg %lg", &real, &imag);
+    const int i = fscanf_s(f, "%lg %lg", &real, &imag);
     entry = std::complex<double>(real, imag);
     return i == 2;
 }

--- a/kratos/sources/mmio.c
+++ b/kratos/sources/mmio.c
@@ -74,7 +74,7 @@ int mm_read_unsymmetric_sparse(const char *fname, int *M_, int *N_, int *nz_,
  
     for (i=0; i<nz; i++)
     {
-        int rr = fscanf(f, "%d %d %lg\n", &I[i], &J[i], &val[i]);
+        int rr = fscanf_s(f, "%d %d %lg\n", &I[i], &J[i], &val[i]);
  	if(rr == 0)  printf("some error in reading mm file");
         I[i]--;  /* adjust from 1-based to 0-based */
         J[i]--;
@@ -209,7 +209,7 @@ int mm_read_mtx_crd_size(FILE *f, int *M, int *N, int *nz )
     else
     do
     { 
-        num_items_read = fscanf(f, "%d %d %d", M, N, nz); 
+        num_items_read = fscanf_s(f, "%d %d %d", M, N, nz); 
         if (num_items_read == EOF) return MM_PREMATURE_EOF;
     }
     while (num_items_read != 3);
@@ -239,7 +239,7 @@ int mm_read_mtx_array_size(FILE *f, int *M, int *N)
     else /* we have a blank line */
     do
     { 
-        num_items_read = fscanf(f, "%d %d", M, N); 
+        num_items_read = fscanf_s(f, "%d %d", M, N); 
         if (num_items_read == EOF) return MM_PREMATURE_EOF;
     }
     while (num_items_read != 2);
@@ -270,14 +270,14 @@ int mm_read_mtx_crd_data(FILE *f, int M, int N, int nz, int I[], int J[],
     if (mm_is_complex(matcode))
     {
         for (i=0; i<nz; i++)
-            if (fscanf(f, "%d %d %lg %lg", &I[i], &J[i], &val[2*i], &val[2*i+1])
+            if (fscanf_s(f, "%d %d %lg %lg", &I[i], &J[i], &val[2*i], &val[2*i+1])
                 != 4) return MM_PREMATURE_EOF;
     }
     else if (mm_is_real(matcode))
     {
         for (i=0; i<nz; i++)
         {
-            if (fscanf(f, "%d %d %lg\n", &I[i], &J[i], &val[i])
+            if (fscanf_s(f, "%d %d %lg\n", &I[i], &J[i], &val[i])
                 != 3) return MM_PREMATURE_EOF;
 
         }
@@ -286,7 +286,7 @@ int mm_read_mtx_crd_data(FILE *f, int M, int N, int nz, int I[], int J[],
     else if (mm_is_pattern(matcode))
     {
         for (i=0; i<nz; i++)
-            if (fscanf(f, "%d %d", &I[i], &J[i])
+            if (fscanf_s(f, "%d %d", &I[i], &J[i])
                 != 2) return MM_PREMATURE_EOF;
     }
     else
@@ -301,19 +301,19 @@ int mm_read_mtx_crd_entry(FILE *f, int *I, int *J,
 {
     if (mm_is_complex(matcode))
     {
-            if (fscanf(f, "%d %d %lg %lg", I, J, real, imag)
+            if (fscanf_s(f, "%d %d %lg %lg", I, J, real, imag)
                 != 4) return MM_PREMATURE_EOF;
     }
     else if (mm_is_real(matcode))
     {
-            if (fscanf(f, "%d %d %lg\n", I, J, real)
+            if (fscanf_s(f, "%d %d %lg\n", I, J, real)
                 != 3) return MM_PREMATURE_EOF;
 
     }
 
     else if (mm_is_pattern(matcode))
     {
-            if (fscanf(f, "%d %d", I, J) != 2) return MM_PREMATURE_EOF;
+            if (fscanf_s(f, "%d %d", I, J) != 2) return MM_PREMATURE_EOF;
     }
     else
         return MM_UNSUPPORTED_TYPE;


### PR DESCRIPTION
**📝 Description**

This PR updates the Matrix Market file reading functions to use safe input functions. It replaces the use of `fscanf` with `fscanf_s` to prevent potential buffer overflow vulnerabilities. This change enhances the security and robustness of the code when reading Matrix Market files, ensuring that the input data is properly validated and processed. The update affects multiple functions across two files, `matrix_market_interface.h` and `mmio.c`, and involves making similar modifications in each function to use `fscanf_s` for input.

**🆕 Changelog**

- [Replace fscanf with fscanf_s](https://github.com/KratosMultiphysics/Kratos/commit/a4256f9c2c6514ce3139addfe34c5cfe91472830)
