### PR TITLE
[Core] Add `GetDataCommunicator` to `GlobalPointerCommunicator`

### DIFF
--- a/kratos/utilities/pointer_communicator.h
+++ b/kratos/utilities/pointer_communicator.h
@@ -323,6 +323,15 @@ public:
     ///@name Access
     ///@{
 
+    /**
+     * @brief Returns the data communicator.
+     * @return The data communicator.
+     */
+    const DataCommunicator& GetDataCommunicator() const
+    {
+        return mrDataCommunicator;
+    }
+
     ///@}
     ///@name Inquiry
     ///@{


### PR DESCRIPTION
**📝 Description**

In this PR, a new method called `GetDataCommunicator()` has been added to the `GlobalPointerCommunicator` class in the file `pointer_communicator.h`. This method returns the data communicator associated with the `GlobalPointerCommunicator`. This addition enhances the functionality of the class by allowing users to access the data communicator easily.

**🆕 Changelog**

- [Add `GetDataCommunicator` to `GlobalPointerCommunicator`](https://github.com/KratosMultiphysics/Kratos/commit/99e5dbd94e1feb215ea73ba9b2aaa05106eccbb7)
