### PR TITLE
[Core] Fixed a warning reported by CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project (KratosMultiphysics)
 cmake_minimum_required (VERSION 2.8.6)
+project (KratosMultiphysics)
 set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set (CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
**📝 Description**
The `cmake_minimum_required()` command should be called at the beginning of the top-level `CMakeLists.txt` file even before calling the `project()` command.


**🆕 Changelog**
Swapped the `cmake_minimum_required()` and `project()` commands in the top-level `CMakeLists.txt` file.
