### PR TITLE
[StructuralMechanicsApplication] corrected full rotation matrix moving load

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_conditions/moving_load_condition.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/moving_load_condition.cpp
@@ -470,7 +470,9 @@ Vector MovingLoadCondition< TDim, TNumNodes>::CalculateLoadPointDisplacementVect
             full_rotation_matrix(i, j) = rotation_matrix(i, j);
         }
     }
-
+    if constexpr (TDim == 2) {
+        full_rotation_matrix(2, 2) = 1;
+    }
 
     // Calculate local nodal rotation matrix
     bounded_matrix<double, 3, TNumNodes> local_nodal_rotation_matrix = prod(full_rotation_matrix, nodal_rotation_matrix);
@@ -615,6 +617,10 @@ Vector MovingLoadCondition< TDim, TNumNodes>::CalculateLoadPointRotationVector()
             full_rotation_matrix(i, j) = rotation_matrix(i, j);
         }
     }
+    if constexpr (TDim == 2) {
+        full_rotation_matrix(2, 2) = 1;
+    }
+
 
     // calculate local nodal rotation matrix
     bounded_matrix<double, 3, TNumNodes> local_nodal_rotation_matrix = prod(full_rotation_matrix, nodal_rotation_matrix);

--- a/applications/StructuralMechanicsApplication/tests/test_loading_conditions_moving.py
+++ b/applications/StructuralMechanicsApplication/tests/test_loading_conditions_moving.py
@@ -1,8 +1,3 @@
-
-import sys
-sys.path.append(r"D:\software_development\Kratos3\bin\Release")
-sys.path.append(r"D:\software_development\Kratos3\bin\Release\libs")
-
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_loading_conditions_moving.py
+++ b/applications/StructuralMechanicsApplication/tests/test_loading_conditions_moving.py
@@ -1,3 +1,8 @@
+
+import sys
+sys.path.append(r"D:\software_development\Kratos3\bin\Release")
+sys.path.append(r"D:\software_development\Kratos3\bin\Release\libs")
+
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
@@ -565,6 +570,87 @@ class TestLoadingConditionsMoving(KratosUnittest.TestCase):
 
         self.assertAlmostEqual(rot[2], expected_rotation)
 
+    def _MovingLoadCondition2D2NImposedRot_disp_rot_at_load(self):
+        """
+        Tests the MovingLoadCondition2D2N with imposed rotation and checks the displacement and rotation at the position
+        of the load
+        """
+
+        vertical_point_load = 1.0
+        EI = 300
+
+        current_model = KratosMultiphysics.Model()
+        mp = current_model.CreateModelPart("solid_part")
+        mp.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
+        mp.AddNodalSolutionStepVariable(KratosMultiphysics.REACTION)
+        mp.AddNodalSolutionStepVariable(KratosMultiphysics.ROTATION)
+        mp.AddNodalSolutionStepVariable(KratosMultiphysics.REACTION_MOMENT)
+
+        strategy = self.setup_strategy(mp)
+
+        # create nodes
+        coords_node_2 = [5, 0.0, 0.0]
+
+        node_1 = mp.CreateNewNode(1, 0.0, 0.0, 0.0)
+        node_2 = mp.CreateNewNode(2, coords_node_2[0], coords_node_2[1], coords_node_2[2])
+
+        rotation = math.atan(coords_node_2[1] / coords_node_2[0])
+        length = math.sqrt(coords_node_2[0]**2 + coords_node_2[1]**2)
+
+        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.DISPLACEMENT_X, KratosMultiphysics.REACTION_X, mp)
+        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.DISPLACEMENT_Y, KratosMultiphysics.REACTION_Y, mp)
+
+        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ROTATION_X, KratosMultiphysics.REACTION_MOMENT_X, mp)
+        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ROTATION_Y, KratosMultiphysics.REACTION_MOMENT_Y, mp)
+        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ROTATION_Z, KratosMultiphysics.REACTION_MOMENT_Z,
+                                                  mp)
+
+        disp_left, disp_right = 0.0, 0.0
+        node_1.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Y, 0, disp_left)
+        node_2.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Y, 0, disp_right)
+        node_1.Fix(KratosMultiphysics.DISPLACEMENT_Y)
+        node_2.Fix(KratosMultiphysics.DISPLACEMENT_Y)
+
+        # set imposed rotation based on euler beam theory with a point load in the middle of a simply supported beam
+        rot_left = vertical_point_load * length**2 / (16*EI)
+        rot_right = -vertical_point_load * length**2 / (16*EI)
+
+        node_1.SetSolutionStepValue(KratosMultiphysics.ROTATION_Z, 0, rot_left)
+        node_2.SetSolutionStepValue(KratosMultiphysics.ROTATION_Z, 0, rot_right)
+        node_1.Fix(KratosMultiphysics.ROTATION_Z)
+        node_2.Fix(KratosMultiphysics.ROTATION_Z)
+
+        location_load = length/2
+
+        # calculate analytical deflection and rotation at the location of the load
+        expected_deflection_x, expected_deflection_y = self.calculate_deflection_of_beam(disp_left, disp_right,
+                                                                                         rot_left, rot_right, length,
+                                                                                         location_load, rotation)
+
+        expected_rotation = self.calculate_rotation_of_beam(disp_left, disp_right, rot_left, rot_right, length,
+                                                            location_load, rotation)
+
+        # create condition
+        cond = mp.CreateNewCondition("MovingLoadCondition2D2N", 1, [1, 2], mp.GetProperties()[1])
+
+        cond.SetValue(StructuralMechanicsApplication.POINT_LOAD, [0, vertical_point_load, 0])
+        cond.SetValue(StructuralMechanicsApplication.MOVING_LOAD_LOCAL_DISTANCE, location_load)
+
+        # solve system and calculate displacement and rotation at the location of the load
+        strategy.InitializeSolutionStep()
+        strategy.SolveSolutionStep()
+
+        # get calculated displacement at the load
+        disp = cond.GetValue(KratosMultiphysics.DISPLACEMENT)
+
+        self.assertAlmostEqual(disp[0], expected_deflection_x)
+        self.assertAlmostEqual(disp[1], expected_deflection_y)
+
+        # get calculated rotation at the load
+        rot = cond.GetValue(KratosMultiphysics.ROTATION)
+
+        self.assertAlmostEqual(rot[2], expected_rotation)
+
     def _MovingLoadCondition3D2NRot_disp_rot_at_load(self, second_coordinates, axis_1, axis_2):
 
         out_of_plane_axis = list({0, 1, 2} - {axis_1, axis_2})[0]
@@ -892,6 +978,13 @@ class TestLoadingConditionsMoving(KratosUnittest.TestCase):
 
     def test_MovingLoadCondition2D2NRot_disp_rot_at_load(self):
         self._MovingLoadCondition2D2NRot_disp_rot_at_load()
+
+    def test_MovingLoadCondition2D2NImposedRot_disp_rot_at_load(self):
+        """
+        Tests the MovingLoadCondition2D2N with imposed rotation and checks the displacement and rotation at the position
+        of the load
+        """
+        self._MovingLoadCondition2D2NImposedRot_disp_rot_at_load()
 
     def test_MovingLoadCondition3D2NRot_disp_rot_at_load_x_y_plane(self):
         coords_node_2 = [math.sqrt(2.0), math.sqrt(2.0), 0.0]


### PR DESCRIPTION
the full (3x3) rotation matrix for moving load was not correctly implemented in 2D cases. I.e. in the 3rd direction, a 0 was placed in the matrix instead of a 1

