### PR TITLE
[Fluid] Fixing uninitialized value in alternative_d_vms_dem_coupled element

### DIFF
--- a/applications/FluidDynamicsApplication/custom_elements/alternative_d_vms_dem_coupled.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/alternative_d_vms_dem_coupled.cpp
@@ -205,7 +205,12 @@ void AlternativeDVMSDEMCoupled<TElementData>::Initialize(const ProcessInfo& rCur
             mPreviousVelocity[g] = ZeroVector(Dim);
     }
 
-    mPredictedSubscaleVelocity.resize(number_of_gauss_points);
+    if (mPredictedSubscaleVelocity.size() != number_of_gauss_points) {
+        mPredictedSubscaleVelocity.resize(number_of_gauss_points);
+        for (unsigned int g = 0; g < number_of_gauss_points; g++) {
+            mPredictedSubscaleVelocity[g] = ZeroVector(Dim);
+        }
+    }
 
     // The old velocity may be already defined (if restarting)
     // and we want to keep the loaded values in that case.

--- a/applications/FluidDynamicsApplication/custom_elements/alternative_d_vms_dem_coupled.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/alternative_d_vms_dem_coupled.cpp
@@ -206,9 +206,10 @@ void AlternativeDVMSDEMCoupled<TElementData>::Initialize(const ProcessInfo& rCur
     }
 
     if (mPredictedSubscaleVelocity.size() != number_of_gauss_points) {
+        Vector zero_vector = ZeroVector(Dim);
         mPredictedSubscaleVelocity.resize(number_of_gauss_points);
         for (unsigned int g = 0; g < number_of_gauss_points; g++) {
-            mPredictedSubscaleVelocity[g] = ZeroVector(Dim);
+            mPredictedSubscaleVelocity[g] = zero_vector ;
         }
     }
 


### PR DESCRIPTION
**📝 Description**
One of the test from fluid dynamics app was failing in @KratosMultiphysics/altair CI, it seems it was because mPredictedSubscaleVelocity was being used without being initialized. I think this fixes the problem.