### PR TITLE
[MPM] Moving `print_output_process` outside `processes`

### DIFF
--- a/applications/ParticleMechanicsApplication/tests/beam_tests/dynamic_UP_hyperelastic_cantilever_test/dynamic_UP_hyperelastic_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/dynamic_UP_hyperelastic_cantilever_test/dynamic_UP_hyperelastic_test_parameters.json
@@ -74,19 +74,18 @@
                 "modulus"         : 9.81,
                 "direction"       : [0.0,-1.0,0.0]
             }
-        }],
-        "print_output_process" : [{
-            "python_module"   : "particle_json_output_process",
-            "kratos_module"   : "KratosMultiphysics.ParticleMechanicsApplication",
-            "process_name"          : "ParticleJsonOutputProcess",
-            "Parameters"            : {
-                "gauss_points_output_variables"  : ["MP_DISPLACEMENT","MP_PRESSURE"],
-                "output_file_name"  : "beam_tests/dynamic_UP_hyperelastic_cantilever_test/dynamic_UP_hyperelastic_test_results.json",
-                "model_part_name"   : "MPM_Material",
-                "time_frequency"    : 0.05
-                }
         }]
     },
-
+    "print_output_process" : [{
+       "python_module"   : "particle_json_output_process",
+       "kratos_module"   : "KratosMultiphysics.ParticleMechanicsApplication",
+       "process_name"          : "ParticleJsonOutputProcess",
+       "Parameters"            : {
+          "gauss_points_output_variables"  : ["MP_DISPLACEMENT","MP_PRESSURE"],
+          "output_file_name"  : "beam_tests/dynamic_UP_hyperelastic_cantilever_test/dynamic_UP_hyperelastic_test_results.json",
+          "model_part_name"   : "MPM_Material",
+          "time_frequency"    : 0.05
+       }
+    }],
     "analysis_stage"   : "KratosMultiphysics.ParticleMechanicsApplication.particle_mechanics_analysis"
 }

--- a/applications/ParticleMechanicsApplication/tests/cl_tests/fluid_cl/newtonian_fluid_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/cl_tests/fluid_cl/newtonian_fluid_test_parameters.json
@@ -86,18 +86,18 @@
                 "modulus"         : 9.81,
                 "direction"       : [0.0,-1.0,0.0]
             }
-        }],
-    "print_output_process" : [{
-    	"python_module"   : "particle_json_output_process",
-	"kratos_module" : "KratosMultiphysics.ParticleMechanicsApplication",
-	"process_name"          : "ParticleJsonOutputProcess",
-	"Parameters"            : {
-	    "gauss_points_output_variables"  : ["MP_DISPLACEMENT"],
-	    "output_file_name"  : "cl_tests/fluid_cl/newtonian_fluid_test_results.json",
-	    "model_part_name"   : "MPM_Material",
-	    "time_frequency"    : 0.1
-	}
-	}]
+        }]
     },
+    "print_output_process" : [{
+       "python_module"   : "particle_json_output_process",
+       "kratos_module" : "KratosMultiphysics.ParticleMechanicsApplication",
+       "process_name"          : "ParticleJsonOutputProcess",
+       "Parameters"            : {
+          "gauss_points_output_variables"  : ["MP_DISPLACEMENT"],
+          "output_file_name"  : "cl_tests/fluid_cl/newtonian_fluid_test_results.json",
+          "model_part_name"   : "MPM_Material",
+          "time_frequency"    : 0.1
+       }
+    }],
     "analysis_stage"   : "KratosMultiphysics.ParticleMechanicsApplication.particle_mechanics_analysis"
 }


### PR DESCRIPTION
Moving `print_output_process` outside `processes` for `CLDispNewtonianFluidTest` and `BeamCantileverDynamicHyperelasticUPTest`