### PR TITLE
[GeoMechanicsApplication] Settlement output file is not closed on error

### DIFF
--- a/applications/GeoMechanicsApplication/custom_workflows/scoped_output_file_access.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/scoped_output_file_access.cpp
@@ -1,0 +1,30 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Anne van de Graaf
+//
+
+#include "scoped_output_file_access.h"
+#include "strategy_wrapper.hpp"
+
+namespace Kratos
+{
+
+ScopedOutputFileAccess::ScopedOutputFileAccess(StrategyWrapper& rStrategyWrapper)
+    : mrStrategyWrapper{rStrategyWrapper}
+{
+    mrStrategyWrapper.InitializeOutput();
+}
+
+ScopedOutputFileAccess::~ScopedOutputFileAccess()
+{
+    mrStrategyWrapper.FinalizeOutput();
+}
+
+} // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_workflows/scoped_output_file_access.h
+++ b/applications/GeoMechanicsApplication/custom_workflows/scoped_output_file_access.h
@@ -1,0 +1,34 @@
+// KRATOS___
+//     //   ) )
+//    //         ___      ___
+//   //  ____  //___) ) //   ) )
+//  //    / / //       //   / /
+// ((____/ / ((____   ((___/ /  MECHANICS
+//
+//  License:         geo_mechanics_application/license.txt
+//
+//  Main authors:    Anne van de Graaf
+//
+
+#pragma once
+
+namespace Kratos
+{
+
+class StrategyWrapper;
+
+class ScopedOutputFileAccess
+{
+public:
+    explicit ScopedOutputFileAccess(StrategyWrapper& rStrategyWrapper);
+    ~ScopedOutputFileAccess();
+    ScopedOutputFileAccess(const ScopedOutputFileAccess&)            = delete;
+    ScopedOutputFileAccess& operator=(const ScopedOutputFileAccess&) = delete;
+    ScopedOutputFileAccess(ScopedOutputFileAccess&&)                 = delete;
+    ScopedOutputFileAccess& operator=(ScopedOutputFileAccess&&)      = delete;
+
+private:
+    StrategyWrapper& mrStrategyWrapper;
+};
+
+} // namespace Kratos

--- a/applications/GeoMechanicsApplication/custom_workflows/solving_strategy_wrapper.hpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/solving_strategy_wrapper.hpp
@@ -48,9 +48,10 @@ public:
 
     double GetEndTime() const override { return mrModelPart.GetProcessInfo()[TIME]; }
 
-    void Initialize() override
+    void Initialize() override { mpStrategy->Initialize(); }
+
+    void InitializeOutput() override
     {
-        mpStrategy->Initialize();
         const auto gid_output_settings =
             mProjectParameters["output_processes"]["gid_output"][0]["Parameters"];
         mWriter = std::make_unique<GeoOutputWriter>(

--- a/applications/GeoMechanicsApplication/custom_workflows/strategy_wrapper.hpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/strategy_wrapper.hpp
@@ -38,6 +38,7 @@ public:
     virtual void                      OutputProcess()                               = 0;
 
     virtual void                               Initialize()             = 0;
+    virtual void                               InitializeOutput()       = 0;
     virtual void                               InitializeSolutionStep() = 0;
     virtual void                               Predict()                = 0;
     virtual TimeStepEndState::ConvergenceState SolveSolutionStep()      = 0;

--- a/applications/GeoMechanicsApplication/custom_workflows/time_loop_executor.hpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/time_loop_executor.hpp
@@ -17,6 +17,7 @@
 #include <memory>
 #include <vector>
 
+#include "scoped_output_file_access.h"
 #include "strategy_wrapper.hpp"
 #include "time_incrementor.h"
 #include "time_loop_executor_interface.h"
@@ -63,6 +64,7 @@ public:
         mStrategyWrapper->SaveTotalDisplacementFieldAtStartOfTimeLoop();
         std::vector<TimeStepEndState> result;
         TimeStepEndState              NewEndState = EndState;
+        ScopedOutputFileAccess        limit_output_file_access_to_this_scope{*mStrategyWrapper};
         while (mTimeIncrementor->WantNextStep(NewEndState) && !IsCancelled()) {
             mStrategyWrapper->IncrementStepNumber();
             // clone without end time, the end time is overwritten anyway
@@ -73,8 +75,6 @@ public:
             mStrategyWrapper->OutputProcess();
             result.emplace_back(NewEndState);
         }
-
-        mStrategyWrapper->FinalizeOutput();
 
         return result;
     }

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_loop_executor.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_loop_executor.cpp
@@ -113,6 +113,11 @@ public:
         return mCountFinalizeSolutionStepCalled;
     }
 
+    [[nodiscard]] std::size_t GetCountFinalizeOutputCalled() const
+    {
+        return mCountFinalizeOutputCalled;
+    }
+
     void Initialize() override
     {
         // intentionally empty
@@ -132,7 +137,7 @@ public:
     void FinalizeSolutionStep() override { ++mCountFinalizeSolutionStepCalled; }
     void FinalizeOutput() override
     {
-        // intentionally empty
+        ++mCountFinalizeOutputCalled;
     }
 
 private:
@@ -146,6 +151,7 @@ private:
     std::size_t mCountAccumulateTotalDisplacementFieldCalled = 0;
     std::size_t mCountOutputProcessCalled = 0;
     std::size_t mCountFinalizeSolutionStepCalled = 0;
+    std::size_t mCountFinalizeOutputCalled = 0;
 };
 
 class FixedCyclesTimeIncrementor : public TimeIncrementor
@@ -356,6 +362,17 @@ KRATOS_TEST_CASE_IN_SUITE(ExpectFinalizeSolutionStepCalledOnceForEveryStep, Krat
     const auto step_states = executor.Run(TimeStepEndState{});
     KRATOS_EXPECT_EQ(step_states.size(),
                      solver_strategy->GetCountFinalizeSolutionStepCalled());
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ExpectFinalizeOutputIsCalledOnceWhenRunCompletesOk, KratosGeoMechanicsFastSuite)
+{
+    TimeLoopExecutor executor;
+    const auto       wanted_num_of_cycles_per_step = std::size_t{1};
+    executor.SetTimeIncrementor(std::make_unique<FixedCyclesTimeIncrementor>(wanted_num_of_cycles_per_step));
+    auto solver_strategy = std::make_shared<DummySolverStrategy>(TimeStepEndState::ConvergenceState::converged);
+    executor.SetSolverStrategyWrapper(solver_strategy);
+    executor.Run(TimeStepEndState{});
+    KRATOS_EXPECT_EQ(solver_strategy->GetCountFinalizeOutputCalled(), 1);
 }
 
 } // namespace Kratos::Testing

--- a/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_stepping.cpp
+++ b/applications/GeoMechanicsApplication/tests/cpp_tests/test_time_stepping.cpp
@@ -90,6 +90,12 @@ public:
     };
 
     void Initialize() override { ++mSolverStrategyInitializeCalls; }
+
+    void InitializeOutput() override
+    {
+        // Intentionally empty
+    }
+
     void InitializeSolutionStep() override
     {
         ++mSolverStrategyInitializeSolutionStepCalls;


### PR DESCRIPTION
**📝 Description**
Fixed an issue where the output file was not properly closed when an exception was thrown from a settlement calculation.

**🆕 Changelog**
- Added a class for scoped output file access, which opens the output file on construction, and which closes it on destruction. An instance of this class now ensures that any output file access is limited to the runtime of the `Run` method of the time loop executor. That is, the output file is now always closed, regardless whether `Run` is left through a `return` statement or through an exception.
- Split the implementation of the `Initialize` member function of the solver strategy wrapper. Initializing the output has been moved to a separate member function (i.e. the interface for initializing and finalizing the output is now symmetric).
- Added two unit tests that cover the improvements.
