### PR TITLE
[Core] Correcting corner case in `GeometricalObjectBins` + typo ("avarage")

### DIFF
--- a/kratos/spatial_containers/geometrical_objects_bins.cpp
+++ b/kratos/spatial_containers/geometrical_objects_bins.cpp
@@ -222,28 +222,34 @@ bool GeometricalObjectsBins::PointIsInsideBoundingBoxWithTolerance(
 
 void GeometricalObjectsBins::CalculateCellSize(const std::size_t NumberOfCells)
 {
-    const std::size_t avarage_number_of_cells = static_cast<std::size_t>(std::pow(static_cast<double>(NumberOfCells), 1.00 / Dimension));
+    const std::size_t average_number_of_cells = static_cast<std::size_t>(std::pow(static_cast<double>(NumberOfCells), 1.00 / Dimension));
     std::array<double, Dimension> lengths;
-    double avarage_length = 0.0;
+    double average_length = 0.0;
     for (unsigned int i = 0; i < Dimension; i++) {
         lengths[i] = mBoundingBox.GetMaxPoint()[i] - mBoundingBox.GetMinPoint()[i];
-        avarage_length += lengths[i];
+        average_length += lengths[i];
     }
-    avarage_length *= 0.33333333333333333333333333333333;
+    average_length *= 0.33333333333333333333333333333333;
 
-    if (avarage_length < std::numeric_limits<double>::epsilon()) {
+    if (average_length < std::numeric_limits<double>::epsilon()) {
         mNumberOfCells = ScalarVector(3, 1);
+        for (unsigned int i = 0; i < Dimension; i++) {
+            mNumberOfCells[i] = 0;
+            mCellSizes[i] = 0.0;
+            mInverseOfCellSize[i] = std::numeric_limits<double>::max();
+        }
         return;
     }
 
     for (unsigned int i = 0; i < Dimension; i++) {
-        mNumberOfCells[i] = static_cast<std::size_t>(lengths[i] / avarage_length * avarage_number_of_cells) + 1;
-        if (mNumberOfCells[i] > 1)
+        mNumberOfCells[i] = static_cast<std::size_t>(lengths[i] / average_length * average_number_of_cells) + 1;
+        if (mNumberOfCells[i] > 1) {
             mCellSizes[i] = lengths[i] / mNumberOfCells[i];
-        else
-            mCellSizes[i] = avarage_length;
+        } else {
+            mCellSizes[i] = average_length;
+        }
 
-        mInverseOfCellSize[i] = 1.00 / mCellSizes[i];
+        mInverseOfCellSize[i] = 1.0 / mCellSizes[i];
     }
 
 }

--- a/kratos/spatial_containers/geometrical_objects_bins.h
+++ b/kratos/spatial_containers/geometrical_objects_bins.h
@@ -377,8 +377,8 @@ protected:
 
     BoundingBox<PointType> mBoundingBox;             /// The bounding box of the domain
     array_1d<std::size_t, Dimension> mNumberOfCells; /// The number of cells in each direction
-    array_1d<double, 3>  mCellSizes;                 /// The size of each cell in each direction
-    array_1d<double, 3>  mInverseOfCellSize;         /// The inverse of the size of each cell in each direction
+    array_1d<double, 3> mCellSizes;                  /// The size of each cell in each direction
+    array_1d<double, 3> mInverseOfCellSize;          /// The inverse of the size of each cell in each direction
     std::vector<CellType> mCells;                    /// The cells of the domain
     double mTolerance;                               /// The tolerance considered
 
@@ -583,31 +583,30 @@ private:
 }; // Class GeometricalObjectsBins
 
 ///@}
-
 ///@name Type Definitions
 ///@{
-
 
 ///@}
 ///@name Input and output
 ///@{
 
-// /// input stream function
-// inline std::istream& operator >> (std::istream& rIStream,
-//                 GeometricalObjectsBins& rThis){
-//                     return rIStream;
-//                 }
+/// input stream function
+inline std::istream& operator >> (std::istream& rIStream,
+                GeometricalObjectsBins& rThis){
+                    return rIStream;
+                }
 
-// /// output stream function
-// inline std::ostream& operator << (std::ostream& rOStream,
-//                 const GeometricalObjectsBins& rThis)
-// {
-//     rThis.PrintInfo(rOStream);
-//     rOStream << std::endl;
-//     rThis.PrintData(rOStream);
+/// output stream function
+inline std::ostream& operator << (std::ostream& rOStream,
+                const GeometricalObjectsBins& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
 
-//     return rOStream;
-// }
+    return rOStream;
+}
+
 ///@}
 
 ///@} addtogroup block

--- a/kratos/spatial_containers/geometrical_objects_bins.h
+++ b/kratos/spatial_containers/geometrical_objects_bins.h
@@ -590,22 +590,22 @@ private:
 ///@name Input and output
 ///@{
 
-/// input stream function
-inline std::istream& operator >> (std::istream& rIStream,
-                GeometricalObjectsBins& rThis){
-                    return rIStream;
-                }
+// /// input stream function
+// inline std::istream& operator >> (std::istream& rIStream,
+//                 GeometricalObjectsBins& rThis){
+//                     return rIStream;
+//                 }
 
-/// output stream function
-inline std::ostream& operator << (std::ostream& rOStream,
-                const GeometricalObjectsBins& rThis)
-{
-    rThis.PrintInfo(rOStream);
-    rOStream << std::endl;
-    rThis.PrintData(rOStream);
+// /// output stream function
+// inline std::ostream& operator << (std::ostream& rOStream,
+//                 const GeometricalObjectsBins& rThis)
+// {
+//     rThis.PrintInfo(rOStream);
+//     rOStream << std::endl;
+//     rThis.PrintData(rOStream);
 
-    return rOStream;
-}
+//     return rOStream;
+// }
 
 ///@}
 


### PR DESCRIPTION
**📝 Description**

Correcting corner case in `GeometricalObjectBins`, where due to the return clause, `mNumberOfCells`, `mCellSizes` and `mInverseOfCellSize` were not initialized.

**🆕 Changelog**

- [Correcting corner case in `GeometricalObjectBins`](https://github.com/KratosMultiphysics/Kratos/commit/c813cb4dc937937dcadba1a714a31b9fd52b717f)
- [Typo ("avarage")](https://github.com/KratosMultiphysics/Kratos/commit/c813cb4dc937937dcadba1a714a31b9fd52b717f)
- [Minor clean up](https://github.com/KratosMultiphysics/Kratos/commit/481ed83b872f4c6e382d2550eb84db673a05dc0a)