### PR TITLE
[Core][Python] Missing register for `GlobalElementPointersVector` and `GlobalConditionPointersVector`

### DIFF
--- a/kratos/python/add_global_pointers_to_python.cpp
+++ b/kratos/python/add_global_pointers_to_python.cpp
@@ -11,7 +11,6 @@
 //  Main authors:    Riccardo Rossi
 //
 
-
 // System includes
 
 // External includes
@@ -37,7 +36,8 @@ void AddGlobalPointersToPython(pybind11::module& m)
     py::class_< GlobalPointer<Condition>  >(m,"GlobalConditionPointer");
 
     py::class_< GlobalPointersVector<Node> >(m,"GlobalNodePointersVector");
-
+    py::class_< GlobalPointersVector<Element> >(m,"GlobalElementPointersVector");
+    py::class_< GlobalPointersVector<Condition> >(m,"GlobalConditionPointersVector");
 }
 
 } // namespace Kratos::Python.


### PR DESCRIPTION
**📝 Description**

Missing register for `GlobalElementPointersVector` and `GlobalConditionPointersVector`

**🆕 Changelog**

- [Missing register for `GlobalElementPointersVector` and `GlobalConditionPointersVector`](https://github.com/KratosMultiphysics/Kratos/commit/bf457e631864254fb9cc71d79c36c1459fa11516)
