### PR TITLE
[PfemFluid][FastPR] Removing useless override

### DIFF
--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_fluid_FIC_element.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_fluid_FIC_element.cpp
@@ -35,24 +35,6 @@ namespace Kratos
   }
 
   template <unsigned int TDim>
-  void TwoStepUpdatedLagrangianVPImplicitFluidFicElement<TDim>::Initialize(const ProcessInfo &rCurrentProcessInfo)
-  {
-    KRATOS_TRY;
-
-    // If we are restarting, the constitutive law will be already defined
-    if (mpConstitutiveLaw == nullptr)
-    {
-      const Properties &r_properties = this->GetProperties();
-      KRATOS_ERROR_IF_NOT(r_properties.Has(CONSTITUTIVE_LAW))
-          << "In initialization of Element " << this->Info() << ": No CONSTITUTIVE_LAW defined for property "
-          << r_properties.Id() << "." << std::endl;
-      mpConstitutiveLaw = r_properties[CONSTITUTIVE_LAW]->Clone();
-    }
-
-    KRATOS_CATCH("");
-  }
-
-  template <unsigned int TDim>
   int TwoStepUpdatedLagrangianVPImplicitFluidFicElement<TDim>::Check(const ProcessInfo &rCurrentProcessInfo) const
   {
     KRATOS_TRY;
@@ -156,7 +138,7 @@ namespace Kratos
     }
 
     // Check constitutive law
-    return mpConstitutiveLaw->Check(r_properties, r_geometry, rCurrentProcessInfo);
+    return this->mpConstitutiveLaw->Check(r_properties, r_geometry, rCurrentProcessInfo);
 
     return ierr;
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_fluid_FIC_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_fluid_FIC_element.h
@@ -193,8 +193,6 @@ namespace Kratos
 
     Element::Pointer Clone(IndexType NewId, NodesArrayType const &ThisNodes) const override;
 
-    void Initialize(const ProcessInfo &rCurrentProcessInfo) override;
-
     /// Initializes the element and all geometric information required for the problem.
     void InitializeSolutionStep(const ProcessInfo &rCurrentProcessInfo) override{};
 
@@ -288,8 +286,6 @@ namespace Kratos
     ///@}
     ///@name Protected member Variables
     ///@{
-
-    ConstitutiveLaw::Pointer mpConstitutiveLaw = nullptr;
 
     ///@}
     ///@name Protected Operators


### PR DESCRIPTION
**📝 Description**
This removes an useless override. The base `TwoStepUpdatedLagrangianVPImplicitFluidElement` has the very same implementation. The same applies to the member pointer variable (at this moment unused).
