### PR TITLE
[Core] Get boost from archive until jfrog works again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
 
     - name: Download boost
       run: |
-        $url = "https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.gz"
+        $url = "https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.gz"
         (New-Object System.Net.WebClient).DownloadFile($url, "$env:TEMP\boost.tar.gz")
         7z.exe x "$env:TEMP\boost.tar.gz" -o"$env:TEMP\boostArchive" -y | Out-Null
         7z.exe x "$env:TEMP\boostArchive" -o"$env:TEMP\boost" -y | Out-Null
@@ -394,7 +394,7 @@ jobs:
 
     - name: Download boost
       run: |
-        $url = "https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.gz"
+        $url = "https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.gz"
         (New-Object System.Net.WebClient).DownloadFile($url, "$env:TEMP\boost.tar.gz")
         7z.exe x "$env:TEMP\boost.tar.gz" -o"$env:TEMP\boostArchive" -y | Out-Null
         7z.exe x "$env:TEMP\boostArchive" -o"$env:TEMP\boost" -y | Out-Null

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -116,7 +116,7 @@ jobs:
 
     - name: Download boost
       run: |
-        $url = "https://boostorg.jfrog.io/artifactory/main/release/1.74.0/source/boost_1_74_0.tar.gz"
+        $url = "https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.gz"
         (New-Object System.Net.WebClient).DownloadFile($url, "$env:TEMP\boost.tar.gz")
         7z.exe x "$env:TEMP\boost.tar.gz" -o"$env:TEMP\boostArchive" -y | Out-Null
         7z.exe x "$env:TEMP\boostArchive" -o"$env:TEMP\boost" -y | Out-Null

--- a/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux/Dockerfile
@@ -15,12 +15,12 @@ RUN mkdir -p /workspace/scripts; \
     mkdir -p /workspace/boost
 
 # Install Boost (from source)
-# RUN git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git /workspace/boost/boost_1_71_0
+# RUN git clone -b 'boost-1.74.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git /workspace/boost/boost_1_74_0
 
 # Install Boost (form zip)
-RUN wget -P /workspace/boost https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.gz; \
-	tar -C /workspace/boost -xzf /workspace/boost/boost_1_71_0.tar.gz; \
-	rm /workspace/boost/boost_1_71_0.tar.gz
+RUN wget -P /workspace/boost https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.gz; \
+	tar -C /workspace/boost -xzf /workspace/boost/boost_1_74_0.tar.gz; \
+	rm /workspace/boost/boost_1_74_0.tar.gz
 
 # Install MMG 5.5.1
 # Note ( upgraded from 5.4.1 because of https://github.com/MmgTools/mmg/issues/85)

--- a/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_linux_mpi/Dockerfile
@@ -15,12 +15,12 @@ RUN mkdir -p /workspace/scripts; \
     mkdir -p /workspace/boost
 
 # Install Boost (from source)
-# RUN git clone -b 'boost-1.71.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git /workspace/boost/boost_1_71_0
+# RUN git clone -b 'boost-1.74.0' --depth 1 --recurse-submodules -j24 https://github.com/boostorg/boost.git /workspace/boost/boost_1_74_0
 
 # Install Boost (form zip)
-RUN wget -P /workspace/boost https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.tar.gz; \
-	tar -C /workspace/boost -xzf /workspace/boost/boost_1_71_0.tar.gz; \
-	rm /workspace/boost/boost_1_71_0.tar.gz
+RUN wget -P /workspace/boost https://archives.boost.io/release/1.74.0/source/boost_1_74_0.tar.gz; \
+	tar -C /workspace/boost -xzf /workspace/boost/boost_1_74_0.tar.gz; \
+	rm /workspace/boost/boost_1_74_0.tar.gz
 
 # Install MMG 5.5.1
 # Note ( upgraded from 5.4.1 because of https://github.com/MmgTools/mmg/issues/85)

--- a/scripts/docker_files/docker_file_wheelbuilder_windows/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_windows/Dockerfile
@@ -40,7 +40,7 @@ RUN powershell.exe -Command \
 #download and extract boost
 RUN powershell.exe -Command \
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-    wget https://boostorg.jfrog.io/artifactory/main/release/1.71.0/source/boost_1_71_0.zip -OutFile c:\TEMP\boost.zip; \
+    wget https://archives.boost.io/release/1.74.0/source/boost_1_74_0.zip -OutFile c:\TEMP\boost.zip; \
     mkdir c:\boost; \
     7z x c:\TEMP\boost.zip -o"c:\boost"
 


### PR DESCRIPTION
**📝 Description**
Changing boost source from jfrog to boost.archive until the former works again.

Please @KratosMultiphysics/all if you have problems with the windows CI having errors merge this PR or commit into your branch directly.

