### PR TITLE
[TrilinosApplication] Some minor improvements in MPC B&S

### DIFF
--- a/applications/TrilinosApplication/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
+++ b/applications/TrilinosApplication/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
@@ -1343,7 +1343,7 @@ protected:
     {
         KRATOS_TRY
 
-        // Reference of the matrix and vectpr
+        // Reference of the matrix and vector
         auto& r_T = GetConstraintRelationMatrix();
         auto& r_constant_vector = GetConstraintConstantVector();
 

--- a/applications/TrilinosApplication/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
+++ b/applications/TrilinosApplication/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
@@ -1371,6 +1371,7 @@ protected:
 
         // We clear the set
         mInactiveSlaveDofs.clear();
+        std::size_t num_inactive_slave_dofs_other_partitions = 0;
 
         // Iterate over the constraints
         for (auto& r_const : rModelPart.MasterSlaveConstraints()) {
@@ -1389,24 +1390,30 @@ protected:
                         mInactiveSlaveDofs.insert(slave_id);
                     } else {
                         auxiliary_inactive_slave_ids[index_rank].insert(slave_id);
+                        ++num_inactive_slave_dofs_other_partitions;
                     }
                 }
             }
         }
 
+        // Compute total number of inactive slave dofs in other partitions
+        num_inactive_slave_dofs_other_partitions = r_data_comm.SumAll(num_inactive_slave_dofs_other_partitions);
+
         // Now we pass the info between partitions
-        const int tag_sync_inactive_slave_id = 0;
-        for (int i_rank = 0; i_rank < world_size; ++i_rank) {
-            if (i_rank != current_rank) {
-                std::vector<IndexType> receive_inactive_slave_ids_vector;
-                r_data_comm.Recv(receive_inactive_slave_ids_vector, i_rank, tag_sync_inactive_slave_id);
-                mInactiveSlaveDofs.insert(receive_inactive_slave_ids_vector.begin(), receive_inactive_slave_ids_vector.end());
-            } else {
-                for (int j_rank = 0; j_rank < world_size; ++j_rank) {
-                    if (j_rank != current_rank) {
-                        const auto& r_inactive_slave_ids = auxiliary_inactive_slave_ids[j_rank];
-                        std::vector<IndexType> send_inactive_slave_ids_vector(r_inactive_slave_ids.begin(), r_inactive_slave_ids.end());
-                        r_data_comm.Send(send_inactive_slave_ids_vector, j_rank, tag_sync_inactive_slave_id);
+        if (num_inactive_slave_dofs_other_partitions > 0) {
+            const int tag_sync_inactive_slave_id = 0;
+            for (int i_rank = 0; i_rank < world_size; ++i_rank) {
+                if (i_rank != current_rank) {
+                    std::vector<IndexType> receive_inactive_slave_ids_vector;
+                    r_data_comm.Recv(receive_inactive_slave_ids_vector, i_rank, tag_sync_inactive_slave_id);
+                    mInactiveSlaveDofs.insert(receive_inactive_slave_ids_vector.begin(), receive_inactive_slave_ids_vector.end());
+                } else {
+                    for (int j_rank = 0; j_rank < world_size; ++j_rank) {
+                        if (j_rank != current_rank) {
+                            const auto& r_inactive_slave_ids = auxiliary_inactive_slave_ids[j_rank];
+                            std::vector<IndexType> send_inactive_slave_ids_vector(r_inactive_slave_ids.begin(), r_inactive_slave_ids.end());
+                            r_data_comm.Send(send_inactive_slave_ids_vector, j_rank, tag_sync_inactive_slave_id);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
**📝 Description**

In this PR, changes have been made to the `TrilinosBlockBuilderAndSolver` class in the file `trilinos_block_builder_and_solver.h`. The main purpose of the commit is to optimize the synchronization of inactive slave degree of freedom (DOF) information between partitions. 

1. It begins by initializing a variable `num_inactive_slave_dofs_other_partitions` to 0.
2. It then iterates over master-slave constraints, updating `mInactiveSlaveDofs` and `num_inactive_slave_dofs_other_partitions` accordingly.
3. After this, it calculates the total number of inactive slave DOFs in other partitions using communication via `r_data_comm`.
4. If there are inactive slave DOFs in other partitions (`num_inactive_slave_dofs_other_partitions > 0`), it proceeds to synchronize this information between partitions using communication via `r_data_comm`. The synchronization process involves sending and receiving inactive slave DOF IDs between different ranks.

**🆕 Changelog**

- [Some minor improvements in MPC B&S](https://github.com/KratosMultiphysics/Kratos/commit/b860f9be17710017f6387cdf7098bb9688f938d9)
