### PR TITLE
[Core] Add mising methods on GaussPoints to Elements and Conditions

### DIFF
--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -785,6 +785,7 @@ public:
         const ProcessInfo& rCurrentProcessInfo)
     {
     }
+
     virtual void SetValuesOnIntegrationPoints(
         const Variable<int>& rVariable,
         const std::vector<int>& rValues,

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -703,45 +703,66 @@ public:
      * CalculateValueOnIntegrationPoints: calculates the values of given Variable.
      */
 
-    virtual void CalculateOnIntegrationPoints(const Variable<bool>& rVariable,
-                          std::vector<bool>& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo)
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<bool>& rVariable,
+        std::vector<bool>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void CalculateOnIntegrationPoints(const Variable<int>& rVariable,
-                          std::vector<int>& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo)
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<int>& rVariable,
+        std::vector<int>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
-                          std::vector<double>& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo)
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<double>& rVariable,
+        std::vector<double>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void CalculateOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
-                          std::vector< array_1d<double, 3 > >& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo)
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<array_1d<double, 3>>& rVariable,
+        std::vector< array_1d<double, 3>>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void CalculateOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
-                          std::vector< array_1d<double, 6 > >& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo)
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<array_1d<double, 4>>& rVariable,
+        std::vector< array_1d<double, 4>>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void CalculateOnIntegrationPoints(const Variable<Vector >& rVariable,
-                          std::vector< Vector >& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo)
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<array_1d<double, 6>>& rVariable,
+        std::vector<array_1d<double, 6>>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void CalculateOnIntegrationPoints(const Variable<Matrix >& rVariable,
-                          std::vector< Matrix >& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo)
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<array_1d<double, 9>>& rVariable,
+        std::vector<array_1d<double, 9>>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
+    {
+    }
+
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<Vector>& rVariable,
+        std::vector<Vector>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
+    {
+    }
+
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<Matrix>& rVariable,
+        std::vector<Matrix>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
@@ -758,45 +779,65 @@ public:
 
     //SET ON INTEGRATION POINTS - METHODS
 
-    virtual void SetValuesOnIntegrationPoints(const Variable<bool>& rVariable,
-                         const std::vector<bool>& rValues,
-                         const ProcessInfo& rCurrentProcessInfo)
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<bool>& rVariable,
+        const std::vector<bool>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
+    {
+    }
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<int>& rVariable,
+        const std::vector<int>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void SetValuesOnIntegrationPoints(const Variable<int>& rVariable,
-                         const std::vector<int>& rValues,
-                         const ProcessInfo& rCurrentProcessInfo)
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<double>& rVariable,
+        const std::vector<double>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void SetValuesOnIntegrationPoints(const Variable<double>& rVariable,
-                         const std::vector<double>& rValues,
-                         const ProcessInfo& rCurrentProcessInfo)
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<array_1d<double, 3>>& rVariable,
+        const std::vector<array_1d<double, 3>>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void SetValuesOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
-                         const std::vector<array_1d<double, 3 > >& rValues,
-                         const ProcessInfo& rCurrentProcessInfo)
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<array_1d<double, 4>>& rVariable,
+        const std::vector<array_1d<double, 4>>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void SetValuesOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
-                         const std::vector<array_1d<double, 6 > >& rValues,
-                         const ProcessInfo& rCurrentProcessInfo)
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<array_1d<double, 6>>& rVariable,
+        const std::vector<array_1d<double, 6>>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void SetValuesOnIntegrationPoints(const Variable<Vector>& rVariable,
-                         const std::vector<Vector>& rValues,
-                         const ProcessInfo& rCurrentProcessInfo)
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<array_1d<double, 9>>& rVariable,
+        const std::vector<array_1d<double, 9>>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void SetValuesOnIntegrationPoints(const Variable<Matrix>& rVariable,
-                         const std::vector<Matrix>& rValues,
-                         const ProcessInfo& rCurrentProcessInfo)
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<Vector>& rVariable,
+        const std::vector<Vector>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
+    {
+    }
+
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<Matrix>& rVariable,
+        const std::vector<Matrix>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -716,39 +716,73 @@ public:
      * CalculateValueOnIntegrationPoints: calculates the values of given Variable.
      */
 
-    virtual void CalculateOnIntegrationPoints(const Variable<bool>& rVariable,
-                          std::vector<bool>& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo)
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<bool>& rVariable,
+        std::vector<bool>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void CalculateOnIntegrationPoints(const Variable<int>& rVariable,
-                          std::vector<int>& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo)
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<int>& rVariable,
+        std::vector<int>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
-                          std::vector<double>& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo)
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<double>& rVariable,
+        std::vector<double>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void CalculateOnIntegrationPoints(const Variable<array_1d<double,3>>& rVariable,
-                          std::vector< array_1d<double,3>>& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo)
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<array_1d<double, 3>>& rVariable,
+        std::vector< array_1d<double, 3>>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void CalculateOnIntegrationPoints(const Variable<array_1d<double,6>>& rVariable,
-                          std::vector<array_1d<double,6>>& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo)
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<array_1d<double, 4>>& rVariable,
+        std::vector< array_1d<double, 4>>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
-                          std::vector<Vector>& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo)
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<array_1d<double, 6>>& rVariable,
+        std::vector<array_1d<double, 6>>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
+    {
+    }
+
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<array_1d<double, 9>>& rVariable,
+        std::vector<array_1d<double, 9>>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
+    {
+    }
+
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<Vector>& rVariable,
+        std::vector<Vector>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
+    {
+    }
+
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<Matrix>& rVariable,
+        std::vector<Matrix>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
+    {
+    }
+
+    virtual void CalculateOnIntegrationPoints(
+        const Variable<ConstitutiveLaw::Pointer>& rVariable,
+        std::vector<ConstitutiveLaw::Pointer>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
@@ -764,12 +798,6 @@ public:
     // {
     // }
 
-    virtual void CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,
-                          std::vector<Matrix>& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo)
-    {
-    }
-
     // virtual void CalculateOnIntegrationPoints(const Variable<ConstitutiveLaw::VoigtSizeMatrixType>& rVariable,
     //                       std::vector<ConstitutiveLaw::VoigtSizeMatrixType>& rOutput,
     //                       const ProcessInfo& rCurrentProcessInfo)
@@ -781,12 +809,6 @@ public:
     //                       const ProcessInfo& rCurrentProcessInfo)
     // {
     // }
-
-    virtual void CalculateOnIntegrationPoints(const Variable<ConstitutiveLaw::Pointer>& rVariable,
-                         std::vector<ConstitutiveLaw::Pointer>& rOutput,
-                         const ProcessInfo& rCurrentProcessInfo)
-    {
-    }
 
     /**
      * Access for variables on Integration points.
@@ -800,50 +822,72 @@ public:
      */
 
     //SET ON INTEGRATION POINTS - METHODS
-    virtual void SetValuesOnIntegrationPoints(const Variable<bool>& rVariable,
-                         const std::vector<bool>& rValues,
-                         const ProcessInfo& rCurrentProcessInfo)
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<bool>& rVariable,
+        const std::vector<bool>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
-    virtual void SetValuesOnIntegrationPoints(const Variable<int>& rVariable,
-                         const std::vector<int>& rValues,
-                         const ProcessInfo& rCurrentProcessInfo)
-    {
-    }
-
-    virtual void SetValuesOnIntegrationPoints(const Variable<double>& rVariable,
-                         const std::vector<double>& rValues,
-                         const ProcessInfo& rCurrentProcessInfo)
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<int>& rVariable,
+        const std::vector<int>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void SetValuesOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
-                         const std::vector<array_1d<double, 3 > >& rValues,
-                         const ProcessInfo& rCurrentProcessInfo)
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<double>& rVariable,
+        const std::vector<double>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void SetValuesOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
-                         const std::vector<array_1d<double, 6 > >& rValues,
-                         const ProcessInfo& rCurrentProcessInfo)
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<array_1d<double, 3>>& rVariable,
+        const std::vector<array_1d<double, 3>>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void SetValuesOnIntegrationPoints(const Variable<Vector>& rVariable,
-                         const std::vector<Vector>& rValues,
-                         const ProcessInfo& rCurrentProcessInfo)
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<array_1d<double, 4>>& rVariable,
+        const std::vector<array_1d<double, 4>>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void SetValuesOnIntegrationPoints(const Variable<Matrix>& rVariable,
-                         const std::vector<Matrix>& rValues,
-                         const ProcessInfo& rCurrentProcessInfo)
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<array_1d<double, 6>>& rVariable,
+        const std::vector<array_1d<double, 6>>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    virtual void SetValuesOnIntegrationPoints(const Variable<ConstitutiveLaw::Pointer>& rVariable,
-                         const std::vector<ConstitutiveLaw::Pointer>& rValues,
-                         const ProcessInfo& rCurrentProcessInfo)
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<array_1d<double, 9>>& rVariable,
+        const std::vector<array_1d<double, 9>>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
+    {
+    }
+
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<Vector>& rVariable,
+        const std::vector<Vector>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
+    {
+    }
+
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<Matrix>& rVariable,
+        const std::vector<Matrix>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
+    {
+    }
+
+    virtual void SetValuesOnIntegrationPoints(
+        const Variable<ConstitutiveLaw::Pointer>& rVariable,
+        const std::vector<ConstitutiveLaw::Pointer>& rValues,
+        const ProcessInfo& rCurrentProcessInfo)
     {
     }
 

--- a/kratos/python/add_mesh_to_python.cpp
+++ b/kratos/python/add_mesh_to_python.cpp
@@ -192,25 +192,25 @@ void SetValuesOnIntegrationPoints(
     dummy.SetValuesOnIntegrationPoints(rVariable, values, rCurrentProcessInfo);
 }
 
-template< class TObject >
+template< class TObject, std::size_t TSize>
 void SetValuesOnIntegrationPointsArray1d(
     TObject& dummy,
-    const Variable< array_1d<double, 3> >& rVariable,
+    const Variable<array_1d<double, TSize>>& rVariable,
     pybind11::list values_list,
     const ProcessInfo& rCurrentProcessInfo)
 {
-    std::vector< array_1d<double, 3> > values(values_list.size());
+    std::vector<array_1d<double, TSize>> values(values_list.size());
     for (std::size_t i = 0; i < values_list.size(); i++) {
-        if (py::isinstance<array_1d<double, 3>>(values_list[i])) {
-            values[i] = (values_list[i]).cast<array_1d<double, 3> >();
+        if (py::isinstance<array_1d<double, TSize>>(values_list[i])) {
+            values[i] = (values_list[i]).cast<array_1d<double, TSize> >();
         } else if (py::isinstance<pybind11::list>(values_list[i]) ||
             py::isinstance<Vector>(values_list[i])) {
             Vector value = (values_list[i]).cast<Vector>();
-            KRATOS_ERROR_IF(value.size() != 3)
-                << " parsed vector is not of size 3. Size of vector: " << value.size() << std::endl;
+            KRATOS_ERROR_IF(value.size() != TSize)
+                << " parsed vector is not of size " << TSize << ". Size of vector: " << value.size() << std::endl;
             values[i] = value;
         } else {
-            KRATOS_ERROR << "expecting a list of array_1d<double,3> " << std::endl;
+            KRATOS_ERROR << "expecting a list of array_1d<double, " << TSize << ">" << std::endl;
         }
     }
     dummy.SetValuesOnIntegrationPoints( rVariable, values, rCurrentProcessInfo );
@@ -464,6 +464,9 @@ void  AddMeshToPython(pybind11::module& m)
     .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Element, int>)
     .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Element, double>)
     .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Element, array_1d<double, 3>>)
+    .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Element, array_1d<double, 4>>)
+    .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Element, array_1d<double, 6>>)
+    .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Element, array_1d<double, 9>>)
     .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Element, Vector>)
     .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Element, Matrix>)
     // GetValuesOnIntegrationPoints
@@ -474,7 +477,10 @@ void  AddMeshToPython(pybind11::module& m)
     .def("SetValuesOnIntegrationPoints", SetValuesOnIntegrationPointsVector<Element>)
     .def("SetValuesOnIntegrationPoints", SetValuesOnIntegrationPointsConstitutiveLaw)
     .def("SetValuesOnIntegrationPoints", SetValuesOnIntegrationPoints<Element, double>)
-    .def("SetValuesOnIntegrationPoints", SetValuesOnIntegrationPointsArray1d<Element>)
+    .def("SetValuesOnIntegrationPoints", SetValuesOnIntegrationPointsArray1d<Element, 3>)
+    .def("SetValuesOnIntegrationPoints", SetValuesOnIntegrationPointsArray1d<Element, 4>)
+    .def("SetValuesOnIntegrationPoints", SetValuesOnIntegrationPointsArray1d<Element, 6>)
+    .def("SetValuesOnIntegrationPoints", SetValuesOnIntegrationPointsArray1d<Element, 9>)
     .def("ResetConstitutiveLaw", &Element::ResetConstitutiveLaw)
     .def("Calculate", &EntityCalculateInterface<Element, double>)
     .def("Calculate", &EntityCalculateInterface<Element, array_1d<double,3> >)
@@ -604,6 +610,9 @@ void  AddMeshToPython(pybind11::module& m)
     .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Condition, int>)
     .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Condition, double>)
     .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Condition, array_1d<double, 3>>)
+    .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Condition, array_1d<double, 4>>)
+    .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Condition, array_1d<double, 6>>)
+    .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Condition, array_1d<double, 9>>)
     .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Condition, Vector>)
     .def("CalculateOnIntegrationPoints", CalculateOnIntegrationPoints<Condition, Matrix>)
     // GetValuesOnIntegrationPoints
@@ -613,7 +622,10 @@ void  AddMeshToPython(pybind11::module& m)
     .def("SetValuesOnIntegrationPoints", SetValuesOnIntegrationPoints<Condition, int>)
     .def("SetValuesOnIntegrationPoints", SetValuesOnIntegrationPoints<Condition, double>)
     .def("SetValuesOnIntegrationPoints", SetValuesOnIntegrationPointsVector<Condition>)
-    .def("SetValuesOnIntegrationPoints", SetValuesOnIntegrationPointsArray1d<Condition>)
+    .def("SetValuesOnIntegrationPoints", SetValuesOnIntegrationPointsArray1d<Condition, 3>)
+    .def("SetValuesOnIntegrationPoints", SetValuesOnIntegrationPointsArray1d<Condition, 4>)
+    .def("SetValuesOnIntegrationPoints", SetValuesOnIntegrationPointsArray1d<Condition, 6>)
+    .def("SetValuesOnIntegrationPoints", SetValuesOnIntegrationPointsArray1d<Condition, 9>)
     //.def("SetValuesOnIntegrationPoints", SetValuesOnIntegrationPointsConstitutiveLaw)
 
 //     .def(VariableIndexingPython<Condition, Variable<int> >())


### PR DESCRIPTION
**📝 Description**
This PR adds `array_1d<double, 4>` and `array_1d<double, 9>` method variants of `CalculateOnIntegrationPoints` and `SetValuesOnIntegrationPoints` in `Condition` and `Element`. Python exposure is also added.

**🆕 Changelog**
- Added `array_1d<double, 4>` and `array_1d<double, 9>` variants for `CalculateOnIntegrationPoints` in `Element` and `Condition`.
- Added `array_1d<double, 4>` and `array_1d<double, 9>` variants for `SetValuesOnIntegrationPoints` in `Element` and `Condition`.
- Python exposure of above methods.
