### PR TITLE
[CoSimulationApplication] Update Cmake from `CoSimIO` porting  KratosMultiphysics/CoSimIO#365

### DIFF
--- a/applications/CoSimulationApplication/custom_external_libraries/CoSimIO/CMakeLists.txt
+++ b/applications/CoSimulationApplication/custom_external_libraries/CoSimIO/CMakeLists.txt
@@ -97,9 +97,9 @@ elseif(${CMAKE_COMPILER_IS_GNUCXX})
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override -Wignored-qualifiers")
     endif()
 
-    # Always link with libstdc++fs.a when using GCC 8.
+    # Always link with libstdc++fs.a when using GCC 8 (greater than 7 and less than 9)
     # Note: This command makes sure that this option comes pretty late on the cmdline.
-    link_libraries( "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:-lstdc++fs>" )
+    link_libraries("$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER:$<CXX_COMPILER_VERSION>,7.0>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:-lstdc++fs>")
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c89")


### PR DESCRIPTION
**📝 Description**

In this PR, changes were made to the CMakeLists.txt file located at `applications/CoSimulationApplication/custom_external_libraries/CoSimIO/CMakeLists.txt`, porting https://github.com/KratosMultiphysics/CoSimIO/pull/365/.  An adjustment was made to the linkage of the `libstdc++fs.a` library. Specifically, it is now linked under the condition that the CXX compiler is GNU (GCC) and the compiler version is greater than 7 but less than 9.

**🆕 Changelog**

- [Update Cmake from KratosMultiphysics/CoSimIO#365] (https://github.com/KratosMultiphysics/Kratos/commit/c57e02104bd94285c630f7d3dfe9cd1a8c1487d3) 