### PR TITLE
[FastPR][Structural] Skip test and verbosity in structural mechanics application tests

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_small_displacement_mixed_volumetric_strain_element.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_small_displacement_mixed_volumetric_strain_element.cpp
@@ -456,6 +456,7 @@ namespace
             calculate_norm_dx);
 
         p_solving_strategy->Check();
+        p_solving_strategy->SetEchoLevel(0);
 
         // Fix the boundary nodes
         p_node_1->Fix(DISPLACEMENT_X);

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_solid_static_sensitivity.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_solid_static_sensitivity.cpp
@@ -284,6 +284,7 @@ PrimalTestSolver::PrimalTestSolver(ModelPart* pPrimalModelPart, unsigned Respons
 double PrimalTestSolver::CalculateResponseValue()
 {
     auto p_solver = CreateSolvingStrategy();
+    p_solver->SetEchoLevel(0);
     p_solver->Initialize();
     p_solver->Solve();
     auto p_response_function = ResponseFunctionFactory(mpPrimalModelPart, mResponseNodeId);
@@ -335,6 +336,7 @@ AdjointTestSolver::AdjointTestSolver(ModelPart* pAdjointModelPart, unsigned Resp
     auto p_adjoint_response_function =
         ResponseFunctionFactory(mpAdjointModelPart, mResponseNodeId);
     auto p_adjoint_solver = CreateAdjointSolvingStrategy(p_adjoint_response_function);
+    p_adjoint_solver->SetEchoLevel(0);
     p_adjoint_solver->Initialize();
     p_adjoint_solver->Solve();
     SensitivityBuilder sensitivity_builder(

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_solid_transient_sensitivity.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_solid_transient_sensitivity.cpp
@@ -207,6 +207,7 @@ void SolvePrimal(ModelPart* pModelPart,
                  std::function<void(ModelPart*)> CallerFun)
 {
     auto p_solver = CreatePrimalSolvingStrategy(pModelPart);
+    p_solver->SetEchoLevel(0);
     p_solver->Initialize();
     const double start_time = 0.0;
     pModelPart->CloneTimeStep(start_time - DeltaTime);
@@ -291,6 +292,7 @@ void SolveAdjoint(ModelPart* pAdjointModelPart,
     auto p_response_function = ResponseFunctionFactory(pAdjointModelPart, ResponseNodeId);
     auto p_adjoint_solver =
         CreateAdjointSolvingStrategy(pAdjointModelPart, p_response_function);
+    p_adjoint_solver->SetEchoLevel(0);
     p_adjoint_solver->Initialize();
     SensitivityBuilder sensitivity_builder(
         Parameters(R"(

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_total_lagrangian_mixed_volumetric_strain_element.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_total_lagrangian_mixed_volumetric_strain_element.cpp
@@ -144,6 +144,11 @@ namespace Kratos::Testing
      */
     KRATOS_TEST_CASE_IN_SUITE(TotalLagrangianMixedVolumetricStrainElementBonetPatch, KratosStructuralMechanicsFastSuite)
     {
+        // Skip the test if the constitutive law is not available (i.e. the ConstitutiveLawsApplication is not compiled)
+        if (!KratosComponents<ConstitutiveLaw>::Has("HyperElasticPlaneStrain2DLaw")) {
+            return;
+        }
+
         // Set the test model part
         Model current_model;
         auto &r_model_part = current_model.CreateModelPart("ModelPart",1);

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_total_lagrangian_mixed_volumetric_strain_element.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_total_lagrangian_mixed_volumetric_strain_element.cpp
@@ -145,7 +145,8 @@ namespace Kratos::Testing
     KRATOS_TEST_CASE_IN_SUITE(TotalLagrangianMixedVolumetricStrainElementBonetPatch, KratosStructuralMechanicsFastSuite)
     {
         // Skip the test if the constitutive law is not available (i.e. the ConstitutiveLawsApplication is not compiled)
-        if (!KratosComponents<ConstitutiveLaw>::Has("HyperElasticPlaneStrain2DLaw")) {
+        const std::string claw_name = "HyperElasticPlaneStrain2DLaw";
+        if (!KratosComponents<ConstitutiveLaw>::Has(claw_name)) {
             return;
         }
 
@@ -180,7 +181,7 @@ namespace Kratos::Testing
         auto p_elem_prop = r_model_part.CreateNewProperties(1);
         p_elem_prop->SetValue(YOUNG_MODULUS, 250.0);
         p_elem_prop->SetValue(POISSON_RATIO, 0.25);
-        const auto &r_clone_cl = KratosComponents<ConstitutiveLaw>::Get("HyperElasticPlaneStrain2DLaw");
+        const auto &r_clone_cl = KratosComponents<ConstitutiveLaw>::Get(claw_name);
         p_elem_prop->SetValue(CONSTITUTIVE_LAW, r_clone_cl.Clone());
         for (auto& r_elem: r_model_part.Elements()) {
             r_elem.SetProperties(p_elem_prop);

--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -600,6 +600,7 @@ class ResidualBasedNewtonRaphsonStrategy
     {
         BaseType::mEchoLevel = Level;
         GetBuilderAndSolver()->SetEchoLevel(Level);
+        mpConvergenceCriteria->SetEchoLevel(Level);
     }
 
     //*********************************************************************************


### PR DESCRIPTION
**📝 Description**
This fixes #12160. Besides, I took the chance to clean the terminal output as some of the tests were way too verbose. In order to get the clean output,  #12161 must be merged first.

Closes #12160.
