### PR TITLE
[Core] Making PointerVectorSet to be always ordered and unique

### DIFF
--- a/applications/MappingApplication/custom_utilities/closest_points.cpp
+++ b/applications/MappingApplication/custom_utilities/closest_points.cpp
@@ -36,6 +36,12 @@ bool PointWithId::operator<(const PointWithId& rOther) const
     return mDistance < rOther.mDistance;
 }
 
+bool PointWithId::operator==(const PointWithId& rOther) const
+{
+    return IndexedObject::operator==(rOther) &&
+           Point::operator==(rOther);
+}
+
 void PointWithId::save(Serializer &rSerializer) const
 {
     KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, IndexedObject);

--- a/applications/MappingApplication/custom_utilities/closest_points.h
+++ b/applications/MappingApplication/custom_utilities/closest_points.h
@@ -44,6 +44,8 @@ public:
 
     bool operator<(const PointWithId& rOther) const;
 
+    bool operator==(const PointWithId& rOther) const;
+
     double GetDistance() const { return mDistance; }
 
 private:

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -755,20 +755,19 @@ public:
 
     void Sort()
     {
-        Conform(mData.begin(), mData.end());
+        Conform();
     }
 
     void Unique()
     {
-        Conform(mData.begin(), mData.end());
+        Conform();
     }
 
-    template<class TIteratorType>
-    void Conform(TIteratorType first, TIteratorType last)
+    void Conform()
     {
-        std::sort(first, last, CompareKey());
-        auto new_last = std::unique(first, last, EqualKeyTo());
-        mData.erase(new_last, last);
+        std::sort(mData.begin(), mData.end(), CompareKey());
+        auto new_last = std::unique(mData.begin(), mData.end(), EqualKeyTo());
+        mData.erase(new_last, mData.end());
     }
 
     ///@}

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -136,7 +136,7 @@ public:
      */
     PointerVectorSet(const PointerVectorSet& rOther)
         :  mData(rOther.mData), mSortedPartSize(rOther.mSortedPartSize), mMaxBufferSize(rOther.mMaxBufferSize) {}
-    
+
     /**
      * @brief Constructs a PointerVectorSet from a container.
      * @details This constructor initializes a PointerVectorSet with elements from a container.
@@ -677,20 +677,7 @@ public:
      */
     iterator find(const key_type& Key)
     {
-        ptr_iterator sorted_part_end;
-
-        if (mData.size() - mSortedPartSize >= mMaxBufferSize) {
-            Sort();
-            sorted_part_end = mData.end();
-        } else
-            sorted_part_end = mData.begin() + mSortedPartSize;
-
-        ptr_iterator i(std::lower_bound(mData.begin(), sorted_part_end, Key, CompareKey()));
-        if (i == sorted_part_end || (!EqualKeyTo(Key)(*i)))
-            if ((i = std::find_if(sorted_part_end, mData.end(), EqualKeyTo(Key))) == mData.end())
-                return mData.end();
-
-        return i;
+        return iterator(std::lower_bound(mData.begin(), mData.end(), Key, CompareKey()));
     }
 
     /**
@@ -703,14 +690,7 @@ public:
      */
     const_iterator find(const key_type& Key) const
     {
-        ptr_const_iterator sorted_part_end(mData.begin() + mSortedPartSize);
-
-        ptr_const_iterator i(std::lower_bound(mData.begin(), sorted_part_end, Key, CompareKey()));
-        if (i == sorted_part_end || (!EqualKeyTo(Key)(*i)))
-            if ((i = std::find_if(sorted_part_end, mData.end(), EqualKeyTo(Key))) == mData.end())
-                return mData.end();
-
-        return const_iterator(i);
+        return const_iterator(std::lower_bound(mData.begin(), mData.end(), Key, CompareKey()));
     }
 
     /**
@@ -789,15 +769,15 @@ public:
     /**
      * @brief Get the maximum size of buffer used in the container
      */
-    size_type GetMaxBufferSize() const 
+    size_type GetMaxBufferSize() const
     {
         return mMaxBufferSize;
     }
 
-    /** 
+    /**
      * @brief Set the maximum size of buffer used in the container.
      * @details This container uses a buffer which keep data unsorted. After buffer size arrived to the MaxBufferSize it will sort all container and empties buffer.
-     * @param NewSize Is the new buffer maximum size. 
+     * @param NewSize Is the new buffer maximum size.
      */
     void SetMaxBufferSize(const size_type NewSize)
     {
@@ -805,16 +785,16 @@ public:
     }
 
     /**
-     * @brief Get the sorted part size of buffer used in the container. 
+     * @brief Get the sorted part size of buffer used in the container.
      */
-    size_type GetSortedPartSize() const 
+    size_type GetSortedPartSize() const
     {
         return mSortedPartSize;
     }
 
-    /** 
+    /**
      * @brief Set the sorted part size of buffer used in the container.
-     * @param NewSize Is the new buffer maximum size. 
+     * @param NewSize Is the new buffer maximum size.
      */
     void SetSortedPartSize(const size_type NewSize)
     {
@@ -980,10 +960,10 @@ private:
 
     /// The data container holding the elements.
     TContainerType mData;
-    
+
     /// The size of the sorted portion of the data.
     size_type mSortedPartSize;
-    
+
     /// The maximum buffer size for data storage.
     size_type mMaxBufferSize;
 

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -178,29 +178,18 @@ public:
      */
     TDataType& operator[](const key_type& Key)
     {
-        ptr_iterator sorted_part_end;
-
-        if (mData.size() - mSortedPartSize >= mMaxBufferSize) {
-            Sort();
-            sorted_part_end = mData.end();
+        auto itr_pos = std::lower_bound(mData.begin(), mData.end(), Key, CompareKey());
+        if (itr_pos == mData.end()) {
+            // insert a new element with id.
+            mData.push_back(TPointerType(new TDataType(Key)));
+            return back();
+        } else if (EqualKeyTo(Key)(*itr_pos)) {
+            // already found existing element with the same key, hence returning the existing element.
+            return **itr_pos;
         } else {
-            sorted_part_end = mData.begin() + mSortedPartSize;
+            // insert the new value before the itr_pos.
+            return **(mData.insert(itr_pos, TPointerType(new TDataType(Key))));
         }
-
-        ptr_iterator i(std::lower_bound(mData.begin(), sorted_part_end, Key, CompareKey()));
-        if (i == sorted_part_end) {
-            mSortedPartSize++;
-            return **mData.insert(sorted_part_end, TPointerType(new TDataType(Key)));
-        }
-
-        if (!EqualKeyTo(Key)(*i)) {
-            if ((i = std::find_if(sorted_part_end, mData.end(), EqualKeyTo(Key))) == mData.end()) {
-                mData.push_back(TPointerType(new TDataType(Key)));
-                return **(mData.end() - 1);
-            }
-        }
-
-        return **i;
     }
 
     /**
@@ -213,27 +202,18 @@ public:
      */
     pointer& operator()(const key_type& Key)
     {
-        ptr_iterator sorted_part_end;
-
-        if (mData.size() - mSortedPartSize >= mMaxBufferSize) {
-            Sort();
-            sorted_part_end = mData.end();
-        } else
-            sorted_part_end = mData.begin() + mSortedPartSize;
-
-        ptr_iterator i(std::lower_bound(mData.begin(), sorted_part_end, Key, CompareKey()));
-        if (i == sorted_part_end) {
-            mSortedPartSize++;
-            return *mData.insert(sorted_part_end, TPointerType(new TDataType(Key)));
+        auto itr_pos = std::lower_bound(mData.begin(), mData.end(), Key, CompareKey());
+        if (itr_pos == mData.end()) {
+            // insert a new element with id.
+            mData.push_back(TPointerType(new TDataType(Key)));
+            return mData.back();
+        } else if (EqualKeyTo(Key)(*itr_pos)) {
+            // already found existing element with the same key, hence returning the existing element.
+            return *itr_pos;
+        } else {
+            // insert the new value before the itr_pos.
+            return *(mData.insert(itr_pos, TPointerType(new TDataType(Key))));
         }
-
-        if (!EqualKeyTo(Key)(*i))
-            if ((i = std::find_if(sorted_part_end, mData.end(), EqualKeyTo(Key))) == mData.end()) {
-                mData.push_back(TPointerType(new TDataType(Key)));
-                return *(mData.end() - 1);
-            }
-
-        return *i;
     }
 
     /**

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -615,7 +615,7 @@ public:
 
     /**
      * @brief Insert elements from a range of iterators.
-     * @details This function inserts elements from a range defined by the iterators `first` and `last`
+     * @details This function inserts element pointers from a range defined by the iterators `first` and `last`
      * into the set. This will not insert any elements in the range, if there exists an element with a key
      * which is equal to an element's key in the input range.
      * @param first An input iterator pointing to the beginning of the range to insert.
@@ -637,9 +637,9 @@ public:
             // now add the new elements
             for (; first != new_last; ++first) {
                 // find the lower bound element.
-                p_current_itr = std::lower_bound(p_current_itr, mData.end(), KeyOf(*first), CompareKey());
-                if (!EqualKeyTo(KeyOf(*first))(*p_current_itr)) {
-                    mData.insert(p_current_itr, *first);
+                p_current_itr = std::lower_bound(p_current_itr, mData.end(), KeyOf(**first), CompareKey());
+                if (!EqualKeyTo(KeyOf(**first))(*p_current_itr)) {
+                    p_current_itr = mData.insert(p_current_itr, *first);
                 }
             }
         }

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -694,18 +694,6 @@ public:
     }
 
     /**
-     * @brief Count the number of elements with the specified key.
-     * @details This function counts the number of elements with the specified key in the set. It returns 1
-     * if the element is found and 0 if it's not found.
-     * @param Key The key to count.
-     * @return The number of elements with the specified key (0 or 1).
-     */
-    size_type count(const key_type& Key)
-    {
-        return find(Key) == mData.end() ? 0 : 1;
-    }
-
-    /**
      * @brief Reserves memory for a specified number of elements.
      * @details This function reserves memory in the underlying data container for a specified number of elements.
      * @param reservedsize The number of elements to reserve memory for.

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -521,9 +521,9 @@ public:
      * @details This function appends a given pointer to the end of the set.
      * @param x The pointer to be added to the end of the set.
      */
-    void push_back(TPointerType x)
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version (use insert instead)") void push_back(TPointerType x)
     {
-        mData.push_back(x);
+        insert(x);
     }
 
     /**

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -132,6 +132,7 @@ public:
         size_type NewMaxBufferSize = 1)
         : mMaxBufferSize(NewMaxBufferSize)
     {
+        mData.reserve(std::distance(First, Last));
         insert(First, Last);
     }
 
@@ -153,9 +154,7 @@ public:
         :  mData(rContainer),
            mMaxBufferSize(1)
     {
-        std::sort(mData.begin(), mData.end());
-        auto last = std::unique(mData.begin(), mData.end(), EqualKeyTo());
-        mData.erase(last, mData.end());
+        Conform(mData.begin(), mData.end());
     }
 
     /// Destructor.
@@ -756,10 +755,20 @@ public:
 
     void Sort()
     {
+        Conform(mData.begin(), mData.end());
     }
 
     void Unique()
     {
+        Conform(mData.begin(), mData.end());
+    }
+
+    template<class TIteratorType>
+    void Conform(TIteratorType first, TIteratorType last)
+    {
+        std::sort(first, last, CompareKey());
+        auto new_last = std::unique(first, last, EqualKeyTo());
+        mData.erase(new_last, last);
     }
 
     ///@}

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -113,8 +113,7 @@ public:
 
     /// Default constructor.
     PointerVectorSet()
-        : mData(),
-          mMaxBufferSize(1)
+        : mData()
     {}
 
     /**
@@ -128,9 +127,7 @@ public:
     template <class TInputIteratorType>
     PointerVectorSet(
         TInputIteratorType First,
-        TInputIteratorType Last,
-        size_type NewMaxBufferSize = 1)
-        : mMaxBufferSize(NewMaxBufferSize)
+        TInputIteratorType Last)
     {
         mData.reserve(std::distance(First, Last));
         insert(First, Last);
@@ -141,8 +138,7 @@ public:
      * @param rOther The PointerVectorSet to copy from.
      */
     PointerVectorSet(const PointerVectorSet& rOther)
-        : mData(rOther.mData),
-          mMaxBufferSize(rOther.mMaxBufferSize)
+        : mData(rOther.mData)
     {}
 
     /**
@@ -151,10 +147,9 @@ public:
      * @param rContainer The container to copy elements from.
      */
     explicit PointerVectorSet(const TContainerType& rContainer)
-        :  mData(rContainer),
-           mMaxBufferSize(1)
+        : mData(rContainer)
     {
-        Conform(mData.begin(), mData.end());
+        Conform();
     }
 
     /// Destructor.
@@ -517,7 +512,6 @@ public:
      */
     void swap(PointerVectorSet& rOther)
     {
-        std::swap(mMaxBufferSize, rOther.mMaxBufferSize);
         mData.swap(rOther.mData);
     }
 
@@ -526,7 +520,7 @@ public:
      * @details This function appends a given pointer to the end of the set.
      * @param x The pointer to be added to the end of the set.
      */
-    void push_back(TPointerType x)
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version (use insert instead)") void push_back(TPointerType x)
     {
         insert(x);
     }
@@ -688,13 +682,11 @@ public:
 
     /**
      * @brief Clear the set, removing all elements.
-     * @details This function clears the set by removing all elements,
-     * and setting `mMaxBufferSize` to 1.
-     */
+     * @details This function clears the set by removing all elements
+    */
     void clear()
     {
         mData.clear();
-        mMaxBufferSize = 1;
     }
 
     /**
@@ -753,12 +745,12 @@ public:
         return mData.capacity();
     }
 
-    void Sort()
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version (use Conform instead)") void Sort()
     {
         Conform();
     }
 
-    void Unique()
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version (use Conform instead)") void Unique()
     {
         Conform();
     }
@@ -789,9 +781,9 @@ public:
     /**
      * @brief Get the maximum size of buffer used in the container
      */
-    size_type GetMaxBufferSize() const
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version. This is a blank call") size_type GetMaxBufferSize() const
     {
-        return mMaxBufferSize;
+        return 0;
     }
 
     /**
@@ -799,15 +791,14 @@ public:
      * @details This container uses a buffer which keep data unsorted. After buffer size arrived to the MaxBufferSize it will sort all container and empties buffer.
      * @param NewSize Is the new buffer maximum size.
      */
-    void SetMaxBufferSize(const size_type NewSize)
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version. This is a blank call") void SetMaxBufferSize(const size_type NewSize)
     {
-        mMaxBufferSize = NewSize;
     }
 
     /**
      * @brief Get the sorted part size of buffer used in the container.
      */
-    size_type GetSortedPartSize() const
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version. This is a blank call") size_type GetSortedPartSize() const
     {
         return 0;
     }
@@ -816,7 +807,7 @@ public:
      * @brief Set the sorted part size of buffer used in the container.
      * @param NewSize Is the new buffer maximum size.
      */
-    void SetSortedPartSize(const size_type NewSize)
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version. This is a blank call") void SetSortedPartSize(const size_type NewSize)
     {
     }
 
@@ -975,9 +966,6 @@ private:
     /// The data container holding the elements.
     TContainerType mData;
 
-    /// The maximum buffer size for data storage.
-    size_type mMaxBufferSize;
-
     ///@}
     ///@name Private Operators
     ///@{
@@ -1041,8 +1029,6 @@ private:
 
         for(size_type i = 0 ; i < local_size ; i++)
             rSerializer.save("E", mData[i]);
-
-        rSerializer.save("Max Buffer Size",mMaxBufferSize);
     }
 
     /**
@@ -1059,8 +1045,6 @@ private:
 
         for(size_type i = 0 ; i < local_size ; i++)
             rSerializer.load("E", mData[i]);
-
-        rSerializer.load("Max Buffer Size",mMaxBufferSize);
     }
 
     ///@}

--- a/kratos/includes/geometrical_object.h
+++ b/kratos/includes/geometrical_object.h
@@ -116,6 +116,12 @@ public:
         return *this;
     }
 
+    bool operator==(GeometricalObject const& rOther) const
+    {
+        return IndexedObject::operator==(rOther) &&
+               static_cast<const Flags&>(*this) == static_cast<const Flags&>(rOther);
+    }
+
     ///@}
     ///@name Operations
     ///@{

--- a/kratos/includes/indexed_object.h
+++ b/kratos/includes/indexed_object.h
@@ -96,6 +96,18 @@ public:
         return rThisObject.Id();
     }
 
+    template<class TObjectType>
+    bool operator<(TObjectType const& rThisObject) const
+    {
+        return mId < rThisObject.Id();
+    }
+
+    template<class TObjectType>
+    bool operator==(TObjectType const& rThisObject) const
+    {
+        return mId == rThisObject.Id();
+    }
+
     ///@}
     ///@name Operations
     ///@{

--- a/kratos/includes/indexed_object.h
+++ b/kratos/includes/indexed_object.h
@@ -102,12 +102,6 @@ public:
         return mId < rThisObject.Id();
     }
 
-    template<class TObjectType>
-    bool operator==(TObjectType const& rThisObject) const
-    {
-        return mId == rThisObject.Id();
-    }
-
     ///@}
     ///@name Operations
     ///@{

--- a/kratos/includes/indexed_object.h
+++ b/kratos/includes/indexed_object.h
@@ -102,6 +102,11 @@ public:
         return mId < rThisObject.Id();
     }
 
+    bool operator==(IndexedObject const& rOther) const
+    {
+        return mId == rOther.mId;
+    }
+
     ///@}
     ///@name Operations
     ///@{

--- a/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
+++ b/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
@@ -296,7 +296,7 @@ public:
         KRATOS_TRY;
         // Generate an auxilary model part and populate it by elements of type DistanceCalculationElementSimplex
         this->GenerateIntersectedEdgesElementsModelPart();
-        
+
         // Set the linear strategy to solve the regression problem
         this->SetLinearStrategy();
 
@@ -599,12 +599,16 @@ protected:
 
         // Populate the modelpart with all the nodes in NodesMap
         // Note that a temporary vector is created from the set to add all nodes at once
-        PointerVectorSet<Node> tmp;
+        PointerVectorSet<
+            Node,
+            IndexedObject,
+            std::less<typename IndexedObject::result_type>,
+            std::equal_to<typename IndexedObject::result_type>> tmp;
         tmp.reserve(rModelPart.NumberOfElements()*2);
         for(auto& item: map_of_nodes){
             tmp.push_back(item.second);
         }
-        rModelPart.AddNodes(tmp.begin(), tmp.end());    
+        rModelPart.AddNodes(tmp.begin(), tmp.end());
     }
 
     void SetLinearStrategy()
@@ -742,7 +746,7 @@ private:
     {
         const auto& rp_var_list = rModelPart.pGetNodalSolutionStepVariablesList();
         unsigned int buffer_size = rModelPart.GetBufferSize();
-        
+
         // Loop the edge nodes
         for (std::size_t i = 0; i < 2; ++i) {
             auto p_i_node = rEdgeGeometry(i);
@@ -750,7 +754,7 @@ private:
             if (!p_i_node->Is(VISITED)) {
                 p_i_node->Set(VISITED, true);
                 auto p_node_copy = Kratos::make_intrusive< Node >(
-                    p_i_node->Id(), 
+                    p_i_node->Id(),
                     p_i_node->Coordinates());
                 p_node_copy->SetSolutionStepVariablesList(rp_var_list);
                 p_node_copy->SetBufferSize(buffer_size);

--- a/kratos/tests/cpp_tests/containers/test_pointer_vector_set.cpp
+++ b/kratos/tests/cpp_tests/containers/test_pointer_vector_set.cpp
@@ -34,12 +34,270 @@ KRATOS_TEST_CASE_IN_SUITE(PointerVectorSetCBeginAndCEnd, KratosCoreFastSuite)
     auto p_element_1 = Kratos::make_intrusive<Element>(1);
     auto p_element_2 = Kratos::make_intrusive<Element>(2);
     auto p_element_3 = Kratos::make_intrusive<Element>(3);
-    test_container.push_back(p_element_1);
-    test_container.push_back(p_element_2);
-    test_container.push_back(p_element_3);
+    test_container.insert(p_element_1);
+    test_container.insert(p_element_2);
+    test_container.insert(p_element_3);
 
     KRATOS_EXPECT_EQ(test_container.cbegin()->Id(), 1);
     KRATOS_EXPECT_EQ((test_container.cend()-1)->Id(), 3);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(PointerVectorSetInsert1, KratosCoreFastSuite)
+{
+    PointerVectorSet<const Element> test_container;
+    auto p_element_1 = Kratos::make_intrusive<Element>(1);
+    auto p_element_2 = Kratos::make_intrusive<Element>(2);
+    auto p_element_3 = Kratos::make_intrusive<Element>(3);
+    auto p_element_4 = Kratos::make_intrusive<Element>(4);
+    auto p_element_5 = Kratos::make_intrusive<Element>(5);
+    auto p_element_6 = Kratos::make_intrusive<Element>(6);
+    auto p_element_3_copy = Kratos::make_intrusive<Element>(3);
+    test_container.insert(p_element_3);
+    test_container.insert(p_element_2);
+    test_container.insert(p_element_1);
+    test_container.insert(p_element_5);
+    test_container.insert(p_element_6);
+    test_container.insert(p_element_4);
+    test_container.insert(p_element_3_copy);
+
+    KRATOS_EXPECT_EQ(test_container.size(), 6);
+
+    auto itr = test_container.begin();
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_1);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_2);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_3);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_4);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_5);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_6);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(PointerVectorSetInsert2, KratosCoreFastSuite)
+{
+    PointerVectorSet<const Element> test_container;
+    auto p_element_1 = Kratos::make_intrusive<Element>(1);
+    auto p_element_2 = Kratos::make_intrusive<Element>(2);
+    auto p_element_3 = Kratos::make_intrusive<Element>(3);
+    auto p_element_4 = Kratos::make_intrusive<Element>(4);
+    auto p_element_5 = Kratos::make_intrusive<Element>(5);
+    auto p_element_6 = Kratos::make_intrusive<Element>(6);
+    auto p_element_3_copy = Kratos::make_intrusive<Element>(3);
+    test_container.insert(test_container.end(), p_element_3);
+    test_container.insert(test_container.end(), p_element_6);
+    test_container.insert(test_container.end(), p_element_2);
+    test_container.insert(test_container.begin(), p_element_1);
+    test_container.insert(test_container.begin(), p_element_5);
+    test_container.insert(test_container.begin() + 3, p_element_4);
+    test_container.insert(test_container.begin() + 3, p_element_1);
+
+    KRATOS_EXPECT_EQ(test_container.size(), 6);
+
+    auto itr = test_container.begin();
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_1);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_2);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_3);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_4);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_5);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_6);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(PointerVectorSetInsert3, KratosCoreFastSuite)
+{
+    PointerVectorSet<const Element> test_container;
+    auto p_element_1 = Kratos::make_intrusive<Element>(1);
+    auto p_element_2 = Kratos::make_intrusive<Element>(2);
+    auto p_element_3 = Kratos::make_intrusive<Element>(3);
+    auto p_element_4 = Kratos::make_intrusive<Element>(4);
+    auto p_element_5 = Kratos::make_intrusive<Element>(5);
+    auto p_element_6 = Kratos::make_intrusive<Element>(6);
+    auto p_element_3_copy = Kratos::make_intrusive<Element>(3);
+
+    std::vector<Element::Pointer> tmp;
+    tmp.push_back(p_element_2);
+    tmp.push_back(p_element_1);
+    tmp.push_back(p_element_4);
+    tmp.push_back(p_element_3);
+    tmp.push_back(p_element_4);
+    tmp.push_back(p_element_6);
+    tmp.push_back(p_element_1);
+    tmp.push_back(p_element_5);
+    tmp.push_back(p_element_3_copy);
+    test_container.insert(tmp.begin(), tmp.end());
+
+    KRATOS_EXPECT_EQ(test_container.size(), 6);
+
+    auto itr = test_container.begin();
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_1);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_2);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_3);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_4);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_5);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_6);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(PointerVectorSetInsert4, KratosCoreFastSuite)
+{
+    PointerVectorSet<const Element> test_container;
+    auto p_element_1 = Kratos::make_intrusive<Element>(1);
+    auto p_element_2 = Kratos::make_intrusive<Element>(2);
+    auto p_element_3 = Kratos::make_intrusive<Element>(3);
+    auto p_element_4 = Kratos::make_intrusive<Element>(4);
+    auto p_element_5 = Kratos::make_intrusive<Element>(5);
+    auto p_element_6 = Kratos::make_intrusive<Element>(6);
+    auto p_element_7 = Kratos::make_intrusive<Element>(7);
+    auto p_element_8 = Kratos::make_intrusive<Element>(8);
+    auto p_element_3_copy = Kratos::make_intrusive<Element>(3);
+
+    std::vector<Element::Pointer> tmp;
+    tmp.push_back(p_element_2);
+    tmp.push_back(p_element_1);
+    tmp.push_back(p_element_5);
+    tmp.push_back(p_element_8);
+    test_container.insert(tmp.begin(), tmp.end());
+
+    KRATOS_EXPECT_EQ(test_container.size(), 4);
+    auto itr = test_container.begin();
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_1);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_2);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_5);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_8);
+
+    tmp.clear();
+    tmp.push_back(p_element_3);
+    tmp.push_back(p_element_4);
+    tmp.push_back(p_element_5);
+    tmp.push_back(p_element_3);
+    tmp.push_back(p_element_3_copy);
+    tmp.push_back(p_element_1);
+    tmp.push_back(p_element_7);
+    tmp.push_back(p_element_6);
+    test_container.insert(tmp.begin(), tmp.end());
+
+    KRATOS_EXPECT_EQ(test_container.size(), 8);
+    itr = test_container.begin();
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_1);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_2);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_3);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_4);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_5);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_6);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_7);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_8);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(PointerVectorSetOperator1, KratosCoreFastSuite)
+{
+    PointerVectorSet<Element> test_container;
+    auto p_element_1 = Kratos::make_intrusive<Element>(1);
+    auto p_element_2 = Kratos::make_intrusive<Element>(2);
+    auto p_element_3 = Kratos::make_intrusive<Element>(3);
+    auto p_element_4 = Kratos::make_intrusive<Element>(4);
+    auto p_element_5 = Kratos::make_intrusive<Element>(5);
+    auto p_element_3_copy = Kratos::make_intrusive<Element>(3);
+    test_container.insert(p_element_3);
+    test_container.insert(p_element_1);
+    test_container.insert(p_element_2);
+
+    KRATOS_EXPECT_EQ(&test_container[*p_element_2], &*p_element_2);
+    KRATOS_EXPECT_EQ(test_container[*p_element_5].Id(), 5);
+    KRATOS_EXPECT_EQ(test_container[*p_element_4].Id(), 4);
+    KRATOS_EXPECT_EQ(&test_container[*p_element_3_copy], &*p_element_3);
+
+    KRATOS_EXPECT_EQ(test_container.size(), 5);
+    auto itr = test_container.begin();
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_1);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_2);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_3);
+    KRATOS_EXPECT_EQ((itr++)->Id(), 4);
+    KRATOS_EXPECT_EQ((itr++)->Id(), 5);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(PointerVectorSetOperator2, KratosCoreFastSuite)
+{
+    PointerVectorSet<Element> test_container;
+    auto p_element_1 = Kratos::make_intrusive<Element>(1);
+    auto p_element_2 = Kratos::make_intrusive<Element>(2);
+    auto p_element_3 = Kratos::make_intrusive<Element>(3);
+    auto p_element_4 = Kratos::make_intrusive<Element>(4);
+    auto p_element_5 = Kratos::make_intrusive<Element>(5);
+    auto p_element_3_copy = Kratos::make_intrusive<Element>(3);
+    test_container.insert(p_element_3);
+    test_container.insert(p_element_1);
+    test_container.insert(p_element_2);
+
+    KRATOS_EXPECT_EQ(test_container(*p_element_2), p_element_2);
+    KRATOS_EXPECT_EQ(test_container(*p_element_5)->Id(), 5);
+    KRATOS_EXPECT_EQ(test_container(*p_element_4)->Id(), 4);
+    KRATOS_EXPECT_EQ(test_container(*p_element_3_copy), p_element_3);
+
+    KRATOS_EXPECT_EQ(test_container.size(), 5);
+    auto itr = test_container.begin();
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_1);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_2);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_3);
+    KRATOS_EXPECT_EQ((itr++)->Id(), 4);
+    KRATOS_EXPECT_EQ((itr++)->Id(), 5);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(PointerVectorSetFind1, KratosCoreFastSuite)
+{
+    PointerVectorSet<Element> test_container;
+    auto p_element_1 = Kratos::make_intrusive<Element>(1);
+    auto p_element_2 = Kratos::make_intrusive<Element>(2);
+    auto p_element_3 = Kratos::make_intrusive<Element>(3);
+    auto p_element_4 = Kratos::make_intrusive<Element>(4);
+    auto p_element_3_copy = Kratos::make_intrusive<Element>(3);
+    test_container.insert(p_element_3);
+    test_container.insert(p_element_1);
+    test_container.insert(p_element_2);
+
+    KRATOS_EXPECT_EQ(test_container.size(), 3);
+    auto itr = test_container.begin();
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_1);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_2);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_3);
+
+    KRATOS_EXPECT_EQ(&*test_container.find(*p_element_1), &*p_element_1);
+    KRATOS_EXPECT_EQ(&*test_container.find(*p_element_3), &*p_element_3);
+    KRATOS_EXPECT_EQ(&*test_container.find(*p_element_3_copy), &*p_element_3);
+    KRATOS_EXPECT_EQ(test_container.find(*p_element_4), test_container.end());
+
+    KRATOS_EXPECT_EQ(test_container.size(), 3);
+    itr = test_container.begin();
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_1);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_2);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_3);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(PointerVectorSetFind2, KratosCoreFastSuite)
+{
+    PointerVectorSet<Element> test_container;
+    auto p_element_1 = Kratos::make_intrusive<Element>(1);
+    auto p_element_2 = Kratos::make_intrusive<Element>(2);
+    auto p_element_3 = Kratos::make_intrusive<Element>(3);
+    auto p_element_4 = Kratos::make_intrusive<Element>(4);
+    auto p_element_3_copy = Kratos::make_intrusive<Element>(3);
+    test_container.insert(p_element_3);
+    test_container.insert(p_element_1);
+    test_container.insert(p_element_2);
+
+    KRATOS_EXPECT_EQ(test_container.size(), 3);
+    auto itr = test_container.begin();
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_1);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_2);
+    KRATOS_EXPECT_EQ(&*(itr++), &*p_element_3);
+
+    const auto& const_test_container = test_container;
+
+    KRATOS_EXPECT_EQ(&*const_test_container.find(*p_element_1), &*p_element_1);
+    KRATOS_EXPECT_EQ(&*const_test_container.find(*p_element_3), &*p_element_3);
+    KRATOS_EXPECT_EQ(&*const_test_container.find(*p_element_3_copy), &*p_element_3);
+    KRATOS_EXPECT_EQ(const_test_container.find(*p_element_4), const_test_container.cend());
+
+    KRATOS_EXPECT_EQ(const_test_container.size(), 3);
+    auto c_itr = const_test_container.cbegin();
+    KRATOS_EXPECT_EQ(&*(c_itr++), &*p_element_1);
+    KRATOS_EXPECT_EQ(&*(c_itr++), &*p_element_2);
+    KRATOS_EXPECT_EQ(&*(c_itr++), &*p_element_3);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(TestPointerVectorSet, KratosCoreFastSuite)

--- a/kratos/tests/test_dofs.py
+++ b/kratos/tests/test_dofs.py
@@ -161,8 +161,6 @@ class TestDofs(KratosUnittest.TestCase):
             dofs_vector.append(node.GetDof(KratosMultiphysics.PRESSURE))
             dofs_vector.append(node.GetDof(KratosMultiphysics.PRESSURE))
 
-        self.assertEqual(len(dofs_vector), 3*test_model_part.NumberOfNodes())
-        dofs_vector.unique()
         self.assertEqual(len(dofs_vector), test_model_part.NumberOfNodes())
 
 if __name__ == '__main__':


### PR DESCRIPTION
**📝 Description**
❗ CI IS FAILING BECAUSE, I WANT TO CONFIRM THE PROPOSED CHANGES ARE OK FIRST BEFORE PROCEEDING, AFTERWARDS I WILL FIX THE PROBLEMS ❗ 

Finally got time to work on the issue #11363. This PR intends to make `PointerVectorSet` to be always sorted and unique. Following changes are made:

- immutable and mutable `find` do not sort. It assumes the container is sorted and returns the found items.
- `count` method is removed [count should be always one for the unique `PointerVectorSet`].
- `push_back` will be deprecated, and will use `insert`
- `Sort` and `Unique` will be deprecated, and will use `Conform`
- ...

:warning: Followings also needs to be addressed in future:

- mutuable and immutable `PointerVectorSet::GetContainer` can kill the sorted orderedness of the `PointerVectorSet` from outside.

⚠️ Unfortunately, we will not be able to have the `PointerVectorSet` always ordered and unique:
- The `SetId` method of `Node`, `Condition`, `Element` or any `IndexedObject` allows mutating the ids of the entities in the `PointerVectorSet`, hence making it unordered and not unique. Therefore, we still need to have either `Sort` and `Unique` methods, or I would like to introduce `Conform` method which does both, and deprecate `Sort` and `Unique`.
- The `SetId` is heavily used, hence we cannot disallow it.
- So if someone uses `SetId`, then they should call `Conform` afterwards, otherwise, results may be affected.
- The danger is, the current implementation, and the proposed implementation `find` will fail, if the `PointerVectorSet` is not sorted and unique.

🧪 This is ready for review. CI may be failing because, We first need to agree on the suggested changes in this PR before proceeding further. @KratosMultiphysics/technical-committee

**🆕 Changelog**
- `PointerVectorSet::find` immutable and mutable versions does not sort any more.
- Removed `PointerVectorSet::count` method