### PR TITLE
[Core] Nodal Gradient process - missing include for NODAL_AREA

### DIFF
--- a/kratos/processes/compute_nodal_gradient_process.h
+++ b/kratos/processes/compute_nodal_gradient_process.h
@@ -18,10 +18,11 @@
 // External includes
 
 // Project includes
-#include "processes/process.h"
-#include "includes/node.h"
 #include "geometries/geometry.h"
+#include "includes/node.h"
 #include "includes/kratos_parameters.h"
+#include "includes/variables.h"
+#include "processes/process.h"
 
 namespace Kratos
 {


### PR DESCRIPTION
Just that, this missing include is making my compilation fail when this process is called from altair repo.
