### PR TITLE
[FastPR][OptApp] Fix LinearStrainEnergy thickness sensitivity

### DIFF
--- a/applications/OptimizationApplication/custom_utilities/response/linear_strain_energy_response_utils.cpp
+++ b/applications/OptimizationApplication/custom_utilities/response/linear_strain_energy_response_utils.cpp
@@ -96,7 +96,7 @@ void LinearStrainEnergyResponseUtils::CalculateGradient(
             CalculateStrainEnergyLinearlyDependentPropertyGradient(rGradientComputedModelPart, YOUNG_MODULUS, YOUNG_MODULUS_SENSITIVITY);
         } else if (*pVariable == THICKNESS) {
             block_for_each(rGradientRequiredModelPart.Elements(), [](auto& rElement) { rElement.GetProperties().SetValue(THICKNESS_SENSITIVITY, 0.0); });
-            CalculateStrainEnergyLinearlyDependentPropertyGradient(rGradientComputedModelPart, THICKNESS, THICKNESS_SENSITIVITY);
+            CalculateStrainEnergySemiAnalyticPropertyGradient(rGradientComputedModelPart, PerturbationSize, THICKNESS, THICKNESS_SENSITIVITY);
         } else if (*pVariable == POISSON_RATIO) {
             block_for_each(rGradientRequiredModelPart.Elements(), [](auto& rElement) { rElement.GetProperties().SetValue(POISSON_RATIO_SENSITIVITY, 0.0); });
             CalculateStrainEnergySemiAnalyticPropertyGradient(rGradientComputedModelPart, PerturbationSize, POISSON_RATIO, POISSON_RATIO_SENSITIVITY);


### PR DESCRIPTION
**📝 Description**

Strain energy is in general not linearly dependent on the element thickness (e.g. shells). Hence, in this PR the strain energy sensitivity calculation is changed to the semi-analytic method.

Comparison of a shell thickness optimization with previous linear sensitivities and new semi-analytic sensitivities. 
One can identify, that the strain energy constraint is strongly oscillating and slowing down the optimization due to the previously wrong calculated sensitivities.

| Linear Dependent Sensitivity | Semi-Analytic Sensitivity |
|--------|--------|
| ![linear_dependent_objective](https://github.com/KratosMultiphysics/Kratos/assets/61698470/5045adc1-0317-40a9-9341-fc88f7c1db2d) |![semi_analytic_objective](https://github.com/KratosMultiphysics/Kratos/assets/61698470/7fc0a2d6-73e8-4158-9b6d-085f88d4828e)  |
|![linear_dependent_constraint](https://github.com/KratosMultiphysics/Kratos/assets/61698470/dbc2fa6d-fc65-4466-bfd2-3aaa80cbf2e8) |![semi_analytic_constraint](https://github.com/KratosMultiphysics/Kratos/assets/61698470/67cae071-c0d4-4c05-b262-4735191beb50)  | 