### PR TITLE
[Core] Separate source/header in `CheckSkinProcess`

### DIFF
--- a/kratos/processes/check_skin_process.cpp
+++ b/kratos/processes/check_skin_process.cpp
@@ -1,0 +1,69 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Riccardo Rossi
+//
+
+// System includes
+#include <unordered_map>
+
+// External includes
+
+// Project includes
+#include "processes/check_skin_process.h"
+#include "includes/model_part.h"
+#include "includes/key_hash.h"
+
+namespace Kratos
+{
+
+void CheckSkinProcess::Execute()
+{
+    KRATOS_TRY;
+
+    KRATOS_ERROR_IF(mrModelPart.Conditions().size() == 0 && mrModelPart.Elements().size() != 0) << "The number of conditions is zero and the number of elements is not, hence the skin can not envelope the domain" << std::endl;
+
+    using hashmap = std::unordered_map<DenseVector<IndexType>, IndexType, KeyHasherRange<DenseVector<IndexType>>, KeyComparorRange<DenseVector<IndexType>>>;
+    hashmap edge_map;
+
+    DenseVector<IndexType> ids(2);
+
+    // Add 1 to the counter for every edge find in the model part
+    for (auto& r_cond : mrModelPart.Conditions()) {
+        const auto edges = r_cond.GetGeometry().GenerateEdges();
+
+        for(IndexType edge=0; edge<edges.size(); edge++) {
+            for(IndexType i=0; i<edges[edge].size(); i++) {
+                ids[i] = edges[edge][i].Id();
+            }
+
+            //*** THE ARRAY OF IDS MUST BE ORDERED!!! ***
+            std::sort(ids.begin(), ids.end());
+
+            edge_map[ids] += 1;
+        }
+    }
+
+    // Now loop over the entire edge map.
+    // All values shall have a value of 2
+    // If that is not the case throw an error
+    for(auto it=edge_map.begin(); it!=edge_map.end(); ++it) {
+        if(it->second > 2) {
+            KRATOS_ERROR << "ERROR OVERLAPPING CONDITIONS IN SKIN FOUND : " << std::endl << "The edge between nodes " << it->first[0] << " and " << it->first[1] << std::endl << " belongs to an overlapping condition " << std::endl;
+        } else if(it->second < 2) {
+            KRATOS_ERROR << "ERROR NON CLOSED SKIN " << std::endl << "The edge between nodes " << it->first[0] << " and " << it->first[1] << std::endl << " only appears once, hence it belongs to a non watertight boundary " << std::endl;
+        }
+    }
+
+    KRATOS_INFO("CheckSkinProcess") << "Checked " << edge_map.size() << " edges in the skin. No gap or overlap found " << std::endl;
+
+    KRATOS_CATCH("");
+}
+
+} // namespace Kratos

--- a/kratos/processes/check_skin_process.h
+++ b/kratos/processes/check_skin_process.h
@@ -4,30 +4,25 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //
 
-#ifndef KRATOS_VERIFY_WATERTIGHTNESS_PROCESS_H
-#define KRATOS_VERIFY_WATERTIGHTNESS_PROCESS_H
+#pragma once
 
 // System includes
-#include <unordered_map>
 
 // External includes
 
 // Project includes
-#include "includes/define.h"
-#include "includes/model_part.h"
 #include "processes/process.h"
-#include "includes/key_hash.h"
 
 namespace Kratos
 {
 
-/** 
+/**
  * @class CheckSkinProcess
  * @ingroup KratosCore
  * @brief This function verifies that the skin has no holes nor overlapped geometries this is accomplished by storing all of the edges in the model in a hash map and verifying that no edge appears more than twice (which would imply an overlap)
@@ -46,7 +41,7 @@ public:
     KRATOS_CLASS_POINTER_DEFINITION(CheckSkinProcess);
 
     /// The index type definition
-    typedef std::size_t IndexType;
+    using IndexType = std::size_t;
 
     ///@}
     ///@name Life Cycle
@@ -78,62 +73,18 @@ public:
     ///@name Operations
     ///@{
 
-
     /**
      * @brief Check elements to make sure that their jacobian is positive and conditions to ensure that their face normals point outwards
      */
-    void Execute() override
-    {
-        KRATOS_TRY;
-            
-        KRATOS_ERROR_IF(mrModelPart.Conditions().size() == 0 && mrModelPart.Elements().size() != 0) << "The number of conditions is zero and the number of elements is not, hence the skin can not envelope the domain" << std::endl;
-
-        typedef std::unordered_map<DenseVector<IndexType>, IndexType, KeyHasherRange<DenseVector<IndexType>>, KeyComparorRange<DenseVector<IndexType>> > hashmap;
-        hashmap edge_map;
-
-        DenseVector<IndexType> ids(2);
-
-        // Add 1 to the counter for every edge find in the model part
-        for (auto& r_cond : mrModelPart.Conditions()) {
-            const auto edges = r_cond.GetGeometry().GenerateEdges();
-
-            for(IndexType edge=0; edge<edges.size(); edge++) {
-                for(IndexType i=0; i<edges[edge].size(); i++) {
-                    ids[i] = edges[edge][i].Id();
-                }
-
-                //*** THE ARRAY OF IDS MUST BE ORDERED!!! ***
-                std::sort(ids.begin(), ids.end());
-
-                edge_map[ids] += 1;
-            }
-        }
-
-        // Now loop over the entire edge map.
-        // All values shall have a value of 2
-        // If that is not the case throw an error
-        for(auto it=edge_map.begin(); it!=edge_map.end(); ++it) {
-            if(it->second > 2) {
-                KRATOS_ERROR << "ERROR OVERLAPPING CONDITIONS IN SKIN FOUND : " << std::endl << "The edge between nodes " << it->first[0] << " and " << it->first[1] << std::endl << " belongs to an overlapping condition " << std::endl;
-            } else if(it->second < 2) {
-                KRATOS_ERROR << "ERROR NON CLOSED SKIN " << std::endl << "The edge between nodes " << it->first[0] << " and " << it->first[1] << std::endl << " only appears once, hence it belongs to a non watertight boundary " << std::endl;
-            }
-        }
-
-        KRATOS_INFO("CheckSkinProcess") << "Checked " << edge_map.size() << " edges in the skin. No gap or overlap found " << std::endl;
-
-        KRATOS_CATCH("");
-    }
+    void Execute() override;
 
     ///@}
     ///@name Access
     ///@{
 
-
     ///@}
     ///@name Inquiry
     ///@{
-
 
     ///@}
     ///@name Input and output
@@ -170,7 +121,7 @@ private:
     ///@name Member Variables
     ///@{
 
-    ModelPart& mrModelPart;
+    ModelPart& mrModelPart; /// The model part to be checked
 
     ///@}
     ///@name Private Operations
@@ -215,9 +166,4 @@ inline std::ostream& operator << (std::ostream& rOStream,
 }
 ///@}
 
-
-
 } // namespace Kratos
-
-
-#endif // KRATOS_VERIFY_WATERTIGHTNESS_PROCESS_H

--- a/kratos/processes/check_skin_process.h
+++ b/kratos/processes/check_skin_process.h
@@ -30,7 +30,7 @@ namespace Kratos
  * @details In the case such condition is violated an error is thrown
  * @author Riccardo Rossi
  */
-class CheckSkinProcess
+class KRATOS_API(KRATOS_CORE) CheckSkinProcess
     : public Process
 {
 public:


### PR DESCRIPTION
**📝 Description**

Separate source/header in `CheckSkinProcess`. Also optimize includes to reduce compilation time.

**🆕 Changelog**

- [Separate source/header in `CheckSkinProcess`](https://github.com/KratosMultiphysics/Kratos/commit/434fdba0de41054dfd66a2d3affb0a3c71a630fa)
