### PR TITLE
[Core] Cleaning the `DisplacementCriteria` and `ResidualCriteria` and adding tests

### DIFF
--- a/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
@@ -430,7 +430,7 @@ private:
                 rTLS.variation_dof_value = Dx[rTLS.dof_id];
                 return std::make_tuple(std::pow(rTLS.variation_dof_value, 2), 1);
             } else {
-                return std::make_tuple(0.0, 0);
+                return std::make_tuple(TDataType(), 0);
             }
         });
 

--- a/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
@@ -61,7 +61,7 @@ public:
     ///@name Type Definitions
     ///@{
 
-    /// Pointer definition of ResidualCriteria
+    /// Pointer definition of DisplacementCriteria
     KRATOS_CLASS_POINTER_DEFINITION( DisplacementCriteria );
 
     /// The definition of the base ConvergenceCriteria

--- a/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
@@ -4,21 +4,20 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //
 //
 
-#if !defined(KRATOS_DISPLACEMENT_CRITERIA )
-#define  KRATOS_DISPLACEMENT_CRITERIA
+#pragma once
 
-/* System includes */
+// System includes
 
-/* External includes */
+// External includes
 
-/* Project includes */
+// Project includes
 #include "includes/model_part.h"
 #include "includes/define.h"
 #include "solving_strategies/convergencecriterias/convergence_criteria.h"
@@ -47,7 +46,7 @@ namespace Kratos
 /**
  * @class DisplacementCriteria
  * @ingroup KratosCore
- * @brief This is a convergence criteria that employes the increment on the solution as criteria
+ * @brief This is a convergence criteria that considers the increment on the solution as criteria
  * @details The reactions from the RHS are not computed in the solution
  * @author Riccardo Rossi
 */
@@ -61,26 +60,32 @@ public:
     ///@name Type Definitions
     ///@{
 
+    /// Pointer definition of ResidualCriteria
     KRATOS_CLASS_POINTER_DEFINITION( DisplacementCriteria );
 
-    typedef ConvergenceCriteria< TSparseSpace, TDenseSpace > BaseType;
+    /// The definition of the base ConvergenceCriteria
+    using BaseType = ConvergenceCriteria< TSparseSpace, TDenseSpace >;
 
     /// The definition of the current class
-    typedef DisplacementCriteria< TSparseSpace, TDenseSpace > ClassType;
+    using ClassType = DisplacementCriteria< TSparseSpace, TDenseSpace >;
 
-    typedef TSparseSpace SparseSpaceType;
+    /// The data type
+    using TDataType = typename BaseType::TDataType;
 
-    typedef typename BaseType::TDataType TDataType;
+    /// The dofs array type
+    using DofsArrayType = typename BaseType::DofsArrayType;
 
-    typedef typename BaseType::DofsArrayType DofsArrayType;
+    /// The sparse matrix type
+    using TSystemMatrixType = typename BaseType::TSystemMatrixType;
 
-    typedef typename BaseType::TSystemMatrixType TSystemMatrixType;
+    /// The dense vector type
+    using TSystemVectorType = typename BaseType::TSystemVectorType;
 
-    typedef typename BaseType::TSystemVectorType TSystemVectorType;
+    /// Definition of the IndexType
+    using IndexType = std::size_t;
 
-    typedef std::size_t IndexType;
-
-    typedef std::size_t SizeType;
+    /// Definition of the size type
+    using SizeType = std::size_t;
 
     ///@}
     ///@name Life Cycle
@@ -128,7 +133,6 @@ public:
     /** Destructor.
     */
     ~DisplacementCriteria() override {}
-
 
     ///@}
     ///@name Operators
@@ -285,7 +289,6 @@ public:
     ///@name Access
     ///@{
 
-
     ///@}
     ///@name Inquiry
     ///@{
@@ -316,23 +319,18 @@ public:
     ///@name Friends
     ///@{
 
-
     ///@}
-
 protected:
     ///@name Protected static Member Variables
     ///@{
-
 
     ///@}
     ///@name Protected member Variables
     ///@{
 
-
     ///@}
     ///@name Protected Operators
     ///@{
-
 
     ///@}
     ///@name Protected Operations
@@ -353,22 +351,18 @@ protected:
     ///@name Protected  Access
     ///@{
 
-
     ///@}
     ///@name Protected Inquiry
     ///@{
-
 
     ///@}
     ///@name Protected LifeCycle
     ///@{
 
     ///@}
-
 private:
     ///@name Static Member Variables
     ///@{
-
 
     ///@}
     ///@name Member Variables
@@ -379,7 +373,6 @@ private:
     TDataType mAlwaysConvergedNorm; /// The absolute value threshold for the norm of the residual
 
     TDataType mReferenceDispNorm;   /// The norm at the beginning of the iterations
-
 
     ///@}
     ///@name Private Operators
@@ -448,35 +441,25 @@ private:
     ///@name Private Operations
     ///@{
 
-
     ///@}
     ///@name Private  Access
     ///@{
-
 
     ///@}
     ///@name Private Inquiry
     ///@{
 
-
     ///@}
     ///@name Un accessible methods
     ///@{
 
-
     ///@}
-
 }; /* Class DisplacementCriteria */
 
 ///@}
-
 ///@name Type Definitions
 ///@{
-
 
 ///@}
 
 }  /* namespace Kratos.*/
-
-#endif /* KRATOS_DISPLACEMENT_CRITERIA  defined */
-

--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -214,6 +214,7 @@ public:
     void Initialize(ModelPart& rModelPart) override
     {
         BaseType::Initialize(rModelPart);
+        KRATOS_ERROR_IF(rModelPart.IsDistributed() && rModelPart.NumberOfMasterSlaveConstraints() > 0) << "This Criteria does not yet support constraints in MPI!" << std::endl;
     }
 
     /**

--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -46,7 +46,7 @@ namespace Kratos
 /**
  * @class ResidualCriteria
  * @ingroup KratosCore
- * @brief This is a convergence criteria that employes the residual as criteria
+ * @brief This is a convergence criteria that considers the residual as criteria
  * @details The reactions from the RHS are not computed in the residual
  * @author Riccardo Rossi
 */
@@ -60,31 +60,32 @@ public:
     ///@name Type Definitions
     ///@{
 
+    /// Pointer definition of ResidualCriteria
     KRATOS_CLASS_POINTER_DEFINITION( ResidualCriteria );
 
     /// The definition of the base ConvergenceCriteria
-    typedef ConvergenceCriteria< TSparseSpace, TDenseSpace > BaseType;
+    using BaseType = ConvergenceCriteria< TSparseSpace, TDenseSpace >;
 
     /// The definition of the current class
-    typedef ResidualCriteria< TSparseSpace, TDenseSpace > ClassType;
+    using ClassType = ResidualCriteria< TSparseSpace, TDenseSpace >;
 
     /// The data type
-    typedef typename BaseType::TDataType TDataType;
+    using TDataType = typename BaseType::TDataType;
 
     /// The dofs array type
-    typedef typename BaseType::DofsArrayType DofsArrayType;
+    using DofsArrayType = typename BaseType::DofsArrayType;
 
     /// The sparse matrix type
-    typedef typename BaseType::TSystemMatrixType TSystemMatrixType;
+    using TSystemMatrixType = typename BaseType::TSystemMatrixType;
 
     /// The dense vector type
-    typedef typename BaseType::TSystemVectorType TSystemVectorType;
+    using TSystemVectorType = typename BaseType::TSystemVectorType;
 
     /// Definition of the IndexType
-    typedef std::size_t IndexType;
+    using IndexType = std::size_t;
 
     /// Definition of the size type
-    typedef std::size_t SizeType;
+    using SizeType = std::size_t;
 
     ///@}
     ///@name Life Cycle
@@ -211,7 +212,6 @@ public:
     void Initialize(ModelPart& rModelPart) override
     {
         BaseType::Initialize(rModelPart);
-        KRATOS_ERROR_IF(rModelPart.IsDistributed() && rModelPart.NumberOfMasterSlaveConstraints() > 0) << "This Criteria does not yet support constraints in MPI!" << std::endl;
     }
 
     /**
@@ -323,7 +323,6 @@ public:
     ///@{
 
     ///@}
-
 protected:
     ///@name Protected static Member Variables
     ///@{
@@ -422,7 +421,6 @@ protected:
     ///@{
 
     ///@}
-
 private:
     ///@name Static Member Variables
     ///@{

--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -377,7 +377,7 @@ protected:
                     rTLS.residual_dof_value = TSparseSpace::GetValue(rb, dof_id);
                     return std::make_tuple(std::pow(rTLS.residual_dof_value, 2), 1);
                 } else {
-                    return std::make_tuple(0.0, 0);
+                    return std::make_tuple(TDataType(), 0);;
                 }
             });
         } else {
@@ -387,7 +387,7 @@ protected:
                     rTLS.residual_dof_value = TSparseSpace::GetValue(rb, dof_id);
                     return std::make_tuple(std::pow(rTLS.residual_dof_value, 2), 1);
                 } else {
-                    return std::make_tuple(0.0, 0);
+                    return std::make_tuple(TDataType(), 0);;
                 }
             });
         }

--- a/kratos/tests/cpp_tests/strategies/convergence_criteria/test_displacement_criteria.cpp
+++ b/kratos/tests/cpp_tests/strategies/convergence_criteria/test_displacement_criteria.cpp
@@ -26,8 +26,7 @@
 
 namespace Kratos::Testing
 {
-using NodeType = Node;
-using GeometryType = Geometry<NodeType>;
+using GeometryType = Geometry<Node>;
 using LocalSpaceType = UblasSpace<double, Matrix, Vector>;
 using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;
 

--- a/kratos/tests/cpp_tests/strategies/convergence_criteria/test_displacement_criteria.cpp
+++ b/kratos/tests/cpp_tests/strategies/convergence_criteria/test_displacement_criteria.cpp
@@ -1,0 +1,115 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+// System includes
+#include <limits>
+
+// External includes
+
+// Project includes
+#include "testing/testing.h"
+#include "containers/model.h"
+#include "geometries/point_3d.h"
+#include "includes/define.h"
+#include "includes/model_part.h"
+#include "solving_strategies/convergencecriterias/displacement_criteria.h"
+#include "spaces/ublas_space.h"
+
+namespace Kratos::Testing
+{
+using NodeType = Node;
+using GeometryType = Geometry<NodeType>;
+using LocalSpaceType = UblasSpace<double, Matrix, Vector>;
+using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;
+
+using DofsArrayType = ModelPart::DofsArrayType;
+
+using DisplacementCriteriaType = DisplacementCriteria<SparseSpaceType, LocalSpaceType>;
+
+void GenerateTestDisplacementCriteriaModelPart(ModelPart& rModelPart)
+{
+    // Model part settings
+    rModelPart.SetBufferSize(1);
+    rModelPart.AddNodalSolutionStepVariable(PRESSURE);
+
+    // Create the auxiliary set of nodes
+    const unsigned int n_nodes = 10;
+    for (unsigned int i_node = 0; i_node < n_nodes; ++i_node) {
+        auto p_node = rModelPart.CreateNewNode(i_node + 1, 0.0, 0.0, 0.0); // Coordinates do not matter in this test
+        rModelPart.AddNode(p_node);
+    }
+}
+
+/**
+ * Checks the displacement criteria with two double variables
+ */
+KRATOS_TEST_CASE_IN_SUITE(DisplacementCriteria, KratosCoreFastSuite)
+{
+    Model current_model;
+    ModelPart& r_model_part = current_model.CreateModelPart("TestModelPart");
+
+    // Set the test model part
+    GenerateTestDisplacementCriteriaModelPart(r_model_part); // Create the geometry
+
+    // Add the corresponding test DOFs
+    r_model_part.GetNodalSolutionStepVariablesList().AddDof(&PRESSURE);
+    for (auto& r_node : r_model_part.Nodes()) {
+        r_node.AddDof(PRESSURE);
+    }
+
+    // Create the displacement criteria
+    const double rel_tol = 1.0e-3;
+    const double abs_tol = 1.0e-5;
+    auto displacement_criteria = DisplacementCriteriaType(rel_tol, abs_tol);
+
+    // Set the auxiliary arrays
+    DofsArrayType aux_dof_set;
+    aux_dof_set.reserve(10);
+    for (auto& r_node : r_model_part.Nodes()) {
+        aux_dof_set.push_back(r_node.pGetDof(PRESSURE));
+    }
+    aux_dof_set.Sort();
+    typename DisplacementCriteriaType::TSystemMatrixType A; // Only required to match the API
+    typename DisplacementCriteriaType::TSystemVectorType b; // Only required to match the API
+    typename DisplacementCriteriaType::TSystemVectorType Dx(10);
+
+    // Set the auxiliary fake data to check the convergence for
+    unsigned int i = 0;
+    const double aux_constant = 1.0e-3;
+
+    // Set the auxiliary fake data to check the convergence for (failing)
+    for (auto& r_node : r_model_part.Nodes()) {
+        const double aux_val = r_node.Id() * aux_constant;
+        r_node.FastGetSolutionStepValue(PRESSURE) = aux_val;
+        Dx[i] = aux_val;
+        i++;
+    }
+
+    // Check convergence
+    bool convergence = displacement_criteria.PostCriteria(r_model_part, aux_dof_set, A, Dx, b);
+    KRATOS_EXPECT_FALSE(convergence)
+
+    // Set the auxiliary fake data to check the convergence for (passing)
+    i = 0;
+    for (auto& r_node : r_model_part.Nodes()) {
+        const double aux_val = r_node.Id() * aux_constant;
+        r_node.FastGetSolutionStepValue(PRESSURE) = aux_val;
+        Dx[i] = aux_val / 200.0;
+        i++;
+    }
+
+    // Check convergence
+    convergence = displacement_criteria.PostCriteria(r_model_part, aux_dof_set, A, Dx, b);
+    KRATOS_EXPECT_TRUE(convergence)
+}
+
+} // namespace Kratos::Testing

--- a/kratos/tests/cpp_tests/strategies/convergence_criteria/test_displacement_criteria.cpp
+++ b/kratos/tests/cpp_tests/strategies/convergence_criteria/test_displacement_criteria.cpp
@@ -105,7 +105,7 @@ KRATOS_TEST_CASE_IN_SUITE(DisplacementCriteria, KratosCoreFastSuite)
     for (auto& r_node : r_model_part.Nodes()) {
         const double aux_val = r_node.Id() * aux_constant;
         r_node.FastGetSolutionStepValue(PRESSURE) = aux_val;
-        Dx[i] = aux_val / 200.0;
+        Dx[i] = aux_val / 1000.0;
         i++;
     }
 

--- a/kratos/tests/cpp_tests/strategies/convergence_criteria/test_displacement_criteria.cpp
+++ b/kratos/tests/cpp_tests/strategies/convergence_criteria/test_displacement_criteria.cpp
@@ -49,7 +49,7 @@ void GenerateTestDisplacementCriteriaModelPart(ModelPart& rModelPart)
 }
 
 /**
- * Checks the displacement criteria with two double variables
+ * Checks the displacement criteria
  */
 KRATOS_TEST_CASE_IN_SUITE(DisplacementCriteria, KratosCoreFastSuite)
 {

--- a/kratos/tests/cpp_tests/strategies/convergence_criteria/test_displacement_criteria.cpp
+++ b/kratos/tests/cpp_tests/strategies/convergence_criteria/test_displacement_criteria.cpp
@@ -71,6 +71,9 @@ KRATOS_TEST_CASE_IN_SUITE(DisplacementCriteria, KratosCoreFastSuite)
     auto displacement_criteria = DisplacementCriteriaType(rel_tol, abs_tol);
 
     // Set the auxiliary arrays
+    for (auto& r_node : r_model_part.Nodes()) {
+        r_node.pGetDof(PRESSURE)->SetEquationId(r_node.Id() - 1);
+    }
     DofsArrayType aux_dof_set;
     aux_dof_set.reserve(10);
     for (auto& r_node : r_model_part.Nodes()) {

--- a/kratos/tests/cpp_tests/strategies/convergence_criteria/test_residual_criteria.cpp
+++ b/kratos/tests/cpp_tests/strategies/convergence_criteria/test_residual_criteria.cpp
@@ -26,8 +26,7 @@
 
 namespace Kratos::Testing
 {
-using NodeType = Node;
-using GeometryType = Geometry<NodeType>;
+using GeometryType = Geometry<Node>;
 using LocalSpaceType = UblasSpace<double, Matrix, Vector>;
 using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;
 

--- a/kratos/tests/cpp_tests/strategies/convergence_criteria/test_residual_criteria.cpp
+++ b/kratos/tests/cpp_tests/strategies/convergence_criteria/test_residual_criteria.cpp
@@ -1,0 +1,112 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+// System includes
+#include <limits>
+
+/* External includes */
+
+/* Project includes */
+#include "testing/testing.h"
+#include "containers/model.h"
+#include "geometries/point_3d.h"
+#include "includes/define.h"
+#include "includes/model_part.h"
+#include "solving_strategies/convergencecriterias/residual_criteria.h"
+#include "spaces/ublas_space.h"
+
+namespace Kratos::Testing
+{
+using NodeType = Node;
+using GeometryType = Geometry<NodeType>;
+using LocalSpaceType = UblasSpace<double, Matrix, Vector>;
+using SparseSpaceType = UblasSpace<double, CompressedMatrix, Vector>;
+
+using DofsArrayType = ModelPart::DofsArrayType;
+
+using ResidualCriteriaType = ResidualCriteria<SparseSpaceType, LocalSpaceType>;
+
+void GenerateTestResidualCriteriaModelPart(ModelPart& rModelPart)
+{
+    // Model part settings
+    rModelPart.SetBufferSize(1);
+    rModelPart.AddNodalSolutionStepVariable(PRESSURE);
+
+    // Create the auxiliary set of nodes
+    const unsigned int n_nodes = 10;
+    for (unsigned int i_node = 0; i_node < n_nodes; ++i_node) {
+        auto p_node = rModelPart.CreateNewNode(i_node + 1, 0.0, 0.0, 0.0); // Coordinates do not matter in this test
+        rModelPart.AddNode(p_node);
+    }
+}
+
+/**
+ * Checks the residual criteria with two double variables
+ */
+KRATOS_TEST_CASE_IN_SUITE(ResidualCriteria, KratosCoreFastSuite)
+{
+    Model current_model;
+    ModelPart& r_model_part = current_model.CreateModelPart("TestModelPart");
+
+    // Set the test model part
+    GenerateTestResidualCriteriaModelPart(r_model_part); // Create the geometry
+
+    // Add the corresponding test DOFs
+    r_model_part.GetNodalSolutionStepVariablesList().AddDof(&PRESSURE);
+    for (auto& r_node : r_model_part.Nodes()) {
+        r_node.AddDof(PRESSURE);
+    }
+
+    // Create the residual criteria
+    const double rel_tol = 1.0e-3;
+    const double abs_tol = 1.0e-5;
+    auto residual_criteria = ResidualCriteriaType(rel_tol, abs_tol);
+
+    // Set the auxiliary arrays
+    DofsArrayType aux_dof_set;
+    aux_dof_set.reserve(10);
+    for (auto& r_node : r_model_part.Nodes()) {
+        aux_dof_set.push_back(r_node.pGetDof(PRESSURE));
+    }
+    aux_dof_set.Sort();
+    typename ResidualCriteriaType::TSystemMatrixType A; // Only required to match the API
+    typename ResidualCriteriaType::TSystemVectorType b(10);
+    typename ResidualCriteriaType::TSystemVectorType Dx; // Only required to match the API
+
+    // Set the auxiliary fake data to check the convergence for
+    unsigned int i = 0;
+    const double aux_constant = 1.0e-3;
+
+    // Set the auxiliary fake data to check the convergence for (initialization)
+    for (auto& r_node : r_model_part.Nodes()) {
+        const double aux_val = r_node.Id() * aux_constant;
+        b[i] = aux_val;
+        i++;
+    }
+
+    // Initialize the solution step
+    residual_criteria.InitializeSolutionStep(r_model_part, aux_dof_set, A, Dx, b);
+
+    // Set the auxiliary fake data to check the convergence for (passing)
+    i = 0;
+    for (auto& r_node : r_model_part.Nodes()) {
+        const double aux_val = r_node.Id() * aux_constant;
+        b[i] = aux_val / 200.0;
+        i++;
+    }
+
+    // Check convergence
+    const bool convergence = residual_criteria.PostCriteria(r_model_part, aux_dof_set, A, Dx, b);
+    KRATOS_EXPECT_TRUE(convergence)
+}
+
+} // namespace Kratos::Testing

--- a/kratos/tests/cpp_tests/strategies/convergence_criteria/test_residual_criteria.cpp
+++ b/kratos/tests/cpp_tests/strategies/convergence_criteria/test_residual_criteria.cpp
@@ -13,9 +13,9 @@
 // System includes
 #include <limits>
 
-/* External includes */
+// External includes
 
-/* Project includes */
+// Project includes
 #include "testing/testing.h"
 #include "containers/model.h"
 #include "geometries/point_3d.h"
@@ -71,6 +71,9 @@ KRATOS_TEST_CASE_IN_SUITE(ResidualCriteria, KratosCoreFastSuite)
     auto residual_criteria = ResidualCriteriaType(rel_tol, abs_tol);
 
     // Set the auxiliary arrays
+    for (auto& r_node : r_model_part.Nodes()) {
+        r_node.pGetDof(PRESSURE)->SetEquationId(r_node.Id() - 1);
+    }
     DofsArrayType aux_dof_set;
     aux_dof_set.reserve(10);
     for (auto& r_node : r_model_part.Nodes()) {

--- a/kratos/tests/cpp_tests/strategies/convergence_criteria/test_residual_criteria.cpp
+++ b/kratos/tests/cpp_tests/strategies/convergence_criteria/test_residual_criteria.cpp
@@ -49,7 +49,7 @@ void GenerateTestResidualCriteriaModelPart(ModelPart& rModelPart)
 }
 
 /**
- * Checks the residual criteria with two double variables
+ * Checks the residual criteria
  */
 KRATOS_TEST_CASE_IN_SUITE(ResidualCriteria, KratosCoreFastSuite)
 {
@@ -103,6 +103,81 @@ KRATOS_TEST_CASE_IN_SUITE(ResidualCriteria, KratosCoreFastSuite)
     for (auto& r_node : r_model_part.Nodes()) {
         const double aux_val = r_node.Id() * aux_constant;
         b[i] = aux_val / 200.0;
+        i++;
+    }
+
+    // Check convergence
+    const bool convergence = residual_criteria.PostCriteria(r_model_part, aux_dof_set, A, Dx, b);
+    KRATOS_EXPECT_TRUE(convergence)
+}
+
+/**
+ * Checks the residual criteria with MPC
+ */
+KRATOS_TEST_CASE_IN_SUITE(ResidualCriteriaWithMPC, KratosCoreFastSuite)
+{
+    Model current_model;
+    ModelPart& r_model_part = current_model.CreateModelPart("TestModelPart");
+
+    // Set the test model part
+    GenerateTestResidualCriteriaModelPart(r_model_part); // Create the geometry
+
+    // Add the corresponding test DOFs
+    r_model_part.GetNodalSolutionStepVariablesList().AddDof(&PRESSURE);
+    for (auto& r_node : r_model_part.Nodes()) {
+        r_node.AddDof(PRESSURE);
+    }
+
+    // Create the residual criteria
+    const double rel_tol = 1.0e-3;
+    const double abs_tol = 1.0e-5;
+    auto residual_criteria = ResidualCriteriaType(rel_tol, abs_tol);
+
+    // Set the auxiliary arrays
+    for (auto& r_node : r_model_part.Nodes()) {
+        r_node.pGetDof(PRESSURE)->SetEquationId(r_node.Id() - 1);
+    }
+    DofsArrayType aux_dof_set;
+    aux_dof_set.reserve(10);
+    for (auto& r_node : r_model_part.Nodes()) {
+        aux_dof_set.push_back(r_node.pGetDof(PRESSURE));
+    }
+    aux_dof_set.Sort();
+
+    // Adding MPC
+    auto p_mpc_1 = r_model_part.CreateNewMasterSlaveConstraint("LinearMasterSlaveConstraint", 1, r_model_part.GetNode(1), PRESSURE, r_model_part.GetNode(2), PRESSURE, 1.0, 0.0);
+    auto p_mpc_2 = r_model_part.CreateNewMasterSlaveConstraint("LinearMasterSlaveConstraint", 2, r_model_part.GetNode(3), PRESSURE, r_model_part.GetNode(4), PRESSURE, 1.0, 0.0);
+
+    // Fix nodes
+    r_model_part.GetNode(1).Fix(PRESSURE);
+    r_model_part.GetNode(3).Fix(PRESSURE);
+
+    typename ResidualCriteriaType::TSystemMatrixType A; // Only required to match the API
+    typename ResidualCriteriaType::TSystemVectorType b(10);
+    typename ResidualCriteriaType::TSystemVectorType Dx; // Only required to match the API
+
+    // Set the auxiliary fake data to check the convergence for
+    unsigned int i = 0;
+    const double aux_constant = 1.0e-3;
+
+    // Set the auxiliary fake data to check the convergence for (initialization)
+    for (auto& r_node : r_model_part.Nodes()) {
+        const double aux_val = r_node.Id() * aux_constant;
+        b[i] = aux_val;
+        i++;
+    }
+
+    // Initialize the solution step
+    residual_criteria.InitializeSolutionStep(r_model_part, aux_dof_set, A, Dx, b);
+
+    // Set the auxiliary fake data to check the convergence for (passing)
+    i = 0;
+    for (auto& r_node : r_model_part.Nodes()) {
+        // Non fixed or MPC nodes
+        if (i > 3) {
+            const double aux_val = r_node.Id() * aux_constant;
+            b[i] = aux_val / 1000.0;
+        }
         i++;
     }
 


### PR DESCRIPTION
**📝 Description**

The following PR cleans up the `DisplacementCriteria` and `ResidualCriteria` and adding tests, in summary:

1. In the file "kratos/solving_strategies/convergencecriterias/displacement_criteria.h":
   - Improved documentation and comments.
   - Updated type definitions and member variables.
   - Using parallel utilities.
   - Adding C++ test.

2. In the file "kratos/solving_strategies/convergencecriterias/residual_criteria.h":
   - Updated type definitions and comments.
   - Improved documentation and comments.
   - Using parallel utilities.
   - Adding C++ test.

**🆕 Changelog**

- [Cleaning the `DisplacementCriteria` and `ResidualCriteria`](https://github.com/KratosMultiphysics/Kratos/commit/873813e3e88dcb2e150b4fbbc7ed87d512c93a0d)
- [Using paralell utilities in `DisplacementCriteria` and `ResidualCriteria`](https://github.com/KratosMultiphysics/Kratos/commit/dfc099d094774e5564bd5d49a90f947b12d66a9a)
- [Adding test for `DisplacementCriteria` and `ResidualCriteria`](https://github.com/KratosMultiphysics/Kratos/commit/a4dd19694c6cabd082ea2fbc5a3cab940f3ca2e5)
