### PR TITLE
[GeoMechanics] Removing forward declaration of ProcessFactory

### DIFF
--- a/applications/GeoMechanicsApplication/GeoMechanicsApplication.json
+++ b/applications/GeoMechanicsApplication/GeoMechanicsApplication.json
@@ -3,7 +3,7 @@
 	"included_modules": ["GeoMechanicsApplication"],
 	"included_binaries": ["KratosGeoMechanicsApplication.*", "KratosGeoMechanicsCore.*", "libKratosGeoMechanicsCore.*"],
     "excluded_binaries": [],
-	"dependencies": ["KratosMultiphysics==${KRATOS_VERSION}"],
+	"dependencies": ["KratosMultiphysics==${KRATOS_VERSION}", "KratosStructuralMechanicsApplication==${KRATOS_VERSION}", "KratosLinearSolversApplication==${KRATOS_VERSION}"],
 	"author": "Kratos Team",
 	"author_email": "Vahid.Galavi@gmail.com",
 	"description": "KRATOS Multiphysics (\"Kratos\") is a framework for building parallel, multi-disciplinary simulation software, aiming at modularity, extensibility, and high performance. Kratos is written in C++, and counts with an extensive Python interface.",

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h
@@ -28,7 +28,6 @@
 namespace Kratos
 {
 
-class ProcessFactory;
 class InputUtility;
 class ProcessInfoParser;
 class Process;

--- a/kratos/KratosMultiphysics-all.json
+++ b/kratos/KratosMultiphysics-all.json
@@ -18,7 +18,8 @@
         "KratosParticleMechanicsApplication==${KRATOS_VERSION}",
         "KratosPoroMechanicsApplication==${KRATOS_VERSION}",
         "KratosShallowWaterApplication==${KRATOS_VERSION}",
-        "KratosStructuralMechanicsApplication==${KRATOS_VERSION}"
+        "KratosStructuralMechanicsApplication==${KRATOS_VERSION}",
+        "KratosGeoMechanicsApplication==${KRATOS_VERSION}"
     ],
 	"author": "Kratos Team",
 	"author_email": "kratos@listas.cimne.upc.edu",


### PR DESCRIPTION
**📝 Description**
This PR replaces the forward declaration of the process factory in `GeoMechanicsApplication/custom_workflows/dgeosettlement.h`

The problem appears when using the class in:

```C++
std::unique_ptr<ProcessFactory> mProcessFactory = std::make_unique<ProcessFactory>();
```

According to [Here](http://howardhinnant.github.io/incomplete.html) the problem comes due to the fact that assignment operation needs for type completeness, which is consistent from the error the CI is reporting:

```bash
In file included from /opt/rh/devtoolset-10/root/usr/include/c++/10/bits/locale_conv.h:41,
                 from /opt/rh/devtoolset-10/root/usr/include/c++/10/locale:43,
                 from /opt/rh/devtoolset-10/root/usr/include/c++/10/bits/fs_path.h:37,
                 from /opt/rh/devtoolset-10/root/usr/include/c++/10/filesystem:45,
                 from /workspace/kratos/Kratos/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h:15,
                 from /workspace/kratos/Kratos/applications/GeoMechanicsApplication/custom_workflows/custom_workflow_factory.cpp:14:
/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/unique_ptr.h: In instantiation of ‘typename std::_MakeUniq<_Tp>::__single_object std::make_unique(_Args&& ...) [with _Tp = Kratos::ProcessFactory; _Args = {}; typename std::_MakeUniq<_Tp>::__single_object = std::unique_ptr<Kratos::ProcessFactory>]’:
/workspace/kratos/Kratos/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h:95:88:   required from here
/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/unique_ptr.h:962:30: error: invalid use of incomplete type ‘class Kratos::ProcessFactory’
  962 |     { return unique_ptr<_Tp>(new _Tp(std::forward<_Args>(__args)...)); }
      |                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /workspace/kratos/Kratos/applications/GeoMechanicsApplication/custom_workflows/custom_workflow_factory.cpp:14:
/workspace/kratos/Kratos/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h:30:7: note: forward declaration of ‘class Kratos::ProcessFactory’
   30 | class ProcessFactory;
      |       ^~~~~~~~~~~~~~
In file included from /opt/rh/devtoolset-10/root/usr/include/c++/10/bits/locale_conv.h:41,
                 from /opt/rh/devtoolset-10/root/usr/include/c++/10/locale:43,
                 from /opt/rh/devtoolset-10/root/usr/include/c++/10/bits/fs_path.h:37,
                 from /opt/rh/devtoolset-10/root/usr/include/c++/10/filesystem:45,
                 from /workspace/kratos/Kratos/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h:15,
                 from /workspace/kratos/Kratos/applications/GeoMechanicsApplication/custom_workflows/custom_workflow_factory.cpp:14:
/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/unique_ptr.h: In instantiation of ‘void std::default_delete<_Tp>::operator()(_Tp*) const [with _Tp = Kratos::ProcessFactory]’:
/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/unique_ptr.h:361:17:   required from ‘std::unique_ptr<_Tp, _Dp>::~unique_ptr() [with _Tp = Kratos::ProcessFactory; _Dp = std::default_delete<Kratos::ProcessFactory>]’
/workspace/kratos/Kratos/applications/GeoMechanicsApplication/custom_workflows/dgeosettlement.h:95:88:   required from here
/opt/rh/devtoolset-10/root/usr/include/c++/10/bits/unique_ptr.h:83:16: error: invalid application of ‘sizeof’ to incomplete type ‘Kratos::ProcessFactory’
   83 |  static_assert(sizeof(_Tp)>0,
      |                ^~~~~~~~~~~
``` 



**🆕 Changelog**
- Using ProcessFactory complete type in GeoSettlement
