### PR TITLE
[FastPR][Core] Newton-Raphson convergence criteria echo level

### DIFF
--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -600,6 +600,7 @@ class ResidualBasedNewtonRaphsonStrategy
     {
         BaseType::mEchoLevel = Level;
         GetBuilderAndSolver()->SetEchoLevel(Level);
+        mpConvergenceCriteria->SetEchoLevel(Level);
     }
 
     //*********************************************************************************


### PR DESCRIPTION
**📝 Description**
Current `SetEchoLevel` method in the Newton-Raphson strategy sets the verbosity value in the B&S but not in the convergence criteria, which keep the default one. This PR fixes such inconsistency.