### PR TITLE
[GeoMechanicsApplication] Fixed two warnings reported by the clang compiler

### DIFF
--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_GeoMechanicsNewtonRaphsonErosionProcessStrategy.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_GeoMechanicsNewtonRaphsonErosionProcessStrategy.cpp
@@ -10,8 +10,6 @@
 //  Main authors:    Jonathan Nuttall
 //
 
-#pragma once
-
 // System includes
 #include <limits>
 #include <map>

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_head_extrapolation_flow_workflow.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_head_extrapolation_flow_workflow.cpp
@@ -10,7 +10,6 @@
 //  Main authors:    Jonathan Nuttall
 //
 
-#pragma once
 #include <string>
 #include <iostream>
 


### PR DESCRIPTION
**📝 Description**
Don't use `#pragma once` in implementation files (`*.cpp`).
