### PR TITLE
[Core][MPI] Adding `RanksList` and `InitializeRanksList` in `DataCommunicator`

### DIFF
--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -381,8 +381,18 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         return Kratos::make_unique<DataCommunicator>();
     }
 
-    /// Pause program execution until all threads reach this call.
-    /** Wrapper for MPI_Barrier. */
+    /**
+     * @brief Initializes the rank list.
+     * @details This function is responsible for initializing the rank list. You should call this function before using any ranking-related operations.
+     */
+    virtual void InitializeRanksList() const
+    {
+    }
+
+    /**
+     * @brief Pause program execution until all threads reach this call.
+     * @details This function serves as a wrapper for MPI_Barrier, which ensures synchronization among all threads before proceeding further in the program.
+     */
     virtual void Barrier() const {}
 
     // Complete interface for basic types
@@ -578,6 +588,17 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     ///@}
     ///@name Inquiry
     ///@{
+
+    /**
+     * @brief Retrieves a list of ranks.
+     * @brief This method returns a list of integer ranks. The current implementation simply returns a list containing a single element, 0. This method is virtual and can be overridden in derived classes to provide more complex behavior.
+     * @return std::vector<int> A vector of integers representing the ranks.
+     *         By default, it returns a vector with a single element: 0.
+     */
+    virtual std::vector<int> RanksList() const
+    {
+        return {0};
+    }
 
     /**
      * @brief Get the parallel rank for this DataCommunicator.

--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -382,14 +382,6 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     }
 
     /**
-     * @brief Initializes the rank list.
-     * @details This function is responsible for initializing the rank list. You should call this function before using any ranking-related operations.
-     */
-    virtual void InitializeRanksList() const
-    {
-    }
-
-    /**
      * @brief Pause program execution until all threads reach this call.
      * @details This function serves as a wrapper for MPI_Barrier, which ensures synchronization among all threads before proceeding further in the program.
      */

--- a/kratos/mpi/includes/mpi_data_communicator.h
+++ b/kratos/mpi/includes/mpi_data_communicator.h
@@ -210,12 +210,6 @@ class KRATOS_API(KRATOS_MPI_CORE) MPIDataCommunicator: public DataCommunicator
     static MPIDataCommunicator::UniquePointer Create(MPI_Comm MPIComm);
 
     /**
-     * @brief Initializes the rank list.
-     * @details This function is responsible for initializing the rank list. You should call this function before using some ranking-related operations with sub-DataCommunicator.
-     */
-    void InitializeRanksList() const override;
-
-    /**
      * @brief Pause program execution until all threads reach this call.
      * @details This function serves as a wrapper for MPI_Barrier, which ensures synchronization among all threads before proceeding further in the program.
      */
@@ -399,13 +393,24 @@ class KRATOS_API(KRATOS_MPI_CORE) MPIDataCommunicator: public DataCommunicator
     ///@name Member Variables
     ///@{
 
-    MPI_Comm mComm;                      /// The MPI communicator
+    /// The MPI communicator
+    MPI_Comm mComm;
+
     /// The list of ranks involved in this DataCommunicator
     mutable std::vector<int> mRanksList;
 
     ///@}
     ///@name Operations
     ///@{
+
+    /**
+     * @brief Generate a rank list using the current rank and size of the system.
+     * @details This function generates a rank list by first obtaining the current rank and size
+     * of the system, and then using MPI's AllGather function to gather the ranks of all
+     * processes into a vector.
+     * @return A std::vector<int> containing the rank list of all processes.
+     */
+    std::vector<int> GenerateRankList() const;
 
     void CheckMPIErrorCode(const int ierr, const std::string& MPICallName) const;
 

--- a/kratos/mpi/includes/mpi_data_communicator.h
+++ b/kratos/mpi/includes/mpi_data_communicator.h
@@ -209,6 +209,16 @@ class KRATOS_API(KRATOS_MPI_CORE) MPIDataCommunicator: public DataCommunicator
      */
     static MPIDataCommunicator::UniquePointer Create(MPI_Comm MPIComm);
 
+    /**
+     * @brief Initializes the rank list.
+     * @details This function is responsible for initializing the rank list. You should call this function before using some ranking-related operations with sub-DataCommunicator.
+     */
+    void InitializeRanksList() const override;
+
+    /**
+     * @brief Pause program execution until all threads reach this call.
+     * @details This function serves as a wrapper for MPI_Barrier, which ensures synchronization among all threads before proceeding further in the program.
+     */
     void Barrier() const override;
 
     KRATOS_MPI_DATA_COMMUNICATOR_DECLARE_PUBLIC_INTERFACE_FOR_TYPE(char)
@@ -273,6 +283,12 @@ class KRATOS_API(KRATOS_MPI_CORE) MPIDataCommunicator: public DataCommunicator
     ///@}
     ///@name Inquiry
     ///@{
+
+    /**
+     * @brief Get the list of ranks involved in this DataCommunicator.
+     * @return A vector containing the ranks involved in this DataCommunicator.
+     */
+    std::vector<int> RanksList() const override;
 
     /**
      * @brief Get the parallel rank for this DataCommunicator.
@@ -383,7 +399,8 @@ class KRATOS_API(KRATOS_MPI_CORE) MPIDataCommunicator: public DataCommunicator
     ///@name Member Variables
     ///@{
 
-    MPI_Comm mComm;
+    MPI_Comm mComm;                      /// The MPI communicator
+    mutable std::vector<int> mRanksList; /// The list of ranks involved in this DataCommunicator
 
     ///@}
     ///@name Operations

--- a/kratos/mpi/includes/mpi_data_communicator.h
+++ b/kratos/mpi/includes/mpi_data_communicator.h
@@ -397,7 +397,7 @@ class KRATOS_API(KRATOS_MPI_CORE) MPIDataCommunicator: public DataCommunicator
     MPI_Comm mComm;
 
     /// The list of ranks involved in this DataCommunicator
-    mutable std::vector<int> mRanksList;
+    std::vector<int> mRanksList;
 
     ///@}
     ///@name Operations
@@ -410,7 +410,7 @@ class KRATOS_API(KRATOS_MPI_CORE) MPIDataCommunicator: public DataCommunicator
      * processes into a vector.
      * @return A std::vector<int> containing the rank list of all processes.
      */
-    std::vector<int> GenerateRankList() const;
+    std::vector<int> GenerateRankList();
 
     void CheckMPIErrorCode(const int ierr, const std::string& MPICallName) const;
 

--- a/kratos/mpi/includes/mpi_data_communicator.h
+++ b/kratos/mpi/includes/mpi_data_communicator.h
@@ -400,7 +400,8 @@ class KRATOS_API(KRATOS_MPI_CORE) MPIDataCommunicator: public DataCommunicator
     ///@{
 
     MPI_Comm mComm;                      /// The MPI communicator
-    mutable std::vector<int> mRanksList; /// The list of ranks involved in this DataCommunicator
+    /// The list of ranks involved in this DataCommunicator
+    mutable std::vector<int> mRanksList;
 
     ///@}
     ///@name Operations

--- a/kratos/mpi/sources/mpi_data_communicator.cpp
+++ b/kratos/mpi/sources/mpi_data_communicator.cpp
@@ -533,7 +533,7 @@ void MPIDataCommunicator::PrintData(std::ostream &rOStream) const
 
 // Rank generation
 
-std::vector<int> MPIDataCommunicator::GenerateRankList() const
+std::vector<int> MPIDataCommunicator::GenerateRankList()
 {
     // Get the current rank and put it into a vector
     std::vector<int> this_rank = {Rank()};

--- a/kratos/mpi/tests/cpp_tests/utilities/test_pointer_communicator.cpp
+++ b/kratos/mpi/tests/cpp_tests/utilities/test_pointer_communicator.cpp
@@ -116,6 +116,10 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(PointerCommunicatorPartialPartitions, Krat
     if (current_rank < world_size - 1) {
         auto& r_partial_data_comm = r_default_comm.GetSubDataCommunicator(ranks, "SubDataComm");
         auto gp_list = GlobalPointerUtilities::RetrieveGlobalIndexedPointers(mp.Nodes(), indices, r_partial_data_comm );
+        std::vector<int> rank_list = r_partial_data_comm.RanksList();
+        KRATOS_EXPECT_EQ(rank_list.size(), static_cast<std::size_t>(world_size - 1));
+        auto it_find = std::find(rank_list.begin(), rank_list.end(), current_rank);
+        KRATOS_EXPECT_FALSE(it_find == rank_list.end());
 
         GlobalPointerCommunicator< Node> pointer_comm(r_partial_data_comm, gp_list.ptr_begin(), gp_list.ptr_end());
 


### PR DESCRIPTION
**📝 Description**

This PR addresses a limitation encountered in the use of SubDataCommunicators within the KratosMultiphysics project. Initially, the SubDataCommunicators were designed with the primary use of `XxxAll` methods, which did not necessitate the knowledge of specific ranks involved in communication after creation. However, practical applications involving `Send`/`Recv` methods highlighted the inability to identify the specific ranks participating in the SubDataCommunicators. This is particularly challenging when dealing with non-consecutive and non-zero starting rank scenarios.

In contrast to global data communicators, where the `Size` method allows for iteration over all ranks, SubDataCommunicators require a more nuanced approach due to their potential to connect non-consecutive ranks. A workaround involving the `AllGather` method was considered, as implemented in `InitializeRanksList`, but this approach may lead to synchronization issues in certain cases.

To mitigate this challenge, this PR introduces functionality for retrieving a list of ranks involved in a SubDataCommunicator right from its creation. This enhancement improves the usability and flexibility of SubDataCommunicators, especially in complex communication scenarios. While this update is primarily for discussion and the current implementation seeks to circumvent this issue, the added functionality is a significant step forward in managing SubDataCommunicators more effectively.

This PR is intended to spark a discussion on the best ways to handle rank identification in SubDataCommunicators and to provide a potential solution for the issue. In my current implementation I will try to avoid this.

**🆕 Changelog**

- [Adding base methods for `RanksList` and `InitializeRanksList`](https://github.com/KratosMultiphysics/Kratos/commit/833e7e05ccd6e37f26cc30495be56a53cda41781)
- [Adding derived MPI methods for `RanksList` and `InitializeRanksList`. Also initialize at subdatacommunicators creation.](https://github.com/KratosMultiphysics/Kratos/commit/580734e28cad70fd9a4a2b4ee193575e632c96c8)
- [Adding test](https://github.com/KratosMultiphysics/Kratos/commit/ce86e6189729cd622ac49b250bc1c1c243c6c837)
