### PR TITLE
[Core] Add saving distance in skin in `CalculateNodalDistanceToSkinProcess`

### DIFF
--- a/docs/pages/Kratos/Processes/Calculation/calculate_nodal_distance_to_skin_process.md
+++ b/docs/pages/Kratos/Processes/Calculation/calculate_nodal_distance_to_skin_process.md
@@ -44,9 +44,9 @@ This algorithm defines 4 lambda functions for calculating the distance of nodes 
 
 - **`distance_lambda_non_historica_save_skin`**: Performs the same operations as `distance_lambda_historical_save_skin` but for non-historical variables.
 
-These lambdas functions will be chosen depending on the flags `HISTORICAL_VALUE` and `SAVE_DISTANCE_IN_SKIN`, one of the four lambda functions is selected for execution. This decision dictates whether historical or non-historical variables are used and whether distances are saved in the skin model part.
+These lambdas functions will be chosen depending on the flags `mHistoricalValue` and `mSaveDistanceInSkin`, one of the four lambda functions is selected for execution. This decision dictates whether historical or non-historical variables are used and whether distances are saved in the skin model part.
 
-If the `SAVE_DISTANCE_IN_SKIN` flag is set, initializes the distance variable to zero for all elements or conditions in the skin model part.
+If the `mSaveDistanceInSkin` flag is set, initializes the distance variable to zero for all elements or conditions in the skin model part.
 
 Both lambda functions take the following parameters:
 - `Nodes`: A reference to the container holding the nodes for which distances will be calculated.
@@ -61,8 +61,8 @@ The selected lambda function is then applied to calculate the distances for all 
 > A warning is issued if both elements and conditions are found in the skin model part, indicating that elements will be considered for the distance calculation.
 
 #### Flags
-- `HISTORICAL_VALUE`: Determines whether historical or non-historical variables are used for distance calculations.
-- `SAVE_DISTANCE_IN_SKIN`: Indicates whether the calculated distances should be saved back to the skin model part, updating the values if the new distance is greater than the existing one.
+- `mHistoricalValue`: Determines whether historical or non-historical variables are used for distance calculations.
+- `mSaveDistanceInSkin`: Indicates whether the calculated distances should be saved back to the skin model part, updating the values if the new distance is greater than the existing one.
 
 ## Parameters & Defaults
 

--- a/docs/pages/Kratos/Processes/Calculation/calculate_nodal_distance_to_skin_process.md
+++ b/docs/pages/Kratos/Processes/Calculation/calculate_nodal_distance_to_skin_process.md
@@ -68,11 +68,11 @@ The selected lambda function is then applied to calculate the distances for all 
 
 ```json
 {
-    "volume_model_part"     : "",
-    "skin_model_part"       : "",
-    "distance_database"     : "nodal_historical",
-    "save_distance_in_skin" : false,
-    "distance_variable"     : "DISTANCE"
+    "volume_model_part"         : "",
+    "skin_model_part"           : "",
+    "distance_database"         : "nodal_historical",
+    "save_max_distance_in_skin" : false,
+    "distance_variable"         : "DISTANCE"
 }
 ```
 
@@ -85,7 +85,7 @@ Defines the skin model part for distance computations. Like the volume model par
 ##### `distance_database`
 This flag indicating whether historical variable is enabled or otherwise non-historical is considered. It is set by string, options are `nodal_historical` or `nodal_non_historical`. Default value is `nodal_historical`.
 
-#### `save_distance_in_skin`
+#### `save_max_distance_in_skin`
 This flag indicates if the distance is going to be saved in the skin. By default is false, if activated will save the maximum distance in the found skin geometry and set the flag `VISITED`. This also deactivate shared memory parallelization.
 
 ##### `distance_variable`

--- a/docs/pages/Kratos/Processes/Calculation/calculate_nodal_distance_to_skin_process.md
+++ b/docs/pages/Kratos/Processes/Calculation/calculate_nodal_distance_to_skin_process.md
@@ -22,6 +22,8 @@ This process offers a robust solution for calculating the minimum distance from 
 
 - **Support for Historical and Non-Historical Data**: This process supports both historical and non-historical distance variables.
 
+- **Support for Distance Calculation in the Skin if required**: If required the maximum distance to a destination skin entity can be saved.
+
 ### Future Developments
 
 The process is currently optimized for serial execution. However, plans are underway to enable distributed computation, contingent on the integration of improvements from [KratosMultiphysics/Kratos pull request #11719](https://github.com/KratosMultiphysics/Kratos/pull/11719).
@@ -32,13 +34,19 @@ The process is currently optimized for serial execution. However, plans are unde
 
 `Execute` method is used to execute the Process algorithms.
 
-This algorithm defines two lambda functions, `distance_lambda_historical` and `distance_lambda_non_historical`, for calculating the distance of nodes to the nearest geometrical object (element or condition) in a model part. It then determines which lambda to use based on whether the distance variable is historical or non-historical and applies the appropriate lambda to calculate the distances.
+This algorithm defines 4 lambda functions for calculating the distance of nodes to the nearest geometrical object (element or condition) in a model part. It then determines which lambda to use based on whether the distance variable is historical or non-historical, and if we want to save the maximum distance to the found entity in the skin. Then it applies the appropriate lambda to calculate the distances.
 
 - **`distance_lambda_historical`**: This lambda function is used when working with historical data. It iterates over all nodes in the provided nods container and calculates the distance of each node to its nearest geometrical object using a spatial search. The calculated distance is then stored in the node's historical data.
 
 - **`distance_lambda_non_historical`**: This lambda function is similar to `distance_lambda_historical` but is used for non-historical data. It also calculates the distance of each node to its nearest geometrical object and stores the result in the node's non-historical data container.
 
-These lambdas functions will be chosen depending `distance_database` flag.
+- **`distance_lambda_historical_save_skin`**: In addition to calculating distances using historical variables, this lambda also updates the skin model part with the calculated distance if the new distance is greater than the existing value.
+
+- **`distance_lambda_non_historica_save_skin`**: Performs the same operations as `distance_lambda_historical_save_skin` but for non-historical variables.
+
+These lambdas functions will be chosen depending on the flags `HISTORICAL_VALUE` and `SAVE_DISTANCE_IN_SKIN`, one of the four lambda functions is selected for execution. This decision dictates whether historical or non-historical variables are used and whether distances are saved in the skin model part.
+
+If the `SAVE_DISTANCE_IN_SKIN` flag is set, initializes the distance variable to zero for all elements or conditions in the skin model part.
 
 Both lambda functions take the following parameters:
 - `Nodes`: A reference to the container holding the nodes for which distances will be calculated.
@@ -52,14 +60,19 @@ The selected lambda function is then applied to calculate the distances for all 
 
 > A warning is issued if both elements and conditions are found in the skin model part, indicating that elements will be considered for the distance calculation.
 
+#### Flags
+- `HISTORICAL_VALUE`: Determines whether historical or non-historical variables are used for distance calculations.
+- `SAVE_DISTANCE_IN_SKIN`: Indicates whether the calculated distances should be saved back to the skin model part, updating the values if the new distance is greater than the existing one.
+
 ## Parameters & Defaults
 
 ```json
 {
-    "volume_model_part" : "",
-    "skin_model_part"   : "",
-    "distance_database" : "nodal_historical",
-    "distance_variable" : "DISTANCE"
+    "volume_model_part"     : "",
+    "skin_model_part"       : "",
+    "distance_database"     : "nodal_historical",
+    "save_distance_in_skin" : false,
+    "distance_variable"     : "DISTANCE"
 }
 ```
 
@@ -71,6 +84,9 @@ Defines the skin model part for distance computations. Like the volume model par
 
 ##### `distance_database`
 This flag indicating whether historical variable is enabled or otherwise non-historical is considered. It is set by string, options are `nodal_historical` or `nodal_non_historical`. Default value is `nodal_historical`.
+
+#### `save_distance_in_skin`
+This flag indicates if the distance is going to be saved in the skin. By default is false, if activated will save the maximum distance in the found skin geometry and set the flag `VISITED`. This also deactivate shared memory parallelization.
 
 ##### `distance_variable`
 Denotes the variable for applying the process, with `DISTANCE` set as the default value.

--- a/kratos/processes/calculate_nodal_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_nodal_distance_to_skin_process.cpp
@@ -18,25 +18,38 @@
 // Project includes
 #include "containers/model.h"
 #include "utilities/parallel_utilities.h"
+#include "utilities/variable_utils.h"
 #include "processes/calculate_nodal_distance_to_skin_process.h"
 #include "spatial_containers/geometrical_objects_bins.h"
 
 namespace Kratos
 {
+/// Local Flags
+KRATOS_CREATE_LOCAL_FLAG( CalculateNodalDistanceToSkinProcess, HISTORICAL_VALUE,      0 );
+KRATOS_CREATE_LOCAL_FLAG( CalculateNodalDistanceToSkinProcess, SAVE_DISTANCE_IN_SKIN, 1 );
+
+/***********************************************************************************/
+/***********************************************************************************/
 
 CalculateNodalDistanceToSkinProcess::CalculateNodalDistanceToSkinProcess(
     ModelPart& rVolumeModelPart,
     ModelPart& rSkinModelPart,
     const bool HistoricalVariable,
-    const std::string& rDistanceVariableName
+    const std::string& rDistanceVariableName,
+    const bool SaveDistanceInSkin
     ) : mrVolumeModelPart(rVolumeModelPart),
-        mrSkinModelPart(rSkinModelPart),
-        mHistoricalVariable(HistoricalVariable)
+        mrSkinModelPart(rSkinModelPart)
 {
     // Assign distance variable
     if (rDistanceVariableName != "") {
         mpDistanceVariable = &KratosComponents<Variable<double>>::Get(rDistanceVariableName);
     }
+
+    // Setting flags
+    this->Set(HISTORICAL_VALUE, HistoricalVariable);
+    // If SaveDistanceInSkin is true we can not use parallel algorithms and therefore a warning will be raised
+    KRATOS_WARNING_IF("CalculateNodalDistanceToSkinProcess", SaveDistanceInSkin) << "SaveDistanceInSkin is true, therefore the parallel algorithms will not be used." << std::endl;
+    this->Set(SAVE_DISTANCE_IN_SKIN, SaveDistanceInSkin);
 
     // Check it is serial
     KRATOS_ERROR_IF(mrVolumeModelPart.IsDistributed()) << "Distributed computation still not supported. Please update implementation as soon as MPI search is merged. See https://github.com/KratosMultiphysics/Kratos/pull/11719" << std::endl;
@@ -57,12 +70,15 @@ CalculateNodalDistanceToSkinProcess::CalculateNodalDistanceToSkinProcess(
     // If historical or non-historical variables
     const std::string database = ThisParameters["distance_database"].GetString();
     if (database == "nodal_historical") {
-        mHistoricalVariable = true;
+        this->Set(HISTORICAL_VALUE, true);
     } else if (database == "nodal_non_historical") {
-        mHistoricalVariable = false;
+        this->Set(HISTORICAL_VALUE, false);
     } else {
         KRATOS_ERROR << "Only options are nodal_historical and nodal_non_historical, provided is: " << database << std::endl;
     }
+
+    // Save distance in skin flag
+    this->Set(SAVE_DISTANCE_IN_SKIN, ThisParameters["save_distance_in_skin"].GetBool());
 
     // Assign distance variable
     mpDistanceVariable = &KratosComponents<Variable<double>>::Get(ThisParameters["distance_variable"].GetString());
@@ -92,7 +108,35 @@ void CalculateNodalDistanceToSkinProcess::Execute()
         });
     };
 
-    const auto* p_distance_lambda = mHistoricalVariable ? &distance_lambda_historical : &distance_lambda_non_historical;
+    const std::function<void(ModelPart::NodesContainerType& rNodes, GeometricalObjectsBins& rBins)> distance_lambda_historical_save_skin = [this](ModelPart::NodesContainerType& rNodes, GeometricalObjectsBins& rBins) {
+        const auto& r_variable = *mpDistanceVariable;
+        for (Node& rNode: rNodes) {
+            auto result = rBins.SearchNearest(rNode);
+            const double value = result.GetDistance();
+            auto p_result = result.Get().get();
+            if (p_result->GetValue(r_variable) < value) {
+                p_result->SetValue(r_variable, value);
+                p_result->Set(VISITED);
+            }
+            rNode.FastGetSolutionStepValue(r_variable) = value;
+        }
+    };
+    const std::function<void(ModelPart::NodesContainerType& rNodes, GeometricalObjectsBins& rBins)> distance_lambda_non_historica_save_skin = [this](ModelPart::NodesContainerType& rNodes, GeometricalObjectsBins& rBins) {
+        const auto& r_variable = *mpDistanceVariable;
+        for (Node& rNode: rNodes) {
+            auto result = rBins.SearchNearest(rNode);
+            const double value = result.GetDistance();
+            auto p_result = result.Get().get();
+            if (p_result->GetValue(r_variable) < value) {
+                p_result->SetValue(r_variable, value);
+                p_result->Set(VISITED);
+            }
+            rNode.SetValue(r_variable, value);
+        }
+    };
+
+    // Call lambda depending on the flags
+    const auto* p_distance_lambda = this->Is(HISTORICAL_VALUE) ? (this->Is(SAVE_DISTANCE_IN_SKIN) ? &distance_lambda_historical_save_skin : &distance_lambda_historical) : (this->Is(SAVE_DISTANCE_IN_SKIN) ? &distance_lambda_non_historica_save_skin : &distance_lambda_non_historical);
 
     // First try to detect if elements or conditions
     const std::size_t number_of_elements_skin = mrSkinModelPart.NumberOfElements();
@@ -101,10 +145,20 @@ void CalculateNodalDistanceToSkinProcess::Execute()
         KRATOS_WARNING_IF("CalculateNodalDistanceToSkinProcess", number_of_conditions_skin > 0) << "Skin model part has elements and conditions. Considering elements. " << std::endl;
         GeometricalObjectsBins bins(mrSkinModelPart.ElementsBegin(), mrSkinModelPart.ElementsEnd());
 
+        // Set to zero in skin if required
+        if (this->Is(SAVE_DISTANCE_IN_SKIN)) {
+            VariableUtils().SetNonHistoricalVariableToZero(*mpDistanceVariable, mrSkinModelPart.Elements());
+        }
+
         // Call lambda
         (*p_distance_lambda)(mrVolumeModelPart.Nodes(), bins);
     } else if (number_of_conditions_skin > 0) {
         GeometricalObjectsBins bins(mrSkinModelPart.ConditionsBegin(), mrSkinModelPart.ConditionsEnd());
+
+        // Set to zero in skin if required
+        if (this->Is(SAVE_DISTANCE_IN_SKIN)) {
+            VariableUtils().SetNonHistoricalVariableToZero(*mpDistanceVariable, mrSkinModelPart.Conditions());
+        }
 
         // Call lambda
         (*p_distance_lambda)(mrVolumeModelPart.Nodes(), bins);
@@ -117,10 +171,11 @@ void CalculateNodalDistanceToSkinProcess::Execute()
 const Parameters CalculateNodalDistanceToSkinProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"({
-        "volume_model_part" : "",
-        "skin_model_part"   : "",
-        "distance_database" : "nodal_historical",
-        "distance_variable" : "DISTANCE"
+        "volume_model_part"     : "",
+        "skin_model_part"       : "",
+        "distance_database"     : "nodal_historical",
+        "save_distance_in_skin" : false,
+        "distance_variable"     : "DISTANCE"
     })");
     return default_parameters;
 }
@@ -148,7 +203,7 @@ void CalculateNodalDistanceToSkinProcess::PrintInfo(std::ostream& rOStream) cons
 
 void CalculateNodalDistanceToSkinProcess::PrintData(std::ostream& rOStream) const
 {
-    rOStream << "Volume model part:\n" << mrVolumeModelPart << "\nSkin model part:\n" << mrSkinModelPart << "\nHistorical variable: " << std::boolalpha << mHistoricalVariable << "\nDistance variable: " << mpDistanceVariable->Name() << std::endl;
+    rOStream << "Volume model part:\n" << mrVolumeModelPart << "\nSkin model part:\n" << mrSkinModelPart << "\nHistorical variable: " << std::boolalpha << this->Is(HISTORICAL_VALUE) << "\nSave distance in skin: " << std::boolalpha << this->Is(SAVE_DISTANCE_IN_SKIN) << "\nDistance variable: " << mpDistanceVariable->Name() << std::endl;
 }
 
 } // namespace Kratos.

--- a/kratos/processes/calculate_nodal_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_nodal_distance_to_skin_process.cpp
@@ -56,33 +56,6 @@ template class NodalValueRetriever<false>;
 /***********************************************************************************/
 
 CalculateNodalDistanceToSkinProcess::CalculateNodalDistanceToSkinProcess(
-    ModelPart& rVolumeModelPart,
-    ModelPart& rSkinModelPart,
-    const bool HistoricalVariable,
-    const std::string& rDistanceVariableName,
-    const bool SaveDistanceInSkin
-    ) : mrVolumeModelPart(rVolumeModelPart),
-        mrSkinModelPart(rSkinModelPart),
-        mHistoricalValue(HistoricalVariable),
-        mSaveDistanceInSkin(SaveDistanceInSkin)
-{
-    // Assign distance variable
-    if (rDistanceVariableName != "") {
-        mpDistanceVariable = &KratosComponents<Variable<double>>::Get(rDistanceVariableName);
-    }
-
-    // Setting flags
-    // If SaveDistanceInSkin is true we can not use parallel algorithms and therefore a warning will be raised
-    KRATOS_WARNING_IF("CalculateNodalDistanceToSkinProcess", mSaveDistanceInSkin) << "SaveDistanceInSkin is true, therefore the parallel algorithms will not be used." << std::endl;
-
-    // Check it is serial
-    KRATOS_ERROR_IF(mrVolumeModelPart.IsDistributed()) << "Distributed computation still not supported. Please update implementation as soon as MPI search is merged. See https://github.com/KratosMultiphysics/Kratos/pull/11719" << std::endl;
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-CalculateNodalDistanceToSkinProcess::CalculateNodalDistanceToSkinProcess(
     Model& rModel,
     Parameters ThisParameters
     ) : mrVolumeModelPart(rModel.GetModelPart(ThisParameters["volume_model_part"].GetString())),

--- a/kratos/processes/calculate_nodal_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_nodal_distance_to_skin_process.cpp
@@ -71,7 +71,7 @@ CalculateNodalDistanceToSkinProcess::CalculateNodalDistanceToSkinProcess(
     }
 
     // Save distance in skin flag
-    mSaveDistanceInSkin = ThisParameters["save_distance_in_skin"].GetBool();
+    mSaveDistanceInSkin = ThisParameters["save_max_distance_in_skin"].GetBool();
 
     // Assign distance variable
     mpDistanceVariable = &KratosComponents<Variable<double>>::Get(ThisParameters["distance_variable"].GetString());
@@ -164,11 +164,11 @@ void CalculateNodalDistanceToSkinProcess::Execute()
 const Parameters CalculateNodalDistanceToSkinProcess::GetDefaultParameters() const
 {
     const Parameters default_parameters = Parameters(R"({
-        "volume_model_part"     : "",
-        "skin_model_part"       : "",
-        "distance_database"     : "nodal_historical",
-        "save_distance_in_skin" : false,
-        "distance_variable"     : "DISTANCE"
+        "volume_model_part"         : "",
+        "skin_model_part"           : "",
+        "distance_database"         : "nodal_historical",
+        "save_max_distance_in_skin" : false,
+        "distance_variable"         : "DISTANCE"
     })");
     return default_parameters;
 }

--- a/kratos/processes/calculate_nodal_distance_to_skin_process.h
+++ b/kratos/processes/calculate_nodal_distance_to_skin_process.h
@@ -38,6 +38,12 @@ namespace Kratos
 class NodalValueRetrieverBaseClass
 {
 public:
+    // Default Constructor
+    NodalValueRetrieverBaseClass() = default;
+
+    // Default Destructor
+    virtual ~NodalValueRetrieverBaseClass() = default;
+
     /**
      * @brief This method gets the current value of the rVariable
      * @param rNode The node iterator to be get
@@ -65,6 +71,12 @@ class KRATOS_API(KRATOS_CORE) NodalValueRetriever
     : public NodalValueRetrieverBaseClass
 {
 public:
+    // Default Constructor
+    NodalValueRetriever() = default;
+
+    // Default Destructor
+    ~NodalValueRetriever() override = default;
+
     /**
      * @brief This method gets the current value of the rVariable
      * @param rNode The node iterator to be get

--- a/kratos/processes/calculate_nodal_distance_to_skin_process.h
+++ b/kratos/processes/calculate_nodal_distance_to_skin_process.h
@@ -25,8 +25,55 @@ namespace Kratos
 ///@addtogroup Kratos Core
 ///@{
 
+///@}
 ///@name Kratos Classes
 ///@{
+
+/**
+ * @class NodalValueRetrieverBaseClass
+ * @ingroup KratosCore
+ * @brief A class for retrieving nodal values (base dummy class).
+ * @details This class provides methods to retrieve nodal values. This is a dummy class to be specialized
+ */
+struct NodalValueRetrieverBaseClass
+{
+    /**
+     * @brief This method gets the current value of the rVariable
+     * @param rNode The node iterator to be get
+     * @param rVariable The variable to be get
+     * @return The value of the variable
+     */
+    virtual double& GetValue(
+        Node& rNode,
+        const Variable<double>& rVariable
+        )
+    {
+        KRATOS_ERROR << "This method is not implemented" << std::endl;
+    }
+};
+
+/**
+ * @class NodalValueRetriever
+ * @ingroup KratosCore
+ * @brief A class for retrieving nodal values.
+ * @details This class provides methods to retrieve nodal values.
+ * @tparam THistorical If the variable is part of the historical database of from the non-historical database
+ */
+template<bool THistorical = true>
+struct KRATOS_API(KRATOS_CORE) NodalValueRetriever
+    : public NodalValueRetrieverBaseClass
+{
+    /**
+     * @brief This method gets the current value of the rVariable
+     * @param rNode The node iterator to be get
+     * @param rVariable The variable to be get
+     * @return The value of the variable
+     */
+    double& GetValue(
+        Node& rNode,
+        const Variable<double>& rVariable
+        ) override;
+};
 
 /**
  * @class CalculateNodalDistanceToSkinProcess

--- a/kratos/processes/calculate_nodal_distance_to_skin_process.h
+++ b/kratos/processes/calculate_nodal_distance_to_skin_process.h
@@ -42,6 +42,10 @@ public:
     ///@name Type Definitions
     ///@{
 
+    /// Local Flags
+    KRATOS_DEFINE_LOCAL_FLAG( HISTORICAL_VALUE );               /// This flag is used in order to check if the values are historical
+    KRATOS_DEFINE_LOCAL_FLAG( SAVE_DISTANCE_IN_SKIN );          /// This flag is used in order to save the highest distance in the found geometries of the skin
+
     /// Pointer definition of CalculateNodalDistanceToSkinProcess
     KRATOS_CLASS_POINTER_DEFINITION(CalculateNodalDistanceToSkinProcess);
 
@@ -56,12 +60,14 @@ public:
      * @param rSkinModelPart Model part containing the skin to compute the distance to as conditions
      * @param HistoricalVariable If the variable is part of the historical database of from the non-historical database
      * @param rDistanceVariableName The distance variable considered
+     * @param SaveDistanceInSkin If distances are saved into the skin
      */
     CalculateNodalDistanceToSkinProcess(
         ModelPart& rVolumeModelPart,
         ModelPart& rSkinModelPart,
         const bool HistoricalVariable = true,
-        const std::string& rDistanceVariableName = ""
+        const std::string& rDistanceVariableName = "",
+        const bool SaveDistanceInSkin = false
         );
 
     /**
@@ -139,9 +145,6 @@ private:
 
     /// Reference to the skin model part.
     ModelPart& mrSkinModelPart;
-
-    /// Flag indicating whether historical variable is enabled.
-    bool mHistoricalVariable;
 
     /// Pointer to the distance variable.
     const Variable<double>* mpDistanceVariable = &DISTANCE;

--- a/kratos/processes/calculate_nodal_distance_to_skin_process.h
+++ b/kratos/processes/calculate_nodal_distance_to_skin_process.h
@@ -35,8 +35,9 @@ namespace Kratos
  * @brief A class for retrieving nodal values (base dummy class).
  * @details This class provides methods to retrieve nodal values. This is a dummy class to be specialized
  */
-struct NodalValueRetrieverBaseClass
+class NodalValueRetrieverBaseClass
 {
+public:
     /**
      * @brief This method gets the current value of the rVariable
      * @param rNode The node iterator to be get
@@ -60,9 +61,10 @@ struct NodalValueRetrieverBaseClass
  * @tparam THistorical If the variable is part of the historical database of from the non-historical database
  */
 template<bool THistorical = true>
-struct KRATOS_API(KRATOS_CORE) NodalValueRetriever
+class KRATOS_API(KRATOS_CORE) NodalValueRetriever
     : public NodalValueRetrieverBaseClass
 {
+public:
     /**
      * @brief This method gets the current value of the rVariable
      * @param rNode The node iterator to be get

--- a/kratos/processes/calculate_nodal_distance_to_skin_process.h
+++ b/kratos/processes/calculate_nodal_distance_to_skin_process.h
@@ -98,23 +98,6 @@ public:
 
     /**
      * @brief Construct a new Calculate Nodal Distance To Skin Process object
-     * @details This constructor considers the model parts of the volume and skin
-     * @param rVolumeModelPart Model part containing the volume elements
-     * @param rSkinModelPart Model part containing the skin to compute the distance to as conditions
-     * @param HistoricalVariable If the variable is part of the historical database of from the non-historical database
-     * @param rDistanceVariableName The distance variable considered
-     * @param SaveDistanceInSkin If distances are saved into the skin
-     */
-    CalculateNodalDistanceToSkinProcess(
-        ModelPart& rVolumeModelPart,
-        ModelPart& rSkinModelPart,
-        const bool HistoricalVariable = true,
-        const std::string& rDistanceVariableName = "",
-        const bool SaveDistanceInSkin = false
-        );
-
-    /**
-     * @brief Construct a new Calculate Nodal Distance To Skin Process object
      * @details This constructor considers the model and retrieves the model parts
      * @param rModel The model containing the model parts of the volume and the skin
      * @param ThisParameters User-defined parameters to construct the

--- a/kratos/processes/calculate_nodal_distance_to_skin_process.h
+++ b/kratos/processes/calculate_nodal_distance_to_skin_process.h
@@ -42,10 +42,6 @@ public:
     ///@name Type Definitions
     ///@{
 
-    /// Local Flags
-    KRATOS_DEFINE_LOCAL_FLAG( HISTORICAL_VALUE );               /// This flag is used in order to check if the values are historical
-    KRATOS_DEFINE_LOCAL_FLAG( SAVE_DISTANCE_IN_SKIN );          /// This flag is used in order to save the highest distance in the found geometries of the skin
-
     /// Pointer definition of CalculateNodalDistanceToSkinProcess
     KRATOS_CLASS_POINTER_DEFINITION(CalculateNodalDistanceToSkinProcess);
 
@@ -148,6 +144,12 @@ private:
 
     /// Pointer to the distance variable.
     const Variable<double>* mpDistanceVariable = &DISTANCE;
+
+    /// This flag is used in order to check if the values are historical
+    bool mHistoricalValue = true;
+
+    /// This flag is used in order to save the highest distance in the found geometries of the skin
+    bool mSaveDistanceInSkin = false;
 
     ///@}
     ///@name Private Operators

--- a/kratos/tests/test_calculate_nodal_distance_to_skin_process.py
+++ b/kratos/tests/test_calculate_nodal_distance_to_skin_process.py
@@ -156,7 +156,7 @@ class TestCalculateNodalDistanceToSkinProcessCoarseSphere(KratosUnittest.TestCas
 
     @KratosUnittest.skipIf(KratosMultiphysics.IsDistributedRun(), "This test is designed for serial runs only.")
     def test_ComputeDistanceToSkinWithSavedDistanceInSkin(self):
-        """Test the computation of nodal distances to the skin in the model part."""
+        """Test the computation of nodal distances to the skin in the model part. Case saving distances in the skin."""
         # Define the settings for the distance calculation process
         settings = KratosMultiphysics.Parameters("""
         {

--- a/kratos/tests/test_calculate_nodal_distance_to_skin_process.py
+++ b/kratos/tests/test_calculate_nodal_distance_to_skin_process.py
@@ -154,6 +154,36 @@ class TestCalculateNodalDistanceToSkinProcessCoarseSphere(KratosUnittest.TestCas
             solution_distance = node.GetValue(KratosMultiphysics.DISTANCE)
             self.assertAlmostEqual(distance, solution_distance, delta=3.8e-2)
 
+    @KratosUnittest.skipIf(KratosMultiphysics.IsDistributedRun(), "This test is designed for serial runs only.")
+    def test_ComputeDistanceToSkinWithSavedDistanceInSkin(self):
+        """Test the computation of nodal distances to the skin in the model part."""
+        # Define the settings for the distance calculation process
+        settings = KratosMultiphysics.Parameters("""
+        {
+            "distance_database"      : "nodal_non_historical",
+            "save_distance_in_skin"  : true,
+            "distance_variable"      : "DISTANCE",
+            "volume_model_part"      : "main_model_part",
+            "skin_model_part"        : "skin_model_part"
+        }""")
+        # Execute the distance calculation process
+        KratosMultiphysics.CalculateNodalDistanceToSkinProcess(self.current_model, settings).Execute()
+
+        ## DEBUG
+        # Uncomment to visualize output
+        #post_process_gid(self.model_part)
+        #post_process_vtk(self.current_model)
+
+        ## Check the calculated distances against analytical values
+        for node in self.model_part.Nodes:
+            distance = CalculateAnalyticalDistance(node)
+            solution_distance = node.GetValue(KratosMultiphysics.DISTANCE)
+            self.assertAlmostEqual(distance, solution_distance, delta=3.8e-2)
+        list_of_conditions = [1, 5, 8, 13, 19, 22, 32, 45, 54, 58, 66, 68, 70, 80, 83, 85, 99, 101, 103]
+        for cond in self.skin_model_part.Conditions:
+            if cond.Is(KratosMultiphysics.VISITED):
+                self.assertTrue(cond.Id in list_of_conditions)
+
 if __name__ == '__main__':
     # Configure logging level and start the test runner
     KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.WARNING)

--- a/kratos/tests/test_calculate_nodal_distance_to_skin_process.py
+++ b/kratos/tests/test_calculate_nodal_distance_to_skin_process.py
@@ -160,11 +160,11 @@ class TestCalculateNodalDistanceToSkinProcessCoarseSphere(KratosUnittest.TestCas
         # Define the settings for the distance calculation process
         settings = KratosMultiphysics.Parameters("""
         {
-            "distance_database"      : "nodal_non_historical",
-            "save_distance_in_skin"  : true,
-            "distance_variable"      : "DISTANCE",
-            "volume_model_part"      : "main_model_part",
-            "skin_model_part"        : "skin_model_part"
+            "distance_database"         : "nodal_non_historical",
+            "save_max_distance_in_skin" : true,
+            "distance_variable"         : "DISTANCE",
+            "volume_model_part"         : "main_model_part",
+            "skin_model_part"           : "skin_model_part"
         }""")
         # Execute the distance calculation process
         KratosMultiphysics.CalculateNodalDistanceToSkinProcess(self.current_model, settings).Execute()


### PR DESCRIPTION
**📝 Description**

This PR introduces several enhancements and adjustments in `CalculateNodalDistanceToSkinProcess` (the process for calculating nodal distances to the skin).  Key updates include:

- **Distance value storage in skin model**: Implemented functionality to store distance values directly in the skin model part. By default is deactivated, if activated will save the maximum distance in the found skin geometry and set the flag `VISITED`. This also deactivate shared memory parallelization.

- **Lambda function updates**: Updated lambda functions now support the improved mechanism for saving distance values in the skin model part, facilitating a more streamlined and efficient process.

- **Default parameters**: Added and refined default parameters for the process to enhance user experience by providing clearer guidelines and reducing the need for manual adjustments.

- **Improved printed information**: Adjustments to the information printout provide a better representation of process settings and variables, aiding in debugging and process optimization.

- **Documentation updates**: The `calculate_nodal_distance_to_skin_process.md` documentation has been extensively updated to include detailed explanations of the process enhancements. It covers the support for calculating distances to skin entities, introduces new lambda functions, and discusses the addition of flags for data type selection and decision-making regarding the storage of distances in the skin model part. The documentation also clarifies the functionalities of default parameters.

- **New test method**: Introduced a new test method, `test_ComputeDistanceToSkinWithSavedDistanceInSkin`, to the `test_calculate_nodal_distance_to_skin_process.py` file. This test verifies that specific conditions in the skin model part are correctly addressed during the process, ensuring the reliability of the new features.

**🆕 Changelog**

- Added local flags for enhanced control and clarity, facilitating better customization of the process ([Commit Link](https://github.com/KratosMultiphysics/Kratos/commit/6650b3c2226d740008f18f72d28eca13b2a6e8c2)).

- Implemented functionality for saving maximum distance values to skin entities within the skin model part, optimizing the process by eliminating the need for parallel algorithms in this context ([Commit Link](https://github.com/KratosMultiphysics/Kratos/commit/187c670fb249ffd72a2d593a24790bb83c0b2459)).

- Added a new test case, `test_ComputeDistanceToSkinWithSavedDistanceInSkin`, to ensure the process accurately handles conditions within the skin model part, thereby verifying the enhancements made ([Commit Link](https://github.com/KratosMultiphysics/Kratos/commit/3eac8743bc97054d8314f049c628569ad6a8afb0)).