### PR TITLE
[GeoMechanics] GeoMechanics with Reduced Order Models using Kratos RomApplication

### DIFF
--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
@@ -268,7 +268,7 @@ class UPwSolver(GeoSolver):
             self.settings["prebuild_dynamics"].GetBool()):
             return KratosGeo.ResidualBasedBlockBuilderAndSolverWithMassAndDamping(self.linear_solver)
 
-        return super()._ConstructBuilderAndSolver(block_builder)
+        return super()._CreateBuilderAndSolver()
 
     def _CheckConvergence(self):
         IsConverged = self.solver.IsConverged()

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
@@ -261,7 +261,8 @@ class UPwSolver(GeoSolver):
 
         return convergence_criterion
 
-    def _ConstructBuilderAndSolver(self, block_builder):
+    def _CreateBuilderAndSolver(self):
+        block_builder = self.settings["block_builder"].GetBool()
         if (block_builder and
             self.settings.Has("prebuild_dynamics") and
             self.settings["prebuild_dynamics"].GetBool()):

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
@@ -226,7 +226,7 @@ class GeoMechanicalSolver(PythonSolver):
         self.linear_solver = self._ConstructLinearSolver()
 
         # Builder and solver creation
-        builder_and_solver = self._ConstructBuilderAndSolver(self.settings["block_builder"].GetBool())
+        builder_and_solver = self._CreateBuilderAndSolver()
 
         # Solution scheme creation
         self.scheme = self._ConstructScheme(self.settings["scheme_type"].GetString(),
@@ -370,6 +370,9 @@ class GeoMechanicalSolver(PythonSolver):
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_Y,self.main_model_part)
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_Z,self.main_model_part)
 
+    def _GetLinearSolver(self):
+        return self.linear_solver
+
     def _ExecuteCheckAndPrepare(self):
 
         self.computing_model_part_name = "porous_computational_model_part"
@@ -437,7 +440,8 @@ class GeoMechanicalSolver(PythonSolver):
         import KratosMultiphysics.python_linear_solver_factory as linear_solver_factory
         return linear_solver_factory.ConstructSolver(self.settings["linear_solver_settings"])
 
-    def _ConstructBuilderAndSolver(self, block_builder):
+    def _CreateBuilderAndSolver(self):
+        block_builder = self.settings["block_builder"].GetBool()
 
         # Creating the builder and solver
         if (block_builder):

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
@@ -226,7 +226,7 @@ class GeoMechanicalSolver(PythonSolver):
         self.linear_solver = self._ConstructLinearSolver()
 
         # Builder and solver creation
-        builder_and_solver = self._CreateBuilderAndSolver()
+        self.builder_and_solver = self._CreateBuilderAndSolver()
 
         # Solution scheme creation
         self.scheme = self._ConstructScheme(self.settings["scheme_type"].GetString(),

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solvers_wrapper.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solvers_wrapper.py
@@ -40,5 +40,5 @@ def CreateSolverByParameters(model, custom_settings, parallelism):
 
 
 def CreateSolver(model, custom_settings):
-    parallelism =  custom_settings["problem_data"]["parallel_type"].GetString()
+    parallelism = custom_settings["problem_data"]["parallel_type"].GetString()
     return CreateSolverByParameters(model, custom_settings,parallelism)

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solvers_wrapper.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solvers_wrapper.py
@@ -41,4 +41,4 @@ def CreateSolverByParameters(model, custom_settings, parallelism):
 
 def CreateSolver(model, custom_settings):
     parallelism = custom_settings["problem_data"]["parallel_type"].GetString()
-    return CreateSolverByParameters(model, custom_settings,parallelism)
+    return CreateSolverByParameters(model, custom_settings["solver_settings"], parallelism)

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solvers_wrapper.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solvers_wrapper.py
@@ -9,13 +9,7 @@ def CreateSolverByParameters(model, custom_settings, parallelism):
     if (type(custom_settings) != KratosMultiphysics.Parameters):
         raise Exception("input is expected to be provided as a Kratos Parameters object")
 
-    if custom_settings.Has("solver_settings"):
-        params = custom_settings["solver_settings"]
-        #To conform with other apps where only the "solver_settings" are passed
-    else:
-        params = custom_settings
-
-    solver_type_raw = params["solver_type"].GetString()
+    solver_type_raw = custom_settings["solver_type"].GetString()
 
     # Solvers for OpenMP parallelism
     if (parallelism == "OpenMP"):
@@ -35,7 +29,7 @@ def CreateSolverByParameters(model, custom_settings, parallelism):
         raise Exception(err_msg)
 
     module_full_name = 'KratosMultiphysics.GeoMechanicsApplication.' + solver_module_name
-    solver = import_module(module_full_name).CreateSolver(model, params)
+    solver = import_module(module_full_name).CreateSolver(model, custom_settings)
     return solver
 
 

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solvers_wrapper.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solvers_wrapper.py
@@ -1,16 +1,21 @@
 import KratosMultiphysics
 from importlib import import_module
 
-def CreateSolver(model, custom_settings):
 
+def CreateSolverByParameters(model, custom_settings, parallelism):
     if (type(model) != KratosMultiphysics.Model):
         raise Exception("input is expected to be provided as a Kratos Model object")
 
     if (type(custom_settings) != KratosMultiphysics.Parameters):
         raise Exception("input is expected to be provided as a Kratos Parameters object")
 
-    parallelism = custom_settings["problem_data"]["parallel_type"].GetString()
-    solver_type_raw = custom_settings["solver_settings"]["solver_type"].GetString()
+    if custom_settings.Has("solver_settings"):
+        params = custom_settings["solver_settings"]
+        #To conform with other apps where only the "solver_settings" are passed
+    else:
+        params = custom_settings
+
+    solver_type_raw = params["solver_type"].GetString()
 
     # Solvers for OpenMP parallelism
     if (parallelism == "OpenMP"):
@@ -30,6 +35,10 @@ def CreateSolver(model, custom_settings):
         raise Exception(err_msg)
 
     module_full_name = 'KratosMultiphysics.GeoMechanicsApplication.' + solver_module_name
-    solver = import_module(module_full_name).CreateSolver(model, custom_settings["solver_settings"])
-
+    solver = import_module(module_full_name).CreateSolver(model, params)
     return solver
+
+
+def CreateSolver(model, custom_settings):
+    parallelism =  custom_settings["problem_data"]["parallel_type"].GetString()
+    return CreateSolverByParameters(model, custom_settings,parallelism)


### PR DESCRIPTION
This PR implements the required changes in two python scripts of the GeoMechanics application to conform with the format expected by the RomApplication.

**📝 Description**
The RomApplication works with other applications in Kratos by keeping the behaviour of the specific app, while changing only the builder and solver. To do this, the format inside the scripts should match the expectations by the RomApp. For the GeoMechanics application, changes to two files were required:

- In **geo_mechanics_solver.py**  the required functions should be named `_CreateBuilderAndSolver` rather than `_ConstructBuilderAndSolver`, and there should be a function returning the linear solver.

- In **geomechanics_solvers_wrapper.py**, the mechanism inside the RomApp for setting the RomBuilderAndSolver requires the existance of the `CreateSolver` and `CreateSolverByParameters` functions which did not exist as separate entitied but combined into a single function `CreateSolver(model, custom_settings)`.

**🆕 Changelog**
In **geo_mechanics_solver.py**
- changed `_ConstructBuilderAndSolver(self, param1)` ==> `_CreateBuilderAndSolver(self)`
- added method _GetLinearSolver(self)

In **geomechanics_solvers_wrapper.py**
- splitted operations ` CreateSolver(model, custom_settings)` ==>` CreateSolver(model, custom_settings)` + `CreateSolverByParameters(model, custom_settings, parallelism`)