### PR TITLE
[GeoMechanicsApplication] Fixed the factory function that creates builder-and-solver objects

### DIFF
--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_U_Pw_solver.py
@@ -261,6 +261,14 @@ class UPwSolver(GeoSolver):
 
         return convergence_criterion
 
+    def _ConstructBuilderAndSolver(self, block_builder):
+        if (block_builder and
+            self.settings.Has("prebuild_dynamics") and
+            self.settings["prebuild_dynamics"].GetBool()):
+            return KratosGeo.ResidualBasedBlockBuilderAndSolverWithMassAndDamping(self.linear_solver)
+
+        return super()._ConstructBuilderAndSolver(block_builder)
+
     def _CheckConvergence(self):
         IsConverged = self.solver.IsConverged()
         return IsConverged

--- a/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
+++ b/applications/GeoMechanicsApplication/python_scripts/geomechanics_solver.py
@@ -226,7 +226,7 @@ class GeoMechanicalSolver(PythonSolver):
         self.linear_solver = self._ConstructLinearSolver()
 
         # Builder and solver creation
-        builder_and_solver = self._ConstructBuilderAndSolver(self.settings["block_builder"].GetBool())
+        self.builder_and_solver = self._ConstructBuilderAndSolver(self.settings["block_builder"].GetBool())
 
         # Solution scheme creation
         self.scheme = self._ConstructScheme(self.settings["scheme_type"].GetString(),
@@ -236,7 +236,7 @@ class GeoMechanicalSolver(PythonSolver):
         self.convergence_criterion = self._ConstructConvergenceCriterion(self.settings["convergence_criterion"].GetString())
 
         # Solver creation
-        self.solver = self._ConstructSolver(builder_and_solver,
+        self.solver = self._ConstructSolver(self.builder_and_solver,
                                             self.settings["strategy_type"].GetString())
 
         # Set echo_level

--- a/applications/GeoMechanicsApplication/tests/test_dynamics.py
+++ b/applications/GeoMechanicsApplication/tests/test_dynamics.py
@@ -2,6 +2,7 @@ import os
 import json
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
+import KratosMultiphysics.GeoMechanicsApplication as KratosGeo
 import test_helper
 
 
@@ -59,7 +60,8 @@ class KratosGeoMechanicsDynamicsTests(KratosUnittest.TestCase):
         test_name = 'test_1d_wave_prop_drained_soil_constant_mass_damping.gid'
         file_path = test_helper.get_file_path(os.path.join('.', test_name))
 
-        test_helper.run_kratos(file_path)
+        simulation = test_helper.run_kratos(file_path)
+        self.assertTrue(isinstance(simulation._GetSolver().builder_and_solver, KratosGeo.ResidualBasedBlockBuilderAndSolverWithMassAndDamping))
 
         with open(os.path.join(file_path, "calculated_result.json")) as fp:
             calculated_result = json.load(fp)


### PR DESCRIPTION
**📝 Description**
The factory function used to be able to create builder-and-solver objects of type `ResidualBasedBlockBuilderAndSolverWithMassAndDamping` when solver setting "prebuild_dynamics" was set to `true`. During some refactoring work (see PR 11127), it was accidentally removed. This commit restores that functionality. Also added a regression test.
