### PR TITLE
[GeoMechanicsApplication] Remove redundant pragma once in cpp file dgeoflow (gives clang warning)

### DIFF
--- a/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
@@ -10,8 +10,6 @@
 //  Main authors:    Jonathan Nuttall
 //
 
-#pragma once
-
 #include <sstream>
 #include <iomanip>
 #include "dgeoflow.h"


### PR DESCRIPTION
Found one more pragma once in a cpp file. I did a project wide search after this, with file mask *.cpp and it seems this is the last one.
