### PR TITLE
[Core] Refactor and clean up `CalculateNodalAreaProcess`

### DIFF
--- a/docs/pages/Kratos/Processes/Calculation/calculate_nodal_area_process.md
+++ b/docs/pages/Kratos/Processes/Calculation/calculate_nodal_area_process.md
@@ -22,7 +22,7 @@ It is important to ensure that the `DOMAIN_SIZE` is correctly defined in the `Pr
 
 ## Execution
 
-#### `Execute`
+### `Execute`
 
 When executed proceeds to calculate the nodal areas by integrating over the elements' geometries using their shape functions and Jacobian determinants. The calculated nodal areas are stored as nodal variables, either as historical or non-historical data depending on the template parameter `THistorical`.
 

--- a/docs/pages/Kratos/Processes/Calculation/calculate_nodal_area_process.md
+++ b/docs/pages/Kratos/Processes/Calculation/calculate_nodal_area_process.md
@@ -45,7 +45,7 @@ The process is initialized with a set of parameters specified in JSON format. Th
 ```
 
 ##### `model_part_name`
-A string specifying the name of the model part for which nodal areas will be calculated. Default is `"PLEASE_DEFINE_A_MODEL_PART_NAME"`, which is a placeholder indicating that the user must specify the model part name.
+A string specifying the name of the model part for which nodal areas will be calculated. Default is `PLEASE_DEFINE_A_MODEL_PART_NAME`, which is a placeholder indicating that the user must specify the model part name.
 
 ##### `domain_size`
 An integer defining the spatial dimension of the domain (2 for two-dimensional domains, 3 for three-dimensional domains). Default is `0`, which indicates that the domain size should be inferred from the model part's properties.

--- a/docs/pages/Kratos/Processes/Calculation/calculate_nodal_area_process.md
+++ b/docs/pages/Kratos/Processes/Calculation/calculate_nodal_area_process.md
@@ -4,7 +4,6 @@ keywords: process core
 tags: [calculate nodal area process]
 sidebar: kratos_core_processes
 summary: The Calculate Nodal Area process in Kratos calculates the area associated with each node in a mesh, supporting both historical and non-historical data. This documentation outlines its usage, including descriptions of its functionality, parameters, and defaults.
-
 ---
 
 # Calculate Nodal Area

--- a/docs/pages/Kratos/Processes/Calculation/calculate_nodal_area_process.md
+++ b/docs/pages/Kratos/Processes/Calculation/calculate_nodal_area_process.md
@@ -3,11 +3,49 @@ title: Calculate Nodal Area
 keywords: process core
 tags: [calculate nodal area process]
 sidebar: kratos_core_processes
-summary: 
+summary: The Calculate Nodal Area process in Kratos calculates the area associated with each node in a mesh, supporting both historical and non-historical data. This documentation outlines its usage, including descriptions of its functionality, parameters, and defaults.
+
 ---
 
 # Calculate Nodal Area
 
 ## Description
 
+The Calculate Nodal Area process is designed to compute the nodal area for each node within a specified model part in Kratos. This process is crucial for various simulations where nodal areas impact the calculation of forces, material properties, or other phenomena. It supports calculations for both historical (time-dependent) and non-historical data, making it versatile for different simulation needs. The process iterates through all elements in the model part, calculates the area contributed by each element to its nodes, and sums up these contributions to find the total area associated with each node.
+
+This process is an essential tool for calculating nodal areas, facilitating various types of analyses where such information is critical.
+
+## `CalculateNodalAreaProcess` constructors
+
+The process first checks the provided parameters against the default parameters and validates them to ensure they are correctly specified.
+
+It is important to ensure that the `DOMAIN_SIZE` is correctly defined in the `ProcessInfo` of the model part or explicitly provided in the parameters to avoid runtime errors.
+
+## Execution
+
+#### `Execute`
+
+When executed proceeds to calculate the nodal areas by integrating over the elements' geometries using their shape functions and Jacobian determinants. The calculated nodal areas are stored as nodal variables, either as historical or non-historical data depending on the template parameter `THistorical`.
+
+This function first checks the availability of required variables and initializes nodal area values to zero. It then iterates over all elements in the model part, calculates the area contribution from each element to its nodes, and aggregates these contributions to compute the total area associated with each node.
+
+Finally, it synchronizes the nodal area data across different processors if running in parallel.
+
+Additionally, the process requires that the `NODAL_AREA` variable is available for the nodes in the model part; otherwise, it will terminate with an error.
+
 ## Parameters & Defaults
+
+The process is initialized with a set of parameters specified in JSON format. The available parameters and their default values are as follows:
+
+```json
+{
+    "model_part_name" : "PLEASE_DEFINE_A_MODEL_PART_NAME",
+    "domain_size"     : 0
+}
+```
+
+##### `model_part_name`
+A string specifying the name of the model part for which nodal areas will be calculated. Default is `"PLEASE_DEFINE_A_MODEL_PART_NAME"`, which is a placeholder indicating that the user must specify the model part name.
+
+##### `domain_size`
+An integer defining the spatial dimension of the domain (2 for two-dimensional domains, 3 for three-dimensional domains). Default is `0`, which indicates that the domain size should be inferred from the model part's properties.

--- a/docs/pages/Kratos/Processes/Calculation/calculate_nodal_distance_to_skin_process.md
+++ b/docs/pages/Kratos/Processes/Calculation/calculate_nodal_distance_to_skin_process.md
@@ -28,7 +28,7 @@ The process is currently optimized for serial execution. However, plans are unde
 
 ## Execution
 
-#### `Execute`
+### `Execute`
 
 `Execute` method is used to execute the Process algorithms.
 
@@ -48,7 +48,7 @@ The core of the distance calculation is performed by the `Bins.SearchNearest(Nod
 
 The selected lambda function is then applied to calculate the distances for all nodes in volumetric model part based on the geometrical objects (elements or conditions) found in skin model part. Before applying the lambda, the code checks whether to use elements or conditions from skin model part for the distance calculation, prioritizing elements if both exist.
 
-##### ⚠️ Warning
+#### ⚠️ Warning
 
 > A warning is issued if both elements and conditions are found in the skin model part, indicating that elements will be considered for the distance calculation.
 

--- a/kratos/processes/calculate_nodal_area_process.cpp
+++ b/kratos/processes/calculate_nodal_area_process.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //  Collaborators:   Vicente Mataix Ferrandiz
@@ -16,12 +16,55 @@
 // External includes
 
 // Project includes
+#include "containers/model.h"
 #include "utilities/geometry_utilities.h"
 #include "utilities/variable_utils.h"
 #include "processes/calculate_nodal_area_process.h"
 
 namespace Kratos
 {
+
+template<bool THistorical>
+CalculateNodalAreaProcess<THistorical>::CalculateNodalAreaProcess(
+    Model& rModel,
+    Parameters ThisParameters
+    ) : mrModelPart(rModel.GetModelPart(ThisParameters["model_part_name"].GetString()))
+{
+    KRATOS_TRY
+
+    // We check the parameters
+    const Parameters default_parameters = GetDefaultParameters();
+    ThisParameters.RecursivelyValidateAndAssignDefaults(default_parameters);
+
+    // We get the domain size
+    mDomainSize = ThisParameters["domain_size"].GetInt();
+
+    // In case is not provided we will take from the model part
+    CheckDomainSize();
+
+    KRATOS_CATCH("")
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<bool THistorical>
+CalculateNodalAreaProcess<THistorical>::CalculateNodalAreaProcess(
+    ModelPart& rModelPart,
+    const SizeType DomainSize
+    ): mrModelPart(rModelPart),
+       mDomainSize(DomainSize)
+{
+    KRATOS_TRY
+
+    // In case is not provided we will take from the model part
+    CheckDomainSize();
+
+    KRATOS_CATCH("")
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
 
 template<bool THistorical>
 void CalculateNodalAreaProcess<THistorical>::Execute()
@@ -98,8 +141,34 @@ void CalculateNodalAreaProcess<THistorical>::Execute()
 /***********************************************************************************/
 /***********************************************************************************/
 
+template<bool THistorical>
+const Parameters CalculateNodalAreaProcess<THistorical>::GetDefaultParameters() const
+{
+    return Parameters(R"(
+    {
+        "model_part_name" : "PLEASE_DEFINE_A_MODEL_PART_NAME",
+        "domain_size" : 0
+    })" );
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<bool THistorical>
+void CalculateNodalAreaProcess<THistorical>::CheckDomainSize()
+{
+    // We get the domain size
+    if (mDomainSize == 0) {
+        KRATOS_ERROR_IF_NOT(mrModelPart.GetProcessInfo().Has(DOMAIN_SIZE)) << "\"DOMAIN_SIZE\" has to be specified in the ProcessInfo" << std::endl;
+        mDomainSize = mrModelPart.GetProcessInfo()[DOMAIN_SIZE];
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
 template<>
-double& CalculateNodalAreaProcess<true>::GetAreaValue(NodeType& rNode)
+double& CalculateNodalAreaProcess<true>::GetAreaValue(Node& rNode)
 {
     return rNode.FastGetSolutionStepValue(NODAL_AREA);
 }
@@ -108,7 +177,7 @@ double& CalculateNodalAreaProcess<true>::GetAreaValue(NodeType& rNode)
 /***********************************************************************************/
 
 template<>
-double& CalculateNodalAreaProcess<false>::GetAreaValue(NodeType& rNode)
+double& CalculateNodalAreaProcess<false>::GetAreaValue(Node& rNode)
 {
     return rNode.GetValue(NODAL_AREA);
 }

--- a/kratos/processes/calculate_nodal_area_process.h
+++ b/kratos/processes/calculate_nodal_area_process.h
@@ -19,6 +19,7 @@
 
 // Project includes
 #include "processes/process.h"
+#include "includes/node.h"
 #include "includes/kratos_parameters.h"
 
 namespace Kratos

--- a/kratos/processes/calculate_nodal_area_process.h
+++ b/kratos/processes/calculate_nodal_area_process.h
@@ -4,15 +4,14 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //  Collaborators:   Vicente Mataix Ferrandiz
 //
 
-#if !defined(KRATOS_CALCULATE_NODAL_AREA_PROCESS_H_INCLUDED )
-#define  KRATOS_CALCULATE_NODAL_AREA_PROCESS_H_INCLUDED
+#pragma once
 
 // System includes
 
@@ -20,7 +19,7 @@
 
 // Project includes
 #include "processes/process.h"
-#include "includes/model_part.h"
+#include "includes/kratos_parameters.h"
 
 namespace Kratos
 {
@@ -52,14 +51,18 @@ struct CalculateNodalAreaSettings
     constexpr static bool SaveAsHistoricalVariable = true;
     constexpr static bool SaveAsNonHistoricalVariable = false;
 };
-    
-/** 
+
+/**
  * @class CalculateNodalAreaProcess
- * @ingroup KratosCore 
+ * @ingroup KratosCore
  * @brief Computes NODAL_AREA
- * @details Calculate the NODAL_AREA for computing the weighted area in each node
+ * @details Calculate the NODAL_AREA for computing the weighted area in each node. This process computes the nodal area for each node in the given model part. It supports calculations
+ * for both historical and non-historical data storage. The process iterates over all elements in the
+ * model part, calculates the area contribution from each element to its nodes, and aggregates these
+ * contributions to compute the total area associated with each node.
  * @author Riccardo Rossi
  * @author Vicente Mataix Ferrandiz
+ * @tparam THistorical Determines the type of data storage (historical or non-historical) used for the nodal area variable.
  */
 template<bool THistorical = true>
 class KRATOS_API(KRATOS_CORE) CalculateNodalAreaProcess
@@ -70,14 +73,11 @@ public:
     ///@{
 
     /// Index type definition
-    typedef std::size_t IndexType;
-    
-    /// Size type definition
-    typedef std::size_t SizeType;
+    using IndexType = std::size_t;
 
-    /// The definition of the node
-    typedef Node NodeType;
-    
+    /// Size type definition
+    using SizeType = std::size_t;
+
     /// Pointer definition of CalculateNodalAreaProcess
     KRATOS_CLASS_POINTER_DEFINITION(CalculateNodalAreaProcess);
 
@@ -86,27 +86,27 @@ public:
     ///@{
 
     /**
+     * @brief Constructor with Model and Parameters.
+     * @param rModel The model containing the model part to be computed
+     * @param rParameters The parameters containing the necessary data for the process
+     */
+    CalculateNodalAreaProcess(
+        Model& rModel,
+        Parameters rParameters
+        );
+
+    /**
      * @brief Default constructor.
      * @param rModelPart The model part to be computed
      * @param DomainSize The size of the space, if the value is not provided will compute from the model part
      */
     CalculateNodalAreaProcess(
-        ModelPart& rModelPart, 
+        ModelPart& rModelPart,
         const SizeType DomainSize = 0
-        ): mrModelPart(rModelPart),
-           mDomainSize(DomainSize)
-    {
-        // In case is not provided we will take from the model part
-        if (mDomainSize == 0) {
-            KRATOS_ERROR_IF_NOT(rModelPart.GetProcessInfo().Has(DOMAIN_SIZE)) << "\"DOMAIN_SIZE\" has to be specified in the ProcessInfo" << std::endl;
-            mDomainSize = rModelPart.GetProcessInfo()[DOMAIN_SIZE];
-        }
-    }
+        );
 
     /// Destructor.
-    ~CalculateNodalAreaProcess() override
-    {
-    }
+    ~CalculateNodalAreaProcess() override = default;
 
     ///@}
     ///@name Operators
@@ -117,12 +117,23 @@ public:
         Execute();
     }
 
-
     ///@}
     ///@name Operations
     ///@{
 
+    /**
+     * @brief Execute method is used to execute the Process algorithms for calculating nodal area
+     * @details This function first checks the availability of required variables and initializes nodal area values to zero.
+     * It then iterates over all elements in the model part, calculates the area contribution from each element
+     * to its nodes, and aggregates these contributions to compute the total area associated with each node.
+     * Finally, it synchronizes the nodal area data across different processors if running in parallel.
+     */
     void Execute() override;
+
+    /**
+     * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
+     */
+    const Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access
@@ -131,7 +142,6 @@ public:
     ///@}
     ///@name Inquiry
     ///@{
-
 
     ///@}
     ///@name Input and output
@@ -154,67 +164,25 @@ public:
     {
     }
 
-
     ///@}
     ///@name Friends
     ///@{
 
-
     ///@}
-
-protected:
-    ///@name Protected static Member Variables
-    ///@{
-
-
-    ///@}
-    ///@name Protected member Variables
-    ///@{
-
-
-    ///@}
-    ///@name Protected Operators
-    ///@{
-
-
-    ///@}
-    ///@name Protected Operations
-    ///@{
-
-
-    ///@}
-    ///@name Protected  Access
-    ///@{
-
-
-    ///@}
-    ///@name Protected Inquiry
-    ///@{
-
-
-    ///@}
-    ///@name Protected LifeCycle
-    ///@{
-
-
-    ///@}
-
 private:
     ///@name Static Member Variables
     ///@{
 
-
     ///@}
     ///@name Member Variables
     ///@{
-    
+
     ModelPart& mrModelPart;  /// The model part where the nodal area is computed
     SizeType mDomainSize;    /// The dimension of the space
 
     ///@}
     ///@name Private Operators
     ///@{
-
 
     ///@}
     ///@name Private Operations
@@ -225,17 +193,22 @@ private:
      * @param rNode The node iterator to be get
      * @return The current value of NODAL_AREA
      */
-    double& GetAreaValue(NodeType& rNode);
+    double& GetAreaValue(Node& rNode);
+
+    /**
+     * @brief Checks the domain size and throws an error if it is not specified.
+     * @details This function checks the domain size of the model part and throws an error if it is not specified in the ProcessInfo.
+     * The domain size is obtained from the ProcessInfo and stored in the member variable mDomainSize.
+     */
+    void CheckDomainSize();
 
     ///@}
     ///@name Private  Access
     ///@{
 
-
     ///@}
     ///@name Private Inquiry
     ///@{
-
 
     ///@}
     ///@name Un accessible methods
@@ -246,7 +219,6 @@ private:
 
     /// Copy constructor.
     //CalculateNodalAreaProcess(CalculateNodalAreaProcess const& rOther);
-
 
     ///@}
 
@@ -281,9 +253,6 @@ inline std::ostream& operator << (std::ostream& rOStream,
 }
 ///@}
 
-
 }  // namespace Kratos.
-
-#endif // KRATOS_CALCULATE_NODAL_AREA_PROCESS_H_INCLUDED  defined 
 
 

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -245,11 +245,13 @@ void  AddProcessesToPython(pybind11::module& m)
     ;
 
     py::class_<CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsHistoricalVariable>, CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsHistoricalVariable>::Pointer, Process>(m,"CalculateNodalAreaProcess")
+    .def(py::init<Model&, Parameters>())
     .def(py::init<ModelPart&>())
     .def(py::init<ModelPart&, std::size_t>())
     ;
 
     py::class_<CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsNonHistoricalVariable>, CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsNonHistoricalVariable>::Pointer, Process>(m,"CalculateNonHistoricalNodalAreaProcess")
+    .def(py::init<Model&, Parameters>())
     .def(py::init<ModelPart&>())
     .def(py::init<ModelPart&, std::size_t>())
     ;

--- a/kratos/tests/cpp_tests/processes/test_calculate_nodal_area_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_calculate_nodal_area_process.cpp
@@ -58,7 +58,7 @@ KRATOS_TEST_CASE_IN_SUITE(NodalArea1, KratosCoreFastSuite)
 
     CppTestsUtilities::Create2DGeometry(this_model_part);
 
-    typedef CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsHistoricalVariable> HistNodalAreaProcess;
+    using HistNodalAreaProcess = CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsHistoricalVariable>; ;
     HistNodalAreaProcess hist_process(this_model_part, 2);
     hist_process.Execute();
 
@@ -71,7 +71,7 @@ KRATOS_TEST_CASE_IN_SUITE(NodalArea1, KratosCoreFastSuite)
     KRATOS_EXPECT_LE(std::abs(this_model_part.pGetNode(5)->FastGetSolutionStepValue(NODAL_AREA)) - 1.0/3.0, tolerance);
     KRATOS_EXPECT_LE(std::abs(this_model_part.pGetNode(6)->FastGetSolutionStepValue(NODAL_AREA)) - 1.0/6.0, tolerance);
 
-    typedef CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsNonHistoricalVariable> NonHistNodalAreaProcess;
+    using NonHistNodalAreaProcess= CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsNonHistoricalVariable>; ;
     NonHistNodalAreaProcess nonhist_process(this_model_part, 2);
     nonhist_process.Execute();
 
@@ -103,7 +103,7 @@ KRATOS_TEST_CASE_IN_SUITE(NodalArea2, KratosCoreFastSuite)
     CppTestsUtilities::Create3DGeometry(this_model_part);
 
     // Calculate nodal area
-    typedef CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsHistoricalVariable> HistNodalAreaProcess;
+    using HistNodalAreaProcess = CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsHistoricalVariable>; ;
     HistNodalAreaProcess hist_process(this_model_part, 3);
     hist_process.Execute();
 
@@ -120,7 +120,7 @@ KRATOS_TEST_CASE_IN_SUITE(NodalArea2, KratosCoreFastSuite)
     KRATOS_EXPECT_LE(std::abs(this_model_part.pGetNode(11)->FastGetSolutionStepValue(NODAL_AREA)) - 1.0/12.0, tolerance);
     KRATOS_EXPECT_LE(std::abs(this_model_part.pGetNode(12)->FastGetSolutionStepValue(NODAL_AREA)) - 1.0/12.0, tolerance);
 
-    typedef CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsNonHistoricalVariable> NonHistNodalAreaProcess;
+    using NonHistNodalAreaProcess= CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsNonHistoricalVariable>; ;
     NonHistNodalAreaProcess nonhist_process(this_model_part, 3);
     nonhist_process.Execute();
 
@@ -153,7 +153,7 @@ KRATOS_TEST_CASE_IN_SUITE(NodalArea3, KratosCoreFastSuite)
 
     CppTestsUtilities::Create2DQuadrilateralsGeometry(this_model_part);
 
-    typedef CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsHistoricalVariable> HistNodalAreaProcess;
+    using HistNodalAreaProcess = CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsHistoricalVariable>; ;
     HistNodalAreaProcess hist_process(this_model_part, 2);
     hist_process.Execute();
 
@@ -168,7 +168,7 @@ KRATOS_TEST_CASE_IN_SUITE(NodalArea3, KratosCoreFastSuite)
     KRATOS_EXPECT_LE(std::abs(this_model_part.pGetNode(5)->FastGetSolutionStepValue(NODAL_AREA)) - 0.25, tolerance);
     KRATOS_EXPECT_LE(std::abs(this_model_part.pGetNode(6)->FastGetSolutionStepValue(NODAL_AREA)) - 0.25, tolerance);
 
-    typedef CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsNonHistoricalVariable> NonHistNodalAreaProcess;
+    using NonHistNodalAreaProcess= CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsNonHistoricalVariable>; ;
     NonHistNodalAreaProcess nonhist_process(this_model_part, 2);
     nonhist_process.Execute();
 
@@ -202,7 +202,7 @@ KRATOS_TEST_CASE_IN_SUITE(NodalArea4, KratosCoreFastSuite)
     CppTestsUtilities::Create3DHexahedraGeometry(this_model_part);
 
     // Calculate nodal area
-    typedef CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsHistoricalVariable> HistNodalAreaProcess;
+    using HistNodalAreaProcess = CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsHistoricalVariable>; ;
     HistNodalAreaProcess hist_process(this_model_part, 3);
     hist_process.Execute();
 
@@ -223,7 +223,7 @@ KRATOS_TEST_CASE_IN_SUITE(NodalArea4, KratosCoreFastSuite)
     KRATOS_EXPECT_LE(std::abs(this_model_part.pGetNode(11)->FastGetSolutionStepValue(NODAL_AREA)) - 0125, tolerance);
     KRATOS_EXPECT_LE(std::abs(this_model_part.pGetNode(12)->FastGetSolutionStepValue(NODAL_AREA)) - 0.125, tolerance);
 
-    typedef CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsNonHistoricalVariable> NonHistNodalAreaProcess;
+    using NonHistNodalAreaProcess= CalculateNodalAreaProcess<CalculateNodalAreaSettings::SaveAsNonHistoricalVariable>; ;
     NonHistNodalAreaProcess nonhist_process(this_model_part, 3);
     nonhist_process.Execute();
 


### PR DESCRIPTION
**📝 Description**

 This PR refactors and clean up `CalculateNodalAreaProcess`:

  - Header clean up.
  - Defined Model/Parameters constructors and methods for the `CalculateNodalAreaProcess` class.
  - Added/modified class methods for `CalculateNodalAreaProcess`, including constructors, destructor, `Execute()` method descriptions, and `GetDefaultParameters()` method.
  - Expose new `Model`/`Parameters` constructor to python.
  - Replace `typdef` by `using`.
  - Adds documentation for the `CalculateNodalAreaProcess` process. It describes the functionality, parameters, and defaults of the process.

**🆕 Changelog**

- [Refactor and clean up `CalculateNodalAreaProcess`](https://github.com/KratosMultiphysics/Kratos/commit/f1ba80fdc2db8a2491c195c2f35d7eafac6675bc)
- [Expose new Model/Parameters constructor to python](https://github.com/KratosMultiphysics/Kratos/commit/2fd2da9ba806a9dc08850ad94606ad5318f8750d)
- [Update documentation](https://github.com/KratosMultiphysics/Kratos/commit/6735e7a8bff3059b0d4a63cffa830ddb764623ab)
- [Minor replace for typedef by using in C++ test](https://github.com/KratosMultiphysics/Kratos/commit/c3bd1f2bdbf4bf6076110f5840b86061f4626e32)
