### PR TITLE
[Core] Toward Trilinos/MPI unification of `DisplacementCriteria`/`ResidualCriteria`

### DIFF
--- a/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
@@ -186,8 +186,9 @@ public:
     {
         const int rank = rModelPart.GetCommunicator().MyPID();
         const TDataType approx_zero_tolerance = std::numeric_limits<TDataType>::epsilon();
-        if (SparseSpaceType::Size(rDx) != 0) { //if we are solving for something
-            unsigned int size_solution;
+        const SizeType size_Dx = SparseSpaceType::Size(rDx);
+        if (size_Dx != 0) { //if we are solving for something
+            SizeType size_solution;
             const TDataType final_correction_norm = CalculateFinalCorrectionNorm(size_solution, rDofSet, rDx, rModelPart);
 
             TDataType ratio{};
@@ -455,7 +456,7 @@ private:
      * @todo We should doo as in the residual criteria, and consider the active DoFs (not just free), taking into account the MPC in addition to fixed DoFs
      */
     TDataType CalculateFinalCorrectionNorm(
-        unsigned int& rDofNum,
+        SizeType& rDofNum,
         DofsArrayType& rDofSet,
         const TSystemVectorType& rDx,
         ModelPart& rModelPart
@@ -469,10 +470,10 @@ private:
 
         // Initialize
         TDataType final_correction_norm = TDataType();
-        unsigned int dof_num = 0;
+        SizeType dof_num = 0;
 
         // Custom reduction
-        using CustomReduction = CombinedReduction<SumReduction<TDataType>,SumReduction<unsigned int>>;
+        using CustomReduction = CombinedReduction<SumReduction<TDataType>,SumReduction<SizeType>>;
 
         // Auxiliary struct
         struct TLS {TDataType dof_value{}; TDataType variation_dof_value{};};

--- a/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
@@ -488,7 +488,7 @@ private:
             }
         });
 
-        rDofNum = r_data_communicator.SumAll(dof_num);
+        rDofNum = static_cast<SizeType>(r_data_communicator.SumAll(dof_num));
         return std::sqrt(r_data_communicator.SumAll(final_correction_norm));
     }
 

--- a/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
@@ -70,11 +70,17 @@ public:
     /// The definition of the current class
     using ClassType = DisplacementCriteria< TSparseSpace, TDenseSpace >;
 
+    /// The definition of the sparse space type
+    using SparseSpaceType = TSparseSpace;
+
     /// The data type
     using TDataType = typename BaseType::TDataType;
 
     /// The dofs array type
     using DofsArrayType = typename BaseType::DofsArrayType;
+
+    /// The definition of the DoF data type
+    using DofType = typename Node::DofType;
 
     /// The sparse matrix type
     using TSystemMatrixType = typename BaseType::TSystemMatrixType;
@@ -92,7 +98,7 @@ public:
     ///@name Life Cycle
     ///@{
 
-    //* Constructor.
+    /// Constructor.
     explicit DisplacementCriteria()
         : BaseType()
     {
@@ -110,8 +116,11 @@ public:
         this->AssignSettings(ThisParameters);
     }
 
-    /** Constructor.
-    */
+    /**
+     * @brief Constructor 2 arguments
+     * @param NewRatioTolerance The ratio tolerance for the convergence.
+     * @param AlwaysConvergedNorm The absolute tolerance for the convergence.
+     */
     explicit DisplacementCriteria(
         TDataType NewRatioTolerance,
         TDataType AlwaysConvergedNorm)
@@ -121,8 +130,10 @@ public:
     {
     }
 
-    /** Copy constructor.
-    */
+    /**
+     * @brief Copy constructor
+     * @param rOther The criteria to be copied
+     */
     explicit DisplacementCriteria( DisplacementCriteria const& rOther )
       :BaseType(rOther)
       ,mRatioTolerance(rOther.mRatioTolerance)
@@ -131,13 +142,17 @@ public:
     {
     }
 
-    /** Destructor.
-    */
+    /**
+     * @brief Destructor.
+     */
     ~DisplacementCriteria() override {}
 
     ///@}
     ///@name Operators
     ///@{
+
+    /// Deleted assignment operator.
+    DisplacementCriteria& operator=(DisplacementCriteria const& rOther) = delete;
 
     ///@}
     ///@name Operations
@@ -156,28 +171,29 @@ public:
      * Compute relative and absolute error.
      * @param rModelPart Reference to the ModelPart containing the problem.
      * @param rDofSet Reference to the container of the problem's degrees of freedom (stored by the BuilderAndSolver)
-     * @param A System matrix (unused)
-     * @param Dx Vector of results (variations on nodal variables)
-     * @param b RHS vector (residual + reactions)
+     * @param rA System matrix (unused)
+     * @param rDx Vector of results (variations on nodal variables)
+     * @param rb RHS vector (residual + reactions)
      * @return true if convergence is achieved, false otherwise
      */
     bool PostCriteria(
         ModelPart& rModelPart,
         DofsArrayType& rDofSet,
-        const TSystemMatrixType& A,
-        const TSystemVectorType& Dx,
-        const TSystemVectorType& b
+        const TSystemMatrixType& rA,
+        const TSystemVectorType& rDx,
+        const TSystemVectorType& rb
         ) override
     {
+        const int rank = rModelPart.GetCommunicator().MyPID();
         const TDataType approx_zero_tolerance = std::numeric_limits<TDataType>::epsilon();
-        const SizeType size_Dx = Dx.size();
+        const SizeType size_Dx = SparseSpaceType::Size(rDx);
         if (size_Dx != 0) { //if we are solving for something
             SizeType size_solution;
-            TDataType final_correction_norm = CalculateFinalCorrectionNorm(size_solution, rDofSet, Dx);
+            const TDataType final_correction_norm = CalculateFinalCorrectionNorm(size_solution, rDofSet, rDx, rModelPart);
 
-            TDataType ratio = 0.0;
+            TDataType ratio{};
 
-            CalculateReferenceNorm(rDofSet);
+            CalculateReferenceNorm(rDofSet, rModelPart);
             if (mReferenceDispNorm < approx_zero_tolerance) {
                 KRATOS_WARNING("DisplacementCriteria") << "NaN norm is detected. Setting reference to convergence criteria" << std::endl;
                 mReferenceDispNorm = final_correction_norm;
@@ -193,13 +209,13 @@ public:
 
             const TDataType absolute_norm = (final_correction_norm/std::sqrt(float_size_solution));
 
-            KRATOS_INFO_IF("DISPLACEMENT CRITERION", this->GetEchoLevel() > 0 && rModelPart.GetCommunicator().MyPID() == 0) << " :: [ Obtained ratio = " << ratio << "; Expected ratio = " << mRatioTolerance << "; Absolute norm = " << absolute_norm << "; Expected norm =  " << mAlwaysConvergedNorm << "]" << std::endl;
+            KRATOS_INFO_IF("DISPLACEMENT CRITERION", this->GetEchoLevel() > 0 && rank == 0) << " :: [ Obtained ratio = " << ratio << "; Expected ratio = " << mRatioTolerance << "; Absolute norm = " << absolute_norm << "; Expected norm =  " << mAlwaysConvergedNorm << "]" << std::endl;
 
             rModelPart.GetProcessInfo()[CONVERGENCE_RATIO] = ratio;
             rModelPart.GetProcessInfo()[RESIDUAL_NORM] = absolute_norm;
 
             if ( ratio <= mRatioTolerance  ||  absolute_norm<mAlwaysConvergedNorm )  { //  || (final_correction_norm/x.size())<=1e-7)
-                KRATOS_INFO_IF("DISPLACEMENT CRITERION", this->GetEchoLevel() > 0 && rModelPart.GetCommunicator().MyPID() == 0) << "Convergence is achieved" << std::endl;
+                KRATOS_INFO_IF("DISPLACEMENT CRITERION", this->GetEchoLevel() > 0 && rank == 0) << "Convergence is achieved" << std::endl;
                 return true;
             } else {
                 return false;
@@ -224,38 +240,38 @@ public:
      * This function initializes the solution step
      * @param rModelPart Reference to the ModelPart containing the problem.
      * @param rDofSet Reference to the container of the problem's degrees of freedom (stored by the BuilderAndSolver)
-     * @param A System matrix (unused)
-     * @param Dx Vector of results (variations on nodal variables)
-     * @param b RHS vector (residual + reactions)
+     * @param rA System matrix (unused)
+     * @param rDx Vector of results (variations on nodal variables)
+     * @param rb RHS vector (residual + reactions)
      */
     void InitializeSolutionStep(
         ModelPart& rModelPart,
         DofsArrayType& rDofSet,
-        const TSystemMatrixType& A,
-        const TSystemVectorType& Dx,
-        const TSystemVectorType& b
+        const TSystemMatrixType& rA,
+        const TSystemVectorType& rDx,
+        const TSystemVectorType& rb
         ) override
     {
-        BaseType::InitializeSolutionStep(rModelPart, rDofSet, A, Dx, b);
+        BaseType::InitializeSolutionStep(rModelPart, rDofSet, rA, rDx, rb);
     }
 
     /**
      * This function finalizes the solution step
      * @param rModelPart Reference to the ModelPart containing the problem.
      * @param rDofSet Reference to the container of the problem's degrees of freedom (stored by the BuilderAndSolver)
-     * @param A System matrix (unused)
-     * @param Dx Vector of results (variations on nodal variables)
-     * @param b RHS vector (residual + reactions)
+     * @param rA System matrix (unused)
+     * @param rDx Vector of results (variations on nodal variables)
+     * @param rb RHS vector (residual + reactions)
      */
     void FinalizeSolutionStep(
         ModelPart& rModelPart,
         DofsArrayType& rDofSet,
-        const TSystemMatrixType& A,
-        const TSystemVectorType& Dx,
-        const TSystemVectorType& b
+        const TSystemMatrixType& rA,
+        const TSystemVectorType& rDx,
+        const TSystemVectorType& rb
         ) override
     {
-        BaseType::FinalizeSolutionStep(rModelPart, rDofSet, A, Dx, b);
+        BaseType::FinalizeSolutionStep(rModelPart, rDofSet, rA, rDx, rb);
     }
 
     /**
@@ -329,6 +345,12 @@ protected:
     ///@name Protected member Variables
     ///@{
 
+    TDataType mRatioTolerance;      /// The ratio threshold for the norm of the residual
+
+    TDataType mAlwaysConvergedNorm; /// The absolute value threshold for the norm of the residual
+
+    TDataType mReferenceDispNorm;   /// The norm at the beginning of the iterations
+
     ///@}
     ///@name Protected Operators
     ///@{
@@ -369,35 +391,60 @@ private:
     ///@name Member Variables
     ///@{
 
-    TDataType mRatioTolerance;      /// The ratio threshold for the norm of the residual
-
-    TDataType mAlwaysConvergedNorm; /// The absolute value threshold for the norm of the residual
-
-    TDataType mReferenceDispNorm;   /// The norm at the beginning of the iterations
-
     ///@}
     ///@name Private Operators
     ///@{
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+    /**
+     * @brief Check if a Degree of Freedom (Dof) is free.
+     * @details This function checks if a given Degree of Freedom (Dof) is free.
+     * @param rDof The Degree of Freedom to check.
+     * @param Rank The rank of the Dof.
+     * @return True if the Dof is free, false otherwise.
+     * @todo We should doo as in the residual criteria, and consider the active DoFs (not just free), taking into account the MPC in addition to fixed DoFs
+     */
+    virtual bool IsFreeDof(
+        const DofType& rDof,
+        const int Rank
+        )
+    {
+        return rDof.IsFree();
+    }
 
     /**
      * @brief This method computes the reference norm
      * @details It checks if the dof is fixed
      * @param rDofSet Reference to the container of the problem's degrees of freedom (stored by the BuilderAndSolver)
+     * @param rModelPart Reference to the ModelPart containing the problem.
+     * @todo We should doo as in the residual criteria, and consider the active DoFs (not just free), taking into account the MPC in addition to fixed DoFs
      */
-    void CalculateReferenceNorm(DofsArrayType& rDofSet)
+    void CalculateReferenceNorm(
+        DofsArrayType& rDofSet,
+        ModelPart& rModelPart
+        )
     {
+        // Retrieve the data communicator
+        const auto& r_data_communicator = rModelPart.GetCommunicator().GetDataCommunicator();
+
+        // The current MPI rank
+        const int rank = r_data_communicator.Rank();
+
         // Auxiliary struct
         struct TLS {TDataType dof_value{};};
 
-        const TDataType reference_disp_norm = block_for_each<SumReduction<TDataType>>(rDofSet, TLS(), [](auto& rDof, TLS& rTLS) {
-            if(rDof.IsFree()) {
+        const TDataType reference_disp_norm = block_for_each<SumReduction<TDataType>>(rDofSet, TLS(), [this, &rank](auto& rDof, TLS& rTLS) {
+            if(this->IsFreeDof(rDof, rank)) {
                 rTLS.dof_value = rDof.GetSolutionStepValue();
                 return std::pow(rTLS.dof_value, 2);
             } else {
                 return TDataType();
             }
         });
-        mReferenceDispNorm = std::sqrt(reference_disp_norm);
+        mReferenceDispNorm = std::sqrt(r_data_communicator.SumAll(reference_disp_norm));
     }
 
     /**
@@ -405,14 +452,22 @@ private:
      * @details It checks if the dof is fixed
      * @param rDofNum The number of DoFs
      * @param rDofSet Reference to the container of the problem's degrees of freedom (stored by the BuilderAndSolver)
-     * @param Dx Vector of results (variations on nodal variables)
+     * @param rDx Vector of results (variations on nodal variables)
+     * @todo We should doo as in the residual criteria, and consider the active DoFs (not just free), taking into account the MPC in addition to fixed DoFs
      */
     TDataType CalculateFinalCorrectionNorm(
         SizeType& rDofNum,
         DofsArrayType& rDofSet,
-        const TSystemVectorType& Dx
+        const TSystemVectorType& rDx,
+        ModelPart& rModelPart
         )
     {
+        // Retrieve the data communicator
+        const auto& r_data_communicator = rModelPart.GetCommunicator().GetDataCommunicator();
+
+        // The current MPI rank
+        const int rank = r_data_communicator.Rank();
+
         // Initialize
         TDataType final_correction_norm = TDataType();
         SizeType dof_num = 0;
@@ -421,26 +476,21 @@ private:
         using CustomReduction = CombinedReduction<SumReduction<TDataType>,SumReduction<SizeType>>;
 
         // Auxiliary struct
-        struct TLS {TDataType dof_value{};IndexType dof_id{}; TDataType variation_dof_value{};};
+        struct TLS {TDataType dof_value{}; TDataType variation_dof_value{};};
 
         // Loop over Dofs
-        std::tie(final_correction_norm, dof_num) = block_for_each<CustomReduction>(rDofSet, TLS(), [&Dx](auto& rDof, TLS& rTLS) {
-            if (rDof.IsFree()) {
-                rTLS.dof_id = rDof.EquationId();
-                rTLS.variation_dof_value = Dx[rTLS.dof_id];
+        std::tie(final_correction_norm, dof_num) = block_for_each<CustomReduction>(rDofSet, TLS(), [this, &rDx, &rank](auto& rDof, TLS& rTLS) {
+            if(this->IsFreeDof(rDof, rank)) {
+                rTLS.variation_dof_value = SparseSpaceType::GetValue(rDx, rDof.EquationId());
                 return std::make_tuple(std::pow(rTLS.variation_dof_value, 2), 1);
             } else {
                 return std::make_tuple(TDataType(), 0);
             }
         });
 
-        rDofNum = dof_num;
-        return std::sqrt(final_correction_norm);
+        rDofNum = r_data_communicator.SumAll(dof_num);
+        return std::sqrt(r_data_communicator.SumAll(final_correction_norm));
     }
-
-    ///@}
-    ///@name Private Operations
-    ///@{
 
     ///@}
     ///@name Private  Access

--- a/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
@@ -470,10 +470,10 @@ private:
 
         // Initialize
         TDataType final_correction_norm = TDataType();
-        SizeType dof_num = 0;
+        unsigned int dof_num = 0;
 
         // Custom reduction
-        using CustomReduction = CombinedReduction<SumReduction<TDataType>,SumReduction<SizeType>>;
+        using CustomReduction = CombinedReduction<SumReduction<TDataType>,SumReduction<unsigned int>>;
 
         // Auxiliary struct
         struct TLS {TDataType dof_value{}; TDataType variation_dof_value{};};

--- a/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
@@ -186,9 +186,8 @@ public:
     {
         const int rank = rModelPart.GetCommunicator().MyPID();
         const TDataType approx_zero_tolerance = std::numeric_limits<TDataType>::epsilon();
-        const SizeType size_Dx = SparseSpaceType::Size(rDx);
-        if (size_Dx != 0) { //if we are solving for something
-            SizeType size_solution;
+        if (SparseSpaceType::Size(rDx) != 0) { //if we are solving for something
+            unsigned int size_solution;
             const TDataType final_correction_norm = CalculateFinalCorrectionNorm(size_solution, rDofSet, rDx, rModelPart);
 
             TDataType ratio{};
@@ -456,7 +455,7 @@ private:
      * @todo We should doo as in the residual criteria, and consider the active DoFs (not just free), taking into account the MPC in addition to fixed DoFs
      */
     TDataType CalculateFinalCorrectionNorm(
-        SizeType& rDofNum,
+        unsigned int& rDofNum,
         DofsArrayType& rDofSet,
         const TSystemVectorType& rDx,
         ModelPart& rModelPart
@@ -470,10 +469,10 @@ private:
 
         // Initialize
         TDataType final_correction_norm = TDataType();
-        SizeType dof_num = 0;
+        unsigned int dof_num = 0;
 
         // Custom reduction
-        using CustomReduction = CombinedReduction<SumReduction<TDataType>,SumReduction<SizeType>>;
+        using CustomReduction = CombinedReduction<SumReduction<TDataType>,SumReduction<unsigned int>>;
 
         // Auxiliary struct
         struct TLS {TDataType dof_value{}; TDataType variation_dof_value{};};

--- a/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
@@ -191,7 +191,7 @@ public:
             SizeType size_solution;
             const TDataType final_correction_norm = CalculateFinalCorrectionNorm(size_solution, rDofSet, rDx, rModelPart);
 
-            TDataType ratio{};
+            TDataType ratio = 0.0;
 
             CalculateReferenceNorm(rDofSet, rModelPart);
             if (mReferenceDispNorm < approx_zero_tolerance) {
@@ -345,11 +345,11 @@ protected:
     ///@name Protected member Variables
     ///@{
 
-    TDataType mRatioTolerance;      /// The ratio threshold for the norm of the residual
+    TDataType mRatioTolerance = 0.0;      /// The ratio threshold for the norm of the residual
 
-    TDataType mAlwaysConvergedNorm; /// The absolute value threshold for the norm of the residual
+    TDataType mAlwaysConvergedNorm = 0.0; /// The absolute value threshold for the norm of the residual
 
-    TDataType mReferenceDispNorm;   /// The norm at the beginning of the iterations
+    TDataType mReferenceDispNorm = 0.0;   /// The norm at the beginning of the iterations
 
     ///@}
     ///@name Protected Operators

--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -191,7 +191,7 @@ public:
         const SizeType size_b = TSparseSpace::Size(rb);
         if (size_b != 0) { //if we are solving for something
 
-            unsigned int size_residual;
+            SizeType size_residual;
             CalculateResidualNorm(rModelPart, mCurrentResidualNorm, size_residual, rDofSet, rb);
 
             TDataType ratio{};
@@ -254,7 +254,7 @@ public:
             ConstraintUtilities::ComputeActiveDofs(rModelPart, mActiveDofs, rDofSet);
         }
 
-        unsigned int size_residual;
+        SizeType size_residual;
         CalculateResidualNorm(rModelPart, mInitialResidualNorm, size_residual, rDofSet, rb);
     }
 
@@ -406,7 +406,7 @@ protected:
     virtual void CalculateResidualNorm(
         ModelPart& rModelPart,
         TDataType& rResidualSolutionNorm,
-        unsigned int& rDofNum,
+        SizeType& rDofNum,
         DofsArrayType& rDofSet,
         const TSystemVectorType& rb
         )
@@ -419,10 +419,10 @@ protected:
 
         // Initialize
         TDataType residual_solution_norm = TDataType();
-        unsigned int dof_num = 0;
+        SizeType dof_num = 0;
 
         // Custom reduction
-        using CustomReduction = CombinedReduction<SumReduction<TDataType>,SumReduction<unsigned int>>;
+        using CustomReduction = CombinedReduction<SumReduction<TDataType>,SumReduction<SizeType>>;
 
         // Auxiliary struct
         struct TLS {TDataType residual_dof_value{};};

--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -250,7 +250,7 @@ public:
 
         // Filling mActiveDofs when MPC exist
         if (rModelPart.NumberOfMasterSlaveConstraints() > 0) {
-            ConstraintUtilities::ComputeActiveDofs(rModelPart, mActiveDofs, rDofSet);
+            ComputeActiveDofs(rModelPart, rDofSet);
         }
 
         SizeType size_residual;
@@ -366,6 +366,20 @@ protected:
     ///@}
     ///@name Protected Operations
     ///@{
+
+    /**
+     * @brief This method computes the active dofs
+     * @param rModelPart Reference to the ModelPart containing the problem
+     * @param rDofSet The whole set of dofs
+     */
+    virtual void ComputeActiveDofs(
+        ModelPart& rModelPart,
+        const ModelPart::DofsArrayType& rDofSet
+        )
+    {
+        // Filling mActiveDofs when MPC exist
+        ConstraintUtilities::ComputeActiveDofs(rModelPart, mActiveDofs, rDofSet);
+    }
 
     /**
      * @brief Check if a Degree of Freedom (Dof) is active

--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -421,7 +421,7 @@ protected:
         unsigned int dof_num = 0;
 
         // Custom reduction
-        using CustomReduction = CombinedReduction<SumReduction<TDataType>,SumReduction<SizeType>>;
+        using CustomReduction = CombinedReduction<SumReduction<TDataType>,SumReduction<unsigned int>>;
 
         // Auxiliary struct
         struct TLS {TDataType residual_dof_value{};};

--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -191,7 +191,7 @@ public:
         const SizeType size_b = TSparseSpace::Size(rb);
         if (size_b != 0) { //if we are solving for something
 
-            SizeType size_residual;
+            unsigned int size_residual;
             CalculateResidualNorm(rModelPart, mCurrentResidualNorm, size_residual, rDofSet, rb);
 
             TDataType ratio{};
@@ -254,7 +254,7 @@ public:
             ConstraintUtilities::ComputeActiveDofs(rModelPart, mActiveDofs, rDofSet);
         }
 
-        SizeType size_residual;
+        unsigned int size_residual;
         CalculateResidualNorm(rModelPart, mInitialResidualNorm, size_residual, rDofSet, rb);
     }
 
@@ -406,7 +406,7 @@ protected:
     virtual void CalculateResidualNorm(
         ModelPart& rModelPart,
         TDataType& rResidualSolutionNorm,
-        SizeType& rDofNum,
+        unsigned int& rDofNum,
         DofsArrayType& rDofSet,
         const TSystemVectorType& rb
         )
@@ -419,10 +419,10 @@ protected:
 
         // Initialize
         TDataType residual_solution_norm = TDataType();
-        SizeType dof_num = 0;
+        unsigned int dof_num = 0;
 
         // Custom reduction
-        using CustomReduction = CombinedReduction<SumReduction<TDataType>,SumReduction<SizeType>>;
+        using CustomReduction = CombinedReduction<SumReduction<TDataType>,SumReduction<unsigned int>>;
 
         // Auxiliary struct
         struct TLS {TDataType residual_dof_value{};};

--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -171,7 +171,7 @@ public:
     }
 
     /**
-     * @brief Criterias that need to be called after getting the solution
+     * @brief Criterion that need to be called after getting the solution
      * @details Compute relative and absolute error.
      * @param rModelPart Reference to the ModelPart containing the problem.
      * @param rDofSet Reference to the container of the problem's degrees of freedom (stored by the BuilderAndSolver)
@@ -188,8 +188,7 @@ public:
         const TSystemVectorType& rb
         ) override
     {
-        const SizeType size_b = TSparseSpace::Size(rb);
-        if (size_b != 0) { //if we are solving for something
+        if (TSparseSpace::Size(rb) != 0) { //if we are solving for something
 
             SizeType size_residual;
             CalculateResidualNorm(rModelPart, mCurrentResidualNorm, size_residual, rDofSet, rb);
@@ -419,7 +418,7 @@ protected:
 
         // Initialize
         TDataType residual_solution_norm = TDataType();
-        SizeType dof_num = 0;
+        unsigned int dof_num = 0;
 
         // Custom reduction
         using CustomReduction = CombinedReduction<SumReduction<TDataType>,SumReduction<SizeType>>;
@@ -450,7 +449,7 @@ protected:
             });
         }
 
-        rDofNum = r_data_communicator.SumAll(dof_num);
+        rDofNum = static_cast<SizeType>(r_data_communicator.SumAll(dof_num));
         rResidualSolutionNorm = std::sqrt(r_data_communicator.SumAll(residual_solution_norm));
     }
 

--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -438,7 +438,7 @@ protected:
                     rTLS.residual_dof_value = TSparseSpace::GetValue(rb, rDof.EquationId());
                     return std::make_tuple(std::pow(rTLS.residual_dof_value, 2), 1);
                 } else {
-                    return std::make_tuple(TDataType(), 0);;
+                    return std::make_tuple(TDataType(), 0);
                 }
             });
         } else {
@@ -447,7 +447,7 @@ protected:
                     rTLS.residual_dof_value = TSparseSpace::GetValue(rb, rDof.EquationId());
                     return std::make_tuple(std::pow(rTLS.residual_dof_value, 2), 1);
                 } else {
-                    return std::make_tuple(TDataType(), 0);;
+                    return std::make_tuple(TDataType(), 0);
                 }
             });
         }

--- a/kratos/tests/cpp_tests/strategies/convergence_criteria/test_displacement_criteria.cpp
+++ b/kratos/tests/cpp_tests/strategies/convergence_criteria/test_displacement_criteria.cpp
@@ -18,9 +18,6 @@
 // Project includes
 #include "testing/testing.h"
 #include "containers/model.h"
-#include "geometries/point_3d.h"
-#include "includes/define.h"
-#include "includes/model_part.h"
 #include "solving_strategies/convergencecriterias/displacement_criteria.h"
 #include "spaces/ublas_space.h"
 

--- a/kratos/tests/cpp_tests/strategies/convergence_criteria/test_displacement_criteria.cpp
+++ b/kratos/tests/cpp_tests/strategies/convergence_criteria/test_displacement_criteria.cpp
@@ -93,7 +93,7 @@ KRATOS_TEST_CASE_IN_SUITE(DisplacementCriteria, KratosCoreFastSuite)
         i++;
     }
 
-    // Check convergence
+    // Check convergence (failing)
     bool convergence = displacement_criteria.PostCriteria(r_model_part, aux_dof_set, A, Dx, b);
     KRATOS_EXPECT_FALSE(convergence)
 
@@ -106,7 +106,7 @@ KRATOS_TEST_CASE_IN_SUITE(DisplacementCriteria, KratosCoreFastSuite)
         i++;
     }
 
-    // Check convergence
+    // Check convergence (passing)
     convergence = displacement_criteria.PostCriteria(r_model_part, aux_dof_set, A, Dx, b);
     KRATOS_EXPECT_TRUE(convergence)
 }

--- a/kratos/tests/cpp_tests/strategies/convergence_criteria/test_residual_criteria.cpp
+++ b/kratos/tests/cpp_tests/strategies/convergence_criteria/test_residual_criteria.cpp
@@ -95,6 +95,10 @@ KRATOS_TEST_CASE_IN_SUITE(ResidualCriteria, KratosCoreFastSuite)
     // Initialize the solution step
     residual_criteria.InitializeSolutionStep(r_model_part, aux_dof_set, A, Dx, b);
 
+    // Check convergence (failing)
+    bool convergence = residual_criteria.PostCriteria(r_model_part, aux_dof_set, A, Dx, b);
+    KRATOS_EXPECT_FALSE(convergence)
+
     // Set the auxiliary fake data to check the convergence for (passing)
     i = 0;
     for (auto& r_node : r_model_part.Nodes()) {
@@ -103,8 +107,8 @@ KRATOS_TEST_CASE_IN_SUITE(ResidualCriteria, KratosCoreFastSuite)
         i++;
     }
 
-    // Check convergence
-    const bool convergence = residual_criteria.PostCriteria(r_model_part, aux_dof_set, A, Dx, b);
+    // Check convergence (passing)
+    convergence = residual_criteria.PostCriteria(r_model_part, aux_dof_set, A, Dx, b);
     KRATOS_EXPECT_TRUE(convergence)
 }
 
@@ -167,6 +171,10 @@ KRATOS_TEST_CASE_IN_SUITE(ResidualCriteriaWithMPC, KratosCoreFastSuite)
     // Initialize the solution step
     residual_criteria.InitializeSolutionStep(r_model_part, aux_dof_set, A, Dx, b);
 
+    // Check convergence (failing)
+    bool convergence = residual_criteria.PostCriteria(r_model_part, aux_dof_set, A, Dx, b);
+    KRATOS_EXPECT_FALSE(convergence)
+
     // Set the auxiliary fake data to check the convergence for (passing)
     i = 0;
     for (auto& r_node : r_model_part.Nodes()) {
@@ -178,8 +186,8 @@ KRATOS_TEST_CASE_IN_SUITE(ResidualCriteriaWithMPC, KratosCoreFastSuite)
         i++;
     }
 
-    // Check convergence
-    const bool convergence = residual_criteria.PostCriteria(r_model_part, aux_dof_set, A, Dx, b);
+    // Check convergence (passing)
+    convergence = residual_criteria.PostCriteria(r_model_part, aux_dof_set, A, Dx, b);
     KRATOS_EXPECT_TRUE(convergence)
 }
 

--- a/kratos/tests/cpp_tests/strategies/convergence_criteria/test_residual_criteria.cpp
+++ b/kratos/tests/cpp_tests/strategies/convergence_criteria/test_residual_criteria.cpp
@@ -18,9 +18,6 @@
 // Project includes
 #include "testing/testing.h"
 #include "containers/model.h"
-#include "geometries/point_3d.h"
-#include "includes/define.h"
-#include "includes/model_part.h"
 #include "solving_strategies/convergencecriterias/residual_criteria.h"
 #include "spaces/ublas_space.h"
 


### PR DESCRIPTION
**📝 Description**

This PR involves changes in `displacement_criteria.h` and `residual_criteria.h` toward the unification and simplification of the implementation between serial and MPI/Trilinos. The idea is to minimize diferences and code duplication between serial and MPI code, for a future PR. The changes include:

1. In  `displacement_criteria.h`:
   - Refactoring of the `DisplacementCriteria` class, including updates to type definitions and member functions.
   - The introduction of MPI rank handling in some parts of the code.
   - Improved DoF handling and calculations.
   - Adjustments to the class constructor and destructor.

2. In  `residual_criteria.h`:
   - Refactoring of the `ResidualCriteria` class, including updates to type definitions and member functions.
   - Deletion of the assignment operator.
   - Improvements in handling Degree of Freedom (DoF) status.
   - Improved DoF handling and calculations.
   - Adjustments to the class constructor and destructor.
   - Updates to the calculation of residual solution norms toward unification with MPI/Trilinos.

**🆕 Changelog**

- [Toward Trilinos/MPI unification of DisplacementCriteria`/`ResidualCriteria`](https://github.com/KratosMultiphysics/Kratos/commit/d6e267ba267531150dbc529a77eecf4368d715b7)
