### PR TITLE
mStrainSize and mSpaceDimension by nature are positive integer types

### DIFF
--- a/kratos/includes/constitutive_law.h
+++ b/kratos/includes/constitutive_law.h
@@ -143,14 +143,14 @@ public:
      * its variables will be used to check constitutive law and element compatibility
 
      * @param mOptions        flags  with the current constitutive law characteristics
-     * @param mStrainSize     double with the strain vector size
+     * @param mStrainSize     SizeType with the strain vector size
      * @param mStrainMeasures vector with the strain measures accepted by the constitutive law
 
      */
 
       Flags                mOptions;
-      double               mStrainSize;
-      double               mSpaceDimension;
+      SizeType             mStrainSize;
+      SizeType             mSpaceDimension;
       std::vector< StrainMeasure > mStrainMeasures;
 
       /**
@@ -168,18 +168,18 @@ public:
       }
 
       // Set variables
-      void SetOptions       (const Flags&  rOptions)      {mOptions=rOptions;};
-      void SetStrainSize    (const double StrainSize)     {mStrainSize=StrainSize;};
-      void SetSpaceDimension(const double SpaceDimension) {mSpaceDimension=SpaceDimension;};
-      void SetStrainMeasure (const StrainMeasure Measure) {mStrainMeasures.push_back(Measure);};
+      void SetOptions        (const Flags&  rOptions)        {mOptions=rOptions;};
+      void SetStrainSize     (const SizeType StrainSize)     {mStrainSize=StrainSize;};
+      void SetSpaceDimension (const SizeType SpaceDimension) {mSpaceDimension=SpaceDimension;};
+      void SetStrainMeasure  (const StrainMeasure Measure)   {mStrainMeasures.push_back(Measure);};
 
       void SetStrainMeasures (const std::vector<StrainMeasure> MeasuresVector) {mStrainMeasures = MeasuresVector;};
 
       // Get variables
       const Flags& GetOptions () {return mOptions;};
 
-      const double& GetStrainSize() {return mStrainSize;};
-      const double& GetSpaceDimension() {return mSpaceDimension;};
+      const SizeType& GetStrainSize()     {return mStrainSize;};
+      const SizeType& GetSpaceDimension() {return mSpaceDimension;};
       std::vector<StrainMeasure>& GetStrainMeasures() {return mStrainMeasures;};
     };
 

--- a/kratos/python/add_constitutive_law_to_python.cpp
+++ b/kratos/python/add_constitutive_law_to_python.cpp
@@ -28,6 +28,7 @@ namespace Kratos::Python
 {
 namespace py = pybind11;
 
+using SizeType = std::size_t;
 typedef ConstitutiveLaw ConstitutiveLawBaseType;
 template<class TVariableType> bool ConstitutiveLawHas(ConstitutiveLaw& rThisConstitutiveLaw, TVariableType const& rThisVariable) { return rThisConstitutiveLaw.Has(rThisVariable); }
 
@@ -58,8 +59,8 @@ void NewInterfaceCalculateMaterialResponse(ConstitutiveLaw& rThisConstitutiveLaw
 {rThisConstitutiveLaw.CalculateMaterialResponse (rValues,rStressMeasure);}
 
 Flags GetFeaturesOptions(ConstitutiveLaw::Features& rThisFeatures){ return rThisFeatures.GetOptions();}
-double GetStrainSizeFeatures(ConstitutiveLaw::Features& rThisFeatures){ return rThisFeatures.GetStrainSize();}
-double GetSpaceDimensionFeatures(ConstitutiveLaw::Features& rThisFeatures){ return rThisFeatures.GetSpaceDimension();}
+SizeType GetStrainSizeFeatures(ConstitutiveLaw::Features& rThisFeatures){ return rThisFeatures.GetStrainSize();}
+SizeType GetSpaceDimensionFeatures(ConstitutiveLaw::Features& rThisFeatures){ return rThisFeatures.GetSpaceDimension();}
 std::vector<ConstitutiveLaw::StrainMeasure>& GetStrainMeasuresFeatures(ConstitutiveLaw::Features& rThisFeatures){ return rThisFeatures.GetStrainMeasures(); }
 
 Flags GetLawOptions(ConstitutiveLaw::Parameters& rThisParameters){ return rThisParameters.GetOptions();}
@@ -162,7 +163,6 @@ void  AddConstitutiveLawToPython(pybind11::module& m)
     .def("GetStressMeasure",&ConstitutiveLaw::GetStressMeasure)
     .def("IsIncremental",&ConstitutiveLaw::IsIncremental)
     .def("WorkingSpaceDimension",&ConstitutiveLaw::WorkingSpaceDimension)
-    .def("GetStrainSize",&ConstitutiveLaw::GetStrainSize)
     .def("Has", &ConstitutiveLawHas< Variable<bool> >)
     .def("Has", &ConstitutiveLawHas< Variable<int> >)
     .def("Has", &ConstitutiveLawHas< Variable<double> >)


### PR DESCRIPTION
Constitutive laws generally should use kratos/includes/constitutive_law.h . Its member variables mStrainSize and mSpaceDimension are currently double, this PR changes them to SizeType.
That should avoid unnatural type conversions in the places where constitutive_law.h is used. E.g. see applications\StructuralMechanicsApplication\custom_response_functions\adjoint_elements\adjoint_finite_difference_small_displacement_element.cpp at line 168.
