### PR TITLE
[Docs] Fix KRATOS_API with kratos_doxyfile

### DIFF
--- a/documents/kratos_doxyfile
+++ b/documents/kratos_doxyfile
@@ -2199,7 +2199,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -2207,7 +2207,7 @@ MACRO_EXPANSION        = NO
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -2239,7 +2239,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = KRATOS_API(...)=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The


### PR DESCRIPTION
**📝 Description**
Current `kratos_dxyfile` params set will ignore everyfile which has used `KRATOS_API` from the doxygen generated documentation (basically almost all the classes from Kratos is ignored unless they are headers only). This fixes it.

Now you can see generated doxygen for all the classes in Kratos such as `ModelPart` and so on :) 

**🆕 Changelog**
- Fix doxygen kratos_doxy file to be compatible with Kratos_API
