### PR TITLE
[Core] Clean up and refactor `ApplyConstantScalarValueProcess`

### DIFF
--- a/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
@@ -34,6 +34,8 @@ public:
     }
 
     bool hasWaterPressure() const { return mVariableName == "WATER_PRESSURE"; }
+
+    Kratos::ModelPart& GetModelPart() { return mrModelPart; }
 };
 
 class GeoFlowApplyConstantHydrostaticPressureProcess : public Kratos::ApplyConstantHydrostaticPressureProcess

--- a/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
+++ b/applications/GeoMechanicsApplication/custom_workflows/dgeoflow.cpp
@@ -33,9 +33,7 @@ public:
     {
     }
 
-    bool hasWaterPressure() const { return mvariable_name == "WATER_PRESSURE"; }
-
-    Kratos::ModelPart& GetModelPart() { return mr_model_part; }
+    bool hasWaterPressure() const { return mVariableName == "WATER_PRESSURE"; }
 };
 
 class GeoFlowApplyConstantHydrostaticPressureProcess : public Kratos::ApplyConstantHydrostaticPressureProcess

--- a/docs/pages/Kratos/Processes/Legacy/apply_constant_scalar_value_process.md
+++ b/docs/pages/Kratos/Processes/Legacy/apply_constant_scalar_value_process.md
@@ -16,7 +16,7 @@ This is a Legacy process and should not be used directly. Please see [Assign Sca
 
 This process is intended to be used for setting scalar values (`bool`, `int`, `double`) to a variable in a model part.
 
-This process is executed on the follwing hooks:
+This process is executed on the following hooks:
 - `ExecuteInitialize`
 
 ## Parameters & Defaults

--- a/docs/pages/Kratos/Processes/Legacy/apply_constant_vector_value_process.md
+++ b/docs/pages/Kratos/Processes/Legacy/apply_constant_vector_value_process.md
@@ -16,7 +16,7 @@ This is a Legacy process and should not be used directly. Please see [Assign Sca
 
 This process is intended to be used for setting vector values (`double`) to a variable in a model part.
 
-This process is executed on the follwing hooks:
+This process is executed on the following hooks:
 - `ExecuteInitialize`
 
 ## Parameters & Defaults

--- a/kratos/processes/apply_constant_scalarvalue_process.cpp
+++ b/kratos/processes/apply_constant_scalarvalue_process.cpp
@@ -4,17 +4,255 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //
 //
 
+// System includes
+
+// External includes
+
+// Project includes
+#include "containers/model.h"
+#include "utilities/variable_utils.h"
 #include "processes/apply_constant_scalarvalue_process.h"
-#include "includes/define.h"
 
 namespace Kratos
 {
-    KRATOS_CREATE_LOCAL_FLAG(ApplyConstantScalarValueProcess, VARIABLE_IS_FIXED, 0)
+KRATOS_CREATE_LOCAL_FLAG(ApplyConstantScalarValueProcess, VARIABLE_IS_FIXED, 0)
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+ApplyConstantScalarValueProcess::ApplyConstantScalarValueProcess(
+    Model& rModel,
+    Parameters ThisParameters
+    ) : ApplyConstantScalarValueProcess(rModel.GetModelPart(ThisParameters["model_part_name"].GetString()), ThisParameters)
+{
+
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+ApplyConstantScalarValueProcess::ApplyConstantScalarValueProcess(
+    ModelPart& rModelPart,
+    Parameters ThisParameters
+    ) : Process(Flags()) ,
+        mrModelPart(rModelPart)
+{
+    KRATOS_TRY
+
+    // Some values need to be mandatorily prescribed since no meaningful default value exist.
+    // So that an error is thrown if they don't exist
+    KRATOS_ERROR_IF_NOT(ThisParameters.Has("value")) << "Missing 'value' parameter in ThisParameters" << std::endl;
+    KRATOS_ERROR_IF_NOT(ThisParameters.Has("variable_name")) << "Missing 'variable_name' parameter in ThisParameters" << std::endl;
+    KRATOS_ERROR_IF_NOT(ThisParameters.Has("model_part_name")) << "Missing 'model_part_name' parameter in ThisParameters" << std::endl;
+
+    // Now validate against defaults -- this also ensures no type mismatch
+    ThisParameters.ValidateAndAssignDefaults(GetDefaultParameters());
+
+    mMeshId = ThisParameters["mesh_id"].GetInt();
+    mVariableName = ThisParameters["variable_name"].GetString();
+    this->Set( VARIABLE_IS_FIXED, ThisParameters["is_fixed"].GetBool());
+
+    if( KratosComponents<Variable<double>>::Has( mVariableName ) ) { //case of double variable
+        mDoubleValue = ThisParameters["value"].GetDouble();
+        KRATOS_ERROR_IF_NOT(rModelPart.GetNodalSolutionStepVariablesList().Has(KratosComponents<Variable<double>>::Get(mVariableName))) << "Trying to fix a variable that is not in the rModelPart - variable name is " << mVariableName << std::endl;
+    } else if( KratosComponents<Variable<int>>::Has( mVariableName ) ) { // Case of int variable
+        mIntValue = ThisParameters["value"].GetInt();
+        KRATOS_ERROR_IF_NOT(rModelPart.GetNodalSolutionStepVariablesList().Has(KratosComponents<Variable<int>>::Get(mVariableName))) << "Trying to fix a variable that is not in the rModelPart - variable name is " << mVariableName << std::endl;
+        KRATOS_ERROR_IF(this->Is(VARIABLE_IS_FIXED)) << "Sorry it is not possible to fix variables of type Variable<int>. Only double variables or vector components can be fixed" << std::endl;
+    } else if( KratosComponents< Variable<bool> >::Has( mVariableName ) ) { // Case of bool variable
+        mBoolValue = ThisParameters["value"].GetBool();
+        KRATOS_ERROR_IF_NOT(rModelPart.GetNodalSolutionStepVariablesList().Has(KratosComponents<Variable<bool>>::Get(mVariableName))) << "Trying to fix a variable that is not in the rModelPart - variable name is " << mVariableName << std::endl;
+        KRATOS_ERROR_IF(this->Is(VARIABLE_IS_FIXED)) << "Sorry it is not possible to fix variables of type Variable<bool>. Only double variables or vector components can be fixed" << std::endl;
+    }
+
+    KRATOS_CATCH("");
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+ApplyConstantScalarValueProcess::ApplyConstantScalarValueProcess(
+    ModelPart& rModelPart,
+    const Variable<double>& rVariable,
+    const double DoubleValue,
+    std::size_t MeshId,
+    const Flags Options
+    ) : Process(Options) ,
+        mrModelPart(rModelPart),
+        mDoubleValue(DoubleValue),
+        mMeshId(MeshId)
+{
+    KRATOS_TRY;
+
+    KRATOS_ERROR_IF(this->IsDefined(VARIABLE_IS_FIXED) == false) << "Please specify if the variable is to be fixed or not (flag VARIABLE_IS_FIXED)" << std::endl;
+    KRATOS_ERROR_IF_NOT(rModelPart.GetNodalSolutionStepVariablesList().Has(rVariable)) << "Trying to fix a variable that is not in the rModelPart - variable name is " << rVariable << std::endl;
+
+    mVariableName = rVariable.Name();
+
+    KRATOS_CATCH("");
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+ApplyConstantScalarValueProcess::ApplyConstantScalarValueProcess(
+    ModelPart& rModelPart,
+    const Variable<int>& rVariable,
+    const int IntValue,
+    std::size_t MeshId,
+    const Flags Options
+    ) : Process(Options),
+        mrModelPart(rModelPart),
+        mIntValue(IntValue),
+        mMeshId(MeshId)
+{
+    KRATOS_TRY;
+
+    KRATOS_ERROR_IF_NOT(this->IsDefined(VARIABLE_IS_FIXED)) << "Please specify if the variable is to be fixed or not (flag VARIABLE_IS_FIXED)" << std::endl;
+    KRATOS_ERROR_IF(this->Is(VARIABLE_IS_FIXED)) << "Sorry it is not possible to fix variables of type Variable<int>. Only double variables or vector components can be fixed" << std::endl;
+    KRATOS_ERROR_IF_NOT(rModelPart.GetNodalSolutionStepVariablesList().Has(rVariable)) << "Trying to fix a variable that is not in the rModelPart - variable name is " << rVariable << std::endl;
+
+    mVariableName = rVariable.Name();
+
+    KRATOS_CATCH("");
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+ApplyConstantScalarValueProcess::ApplyConstantScalarValueProcess(
+    ModelPart& rModelPart,
+    const Variable< bool >& rVariable,
+    const bool BoolValue,
+    std::size_t MeshId,
+    const Flags options
+        ) : Process(options) ,
+        mrModelPart(rModelPart),
+        mBoolValue(BoolValue),
+        mMeshId(MeshId)
+{
+    KRATOS_TRY;
+
+    KRATOS_ERROR_IF_NOT(this->IsDefined(VARIABLE_IS_FIXED)) << "Please specify if the variable is to be fixed or not (flag VARIABLE_IS_FIXED)" << std::endl;
+    KRATOS_ERROR_IF(this->Is(VARIABLE_IS_FIXED)) << "Sorry it is not possible to fix variables of type Variable<int>. Only double variables or vector components can be fixed" << std::endl;
+    KRATOS_ERROR_IF_NOT(rModelPart.GetNodalSolutionStepVariablesList().Has(rVariable)) << "Trying to fix a variable that is not in the rModelPart - variable name is " << rVariable << std::endl;
+
+    mVariableName = rVariable.Name();
+
+    KRATOS_CATCH("");
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void ApplyConstantScalarValueProcess::ExecuteInitialize()
+{
+    KRATOS_TRY;
+    const bool is_fixed = this->Is(VARIABLE_IS_FIXED);
+
+    if( KratosComponents<Variable<double>>::Has( mVariableName ) ) { //case of double variable
+        InternalApplyValue<>(KratosComponents< Variable<double> >::Get(mVariableName) , is_fixed, mDoubleValue);
+    } else if( KratosComponents<Variable<int>>::Has( mVariableName ) ) { // Case of int variable
+        InternalApplyValueWithoutFixing<>(KratosComponents<Variable<int>>::Get(mVariableName) , mIntValue);
+    } else if( KratosComponents< Variable<bool> >::Has( mVariableName ) )  { // Case of bool variable
+        InternalApplyValueWithoutFixing<>(KratosComponents<Variable<bool>>::Get(mVariableName), mBoolValue);
+    } else {
+        KRATOS_ERROR << "Not able to fix the variable. Attempting to fix variable: " << mVariableName << std::endl;
+    }
+
+    KRATOS_CATCH("");
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<class TVarType>
+void ApplyConstantScalarValueProcess::InternalApplyValue(
+    const TVarType& rVariable,
+    const bool ToBeFixed,
+    const typename TVarType::Type Value
+    )
+{
+    const std::size_t number_of_nodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+
+    if(number_of_nodes != 0) {
+        block_for_each(mrModelPart.GetMesh(mMeshId).Nodes(), [&](Node& rNode){
+            if constexpr (std::is_same<TVarType, Variable<double>>::value) { // For nodes
+                if(ToBeFixed) {
+                    rNode.Fix(rVariable);
+                }
+            }
+            rNode.FastGetSolutionStepValue(rVariable) = Value;
+        });
+    }
+}
+
+template void ApplyConstantScalarValueProcess::InternalApplyValue<Variable<bool>>(
+    const Variable<bool>& rVariable,
+    const bool ToBeFixed,
+    const bool Value
+    );
+template void ApplyConstantScalarValueProcess::InternalApplyValue<Variable<int>>(
+    const Variable<int>& rVariable,
+    const bool ToBeFixed,
+    const int Value
+    );
+template void ApplyConstantScalarValueProcess::InternalApplyValue<Variable<double>>(
+    const Variable<double>& rVariable,
+    const bool ToBeFixed,
+    const double Value
+    );
+
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<class TVarType>
+void ApplyConstantScalarValueProcess::InternalApplyValueWithoutFixing(
+    const TVarType& rVariable,
+    const typename TVarType::Type Value
+    )
+{
+    const std::size_t number_of_nodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+
+    if(number_of_nodes != 0) {
+        VariableUtils().SetVariable(rVariable, Value, mrModelPart.GetMesh(mMeshId).Nodes());
+    }
+}
+
+template void ApplyConstantScalarValueProcess::InternalApplyValueWithoutFixing<Variable<bool>>(
+    const Variable<bool>& rVariable,
+    const bool Value
+    );
+template void ApplyConstantScalarValueProcess::InternalApplyValueWithoutFixing<Variable<int>>(
+    const Variable<int>& rVariable,
+    const int Value
+    );
+template void ApplyConstantScalarValueProcess::InternalApplyValueWithoutFixing<Variable<double>>(
+    const Variable<double>& rVariable,
+    const double Value
+    );
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+const Parameters ApplyConstantScalarValueProcess::GetDefaultParameters() const
+{
+    return Parameters( R"(
+    {
+        "model_part_name" : "PLEASE_CHOOSE_MODEL_PART_NAME",
+        "mesh_id"         : 0,
+        "variable_name"   : "PLEASE_PRESCRIBE_VARIABLE_NAME",
+        "is_fixed"        : false,
+        "value"           : 1.0
+    }  )" );
+}
+
 }

--- a/kratos/processes/apply_constant_scalarvalue_process.h
+++ b/kratos/processes/apply_constant_scalarvalue_process.h
@@ -193,20 +193,6 @@ protected:
     std::size_t mMeshId = 0;   /// Mesh ID.
 
     ///@}
-    ///@name Protected Access
-    ///@{
-
-    /**
-     * @brief GetModelPart returns the reference to the ModelPart.
-     * @details This function provides access to the ModelPart associated with the current object.
-     * @return Reference to the ModelPart.
-     */
-    ModelPart& GetModelPart() 
-    { 
-        return mrModelPart; 
-    }
-
-    ///@}
 private:
     ///@name Private Operations
     ///@{

--- a/kratos/processes/apply_constant_scalarvalue_process.h
+++ b/kratos/processes/apply_constant_scalarvalue_process.h
@@ -151,6 +151,16 @@ public:
     ///@name Access
     ///@{
 
+    /**
+     * @brief GetModelPart returns the reference to the ModelPart.
+     * @details This function provides access to the ModelPart associated with the current object.
+     * @return Reference to the ModelPart.
+     */
+    ModelPart& GetModelPart() 
+    { 
+        return mrModelPart; 
+    }
+
     ///@}
     ///@name Inquiry
     ///@{

--- a/kratos/processes/apply_constant_scalarvalue_process.h
+++ b/kratos/processes/apply_constant_scalarvalue_process.h
@@ -151,16 +151,6 @@ public:
     ///@name Access
     ///@{
 
-    /**
-     * @brief GetModelPart returns the reference to the ModelPart.
-     * @details This function provides access to the ModelPart associated with the current object.
-     * @return Reference to the ModelPart.
-     */
-    ModelPart& GetModelPart() 
-    { 
-        return mrModelPart; 
-    }
-
     ///@}
     ///@name Inquiry
     ///@{
@@ -192,16 +182,33 @@ public:
 
     ///@}
 protected:
+    ///@name Protected Member Variables
+    ///@{
 
-    ModelPart& mrModelPart;
-    std::string mVariableName;
-    double mDoubleValue = 0.0;
-    int mIntValue = 0;
-    bool mBoolValue = false;
-    std::size_t mMeshId = 0;
+    ModelPart& mrModelPart;    /// Reference to the model part.
+    std::string mVariableName; /// Name of the variable.
+    double mDoubleValue = 0.0; /// Double value.
+    int mIntValue = 0;         /// Integer value.
+    bool mBoolValue = false;   /// Boolean value.
+    std::size_t mMeshId = 0;   /// Mesh ID.
 
+    ///@}
+    ///@name Protected Access
+    ///@{
+
+    /**
+     * @brief GetModelPart returns the reference to the ModelPart.
+     * @details This function provides access to the ModelPart associated with the current object.
+     * @return Reference to the ModelPart.
+     */
+    ModelPart& GetModelPart() 
+    { 
+        return mrModelPart; 
+    }
+
+    ///@}
 private:
-    ///@name Static Member Variables
+    ///@name Private Operations
     ///@{
 
     /**

--- a/kratos/processes/apply_constant_scalarvalue_process.h
+++ b/kratos/processes/apply_constant_scalarvalue_process.h
@@ -4,32 +4,22 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //
 //
 
-#if !defined(KRATOS_APPLY_CONSTANT_VALUE_PROCESS_H_INCLUDED )
-#define  KRATOS_APPLY_CONSTANT_VALUE_PROCESS_H_INCLUDED
-
-
+#pragma once
 
 // System includes
-#include <string>
-#include <iostream>
-
 
 // External includes
 
-
 // Project includes
-#include "includes/define.h"
-#include "includes/kratos_flags.h"
 #include "includes/kratos_parameters.h"
 #include "processes/process.h"
-#include "utilities/variable_utils.h"
 
 namespace Kratos
 {
@@ -37,16 +27,22 @@ namespace Kratos
 ///@name Kratos Classes
 ///@{
 
-/// The base class for all processes in Kratos.
-/** This function applies a constant value (and fixity) to all of the nodes in a given mesh
-*/
-class KRATOS_API(KRATOS_CORE) ApplyConstantScalarValueProcess : public Process
+/**
+ * @class ApplyConstantScalarValueProcess
+ * @brief A class to apply a constant scalar value to nodes in a model part for a given variable.
+ * @details This function applies a constant value (and fixity) to all of the nodes in a given mesh
+ * @ingroup KratosCore
+ * @author Riccardo Rossi
+ */
+class KRATOS_API(KRATOS_CORE) ApplyConstantScalarValueProcess
+    : public Process
 {
 public:
     ///@name Type Definitions
     ///@{
-    KRATOS_DEFINE_LOCAL_FLAG(VARIABLE_IS_FIXED);
 
+    /// Definition of the local flags
+    KRATOS_DEFINE_LOCAL_FLAG(VARIABLE_IS_FIXED);
 
     /// Pointer definition of ApplyConstantScalarValueProcess
     KRATOS_CLASS_POINTER_DEFINITION(ApplyConstantScalarValueProcess);
@@ -54,154 +50,77 @@ public:
     ///@}
     ///@name Life Cycle
     ///@{
-    ApplyConstantScalarValueProcess(ModelPart& model_part,
-                              Parameters rParameters
-                                   ) : Process(Flags()) , mr_model_part(model_part)
-    {
-        KRATOS_TRY
 
-//only include validation with c++11 since raw_literals do not exist in c++03
+    /**
+     * @brief Constructor to apply a constant scalar value to nodes in a model part for a given variable.
+     * @param rModel Reference to the model.
+     * @param rParameters Parameters containing information about the variable, value, mesh ID, and options.
+     */
+    ApplyConstantScalarValueProcess(
+        Model& rModel,
+        Parameters ThisParameters
+        );
 
+    /**
+     * @brief Constructor to apply a constant scalar value to nodes in a model part for a given variable.
+     * @param rModelPart Reference to the model part.
+     * @param ThisParameters Parameters containing information about the variable, value, mesh ID, and options.
+     */
+    ApplyConstantScalarValueProcess(
+        ModelPart& rModelPart,
+        Parameters ThisParameters
+    );
 
-        // Some values need to be mandatorily prescribed since no meaningful default value exist. For this reason try accessing to them
-        // So that an error is thrown if they don't exist
-        rParameters["value"];
-        rParameters["variable_name"];
-        rParameters["model_part_name"];
+    /**
+     * @brief Constructor to apply a constant scalar value to nodes in a model part for a given double variable.
+     * @param rModelPart Reference to the model part.
+     * @param rVariable Reference to the double variable.
+     * @param DoubleValue The double value to apply.
+     * @param MeshId ID of the mesh.
+     * @param Options Flags specifying additional options.
+     */
+    ApplyConstantScalarValueProcess(
+        ModelPart& rModelPart,
+        const Variable<double>& rVariable,
+        const double DoubleValue,
+        std::size_t MeshId,
+        const Flags Options
+        );
 
-        // Now validate agains defaults -- this also ensures no type mismatch
+    /**
+     * @brief Constructor to apply a constant scalar value to nodes in a model part for a given integer variable.
+     * @param rModelPart Reference to the model part.
+     * @param rVariable Reference to the integer variable.
+     * @param IntValue The integer value to apply.
+     * @param MeshId ID of the mesh.
+     * @param options Flags specifying additional options.
+     */
+    ApplyConstantScalarValueProcess(
+        ModelPart& rModelPart,
+        const Variable<int>& rVariable,
+        const int IntValue,
+        std::size_t MeshId,
+        const Flags options
+        );
 
-        rParameters.ValidateAndAssignDefaults(GetDefaultParameters());
-
-        mmesh_id = rParameters["mesh_id"].GetInt();
-        mvariable_name = rParameters["variable_name"].GetString();
-        this->Set( VARIABLE_IS_FIXED, rParameters["is_fixed"].GetBool());
-
-        if( KratosComponents< Variable<double> >::Has( mvariable_name ) ) //case of double variable
-        {
-            mdouble_value = rParameters["value"].GetDouble();
-
-            if( model_part.GetNodalSolutionStepVariablesList().Has( KratosComponents< Variable<double> >::Get( mvariable_name ) ) == false )
-            {
-                KRATOS_THROW_ERROR(std::runtime_error,"trying to fix a variable that is not in the model_part - variable name is ",mvariable_name);
-            }
-        }
-        else if( KratosComponents< Variable<int> >::Has( mvariable_name ) ) //case of int variable
-        {
-            mint_value = rParameters["value"].GetInt();
-
-            if( model_part.GetNodalSolutionStepVariablesList().Has( KratosComponents< Variable<int> >::Get( mvariable_name ) ) == false )
-            {
-                KRATOS_THROW_ERROR(std::runtime_error,"trying to fix a variable that is not in the model_part - variable name is ",mvariable_name);
-            }
-
-            if(this->Is(VARIABLE_IS_FIXED))
-            {
-                KRATOS_THROW_ERROR(std::runtime_error,"sorry it is not possible to fix variables of type Variable<int>. Only double variables or vector components can be fixed","");
-            }
-        }
-        else if( KratosComponents< Variable<bool> >::Has( mvariable_name ) ) //case of bool variable
-        {
-            mbool_value = rParameters["value"].GetBool();
-
-            if( model_part.GetNodalSolutionStepVariablesList().Has( KratosComponents< Variable<bool> >::Get( mvariable_name ) ) == false )
-            {
-                KRATOS_THROW_ERROR(std::runtime_error,"trying to fix a variable that is not in the model_part - variable name is ",mvariable_name);
-            }
-
-            if(this->Is(VARIABLE_IS_FIXED))
-            {
-                KRATOS_THROW_ERROR(std::runtime_error,"sorry it is not possible to fix variables of type Variable<bool>. Only double variables or vector components can be fixed","");
-            }
-        }
-
-        KRATOS_CATCH("");
-    }
-
-    ApplyConstantScalarValueProcess(ModelPart& model_part,
-                              const Variable<double>& rVariable,
-                              const double double_value,
-                              std::size_t mesh_id,
-                              const Flags options
-                                   ) : Process(options) , mr_model_part(model_part),mdouble_value(double_value), mint_value(0), mbool_value(false),mmesh_id(mesh_id)
-    {
-        KRATOS_TRY;
-
-        if(this->IsDefined(VARIABLE_IS_FIXED) == false )
-        {
-            KRATOS_THROW_ERROR(std::runtime_error,"please specify if the variable is to be fixed or not (flag VARIABLE_IS_FIXED)","");
-        }
-
-        if( model_part.GetNodalSolutionStepVariablesList().Has( rVariable ) == false )
-        {
-                KRATOS_THROW_ERROR(std::runtime_error,"trying to fix a variable that is not in the model_part - variable name is ",rVariable);
-        }
-
-        mvariable_name = rVariable.Name();
-
-        KRATOS_CATCH("");
-    }
-
-    ApplyConstantScalarValueProcess(ModelPart& model_part,
-                              const Variable< int >& rVariable,
-                              const int int_value,
-                              std::size_t mesh_id,
-                              const Flags options
-                                   ) : Process(options) , mr_model_part(model_part),mdouble_value(0.0), mint_value(int_value), mbool_value(false),mmesh_id(mesh_id)
-    {
-        KRATOS_TRY;
-
-        if(this->IsDefined(VARIABLE_IS_FIXED) == false )
-        {
-            KRATOS_THROW_ERROR(std::runtime_error,"Please specify if the variable is to be fixed or not (flag VARIABLE_IS_FIXED)","");
-        }
-        if(this->Is(VARIABLE_IS_FIXED))
-        {
-            KRATOS_THROW_ERROR(std::runtime_error,"Sorry it is not possible to fix variables of type Variable<int>. Only double variables or vector components can be fixed","");
-        }
-
-        if( model_part.GetNodalSolutionStepVariablesList().Has( rVariable ) == false )
-        {
-                KRATOS_THROW_ERROR(std::runtime_error,"Trying to fix a variable that is not in the model_part - variable name is ",rVariable);
-        }
-
-        mvariable_name = rVariable.Name();
-
-        KRATOS_CATCH("");
-    }
-
-    ApplyConstantScalarValueProcess(ModelPart& model_part,
-                              const Variable< bool >& rVariable,
-                              const bool bool_value,
-                              std::size_t mesh_id,
-                              const Flags options
-                                   ) : Process(options) , mr_model_part(model_part),mdouble_value(0.0), mint_value(0), mbool_value(bool_value),mmesh_id(mesh_id)
-    {
-        KRATOS_TRY;
-
-        if(this->IsDefined(VARIABLE_IS_FIXED) == false )
-        {
-            KRATOS_THROW_ERROR(std::runtime_error,"Please specify if the variable is to be fixed or not (flag VARIABLE_IS_FIXED)","");
-        }
-        if(this->Is(VARIABLE_IS_FIXED))
-        {
-            KRATOS_THROW_ERROR(std::runtime_error,"Sorry it is not possible to fix variables of type Variable<int>. Only double variables or vector components can be fixed","");
-        }
-
-        if( model_part.GetNodalSolutionStepVariablesList().Has( rVariable ) == false )
-        {
-                KRATOS_THROW_ERROR(std::runtime_error,"Trying to fix a variable that is not in the model_part - variable name is ",rVariable);
-        }
-
-        mvariable_name = rVariable.Name();
-
-        KRATOS_CATCH("");
-    }
-
+    /**
+     * @brief Constructor to apply a constant scalar value to nodes in a model part for a given boolean variable.
+     * @param rModelPart Reference to the model part.
+     * @param rVariable Reference to the boolean variable.
+     * @param BoolValue The boolean value to apply.
+     * @param MeshId ID of the mesh.
+     * @param options Flags specifying additional options.
+     */
+    ApplyConstantScalarValueProcess(
+        ModelPart& rModelPart,
+        const Variable<bool>& rVariable,
+        const bool BoolValue,
+        std::size_t MeshId,
+        const Flags options
+        );
 
     /// Destructor.
-    ~ApplyConstantScalarValueProcess() override {}
-
+    ~ApplyConstantScalarValueProcess() override = default;
 
     ///@}
     ///@name Operators
@@ -213,100 +132,28 @@ public:
         Execute();
     }
 
-    const Parameters GetDefaultParameters() const override
-    {
-        const Parameters default_parameters( R"(
-        {
-            "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
-            "mesh_id": 0,
-            "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
-            "is_fixed": false,
-            "value" : 1.0
-        }  )" );
-        return default_parameters;
-    }
-
     ///@}
     ///@name Operations
     ///@{
 
+    /**
+     * @brief This function is designed for being called at the beginning of the computations
+     * right after reading the model and the groups
+     */
+    void ExecuteInitialize() override;
 
-    /// Execute method is used to execute the ApplyConstantScalarValueProcess algorithms.
-    void Execute() override {}
-
-    /// this function is designed for being called at the beginning of the computations
-    /// right after reading the model and the groups
-    void ExecuteInitialize() override
-    {
-        KRATOS_TRY;
-        const bool is_fixed = this->Is(VARIABLE_IS_FIXED);
-
-        if( KratosComponents< Variable<double> >::Has( mvariable_name ) ) //case of double variable
-        {
-            InternalApplyValue<>(KratosComponents< Variable<double> >::Get(mvariable_name) , is_fixed, mdouble_value);
-        }
-        else if( KratosComponents< Variable<int> >::Has( mvariable_name ) ) //case of int variable
-        {
-            InternalApplyValueWithoutFixing<>(KratosComponents< Variable<int> >::Get(mvariable_name) , mint_value);
-        }
-        else if( KratosComponents< Variable<bool> >::Has( mvariable_name ) ) //case of bool variable
-        {
-            InternalApplyValueWithoutFixing<>(KratosComponents< Variable<bool> >::Get(mvariable_name), mbool_value);
-        }
-        else
-        {
-            KRATOS_THROW_ERROR(std::logic_error, "Not able to fix the variable. Attempting to fix variable:",mvariable_name);
-        }
-
-        KRATOS_CATCH("");
-    }
-
-    /// this function is designed for being execute once before the solution loop but after all of the
-    /// solvers where built
-    void ExecuteBeforeSolutionLoop() override
-    {
-    }
-
-
-    /// this function will be executed at every time step BEFORE performing the solve phase
-    void ExecuteInitializeSolutionStep() override
-    {
-    }
-
-    /// this function will be executed at every time step AFTER performing the solve phase
-    void ExecuteFinalizeSolutionStep() override
-    {
-    }
-
-
-    /// this function will be executed at every time step BEFORE  writing the output
-    void ExecuteBeforeOutputStep() override
-    {
-    }
-
-
-    /// this function will be executed at every time step AFTER writing the output
-    void ExecuteAfterOutputStep() override
-    {
-    }
-
-
-    /// this function is designed for being called at the end of the computations
-    /// right after reading the model and the groups
-    void ExecuteFinalize() override
-    {
-    }
-
+    /**
+     * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
+     */
+    const Parameters GetDefaultParameters() const override;
 
     ///@}
     ///@name Access
     ///@{
 
-
     ///@}
     ///@name Inquiry
     ///@{
-
 
     ///@}
     ///@name Input and output
@@ -329,52 +176,49 @@ public:
     {
     }
 
-
     ///@}
     ///@name Friends
     ///@{
 
-
     ///@}
 protected:
 
-    ModelPart& mr_model_part;
-    std::string mvariable_name;
-    double mdouble_value;
-    int mint_value;
-    bool mbool_value;
-    std::size_t mmesh_id;
+    ModelPart& mrModelPart;
+    std::string mVariableName;
+    double mDoubleValue = 0.0;
+    int mIntValue = 0;
+    bool mBoolValue = false;
+    std::size_t mMeshId = 0;
 
 private:
     ///@name Static Member Variables
     ///@{
-    template< class TVarType, class TDataType >
-    void InternalApplyValue(const TVarType& rVar, const bool to_be_fixed, const TDataType value)
-    {
-        const int nnodes = mr_model_part.GetMesh(mmesh_id).Nodes().size();
 
-        if(nnodes != 0)
-        {
-            block_for_each(mr_model_part.GetMesh(mmesh_id).Nodes(), [&](Node& rNode){
-                if(to_be_fixed)
-                {
-                    rNode.Fix(rVar);
-                }
-                rNode.FastGetSolutionStepValue(rVar) = value;
-            });
-        }
-    }
+    /**
+    * @brief Apply a value to all nodes of the model part for a given variable, optionally fixing the variable.
+    * @tparam TVarType Type of the variable.
+    * @param rVariable The variable to apply the value to.
+    * @param ToBeFixed Boolean indicating whether the variable should be fixed.
+    * @param Value The value to apply to the variable.
+    */
+    template<class TVarType>
+    void InternalApplyValue(
+        const TVarType& rVariable,
+        const bool ToBeFixed,
+        const typename TVarType::Type Value
+        );
 
-    template< class TVarType, class TDataType >
-    void InternalApplyValueWithoutFixing(const TVarType& rVar, const TDataType value)
-    {
-        const int nnodes = mr_model_part.GetMesh(mmesh_id).Nodes().size();
-
-        if(nnodes != 0)
-        {
-            VariableUtils().SetVariable(rVar, value, mr_model_part.GetMesh(mmesh_id).Nodes());
-        }
-    }
+    /**
+    * @brief Apply a value to all nodes of the model part for a given variable without fixing the variable.
+    * @tparam TVarType Type of the variable.
+    * @param rVariable The variable to apply the value to.
+    * @param Value The value to apply to the variable.
+    */
+    template<class TVarType>
+    void InternalApplyValueWithoutFixing(
+        const TVarType& rVariable,
+        const typename TVarType::Type Value
+        );
 
     ///@}
     ///@name Un accessible methods
@@ -386,21 +230,16 @@ private:
     /// Copy constructor.
     //ApplyConstantScalarValueProcess(ApplyConstantScalarValueProcess const& rOther);
 
-
     ///@}
-
 }; // Class ApplyConstantScalarValueProcess
 
 ///@}
-
 ///@name Type Definitions
 ///@{
-
 
 ///@}
 ///@name Input and output
 ///@{
-
 
 /// input stream function
 inline std::istream& operator >> (std::istream& rIStream,
@@ -418,7 +257,4 @@ inline std::ostream& operator << (std::ostream& rOStream,
 }
 ///@}
 
-
 }  // namespace Kratos.
-
-#endif // KRATOS_APPLY_CONSTANT_VALUE_PROCESS_H_INCLUDED  defined

--- a/kratos/processes/apply_constant_vectorvalue_process.cpp
+++ b/kratos/processes/apply_constant_vectorvalue_process.cpp
@@ -16,6 +16,7 @@
 // External includes
 
 // Project includes
+#include "containers/model.h"
 #include "includes/model_part.h"
 #include "processes/apply_constant_vectorvalue_process.h"
 
@@ -29,10 +30,22 @@ KRATOS_CREATE_LOCAL_FLAG(ApplyConstantVectorValueProcess,Z_COMPONENT_FIXED, 2);
 /***********************************************************************************/
 /***********************************************************************************/
 
-ApplyConstantVectorValueProcess::ApplyConstantVectorValueProcess(ModelPart& rModelPart,
-                                Parameters parameters
-                                ) : Process(Flags()),
-                                    mrModelPart(rModelPart)
+ApplyConstantVectorValueProcess::ApplyConstantVectorValueProcess(
+    Model& rModel,
+    Parameters ThisParameters
+    ) : ApplyConstantVectorValueProcess(rModel.GetModelPart(ThisParameters["model_part_name"].GetString()), ThisParameters)
+{
+
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+ApplyConstantVectorValueProcess::ApplyConstantVectorValueProcess(
+    ModelPart& rModelPart,
+    Parameters ThisParameters
+    ) : Process(Flags()),
+        mrModelPart(rModelPart)
 {
     KRATOS_TRY
 
@@ -41,29 +54,29 @@ ApplyConstantVectorValueProcess::ApplyConstantVectorValueProcess(ModelPart& rMod
 
     // Some values need to be mandatorily prescribed since no meaningful default Value exist. For this reason try accessing to them
     // So that an error is thrown if they don't exist
-    KRATOS_ERROR_IF(parameters["direction"].IsArray() && parameters["direction"].size() != 3) << "direction vector is not a vector or it does not have size 3. Direction vector currently passed" << parameters.PrettyPrintJsonString() << std::endl;
-    KRATOS_ERROR_IF_NOT(parameters["modulus"].IsNumber()) << "modulus shall be a number. Parameter list in which is included is :" <<  parameters.PrettyPrintJsonString() << std::endl;
-    KRATOS_ERROR_IF_NOT(parameters["variable_name"].IsString()) << "variable_name shall be a String. Parameter list in which is included is :" << parameters.PrettyPrintJsonString() << std::endl;
-    KRATOS_ERROR_IF_NOT(parameters["model_part_name"].IsString()) << "model_part_name shall be a String. Parameter list in which is included is :" << parameters.PrettyPrintJsonString() << std::endl;
+    KRATOS_ERROR_IF(ThisParameters["direction"].IsArray() && ThisParameters["direction"].size() != 3) << "direction vector is not a vector or it does not have size 3. Direction vector currently passed" << ThisParameters.PrettyPrintJsonString() << std::endl;
+    KRATOS_ERROR_IF_NOT(ThisParameters["modulus"].IsNumber()) << "modulus shall be a number. Parameter list in which is included is :" <<  ThisParameters.PrettyPrintJsonString() << std::endl;
+    KRATOS_ERROR_IF_NOT(ThisParameters["variable_name"].IsString()) << "variable_name shall be a String. Parameter list in which is included is :" << ThisParameters.PrettyPrintJsonString() << std::endl;
+    KRATOS_ERROR_IF_NOT(ThisParameters["model_part_name"].IsString()) << "model_part_name shall be a String. Parameter list in which is included is :" << ThisParameters.PrettyPrintJsonString() << std::endl;
 
     // Validate against defaults -- this also ensures no type mismatch
-    parameters.ValidateAndAssignDefaults(default_parameters);
+    ThisParameters.ValidateAndAssignDefaults(default_parameters);
 
     // Read from the parameters and assign to the values
-    mMeshId = parameters["mesh_id"].GetInt();
+    mMeshId = ThisParameters["mesh_id"].GetInt();
 
-    this->Set(X_COMPONENT_FIXED, parameters["is_fixed_x"].GetBool());
-    this->Set(Y_COMPONENT_FIXED, parameters["is_fixed_y"].GetBool());
-    this->Set(Z_COMPONENT_FIXED, parameters["is_fixed_z"].GetBool());
+    this->Set(X_COMPONENT_FIXED, ThisParameters["is_fixed_x"].GetBool());
+    this->Set(Y_COMPONENT_FIXED, ThisParameters["is_fixed_y"].GetBool());
+    this->Set(Z_COMPONENT_FIXED, ThisParameters["is_fixed_z"].GetBool());
 
     // Get the modulus and variable name
-    mVariableName = parameters["variable_name"].GetString();
-    mModulus = parameters["modulus"].GetDouble();
+    mVariableName = ThisParameters["variable_name"].GetString();
+    mModulus = ThisParameters["modulus"].GetDouble();
 
     mDirection.resize(3,false);
-    mDirection[0] = parameters["direction"][0].GetDouble();
-    mDirection[1] = parameters["direction"][1].GetDouble();
-    mDirection[2] = parameters["direction"][2].GetDouble();
+    mDirection[0] = ThisParameters["direction"][0].GetDouble();
+    mDirection[1] = ThisParameters["direction"][1].GetDouble();
+    mDirection[2] = ThisParameters["direction"][2].GetDouble();
 
     const double dim_norm = norm_2(mDirection);
     KRATOS_ERROR_IF(dim_norm < 1e-20) << " Norm of direction given is approximately zero. Please give a direction vector with a non zero norm : current Value of direction vector = " << mDirection << std::endl;
@@ -181,17 +194,16 @@ void ApplyConstantVectorValueProcess::InternalApplyValue(
 
 const Parameters ApplyConstantVectorValueProcess::GetDefaultParameters() const
 {
-    Parameters default_settings(R"({
-        "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
-        "mesh_id"        : 0,
-        "variable_name"  : "PLEASE_PRESCRIBE_VARIABLE_NAME",
-        "is_fixed_x"     : false,
-        "is_fixed_y"     : false,
-        "is_fixed_z"     : false,
-        "modulus"        : 1.0,
-        "direction"      : [1.0, 0.0, 0.0]
+    return Parameters(R"({
+        "model_part_name" :"PLEASE_CHOOSE_MODEL_PART_NAME",
+        "mesh_id"         : 0,
+        "variable_name"   : "PLEASE_PRESCRIBE_VARIABLE_NAME",
+        "is_fixed_x"      : false,
+        "is_fixed_y"      : false,
+        "is_fixed_z"      : false,
+        "modulus"         : 1.0,
+        "direction"       : [1.0, 0.0, 0.0]
     })");
-    return default_settings;
 }
 
 }  // namespace Kratos.

--- a/kratos/processes/apply_constant_vectorvalue_process.h
+++ b/kratos/processes/apply_constant_vectorvalue_process.h
@@ -58,8 +58,19 @@ public:
      * @brief Constructor for ApplyConstantVectorValueProcess.
      * @details This constructor initializes an instance of the ApplyConstantVectorValueProcess class with the given model part
      * and parameters.
+     * @param rModel Reference to the model to which the process is applied.
+     * @param ThisParameters Parameters defining the behavior of the process.
+     */
+    ApplyConstantVectorValueProcess(Model& rModel,
+                                    Parameters ThisParameters
+                                   );
+
+    /**
+     * @brief Constructor for ApplyConstantVectorValueProcess.
+     * @details This constructor initializes an instance of the ApplyConstantVectorValueProcess class with the given model part
+     * and parameters.
      * @param rModelPart Reference to the model part to which the process is applied.
-     * @param parameters Parameters defining the behavior of the process.
+     * @param ThisParameters Parameters defining the behavior of the process.
      */
     ApplyConstantVectorValueProcess(ModelPart& rModelPart,
                                     Parameters ThisParameters

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -361,6 +361,7 @@ void  AddProcessesToPython(pybind11::module& m)
     ;
 
     py::class_<ApplyConstantScalarValueProcess, ApplyConstantScalarValueProcess::Pointer, Process>(m,"ApplyConstantScalarValueProcess")
+            .def(py::init<Model&, Parameters>())
             .def(py::init<ModelPart&, Parameters>())
             .def(py::init<ModelPart&, const Variable<double>&, double, std::size_t, Flags>())
             .def(py::init< ModelPart&, Parameters >())
@@ -371,6 +372,7 @@ void  AddProcessesToPython(pybind11::module& m)
     ;
 
     py::class_<ApplyConstantVectorValueProcess, ApplyConstantVectorValueProcess::Pointer, Process>(m,"ApplyConstantVectorValueProcess")
+            .def(py::init<Model&, Parameters>())
             .def(py::init<ModelPart&, Parameters>())
             .def(py::init<ModelPart&, const Variable<array_1d<double, 3 > >& , const double, const Vector , std::size_t, Flags>())
             .def(py::init< ModelPart&, Parameters >())


### PR DESCRIPTION
**📝 Description**

Clean up and refactor `ApplyConstantScalarValueProcess`, separating code to source file and improve refactor includes to reduce code duplication. Refactor with modern `KRATOS_ERROR`.

**🆕 Changelog**

- [Clean up and refactor `ApplyConstantScalarValueProcess`](https://github.com/KratosMultiphysics/Kratos/commit/3a2ca849d70df6612f0839a428a7e7f294095040)
- [Adding `Model` constructor to `ApplyConstantScalarValueProcess`](https://github.com/KratosMultiphysics/Kratos/commit/2813a7f48b6ddd76cc235a5f943da6c59d900003)
- [Add new constructors to python](https://github.com/KratosMultiphysics/Kratos/commit/3ff82388de1c99ba785338c91466132c3e3a4f79)
- [Minor typos](https://github.com/KratosMultiphysics/Kratos/commit/cc50f51611991f59c2d014fdf0e894af11f744c4)
