### PR TITLE
[Core][TrilinosApplication] Adding `IsDistributedSpace` to `TrilinosSpace` and `UblasSpace`in order to recognize statically

### DIFF
--- a/applications/TrilinosApplication/trilinos_space.h
+++ b/applications/TrilinosApplication/trilinos_space.h
@@ -1286,6 +1286,16 @@ public:
         KRATOS_CATCH("");
     }
 
+   /**
+    * @brief Check if the TrilinosSpace is distributed.
+    * @details This static member function checks whether the TrilinosSpace is distributed or not.
+    * @return True if the space is distributed, false otherwise.
+    */
+    static constexpr bool IsDistributedSpace()
+    {
+        return true;
+    }
+
     ///@}
     ///@name Access
     ///@{

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -4,12 +4,11 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //  Collaborator:    Vicente Mataix Ferrandiz
-//
 //
 
 #pragma once
@@ -106,9 +105,16 @@ enum class SCALING_DIAGONAL {NO_SCALING = 0, CONSIDER_NORM_DIAGONAL = 1, CONSIDE
 ///@name Kratos Classes
 ///@{
 
-/// Short class definition.
-
-/** Detail class definition.
+/**
+ * @class UblasSpace
+ * @ingroup KratosCore
+ * @brief A class template for handling data types, matrices, and vectors in a Ublas space.
+ * @details This class template is designed to work with different data types, matrix types, and vector types
+ * within a Ublas space. It provides typedefs and utilities for managing these types effectively.
+ * @tparam TDataType The data type used in the Ublas space.
+ * @tparam TMatrixType The matrix type used in the Ublas space.
+ * @tparam TVectorType The vector type used in the Ublas space.
+ * @author Riccardo Rossi
  */
 template<class TDataType, class TMatrixType, class TVectorType>
 class UblasSpace
@@ -120,21 +126,32 @@ public:
     /// Pointer definition of UblasSpace
     KRATOS_CLASS_POINTER_DEFINITION(UblasSpace);
 
-    typedef TDataType DataType;
+    /// The data type considered
+    using DataType = TDataType;
 
-    typedef TMatrixType MatrixType;
+    /// The matrix type considered
+    using MatrixType = TMatrixType;
 
-    typedef TVectorType VectorType;
+    /// The vector type considered
+    using VectorType = TVectorType;
 
-    typedef std::size_t IndexType;
+    /// The index type considered
+    using IndexType = std::size_t;
 
-    typedef std::size_t SizeType;
+    /// The size type considered
+    using SizeType = std::size_t;
 
-    typedef typename Kratos::shared_ptr< TMatrixType > MatrixPointerType;
-    typedef typename Kratos::shared_ptr< TVectorType > VectorPointerType;
+    /// The pointer to the matrix type
+    using MatrixPointerType = typename Kratos::shared_ptr<TMatrixType>;
 
-    typedef DofUpdater< UblasSpace<TDataType,TMatrixType,TVectorType> > DofUpdaterType;
-    typedef typename DofUpdaterType::UniquePointer DofUpdaterPointerType;
+    /// The pointer to the vector type
+    using VectorPointerType = typename Kratos::shared_ptr<TVectorType>;
+
+    /// The DoF updater type
+    using DofUpdaterType = DofUpdater<UblasSpace<TDataType, TMatrixType, TVectorType>>;
+
+    /// The pointer to the DoF updater type
+    using DofUpdaterPointerType = typename DofUpdaterType::UniquePointer;
 
     ///@}
     ///@name Life Cycle
@@ -910,6 +927,16 @@ public:
     {
         DofUpdaterType tmp;
         return tmp.Create();
+    }
+
+   /**
+    * @brief Check if the UblasSpace is distributed.
+    * @details This static member function checks whether the UblasSpace is distributed or not.
+    * @return True if the space is distributed, false otherwise.
+    */
+    static constexpr bool IsDistributedSpace()
+    {
+        return false;
     }
 
     ///@}


### PR DESCRIPTION
**📝 Description**

This PR makes changes to two header files: `trilinos_space.h` in the `TrilinosApplication` directory and `ublas_space.h` in the `kratos/spaces` directory. Here's a summary of the changes:

1. In `trilinos_space.h`:
   - Added a new member function `IsDistributedSpace()` to the `TrilinosSpace` class.
   - This function is declared as `static constexpr bool` and returns `true`, indicating that the `TrilinosSpace` is distributed.

2. In `ublas_space.h`:
   - Added a new member function `IsDistributedSpace()` to the `UblasSpace` class.
   - This function is declared as `static constexpr bool` and returns `false`, indicating that the `UblasSpace` is not distributed.
   - Replace `typedef` by `using`
   - Replace tabulations for spaces in header
   - Adding some documentation in class

Overall, this PR introduces a new function `IsDistributedSpace()` to both `TrilinosSpace` and `UblasSpace` classes, allowing the code to determine whether the space is distributed or not.

**🆕 Changelog**

- [Adding IsDistributedSpace to spaces in order to recognize statically](https://github.com/KratosMultiphysics/Kratos/commit/8adbc7d3a491a0d2649dd9736711d82aa8cfa758)
