### PR TITLE
Display MKL version info if available

### DIFF
--- a/applications/LinearSolversApplication/linear_solvers_application.cpp
+++ b/applications/LinearSolversApplication/linear_solvers_application.cpp
@@ -44,7 +44,7 @@ void KratosLinearSolversApplication::Register()
     mkl_get_version(&mkl_version);
     KRATOS_INFO("") << "Using Intel MKL version "
                     << mkl_version.MajorVersion << "." << mkl_version.MinorVersion << "." << mkl_version.UpdateVersion
-                    << " build: " << mkl_version.Build << std::endl
+                    << " build " << mkl_version.Build << std::endl
                     << "MKL processor: " << mkl_version.Processor << std::endl;
     #endif
 

--- a/applications/LinearSolversApplication/linear_solvers_application.cpp
+++ b/applications/LinearSolversApplication/linear_solvers_application.cpp
@@ -24,6 +24,7 @@
 #include "custom_solvers/eigen_pardiso_lu_solver.h"
 #include "custom_solvers/eigen_pardiso_llt_solver.h"
 #include "custom_solvers/eigen_pardiso_ldlt_solver.h"
+#include "mkl_service.h"
 #endif
 
 namespace Kratos
@@ -37,6 +38,15 @@ void KratosLinearSolversApplication::Register()
                     << "           | |___| | | | |  __/ (_| | |   ___) | (_) | |\\ V /  __/ |  \\__ \\\n"
                     << "           |_____|_|_| |_|\\___|\\__,_|_|  |____/ \\___/|_| \\_/ \\___|_|  |___/\n"
                     << "Initializing KratosLinearSolversApplication..." << std::endl;
+
+    #if defined USE_EIGEN_MKL
+    MKLVersion mkl_version;
+    mkl_get_version(&mkl_version);
+    KRATOS_INFO("") << "Using Intel MKL version "
+                    << mkl_version.MajorVersion << "." << mkl_version.MinorVersion << "." << mkl_version.UpdateVersion
+                    << " build: " << mkl_version.Build << std::endl
+                    << "MKL processor: " << mkl_version.Processor << std::endl;
+    #endif
 
     RegisterDenseLinearSolvers();
 


### PR DESCRIPTION
**📝 Description**
If Kratos is compiled with MKL support, display MKL version info when importing the LinearSolversApplication. For example:
```
>>> from KratosMultiphysics import LinearSolversApplication
 |  /           |                  
 ' /   __| _` | __|  _ \   __|    
 . \  |   (   | |   (   |\__ \  
_|\_\_|  \__,_|\__|\___/ ____/
           Multi-Physics 9.4."3"-extension/hierarchical-linear-solver-369de97fa4-RelWithDebInfo-x86_64
           Compiled for GNU/Linux and Python3.10 with GCC-11.3
Compiled with threading support.
Maximum number of threads: 24.
Process Id: 829 
Importing    LinearSolversApplication 
    Kratos  _     _                       ____        _
           | |   (_)_ __   ___  __ _ _ __/ ___|  ___ | |_   _____ _ __ ___
           | |   | | '_ \ / _ \/ _` | '__\___ \ / _ \| \ \ / / _ \ '__/ __|
           | |___| | | | |  __/ (_| | |   ___) | (_) | |\ V /  __/ |  \__ \
           |_____|_|_| |_|\___|\__,_|_|  |____/ \___/|_| \_/ \___|_|  |___/
Initializing KratosLinearSolversApplication...
Using Intel MKL version 2024.0.0 build: 20231011
MKL processor: Intel(R) Advanced Vector Extensions 2 (Intel(R) AVX-2) with support of Intel(R) Deep Learning Boost (Intel(R) DL Boost)
>>>
```

@loumalouomega found out that version 2022 of MKL has [poor performance on Linux](https://community.intel.com/t5/Intel-oneAPI-Math-Kernel-Library/MKL-Pardiso-shows-difference-behavior-on-Windows-and-Linux/td-p/1467014) due to some missing processor detection logic and I can confirm that it was a severe issue for me (I have a case that runs 7x slower with MKL 2022 on linux, compared to either MKL 2022 on windows or MKL 2024 on linux). After finding this out, I think that having a way to display MKL build info may be useful to diagnose similar problems in the future.

**🆕 Changelog**
- Display MKL version info when importing LinearSolversApplication if MKL is available.

