### PR TITLE
[Core] Missing colon in check_same_model_part_using_skin_process.py

### DIFF
--- a/kratos/python_scripts/check_same_model_part_using_skin_process.py
+++ b/kratos/python_scripts/check_same_model_part_using_skin_process.py
@@ -32,7 +32,7 @@ class CheckSameModelPartUsingSkinDistanceProcess(KratosMultiphysics.Process):
 
         # Get first model part (must be defined anyway)
         self.model_part = self.model[settings["skin_model_part_1_name"].GetString()]
-        if not self.model_part.ProcessInfo.Has(KratosMultiphysics.DOMAIN_SIZE)
+        if not self.model_part.ProcessInfo.Has(KratosMultiphysics.DOMAIN_SIZE):
             raise ValueError("DOMAIN_SIZE nor defined in ProcessInfo")
 
 


### PR DESCRIPTION
**📝 Description**
This PR is a quick fix for a missing colon. It is causing cx_freeze to error out when trying to import this script.


**🆕 Changelog**
- Add missing colon
