### PR TITLE
[Releases][MedApplication] Adding Med Application support for windows.

### DIFF
--- a/applications/MedApplication/MedApplication.json
+++ b/applications/MedApplication/MedApplication.json
@@ -1,0 +1,11 @@
+{
+	"wheel_name": "KratosMedApplication",
+	"included_modules": ["MedApplication"],
+	"included_binaries": ["KratosMedApplication.*", "KratosMedCore.*", "libKratosMedCore.*", "hdf5.*", "hdf5_hl.*", "hdf5_tools.*", "medC.*", "medimport.*"],
+    "excluded_binaries": [],
+	"dependencies": ["KratosMultiphysics==${KRATOS_VERSION}"],
+	"author": "Kratos Team",
+	"author_email": "kratos@listas.cimne.upc.edu",
+	"description": "KRATOS Multiphysics (\"Kratos\") is a framework for building parallel, multi-disciplinary simulation software, aiming at modularity, extensibility, and high performance. Kratos is written in C++, and counts with an extensive Python interface.",
+	"readme": "applications/MedApplication/README.md"
+}

--- a/applications/MedApplication/custom_io/med_model_part_io.cpp
+++ b/applications/MedApplication/custom_io/med_model_part_io.cpp
@@ -362,6 +362,9 @@ public:
         // read only by default, unless other settings are specified
         med_access_mode open_mode;
 
+        // Fix to allow windows conversion from whatever eldritch format is using to something convertible to c_str()
+        std::string med_file_mame{rFileName.string()};
+
         if (mIsReadMode) {
             open_mode = MED_ACC_RDONLY;
 
@@ -371,7 +374,9 @@ public:
             // basic checks if the file is compatible with the MED library
             med_bool hdf_ok;
             med_bool med_ok;
-            const med_err err = MEDfileCompatibility(rFileName.c_str(), &hdf_ok, &med_ok);
+
+            const med_err err = MEDfileCompatibility(med_file_mame.c_str(), &hdf_ok, &med_ok);
+
             CheckMEDErrorCode(err, "MEDfileCompatibility");
 
             KRATOS_ERROR_IF(err != 0) << "A problem occured while trying to check the compatibility of file " << rFileName << "!" << std::endl;
@@ -382,7 +387,7 @@ public:
             mMeshName = "Kratos_Mesh"; // Maybe could use the name of the ModelPart (this is what is displayed in Salome)
         }
 
-        mFileHandle = MEDfileOpen(rFileName.c_str(), open_mode);
+        mFileHandle = MEDfileOpen(med_file_mame.c_str(), open_mode);
         KRATOS_ERROR_IF(mFileHandle < 0) << "A problem occured while opening file " << rFileName << "!" << std::endl;
 
         if (mIsReadMode) {

--- a/scripts/docker_files/docker_file_wheelbuilder_windows/Dockerfile
+++ b/scripts/docker_files/docker_file_wheelbuilder_windows/Dockerfile
@@ -98,6 +98,11 @@ RUN powershell.exe -Command \
     ./cmake.exe -H"c:\hdf5\source\hdf5-1.12.2" -B"c:\hdf5\build" -DCMAKE_INSTALL_PREFIX="c:\hdf5\bin" -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON; \
     ./cmake.exe --build "c:\hdf5\build" --target install -- /property:configuration=Release
 
+RUN powershell.exe -Command \
+    cd 'c:/Program Files/CMake/bin/'; \
+    ./cmake.exe -H"c:\med\source\med-5.0.0" -B"c:\med\build" -DCMAKE_INSTALL_PREFIX="c:\med\bin" -DMEDFILE_BUILD_TESTS=OFF -DMEDFILE_BUILD_SHARED_LIBS=ON -DHDF5_ROOT="c:\hdf5\bin"; \
+    ./cmake.exe --build "c:\med\build" --target install -- /property:configuration=Release
+
 # #Downloand blas/lapack
 # RUN powershell.exe -Command \
 # 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \

--- a/scripts/wheels/windows/configure.bat
+++ b/scripts/wheels/windows/configure.bat
@@ -39,6 +39,7 @@ CALL :add_app %KRATOS_APP_DIR%\RANSApplication;
 CALL :add_app %KRATOS_APP_DIR%\MappingApplication;
 CALL :add_app %KRATOS_APP_DIR%\CompressiblePotentialFlowApplication;
 CALL :add_app %KRATOS_APP_DIR%\HDF5Application;
+CALL :add_app %KRATOS_APP_DIR%\MedApplication;
 CALL :add_app %KRATOS_APP_DIR%\IgaApplication;
 CALL :add_app %KRATOS_APP_DIR%\ChimeraApplication;
 CALL :add_app %KRATOS_APP_DIR%\StatisticsApplication;

--- a/scripts/wheels/windows/configure.bat
+++ b/scripts/wheels/windows/configure.bat
@@ -63,6 +63,7 @@ cmake -G"Visual Studio 16 2019" -H"%KRATOS_SOURCE%" -B"%KRATOS_BUILD%\%KRATOS_BU
 -DBOOST_ROOT=%BOOST_ROOT%                                                                   ^
 -DKRATOS_BUILD_TESTING=ON                                                                   ^
 -DHDF5_ROOT="c:\hdf5\bin"                                                                   ^
+-DMED_ROOT="c:\med\bin"                                                                     ^
 -DKRATOS_GENERATE_PYTHON_STUBS=ON
 
 :add_app


### PR DESCRIPTION
**📝 Description**
This allows the MedApplication to be compiled in windows. Also added the necessary files to be able to release it as a pip package.

Ping @Marco1410 because you use salome
Also ping @philbucher @sunethwarna you can find how to compile the med in win in the dockerfile.

**🆕 Changelog**
Med compilable in win