### PR TITLE
[GeoMechanicsApplication] Implement SetValueOnIntegrationPoints for Vectors in U_Pw_small_strain_element.

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
@@ -57,7 +57,7 @@ public:
         mThisIntegrationMethod = this->GetIntegrationMethod();
     }
 
-    ~UPwBaseElement() override {}
+    ~UPwBaseElement() override = default;
 
     Element::Pointer Create(IndexType NewId,
                             NodesArrayType const& ThisNodes,

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
@@ -11,8 +11,7 @@
 //                   Vahid Galavi
 //
 
-#if !defined(KRATOS_GEO_U_PW_ELEMENT_H_INCLUDED )
-#define  KRATOS_GEO_U_PW_ELEMENT_H_INCLUDED
+#pragma once
 
 // Project includes
 #include "containers/array_1d.h"
@@ -37,15 +36,10 @@ class KRATOS_API(GEO_MECHANICS_APPLICATION) UPwBaseElement : public Element
 {
 
 public:
-
-    /// The definition of the sizetype
     using SizeType = std::size_t;
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwBaseElement );
 
-///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-    /// Default Constructor
     UPwBaseElement(IndexType NewId = 0) : Element( NewId ) {}
 
     /// Constructor using an array of nodes
@@ -63,10 +57,7 @@ public:
         mThisIntegrationMethod = this->GetIntegrationMethod();
     }
 
-    /// Destructor
-    virtual ~UPwBaseElement() {}
-
-///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    ~UPwBaseElement() override {}
 
     Element::Pointer Create(IndexType NewId,
                             NodesArrayType const& ThisNodes,
@@ -86,26 +77,25 @@ public:
     void ResetConstitutiveLaw() override;
 
     GeometryData::IntegrationMethod GetIntegrationMethod() const override;
-///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    void CalculateLocalSystem( MatrixType& rLeftHandSideMatrix,
-                               VectorType& rRightHandSideVector,
-                               const ProcessInfo& rCurrentProcessInfo ) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+                              VectorType& rRightHandSideVector,
+                              const ProcessInfo& rCurrentProcessInfo) override;
 
-    void CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix,
-                                const ProcessInfo& rCurrentProcessInfo ) override;
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
+                               const ProcessInfo& rCurrentProcessInfo) override;
 
-    void CalculateRightHandSide( VectorType& rRightHandSideVector,
-                                 const ProcessInfo& rCurrentProcessInfo ) override;
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,
+                                const ProcessInfo& rCurrentProcessInfo) override;
 
-    void EquationIdVector( EquationIdVectorType& rResult,
-                           const ProcessInfo& rCurrentProcessInfo ) const override;
+    void EquationIdVector(EquationIdVectorType& rResult,
+                          const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void CalculateMassMatrix( MatrixType& rMassMatrix,
-                              const ProcessInfo& rCurrentProcessInfo ) override;
+    void CalculateMassMatrix(MatrixType& rMassMatrix,
+                             const ProcessInfo& rCurrentProcessInfo) override;
 
-    void CalculateDampingMatrix( MatrixType& rDampingMatrix,
-                                 const ProcessInfo& rCurrentProcessInfo ) override;
+    void CalculateDampingMatrix(MatrixType& rDampingMatrix,
+                                const ProcessInfo& rCurrentProcessInfo) override;
 
     void GetValuesVector(Vector& rValues, int Step = 0) const override;
 
@@ -113,27 +103,27 @@ public:
 
     void GetSecondDerivativesVector(Vector& rValues, int Step = 0) const override;
 
-///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    void CalculateOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable,
+    void CalculateOnIntegrationPoints(const Variable<ConstitutiveLaw::Pointer>& rVariable,
                                       std::vector<ConstitutiveLaw::Pointer>& rValues,
                                       const ProcessInfo& rCurrentProcessInfo ) override;
 
     void CalculateOnIntegrationPoints(const Variable<array_1d<double, 3>>& rVariable,
-        std::vector<array_1d<double, 3>>& rValues,
-        const ProcessInfo& rCurrentProcessInfo) override;
+                                      std::vector<array_1d<double, 3>>& rValues,
+                                      const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,
-        std::vector<Matrix>& rValues,
-        const ProcessInfo& rCurrentProcessInfo) override;
+                                      std::vector<Matrix>& rValues,
+                                      const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
-        std::vector<double>& rValues,
-        const ProcessInfo& rCurrentProcessInfo) override;
+                                      std::vector<double>& rValues,
+                                      const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
-        std::vector<Vector>& rValues,
-        const ProcessInfo& rCurrentProcessInfo) override;
+                                      std::vector<Vector>& rValues,
+                                      const ProcessInfo& rCurrentProcessInfo) override;
 
+    using Element::CalculateOnIntegrationPoints;
 
     void SetValuesOnIntegrationPoints(const Variable<double>& rVariable,
                                       const std::vector<double>& rValues,
@@ -147,21 +137,17 @@ public:
                                       const std::vector<Matrix>& rValues,
                                       const ProcessInfo& rCurrentProcessInfo) override;
 
-    // Turn back information as a string.
+    using Element::SetValuesOnIntegrationPoints;
+
     std::string Info() const override
     {
-        std::stringstream buffer;
-        buffer << "U-Pw Base class Element #" << this->Id() << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
-        return buffer.str();
+        return "U-Pw Base class Element #" + std::to_string(Id()) + "\nConstitutive law: " + mConstitutiveLawVector[0]->Info();
     }
 
-    // Print information about this object.
     void PrintInfo(std::ostream& rOStream) const override
     {
-        rOStream << "U-Pw Base class Element #" << this->Id() << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
+        rOStream << Info();
     }
-
-///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 protected:
 
@@ -175,16 +161,14 @@ protected:
     std::vector<Vector> mStateVariablesFinalized;
     bool mIsInitialised = false;
 
-///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
     virtual void CalculateMaterialStiffnessMatrix( MatrixType& rStiffnessMatrix,
                                                    const ProcessInfo& CurrentProcessInfo );
 
     virtual void CalculateAll( MatrixType& rLeftHandSideMatrix,
                                VectorType& rRightHandSideVector,
                                const ProcessInfo& CurrentProcessInfo,
-                               const bool CalculateStiffnessMatrixFlag,
-                               const bool CalculateResidualVectorFlag);
+                               bool CalculateStiffnessMatrixFlag,
+                               bool CalculateResidualVectorFlag);
 
     virtual double CalculateIntegrationCoefficient( const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
                                                     unsigned int PointNumber,
@@ -233,11 +217,7 @@ protected:
 
     virtual unsigned int GetNumberOfDOF() const;
 
-///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
 private:
-
-    /// Serialization
 
     friend class Serializer;
 
@@ -251,15 +231,11 @@ private:
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, Element )
     }
 
-    /// Assignment operator.
     UPwBaseElement & operator=(UPwBaseElement const& rOther);
 
-    /// Copy constructor.
     UPwBaseElement(UPwBaseElement const& rOther);
 
 
 }; // Class UPwBaseElement
 
 } // namespace Kratos
-
-#endif // KRATOS_GEO_U_PW_ELEMENT_H_INCLUDED  defined

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_base_element.hpp
@@ -40,7 +40,7 @@ public:
 
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION( UPwBaseElement );
 
-    UPwBaseElement(IndexType NewId = 0) : Element( NewId ) {}
+    explicit UPwBaseElement(IndexType NewId = 0) : Element( NewId ) {}
 
     /// Constructor using an array of nodes
     UPwBaseElement(IndexType NewId, const NodesArrayType& ThisNodes) : Element(NewId, ThisNodes) {}
@@ -58,6 +58,10 @@ public:
     }
 
     ~UPwBaseElement() override = default;
+    UPwBaseElement(const UPwBaseElement&) = delete;
+    UPwBaseElement& operator=(const UPwBaseElement&) = delete;
+    UPwBaseElement(UPwBaseElement&&) noexcept = delete;
+    UPwBaseElement& operator=(UPwBaseElement&&) noexcept = delete;
 
     Element::Pointer Create(IndexType NewId,
                             NodesArrayType const& ThisNodes,
@@ -230,10 +234,6 @@ private:
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, Element )
     }
-
-    UPwBaseElement & operator=(UPwBaseElement const& rOther);
-
-    UPwBaseElement(UPwBaseElement const& rOther);
 
 
 }; // Class UPwBaseElement

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -17,7 +17,7 @@
 namespace Kratos
 {
 
-template< unsigned int TDim, unsigned int TNumNodes >
+template < unsigned int TDim, unsigned int TNumNodes >
 Element::Pointer UPwSmallStrainElement<TDim,TNumNodes>::
     Create(IndexType NewId,
            NodesArrayType const& ThisNodes,
@@ -26,7 +26,7 @@ Element::Pointer UPwSmallStrainElement<TDim,TNumNodes>::
     return Element::Pointer( new UPwSmallStrainElement( NewId, this->GetGeometry().Create( ThisNodes ), pProperties ) );
 }
 
-template< unsigned int TDim, unsigned int TNumNodes >
+template < unsigned int TDim, unsigned int TNumNodes >
 Element::Pointer UPwSmallStrainElement<TDim,TNumNodes>::
     Create(IndexType NewId,
            GeometryType::Pointer pGeom,
@@ -35,7 +35,7 @@ Element::Pointer UPwSmallStrainElement<TDim,TNumNodes>::
     return Element::Pointer( new UPwSmallStrainElement( NewId, pGeom, pProperties ) );
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 int UPwSmallStrainElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
@@ -121,7 +121,7 @@ int UPwSmallStrainElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentPro
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
@@ -170,7 +170,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeSolutionStep(const Proces
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::ResetHydraulicDischarge()
 {
     KRATOS_TRY
@@ -184,7 +184,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::ResetHydraulicDischarge()
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateHydraulicDischarge(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
@@ -233,7 +233,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateHydraulicDischarge(const P
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
@@ -271,7 +271,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeNonLinearIteration(const 
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
@@ -281,7 +281,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::FinalizeNonLinearIteration(const Pr
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
@@ -334,7 +334,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessI
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::SaveGPStress(Matrix& rStressContainer,
                                                           const Vector& StressVector,
                                                           unsigned int GPoint)
@@ -358,7 +358,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::SaveGPStress(Matrix& rStressContain
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::ExtrapolateGPValues(const Matrix& StressContainer)
 {
     KRATOS_TRY
@@ -413,7 +413,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::ExtrapolateGPValues(const Matrix& S
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::SetValuesOnIntegrationPoints(const Variable<Vector>& rVariable,
                                                                           const std::vector<Vector>& rValues,
                                                                           const ProcessInfo& rCurrentProcessInfo)
@@ -435,7 +435,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::SetValuesOnIntegrationPoints(const 
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variable<double>& rVariable,
                                                                           std::vector<double>& rOutput,
                                                                           const ProcessInfo& rCurrentProcessInfo)
@@ -611,7 +611,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const 
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variable<array_1d<double,3>>& rVariable,
                                                                           std::vector<array_1d<double,3>>& rOutput,
                                                                           const ProcessInfo& rCurrentProcessInfo)
@@ -681,7 +681,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const 
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
                                                                           std::vector<Vector>& rOutput,
                                                                           const ProcessInfo& rCurrentProcessInfo)
@@ -812,7 +812,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const 
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,
                                                                           std::vector<Matrix>& rOutput,
                                                                           const ProcessInfo& rCurrentProcessInfo)
@@ -888,7 +888,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateOnIntegrationPoints(const 
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateMaterialStiffnessMatrix(MatrixType& rStiffnessMatrix,
                                                                               const ProcessInfo& rCurrentProcessInfo)
 {
@@ -942,7 +942,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateMaterialStiffnessMatrix(Ma
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddGeometricStiffnessMatrix(MatrixType& rLeftHandSideMatrix,
                                                                                      ElementVariables& rVariables,
                                                                                      unsigned int GPoint)
@@ -964,7 +964,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddGeometricStiffnessMa
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateMassMatrix(MatrixType& rMassMatrix,
                                                                  const ProcessInfo& rCurrentProcessInfo)
 {
@@ -1025,12 +1025,12 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateMassMatrix(MatrixType& rMa
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHandSideMatrix,
                                                           VectorType& rRightHandSideVector,
                                                           const ProcessInfo& rCurrentProcessInfo,
-                                                          const bool CalculateStiffnessMatrixFlag,
-                                                          const bool CalculateResidualVectorFlag)
+                                                          bool CalculateStiffnessMatrixFlag,
+                                                          bool CalculateResidualVectorFlag)
 {
     KRATOS_TRY
 
@@ -1103,7 +1103,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHandS
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 double UPwSmallStrainElement<TDim, TNumNodes>::CalculateBiotCoefficient(const ElementVariables& rVariables,
                                                                         const bool &hasBiotCoefficient) const
 {
@@ -1123,7 +1123,7 @@ double UPwSmallStrainElement<TDim, TNumNodes>::CalculateBiotCoefficient(const El
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::InitializeBiotCoefficients(ElementVariables& rVariables,
                                                                         const bool &hasBiotCoefficient)
 {
@@ -1148,7 +1148,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeBiotCoefficients(ElementV
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculatePermeabilityUpdateFactor( ElementVariables &rVariables)
 {
     KRATOS_TRY
@@ -1170,7 +1170,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculatePermeabilityUpdateFactor( 
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 double UPwSmallStrainElement<TDim, TNumNodes>::CalculateBulkModulus(const Matrix &ConstitutiveMatrix) const
 {
     KRATOS_TRY
@@ -1181,7 +1181,7 @@ double UPwSmallStrainElement<TDim, TNumNodes>::CalculateBulkModulus(const Matrix
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::InitializeElementVariables(ElementVariables& rVariables,
                                                                         const ProcessInfo& rCurrentProcessInfo)
 {
@@ -1244,7 +1244,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeElementVariables(ElementV
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateBMatrix(Matrix& rB,
                                                               const Matrix& GradNpT,
                                                               const Vector &Np)
@@ -1281,7 +1281,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateBMatrix(Matrix& rB,
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddLHS(MatrixType& rLeftHandSideMatrix,
                                                                 ElementVariables& rVariables)
 {
@@ -1298,7 +1298,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddLHS(MatrixType& rLef
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddStiffnessMatrix(MatrixType& rLeftHandSideMatrix,
                                                                             ElementVariables& rVariables)
 {
@@ -1313,7 +1313,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddStiffnessMatrix(Matr
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCouplingMatrix(MatrixType& rLeftHandSideMatrix,
                                                                            ElementVariables& rVariables)
 {
@@ -1344,7 +1344,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCouplingMatrix(Matri
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateCompressibilityMatrix(BoundedMatrix<double,TNumNodes,TNumNodes> &PMatrix,
                                                                             const ElementVariables &rVariables) const
 {
@@ -1359,7 +1359,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateCompressibilityMatrix(Boun
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCompressibilityMatrix(MatrixType& rLeftHandSideMatrix,
                                                                                   ElementVariables& rVariables)
 {
@@ -1374,7 +1374,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCompressibilityMatri
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculatePermeabilityMatrix(BoundedMatrix<double, TNumNodes, TDim>& rPDimMatrix,
                                                                          BoundedMatrix<double, TNumNodes, TNumNodes>& rPMatrix,
                                                                          const ElementVariables& rVariables) const
@@ -1393,7 +1393,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculatePermeabilityMatrix(Bounded
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddPermeabilityMatrix(MatrixType &rLeftHandSideMatrix,
                                                                                ElementVariables &rVariables)
 {
@@ -1410,7 +1410,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddPermeabilityMatrix(M
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddRHS(VectorType& rRightHandSideVector,
                                                                 ElementVariables& rVariables,
                                                                 unsigned int GPoint)
@@ -1434,7 +1434,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddRHS(VectorType& rRig
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddStiffnessForce(VectorType& rRightHandSideVector,
                                                                            ElementVariables& rVariables,
                                                                            unsigned int GPoint)
@@ -1450,7 +1450,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddStiffnessForce(Vecto
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddMixBodyForce(VectorType& rRightHandSideVector,
                                                                          ElementVariables& rVariables)
 {
@@ -1467,7 +1467,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddMixBodyForce(VectorT
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateSoilDensity(ElementVariables &rVariables)
 {
     KRATOS_TRY
@@ -1478,7 +1478,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateSoilDensity(ElementVariabl
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateSoilGamma(ElementVariables &rVariables)
 {
     KRATOS_TRY
@@ -1490,7 +1490,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateSoilGamma(ElementVariables
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddCouplingTerms(VectorType& rRightHandSideVector,
                                                                          ElementVariables& rVariables)
 {
@@ -1522,7 +1522,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddCouplingTerms(VectorT
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateCompressibilityFlow(BoundedMatrix<double, TNumNodes, TNumNodes>& rPMatrix,
                                                                           array_1d<double, TNumNodes>& rPVector,
                                                                           const ElementVariables &rVariables) const
@@ -1539,7 +1539,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateCompressibilityFlow(Bounde
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCompressibilityFlow(VectorType& rRightHandSideVector,
                                                                                 ElementVariables& rVariables)
 {
@@ -1555,7 +1555,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCompressibilityFlow(
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculatePermeabilityFlow(BoundedMatrix<double, TNumNodes, TDim>& rPDimMatrix,
                                                                        BoundedMatrix<double, TNumNodes, TNumNodes>& rPMatrix,
                                                                        array_1d<double, TNumNodes>& rPVector,
@@ -1577,7 +1577,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculatePermeabilityFlow(BoundedMa
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddPermeabilityFlow(VectorType &rRightHandSideVector,
                                                                              ElementVariables &rVariables)
 {
@@ -1594,7 +1594,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddPermeabilityFlow(Vec
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateFluidBodyFlow(BoundedMatrix<double, TNumNodes, TDim>& rPDimMatrix,
                                                                     array_1d<double, TNumNodes>& rPVector,
                                                                     const ElementVariables& rVariables) const
@@ -1613,7 +1613,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateFluidBodyFlow(BoundedMatri
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddFluidBodyFlow(VectorType& rRightHandSideVector,
                                                                           ElementVariables& rVariables)
 {
@@ -1629,7 +1629,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddFluidBodyFlow(Vector
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateStrain(ElementVariables& rVariables,
                                                              unsigned int GPoint)
 {
@@ -1641,13 +1641,13 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateStrain(ElementVariables& r
     }
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateCauchyStrain(ElementVariables& rVariables)
 {
     noalias(rVariables.StrainVector) = prod(rVariables.B, rVariables.DisplacementVector);
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateCauchyGreenStrain(ElementVariables& rVariables)
 {
     KRATOS_TRY
@@ -1676,7 +1676,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateCauchyGreenStrain(ElementV
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim,TNumNodes>::CalculateCauchyAlmansiStrain(ElementVariables& rVariables)
 {
     // Compute total deformation gradient
@@ -1707,7 +1707,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateCauchyAlmansiStrain(Element
 
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateDeformationGradient(ElementVariables& rVariables,
                                                                           unsigned int GPoint)
 {
@@ -1746,7 +1746,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateDeformationGradient(Elemen
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::InitializeNodalPorePressureVariables(ElementVariables& rVariables)
 {
     KRATOS_TRY
@@ -1762,7 +1762,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeNodalPorePressureVariable
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::InitializeNodalDisplacementVariables(ElementVariables& rVariables)
 {
     KRATOS_TRY
@@ -1776,7 +1776,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeNodalDisplacementVariable
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::InitializeNodalVolumeAccelerationVariables(ElementVariables& rVariables)
 {
     KRATOS_TRY
@@ -1791,7 +1791,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeNodalVolumeAccelerationVa
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::InitializeProperties(ElementVariables& rVariables)
 {
     KRATOS_TRY
@@ -1818,7 +1818,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeProperties(ElementVariabl
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateKinematics(ElementVariables& rVariables,
                                                                  unsigned int GPoint)
 {
@@ -1843,7 +1843,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateKinematics(ElementVariable
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::SetConstitutiveParameters(ElementVariables& rVariables,
                                                                        ConstitutiveLaw::Parameters& rConstitutiveParameters)
 {
@@ -1859,7 +1859,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::SetConstitutiveParameters(ElementVa
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::SetRetentionParameters(const ElementVariables& rVariables,
                                                                     RetentionLaw::Parameters& rRetentionParameters)
 {
@@ -1870,7 +1870,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::SetRetentionParameters(const Elemen
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 double UPwSmallStrainElement<TDim, TNumNodes>::CalculateFluidPressure(const ElementVariables &rVariables)
 {
     KRATOS_TRY
@@ -1880,7 +1880,7 @@ double UPwSmallStrainElement<TDim, TNumNodes>::CalculateFluidPressure(const Elem
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateRetentionResponse(ElementVariables& rVariables,
                                                                         RetentionLaw::Parameters& rRetentionParameters,
                                                                         unsigned int GPoint)
@@ -1899,7 +1899,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateRetentionResponse(ElementV
     KRATOS_CATCH("")
 }
 
-template<unsigned int TDim, unsigned int TNumNodes>
+template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateExtrapolationMatrix(BoundedMatrix<double, TNumNodes, TNumNodes>& rExtrapolationMatrix)
 {
     KRATOS_TRY
@@ -1913,7 +1913,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateExtrapolationMatrix(Bounde
     KRATOS_CATCH("")
 }
 
-template< >
+template < >
 void UPwSmallStrainElement<2, 3>::CalculateExtrapolationMatrix(BoundedMatrix<double, 3, 3>& rExtrapolationMatrix)
 {
     // The matrix contains the shape functions at each GP evaluated at each node.
@@ -1927,7 +1927,7 @@ void UPwSmallStrainElement<2, 3>::CalculateExtrapolationMatrix(BoundedMatrix<dou
     rExtrapolationMatrix(2,0) = -0.33333333333333333333; rExtrapolationMatrix(2,1) = -0.33333333333333333333; rExtrapolationMatrix(2,2) = 1.6666666666666666666;
 }
 
-template< >
+template < >
 void UPwSmallStrainElement<2, 4>::CalculateExtrapolationMatrix(BoundedMatrix<double, 4, 4>& rExtrapolationMatrix)
 {
     // Quadrilateral_2d_4
@@ -1938,7 +1938,7 @@ void UPwSmallStrainElement<2, 4>::CalculateExtrapolationMatrix(BoundedMatrix<dou
     rExtrapolationMatrix(3,0) = -0.5; rExtrapolationMatrix(3,1) = 0.13397459621556132; rExtrapolationMatrix(3,2) = -0.5; rExtrapolationMatrix(3,3) = 1.8660254037844386;
 }
 
-template< >
+template < >
 void UPwSmallStrainElement<3, 4>::CalculateExtrapolationMatrix(BoundedMatrix<double, 4, 4>& rExtrapolationMatrix)
 {
     // Tetrahedra_3d_4
@@ -1949,7 +1949,7 @@ void UPwSmallStrainElement<3, 4>::CalculateExtrapolationMatrix(BoundedMatrix<dou
     rExtrapolationMatrix(3,0) = -0.3090169887498949048; rExtrapolationMatrix(3,1) = -0.30901698874989490471; rExtrapolationMatrix(3,2) = 1.9270509662496847143; rExtrapolationMatrix(3,3) = -0.30901698874989490481;
 }
 
-template< >
+template < >
 void UPwSmallStrainElement<3, 8>::CalculateExtrapolationMatrix(BoundedMatrix<double, 8, 8>& rExtrapolationMatrix)
 {
     // Hexahedra_3d_8

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -1105,7 +1105,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAll(MatrixType& rLeftHandS
 
 template <unsigned int TDim, unsigned int TNumNodes>
 double UPwSmallStrainElement<TDim, TNumNodes>::CalculateBiotCoefficient(const ElementVariables& rVariables,
-                                                                        const bool &hasBiotCoefficient) const
+                                                                        bool hasBiotCoefficient) const
 {
     KRATOS_TRY
 
@@ -1115,7 +1115,7 @@ double UPwSmallStrainElement<TDim, TNumNodes>::CalculateBiotCoefficient(const El
     if (hasBiotCoefficient) {
         return rProp[BIOT_COEFFICIENT];
     } else {
-        // calculate Bulk modulus from stiffness matrix
+        // Calculate Bulk modulus from stiffness matrix
         const double BulkModulus = CalculateBulkModulus(rVariables.ConstitutiveMatrix);
         return 1.0 - BulkModulus / rProp[BULK_MODULUS_SOLID];
     }
@@ -1125,7 +1125,7 @@ double UPwSmallStrainElement<TDim, TNumNodes>::CalculateBiotCoefficient(const El
 
 template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::InitializeBiotCoefficients(ElementVariables& rVariables,
-                                                                        const bool &hasBiotCoefficient)
+                                                                        bool hasBiotCoefficient)
 {
     KRATOS_TRY
 
@@ -1149,7 +1149,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeBiotCoefficients(ElementV
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>
-void UPwSmallStrainElement<TDim, TNumNodes>::CalculatePermeabilityUpdateFactor( ElementVariables &rVariables)
+void UPwSmallStrainElement<TDim, TNumNodes>::CalculatePermeabilityUpdateFactor(ElementVariables& rVariables)
 {
     KRATOS_TRY
 
@@ -1171,7 +1171,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculatePermeabilityUpdateFactor( 
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>
-double UPwSmallStrainElement<TDim, TNumNodes>::CalculateBulkModulus(const Matrix &ConstitutiveMatrix) const
+double UPwSmallStrainElement<TDim, TNumNodes>::CalculateBulkModulus(const Matrix& ConstitutiveMatrix) const
 {
     KRATOS_TRY
 
@@ -1247,7 +1247,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::InitializeElementVariables(ElementV
 template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateBMatrix(Matrix& rB,
                                                               const Matrix& GradNpT,
-                                                              const Vector &Np)
+                                                              const Vector& Np)
 {
     KRATOS_TRY
 
@@ -1345,12 +1345,12 @@ void UPwSmallStrainElement<TDim, TNumNodes>::CalculateAndAddCouplingMatrix(Matri
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>
-void UPwSmallStrainElement<TDim, TNumNodes>::CalculateCompressibilityMatrix(BoundedMatrix<double,TNumNodes,TNumNodes> &PMatrix,
-                                                                            const ElementVariables &rVariables) const
+void UPwSmallStrainElement<TDim, TNumNodes>::CalculateCompressibilityMatrix(BoundedMatrix<double,TNumNodes,TNumNodes>& rPMatrix,
+                                                                            const ElementVariables& rVariables) const
 {
     KRATOS_TRY
 
-    noalias(PMatrix) = - PORE_PRESSURE_SIGN_FACTOR 
+    noalias(rPMatrix) = - PORE_PRESSURE_SIGN_FACTOR
                        * rVariables.DtPressureCoefficient
                        * rVariables.BiotModulusInverse
                        * outer_prod(rVariables.Np, rVariables.Np)
@@ -1525,7 +1525,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddCouplingTerms(VectorT
 template <unsigned int TDim, unsigned int TNumNodes>
 void UPwSmallStrainElement<TDim, TNumNodes>::CalculateCompressibilityFlow(BoundedMatrix<double, TNumNodes, TNumNodes>& rPMatrix,
                                                                           array_1d<double, TNumNodes>& rPVector,
-                                                                          const ElementVariables &rVariables) const
+                                                                          const ElementVariables& rVariables) const
 {
     KRATOS_TRY
 
@@ -1871,7 +1871,7 @@ void UPwSmallStrainElement<TDim, TNumNodes>::SetRetentionParameters(const Elemen
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>
-double UPwSmallStrainElement<TDim, TNumNodes>::CalculateFluidPressure(const ElementVariables &rVariables)
+double UPwSmallStrainElement<TDim, TNumNodes>::CalculateFluidPressure(const ElementVariables& rVariables)
 {
     KRATOS_TRY
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -17,7 +17,6 @@
 namespace Kratos
 {
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
 Element::Pointer UPwSmallStrainElement<TDim,TNumNodes>::
     Create(IndexType NewId,
@@ -27,7 +26,6 @@ Element::Pointer UPwSmallStrainElement<TDim,TNumNodes>::
     return Element::Pointer( new UPwSmallStrainElement( NewId, this->GetGeometry().Create( ThisNodes ), pProperties ) );
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
 Element::Pointer UPwSmallStrainElement<TDim,TNumNodes>::
     Create(IndexType NewId,
@@ -37,10 +35,8 @@ Element::Pointer UPwSmallStrainElement<TDim,TNumNodes>::
     return Element::Pointer( new UPwSmallStrainElement( NewId, pGeom, pProperties ) );
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-int UPwSmallStrainElement<TDim,TNumNodes>::
-    Check( const ProcessInfo& rCurrentProcessInfo ) const
+int UPwSmallStrainElement<TDim,TNumNodes>::Check( const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
@@ -52,43 +48,39 @@ int UPwSmallStrainElement<TDim,TNumNodes>::
     const PropertiesType& rProp = this->GetProperties();
     const GeometryType& rGeom = this->GetGeometry();
 
-    if (rGeom.DomainSize() < 1.0e-15)
-        KRATOS_ERROR << "DomainSize < 1.0e-15 for the element " << this->Id() << std::endl;
+    KRATOS_ERROR_IF(rGeom.DomainSize() < 1.0e-15) << "DomainSize < 1.0e-15 for the element " << this->Id() << std::endl;
 
     // Verify specific properties
-    if ( rProp.Has( IGNORE_UNDRAINED ) == false)
-        KRATOS_ERROR << "IGNORE_UNDRAINED does not exist in the parameter list" << this->Id() << std::endl;
+    KRATOS_ERROR_IF_NOT(rProp.Has(IGNORE_UNDRAINED))
+        << "IGNORE_UNDRAINED does not exist in the parameter list" << this->Id() << std::endl;
 
-    bool IgnoreUndrained = rProp[IGNORE_UNDRAINED];
+    if (!rProp[IGNORE_UNDRAINED]) {
+        KRATOS_ERROR_IF(!rProp.Has( BULK_MODULUS_FLUID ) || rProp[BULK_MODULUS_FLUID] < 0.0)
+            << "BULK_MODULUS_FLUID has Key zero, is not defined or has an invalid value at element" << this->Id() << std::endl;
 
-    if (!IgnoreUndrained) {
-        if ( rProp.Has( BULK_MODULUS_FLUID ) == false || rProp[BULK_MODULUS_FLUID] < 0.0 )
-            KRATOS_ERROR << "BULK_MODULUS_FLUID has Key zero, is not defined or has an invalid value at element" << this->Id() << std::endl;
+        KRATOS_ERROR_IF(!rProp.Has( DYNAMIC_VISCOSITY ) || rProp[DYNAMIC_VISCOSITY] < 0.0)
+            << "DYNAMIC_VISCOSITY has Key zero, is not defined or has an invalid value at element" << this->Id() << std::endl;
 
-        if ( rProp.Has( DYNAMIC_VISCOSITY ) == false || rProp[DYNAMIC_VISCOSITY] < 0.0 )
-            KRATOS_ERROR << "DYNAMIC_VISCOSITY has Key zero, is not defined or has an invalid value at element" << this->Id() << std::endl;
+        KRATOS_ERROR_IF(!rProp.Has( PERMEABILITY_XX ) || rProp[PERMEABILITY_XX] < 0.0)
+            << "PERMEABILITY_XX has Key zero, is not defined or has an invalid value at element" << this->Id() << std::endl;
 
-        if ( rProp.Has( PERMEABILITY_XX ) == false || rProp[PERMEABILITY_XX] < 0.0 )
-            KRATOS_ERROR << "PERMEABILITY_XX has Key zero, is not defined or has an invalid value at element" << this->Id() << std::endl;
+        KRATOS_ERROR_IF(!rProp.Has( PERMEABILITY_YY ) || rProp[PERMEABILITY_YY] < 0.0)
+            << "PERMEABILITY_YY has Key zero, is not defined or has an invalid value at element" << this->Id() << std::endl;
 
-        if ( rProp.Has( PERMEABILITY_YY ) == false || rProp[PERMEABILITY_YY] < 0.0 )
-            KRATOS_ERROR << "PERMEABILITY_YY has Key zero, is not defined or has an invalid value at element" << this->Id() << std::endl;
-
-        if ( rProp.Has( PERMEABILITY_XY ) == false || rProp[PERMEABILITY_XY] < 0.0 )
-            KRATOS_ERROR << "PERMEABILITY_XY has Key zero, is not defined or has an invalid value at element" << this->Id() << std::endl;
+        KRATOS_ERROR_IF(!rProp.Has( PERMEABILITY_XY ) || rProp[PERMEABILITY_XY] < 0.0)
+            << "PERMEABILITY_XY has Key zero, is not defined or has an invalid value at element" << this->Id() << std::endl;
 
         if constexpr (TDim > 2) {
-            if ( rProp.Has( PERMEABILITY_ZZ ) == false || rProp[PERMEABILITY_ZZ] < 0.0 )
-                KRATOS_ERROR << "PERMEABILITY_ZZ has Key zero, is not defined or has an invalid value at element" << this->Id() << std::endl;
+            KRATOS_ERROR_IF(!rProp.Has( PERMEABILITY_ZZ ) || rProp[PERMEABILITY_ZZ] < 0.0)
+                << "PERMEABILITY_ZZ has Key zero, is not defined or has an invalid value at element" << this->Id() << std::endl;
 
-            if ( rProp.Has( PERMEABILITY_YZ ) == false || rProp[PERMEABILITY_YZ] < 0.0 )
-                KRATOS_ERROR << "PERMEABILITY_YZ has Key zero, is not defined or has an invalid value at element" << this->Id() << std::endl;
+            KRATOS_ERROR_IF(!rProp.Has( PERMEABILITY_YZ ) || rProp[PERMEABILITY_YZ] < 0.0)
+                << "PERMEABILITY_YZ has Key zero, is not defined or has an invalid value at element" << this->Id() << std::endl;
 
-            if ( rProp.Has( PERMEABILITY_ZX ) == false || rProp[PERMEABILITY_ZX] < 0.0 )
-                KRATOS_ERROR << "PERMEABILITY_ZX has Key zero, is not defined or has an invalid value at element" << this->Id() << std::endl;
+            KRATOS_ERROR_IF(!rProp.Has( PERMEABILITY_ZX ) || rProp[PERMEABILITY_ZX] < 0.0)
+                << "PERMEABILITY_ZX has Key zero, is not defined or has an invalid value at element" << this->Id() << std::endl;
         }
     }
-
 
     // Verify that the constitutive law exists
     KRATOS_ERROR_IF_NOT(this->GetProperties().Has( CONSTITUTIVE_LAW )) 
@@ -126,14 +118,13 @@ int UPwSmallStrainElement<TDim,TNumNodes>::
 
     return ierr;
 
-    KRATOS_CATCH( "" );
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
 void UPwSmallStrainElement<TDim,TNumNodes>::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     if (!mIsInitialised) this->Initialize(rCurrentProcessInfo);
 
@@ -158,10 +149,10 @@ void UPwSmallStrainElement<TDim,TNumNodes>::InitializeSolutionStep(const Process
         //Compute Np, GradNpT, B and StrainVector
         this->CalculateKinematics(Variables, GPoint);
 
-        //Compute infinitessimal strain
+        //Compute infinitesimal strain
         this->CalculateStrain(Variables, GPoint);
 
-        //set gauss points variables to constitutivelaw parameters
+        //set Gauss points variables to constitutive law parameters
         this->SetConstitutiveParameters(Variables, ConstitutiveParameters);
 
         // Initialize constitutive law
@@ -176,15 +167,13 @@ void UPwSmallStrainElement<TDim,TNumNodes>::InitializeSolutionStep(const Process
     // reset hydraulic discharge
     this->ResetHydraulicDischarge();
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    ResetHydraulicDischarge()
+void UPwSmallStrainElement<TDim,TNumNodes>::ResetHydraulicDischarge()
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     // reset hydraulic discharge
     GeometryType& rGeom = this->GetGeometry();
@@ -192,15 +181,13 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
         ThreadSafeNodeWrite(rGeom[i], HYDRAULIC_DISCHARGE, 0.0 );
     }
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateHydraulicDischarge(const ProcessInfo& rCurrentProcessInfo)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateHydraulicDischarge(const ProcessInfo& rCurrentProcessInfo)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     std::vector<array_1d<double,3>> FluidFlux;
     this->CalculateOnIntegrationPoints( FLUID_FLUX_VECTOR,
@@ -216,7 +203,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
 
     Variables.GradNpTInitialConfiguration.resize(TNumNodes, TDim, false);
     Variables.GradNpT.resize(TNumNodes, TDim, false);
-    (Variables.detJContainer).resize(NumGPoints, false);
+    Variables.detJContainer.resize(NumGPoints, false);
     rGeom.ShapeFunctionsIntegrationPointsGradients( Variables.DN_DXContainer,
                                                    Variables.detJContainer,
                                                    mThisIntegrationMethod );
@@ -244,15 +231,13 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
         }
     }
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
+void UPwSmallStrainElement<TDim,TNumNodes>::InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     //Defining necessary variables
     const GeometryType& rGeom = this->GetGeometry();
@@ -273,10 +258,10 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
     for ( unsigned int GPoint = 0; GPoint < NumGPoints; ++GPoint) {
         this->CalculateKinematics(Variables, GPoint);
 
-        //Compute infinitessimal strain
+        //Compute infinitesimal strain
         this->CalculateStrain(Variables, GPoint);
 
-        //set gauss points variables to constitutivelaw parameters
+        //set gauss points variables to constitutive law parameters
         this->SetConstitutiveParameters(Variables, ConstitutiveParameters);
 
         // Compute Stress
@@ -284,25 +269,21 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
         mConstitutiveLawVector[GPoint]->CalculateMaterialResponseCauchy(ConstitutiveParameters);
     }
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
-
-//----------------------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
 void UPwSmallStrainElement<TDim,TNumNodes>::FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     this->InitializeNonLinearIteration(rCurrentProcessInfo);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo )
+void UPwSmallStrainElement<TDim,TNumNodes>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -351,10 +332,9 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
     if (rCurrentProcessInfo[NODAL_SMOOTHING])
         this->ExtrapolateGPValues(StressContainer);
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
 void UPwSmallStrainElement<TDim,TNumNodes>::SaveGPStress(Matrix& rStressContainer,
                                                          const Vector& StressVector,
@@ -376,10 +356,9 @@ void UPwSmallStrainElement<TDim,TNumNodes>::SaveGPStress(Matrix& rStressContaine
      * S1-0 = S[1] at GP 0
     */
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
 void UPwSmallStrainElement<TDim, TNumNodes>::ExtrapolateGPValues(const Matrix& StressContainer)
 {
@@ -456,7 +435,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::SetValuesOnIntegrationPoints(const V
 
     KRATOS_CATCH("")
 }
-//----------------------------------------------------------------------------------------------------
+
 template< unsigned int TDim, unsigned int TNumNodes >
 void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints(const Variable<double>& rVariable,
                                                                          std::vector<double>& rOutput,
@@ -575,33 +554,20 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints(const V
     } 
     else if (rVariable == CONFINED_STIFFNESS || rVariable == SHEAR_STIFFNESS) {
         size_t variable_index;
-        if (rVariable == CONFINED_STIFFNESS)
-        {
-            if (TDim == 2)
-            {
+        if (rVariable == CONFINED_STIFFNESS) {
+            if (TDim == 2) {
                 variable_index = INDEX_2D_PLANE_STRAIN_XX;
-            }
-            else if (TDim == 3)
-            {
+            } else if (TDim == 3) {
                 variable_index = INDEX_3D_XX;
-            }
-            else
-            {
+            } else {
                 KRATOS_ERROR << "CONFINED_STIFFNESS can not be retrieved for dim " << TDim << " in element: " << this->Id() << std::endl;
             }
-        }
-        else if (rVariable == SHEAR_STIFFNESS)
-        {
-            if (TDim == 2)
-            {
+        } else if (rVariable == SHEAR_STIFFNESS) {
+            if (TDim == 2) {
                 variable_index = INDEX_2D_PLANE_STRAIN_XY;
-            }
-            else if (TDim == 3)
-            {
+            } else if (TDim == 3) {
                 variable_index = INDEX_3D_XZ;
-            }
-            else
-            {
+            } else {
                 KRATOS_ERROR << "SHEAR_STIFFNESS can not be retrieved for dim " << TDim << " in element: " << this->Id() << std::endl;
             }
         }
@@ -654,10 +620,9 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints(const V
         }
     }
     
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
 void UPwSmallStrainElement<TDim,TNumNodes>::
     CalculateOnIntegrationPoints( const Variable<array_1d<double,3>>& rVariable,
@@ -728,10 +693,9 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
         }
     }
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
 void UPwSmallStrainElement<TDim,TNumNodes>::
     CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
@@ -870,15 +834,13 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
             rOutput[i] = mConstitutiveLawVector[i]->GetValue( rVariable , rOutput[i] );
     }
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,
-                                 std::vector<Matrix>& rOutput,
-                                 const ProcessInfo& rCurrentProcessInfo )
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,
+                                                                         std::vector<Matrix>& rOutput,
+                                                                         const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -955,14 +917,12 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
         }
     }
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateMaterialStiffnessMatrix( MatrixType& rStiffnessMatrix,
-                                      const ProcessInfo& rCurrentProcessInfo )
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateMaterialStiffnessMatrix(MatrixType& rStiffnessMatrix,
+                                                                             const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -1015,15 +975,13 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
         this->CalculateAndAddStiffnessMatrix(rStiffnessMatrix, Variables);
     }
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateAndAddGeometricStiffnessMatrix( MatrixType& rLeftHandSideMatrix,
-                                             ElementVariables& rVariables,
-                                             unsigned int GPoint )
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddGeometricStiffnessMatrix(MatrixType& rLeftHandSideMatrix,
+                                                                                    ElementVariables& rVariables,
+                                                                                    unsigned int GPoint)
 {
     KRATOS_TRY
 
@@ -1039,14 +997,12 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
     //Distribute stiffness block matrix into the elemental matrix
     GeoElementUtilities::AssembleUBlockMatrix(rLeftHandSideMatrix, UMatrix, TNumNodes, TDim);
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateMassMatrix( MatrixType& rMassMatrix,
-                         const ProcessInfo& rCurrentProcessInfo )
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateMassMatrix(MatrixType& rMassMatrix,
+                                                                const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -1063,10 +1019,10 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
 
     //Element variables
     ElementVariables Variables;
-    this->InitializeElementVariables( Variables,
-                                      rCurrentProcessInfo );
+    this->InitializeElementVariables(Variables,
+                                     rCurrentProcessInfo);
 
-    // create general parametes of retention law
+    // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
 
     //Defining shape functions at all integration points
@@ -1106,18 +1062,15 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
                                * Variables.IntegrationCoefficientInitialConfiguration;
     }
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateAll( MatrixType& rLeftHandSideMatrix,
-                  VectorType& rRightHandSideVector,
-                  const ProcessInfo& rCurrentProcessInfo,
-                  const bool CalculateStiffnessMatrixFlag,
-                  const bool CalculateResidualVectorFlag)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAll(MatrixType& rLeftHandSideMatrix,
+                                                         VectorType& rRightHandSideVector,
+                                                         const ProcessInfo& rCurrentProcessInfo,
+                                                         const bool CalculateStiffnessMatrixFlag,
+                                                         const bool CalculateResidualVectorFlag)
 {
     KRATOS_TRY
 
@@ -1137,8 +1090,8 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
 
     //Element variables
     ElementVariables Variables;
-    this->InitializeElementVariables( Variables,
-                                      rCurrentProcessInfo );
+    this->InitializeElementVariables(Variables,
+                                     rCurrentProcessInfo);
 
     // create general parameters of retention law
     RetentionLaw::Parameters RetentionParameters(this->GetProperties(), rCurrentProcessInfo);
@@ -1192,14 +1145,13 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
         if (CalculateResidualVectorFlag)  this->CalculateAndAddRHS(rRightHandSideVector, Variables, GPoint);
     }
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-double UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateBiotCoefficient( const ElementVariables& rVariables,
-                              const bool &hasBiotCoefficient) const
+double UPwSmallStrainElement<TDim,TNumNodes>::CalculateBiotCoefficient(const ElementVariables& rVariables,
+                                                                       const bool &hasBiotCoefficient) const
 {
     KRATOS_TRY
 
@@ -1214,14 +1166,12 @@ double UPwSmallStrainElement<TDim,TNumNodes>::
         return 1.0 - BulkModulus / rProp[BULK_MODULUS_SOLID];
     }
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    InitializeBiotCoefficients( ElementVariables& rVariables,
-                                const bool &hasBiotCoefficient)
+void UPwSmallStrainElement<TDim,TNumNodes>::InitializeBiotCoefficients(ElementVariables& rVariables,
+                                                                       const bool &hasBiotCoefficient)
 {
     KRATOS_TRY
 
@@ -1241,13 +1191,11 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
     rVariables.BiotModulusInverse *= rVariables.DegreeOfSaturation;
     rVariables.BiotModulusInverse -= rVariables.DerivativeOfSaturation*rProp[POROSITY];
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculatePermeabilityUpdateFactor( ElementVariables &rVariables)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculatePermeabilityUpdateFactor( ElementVariables &rVariables)
 {
     KRATOS_TRY
 
@@ -1265,31 +1213,23 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
         rVariables.PermeabilityUpdateFactor = 1.0;
     }
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-double UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateBulkModulus(const Matrix &ConstitutiveMatrix) const
+double UPwSmallStrainElement<TDim,TNumNodes>::CalculateBulkModulus(const Matrix &ConstitutiveMatrix) const
 {
     KRATOS_TRY
 
     const int IndexG = ConstitutiveMatrix.size1() - 1;
+    return ConstitutiveMatrix(0, 0) - (4.0/3.0)*ConstitutiveMatrix(IndexG, IndexG);
 
-    const double M = ConstitutiveMatrix(0, 0);
-    const double G = ConstitutiveMatrix(IndexG, IndexG);
-
-    return M - (4.0/3.0)*G;
-
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    InitializeElementVariables( ElementVariables& rVariables,
-                                const ProcessInfo& rCurrentProcessInfo )
+void UPwSmallStrainElement<TDim,TNumNodes>::InitializeElementVariables(ElementVariables& rVariables,
+                                                                       const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -1338,7 +1278,6 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
                                                    mThisIntegrationMethod );
 
     //Constitutive Law parameters
-    
     rVariables.StressVector.resize(VoigtSize, false);
     rVariables.StrainVector.resize(VoigtSize, false);
     rVariables.ConstitutiveMatrix.resize(VoigtSize, VoigtSize, false);
@@ -1353,15 +1292,13 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
     rVariables.RelativePermeability = 1.0;
     rVariables.BishopCoefficient = 1.0;
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateBMatrix(Matrix& rB,
-                     const Matrix& GradNpT,
-                     const Vector &Np)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateBMatrix(Matrix& rB,
+                                                             const Matrix& GradNpT,
+                                                             const Vector &Np)
 {
     KRATOS_TRY
 
@@ -1393,15 +1330,14 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
         }
     }
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateAndAddLHS(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddLHS(MatrixType& rLeftHandSideMatrix,
+                                                               ElementVariables& rVariables)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     this->CalculateAndAddStiffnessMatrix(rLeftHandSideMatrix,rVariables);
     this->CalculateAndAddCompressibilityMatrix(rLeftHandSideMatrix,rVariables);
@@ -1411,15 +1347,14 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
         this->CalculateAndAddPermeabilityMatrix(rLeftHandSideMatrix,rVariables);
     }
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateAndAddStiffnessMatrix(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddStiffnessMatrix(MatrixType& rLeftHandSideMatrix,
+                                                                           ElementVariables& rVariables)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     noalias(rVariables.UVoigtMatrix) = prod(trans(rVariables.B), rVariables.ConstitutiveMatrix);
     noalias(rVariables.UMatrix) = prod(rVariables.UVoigtMatrix, rVariables.B)*rVariables.IntegrationCoefficient;
@@ -1427,15 +1362,14 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
     //Distribute stiffness block matrix into the elemental matrix
     GeoElementUtilities::AssembleUBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix, rVariables.UMatrix);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateAndAddCouplingMatrix(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddCouplingMatrix(MatrixType& rLeftHandSideMatrix,
+                                                                          ElementVariables& rVariables)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     noalias(rVariables.UVector) = prod(trans(rVariables.B),rVariables.VoigtVector);
 
@@ -1459,16 +1393,14 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
         GeoElementUtilities::AssemblePUBlockMatrix<TDim, TNumNodes>(rLeftHandSideMatrix,rVariables.PUMatrix);
     }
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateCompressibilityMatrix(BoundedMatrix<double,TNumNodes,TNumNodes> &PMatrix,
-                                   const ElementVariables &rVariables) const
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateCompressibilityMatrix(BoundedMatrix<double,TNumNodes,TNumNodes> &PMatrix,
+                                                                           const ElementVariables &rVariables) const
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     noalias(PMatrix) = - PORE_PRESSURE_SIGN_FACTOR 
                        * rVariables.DtPressureCoefficient
@@ -1476,35 +1408,30 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
                        * outer_prod(rVariables.Np, rVariables.Np)
                        * rVariables.IntegrationCoefficient;
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateAndAddCompressibilityMatrix(MatrixType& rLeftHandSideMatrix,
-                                         ElementVariables& rVariables)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddCompressibilityMatrix(MatrixType& rLeftHandSideMatrix,
+                                                                                 ElementVariables& rVariables)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     this->CalculateCompressibilityMatrix(rVariables.PMatrix, rVariables);
 
     //Distribute compressibility block matrix into the elemental matrix
-    GeoElementUtilities::
-        AssemblePBlockMatrix< TDim, TNumNodes >(rLeftHandSideMatrix,
-                                                rVariables.PMatrix);
+    GeoElementUtilities::AssemblePBlockMatrix< TDim, TNumNodes >(rLeftHandSideMatrix,
+                                                                 rVariables.PMatrix);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculatePermeabilityMatrix(BoundedMatrix<double,TNumNodes,TDim> &PDimMatrix,
-                                BoundedMatrix<double,TNumNodes,TNumNodes> &PMatrix,
-                                const ElementVariables &rVariables) const
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculatePermeabilityMatrix(BoundedMatrix<double,TNumNodes,TDim> &PDimMatrix,
+                                                                        BoundedMatrix<double,TNumNodes,TNumNodes> &PMatrix,
+                                                                        const ElementVariables &rVariables) const
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     noalias(PDimMatrix) = - PORE_PRESSURE_SIGN_FACTOR 
                           * prod(rVariables.GradNpT, rVariables.PermeabilityMatrix);
@@ -1515,36 +1442,32 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
                       * prod(PDimMatrix, trans(rVariables.GradNpT))
                       * rVariables.IntegrationCoefficient;
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateAndAddPermeabilityMatrix(MatrixType &rLeftHandSideMatrix,
-                                      ElementVariables &rVariables)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddPermeabilityMatrix(MatrixType &rLeftHandSideMatrix,
+                                                                              ElementVariables &rVariables)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     this->CalculatePermeabilityMatrix(rVariables.PDimMatrix,
                                       rVariables.PMatrix,
                                       rVariables);
 
     //Distribute permeability block matrix into the elemental matrix
-    GeoElementUtilities::
-        AssemblePBlockMatrix< TDim, TNumNodes >(rLeftHandSideMatrix, rVariables.PMatrix);
+    GeoElementUtilities::AssemblePBlockMatrix< TDim, TNumNodes >(rLeftHandSideMatrix,
+                                                      rVariables.PMatrix);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateAndAddRHS(VectorType& rRightHandSideVector,
-                       ElementVariables& rVariables,
-                       unsigned int GPoint)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddRHS(VectorType& rRightHandSideVector,
+                                                               ElementVariables& rVariables,
+                                                               unsigned int GPoint)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     this->CalculateAndAddStiffnessForce(rRightHandSideVector, rVariables, GPoint);
 
@@ -1560,17 +1483,15 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
         this->CalculateAndAddFluidBodyFlow(rRightHandSideVector, rVariables);
     }
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateAndAddStiffnessForce( VectorType& rRightHandSideVector,
-                                   ElementVariables& rVariables,
-                                   unsigned int GPoint )
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddStiffnessForce(VectorType& rRightHandSideVector,
+                                                                          ElementVariables& rVariables,
+                                                                          unsigned int GPoint)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     noalias(rVariables.UVector) = -1.0 * prod(trans(rVariables.B), mStressVector[GPoint])
                                        * rVariables.IntegrationCoefficient;
@@ -1578,15 +1499,14 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
     //Distribute stiffness block vector into elemental vector
     GeoElementUtilities::AssembleUBlockVector<TDim, TNumNodes>(rRightHandSideVector, rVariables.UVector);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateAndAddMixBodyForce(VectorType& rRightHandSideVector, ElementVariables& rVariables)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddMixBodyForce(VectorType& rRightHandSideVector,
+                                                                        ElementVariables& rVariables)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     this->CalculateSoilGamma(rVariables);
 
@@ -1596,47 +1516,41 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
     //Distribute body force block vector into elemental vector
     GeoElementUtilities::AssembleUBlockVector<TDim, TNumNodes>(rRightHandSideVector,rVariables.UVector);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateSoilDensity(ElementVariables &rVariables)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateSoilDensity(ElementVariables &rVariables)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     rVariables.Density = (  rVariables.DegreeOfSaturation
                           * rVariables.Porosity
                           * rVariables.FluidDensity )
                         + (1.0 - rVariables.Porosity)*rVariables.SolidDensity;
 
-    KRATOS_CATCH("");
-
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateSoilGamma(ElementVariables &rVariables)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateSoilGamma(ElementVariables &rVariables)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     this->CalculateSoilDensity(rVariables);
 
     noalias(rVariables.SoilGamma) = rVariables.Density * rVariables.BodyAcceleration;
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateAndAddCouplingTerms(VectorType& rRightHandSideVector, ElementVariables& rVariables)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddCouplingTerms(VectorType& rRightHandSideVector,
+                                                                         ElementVariables& rVariables)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
-    noalias(rVariables.UVector) = prod(trans(rVariables.B),rVariables.VoigtVector);
+    noalias(rVariables.UVector) = prod(trans(rVariables.B), rVariables.VoigtVector);
 
     noalias(rVariables.UPMatrix) = - PORE_PRESSURE_SIGN_FACTOR
                                    * rVariables.BiotCoefficient
@@ -1659,17 +1573,15 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
         GeoElementUtilities::AssemblePBlockVector< TDim, TNumNodes >(rRightHandSideVector, rVariables.PVector);
     }
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateCompressibilityFlow(BoundedMatrix<double,TNumNodes,TNumNodes> &PMatrix,
-                                 array_1d<double,TNumNodes> &PVector,
-                                 const ElementVariables &rVariables) const
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateCompressibilityFlow(BoundedMatrix<double,TNumNodes,TNumNodes> &PMatrix,
+                                                                         array_1d<double,TNumNodes> &PVector,
+                                                                         const ElementVariables &rVariables) const
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     noalias(PMatrix) = - PORE_PRESSURE_SIGN_FACTOR 
                        * rVariables.BiotModulusInverse
@@ -1678,16 +1590,14 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
 
     noalias(PVector) = - prod(PMatrix, rVariables.DtPressureVector);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateAndAddCompressibilityFlow( VectorType& rRightHandSideVector,
-                                        ElementVariables& rVariables )
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddCompressibilityFlow(VectorType& rRightHandSideVector,
+                                                                               ElementVariables& rVariables)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     this->CalculateCompressibilityFlow(rVariables.PMatrix,
                                        rVariables.PVector,
@@ -1696,18 +1606,16 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
     //Distribute compressibility block vector into elemental vector
     GeoElementUtilities::AssemblePBlockVector<TDim, TNumNodes>(rRightHandSideVector, rVariables.PVector);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculatePermeabilityFlow(BoundedMatrix<double,TNumNodes,TDim> &PDimMatrix,
-                              BoundedMatrix<double,TNumNodes,TNumNodes> &PMatrix,
-                              array_1d<double,TNumNodes> &PVector,
-                              const ElementVariables &rVariables) const
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculatePermeabilityFlow(BoundedMatrix<double,TNumNodes,TDim> &PDimMatrix,
+                                                                      BoundedMatrix<double,TNumNodes,TNumNodes> &PMatrix,
+                                                                      array_1d<double,TNumNodes> &PVector,
+                                                                      const ElementVariables &rVariables) const
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     noalias(PDimMatrix) = prod(rVariables.GradNpT, rVariables.PermeabilityMatrix);
 
@@ -1720,16 +1628,14 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
 
     noalias(PVector) = - prod(PMatrix, rVariables.PressureVector);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateAndAddPermeabilityFlow( VectorType &rRightHandSideVector,
-                                     ElementVariables &rVariables )
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddPermeabilityFlow(VectorType &rRightHandSideVector,
+                                                                            ElementVariables &rVariables)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     this->CalculatePermeabilityFlow(rVariables.PDimMatrix,
                                     rVariables.PMatrix,
@@ -1739,17 +1645,15 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
     //Distribute permeability block vector into elemental vector
     GeoElementUtilities::AssemblePBlockVector<TDim, TNumNodes>(rRightHandSideVector, rVariables.PVector);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateFluidBodyFlow(BoundedMatrix<double,TNumNodes,TDim> &PDimMatrix,
-                           array_1d<double,TNumNodes> &PVector,
-                           const ElementVariables &rVariables) const
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateFluidBodyFlow(BoundedMatrix<double,TNumNodes,TDim> &PDimMatrix,
+                                                                   array_1d<double,TNumNodes> &PVector,
+                                                                   const ElementVariables &rVariables) const
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     noalias(PDimMatrix) =  prod(rVariables.GradNpT,rVariables.PermeabilityMatrix)
                          * rVariables.IntegrationCoefficient;
@@ -1760,16 +1664,14 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
                       * rVariables.PermeabilityUpdateFactor
                       * prod(PDimMatrix,rVariables.BodyAcceleration);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateAndAddFluidBodyFlow(VectorType& rRightHandSideVector,
-                                 ElementVariables& rVariables)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddFluidBodyFlow(VectorType& rRightHandSideVector,
+                                                                         ElementVariables& rVariables)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     this->CalculateFluidBodyFlow(rVariables.PDimMatrix,
                                  rVariables.PVector,
@@ -1778,13 +1680,12 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
     //Distribute fluid body flow block vector into elemental vector
     GeoElementUtilities::AssemblePBlockVector<TDim, TNumNodes>(rRightHandSideVector,rVariables.PVector);
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateStrain( ElementVariables& rVariables, unsigned int GPoint )
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateStrain(ElementVariables& rVariables,
+                                                            unsigned int GPoint)
 {
     if (rVariables.UseHenckyStrain) {
         this->CalculateDeformationGradient(rVariables, GPoint);
@@ -1794,20 +1695,16 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
     }
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateCauchyStrain( ElementVariables& rVariables )
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateCauchyStrain(ElementVariables& rVariables)
 {
     noalias(rVariables.StrainVector) = prod(rVariables.B, rVariables.DisplacementVector);
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateCauchyGreenStrain( ElementVariables& rVariables )
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateCauchyGreenStrain(ElementVariables& rVariables)
 {
-    KRATOS_TRY;
+    KRATOS_TRY
 
     //-Compute total deformation gradient
     const Matrix& F = rVariables.F;
@@ -1830,13 +1727,11 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
         noalias(rVariables.StrainVector) = MathUtils<double>::StrainTensorToVector(ETensor);
     }
 
-    KRATOS_CATCH("");
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateCauchyAlmansiStrain(ElementVariables& rVariables)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateCauchyAlmansiStrain(ElementVariables& rVariables)
 {
 
     //-Compute total deformation gradient
@@ -1867,11 +1762,9 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
 
 }
 
-//----------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateDeformationGradient( ElementVariables& rVariables,
-                                  unsigned int GPoint)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateDeformationGradient(ElementVariables& rVariables,
+                                                                         unsigned int GPoint)
 {
     KRATOS_TRY
 
@@ -1905,13 +1798,11 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
     noalias(rVariables.F) = prod( J, InvJ0 );
     rVariables.detF = MathUtils<double>::Det(rVariables.F);
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    InitializeNodalPorePressureVariables( ElementVariables& rVariables )
+void UPwSmallStrainElement<TDim,TNumNodes>::InitializeNodalPorePressureVariables(ElementVariables& rVariables)
 {
     KRATOS_TRY
 
@@ -1923,13 +1814,11 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
         rVariables.DtPressureVector[i] = rGeom[i].FastGetSolutionStepValue(DT_WATER_PRESSURE);
     }
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    InitializeNodalDisplacementVariables( ElementVariables& rVariables )
+void UPwSmallStrainElement<TDim,TNumNodes>::InitializeNodalDisplacementVariables(ElementVariables& rVariables)
 {
     KRATOS_TRY
 
@@ -1939,28 +1828,27 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
     GeoElementUtilities::GetNodalVariableVector<TDim, TNumNodes>(rVariables.DisplacementVector, rGeom, DISPLACEMENT);
     GeoElementUtilities::GetNodalVariableVector<TDim, TNumNodes>(rVariables.VelocityVector,     rGeom, VELOCITY);
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    InitializeNodalVolumeAccelerationVariables( ElementVariables& rVariables )
+void UPwSmallStrainElement<TDim,TNumNodes>::InitializeNodalVolumeAccelerationVariables(ElementVariables& rVariables)
 {
     KRATOS_TRY
 
     const GeometryType& rGeom = this->GetGeometry();
 
     //Nodal Variables
-    GeoElementUtilities::GetNodalVariableVector<TDim, TNumNodes>(rVariables.VolumeAcceleration, rGeom, VOLUME_ACCELERATION);
+    GeoElementUtilities::GetNodalVariableVector<TDim, TNumNodes>(rVariables.VolumeAcceleration,
+                                                           rGeom,
+                                                                 VOLUME_ACCELERATION);
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    InitializeProperties( ElementVariables& rVariables )
+void UPwSmallStrainElement<TDim,TNumNodes>::InitializeProperties(ElementVariables& rVariables)
 {
     KRATOS_TRY
 
@@ -1983,14 +1871,12 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
 
     rVariables.PermeabilityUpdateFactor = 1.0;
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateKinematics( ElementVariables& rVariables,
-                         unsigned int GPoint )
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateKinematics(ElementVariables& rVariables,
+                                                                unsigned int GPoint)
 {
     KRATOS_TRY
 
@@ -2010,14 +1896,12 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
                                                      rVariables.GradNpTInitialConfiguration,
                                                      GPoint);
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    SetConstitutiveParameters(ElementVariables& rVariables,
-                              ConstitutiveLaw::Parameters& rConstitutiveParameters)
+void UPwSmallStrainElement<TDim,TNumNodes>::SetConstitutiveParameters(ElementVariables& rVariables,
+                                                                      ConstitutiveLaw::Parameters& rConstitutiveParameters)
 {
     KRATOS_TRY
 
@@ -2028,40 +1912,34 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
     rConstitutiveParameters.SetDeformationGradientF(rVariables.F);
     rConstitutiveParameters.SetDeterminantF(rVariables.detF);
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    SetRetentionParameters(const ElementVariables& rVariables,
-                           RetentionLaw::Parameters& rRetentionParameters)
+void UPwSmallStrainElement<TDim,TNumNodes>::SetRetentionParameters(const ElementVariables& rVariables,
+                                                                   RetentionLaw::Parameters& rRetentionParameters)
 {
     KRATOS_TRY
 
     rRetentionParameters.SetFluidPressure(rVariables.FluidPressure);
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-double UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateFluidPressure(const ElementVariables &rVariables)
+double UPwSmallStrainElement<TDim,TNumNodes>::CalculateFluidPressure(const ElementVariables &rVariables)
 {
     KRATOS_TRY
 
     return inner_prod(rVariables.Np, rVariables.PressureVector);
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateRetentionResponse( ElementVariables& rVariables,
-                                RetentionLaw::Parameters& rRetentionParameters,
-                                unsigned int GPoint )
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateRetentionResponse(ElementVariables& rVariables,
+                                                                       RetentionLaw::Parameters& rRetentionParameters,
+                                                                       unsigned int GPoint)
 {
     KRATOS_TRY
 
@@ -2074,12 +1952,11 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
     rVariables.BishopCoefficient      = mRetentionLawVector[GPoint]->CalculateBishopCoefficient(rRetentionParameters);
     rVariables.EffectiveSaturation    = mRetentionLawVector[GPoint]->CalculateEffectiveSaturation(rRetentionParameters);
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::
-    CalculateExtrapolationMatrix(BoundedMatrix<double,TNumNodes,TNumNodes>& rExtrapolationMatrix)
+void UPwSmallStrainElement<TDim,TNumNodes>::CalculateExtrapolationMatrix(BoundedMatrix<double,TNumNodes,TNumNodes>& rExtrapolationMatrix)
 {
     KRATOS_TRY
 
@@ -2089,13 +1966,11 @@ void UPwSmallStrainElement<TDim,TNumNodes>::
                  << this->Id()
                  << std::endl;
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 template< >
-void UPwSmallStrainElement< 2, 3 >::
-    CalculateExtrapolationMatrix(BoundedMatrix<double,3,3>& rExtrapolationMatrix)
+void UPwSmallStrainElement< 2, 3 >::CalculateExtrapolationMatrix(BoundedMatrix<double,3,3>& rExtrapolationMatrix)
 {
     /// The matrix contains the shape functions at each GP evaluated at each node.
     /// Rows: nodes
@@ -2109,10 +1984,8 @@ void UPwSmallStrainElement< 2, 3 >::
     rExtrapolationMatrix(2,0) = -0.33333333333333333333; rExtrapolationMatrix(2,1) = -0.33333333333333333333; rExtrapolationMatrix(2,2) = 1.6666666666666666666;
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 template< >
-void UPwSmallStrainElement< 2, 4 >::
-    CalculateExtrapolationMatrix(BoundedMatrix<double,4,4>& rExtrapolationMatrix)
+void UPwSmallStrainElement< 2, 4 >::CalculateExtrapolationMatrix(BoundedMatrix<double,4,4>& rExtrapolationMatrix)
 {
     //Quadrilateral_2d_4
     //GI_GAUSS_2
@@ -2123,10 +1996,8 @@ void UPwSmallStrainElement< 2, 4 >::
     rExtrapolationMatrix(3,0) = -0.5; rExtrapolationMatrix(3,1) = 0.13397459621556132; rExtrapolationMatrix(3,2) = -0.5; rExtrapolationMatrix(3,3) = 1.8660254037844386;
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 template< >
-void UPwSmallStrainElement< 3, 4 >::
-    CalculateExtrapolationMatrix(BoundedMatrix<double,4,4>& rExtrapolationMatrix)
+void UPwSmallStrainElement< 3, 4 >::CalculateExtrapolationMatrix(BoundedMatrix<double,4,4>& rExtrapolationMatrix)
 {
     //Tetrahedra_3d_4
     //GI_GAUSS_2
@@ -2137,10 +2008,8 @@ void UPwSmallStrainElement< 3, 4 >::
     rExtrapolationMatrix(3,0) = -0.3090169887498949048; rExtrapolationMatrix(3,1) = -0.30901698874989490471; rExtrapolationMatrix(3,2) = 1.9270509662496847143; rExtrapolationMatrix(3,3) = -0.30901698874989490481;
 }
 
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 template< >
-void UPwSmallStrainElement< 3, 8 >::
-    CalculateExtrapolationMatrix(BoundedMatrix<double,8,8>& rExtrapolationMatrix)
+void UPwSmallStrainElement< 3, 8 >::CalculateExtrapolationMatrix(BoundedMatrix<double,8,8>& rExtrapolationMatrix)
 {
     //Hexahedra_3d_8
     //GI_GAUSS_2
@@ -2169,8 +2038,6 @@ void UPwSmallStrainElement< 3, 8 >::
     rExtrapolationMatrix(7,0) = 0.18301270189221927; rExtrapolationMatrix(7,1) = -0.04903810567665795; rExtrapolationMatrix(7,2) = 0.18301270189221927; rExtrapolationMatrix(7,3) = -0.6830127018922192;
     rExtrapolationMatrix(7,4) = -0.6830127018922192; rExtrapolationMatrix(7,5) = 0.18301270189221927; rExtrapolationMatrix(7,6) = -0.6830127018922192; rExtrapolationMatrix(7,7) = 2.549038105676658;
 }
-
-//----------------------------------------------------------------------------------------------------
 
 template class UPwSmallStrainElement<2,3>;
 template class UPwSmallStrainElement<2,4>;

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -432,9 +432,30 @@ void UPwSmallStrainElement<TDim, TNumNodes>::ExtrapolateGPValues(const Matrix& S
         rGeom[i].UnSetLock();
     }
 
-    KRATOS_CATCH( "" )
+    KRATOS_CATCH("")
 }
 
+template< unsigned int TDim, unsigned int TNumNodes >
+void UPwSmallStrainElement<TDim,TNumNodes>::SetValuesOnIntegrationPoints(const Variable<Vector>& rVariable,
+                                                                         const std::vector<Vector>& rValues,
+                                                                         const ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_TRY
+
+    if (rVariable == CAUCHY_STRESS_VECTOR) {
+        KRATOS_ERROR_IF (rValues.size() != mStressVector.size()) <<
+            "Unexpected number of values for UPwSmallStrainElement::SetValuesOnIntegrationPoints" << std::endl;
+        std::copy(rValues.begin(), rValues.end(), mStressVector.begin());
+    } else {
+        KRATOS_ERROR_IF (rValues.size() < mConstitutiveLawVector.size()) <<
+            "Insufficient number of values for UPwSmallStrainElement::SetValuesOnIntegrationPoints" << std::endl;
+        for (unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); ++GPoint) {
+            mConstitutiveLawVector[GPoint]->SetValue(rVariable, rValues[GPoint], rCurrentProcessInfo);
+        }
+    }
+
+    KRATOS_CATCH("")
+}
 //----------------------------------------------------------------------------------------------------
 template< unsigned int TDim, unsigned int TNumNodes >
 void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints(const Variable<double>& rVariable,

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -51,9 +51,6 @@ public:
     using UPwBaseElement<TDim,TNumNodes>::CalculateDerivativesOnInitialConfiguration;
     using UPwBaseElement<TDim,TNumNodes>::mThisIntegrationMethod;
 
-///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-    /// Default Constructor
     explicit UPwSmallStrainElement(IndexType NewId = 0) : UPwBaseElement<TDim,TNumNodes>( NewId ) {}
 
     /// Constructor using an array of nodes
@@ -75,7 +72,6 @@ public:
     UPwSmallStrainElement(UPwSmallStrainElement&&) = delete;
     UPwSmallStrainElement& operator=(UPwSmallStrainElement&&) = delete;
 
-///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     Element::Pointer Create( IndexType NewId,
                              NodesArrayType const& ThisNodes,
@@ -117,13 +113,11 @@ public:
                                       std::vector<Matrix>& rOutput,
                                       const ProcessInfo& rCurrentProcessInfo) override;
 
-    // Turn back information as a string.
     std::string Info() const override
     {
         return "U-Pw small strain Element #" + std::to_string(this->Id()) + "\nConstitutive law: " + mConstitutiveLawVector[0]->Info();
     }
 
-    // Print information about this object.
     void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info();
@@ -335,11 +329,7 @@ protected:
                                                           ElementVariables& rVariables,
                                                           unsigned int GPoint );
 
-///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
 private:
-    /// Serialization
-
     friend class Serializer;
 
     void save(Serializer& rSerializer) const override

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -98,6 +98,9 @@ public:
     void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+    void SetValuesOnIntegrationPoints(const Variable<Vector>& rVariable,
+                                      const std::vector<Vector>& rValues,
+                                      const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
                                       std::vector<double>& rOutput,

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -87,8 +87,6 @@ public:
 
     int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
-///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
     void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
@@ -97,10 +95,11 @@ public:
 
     void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
-///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     void SetValuesOnIntegrationPoints(const Variable<Vector>& rVariable,
                                       const std::vector<Vector>& rValues,
                                       const ProcessInfo& rCurrentProcessInfo) override;
+
+    using UPwBaseElement<TDim,TNumNodes>::SetValuesOnIntegrationPoints;
 
     void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
                                       std::vector<double>& rOutput,
@@ -121,18 +120,14 @@ public:
     // Turn back information as a string.
     std::string Info() const override
     {
-        std::stringstream buffer;
-        buffer << "U-Pw small strain Element #" << this->Id() << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
-        return buffer.str();
+        return "U-Pw small strain Element #" + std::to_string(this->Id()) + "\nConstitutive law: " + mConstitutiveLawVector[0]->Info();
     }
 
     // Print information about this object.
     void PrintInfo(std::ostream& rOStream) const override
     {
-        rOStream << "U-Pw small strain Element #" << this->Id() << "\nConstitutive law: " << mConstitutiveLawVector[0]->Info();
+        rOStream << Info();
     }
-
-///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 protected:
 

--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -25,9 +25,9 @@
 namespace Kratos
 {
 
-template< unsigned int TDim, unsigned int TNumNodes >
+template <unsigned int TDim, unsigned int TNumNodes>
 class KRATOS_API(GEO_MECHANICS_APPLICATION) UPwSmallStrainElement :
-    public UPwBaseElement<TDim,TNumNodes>
+    public UPwBaseElement<TDim, TNumNodes>
 {
 
 public:
@@ -43,28 +43,28 @@ public:
     using MatrixType = Matrix;
     /// The definition of the sizetype
     using SizeType = std::size_t;
-    using UPwBaseElement<TDim,TNumNodes>::mConstitutiveLawVector;
-    using UPwBaseElement<TDim,TNumNodes>::mRetentionLawVector;
-    using UPwBaseElement<TDim,TNumNodes>::mStressVector;
-    using UPwBaseElement<TDim,TNumNodes>::mStateVariablesFinalized;
-    using UPwBaseElement<TDim,TNumNodes>::mIsInitialised;
-    using UPwBaseElement<TDim,TNumNodes>::CalculateDerivativesOnInitialConfiguration;
-    using UPwBaseElement<TDim,TNumNodes>::mThisIntegrationMethod;
+    using UPwBaseElement<TDim, TNumNodes>::mConstitutiveLawVector;
+    using UPwBaseElement<TDim, TNumNodes>::mRetentionLawVector;
+    using UPwBaseElement<TDim, TNumNodes>::mStressVector;
+    using UPwBaseElement<TDim, TNumNodes>::mStateVariablesFinalized;
+    using UPwBaseElement<TDim, TNumNodes>::mIsInitialised;
+    using UPwBaseElement<TDim, TNumNodes>::CalculateDerivativesOnInitialConfiguration;
+    using UPwBaseElement<TDim, TNumNodes>::mThisIntegrationMethod;
 
-    explicit UPwSmallStrainElement(IndexType NewId = 0) : UPwBaseElement<TDim,TNumNodes>( NewId ) {}
+    explicit UPwSmallStrainElement(IndexType NewId = 0) : UPwBaseElement<TDim, TNumNodes>(NewId) {}
 
     /// Constructor using an array of nodes
     UPwSmallStrainElement(IndexType NewId,
-                          const NodesArrayType& ThisNodes) : UPwBaseElement<TDim,TNumNodes>(NewId, ThisNodes) {}
+                          const NodesArrayType& ThisNodes) : UPwBaseElement<TDim, TNumNodes>(NewId, ThisNodes) {}
 
     /// Constructor using Geometry
     UPwSmallStrainElement(IndexType NewId,
-                          GeometryType::Pointer pGeometry) : UPwBaseElement<TDim,TNumNodes>(NewId, pGeometry) {}
+                          GeometryType::Pointer pGeometry) : UPwBaseElement<TDim, TNumNodes>(NewId, pGeometry) {}
 
     /// Constructor using Properties
     UPwSmallStrainElement(IndexType NewId,
                           GeometryType::Pointer pGeometry,
-                          PropertiesType::Pointer pProperties) : UPwBaseElement<TDim,TNumNodes>( NewId, pGeometry, pProperties ) {}
+                          PropertiesType::Pointer pProperties) : UPwBaseElement<TDim, TNumNodes>(NewId, pGeometry, pProperties) {}
 
     ~UPwSmallStrainElement() override = default;
     UPwSmallStrainElement(const UPwSmallStrainElement&) = delete;
@@ -73,13 +73,13 @@ public:
     UPwSmallStrainElement& operator=(UPwSmallStrainElement&&) = delete;
 
 
-    Element::Pointer Create( IndexType NewId,
-                             NodesArrayType const& ThisNodes,
-                             PropertiesType::Pointer pProperties ) const override;
+    Element::Pointer Create(IndexType NewId,
+                            NodesArrayType const& ThisNodes,
+                            PropertiesType::Pointer pProperties) const override;
 
-    Element::Pointer Create( IndexType NewId,
-                             GeometryType::Pointer pGeom,
-                             PropertiesType::Pointer pProperties ) const override;
+    Element::Pointer Create(IndexType NewId,
+                            GeometryType::Pointer pGeom,
+                            PropertiesType::Pointer pProperties) const override;
 
     int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
@@ -143,18 +143,18 @@ protected:
 
         double BiotCoefficient;
         double BiotModulusInverse;
-        BoundedMatrix<double,TDim, TDim> PermeabilityMatrix;
+        BoundedMatrix<double, TDim, TDim> PermeabilityMatrix;
 
         ///ProcessInfo variables
         double VelocityCoefficient;
         double DtPressureCoefficient;
 
         ///Nodal variables
-        array_1d<double,TNumNodes> PressureVector;
-        array_1d<double,TNumNodes> DtPressureVector;
-        array_1d<double,TNumNodes*TDim> DisplacementVector;
-        array_1d<double,TNumNodes*TDim> VelocityVector;
-        array_1d<double,TNumNodes*TDim> VolumeAcceleration;
+        array_1d<double, TNumNodes> PressureVector;
+        array_1d<double, TNumNodes> DtPressureVector;
+        array_1d<double, TNumNodes*TDim> DisplacementVector;
+        array_1d<double, TNumNodes*TDim> VelocityVector;
+        array_1d<double, TNumNodes*TDim> VolumeAcceleration;
 
         ///General elemental variables
         Vector VoigtVector;
@@ -194,140 +194,139 @@ protected:
         double IntegrationCoefficientInitialConfiguration;
 
         //Auxiliary Variables
-        BoundedMatrix<double,TNumNodes*TDim,TNumNodes*TDim> UMatrix;
-        BoundedMatrix<double,TNumNodes*TDim,TNumNodes> UPMatrix;
-        BoundedMatrix<double,TNumNodes,TNumNodes*TDim> PUMatrix;
-        BoundedMatrix<double,TNumNodes,TNumNodes> PMatrix;
+        BoundedMatrix<double, TNumNodes*TDim, TNumNodes*TDim> UMatrix;
+        BoundedMatrix<double, TNumNodes*TDim, TNumNodes> UPMatrix;
+        BoundedMatrix<double, TNumNodes, TNumNodes*TDim> PUMatrix;
+        BoundedMatrix<double, TNumNodes, TNumNodes> PMatrix;
         Matrix UVoigtMatrix;
-        BoundedMatrix<double,TNumNodes,TDim> PDimMatrix;
-        array_1d<double,TNumNodes*TDim> UVector;
-        array_1d<double,TNumNodes> PVector;
+        BoundedMatrix<double, TNumNodes, TDim> PDimMatrix;
+        array_1d<double, TNumNodes*TDim> UVector;
+        array_1d<double, TNumNodes> PVector;
 
     };
 
-    void SaveGPStress( Matrix &rStressContainer,
-                       const Vector &StressVector,
-                       unsigned int GPoint );
+    void SaveGPStress(Matrix &rStressContainer,
+                      const Vector& rStressVector,
+                      unsigned int GPoint);
 
-    void ExtrapolateGPValues( const Matrix &StressContainer);
+    void ExtrapolateGPValues(const Matrix& rStressContainer);
 
-    void CalculateMaterialStiffnessMatrix( MatrixType& rStiffnessMatrix,
-                                           const ProcessInfo& CurrentProcessInfo ) override;
+    void CalculateMaterialStiffnessMatrix(MatrixType& rStiffnessMatrix,
+                                          const ProcessInfo& CurrentProcessInfo) override;
 
-    void CalculateMassMatrix( MatrixType& rMassMatrix,
-                              const ProcessInfo& rCurrentProcessInfo ) override;
+    void CalculateMassMatrix(MatrixType& rMassMatrix,
+                             const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateAll( MatrixType &rLeftHandSideMatrix,
                        VectorType &rRightHandSideVector,
                        const ProcessInfo& CurrentProcessInfo,
-                       const bool CalculateStiffnessMatrixFlag,
-                       const bool CalculateResidualVectorFlag ) override;
+                       bool CalculateStiffnessMatrixFlag,
+                       bool CalculateResidualVectorFlag) override;
 
-    virtual void InitializeElementVariables( ElementVariables &rVariables,
-                                             const ProcessInfo &CurrentProcessInfo );
+    virtual void InitializeElementVariables(ElementVariables& rVariables,
+                                            const ProcessInfo& CurrentProcessInfo);
 
-    void SetConstitutiveParameters(ElementVariables &rVariables,
-                                   ConstitutiveLaw::Parameters &rConstitutiveParameters);
+    void SetConstitutiveParameters(ElementVariables& rVariables,
+                                   ConstitutiveLaw::Parameters& rConstitutiveParameters);
 
-    void SetRetentionParameters(const ElementVariables &rVariables,
-                                RetentionLaw::Parameters &rRetentionParameters);
+    void SetRetentionParameters(const ElementVariables& rVariables,
+                                RetentionLaw::Parameters& rRetentionParameters);
 
     virtual void CalculateKinematics( ElementVariables &rVariables, unsigned int PointNumber );
 
-    void InitializeBiotCoefficients( ElementVariables &rVariables,
-                                     const bool &hasBiotCoefficient=false );
+    void InitializeBiotCoefficients(ElementVariables& rVariables,
+                                    bool hasBiotCoefficient=false );
 
-    void CalculatePermeabilityUpdateFactor( ElementVariables &rVariables);
+    void CalculatePermeabilityUpdateFactor(ElementVariables &rVariables);
 
     virtual void CalculateBMatrix( Matrix &rB,
                                    const Matrix &GradNpT,
                                    const Vector &Np );
 
-    virtual void CalculateAndAddLHS(MatrixType &rLeftHandSideMatrix, ElementVariables &rVariables);
+    virtual void CalculateAndAddLHS(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables);
 
-    void CalculateAndAddStiffnessMatrix(MatrixType &rLeftHandSideMatrix, ElementVariables &rVariables);
+    void CalculateAndAddStiffnessMatrix(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables);
 
-    void CalculateAndAddCouplingMatrix(MatrixType &rLeftHandSideMatrix, ElementVariables &rVariables);
+    void CalculateAndAddCouplingMatrix(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables);
 
-    virtual void CalculateAndAddCompressibilityMatrix(MatrixType &rLeftHandSideMatrix,
+    virtual void CalculateAndAddCompressibilityMatrix(MatrixType& rLeftHandSideMatrix,
                                                       ElementVariables& rVariables);
 
-    virtual void CalculateCompressibilityMatrix(BoundedMatrix<double,TNumNodes,TNumNodes> &PMatrix,
-                                                const ElementVariables &rVariables) const;
+    virtual void CalculateCompressibilityMatrix(BoundedMatrix<double,TNumNodes,TNumNodes>& rPMatrix,
+                                                const ElementVariables& rVariables) const;
 
-    virtual void CalculateAndAddPermeabilityMatrix(MatrixType &rLeftHandSideMatrix,
-                                                   ElementVariables &rVariables);
+    virtual void CalculateAndAddPermeabilityMatrix(MatrixType& rLeftHandSideMatrix,
+                                                   ElementVariables& rVariables);
 
-    virtual void CalculatePermeabilityMatrix(BoundedMatrix<double,TNumNodes,TDim> &PDimMatrix,
-                                             BoundedMatrix<double,TNumNodes,TNumNodes> &PMatrix,
-                                             const ElementVariables &rVariables) const;
+    virtual void CalculatePermeabilityMatrix(BoundedMatrix<double, TNumNodes, TDim>& rPDimMatrix,
+                                             BoundedMatrix<double, TNumNodes, TNumNodes>& rPMatrix,
+                                             const ElementVariables& rVariables) const;
 
-    virtual void CalculateAndAddRHS(VectorType &rRightHandSideVector,
-                                    ElementVariables &rVariables,
+    virtual void CalculateAndAddRHS(VectorType& rRightHandSideVector,
+                                    ElementVariables& rVariables,
                                     unsigned int GPoint);
 
-    void CalculateAndAddStiffnessForce(VectorType &rRightHandSideVector,
+    void CalculateAndAddStiffnessForce(VectorType& rRightHandSideVector,
                                        ElementVariables& rVariables,
                                        unsigned int GPoint);
 
-    void CalculateAndAddMixBodyForce(VectorType &rRightHandSideVector, ElementVariables &rVariables);
+    void CalculateAndAddMixBodyForce(VectorType& rRightHandSideVector, ElementVariables& rVariables);
 
-    void CalculateAndAddCouplingTerms(VectorType& rRightHandSideVector, ElementVariables &rVariables);
+    void CalculateAndAddCouplingTerms(VectorType& rRightHandSideVector, ElementVariables& rVariables);
 
-    virtual void CalculateAndAddCompressibilityFlow(VectorType &rRightHandSideVector,
-                                                    ElementVariables &rVariables);
+    virtual void CalculateAndAddCompressibilityFlow(VectorType& rRightHandSideVector,
+                                                    ElementVariables& rVariables);
 
-    virtual void CalculateCompressibilityFlow(BoundedMatrix<double,TNumNodes,TNumNodes> &PMatrix,
-                                              array_1d<double,TNumNodes> &PVector,
-                                              const ElementVariables &rVariables) const;
+    virtual void CalculateCompressibilityFlow(BoundedMatrix<double,TNumNodes,TNumNodes>& rPMatrix,
+                                              array_1d<double,TNumNodes>& rPVector,
+                                              const ElementVariables& rVariables) const;
 
-    virtual void CalculateAndAddPermeabilityFlow(VectorType &rRightHandSideVector,
-                                                 ElementVariables &rVariables);
+    virtual void CalculateAndAddPermeabilityFlow(VectorType& rRightHandSideVector,
+                                                 ElementVariables& rVariables);
 
-    virtual void CalculatePermeabilityFlow(BoundedMatrix<double,TNumNodes,TDim> &PDimMatrix,
-                                           BoundedMatrix<double,TNumNodes,TNumNodes> &PMatrix,
-                                           array_1d<double,TNumNodes> &PVector,
-                                           const ElementVariables &rVariables) const;
+    virtual void CalculatePermeabilityFlow(BoundedMatrix<double, TNumNodes, TDim>& rPDimMatrix,
+                                           BoundedMatrix<double, TNumNodes, TNumNodes>& rPMatrix,
+                                           array_1d<double, TNumNodes>& rPVector,
+                                           const ElementVariables& rVariables) const;
 
 
-    virtual void CalculateAndAddFluidBodyFlow(VectorType &rRightHandSideVector,
-                                              ElementVariables &rVariables);
-    virtual void CalculateFluidBodyFlow(BoundedMatrix<double,TNumNodes,TDim> &PDimMatrix,
-                                        array_1d<double,TNumNodes> &PVector,
-                                        const ElementVariables &rVariables) const;
+    virtual void CalculateAndAddFluidBodyFlow(VectorType& rRightHandSideVector,
+                                              ElementVariables& rVariables);
+    virtual void CalculateFluidBodyFlow(BoundedMatrix<double, TNumNodes, TDim>& rPDimMatrix,
+                                        array_1d<double, TNumNodes>& rPVector,
+                                        const ElementVariables& rVariables) const;
 
     double CalculateBulkModulus(const Matrix &ConstitutiveMatrix) const;
-    double CalculateBiotCoefficient( const ElementVariables &rVariables,
-                                     const bool &hasBiotCoefficient) const;
+    double CalculateBiotCoefficient(const ElementVariables& rVariables,
+                                    bool hasBiotCoefficient) const;
 
-    virtual void CalculateCauchyAlmansiStrain( ElementVariables &rVariables );
-    virtual void CalculateCauchyGreenStrain( ElementVariables &rVariables );
-    virtual void CalculateCauchyStrain( ElementVariables &rVariables );
-    virtual void CalculateStrain( ElementVariables &rVariables, unsigned int GPoint );
-    virtual void CalculateDeformationGradient( ElementVariables& rVariables,
-                                               unsigned int GPoint );
+    virtual void CalculateCauchyAlmansiStrain(ElementVariables& rVariables);
+    virtual void CalculateCauchyGreenStrain(ElementVariables& rVariables);
+    virtual void CalculateCauchyStrain(ElementVariables& rVariables);
+    virtual void CalculateStrain(ElementVariables &rVariables, unsigned int GPoint);
+    virtual void CalculateDeformationGradient(ElementVariables& rVariables, unsigned int GPoint);
 
-    void InitializeNodalDisplacementVariables( ElementVariables &rVariables );
-    void InitializeNodalPorePressureVariables( ElementVariables &rVariables );
-    void InitializeNodalVolumeAccelerationVariables( ElementVariables &rVariables );
+    void InitializeNodalDisplacementVariables(ElementVariables& rVariables);
+    void InitializeNodalPorePressureVariables(ElementVariables& rVariables);
+    void InitializeNodalVolumeAccelerationVariables(ElementVariables& rVariables);
 
-    void InitializeProperties( ElementVariables &rVariables );
-    double CalculateFluidPressure( const ElementVariables &rVariables);
+    void InitializeProperties(ElementVariables& rVariables);
+    double CalculateFluidPressure(const ElementVariables& rVariables);
 
-    void CalculateRetentionResponse( ElementVariables &rVariables,
-                                     RetentionLaw::Parameters &rRetentionParameters,
-                                     unsigned int GPoint );
+    void CalculateRetentionResponse(ElementVariables& rVariables,
+                                    RetentionLaw::Parameters& rRetentionParameters,
+                                    unsigned int GPoint);
 
-    void CalculateExtrapolationMatrix(BoundedMatrix<double,TNumNodes,TNumNodes> &rExtrapolationMatrix);
+    void CalculateExtrapolationMatrix(BoundedMatrix<double, TNumNodes, TNumNodes>& rExtrapolationMatrix);
 
     void ResetHydraulicDischarge();
     void CalculateHydraulicDischarge(const ProcessInfo& rCurrentProcessInfo);
-    void CalculateSoilGamma(ElementVariables &rVariables);
-    virtual void CalculateSoilDensity(ElementVariables &rVariables);
+    void CalculateSoilGamma(ElementVariables& rVariables);
+    virtual void CalculateSoilDensity(ElementVariables& rVariables);
 
-    virtual void CalculateAndAddGeometricStiffnessMatrix( MatrixType& rLeftHandSideMatrix,
-                                                          ElementVariables& rVariables,
-                                                          unsigned int GPoint );
+    virtual void CalculateAndAddGeometricStiffnessMatrix(MatrixType& rLeftHandSideMatrix,
+                                                         ElementVariables& rVariables,
+                                                         unsigned int GPoint);
 
 private:
     friend class Serializer;
@@ -342,10 +341,8 @@ private:
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, Element )
     }
 
-    // Private Operations
-
-    template < class TValueType >
-    inline void ThreadSafeNodeWrite(NodeType& rNode, const Variable<TValueType> &Var, const TValueType Value)
+    template <class TValueType>
+    inline void ThreadSafeNodeWrite(NodeType& rNode, const Variable<TValueType>& Var, const TValueType Value)
     {
         rNode.SetLock();
         rNode.FastGetSolutionStepValue(Var) = Value;

--- a/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_layers/mesh_stage1.mdpa
+++ b/applications/GeoMechanicsApplication/tests/test_k0_procedure_process/test_k0_procedure_k0_nc_layers/mesh_stage1.mdpa
@@ -59,7 +59,7 @@ Begin Nodes
    53  10.0000000000 -100.0000000000   0.0000000000
 End Nodes
 
-Begin Elements SmallStrainUPwDiffOrderElement2D8N
+Begin Elements UPwSmallStrainElement2D8N
   1  3  51 53 48 46 52 50 47 49
   2  3  46 48 43 41 47 45 42 44
   3  3  41 43 38 36 42 40 37 39


### PR DESCRIPTION
**📝 Description**
The UPwSmallStrainElements did not show the effect of K0 procedure process, because SetValuesOnIntegrationPoints was not overridden for CAUCHY_STRESS_VECTOR.

**🆕 Changelog**
- Added SetValuesOnIntegrationPoints in U_Pw_small_strain_elements.
- Tried to prevent function hiding of SetValuesOnIntegrationPoints and CalculateOnIntegrationPoints.
- Removed empty statements connected to KRATOS_TRY and KRATOS_CATCH
- Simplified the Info() and PrintInfo() functions.