### PR TITLE
[Docs] Add python processing locally

### DIFF
--- a/docs/pages/Kratos/Documentation_Guide/How_Tos/Create_Content/Documentation_Pages.md
+++ b/docs/pages/Kratos/Documentation_Guide/How_Tos/Create_Content/Documentation_Pages.md
@@ -49,7 +49,10 @@ It is allowed to create subfolders to store page data such as ```images```. If t
 
 ## Python snippets
 
-Python snippets can be added to markdown as usual. In this case, if one required to generate the output of the python snippet automatically and then to be added to the same markdown file, then ```## POST_PROCESS_PAGES_PYTHON_OUTPUT_GENERATION``` can be added somewhere within the python snippet.
+Python snippets can be added to markdown as usual. In this case, if one requires to generate the output of the python snippet automatically and append after the python snippet, then following steps can be followed.
+1. Add `## POST_PROCESS_PAGES_PYTHON_OUTPUT_GENERATION` anywhere in the python snippet. It should not have any leading or trailing spaces/tabs.
+2. Run the local build in your computer [Make sure to initialize kratos environment or any other library environments in the terminal which is being used by the snippet]. This will run the snippet and capture the output. It will also remove the `## POST_PROCESS_PAGES_PYTHON_OUTPUT_GENERATION` tag line from the python snippet.
+3. Now you will see some block after the python snippet which contains the python output.
 
 This generation is only done if ```process_pages.py``` is passed with `-t local` flag.
 Following is an example:

--- a/docs/pages/Kratos/Documentation_Guide/How_Tos/Create_Content/Documentation_Pages.md
+++ b/docs/pages/Kratos/Documentation_Guide/How_Tos/Create_Content/Documentation_Pages.md
@@ -47,4 +47,21 @@ It is allowed to create subfolders to store page data such as ```images```. If t
 <p align="center">Figure 2: Vertex morphing filtering</p>
 ```
 
+## Python snippets
+
+Python snippets can be added to markdown as usual. In this case, if one required to generate the output of the python snippet automatically and then to be added to the same markdown file, then ```## POST_PROCESS_PAGES_PYTHON_OUTPUT_GENERATION``` can be added somewhere within the python snippet.
+
+This generation is only done if ```process_pages.py``` is passed with `-t local` flag.
+Following is an example:
+```python
+print(1)
+## POST_PROCESS_PAGES_PYTHON_OUTPUT_GENERATION
+```
+
+This will generate the following markdown
+```
+Expected output:
+1
+```
+
 

--- a/docs/pages/Kratos/Documentation_Guide/How_Tos/Create_Content/Documentation_Pages.md
+++ b/docs/pages/Kratos/Documentation_Guide/How_Tos/Create_Content/Documentation_Pages.md
@@ -56,7 +56,7 @@ Python snippets can be added to markdown as usual. In this case, if one requires
 
 This generation is only done if ```process_pages.py``` is passed with `-t local` flag.
 Following is an example:
-```python
+```python-example
 print(1)
 ## POST_PROCESS_PAGES_PYTHON_OUTPUT_GENERATION
 ```

--- a/docs/process_pages.py
+++ b/docs/process_pages.py
@@ -251,7 +251,7 @@ def AddPythonSnippetOutputs(file_path: Path) -> None:
                     with open(temp_file_path, "w") as temp_file_output:
                         temp_file_output.writelines(snippet_lines)
 
-                    subprocess_run = subprocess.run([GetPython3Command(), temp_file_path], stdout=subprocess.PIPE, universal_newlines=True, check=True)
+                    subprocess_run = subprocess.run([GetPython3Command(), "-u", temp_file_path], stdout=subprocess.PIPE, universal_newlines=True, check=True)
                     output_lines.append("\n")
                     output_lines.append("Expected output:\n")
                     output_lines.append("```bash\n")

--- a/docs/process_pages.py
+++ b/docs/process_pages.py
@@ -273,7 +273,7 @@ def AddPythonSnippetOutputs(file_path: Path) -> None:
             found_python_snippet_block = True
             snippet_lines = []
 
-    with open(str(file_path), "w") as file_output:
+    with open(file_path, "w") as file_output:
         file_output.writelines(output_lines)
 
 if __name__ == "__main__":

--- a/docs/process_pages.py
+++ b/docs/process_pages.py
@@ -3,7 +3,6 @@ from argparse import ArgumentParser
 from collections import OrderedDict
 from pathlib import Path
 import subprocess
-import os
 
 from entry_utilities import default_header_dict
 from entry_utilities import file_navigation_levels
@@ -260,7 +259,7 @@ def AddPythonSnippetOutputs(file_path: Path) -> None:
                     output_lines.append("```\n")
 
                     # remove the temp file
-                    os.remove(temp_file_path)
+                    Path(temp_file_path).unlink()
 
                     if is_existing_output_found:
                         index += temp_index + lines[temp_index:].index("```\n") + 1

--- a/docs/process_pages.py
+++ b/docs/process_pages.py
@@ -248,16 +248,15 @@ def AddPythonSnippetOutputs(file_path: Path) -> None:
                     # existing is not found or force re-write is enabled
 
                     # create a temp file
-                    temp_file_path = str(file_path.absolute()) + ".temp.py"
+                    temp_file_path = f"{file_path.name}.temp.py"
                     with open(temp_file_path, "w") as temp_file_output:
                         temp_file_output.writelines(snippet_lines)
 
-                    popen = subprocess.Popen(["python3", temp_file_path], stdout=subprocess.PIPE, universal_newlines=True)
+                    subprocess_run = subprocess.run([GetPython3Command(), temp_file_path], stdout=subprocess.PIPE, universal_newlines=True)
                     output_lines.append("\n")
                     output_lines.append("Expected output:\n")
                     output_lines.append("```bash\n")
-                    for stdout_line in iter(popen.stdout.readline, ""):
-                        output_lines.append(stdout_line)
+                    output_lines.append(subprocess_run.stdout)
                     output_lines.append("```\n")
 
                     # remove the temp file
@@ -269,7 +268,7 @@ def AddPythonSnippetOutputs(file_path: Path) -> None:
         if found_python_snippet_block:
             snippet_lines.append(line)
 
-        if line.startswith("```python"):
+        if line == "```python\n":
             found_python_snippet_block = True
             snippet_lines = []
 
@@ -320,6 +319,7 @@ if __name__ == "__main__":
                         file_output.writelines(list_of_strings)
 
     if is_locally_built:
+        from KratosMultiphysics.testing.utilities import GetPython3Command
         for file_path in Path("pages").rglob("*.md"):
             AddPythonSnippetOutputs(file_path)
 

--- a/docs/process_pages.py
+++ b/docs/process_pages.py
@@ -252,7 +252,7 @@ def AddPythonSnippetOutputs(file_path: Path) -> None:
                     with open(temp_file_path, "w") as temp_file_output:
                         temp_file_output.writelines(snippet_lines)
 
-                    subprocess_run = subprocess.run([GetPython3Command(), temp_file_path], stdout=subprocess.PIPE, universal_newlines=True)
+                    subprocess_run = subprocess.run([GetPython3Command(), temp_file_path], stdout=subprocess.PIPE, universal_newlines=True, check=True)
                     output_lines.append("\n")
                     output_lines.append("Expected output:\n")
                     output_lines.append("```bash\n")

--- a/docs/process_pages.py
+++ b/docs/process_pages.py
@@ -238,7 +238,7 @@ def AddPythonSnippetOutputs(file_path: Path) -> None:
                 temp_index = index
                 is_existing_output_found = False
                 while temp_index < len(lines):
-                    if lines[temp_index].strip() != "":
+                    if lines[temp_index].strip():
                         is_existing_output_found  = lines[temp_index] == "Expected output:\n"
                         is_existing_output_found &= lines[temp_index+1] == "```bash\n"
                         break

--- a/docs/process_pages.py
+++ b/docs/process_pages.py
@@ -2,6 +2,8 @@ import requests
 from argparse import ArgumentParser
 from collections import OrderedDict
 from pathlib import Path
+import subprocess
+import os
 
 from entry_utilities import default_header_dict
 from entry_utilities import file_navigation_levels
@@ -215,6 +217,59 @@ def CreateNavigatonBar(root_path: str, max_levels: int, default_header_dict: dic
     list_of_strings = GenerateStrings(list_of_entries, is_locally_built)
     return list_of_strings
 
+def AddPythonSnippetOutputs(file_path: Path) -> None:
+    with open(str(file_path), "r") as file_input:
+        lines = file_input.readlines()
+
+    found_python_snippet_block = False
+    snippet_lines = []
+    output_lines = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        index += 1
+        output_lines.append(line)
+
+        if found_python_snippet_block and line.startswith("```"):
+            found_python_snippet_block = False
+            if "## POST_PROCESS_PAGES_PYTHON_OUTPUT_GENERATION\n" in snippet_lines:
+                # create a temp file
+                temp_file_path = str(file_path.absolute()) + ".temp.py"
+                with open(temp_file_path, "w") as temp_file_output:
+                    temp_file_output.writelines(snippet_lines)
+
+                popen = subprocess.Popen(["python3", temp_file_path], stdout=subprocess.PIPE, universal_newlines=True)
+
+                output_lines.append("\n")
+                output_lines.append("Expected output:\n")
+                output_lines.append("```bash\n")
+                for stdout_line in iter(popen.stdout.readline, ""):
+                    output_lines.append(stdout_line)
+                output_lines.append("```\n")
+
+                # remove the temp file
+                os.remove(temp_file_path)
+
+                # now check this output already exists. then remove that output since
+                # this will be only called when processing is done with -t local flag.
+                # raise RuntimeError(lines[index:index+3])
+                if lines[index:index+3] == ["\n", "Expected output:\n", "```bash\n"]:
+                    while index < len(lines):
+                        if lines[index] == "```\n":
+                            index += 1
+                            break
+                        index += 1
+
+        if found_python_snippet_block:
+            snippet_lines.append(line)
+
+        if line.startswith("```python"):
+            found_python_snippet_block = True
+            snippet_lines = []
+
+    with open(str(file_path), "w") as file_output:
+        file_output.writelines(output_lines)
+
 if __name__ == "__main__":
     ## process the index file.
     r = requests.get("https://raw.githubusercontent.com/KratosMultiphysics/Kratos/master/README.md", allow_redirects=True)
@@ -258,6 +313,9 @@ if __name__ == "__main__":
                         file_output.write("entries:\n")
                         file_output.writelines(list_of_strings)
 
+    if is_locally_built:
+        for file_path in Path("pages").rglob("*.md"):
+            AddPythonSnippetOutputs(file_path)
 
     # sub_itr_dir = Path("pages/1_Kratos/1_For_Users")
     # print("Creating side bar for {:s}...".format(str(sub_itr_dir)))

--- a/docs/process_pages.py
+++ b/docs/process_pages.py
@@ -218,7 +218,7 @@ def CreateNavigatonBar(root_path: str, max_levels: int, default_header_dict: dic
     return list_of_strings
 
 def AddPythonSnippetOutputs(file_path: Path) -> None:
-    with open(str(file_path), "r") as file_input:
+    with open(file_path, "r") as file_input:
         lines = file_input.readlines()
 
     found_python_snippet_block = False


### PR DESCRIPTION
This PR adds capability to add python snippet output to the docs automatically. Following is the documentation on how to use it.

1. Add `## POST_PROCESS_PAGES_PYTHON_OUTPUT_GENERATION` anywhere in the python snippet. It should not have any leading or trailing spaces/tabs.
2. Run the local build in your computer [Make sure to initialize kratos environment or any other library environments in the terminal which is being used by the snippet]. This will run the snippet and capture the output. It will also remove the `## POST_PROCESS_PAGES_PYTHON_OUTPUT_GENERATION` tag line from the python snippet.
3. Now you will see some block after the python snippet which contains the python output.

This generation is only done if ```process_pages.py``` is passed with `-t local` flag.

** This will not change any existing python snippets. If the automated output is required, the above tag needs to be placed within the python snippet. **

**🆕 Changelog**
- Adds capability to automatically add python snippet output.
