### PR TITLE
[Exp] Renaming IO subclasses for consistency

### DIFF
--- a/applications/OptimizationApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/OptimizationApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -341,22 +341,22 @@ void  AddCustomUtilitiesToPython(pybind11::module& m)
     properties_variable_expression_io.def("Write", &PropertiesVariableExpressionIO::Write<ModelPart::ConditionsContainerType>, py::arg("condition_container_expression"), py::arg("variable"));
     properties_variable_expression_io.def("Write", &PropertiesVariableExpressionIO::Write<ModelPart::ElementsContainerType>, py::arg("element_container_expression"), py::arg("variable"));
 
-    py::class_<PropertiesVariableExpressionIO::PropertiesVariableExpressionInput, PropertiesVariableExpressionIO::PropertiesVariableExpressionInput::Pointer, ExpressionInput>(properties_variable_expression_io, "Input")
+    py::class_<PropertiesVariableExpressionIO::Input, PropertiesVariableExpressionIO::Input::Pointer, ExpressionInput>(properties_variable_expression_io, "Input")
         .def(py::init<const ModelPart&,
                       const PropertiesVariableExpressionIO::VariableType&,
-                      const ContainerType&>(),
+                      Globals::DataLocation>(),
              py::arg("model_part"),
              py::arg("variable"),
-             py::arg("container_type"))
+             py::arg("data_location"))
         ;
 
-    py::class_<PropertiesVariableExpressionIO::PropertiesVariableExpressionOutput, PropertiesVariableExpressionIO::PropertiesVariableExpressionOutput::Pointer, ExpressionOutput>(properties_variable_expression_io, "Output")
+    py::class_<PropertiesVariableExpressionIO::Output, PropertiesVariableExpressionIO::Output::Pointer, ExpressionOutput>(properties_variable_expression_io, "Output")
         .def(py::init<ModelPart&,
                       const PropertiesVariableExpressionIO::VariableType&,
-                      const ContainerType&>(),
+                      Globals::DataLocation>(),
              py::arg("model_part"),
              py::arg("variable"),
-             py::arg("container_type"))
+             py::arg("data_location"))
         ;
 }
 

--- a/applications/OptimizationApplication/custom_utilities/properties_variable_expression_io.h
+++ b/applications/OptimizationApplication/custom_utilities/properties_variable_expression_io.h
@@ -23,6 +23,7 @@
 #include "containers/variable.h"
 #include "includes/define.h"
 #include "includes/model_part.h"
+#include "includes/global_variables.h"
 
 namespace Kratos {
 
@@ -47,24 +48,22 @@ public:
     ///@name Public classes
     ///@{
 
-    class KRATOS_API(OPTIMIZATION_APPLICATION) PropertiesVariableExpressionInput : public ExpressionInput
+    class KRATOS_API(OPTIMIZATION_APPLICATION) Input : public ExpressionInput
     {
     public:
         ///@name Type definitions
         ///@{
 
-        KRATOS_CLASS_POINTER_DEFINITION(PropertiesVariableExpressionInput);
+        KRATOS_CLASS_POINTER_DEFINITION(Input);
 
         ///@}
         ///@name Life cycle
         ///@{
 
-        PropertiesVariableExpressionInput(
+        Input(
             const ModelPart& rModelPart,
             const VariableType& rVariable,
-            const ContainerType& rContainerType);
-
-        ~PropertiesVariableExpressionInput() override = default;
+            Globals::DataLocation CurrentLocation);
 
         ///@}
         ///@name Public operations
@@ -78,34 +77,32 @@ public:
         ///@name Private member variables
         ///@{
 
-        const ModelPart& mrModelPart;
+        ModelPart const * mpModelPart;
 
-        const VariableType mpVariable;
+        VariableType mpVariable;
 
-        const ContainerType mContainerType;
+        Globals::DataLocation mDataLocation;
 
         ///@}
 
     };
 
-    class KRATOS_API(OPTIMIZATION_APPLICATION) PropertiesVariableExpressionOutput : public ExpressionOutput
+    class KRATOS_API(OPTIMIZATION_APPLICATION) Output : public ExpressionOutput
     {
     public:
         ///@name Type definitions
         ///@{
 
-        KRATOS_CLASS_POINTER_DEFINITION(PropertiesVariableExpressionOutput);
+        KRATOS_CLASS_POINTER_DEFINITION(Output);
 
         ///@}
         ///@name Life cycle
         ///@{
 
-        PropertiesVariableExpressionOutput(
+        Output(
             ModelPart& rModelPart,
             const VariableType& rVariable,
-            const ContainerType& rContainerType);
-
-        ~PropertiesVariableExpressionOutput() override = default;
+            Globals::DataLocation CurrentLocation);
 
         ///@}
         ///@name Public operations
@@ -119,11 +116,11 @@ public:
         ///@name Private member variables
         ///@{
 
-        ModelPart& mrModelPart;
+        ModelPart * mpModelPart;
 
-        const VariableType mpVariable;
+        VariableType mpVariable;
 
-        const ContainerType mContainerType;
+        Globals::DataLocation mDataLocation;
 
         ///@}
 

--- a/kratos/expression/integration_point_expression_io.h
+++ b/kratos/expression/integration_point_expression_io.h
@@ -23,6 +23,7 @@
 #include "expression_io.h"
 #include "includes/define.h"
 #include "includes/model_part.h"
+#include "includes/global_variables.h"
 
 namespace Kratos {
 
@@ -63,8 +64,8 @@ public:
         Input(
             ModelPart& rModelPart,
             const VariableType& rVariable,
-            const ContainerType& rContainerType,
-            const MeshType& rMeshType = MeshType::Local);
+            Globals::DataLocation CurrentLocation,
+            MeshType CurrentMeshType = MeshType::Local);
 
         ~Input() override = default;
 
@@ -84,9 +85,9 @@ public:
 
         VariableType mpVariable;
 
-        ContainerType mContainerType;
+        Globals::DataLocation mDataLocation;
 
-        const MeshType mMeshType;
+        MeshType mMeshType;
 
         ///@}
 
@@ -107,8 +108,8 @@ public:
         Output(
             ModelPart& rModelPart,
             const VariableType& rVariable,
-            const ContainerType& rContainerType,
-            MeshType rMeshType = MeshType::Local);
+            Globals::DataLocation CurrentLocation,
+            MeshType CurrentMeshType = MeshType::Local);
 
         ~Output() override = default;
 
@@ -128,7 +129,7 @@ public:
 
         VariableType mpVariable;
 
-        ContainerType mContainerType;
+        Globals::DataLocation mDataLocation;
 
         MeshType mMeshType;
 

--- a/kratos/expression/literal_expression_input.cpp
+++ b/kratos/expression/literal_expression_input.cpp
@@ -22,7 +22,7 @@
 
 namespace Kratos {
 
-LiteralExpressionIO::LiteralExpressionInput::LiteralExpressionInput(
+LiteralExpressionIO::Input::Input(
     const ModelPart& rModelPart,
     const DataType& rValue,
     const ContainerType& rContainerType,
@@ -33,7 +33,7 @@ LiteralExpressionIO::LiteralExpressionInput::LiteralExpressionInput(
       mMeshType(rMeshType)
 {
 }
-Expression::Pointer LiteralExpressionIO::LiteralExpressionInput::Execute() const
+Expression::Pointer LiteralExpressionIO::Input::Execute() const
 {
     return std::visit([&](auto& rValue){
         using data_type = std::remove_const_t<std::remove_reference_t<decltype(rValue)>>;
@@ -64,7 +64,7 @@ void LiteralExpressionIO::SetData(
     const DataType& rValue)
 {
     rContainerExpression.SetExpression(
-        LiteralExpressionInput(rContainerExpression.GetModelPart(), rValue,
+        Input(rContainerExpression.GetModelPart(), rValue,
                             std::is_same_v<TContainerType, ModelPart::NodesContainerType>
                                 ? ContainerType::NodalNonHistorical
                                 : std::is_same_v<TContainerType, ModelPart::ConditionsContainerType>
@@ -81,7 +81,7 @@ void LiteralExpressionIO::SetDataToZero(
 {
     std::visit([&rContainerExpression](const auto pVariable) {
         rContainerExpression.SetExpression(
-            LiteralExpressionInput(rContainerExpression.GetModelPart(), pVariable->Zero(),
+            Input(rContainerExpression.GetModelPart(), pVariable->Zero(),
                                 std::is_same_v<TContainerType, ModelPart::NodesContainerType>
                                     ? ContainerType::NodalNonHistorical
                                     : std::is_same_v<TContainerType, ModelPart::ConditionsContainerType>

--- a/kratos/expression/literal_expression_input.h
+++ b/kratos/expression/literal_expression_input.h
@@ -23,6 +23,7 @@
 #include "expression_io.h"
 #include "includes/define.h"
 #include "includes/model_part.h"
+#include "includes/global_variables.h"
 
 namespace Kratos {
 
@@ -72,8 +73,8 @@ public:
         Input(
             const ModelPart& rModelPart,
             const DataType& rValue,
-            const ContainerType& rContainerType,
-            const MeshType& rMeshType = MeshType::Local);
+            Globals::DataLocation CurrentLocation,
+            MeshType CurrentMeshType = MeshType::Local);
 
         ~Input() override = default;
 
@@ -89,13 +90,13 @@ public:
         ///@name Private member variables
         ///@{
 
-        const ModelPart& mrModelPart;
+        ModelPart const * mpModelPart;
 
-        const DataType mValue;
+        DataType mValue;
 
-        const ContainerType mContainerType;
+        Globals::DataLocation mDataLocation;
 
-        const MeshType mMeshType;
+        MeshType mMeshType;
 
         ///@}
 

--- a/kratos/expression/literal_expression_input.h
+++ b/kratos/expression/literal_expression_input.h
@@ -57,25 +57,25 @@ public:
     ///@name Public classes
     ///@{
 
-    class KRATOS_API(KRATOS_CORE) LiteralExpressionInput : public ExpressionInput
+    class KRATOS_API(KRATOS_CORE) Input : public ExpressionInput
     {
     public:
         ///@name Type definitions
         ///@{
 
-        KRATOS_CLASS_POINTER_DEFINITION(LiteralExpressionInput);
+        KRATOS_CLASS_POINTER_DEFINITION(Input);
 
         ///@}
         ///@name Life cycle
         ///@{
 
-        LiteralExpressionInput(
+        Input(
             const ModelPart& rModelPart,
             const DataType& rValue,
             const ContainerType& rContainerType,
             const MeshType& rMeshType = MeshType::Local);
 
-        ~LiteralExpressionInput() override = default;
+        ~Input() override = default;
 
         ///@}
         ///@name Public operations

--- a/kratos/expression/nodal_position_expression_io.cpp
+++ b/kratos/expression/nodal_position_expression_io.cpp
@@ -22,7 +22,7 @@
 
 namespace Kratos {
 
-NodalPositionExpressionIO::NodalPositionExpressionInput::NodalPositionExpressionInput(
+NodalPositionExpressionIO::Input::Input(
     const ModelPart& rModelPart,
     const Configuration& rConfiguration,
     const MeshType& rMeshType)
@@ -32,7 +32,7 @@ NodalPositionExpressionIO::NodalPositionExpressionInput::NodalPositionExpression
 {
 }
 
-Expression::Pointer NodalPositionExpressionIO::NodalPositionExpressionInput::Execute() const
+Expression::Pointer NodalPositionExpressionIO::Input::Execute() const
 {
     const auto& r_mesh = ExpressionIOUtils::GetMesh(mrModelPart.GetCommunicator(), mMeshType);
     const auto number_of_nodes = r_mesh.Nodes().size();
@@ -65,7 +65,7 @@ Expression::Pointer NodalPositionExpressionIO::NodalPositionExpressionInput::Exe
     return expression;
 }
 
-NodalPositionExpressionIO::NodalPositionExpressionOutput::NodalPositionExpressionOutput(
+NodalPositionExpressionIO::Output::Output(
     ModelPart& rModelPart,
     const Configuration& rConfiguration,
     const MeshType& rMeshType)
@@ -75,7 +75,7 @@ NodalPositionExpressionIO::NodalPositionExpressionOutput::NodalPositionExpressio
 {
 }
 
-void NodalPositionExpressionIO::NodalPositionExpressionOutput::Execute(const Expression& rExpression)
+void NodalPositionExpressionIO::Output::Execute(const Expression& rExpression)
 {
     KRATOS_TRY
 
@@ -145,7 +145,7 @@ void NodalPositionExpressionIO::Read(
     ContainerExpression<ModelPart::NodesContainerType, TMeshType>& rContainerExpression,
     const Configuration& rConfiguration)
 {
-    auto p_expression = NodalPositionExpressionInput(rContainerExpression.GetModelPart(),
+    auto p_expression = Input(rContainerExpression.GetModelPart(),
                                                      rConfiguration, TMeshType)
                             .Execute();
 
@@ -157,7 +157,7 @@ void NodalPositionExpressionIO::Write(
     const ContainerExpression<ModelPart::NodesContainerType, TMeshType>& rContainerExpression,
     const Configuration& rConfiguration)
 {
-    NodalPositionExpressionOutput(*rContainerExpression.pGetModelPart(),
+    Output(*rContainerExpression.pGetModelPart(),
                                   rConfiguration, TMeshType)
         .Execute(rContainerExpression.GetExpression());
 }

--- a/kratos/expression/nodal_position_expression_io.h
+++ b/kratos/expression/nodal_position_expression_io.h
@@ -37,24 +37,24 @@ public:
     ///@name Public classes
     ///@{
 
-    class KRATOS_API(KRATOS_CORE) NodalPositionExpressionInput : public ExpressionInput
+    class KRATOS_API(KRATOS_CORE) Input : public ExpressionInput
     {
     public:
         ///@name Type definitions
         ///@{
 
-        KRATOS_CLASS_POINTER_DEFINITION(NodalPositionExpressionInput);
+        KRATOS_CLASS_POINTER_DEFINITION(Input);
 
         ///@}
         ///@name Life cycle
         ///@{
 
-        NodalPositionExpressionInput(
+        Input(
             const ModelPart& rModelPart,
             const Configuration& rConfiguration,
             const MeshType& rMeshType = MeshType::Local);
 
-        ~NodalPositionExpressionInput() override = default;
+        ~Input() override = default;
 
         ///@}
         ///@name Public operations
@@ -78,24 +78,24 @@ public:
 
     };
 
-    class KRATOS_API(KRATOS_CORE) NodalPositionExpressionOutput : public ExpressionOutput
+    class KRATOS_API(KRATOS_CORE) Output : public ExpressionOutput
     {
     public:
         ///@name Type definitions
         ///@{
 
-        KRATOS_CLASS_POINTER_DEFINITION(NodalPositionExpressionOutput);
+        KRATOS_CLASS_POINTER_DEFINITION(Output);
 
         ///@}
         ///@name Life cycle
         ///@{
 
-        NodalPositionExpressionOutput(
+        Output(
             ModelPart& rModelPart,
             const Configuration& rConfiguration,
             const MeshType& rMeshType = MeshType::Local);
 
-        ~NodalPositionExpressionOutput() override = default;
+        ~Output() override = default;
 
         ///@}
         ///@name Public operations

--- a/kratos/expression/traits.h
+++ b/kratos/expression/traits.h
@@ -22,13 +22,4 @@ enum MeshType {
     Interface
 }; // enum MeshType
 
-enum ContainerType
-{
-    NodalHistorical,
-    NodalNonHistorical,
-    ConditionNonHistorical,
-    ElementNonHistorical
-}; // enum ContainerType
-
-
 } // namespace Kratos

--- a/kratos/expression/variable_expression_io.cpp
+++ b/kratos/expression/variable_expression_io.cpp
@@ -25,41 +25,32 @@ namespace Kratos {
 VariableExpressionIO::Input::Input(
     const ModelPart& rModelPart,
     const VariableType& rVariable,
-    const ContainerType& rContainerType,
-    const MeshType& rMeshType)
-    : mrModelPart(rModelPart),
+    Globals::DataLocation CurrentLocation,
+    MeshType CurrentMeshType)
+    : mpModelPart(&rModelPart),
       mpVariable(rVariable),
-      mContainerType(rContainerType),
-      mMeshType(rMeshType)
+      mDataLocation(CurrentLocation),
+      mMeshType(CurrentMeshType)
 {
 }
 
 Expression::Pointer VariableExpressionIO::Input::Execute() const
 {
-    const auto& r_mesh = ExpressionIOUtils::GetMesh(mrModelPart.GetCommunicator(), mMeshType);
-    const auto& r_data_communicator = mrModelPart.GetCommunicator().GetDataCommunicator();
+    const auto& r_mesh = ExpressionIOUtils::GetMesh(mpModelPart->GetCommunicator(), mMeshType);
+    const auto& r_data_communicator = mpModelPart->GetCommunicator().GetDataCommunicator();
 
-    switch (mContainerType) {
-        case ContainerType::NodalHistorical: {
-                return ExpressionIOUtils::ReadToExpression<ModelPart::NodesContainerType, ContainerDataIO<ContainerDataIOTags::Historical>, const VariableType>(r_mesh.Nodes(), mpVariable, r_data_communicator);
-                break;
-            }
-        case ContainerType::NodalNonHistorical: {
-                return ExpressionIOUtils::ReadToExpression<ModelPart::NodesContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Nodes(), mpVariable, r_data_communicator);
-                break;
-            }
-        case ContainerType::ConditionNonHistorical: {
-                return ExpressionIOUtils::ReadToExpression<ModelPart::ConditionsContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Conditions(), mpVariable, r_data_communicator);
-                break;
-            }
-        case ContainerType::ElementNonHistorical: {
-                return ExpressionIOUtils::ReadToExpression<ModelPart::ElementsContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Elements(), mpVariable, r_data_communicator);
-                break;
-            }
-        default: {
-                KRATOS_ERROR << "Invalid container type";
+    switch (mDataLocation) {
+        case Globals::DataLocation::NodeHistorical:
+            return ExpressionIOUtils::ReadToExpression<ModelPart::NodesContainerType, ContainerDataIO<ContainerDataIOTags::Historical>, const VariableType>(r_mesh.Nodes(), mpVariable, r_data_communicator);
+        case Globals::DataLocation::NodeNonHistorical:
+            return ExpressionIOUtils::ReadToExpression<ModelPart::NodesContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Nodes(), mpVariable, r_data_communicator);
+        case Globals::DataLocation::Condition:
+            return ExpressionIOUtils::ReadToExpression<ModelPart::ConditionsContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Conditions(), mpVariable, r_data_communicator);
+        case Globals::DataLocation::Element:
+            return ExpressionIOUtils::ReadToExpression<ModelPart::ElementsContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Elements(), mpVariable, r_data_communicator);
+        default:
+            KRATOS_ERROR << "Invalid container type. Only supports NodeHistorical, NodeNonHistorical, Condition, Element.";
             break;
-        }
     }
 
     return nullptr;
@@ -68,33 +59,36 @@ Expression::Pointer VariableExpressionIO::Input::Execute() const
 VariableExpressionIO::Output::Output(
     ModelPart& rModelPart,
     const VariableType& rVariable,
-    const ContainerType& rContainerType,
-    MeshType  rMeshType)
-    : mrModelPart(rModelPart),
+    Globals::DataLocation CurrentLocation,
+    MeshType CurrentMeshType)
+    : mpModelPart(&rModelPart),
       mpVariable(rVariable),
-      mContainerType(rContainerType),
-      mMeshType(rMeshType)
+      mDataLocation(CurrentLocation),
+      mMeshType(CurrentMeshType)
 {
 }
 
 void VariableExpressionIO::Output::Execute(const Expression& rExpression)
 {
     KRATOS_TRY
-    auto& r_communicator = mrModelPart.GetCommunicator();
+    auto& r_communicator = mpModelPart->GetCommunicator();
     auto& r_mesh = ExpressionIOUtils::GetMesh(r_communicator, mMeshType);
 
-    switch (mContainerType) {
-        case ContainerType::NodalHistorical:
+    switch (mDataLocation) {
+        case Globals::DataLocation::NodeHistorical:
             ExpressionIOUtils::WriteFromExpression<ModelPart::NodesContainerType, ContainerDataIO<ContainerDataIOTags::Historical>, const VariableType>(r_mesh.Nodes(), r_communicator, rExpression, mpVariable);
             break;
-        case ContainerType::NodalNonHistorical:
+        case Globals::DataLocation::NodeNonHistorical:
             ExpressionIOUtils::WriteFromExpression<ModelPart::NodesContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Nodes(), r_communicator, rExpression, mpVariable);
             break;
-        case ContainerType::ConditionNonHistorical:
+        case Globals::DataLocation::Condition:
             ExpressionIOUtils::WriteFromExpression<ModelPart::ConditionsContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Conditions(), r_communicator, rExpression, mpVariable);
             break;
-        case ContainerType::ElementNonHistorical:
+        case Globals::DataLocation::Element:
             ExpressionIOUtils::WriteFromExpression<ModelPart::ElementsContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Elements(), r_communicator, rExpression, mpVariable);
+            break;
+        default:
+            KRATOS_ERROR << "Invalid container type. Only supports NodeHistorical, NodeNonHistorical, Condition, Element.";
             break;
     }
     KRATOS_CATCH("");
@@ -108,8 +102,8 @@ void VariableExpressionIO::Read(
 {
     auto p_expression =
         Input(rContainerExpression.GetModelPart(), rVariable,
-                                IsHistorical ? ContainerType::NodalHistorical
-                                             : ContainerType::NodalNonHistorical,
+                                IsHistorical ? Globals::DataLocation::NodeHistorical
+                                             : Globals::DataLocation::NodeNonHistorical,
                                 TMeshType)
             .Execute();
 
@@ -128,8 +122,8 @@ void VariableExpressionIO::Read(
     auto p_expression =
         Input(rContainerExpression.GetModelPart(), rVariable,
                                 std::is_same_v<TContainerType, ModelPart::ConditionsContainerType>
-                                    ? ContainerType::ConditionNonHistorical
-                                    : ContainerType::ElementNonHistorical,
+                                    ? Globals::DataLocation::Condition
+                                    : Globals::DataLocation::Element,
                                 TMeshType)
             .Execute();
 
@@ -143,8 +137,8 @@ void VariableExpressionIO::Write(
     const bool IsHistorical)
 {
     Output(*rContainerExpression.pGetModelPart(), rVariable,
-                             IsHistorical ? ContainerType::NodalHistorical
-                                          : ContainerType::NodalNonHistorical,
+                             IsHistorical ? Globals::DataLocation::NodeHistorical
+                                          : Globals::DataLocation::NodeNonHistorical,
                              TMeshType)
         .Execute(rContainerExpression.GetExpression());
 }
@@ -160,8 +154,8 @@ void VariableExpressionIO::Write(
 
     Output(*rContainerExpression.pGetModelPart(), rVariable,
                              std::is_same_v<TContainerType, ModelPart::ConditionsContainerType>
-                                 ? ContainerType::ConditionNonHistorical
-                                 : ContainerType::ElementNonHistorical,
+                                 ? Globals::DataLocation::Condition
+                                 : Globals::DataLocation::Element,
                              TMeshType)
         .Execute(rContainerExpression.GetExpression());
 }

--- a/kratos/expression/variable_expression_io.cpp
+++ b/kratos/expression/variable_expression_io.cpp
@@ -22,7 +22,7 @@
 
 namespace Kratos {
 
-VariableExpressionIO::VariableExpressionInput::VariableExpressionInput(
+VariableExpressionIO::Input::Input(
     const ModelPart& rModelPart,
     const VariableType& rVariable,
     const ContainerType& rContainerType,
@@ -34,7 +34,7 @@ VariableExpressionIO::VariableExpressionInput::VariableExpressionInput(
 {
 }
 
-Expression::Pointer VariableExpressionIO::VariableExpressionInput::Execute() const
+Expression::Pointer VariableExpressionIO::Input::Execute() const
 {
     const auto& r_mesh = ExpressionIOUtils::GetMesh(mrModelPart.GetCommunicator(), mMeshType);
     const auto& r_data_communicator = mrModelPart.GetCommunicator().GetDataCommunicator();
@@ -65,7 +65,7 @@ Expression::Pointer VariableExpressionIO::VariableExpressionInput::Execute() con
     return nullptr;
 }
 
-VariableExpressionIO::VariableExpressionOutput::VariableExpressionOutput(
+VariableExpressionIO::Output::Output(
     ModelPart& rModelPart,
     const VariableType& rVariable,
     const ContainerType& rContainerType,
@@ -77,7 +77,7 @@ VariableExpressionIO::VariableExpressionOutput::VariableExpressionOutput(
 {
 }
 
-void VariableExpressionIO::VariableExpressionOutput::Execute(const Expression& rExpression)
+void VariableExpressionIO::Output::Execute(const Expression& rExpression)
 {
     KRATOS_TRY
     auto& r_communicator = mrModelPart.GetCommunicator();
@@ -107,7 +107,7 @@ void VariableExpressionIO::Read(
     const bool IsHistorical)
 {
     auto p_expression =
-        VariableExpressionInput(rContainerExpression.GetModelPart(), rVariable,
+        Input(rContainerExpression.GetModelPart(), rVariable,
                                 IsHistorical ? ContainerType::NodalHistorical
                                              : ContainerType::NodalNonHistorical,
                                 TMeshType)
@@ -126,7 +126,7 @@ void VariableExpressionIO::Read(
                   "stated.\n");
 
     auto p_expression =
-        VariableExpressionInput(rContainerExpression.GetModelPart(), rVariable,
+        Input(rContainerExpression.GetModelPart(), rVariable,
                                 std::is_same_v<TContainerType, ModelPart::ConditionsContainerType>
                                     ? ContainerType::ConditionNonHistorical
                                     : ContainerType::ElementNonHistorical,
@@ -142,7 +142,7 @@ void VariableExpressionIO::Write(
     const VariableType& rVariable,
     const bool IsHistorical)
 {
-    VariableExpressionOutput(*rContainerExpression.pGetModelPart(), rVariable,
+    Output(*rContainerExpression.pGetModelPart(), rVariable,
                              IsHistorical ? ContainerType::NodalHistorical
                                           : ContainerType::NodalNonHistorical,
                              TMeshType)
@@ -158,7 +158,7 @@ void VariableExpressionIO::Write(
                   "NodesContainerType expressions should have the IsHistorical "
                   "stated.\n");
 
-    VariableExpressionOutput(*rContainerExpression.pGetModelPart(), rVariable,
+    Output(*rContainerExpression.pGetModelPart(), rVariable,
                              std::is_same_v<TContainerType, ModelPart::ConditionsContainerType>
                                  ? ContainerType::ConditionNonHistorical
                                  : ContainerType::ElementNonHistorical,

--- a/kratos/expression/variable_expression_io.h
+++ b/kratos/expression/variable_expression_io.h
@@ -23,6 +23,7 @@
 #include "expression_io.h"
 #include "includes/define.h"
 #include "includes/model_part.h"
+#include "includes/global_variables.h"
 
 namespace Kratos {
 
@@ -62,8 +63,8 @@ public:
         Input(
             const ModelPart& rModelPart,
             const VariableType& rVariable,
-            const ContainerType& rContainerType,
-            const MeshType& rMeshType = MeshType::Local);
+            Globals::DataLocation CurrentLocation,
+            MeshType CurrentMeshType = MeshType::Local);
 
         ~Input() override = default;
 
@@ -79,13 +80,13 @@ public:
         ///@name Private member variables
         ///@{
 
-        const ModelPart& mrModelPart;
+        ModelPart const * mpModelPart;
 
-        const VariableType mpVariable;
+        VariableType mpVariable;
 
-        const ContainerType mContainerType;
+        Globals::DataLocation mDataLocation;
 
-        const MeshType mMeshType;
+        MeshType mMeshType;
 
         ///@}
 
@@ -106,8 +107,8 @@ public:
         Output(
             ModelPart& rModelPart,
             const VariableType& rVariable,
-            const ContainerType& rContainerType,
-            MeshType rMeshType = MeshType::Local);
+            Globals::DataLocation CurrentLocation,
+            MeshType CurrentMeshType = MeshType::Local);
 
         ~Output() override = default;
 
@@ -123,13 +124,13 @@ public:
         ///@name Private member variables
         ///@{
 
-        ModelPart& mrModelPart;
+        ModelPart * mpModelPart;
 
-        const VariableType mpVariable;
+        VariableType mpVariable;
 
-        const ContainerType mContainerType;
+        Globals::DataLocation mDataLocation;
 
-        const MeshType mMeshType;
+        MeshType mMeshType;
 
         ///@}
 

--- a/kratos/expression/variable_expression_io.h
+++ b/kratos/expression/variable_expression_io.h
@@ -47,25 +47,25 @@ public:
     ///@name Public classes
     ///@{
 
-    class KRATOS_API(KRATOS_CORE) VariableExpressionInput : public ExpressionInput
+    class KRATOS_API(KRATOS_CORE) Input : public ExpressionInput
     {
     public:
         ///@name Type definitions
         ///@{
 
-        KRATOS_CLASS_POINTER_DEFINITION(VariableExpressionInput);
+        KRATOS_CLASS_POINTER_DEFINITION(Input);
 
         ///@}
         ///@name Life cycle
         ///@{
 
-        VariableExpressionInput(
+        Input(
             const ModelPart& rModelPart,
             const VariableType& rVariable,
             const ContainerType& rContainerType,
             const MeshType& rMeshType = MeshType::Local);
 
-        ~VariableExpressionInput() override = default;
+        ~Input() override = default;
 
         ///@}
         ///@name Public operations
@@ -91,25 +91,25 @@ public:
 
     };
 
-    class KRATOS_API(KRATOS_CORE) VariableExpressionOutput : public ExpressionOutput
+    class KRATOS_API(KRATOS_CORE) Output : public ExpressionOutput
     {
     public:
         ///@name Type definitions
         ///@{
 
-        KRATOS_CLASS_POINTER_DEFINITION(VariableExpressionOutput);
+        KRATOS_CLASS_POINTER_DEFINITION(Output);
 
         ///@}
         ///@name Life cycle
         ///@{
 
-        VariableExpressionOutput(
+        Output(
             ModelPart& rModelPart,
             const VariableType& rVariable,
             const ContainerType& rContainerType,
             MeshType rMeshType = MeshType::Local);
 
-        ~VariableExpressionOutput() override = default;
+        ~Output() override = default;
 
         ///@}
         ///@name Public operations

--- a/kratos/python/add_expression_io_to_python.cpp
+++ b/kratos/python/add_expression_io_to_python.cpp
@@ -314,13 +314,6 @@ void AddExpressionIOToPython(pybind11::module& rModule)
         .def("Execute", &ExpressionOutput::Execute)
         ;
 
-    pybind11::enum_<ContainerType>(rModule, "ContainerType")
-        .value("NodalHistorical", ContainerType::NodalHistorical)
-        .value("NodalNonHistorical", ContainerType::NodalNonHistorical)
-        .value("ElementNonHistorical", ContainerType::ElementNonHistorical)
-        .value("ConditionNonHistorical", ContainerType::ConditionNonHistorical)
-        ;
-
     pybind11::enum_<MeshType>(rModule, "MeshType")
         .value("Local", MeshType::Local)
         .value("Interface", MeshType::Interface)

--- a/kratos/python/add_expression_io_to_python.cpp
+++ b/kratos/python/add_expression_io_to_python.cpp
@@ -348,19 +348,19 @@ void AddExpressionIOToPython(pybind11::module& rModule)
     pybind11::class_<IntegrationPointExpressionIO::Input, IntegrationPointExpressionIO::Input::Pointer, ExpressionInput>(integration_point_expression_io, "Input")
         .def(pybind11::init<ModelPart&,
                             const IntegrationPointExpressionIO::VariableType&,
-                            const ContainerType&>(),
+                            Globals::DataLocation>(),
              pybind11::arg("model_part"),
              pybind11::arg("variable"),
-             pybind11::arg("container_type"))
+             pybind11::arg("data_location"))
         ;
 
     pybind11::class_<IntegrationPointExpressionIO::Output, IntegrationPointExpressionIO::Output::Pointer, ExpressionOutput>(integration_point_expression_io, "Output")
         .def(pybind11::init<ModelPart&,
                             const IntegrationPointExpressionIO::VariableType&,
-                            const ContainerType&>(),
+                            Globals::DataLocation>(),
              pybind11::arg("model_part"),
              pybind11::arg("variable"),
-             pybind11::arg("container_type"))
+             pybind11::arg("data_location"))
         ;
 
     auto carray_expression_io = rModule.def_submodule("CArrayExpressionIO");

--- a/kratos/python/add_expression_io_to_python.cpp
+++ b/kratos/python/add_expression_io_to_python.cpp
@@ -404,10 +404,10 @@ void AddExpressionIOToPython(pybind11::module& rModule)
         data_expression_io, "Input")
         .def(pybind11::init<const ModelPart&,
                             const LiteralExpressionIO::DataType&,
-                            const ContainerType&>(),
+                            Globals::DataLocation&>(),
              pybind11::arg("model_part"),
              pybind11::arg("variable"),
-             pybind11::arg("container_type"))
+             pybind11::arg("data_location"))
         ;
 
     auto nodal_expression_io = rModule.def_submodule("NodalPositionExpressionIO");

--- a/kratos/python/add_expression_io_to_python.cpp
+++ b/kratos/python/add_expression_io_to_python.cpp
@@ -330,19 +330,19 @@ void AddExpressionIOToPython(pybind11::module& rModule)
     pybind11::class_<VariableExpressionIO::Input, VariableExpressionIO::Input::Pointer, ExpressionInput>(variable_expression_io, "Input")
         .def(pybind11::init<const ModelPart&,
                             const VariableExpressionIO::VariableType&,
-                            const ContainerType&>(),
+                            Globals::DataLocation>(),
              pybind11::arg("model_part"),
              pybind11::arg("variable"),
-             pybind11::arg("container_type"))
+             pybind11::arg("data_location"))
         ;
 
     pybind11::class_<VariableExpressionIO::Output, VariableExpressionIO::Output::Pointer, ExpressionOutput>(variable_expression_io, "Output")
         .def(pybind11::init<ModelPart&,
                             const VariableExpressionIO::VariableType&,
-                            const ContainerType&>(),
+                            Globals::DataLocation>(),
              pybind11::arg("model_part"),
              pybind11::arg("variable"),
-             pybind11::arg("container_type"))
+             pybind11::arg("data_location"))
         ;
 
     pybind11::class_<IntegrationPointExpressionIO::Input, IntegrationPointExpressionIO::Input::Pointer, ExpressionInput>(integration_point_expression_io, "Input")

--- a/kratos/python/add_expression_io_to_python.cpp
+++ b/kratos/python/add_expression_io_to_python.cpp
@@ -327,7 +327,7 @@ void AddExpressionIOToPython(pybind11::module& rModule)
         .value("Ghost", MeshType::Ghost)
         ;
 
-    pybind11::class_<VariableExpressionIO::VariableExpressionInput, VariableExpressionIO::VariableExpressionInput::Pointer, ExpressionInput>(variable_expression_io, "Input")
+    pybind11::class_<VariableExpressionIO::Input, VariableExpressionIO::Input::Pointer, ExpressionInput>(variable_expression_io, "Input")
         .def(pybind11::init<const ModelPart&,
                             const VariableExpressionIO::VariableType&,
                             const ContainerType&>(),
@@ -336,7 +336,7 @@ void AddExpressionIOToPython(pybind11::module& rModule)
              pybind11::arg("container_type"))
         ;
 
-    pybind11::class_<VariableExpressionIO::VariableExpressionOutput, VariableExpressionIO::VariableExpressionOutput::Pointer, ExpressionOutput>(variable_expression_io, "Output")
+    pybind11::class_<VariableExpressionIO::Output, VariableExpressionIO::Output::Pointer, ExpressionOutput>(variable_expression_io, "Output")
         .def(pybind11::init<ModelPart&,
                             const VariableExpressionIO::VariableType&,
                             const ContainerType&>(),
@@ -400,7 +400,7 @@ void AddExpressionIOToPython(pybind11::module& rModule)
     Detail::AddLiteralExpressionIOMethods<ModelPart::ElementsContainerType, int>(data_expression_io);
     Detail::AddLiteralExpressionIOMethods<ModelPart::ElementsContainerType, double>(data_expression_io);
 
-    pybind11::class_<LiteralExpressionIO::LiteralExpressionInput, LiteralExpressionIO::LiteralExpressionInput::Pointer, ExpressionInput>(
+    pybind11::class_<LiteralExpressionIO::Input, LiteralExpressionIO::Input::Pointer, ExpressionInput>(
         data_expression_io, "Input")
         .def(pybind11::init<const ModelPart&,
                             const LiteralExpressionIO::DataType&,
@@ -411,13 +411,20 @@ void AddExpressionIOToPython(pybind11::module& rModule)
         ;
 
     auto nodal_expression_io = rModule.def_submodule("NodalPositionExpressionIO");
-    pybind11::class_<NodalPositionExpressionIO::NodalPositionExpressionInput, NodalPositionExpressionIO::NodalPositionExpressionInput::Pointer, ExpressionInput>(
+    pybind11::class_<NodalPositionExpressionIO::Input, NodalPositionExpressionIO::Input::Pointer, ExpressionInput>(
         nodal_expression_io, "Input")
         .def(pybind11::init<const ModelPart&,
                             const NodalPositionExpressionIO::Configuration&>(),
              pybind11::arg("model_part"),
              pybind11::arg("configuration"))
         ;
+    pybind11::class_<NodalPositionExpressionIO::Output, NodalPositionExpressionIO::Output::Pointer, ExpressionOutput>(
+        nodal_expression_io, "Output")
+        .def(pybind11::init<ModelPart&,
+                            const NodalPositionExpressionIO::Configuration&>(),
+             pybind11::arg("model_part"),
+             pybind11::arg("configuration"))
+    ;
     nodal_expression_io.def("Read", &NodalPositionExpressionIO::Read<MeshType::Local>, pybind11::arg("nodal_expression"), pybind11::arg("configuration"));
     nodal_expression_io.def("Write", &NodalPositionExpressionIO::Write<MeshType::Local>, pybind11::arg("nodal_expression"), pybind11::arg("configuration"));
 }

--- a/kratos/tests/test_container_expression.py
+++ b/kratos/tests/test_container_expression.py
@@ -764,7 +764,7 @@ class TestContainerExpression(ABC):
         pass
 
     @abstractmethod
-    def _GetContainerType(self) -> Kratos.Expression.ContainerType:
+    def _GetContainerType(self) -> Kratos.Globals.DataLocation:
         pass
 
     @abstractmethod
@@ -791,8 +791,8 @@ class TestHistoricalContainerExpression(kratos_unittest.TestCase, TestContainerE
     def _GetContainerExpression(self) -> Kratos.Expression.NodalExpression:
         return Kratos.Expression.NodalExpression(self.model_part)
 
-    def _GetContainerType(self) -> Kratos.Expression.ContainerType:
-        return Kratos.Expression.ContainerType.NodalHistorical
+    def _GetContainerType(self) -> Kratos.Globals.DataLocation:
+        return Kratos.Globals.DataLocation.NodeHistorical
 
     def _GetContainer(self):
         return self.model_part.GetCommunicator().LocalMesh().Nodes
@@ -814,8 +814,8 @@ class TestNodalContainerExpression(kratos_unittest.TestCase, TestContainerExpres
     def _GetContainerExpression(self) -> Kratos.Expression.NodalExpression:
         return Kratos.Expression.NodalExpression(self.model_part)
 
-    def _GetContainerType(self) -> Kratos.Expression.ContainerType:
-        return Kratos.Expression.ContainerType.NodalNonHistorical
+    def _GetContainerType(self) -> Kratos.Globals.DataLocation:
+        return Kratos.Globals.DataLocation.NodeNonHistorical
 
     def _GetContainer(self):
         return self.model_part.GetCommunicator().LocalMesh().Nodes
@@ -837,8 +837,8 @@ class TestConditionContainerExpression(kratos_unittest.TestCase, TestContainerEx
     def _GetContainerExpression(self) -> Kratos.Expression.ConditionExpression:
         return Kratos.Expression.ConditionExpression(self.model_part)
 
-    def _GetContainerType(self) -> Kratos.Expression.ContainerType:
-        return Kratos.Expression.ContainerType.ConditionNonHistorical
+    def _GetContainerType(self) -> Kratos.Globals.DataLocation:
+        return Kratos.Globals.DataLocation.Condition
 
     def _GetContainer(self):
         return self.model_part.GetCommunicator().LocalMesh().Conditions
@@ -860,8 +860,8 @@ class TestElementContainerExpression(kratos_unittest.TestCase, TestContainerExpr
     def _GetContainerExpression(self):
         return Kratos.Expression.ElementExpression(self.model_part)
 
-    def _GetContainerType(self) -> Kratos.Expression.ContainerType:
-        return Kratos.Expression.ContainerType.ElementNonHistorical
+    def _GetContainerType(self) -> Kratos.Globals.DataLocation:
+        return Kratos.Globals.DataLocation.Element
 
     def _GetContainer(self):
         return self.model_part.GetCommunicator().LocalMesh().Elements


### PR DESCRIPTION
**📝 Description**
This PR purely renames the IO classes to be consistent with the python namings used.

**🆕 Changelog**
- Changed `VariableExpressionIO::VariableExpressionInput`  to `VariableExpressionIO::Input`
- Changed `VariableExpressionIO::VariableExpressionOutput`  to `VariableExpressionIO::Output`
- Changed `NodalPositionExpressionIO::NodalPositionExpressionInput`  to `NodalPositionExpressionIO::Input`
- Changed `NodalPositionExpressionIO::NodalPositionExpressionOutput`  to `NodalPositionExpressionIO::Output`
- Changed `LiteralExpressionIO::LiteralExpressionInput` to `LiteralExpressionIO::Input`
