### PR TITLE
Geo/extract extrapolate and smooth results

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -417,8 +417,9 @@ void UPwSmallStrainElement<TDim, TNumNodes>::SetValuesOnIntegrationPoints(const 
 
     if (rVariable == CAUCHY_STRESS_VECTOR) {
         KRATOS_ERROR_IF(rValues.size() != mStressVector.size())
-            << "Unexpected number of values for "
-               "UPwSmallStrainElement::SetValuesOnIntegrationPoints"
+            << "Unexpected number of values "<< rValues.size() << "for "
+               "UPwSmallStrainElement::SetValuesOnIntegrationPoints" <<
+               " wanted " << mStressVector.size()
             << std::endl;
         std::copy(rValues.begin(), rValues.end(), mStressVector.begin());
     } else {

--- a/applications/GeoMechanicsApplication/custom_processes/extrapolate_and_smooth_results_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/extrapolate_and_smooth_results_process.cpp
@@ -46,46 +46,57 @@ namespace Kratos
         //mParameters.RecursivelyValidateAndAssignDefaults(default_parameters);
     }
 
-void ExtrapolateAndSmoothResultsProcess::ExecuteBeforeOutputStep()
-{
+void ExtrapolateAndSmoothResultsProcess::ExecuteInitializeSolutionStep() {
     if (!mrModelPart.GetProcessInfo().Has(NODAL_SMOOTHING) ||
         !mrModelPart.GetProcessInfo()[NODAL_SMOOTHING]) return;
-        // loop over variables from process parameters ( currently CAUCHY_STRESS, DAMAGE_VARIABLE, JOINT_WIDTH, JOINT_DAMAGE )
-        // From parameters find i.p. variable name to extrapolate
-        // check for its existence.
-        // from i.p. variable get its size and then claim memory and fill with zeros
-        const unsigned int dim = mrModelPart.GetProcessInfo()[DOMAIN_SIZE];
-        // bij modellen met structurele elementen en interfaces erin gaat dit mank.
-        const auto stress_tensor_size =
-                dim == N_DIM_3D ? STRESS_TENSOR_SIZE_3D : STRESS_TENSOR_SIZE_2D;
+    // loop over variables from process parameters ( currently CAUCHY_STRESS, DAMAGE_VARIABLE, JOINT_WIDTH, JOINT_DAMAGE )
+    // From parameters find i.p. variable name to extrapolate
+    // check for its existence.
+    // from i.p. variable get its size and then claim memory and fill with zeros
+    const unsigned int dim = mrModelPart.GetProcessInfo()[DOMAIN_SIZE];
+    // bij modellen met structurele elementen en interfaces erin gaat dit mank.
+    const auto stress_tensor_size =
+            dim == N_DIM_3D ? STRESS_TENSOR_SIZE_3D : STRESS_TENSOR_SIZE_2D;
 
-        // Clear nodal variables
-        Matrix zero_nodal_stress_tensor = zero_matrix(stress_tensor_size, stress_tensor_size);
-        block_for_each(mrModelPart.Nodes(), [&zero_nodal_stress_tensor](Node &rNode) {
-            rNode.FastGetSolutionStepValue(NODAL_AREA)                 = 0.0;
-            rNode.FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR) = zero_nodal_stress_tensor;
-        });
-/*
-        // Walk the elements and extrapolate values to nodes
-        block_for_each(mrModelPart.Elements(), [](Element& rElement)
-        {
-            // Walk integration points and retrieve i.p. result
-            // extrapolate those to element nodes
-            // add element nodal values to system nodal vector
-        }
-        // Compute smoothed nodal variables
-        block_for_each(mrModelPart.Nodes(), [](Node& rNode)
-        {
-            if (const double& nodal_area = rNode.FastGetSolutionStepValue(NODAL_AREA);
-                    nodal_area > 1.0e-20)
-            {
-                const double inv_nodal_area = 1.0 / nodal_area;
-                rNode.FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR) *= inv_nodal_area;
-            }
-        });
+    // Clear nodal variables
+    Matrix zero_nodal_stress_tensor = zero_matrix(stress_tensor_size, stress_tensor_size);
+    block_for_each(mrModelPart.Nodes(), [&zero_nodal_stress_tensor](Node &rNode) {
+        rNode.FastGetSolutionStepValue(NODAL_AREA)                 = 0.0;
+        rNode.FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR) = zero_nodal_stress_tensor;
+    });
+}
 
-    }
+void ExtrapolateAndSmoothResultsProcess::ExecuteBeforeOutputStep(){
+    if (!mrModelPart.GetProcessInfo().Has(NODAL_SMOOTHING) ||
+        !mrModelPart.GetProcessInfo()[NODAL_SMOOTHING]) return;
+    /*
+    dit element deel laat ik nog even staan in de element FinalizeSolutionStepActiveEntities. Daar moet het later wel uit.
+    const auto stress_vector_size =
+        mrModelPart.GetProcessInfo()[DOMAIN_SIZE] == N_DIM_3D ? VOIGT_SIZE_3D : VOIGT_SIZE_2D_PLANE_STRAIN;
+
+    // Walk the elements and extrapolate values to nodes
+    block_for_each(mrModelPart.Elements(), [&stress_vector_size, this](Element& rElement)
+    {
+        // get the element integration point variables
+        //Matrix all_ip_stress_vectors(rElement.GetGeometry().IntegrationPointsNumber(rElement.GetIntegrationMethod()),stress_vector_size);
+        std::vector<Vector> all_ip_stress_vectors(stress_vector_size);
+        all_ip_stress_vectors.resize(rElement.GetGeometry().IntegrationPointsNumber(rElement.GetIntegrationMethod()));
+        rElement.CalculateOnIntegrationPoints(CAUCHY_STRESS_VECTOR, all_ip_stress_vectors, mrModelPart.GetProcessInfo());
+        // extrapolate those to element nodes
+        // add element nodal values to system nodal vector
+    });Exe
     */
+    // Compute smoothed nodal variables
+    block_for_each(mrModelPart.Nodes(), [](Node& rNode)
+    {
+        if (const double& nodal_area = rNode.FastGetSolutionStepValue(NODAL_AREA);
+                nodal_area > 1.0e-20) {
+            const double inv_nodal_area = 1.0 / nodal_area;
+            rNode.FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR) *= inv_nodal_area;
+            KRATOS_INFO("ExtrapolateAndSmoothResultsProcess::ExecuteBeforeOutputStep") << "sig = " << rNode.FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR) << std::endl;
+        }
+    });
+
 }
 
 } // namespace Kratos.

--- a/applications/GeoMechanicsApplication/custom_processes/extrapolate_and_smooth_results_process.cpp
+++ b/applications/GeoMechanicsApplication/custom_processes/extrapolate_and_smooth_results_process.cpp
@@ -1,0 +1,91 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Wijtze Pieter Kikstra
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "extrapolate_and_smooth_results_process.hpp"
+
+#include "geo_mechanics_application_variables.h"
+
+
+namespace Kratos
+{
+
+    ExtrapolateAndSmoothResultsProcess::ExtrapolateAndSmoothResultsProcess(ModelPart& rModelPart,
+        const Parameters& rSettings)
+        : Process(),
+        mrModelPart(rModelPart),
+        mParameters(rSettings)
+    {
+        // function type: python, cpp, input
+        const Parameters default_parameters(R"(
+        {
+            "help"              : "This process sets a parameter field on a model part, where each element can have different material properties.",
+            "model_part_name"   : "please_specify_model_part_name",
+            "variable_name"     : "CUSTOM",
+            "func_type"         : "input",               
+            "function"          : "0",
+            "dataset"           : "dummy",
+            "dataset_file_name" : "dummy",
+            "vector_variable_indices"      : []
+        }  )"
+        );
+
+        //mParameters.RecursivelyValidateAndAssignDefaults(default_parameters);
+    }
+
+void ExtrapolateAndSmoothResultsProcess::ExecuteBeforeOutputStep()
+{
+    if (!mrModelPart.GetProcessInfo().Has(NODAL_SMOOTHING) ||
+        !mrModelPart.GetProcessInfo()[NODAL_SMOOTHING]) return;
+        // loop over variables from process parameters ( currently CAUCHY_STRESS, DAMAGE_VARIABLE, JOINT_WIDTH, JOINT_DAMAGE )
+        // From parameters find i.p. variable name to extrapolate
+        // check for its existence.
+        // from i.p. variable get its size and then claim memory and fill with zeros
+        const unsigned int dim = mrModelPart.GetProcessInfo()[DOMAIN_SIZE];
+        // bij modellen met structurele elementen en interfaces erin gaat dit mank.
+        const auto stress_tensor_size =
+                dim == N_DIM_3D ? STRESS_TENSOR_SIZE_3D : STRESS_TENSOR_SIZE_2D;
+
+        // Clear nodal variables
+        Matrix zero_nodal_stress_tensor = zero_matrix(stress_tensor_size, stress_tensor_size);
+        block_for_each(mrModelPart.Nodes(), [&zero_nodal_stress_tensor](Node &rNode) {
+            rNode.FastGetSolutionStepValue(NODAL_AREA)                 = 0.0;
+            rNode.FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR) = zero_nodal_stress_tensor;
+        });
+/*
+        // Walk the elements and extrapolate values to nodes
+        block_for_each(mrModelPart.Elements(), [](Element& rElement)
+        {
+            // Walk integration points and retrieve i.p. result
+            // extrapolate those to element nodes
+            // add element nodal values to system nodal vector
+        }
+        // Compute smoothed nodal variables
+        block_for_each(mrModelPart.Nodes(), [](Node& rNode)
+        {
+            if (const double& nodal_area = rNode.FastGetSolutionStepValue(NODAL_AREA);
+                    nodal_area > 1.0e-20)
+            {
+                const double inv_nodal_area = 1.0 / nodal_area;
+                rNode.FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR) *= inv_nodal_area;
+            }
+        });
+
+    }
+    */
+}
+
+} // namespace Kratos.

--- a/applications/GeoMechanicsApplication/custom_processes/extrapolate_and_smooth_results_process.hpp
+++ b/applications/GeoMechanicsApplication/custom_processes/extrapolate_and_smooth_results_process.hpp
@@ -62,8 +62,10 @@ namespace Kratos {
         ///@{
 
         /**
-         * \brief  Initializes the set parameter field process. Checks if the value that needs to be changed is a UMAT_PARAMETERS(so Vector) or double.
+         * \brief  Initializes the ExtrapolateAndSmoothProcess, prepares nodal zero vectors for needed variables
          */
+        void ExecuteInitializeSolutionStep() override;
+
         void ExecuteBeforeOutputStep() override;
 
         ///@}

--- a/applications/GeoMechanicsApplication/custom_processes/extrapolate_and_smooth_results_process.hpp
+++ b/applications/GeoMechanicsApplication/custom_processes/extrapolate_and_smooth_results_process.hpp
@@ -1,0 +1,100 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Wijtze Pieter Kikstra
+//
+
+#pragma once
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define.h"
+#include "processes/process.h"
+#include "includes/model_part.h"
+#include "includes/kratos_parameters.h"
+
+namespace Kratos {
+
+    ///@name Kratos Globals
+    ///@{
+
+    ///@name Kratos Classes
+    ///@{
+
+
+    /**
+     * @class ExtrapolateAndSmoothProcess
+     * @ingroup GeoMechanicsApplication
+     * @brief Process to extrapolate results from integration points to nodes and average/smooth the nodal values.
+     * @details For linear elements, results are extrapolated from integration points to nodes and their weight ( area or
+     * volume ) is accumulated. On the nodes the results are then scaled back using the accumulated weight.
+     * @author Wijtze Pieter Kikstra
+    */
+    class KRATOS_API(GEO_MECHANICS_APPLICATION) ExtrapolateAndSmoothResultsProcess : public Process
+    {
+    public:
+        ///@name Type Definitions
+        ///@{
+
+        ///@}
+
+        ///@name Pointer Definitions
+        /// Pointer definition of ExtrapolateAndSmoothProcess
+        KRATOS_CLASS_POINTER_DEFINITION(ExtrapolateAndSmoothResultsProcess);
+
+        ///@}
+        ///@name Life Cycle
+        ///@{
+
+        ExtrapolateAndSmoothResultsProcess(ModelPart& rModelPart, const Parameters& rParameters);
+
+        ///@}
+        ///@name Operations
+        ///@{
+
+        /**
+         * \brief  Initializes the set parameter field process. Checks if the value that needs to be changed is a UMAT_PARAMETERS(so Vector) or double.
+         */
+        void ExecuteBeforeOutputStep() override;
+
+        ///@}
+        ///@name Input and output
+        ///@{
+
+        /// Turn back information as a string.
+        std::string Info() const override {
+            return "ExtrapolateAndSmoothResultsProcess";
+        }
+        ///@}
+
+    private:
+        ///@name Member Variables
+        ///@{
+
+        ModelPart& mrModelPart;
+        Parameters mParameters;
+
+        ///@}
+        ///@name Private Operations
+        ///@{
+
+        ///@}
+        ///@name Serialization
+        ///@{
+
+        ///@}
+
+    }; // Class ExtrapolateAndSmoothProcess
+
+    ///@}
+
+}  // namespace Kratos.

--- a/applications/GeoMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/GeoMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
@@ -161,6 +161,11 @@ void  AddCustomProcessesToPython(pybind11::module& m)
     py::class_<ApplyNormalLoadTableProcess, ApplyNormalLoadTableProcess::Pointer, Process>
         (m, "ApplyNormalLoadTableProcess")
         .def(py::init<ModelPart&, const Parameters&>());
+
+    //py::class_<ExtrapolateAndSmoothResultsProcess, ExtrapolateAndSmoothResultsProcess::Pointer, Process>
+    //        (m, "ExtrapolateAndSmoothResultsProcess")
+    //        .def(py::init<ModelPart&, const Parameters&>());
+
 }
 
 } // Namespace Kratos::Python.

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_extrapolate_and_smooth_results_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_extrapolate_and_smooth_results_process.cpp
@@ -1,0 +1,88 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Richard Faasse
+//                   Wijtze Pieter Kikstra
+//
+
+#include "testing/testing.h"
+#include "custom_processes/extrapolate_and_smooth_results_process.hpp"
+#include "containers/model.h"
+#include "geo_mechanics_application_variables.h"
+
+using namespace Kratos;
+namespace Kratos::Testing {
+
+namespace {
+
+ModelPart& CreateValidModelPart(Model& rModel)
+{
+    auto& result = rModel.CreateModelPart("dummy", 2);
+    result.AddNodalSolutionStepVariable(NODAL_AREA);
+    result.AddNodalSolutionStepVariable(NODAL_CAUCHY_STRESS_TENSOR);
+    auto pNode = result.CreateNewNode(1, 0., 0., 0.);
+    result.GetProcessInfo()[DOMAIN_SIZE] = 3;
+    pNode->FastGetSolutionStepValue(NODAL_AREA) = 20.;
+    Matrix unit_nodal_stress_tensor = identity_matrix<double>(result.GetProcessInfo()[DOMAIN_SIZE]);
+    pNode->FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR) = unit_nodal_stress_tensor;
+
+    return result;
+}
+
+} // namespace
+
+
+KRATOS_TEST_CASE_IN_SUITE(CreateExtrapolateAndSmoothProcess, KratosGeoMechanicsFastSuite) {
+    Model model;
+    auto& model_part = CreateValidModelPart(model);
+    const Parameters settings;
+
+    bool has_thrown = false;
+    try{
+        ExtrapolateAndSmoothResultsProcess my_process(model_part, settings);
+    }
+    catch(...){
+        has_thrown = true;
+    }
+    KRATOS_EXPECT_FALSE(has_thrown)
+}
+
+KRATOS_TEST_CASE_IN_SUITE(CheckNodalAreaAndStressSetToZero, KratosGeoMechanicsFastSuite) {
+    Model model;
+    auto& model_part = CreateValidModelPart(model);
+    model_part.GetProcessInfo().SetValue(NODAL_SMOOTHING, true);
+    const Parameters settings;
+
+    ExtrapolateAndSmoothResultsProcess my_process(model_part, settings);
+
+    my_process.ExecuteBeforeOutputStep();
+    const auto node1_area = model_part.GetNode(1).FastGetSolutionStepValue(NODAL_AREA);
+    KRATOS_EXPECT_DOUBLE_EQ(node1_area, 0.);
+    const auto node1_stress = model_part.GetNode(1).FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR);
+    KRATOS_EXPECT_DOUBLE_EQ(node1_stress(2,2),0.);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(CheckProcesInfoNodalSmoothingNotSet, KratosGeoMechanicsFastSuite) {
+    Model model;
+    auto& model_part = CreateValidModelPart(model);
+    Parameters settings;
+
+    ExtrapolateAndSmoothResultsProcess my_process(model_part, settings);
+    my_process.ExecuteBeforeOutputStep();
+
+    // The wrong value of 20 set in the model_part initialization should remain.
+    const auto node1_area = model_part.GetNode(1).FastGetSolutionStepValue(NODAL_AREA);
+    KRATOS_EXPECT_DOUBLE_EQ(node1_area, 20.);
+    // The wrong value of unity matrix in the model_part initialization should remain.
+    const auto node1_stress = model_part.GetNode(1).FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR);
+    KRATOS_EXPECT_DOUBLE_EQ(node1_stress(0,0), 1.);
+
+}
+
+}

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_extrapolate_and_smooth_results_process.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_extrapolate_and_smooth_results_process.cpp
@@ -15,6 +15,8 @@
 #include "custom_processes/extrapolate_and_smooth_results_process.hpp"
 #include "containers/model.h"
 #include "geo_mechanics_application_variables.h"
+#include "processes/structured_mesh_generator_process.h"
+#include "custom_constitutive/linear_elastic_plane_strain_2D_law.h"
 
 using namespace Kratos;
 namespace Kratos::Testing {
@@ -31,6 +33,57 @@ ModelPart& CreateValidModelPart(Model& rModel)
     pNode->FastGetSolutionStepValue(NODAL_AREA) = 20.;
     Matrix unit_nodal_stress_tensor = identity_matrix<double>(result.GetProcessInfo()[DOMAIN_SIZE]);
     pNode->FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR) = unit_nodal_stress_tensor;
+
+    return result;
+}
+
+ModelPart& CreateValidMeshedModelPart(Model& rModel)
+{
+    auto& result = rModel.CreateModelPart("dummy_mesh", 2);
+
+    // add variables to model part before meshing, these need to be there for the FinalizeSolutionStep of the UPw element
+    result.AddNodalSolutionStepVariable(NODAL_AREA);
+    result.AddNodalSolutionStepVariable(NODAL_CAUCHY_STRESS_TENSOR);
+
+    result.AddNodalSolutionStepVariable(NODAL_DAMAGE_VARIABLE);
+
+
+    result.AddNodalSolutionStepVariable(DISPLACEMENT);
+    result.AddNodalSolutionStepVariable(WATER_PRESSURE);
+    result.AddNodalSolutionStepVariable(VELOCITY);
+    result.AddNodalSolutionStepVariable(DT_WATER_PRESSURE);
+    result.AddNodalSolutionStepVariable(VOLUME_ACCELERATION);
+    result.AddNodalSolutionStepVariable(HYDRAULIC_DISCHARGE);
+
+    // Set up the test model part mesh
+    // For some strange reason counterclockwise gives a negative area, so I used clockwise here
+    auto p_point_1 = Kratos::make_intrusive<Node>(1, 1.0, 0.0, 0.0);
+    auto p_point_2 = Kratos::make_intrusive<Node>(2, 1.0, 2.0, 0.0);
+    auto p_point_3 = Kratos::make_intrusive<Node>(3, 3.0, 2.0, 0.0);
+    auto p_point_4 = Kratos::make_intrusive<Node>(4, 3.0, 0.0, 0.0);
+    Quadrilateral2D4<Node> domain_geometry(p_point_1, p_point_2, p_point_3, p_point_4);
+
+    Parameters mesher_parameters(R"({"number_of_divisions": 2,
+                                              "element_name": "UPwSmallStrainElement2D3N",
+                                              "condition_name": "LineCondition",
+                                              "create_skin_sub_model_part": true
+    })");
+    StructuredMeshGeneratorProcess(domain_geometry, result, mesher_parameters).Execute();
+
+    auto p_linear_law            = std::make_shared<GeoLinearElasticPlaneStrain2DLaw>();
+    auto& r_model_part_properties = result.GetProperties(0);
+    r_model_part_properties.SetValue(CONSTITUTIVE_LAW, p_linear_law);
+
+    // Provide every element with a CAUCHY_STRESS_VECTOR for its integration points
+    Vector one_ip_stress_vector(VOIGT_SIZE_2D_PLANE_STRAIN, 2.0);
+    for (auto& rElement : result.Elements()) {
+        rElement.Initialize(result.GetProcessInfo());
+        std::vector<Vector> all_ip_stress_vectors;
+        for (auto i = 0; i < rElement.GetGeometry().IntegrationPointsNumber(rElement.GetIntegrationMethod()); ++i) {
+            all_ip_stress_vectors.push_back(one_ip_stress_vector);
+        }
+        rElement.SetValuesOnIntegrationPoints(CAUCHY_STRESS_VECTOR, all_ip_stress_vectors, result.GetProcessInfo());
+    }
 
     return result;
 }
@@ -61,7 +114,7 @@ KRATOS_TEST_CASE_IN_SUITE(CheckNodalAreaAndStressSetToZero, KratosGeoMechanicsFa
 
     ExtrapolateAndSmoothResultsProcess my_process(model_part, settings);
 
-    my_process.ExecuteBeforeOutputStep();
+    my_process.ExecuteInitializeSolutionStep();
     const auto node1_area = model_part.GetNode(1).FastGetSolutionStepValue(NODAL_AREA);
     KRATOS_EXPECT_DOUBLE_EQ(node1_area, 0.);
     const auto node1_stress = model_part.GetNode(1).FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR);
@@ -74,7 +127,7 @@ KRATOS_TEST_CASE_IN_SUITE(CheckProcesInfoNodalSmoothingNotSet, KratosGeoMechanic
     Parameters settings;
 
     ExtrapolateAndSmoothResultsProcess my_process(model_part, settings);
-    my_process.ExecuteBeforeOutputStep();
+    my_process.ExecuteInitializeSolutionStep();
 
     // The wrong value of 20 set in the model_part initialization should remain.
     const auto node1_area = model_part.GetNode(1).FastGetSolutionStepValue(NODAL_AREA);
@@ -83,6 +136,45 @@ KRATOS_TEST_CASE_IN_SUITE(CheckProcesInfoNodalSmoothingNotSet, KratosGeoMechanic
     const auto node1_stress = model_part.GetNode(1).FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR);
     KRATOS_EXPECT_DOUBLE_EQ(node1_stress(0,0), 1.);
 
+}
+
+KRATOS_TEST_CASE_IN_SUITE(CheckCauchyStressVectorPresentInIntegrationPoints, KratosGeoMechanicsFastSuite) {
+    Model model;
+    auto& model_part = CreateValidMeshedModelPart(model);
+    Parameters settings;
+    std::vector<Vector> all_ip_stress_vectors;
+
+    // Get Cauchy stresses ( the Calculate does not calculate, only retrieve )
+    model_part.GetElement(4).CalculateOnIntegrationPoints(CAUCHY_STRESS_VECTOR, all_ip_stress_vectors, model_part.GetProcessInfo());
+
+    KRATOS_EXPECT_DOUBLE_EQ(2.0, all_ip_stress_vectors[2][3]);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(CheckSummedNodalAreaAndAveragedStressTensor, KratosGeoMechanicsFastSuite) {
+    Model model;
+    auto& model_part = CreateValidMeshedModelPart(model);
+
+    model_part.GetProcessInfo().SetValue(NODAL_SMOOTHING, true);
+    const Parameters settings;
+    ExtrapolateAndSmoothResultsProcess my_process(model_part, settings);
+    my_process.ExecuteInitializeSolutionStep();
+
+    // loop over the elements calling the FinalizeSolutionStep
+    for (auto& rElement : model_part.Elements()) {
+        rElement.FinalizeSolutionStep(model_part.GetProcessInfo());
+    }
+
+    my_process.ExecuteBeforeOutputStep();
+
+    KRATOS_EXPECT_DOUBLE_EQ(1.0, model_part.GetNode(1).FastGetSolutionStepValue(NODAL_AREA));
+    KRATOS_EXPECT_DOUBLE_EQ(1.5, model_part.GetNode(2).FastGetSolutionStepValue(NODAL_AREA));
+    KRATOS_EXPECT_DOUBLE_EQ(0.5, model_part.GetNode(3).FastGetSolutionStepValue(NODAL_AREA));
+    KRATOS_EXPECT_DOUBLE_EQ(3.0, model_part.GetNode(5).FastGetSolutionStepValue(NODAL_AREA));
+
+    KRATOS_EXPECT_NEAR(2.0, model_part.GetNode(1).FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR)(0,0), 1.E-6);
+    KRATOS_EXPECT_NEAR(2.0, model_part.GetNode(2).FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR)(0,0), 1.E-6);
+    KRATOS_EXPECT_NEAR(2.0, model_part.GetNode(3).FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR)(0,0), 1.E-6);
+    KRATOS_EXPECT_NEAR(2.0, model_part.GetNode(5).FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR)(0,0), 1.E-6);
 }
 
 }


### PR DESCRIPTION
**📝 Description**
In the NewmarkQuasistaticUPwScheme::FinalizeSolutionStep, nodal smoothing functionality is found. At first glance this does not seem the correct position for functionality which is done to make output look more smooth. An investigation is needed to find a more suitable location for nodal smoothing.

Likely all was a straight copy from PoroMechanics. Its code is almost identical for the extrapolation to and smoothing in nodes.

The processes have ExecuteBeforeOutputStep. That seems a more logical place to take the following steps:

set nodal vectors for NODAL_AREA, CAUCHY_STRESS_TENSOR and NODAL_DAMAGE_VARIABLE to zero ( for the continuum element results of Cauchy stress and damage.
set nodal vectors for NODAL_JOINT_AREA, NODAL_JOINT_WIDTH and NODAL_JOINT_DAMAGE to zero ( for the interface element results Joint with and joint damage )
ask the elements to extrapolate these variables from integration points to nodes
accumulate these element nodal values on the nodal vector
do the averaging for the nodal vector ( division by nodal area )
So creating a process that implements nodal smoothing in ExecuteBeforeOutputStep ( see analysis_stage.py line 170 )

To leave the implementation in the upw_small_strain_element and the corresponding interface element intact until the elements have been further analyzed for restructuring, the setting of nodal variables to zero takes places in ExecuteInitializeSolutionStep. The nodal averaging takes place in ExeccuteBeforeOutputStep. In between those the ExecuteFinalizeSolutionStep of the elements brings the integration point results to nodes.

Current testing is non existing. Although for some continuum element tests under test_elements.py NODAL_CAUCHY_STRESS_TENSOR is asked for in the ProjectParameters.json files, none of these are checked against a desired value. I have not found any interface tests that try to use the functionality. For damage variables there is no checking either, the tests in which the result is requested contain linear materials.

To saveguard the work done sofar, Wijtze Pieter will publish his branch and link this issue.