### PR TITLE
Rename `KRATOS_EXPECT_MATRIX_EQUAL` to `KRATOS_EXPECT_MATRIX_EQ`

### DIFF
--- a/applications/HDF5Application/tests/test_hdf5_file.cpp
+++ b/applications/HDF5Application/tests/test_hdf5_file.cpp
@@ -947,7 +947,7 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5_File_ReadWriteParameterAttribute1, KratosHDF5Test
         mat_values.data()[2] = 2;
         mat_values.data()[3] = 3;
         KRATOS_EXPECT_TRUE(attr_in["matrix"].IsMatrix());
-        KRATOS_EXPECT_MATRIX_EQUAL(attr_in["matrix"].GetMatrix(), mat_values);
+        KRATOS_EXPECT_MATRIX_EQ(attr_in["matrix"].GetMatrix(), mat_values);
         KRATOS_EXPECT_TRUE(attr_in["int_array"].IsArray());
         int local_index = 1;
         for (const auto& v : attr_in["int_array"]) {

--- a/kratos/includes/expect.h
+++ b/kratos/includes/expect.h
@@ -156,7 +156,7 @@ for (std::size_t _i = 0; _i < a.size1(); _i++) {                                
 }                                                                                    \
 }
 
-#define KRATOS_EXPECT_MATRIX_EQUAL(a, b) KRATOS_EXPECT_MATRIX_NEAR(a,b,std::numeric_limits<double>::epsilon())
+#define KRATOS_EXPECT_MATRIX_EQ(a, b) KRATOS_EXPECT_MATRIX_NEAR(a,b,std::numeric_limits<double>::epsilon())
 
 #define KRATOS_EXPECT_EXCEPTION_IS_THROWN(TheStatement, TheErrorMessage)                 \
 try {                                                                                   \

--- a/kratos/mpi/tests/cpp_tests/sources/test_mpi_data_communicator.cpp
+++ b/kratos/mpi/tests/cpp_tests/sources/test_mpi_data_communicator.cpp
@@ -370,8 +370,8 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorSumMatrix, KratosMPICor
             // TODO: For some reason, if the following line is uncommented,
             //       It produces an error which is totally unrelated.
             // resultant_matrix = base_values * (world_size * (i + 2));
-            KRATOS_EXPECT_MATRIX_EQUAL(vec_result[i], resultant_matrix);
-            KRATOS_EXPECT_MATRIX_EQUAL(global_results[i], resultant_matrix);
+            KRATOS_EXPECT_MATRIX_EQ(vec_result[i], resultant_matrix);
+            KRATOS_EXPECT_MATRIX_EQ(global_results[i], resultant_matrix);
         }
     }
 
@@ -697,8 +697,8 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorMinMatrix, KratosMPICor
 
         for (unsigned int i = 0; i < 3; ++i) {
             resultant_matrix = base_values * (world_size - 1) * (i + 1);
-            KRATOS_EXPECT_MATRIX_EQUAL(vec_result[i], resultant_matrix);
-            KRATOS_EXPECT_MATRIX_EQUAL(global_results[i], resultant_matrix);
+            KRATOS_EXPECT_MATRIX_EQ(vec_result[i], resultant_matrix);
+            KRATOS_EXPECT_MATRIX_EQ(global_results[i], resultant_matrix);
         }
     }
 
@@ -1016,8 +1016,8 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorMaxMatrix, KratosMPICor
         base_values.data()[0] = 0; base_values.data()[1] = 1; base_values.data()[2] = 2; base_values.data()[3] = 0;
         for (unsigned int i = 0; i < 3; ++i) {
             resultant_matrix = base_values * (world_size - 1) * (i + 1);
-            KRATOS_EXPECT_MATRIX_EQUAL(vec_result[i], resultant_matrix);
-            KRATOS_EXPECT_MATRIX_EQUAL(global_results[i], resultant_matrix);
+            KRATOS_EXPECT_MATRIX_EQ(vec_result[i], resultant_matrix);
+            KRATOS_EXPECT_MATRIX_EQ(global_results[i], resultant_matrix);
         }
     }
 
@@ -1285,8 +1285,8 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorSumAllMatrix, KratosMPI
         // TODO: For some reason, if the following line is uncommented,
         //       It produces an error which is totally unrelated.
         // resultant_matrix = base_values * (world_size * (i + 2));
-        KRATOS_EXPECT_MATRIX_EQUAL(vec_result[i], resultant_matrix);
-        KRATOS_EXPECT_MATRIX_EQUAL(global_results[i], resultant_matrix);
+        KRATOS_EXPECT_MATRIX_EQ(vec_result[i], resultant_matrix);
+        KRATOS_EXPECT_MATRIX_EQ(global_results[i], resultant_matrix);
     }
 }
 
@@ -1535,8 +1535,8 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorMinAllMatrix, KratosMPI
 
     for (unsigned int i = 0; i < 3; ++i) {
         resultant_matrix = base_values * (world_size - 1) * (i + 1);
-        KRATOS_EXPECT_MATRIX_EQUAL(vec_result[i], resultant_matrix);
-        KRATOS_EXPECT_MATRIX_EQUAL(global_results[i], resultant_matrix);
+        KRATOS_EXPECT_MATRIX_EQ(vec_result[i], resultant_matrix);
+        KRATOS_EXPECT_MATRIX_EQ(global_results[i], resultant_matrix);
     }
 }
 
@@ -1777,8 +1777,8 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorMaxAllMatrix, KratosMPI
     base_values.data()[0] = 0; base_values.data()[1] = 1; base_values.data()[2] = 2; base_values.data()[3] = 0;
     for (unsigned int i = 0; i < 3; ++i) {
         resultant_matrix = base_values * (world_size - 1) * (i + 1);
-        KRATOS_EXPECT_MATRIX_EQUAL(vec_result[i], resultant_matrix);
-        KRATOS_EXPECT_MATRIX_EQUAL(global_results[i], resultant_matrix);
+        KRATOS_EXPECT_MATRIX_EQ(vec_result[i], resultant_matrix);
+        KRATOS_EXPECT_MATRIX_EQ(global_results[i], resultant_matrix);
     }
 }
 
@@ -2029,7 +2029,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorScanSumMatrix, KratosMP
     local.data()[0] = 2.0; local.data()[1] = 3.0; local.data()[2] = 4.0; local.data()[3] = 5.0;
     resultant.data()[0] = 2.0*(rank+1); resultant.data()[1] = 3.0*(rank+1); resultant.data()[2] = 4.0*(rank+1); resultant.data()[3] = 5.0*(rank+1);
     const auto& partial_sum = mpi_world_communicator.ScanSum(local);
-    KRATOS_EXPECT_MATRIX_EQUAL(partial_sum, resultant);
+    KRATOS_EXPECT_MATRIX_EQ(partial_sum, resultant);
 
     // check std::vector methods
     std::vector<Matrix> vec_local(3, Matrix(2, 2));
@@ -2047,8 +2047,8 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorScanSumMatrix, KratosMP
     KRATOS_EXPECT_EQ(vec_partial_sum.size(), 3);
     for (unsigned int i = 0; i < 3; ++i) {
         resultant_matrix = base_values * (i+1);
-        KRATOS_EXPECT_MATRIX_EQUAL(vec_partial_sum[i], resultant_matrix);
-        KRATOS_EXPECT_MATRIX_EQUAL(global_vec[i], resultant_matrix);
+        KRATOS_EXPECT_MATRIX_EQ(vec_partial_sum[i], resultant_matrix);
+        KRATOS_EXPECT_MATRIX_EQ(global_vec[i], resultant_matrix);
     }
 }
 
@@ -2421,11 +2421,11 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorSendRecvMatrix, KratosM
 
         // value two-buffer version
         mpi_world_communicator.SendRecv(send_value, send_rank, 0, recv_value, recv_rank, 0);
-        KRATOS_EXPECT_MATRIX_EQUAL(recv_value, expected_recv);
+        KRATOS_EXPECT_MATRIX_EQ(recv_value, expected_recv);
 
         // value return version
         const auto& return_value = mpi_world_communicator.SendRecv(send_value, send_rank, 0, recv_rank, 0);
-        KRATOS_EXPECT_MATRIX_EQUAL(return_value, expected_recv);
+        KRATOS_EXPECT_MATRIX_EQ(return_value, expected_recv);
 
         // two-buffer version
         mpi_world_communicator.SendRecv(send_buffer, send_rank, 0, recv_buffer, recv_rank, 0);
@@ -2436,8 +2436,8 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorSendRecvMatrix, KratosM
         KRATOS_EXPECT_EQ(return_buffer.size(), 2);
         for (int i = 0; i < 2; i++) {
             result = expected_recv * (i+1);
-            KRATOS_EXPECT_MATRIX_EQUAL(recv_buffer[i], result);
-            KRATOS_EXPECT_MATRIX_EQUAL(return_buffer[i], result);
+            KRATOS_EXPECT_MATRIX_EQ(recv_buffer[i], result);
+            KRATOS_EXPECT_MATRIX_EQ(return_buffer[i], result);
         }
     }
 }
@@ -2596,7 +2596,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorSendAndRecvMatrix, Krat
         // value two-buffer version
         mpi_world_communicator.Send(send_value, send_rank, 0);
         mpi_world_communicator.Recv(recv_value, recv_rank, 0);
-        KRATOS_EXPECT_MATRIX_EQUAL(recv_value, expected_recv);
+        KRATOS_EXPECT_MATRIX_EQ(recv_value, expected_recv);
 
         // two-buffer version
         mpi_world_communicator.Send(send_buffer, send_rank, 0);
@@ -2606,7 +2606,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorSendAndRecvMatrix, Krat
 
         for (int i = 0; i < 2; i++) {
             result = expected_recv * (i+1);
-            KRATOS_EXPECT_MATRIX_EQUAL(recv_buffer[i], result);
+            KRATOS_EXPECT_MATRIX_EQ(recv_buffer[i], result);
         }
     }
 }
@@ -2758,7 +2758,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorBroadcastMatrix, Kratos
     result.data()[3] = 7.0*(send_rank+1);
 
     mpi_world_communicator.Broadcast(send, send_rank);
-    KRATOS_EXPECT_MATRIX_EQUAL(send, result);
+    KRATOS_EXPECT_MATRIX_EQ(send, result);
 }
 
 namespace {
@@ -2949,7 +2949,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorBroadcastMatrixVector, 
 
     mpi_world_communicator.Broadcast(send,send_rank);
     for (unsigned int i = 0; i < 2; i++) {
-        KRATOS_EXPECT_MATRIX_EQUAL(send[i], result[i]);
+        KRATOS_EXPECT_MATRIX_EQ(send[i], result[i]);
     }
 
     #ifdef KRATOS_DEBUG
@@ -3228,7 +3228,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorScatterMatrix, KratosMP
     base_values.data()[0] = 2; base_values.data()[1] = 3; base_values.data()[2] = 5; base_values.data()[3] = 7;
     for (int i = 0; i < 2; i++) {
         resultant = base_values * (world_rank * 2 + i + 1);
-        KRATOS_EXPECT_MATRIX_EQUAL(recv_buffer[i], resultant);
+        KRATOS_EXPECT_MATRIX_EQ(recv_buffer[i], resultant);
     }
 
     // return version
@@ -3236,7 +3236,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorScatterMatrix, KratosMP
     KRATOS_EXPECT_EQ(return_buffer.size(), 2);
     for (int i = 0; i < 2; i++) {
         resultant = base_values * (world_rank * 2 + i + 1);
-        KRATOS_EXPECT_MATRIX_EQUAL(return_buffer[i], resultant);
+        KRATOS_EXPECT_MATRIX_EQ(return_buffer[i], resultant);
     }
 
     #ifdef KRATOS_DEBUG
@@ -3739,7 +3739,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorScattervMatrix, KratosM
     Matrix result(2,2);
     result.data()[0] = 2.0*world_rank; result.data()[1] = 3.0*world_rank; result.data()[2] = 4.0*world_rank; result.data()[3] = 5.0*world_rank;
     for (int i = 0; i < recv_size; i++) {
-        KRATOS_EXPECT_MATRIX_EQUAL(recv_buffer[i], result);
+        KRATOS_EXPECT_MATRIX_EQ(recv_buffer[i], result);
     }
 
     // return buffer version
@@ -3757,7 +3757,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorScattervMatrix, KratosM
     }
     const auto& returned_result = mpi_world_communicator.Scatterv(scatterv_message, send_rank);
     for (int i = 0; i < recv_size; i++) {
-        KRATOS_EXPECT_MATRIX_EQUAL(returned_result[i], result);
+        KRATOS_EXPECT_MATRIX_EQ(returned_result[i], result);
     }
 
     #ifdef KRATOS_DEBUG
@@ -4079,7 +4079,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorGatherMatrix, KratosMPI
         for (int rank = 0; rank < world_size; rank++) {
             for (int j = 2*rank; j < 2*rank+2; j++) {
                 result = base_values * (rank + 1) * (j % 2 + 1);
-                KRATOS_EXPECT_MATRIX_EQUAL(recv_buffer[j], result);
+                KRATOS_EXPECT_MATRIX_EQ(recv_buffer[j], result);
             }
         }
     }
@@ -4091,7 +4091,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorGatherMatrix, KratosMPI
         for (int rank = 0; rank < world_size; rank++) {
             for (int j = 2*rank; j < 2*rank+2; j++) {
                 result = base_values * (rank + 1) * (j % 2 + 1);
-                KRATOS_EXPECT_MATRIX_EQUAL(return_buffer[j], result);
+                KRATOS_EXPECT_MATRIX_EQ(return_buffer[j], result);
             }
         }
     }
@@ -4633,11 +4633,11 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorGathervMatrix, KratosMP
             // the message from this rank...
             for (int i = recv_offset; i < recv_offset + recv_size; i++) {
                 result = base_value * (rank+1);
-                KRATOS_EXPECT_MATRIX_EQUAL(recv_buffer[i], result);
+                KRATOS_EXPECT_MATRIX_EQ(recv_buffer[i], result);
             }
             // ...followed by the expected padding.
             for (int i = recv_offset + recv_size; i < recv_offset + recv_size + message_padding; i++) {
-                KRATOS_EXPECT_MATRIX_EQUAL(recv_buffer[i], padded_value);
+                KRATOS_EXPECT_MATRIX_EQ(recv_buffer[i], padded_value);
             }
 
         }
@@ -4653,7 +4653,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorGathervMatrix, KratosMP
             KRATOS_EXPECT_EQ(return_buffer[rank].size(), expected_size);
             for (unsigned int i = 0; i < expected_size; i++) {
                 result = base_value * (rank+1);
-                KRATOS_EXPECT_MATRIX_EQUAL(return_buffer[rank][i], result);
+                KRATOS_EXPECT_MATRIX_EQ(return_buffer[rank][i], result);
             }
             // no padding in return version
         }
@@ -4963,7 +4963,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorAllGatherMatrix, Kratos
     for (int rank = 0; rank < world_size; rank++) {
         for (int j = 2*rank; j < 2*rank+2; j++) {
             result = base_values * (rank + 1) * (j % 2 + 1);
-            KRATOS_EXPECT_MATRIX_EQUAL(recv_buffer[j], result);
+            KRATOS_EXPECT_MATRIX_EQ(recv_buffer[j], result);
         }
     }
 
@@ -4974,7 +4974,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorAllGatherMatrix, Kratos
     for (int rank = 0; rank < world_size; rank++) {
         for (int j = 2*rank; j < 2*rank+2; j++) {
             result = base_values * (rank + 1) * (j % 2 + 1);
-            KRATOS_EXPECT_MATRIX_EQUAL(return_buffer[j], result);
+            KRATOS_EXPECT_MATRIX_EQ(return_buffer[j], result);
         }
     }
 
@@ -5449,11 +5449,11 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorAllGathervMatrix, Krato
         // the message from this rank...
         for (int i = recv_offset; i < recv_offset + recv_size; i++) {
             result = base_value * (rank + 1);
-            KRATOS_EXPECT_MATRIX_EQUAL(recv_buffer[i], result);
+            KRATOS_EXPECT_MATRIX_EQ(recv_buffer[i], result);
         }
         // ...followed by the expected padding.
         for (int i = recv_offset + recv_size; i < recv_offset + recv_size + message_padding; i++) {
-            KRATOS_EXPECT_MATRIX_EQUAL(recv_buffer[i], padding);
+            KRATOS_EXPECT_MATRIX_EQ(recv_buffer[i], padding);
         }
 
     }
@@ -5467,7 +5467,7 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorAllGathervMatrix, Krato
         KRATOS_EXPECT_EQ(return_buffer[rank].size(), expected_size);
         for (unsigned int i = 0; i < expected_size; i++) {
             result = base_value * (rank + 1);
-            KRATOS_EXPECT_MATRIX_EQUAL(return_buffer[rank][i], result);
+            KRATOS_EXPECT_MATRIX_EQ(return_buffer[rank][i], result);
         }
         // no padding in return version
     }

--- a/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_parameters.cpp
@@ -748,7 +748,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersSetMethods, KratosCoreFastSuite)
             matrix(2,1) = 6.0;
             tmp[key].SetMatrix(matrix);
             const auto& A = tmp[key].GetMatrix();
-            KRATOS_EXPECT_MATRIX_EQUAL(A,matrix);
+            KRATOS_EXPECT_MATRIX_EQ(A,matrix);
         } else {
             KRATOS_EXPECT_EXCEPTION_IS_THROWN(tmp[key].GetMatrix(), "");
         }
@@ -795,7 +795,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersAddMethods, KratosCoreFastSuite)
     matrix(2,1) = 6.0;
     tmp.AddMatrix(key, matrix);
     const auto& A = tmp[key].GetMatrix();
-    KRATOS_EXPECT_MATRIX_EQUAL(A,matrix);
+    KRATOS_EXPECT_MATRIX_EQ(A,matrix);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(KratosParametersIsStringArray, KratosCoreFastSuite)
@@ -940,7 +940,7 @@ KRATOS_TEST_CASE_IN_SUITE(KratosParametersMatrixInterface, KratosCoreFastSuite)
     KRATOS_EXPECT_TRUE(tmp["matrix_value"].IsMatrix());
 
     const auto& A2 = tmp["matrix_value"].GetMatrix();
-    KRATOS_EXPECT_MATRIX_EQUAL(A2, mat);
+    KRATOS_EXPECT_MATRIX_EQ(A2, mat);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(KratosParametersNullvsNullValidation, KratosCoreFastSuite)

--- a/kratos/tests/cpp_tests/utilities/test_data_type_traits.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_data_type_traits.cpp
@@ -157,11 +157,11 @@ KRATOS_TEST_CASE_IN_SUITE(DataTypeTraitsMatrixDouble, KratosCoreFastSuite)
 
     Matrix dummy(4, 5);
     type_trait::CopyToContiguousData(dummy.data().begin(), test);
-    KRATOS_EXPECT_MATRIX_EQUAL(dummy, test);
+    KRATOS_EXPECT_MATRIX_EQ(dummy, test);
 
     dummy = Matrix(4, 5, -2);
     type_trait::CopyFromContiguousData(dummy, test.data().begin());
-    KRATOS_EXPECT_MATRIX_EQUAL(dummy, test);
+    KRATOS_EXPECT_MATRIX_EQ(dummy, test);
 
     KRATOS_EXPECT_EXCEPTION_IS_THROWN(
         type_trait::Reshape(test, std::vector<unsigned int>{}),
@@ -411,7 +411,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataTypeTraitsMatrixNested, KratosCoreFastSuite)
     type_trait::CopyFromContiguousData(result, values.data());
     for (unsigned int i = 0; i < 6; ++i) {
         for (unsigned int j = 0; j < 20; ++j) {
-            KRATOS_EXPECT_MATRIX_EQUAL(result.data()[i].data()[j], test.data()[i].data()[j]);
+            KRATOS_EXPECT_MATRIX_EQ(result.data()[i].data()[j], test.data()[i].data()[j]);
         }
     }
 }


### PR DESCRIPTION
**📝 Description**
This PR extracts the changes related to the macro renaming from PR #11506. The aim is to assist in breaking down PR #11506 into smaller pieces that can be reviewed more easily and which can be merged back separately. This commit renames the macro and it updates all of its usages.
