### PR TITLE
[TrilinosApplication] `SystemSolve` methods not defined in block B&S

### DIFF
--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -359,40 +359,40 @@ public:
 
     /**
      * @brief This is a call to the linear system solver
-     * @param A The LHS matrix
-     * @param Dx The Unknowns vector
-     * @param b The RHS vector
+     * @param rA The LHS matrix
+     * @param rDx The Unknowns vector
+     * @param rb The RHS vector
      */
     void SystemSolve(
-        TSystemMatrixType& A,
-        TSystemVectorType& Dx,
-        TSystemVectorType& b
-    ) override
+        TSystemMatrixType& rA,
+        TSystemVectorType& rDx,
+        TSystemVectorType& rb
+        ) override
     {
         KRATOS_TRY
         double norm_b;
-        if (TSparseSpace::Size(b) != 0)
-            norm_b = TSparseSpace::TwoNorm(b);
-        else
-            norm_b = 0.00;
-
-        if (norm_b != 0.00)
-        {
-            //do solve
-            BaseType::mpLinearSystemSolver->Solve(A, Dx, b);
-        }
-        else
-            TSparseSpace::SetToZero(Dx);
-
-        if(mT.size1() != 0) //if there are master-slave constraints
-        {
-            //recover solution of the original problem
-            TSystemVectorType Dxmodified = Dx;
-
-            TSparseSpace::Mult(mT, Dxmodified, Dx);
+        if (TSparseSpace::Size(rb) != 0) {
+            norm_b = TSparseSpace::TwoNorm(rb);
+        } else {
+            norm_b = 0.0;
         }
 
-        //prints information about the current time
+        if (norm_b != 0.0) {
+            // Do solve
+            BaseType::mpLinearSystemSolver->Solve(rA, rDx, rb);
+        } else {
+            TSparseSpace::SetToZero(rDx);
+        }
+
+        if(mT.size1() != 0) { // If there are master-slave constraints
+            // Recover solution of the original problem
+            TSystemVectorType Dxmodified = rDx;
+
+            // Recover solution of the original problem
+            TSparseSpace::Mult(mT, Dxmodified, rDx);
+        }
+
+        // Prints information about the current time
         KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolver", this->GetEchoLevel() > 1) << *(BaseType::mpLinearSystemSolver) << std::endl;
 
         KRATOS_CATCH("")
@@ -428,34 +428,34 @@ public:
     }
 
     /**
-      *@brief This is a call to the linear system solver (taking into account some physical particularities of the problem)
-     * @param A The LHS matrix
-     * @param Dx The Unknowns vector
-     * @param b The RHS vector
+     * @brief This is a call to the linear system solver (taking into account some physical particularities of the problem)
+     * @param rA The LHS matrix
+     * @param rDx The Unknowns vector
+     * @param rb The RHS vector
      * @param rModelPart The model part of the problem to solve
      */
     void InternalSystemSolveWithPhysics(
-        TSystemMatrixType& A,
-        TSystemVectorType& Dx,
-        TSystemVectorType& b,
+        TSystemMatrixType& rA,
+        TSystemVectorType& rDx,
+        TSystemVectorType& rb,
         ModelPart& rModelPart
     )
     {
         KRATOS_TRY
 
         double norm_b;
-        if (TSparseSpace::Size(b) != 0)
-            norm_b = TSparseSpace::TwoNorm(b);
+        if (TSparseSpace::Size(rb) != 0)
+            norm_b = TSparseSpace::TwoNorm(rb);
         else
             norm_b = 0.00;
 
         if (norm_b != 0.00) {
             //provide physical data as needed
             if(BaseType::mpLinearSystemSolver->AdditionalPhysicalDataIsNeeded() )
-                BaseType::mpLinearSystemSolver->ProvideAdditionalData(A, Dx, b, BaseType::mDofSet, rModelPart);
+                BaseType::mpLinearSystemSolver->ProvideAdditionalData(rA, rDx, rb, BaseType::mDofSet, rModelPart);
 
             //do solve
-            BaseType::mpLinearSystemSolver->Solve(A, Dx, b);
+            BaseType::mpLinearSystemSolver->Solve(rA, rDx, rb);
         } else {
             KRATOS_WARNING_IF("ResidualBasedBlockBuilderAndSolver", mOptions.IsNot(SILENT_WARNINGS)) << "ATTENTION! setting the RHS to zero!" << std::endl;
         }


### PR DESCRIPTION
**📝 Description**

This PR adds `SystemSolve` methods not defined in block B&S in the `TrilinosApplication`, also a minor clean up in serial block B&S. The changes are:

**TrilinosApplication/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h**:
- Added an override method `InternalSystemSolveWithPhysics` that calls the linear system solver, taking into account some physical particularities of the problem.
- Introduced a check for the size of the input vectors `rA`, `rDx`, and `rb`.
- Updated the calculation of `norm_b`.
- Recovered the solution of the original problem using the master-slave constraints if they exist.
- Added comments for clarity.

**Kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h**:
- Modified the `Solve` method's signature to accept `rA` and `rb` instead of `A` and `b`.
- Updated the comments for clarity.

**🆕 Changelog**

- [`SystemSolve` methods not defined in block B&S](https://github.com/KratosMultiphysics/Kratos/commit/4b60f688a3a94f4370f2dd35324b57dddbf90219)
- [Minor modification serial block B&S](https://github.com/KratosMultiphysics/Kratos/commit/d22758b8bf3c09e75879e3de9c387d84ec36c0b4)
