### PR TITLE
[Core] Adding `GetObjectType` and define `ObjectType` in `Tree`

### DIFF
--- a/kratos/spatial_containers/tree.h
+++ b/kratos/spatial_containers/tree.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <iostream>
 #include <cmath>
+#include <type_traits>
 
 // External includes
 
@@ -40,6 +41,17 @@ namespace Kratos
 ///@}
 ///@name  Functions
 ///@{
+
+// Helper template to extract ObjectType or default to void
+template <typename T, typename = void>
+struct GetObjectType {
+    using type = void;
+};
+
+template <typename T>
+struct GetObjectType<T, std::void_t<typename T::ObjectType>> {
+    using type = typename T::ObjectType;
+};
 
 ///@}
 ///@name Kratos Classes
@@ -225,6 +237,9 @@ public:
 
     /// The iterator type definition
     using IteratorType = typename PartitionType::IteratorType;
+
+    /// The object type
+    using ObjectType = typename GetObjectType<PointType>::type;
 
     /// The distance iterator type definition
     using DistanceIteratorType = typename PartitionType::DistanceIteratorType;


### PR DESCRIPTION
**📝 Description**

Adding `GetObjectType` and define `ObjectType` in `Tree`. The `ObjectType` is taken from `PointType` when this is defined, otherwise `void` is defined. An auxiliary static method is defined in order to determine when `ObjectType` is defined.

**🆕 Changelog**

- [Adding `GetObjectType` and define `ObjectType` in `Tree`](https://github.com/KratosMultiphysics/Kratos/commit/fd8961f0cb9fc40447d97ca0be2eef9c0a69fbff)
