### PR TITLE
[core] minor performance improvement in tetrahedra_3d_10

### DIFF
--- a/kratos/geometries/tetrahedra_3d_10.h
+++ b/kratos/geometries/tetrahedra_3d_10.h
@@ -1075,10 +1075,13 @@ private:
     bool FacesArePlanar() const
     {
         constexpr double tol = 1e-6;
-        for (auto& r_edge : this->GenerateEdges()) {
-            const double a = MathUtils<double>::Norm3(r_edge.GetPoint(0)-r_edge.GetPoint(1));
-            const double b = MathUtils<double>::Norm3(r_edge.GetPoint(1)-r_edge.GetPoint(2));
-            const double c = MathUtils<double>::Norm3(r_edge.GetPoint(2)-r_edge.GetPoint(0));
+        constexpr std::array<std::array<size_t, 3>, 6> edges{
+            {{0, 1, 4}, {1, 2, 5}, {2, 0, 6}, {0, 3, 7}, {1, 3, 8}, {2, 3, 9}}};
+        const auto& r_points = Points();
+        for (const auto& r_edge : edges) {
+            const double a = MathUtils<double>::Norm3(r_points[r_edge[0]] - r_points[r_edge[1]]);
+            const double b = MathUtils<double>::Norm3(r_points[r_edge[1]] - r_points[r_edge[2]]);
+            const double c = MathUtils<double>::Norm3(r_points[r_edge[2]] - r_points[r_edge[0]]);
             if (b + c > a*(1.0+tol) ) {
                 return false;
             }

--- a/kratos/geometries/tetrahedra_3d_10.h
+++ b/kratos/geometries/tetrahedra_3d_10.h
@@ -1077,7 +1077,7 @@ private:
         constexpr double tol = 1e-6;
         constexpr std::array<std::array<size_t, 3>, 6> edges{
             {{0, 1, 4}, {1, 2, 5}, {2, 0, 6}, {0, 3, 7}, {1, 3, 8}, {2, 3, 9}}};
-        const auto& r_points = Points();
+        const auto& r_points = this->Points();
         for (const auto& r_edge : edges) {
             const double a = MathUtils<double>::Norm3(r_points[r_edge[0]] - r_points[r_edge[1]]);
             const double b = MathUtils<double>::Norm3(r_points[r_edge[1]] - r_points[r_edge[2]]);


### PR DESCRIPTION
**📝 Description**
In Tetrahedra3D10::FacesArePlanar we are creating a local Edges object which has a noticeable performance cost if the function is called many times (as in a spatial search). I am rewriting the function to prevent this.

**🆕 Changelog**
- Avoid creating an Edges object in Tetrahedra3D10::FacesArePlanar
