### PR TITLE
[TrilinosApplication] Fix master DoFs in block builder and solver

### DIFF
--- a/applications/TrilinosApplication/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
+++ b/applications/TrilinosApplication/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
@@ -1310,8 +1310,12 @@ protected:
             for (IndexType i = 0; i < number_of_local_rows; ++i) {
                 temp_master_ids.insert(mFirstMyId + i);
             }
-            for (auto id_slave : mSlaveIds) {
-                temp_master_ids.erase(id_slave);
+
+            // Remove ids
+            for (auto id_slave_vector : auxiliary_slave_ids) {
+                for (auto id_slave : id_slave_vector) {
+                    temp_master_ids.erase(id_slave);
+                }
             }
             mMasterIds = std::vector<IndexType>(temp_master_ids.begin(), temp_master_ids.end());
 

--- a/applications/TrilinosApplication/tests/cpp_tests/strategies/builder_and_solvers/test_builder_and_solver.cpp
+++ b/applications/TrilinosApplication/tests/cpp_tests/strategies/builder_and_solvers/test_builder_and_solver.cpp
@@ -1031,7 +1031,7 @@ namespace Kratos::Testing
     /**
     * Checks if the block builder and solver performs correctly the assemble of the system
     */
-    KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosDynamicAllocationBasicDisplacementBlockBuilderAndSolverWithConstraints, KratosTrilinosApplicationMPITestSuite2)
+    KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosDynamicAllocationBasicDisplacementBlockBuilderAndSolverWithConstraints, KratosTrilinosApplicationMPITestSuite)
     {
         // The base model part
         Model current_model;

--- a/applications/TrilinosApplication/tests/cpp_tests/strategies/builder_and_solvers/test_builder_and_solver.cpp
+++ b/applications/TrilinosApplication/tests/cpp_tests/strategies/builder_and_solvers/test_builder_and_solver.cpp
@@ -67,6 +67,96 @@ namespace Kratos::Testing
     /**
     * @brief It generates a truss structure with an expected solution
     */
+    static inline void DynamicAllocationBasicTestBuilderAndSolverDisplacement(
+        ModelPart& rModelPart,
+        const DataCommunicator& rDataCommunicator,
+        const bool WithConstraint = false
+        )
+    {
+        // Set MPI communicator
+        ModelPartCommunicatorUtilities::SetMPICommunicator(rModelPart, rDataCommunicator);
+
+        // Add variables
+        rModelPart.AddNodalSolutionStepVariable(PARTITION_INDEX);
+        rModelPart.AddNodalSolutionStepVariable(DISPLACEMENT);
+        rModelPart.AddNodalSolutionStepVariable(VELOCITY);
+        rModelPart.AddNodalSolutionStepVariable(ACCELERATION);
+        rModelPart.AddNodalSolutionStepVariable(REACTION);
+        rModelPart.AddNodalSolutionStepVariable(VOLUME_ACCELERATION);
+
+        // Create properties
+        auto p_prop = rModelPart.CreateNewProperties(1, 0);
+        p_prop->SetValue(YOUNG_MODULUS, 206900000000.0);
+        p_prop->SetValue(NODAL_AREA, 0.01);
+
+        // MPI data
+        const int rank = rDataCommunicator.Rank();
+        const int world_size = rDataCommunicator.Size();
+
+        // Create two nodes per partition
+        Node::Pointer pnode0 = rModelPart.CreateNewNode(1, 0.0, 0.0, 0.0);
+        Node::Pointer pnode1 = rank == 0 ? pnode0 : rModelPart.CreateNewNode(rank + 1, static_cast<double>(rank), 0.0, 0.0);
+        Node::Pointer pnode2 = rModelPart.CreateNewNode(rank + 2, static_cast<double>(rank + 1), 0.0, 0.0);
+
+        /// Add PARTITION_INDEX
+        pnode0->FastGetSolutionStepValue(PARTITION_INDEX) = 0;
+        pnode1->FastGetSolutionStepValue(PARTITION_INDEX) = rank;
+        if (rank + 1 < world_size) {
+            pnode2->FastGetSolutionStepValue(PARTITION_INDEX) = rank + 1;
+        } else {
+            pnode2->FastGetSolutionStepValue(PARTITION_INDEX) = rank;
+        }
+
+        // Create elements
+        GeometryType::Pointer pgeom = Kratos::make_shared<Line2D2<Node>>(PointerVector<Node>{std::vector<Node::Pointer>({pnode1, pnode2})});
+        rModelPart.AddElement(Kratos::make_intrusive<TestBarElement>( rank + 1, pgeom, p_prop));
+
+
+        /// Add dof
+        for (auto& r_node : rModelPart.Nodes()) {
+            r_node.AddDof(DISPLACEMENT_X, REACTION_X);
+            r_node.AddDof(DISPLACEMENT_Y, REACTION_Y);
+            r_node.AddDof(DISPLACEMENT_Z, REACTION_Z);
+        }
+
+        /// Initialize elements
+        const auto& r_process_info = rModelPart.GetProcessInfo();
+        for (auto& r_elem : rModelPart.Elements()) {
+            r_elem.Initialize(r_process_info);
+            r_elem.InitializeSolutionStep(r_process_info);
+        }
+
+        // Set initial solution
+        for (auto& r_node : rModelPart.Nodes()) {
+            (r_node.FastGetSolutionStepValue(DISPLACEMENT)).clear();
+            (r_node.FastGetSolutionStepValue(DISPLACEMENT, 1)).clear();
+            (r_node.FastGetSolutionStepValue(DISPLACEMENT, 2)).clear();
+        }
+
+        // Fix dofs
+        for (auto& r_node : rModelPart.Nodes()) {
+            r_node.Fix(DISPLACEMENT_Y);
+            r_node.Fix(DISPLACEMENT_Z);
+        }
+        // Fix X in first node
+        if (rModelPart.HasNode(1)) {
+            auto pnode = rModelPart.pGetNode(1);
+            pnode->Fix(DISPLACEMENT_X);
+        }
+
+        // Adding constraints
+        if (WithConstraint) {
+            rModelPart.CreateNewMasterSlaveConstraint("LinearMasterSlaveConstraint", (2 * rank) + 1, *pnode0, DISPLACEMENT_X, *pnode2, DISPLACEMENT_X, 1.0, 0.0);
+            rModelPart.CreateNewMasterSlaveConstraint("LinearMasterSlaveConstraint", (2 * rank) + 2, *pnode0, DISPLACEMENT_Y, *pnode2, DISPLACEMENT_Y, 1.0, 0.0);
+        }
+
+        // Compute communication plan and fill communicator meshes correctly
+        ParallelFillCommunicator(rModelPart, rDataCommunicator).Execute();
+    }
+
+    /**
+    * @brief It generates a truss structure with an expected solution
+    */
     static inline void BasicTestBuilderAndSolverDisplacement(
         ModelPart& rModelPart,
         const DataCommunicator& rDataCommunicator,
@@ -217,7 +307,7 @@ namespace Kratos::Testing
         const bool MasterElementBelongsToStructure = false
         )
     {
-        // Set MPI coomunicator
+        // Set MPI communicator
         ModelPartCommunicatorUtilities::SetMPICommunicator(rModelPart, rDataCommunicator);
 
         // Add variables
@@ -341,7 +431,7 @@ namespace Kratos::Testing
             }
         }
 
-        // Compute communicaton plan and fill communicator meshes correctly
+        // Compute communication plan and fill communicator meshes correctly
         ParallelFillCommunicator(rModelPart, rDataCommunicator).Execute();
     }
 
@@ -353,7 +443,7 @@ namespace Kratos::Testing
         const DataCommunicator& rDataCommunicator
         )
     {
-        // Set MPI coomunicator
+        // Set MPI communicator
         ModelPartCommunicatorUtilities::SetMPICommunicator(rModelPart, rDataCommunicator);
 
         // Add variables
@@ -449,7 +539,7 @@ namespace Kratos::Testing
             pnode->Fix(DISPLACEMENT_X);
         }
 
-        // Compute communicaton plan and fill communicator meshes correctly
+        // Compute communication plan and fill communicator meshes correctly
         ParallelFillCommunicator(rModelPart, rDataCommunicator).Execute();
     }
 
@@ -471,12 +561,12 @@ namespace Kratos::Testing
 
         // Fill model part
         MPICppTestUtilities::GenerateDistributedBarStructure(rModelPart, rDataCommunicator);
-   
+
         // Create properties
         auto p_prop = rModelPart.pGetProperties(1, 0);
         p_prop->SetValue(YOUNG_MODULUS, 206900000000.0);
         p_prop->SetValue(NODAL_AREA, 0.01);
-      
+
         /// Add dof
         for (auto& r_node : rModelPart.Nodes()) {
             r_node.AddDof(DISPLACEMENT_X, REACTION_X);
@@ -522,7 +612,7 @@ namespace Kratos::Testing
                 rModelPart.CreateNewMasterSlaveConstraint("LinearMasterSlaveConstraint", 1, *pnode1, DISPLACEMENT_Y, *pnode2, DISPLACEMENT_Y, 1.0, 0.0);
             }
 
-            // Compute communicaton plan and fill communicator meshes correctly
+            // Compute communication plan and fill communicator meshes correctly
             ParallelFillCommunicator(rModelPart, rDataCommunicator).Execute();
         }
     }
@@ -612,9 +702,11 @@ namespace Kratos::Testing
         KRATOS_EXPECT_EQ(rA.NumGlobalNonzeros(), 28);
 
         // Values to check
+        auto p_prop = r_model_part.pGetProperties(1);
+        const double E_100 = p_prop->GetValue(YOUNG_MODULUS)/100.0;
         std::vector<int> row_indexes = {0, 1, 2, 2, 3, 4, 4, 5};
         std::vector<int> column_indexes = {0, 1, 2, 4, 3, 2, 4, 5};
-        std::vector<double> values = {2069000000.0, 1.0, 4138000000.0, -2069000000.0, 1.0, -2069000000.0, 2069000000.0, 1.0};
+        std::vector<double> values = {E_100, 1.0, 2 * E_100, -E_100, 1.0, -E_100, E_100, 1.0};
 
         // Check assembly
         TrilinosCPPTestUtilities::CheckSparseMatrix(rA, row_indexes, column_indexes, values);
@@ -636,10 +728,87 @@ namespace Kratos::Testing
         // Values to check
         row_indexes = {0, 1, 2, 2, 3, 4, 4, 5};
         column_indexes = {0, 1, 2, 4, 3, 2, 4, 5};
-        values = {2069000000.0, 22664800000.0, 4138000000.0, -2069000000.0, 22664800000.0, -2069000000.0, 2069000000.0, 22664800000.0};
+        values = {E_100, 22664800000.0, 2 * E_100, -E_100, 22664800000.0, -E_100, E_100, 22664800000.0};
 
         // Check assembly
         TrilinosCPPTestUtilities::CheckSparseMatrix(rA_scale, row_indexes, column_indexes, values);
+    }
+
+    /**
+    * Checks if the block builder and solver performs correctly the assemble of the system
+    */
+    KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosDynamicAllocationBasicDisplacementBlockBuilderAndSolver, KratosTrilinosApplicationMPITestSuite)
+    {
+        // The base model part
+        Model current_model;
+        ModelPart& r_model_part = current_model.CreateModelPart("Main", 3);
+
+        // The data communicator
+        const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
+
+        // The world size
+        const int world_size = r_comm.Size();
+
+        // Generate Epetra communicator
+        KRATOS_ERROR_IF_NOT(r_comm.IsDistributed()) << "Only distributed DataCommunicators can be used!" << std::endl;
+        auto raw_mpi_comm = MPIDataCommunicator::GetMPICommunicator(r_comm);
+        Epetra_MpiComm epetra_comm(raw_mpi_comm);
+
+        // Basic build
+        DynamicAllocationBasicTestBuilderAndSolverDisplacement(r_model_part, r_comm);
+
+        // Create the solvers and things required
+        auto p_scheme = TrilinosSchemeType::Pointer( new TrilinosResidualBasedIncrementalUpdateStaticSchemeType() );
+        auto p_solver = TrilinosLinearSolverType::Pointer( new AmgclMPISolverType() );
+        Parameters parameters = Parameters(R"(
+        {
+            "diagonal_values_for_dirichlet_dofs" : "no_scaling",
+            "guess_row_size"                     : 15,
+            "silent_warnings"                    : false
+        })" );
+        auto p_builder_and_solver = TrilinosBuilderAndSolverType::Pointer( new TrilinosBlockBuilderAndSolverType(epetra_comm, p_solver, parameters) );
+
+        const auto& rA = BuildSystem(r_model_part, p_scheme, p_builder_and_solver);
+
+        // // To create the solution of reference
+        // DebugLHS(rA);
+
+        // The solution check
+        KRATOS_EXPECT_EQ(rA.NumGlobalRows(), 2 * (world_size + 1));
+        KRATOS_EXPECT_EQ(rA.NumGlobalCols(), 2 * (world_size + 1));
+        KRATOS_EXPECT_EQ(rA.NumGlobalNonzeros(), 16 + 12 * (world_size - 1));
+
+        // Values to check
+        auto p_prop = r_model_part.pGetProperties(1);
+        const double E_100 = p_prop->GetValue(YOUNG_MODULUS)/100.0;
+        std::vector<int> row_indexes = {0, 1, 2, 3};
+        std::vector<int> column_indexes = {0, 1, 2, 3};
+        std::vector<double> values = {E_100, 1.0, E_100, 1.0};
+        if (world_size > 1) {
+            values[2] *= 2;
+        }
+        for (int i = 1; i < world_size; ++i) {
+            // Diagonal values
+            row_indexes.push_back(2 * (world_size + 1) - 2);
+            row_indexes.push_back(2 * (world_size + 1) - 1);
+            column_indexes.push_back(2 * (world_size + 1) - 2);
+            column_indexes.push_back(2 * (world_size + 1) - 1);
+            values.push_back(E_100);
+            values.push_back(1.0);
+
+            // Non diagonal values
+            const unsigned int index_i = 2 * (world_size + 1) - 2;
+            const unsigned int index_j = 2 * (world_size + 1) - 4;
+            row_indexes.push_back(index_i);
+            row_indexes.push_back(index_j);
+            column_indexes.push_back(index_j);
+            column_indexes.push_back(index_i);
+            values.push_back(-E_100);
+            values.push_back(-E_100);
+        }
+
+        // Check assembly
+        TrilinosCPPTestUtilities::CheckSparseMatrix(rA, row_indexes, column_indexes, values);
     }
 
     /**
@@ -684,9 +853,11 @@ namespace Kratos::Testing
         KRATOS_EXPECT_EQ(rA.NumGlobalNonzeros(), 28);
 
         // Values to check
+        auto p_prop = r_model_part.pGetProperties(1);
+        const double E_100 = p_prop->GetValue(YOUNG_MODULUS)/100.0;
         std::vector<int> row_indexes = {0, 1, 2, 3, 4, 5};
         std::vector<int> column_indexes = {0, 1, 2, 3, 4, 5};
-        std::vector<double> values = {2069000000.0, 1.0, 2069000000.0, 1.0, 1.0, 1.0};
+        std::vector<double> values = {E_100, 1.0, E_100, 1.0, 1.0, 1.0};
 
         // Check assembly
         TrilinosCPPTestUtilities::CheckSparseMatrix(rA, row_indexes, column_indexes, values);
@@ -708,7 +879,7 @@ namespace Kratos::Testing
         // Values to check
         row_indexes = {0, 1, 2, 3, 4, 5};
         column_indexes = {0, 1, 2, 3, 4, 5};
-        values = {2069000000.0, 22664800000.0, 2069000000.0, 22664800000.0, 22664800000.0, 22664800000.0};
+        values = {E_100, 22664800000.0, E_100, 22664800000.0, 22664800000.0, 22664800000.0};
 
         // Check assembly
         TrilinosCPPTestUtilities::CheckSparseMatrix(rA_scale, row_indexes, column_indexes, values);
@@ -756,9 +927,11 @@ namespace Kratos::Testing
         KRATOS_EXPECT_EQ(rA.NumGlobalNonzeros(), 28);
 
         // Values to check
+        auto p_prop = r_model_part.pGetProperties(1);
+        const double E_100 = p_prop->GetValue(YOUNG_MODULUS)/100.0;
         std::vector<int> row_indexes = {0, 1, 2, 3, 4, 5};
         std::vector<int> column_indexes = {0, 1, 2, 3, 4, 5};
-        std::vector<double> values = {2069000000.0, 1.0, 2069000000.0, 1.0, 1.0, 1.0};
+        std::vector<double> values = {E_100, 1.0, E_100, 1.0, 1.0, 1.0};
 
         // Check assembly
         TrilinosCPPTestUtilities::CheckSparseMatrix(rA, row_indexes, column_indexes, values);
@@ -827,9 +1000,11 @@ namespace Kratos::Testing
         KRATOS_EXPECT_EQ(rA.NumGlobalNonzeros(), 28);
 
         // Values to check
+        auto p_prop = r_model_part.pGetProperties(1);
+        const double E_100 = p_prop->GetValue(YOUNG_MODULUS)/100.0;
         std::vector<int> row_indexes = {0, 1, 2, 2, 3, 4, 4, 5};
         std::vector<int> column_indexes = {0, 1, 2, 4, 3, 2, 4, 5};
-        std::vector<double> values = {2069000000.0, 1.0, 4138000000.0, -2069000000.0, 1.0, -2069000000.0, 2069000000.0, 1.0};
+        std::vector<double> values = {E_100, 1.0, 2 * E_100, -E_100, 1.0, -E_100, E_100, 1.0};
 
         // Check assembly
         TrilinosCPPTestUtilities::CheckSparseMatrix(rA, row_indexes, column_indexes, values);
@@ -850,6 +1025,98 @@ namespace Kratos::Testing
         values = {1.0, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0};
 
         // Check assembly T matrix
+        TrilinosCPPTestUtilities::CheckSparseMatrix(r_T, row_indexes, column_indexes, values);
+    }
+
+    /**
+    * Checks if the block builder and solver performs correctly the assemble of the system
+    */
+    KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(TrilinosDynamicAllocationBasicDisplacementBlockBuilderAndSolverWithConstraints, KratosTrilinosApplicationMPITestSuite2)
+    {
+        // The base model part
+        Model current_model;
+        ModelPart& r_model_part = current_model.CreateModelPart("Main", 3);
+
+        // The data communicator
+        const DataCommunicator& r_comm = Testing::GetDefaultDataCommunicator();
+
+        // The world size
+        const int world_size = r_comm.Size();
+
+        // Generate Epetra communicator
+        KRATOS_ERROR_IF_NOT(r_comm.IsDistributed()) << "Only distributed DataCommunicators can be used!" << std::endl;
+        auto raw_mpi_comm = MPIDataCommunicator::GetMPICommunicator(r_comm);
+        Epetra_MpiComm epetra_comm(raw_mpi_comm);
+
+        // Basic build
+        DynamicAllocationBasicTestBuilderAndSolverDisplacement(r_model_part, r_comm, true);
+
+        // Create the solvers and things required
+        auto p_scheme = TrilinosSchemeType::Pointer( new TrilinosResidualBasedIncrementalUpdateStaticSchemeType() );
+        auto p_solver = TrilinosLinearSolverType::Pointer( new AmgclMPISolverType() );
+        Parameters parameters = Parameters(R"(
+        {
+            "diagonal_values_for_dirichlet_dofs" : "no_scaling",
+            "guess_row_size"                     : 15,
+            "silent_warnings"                    : false
+        })" );
+        auto p_builder_and_solver = TrilinosBuilderAndSolverType::Pointer( new TrilinosBlockBuilderAndSolverType(epetra_comm, p_solver, parameters) );
+
+        const auto& rA = BuildSystem(r_model_part, p_scheme, p_builder_and_solver);
+
+        // To create the solution of reference
+        // DebugLHS(rA);
+
+        // The solution check
+        KRATOS_EXPECT_EQ(rA.NumGlobalRows(), 2 * (world_size + 1));
+        KRATOS_EXPECT_EQ(rA.NumGlobalCols(), 2 * (world_size + 1));
+        KRATOS_EXPECT_EQ(rA.NumGlobalNonzeros(), 16 + 14 * (world_size - 1));
+
+        // Values to check
+        std::vector<int> row_indexes = {0, 1, 2, 3};
+        std::vector<int> column_indexes = {0, 1, 2, 3};
+        std::vector<double> values = {1.0, 1.0, 1.0, 1.0};
+        for (int i = 1; i < world_size; ++i) {
+            const unsigned int index_0 = 4 + 2 * (i - 1);
+            const unsigned int index_1 = 5 + 2 * (i - 1);
+            row_indexes.push_back(index_0);
+            row_indexes.push_back(index_1);
+            column_indexes.push_back(index_0);
+            column_indexes.push_back(index_1);
+            values.push_back(1.0);
+            values.push_back(1.0);
+        }
+
+        // Check assembly
+        TrilinosCPPTestUtilities::CheckSparseMatrix(rA, row_indexes, column_indexes, values);
+
+        // Now checking relation T matrix
+        const auto& r_T = p_builder_and_solver->GetConstraintRelationMatrix();
+
+        // To create the solution of reference
+        // DebugLHS(r_T);
+
+        row_indexes = std::vector<int>({0, 1, 2, 2, 3 ,3});
+        column_indexes = std::vector<int>({0, 1, 0, 2 , 1, 3});
+        values = std::vector<double>({1.0, 1.0, 1.0, 0.0, 1.0, 0.0});
+        for (int i = 1; i < world_size; ++i) {
+            const unsigned int index_0 = 4 + 2 * (i - 1);
+            const unsigned int index_1 = 5 + 2 * (i - 1);
+            row_indexes.push_back(index_0);
+            row_indexes.push_back(index_0);
+            row_indexes.push_back(index_1);
+            row_indexes.push_back(index_1);
+            column_indexes.push_back(index_0);
+            column_indexes.push_back(0);
+            column_indexes.push_back(index_1);
+            column_indexes.push_back(1);
+            values.push_back(0.0);
+            values.push_back(1.0);
+            values.push_back(0.0);
+            values.push_back(1.0);
+        }
+
+        // Check assembly
         TrilinosCPPTestUtilities::CheckSparseMatrix(r_T, row_indexes, column_indexes, values);
     }
 
@@ -895,9 +1162,11 @@ namespace Kratos::Testing
         KRATOS_EXPECT_EQ(rA.NumGlobalNonzeros(), 32);
 
         // Values to check
+        auto p_prop = r_model_part.pGetProperties(1);
+        const double E_100 = p_prop->GetValue(YOUNG_MODULUS)/100.0;
         std::vector<int> row_indexes = {0, 1, 2, 3, 4, 5, 6, 7};
         std::vector<int> column_indexes = {0, 1, 2, 3, 4, 5, 6, 7};
-        std::vector<double> values = {2069000000.0, 1.0, 2069000000.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+        std::vector<double> values = {E_100, 1.0, E_100, 1.0, 1.0, 1.0, 1.0, 1.0};
 
         // Check assembly
         TrilinosCPPTestUtilities::CheckSparseMatrix(rA, row_indexes, column_indexes, values);
@@ -963,9 +1232,11 @@ namespace Kratos::Testing
         KRATOS_EXPECT_EQ(rA.NumGlobalNonzeros(), 38);
 
         // Values to check
+        auto p_prop = r_model_part.pGetProperties(1);
+        const double E_100 = p_prop->GetValue(YOUNG_MODULUS)/100.0;
         std::vector<int> row_indexes = {0, 1, 2, 3, 4, 5, 6, 6, 7, 7};
         std::vector<int> column_indexes = {0, 1, 2, 3, 4, 5, 6, 7, 6, 7};
-        std::vector<double> values = {2069000000.0, 1.0, 2069000000.0, 1.0, 1.0, 1.0, 2069000000.0, 2069000000.0, 2069000000.0, 2069000000.0};
+        std::vector<double> values = {E_100, 1.0, E_100, 1.0, 1.0, 1.0, E_100, E_100, E_100, E_100};
 
         // Check assembly
         TrilinosCPPTestUtilities::CheckSparseMatrix(rA, row_indexes, column_indexes, values);
@@ -1162,9 +1433,11 @@ namespace Kratos::Testing
     //     KRATOS_EXPECT_EQ(rA.NumGlobalNonzeros(), 4);
 
     //     // Values to check
+    //     auto p_prop = r_model_part.pGetProperties(1);
+    //     const double E_100 = p_prop->GetValue(YOUNG_MODULUS)/100.0;
     //     std::vector<int> row_indexes = {0, 0, 1, 1};
     //     std::vector<int> column_indexes = {0, 1, 0, 1};
-    //     std::vector<double> values = {4138000000.0, -2069000000.0, -2069000000.0, 2069000000.0};
+    //     std::vector<double> values = {2 * E_100, -E_100, -E_100, E_100};
 
     //     // Check assembly
     //     TrilinosCPPTestUtilities::CheckSparseMatrix(rA, row_indexes, column_indexes, values);
@@ -1209,7 +1482,7 @@ namespace Kratos::Testing
     //     // Values to check
     //     std::vector<int> row_indexes = {0};
     //     std::vector<int> column_indexes = {0};
-    //     std::vector<double> values = {2069000000.0};
+    //     std::vector<double> values = {E_100};
 
     //     // Check assembly
     //     TrilinosCPPTestUtilities::CheckSparseMatrix(rA, row_indexes, column_indexes, values);
@@ -1256,9 +1529,11 @@ namespace Kratos::Testing
         KRATOS_EXPECT_EQ(rA.NumGlobalNonzeros(), 196);
 
         // Values to check
+        auto p_prop = r_model_part.pGetProperties(1);
+        const double E_100 = p_prop->GetValue(YOUNG_MODULUS)/100.0;
         std::vector<int> row_indexes = {0, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 7, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 12, 12, 12, 13, 13, 13, 13, 13, 13, 13, 13, 13, 14, 14, 14, 14, 14, 14, 15, 15, 15, 15, 15, 16, 16, 16, 16, 16, 16, 16, 16, 17, 17, 17, 17, 17, 17, 17, 17, 17, 18, 18, 18, 19, 19, 20, 20, 20, 20, 20, 21, 21, 21, 21};
         std::vector<int> column_indexes = {0, 1, 2, 3, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 9, 2, 3, 4, 5, 8, 9, 12, 13, 2, 3, 4, 5, 8, 9, 11, 12, 13, 6, 7, 4, 5, 8, 9, 10, 3, 4, 5, 8, 9, 8, 10, 11, 12, 13, 14, 5, 10, 11, 12, 13, 4, 5, 10, 11, 12, 13, 16, 17, 4, 5, 10, 11, 12, 13, 15, 16, 17, 10, 14, 15, 16, 17, 18, 13, 14, 15, 16, 17, 12, 13, 14, 15, 16, 17, 20, 21, 12, 13, 14, 15, 16, 17, 19, 20, 21, 14, 18, 20, 17, 19, 16, 17, 18, 20, 21, 16, 17, 20, 21};
-        std::vector<double> values = {740227943.2715302705764771, 598856985.8178827762603760, 370113971.6357653141021729, -185056985.8178827166557312, 370113971.6357653141021729, 1572984379.4520018100738525, -555170957.4536480903625488, -740227943.2715302705764771, 370113971.6357653141021729, -185056985.8178827166557312, -555170957.4536479711532593, 1257477943.2715306282043457, 370113971.6357653141021729, -185056985.8178827166557312, -517250000.0, -740227943.2715302705764771, 370113971.6357653141021729, 1657021225.9261374473571777, -475379934.1969153881072998, -176565339.3830768167972565, -264848009.0746152102947235, -740227943.2715302705764771, 370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -475379934.1969153881072998, 1457052651.9143548011779785, -264848009.0746152102947235, -397272013.6119228005409241, -689666666.6666666269302368, 370113971.6357653141021729, -185056985.8178827166557312, 1127028492.9089412689208984, 783913971.6357650756835938, -176565339.3830768167972565, -264848009.0746152102947235, 2245565339.3830766677856445, 264848009.0746151804924011, -1034500000.0, -517250000.0, -264848009.0746152102947235, -397272013.6119228005409241, 264848009.0746151804924011, 914522013.6119227409362793, -1034500000.0, 2434750982.5687417984008789, 365750982.5687416195869446, -365750982.5687417387962341, -365750982.5687416791915894, -1034500000.0, -689666666.6666666269302368, 365750982.5687416195869446, 1055417649.2354083061218262, -365750982.5687416791915894, -365750982.5687416195869446, -740227943.2715302705764771, 370113971.6357653141021729, -365750982.5687417387962341, -365750982.5687416791915894, 1846206869.1118023395538330, -374476960.7027890682220459, -740227943.2715302705764771, 370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -365750982.5687416791915894, -365750982.5687416195869446, -374476960.7027890682220459, 1770364954.2045071125030518, -1034500000.0, 370113971.6357653141021729, -185056985.8178827166557312, -1034500000.0, 2809227943.2715301513671875, 370113971.6357650756835938, -740227943.2715302705764771, -370113971.6357651352882385, -1034500000.0, -1034500000.0, 370113971.6357650756835938, 1219556985.8178825378417969, -370113971.6357651352882385, -185056985.8178825676441193, -740227943.2715302705764771, 370113971.6357653141021729, -740227943.2715302705764771, -370113971.6357651352882385, 2220683829.8145909309387207, -370113971.6357656121253967, -740227943.2715302705764771, 370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -370113971.6357651352882385, -185056985.8178825676441193, -370113971.6357656121253967, 2624170957.4536480903625488, -2069000000.0, 370113971.6357653141021729, -185056985.8178827166557312, -1034500000.0, 2069000000.0, -1034500000.0, -2069000000.0, 2069000000.0, -740227943.2715302705764771, 370113971.6357653141021729, -1034500000.0, 1774727943.2715301513671875, -370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -370113971.6357653141021729, 185056985.8178827166557312};
+        std::vector<double> values = {740227943.2715302705764771, 598856985.8178827762603760, 370113971.6357653141021729, -185056985.8178827166557312, 370113971.6357653141021729, 1572984379.4520018100738525, -555170957.4536480903625488, -740227943.2715302705764771, 370113971.6357653141021729, -185056985.8178827166557312, -555170957.4536479711532593, 1257477943.2715306282043457, 370113971.6357653141021729, -185056985.8178827166557312, -517250000.0, -740227943.2715302705764771, 370113971.6357653141021729, 1657021225.9261374473571777, -475379934.1969153881072998, -176565339.3830768167972565, -264848009.0746152102947235, -740227943.2715302705764771, 370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -475379934.1969153881072998, 1457052651.9143548011779785, -264848009.0746152102947235, -397272013.6119228005409241, -689666666.6666666269302368, 370113971.6357653141021729, -185056985.8178827166557312, 1127028492.9089412689208984, 783913971.6357650756835938, -176565339.3830768167972565, -264848009.0746152102947235, 2245565339.3830766677856445, 264848009.0746151804924011, -1034500000.0, -517250000.0, -264848009.0746152102947235, -397272013.6119228005409241, 264848009.0746151804924011, 914522013.6119227409362793, -1034500000.0, 2434750982.5687417984008789, 365750982.5687416195869446, -365750982.5687417387962341, -365750982.5687416791915894, -1034500000.0, -689666666.6666666269302368, 365750982.5687416195869446, 1055417649.2354083061218262, -365750982.5687416791915894, -365750982.5687416195869446, -740227943.2715302705764771, 370113971.6357653141021729, -365750982.5687417387962341, -365750982.5687416791915894, 1846206869.1118023395538330, -374476960.7027890682220459, -740227943.2715302705764771, 370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -365750982.5687416791915894, -365750982.5687416195869446, -374476960.7027890682220459, 1770364954.2045071125030518, -1034500000.0, 370113971.6357653141021729, -185056985.8178827166557312, -1034500000.0, 2809227943.2715301513671875, 370113971.6357650756835938, -740227943.2715302705764771, -370113971.6357651352882385, -1034500000.0, -1034500000.0, 370113971.6357650756835938, 1219556985.8178825378417969, -370113971.6357651352882385, -185056985.8178825676441193, -740227943.2715302705764771, 370113971.6357653141021729, -740227943.2715302705764771, -370113971.6357651352882385, 2220683829.8145909309387207, -370113971.6357656121253967, -740227943.2715302705764771, 370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -370113971.6357651352882385, -185056985.8178825676441193, -370113971.6357656121253967, 2624170957.4536480903625488, -E_100, 370113971.6357653141021729, -185056985.8178827166557312, -1034500000.0, E_100, -1034500000.0, -E_100, E_100, -740227943.2715302705764771, 370113971.6357653141021729, -1034500000.0, 1774727943.2715301513671875, -370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -370113971.6357653141021729, 185056985.8178827166557312};
 
         // Check assembly
         TrilinosCPPTestUtilities::CheckSparseMatrix(rA, row_indexes, column_indexes, values);
@@ -1307,9 +1582,11 @@ namespace Kratos::Testing
         KRATOS_EXPECT_EQ(rA.NumGlobalNonzeros(), 204);
 
         // Values to check
+        auto p_prop = r_model_part.pGetProperties(1);
+        const double E_100 = p_prop->GetValue(YOUNG_MODULUS)/100.0;
         std::vector<int> row_indexes = {0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 7, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 12, 12, 12, 13, 13, 13, 13, 13, 13, 13, 13, 13, 14, 14, 14, 14, 14, 14, 15, 15, 15, 15, 15, 16, 16, 16, 16, 16, 16, 16, 16, 17, 17, 17, 17, 17, 17, 17, 17, 17, 18, 18, 18, 19, 19, 20, 20, 20, 20, 20, 21, 21, 21, 21};
         std::vector<int> column_indexes = {0, 1, 2, 4, 5, 9, 1, 2, 4, 5, 3, 1, 2, 4, 5, 8, 9, 12, 13, 1, 2, 4, 5, 8, 9, 11, 12, 13, 6, 7, 4, 5, 8, 9, 10, 1, 4, 5, 8, 9, 8, 10, 11, 12, 13, 14, 5, 10, 11, 12, 13, 4, 5, 10, 11, 12, 13, 16, 17, 4, 5, 10, 11, 12, 13, 15, 16, 17, 10, 14, 15, 16, 17, 18, 13, 14, 15, 16, 17, 12, 13, 14, 15, 16, 17, 20, 21, 12, 13, 14, 15, 16, 17, 19, 20, 21, 14, 18, 20, 17, 19, 16, 17, 18, 20, 21, 16, 17, 20, 21};
-        std::vector<double> values = {740227943.2715302705764771, 1486220957.4536478519439697, -185056985.8178826570510864, 370113971.6357653141021729, -185056985.8178827166557312, -517250000.0, -185056985.8178827762603760, 1572984379.4520018100738525, -740227943.2715302705764771, 370113971.6357653141021729, 1.0, 370113971.6357653141021729, -740227943.2715302705764771, 1657021225.9261374473571777, -475379934.1969153881072998, -176565339.3830768167972565, -264848009.0746152102947235, -740227943.2715302705764771, 370113971.6357653141021729, -185056985.8178827166557312, 370113971.6357652544975281, -475379934.1969153881072998, 1457052651.9143548011779785, -264848009.0746152102947235, -397272013.6119228005409241, -689666666.6666666269302368, 370113971.6357653141021729, -185056985.8178827166557312, 1127028492.9089412689208984, 783913971.6357650756835938, -176565339.3830768167972565, -264848009.0746152102947235, 2245565339.3830766677856445, 264848009.0746151804924011, -1034500000.0, -517250000.0, -264848009.0746152102947235, -397272013.6119228005409241, 264848009.0746151804924011, 914522013.6119227409362793, -1034500000.0, 2434750982.5687417984008789, 365750982.5687416195869446, -365750982.5687417387962341, -365750982.5687416791915894, -1034500000.0, -689666666.6666666269302368, 365750982.5687416195869446, 1055417649.2354083061218262, -365750982.5687416791915894, -365750982.5687416195869446, -740227943.2715302705764771, 370113971.6357653141021729, -365750982.5687417387962341, -365750982.5687416791915894, 1846206869.1118023395538330, -374476960.7027890682220459, -740227943.2715302705764771, 370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -365750982.5687416791915894, -365750982.5687416195869446, -374476960.7027890682220459, 1770364954.2045071125030518, -1034500000.0, 370113971.6357653141021729, -185056985.8178827166557312, -1034500000.0, 2809227943.2715301513671875, 370113971.6357650756835938, -740227943.2715302705764771, -370113971.6357651352882385, -1034500000.0, -1034500000.0, 370113971.6357650756835938, 1219556985.8178825378417969, -370113971.6357651352882385, -185056985.8178825676441193, -740227943.2715302705764771, 370113971.6357653141021729, -740227943.2715302705764771, -370113971.6357651352882385, 2220683829.8145909309387207, -370113971.6357656121253967, -740227943.2715302705764771, 370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -370113971.6357651352882385, -185056985.8178825676441193, -370113971.6357656121253967, 2624170957.4536480903625488, -2069000000.0, 370113971.6357653141021729, -185056985.8178827166557312, -1034500000.0, 2069000000.0, -1034500000.0, -2069000000.0, 2069000000.0, -740227943.2715302705764771, 370113971.6357653141021729, -1034500000.0, 1774727943.2715301513671875, -370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -370113971.6357653141021729, 185056985.8178827166557312};
+        std::vector<double> values = {740227943.2715302705764771, 1486220957.4536478519439697, -185056985.8178826570510864, 370113971.6357653141021729, -185056985.8178827166557312, -517250000.0, -185056985.8178827762603760, 1572984379.4520018100738525, -740227943.2715302705764771, 370113971.6357653141021729, 1.0, 370113971.6357653141021729, -740227943.2715302705764771, 1657021225.9261374473571777, -475379934.1969153881072998, -176565339.3830768167972565, -264848009.0746152102947235, -740227943.2715302705764771, 370113971.6357653141021729, -185056985.8178827166557312, 370113971.6357652544975281, -475379934.1969153881072998, 1457052651.9143548011779785, -264848009.0746152102947235, -397272013.6119228005409241, -689666666.6666666269302368, 370113971.6357653141021729, -185056985.8178827166557312, 1127028492.9089412689208984, 783913971.6357650756835938, -176565339.3830768167972565, -264848009.0746152102947235, 2245565339.3830766677856445, 264848009.0746151804924011, -1034500000.0, -517250000.0, -264848009.0746152102947235, -397272013.6119228005409241, 264848009.0746151804924011, 914522013.6119227409362793, -1034500000.0, 2434750982.5687417984008789, 365750982.5687416195869446, -365750982.5687417387962341, -365750982.5687416791915894, -1034500000.0, -689666666.6666666269302368, 365750982.5687416195869446, 1055417649.2354083061218262, -365750982.5687416791915894, -365750982.5687416195869446, -740227943.2715302705764771, 370113971.6357653141021729, -365750982.5687417387962341, -365750982.5687416791915894, 1846206869.1118023395538330, -374476960.7027890682220459, -740227943.2715302705764771, 370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -365750982.5687416791915894, -365750982.5687416195869446, -374476960.7027890682220459, 1770364954.2045071125030518, -1034500000.0, 370113971.6357653141021729, -185056985.8178827166557312, -1034500000.0, 2809227943.2715301513671875, 370113971.6357650756835938, -740227943.2715302705764771, -370113971.6357651352882385, -1034500000.0, -1034500000.0, 370113971.6357650756835938, 1219556985.8178825378417969, -370113971.6357651352882385, -185056985.8178825676441193, -740227943.2715302705764771, 370113971.6357653141021729, -740227943.2715302705764771, -370113971.6357651352882385, 2220683829.8145909309387207, -370113971.6357656121253967, -740227943.2715302705764771, 370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -370113971.6357651352882385, -185056985.8178825676441193, -370113971.6357656121253967, 2624170957.4536480903625488, -E_100, 370113971.6357653141021729, -185056985.8178827166557312, -1034500000.0, E_100, -1034500000.0, -E_100, E_100, -740227943.2715302705764771, 370113971.6357653141021729, -1034500000.0, 1774727943.2715301513671875, -370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -370113971.6357653141021729, 185056985.8178827166557312};
 
         // Check assembly
         TrilinosCPPTestUtilities::CheckSparseMatrix(rA, row_indexes, column_indexes, values);
@@ -1370,9 +1647,11 @@ namespace Kratos::Testing
     //     KRATOS_EXPECT_EQ(rA.NumGlobalNonzeros(), 161);
 
     //     // Values to check
+    //     auto p_prop = r_model_part.pGetProperties(1);
+    //     const double E_100 = p_prop->GetValue(YOUNG_MODULUS)/100.0;
     //     std::vector<int> row_indexes = {0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11, 11, 12, 12, 12, 12, 12, 13, 13, 13, 13, 13, 13, 13, 13, 14, 14, 14, 14, 14, 14, 14, 14, 14, 15, 15, 15, 16, 16, 17, 17, 17, 17, 17, 18, 18, 18, 18};
     //     std::vector<int> column_indexes = {0, 1, 2, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 6, 1, 2, 3, 4, 5, 6, 9, 10, 1, 2, 3, 4, 5, 6, 8, 9, 10, 3, 4, 5, 6, 7, 2, 3, 4, 5, 6, 5, 7, 8, 9, 10, 11, 4, 7, 8, 9, 10, 3, 4, 7, 8, 9, 10, 13, 14, 3, 4, 7, 8, 9, 10, 12, 13, 14, 7, 11, 12, 13, 14, 15, 10, 11, 12, 13, 14, 9, 10, 11, 12, 13, 14, 17, 18, 9, 10, 11, 12, 13, 14, 16, 17, 18, 11, 15, 17, 14, 16, 13, 14, 15, 17, 18, 13, 14, 17, 18};
-    //     std::vector<double> values = {598856985.8178827762603760, 370113971.6357653141021729, -185056985.8178827166557312, 370113971.6357653141021729, 1572984379.4520018100738525, -555170957.4536480903625488, -740227943.2715302705764771, 370113971.6357653141021729, -185056985.8178827166557312, -555170957.4536479711532593, 1257477943.2715306282043457, 370113971.6357653141021729, -185056985.8178827166557312, -517250000.0, -740227943.2715302705764771, 370113971.6357653141021729, 1657021225.9261374473571777, -475379934.1969153881072998, -176565339.3830768167972565, -264848009.0746152102947235, -740227943.2715302705764771, 370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -475379934.1969153881072998, 1457052651.9143548011779785, -264848009.0746152102947235, -397272013.6119228005409241, -689666666.6666666269302368, 370113971.6357653141021729, -185056985.8178827166557312, -176565339.3830768167972565, -264848009.0746152102947235, 2245565339.3830766677856445, 264848009.0746151804924011, -1034500000.0, -517250000.0, -264848009.0746152102947235, -397272013.6119228005409241, 264848009.0746151804924011, 914522013.6119227409362793, -1034500000.0, 2434750982.5687417984008789, 365750982.5687416195869446, -365750982.5687417387962341, -365750982.5687416791915894, -1034500000.0, -689666666.6666666269302368, 365750982.5687416195869446, 1055417649.2354083061218262, -365750982.5687416791915894, -365750982.5687416195869446, -740227943.2715302705764771, 370113971.6357653141021729, -365750982.5687417387962341, -365750982.5687416791915894, 1846206869.1118023395538330, -374476960.7027890682220459, -740227943.2715302705764771, 370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -365750982.5687416791915894, -365750982.5687416195869446, -374476960.7027890682220459, 1770364954.2045071125030518, -1034500000.0, 370113971.6357653141021729, -185056985.8178827166557312, -1034500000.0, 2809227943.2715301513671875, 370113971.6357650756835938, -740227943.2715302705764771, -370113971.6357651352882385, -1034500000.0, -1034500000.0, 370113971.6357650756835938, 1219556985.8178825378417969, -370113971.6357651352882385, -185056985.8178825676441193, -740227943.2715302705764771, 370113971.6357653141021729, -740227943.2715302705764771, -370113971.6357651352882385, 2220683829.8145909309387207, -370113971.6357656121253967, -740227943.2715302705764771, 370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -370113971.6357651352882385, -185056985.8178825676441193, -370113971.6357656121253967, 2624170957.4536480903625488, -2069000000.0, 370113971.6357653141021729, -185056985.8178827166557312, -1034500000.0, 2069000000.0, -1034500000.0, -2069000000.0, 2069000000.0, -740227943.2715302705764771, 370113971.6357653141021729, -1034500000.0, 1774727943.2715301513671875, -370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -370113971.6357653141021729, 185056985.8178827166557312};
+    //     std::vector<double> values = {598856985.8178827762603760, 370113971.6357653141021729, -185056985.8178827166557312, 370113971.6357653141021729, 1572984379.4520018100738525, -555170957.4536480903625488, -740227943.2715302705764771, 370113971.6357653141021729, -185056985.8178827166557312, -555170957.4536479711532593, 1257477943.2715306282043457, 370113971.6357653141021729, -185056985.8178827166557312, -517250000.0, -740227943.2715302705764771, 370113971.6357653141021729, 1657021225.9261374473571777, -475379934.1969153881072998, -176565339.3830768167972565, -264848009.0746152102947235, -740227943.2715302705764771, 370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -475379934.1969153881072998, 1457052651.9143548011779785, -264848009.0746152102947235, -397272013.6119228005409241, -689666666.6666666269302368, 370113971.6357653141021729, -185056985.8178827166557312, -176565339.3830768167972565, -264848009.0746152102947235, 2245565339.3830766677856445, 264848009.0746151804924011, -1034500000.0, -517250000.0, -264848009.0746152102947235, -397272013.6119228005409241, 264848009.0746151804924011, 914522013.6119227409362793, -1034500000.0, 2434750982.5687417984008789, 365750982.5687416195869446, -365750982.5687417387962341, -365750982.5687416791915894, -1034500000.0, -689666666.6666666269302368, 365750982.5687416195869446, 1055417649.2354083061218262, -365750982.5687416791915894, -365750982.5687416195869446, -740227943.2715302705764771, 370113971.6357653141021729, -365750982.5687417387962341, -365750982.5687416791915894, 1846206869.1118023395538330, -374476960.7027890682220459, -740227943.2715302705764771, 370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -365750982.5687416791915894, -365750982.5687416195869446, -374476960.7027890682220459, 1770364954.2045071125030518, -1034500000.0, 370113971.6357653141021729, -185056985.8178827166557312, -1034500000.0, 2809227943.2715301513671875, 370113971.6357650756835938, -740227943.2715302705764771, -370113971.6357651352882385, -1034500000.0, -1034500000.0, 370113971.6357650756835938, 1219556985.8178825378417969, -370113971.6357651352882385, -185056985.8178825676441193, -740227943.2715302705764771, 370113971.6357653141021729, -740227943.2715302705764771, -370113971.6357651352882385, 2220683829.8145909309387207, -370113971.6357656121253967, -740227943.2715302705764771, 370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -370113971.6357651352882385, -185056985.8178825676441193, -370113971.6357656121253967, 2624170957.4536480903625488, -E_100, 370113971.6357653141021729, -185056985.8178827166557312, -1034500000.0, E_100, -1034500000.0, -E_100, E_100, -740227943.2715302705764771, 370113971.6357653141021729, -1034500000.0, 1774727943.2715301513671875, -370113971.6357653141021729, 370113971.6357652544975281, -185056985.8178827166557312, -370113971.6357653141021729, 185056985.8178827166557312};
 
     //     // Check assembly
     //     TrilinosCPPTestUtilities::CheckSparseMatrix(rA, row_indexes, column_indexes, values);


### PR DESCRIPTION
**📝 Description**

Until now only local slave DoFs were filtered for the `mMasterIds` vector, in here all partitions slave DoFs are considered. I added two dynamic size C++ test (until now I was only checking up two partitions, therefore I was checking many cornercases), so the size of the test depends in the number of partitions considered.

(I discovered this looking for another bug) 

**🆕 Changelog**

- [Fix master dofs](https://github.com/KratosMultiphysics/Kratos/commit/b9c37f56e27a2c26e9bd4f6a72f0e0a363bceb6c)
- [Adding dynamic size testing in order to properly check fix](https://github.com/KratosMultiphysics/Kratos/commit/3a40ac97cb60f5cdaed6996688a8480f1387e915)
