### PR TITLE
[Exps] Remove container type and use Globals::DataLocation

### DIFF
--- a/applications/OptimizationApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/OptimizationApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -341,22 +341,22 @@ void  AddCustomUtilitiesToPython(pybind11::module& m)
     properties_variable_expression_io.def("Write", &PropertiesVariableExpressionIO::Write<ModelPart::ConditionsContainerType>, py::arg("condition_container_expression"), py::arg("variable"));
     properties_variable_expression_io.def("Write", &PropertiesVariableExpressionIO::Write<ModelPart::ElementsContainerType>, py::arg("element_container_expression"), py::arg("variable"));
 
-    py::class_<PropertiesVariableExpressionIO::PropertiesVariableExpressionInput, PropertiesVariableExpressionIO::PropertiesVariableExpressionInput::Pointer, ExpressionInput>(properties_variable_expression_io, "Input")
+    py::class_<PropertiesVariableExpressionIO::Input, PropertiesVariableExpressionIO::Input::Pointer, ExpressionInput>(properties_variable_expression_io, "Input")
         .def(py::init<const ModelPart&,
                       const PropertiesVariableExpressionIO::VariableType&,
-                      const ContainerType&>(),
+                      Globals::DataLocation>(),
              py::arg("model_part"),
              py::arg("variable"),
-             py::arg("container_type"))
+             py::arg("data_location"))
         ;
 
-    py::class_<PropertiesVariableExpressionIO::PropertiesVariableExpressionOutput, PropertiesVariableExpressionIO::PropertiesVariableExpressionOutput::Pointer, ExpressionOutput>(properties_variable_expression_io, "Output")
+    py::class_<PropertiesVariableExpressionIO::Output, PropertiesVariableExpressionIO::Output::Pointer, ExpressionOutput>(properties_variable_expression_io, "Output")
         .def(py::init<ModelPart&,
                       const PropertiesVariableExpressionIO::VariableType&,
-                      const ContainerType&>(),
+                      Globals::DataLocation>(),
              py::arg("model_part"),
              py::arg("variable"),
-             py::arg("container_type"))
+             py::arg("data_location"))
         ;
 }
 

--- a/applications/OptimizationApplication/custom_utilities/properties_variable_expression_io.h
+++ b/applications/OptimizationApplication/custom_utilities/properties_variable_expression_io.h
@@ -23,6 +23,7 @@
 #include "containers/variable.h"
 #include "includes/define.h"
 #include "includes/model_part.h"
+#include "includes/global_variables.h"
 
 namespace Kratos {
 
@@ -47,24 +48,22 @@ public:
     ///@name Public classes
     ///@{
 
-    class KRATOS_API(OPTIMIZATION_APPLICATION) PropertiesVariableExpressionInput : public ExpressionInput
+    class KRATOS_API(OPTIMIZATION_APPLICATION) Input : public ExpressionInput
     {
     public:
         ///@name Type definitions
         ///@{
 
-        KRATOS_CLASS_POINTER_DEFINITION(PropertiesVariableExpressionInput);
+        KRATOS_CLASS_POINTER_DEFINITION(Input);
 
         ///@}
         ///@name Life cycle
         ///@{
 
-        PropertiesVariableExpressionInput(
+        Input(
             const ModelPart& rModelPart,
             const VariableType& rVariable,
-            const ContainerType& rContainerType);
-
-        ~PropertiesVariableExpressionInput() override = default;
+            Globals::DataLocation CurrentLocation);
 
         ///@}
         ///@name Public operations
@@ -78,34 +77,32 @@ public:
         ///@name Private member variables
         ///@{
 
-        const ModelPart& mrModelPart;
+        ModelPart const * mpModelPart;
 
-        const VariableType mpVariable;
+        VariableType mpVariable;
 
-        const ContainerType mContainerType;
+        Globals::DataLocation mDataLocation;
 
         ///@}
 
     };
 
-    class KRATOS_API(OPTIMIZATION_APPLICATION) PropertiesVariableExpressionOutput : public ExpressionOutput
+    class KRATOS_API(OPTIMIZATION_APPLICATION) Output : public ExpressionOutput
     {
     public:
         ///@name Type definitions
         ///@{
 
-        KRATOS_CLASS_POINTER_DEFINITION(PropertiesVariableExpressionOutput);
+        KRATOS_CLASS_POINTER_DEFINITION(Output);
 
         ///@}
         ///@name Life cycle
         ///@{
 
-        PropertiesVariableExpressionOutput(
+        Output(
             ModelPart& rModelPart,
             const VariableType& rVariable,
-            const ContainerType& rContainerType);
-
-        ~PropertiesVariableExpressionOutput() override = default;
+            Globals::DataLocation CurrentLocation);
 
         ///@}
         ///@name Public operations
@@ -119,11 +116,11 @@ public:
         ///@name Private member variables
         ///@{
 
-        ModelPart& mrModelPart;
+        ModelPart * mpModelPart;
 
-        const VariableType mpVariable;
+        VariableType mpVariable;
 
-        const ContainerType mContainerType;
+        Globals::DataLocation mDataLocation;
 
         ///@}
 

--- a/kratos/expression/integration_point_expression_io.h
+++ b/kratos/expression/integration_point_expression_io.h
@@ -23,6 +23,7 @@
 #include "expression_io.h"
 #include "includes/define.h"
 #include "includes/model_part.h"
+#include "includes/global_variables.h"
 
 namespace Kratos {
 
@@ -63,8 +64,8 @@ public:
         Input(
             ModelPart& rModelPart,
             const VariableType& rVariable,
-            const ContainerType& rContainerType,
-            const MeshType& rMeshType = MeshType::Local);
+            Globals::DataLocation CurrentLocation,
+            MeshType CurrentMeshType = MeshType::Local);
 
         ~Input() override = default;
 
@@ -84,9 +85,9 @@ public:
 
         VariableType mpVariable;
 
-        ContainerType mContainerType;
+        Globals::DataLocation mDataLocation;
 
-        const MeshType mMeshType;
+        MeshType mMeshType;
 
         ///@}
 
@@ -107,8 +108,8 @@ public:
         Output(
             ModelPart& rModelPart,
             const VariableType& rVariable,
-            const ContainerType& rContainerType,
-            MeshType rMeshType = MeshType::Local);
+            Globals::DataLocation CurrentLocation,
+            MeshType CurrentMeshType = MeshType::Local);
 
         ~Output() override = default;
 
@@ -128,7 +129,7 @@ public:
 
         VariableType mpVariable;
 
-        ContainerType mContainerType;
+        Globals::DataLocation mDataLocation;
 
         MeshType mMeshType;
 

--- a/kratos/expression/literal_expression_input.h
+++ b/kratos/expression/literal_expression_input.h
@@ -23,6 +23,7 @@
 #include "expression_io.h"
 #include "includes/define.h"
 #include "includes/model_part.h"
+#include "includes/global_variables.h"
 
 namespace Kratos {
 
@@ -72,8 +73,8 @@ public:
         Input(
             const ModelPart& rModelPart,
             const DataType& rValue,
-            const ContainerType& rContainerType,
-            const MeshType& rMeshType = MeshType::Local);
+            Globals::DataLocation CurrentLocation,
+            MeshType CurrentMeshType = MeshType::Local);
 
         ~Input() override = default;
 
@@ -89,13 +90,13 @@ public:
         ///@name Private member variables
         ///@{
 
-        const ModelPart& mrModelPart;
+        ModelPart const * mpModelPart;
 
-        const DataType mValue;
+        DataType mValue;
 
-        const ContainerType mContainerType;
+        Globals::DataLocation mDataLocation;
 
-        const MeshType mMeshType;
+        MeshType mMeshType;
 
         ///@}
 

--- a/kratos/expression/traits.h
+++ b/kratos/expression/traits.h
@@ -22,13 +22,4 @@ enum MeshType {
     Interface
 }; // enum MeshType
 
-enum ContainerType
-{
-    NodalHistorical,
-    NodalNonHistorical,
-    ConditionNonHistorical,
-    ElementNonHistorical
-}; // enum ContainerType
-
-
 } // namespace Kratos

--- a/kratos/expression/variable_expression_io.cpp
+++ b/kratos/expression/variable_expression_io.cpp
@@ -25,41 +25,32 @@ namespace Kratos {
 VariableExpressionIO::Input::Input(
     const ModelPart& rModelPart,
     const VariableType& rVariable,
-    const ContainerType& rContainerType,
-    const MeshType& rMeshType)
-    : mrModelPart(rModelPart),
+    Globals::DataLocation CurrentLocation,
+    MeshType CurrentMeshType)
+    : mpModelPart(&rModelPart),
       mpVariable(rVariable),
-      mContainerType(rContainerType),
-      mMeshType(rMeshType)
+      mDataLocation(CurrentLocation),
+      mMeshType(CurrentMeshType)
 {
 }
 
 Expression::Pointer VariableExpressionIO::Input::Execute() const
 {
-    const auto& r_mesh = ExpressionIOUtils::GetMesh(mrModelPart.GetCommunicator(), mMeshType);
-    const auto& r_data_communicator = mrModelPart.GetCommunicator().GetDataCommunicator();
+    const auto& r_mesh = ExpressionIOUtils::GetMesh(mpModelPart->GetCommunicator(), mMeshType);
+    const auto& r_data_communicator = mpModelPart->GetCommunicator().GetDataCommunicator();
 
-    switch (mContainerType) {
-        case ContainerType::NodalHistorical: {
-                return ExpressionIOUtils::ReadToExpression<ModelPart::NodesContainerType, ContainerDataIO<ContainerDataIOTags::Historical>, const VariableType>(r_mesh.Nodes(), mpVariable, r_data_communicator);
-                break;
-            }
-        case ContainerType::NodalNonHistorical: {
-                return ExpressionIOUtils::ReadToExpression<ModelPart::NodesContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Nodes(), mpVariable, r_data_communicator);
-                break;
-            }
-        case ContainerType::ConditionNonHistorical: {
-                return ExpressionIOUtils::ReadToExpression<ModelPart::ConditionsContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Conditions(), mpVariable, r_data_communicator);
-                break;
-            }
-        case ContainerType::ElementNonHistorical: {
-                return ExpressionIOUtils::ReadToExpression<ModelPart::ElementsContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Elements(), mpVariable, r_data_communicator);
-                break;
-            }
-        default: {
-                KRATOS_ERROR << "Invalid container type";
+    switch (mDataLocation) {
+        case Globals::DataLocation::NodeHistorical:
+            return ExpressionIOUtils::ReadToExpression<ModelPart::NodesContainerType, ContainerDataIO<ContainerDataIOTags::Historical>, const VariableType>(r_mesh.Nodes(), mpVariable, r_data_communicator);
+        case Globals::DataLocation::NodeNonHistorical:
+            return ExpressionIOUtils::ReadToExpression<ModelPart::NodesContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Nodes(), mpVariable, r_data_communicator);
+        case Globals::DataLocation::Condition:
+            return ExpressionIOUtils::ReadToExpression<ModelPart::ConditionsContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Conditions(), mpVariable, r_data_communicator);
+        case Globals::DataLocation::Element:
+            return ExpressionIOUtils::ReadToExpression<ModelPart::ElementsContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Elements(), mpVariable, r_data_communicator);
+        default:
+            KRATOS_ERROR << "Invalid container type. Only supports NodeHistorical, NodeNonHistorical, Condition, Element.";
             break;
-        }
     }
 
     return nullptr;
@@ -68,33 +59,36 @@ Expression::Pointer VariableExpressionIO::Input::Execute() const
 VariableExpressionIO::Output::Output(
     ModelPart& rModelPart,
     const VariableType& rVariable,
-    const ContainerType& rContainerType,
-    MeshType  rMeshType)
-    : mrModelPart(rModelPart),
+    Globals::DataLocation CurrentLocation,
+    MeshType CurrentMeshType)
+    : mpModelPart(&rModelPart),
       mpVariable(rVariable),
-      mContainerType(rContainerType),
-      mMeshType(rMeshType)
+      mDataLocation(CurrentLocation),
+      mMeshType(CurrentMeshType)
 {
 }
 
 void VariableExpressionIO::Output::Execute(const Expression& rExpression)
 {
     KRATOS_TRY
-    auto& r_communicator = mrModelPart.GetCommunicator();
+    auto& r_communicator = mpModelPart->GetCommunicator();
     auto& r_mesh = ExpressionIOUtils::GetMesh(r_communicator, mMeshType);
 
-    switch (mContainerType) {
-        case ContainerType::NodalHistorical:
+    switch (mDataLocation) {
+        case Globals::DataLocation::NodeHistorical:
             ExpressionIOUtils::WriteFromExpression<ModelPart::NodesContainerType, ContainerDataIO<ContainerDataIOTags::Historical>, const VariableType>(r_mesh.Nodes(), r_communicator, rExpression, mpVariable);
             break;
-        case ContainerType::NodalNonHistorical:
+        case Globals::DataLocation::NodeNonHistorical:
             ExpressionIOUtils::WriteFromExpression<ModelPart::NodesContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Nodes(), r_communicator, rExpression, mpVariable);
             break;
-        case ContainerType::ConditionNonHistorical:
+        case Globals::DataLocation::Condition:
             ExpressionIOUtils::WriteFromExpression<ModelPart::ConditionsContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Conditions(), r_communicator, rExpression, mpVariable);
             break;
-        case ContainerType::ElementNonHistorical:
+        case Globals::DataLocation::Element:
             ExpressionIOUtils::WriteFromExpression<ModelPart::ElementsContainerType, ContainerDataIO<ContainerDataIOTags::NonHistorical>, const VariableType>(r_mesh.Elements(), r_communicator, rExpression, mpVariable);
+            break;
+        default:
+            KRATOS_ERROR << "Invalid container type. Only supports NodeHistorical, NodeNonHistorical, Condition, Element.";
             break;
     }
     KRATOS_CATCH("");
@@ -108,8 +102,8 @@ void VariableExpressionIO::Read(
 {
     auto p_expression =
         Input(rContainerExpression.GetModelPart(), rVariable,
-                                IsHistorical ? ContainerType::NodalHistorical
-                                             : ContainerType::NodalNonHistorical,
+                                IsHistorical ? Globals::DataLocation::NodeHistorical
+                                             : Globals::DataLocation::NodeNonHistorical,
                                 TMeshType)
             .Execute();
 
@@ -128,8 +122,8 @@ void VariableExpressionIO::Read(
     auto p_expression =
         Input(rContainerExpression.GetModelPart(), rVariable,
                                 std::is_same_v<TContainerType, ModelPart::ConditionsContainerType>
-                                    ? ContainerType::ConditionNonHistorical
-                                    : ContainerType::ElementNonHistorical,
+                                    ? Globals::DataLocation::Condition
+                                    : Globals::DataLocation::Element,
                                 TMeshType)
             .Execute();
 
@@ -143,8 +137,8 @@ void VariableExpressionIO::Write(
     const bool IsHistorical)
 {
     Output(*rContainerExpression.pGetModelPart(), rVariable,
-                             IsHistorical ? ContainerType::NodalHistorical
-                                          : ContainerType::NodalNonHistorical,
+                             IsHistorical ? Globals::DataLocation::NodeHistorical
+                                          : Globals::DataLocation::NodeNonHistorical,
                              TMeshType)
         .Execute(rContainerExpression.GetExpression());
 }
@@ -160,8 +154,8 @@ void VariableExpressionIO::Write(
 
     Output(*rContainerExpression.pGetModelPart(), rVariable,
                              std::is_same_v<TContainerType, ModelPart::ConditionsContainerType>
-                                 ? ContainerType::ConditionNonHistorical
-                                 : ContainerType::ElementNonHistorical,
+                                 ? Globals::DataLocation::Condition
+                                 : Globals::DataLocation::Element,
                              TMeshType)
         .Execute(rContainerExpression.GetExpression());
 }

--- a/kratos/expression/variable_expression_io.h
+++ b/kratos/expression/variable_expression_io.h
@@ -23,6 +23,7 @@
 #include "expression_io.h"
 #include "includes/define.h"
 #include "includes/model_part.h"
+#include "includes/global_variables.h"
 
 namespace Kratos {
 
@@ -62,8 +63,8 @@ public:
         Input(
             const ModelPart& rModelPart,
             const VariableType& rVariable,
-            const ContainerType& rContainerType,
-            const MeshType& rMeshType = MeshType::Local);
+            Globals::DataLocation CurrentLocation,
+            MeshType CurrentMeshType = MeshType::Local);
 
         ~Input() override = default;
 
@@ -79,13 +80,13 @@ public:
         ///@name Private member variables
         ///@{
 
-        const ModelPart& mrModelPart;
+        ModelPart const * mpModelPart;
 
-        const VariableType mpVariable;
+        VariableType mpVariable;
 
-        const ContainerType mContainerType;
+        Globals::DataLocation mDataLocation;
 
-        const MeshType mMeshType;
+        MeshType mMeshType;
 
         ///@}
 
@@ -106,8 +107,8 @@ public:
         Output(
             ModelPart& rModelPart,
             const VariableType& rVariable,
-            const ContainerType& rContainerType,
-            MeshType rMeshType = MeshType::Local);
+            Globals::DataLocation CurrentLocation,
+            MeshType CurrentMeshType = MeshType::Local);
 
         ~Output() override = default;
 
@@ -123,13 +124,13 @@ public:
         ///@name Private member variables
         ///@{
 
-        ModelPart& mrModelPart;
+        ModelPart * mpModelPart;
 
-        const VariableType mpVariable;
+        VariableType mpVariable;
 
-        const ContainerType mContainerType;
+        Globals::DataLocation mDataLocation;
 
-        const MeshType mMeshType;
+        MeshType mMeshType;
 
         ///@}
 

--- a/kratos/python/add_expression_io_to_python.cpp
+++ b/kratos/python/add_expression_io_to_python.cpp
@@ -314,13 +314,6 @@ void AddExpressionIOToPython(pybind11::module& rModule)
         .def("Execute", &ExpressionOutput::Execute)
         ;
 
-    pybind11::enum_<ContainerType>(rModule, "ContainerType")
-        .value("NodalHistorical", ContainerType::NodalHistorical)
-        .value("NodalNonHistorical", ContainerType::NodalNonHistorical)
-        .value("ElementNonHistorical", ContainerType::ElementNonHistorical)
-        .value("ConditionNonHistorical", ContainerType::ConditionNonHistorical)
-        ;
-
     pybind11::enum_<MeshType>(rModule, "MeshType")
         .value("Local", MeshType::Local)
         .value("Interface", MeshType::Interface)

--- a/kratos/python/add_expression_io_to_python.cpp
+++ b/kratos/python/add_expression_io_to_python.cpp
@@ -348,19 +348,19 @@ void AddExpressionIOToPython(pybind11::module& rModule)
     pybind11::class_<IntegrationPointExpressionIO::Input, IntegrationPointExpressionIO::Input::Pointer, ExpressionInput>(integration_point_expression_io, "Input")
         .def(pybind11::init<ModelPart&,
                             const IntegrationPointExpressionIO::VariableType&,
-                            const ContainerType&>(),
+                            Globals::DataLocation>(),
              pybind11::arg("model_part"),
              pybind11::arg("variable"),
-             pybind11::arg("container_type"))
+             pybind11::arg("data_location"))
         ;
 
     pybind11::class_<IntegrationPointExpressionIO::Output, IntegrationPointExpressionIO::Output::Pointer, ExpressionOutput>(integration_point_expression_io, "Output")
         .def(pybind11::init<ModelPart&,
                             const IntegrationPointExpressionIO::VariableType&,
-                            const ContainerType&>(),
+                            Globals::DataLocation>(),
              pybind11::arg("model_part"),
              pybind11::arg("variable"),
-             pybind11::arg("container_type"))
+             pybind11::arg("data_location"))
         ;
 
     auto carray_expression_io = rModule.def_submodule("CArrayExpressionIO");

--- a/kratos/python/add_expression_io_to_python.cpp
+++ b/kratos/python/add_expression_io_to_python.cpp
@@ -404,10 +404,10 @@ void AddExpressionIOToPython(pybind11::module& rModule)
         data_expression_io, "Input")
         .def(pybind11::init<const ModelPart&,
                             const LiteralExpressionIO::DataType&,
-                            const ContainerType&>(),
+                            Globals::DataLocation&>(),
              pybind11::arg("model_part"),
              pybind11::arg("variable"),
-             pybind11::arg("container_type"))
+             pybind11::arg("data_location"))
         ;
 
     auto nodal_expression_io = rModule.def_submodule("NodalPositionExpressionIO");

--- a/kratos/python/add_expression_io_to_python.cpp
+++ b/kratos/python/add_expression_io_to_python.cpp
@@ -330,19 +330,19 @@ void AddExpressionIOToPython(pybind11::module& rModule)
     pybind11::class_<VariableExpressionIO::Input, VariableExpressionIO::Input::Pointer, ExpressionInput>(variable_expression_io, "Input")
         .def(pybind11::init<const ModelPart&,
                             const VariableExpressionIO::VariableType&,
-                            const ContainerType&>(),
+                            Globals::DataLocation>(),
              pybind11::arg("model_part"),
              pybind11::arg("variable"),
-             pybind11::arg("container_type"))
+             pybind11::arg("data_location"))
         ;
 
     pybind11::class_<VariableExpressionIO::Output, VariableExpressionIO::Output::Pointer, ExpressionOutput>(variable_expression_io, "Output")
         .def(pybind11::init<ModelPart&,
                             const VariableExpressionIO::VariableType&,
-                            const ContainerType&>(),
+                            Globals::DataLocation>(),
              pybind11::arg("model_part"),
              pybind11::arg("variable"),
-             pybind11::arg("container_type"))
+             pybind11::arg("data_location"))
         ;
 
     pybind11::class_<IntegrationPointExpressionIO::Input, IntegrationPointExpressionIO::Input::Pointer, ExpressionInput>(integration_point_expression_io, "Input")

--- a/kratos/tests/test_container_expression.py
+++ b/kratos/tests/test_container_expression.py
@@ -764,7 +764,7 @@ class TestContainerExpression(ABC):
         pass
 
     @abstractmethod
-    def _GetContainerType(self) -> Kratos.Expression.ContainerType:
+    def _GetContainerType(self) -> Kratos.Globals.DataLocation:
         pass
 
     @abstractmethod
@@ -791,8 +791,8 @@ class TestHistoricalContainerExpression(kratos_unittest.TestCase, TestContainerE
     def _GetContainerExpression(self) -> Kratos.Expression.NodalExpression:
         return Kratos.Expression.NodalExpression(self.model_part)
 
-    def _GetContainerType(self) -> Kratos.Expression.ContainerType:
-        return Kratos.Expression.ContainerType.NodalHistorical
+    def _GetContainerType(self) -> Kratos.Globals.DataLocation:
+        return Kratos.Globals.DataLocation.NodeHistorical
 
     def _GetContainer(self):
         return self.model_part.GetCommunicator().LocalMesh().Nodes
@@ -814,8 +814,8 @@ class TestNodalContainerExpression(kratos_unittest.TestCase, TestContainerExpres
     def _GetContainerExpression(self) -> Kratos.Expression.NodalExpression:
         return Kratos.Expression.NodalExpression(self.model_part)
 
-    def _GetContainerType(self) -> Kratos.Expression.ContainerType:
-        return Kratos.Expression.ContainerType.NodalNonHistorical
+    def _GetContainerType(self) -> Kratos.Globals.DataLocation:
+        return Kratos.Globals.DataLocation.NodeNonHistorical
 
     def _GetContainer(self):
         return self.model_part.GetCommunicator().LocalMesh().Nodes
@@ -837,8 +837,8 @@ class TestConditionContainerExpression(kratos_unittest.TestCase, TestContainerEx
     def _GetContainerExpression(self) -> Kratos.Expression.ConditionExpression:
         return Kratos.Expression.ConditionExpression(self.model_part)
 
-    def _GetContainerType(self) -> Kratos.Expression.ContainerType:
-        return Kratos.Expression.ContainerType.ConditionNonHistorical
+    def _GetContainerType(self) -> Kratos.Globals.DataLocation:
+        return Kratos.Globals.DataLocation.Condition
 
     def _GetContainer(self):
         return self.model_part.GetCommunicator().LocalMesh().Conditions
@@ -860,8 +860,8 @@ class TestElementContainerExpression(kratos_unittest.TestCase, TestContainerExpr
     def _GetContainerExpression(self):
         return Kratos.Expression.ElementExpression(self.model_part)
 
-    def _GetContainerType(self) -> Kratos.Expression.ContainerType:
-        return Kratos.Expression.ContainerType.ElementNonHistorical
+    def _GetContainerType(self) -> Kratos.Globals.DataLocation:
+        return Kratos.Globals.DataLocation.Element
 
     def _GetContainer(self):
         return self.model_part.GetCommunicator().LocalMesh().Elements


### PR DESCRIPTION
**📝 Description**
This PR removes all the use cases of `Traits::ContainerType` and replaces it with the `Globals::DataLocation`.

**🆕 Changelog**
- Replaces `Traits::ContainerType` with `Globals::DataLocation`
- Updated tests.
