### PR TITLE
[CI] Adding `CoSimulationApplication` to Centos CI

### DIFF
--- a/.github/workflows/centos_configure.sh
+++ b/.github/workflows/centos_configure.sh
@@ -25,6 +25,7 @@ add_app ${KRATOS_APP_DIR}/StructuralMechanicsApplication;
 add_app ${KRATOS_APP_DIR}/MeshingApplication;
 add_app ${KRATOS_APP_DIR}/LinearSolversApplication;
 add_app ${KRATOS_APP_DIR}/ConstitutiveLawsApplication;
+add_app ${KRATOS_APP_DIR}/CoSimulationApplication;
 
 # Clean
 clear
@@ -39,11 +40,11 @@ source scl_source enable devtoolset-8
 
 # Configure
 cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
-${KRATOS_CMAKE_OPTIONS_FLAGS} \
--DUSE_MPI=OFF \
--DPYBIND11_PYTHON_VERSION="3.8" \
--DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall" \
--DCMAKE_UNITY_BUILD=ON                              \
+${KRATOS_CMAKE_OPTIONS_FLAGS}                                       \
+-DUSE_MPI=OFF                                                       \
+-DPYBIND11_PYTHON_VERSION="3.8"                                     \
+-DCMAKE_CXX_FLAGS="${KRATOS_CMAKE_CXX_FLAGS} -O0 -Wall"             \
+-DCMAKE_UNITY_BUILD=ON                                              \
 
 # Build
 cmake --build "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" --target install -- -j2

--- a/applications/CoSimulationApplication/custom_external_libraries/CoSimIO/CMakeLists.txt
+++ b/applications/CoSimulationApplication/custom_external_libraries/CoSimIO/CMakeLists.txt
@@ -97,6 +97,9 @@ elseif(${CMAKE_COMPILER_IS_GNUCXX})
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override -Wignored-qualifiers")
     endif()
 
+    # Always link with libstdc++fs.a when using GCC 8.
+    # Note: This command makes sure that this option comes pretty late on the cmdline.
+    link_libraries( "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:-lstdc++fs>" )
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c89")


### PR DESCRIPTION
**📝 Description**

In this PR we modify the `.github/workflows/centos_configure.sh` file.

1. An additional application, `CoSimulationApplication`, was added to the configuration script for CentOS. This is accomplished with the following line:
   ```
   add_app ${KRATOS_APP_DIR}/CoSimulationApplication;
   ```

2. Some modifications were made to the cmake configuration section, basically aesthetic modifying spaces.

NOTE: A priori this will fail until modifications in CoSimIO lib is updated. 

**🆕 Changelog**

- [Adding `CoSimulationApplication` to Centos CI](https://github.com/KratosMultiphysics/Kratos/commit/5e96795819053566de94b093fa06a18082fa3bf1)
