### PR TITLE
[Core] Clean up and codumentation in `GlobalPointersVector`

### DIFF
--- a/kratos/containers/global_pointers_vector.h
+++ b/kratos/containers/global_pointers_vector.h
@@ -4,14 +4,13 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //
 
-#if !defined(KRATOS_GLOBAL_POINTER_VECTOR_H_INCLUDED )
-#define  KRATOS_GLOBAL_POINTER_VECTOR_H_INCLUDED
+#pragma once
 
 // System includes
 #include <vector>
@@ -67,28 +66,27 @@ public:
     /// Pointer definition of GlobalPointersVector
     KRATOS_CLASS_POINTER_DEFINITION(GlobalPointersVector);
 
-    typedef std::vector< GlobalPointer<TDataType> > TContainerType;
-    typedef GlobalPointer<TDataType> TPointerType;
-    typedef TDataType data_type;
-    typedef TPointerType value_type;
-    typedef TPointerType pointer;
-    typedef const TPointerType const_pointer;
-    typedef TDataType& reference;
-    typedef const TDataType& const_reference;
-    typedef TContainerType ContainerType;
+    using TContainerType = std::vector<GlobalPointer<TDataType>>;
+    using TPointerType = GlobalPointer<TDataType>;
+    using data_type = TDataType;
+    using value_type = TPointerType;
+    using pointer = TPointerType;
+    using const_pointer = const TPointerType;
+    using reference = TDataType&;
+    using const_reference = const TDataType&;
+    using ContainerType = TContainerType;
 
+    using iterator = boost::indirect_iterator<typename TContainerType::iterator>;
+    using const_iterator = boost::indirect_iterator<typename TContainerType::const_iterator>;
+    using reverse_iterator = boost::indirect_iterator<typename TContainerType::reverse_iterator>;
+    using const_reverse_iterator = boost::indirect_iterator<typename TContainerType::const_reverse_iterator>;
 
-    typedef boost::indirect_iterator<typename TContainerType::iterator>                iterator;
-    typedef boost::indirect_iterator<typename TContainerType::const_iterator>          const_iterator;
-    typedef boost::indirect_iterator<typename TContainerType::reverse_iterator>        reverse_iterator;
-    typedef boost::indirect_iterator<typename TContainerType::const_reverse_iterator>  const_reverse_iterator;
-
-    typedef typename TContainerType::size_type size_type;
-    typedef typename TContainerType::iterator ptr_iterator;
-    typedef typename TContainerType::const_iterator ptr_const_iterator;
-    typedef typename TContainerType::reverse_iterator ptr_reverse_iterator;
-    typedef typename TContainerType::const_reverse_iterator ptr_const_reverse_iterator;
-    typedef typename TContainerType::difference_type difference_type;
+    using size_type = typename TContainerType::size_type;
+    using ptr_iterator = typename TContainerType::iterator;
+    using ptr_const_iterator = typename TContainerType::const_iterator;
+    using ptr_reverse_iterator = typename TContainerType::reverse_iterator;
+    using ptr_const_reverse_iterator = typename TContainerType::const_reverse_iterator;
+    using difference_type = typename TContainerType::difference_type;
 
     ///@}
     ///@name Life Cycle
@@ -104,21 +102,32 @@ public:
     /// Destructor.
     ~GlobalPointersVector() {}
 
-    template < class TContainerType >
-    void FillFromContainer( TContainerType& container)
+    /**
+    * @brief Fill the container from another container.
+    * @tparam TContainerType The type of the source container.
+    * @param rContainer The source container.
+    */
+    template <class TContainerType>
+    void FillFromContainer(TContainerType& rContainer)
     {
-        this->reserve(container.size());
-        for(auto& item : container)
-        {
-            this->push_back(GlobalPointer<TDataType>(&item));
+        this->reserve(rContainer.size());
+        for (auto& r_item : rContainer) {
+            this->push_back(GlobalPointer<TDataType>(&r_item));
         }
     }
 
+    /**
+     * @brief Sort the elements in the container.
+     */
     void Sort()
     {
         std::sort(mData.begin(), mData.end(), GlobalPointerCompare<TDataType>());
     }
 
+    /**
+     * @brief Remove duplicate elements from the container.
+     * @details This function first sorts the elements and then removes duplicates.
+     */
     void Unique()
     {
         Sort();
@@ -127,82 +136,79 @@ public:
         this->erase(new_end_it, end_it);
     }
 
+    /**
+    * @brief Reduce the capacity of the container to fit its size.
+    */
     void shrink_to_fit()
     {
         mData.shrink_to_fit();
     }
 
-
     ///@}
     ///@name Operators
     ///@{
 
-
-    ///@}
-    ///@name Operations
-    ///@{
-
-
-    ///@}
-    ///@name Access
-    ///@{
-
-
-    ///@}
-    ///@name Inquiry
-    ///@{
-
-
-    ///@}
-    ///@name Input and output
-    ///@{
-
-    /// Turn back information as a string.
-    std::string Info() const
-    {
-        std::stringstream buffer;
-        buffer << "GlobalPointersVector" ;
-        return buffer.str();
-    }
-
-    /// Print information about this object.
-    void PrintInfo(std::ostream& rOStream) const
-    {
-        rOStream << "GlobalPointersVector";
-    }
-
-    /// Print object's data.
-    void PrintData(std::ostream& rOStream) const {}
-
+    /**
+     * @brief Assignment operator to copy the contents of another GlobalPointersVector.
+     * @param rOther The GlobalPointersVector to copy from.
+     * @return A reference to the modified GlobalPointersVector.
+     */
     GlobalPointersVector& operator=(const GlobalPointersVector& rOther)
     {
         mData = rOther.mData;
         return *this;
     }
 
+    /**
+     * @brief Access an element in the container by index.
+     * @param i The index of the element to access.
+     * @return A reference to the element.
+     */
     TDataType& operator[](const size_type& i)
     {
         return *(mData[i]);
     }
 
+    /**
+     * @brief Access a constant element in the container by index.
+     * @param i The index of the element to access.
+     * @return A constant reference to the element.
+     */
     TDataType const& operator[](const size_type& i) const
     {
         return *(mData[i]);
     }
 
+    /**
+     * @brief Access an element in the container by index.
+     * @param i The index of the element to access.
+     * @return A reference to the element.
+     */
     pointer& operator()(const size_type& i)
     {
         return mData[i];
     }
 
+    /**
+     * @brief Access a constant element in the container by index.
+     * @param i The index of the element to access.
+     * @return A constant reference to the element.
+     */
     const_pointer& operator()(const size_type& i) const
     {
         return mData[i];
     }
 
-    bool operator==( const GlobalPointersVector& r ) const // nothrow
+    /**
+     * @brief Equality comparison operator to check if two GlobalPointersVector objects are equal.
+     * @details This function checks if the sizes are equal and then compares the elements for equality
+     * using the EqualKeyTo() function.
+     * @param r The GlobalPointersVector to compare with.
+     * @return True if the containers are equal, false otherwise.
+     */
+    bool operator==(const GlobalPointersVector& r) const // nothrow
     {
-        if( size() != r.size() )
+        if (size() != r.size())
             return false;
         else
             return std::equal(mData.begin(), mData.end(), r.mData.begin(), this->EqualKeyTo());
@@ -318,17 +324,17 @@ public:
         mData.push_back(x);
     }
 
-//     template<class TOtherDataType>
-//     void push_back(TOtherDataType const& x)
-//     {
-//         push_back(TPointerType(new TOtherDataType(x)));
-//     }
-/*
-    template<class TOtherDataType>
-    iterator insert(iterator Position, const TOtherDataType& rData)
-    {
-        return iterator(mData.insert(Position, TPointerType(new TOtherDataType(rData))));
-    }*/
+    // template<class TOtherDataType>
+    // void push_back(TOtherDataType const& x)
+    // {
+    //     push_back(TPointerType(new TOtherDataType(x)));
+    // }
+
+    // template<class TOtherDataType>
+    // iterator insert(iterator Position, const TOtherDataType& rData)
+    // {
+    //     return iterator(mData.insert(Position, TPointerType(new TOtherDataType(rData))));
+    // }
 
     iterator insert(iterator Position, const TPointerType pData)
     {
@@ -341,7 +347,6 @@ public:
         for(; First != Last; ++First)
             insert(*First);
     }
-
 
     iterator erase(iterator pos)
     {
@@ -377,6 +382,34 @@ public:
         return mData.capacity();
     }
 
+    ///@}
+    ///@name Access
+    ///@{
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const
+    {
+        std::stringstream buffer;
+        buffer << "GlobalPointersVector" ;
+        return buffer.str();
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const
+    {
+        rOStream << "GlobalPointersVector";
+    }
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const {}
 
     ///@}
     ///@name Access
@@ -394,123 +427,114 @@ public:
         return mData;
     }
 
-
     ///@}
     ///@name Friends
     ///@{
 
-
     ///@}
-
 protected:
     ///@name Protected static Member Variables
     ///@{
-
 
     ///@}
     ///@name Protected member Variables
     ///@{
 
-
     ///@}
     ///@name Protected Operators
     ///@{
-
 
     ///@}
     ///@name Protected Operations
     ///@{
 
-
     ///@}
     ///@name Protected  Access
     ///@{
-
 
     ///@}
     ///@name Protected Inquiry
     ///@{
 
-
     ///@}
     ///@name Protected LifeCycle
     ///@{
 
-
     ///@}
-
 private:
     ///@name Static Member Variables
     ///@{
 
-
     ///@}
     ///@name Member Variables
     ///@{
-    TContainerType mData;
 
+    TContainerType mData; /// The data stored in the class
 
     ///@}
     ///@name Private Operators
     ///@{
+
     friend class Serializer;
 
+    /**
+    * @brief Serialize the GlobalPointersVector for saving.
+    * @details This function saves the size of the container and each element in the container using the provided serializer.
+    * @param rSerializer The serializer used for saving.
+    */
     void save(Serializer& rSerializer) const
     {
         rSerializer.save("Size", this->size());
 
-        for(std::size_t i=0; i<this->size(); i++) {
+        for (std::size_t i = 0; i < this->size(); i++) {
             rSerializer.save("Data", mData[i]);
         }
     }
 
+    /**
+    * @brief Deserialize the GlobalPointersVector for loading.
+    * @details This function loads the size of the container and each element from the serializer and populates the container.
+    * @param rSerializer The serializer used for loading.
+    */
     void load(Serializer& rSerializer)
     {
         std::size_t size;
 
         rSerializer.load("Size", size);
 
-        for(std::size_t i = 0; i < size; i++) {
+        for (std::size_t i = 0; i < size; i++) {
             GlobalPointer<TDataType> p(nullptr);
             rSerializer.load("Data", p);
             this->push_back(p);
         }
     }
 
-
     ///@}
     ///@name Private Operations
     ///@{
-
 
     ///@}
     ///@name Private  Access
     ///@{
 
-
     ///@}
     ///@name Private Inquiry
     ///@{
-
 
     ///@}
     ///@name Un accessible methods
     ///@{
 
     ///@}
-
 }; // Class GlobalPointersVector
 
 ///@}
-
 ///@name Type Definitions
 ///@{
-
 
 ///@}
 ///@name Input and output
 ///@{
-
 
 /// input stream function
 template< class TDataType >
@@ -533,8 +557,6 @@ inline std::ostream& operator << (std::ostream& rOStream,
 }
 ///@}
 
-///@} addtogroup block
+///@} addtogroup KratosCore
 
 }  // namespace Kratos.
-
-#endif // KRATOS_GLOBAL_POINTER_VECTOR_H_INCLUDED  defined


### PR DESCRIPTION
**📝 Description**

This PR makes several changes to the `GlobalPointersVector` class in the `global_pointers_vector.h` file. Here's a summary of the changes made:

1. License Information: remove the tabulations
2. Type Aliases: Replaced typedefs with modern using declarations for better readability.
3. Added documentation to several methods.

Overall, these changes aim to improve code readability and maintainability while providing better documentation for the class's functions and operators.

**🆕 Changelog**

-  Clean up in `GlobalPointersVector`
