### PR TITLE
[Core] Minor fix `CppTestsUtilities`. Moving also initial coordinates and fix radius

### DIFF
--- a/kratos/utilities/cpp_tests_utilities.cpp
+++ b/kratos/utilities/cpp_tests_utilities.cpp
@@ -489,9 +489,12 @@ void CreateSphereTriangularMesh(
 
     // Modify center
     block_for_each(rModelPart.Nodes(), [&rCenter](Node& rNode) {
-        rNode.X() += rCenter[0];
-        rNode.Y() += rCenter[1];
-        rNode.Z() += rCenter[2];
+        rNode.X()  += rCenter[0];
+        rNode.X0() += rCenter[0];
+        rNode.Y()  += rCenter[1];
+        rNode.Y0() += rCenter[1];
+        rNode.Z()  += rCenter[2];
+        rNode.Z0() += rCenter[2];
     });
 
     // Get the Initial Id

--- a/kratos/utilities/cpp_tests_utilities.cpp
+++ b/kratos/utilities/cpp_tests_utilities.cpp
@@ -408,7 +408,7 @@ void CreateSphereTriangularMesh(
     const std::array<double, 3>& rCenter
     )
 {
-    const double scale = Radius/0.25;
+    const double scale = Radius/0.5;
     Properties::Pointer p_prop = rModelPart.HasProperties(0) ? rModelPart.pGetProperties(0) : rModelPart.CreateNewProperties(0);
 
     // Get the Initial Id


### PR DESCRIPTION
**📝 Description**

Minor fix `CppTestsUtilities`. Moving also initial coordinates and fix radius.

**🆕 Changelog**

- [Minor fix `CppTestsUtilities`. Moving also initial coordinates](https://github.com/KratosMultiphysics/Kratos/commit/8dca4541eb5acd7543e5d6f5a170acccbb6861e0)
- [Reference radius is 0.5, not 0.25](https://github.com/KratosMultiphysics/Kratos/commit/f9db0aff0c8b361b8b412bbd8f4f8faac08bb0e4)
