### PR TITLE
[Core] Fix `residual_criteria.h` in MPI in debug mode

### DIFF
--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -393,7 +393,7 @@ protected:
         if constexpr (!TSparseSpace::IsDistributedSpace()) {
             return mActiveDofs[dof_id] == 1;
         } else {
-            KRATOS_DEBUG_ERROR_IF((dof_id - mInitialDoFId) >= mActiveDofs.size()) << "DofId is greater than the size of the active Dofs vector. DofId: " << dof_id << "\tInitialDoFId: " << mInitialDoFId << "\tActiveDofs size: " << mActiveDofs.size() << std::endl;
+            KRATOS_DEBUG_ERROR_IF((dof_id - mInitialDoFId) >= mActiveDofs.size() && (rDof.GetSolutionStepValue(PARTITION_INDEX) == Rank)) << "DofId is greater than the size of the active Dofs vector. DofId: " << dof_id << "\tInitialDoFId: " << mInitialDoFId << "\tActiveDofs size: " << mActiveDofs.size() << std::endl;
             return (mActiveDofs[dof_id - mInitialDoFId] == 1 && (rDof.GetSolutionStepValue(PARTITION_INDEX) == Rank));
         }
     }


### PR DESCRIPTION
**📝 Description**

Missing check that induces a fail when running in MPI and full debug as missing check

**🆕 Changelog**

- [Fix `residual_criteria.h` in MPI in debug mode](https://github.com/KratosMultiphysics/Kratos/commit/db4a4f9d968fa8fa581f9ceac7635944e275b68d)
