### PR TITLE
Remove EigenSolversApplication

### DIFF
--- a/applications/DamApplication/python_scripts/dam_eigen_solver.py
+++ b/applications/DamApplication/python_scripts/dam_eigen_solver.py
@@ -1,6 +1,5 @@
 #import kratos core and applications
 import KratosMultiphysics
-import KratosMultiphysics.EigenSolversApplication as KratosEigen
 import KratosMultiphysics.StructuralMechanicsApplication as KratosStructural
 import KratosMultiphysics.DamApplication as KratosDam
 import KratosMultiphysics.PoromechanicsApplication as KratosPoro
@@ -69,7 +68,7 @@ class DamEigenSolver():
 
 
     def GetMinimumBufferSize(self):
-        return 2;
+        return 2
 
 
     def AddDofs(self):

--- a/applications/EigenSolversApplication/CMakeLists.txt
+++ b/applications/EigenSolversApplication/CMakeLists.txt
@@ -1,6 +1,0 @@
-message("    !!! DEPRECATION WARNING !!!")
-message("    The EigenSolversApplication was replaced by the LinearSolversApplication")
-message("    Please update your configure script")
-kratos_add_dependency(${KRATOS_SOURCE_DIR}/applications/LinearSolversApplication)
-
-kratos_python_install(${INSTALL_PYTHON_USING_LINKS} ${CMAKE_CURRENT_SOURCE_DIR}/EigenSolversApplication.py KratosMultiphysics/EigenSolversApplication/__init__.py )

--- a/applications/EigenSolversApplication/EigenSolversApplication.py
+++ b/applications/EigenSolversApplication/EigenSolversApplication.py
@@ -1,6 +1,0 @@
-from KratosMultiphysics.kratos_utilities import IssueDeprecationWarning
-
-IssueDeprecationWarning('EigenSolversApplication', 'please use the "LinearSolversApplication" instead')
-
-from KratosMultiphysics.LinearSolversApplication import *
-from KratosMultiphysics.LinearSolversApplication import dense_linear_solver_factory

--- a/docs/pages/Kratos/For_Users/How_To_Get_Kratos/Binaries.md
+++ b/docs/pages/Kratos/For_Users/How_To_Get_Kratos/Binaries.md
@@ -1,9 +1,9 @@
 ---
 title: Getting Kratos Binaries for Linux
-keywords: 
+keywords:
 tags: [Getting-Kratos-Binaries-for-Linux.md]
 sidebar: kratos_for_users
-summary: 
+summary:
 ---
 
 # Pip Install
@@ -35,7 +35,6 @@ The following Kratos Pakcages ara avaialable
 - KratosPoromechanicsApplication;
 - KratosFSIApplication;
 - KratosSwimmingDEMApplication;
-- KratosEigenSolversApplication;
 - KratosLinearSolversApplication;
 - KratosConstitutiveLawsApplication;
 - KratosDelaunayMeshingApplication;

--- a/scripts/wheels/linux/configure.sh
+++ b/scripts/wheels/linux/configure.sh
@@ -31,7 +31,6 @@ add_app ${KRATOS_APP_DIR}/DamApplication;
 add_app ${KRATOS_APP_DIR}/PoromechanicsApplication;
 add_app ${KRATOS_APP_DIR}/FSIApplication;
 add_app ${KRATOS_APP_DIR}/SwimmingDEMApplication;
-add_app ${KRATOS_APP_DIR}/EigenSolversApplication;
 add_app ${KRATOS_APP_DIR}/LinearSolversApplication;
 add_app ${KRATOS_APP_DIR}/ConstitutiveLawsApplication;
 # add_app ${KRATOS_APP_DIR}/FemToDemApplication;

--- a/scripts/wheels/windows/configure.bat
+++ b/scripts/wheels/windows/configure.bat
@@ -22,7 +22,6 @@ CALL :add_app %KRATOS_APP_DIR%\DamApplication;
 CALL :add_app %KRATOS_APP_DIR%\PoromechanicsApplication;
 CALL :add_app %KRATOS_APP_DIR%\FSIApplication;
 CALL :add_app %KRATOS_APP_DIR%\SwimmingDEMApplication;
-CALL :add_app %KRATOS_APP_DIR%\EigenSolversApplication;
 CALL :add_app %KRATOS_APP_DIR%\LinearSolversApplication;
 CALL :add_app %KRATOS_APP_DIR%\ConstitutiveLawsApplication;
 CALL :add_app %KRATOS_APP_DIR%\FemToDemApplication;


### PR DESCRIPTION
This application is pure legacy, it was renamed to `LinearSolversApplication` almost 4 years ago => #7182

It is an empty shell only existing for backward compatibility, with large deprecation warnings. IMO 4 years is enough for migrating :)
