### PR TITLE
[Expressions] Fixes the test failure

### DIFF
--- a/kratos/tests/test_container_expression.py
+++ b/kratos/tests/test_container_expression.py
@@ -753,7 +753,13 @@ class TestContainerExpression(ABC):
         self._Read(a, Kratos.VELOCITY)
         a *= -1
         c = a.Evaluate().reshape([len(self._GetContainer()) * 3])
-        self.assertAlmostEqual(Kratos.Expression.Utils.NormInf(a), self.data_comm.MaxAll(numpy.linalg.norm(c, ord=numpy.inf)), 9)
+        if c.shape == (0,):
+            # numpy norm inf throws an error if the array shape is zero.
+            # hence this is checked before.
+            norm_inf = 0.0
+        else:
+            norm_inf = numpy.linalg.norm(c, ord=numpy.inf)
+        self.assertAlmostEqual(Kratos.Expression.Utils.NormInf(a), self.data_comm.MaxAll(norm_inf), 9)
 
     def test_NormL2(self):
         a = self._GetContainerExpression()


### PR DESCRIPTION
**📝 Description**
`Expression::Utils::NormInf` test was failing when the numpy array generated was of zero size because, `numpy.linalg.norm(ord=numpy.inf)` throws an error when used with zero shape numpy arrays. This PR fixes it.

Fixes and closes #12159. Thanks for the bug report @ddiezrod :)

@ddiezrod Could you check whether this fixes your CI problems? Thanks.

**🆕 Changelog**
- Fixes bug in numpy norm inf test
