### PR TITLE
[GeoMechanicsApplication] Added missing include to GeoStructalBaseElement 

### DIFF
--- a/applications/GeoMechanicsApplication/custom_elements/geo_structural_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_structural_base_element.cpp
@@ -13,7 +13,6 @@
 // Application includes
 #include "custom_elements/geo_structural_base_element.hpp"
 #include "custom_utilities/element_utilities.hpp"
-#include "geo_mechanics_application_variables.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_elements/geo_structural_base_element.cpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_structural_base_element.cpp
@@ -13,6 +13,7 @@
 // Application includes
 #include "custom_elements/geo_structural_base_element.hpp"
 #include "custom_utilities/element_utilities.hpp"
+#include "geo_mechanics_application_variables.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_elements/geo_structural_base_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_structural_base_element.hpp
@@ -19,7 +19,7 @@
 #include "includes/variables.h"
 
 // Application includes
-#include "geo_mechanics_application_variables.h"
+#include "geo_mechanics_application_constants.h"
 
 namespace Kratos
 {

--- a/applications/GeoMechanicsApplication/custom_elements/geo_structural_base_element.hpp
+++ b/applications/GeoMechanicsApplication/custom_elements/geo_structural_base_element.hpp
@@ -19,6 +19,7 @@
 #include "includes/variables.h"
 
 // Application includes
+#include "geo_mechanics_application_variables.h"
 
 namespace Kratos
 {


### PR DESCRIPTION
**📝 Description**
Since the header file of the `GeoStructalBaseElement` uses some variables defined in  geo_mechanics_application_variables.h, the include needs to be in the header.