### PR TITLE
[Core] Missing & in `Get` method in `SpatialSearchResult`

### DIFF
--- a/kratos/spatial_containers/spatial_search_result.h
+++ b/kratos/spatial_containers/spatial_search_result.h
@@ -23,7 +23,7 @@
 
 namespace Kratos
 {
-///@addtogroup ApplicationNameApplication
+///@addtogroup Core
 ///@{
 
 ///@name Kratos Classes
@@ -108,13 +108,13 @@ public:
     ///@name Access
     ///@{
 
-    /// Returns the global pointer to the object
-    TPointerType Get() {
+    /// Returns the global pointer to the object (reference as GlobalPointer is a class and therefore we are copying values)
+    TPointerType& Get() {
         return mpObject;
     }
 
-    /// Returns a const global pointer to the object
-    TPointerType const Get() const {
+    /// Returns a const global pointer to the object (reference as GlobalPointer is a class and therefore we are copying values)
+    const TPointerType& Get() const {
         return mpObject;
     }
 


### PR DESCRIPTION
**📝 Description**

Missing & in `Get` method in `SpatialSearchResult`. Reference as `GlobalPointer` is a class and therefore we are copying values when using `Get`, probably we got confused with the `Pointer` name. 

**🆕 Changelog**

- [Missing & in Get method in SpatialSearchResult](https://github.com/KratosMultiphysics/Kratos/commit/089d78e38cf58467d43046ac56b9181fd2324a53)
