### PR TITLE
[GeoMechanicsApplication] Added a .git-blame-ignore-revs file to avoid seeing the auto-format commits in our history

### DIFF
--- a/applications/GeoMechanicsApplication/.git-blame-ignore-revs
+++ b/applications/GeoMechanicsApplication/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Clang-format commits
+42812c76886157f305718ef13f66c6b4274f3780


### PR DESCRIPTION
To use this, you need to configure this once on your machine by running the following command in the root of your repo and bring all your branches up to date with master (such that the .git-blame-ignore-revs file is there).
git config --global blame.ignoreRevsFile applications\GeoMechanicsApplication\.git-blame-ignore-revs