### PR TITLE
[Core] ComputeNormalsOnSimplex - fix when there are other geometries

### DIFF
--- a/kratos/tests/test_normal_utils.py
+++ b/kratos/tests/test_normal_utils.py
@@ -130,6 +130,18 @@ class TestNormalUtilsCoarseSphere(KratosUnittest.TestCase):
 
             self.assertLess(CalculateNorm(normal - solution_normal), 0.15)
 
+    def test_ComputeSimplexNormalModelPartWithLineCondition(self):
+        #Adding one line, to make sure it is getting ignored
+        self.model_part.CreateNewCondition("LineCondition3D2N", 1000, [1,2], self.model_part.GetProperties()[1])
+        KratosMultiphysics.NormalCalculationUtils().CalculateOnSimplex(self.model_part)
+        for node in self.model_part.GetSubModelPart("Skin_Part").Nodes:
+            normal = CalculateAnalyticalNormal(node)
+
+            solution_normal = node.GetSolutionStepValue(KratosMultiphysics.NORMAL)
+            solution_normal /= CalculateNorm(solution_normal)
+
+            self.assertLess(CalculateNorm(normal - solution_normal), 0.15)
+
     def test_ComputeSimplexNormalModelPartWithCustomVariable(self):
         ## Calculate the normals using NODAL_VAUX as custom variable
         KratosMultiphysics.NormalCalculationUtils().CalculateOnSimplex(

--- a/kratos/tests/test_normal_utils.py
+++ b/kratos/tests/test_normal_utils.py
@@ -130,6 +130,7 @@ class TestNormalUtilsCoarseSphere(KratosUnittest.TestCase):
 
             self.assertLess(CalculateNorm(normal - solution_normal), 0.15)
 
+    @KratosUnittest.skipIf(KratosMultiphysics.IsDistributedRun(), "This test is designed for serial runs only.")
     def test_ComputeSimplexNormalModelPartWithLineCondition(self):
         #Adding one line, to make sure it is getting ignored
         self.model_part.CreateNewCondition("LineCondition3D2N", 1000, [1,2], self.model_part.GetProperties()[1])

--- a/kratos/utilities/normal_calculation_utils.cpp
+++ b/kratos/utilities/normal_calculation_utils.cpp
@@ -754,13 +754,17 @@ void NormalCalculationUtils::AuxiliaryCalculateOnSimplex(
         });
     }
 
+    const auto condition_simplex_type = Dimension == 2
+            ? GeometryData::KratosGeometryType::Kratos_Line2D2
+            : GeometryData::KratosGeometryType::Kratos_Triangle3D3;
+
     // Adding the normals to the nodes
-    block_for_each(rConditions, [&rNormalVariable, this](Condition& rCondition) {
+    block_for_each(rConditions, [&rNormalVariable, &condition_simplex_type, this](Condition& rCondition) {
         auto& r_geometry = rCondition.GetGeometry();
-        if (rCondition.GetGeometry().PointsNumber() == 3) {
-            constexpr double coeff = 1.0 / 3.0;
+        if (rCondition.GetGeometry().GetGeometryType() == condition_simplex_type) {
+            const double coeff = 1.0 / r_geometry.size();
             const auto& r_normal = rCondition.GetValue(rNormalVariable);
-            for (unsigned int i = 0; i < 3; ++i) {
+            for (unsigned int i = 0; i < r_geometry.size(); ++i) {
                 auto& r_node = r_geometry[i];
                 r_node.SetLock();
                 noalias(GetNormalValue<TIsHistorical>(r_node, rNormalVariable)) += coeff * r_normal;

--- a/kratos/utilities/normal_calculation_utils.cpp
+++ b/kratos/utilities/normal_calculation_utils.cpp
@@ -29,6 +29,8 @@ void NormalCalculationUtils::CalculateNormalsInContainer(
     const Variable<array_1d<double,3>>& rNormalVariable
     )
 {
+    KRATOS_TRY;
+
     // Declare auxiliar coordinates
     Point::CoordinatesArrayType aux_coords;
 
@@ -50,6 +52,8 @@ void NormalCalculationUtils::CalculateNormalsInContainer(
         r_geometry.PointLocalCoordinates(aux_coords, r_geometry.Center());
         it_entity->SetValue(rNormalVariable, r_geometry.UnitNormal(aux_coords));
     }
+
+    KRATOS_CATCH("Error in CalculateNormalsInContainer");
 }
 
 /***********************************************************************************/
@@ -61,6 +65,8 @@ void NormalCalculationUtils::InitializeNormals(
     const Variable<array_1d<double,3>>& rNormalVariable
     )
 {
+    KRATOS_TRY
+
     // Resetting the normals
     const array_1d<double, 3> zero = ZeroVector(3);
 
@@ -94,6 +100,8 @@ void NormalCalculationUtils::InitializeNormals(
                 }
         });
     }
+
+    KRATOS_CATCH("Error in InitializeNormals");
 }
 
 /***********************************************************************************/
@@ -107,6 +115,8 @@ KRATOS_API(KRATOS_CORE) void NormalCalculationUtils::CalculateNormals<ModelPart:
     const Variable<array_1d<double,3>>& rNormalVariable
     )
 {
+    KRATOS_TRY
+
     if (CheckUseSimplex(rModelPart, EnforceGenericGeometryAlgorithm)) {
         const auto& r_process_info = rModelPart.GetProcessInfo();
         const SizeType dimension = r_process_info.GetValue(DOMAIN_SIZE);
@@ -114,6 +124,8 @@ KRATOS_API(KRATOS_CORE) void NormalCalculationUtils::CalculateNormals<ModelPart:
     } else {
         CalculateNormalsUsingGenericAlgorithm<ModelPart::ConditionsContainerType, true>(rModelPart, ConsiderUnitNormal, rNormalVariable);
     }
+
+    KRATOS_CATCH("Error in CalculateNormals");
 }
 
 /***********************************************************************************/
@@ -297,6 +309,8 @@ void NormalCalculationUtils::CalculateOnSimplex(
     const Variable<array_1d<double,3>>& rNormalVariable
     )
 {
+    KRATOS_TRY
+
     // Initialize the normals
     InitializeNormals<ModelPart::ConditionsContainerType,true>(rModelPart, rNormalVariable);
 
@@ -305,6 +319,8 @@ void NormalCalculationUtils::CalculateOnSimplex(
 
     // Synchronize the normal
     rModelPart.GetCommunicator().AssembleCurrentData(rNormalVariable);
+
+    KRATOS_CATCH("Error in CalculateOnSimplex");
 }
 
 /***********************************************************************************/
@@ -713,6 +729,8 @@ void NormalCalculationUtils::AuxiliaryCalculateOnSimplex(
     const NormalVariableType& rNormalVariable
     )
 {
+    KRATOS_TRY
+
     // Calculating the normals and storing on the conditions
     if (Dimension == 2) {
         block_for_each(rConditions, array_1d<double,3>(), [&rNormalVariable](Condition& rCondition, array_1d<double,3>& rAn){
@@ -739,15 +757,19 @@ void NormalCalculationUtils::AuxiliaryCalculateOnSimplex(
     // Adding the normals to the nodes
     block_for_each(rConditions, [&rNormalVariable, this](Condition& rCondition) {
         auto& r_geometry = rCondition.GetGeometry();
-        const double coeff = 1.0 / r_geometry.size();
-        const auto& r_normal = rCondition.GetValue(rNormalVariable);
-        for (unsigned int i = 0; i < r_geometry.size(); ++i) {
-            auto& r_node = r_geometry[i];
-            r_node.SetLock();
-            noalias(GetNormalValue<TIsHistorical>(r_node, rNormalVariable)) += coeff * r_normal;
-            r_node.UnSetLock();
+        if (rCondition.GetGeometry().PointsNumber() == 3) {
+            constexpr double coeff = 1.0 / 3.0;
+            const auto& r_normal = rCondition.GetValue(rNormalVariable);
+            for (unsigned int i = 0; i < 3; ++i) {
+                auto& r_node = r_geometry[i];
+                r_node.SetLock();
+                noalias(GetNormalValue<TIsHistorical>(r_node, rNormalVariable)) += coeff * r_normal;
+                r_node.UnSetLock();
+            }
         }
     });
+
+    KRATOS_CATCH("AuxiliaryCalculateOnSimplex");
 }
 
 // template instantiations


### PR DESCRIPTION
Im getting an error in FullDebug when calling ComputeNormalsOnSimplex for a model part that contains lines besides the triangle conditions.

The problem is that line conditions they were being ignored for the calculation 
https://github.com/KratosMultiphysics/Kratos/blob/45ff863aad6687ba95362b558a698eeb317d039d/kratos/utilities/normal_calculation_utils.cpp#L730

but later, we were tring to read the NORMAL value from them to assign them to the nodes
https://github.com/KratosMultiphysics/Kratos/blob/45ff863aad6687ba95362b558a698eeb317d039d/kratos/utilities/normal_calculation_utils.cpp#L747

In this MR I make sure that only simplex conditions are used in the last part of code, where we assign the normal values to the nodes. A test is added to make sure this works correctly.

This MR also includes some KRATOS_TRY/CATCH that I added during the debugging.