### PR TITLE
[Docs] Change bash to console

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -109,71 +109,71 @@ Additionaly, Visual Studio is required to compile in *Windows*.
   MingGw compilation details are hidden by default to avoid confusion, please click the button below to show them.
   <details>
     <summary>Show MinGW compilation details</summary>
-  
+
     *MinGW* means minimal GNU for *Windows*. There are different manners of installing, the simplest one using *MSYS2*.
-  
+
     - MSYS2
-  
+
         First, we download *MSYS2* in the following [link](https://www.msys2.org/). This will install *MinGW*, which allows to easiy install packages *a la* Arch-Linux (Pacman package manager). We install it, and with it the first thing we do is to update as follows ([in the *MSYS2* bash](https://www.msys2.org/docs/terminals/)):
         ![](https://www.msys2.org/docs/mintty.png) ![](https://www.msys2.org/docs/launchers.png)
-  
+
         ```Shell
         pacman -Syu
         ```
-  
+
         It is very relevant to add to the *Windows* `PATH` your `msys64\mingw64\bin` folder in order that the system locates the binaries.
-  
+
     - Git
-  
+
         The first thing you will need is the *Kratos* Multiphysics source code. To download the code you will have to use a git. You can install the default git by using this command:
-  
+
         ```Shell
         pacman -S git
         ```
-  
+
         Once git is installed you can fetch the code by using these commands:
-  
+
         ```Shell
         git clone https://github.com/KratosMultiphysics/Kratos Kratos
         ```
     - Dev Packages
-  
+
         You will need a series of packages with some *Kratos* dependencies. These include the compilers (*GCC*,*Clang/LLVM*), *CMake*, *Blas and Lapack* libraries and the *OpenMP* support. The command below will install all the packages needed. The command below will install all the packages needed.
-  
+
         ```Shell
         pacman -S mingw64/mingw-w64-x86_64-lapack mingw64/mingw-w64-x86_64-openblas mingw64/mingw-w64-x86_64-cmake mingw64/mingw-w64-x86_64-clang mingw64/mingw-w64-x86_64-gcc mingw64/mingw-w64-x86_64-gcc-fortran mingw-w64-x86_64-make mingw64/mingw-w64-x86_64-openmp mingw64/mingw-w64-x86_64-dlfcn
         ```
-  
-    - Python 
+
+    - Python
         You will need at least *Python* 3.8 (recommended 3.8/3.9/3.10) in your computer in order to compile *Kratos*. You can download python from its official webpage:
-  
+
         * [Download Python](http://www.python.org/downloads/)
-  
+
         Please, take special care to download a installer that suits your desired architecture **x86 for 32 bits**  compilations and **x86_64 for 64 bits**  compilations. Otherwise it won't work.
-  
+
         Unfortunately, we cannot use right now *MSYS2* directly, as the development files are not available (`python3-dev` equivalent to *GNU/Linux*).
-  
+
     - Boost
         The next step will consist in obtain Boost. *Kratos Multiphysics* needs *Boost* libraries to support some of its functions. You can use any version from `version 1.67` onward. For that, we will use `pacman` again:
-  
+
         ```Shell
         pacman -S mingw64/mingw-w64-x86_64-boost
         ```
-  
+
     ##### Using UCRT64
-  
+
     UCRT (Universal C Runtime) is a newer version which is also used by Microsoft Visual Studio by default, see https://www.msys2.org/docs/environments/. It should work and behave as if the code was compiled with MSVC.
-  
+
     - Better compatibility with MSVC, both at build time and at run time.
     - It only ships by default on Windows 10 and for older versions you have to provide it yourself or depend on the user having it installed.
-  
+
     If using UCRT64 the dependencies will be like:
-  
+
     ```Shell
     pacman -S ucrt64/mingw-w64-ucrt-x86_64-lapack ucrt64/mingw-w64-ucrt-x86_64-openblas ucrt64/mingw-w64-ucrt-x86_64-cmake ucrt64/mingw-w64-ucrt-x86_64-clang ucrt64/mingw-w64-ucrt-x86_64-gcc ucrt64/mingw-w64-ucrt-x86_64-gcc-fortran mingw-w64-ucrt-x86_64-make ucrt64/mingw-w64-ucrt-x86_64-openmp ucrt64/mingw-w64-ucrt-x86_64-dlfcn ucrt64/mingw-w64-ucrt-x86_64-boost
     ```
   </details>
-  
+
 ### Specific Application Dependencies
 
 Some applications have additional dependencies. Please check the `README` files of the applications that are compiled
@@ -236,7 +236,7 @@ The example scripts for every system are shown next.
 
 ### GNU/Linux
 
-```bash
+```console
 # Function to add apps
 add_app () {
     export KRATOS_APPLICATIONS="${KRATOS_APPLICATIONS}$1;"
@@ -373,7 +373,7 @@ sh %KRATOS_BUILD%\configure_MINGW.sh
 
 And the second is the bash script that will be called by the former script (it is similar to the one in *GNU/Linux*):
 
-```bash
+```console
 # Function to add apps
 add_app () {
     export KRATOS_APPLICATIONS="${KRATOS_APPLICATIONS}$1;"
@@ -417,7 +417,7 @@ cmake --build "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" --target install -- -j$(npr
 ```
 ### MacOS
 
-```bash
+```console
 # Function to add apps
 add_app () {
     export KRATOS_APPLICATIONS="${KRATOS_APPLICATIONS}$1;"
@@ -488,7 +488,7 @@ For *Windows* with *MinGW* it works in the same way as in *GNU/Linux* as it work
 As *Kratos* is not an executable but a set of modules and libraries, you will need to add them to the path. In order to do that please add the *Kratos* install folder (If you didn't touch anything should be `$KRATOS_SOURCE/bin/Release`)
 
 ### GNU/Linux
-```bash
+```console
 export PYTHONPATH=$PYTHONPATH:$HOME/Kratos/bin/Release
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$HOME/Kratos/bin/Release/libs
 ```
@@ -518,9 +518,9 @@ from KratosMultiphysics import *
 The result should be:
 
 ```
- |  /           |                  
- ' /   __| _` | __|  _ \   __|    
- . \  |   (   | |   (   |\__ \  
+ |  /           |
+ ' /   __| _` | __|  _ \   __|
+ . \  |   (   | |   (   |\__ \
 _|\_\_|  \__,_|\__|\___/ ____/
            Multi-Physics 9.X.Y-4afb88094a-Release-ARM64
            Compiled for GNU/Linux and Python3.8 with GCC-8.5

--- a/applications/LinearSolversApplication/README.md
+++ b/applications/LinearSolversApplication/README.md
@@ -107,7 +107,7 @@ If the application is compiled with MKL, [FEAST 4.0](http://www.ecs.umass.edu/~p
 
     **Linux:** in `configure.sh`
 
-    ```bash
+    ```console
     add_app ${KRATOS_APP_DIR}/LinearSolversApplication
     ```
 
@@ -137,7 +137,7 @@ In case you have installed [MKL](https://software.intel.com/en-us/mkl) (see belo
 
     **Linux:**
 
-    ```bash
+    ```console
     source /opt/intel/oneapi/setvars.sh intel64
     ```
 
@@ -151,7 +151,7 @@ In case you have installed [MKL](https://software.intel.com/en-us/mkl) (see belo
 
     **Linux:**
 
-    ```bash
+    ```console
     -DUSE_EIGEN_MKL=ON \
     ```
 
@@ -168,8 +168,8 @@ In case you have installed [MKL](https://software.intel.com/en-us/mkl) (see belo
     **Linux:**
 
     Set the environment before using MKL
-    
-    ```bash
+
+    ```console
     source /opt/intel/oneapi/setvars.sh intel64
     ```
 
@@ -178,7 +178,7 @@ In case you have installed [MKL](https://software.intel.com/en-us/mkl) (see belo
 Intel MKL can be installed with apt on Ubuntu. A guide can be found in [here](https://neelravi.com/post/intel-oneapi-install/).
 For example to install the MKL 2022 version
 
-```bash
+```console
 sudo bash
 # <type your user password when prompted.  this will put you in a root shell>
 # If they are not installed, you can install using the following command:
@@ -200,6 +200,6 @@ exit
 
 To enable the MKL environment (needs to be done before build/run) use
 
-```bash
+```console
 source /opt/intel/oneapi/setvars.sh intel64
 ```

--- a/applications/LinearSolversApplication/external_libraries/spectra1/COPYING.README.md
+++ b/applications/LinearSolversApplication/external_libraries/spectra1/COPYING.README.md
@@ -245,7 +245,7 @@ More information can be found in the project page [https://spectralib.org](https
 
 An optional CMake installation is supported, if you have CMake with at least v3.10 installed. You can install the headers using the following commands:
 
-```bash
+```console
 mkdir build && cd build
 cmake .. -DCMAKE_INSTALL_PREFIX='intended installation directory' -DCMAKE_PREFIX_PATH='path where the installation of Eigen3 can be found' -DBUILD_TESTS=TRUE
 make all && make tests && make install

--- a/applications/MetisApplication/README.md
+++ b/applications/MetisApplication/README.md
@@ -14,7 +14,7 @@ which generates a partition of the mesh based on the nodal graph and can be used
 
 Building the `MetisApplication` requires *METIS* libraries and their dependencies already installed on the system. The easiest way to get them is by the package manager of the *GNU/Linux* distribution. For example, in *Ubuntu GNU/Linux*:
 
-```bash
+```console
 sudo apt install libmetis-dev
 ```
 
@@ -25,7 +25,7 @@ Assuming that the dependencies are installed, the following steps are:
 1. Add the `MetisApplication` to the list of applications to be compiled in the building script for Kratos,
 as described in the [install instructions](https://github.com/KratosMultiphysics/Kratos/blob/master/INSTALL.md#adding-applications).
 
-```bash
+```console
 export KRATOS_APPLICATIONS=
 ...
 add_app ${KRATOS_APP_DIR}/MetisApplication
@@ -33,7 +33,7 @@ add_app ${KRATOS_APP_DIR}/MetisApplication
 
 2. Tell CMake where are located the libraries and headers of *METIS*, if CMake does not find them automatically. For example:
 
-```bash
+```console
 cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}" \
 ...
 -DMETIS_ROOT_DIR="${HOME}/Projects/METIS/build"
@@ -45,38 +45,38 @@ cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}" \
 
 To install *Spack* you just need to run the following command:
 
-```bash
+```console
 git clone -c feature.manyFiles=true https://github.com/spack/spack.git
 ```
 
 To use it you will need to add the corresponding environment variables (or call `spack_location/spack/bin/spack`):
 
-```bash
+```console
 . spack_location/spack/share/spack/setup-env.sh
 ```
 
 Then in order to install *METIS*:
 
-```bash
+```console
 spack install parmetis
 ```
 
 If you want that the libraries are added automatically to `LD_LIBRARY_PATH` to run the following commands before loading the modules:
 
-```bash
+```console
 spack config add modules:prefix_inspections:lib64:[LD_LIBRARY_PATH]
 spack config add modules:prefix_inspections:lib:[LD_LIBRARY_PATH]
 ```
 
 Now you just need to load *METIS*:
 
-```bash
+```console
 spack load parmetis
 ```
 
-Once to compile `MetisApplication` just remember to add the application to the `cofigure` bash script: 
+Once to compile `MetisApplication` just remember to add the application to the `cofigure` bash script:
 
-```bash
+```console
 export KRATOS_APPLICATIONS=
 ...
 add_app ${KRATOS_APP_DIR}/MetisApplication

--- a/applications/TrilinosApplication/README.md
+++ b/applications/TrilinosApplication/README.md
@@ -69,7 +69,7 @@ Assuming that the dependencies are installed, the following steps are:
 1. Add the `TrilinosApplication` to the list of applications to be compiled in the building script for Kratos,
 as described in the [install instructions](https://github.com/KratosMultiphysics/Kratos/blob/master/INSTALL.md#adding-applications).
 
-```bash
+```console
 export KRATOS_APPLICATIONS=
 ...
 add_app ${KRATOS_APP_DIR}/TrilinosApplication
@@ -78,7 +78,7 @@ add_app ${KRATOS_APP_DIR}/TrilinosApplication
 2. Tell cmake where are located the libraries and headers of *Trilinos*.
 If Trilinos was compiled (instead of downloaded with a package manager), it is usually enough to point the `TRILINOS_ROOT` variable to the build directory. For example:
 
-```bash
+```console
 cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}" \
 ...
 -DTRILINOS_ROOT="${HOME}/Projects/Trilinos/build"
@@ -88,14 +88,14 @@ Or, if *Trilinos* is installed with a package manager, then libraries and header
 Moreover, the name of the libraries may not be standard.
 In this case, instead of setting `TRILINOS_ROOT`, set `-DTRILINOS_INCLUDE_DIR=String` with the path to the include dir, `-DTRILINOS_LIBRARY_DIR=String` with the path to the library dir, and set `-DTRILINOS_LIBRARY_PREFIX=String` with the prefix to use when looking for the *Trilinos* libraries, i.e.,
 
-```bash
+```console
 libepetra.so  # No need to set TRILINOS_PREFIX
 libtrilinos_epetra.so  # -DTRILINOS_PREFIX="trilinos_"
 ```
 
 For example, in the case of Ubuntu with *Trilinos* installed by `sudo apt install trilinos-all-dev`:
 
-```bash
+```console
 -DTRILINOS_INCLUDE_DIR="/usr/include/trilinos"
 -DTRILINOS_LIBRARY_DIR="/usr/lib/x86_64-linux-gnu"
 -DTRILINOS_LIBRARY_PREFIX="trilinos_"
@@ -108,7 +108,7 @@ Check the [docker of the CI](https://github.com/KratosMultiphysics/Kratos/blob/m
 
 At the moment, the list of required packages is:
 
-```bash
+```console
 sudo apt install \
         libtrilinos-amesos-dev \
         libtrilinos-amesos2-dev \
@@ -127,7 +127,7 @@ sudo apt install \
 -It is possible to do a minimal installation of the TrilinosApplication only using the Epetra package.
 Other packages can be disabled with the following flags:
 
-```bash
+```console
 -DTRILINOS_EXCLUDE_ML_SOLVER=ON  # exclude the interface to the Trilinos ML solver package
 -DTRILINOS_EXCLUDE_AZTEC_SOLVER=ON  # exclude solvers from the Trilinos AztecOO package
 -DTRILINOS_EXCLUDE_AMESOS_SOLVER=ON  # exclude solvers using features of the Trilinos Amesos package
@@ -140,50 +140,50 @@ Other packages can be disabled with the following flags:
 
 To install *Spack* you just need to run the following command:
 
-```bash
+```console
 git clone -c feature.manyFiles=true https://github.com/spack/spack.git
 ```
 
 To use it you will need to add the corresponding environment variables (or call `spack_location/spack/bin/spack`):
 
-```bash
+```console
 . spack_location/spack/share/spack/setup-env.sh
 ```
 
 Then in order to install *Trilinos*:
 
-```bash
+```console
 spack install trilinos
 ```
 
 In case we want to use [*MUMPS*](https://graal.ens-lyon.fr/MUMPS/index.php) and [SuperLUDist](https://portal.nersc.gov/project/sparse/superlu/) with *Trilinos*, you can install them all together and properly liked with:
 
-```bash
+```console
 spack install trilinos+mumps+superlu-dist
 ```
 
 If you want that the libraries are added automatically to `LD_LIBRARY_PATH` to run the following commands before loading the modules:
 
-```bash
+```console
 spack config add modules:prefix_inspections:lib64:[LD_LIBRARY_PATH]
 spack config add modules:prefix_inspections:lib:[LD_LIBRARY_PATH]
 ```
 
 Now you just need to load *Trilinos*:
 
-```bash
+```console
 spack load trilinos
 ```
 
 or (if installed):
 
-```bash
+```console
 spack load trilinos+mumps+superlu-dist
 ```
 
-Once to compile `TrilinosApplication` just remember to add the application to the `configure` bash script: 
+Once to compile `TrilinosApplication` just remember to add the application to the `configure` bash script:
 
-```bash
+```console
 export KRATOS_APPLICATIONS=
 ...
 add_app ${KRATOS_APP_DIR}/TrilinosApplication

--- a/docs/pages/Applications/Meshing_Application/General/Utilities-MMG-Process.md
+++ b/docs/pages/Applications/Meshing_Application/General/Utilities-MMG-Process.md
@@ -1,9 +1,9 @@
 ---
 title: Utilities MMG Process
-keywords: 
+keywords:
 tags: [Utilities-MMG-Process.md]
 sidebar: mmg_application
-summary: 
+summary:
 ---
 
 # Content
@@ -22,7 +22,7 @@ summary:
 [man]: https://github.com/KratosMultiphysics/Kratos/wiki/%5BUtilities%5D-MMG-Process#manually
 [pro]: https://github.com/KratosMultiphysics/Kratos/wiki/%5BUtilities%5D-MMG-Process#using-the-process
 
-# What is MMG? 
+# What is MMG?
 
 *MMG* is an open source software for simplicial remeshing. [*MMG* main page](http://www.mmgtools.org/ ), and you can download the code in [GitHub](https://github.com/MmgTools/mmg).
 
@@ -32,14 +32,14 @@ summary:
 	*  The `mmg3d` application and the `libmmg3d` library: adaptation and optimization of a tetrahedral mesh and implicit domain meshing
 	*  The `libmmg` library gathering the `libmmg2d`, `libmmgs` and `libmmg3d` libraries
 
-* It uses a [LGPL](https://www.gnu.org/licenses/lgpl-3.0.en.html) license and it has been integrated in *Kratos* via the `mmg_process.h` in the `MeshingApplication`. 
+* It uses a [LGPL](https://www.gnu.org/licenses/lgpl-3.0.en.html) license and it has been integrated in *Kratos* via the `mmg_process.h` in the `MeshingApplication`.
 <span style="color:red">Important: For use it you need to download first (look in the installation section)</span>
 * It is used like a process, using the `mmg_process.py` in the `MeshingApplication`.
 * There are basically two different types of re-meshing strategies (both of them compatibles with an anisotropic re-meshing):
-	* `Level-Set`: This re-meshing technique is based in the gradient of the `DISTANCE` function, and can be used to re-mesh when you are getting closer to the reference geometry. 
+	* `Level-Set`: This re-meshing technique is based in the gradient of the `DISTANCE` function, and can be used to re-mesh when you are getting closer to the reference geometry.
 	* `Hessian`: This re-meshing technique is based in the computation of the Hessian of any variable, in the case of more than one variable or a variable by components is considered them the intersection of the corresponding tensors is computed.
 
-![](https://raw.githubusercontent.com/KratosMultiphysics/Examples/master/mmg_remeshing_examples/validation/bunny/data/Bunny.png) 
+![](https://raw.githubusercontent.com/KratosMultiphysics/Examples/master/mmg_remeshing_examples/validation/bunny/data/Bunny.png)
 
 # How can I install this library?
 
@@ -71,7 +71,7 @@ Windows
 ./configure.bat
 ```
 
-* Once the compilation is done go to the main *Kratos* folder and go to your `scripts` folder. Here you modify the `configure.sh` or `configure.bat` adding the following lines (modify the `kratos_dir` for your current *Kratos* installation directory): 
+* Once the compilation is done go to the main *Kratos* folder and go to your `scripts` folder. Here you modify the `configure.sh` or `configure.bat` adding the following lines (modify the `kratos_dir` for your current *Kratos* installation directory):
 
 ```sh
 -DINCLUDE_MMG=ON                                                     \
@@ -102,7 +102,7 @@ Kratos/scripts/configure.sh
 Once Kratos is compiled, you will have to tell the OS where to find the libraries. You can do that by executing this command.
 
 Linux
-```bash
+```console
 echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/path/to/my/src/folder/mmg/build/lib" >> $HOME/.bashrc
 ```
 
@@ -144,7 +144,7 @@ You should get an OK, if you don't get an OK there is something wrong:
 ## Manually
 
 Taking for example the following [mesh](https://github.com/KratosMultiphysics/Examples/tree/master/mmg_remeshing_examples/use_cases/coarse_sphere), and using the following python script (included in the previous compressed file) it is possible to re-mesh a very coarsed mesh of a sphere into a fine an anisotropic sphere.
-    
+
 ```py
 from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
@@ -155,7 +155,7 @@ current_model = KratosMultiphysics.Model()
 main_model_part = current_model.CreateModelPart("MainModelPart")
 main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, 3)
 
-# We add the variables needed 
+# We add the variables needed
 main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
 main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE_GRADIENT)
 main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.NODAL_AREA)
@@ -168,7 +168,7 @@ local_gradient = KratosMultiphysics.ComputeNodalGradientProcess3D(main_model_par
 local_gradient.Execute()
 
 # We set to zero the metric
-ZeroVector = KratosMultiphysics.Vector(6) 
+ZeroVector = KratosMultiphysics.Vector(6)
 ZeroVector[0] = 0.0
 ZeroVector[1] = 0.0
 ZeroVector[2] = 0.0
@@ -177,17 +177,17 @@ ZeroVector[4] = 0.0
 ZeroVector[5] = 0.0
 for node in main_model_part.Nodes:
     node.SetValue(MeshingApplication.METRIC_TENSOR_3D, ZeroVector)
-            
+
 # We define a metric using the ComputeLevelSetSolMetricProcess
 level_set_param = KratosMultiphysics.Parameters("""
                         {
-                            "minimal_size"                         : 0.1, 
-                            "enforce_current"                      : false, 
-                            "anisotropy_remeshing"                 : true, 
-                            "anisotropy_parameters": 
+                            "minimal_size"                         : 0.1,
+                            "enforce_current"                      : false,
+                            "anisotropy_remeshing"                 : true,
+                            "anisotropy_parameters":
                             {
-                                "hmin_over_hmax_anisotropic_ratio"      : 0.01, 
-                                "boundary_layer_max_distance"           : 0.5, 
+                                "hmin_over_hmax_anisotropic_ratio"      : 0.01,
+                                "boundary_layer_max_distance"           : 0.5,
                                 "interpolation"                         : "Linear"
                             }
                         }
@@ -212,7 +212,7 @@ gid_output = GiDOutputProcess(main_model_part,
                                             "WriteDeformedMeshFlag": "WriteUndeformed",
                                             "WriteConditionsFlag": "WriteConditions",
                                             "MultiFileFlag": "SingleFile"
-                                        },        
+                                        },
                                         "nodal_results"       : []
                                     }
                                 }
@@ -224,7 +224,7 @@ gid_output.ExecuteBeforeSolutionLoop()
 gid_output.ExecuteInitializeSolutionStep()
 gid_output.PrintOutput()
 gid_output.ExecuteFinalizeSolutionStep()
-gid_output.ExecuteFinalize()   
+gid_output.ExecuteFinalize()
 ```
 
 The metric can be calculated by hand if you prefer, for example to get the same result than the previous script:
@@ -241,7 +241,7 @@ current_model = KratosMultiphysics.Model()
 main_model_part = current_model.CreateModelPart("MainModelPart")
 main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, 3)
 
-# We add the variables needed 
+# We add the variables needed
 main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
 main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.NODAL_H)
 
@@ -249,13 +249,13 @@ main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.NODAL_H)
 KratosMultiphysics.ModelPartIO("coarse_sphere").ReadModelPart(main_model_part)
 
 # We know that the gradient is unitary and in X direction
-UnityVector = KratosMultiphysics.Vector(3) 
+UnityVector = KratosMultiphysics.Vector(3)
 UnityVector[0] = 1.0
 UnityVector[1] = 0.0
 UnityVector[2] = 0.0
 
 # We set to zero the metric
-MetricVector = KratosMultiphysics.Vector(6) 
+MetricVector = KratosMultiphysics.Vector(6)
 
 for node in main_model_part.Nodes:
     # Calculate the element size
@@ -309,7 +309,7 @@ gid_output = GiDOutputProcess(main_model_part,
                                         "WriteDeformedMeshFlag": "WriteUndeformed",
                                         "WriteConditionsFlag": "WriteConditions",
                                         "MultiFileFlag": "SingleFile"
-                                    },        
+                                    },
                                     "nodal_results"       : []
                                 }
                             }
@@ -321,10 +321,10 @@ gid_output.ExecuteBeforeSolutionLoop()
 gid_output.ExecuteInitializeSolutionStep()
 gid_output.PrintOutput()
 gid_output.ExecuteFinalizeSolutionStep()
-gid_output.ExecuteFinalize()   
+gid_output.ExecuteFinalize()
 ```
 
-![](https://github.com/KratosMultiphysics/Examples/raw/master/mmg_remeshing_examples/use_cases/coarse_sphere/data/solution.png) 
+![](https://github.com/KratosMultiphysics/Examples/raw/master/mmg_remeshing_examples/use_cases/coarse_sphere/data/solution.png)
 
 ## Using the process
 
@@ -441,7 +441,7 @@ The meaning of each of the parameters is the following one:
 	* `metric_variable`: The list of variables that can be considered to calculate the metrics of re-meshing.
 	* `interpolation_error`: The interpolation error considered in the re-mesh.
 	* `mesh_dependent_constant`: This value is automatically calculated if set to 0, but many definitions can be found in the literature.
-	
+
 * `framework`: Whatever you want to work "fluids" using `Eulerian` or "solids" using `Lagrangian`. If you choose `Lagrangian` you will need to interpolate the internal variables if you are considering any constitutive model with history (damage or plasticity).
 	* `bucket_size`: The size of the bucket used in the tree search.
 	* `allocation_size`: The maximum size to allocate the GP used in the search.
@@ -486,17 +486,17 @@ The meaning of each of the parameters is the following one:
 * `max_number_of_searchs`: This is the max. number of search that can be done in the value interpolation process (when values are interpolated from the old mesh to the new mesh)
 * `debug_mode`: If true will output a *GiD* file with just after each remesh (could be useful to check if the error is in the generated mesh).
 * `echo_level`: This sets the `echo_level`, 0 for no output at all, 3 for standard output.
- 
-Can you show us a little example? 
 
-Of course, in the [examples repository](https://github.com/KratosMultiphysics/Examples/tree/master/mmg_remeshing_examples) you can find some examples using the process that you can run in your machine. 
+Can you show us a little example?
+
+Of course, in the [examples repository](https://github.com/KratosMultiphysics/Examples/tree/master/mmg_remeshing_examples) you can find some examples using the process that you can run in your machine.
 
 [This problem](https://github.com/KratosMultiphysics/Examples/tree/master/mmg_remeshing_examples/use_cases/channel_sphere2D) consists in a 2D fluid problem with continuous re-meshing using the Hessian of the velocity as reference. The resulting output should look something similar to the [this](https://www.youtube.com/watch?v=Yd57qxtnNFk&feature=youtu.be).
 
-![](https://github.com/KratosMultiphysics/Examples/blob/master/mmg_remeshing_examples/use_cases/channel_sphere2D/data/result.gif) 
+![](https://github.com/KratosMultiphysics/Examples/blob/master/mmg_remeshing_examples/use_cases/channel_sphere2D/data/result.gif)
 
 [The same case in 3D](https://github.com/KratosMultiphysics/Examples/tree/master/mmg_remeshing_examples/use_cases/channel_sphere3D). The resulting output should look something similar to the [this](https://youtu.be/HVNa5O6h4wM).
 
-![](https://github.com/KratosMultiphysics/Examples/blob/master/mmg_remeshing_examples/use_cases/channel_sphere3D/data/result.gif) 
+![](https://github.com/KratosMultiphysics/Examples/blob/master/mmg_remeshing_examples/use_cases/channel_sphere3D/data/result.gif)
 
 The problems presented in the tests can be used as reference too.

--- a/docs/pages/Kratos/Debugging/General/Profiling Kratos with cProfile and VTune.md
+++ b/docs/pages/Kratos/Debugging/General/Profiling Kratos with cProfile and VTune.md
@@ -1,9 +1,9 @@
 ---
 title: Profiling Kratos with cProfile and VTune
-keywords: 
+keywords:
 tags: [Profiling Kratos with cProfile and VTune.md]
 sidebar: kratos_debugging
-summary: 
+summary:
 ---
 
 # Profiling Kratos with cProfile and VTune
@@ -11,21 +11,21 @@ summary:
 ## Profiling Python code with cProfile
 This page details the steps to follow in order to profile Kratos. Profiling the python part can be done with cProfile. For this no modification of the code is necessary. To visualize the profilling results **SnakeViz** is recommended. SnakeViz can be installed with the following command using pip:
 
-```bash
+```console
 pip install snakeviz
 ```
 or using anaconda:
-```bash
+```console
 conda install -c anaconda snakeviz
 ```
 More details can be found here: https://jiffyclub.github.io/snakeviz/
 
 In order to run the profiler type the following command:
-```bash
+```console
 python -m cProfile -o outputFile.prof MainKratos.py
 ```
 To view the results graphically in the browser:
-```bash
+```console
 snakeviz outputFile.prof
 ```
 The profiling results contain the number of calls for each function, the time per call, the total time and the cummulative time.
@@ -47,12 +47,12 @@ After installation VTune can be run with the gui or the command line. For viewin
 
 After starting kratos:
 
-```bash
+```console
 startkratos
 ```
 vtune can be run with the gui or the command line.
 
 The hotspot analysis gives the run time for each **function**. To see the runtime for each line of code kratos needs to be compiled with debug symbols:
-```bash
+```console
 compilekratosrelwdbg
 ```

--- a/docs/pages/Kratos/Debugging/General/Profiling-Kratos-with-LineProfile.md
+++ b/docs/pages/Kratos/Debugging/General/Profiling-Kratos-with-LineProfile.md
@@ -1,9 +1,9 @@
 ---
 title: Profiling Kratos with LineProfile
-keywords: 
+keywords:
 tags: [Profiling-Kratos-with-LineProfile.md]
 sidebar: kratos_debugging
-summary: 
+summary:
 ---
 
 ## Profiling Kratos with LineProfile
@@ -14,12 +14,12 @@ Obtaining the profiler:
 You can find the python line profiler an all the relevant information here: https://github.com/pyutils/line_profiler.
 
 If you prefer only to install it just:
-```bash
+```console
 python -m pip install line_profiler
 ```
 
 ### Preparing your code.
-The python line profiler needs to know beforehand which functions are you interested in debugger. In that sense, it is helpful that you already have a slight idea on what sections of your code are interested on. 
+The python line profiler needs to know beforehand which functions are you interested in debugger. In that sense, it is helpful that you already have a slight idea on what sections of your code are interested on.
 
 In order to mark such parts, you will have to use the `@profile` decorator. A example is presented below:
 
@@ -55,12 +55,12 @@ print("Profile output written in:", "profile_"+str(os.getpid())+".prof")
 We do recommend to launch your case with this launcher as well if you intend to run with MPI, as it will automatically generate a different report for every process. An example of an invocation call will look like this:
 
 Serial
-```bash
+```console
 python profiler.py MainKratos.py
 ```
 
 Distributed
-```bash
+```console
 mpirun -np [N] --output-filename profile python profiler.py MainKratos.py
 ```
 ## Analyzing output
@@ -172,7 +172,7 @@ def CalculateTotalSpeedUp(input_files, ref):
         if(proc != ref):
             speedups[proc] = speedups[ref]/speedups[proc]
     speedups[ref] = 1
-    
+
     print(speedups)
 
 def CalculateSpeedUpByLine(input_files, ref):
@@ -208,7 +208,7 @@ def GenerateFieldTable(input_files, function_lines, field, min_procs, max_procs,
         function_line = e_line["Line"]
 
         buffer = str(file_name.split("/")[-1])+":"+str(function_name)+":"+str(function_line["Line"])+":"+str(function_line["Line Content"])
-        
+
         for proc in input_files:
             trace = input_files[proc]
             value = trace[file_name][function_name][function_line["Line"]][field]

--- a/docs/pages/Kratos/For_Developers/General/Windows-Install.md
+++ b/docs/pages/Kratos/For_Developers/General/Windows-Install.md
@@ -1,9 +1,9 @@
 ---
 title: Windows Install
-keywords: 
+keywords:
 tags: [Windows-Install.md]
 sidebar: kratos_for_developers
-summary: 
+summary:
 ---
 
 # How to compile Kratos:
@@ -23,12 +23,12 @@ Notice that these installers will overwrite any previous version of the prerequi
 
 - Python 3.3
 - SVN 1.8.0.1
-- CMake 3.0.2 
+- CMake 3.0.2
 - ACML 4.4
 
 # How to compile Kratos: Windows
 
-In this section we are going to go through the process of compiling a basic version of *Kratos Multiphysics* under *Windows* environments. We recommend you to use *Windows 10* but you can compile *Kratos* with *Windows 7* or higher. 
+In this section we are going to go through the process of compiling a basic version of *Kratos Multiphysics* under *Windows* environments. We recommend you to use *Windows 10* but you can compile *Kratos* with *Windows 7* or higher.
 
 A basic knowledge of *Windows* is assumed ( execute commands in cmd, create directories, etc...)
 
@@ -51,12 +51,12 @@ Since *Visual Studio* is a multi-language IDE, some distributions come without C
 
 ## Git
 
-- Objectives: 
+- Objectives:
 	- Install git
 	- Get Kratos Multiphysics source code
 
 
-The first thing you will need is the *Kratos Multiphysics* source code. To download the code you will have to use a git manager. You can install a git manager from the link below. There are may other git clients that you can use. 
+The first thing you will need is the *Kratos Multiphysics* source code. To download the code you will have to use a git manager. You can install a git manager from the link below. There are may other git clients that you can use.
 
 [GitKraken](https://www.gitkraken.com/download)
 
@@ -68,7 +68,7 @@ https://github.com/KratosMultiphysics/Kratos
 
 Once this is done, you should have a "Kratos" directory containing Kratos soruces
 
-## CMake 
+## CMake
 
 - Objectives:
 	- Install CMake
@@ -77,11 +77,11 @@ Once this is done, you should have a "Kratos" directory containing Kratos soruce
 
 [CMake](http://cmake.org/download/)
 
-Once installing, please <span style="color:red"> do not forget to mark the option: '''"Add CMake to the system PATH for all users"'''</span> 
+Once installing, please <span style="color:red"> do not forget to mark the option: '''"Add CMake to the system PATH for all users"'''</span>
 
 Please notice that if you want to use *python* 3.4 or higher, you will need *CMake* 3.0.2 or higher.
 
-## Python 
+## Python
 
 - Objectives:
 	- Install Python3
@@ -95,7 +95,7 @@ Please, take special care to download a installer that suits your desired archit
 ## BLAS and LAPACK
 
 - Objectives:
-	- Get LIBBLAS and LIBLAPACK 
+	- Get LIBBLAS and LIBLAPACK
 
 *Blas* and *Lapack* are needed for many solvers, specially those present in the *ExternalSolversApplication*, that you will likely need to compile. You can get these libraries from:
 
@@ -113,7 +113,7 @@ Additionally, you will need some extra dependencies for these libs. The easiest 
 
 **Warning:** After launching the installer, several options must be selected. Choose **version 6.4.0**. Please take special care to select the correct architecture during this installation (32 bits is called `i868`, 64 bits is called `x86_64`).
 
-## Boost 
+## Boost
 
 - Objectives:
 	- Download boost libraries
@@ -139,16 +139,16 @@ This file controls where Kratos is going to search for the libraries, which appl
 The first thing you need to do is to tell *CMake* that you intend to build a *VisualStudio* project. This is done automatically by *CMake*, but is highly recommended to add it yourself. To do it add `-G` option followed by your target. For example, if you are using *VisualStudio 2015*:
 
 **For 32 bits:**
-```bash
+```console
   cmake -G "Visual Studio 14 2015" ^
 ```
 
 **For 64 bits:**
-```bash
+```console
   cmake -G "Visual Studio 14 2015 Win64" ^
 ```
 **For 64 bits and VS 2017:**
-```bash
+```console
   cmake -G "Visual Studio 15 2017 Win64" ^
 ```
 
@@ -163,7 +163,7 @@ You can find more info and a list of available generators here:
 Once the generator is correctly set, you have to make sure that the paths to all libraries are correctly set. Please make sure that you configure.bat
 file has the following lines with the correct path:
 
-```bash
+```console
   -DBOOST_ROOT="example/boost_1_67_0/" ^
   -DBLAS_LIBRARIES="example/libblas.lib" ^
   -DLAPACK_LIBRARIES="example/liblapack.lib" ^
@@ -171,7 +171,7 @@ file has the following lines with the correct path:
 
 It is possible that if you have multiple python versions in your system CMake detects the wrong one ( typically, the one with the highest version ) to avoid that, please set it manually. For instance, for Python 3.6:
 
-```bash
+```console
   -DPYTHON_EXECUTABLE=C:\Python36\python.exe"
 ```
 
@@ -179,13 +179,13 @@ It is possible that if you have multiple python versions in your system CMake de
 
 Now, you can enable and  disable the applications you may want to compile or not. For instance:
 
-```bash
+```console
   -DSTRUCTURAL_APPLICATION=ON/OFF ^
 ```
 
 We recommend you to enable:
 
-```bash
+```console
   -DINSTALL_EMBEDDED_PYTHON=ON ^
 ```
 
@@ -199,10 +199,10 @@ Here we present a full example using these assumptions:
 - You have blas and lapack in "C:\external_libraries"
 - You have Python36 in "C:\Python36"
 - You downloaded Kratos in "C:\Kratos"
- 
-```bash
+
+```console
   del CMakeCache.txt
-  
+
   cmake -G "Visual Studio 14 2015 Win64"                                              ^
   -DCMAKE_BUILD_TYPE=Release                                                          ^
   -DCMAKE_CXX_FLAGS=" -D_SCL_SECURE_NO_WARNINGS "                                     ^
@@ -236,7 +236,7 @@ Here we present a full example using these assumptions:
 
 Once the modifications of the file are done, it needs to be executed. You can do that by executing the command:
 
-```bash
+```console
   configure
 ```
 
@@ -275,7 +275,7 @@ Once Kratos is compiled and correctly install all its left is to execute some ca
 
 To to test the compilation, you can prepare a simple script (for example `test_kratos.py`) that contains this line:
 
-```bash
+```console
   from KratosMultiphysics import *
 ```
 
@@ -288,24 +288,24 @@ The most easy way to execute a KratosMultiphysics script from the command line i
 - Your Downloaded Kratos in `C:\Kratos`
 - Your script is called `test_kratos.py`
 
-```bash
+```console
   set PATH=C:\\Kratos;C:\\Kratos\\libs;%PATH%
   "python" test_kratos.py
 ```
 
-```bash
+```console
   python test.py
 ```
 
 Or more exactly, you can go to the folder where your case is (input files and main *python* script) and type:
 
-```bash
+```console
   python test.py
 ```
 
 You can also run them directly using the python you have installed in your system (provided that the system knows where python is and the environment variables have the correct values assigned, `PYTHONPATH`, `LD_LIBRARY_PATH` and `PATH`).
 
-```bash
+```console
   python test.py
   python3 test.py
   python36 test.py
@@ -313,10 +313,10 @@ You can also run them directly using the python you have installed in your syste
 
 If everything is correct you will see this message:
 
-```bash
-   |  /           |             
+```console
+   |  /           |
    ' /   __| _` | __|  _ \   __|
-   . \  |   (   | |   (   |\__ \ 
+   . \  |   (   | |   (   |\__ \
   _|\_\_|  \__,_|\__|\___/ ____/
            Multi-Physics 6.1.XXXXX
 ```
@@ -336,7 +336,7 @@ Add this to the `*.vsproj` file of the project is giving you problems under the 
 
 or by setting:
 
-```bash
+```console
 set PreferredToolArchitecture=x64
 ```
 
@@ -348,7 +348,7 @@ before calling `Msbuild.exe` if you are compiling directly from the cmd.
 
 You have a conflicting declaration of round. This could happen for example if you have multiple versions of Visual Studio in your computer. Please add `-DHAVE_ROUND` to the configure `cxxflags` entry:
 
-```bash
+```console
  -DCMAKE_CXX_FLAGS=" -D_SCL_SECURE_NO_WARNINGS -DHAVE_ROUND"
 ```
 

--- a/docs/pages/Kratos/For_Users/Getting_started/Data_Structure/modelpart-and-submodelpart.md
+++ b/docs/pages/Kratos/For_Users/Getting_started/Data_Structure/modelpart-and-submodelpart.md
@@ -1,9 +1,9 @@
 ---
 title: Python Script  ModelPart and SubModelPart
-keywords: 
+keywords:
 tags: [Python Script Tutorial ModelPart SubModelPart]
 sidebar: kratos_for_users
-summary: 
+summary:
 ---
 
 In the previous part of the tutorial, we already saw how the `ModelPart` is the object containing `Element`, `Conditions`, `Nodes` and `Properties`.
@@ -12,9 +12,9 @@ A fundamental feature is that it can also hierarchically contain **"SubModelPart
 
 A quite extensive testing can be found [here](https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/tests/test_model_part.py)
 
-However let's try to make an example to explain this better. 
+However let's try to make an example to explain this better.
 
-```py        
+```py
 # Create a ModelPart root
 current_model = Model()
 model_part = current_model.CreateModelPart("Main")
@@ -28,14 +28,14 @@ print(model_part)
 
 the output is:
 
-```bash      
+```console
 -Main- model part
     Buffer Size : 1
     Number of tables : 0
     Number of sub model parts : 1
     Current solution step index : 0
 
-    Mesh 0 : 
+    Mesh 0 :
         Number of Nodes      : 0
         Number of Properties : 0
         Number of Elements   : 0
@@ -45,7 +45,7 @@ the output is:
         Number of tables : 0
         Number of sub model parts : 0
 
-        Mesh 0 : 
+        Mesh 0 :
             Number of Nodes      : 0
             Number of Properties : 0
             Number of Elements   : 0
@@ -54,11 +54,11 @@ the output is:
 
 We could now verify if a given submodelpart exists, or how many SubModelParts exist as
 
-```py        
+```py
 model_part.HasSubModelPart("Inlets") #returns True
 model_part.NumberOfSubModelParts() #returns 1
 model_part.GetSubModelPart("Inlets").Name #returns the name --> Inlets
-```     
+```
 
 Let's now create some other SubModelParts
 
@@ -78,14 +78,14 @@ print(model_part)
 
 to give
 
-```bash
+```console
 -Main- model part
     Buffer Size : 1
     Number of tables : 0
     Number of sub model parts : 3
     Current solution step index : 0
 
-    Mesh 0 : 
+    Mesh 0 :
         Number of Nodes      : 0
         Number of Properties : 0
         Number of Elements   : 0
@@ -95,7 +95,7 @@ to give
         Number of tables : 0
         Number of sub model parts : 0
 
-        Mesh 0 : 
+        Mesh 0 :
             Number of Nodes      : 0
             Number of Properties : 0
             Number of Elements   : 0
@@ -104,7 +104,7 @@ to give
         Number of tables : 0
         Number of sub model parts : 0
 
-        Mesh 0 : 
+        Mesh 0 :
             Number of Nodes      : 0
             Number of Properties : 0
             Number of Elements   : 0
@@ -113,7 +113,7 @@ to give
         Number of tables : 0
         Number of sub model parts : 2
 
-        Mesh 0 : 
+        Mesh 0 :
             Number of Nodes      : 0
             Number of Properties : 0
             Number of Elements   : 0
@@ -122,7 +122,7 @@ to give
             Number of tables : 0
             Number of sub model parts : 0
 
-            Mesh 0 : 
+            Mesh 0 :
                 Number of Nodes      : 0
                 Number of Properties : 0
                 Number of Elements   : 0
@@ -131,7 +131,7 @@ to give
             Number of tables : 0
             Number of sub model parts : 0
 
-            Mesh 0 : 
+            Mesh 0 :
                 Number of Nodes      : 0
                 Number of Properties : 0
                 Number of Elements   : 0
@@ -166,7 +166,7 @@ Temp
 ```
 
 ## Data Ownership
-The parent-son relation is such that **anything that belongs to a given SubModelPart also belongs to the parent ModelPart**. 
+The parent-son relation is such that **anything that belongs to a given SubModelPart also belongs to the parent ModelPart**.
 
 This implies that the ultimate "owner" of any `Node`, `Element`, etc, will be the "root" `ModelPart`. The consistency of the tree is ensured by the `ModelPart` **API**, which provides the tools needed for creating or removing anything any of the contained objects.
 
@@ -185,7 +185,7 @@ model_part.CreateNewNode(1, 0.00,0.00,0.00)  # Here an error is thrown
 However if we try to create a node with the same coordinates twice nothing is actually done (and no error is thrown)
 
 ```py
-model_part.CreateNewNode(1, 1.00,0.00,0.00) 
+model_part.CreateNewNode(1, 1.00,0.00,0.00)
 print(model_part.NumberOfNodes()) # This still returns 1!!
 ```
 
@@ -231,12 +231,12 @@ inlet2_model_part = inlets_model_part.GetSubModelPart("Inlet2")
 inlet2_model_part.CreateNewNode(4, 4.00,0.00,0.00)
 ```
 
-Multiple nodes can be removed at once (and from all levels) by flagging them 
+Multiple nodes can be removed at once (and from all levels) by flagging them
 
 ```py
 for node in model_part.Nodes:
     if(node.Id < 3):
-        node.Set(TO_ERASE,True) 
+        node.Set(TO_ERASE,True)
 
 model_part.RemoveNodesFromAllLevels(TO_ERASE)
 ```

--- a/docs/pages/Kratos/For_Users/Getting_started/From_scratch/Creating-a-base-application.md
+++ b/docs/pages/Kratos/For_Users/Getting_started/From_scratch/Creating-a-base-application.md
@@ -1,9 +1,9 @@
 ---
 title: Creating a base application
-keywords: 
+keywords:
 tags: [Creating-a-base-application.md]
 sidebar: kratos_for_users
-summary: 
+summary:
 ---
 
 ## Quick start
@@ -14,7 +14,7 @@ The process of creating such a basic application is very simple and it is done t
 
 You will find a couple of python files there. If you are the **TL;DR** kind of person you can execute right away the file `createApplication.py` with your application name and it will generate your application or you can jump to "In detail" to learn how to customize your app. It is important that your application name is in camel case format (first letter of every word in caps). For example:
 
-```bash
+```console
 python createApplication.py MyExample
 ```
 
@@ -22,7 +22,7 @@ That's it! Your application has been generated, You can check that it has been c
 
 In order to compile it just add:
 
-```bash
+```console
 -DMY_EXAMPLE_APPLICATION=ON \
 ```
 
@@ -98,7 +98,7 @@ debugApp.AddProcesses([
 ```
 -->
 
-Finally you can create processes. There is no custom options for processes yet but its name and you will probably need at least one. 
+Finally you can create processes. There is no custom options for processes yet but its name and you will probably need at least one.
 
 #### Generating the app
 ```python
@@ -151,7 +151,7 @@ if(Import_MyExampleApplication):
     kernel.AddApplication(my_example_application)
     print("KratosMyExampleApplication Succesfully imported")
 
-# ... 
+# ...
 # And finally:
 
 if(Import_MyExampleApplication):
@@ -172,8 +172,8 @@ Here is a list of common problems that can appear while using the generator:
 FileExistsError: [Errno 17] File exists: '/path/Kratos/kratos/python_scripts/application_generator
 /utils/../../../../applications/MyExampleApplication'
 ```
-- **Cause**: 
+- **Cause**:
 The application name you used is used by another application
 
-- **Solution**: 
+- **Solution**:
 Use another name.

--- a/docs/pages/Kratos/For_Users/Getting_started/getting-started.md
+++ b/docs/pages/Kratos/For_Users/Getting_started/getting-started.md
@@ -1,33 +1,33 @@
 ---
 title: Python Script  Getting Started
-keywords: 
+keywords:
 tags: [Python Script Tutorial Getting Started]
 sidebar: kratos_for_users
-summary: 
+summary:
 ---
 
-In order to write a python script with *Kratos* the first step would be to *"Obtain"* the `KratosMultiphysics` module and then *"add"* it as an external module to the *Python*. 
+In order to write a python script with *Kratos* the first step would be to *"Obtain"* the `KratosMultiphysics` module and then *"add"* it as an external module to the *Python*.
 
 There are two ways to "Obtain" the module:
 
 - Download the latest release of *Kratos* from Kratos' [release page](https://github.com/KratosMultiphysics/Kratos/releases)
 - Getting the *Kratos* and its **GUI** from *GiD* internet retrieve.
 
-A simple way would be to add the `KratosMultiphysics` module path to the `PYTHONPATH` environment variable. 
+A simple way would be to add the `KratosMultiphysics` module path to the `PYTHONPATH` environment variable.
 
 # Linux
 In Linux you can set the python path to the Kratos root directory using `export` command in terminal:
 
-```bash
+```console
 export PYTHONPATH=/path/to/Kratos
 ```
 ## Example:
 For a release version extracted your home directory
-```bash
+```console
 export PYTHONPATH=$HOME/Kratos
 ```
-In case of having a GiD installed in `GiDx64/GiD14.0.0` subfolder of home: 
-```bash
+In case of having a GiD installed in `GiDx64/GiD14.0.0` subfolder of home:
+```console
 export PYTHONPATH=$HOME/GiDx64/GiD14.0.0/problemtypes/kratos.gid/exec/Kratos
 ```
 # Windows

--- a/docs/pages/Kratos/For_Users/Getting_started/hello-world.md
+++ b/docs/pages/Kratos/For_Users/Getting_started/hello-world.md
@@ -1,9 +1,9 @@
 ---
 title: Python Script  Hello Kratos
-keywords: 
+keywords:
 tags: [Python Script Tutorial Hello World Kratos]
 sidebar: kratos_for_users
-summary: 
+summary:
 ---
 
 The first step in writing a python script for *Kratos* is importing the KratosMultiphysics as follow:
@@ -14,10 +14,10 @@ from KratosMultiphysics import *
 
 This imports the *Kratos* and shows a logo of *Kratos*:
 
-```bash
- |  /           |             
+```console
+ |  /           |
  ' /   __| _` | __|  _ \   __|
- . \  |   (   | |   (   |\__ \ 
+ . \  |   (   | |   (   |\__ \
 _|\_\_|  \__,_|\__|\___/ ____/
            Multi-Physics 6.0.0
 ```

--- a/docs/pages/Kratos/For_Users/How_to_get_Kratos/Binaries/Getting-Kratos-Binaries-for-Linux.md
+++ b/docs/pages/Kratos/For_Users/How_to_get_Kratos/Binaries/Getting-Kratos-Binaries-for-Linux.md
@@ -1,12 +1,12 @@
 ---
 title: Getting Kratos Binaries for Linux
-keywords: 
+keywords:
 tags: [Getting-Kratos-Binaries-for-Linux.md]
 sidebar: kratos_for_users
-summary: 
+summary:
 ---
 
-This page covers the process of downloading a compiled version of Kratos for Linux and how to use it to run an example. 
+This page covers the process of downloading a compiled version of Kratos for Linux and how to use it to run an example.
 
 ## Minimum requirements
 
@@ -48,18 +48,18 @@ python $*
 ```
 
 Do not forget to give the script execution rights:
-```bash
+```console
 chmod +x runner.sh
 ```
 
 2 - Make an alias for the script
 
-```bash
+```console
 echo "alias kratos=runner.sh" >> $HOME/.bashrc
 ```
 
 3 - Open the terminal and execute the problem script using kratos:
 
-```bash
+```console
 kratos MainKratos.py
 ```

--- a/docs/process_pages.py
+++ b/docs/process_pages.py
@@ -239,7 +239,7 @@ def AddPythonSnippetOutputs(file_path: Path) -> None:
                 while temp_index < len(lines):
                     if lines[temp_index].strip():
                         is_existing_output_found  = lines[temp_index] == "Expected output:\n"
-                        is_existing_output_found &= lines[temp_index+1] == "```bash\n"
+                        is_existing_output_found &= lines[temp_index+1] == "```console\n"
                         break
                     temp_index += 1
 
@@ -254,7 +254,7 @@ def AddPythonSnippetOutputs(file_path: Path) -> None:
                     subprocess_run = subprocess.run([GetPython3Command(), "-u", temp_file_path], stdout=subprocess.PIPE, universal_newlines=True, check=True)
                     output_lines.append("\n")
                     output_lines.append("Expected output:\n")
-                    output_lines.append("```bash\n")
+                    output_lines.append("```console\n")
                     output_lines.append(subprocess_run.stdout)
                     output_lines.append("```\n")
 


### PR DESCRIPTION
**📝 Description**
In markdown, proper way to have console output is to use ```console``` not the ```bash```. This PR changes the occurances of ```bash``` to ```console```.

**🆕 Changelog**
- Change occurances of ```bash``` to ```console```
