### PR TITLE
[Core] Moving `GetObjectType` in `tree.h`

### DIFF
--- a/kratos/spatial_containers/tree.h
+++ b/kratos/spatial_containers/tree.h
@@ -42,17 +42,6 @@ namespace Kratos
 ///@name  Functions
 ///@{
 
-// Helper template to extract ObjectType or default to void
-template <typename T, typename = void>
-struct GetObjectType {
-    using type = void;
-};
-
-template <typename T>
-struct GetObjectType<T, std::void_t<typename T::ObjectType>> {
-    using type = typename T::ObjectType;
-};
-
 ///@}
 ///@name Kratos Classes
 ///@{
@@ -202,6 +191,17 @@ class Tree
 public:
     ///@name Type Definitions
     ///@{
+
+    // Helper template to extract ObjectType or default to void
+    template <typename T, typename = void>
+    struct GetObjectType {
+        using type = void;
+    };
+
+    template <typename T>
+    struct GetObjectType<T, std::void_t<typename T::ObjectType>> {
+        using type = typename T::ObjectType;
+    };
 
     /**
      * @class Partitions


### PR DESCRIPTION
**📝 Description**

This commit refactors the `GetObjectType` template in the `kratos/spatial_containers/tree.h` file. The changes include moving the original `GetObjectType` template inside the class.

**🆕 Changelog**

- [Moving definition](https://github.com/KratosMultiphysics/Kratos/commit/50863c84ae7a762320e81e13cea46a13cd8dfcc0)
