### PR TITLE
[CMake][Core] Bumping min CMake version to 3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.6)
+cmake_minimum_required (VERSION 3.21.0)
 project (KratosMultiphysics)
 set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.21.0)
+cmake_minimum_required (VERSION 3.15.0)
 project (KratosMultiphysics)
 set (CMAKE_CXX_STANDARD 17)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
**📝 Description**

Bumping minimal cmake version to 3.15 until CentOS version is updated.

@KratosMultiphysics/altair Please check that this PR does not break your CI's
@KratosMultiphysics/geomechanics Same, please check that this does not break any CI on your side.

🆕 Changelog

- [Bumping min CMake version](https://github.com/KratosMultiphysics/Kratos/pull/12094/commits/7273e117c895287529c5d08ba9cdf080d2603124)
- [Set to 3.15 until upgrade centos](https://github.com/KratosMultiphysics/Kratos/pull/12094/commits/df2d43a65fabb90adceb6d5ca2f855a7cf85a323)