### PR TITLE
[GeoMechanicsApplication] Fixed a bug and removed some duplicated code

### DIFF
--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.cpp
@@ -21,7 +21,6 @@
 #include "custom_processes/apply_excavation_process.h"
 
 #include "custom_utilities/input_utility.h"
-#include "custom_utilities/process_factory.hpp"
 #include "custom_utilities/process_info_parser.h"
 #include "custom_utilities/solving_strategy_factory.hpp"
 #include "spaces/ublas_space.h"
@@ -130,51 +129,17 @@ KratosGeoSettlement::KratosGeoSettlement(std::unique_ptr<InputUtility> pInputUti
 void KratosGeoSettlement::InitializeProcessFactory()
 {
     mProcessFactory->AddCreator("ApplyScalarConstraintTableProcess",
-                                [&model = mModel](const Parameters& rParameters)
-                                {
-                                    auto& model_part = model.GetModelPart(rParameters["model_part_name"].GetString());
-                                    return std::make_unique<ApplyScalarConstraintTableProcess>(model_part,
-                                                                                               rParameters);
-                                });
-
+                                MakeCreatorFor<ApplyScalarConstraintTableProcess>());
     mProcessFactory->AddCreator("ApplyNormalLoadTableProcess",
-                                [this](const Parameters& rParameters)
-                                {
-                                      return std::make_unique<ApplyNormalLoadTableProcess>(GetMainModelPart(),
-                                                                                           rParameters);
-                                });
-
+                                MakeCreatorFor<ApplyNormalLoadTableProcess>());
     mProcessFactory->AddCreator("ApplyVectorConstraintTableProcess",
-                                [&model = mModel](const Parameters& rParameters)
-                                {
-                                    auto& model_part = model.GetModelPart(rParameters["model_part_name"].GetString());
-                                    return std::make_unique<ApplyVectorConstraintTableProcess>(model_part,
-                                                                                               rParameters);
-                                });
-
+                                MakeCreatorFor<ApplyVectorConstraintTableProcess>());
     mProcessFactory->AddCreator("SetParameterFieldProcess",
-                                [&model = mModel](const Parameters& rParameters)
-                                {
-                                    auto& model_part = model.GetModelPart(rParameters["model_part_name"].GetString());
-                                    return std::make_unique<SetParameterFieldProcess>(model_part,
-                                                                                      rParameters);
-                                });
-
+                                MakeCreatorFor<SetParameterFieldProcess>());
     mProcessFactory->AddCreator("ApplyExcavationProcess",
-                                [&model = mModel](const Parameters& rParameters)
-                                {
-                                    auto& model_part = model.GetModelPart(rParameters["model_part_name"].GetString());
-                                    return std::make_unique<ApplyExcavationProcess>(model_part,
-                                                                                    rParameters);
-                                });
-
+                                MakeCreatorFor<ApplyExcavationProcess>());
     mProcessFactory->AddCreator("ApplyK0ProcedureProcess",
-                                [&model = mModel](const Parameters& rParameters)
-                                {
-                                    auto& model_part = model.GetModelPart(rParameters["model_part_name"].GetString());
-                                    return std::make_unique<ApplyK0ProcedureProcess>(model_part,
-                                                                                     rParameters);
-                                });
+                                MakeCreatorFor<ApplyK0ProcedureProcess>());
 
     mProcessFactory->SetCallBackWhenProcessIsUnknown([](const std::string& rProcessName)
     {

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h
@@ -23,6 +23,7 @@
 #include "linear_solvers_application.h"
 #include "structural_mechanics_application.h"
 #include "utilities/variable_utils.h"
+#include "custom_utilities/process_factory.hpp"
 
 namespace Kratos
 {
@@ -84,6 +85,16 @@ private:
                        [&rVariable, SourceIndex, DestinationIndex](auto& node) {
             node.GetSolutionStepValue(rVariable, DestinationIndex) = node.GetSolutionStepValue(rVariable, SourceIndex);
         });
+    }
+
+    template <typename ProcessType>
+    std::function<ProcessFactory::ProductType(const Parameters&)> MakeCreatorFor()
+    {
+        return [&model = mModel](const Parameters& rProcessSettings)
+        {
+            auto& model_part = model.GetModelPart(rProcessSettings["model_part_name"].GetString());
+            return std::make_unique<ProcessType>(model_part, rProcessSettings);
+        };
     }
 
     Kernel mKernel;


### PR DESCRIPTION
**📝 Description**
- Pass the correct model part to `ApplyNormalLoadTableProcess`. In the settlement work flow, when creating an `ApplyNormalLoadTableProcess` object, we mistakenly passed it the main model part rather than the model part that is defined in the process's settings. That has been corrected now.
- Extracted a function that makes process creators. By extracting a function that produces process creators, we have removed some duplicated code.