### PR TITLE
[OptApp] Fixing tolerance issue in the test

### DIFF
--- a/applications/OptimizationApplication/tests/filtering/implicit_filters_tests.py
+++ b/applications/OptimizationApplication/tests/filtering/implicit_filters_tests.py
@@ -29,6 +29,9 @@ class HelmholtzAnalysisTest(TestCase):
                                         "model_part_name" : "solid_scalar.structure",
                                         "model_import_settings"              : {
                                             "input_type"     : "use_input_model_part"
+                                        },
+                                        "linear_solver_settings": {
+                                            "solver_type": "LinearSolversApplication.pardiso_lu"
                                         }
                                     },
                                     "problem_data": {
@@ -49,6 +52,9 @@ class HelmholtzAnalysisTest(TestCase):
                                         "model_part_name" : "solid_vector.structure",
                                         "model_import_settings"              : {
                                             "input_type"     : "use_input_model_part"
+                                        },
+                                        "linear_solver_settings": {
+                                            "solver_type": "LinearSolversApplication.pardiso_lu"
                                         }
                                     },
                                     "problem_data": {
@@ -69,6 +75,9 @@ class HelmholtzAnalysisTest(TestCase):
                                         "model_part_name" : "solid_bulk_surf.design",
                                         "model_import_settings"              : {
                                             "input_type"     : "use_input_model_part"
+                                        },
+                                        "linear_solver_settings": {
+                                            "solver_type": "LinearSolversApplication.pardiso_lu"
                                         }
                                     },
                                     "problem_data": {
@@ -98,6 +107,9 @@ class HelmholtzAnalysisTest(TestCase):
                                         "model_part_name" : "shell",
                                         "model_import_settings"              : {
                                             "input_type"     : "use_input_model_part"
+                                        },
+                                        "linear_solver_settings": {
+                                            "solver_type": "LinearSolversApplication.pardiso_lu"
                                         }
                                     },
                                     "problem_data": {
@@ -146,6 +158,9 @@ class HelmholtzAnalysisTest(TestCase):
                                         "model_part_name" : "closed_surface_shell",
                                         "model_import_settings"              : {
                                             "input_type"     : "use_input_model_part"
+                                        },
+                                        "linear_solver_settings": {
+                                            "solver_type": "LinearSolversApplication.pardiso_lu"
                                         }
                                     },
                                     "problem_data": {
@@ -277,7 +292,7 @@ class HelmholtzAnalysisTest(TestCase):
 
         filtered_field = self.shell_vector_filter.UnFilterField(unfiltered_uniform_field_nodal)
         filtered_field = self.shell_vector_filter.FilterField(filtered_field)
-        self.assertAlmostEqual(KOA.ExpressionUtils.NormL2(filtered_field), 5.196058, 4)
+        self.assertAlmostEqual(KOA.ExpressionUtils.NormL2(filtered_field), 5.196153341144455, 4)
 
         filtered_field = self.shell_vector_filter.FilterField(unfiltered_uniform_field_nodal)
         self.assertAlmostEqual(KOA.ExpressionUtils.NormL2(filtered_field), 5.1961524, 4)
@@ -295,7 +310,7 @@ class HelmholtzAnalysisTest(TestCase):
         KM.Expression.VariableExpressionIO.Read(nodal_area, KM.VELOCITY, False)
 
         filtered_field = self.shell_vector_filter.FilterIntegratedField(nodal_area)
-        self.assertAlmostEqual(KOA.ExpressionUtils.NormL2(filtered_field), 5.1961524, 4)
+        self.assertAlmostEqual(KOA.ExpressionUtils.NormL2(filtered_field), 5.196118198546968, 4)
 
     def test_bulk_surface_shape(self):
         # initialization of the filter done here so that filtering radius is set.

--- a/applications/OptimizationApplication/tests/filtering/implicit_filters_tests.py
+++ b/applications/OptimizationApplication/tests/filtering/implicit_filters_tests.py
@@ -31,7 +31,7 @@ class HelmholtzAnalysisTest(TestCase):
                                             "input_type"     : "use_input_model_part"
                                         },
                                         "linear_solver_settings": {
-                                            "solver_type": "LinearSolversApplication.pardiso_lu"
+                                            "solver_type": "skyline_lu_factorization"
                                         }
                                     },
                                     "problem_data": {
@@ -54,7 +54,7 @@ class HelmholtzAnalysisTest(TestCase):
                                             "input_type"     : "use_input_model_part"
                                         },
                                         "linear_solver_settings": {
-                                            "solver_type": "LinearSolversApplication.pardiso_lu"
+                                            "solver_type": "skyline_lu_factorization"
                                         }
                                     },
                                     "problem_data": {
@@ -77,7 +77,7 @@ class HelmholtzAnalysisTest(TestCase):
                                             "input_type"     : "use_input_model_part"
                                         },
                                         "linear_solver_settings": {
-                                            "solver_type": "LinearSolversApplication.pardiso_lu"
+                                            "solver_type": "skyline_lu_factorization"
                                         }
                                     },
                                     "problem_data": {
@@ -109,7 +109,7 @@ class HelmholtzAnalysisTest(TestCase):
                                             "input_type"     : "use_input_model_part"
                                         },
                                         "linear_solver_settings": {
-                                            "solver_type": "LinearSolversApplication.pardiso_lu"
+                                            "solver_type": "skyline_lu_factorization"
                                         }
                                     },
                                     "problem_data": {
@@ -160,7 +160,7 @@ class HelmholtzAnalysisTest(TestCase):
                                             "input_type"     : "use_input_model_part"
                                         },
                                         "linear_solver_settings": {
-                                            "solver_type": "LinearSolversApplication.pardiso_lu"
+                                            "solver_type": "skyline_lu_factorization"
                                         }
                                     },
                                     "problem_data": {


### PR DESCRIPTION
**📝 Description**
As you have noticed, OptApp started having a test failure in CI. It was due to tolerance of the `AMGCL` solver used in solving the PDE. Now I changed everything to use `Intel-Pardiso` direct solver so not to have tolerance issues.

Sorry for the inconvinience.

**🆕 Changelog**
- Fix tolerance issue in the test
