### PR TITLE
[Docs] Fix core stub generation

### DIFF
--- a/scripts/post_install/kratos__init__.pyi
+++ b/scripts/post_install/kratos__init__.pyi
@@ -1,0 +1,18 @@
+import Kratos.python_registry as python_registry
+import Kratos.kratos_globals as kratos_globals
+
+class KratosPaths:
+    kratos_install_path: str
+    kratos_libs: str
+    kratos_module_libs: str
+    kratos_applications: str
+    kratos_scripts: str
+    kratos_tests: str
+
+KratosGlobals: kratos_globals.KratosGlobalsImpl
+Registry: python_registry.PythonRegistry
+RegisterPrototype = python_registry.RegisterPrototype
+python_version: str
+kratos_version_info: str
+
+def IsDistributedRun() -> bool: ...

--- a/scripts/post_install/kratos__init__.pyi
+++ b/scripts/post_install/kratos__init__.pyi
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import Kratos.python_registry as python_registry
 import Kratos.kratos_globals as kratos_globals
 

--- a/scripts/post_install/kratos__init__.pyi
+++ b/scripts/post_install/kratos__init__.pyi
@@ -1,6 +1,7 @@
 import Kratos.python_registry as python_registry
 import Kratos.kratos_globals as kratos_globals
 
+@dataclass
 class KratosPaths:
     kratos_install_path: str
     kratos_libs: str
@@ -8,6 +9,7 @@ class KratosPaths:
     kratos_applications: str
     kratos_scripts: str
     kratos_tests: str
+
 
 KratosGlobals: kratos_globals.KratosGlobalsImpl
 Registry: python_registry.PythonRegistry

--- a/scripts/post_install/stub_generation.py
+++ b/scripts/post_install/stub_generation.py
@@ -23,8 +23,8 @@ def PostProcessGeneratedStubFiles():
         with open(str(file.absolute()), "r") as file_input:
             data = file_input.read()
 
-        data = re.sub(R"import +Kratos(\w+)\n", R"import KratosMultiphysics.\1 as Kratos\1\n", data)
-        data = re.sub(R"import +Kratos.(\w.+)\n", R"import KratosMultiphysics.\1\n", data)
+        data = re.sub(R"import +Kratos([a-zA-Z0-9_]+)\n", R"import KratosMultiphysics.\1 as Kratos\1\n", data)
+        data = re.sub(R"import +Kratos.([a-zA-Z0-9_.]+)\n", R"import KratosMultiphysics.\1\n", data)
         data = data.replace("import Kratos\n", "import KratosMultiphysics as Kratos\n")
 
         # adding Kratos import to every pyi file because, some of the

--- a/scripts/post_install/stub_generation.py
+++ b/scripts/post_install/stub_generation.py
@@ -31,7 +31,8 @@ def PostProcessGeneratedStubFiles():
         # stub files may not have it.
         data = "import KratosMultiphysics as Kratos\n" + data
 
-        with open(str(file.absolute()), "w") as file_output:
+        with open(file.absolute(), "w") as file_output:
+
             file_output.write(data)
 
 class KratosPythonCppLib:

--- a/scripts/post_install/stub_generation.py
+++ b/scripts/post_install/stub_generation.py
@@ -39,7 +39,8 @@ class KratosPythonCppLib:
     def __init__(self, cpp_lib_path: Path) -> None:
         self.base_path = cpp_lib_path.parent.parent
         self.cpp_lib_path = cpp_lib_path
-        self.python_module: 'typing.Optional[Path]' = None
+        self.python_module: typing.Optional[Path] = None
+
         self.dependent_modules: 'list[KratosPythonCppLib]' = []
 
     def AddDependentModule(self, kratos_python_cpp_lib) -> None:

--- a/scripts/post_install/stub_generation.py
+++ b/scripts/post_install/stub_generation.py
@@ -2,9 +2,9 @@
 import sys
 import re
 from pathlib import Path
-from importlib import import_module
 import shutil
 import subprocess
+import typing
 
 # External imports
 try:
@@ -15,161 +15,6 @@ except ImportError:
 
 warnings_and_errors_list = []
 
-def __AddSubmodules(output_path: Path):
-    if output_path.is_dir():
-        with open(str(output_path / "__init__.pyi"), "a") as file_output:
-            file_output.write("\n\n#   ---- start of includes of sub modules --- \n\n")
-
-            for cpp_sub_module_path in output_path.iterdir():
-                if cpp_sub_module_path.is_dir():
-                    cpp_sub_module_name = str(cpp_sub_module_path.relative_to(cpp_sub_module_path.parent))
-                else:
-                    cpp_sub_module_name = str(cpp_sub_module_path.relative_to(cpp_sub_module_path.parent))[:-4]
-                if cpp_sub_module_name != "__init__":
-                    file_output.write("from . import {:s}\n".format(cpp_sub_module_name))
-
-            file_output.write("\n#   ---- end of includes of sub modules --- \n\n")
-
-        for cpp_sub_module_path in output_path.iterdir():
-            __AddSubmodules(cpp_sub_module_path)
-
-
-def __FindCPPModuleImportsInPythonModules(current_path: Path, cpp_module_names_list: "list[str]", cpp_python_modules_dict: "dict[str, Path]") -> None:
-
-    if len(cpp_module_names_list) != 0:
-        for sub_path in current_path.iterdir():
-            if sub_path.is_file() and str(sub_path).endswith(".py"):
-                with open(str(sub_path), "r") as file_input:
-                    data = file_input.read()
-
-                for match in re.finditer(R"from +(\w+) +import +\*", data):
-                    cpp_module_name = match.group(1)
-                    if cpp_module_name in cpp_module_names_list:
-                        cpp_python_modules_dict[cpp_module_name] = sub_path
-                        print(f"--- Found {cpp_module_name} binary module include in {str(sub_path)}.")
-                        del cpp_module_names_list[cpp_module_names_list.index(cpp_module_name)]
-                        break
-
-        for sub_path in current_path.iterdir():
-            if sub_path.is_dir():
-                __FindCPPModuleImportsInPythonModules(sub_path, cpp_module_names_list, cpp_python_modules_dict)
-
-
-def __GetPythonModulesImportingCppModules(kratos_python_module_path: Path, kratos_library_path: Path) -> "dict[Path, Path]":
-
-    # generate list of cpp modules
-    list_of_binary_modules = []
-    for custom_library_path in kratos_library_path.iterdir():
-        custom_library_name = custom_library_path.name
-
-        if any(key in custom_library_name for key in (".cpython", "Application")):
-            cpython_location = custom_library_name.find(".cpython")
-            if cpython_location != -1:
-                custom_library_name = custom_library_name[:cpython_location]
-                list_of_binary_modules.append(custom_library_name)
-            else:
-                list_of_binary_modules.append(custom_library_path.stem)
-
-    cpp_python_modules_dict = {}
-    copy_list_of_binary_modules = list(list_of_binary_modules)
-    __FindCPPModuleImportsInPythonModules(kratos_python_module_path, list_of_binary_modules, cpp_python_modules_dict)
-
-    if len(list_of_binary_modules) != 0:
-        msg = "------ Warning: Could not find imports within python modules for following binaries: " + ", ".join(list_of_binary_modules)
-        print(msg)
-
-    return copy_list_of_binary_modules, cpp_python_modules_dict
-
-def __GenerateStubFilesForModule(
-        kratos_python_module_path: Path,
-        kratos_library_path: Path,
-        output_path: Path,
-        cpp_module_name: str,
-        python_import_module_path_dict: "dict[str, Path]") -> None:
-
-
-    def __generate(output_path: Path, cpp_module_name: str, custom_args: "list[str]"):
-
-        args = ["-o", str(output_path.absolute())]
-        args.extend(custom_args)
-        args.append(cpp_module_name)
-        options = parse_options(args)
-        generate_stubs(options)
-
-    def __append_cpp_module_stub(cpp_module_file_path: Path, python_module_file_path: Path):
-        # read python module stub file
-        try:
-            with open(str(python_module_file_path), "r") as file_input:
-                data = file_input.read()
-            # now delete the python module stub file
-            shutil.rmtree(str(python_module_file_path.parent.absolute()))
-
-            # now append cpp module stub file
-            with open(str(cpp_module_file_path), "r") as file_input:
-                lines = file_input.read()
-
-            with open(str(cpp_module_file_path), "w") as file_output:
-                file_output.write(lines)
-                file_output.write("\n\n#   ---- start of includes of python modules --- \n\n")
-                data = data.replace("from Kratos", "from KratosMultiphysics.")
-                data = data.replace("from KratosMultiphysics. import", "from KratosMultiphysics import")
-                file_output.write(data)
-                file_output.write("\n#   ---- end of includes of python modules --- \n\n")
-        except Exception as e:
-            msg = f"------ Error: Cannot unify stubs for {cpp_module_file_path}. Error details: {str(e)}"
-            print(msg)
-            warnings_and_errors_list.append(msg)
-
-    __generate(output_path, cpp_module_name, ["-p"])
-
-    # if sub modules are found, include them in the __init__.pyi
-    submodule_path = kratos_library_path / cpp_module_name
-    __AddSubmodules(submodule_path)
-
-    # now add appropriate python module hints
-    if cpp_module_name in python_import_module_path_dict.keys():
-        python_import_module_path = python_import_module_path_dict[cpp_module_name]
-        if str(python_import_module_path).endswith("__init__.py"):
-            found_package = True
-            kratos_full_module_name = str(python_import_module_path.parent.relative_to(kratos_python_module_path)).replace("/", ".")
-        else:
-            found_package = False
-            kratos_full_module_name = str(python_import_module_path.relative_to(kratos_python_module_path)).replace("/", ".")[:-3]
-
-        if (kratos_full_module_name == "."):
-            kratos_full_module_name = "KratosMultiphysics"
-        else:
-            kratos_full_module_name = "KratosMultiphysics." + kratos_full_module_name
-        __generate(output_path, kratos_full_module_name, ["--parse-only", "--export-less", "-m"])
-
-        cpp_module_path = output_path / cpp_module_name
-        if cpp_module_path.is_dir():
-            __append_cpp_module_stub(cpp_module_path / "__init__.pyi", (output_path / kratos_full_module_name.replace(".", "/")) / "__init__.pyi")
-            # now move the directory to appropriate python module path
-            shutil.copytree(str(cpp_module_path), str(python_import_module_path.parent), dirs_exist_ok=True)
-            # delete it from output path
-            shutil.rmtree(str(cpp_module_path))
-            print(f"-- Moved {str(cpp_module_path)} package and its submodules to {str(python_import_module_path.parent)}")
-
-        else:
-            cpp_module_path = output_path / (cpp_module_name + ".pyi")
-            if cpp_module_path.is_file():
-                if found_package:
-                    __append_cpp_module_stub(cpp_module_path, (output_path / kratos_full_module_name.replace(".", "/")) / "__init__.pyi")
-                    shutil.move(str(cpp_module_path), str(python_import_module_path.parent / "__init__.pyi"))
-                    print(f"-- Moved {str(cpp_module_path)} package to {str(python_import_module_path.parent)}")
-                else:
-                    __append_cpp_module_stub(cpp_module_path, output_path / (kratos_full_module_name.replace(".", "/") + ".pyi"))
-                    stub_file_name = str(python_import_module_path.parent / str(python_import_module_path.relative_to(python_import_module_path.parent)))[:-2] + "pyi"
-                    shutil.move(str(cpp_module_path), stub_file_name)
-                    print(f"-- Moved {str(cpp_module_path)} module to {stub_file_name}")
-    else:
-        msg = f"------ Warning: No python import module found for binary module {cpp_module_name}. Python hints may not be working for this binary."
-        warnings_and_errors_list.append(msg)
-        print(msg)
-
-    return cpp_module_name
-
 def PostProcessGeneratedStubFiles():
     kratos_installation_path = Path(sys.argv[1]).absolute()
 
@@ -179,11 +24,145 @@ def PostProcessGeneratedStubFiles():
             data = file_input.read()
 
         data = re.sub(R"import +Kratos(\w+)\n", R"import KratosMultiphysics.\1 as Kratos\1\n", data)
-        data = re.sub(R"import +Kratos.(\w+)\n", R"import KratosMultiphysics.\1\n", data)
+        data = re.sub(R"import +Kratos.(\w.+)\n", R"import KratosMultiphysics.\1\n", data)
         data = data.replace("import Kratos\n", "import KratosMultiphysics as Kratos\n")
+
+        # adding Kratos import to every pyi file because, some of the
+        # stub files may not have it.
+        data = "import KratosMultiphysics as Kratos\n" + data
 
         with open(str(file.absolute()), "w") as file_output:
             file_output.write(data)
+
+class KratosPythonCppLib:
+    def __init__(self, cpp_lib_path: Path) -> None:
+        self.base_path = cpp_lib_path.parent.parent
+        self.cpp_lib_path = cpp_lib_path
+        self.python_module: 'typing.Optional[Path]' = None
+        self.dependent_modules: 'list[KratosPythonCppLib]' = []
+
+    def AddDependentModule(self, kratos_python_cpp_lib) -> None:
+        if kratos_python_cpp_lib is not None:
+            self.dependent_modules.append(kratos_python_cpp_lib)
+
+    def GetDependentModulesList(self) -> 'list[KratosPythonCppLib]':
+        return self.dependent_modules
+
+    def GetPythonModule(self) -> str:
+        relative_path = self.python_module.relative_to(self.base_path)
+        if relative_path.name == "__init__.py":
+            return str(relative_path.parent).replace("/", ".")
+        else:
+            return str(relative_path)[:-3].replace("/", ".")
+
+    def GetCppLibModule(self) -> str:
+        return self.GetCppLibModuleName(self.cpp_lib_path)
+
+    def SetPythonModule(self, python_module: Path) -> None:
+        self.python_module = python_module
+
+    def GetCppLibPath(self) -> Path:
+        return self.cpp_lib_path
+
+    def GetPythonPath(self) -> Path:
+        return self.python_module
+
+    def IsPythonModuleDefined(self) -> bool:
+        return self.python_module != None
+
+    @staticmethod
+    def GetCppLibModuleName(cpp_lib_path: Path) -> str:
+        loc = cpp_lib_path.name.find(".cpython")
+        if loc == -1:
+            return ""
+        else:
+            return cpp_lib_path.name[:loc]
+
+def GetCppLibs(kratos_libs_path: Path) -> 'list[KratosPythonCppLib]':
+    # generate list of cpp modules
+    list_of_python_cpp_libs: 'list[KratosPythonCppLib]' = []
+    for cpp_lib_path in kratos_libs_path.iterdir():
+        if KratosPythonCppLib.GetCppLibModuleName(cpp_lib_path) != "":
+            list_of_python_cpp_libs.append(KratosPythonCppLib(cpp_lib_path))
+    return list_of_python_cpp_libs
+
+def FindModule(module_name: str, list_of_python_cpp_libs: 'list[KratosPythonCppLib]') -> KratosPythonCppLib:
+    for kratos_dependent_module in list_of_python_cpp_libs:
+        if kratos_dependent_module.GetPythonModule() == module_name:
+            return kratos_dependent_module
+    return None
+
+def MoveKratosModuleStubFilesToPythonModule(stub_file_path: Path, list_of_python_cpp_libs: 'list[KratosPythonCppLib]') -> None:
+    for kratos_module in list_of_python_cpp_libs:
+        stub_source_file_name = stub_file_path / f"{kratos_module.GetCppLibModule()}.pyi"
+
+        if not Path(stub_source_file_name).is_file():
+            # it is not a single stub file, it has multiple nested packages.
+            # hence it is a directory
+            stub_source_file_name = stub_source_file_name.parent / stub_source_file_name.name[:-4]
+            stub_dest_file_name = kratos_module.GetPythonPath().parent
+            shutil.copytree(stub_source_file_name, stub_dest_file_name, dirs_exist_ok=True)
+            shutil.rmtree(stub_source_file_name)
+        else:
+            # it is a single stub file.
+            if kratos_module.GetPythonPath().name == "__init__.py":
+                stub_dest_file_name = kratos_module.GetPythonPath().parent / "__init__.pyi"
+            else:
+                stub_dest_file_name = kratos_module.GetPythonPath().parent / f"{kratos_module.GetPythonPath().name[:-2]}.pyi"
+            shutil.move(str(stub_source_file_name), str(stub_dest_file_name))
+
+def SetPythonModulesForCppModules(list_of_python_cpp_libs: 'list[KratosPythonCppLib]', kratos_python_module_path: Path) -> None:
+    kratos_module_dependent_module_names_dict: 'dict[KratosPythonCppLib, list[str]]' = {}
+    for file_path in kratos_python_module_path.rglob("*.py"):
+        with open(file_path, "r") as file_input:
+            lines = file_input.read()
+
+            for kratos_python_cpp_lib in list_of_python_cpp_libs:
+                if not kratos_python_cpp_lib.IsPythonModuleDefined():
+                    kratos_module_dependent_module_names_dict[kratos_python_cpp_lib] = []
+                    for match_cpp_lib_import in re.finditer(f"from +{kratos_python_cpp_lib.GetCppLibModule()} +import +\*", lines):
+                        kratos_python_cpp_lib.SetPythonModule(file_path)
+                        for match_dependent_imports in re.finditer(f"import +([a-zA-Z0-9_.]+)", lines[:match_cpp_lib_import.start()]):
+                            kratos_module_dependent_module_names_dict[kratos_python_cpp_lib].append(match_dependent_imports.group(1))
+                        break
+
+        if all([v.IsPythonModuleDefined() for v in list_of_python_cpp_libs]):
+            break
+
+    # first add dependencies based on the python module name
+    for kratos_module in list_of_python_cpp_libs:
+        sub_names = kratos_module.GetPythonModule().split(".")
+        sub_module_names: 'list[str]' = []
+        for i, _ in enumerate(sub_names[:-1]):
+            sub_module_names.append(".".join(sub_names[:i+1]))
+        for sub_module_name in sub_module_names:
+            kratos_module.AddDependentModule(FindModule(sub_module_name, list_of_python_cpp_libs))
+
+    # now add specific dependencies from the python scripts.
+    for kratos_module, dependent_module_names_list in kratos_module_dependent_module_names_dict.items():
+        for dependent_module_name in dependent_module_names_list:
+            kratos_module.AddDependentModule(FindModule(dependent_module_name, list_of_python_cpp_libs))
+
+def SortModules(list_of_python_cpp_libs: 'list[KratosPythonCppLib]') -> 'list[KratosPythonCppLib]':
+    iteration = 0
+    all_modules_ordered = False
+    while iteration < 100 and not all_modules_ordered:
+        iteration += 1
+        all_modules_ordered = True
+        for i, kratos_module in enumerate(list_of_python_cpp_libs):
+            for dependent_module in kratos_module.GetDependentModulesList():
+                temp = FindModule(dependent_module.GetPythonModule(), list_of_python_cpp_libs[:i])
+                if temp is None:
+                    del list_of_python_cpp_libs[list_of_python_cpp_libs.index(dependent_module)]
+                    list_of_python_cpp_libs.insert(i, dependent_module)
+                    all_modules_ordered = False
+                    break
+
+            if not all_modules_ordered:
+                break
+
+    if iteration == 100:
+        raise RuntimeError("Cyclic dependency detected.")
 
 def Main():
     print("--- Generating python stub files from {:s}".format(sys.argv[1]))
@@ -194,49 +173,46 @@ def Main():
     sys.path.insert(0, str(kratos_installation_path.absolute()))
     sys.path.insert(0, str(kratos_library_path.absolute()))
 
-    list_of_cpp_libs = []
+    # get list of cpp libs
+    list_of_cpp_libs = GetCppLibs(kratos_library_path)
 
-    # first look for cpp module imports in python modules
-    available_cpp_libs, cpp_python_modules_dict = __GetPythonModulesImportingCppModules(kratos_python_module_path, kratos_library_path)
+    # set python modules corresponding to cpp libs
+    SetPythonModulesForCppModules(list_of_cpp_libs, kratos_python_module_path)
 
-    if len(available_cpp_libs) > 0:
-        # generate Kratos core cpp stubs files
-        import_module("KratosMultiphysics")
-        list_of_cpp_libs.append(__GenerateStubFilesForModule(kratos_python_module_path, kratos_library_path, kratos_library_path, "Kratos", cpp_python_modules_dict))
+    # now sort
+    SortModules(list_of_cpp_libs)
 
-        # Collect Kratos applications
-        from KratosMultiphysics.kratos_utilities import GetListOfAvailableApplications
-        list_of_available_applications = GetListOfAvailableApplications()
+    for kratos_module in list_of_cpp_libs:
+        print("Module information: ")
+        print(f"           Python module name: {kratos_module.GetPythonModule()}")
+        print(f"             Cpp  module name: {kratos_module.GetCppLibModule()}")
+        print( "         List of dependencies:")
+        for dependency in kratos_module.GetDependentModulesList():
+            print(f"               {dependency.GetPythonModule()}")
 
-        # Generate stubs for all installed applications
-        for application_name in list_of_available_applications:
-            # Import the application
-            import_module("KratosMultiphysics." + application_name)
-            application_lib_name = "Kratos" + application_name
+    # now generate the stubs
+    args: 'list[str]' = ["-o", str(kratos_library_path)]
+    for k in list_of_cpp_libs:
+        args.extend(["-p", k.GetCppLibModule()])
+    # args.extend(["-p", "Kratos", "-p", ])
+    options = parse_options(args)
+    generate_stubs(options)
 
-            # Generate stubs to temporary directory
-            list_of_cpp_libs.append(__GenerateStubFilesForModule(kratos_python_module_path, kratos_library_path, kratos_library_path, application_lib_name, cpp_python_modules_dict))
+    MoveKratosModuleStubFilesToPythonModule(kratos_library_path, list_of_cpp_libs)
 
-        # now iterate through auxiliary libraries and generate stub files
-        for custom_library_path in kratos_library_path.iterdir():
-            if custom_library_path.is_file():
-                custom_library_name = str(custom_library_path.relative_to(custom_library_path.parent))
-                cpython_location = custom_library_name.find(".cpython")
-                if cpython_location != -1:
-                    custom_library_name = custom_library_name[:cpython_location]
-                    if custom_library_name not in list_of_cpp_libs:
-                        list_of_cpp_libs.append(__GenerateStubFilesForModule(kratos_python_module_path, kratos_library_path, kratos_library_path, custom_library_name, cpp_python_modules_dict))
-
-        # now check for the empty dir in libs
-        if (kratos_library_path / "KratosMultiphysics").is_dir():
-            shutil.rmtree(str(kratos_library_path / "KratosMultiphysics"))
+    ## special edit for the KratosMultiphysics pyi
+    with open(Path(__file__).parent / "kratos__init__.pyi", "r") as file_input:
+        data = file_input.read()
+    with open(kratos_python_module_path / "__init__.pyi", "a") as file_output:
+        file_output.write("\n\n# ==== Start of predefined stubs === #\n\n")
+        file_output.write(data)
+        file_output.write("\n\n# ==== End of predefined stubs === #\n\n")
 
 if __name__ == "__main__":
     error_and_warning_outut_file = f"{sys.argv[1]}/stub_generation_errors_and_warnings.txt"
     if "--quiet" in sys.argv: # suppress output from Kratos imports
         args = [arg for arg in sys.argv if arg != "--quiet"]
         subprocess.run([sys.executable] + args, stdout = subprocess.PIPE, stderr = sys.stderr, check=True)
-
     else:
         Main()
         PostProcessGeneratedStubFiles()


### PR DESCRIPTION
**📝 Description**
Recently thestub generation started fail due to failure in linking shared libs. The implemented design with old mypy allowed to load cpp libs seperately and generate stubs while linking correctly. Recently, it started to fail with linking erros. This PR identifies all the cpp libs, and generte stubs with one command, so the mypy can link them correctly.

This fixes the segmentation fault in manjaro when `LinearSolversApplication` is compiled for stub generation.

This also adds the ability to add predefined stubs, if mypy fails to add special commands in the `__init__.pyi`.

**🆕 Changelog**
- Fix stub generation
